### PR TITLE
Allow RayRunner to proceed when Ray context has already been initialized

### DIFF
--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -210,9 +210,8 @@ class RayRunner(Runner):
     def __init__(self, address: Optional[str]) -> None:
         if ray.is_initialized():
             logger.warning(f"Ray has already been initialized, Daft will reuse the existing Ray context")
-            self._ray_context = ray.init(address=address, ignore_reinit_error=True)
         else:
-            self._ray_context = ray.init(address=address)
+            ray.init(address=address)
         self._part_manager = PartitionManager(lambda: RayPartitionSet({}))
         self._part_op_runner = RayLogicalPartitionOpRunner()
         self._global_op_runner = RayLogicalGlobalOpRunner()


### PR DESCRIPTION
`ray.init()` errors out if it is called more than once

However, there are situations where a user may call `ray.init()` outside of Daft, for example to initialize runtime environments. In this case, Daft will log a warning and allow this behavior, opting to reuse the already-initialized Ray context.