### PR TITLE
DataBlock typing

### DIFF
--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -10,7 +10,7 @@ import pyarrow as pa
 
 from daft.expressions import ColID, Expression, ExpressionExecutor
 from daft.logical.schema import ExpressionList
-from daft.runners.blocks import ArrowEvaluator, DataBlock
+from daft.runners.blocks import ArrowArrType, ArrowEvaluator, DataBlock
 
 from ..execution.operators import OperatorEnum
 
@@ -120,7 +120,7 @@ class vPartition:
         tiles = {}
         for i, (col_id, name) in enumerate(zip(column_ids, names)):
             arr = table[i]
-            block = DataBlock.make_block(arr)
+            block: DataBlock[ArrowArrType] = DataBlock.make_block(arr)
             tiles[col_id] = PyListTile(column_id=col_id, column_name=name, partition_id=partition_id, block=block)
         return vPartition(columns=tiles, partition_id=partition_id)
 
@@ -150,7 +150,7 @@ class vPartition:
     def sample(self, num: int) -> vPartition:
         if len(self) == 0:
             return self
-        sample_idx = DataBlock.make_block(data=np.random.randint(0, len(self), num))
+        sample_idx: DataBlock[ArrowArrType] = DataBlock.make_block(data=np.random.randint(0, len(self), num))
         return self.for_each_column_block(partial(DataBlock.take, indices=sample_idx))
 
     def filter(self, predicate: ExpressionList) -> vPartition:

--- a/daft/runners/shuffle_ops.py
+++ b/daft/runners/shuffle_ops.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 import numpy as np
 
 from daft.expressions import Expression
-from daft.runners.blocks import DataBlock
+from daft.runners.blocks import ArrowArrType, DataBlock
 from daft.runners.partitioning import PartID, vPartition
 
 
@@ -34,7 +34,9 @@ class RepartitionRandomOp(ShuffleOp):
             seed += input.partition_id
 
         rng = np.random.default_rng(seed=seed)
-        target_idx = DataBlock.make_block(data=rng.integers(low=0, high=output_partitions, size=len(input)))
+        target_idx: DataBlock[ArrowArrType] = DataBlock.make_block(
+            data=rng.integers(low=0, high=output_partitions, size=len(input))
+        )
         new_parts = input.split_by_index(num_partitions=output_partitions, target_partition_indices=target_idx)
         return {PartID(i): part for i, part in enumerate(new_parts)}
 


### PR DESCRIPTION
* Corrects typing of DataBlock to use generics where possible
* Some methods actually require taking in a `DataBlock[ArrowArrType]` instead of a generic `DataBlock[ArrType]`, and that has been changed accordingly