### PR TITLE
Expression is now a subclass of Treenode

### DIFF
--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from daft.expressions import ColumnExpression, Expression, col, udf
 
 
@@ -44,12 +42,25 @@ def test_udf_multiple_return() -> None:
     assert out2.is_operation()
 
 
-def test_col_eval() -> None:
-    id = col("id")
-    assert id.eval(id=[1, 2, 3]) == [1, 2, 3]
+def test_name() -> None:
+    expr = col("a") + col("b")
+    assert expr.name() == "a"
+    assert set(expr.required_columns()) == {"a", "b"}
+
+    new_expr = col("c") + expr
+    new_expr.name() == "c"
+    assert set(new_expr.required_columns()) == {"c", "a", "b"}
 
 
-def test_add_col_eval() -> None:
-    id = col("id")
-    result = (id + 1).eval(id=np.ones(10))
-    assert np.all(result == 2)
+def test_alias() -> None:
+    expr = col("a") + col("b")
+    assert expr.name() == "a"
+
+    alias_expr = expr.alias("ab")
+    assert alias_expr.name() == "ab"
+
+    assert set(alias_expr.required_columns()) == {"a", "b"}
+    assert (alias_expr + col("c")) == "ab"
+    assert (col("c") + alias_expr) == "c"
+
+    assert set((col("c") + alias_expr).required_columns()) == {"c", "a", "b"}


### PR DESCRIPTION
* Expression methods use treenode children / register_child methods
* Implements name method with uses left hand evaluation to generate names
* Implements required_columns which displays the names needed for this expression
* Enable AliasExpression to rename expression output names
* Adds tests for required_columns and name