### PR TITLE
Adds DataFrame.from_json and associated bugfixes

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -1,6 +1,8 @@
 from daft.dataclasses import dataclass
+from daft.dataframe import DataFrame
+from daft.expressions import col, udf
 from daft.logging import setup_logger
 
-__all__ = ["dataclass"]
+__all__ = ["DataFrame", "col", "udf"]
 
 setup_logger()

--- a/daft/datasources.py
+++ b/daft/datasources.py
@@ -7,6 +7,7 @@ class ScanType(Enum):
     CSV = "CSV"
     PARQUET = "PARQUET"
     IN_MEMORY = "IN_MEMORY"
+    JSON = "JSON"
 
 
 class SourceInfo(Protocol):
@@ -28,6 +29,18 @@ class CSVSourceInfo(SourceInfo):
 
     def scan_type(self):
         return ScanType.CSV
+
+    def get_num_partitions(self) -> int:
+        return len(self.filepaths)
+
+
+@dataclass(frozen=True)
+class JSONSourceInfo(SourceInfo):
+
+    filepaths: List[str]
+
+    def scan_type(self):
+        return ScanType.JSON
 
     def get_num_partitions(self) -> int:
         return len(self.filepaths)

--- a/daft/execution/operators.py
+++ b/daft/execution/operators.py
@@ -22,6 +22,10 @@ import pyarrow as pa
 
 class ExpressionType:
     @staticmethod
+    def is_logical(t: ExpressionType) -> bool:
+        return t == _TYPE_REGISTRY["logical"]
+
+    @staticmethod
     def unknown() -> ExpressionType:
         return _TYPE_REGISTRY["unknown"]
 
@@ -40,8 +44,10 @@ class ExpressionType:
 
     @staticmethod
     def from_arrow_type(datatype: pa.DataType) -> ExpressionType:
+        # We fall back on generic Python object expression types if we encounter types that
+        # are not mapped to an ExpressionType
         if datatype not in _PYARROW_TYPE_TO_EXPRESSION_TYPE:
-            return _TYPE_REGISTRY["unknown"]
+            return ExpressionType.python_object()
         return _PYARROW_TYPE_TO_EXPRESSION_TYPE[datatype]
 
 
@@ -115,7 +121,7 @@ EXPRESSION_TYPE_TO_PYARROW_TYPE = {
 
 
 _PYARROW_TYPE_TO_EXPRESSION_TYPE = {
-    pa.null(): _TYPE_REGISTRY["unknown"],
+    # pa.null(): _TYPE_REGISTRY["unknown"],
     pa.bool_(): _TYPE_REGISTRY["logical"],
     pa.int8(): _TYPE_REGISTRY["integer"],
     pa.int16(): _TYPE_REGISTRY["integer"],
@@ -129,10 +135,10 @@ _PYARROW_TYPE_TO_EXPRESSION_TYPE = {
     pa.float32(): _TYPE_REGISTRY["float"],
     pa.float64(): _TYPE_REGISTRY["float"],
     pa.date32(): _TYPE_REGISTRY["date"],
-    pa.date64(): _TYPE_REGISTRY["unknown"],
+    # pa.date64(): _TYPE_REGISTRY["unknown"],
     pa.string(): _TYPE_REGISTRY["string"],
     pa.utf8(): _TYPE_REGISTRY["string"],
-    pa.large_binary(): _TYPE_REGISTRY["unknown"],
+    # pa.large_binary(): _TYPE_REGISTRY["unknown"],
     pa.large_string(): _TYPE_REGISTRY["string"],
     pa.large_utf8(): _TYPE_REGISTRY["string"],
 }

--- a/daft/expressions.py
+++ b/daft/expressions.py
@@ -431,6 +431,9 @@ class UdfExpression(Expression, Generic[DataBlockValueType]):
             and self._kwargs_ids == other._kwargs_ids
         )
 
+    def has_call(self) -> bool:
+        return True
+
 
 T = TypeVar("T")
 
@@ -598,17 +601,19 @@ class AsPyExpression(Expression):
     def __getitem__(self, key):
         self._attr_name = "__getitem__"
 
-        def f(expr, keys):
+        def __getitem__(expr, keys):
             results = []
             for expr_val, key_val in zip_blocks(expr, keys):
                 method = getattr(self._type.python_cls, self._attr_name)
                 result = method(expr_val, key_val)
                 results.append(result)
+            return DataBlock.make_block(results)
 
         return UdfExpression(
-            f,
+            __getitem__,
             ExpressionType.python_object(),
             func_args=(self._expr, key),
+            func_kwargs={},
         )
 
     def _display_str(self) -> str:

--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -7,6 +7,7 @@ from enum import Enum, IntEnum
 from typing import Any, List, Optional, Tuple
 
 from daft.datasources import SourceInfo
+from daft.execution.operators import ExpressionType
 from daft.expressions import ColumnExpression, Expression
 from daft.internal.treenode import TreeNode
 from daft.logical.schema import ExpressionList
@@ -151,6 +152,12 @@ class Filter(UnaryNode):
         )
         self._register_child(input)
         self._predicate = predicate.resolve(input.schema())
