### PR TITLE
Remove pydantic from dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1711,7 +1711,6 @@ optional = false
 python-versions = ">=3.6.1"
 
 [package.dependencies]
-python-dotenv = {version = ">=0.10.4", optional = true, markers = "extra == \"dotenv\""}
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
@@ -1805,17 +1804,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
 six = ">=1.5"
-
-[[package]]
-name = "python-dotenv"
-version = "0.21.0"
-description = "Read key-value pairs from a .env file and set them as environment variables"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.extras]
-cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-json-logger"
@@ -2673,7 +2661,7 @@ serving = ["fastapi", "docker", "uvicorn", "cloudpickle", "boto3", "PyYAML"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "37787a3fcadffc97102ad3356751180823f32750aeee1904b9a4cb8914fbbf60"
+content-hash = "8a467647a41ca656f462a37fcbc0ef71d36b232d2937434e69c6b3cd21ef8812"
 
 [metadata.files]
 aiobotocore = [
@@ -4125,10 +4113,6 @@ pytest = [
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
-]
-python-dotenv = [
-    {file = "python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
-    {file = "python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
 ]
 python-json-logger = [
     {file = "python-json-logger-2.0.4.tar.gz", hash = "sha256:764d762175f99fcc4630bd4853b09632acb60a6224acb27ce08cd70f0b1b81bd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ python = "^3.7.1"
 ray = "1.13.0"
 numpy = "^1.16.6"
 pyarrow = "^8.0.0"
-pydantic = {extras = ["dotenv"], version = "^1.9.1"}
 fsspec = "*"
 # Ray-protobuf generation issue requires pinning at 3.19:
 # https://github.com/ray-project/ray/issues/25282


### PR DESCRIPTION
We can now remove our dependency on pydantic after the refactor of `daft.config` in #198 