### PR TITLE
Refactor HTML repr code for prettier colab display

### DIFF
--- a/daft/dataframe/schema.py
+++ b/daft/dataframe/schema.py
@@ -40,10 +40,15 @@ class DataFrameSchema:
         return cls(fields)
 
     def _to_pandas(self) -> pd.DataFrame:
-        return pd.DataFrame({field.name: [str(field.daft_type)] for field in self._fields.values()})
+        return pd.DataFrame(
+            {
+                "column_name": [field.name for field in self._fields.values()],
+                "type": [field.daft_type for field in self._fields.values()],
+            },
+        )
 
     def __repr__(self) -> str:
-        return cast(str, self._to_pandas().__repr__())
+        return cast(str, self._to_pandas().to_string(index=False))
 
     def _repr_html_(self) -> str:
-        return cast(str, self._to_pandas()._repr_html_())
+        return cast(str, self._to_pandas().to_html(index=False))

--- a/daft/dataframe/schema.py
+++ b/daft/dataframe/schema.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, cast
 
-from tabulate import tabulate
+import pandas as pd
 
 from daft.execution.operators import ExpressionType
 from daft.logical.schema import ExpressionList
@@ -39,12 +39,11 @@ class DataFrameSchema:
             fields.append(DataFrameSchemaField(e.name(), e.resolved_type()))
         return cls(fields)
 
+    def _to_pandas(self) -> pd.DataFrame:
+        return pd.DataFrame({field.name: [str(field.daft_type)] for field in self._fields.values()})
+
     def __repr__(self) -> str:
-        fields = list(self._fields.values())
-        return tabulate([[field.daft_type for field in fields]], headers=[field.name for field in fields])
+        return cast(str, self._to_pandas().__repr__())
 
     def _repr_html_(self) -> str:
-        fields = list(self._fields.values())
-        return tabulate(
-            [[field.daft_type for field in fields]], headers=[field.name for field in fields], tablefmt="html"
-        )
+        return cast(str, self._to_pandas()._repr_html_())

--- a/daft/execution/operators.py
+++ b/daft/execution/operators.py
@@ -22,6 +22,10 @@ class ExpressionType:
         return t == _TYPE_REGISTRY["logical"]
 
     @staticmethod
+    def is_string(t: ExpressionType) -> bool:
+        return t == _TYPE_REGISTRY["string"]
+
+    @staticmethod
     def is_primitive(t: ExpressionType) -> bool:
         return isinstance(t, PrimitiveExpressionType)
 

--- a/daft/viz/dataframe_display.py
+++ b/daft/viz/dataframe_display.py
@@ -1,23 +1,20 @@
-import base64
-import io
 from dataclasses import dataclass
-from typing import Any
+from typing import cast
 
-import numpy as np
 import pandas
-from tabulate import tabulate
 
 from daft.dataframe.schema import DataFrameSchema
+from daft.viz.repr_html import pd_df_repr_html
 
 HAS_PILLOW = False
 try:
-    import PIL
+    pass
 
     HAS_PILLOW = True
 except ImportError:
     pass
 if HAS_PILLOW:
-    import PIL.Image
+    pass
 
 
 @dataclass(frozen=True)
@@ -29,56 +26,7 @@ class DataFrameDisplay:
     max_col_rows: int = 3
 
     def _repr_html_(self) -> str:
-
-        max_chars_per_cell = self.max_col_rows * self.column_char_width
-
-        # TODO: we should run this only for PyObj columns
-        def stringify_and_truncate(val: Any):
-            if HAS_PILLOW and isinstance(val, PIL.Image.Image):
-                img = val.copy()
-                img.thumbnail((128, 128))
-                bio = io.BytesIO()
-                img.save(bio, "JPEG")
-                base64_img = base64.b64encode(bio.getvalue())
-                return f'<img style="max-height:128px;width:auto" src="data:image/png;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
-            elif isinstance(val, np.ndarray):
-                data_str = np.array2string(val, threshold=3)
-                data_str = (
-                    data_str if len(data_str) <= max_chars_per_cell else data_str[: max_chars_per_cell - 5] + "...]"
-                )
-                return f"&ltnp.ndarray<br>&nbspshape={val.shape}<br>&nbspdtype={val.dtype}<br>&nbspdata={data_str}&gt"
-            else:
-                s = str(val)
-            return s if len(s) <= max_chars_per_cell else s[: max_chars_per_cell - 4] + "..."
-
-        pd_df = self.pd_df.applymap(stringify_and_truncate)
-        table = tabulate(
-            pd_df,
-            headers=[f"{name}<br>{self.schema[name].daft_type}" for name in self.schema.column_names()],
-            tablefmt="unsafehtml",
-            showindex=False,
-            missingval="None",
-        )
-        table_string = table._repr_html_().replace("<td>", '<td style="text-align: left;">')  # type: ignore
-        return f"""
-            <div>
-                {table_string}
-                <p>(Showing first {len(pd_df)} rows)</p>
-            </div>
-        """
+        return pd_df_repr_html(self.pd_df, self.schema)
 
     def __repr__(self) -> str:
