### PR TITLE
Slice Partitioning

### DIFF
--- a/daft/logging.py
+++ b/daft/logging.py
@@ -7,4 +7,4 @@ def setup_logger() -> None:
 
     logger.remove()
     LOGURU_LEVEL = env("LOGURU_LEVEL", str, "INFO")
-    logger.start(sys.stderr, level=LOGURU_LEVEL)
+    logger.add(sys.stderr, level=LOGURU_LEVEL)

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -494,9 +494,10 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
         for i in range(len(pivots) - 1):
             offset = pivots[i]
             size = pivots[i + 1] - offset
-            to_return.append(self.data.slice(offset, size))
+            # Combine chunks otherwise arrow has a serialization issue with giant memory
+            to_return.append(self.data.slice(offset, size).combine_chunks())
         if len(pivots) > 0:
-            to_return.append(self.data.slice(pivots[-1]))
+            to_return.append(self.data.slice(pivots[-1]).combine_chunks())
         return to_return
 
     @staticmethod

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -42,7 +42,7 @@ class PyListTile:
         argsorted_target_partition_indices: DataBlock,
     ) -> List[PyListTile]:
         assert len(argsorted_target_partition_indices) == len(self)
-        new_blocks = self.block.partition2(
+        new_blocks = self.block.partition(
             num_partitions,
             pivots=pivots,
             target_partitions=target_partitions,

--- a/tests/stress_tests/test_tpch.py
+++ b/tests/stress_tests/test_tpch.py
@@ -276,7 +276,6 @@ def gen_tpch(request):
             os.remove(backup_file)
 
     PARQUET_FILE_PATH = os.path.join(SF_TPCH_DIR, "parquet")
-
     if benchmark_mode and not os.path.exists(PARQUET_FILE_PATH):
         for tab_name in SCHEMA.keys():
             logger.info(f"Generating Parquet Files for {tab_name}")


### PR DESCRIPTION
* Refactors partition implementation to use arrow slicing rather than `np.split`.
* [yields over 38% speed for some benchmarks such as tpch](https://docs.google.com/spreadsheets/d/1MZ9iVi9zu5uTC6me4JOFkRub0aql_FQkiNkQQatzWqQ/edit?usp=sharing)
* Fixes null handling with partition since we're no longer casting to numpy