### PR TITLE
Adds parametrization to test various partitioning schemes for Daft Dataframes and --run_tdd flag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import pytest
 import ray
 
+# Global singleton marking whether to run TDD tests, needed just for our custom
+# decorator @partitioned_daft_df to know when to test more advanced partition schemes
+RUN_TDD_OPTION = None
+
 
 @pytest.fixture(scope="session")
 def ray_cluster():
@@ -12,17 +16,31 @@ def ray_cluster():
 def pytest_addoption(parser):
     parser.addoption("--run_conda", action="store_true", default=False, help="run tests that require conda")
     parser.addoption("--run_docker", action="store_true", default=False, help="run tests that require docker")
+    parser.addoption(
+        "--run_tdd", action="store_true", default=False, help="run tests that are marked for Test Driven Development"
+    )
+    parser.addoption(
+        "--run_tdd_all",
+        action="store_true",
+        default=False,
+        help="run tests that are marked for Test Driven Development (including low priority)",
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "conda: mark test as requiring conda to run")
     config.addinivalue_line("markers", "docker: mark test as requiring docker to run")
 
+    global RUN_TDD_OPTION
+    RUN_TDD_OPTION = config.getoption(f"--run_tdd") or config.getoption(f"--run_tdd_all")
+
 
 def pytest_collection_modifyitems(config, items):
     marks = {
         "conda": pytest.mark.skip(reason="need --run_conda option to run"),
         "docker": pytest.mark.skip(reason="need --run_docker option to run"),
+        "tdd": pytest.mark.skip(reason="need --run_tdd option to run"),
+        "tdd_all": pytest.mark.skip(reason="need --run_tdd_all option to run"),
     }
     for item in items:
         for keyword in marks:

--- a/tests/dataframe_cookbook/conftest.py
+++ b/tests/dataframe_cookbook/conftest.py
@@ -3,6 +3,7 @@ import pytest
 
 from daft.dataframe import DataFrame
 from daft.expressions import col
+from tests.conftest import RUN_TDD_OPTION
 
 IRIS_CSV = "tests/assets/iris.csv"
 SERVICE_REQUESTS_CSV = "tests/assets/311-service-requests.1000.csv"
@@ -14,9 +15,36 @@ def pd_df() -> pd.DataFrame:
     return pd.read_csv(SERVICE_REQUESTS_CSV, keep_default_na=False)[COLUMNS]
 
 
-@pytest.fixture(scope="function")
-def daft_df() -> DataFrame:
-    return DataFrame.from_csv(SERVICE_REQUESTS_CSV).select(*[col(c) for c in COLUMNS])
+def partitioned_daft_df(arg_name: str):
+    """Test case fixture to be used as a decorator that injects a DaFt dataframe with multiple different
+    partitioning schemes
+
+    Usage:
+
+    @partitioned_daft_df
+    def test_foo(daft_df):
+
+    """
+
+    def _wrapper(test_case):
+        base_df = DataFrame.from_csv(SERVICE_REQUESTS_CSV).select(*[col(c) for c in COLUMNS])
+        parameters = [
+            base_df,
+            base_df.repartition(1),
+        ]
+        # TODO(jay): Change this once partition behavior is fixed
+        if RUN_TDD_OPTION:
+            parameters.extend(
+                [
+                    base_df.repartition(2),
+                    base_df.repartition(10),
+                    base_df.repartition(1000),
+                    base_df.repartition(1001),
+                ]
+            )
+        return pytest.mark.parametrize(arg_name, parameters)(test_case)
+
+    return _wrapper
 
 
 def assert_df_equals(daft_df: DataFrame, pd_df: pd.DataFrame):

--- a/tests/dataframe_cookbook/test_aggregations.py
+++ b/tests/dataframe_cookbook/test_aggregations.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import pytest
+
+from daft.expressions import col
+from tests.dataframe_cookbook.conftest import assert_df_equals
+
+COL_SUBSET = ["Complaint Type", "Borough", "Descriptor"]
+
+
+@pytest.mark.tdd_all
+def test_sum(daft_df, pd_df):
+    """Sums across an entire column for the entire table"""
+    daft_df = daft_df.select(col("Unique Key").sum().alias("unique_key_sum"))
+    pd_df = pd.DataFrame.from_records[{"unique_key_sum": [pd_df["Unique Key"].sum()]}]
+    assert_df_equals(daft_df, pd_df)

--- a/tests/dataframe_cookbook/test_computations.py
+++ b/tests/dataframe_cookbook/test_computations.py
@@ -1,9 +1,10 @@
 import pytest
 
 from daft.expressions import col
