### PR TITLE
Fix unit test --run_tdd and use of .limits

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
+import argparse
+
 import pytest
 import ray
-
-# Global singleton marking whether to run TDD tests, needed just for our custom
-# decorator @parametrize_partitioned_daft_df to know when to test more advanced partition schemes
-RUN_TDD_OPTION = None
 
 
 @pytest.fixture(scope="session")
@@ -30,9 +28,8 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "conda: mark test as requiring conda to run")
     config.addinivalue_line("markers", "docker: mark test as requiring docker to run")
-
-    global RUN_TDD_OPTION
-    RUN_TDD_OPTION = config.getoption(f"--run_tdd") or config.getoption(f"--run_tdd_all")
+    config.addinivalue_line("markers", "tdd: mark test as for TDD in active development")
+    config.addinivalue_line("markers", "tdd_all: mark test as for TDD but not in active development")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -46,3 +43,10 @@ def pytest_collection_modifyitems(config, items):
         for keyword in marks:
             if keyword in item.keywords and not config.getoption(f"--run_{keyword}"):
                 item.add_marker(marks[keyword])
+
+
+def run_tdd():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run_tdd", action="store_true")
+    args, _ = parser.parse_known_args()
+    return args.run_tdd

--- a/tests/dataframe_cookbook/conftest.py
+++ b/tests/dataframe_cookbook/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 from daft.dataframe import DataFrame
 from daft.expressions import col
-from tests.conftest import RUN_TDD_OPTION
+from tests.conftest import run_tdd
 
 IRIS_CSV = "tests/assets/iris.csv"
 SERVICE_REQUESTS_CSV = "tests/assets/311-service-requests.1000.csv"
@@ -18,7 +18,7 @@ def parametrize_sort_desc(arg_name: str):
 
     def _wrapper(test_case):
         parameters = [False]
-        if RUN_TDD_OPTION:
+        if run_tdd():
             parameters.extend([True])
         return pytest.mark.parametrize(arg_name, parameters)(test_case)
 
@@ -61,7 +61,7 @@ def parametrize_partitioned_daft_df(
             base_df,
         ]
         # TODO(jay): Change this once partition behavior is fixed
