### PR TITLE
use _repr_png_ to display PIL images instead of relying on class/module names

### DIFF
--- a/daft/viz/dataframe_display.py
+++ b/daft/viz/dataframe_display.py
@@ -1,5 +1,4 @@
 import base64
-import io
 from dataclasses import dataclass
 from typing import Any
 
@@ -24,18 +23,10 @@ class DataFrameDisplay:
 
         # TODO: we should run this only for PyObj columns
         def stringify_and_truncate(val: Any):
-            if (
-                hasattr(type(val), "__name__")
-                and type(val).__name__ == "Image"
-                and hasattr(type(val), "__module__")
-                and type(val).__module__ == "PIL.Image"
-            ):
-                bio = io.BytesIO()
-                val_copy = val.copy()
-                val_copy.thumbnail((128, 128))
-                val_copy.save(bio, format="JPEG")
-                base64_img = base64.b64encode(bio.getvalue())
-                return f'<img src="data:image/jpeg;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
+            if hasattr(val, "_repr_png_"):
+                png_bytes = val._repr_png_()
+                base64_img = base64.b64encode(png_bytes)
+                return f'<img src="data:image/png;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
             elif isinstance(val, np.ndarray):
                 data_str = np.array2string(val, threshold=3)
                 data_str = (

--- a/daft/viz/dataframe_display.py
+++ b/daft/viz/dataframe_display.py
@@ -26,7 +26,7 @@ class DataFrameDisplay:
             if hasattr(val, "_repr_png_"):
                 png_bytes = val._repr_png_()
                 base64_img = base64.b64encode(png_bytes)
-                return f'<img src="data:image/png;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
+                return f'<img style="max-height:128px;width:auto" src="data:image/png;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
             elif isinstance(val, np.ndarray):
                 data_str = np.array2string(val, threshold=3)
                 data_str = (

--- a/notebooks/tutorials/quickstart.ipynb
+++ b/notebooks/tutorials/quickstart.ipynb
@@ -17,7 +17,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install getdaft"
+    "!pip install getdaft\n",
+    "!pip install Pillow torch torchvision"
    ]
   },
   {

--- a/notebooks/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/notebooks/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -9,7 +9,11 @@
     "\n",
     "In this tutorial, we will be using a model called Stable Diffusion to generate images from text. We will explore how to use GPUs with Daft to accelerate computations.\n",
     "\n",
-    "To proceed with the tutorial, you will need to create a Huggingface account and an access token so that you can access the Stable Diffusion model: https://huggingface.co/docs/hub/security-tokens\n",
+    "To run this tutorial:\n",
+    "\n",
+    "1. You will need to create a Huggingface account and an access token so that you can access the Stable Diffusion model: https://huggingface.co/docs/hub/security-tokens\n",
+    "\n",
+    "2. You will need access to a GPU. If you are on Google Colab, you may switch to a GPU runtime by going to the menu `Runtime -> Change runtime type -> Hardware accelerator -> GPU -> Save`.\n",
     "\n",
     "Let's get started!"
    ]

--- a/notebooks/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/notebooks/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -21,7 +21,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install getdaft"
+    "!pip install getdaft\n",
+    "!pip install Pillow torch diffusers transformers"
    ]
   },
   {


### PR DESCRIPTION
Relying on class and module names to detect PIL Images doesn't work for certain corner-cases, such as loading from a JPEG file.

This PR uses the existence of `_repr_png_` to determine whether we should display an image.