-        max_chars_per_cell = self.max_col_rows * self.column_char_width
-
-        def stringify_and_truncate(val: Any):
-            s = str(val)
-            return s if len(s) <= max_chars_per_cell else s[: max_chars_per_cell - 4] + "..."
-
-        pd_df = self.pd_df.applymap(stringify_and_truncate)
-        return tabulate(
-            pd_df,
-            headers=[f"{name}\n{self.schema[name].daft_type}" for name in self.schema.column_names()],
-            showindex=False,
-            missingval="None",
-            maxcolwidths=20,
-        )
+        return cast(str, self.pd_df.__repr__())

--- a/daft/viz/repr_html.py
+++ b/daft/viz/repr_html.py
@@ -1,0 +1,62 @@
+import base64
+import io
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from tabulate import tabulate
+
+from daft.dataframe.schema import DataFrameSchema, DataFrameSchemaField
+from daft.execution.operators import ExpressionType
+
+try:
+    import PIL.Image
+
+    HAS_PILLOW = True
+except ImportError:
+    HAS_PILLOW = False
+
+
+def _stringify_object_field(val: Any):
+    if HAS_PILLOW and isinstance(val, PIL.Image.Image):
+        img = val.copy()
+        img.thumbnail((128, 128))
+        bio = io.BytesIO()
+        img.save(bio, "JPEG")
+        base64_img = base64.b64encode(bio.getvalue())
+        return f'<img style="max-height:128px;width:auto" src="data:image/png;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
+    elif isinstance(val, np.ndarray):
+        return f"&ltnp.ndarray<br>&nbspshape={val.shape}<br>&nbspdtype={val.dtype}&gt"
+    return str(val)
+
+
+def pd_df_repr_html(pd_df: pd.DataFrame, daft_schema: DataFrameSchema) -> str:
+    """Converts a Pandas dataframe into a HTML string"""
+
+    def stringify_column(pd_col: pd.Series, field: DataFrameSchemaField) -> pd.Series:
+        # Special handling for visualizing if we know the field
+        if field is not None:
+            if not ExpressionType.is_primitive(field.daft_type):
+                return pd_col.map(_stringify_object_field)
+        return pd_col.map(str)
+
+    stringified_df = pd.DataFrame(
+        {
+            colname: stringify_column(
+                pd_df[colname],
+                daft_schema[colname],
+            )
+            for colname in daft_schema.column_names()
+        }
+    )
+
+    tabulate_html_string = tabulate(
+        stringified_df,
+        headers=[f"{name}<br>{daft_schema[name].daft_type}" for name in daft_schema.column_names()],
+        tablefmt="unsafehtml",
+        showindex=False,
+        missingval="None",
+    )
+    assert tabulate_html_string.startswith("<table")
+    tabulate_html_string = '<table class="dataframe"' + tabulate_html_string[len("<table") :]
+    return tabulate_html_string

--- a/daft/viz/repr_html.py
+++ b/daft/viz/repr_html.py
@@ -17,28 +17,54 @@ except ImportError:
     HAS_PILLOW = False
 
 