-        if RUN_TDD_OPTION:
+        if run_tdd():
             daft_dfs.extend(
                 [
                     base_df.repartition(1),

--- a/tests/dataframe_cookbook/test_aggregations.py
+++ b/tests/dataframe_cookbook/test_aggregations.py
@@ -31,8 +31,8 @@ def test_filtered_sum(daft_df, pd_df):
 @parametrize_partitioned_daft_df()
 def test_limit_mean(daft_df, pd_df):
     """Averages across a column in a sampling of the table"""
-    daft_df = daft_df.limit(100).agg(col("Unique Key").mean().alias("unique_key_mean"))
-    pd_df = pd.DataFrame.from_records[{"unique_key_mean": [pd_df.head(100)["Unique Key"].mean()]}]
+    daft_df = daft_df.agg(col("Unique Key").mean().alias("unique_key_mean"))
+    pd_df = pd.DataFrame.from_records[{"unique_key_mean": [pd_df["Unique Key"].mean()]}]
     assert_df_equals(daft_df, pd_df)
 
 

--- a/tests/dataframe_cookbook/test_computations.py
+++ b/tests/dataframe_cookbook/test_computations.py
@@ -1,5 +1,3 @@
-import pytest
-
 from daft.expressions import col
 from tests.dataframe_cookbook.conftest import (
     assert_df_equals,
@@ -8,28 +6,16 @@ from tests.dataframe_cookbook.conftest import (
 
 
 @parametrize_partitioned_daft_df()
-@pytest.mark.parametrize(
-    "daft_df_ops",
-    [
-        lambda daft_df: daft_df.with_column("unique_key_mod", col("Unique Key") + 1).limit(10),
-        lambda daft_df: daft_df.limit(10).with_column("unique_key_mod", col("Unique Key") + 1),
-    ],
-)
-def test_add_one_to_column(daft_df_ops, daft_df, pd_df):
+def test_add_one_to_column(daft_df, pd_df):
     """Creating a new column that is derived from (1 + other_column) and retrieving the top N results"""
+    daft_df = daft_df.with_column("unique_key_mod", col("Unique Key") + 1)
     pd_df["unique_key_mod"] = pd_df["Unique Key"] + 1
-    assert_df_equals(daft_df_ops(daft_df), pd_df.head(10))
+    assert_df_equals(daft_df, pd_df)
 
 
 @parametrize_partitioned_daft_df()
-@pytest.mark.parametrize(
-    "daft_df_ops",
-    [
-        lambda daft_df: daft_df.with_column("unique_key_mod", col("Unique Key") - col("Unique Key")).limit(10),
-        lambda daft_df: daft_df.limit(10).with_column("unique_key_mod", col("Unique Key") - col("Unique Key")),
-    ],
-)
-def test_difference_cols(daft_df_ops, daft_df, pd_df):
+def test_difference_cols(daft_df, pd_df):
     """Creating a new column that is derived from 2 other columns and retrieving the top N results"""
+    daft_df = daft_df.with_column("unique_key_mod", col("Unique Key") - col("Unique Key"))
     pd_df["unique_key_mod"] = pd_df["Unique Key"] - pd_df["Unique Key"]
-    assert_df_equals(daft_df_ops(daft_df), pd_df.head(10))
+    assert_df_equals(daft_df, pd_df)

--- a/tests/dataframe_cookbook/test_dataloading.py
+++ b/tests/dataframe_cookbook/test_dataloading.py
@@ -14,8 +14,8 @@ from tests.dataframe_cookbook.conftest import (
 @parametrize_partitioned_daft_df()
 def test_load_csv(daft_df, pd_df):
     """Loading data from a CSV works"""
-    pd_slice = pd_df[:100]
-    daft_slice = daft_df.limit(100)
+    pd_slice = pd_df
+    daft_slice = daft_df
     assert_df_equals(daft_slice, pd_slice)
 
 

--- a/tests/dataframe_cookbook/test_filter.py
+++ b/tests/dataframe_cookbook/test_filter.py
@@ -13,23 +13,17 @@ COL_SUBSET = ["Unique Key", "Complaint Type", "Borough", "Descriptor"]
 @pytest.mark.parametrize(
     "daft_df_ops",
     [
-        # Select after the limit clause
+        # Select after where clause
         lambda daft_df: (
-            daft_df.where(col("Complaint Type") == "Noise - Street/Sidewalk")
-            .limit(10)
-            .select(col("Unique Key"), col("Complaint Type"), col("Borough"), col("Descriptor"))
+            daft_df.where(col("Complaint Type") == "Noise - Street/Sidewalk").select(
+                col("Unique Key"), col("Complaint Type"), col("Borough"), col("Descriptor")
+            )
         ),
-        # Select before the limit clause
+        # Select before where clause
         lambda daft_df: (
-            daft_df.where(col("Complaint Type") == "Noise - Street/Sidewalk")
-            .select(col("Unique Key"), col("Complaint Type"), col("Borough"), col("Descriptor"))
-            .limit(10)
-        ),
-        # Select before the where clause
-        lambda daft_df: (
-            daft_df.select(col("Unique Key"), col("Complaint Type"), col("Borough"), col("Descriptor"))
-            .where(col("Complaint Type") == "Noise - Street/Sidewalk")
-            .limit(10)
+            daft_df.select(col("Unique Key"), col("Complaint Type"), col("Borough"), col("Descriptor")).where(
+                col("Complaint Type") == "Noise - Street/Sidewalk"
+            )
         ),
     ],
 )
@@ -38,7 +32,7 @@ def test_filter(daft_df_ops, daft_df, pd_df):
 
     daft_noise_complaints = daft_df_ops(daft_df)
 
-    pd_noise_complaints = pd_df[pd_df["Complaint Type"] == "Noise - Street/Sidewalk"].head(10)[COL_SUBSET]
+    pd_noise_complaints = pd_df[pd_df["Complaint Type"] == "Noise - Street/Sidewalk"][COL_SUBSET]
     assert_df_equals(daft_noise_complaints, pd_noise_complaints)
 
 

--- a/tests/dataframe_cookbook/test_sorting.py
+++ b/tests/dataframe_cookbook/test_sorting.py
@@ -10,26 +10,26 @@ from tests.dataframe_cookbook.conftest import (
 
 @parametrize_partitioned_daft_df()
 @parametrize_sort_desc("sort_desc")
-def test_get_sorted_top_n(daft_df, sort_desc, pd_df):
-    """Sort by a column and retrieve the top N results"""
-    daft_sorted_df = daft_df.sort(col("Unique Key"), desc=sort_desc).limit(10)
+def test_get_sorted(sort_desc, daft_df, pd_df):
+    """Sort by a column"""
+    daft_sorted_df = daft_df.sort(col("Unique Key"), desc=sort_desc)
 
     assert_df_equals(
         daft_sorted_df,
-        pd_df.sort_values(by="Unique Key", ascending=not sort_desc).head(10),
+        pd_df.sort_values(by="Unique Key", ascending=not sort_desc),
         assert_ordering=True,
     )
 
 
 @parametrize_partitioned_daft_df()
 @parametrize_sort_desc("sort_desc")
-def test_sort_on_small_sample(daft_df, sort_desc, pd_df):
-    """Sample the dataframe for N number of items and then sort it"""
-    daft_df = daft_df.limit(10).sort(col("Created Date"), desc=sort_desc)
-    expected = pd_df.head(10).sort_values(by="Created Date", ascending=not sort_desc)
+def test_get_sorted_top_n(sort_desc, daft_df, pd_df):
+    """Sort by a column"""
+    daft_sorted_df = daft_df.sort(col("Unique Key"), desc=sort_desc).limit(100)
+
     assert_df_equals(
-        daft_df,
-        expected,
+        daft_sorted_df,
+        pd_df.sort_values(by="Unique Key", ascending=not sort_desc).head(100),
         assert_ordering=True,
     )
 
@@ -38,26 +38,20 @@ def test_sort_on_small_sample(daft_df, sort_desc, pd_df):
 @pytest.mark.parametrize(
     "daft_df_ops",
     [
-        # Select after limit
-        lambda daft_df, sort_desc: daft_df.sort(col("Created Date"), desc=sort_desc)
-        .limit(10)
-        .select(col("Created Date"), col("Complaint Type")),
-        # Select before limit
-        lambda daft_df, sort_desc: daft_df.sort(col("Created Date"), desc=sort_desc)
-        .select(col("Created Date"), col("Complaint Type"))
-        .limit(10),
+        # Select after sort
+        lambda daft_df, sort_desc: daft_df.sort(col("Unique Key"), desc=sort_desc).select(
+            col("Unique Key"), col("Complaint Type")
+        ),
         # Select before the sort
-        lambda daft_df, sort_desc: daft_df.select(col("Created Date"), col("Complaint Type"))
-        .sort(col("Created Date"), desc=sort_desc)
-        .limit(10),
+        lambda daft_df, sort_desc: daft_df.select(col("Unique Key"), col("Complaint Type")).sort(
+            col("Unique Key"), desc=sort_desc
+        ),
     ],
 )
 @parametrize_sort_desc("sort_desc")
 def test_get_sorted_top_n_projected(daft_df_ops, sort_desc, daft_df, pd_df):
     """Sort by a column and retrieve specific columns from the top N results"""
-    expected = pd_df.sort_values(by="Created Date", ascending=not sort_desc).head(10)[
-        ["Created Date", "Complaint Type"]
-    ]
+    expected = pd_df.sort_values(by="Unique Key", ascending=not sort_desc)[["Unique Key", "Complaint Type"]]
     assert_df_equals(
         daft_df_ops(daft_df, sort_desc),
         expected,


### PR DESCRIPTION
* Fix `--run_tdd` flag
* Remove use of `.limits` which breaks tests after repartitioning as ordering is not maintained after a repartition operation