### PR TITLE
Adds a @polars_udf that uses polars.Series as the input parameters

### DIFF
--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -22,12 +22,16 @@ from typing import (
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pyarrow as pa
 import pyarrow.compute as pac
 from pandas.core.reshape.merge import get_join_indexers
 
 from daft.execution.operators import OperatorEnum, OperatorEvaluator
 from daft.internal.hashing import hash_chunked_array
+
+# A type representing some Python scalar (non-series/array like object)
+PyScalar = Any
 
 ArrType = TypeVar("ArrType", bound=collections.abc.Sequence)
 UnaryFuncType = Callable[[ArrType], ArrType]
@@ -103,6 +107,10 @@ class DataBlock(Generic[ArrType]):
         raise NotImplementedError()
 
     @abstractmethod
+    def to_polars(self) -> Union[PyScalar, pl.Series]:
+        raise NotImplementedError()
+
+    @abstractmethod
     def to_arrow(self) -> pa.ChunkedArray:
         raise NotImplementedError()
 
@@ -113,6 +121,10 @@ class DataBlock(Generic[ArrType]):
             return ArrowDataBlock(data=data)
         elif isinstance(data, pa.Array):
             return ArrowDataBlock(data=pa.chunked_array([data]))
+        elif isinstance(data, pl.Series):
+            if data.dtype == pl.datatypes.Object:
+                return PyListDataBlock(data=data.to_list())
+            return ArrowDataBlock(pa.chunked_array([data.to_arrow()]))
         elif isinstance(data, np.ndarray):
             if data.dtype == np.object_ or len(data.shape) > 1:
                 try:
@@ -369,6 +381,11 @@ class PyListDataBlock(DataBlock[List[T]]):
             res[i] = obj
         return res
 
+    def to_polars(self) -> Union[PyScalar, pl.Series]:
+        if self.is_scalar():
+            return self.data
+        return pl.Series(self.data, dtype=pl.datatypes.Object)
+
     def to_arrow(self) -> pa.ChunkedArray:
         raise NotImplementedError("can not convert pylist block to arrow")
 
@@ -438,6 +455,11 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
         if isinstance(self.data, pa.Scalar):
             return self.data.as_py()
         return self.data.to_numpy()
+
+    def to_polars(self) -> Union[PyScalar, pl.Series]:
+        if isinstance(self.data, pa.Scalar):
+            return self.data.as_py()
+        return pl.Series(self.data)
 
     def to_arrow(self) -> pa.ChunkedArray:
         return self.data

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -244,7 +244,7 @@ class vPartition:
         new_partition_to_columns: List[Dict[ColID, PyListTile]] = [{} for _ in range(num_partitions)]
         argsort_targets = target_partition_indices.argsort()
         sorted_targets = target_partition_indices.take(argsort_targets)
-        sorted_targets_np = sorted_targets.to_numpy()
+        sorted_targets_np = sorted_targets.to_polars().to_numpy()
         pivots = np.where(np.diff(sorted_targets_np, prepend=np.nan))[0]
         target_partitions = sorted_targets_np[pivots]
 

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import warnings
 from typing import Callable, Optional, Sequence, Type, Union
 
 from daft.execution.operators import ExpressionType
@@ -15,6 +16,15 @@ UDF = Union[StatefulUDF, StatelessUDF]
 logger = logging.getLogger(__name__)
 
 
+def _initialize_func(func):
+    """Initializes a function if it is a class, otherwise noop"""
+    try:
+        return func() if isinstance(func, type) else func
+    except:
+        logger.error(f"Encountered error when initializing user-defined function {func.__name__}")
+        raise
+
+
 def udf(
     f: Optional[Callable] = None,
     *,
@@ -23,6 +33,8 @@ def udf(
     num_cpus: Optional[int] = None,
 ) -> Callable:
     """Decorator for creating a UDF
+
+    NOTE: This decorator will be deprecated in favor of @polars_udf in v0.1.0. @polars_udf is much more efficient and handles Null/NaN semantics correctly.
 
     This decorator wraps a function into a DaFt UDF that can then be used on Dataframes.
     At runtime, DaFt will pass columns of data to the function as equal-length Numpy arrays.
@@ -58,7 +70,98 @@ def udf(
     >>>         return self._model(features_col)
 
     Args:
-        f: Function to wrap as a UDF, accepts column inputs as Numpy arrays and returns a column of data as a Numpy array/Python list/Pandas series.
+        f: Function to wrap as a UDF, accepts column inputs as Numpy arrays and returns a column of data as a Polars Series/Numpy array/Python list/Pandas series.
+        return_type: The return type of the UDF
+        num_gpus: How many GPUs the UDF requires for execution, used for resource allocation when running in a distributed setting
+        num_cpus: How many CPUs the UDF requires for execution, used for resource allocation when running in a distributed setting
+    """
+    warnings.warn(
+        "DEPRECATION WARNING: @udf will be deprecated in 0.1.0 in favor of @polars_udf which is much more efficient and handles Null/NaN semantics correctly"
+    )
+
+    func_ret_type = ExpressionType.from_py_type(return_type)
+
+    def udf_decorator(func: UDF) -> Callable:
+        @functools.wraps(func)
+        def wrapped_func(*args, **kwargs):
+            @functools.wraps(func)
+            def prepost_process_data_block_func(*args, **kwargs):
+                # TODO: The initialization of stateful UDFs is currently done on the execution on every partition here,
+                # but should instead be done on a higher level so that state initialization cost can be amortized across partitions.
+                initialized_func = _initialize_func(func)
+
+                converted_args = tuple(arg.to_numpy() if isinstance(arg, DataBlock) else arg for arg in args)
+                converted_kwargs = {
+                    kw: arg.to_numpy() if isinstance(arg, DataBlock) else arg for kw, arg in kwargs.items()
+                }
+
+                try:
+                    results = initialized_func(*converted_args, **converted_kwargs)
+                except:
+                    logger.error(f"Encountered error when running user-defined function {func.__name__}")
+                    raise
+                return DataBlock.make_block(results)
+
+            out_expr = UdfExpression(
+                func=prepost_process_data_block_func,
+                func_ret_type=func_ret_type,
+                func_args=args,
+                func_kwargs=kwargs,
+                resource_request=ResourceRequest(num_cpus=num_cpus, num_gpus=num_gpus),
+            )
+            return out_expr
+
+        return wrapped_func
+
+    if f is None:
+        return udf_decorator
+    return udf_decorator(f)
+
+
+def polars_udf(
+    f: Optional[Callable] = None,
+    *,
+    return_type: Type,
+    num_gpus: Optional[int] = None,
+    num_cpus: Optional[int] = None,
+) -> Callable:
+    """Decorator for creating a Polars UDF
+
+    This decorator wraps a function into a Daft UDF that can then be used on Dataframes.
+    At runtime, DaFt will pass columns of data to the function as separate equal-length Polars Series.
+
+    You may call a UDF on two types of inputs:
+
+    1. Non-Expressions: `f(x)` when `x` is not an Expression - Daft will pass `x` into the function with no modifications. Note that this object must be pickleable, and that users should use this to pass light data around. For heavier initializations, use the __init__ method in a stateful UDF.
+    2. Expressions: `f(expr)` when `expr` is an Expression - Daft will compute the results of the expression and pass the results into the UDF at runtime as a Polars Series.
+
+    For example, a simple UDF that randomly rotates some user-defined Image type could look like:
+
+    >>> @udf(return_type=Image)
+    >>> def random_rotations(image_col, rotation_bounds_degrees: int):
+    >>>     return [
+    >>>         img.rotate(random.uniform(0, 1) * rotation_bounds_degrees)
+    >>>         for img in image_col
+    >>>     ]
+    >>>
+    >>> # Usage on a DataFrame:
+    >>> df.select(random_rotations(col("images"), rotation_bounds_degrees=90))
+
+    UDFs can also be created on Classes, which allow for initialization on some expensive state that can be shared
+    between invocations of the class, for example downloading data or creating a model.
+
+    >>> @udf(return_type=int)
+    >>> class RunModel:
+    >>>
+    >>>     def __init__(self):
+    >>>         # Perform expensive initializations
+    >>>         self._model = create_model()
+    >>>
+    >>>     def __call__(self, features_col):
+    >>>         return self._model(features_col)
+
+    Args:
+        f: Function to wrap as a UDF, accepts column inputs as Polars Series and returns a column of data as a Polars Series/Numpy array/Python list/Pandas series.
         return_type: The return type of the UDF
         num_gpus: How many GPUs the UDF requires for execution, used for resource allocation when running in a distributed setting
         num_cpus: How many CPUs the UDF requires for execution, used for resource allocation when running in a distributed setting
@@ -72,15 +175,11 @@ def udf(
             def prepost_process_data_block_func(*args, **kwargs):
                 # TODO: The initialization of stateful UDFs is currently done on the execution on every partition here,
                 # but should instead be done on a higher level so that state initialization cost can be amortized across partitions.
-                try:
-                    initialized_func = func() if isinstance(func, type) else func
-                except:
-                    logger.error(f"Encountered error when initializing user-defined function {func.__name__}")
-                    raise
+                initialized_func = _initialize_func(func)
 
-                converted_args = tuple(arg.to_numpy() if isinstance(arg, DataBlock) else arg for arg in args)
+                converted_args = tuple(arg.to_polars() if isinstance(arg, DataBlock) else arg for arg in args)
                 converted_kwargs = {
-                    kw: arg.to_numpy() if isinstance(arg, DataBlock) else arg for kw, arg in kwargs.items()
+                    kw: arg.to_polars() if isinstance(arg, DataBlock) else arg for kw, arg in kwargs.items()
                 }
 
                 try:

--- a/tests/dataframe_cookbook/test_python_list_cols.py
+++ b/tests/dataframe_cookbook/test_python_list_cols.py
@@ -4,6 +4,7 @@ from typing import List
 
 import numpy as np
 import pandas as pd
+import polars as pl
 import pytest
 
 from daft.dataframe import DataFrame
@@ -148,7 +149,7 @@ def test_pyobj_add(repartition_nparts, op):
 
 
 @udf(return_type=int)
-def get_length(features: List[np.ndarray]):
+def get_length(features: pl.Series[np.ndarray]):
     return [len(feature) for feature in features]
 
 

--- a/tests/dataframe_cookbook/test_udf.py
+++ b/tests/dataframe_cookbook/test_udf.py
@@ -39,7 +39,7 @@ def multiply_kwarg_pd(x, num=2):
 
 @udf(return_type=int)
 def multiply_kwarg_list(x, num=2):
-    return (x * num).tolist()
+    return x * num
 
 
 @udf(return_type=int)

--- a/tests/dataframe_cookbook/test_udf.py
+++ b/tests/dataframe_cookbook/test_udf.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 from daft.expressions import col
-from daft.udf import udf
+from daft.udf import polars_udf, udf
 from tests.conftest import assert_df_equals
 from tests.dataframe_cookbook.conftest import (
     parametrize_service_requests_csv_daft_df,
@@ -39,17 +39,29 @@ def multiply_kwarg_pd(x, num=2):
 
 @udf(return_type=int)
 def multiply_kwarg_list(x, num=2):
+    return (x * num).tolist()
+
+
+@polars_udf(return_type=int)
+def multiply_kwarg_pl(x, num=2):
     return x * num
 
 
 @udf(return_type=int)
-def multiply(x, num):
+def multiply_arg_np(x, num):
+    return x * num
+
+
+@polars_udf(return_type=int)
+def multiply_arg_pl(x, num):
     return x * num
 
 
 @parametrize_service_requests_csv_daft_df
 @parametrize_service_requests_csv_repartition
-@pytest.mark.parametrize("multiply_kwarg", [multiply_kwarg_np, multiply_kwarg_pd, multiply_kwarg_list])
+@pytest.mark.parametrize(
+    "multiply_kwarg", [multiply_kwarg_np, multiply_kwarg_pd, multiply_kwarg_list, multiply_kwarg_pl]
+)
 def test_single_return_udf(daft_df, service_requests_csv_pd_df, repartition_nparts, multiply_kwarg):
     daft_df = daft_df.repartition(repartition_nparts).with_column(
         "unique_key_identity", multiply_kwarg(col("Unique Key"))
@@ -61,8 +73,11 @@ def test_single_return_udf(daft_df, service_requests_csv_pd_df, repartition_npar
 
 @parametrize_service_requests_csv_daft_df
 @parametrize_service_requests_csv_repartition
-def test_udf_args(daft_df, service_requests_csv_pd_df, repartition_nparts):
-    daft_df = daft_df.repartition(repartition_nparts).with_column("unique_key_identity", multiply(col("Unique Key"), 2))
+@pytest.mark.parametrize("multiply_arg", [multiply_arg_np, multiply_arg_pl])
+def test_udf_args(daft_df, service_requests_csv_pd_df, repartition_nparts, multiply_arg):
+    daft_df = daft_df.repartition(repartition_nparts).with_column(
+        "unique_key_identity", multiply_arg(col("Unique Key"), 2)
+    )
     service_requests_csv_pd_df["unique_key_identity"] = service_requests_csv_pd_df["Unique Key"] * 2
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, service_requests_csv_pd_df)
@@ -73,9 +88,9 @@ def test_udf_args(daft_df, service_requests_csv_pd_df, repartition_nparts):
 @pytest.mark.parametrize("multiply_kwarg", [multiply_kwarg_np, multiply_kwarg_pd, multiply_kwarg_list])
 def test_udf_kwargs(daft_df, service_requests_csv_pd_df, repartition_nparts, multiply_kwarg):
     daft_df = daft_df.repartition(repartition_nparts).with_column(
-        "unique_key_identity", multiply_kwarg(col("Unique Key"), num=2)
+        "unique_key_identity", multiply_kwarg(col("Unique Key"), num=4)
     )
-    service_requests_csv_pd_df["unique_key_identity"] = service_requests_csv_pd_df["Unique Key"] * 2
+    service_requests_csv_pd_df["unique_key_identity"] = service_requests_csv_pd_df["Unique Key"] * 4
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, service_requests_csv_pd_df)
 
@@ -91,7 +106,16 @@ class MyModel:
 
 
 @udf(return_type=int)
-class RunModel:
+class RunModelNumpy:
+    def __init__(self) -> None:
+        self._model = MyModel()
+
+    def __call__(self, x):
+        return self._model.predict(x)
+
+
+@polars_udf(return_type=int)
+class RunModelPolars:
     def __init__(self) -> None:
         self._model = MyModel()
 
@@ -101,7 +125,8 @@ class RunModel:
 
 @parametrize_service_requests_csv_daft_df
 @parametrize_service_requests_csv_repartition
-def test_dependency_injection_udf(daft_df, service_requests_csv_pd_df, repartition_nparts):
+@pytest.mark.parametrize("RunModel", [RunModelNumpy, RunModelPolars])
+def test_dependency_injection_udf(daft_df, service_requests_csv_pd_df, repartition_nparts, RunModel):
     daft_df = daft_df.repartition(repartition_nparts).with_column("model_results", RunModel(col("Unique Key")))
     service_requests_csv_pd_df["model_results"] = service_requests_csv_pd_df["Unique Key"]
     daft_pd_df = daft_df.to_pandas()


### PR DESCRIPTION
See: #200 for the rationale behind this change

* add a deprecation warning to `@udf` that it will be removed in 0.1.0
* make_block has to be polars-aware and properly parse incoming Polars Series
* unit tests updated
* documentation updated