### PR TITLE
Make type_matrix immutable using FrozenSet

### DIFF
--- a/daft/expressions.py
+++ b/daft/expressions.py
@@ -299,8 +299,7 @@ class CallExpression(Expression):
         if any(t is None for t in arg_types):
             return None
         arg_types_not_none = tuple(_assert_not_none(t) for t in arg_types)
-        print(arg_types_not_none)
-        return self._operator.type_matrix.get(arg_types_not_none, ExpressionType.UNKNOWN)
+        return self._operator.type_matrix_dict().get(arg_types_not_none, ExpressionType.UNKNOWN)
 
     @property
     def _args(self) -> Tuple[Expression, ...]:


### PR DESCRIPTION
We use FrozenSet to keep the type_matrix of an Operator immutable, and a cached method that converts it into a MappingProxy.

This roundabout way is necessary because MappingProxies are not pickleable.

We use `lru_cache` instead of `cached_property` here for compatibility with Python <3.8