-def _stringify_object_field(val: Any):
-    if HAS_PILLOW and isinstance(val, PIL.Image.Image):
-        img = val.copy()
-        img.thumbnail((128, 128))
-        bio = io.BytesIO()
-        img.save(bio, "JPEG")
-        base64_img = base64.b64encode(bio.getvalue())
-        return f'<img style="max-height:128px;width:auto" src="data:image/png;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
-    elif isinstance(val, np.ndarray):
-        return f"&ltnp.ndarray<br>&nbspshape={val.shape}<br>&nbspdtype={val.dtype}&gt"
-    return str(val)
+DEFAULT_MAX_COL_WIDTH = 20
+DEFAULT_MAX_LINES = 3
 
 
-def pd_df_repr_html(pd_df: pd.DataFrame, daft_schema: DataFrameSchema) -> str:
+def _truncate(s: str, max_col_width: int, max_lines: int):
+    """Truncates a string and adds an ellipsis if it exceeds (max_col_width * max_lines) number of characters"""
+    if len(s) > (max_col_width * max_lines):
+        s = s[: (max_col_width * max_lines) - 3] + "..."
+    return s
+
+
+def _stringify_object_field(max_col_width: int = DEFAULT_MAX_COL_WIDTH, max_lines: int = DEFAULT_MAX_LINES):
+    def _stringify(val: Any):
+        if HAS_PILLOW and isinstance(val, PIL.Image.Image):
+            img = val.copy()
+            img.thumbnail((128, 128))
+            bio = io.BytesIO()
+            img.save(bio, "JPEG")
+            base64_img = base64.b64encode(bio.getvalue())
+            return f'<img style="max-height:128px;width:auto" src="data:image/png;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
+        elif isinstance(val, np.ndarray):
+            return f"&ltnp.ndarray<br>shape={val.shape}<br>dtype={val.dtype}&gt"
+        return _truncate(str(val), max_col_width, max_lines)
+
+    return _stringify
+
+
+def _stringify_any(max_col_width: int = DEFAULT_MAX_COL_WIDTH, max_lines: int = DEFAULT_MAX_LINES):
+    def _stringify(val: Any):
+        return _truncate(str(val), max_col_width, max_lines)
+
+    return _stringify
+
+
+def pd_df_repr_html(
+    pd_df: pd.DataFrame,
+    daft_schema: DataFrameSchema,
+    max_col_width: int = DEFAULT_MAX_COL_WIDTH,
+    max_lines: int = DEFAULT_MAX_LINES,
+) -> str:
     """Converts a Pandas dataframe into a HTML string"""
 
     def stringify_column(pd_col: pd.Series, field: DataFrameSchemaField) -> pd.Series:
         # Special handling for visualizing if we know the field
         if field is not None:
             if not ExpressionType.is_primitive(field.daft_type):
-                return pd_col.map(_stringify_object_field)
-        return pd_col.map(str)
+                return pd_col.map(_stringify_object_field(max_col_width=max_col_width, max_lines=max_lines))
+        return pd_col.map(_stringify_any(max_col_width=max_col_width, max_lines=max_lines))
 
     stringified_df = pd.DataFrame(
         {
@@ -50,13 +76,27 @@ def pd_df_repr_html(pd_df: pd.DataFrame, daft_schema: DataFrameSchema) -> str:
         }
     )
 
+    maxcolwidths = [
+        max_col_width if ExpressionType.is_primitive(daft_schema[colname].daft_type) else None
+        for colname in daft_schema.column_names()
+    ]
+
     tabulate_html_string = tabulate(
         stringified_df,
         headers=[f"{name}<br>{daft_schema[name].daft_type}" for name in daft_schema.column_names()],
         tablefmt="unsafehtml",
         showindex=False,
         missingval="None",
+        maxcolwidths=maxcolwidths,
     )
+
+    # Appending class="dataframe" here helps Google Colab with applying CSS
     assert tabulate_html_string.startswith("<table")
     tabulate_html_string = '<table class="dataframe"' + tabulate_html_string[len("<table") :]
-    return tabulate_html_string
+
+    return f"""
+        <div>
+            {tabulate_html_string}
+            <small>(Showing first {len(pd_df)} rows)</small>
+        </div>
+    """


### PR DESCRIPTION
Prettier Google Colab display:

* Add `class="dataframe"` tag which gives the table custom CSS from Google Colab
* Refactors the code to be much simpler, rely on Pandas for `__repr__` and only do custom handling for `_repr_html_`