+
+        resolved_type = self._predicate.exprs[0].resolved_type()
+        if not ExpressionType.is_logical(resolved_type):
+            raise ValueError(
+                f"Expected expression {self._predicate.exprs[0]} to resolve to type LOGICAL, but received: {resolved_type}"
+            )
 
     def __repr__(self) -> str:
         return f"Filter\n\toutput={self.schema()}\n\tpredicate={self._predicate}"

--- a/tests/dataframe/test_projection.py
+++ b/tests/dataframe/test_projection.py
@@ -68,4 +68,4 @@ def test_with_column(valid_data: List[Dict[str, float]]) -> None:
     df = DataFrame.from_pylist(valid_data)
     expanded_df = df.with_column("foo", expr)
     # TODO(jay): Test that the expression with name "foo" is equal to the expected expression, except for the IDs of the columns
-    assert expanded_df.column_names() == [c.name for c in df.schema()] + ["foo"]
+    assert expanded_df.column_names() == df.schema().column_names() + ["foo"]

--- a/tests/dataframe/test_schema.py
+++ b/tests/dataframe/test_schema.py
@@ -25,8 +25,8 @@ def daft_df():
         lit(MyObj()).alias("myobjcol"),
     )
 
-    schema_fields = {e.name: e for e in daft_df.schema()}
-    assert schema_fields.keys() == set(COLS)
+    schema_fields = daft_df.schema()
+    assert set(schema_fields.column_names()) == set(COLS)
     assert schema_fields["floatcol"].daft_type == ExpressionType.from_py_type(float)
     assert schema_fields["intcol"].daft_type == ExpressionType.from_py_type(int)
     assert schema_fields["stringcol"].daft_type == ExpressionType.from_py_type(str)
@@ -87,9 +87,9 @@ def test_unary_ops_select_types(daft_df, colname, op, expected_result_type):
         return
 
     df = daft_df.select(getattr(col(colname), op)())
-    fields = [field for field in df.schema()]
+    fields = df.schema()
     assert len(fields) == 1
-    field = fields[0]
+    field = fields[colname]
     assert field.name == colname
     assert field.daft_type == expected_result_type
 
@@ -155,9 +155,9 @@ def test_binary_ops_select_types(daft_df, col1, col2, op, expected_result_type):
         return
 
     df = daft_df.select(getattr(col(col1), op)(col(col2)))
-    fields = [field for field in df.schema()]
+    fields = df.schema()
     assert len(fields) == 1
-    field = fields[0]
+    field = fields[col1]
     assert field.name == col1
     assert field.daft_type == expected_result_type
 
@@ -169,8 +169,8 @@ def test_udf(daft_df):
 
     df = daft_df.select(my_udf(col("floatcol"), col("boolcol")))
 
-    fields = [field for field in df.schema()]
+    fields = df.schema()
     assert len(fields) == 1
-    field = fields[0]
+    field = fields["floatcol"]
     assert field.name == "floatcol"
     assert field.daft_type == ExpressionType.from_py_type(str)

--- a/tests/logical/test_logical_plan.py
+++ b/tests/logical/test_logical_plan.py
@@ -12,7 +12,7 @@ def schema():
     return ExpressionList(
         list(
             map(
-                lambda col_name: ColumnExpression(col_name, expr_type=ExpressionType.python_object()),
+                lambda col_name: ColumnExpression(col_name, expr_type=ExpressionType.from_py_type(int)),
                 ["a", "b", "c"],
             )
         )


### PR DESCRIPTION
1. DataFrame.from_json loads a Dataframe from a line-delimited JSON file(s)
2. Any non-primitive (such as nested structs, lists etc) found in the JSON are loaded as PyObj[object] types
3. `.where` now fails if predicate provided does not resolve to a LOGICAL type