-from tests.dataframe_cookbook.conftest import assert_df_equals
+from tests.dataframe_cookbook.conftest import assert_df_equals, partitioned_daft_df
 
 
+@partitioned_daft_df("daft_df")
 @pytest.mark.parametrize(
     "daft_df_ops",
     [
@@ -17,6 +18,7 @@ def test_add_one_to_column(daft_df_ops, daft_df, pd_df):
     assert_df_equals(daft_df_ops(daft_df), pd_df.head(10))
 
 
+@partitioned_daft_df("daft_df")
 @pytest.mark.parametrize(
     "daft_df_ops",
     [

--- a/tests/dataframe_cookbook/test_dataloading.py
+++ b/tests/dataframe_cookbook/test_dataloading.py
@@ -4,9 +4,14 @@ import pandas as pd
 import pytest
 
 from daft.dataframe import DataFrame
-from tests.dataframe_cookbook.conftest import IRIS_CSV, assert_df_equals
+from tests.dataframe_cookbook.conftest import (
+    IRIS_CSV,
+    assert_df_equals,
+    partitioned_daft_df,
+)
 
 
+@partitioned_daft_df("daft_df")
 def test_load_csv(daft_df, pd_df):
     """Loading data from a CSV works"""
     pd_slice = pd_df[:100]
@@ -14,7 +19,7 @@ def test_load_csv(daft_df, pd_df):
     assert_df_equals(daft_slice, pd_slice)
 
 
-@pytest.mark.skip(reason="TODO: Re-enable once Scan supports CSV headers")
+@pytest.mark.tdd_all
 def test_load_csv_no_headers(tmp_path: pathlib.Path):
     """Generate a default set of headers `col_0, col_1, ... col_{n}` when loading a CSV that has no headers"""
     csv = tmp_path / "headerless_iris.csv"
@@ -25,7 +30,7 @@ def test_load_csv_no_headers(tmp_path: pathlib.Path):
     assert_df_equals(daft_df, pd_df)
 
 
-@pytest.mark.skip(reason="TODO: Re-enable once Scan supports CSV delimiters")
+@pytest.mark.tdd_all
 def test_load_csv_tab_delimited(tmp_path: pathlib.Path):
     """Generate a default set of headers `col_0, col_1, ... col_{n}` when loading a CSV that has no headers"""
     csv = tmp_path / "headerless_iris.csv"
@@ -35,7 +40,7 @@ def test_load_csv_tab_delimited(tmp_path: pathlib.Path):
     assert_df_equals(daft_df, pd_df)
 
 
-@pytest.mark.skip(reason="TODO: Re-enable once Scan supports in-memory")
+@pytest.mark.tdd_all
 def test_load_pydict():
     data = {"foo": [1, 2, 3], "bar": [1.0, None, 3.0], "baz": ["a", "b", "c"]}
     daft_df = DataFrame.from_pydict(data)
@@ -43,7 +48,7 @@ def test_load_pydict():
     assert_df_equals(daft_df, pd_df)
 
 
-@pytest.mark.skip(reason="TODO: Re-enable once Scan supports in-memory")
+@pytest.mark.tdd_all
 def test_load_pylist():
     data = [
         {"foo": 1, "bar": 1.0, "baz": "a"},

--- a/tests/dataframe_cookbook/test_filter.py
+++ b/tests/dataframe_cookbook/test_filter.py
@@ -1,11 +1,12 @@
 import pytest
 
 from daft.expressions import col
-from tests.dataframe_cookbook.conftest import assert_df_equals
+from tests.dataframe_cookbook.conftest import assert_df_equals, partitioned_daft_df
 
 COL_SUBSET = ["Complaint Type", "Borough", "Descriptor"]
 
 
+@partitioned_daft_df("daft_df")
 @pytest.mark.parametrize(
     "daft_df_ops",
     [
@@ -38,6 +39,7 @@ def test_filter(daft_df_ops, daft_df, pd_df):
     assert_df_equals(daft_noise_complaints, pd_noise_complaints)
 
 
+@partitioned_daft_df("daft_df")
 @pytest.mark.parametrize(
     "daft_df_ops",
     [
@@ -78,6 +80,7 @@ def test_composite_filter(daft_df_ops, daft_df, pd_df):
     assert_df_equals(daft_noise_complaints_brooklyn, pd_noise_complaints_brooklyn)
 
 
+@partitioned_daft_df("daft_df")
 @pytest.mark.parametrize(
     "daft_df_ops",
     [

--- a/tests/dataframe_cookbook/test_sorting.py
+++ b/tests/dataframe_cookbook/test_sorting.py
@@ -1,9 +1,10 @@
 import pytest
 
 from daft.expressions import col
-from tests.dataframe_cookbook.conftest import assert_df_equals
+from tests.dataframe_cookbook.conftest import assert_df_equals, partitioned_daft_df
 
 
+@partitioned_daft_df("daft_df")
 def test_get_sorted_top_n(daft_df, pd_df):
     """Sort by a column and retrieve the top N results"""
     daft_sorted_df = daft_df.sort(col("Created Date")).limit(10)
@@ -14,6 +15,7 @@ def test_get_sorted_top_n(daft_df, pd_df):
     )
 
 
+@partitioned_daft_df("daft_df")
 def test_sort_on_small_sample(daft_df, pd_df):
     """Sample the dataframe for N number of items and then sort it"""
     daft_df = daft_df.limit(10).sort(col("Created Date"))
@@ -24,6 +26,7 @@ def test_sort_on_small_sample(daft_df, pd_df):
     )
 
 
+@partitioned_daft_df("daft_df")
 @pytest.mark.parametrize(
     "daft_df_ops",
     [


### PR DESCRIPTION
* @partitioned_daft_df("daft_df") decorator can be added to tests to provision a `daft_df` fixture which will parametrize the test on various daft_df dataframes, each partitioned in a different way
* Adds a --run_tdd flag and `tdd` mark to run all tests that test features currently under active development
* Adds a --run_tdd_all flag and `tdd_all` mark to run all tests that test features that should eventually be added in, but not under active development