### PR TITLE
Use DALL-E model for tutorial instead of Stable Diffusion

### DIFF
--- a/notebooks/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/notebooks/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -3,17 +3,17 @@
   {
    "cell_type": "markdown",
    "id": "78db424a-96b5-46f3-bd32-484f5c6b92a3",
-   "metadata": {},
+   "metadata": {
+    "id": "78db424a-96b5-46f3-bd32-484f5c6b92a3"
+   },
    "source": [
-    "# Generating Images from Text with Stable Diffusion\n",
+    "# Generating Images from Text with DALL-E\n",
     "\n",
-    "In this tutorial, we will be using a model called Stable Diffusion to generate images from text. We will explore how to use GPUs with Daft to accelerate computations.\n",
+    "In this tutorial, we will be using the DALL-E model to generate images from text. We will explore how to use GPUs with Daft to accelerate computations.\n",
     "\n",
     "To run this tutorial:\n",
     "\n",
-    "1. You will need to create a Huggingface account and an access token so that you can access the Stable Diffusion model: https://huggingface.co/docs/hub/security-tokens\n",
-    "\n",
-    "2. You will need access to a GPU. If you are on Google Colab, you may switch to a GPU runtime by going to the menu `Runtime -> Change runtime type -> Hardware accelerator -> GPU -> Save`.\n",
+    "1. You will need access to a GPU. If you are on Google Colab, you may switch to a GPU runtime by going to the menu `Runtime -> Change runtime type -> Hardware accelerator -> GPU -> Save`.\n",
     "\n",
     "Let's get started!"
    ]
@@ -22,42 +22,39 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "019805d9-4e9f-4306-8f18-a565cb1e8845",
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 1000
+    },
+    "id": "019805d9-4e9f-4306-8f18-a565cb1e8845",
+    "outputId": "f48e4a66-21cd-4b93-e8cb-261ae8c8aec8"
+   },
    "outputs": [],
    "source": [
     "!pip install getdaft\n",
-    "!pip install Pillow torch diffusers transformers"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "65e6ff3c-2093-4395-ad0f-1543b2481524",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "# Replace with your auth token as a string\n",
-    "# See: https://huggingface.co/docs/hub/security-tokens\n",
-    "HUGGINGFACE_AUTH_TOKEN = os.getenv(\"HUGGINGFACE_AUTH_TOKEN\", \"\")"
+    "!pip install min-dalle torch Pillow"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "4da65a96-e4fe-4795-92d0-a5e631b58e33",
-   "metadata": {},
+   "metadata": {
+    "id": "4da65a96-e4fe-4795-92d0-a5e631b58e33"
+   },
    "source": [
     "## Setting Up\n",
     "\n",
-    "First, let's download a Parquet file containing some of the data that was used to train the Stable Diffusion model. This data is available on Huggingface as well, and we simply download the file to disk."
+    "First, let's download a Parquet file containing some example data from the laion_improved_aesthetics 6.5 dataset."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "0f574451-9a5f-4795-8aa2-58ce0892411a",
-   "metadata": {},
+   "metadata": {
+    "id": "0f574451-9a5f-4795-8aa2-58ce0892411a"
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -75,7 +72,9 @@
   {
    "cell_type": "markdown",
    "id": "7d8c4950-ca59-4aa9-ad82-6cfaa516850a",
-   "metadata": {},
+   "metadata": {
+    "id": "7d8c4950-ca59-4aa9-ad82-6cfaa516850a"
+   },
    "source": [
     "Now we can load this Parquet file into Daft and peek at the data like so:"
    ]
@@ -84,7 +83,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "806451f8-68af-462a-af7b-ff5480425a3a",
-   "metadata": {},
+   "metadata": {
+    "id": "806451f8-68af-462a-af7b-ff5480425a3a"
+   },
    "outputs": [],
    "source": [
     "from daft import DataFrame, col, udf\n",
@@ -96,7 +97,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e1e3b619-beaf-465e-83f2-5ab71638dcc1",
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 544
+    },
+    "id": "e1e3b619-beaf-465e-83f2-5ab71638dcc1",
+    "outputId": "e52133d2-5694-49a0-e385-758cf5b1b203"
+   },
    "outputs": [],
    "source": [
     "parquet_df.show(10)"
@@ -106,7 +114,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b257cd91-db90-4803-afd9-9fdf571cf755",
-   "metadata": {},
+   "metadata": {
+    "id": "b257cd91-db90-4803-afd9-9fdf571cf755"
+   },
    "outputs": [],
    "source": [
     "parquet_df = parquet_df.select(col(\"URL\"), col(\"TEXT\"), col(\"AESTHETIC_SCORE\"))"
@@ -115,7 +125,9 @@
   {
    "cell_type": "markdown",
    "id": "f28047df-bf05-47df-b4d4-3507a8f7d2ac",
-   "metadata": {},
+   "metadata": {
+    "id": "f28047df-bf05-47df-b4d4-3507a8f7d2ac"
+   },
    "source": [
     "## Downloading Images\n",
     "\n",
@@ -128,7 +140,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f1e5cd84-4526-4a91-9fd5-f4e78f35965d",
-   "metadata": {},
+   "metadata": {
+    "id": "f1e5cd84-4526-4a91-9fd5-f4e78f35965d"
+   },
    "outputs": [],
    "source": [
     "import io\n",
@@ -147,7 +161,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c1361728-8b1a-4e6e-9632-ddd17cad948b",
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 802
+    },
+    "id": "c1361728-8b1a-4e6e-9632-ddd17cad948b",
+    "outputId": "1c2ce3a4-63a1-4f77-ce2e-e3ecea2a3e1f"
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -157,90 +178,193 @@
   },
   {
    "cell_type": "markdown",
+   "id": "gCTmONUl81Vw",
+   "metadata": {
+    "id": "gCTmONUl81Vw"
+   },
+   "source": [
+    "# Downloading the Model\n",
+    "\n",
+    "Let's download the model's weights - the `min-dalle` library that we are using here allows us to cache the downloaded model weights on disk by calling some `.download_*` methods. Since this tutorial is ran entirely on the local machine, this will speed up all subsequent steps by reusing the downloaded model weights!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "y71-_0BIjrVm",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "y71-_0BIjrVm",
+    "outputId": "8d2febb6-e892-4e84-d905-92b86ca3a599"
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "\n",
+    "import torch\n",
+    "from min_dalle import MinDalle\n",
+    "\n",
+    "model = MinDalle(\n",
+    "    models_root='./pretrained',\n",
+    "    dtype=torch.float32,\n",
+    "    device=\"cpu\",\n",
+    "    is_mega=False, \n",
+    "    is_reusable=False,\n",
+    ")\n",
+    "model.download_encoder()\n",
+    "model.download_decoder()\n",
+    "model.download_detokenizer()\n",
+    "del model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a7fa31d0-bcaa-44c6-8a5b-8b1b6ff51f93",
-   "metadata": {},
+   "metadata": {
+    "id": "a7fa31d0-bcaa-44c6-8a5b-8b1b6ff51f93"
+   },
    "source": [
     "## Running a model (without a GPU)\n",
     "\n",
-    "We can run the Huggingface model without a GPU. Note that the next cell will take a while to run - almost 5 minutes! As such, we have commented out the line of code that runs the image generation, but you may run the code simply by uncommenting the last line of the cell."
+    "Let's run the model on our data without a GPU. Note that the next cell will take a while to run - almost 2 minutes!"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "affd603b-86c1-4b77-94ea-6025cd298da8",
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 348
+    },
+    "id": "affd603b-86c1-4b77-94ea-6025cd298da8",
+    "outputId": "e3ce9a76-64b1-4bfc-ca12-104dff3dbe71"
+   },
    "outputs": [],
    "source": [
     "import torch\n",
-    "from diffusers import DiffusionPipeline\n",
+    "from min_dalle import MinDalle\n",
+    "\n",
     "\n",
     "@udf(return_type=PIL.Image.Image)\n",
     "class GenerateImageFromText:\n",
     "    \n",
     "    def __init__(self):\n",
-    "        self.pipeline = DiffusionPipeline.from_pretrained(\n",
-    "            \"CompVis/stable-diffusion-v1-4\",\n",
-    "            use_auth_token=HUGGINGFACE_AUTH_TOKEN,\n",
+    "        self.model = MinDalle(\n",
+    "            models_root='./pretrained',\n",
+    "            dtype=torch.float32,\n",
+    "            device=\"cpu\",\n",
+    "            is_mega=False, \n",
+    "            is_reusable=True\n",
     "        )\n",
     "\n",
-    "    def __call__(self, text_col, num_steps=5):\n",
-    "        return [self.pipeline(t, num_inference_steps=num_steps)[\"sample\"][0] for t in text_col]\n",
+    "    def __call__(self, text_col):\n",
+    "        return [\n",
+    "            self.model.generate_image(\n",
+    "                t,\n",
+    "                seed=-1,\n",
+    "                grid_size=1,\n",
+    "                is_seamless=False,\n",
+    "                temperature=1,\n",
+    "                top_k=256,\n",
+    "                supercondition_factor=32,\n",
+    "            ) for t in text_col\n",
+    "        ]\n",
     "\n",
-    "# Uncomment the following line to run the cell which will take about 5 minutes.\n",
-    "# %time images_df.with_column(\"generated_image\", GenerateImageFromText(col(\"TEXT\"), num_steps=1)).show(1)"
+    "# Uncomment the following line to run the cell which will take about 2 minutes.\n",
+    "# %time images_df.with_column(\"generated_image\", GenerateImageFromText(col(\"TEXT\"))).show(1)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ad627801-b3f7-46fb-8415-579c9118cb78",
-   "metadata": {},
+   "metadata": {
+    "id": "ad627801-b3f7-46fb-8415-579c9118cb78"
+   },
    "source": [
-    "That took a long time, even when we only ran 5 steps of the model on only a single image (CompVis recommends running 50 steps - notice that the generated image is not very good). If you are on the default Google Colab runtime, this would have taken almost 5 minutes! Running it on more images and more steps would take too long.\n",
+    "That took a long time since our model was running only on the CPU. If you are on the default Google Colab runtime, this would have taken almost 2 minutes! Running it on more images and more steps would take too long.\n",
     "\n",
-    "Let's see how we can tell Daft that this UDF requires a GPU, and include a step to load our model on the GPU so that it runs much faster. Note that **the following cell will throw an error if you are not running on a machine with a GPU**."
+    "Let's see how we can tell Daft that this UDF requires a GPU, and load the model to run on a GPU instead. Note that **the following cell will throw an error if you are not running on a machine with a GPU**."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "86781713-b2cc-469a-8764-864d20362418",
-   "metadata": {},
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 348
+    },
+    "id": "86781713-b2cc-469a-8764-864d20362418",
+    "outputId": "8f5a05d5-e57d-4b9d-961d-3d618e09cad3"
+   },
    "outputs": [],
    "source": [
     "import torch\n",
-    "from diffusers import DiffusionPipeline\n",
+    "from min_dalle import MinDalle\n",
     "\n",
     "# Tell Daft to use N number of GPUs with num_gpus=N\n",
     "@udf(return_type=PIL.Image.Image, num_gpus=1)\n",
     "class GenerateImageFromTextGPU:\n",
-    "\n",
+    "    \n",
     "    def __init__(self):\n",
-    "        self.pipeline = DiffusionPipeline.from_pretrained(\n",
-    "            \"CompVis/stable-diffusion-v1-4\",\n",
-    "            use_auth_token=HUGGINGFACE_AUTH_TOKEN,\n",
+    "        self.model = MinDalle(\n",
+    "            models_root='./pretrained',\n",
+    "            dtype=torch.float32,\n",
+    "            # Tell the min-dalle library to load model on GPU\n",
+    "            device=\"cuda\",\n",
+    "            is_mega=False, \n",
+    "            is_reusable=True\n",
     "        )\n",
-    "        # 1 GPU is now available to your code and can be used as per usual in your libraries such as PyTorch\n",
-    "        self.pipeline = self.pipeline.to(\"cuda:0\")\n",
     "\n",
-    "    def __call__(self, text_col, num_steps=5):\n",
-    "        return [self.pipeline(t, num_inference_steps=num_steps)[\"sample\"][0] for t in text_col]\n",
+    "    def __call__(self, text_col):\n",
+    "        return [\n",
+    "            self.model.generate_image(\n",
+    "                t,\n",
+    "                seed=-1,\n",
+    "                grid_size=1,\n",
+    "                is_seamless=False,\n",
+    "                temperature=1,\n",
+    "                top_k=256,\n",
+    "                supercondition_factor=32,\n",
+    "            ) for t in text_col\n",
+    "        ]\n",
     "\n",
-    "%time images_df.with_column(\"generated_image\", GenerateImageFromTextGPU(col(\"TEXT\"), num_steps=30)).show(1)"
+    "%time images_df.with_column(\"generated_image\", GenerateImageFromTextGPU(col(\"TEXT\"))).show(1)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "398b390c",
-   "metadata": {},
+   "metadata": {
+    "id": "398b390c"
+   },
    "source": [
-    "Running the model on a GPU instead lets us run 30 steps in a minute. The generated image now looks much better, and we have a ~30x speedup from just using CPUs."
+    "Much better! On Google Colab, this runs in just under 15 seconds which gives us a speedup of about 8x just by running the model on a GPU instead."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "vCCQboOkpaSo",
+   "metadata": {
+    "id": "vCCQboOkpaSo"
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "provenance": []
+  },
   "kernelspec": {
-   "display_name": "Python 3.10.5 64-bit",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -254,7 +378,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.12"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
* Use the DALL-E model instead of Stable Diffusion for our text to image generation GPU usage tutorial
* This simplifies tutorial setup, no longer requiring learners to create a Huggingface account and grab an API token