### PR TITLE
Multi-column DataFrame sorting

### DIFF
--- a/benchmarking/tpch/answers.py
+++ b/benchmarking/tpch/answers.py
@@ -26,7 +26,7 @@ def q1(get_df: GetDFFunc) -> DataFrame:
                 (col("L_QUANTITY").alias("count_order"), "count"),
             ]
         )
-        .sort(col("L_RETURNFLAG"))
+        .sort(["L_RETURNFLAG", "L_LINESTATUS"])
     )
     return daft_df
 
@@ -69,6 +69,8 @@ def q2(get_df: GetDFFunc) -> DataFrame:
             col("S_PHONE"),
             col("S_COMMENT"),
         )
+        .sort(by=["S_ACCTBAL", "N_NAME", "S_NAME", "P_PARTKEY"], desc=[True, False, False, False])
+        .limit(100)
     )
     return daft_df
 
@@ -93,6 +95,9 @@ def q3(get_df: GetDFFunc) -> DataFrame:
         )
         .groupby(col("O_ORDERKEY"), col("O_ORDERDATE"), col("O_SHIPPRIORITY"))
         .agg([(col("volume").alias("revenue"), "sum")])
+        .sort(by=["revenue", "O_ORDERDATE"], desc=[True, False])
+        .limit(10)
+        .select("O_ORDERKEY", "revenue", "O_ORDERDATE", "O_SHIPPRIORITY")
     )
     return daft_df
 
@@ -196,6 +201,7 @@ def q7(get_df: GetDFFunc) -> DataFrame:
         )
         .groupby(col("supp_nation"), col("cust_nation"), col("l_year"))
         .agg([(col("volume").alias("revenue"), "sum")])
+        .sort(by=["supp_nation", "cust_nation", "l_year"])
     )
     return daft_df
 
@@ -277,6 +283,7 @@ def q9(get_df: GetDFFunc) -> DataFrame:
         )
         .groupby(col("N_NAME"), col("o_year"))
         .agg([(col("amount"), "sum")])
+        .sort(by=["N_NAME", "o_year"], desc=[False, True])
     )
 
     return daft_df

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -490,18 +490,22 @@ class DataFrame:
         )
         return DataFrame(projection)
 
-    def sort(self, by: Union[ColumnInputType, List[ColumnInputType]], desc: bool = False) -> DataFrame:
+    def sort(
+        self, by: Union[ColumnInputType, List[ColumnInputType]], desc: Union[bool, List[bool]] = False
+    ) -> DataFrame:
         """Sorts DataFrame globally according to column.
 
         Example:
             >>> sorted_df = df.sort(col('x') + col('y'))
+            >>> sorted_df = df.sort([col('x'), col('y')], desc=[False, True])
+            >>> sorted_df = df.sort(['z', col('x'), col('y')], desc=[True, False, True])
 
         Note:
             * Since this a global sort, this requires an expensive repartition which can be quite slow.
-            * Only single expression sorts are currently implemented.
+            * Supports multicolumn sorts and can have unique `descending` flag per column.
         Args:
-            column (ColumnInputType): column to sort by. Can be `str` or expression.
-            desc (bool, optional): Sort by descending order. Defaults to False.
+            column (Union[ColumnInputType, List[ColumnInputType]]): column to sort by. Can be `str` or expression as well as a list of either.
+            desc (Union[bool, List[bool]), optional): Sort by descending order. Defaults to False.
 
         Returns:
             DataFrame: Sorted DataFrame.
@@ -510,7 +514,7 @@ class DataFrame:
             by = [
                 by,
             ]
-        sort = logical_plan.Sort(self._plan, self.__column_input_to_expression(by), desc=desc)
+        sort = logical_plan.Sort(self._plan, self.__column_input_to_expression(by), descending=desc)
         return DataFrame(sort)
 
     def limit(self, num: int) -> DataFrame:

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -4,7 +4,18 @@ import io
 import uuid
 from dataclasses import dataclass
 from functools import partial
-from typing import IO, Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import (
+    IO,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 import pandas
 import pyarrow as pa
@@ -380,7 +391,7 @@ class DataFrame:
     # DataFrame operations
     ###
 
-    def __column_input_to_expression(self, columns: Tuple[ColumnInputType, ...]) -> ExpressionList:
+    def __column_input_to_expression(self, columns: Iterable[ColumnInputType]) -> ExpressionList:
         expressions = [col(c) if isinstance(c, str) else c for c in columns]
         return ExpressionList(expressions)
 
@@ -479,7 +490,7 @@ class DataFrame:
         )
         return DataFrame(projection)
 
-    def sort(self, column: ColumnInputType, desc: bool = False) -> DataFrame:
+    def sort(self, by: Union[ColumnInputType, List[ColumnInputType]], desc: bool = False) -> DataFrame:
         """Sorts DataFrame globally according to column.
 
         Example:
@@ -495,7 +506,11 @@ class DataFrame:
         Returns:
             DataFrame: Sorted DataFrame.
         """
-        sort = logical_plan.Sort(self._plan, self.__column_input_to_expression((column,)), desc=desc)
+        if not isinstance(by, list):
+            by = [
+                by,
+            ]
+        sort = logical_plan.Sort(self._plan, self.__column_input_to_expression(by), desc=desc)
         return DataFrame(sort)
 
     def limit(self, num: int) -> DataFrame:

--- a/daft/execution/logical_op_runners.py
+++ b/daft/execution/logical_op_runners.py
@@ -291,21 +291,19 @@ class LogicalGlobalOpRunner:
         def sample_map_func(part: vPartition) -> vPartition:
             return part.sample(SAMPLES_PER_PARTITION).eval_expression_list(exprs)
 
-        def quantile_reduce_func(to_reduce: List[vPartition]) -> DataBlock:
+        def quantile_reduce_func(to_reduce: List[vPartition]) -> vPartition:
             merged = vPartition.merge_partitions(to_reduce, verify_partition_id=False)
-            first_column = list(merged.columns.values())[0]
-            quantiles = first_column.block.quantiles(num_partitions, desc=desc)
-            return quantiles
+            merged_sorted = merged.sort(exprs, desc=desc)
+            return merged_sorted.quantiles(num_partitions)
 
         prev_part = inputs[child_id]
         sampled_partitions = self.map_partitions(prev_part, sample_map_func, sort.resource_request())
         boundaries = self.reduce_partitions(sampled_partitions, quantile_reduce_func)
-        expr = exprs.exprs[0]
         sort_shuffle_op_klass = self._get_shuffle_op_klass(SortOp)
         sort_op = sort_shuffle_op_klass(
             expr_eval_resource_request=sort.resource_request(),
-            map_args={"expr": expr, "boundaries": boundaries, "desc": sort._desc},
-            reduce_args={"expr": expr, "desc": sort._desc},
+            map_args={"exprs": exprs, "boundaries": boundaries, "desc": sort._desc},
+            reduce_args={"exprs": exprs, "desc": sort._desc},
         )
 
         return sort_op.run(input=prev_part, num_target_partitions=num_partitions)

--- a/daft/execution/logical_op_runners.py
+++ b/daft/execution/logical_op_runners.py
@@ -286,14 +286,14 @@ class LogicalGlobalOpRunner:
         SAMPLES_PER_PARTITION = 20
         num_partitions = sort.num_partitions()
         exprs: ExpressionList = sort._sort_by
-        desc = sort._desc
+        descending = sort._descending
 
         def sample_map_func(part: vPartition) -> vPartition:
             return part.sample(SAMPLES_PER_PARTITION).eval_expression_list(exprs)
 
         def quantile_reduce_func(to_reduce: List[vPartition]) -> vPartition:
             merged = vPartition.merge_partitions(to_reduce, verify_partition_id=False)
-            merged_sorted = merged.sort(exprs, desc=desc)
+            merged_sorted = merged.sort(exprs, descending=descending)
             return merged_sorted.quantiles(num_partitions)
 
         prev_part = inputs[child_id]
@@ -302,8 +302,8 @@ class LogicalGlobalOpRunner:
         sort_shuffle_op_klass = self._get_shuffle_op_klass(SortOp)
         sort_op = sort_shuffle_op_klass(
             expr_eval_resource_request=sort.resource_request(),
-            map_args={"exprs": exprs, "boundaries": boundaries, "desc": sort._desc},
-            reduce_args={"exprs": exprs, "desc": sort._desc},
+            map_args={"exprs": exprs, "boundaries": boundaries, "descending": descending},
+            reduce_args={"exprs": exprs, "descending": descending},
         )
 
         return sort_op.run(input=prev_part, num_target_partitions=num_partitions)

--- a/daft/execution/logical_op_runners.py
+++ b/daft/execution/logical_op_runners.py
@@ -286,6 +286,7 @@ class LogicalGlobalOpRunner:
         SAMPLES_PER_PARTITION = 20
         num_partitions = sort.num_partitions()
         exprs: ExpressionList = sort._sort_by
+        desc = sort._desc
 
         def sample_map_func(part: vPartition) -> vPartition:
             return part.sample(SAMPLES_PER_PARTITION).eval_expression_list(exprs)
@@ -293,7 +294,8 @@ class LogicalGlobalOpRunner:
         def quantile_reduce_func(to_reduce: List[vPartition]) -> DataBlock:
             merged = vPartition.merge_partitions(to_reduce, verify_partition_id=False)
             first_column = list(merged.columns.values())[0]
-            return first_column.block.quantiles(num_partitions)
+            quantiles = first_column.block.quantiles(num_partitions, desc=desc)
+            return quantiles
 
         prev_part = inputs[child_id]
         sampled_partitions = self.map_partitions(prev_part, sample_map_func, sort.resource_request())

--- a/daft/internal/kernels/memory_view.h
+++ b/daft/internal/kernels/memory_view.h
@@ -106,11 +106,13 @@ struct CompositeView {
     return false;
   }
 
-  int Compare(const CompositeView &other, const uint64_t left_idx, const uint64_t right_idx) const {
+  int Compare(const CompositeView &other, const uint64_t left_idx, const uint64_t right_idx, const std::vector<bool> &desc) const {
     int result = 0;
     const size_t size = views_.size();
     for (size_t i = 0; i < size; ++i) {
+      const bool is_desc = desc[i];
       result = views_[i]->Compare(other.views_[i].get(), left_idx, right_idx);
+      result = is_desc ? -result : result;
       if (result != 0) {
         break;
       }

--- a/daft/internal/kernels/memory_view.h
+++ b/daft/internal/kernels/memory_view.h
@@ -8,6 +8,22 @@
 
 namespace daft {
 namespace kernels {
+inline int strcmpNoTerminator(const uint8_t *str1, const uint8_t *str2, size_t str1len, size_t str2len) {
+  // https://stackoverflow.com/questions/24770665/comparing-2-char-with-different-lengths-without-null-terminators
+  // Get the length of the shorter string
+  const size_t len = str1len < str2len ? str1len : str2len;
+  // Compare the strings up until one ends
+  const int cmp = memcmp(str1, str2, len);
+  // If they weren't equal, we've got our result
+  // If they are equal and the same length, they matched
+  if (cmp != 0 || str1len == str2len) {
+    return cmp;
+  }
+  // If they were equal but one continues on, the shorter string is
+  // lexicographically smaller
+  return str1len < str2len ? -1 : 1;
+}
+
 struct MemoryViewBase {
   MemoryViewBase(const std::shared_ptr<arrow::ArrayData> &data) : data_(data){};
   virtual ~MemoryViewBase() = default;
@@ -30,6 +46,22 @@ struct PrimativeMemoryView : public MemoryViewBase {
   }
 };
 
+template <typename ArrowType>
+struct BinaryMemoryView : public MemoryViewBase {
+  BinaryMemoryView(const std::shared_ptr<arrow::ArrayData> &data) : MemoryViewBase(data){};
+  ~BinaryMemoryView() = default;
+  int Compare(const MemoryViewBase *other, const uint64_t left_idx, const uint64_t right_idx) const {
+    using T = typename ArrowType::offset_type;
+    const T left_offset = *this->data_->template GetValues<T>(1, left_idx);
+    const T left_size = *this->data_->template GetValues<T>(1, left_idx + 1) - left_offset;
+
+    const T right_offset = *other->data_->template GetValues<T>(1, right_idx);
+    const T right_size = *other->data_->template GetValues<T>(1, right_idx + 1) - right_offset;
+    return strcmpNoTerminator(this->data_->template GetValues<uint8_t>(2, left_offset),
+                              other->data_->template GetValues<uint8_t>(2, right_offset), left_size, right_size);
+  }
+};
+
 struct CompositeView {
   CompositeView(){};
 
@@ -38,10 +70,17 @@ struct CompositeView {
     static_assert(std::is_base_of<MemoryViewBase, T>::value, "T is not derived from MemoryViewBase");
     views_.push_back(std::make_unique<T>(data));
   }
+
   template <typename ArrowType>
   void AddPrimativeMemoryView(const std::shared_ptr<arrow::ArrayData> &data) {
     static_assert(std::is_base_of<arrow::DataType, ArrowType>::value, "T is not derived from MemoryViewBase");
     AddMemoryView<PrimativeMemoryView<ArrowType>>(data);
+  }
+
+  template <typename ArrowType>
+  void AddBinaryMemoryView(const std::shared_ptr<arrow::ArrayData> &data) {
+    static_assert(std::is_base_of<arrow::DataType, ArrowType>::value, "T is not derived from MemoryViewBase");
+    AddMemoryView<BinaryMemoryView<ArrowType>>(data);
   }
 
   int Compare(const CompositeView &other, const uint64_t left_idx, const uint64_t right_idx) const {

--- a/daft/internal/kernels/memory_view.h
+++ b/daft/internal/kernels/memory_view.h
@@ -1,43 +1,54 @@
+#pragma once
+#include <arrow/array/data.h>
+
 #include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <vector>
 
 namespace daft {
-
+namespace kernels {
 struct MemoryViewBase {
-  MemoryViewBase(void *buffer, size_t length) : buffer_(buffer), length_(length){};
-  virtual int Compare(const MemoryViewBase &other, const uint64_t left_idx, const uint64_t right_idx) const;
-  void *buffer_;
-  size_t length_;
+  MemoryViewBase(const std::shared_ptr<arrow::ArrayData> &data) : data_(data){};
+  virtual ~MemoryViewBase() = default;
+
+  virtual int Compare(const MemoryViewBase *other, const uint64_t left_idx, const uint64_t right_idx) const = 0;
+  const std::shared_ptr<arrow::ArrayData> data_;
 };
 
-template <typename T>
-struct MemoryView : public MemoryViewBase {
-  int Compare(const MemoryViewBase &other, const uint64_t left_idx, const uint64_t right_idx) {
-    const T left_val = *(((T *)buffer_) + left_idx);
-    const T right_val = *(((T *)buffer_) + right_idx);
-    int is_less = std::less<T>{}(left_val, right_val);
-    int is_greater = std::greater<T>{}(left_val, right_val);
+template <typename ArrowType>
+struct PrimativeMemoryView : public MemoryViewBase {
+  PrimativeMemoryView(const std::shared_ptr<arrow::ArrayData> &data) : MemoryViewBase(data){};
+  ~PrimativeMemoryView() = default;
+  int Compare(const MemoryViewBase *other, const uint64_t left_idx, const uint64_t right_idx) const {
+    using T = typename ArrowType::c_type;
+    const T left_val = *(this->data_->template GetValues<T>(1) + left_idx);
+    const T right_val = *(other->data_->template GetValues<T>(1) + right_idx);
+    const int is_less = std::less<T>{}(left_val, right_val);
+    const int is_greater = std::less<T>{}(right_val, left_val);
     return is_greater - is_less;
   }
-
-  inline const T &getValue(const uint64_t idx) const { return *(((T *)buffer_) + idx); }
 };
 
 struct CompositeView {
   CompositeView(){};
-  template <typename T>
 
-  void AddMemoryView(void *buffer, size_t length) {
-    views_.push_back(std::make_unique<MemoryView<T>>());
+  template <typename T>
+  void AddMemoryView(const std::shared_ptr<arrow::ArrayData> &data) {
+    static_assert(std::is_base_of<MemoryViewBase, T>::value, "T is not derived from MemoryViewBase");
+    views_.push_back(std::make_unique<T>(data));
+  }
+  template <typename ArrowType>
+  void AddPrimativeMemoryView(const std::shared_ptr<arrow::ArrayData> &data) {
+    static_assert(std::is_base_of<arrow::DataType, ArrowType>::value, "T is not derived from MemoryViewBase");
+    AddMemoryView<PrimativeMemoryView<ArrowType>>(data);
   }
 
-  int compare(const CompositeView &other, const uint64_t left_idx, const uint64_t right_idx) {
+  int Compare(const CompositeView &other, const uint64_t left_idx, const uint64_t right_idx) const {
     int result = 0;
     const size_t size = views_.size();
     for (size_t i = 0; i < size; ++i) {
-      result = views_[i]->Compare(*other.views_[i].get(), left_idx, right_idx);
+      result = views_[i]->Compare(other.views_[i].get(), left_idx, right_idx);
       if (result != 0) {
         break;
       }
@@ -48,4 +59,5 @@ struct CompositeView {
   std::vector<std::unique_ptr<MemoryViewBase>> views_;
 };
 
+}  // namespace kernels
 }  // namespace daft

--- a/daft/internal/kernels/search_sorted.cc
+++ b/daft/internal/kernels/search_sorted.cc
@@ -25,15 +25,15 @@ namespace bit_util = arrow::bit_util;
 
 template <typename InType>
 struct SearchSortedPrimativeSingle {
-  static void Exec(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result) {
+  static void Exec(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result, const bool desc) {
     if (keys->GetNullCount() == 0) {
-      return KernelNonNull(arr, keys, result);
+      return KernelNonNull(arr, keys, result, desc);
     } else {
-      return KernelWithNull(arr, keys, result);
+      return KernelWithNull(arr, keys, result, desc);
     }
   }
 
-  static void KernelNonNull(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result) {
+  static void KernelNonNull(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result, const bool desc) {
     using T = typename InType::c_type;
     ARROW_CHECK(arr->type->id() == keys->type->id());
 
@@ -88,11 +88,11 @@ struct SearchSortedPrimativeSingle {
           max_idx = mid_idx;
         }
       }
-      *result_ptr = min_idx;
+      *result_ptr = desc ? arr_len - min_idx : min_idx;
     }
   }
 
-  static void KernelWithNull(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result) {
+  static void KernelWithNull(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result, const bool desc) {
     using T = typename InType::c_type;
     ARROW_CHECK(arr->GetNullCount() == 0);
     ARROW_CHECK(arr->type->id() == keys->type->id());
@@ -157,59 +157,59 @@ struct SearchSortedPrimativeSingle {
           max_idx = mid_idx;
         }
       }
-      *result_ptr = min_idx;
+      *result_ptr = desc ? arr_len - min_idx : min_idx;
     }
   }
 };
 
-void search_sorted_primative_single(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result) {
+void search_sorted_primative_single(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result, const bool desc) {
   switch (arr->type->id()) {
     case arrow::Type::INT8:
-      return SearchSortedPrimativeSingle<arrow::Int8Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::Int8Type>::Exec(arr, keys, result, desc);
     case arrow::Type::INT16:
-      return SearchSortedPrimativeSingle<arrow::Int16Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::Int16Type>::Exec(arr, keys, result, desc);
     case arrow::Type::INT32:
-      return SearchSortedPrimativeSingle<arrow::Int32Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::Int32Type>::Exec(arr, keys, result, desc);
     case arrow::Type::INT64:
-      return SearchSortedPrimativeSingle<arrow::Int64Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::Int64Type>::Exec(arr, keys, result, desc);
     case arrow::Type::UINT8:
-      return SearchSortedPrimativeSingle<arrow::UInt8Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::UInt8Type>::Exec(arr, keys, result, desc);
     case arrow::Type::UINT16:
-      return SearchSortedPrimativeSingle<arrow::UInt16Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::UInt16Type>::Exec(arr, keys, result, desc);
     case arrow::Type::UINT32:
-      return SearchSortedPrimativeSingle<arrow::UInt32Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::UInt32Type>::Exec(arr, keys, result, desc);
     case arrow::Type::UINT64:
-      return SearchSortedPrimativeSingle<arrow::UInt64Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::UInt64Type>::Exec(arr, keys, result, desc);
     case arrow::Type::FLOAT:
-      return SearchSortedPrimativeSingle<arrow::FloatType>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::FloatType>::Exec(arr, keys, result, desc);
     case arrow::Type::DOUBLE:
-      return SearchSortedPrimativeSingle<arrow::DoubleType>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::DoubleType>::Exec(arr, keys, result, desc);
     case arrow::Type::DATE32:
-      return SearchSortedPrimativeSingle<arrow::Date32Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::Date32Type>::Exec(arr, keys, result, desc);
     case arrow::Type::DATE64:
-      return SearchSortedPrimativeSingle<arrow::Date64Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::Date64Type>::Exec(arr, keys, result, desc);
     case arrow::Type::TIME32:
-      return SearchSortedPrimativeSingle<arrow::Time32Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::Time32Type>::Exec(arr, keys, result, desc);
     case arrow::Type::TIME64:
-      return SearchSortedPrimativeSingle<arrow::Time64Type>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::Time64Type>::Exec(arr, keys, result, desc);
     case arrow::Type::TIMESTAMP:
-      return SearchSortedPrimativeSingle<arrow::TimestampType>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::TimestampType>::Exec(arr, keys, result, desc);
     case arrow::Type::DURATION:
-      return SearchSortedPrimativeSingle<arrow::DurationType>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::DurationType>::Exec(arr, keys, result, desc);
     case arrow::Type::INTERVAL_MONTHS:
-      return SearchSortedPrimativeSingle<arrow::MonthIntervalType>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::MonthIntervalType>::Exec(arr, keys, result, desc);
     // Need custom less function for this since it uses a custom struct for the data structure
     // case arrow::Type::INTERVAL_MONTH_DAY_NANO:
     //   return SearchSortedPrimativeSingle<arrow::MonthDayNanoIntervalType>::Exec(arr, keys, result);
     case arrow::Type::INTERVAL_DAY_TIME:
-      return SearchSortedPrimativeSingle<arrow::DayTimeIntervalType>::Exec(arr, keys, result);
+      return SearchSortedPrimativeSingle<arrow::DayTimeIntervalType>::Exec(arr, keys, result, desc);
     default:
-      break;
+      ARROW_LOG(FATAL) << "Unknown arrow type" << arr->type->id();
   }
 }
 
 template <typename T>
-void search_sorted_binary_single(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result) {
+void search_sorted_binary_single(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result, const bool desc) {
   ARROW_CHECK(arrow::is_base_binary_like(arr->type->id()));
   ARROW_CHECK(arr->type->id() == keys->type->id());
   ARROW_CHECK(result->type->id() == arrow::Type::UINT64);
@@ -291,7 +291,7 @@ void search_sorted_binary_single(const arrow::ArrayData *arr, const arrow::Array
         max_idx = mid_idx;
       }
     }
-    *result_ptr = min_idx;
+    *result_ptr = desc ? arr_len - min_idx : min_idx;
   }
 }
 
@@ -353,7 +353,8 @@ void add_binary_memory_view_to_comp_view(daft::kernels::CompositeView &comp_view
 }
 
 std::shared_ptr<arrow::Array> search_sorted_multiple_columns(const std::vector<std::shared_ptr<arrow::ArrayData>> &sorted,
-                                                             const std::vector<std::shared_ptr<arrow::ArrayData>> &keys) {
+                                                             const std::vector<std::shared_ptr<arrow::ArrayData>> &keys,
+                                                             const std::vector<bool> &desc) {
   daft::kernels::CompositeView sorted_comp_view{}, keys_comp_view{};
   for (auto arr : sorted) {
     ARROW_CHECK_EQ(arr->GetNullCount(), 0);
@@ -409,7 +410,7 @@ std::shared_ptr<arrow::Array> search_sorted_multiple_columns(const std::vector<s
      * gives the search a big boost when keys are sorted, but slightly
      * slows down things for purely random ones.
      */
-    if (keys_comp_view.Compare(keys_comp_view, last_key_idx, key_idx) < 0) {
+    if (keys_comp_view.Compare(keys_comp_view, last_key_idx, key_idx, desc) < 0) {
       max_idx = arr_len;
     } else {
       min_idx = 0;
@@ -420,7 +421,7 @@ std::shared_ptr<arrow::Array> search_sorted_multiple_columns(const std::vector<s
 
     while (min_idx < max_idx) {
       const size_t mid_idx = min_idx + ((max_idx - min_idx) >> 1);
-      if (sorted_comp_view.Compare(keys_comp_view, mid_idx, key_idx) < 0) {
+      if (sorted_comp_view.Compare(keys_comp_view, mid_idx, key_idx, desc) < 0) {
         min_idx = mid_idx + 1;
       } else {
         max_idx = mid_idx;
@@ -435,7 +436,7 @@ std::shared_ptr<arrow::Array> search_sorted_multiple_columns(const std::vector<s
 
 namespace daft {
 namespace kernels {
-std::shared_ptr<arrow::Array> search_sorted_single_array(const arrow::Array *arr, const arrow::Array *keys) {
+std::shared_ptr<arrow::Array> search_sorted_single_array(const arrow::Array *arr, const arrow::Array *keys, const bool desc) {
   ARROW_CHECK(arr != NULL);
   ARROW_CHECK(keys != NULL);
   const size_t size = keys->length();
@@ -448,18 +449,19 @@ std::shared_ptr<arrow::Array> search_sorted_single_array(const arrow::Array *arr
       arrow::ArrayData::Make(std::make_shared<arrow::UInt64Type>(), size, result_buffers, keys->null_count());
   ARROW_CHECK(result.get() != NULL);
   if (arrow::is_primitive(arr->type()->id())) {
-    search_sorted_primative_single(arr->data().get(), keys->data().get(), result.get());
+    search_sorted_primative_single(arr->data().get(), keys->data().get(), result.get(), desc);
   } else if (arrow::is_binary_like(arr->type()->id())) {
-    search_sorted_binary_single<arrow::BinaryType::offset_type>(arr->data().get(), keys->data().get(), result.get());
+    search_sorted_binary_single<arrow::BinaryType::offset_type>(arr->data().get(), keys->data().get(), result.get(), desc);
   } else if (arrow::is_large_binary_like(arr->type()->id())) {
-    search_sorted_binary_single<arrow::LargeBinaryType::offset_type>(arr->data().get(), keys->data().get(), result.get());
+    search_sorted_binary_single<arrow::LargeBinaryType::offset_type>(arr->data().get(), keys->data().get(), result.get(), desc);
   } else {
     ARROW_LOG(FATAL) << "Unsupported Type " << arr->type()->id();
   }
   return arrow::MakeArray(result);
 }
 
-std::shared_ptr<arrow::ChunkedArray> search_sorted_chunked_array(const arrow::ChunkedArray *arr, const arrow::ChunkedArray *keys) {
+std::shared_ptr<arrow::ChunkedArray> search_sorted_chunked_array(const arrow::ChunkedArray *arr, const arrow::ChunkedArray *keys,
+                                                                 const bool desc) {
   ARROW_CHECK_NE(arr, NULL);
   ARROW_CHECK_NE(keys, NULL);
 
@@ -472,12 +474,13 @@ std::shared_ptr<arrow::ChunkedArray> search_sorted_chunked_array(const arrow::Ch
   size_t num_key_chunks = keys->num_chunks();
   std::vector<std::shared_ptr<arrow::Array>> result_arrays;
   for (size_t i = 0; i < num_key_chunks; ++i) {
-    result_arrays.push_back(search_sorted_single_array(arr_single_chunk.get(), keys->chunk(i).get()));
+    result_arrays.push_back(search_sorted_single_array(arr_single_chunk.get(), keys->chunk(i).get(), desc));
   }
   return arrow::ChunkedArray::Make(result_arrays, std::make_shared<arrow::UInt64Type>()).ValueOrDie();
 }
 
-std::shared_ptr<arrow::ChunkedArray> search_sorted_table(const arrow::Table *data, const arrow::Table *keys) {
+std::shared_ptr<arrow::ChunkedArray> search_sorted_table(const arrow::Table *data, const arrow::Table *keys,
+                                                         const std::vector<bool> &desc) {
   ARROW_CHECK_NE(data, NULL);
   ARROW_CHECK_NE(keys, NULL);
   const auto data_schema = data->schema();
@@ -486,7 +489,8 @@ std::shared_ptr<arrow::ChunkedArray> search_sorted_table(const arrow::Table *dat
   if (data_schema->num_fields() == 0) {
     return arrow::ChunkedArray::MakeEmpty(std::make_shared<arrow::UInt64Type>()).ValueOrDie();
   } else if (data_schema->num_fields() == 1) {
-    return search_sorted_chunked_array(data->column(0).get(), keys->column(0).get());
+    ARROW_CHECK_EQ(desc.size(), 1);
+    return search_sorted_chunked_array(data->column(0).get(), keys->column(0).get(), desc[0]);
   } else {
     const auto combined_data_table = data->CombineChunks().ValueOrDie();
     const auto combined_keys_table = keys->CombineChunks().ValueOrDie();
@@ -500,7 +504,7 @@ std::shared_ptr<arrow::ChunkedArray> search_sorted_table(const arrow::Table *dat
       ARROW_CHECK_EQ(chunked_arr->num_chunks(), 1);
       key_vector.push_back(chunked_arr->chunk(0)->data());
     }
-    auto result = search_sorted_multiple_columns(data_vector, key_vector);
+    auto result = search_sorted_multiple_columns(data_vector, key_vector, desc);
     return arrow::ChunkedArray::Make({result}, std::make_shared<arrow::UInt64Type>()).ValueOrDie();
   }
 }

--- a/daft/internal/kernels/search_sorted.h
+++ b/daft/internal/kernels/search_sorted.h
@@ -12,8 +12,9 @@ namespace daft {
 namespace kernels {
 
 std::shared_ptr<arrow::ChunkedArray> search_sorted_chunked_array(const arrow::ChunkedArray *arr, const arrow::ChunkedArray *keys,
-                                                                 const bool desc);
-std::shared_ptr<arrow::ChunkedArray> search_sorted_table(const arrow::Table *data, const arrow::Table *keys, const std::vector<bool> &desc);
+                                                                 const bool input_reversed);
+std::shared_ptr<arrow::ChunkedArray> search_sorted_table(const arrow::Table *data, const arrow::Table *keys,
+                                                         const std::vector<bool> &input_reversed);
 
 }  // namespace kernels
 }  // namespace daft

--- a/daft/internal/kernels/search_sorted.h
+++ b/daft/internal/kernels/search_sorted.h
@@ -4,12 +4,14 @@
 
 namespace arrow {
 class ChunkedArray;
+class Table;
 }  // namespace arrow
 
 namespace daft {
 namespace kernels {
 
-std::shared_ptr<arrow::ChunkedArray> search_sorted_chunked(const arrow::ChunkedArray *arr, const arrow::ChunkedArray *keys);
+std::shared_ptr<arrow::ChunkedArray> search_sorted_chunked_array(const arrow::ChunkedArray *arr, const arrow::ChunkedArray *keys);
+std::shared_ptr<arrow::ChunkedArray> search_sorted_table(const arrow::Table *data, const arrow::Table *keys);
 
 }  // namespace kernels
 }  // namespace daft

--- a/daft/internal/kernels/search_sorted.h
+++ b/daft/internal/kernels/search_sorted.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 namespace arrow {
 class ChunkedArray;
@@ -10,8 +11,9 @@ class Table;
 namespace daft {
 namespace kernels {
 
-std::shared_ptr<arrow::ChunkedArray> search_sorted_chunked_array(const arrow::ChunkedArray *arr, const arrow::ChunkedArray *keys);
-std::shared_ptr<arrow::ChunkedArray> search_sorted_table(const arrow::Table *data, const arrow::Table *keys);
+std::shared_ptr<arrow::ChunkedArray> search_sorted_chunked_array(const arrow::ChunkedArray *arr, const arrow::ChunkedArray *keys,
+                                                                 const bool desc);
+std::shared_ptr<arrow::ChunkedArray> search_sorted_table(const arrow::Table *data, const arrow::Table *keys, const std::vector<bool> &desc);
 
 }  // namespace kernels
 }  // namespace daft

--- a/daft/internal/kernels/search_sorted.pyx
+++ b/daft/internal/kernels/search_sorted.pyx
@@ -18,11 +18,11 @@ import cython
 
 
 cdef extern from "search_sorted.h" namespace "daft::kernels" nogil :
-    cdef shared_ptr[CChunkedArray] search_sorted_chunked_array(const CChunkedArray* arr, const CChunkedArray* keys, const cbool desc);
-    cdef shared_ptr[CChunkedArray] search_sorted_table(const CTable* arr, const CTable* keys, const vector[cbool]& desc);
+    cdef shared_ptr[CChunkedArray] search_sorted_chunked_array(const CChunkedArray* arr, const CChunkedArray* keys, const cbool input_reversed);
+    cdef shared_ptr[CChunkedArray] search_sorted_table(const CTable* arr, const CTable* keys, const vector[cbool]& input_reversed);
 
 
-def search_sorted(data, keys, desc=None):
+def search_sorted(data, keys, input_reversed=None):
 
     cdef shared_ptr[CChunkedArray] result
 
@@ -33,34 +33,34 @@ def search_sorted(data, keys, desc=None):
 
     if isinstance(data, pa.ChunkedArray):
         assert isinstance(keys, pa.ChunkedArray), 'expected keys to be a chunked_array since data is one'
-        if desc is not None:
-            assert isinstance(desc, bool), 'expect desc to be a bool got : ' + type(desc)
+        if input_reversed is not None:
+            assert isinstance(input_reversed, bool), 'expect input_reversed to be a bool got : ' + type(input_reversed)
         else:
-            desc = False
+            input_reversed = False
         carr = pyarrow_unwrap_chunked_array(data)
         if carr.get() == NULL:
             raise TypeError("not a chunked array")
         key_arr = pyarrow_unwrap_chunked_array(keys)
         if key_arr.get() == NULL:
             raise TypeError("not a chunked array")
-        result = search_sorted_chunked_array(carr.get(), key_arr.get(), desc)
+        result = search_sorted_chunked_array(carr.get(), key_arr.get(), input_reversed)
 
     elif isinstance(data, pa.Table):
         assert isinstance(keys, pa.Table), 'expected keys to be a table since data is one'
-        table_desc = []
+        table_input_reversed = []
         num_columns = data.num_columns
         assert keys.num_columns == num_columns, 'mismatch of columns'
-        if desc is not None:
-            if isinstance(desc, bool):
-                table_desc = [desc for _ in range(num_columns)]
-            elif isinstance(desc, list):
-                assert all(isinstance(b, bool) for b in desc)
-                assert len(desc) == num_columns
-                table_desc = desc
+        if input_reversed is not None:
+            if isinstance(input_reversed, bool):
+                table_input_reversed = [input_reversed for _ in range(num_columns)]
+            elif isinstance(input_reversed, list):
+                assert all(isinstance(b, bool) for b in input_reversed)
+                assert len(input_reversed) == num_columns
+                table_input_reversed = input_reversed
             else:
-                raise ValueError("expected `desc` to be either `bool` or list[bool] got: " + desc)
+                raise ValueError("expected `input_reversed` to be either `bool` or list[bool] got: " + input_reversed)
         else:
-            table_desc = [False for _ in range(num_columns)]
+            table_input_reversed = [False for _ in range(num_columns)]
 
         ctab = pyarrow_unwrap_table(data)
         if ctab.get() == NULL:
@@ -68,7 +68,7 @@ def search_sorted(data, keys, desc=None):
         key_table = pyarrow_unwrap_table(keys)
         if key_table.get() == NULL:
             raise TypeError("not a chunked array")
-        result = search_sorted_table(ctab.get(), key_table.get(), table_desc)
+        result = search_sorted_table(ctab.get(), key_table.get(), table_input_reversed)
     else:
         raise ValueError("Unknown type for kernel: " + str(type(data)))
     return pyarrow_wrap_chunked_array(result)

--- a/daft/internal/kernels/search_sorted.pyx
+++ b/daft/internal/kernels/search_sorted.pyx
@@ -1,10 +1,14 @@
 # distutils: language=c++
 # distutils: sources = daft/internal/kernels/search_sorted.cc
+import pyarrow as pa
 
 from pyarrow.lib cimport (
     CChunkedArray,
+    CTable,
     pyarrow_unwrap_chunked_array,
+    pyarrow_unwrap_table,
     pyarrow_wrap_chunked_array,
+    pyarrow_wrap_table,
     shared_ptr,
 )
 
@@ -12,14 +16,39 @@ import cython
 
 
 cdef extern from "search_sorted.h" namespace "daft::kernels" nogil :
-    cdef shared_ptr[CChunkedArray] search_sorted_chunked(const CChunkedArray* arr, const CChunkedArray* keys);
+    cdef shared_ptr[CChunkedArray] search_sorted_chunked_array(const CChunkedArray* arr, const CChunkedArray* keys);
+    cdef shared_ptr[CChunkedArray] search_sorted_table(const CTable* arr, const CTable* keys);
 
-def search_sorted_chunked_array(data_arr, keys):
-    cdef shared_ptr[CChunkedArray] carr = pyarrow_unwrap_chunked_array(data_arr)
-    if carr.get() == NULL:
-        raise TypeError("not a chunked array")
-    cdef shared_ptr[CChunkedArray] key_arr = pyarrow_unwrap_chunked_array(keys)
-    if key_arr.get() == NULL:
-        raise TypeError("not a chunked array")
-    cdef shared_ptr[CChunkedArray] result = search_sorted_chunked(carr.get(), key_arr.get())
+
+
+
+def search_sorted(data, keys):
+
+    cdef shared_ptr[CChunkedArray] result
+
+    cdef shared_ptr[CChunkedArray] carr
+    cdef shared_ptr[CChunkedArray] key_arr
+    cdef shared_ptr[CTable] ctab
+    cdef shared_ptr[CTable] key_table
+    if isinstance(data, pa.ChunkedArray):
+        assert isinstance(keys, pa.ChunkedArray), 'expected keys to be a chunked_array since data is one'
+        carr = pyarrow_unwrap_chunked_array(data)
+        if carr.get() == NULL:
+            raise TypeError("not a chunked array")
+        key_arr = pyarrow_unwrap_chunked_array(keys)
+        if key_arr.get() == NULL:
+            raise TypeError("not a chunked array")
+        result = search_sorted_chunked_array(carr.get(), key_arr.get())
+
+    elif isinstance(data, pa.Table):
+        assert isinstance(keys, pa.Table), 'expected keys to be a table since data is one'
+        ctab = pyarrow_unwrap_table(data)
+        if ctab.get() == NULL:
+            raise TypeError("not a table")
+        key_table = pyarrow_unwrap_table(keys)
+        if key_table.get() == NULL:
+            raise TypeError("not a chunked array")
+        result = search_sorted_table(ctab.get(), key_table.get())
+    else:
+        raise ValueError("Unknown type for kernel: " + str(type(data)))
     return pyarrow_wrap_chunked_array(result)

--- a/daft/internal/kernels/search_sorted.pyx
+++ b/daft/internal/kernels/search_sorted.pyx
@@ -2,6 +2,8 @@
 # distutils: sources = daft/internal/kernels/search_sorted.cc
 import pyarrow as pa
 
+from libcpp cimport bool as cbool
+from libcpp.vector cimport vector
 from pyarrow.lib cimport (
     CChunkedArray,
     CTable,
@@ -16,13 +18,11 @@ import cython
 
 
 cdef extern from "search_sorted.h" namespace "daft::kernels" nogil :
-    cdef shared_ptr[CChunkedArray] search_sorted_chunked_array(const CChunkedArray* arr, const CChunkedArray* keys);
-    cdef shared_ptr[CChunkedArray] search_sorted_table(const CTable* arr, const CTable* keys);
+    cdef shared_ptr[CChunkedArray] search_sorted_chunked_array(const CChunkedArray* arr, const CChunkedArray* keys, const cbool desc);
+    cdef shared_ptr[CChunkedArray] search_sorted_table(const CTable* arr, const CTable* keys, const vector[cbool]& desc);
 
 
-
-
-def search_sorted(data, keys):
+def search_sorted(data, keys, desc=None):
 
     cdef shared_ptr[CChunkedArray] result
 
@@ -30,25 +30,45 @@ def search_sorted(data, keys):
     cdef shared_ptr[CChunkedArray] key_arr
     cdef shared_ptr[CTable] ctab
     cdef shared_ptr[CTable] key_table
+
     if isinstance(data, pa.ChunkedArray):
         assert isinstance(keys, pa.ChunkedArray), 'expected keys to be a chunked_array since data is one'
+        if desc is not None:
+            assert isinstance(desc, bool), 'expect desc to be a bool got : ' + type(desc)
+        else:
+            desc = False
         carr = pyarrow_unwrap_chunked_array(data)
         if carr.get() == NULL:
             raise TypeError("not a chunked array")
         key_arr = pyarrow_unwrap_chunked_array(keys)
         if key_arr.get() == NULL:
             raise TypeError("not a chunked array")
-        result = search_sorted_chunked_array(carr.get(), key_arr.get())
+        result = search_sorted_chunked_array(carr.get(), key_arr.get(), desc)
 
     elif isinstance(data, pa.Table):
         assert isinstance(keys, pa.Table), 'expected keys to be a table since data is one'
+        table_desc = []
+        num_columns = data.num_columns
+        assert keys.num_columns == num_columns, 'mismatch of columns'
+        if desc is not None:
+            if isinstance(desc, bool):
+                table_desc = [desc for _ in range(num_columns)]
+            elif isinstance(desc, list):
+                assert all(isinstance(b, bool) for b in desc)
+                assert len(desc) == num_columns
+                table_desc = desc
+            else:
+                raise ValueError("expected `desc` to be either `bool` or list[bool] got: " + desc)
+        else:
+            table_desc = [False for _ in range(num_columns)]
+
         ctab = pyarrow_unwrap_table(data)
         if ctab.get() == NULL:
             raise TypeError("not a table")
         key_table = pyarrow_unwrap_table(keys)
         if key_table.get() == NULL:
             raise TypeError("not a chunked array")
-        result = search_sorted_table(ctab.get(), key_table.get())
+        result = search_sorted_table(ctab.get(), key_table.get(), table_desc)
     else:
         raise ValueError("Unknown type for kernel: " + str(type(data)))
     return pyarrow_wrap_chunked_array(result)

--- a/daft/internal/kernels/search_sorted.pyx
+++ b/daft/internal/kernels/search_sorted.pyx
@@ -54,7 +54,7 @@ def search_sorted(data, keys, input_reversed=None):
             if isinstance(input_reversed, bool):
                 table_input_reversed = [input_reversed for _ in range(num_columns)]
             elif isinstance(input_reversed, list):
-                assert all(isinstance(b, bool) for b in input_reversed)
+                assert all(isinstance(b, bool) for b in input_reversed), 'found wrong type in input_reversed ' + str(input_reversed)
                 assert len(input_reversed) == num_columns
                 table_input_reversed = input_reversed
             else:

--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -278,7 +278,6 @@ class Sort(UnaryNode):
         pspec = PartitionSpec(scheme=PartitionScheme.RANGE, num_partitions=input.num_partitions(), by=sort_by)
         super().__init__(input.schema().to_column_expressions(), partition_spec=pspec, op_level=OpLevel.GLOBAL)
         self._register_child(input)
-        assert len(sort_by.exprs) == 1, "we can only sort with 1 expression"
         self._sort_by = sort_by.resolve(input_schema=input.schema())
         self._desc = desc
 

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -29,7 +29,7 @@ from pandas.core.reshape.merge import get_join_indexers
 
 from daft.execution.operators import OperatorEnum, OperatorEvaluator
 from daft.internal.hashing import hash_chunked_array
-from daft.internal.kernels.search_sorted import search_sorted_chunked_array
+from daft.internal.kernels.search_sorted import search_sorted
 
 # A type representing some Python scalar (non-series/array like object)
 PyScalar = Any
@@ -514,7 +514,7 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
         return ArrowDataBlock(data=pa.chunked_array([sampled]))
 
     def search_sorted(self, pivots: DataBlock, reverse: bool = False) -> DataBlock[ArrowArrType]:
-        indices = DataBlock.make_block(search_sorted_chunked_array(pivots.data, self.data))
+        indices = DataBlock.make_block(search_sorted(pivots.data, self.data))
         if reverse:
             indices = ArrowEvaluator.SUB(DataBlock.make_block(len(pivots)), indices)
         return indices

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -514,10 +514,7 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
         return ArrowDataBlock(data=pa.chunked_array([sampled]))
 
     def search_sorted(self, pivots: DataBlock, reverse: bool = False) -> DataBlock[ArrowArrType]:
-        indices = DataBlock.make_block(search_sorted(pivots.data, self.data))
-        if reverse:
-            indices = ArrowEvaluator.SUB(DataBlock.make_block(len(pivots)), indices)
-        return indices
+        return DataBlock.make_block(search_sorted(pivots.data, self.data, reverse))
 
     def quantiles(self, num: int) -> DataBlock[ArrowArrType]:
         quantiles = np.linspace(1.0 / num, 1.0, num)[:-1]

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -264,13 +264,44 @@ class DataBlock(Generic[ArrType]):
     def sample(self, num: int) -> DataBlock[ArrType]:
         raise NotImplementedError()
 
+    @staticmethod
     @abstractmethod
-    def _argsort(self, desc: bool = False) -> DataBlock[ArrowArrType]:
+    def _argsort(blocks: List[DataBlock[ArrType]], descending: Optional[List[bool]] = None) -> DataBlock[ArrowArrType]:
         raise NotImplementedError()
 
-    def argsort(self, desc: bool = False) -> DataBlock[ArrowArrType]:
-        assert not self.is_scalar(), "Cannot sort scalar DataBlock"
-        return self._argsort(desc=desc)
+    @classmethod
+    def argsort(cls, blocks: List[DataBlock], descending: Optional[List[bool]] = None) -> DataBlock[ArrowArrType]:
+        first_type = type(blocks[0])
+        assert all(type(b) == first_type for b in blocks), "all block types must match"
+        size = len(blocks)
+        if descending is None:
+            descending = [False for _ in range(size)]
+        else:
+            assert size == len(descending), f"mismatch of size of descending and blocks {size} vs {len(descending)}"
+        return first_type._argsort(blocks, descending=descending)
+
+    @staticmethod
+    @abstractmethod
+    def _search_sorted(
+        sorted_blocks: List[DataBlock], keys: List[DataBlock], input_reversed: Optional[List[bool]] = None
+    ) -> DataBlock[ArrowArrType]:
+        raise NotImplementedError()
+
+    @classmethod
+    def search_sorted(
+        cls, sorted_blocks: List[DataBlock], keys: List[DataBlock], input_reversed: Optional[List[bool]] = None
+    ) -> DataBlock[ArrowArrType]:
+        first_type = type(sorted_blocks[0])
+        assert all(type(b) == first_type for b in sorted_blocks), "all block types must match"
+        assert all(type(b) == first_type for b in keys), "all block types must match"
+
+        size = len(sorted_blocks)
+        if input_reversed is None:
+            input_reversed = [False for _ in range(size)]
+        assert len(sorted_blocks) == len(keys)
+        assert size == len(input_reversed), f"mismatch of size of descending and blocks {size} vs {len(input_reversed)}"
+
+        return first_type._search_sorted(sorted_blocks=sorted_blocks, keys=keys, input_reversed=input_reversed)
 
     @staticmethod
     @abstractmethod
@@ -283,14 +314,6 @@ class DataBlock(Generic[ArrType]):
         first_type = type(blocks[0])
         assert all(type(b) == first_type for b in blocks), "all block types must match"
         return first_type._merge_blocks(blocks)
-
-    @abstractmethod
-    def search_sorted(self, pivots: DataBlock[ArrType], input_reversed: bool = False) -> DataBlock[ArrType]:
-        raise NotImplementedError()
-
-    @abstractmethod
-    def quantiles(self, num: int, desc: bool = False) -> DataBlock[ArrType]:
-        raise NotImplementedError()
 
     @abstractmethod
     def array_hash(self, seed: Optional[DataBlock[ArrType]] = None) -> DataBlock[ArrowArrType]:
@@ -399,7 +422,14 @@ class PyListDataBlock(DataBlock[List[T]]):
     def sample(self, num: int) -> DataBlock[List[T]]:
         return PyListDataBlock(data=random.sample(self.data, num))
 
-    def _argsort(self, desc: bool = False) -> DataBlock[ArrowArrType]:
+    @staticmethod
+    def _search_sorted(
+        sorted_blocks: List[DataBlock], keys: List[DataBlock], input_reversed: Optional[List[bool]] = None
+    ) -> DataBlock[ArrowArrType]:
+        raise NotImplementedError()
+
+    @staticmethod
+    def _argsort(blocks: List[DataBlock[ArrType]], descending: Optional[List[bool]] = None) -> DataBlock[ArrowArrType]:
         raise NotImplementedError("Sorting by Python objects is not implemented")
 
     def _make_empty(self) -> DataBlock[List[T]]:
@@ -414,12 +444,6 @@ class PyListDataBlock(DataBlock[List[T]]):
         for block in blocks:
             concatted_data.extend(block.data)
         return PyListDataBlock(data=concatted_data)
-
-    def search_sorted(self, pivots: DataBlock[List[T]], input_reversed: bool = False) -> DataBlock[ArrowArrType]:
-        raise NotImplementedError("Sorting by Python objects is not implemented")
-
-    def quantiles(self, num: int, desc: bool = False) -> DataBlock[List[T]]:
-        raise NotImplementedError("Sorting by Python objects is not implemented")
 
     def array_hash(self, seed: Optional[DataBlock[ArrType]] = None) -> DataBlock[ArrowArrType]:
         # TODO(jay): seed is ignored here, but perhaps we need to set it in PYTHONHASHSEED?
@@ -475,10 +499,35 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
                 yield py_scalar
         yield from self.data.to_numpy()
 
-    def _argsort(self, desc: bool = False) -> DataBlock[ArrowArrType]:
-        order = "descending" if desc else "ascending"
-        sort_indices = pac.array_sort_indices(self.data, order=order)
-        return ArrowDataBlock(data=sort_indices)
+    # def _argsort(self, desc: bool = False) -> DataBlock[ArrowArrType]:
+    #     order = "descending" if desc else "ascending"
+    #     sort_indices = pac.array_sort_indices(self.data, order=order)
+    #     return ArrowDataBlock(data=sort_indices)
+
+    @staticmethod
+    def _argsort(blocks: List[DataBlock[ArrType]], descending: Optional[List[bool]] = None) -> DataBlock[ArrowArrType]:
+        arrs = [a.data for a in blocks]
+        arr_names = [f"a_{i}" for i in range(len(blocks))]
+        if descending is None:
+            descending = [False for _ in range(len(blocks))]
+        order = ["descending" if desc else "ascending" for desc in descending]
+        table = pa.table(arrs, names=arr_names)
+        indices = pac.sort_indices(table, sort_keys=list(zip(arr_names, order)))
+        return DataBlock.make_block(indices)
+
+    @staticmethod
+    def _search_sorted(
+        sorted_blocks: List[DataBlock], keys: List[DataBlock], input_reversed: Optional[List[bool]] = None
+    ) -> DataBlock[ArrowArrType]:
+
+        arr_names = [f"a_{i}" for i in range(len(sorted_blocks))]
+        if input_reversed is None:
+            input_reversed = [False for _ in range(len(sorted_blocks))]
+        sorted_table = pa.table([a.data for a in sorted_blocks], names=arr_names)
+        key_table = pa.table([a.data for a in keys], names=arr_names)
+        assert sorted_table.schema == key_table.schema
+        result = search_sorted(sorted_table, key_table, input_reversed=input_reversed)
+        return DataBlock.make_block(result)
 
     def _filter(self, mask: DataBlock[ArrowArrType]) -> DataBlock[ArrowArrType]:
         return self._binary_op(mask, fn=pac.array_filter)
@@ -512,19 +561,6 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
             return self
         sampled = np.random.choice(self.data, num, replace=False)
         return ArrowDataBlock(data=pa.chunked_array([sampled]))
-
-    def search_sorted(self, pivots: DataBlock, input_reversed: bool = False) -> DataBlock[ArrowArrType]:
-        return DataBlock.make_block(search_sorted(pivots.data, self.data, input_reversed))
-
-    def quantiles(self, num: int, desc: bool = False) -> DataBlock[ArrowArrType]:
-        quantiles = np.linspace(1.0 / num, 1.0, num)[:-1]
-        if NUMPY_MINOR_VERSION < 22:
-            pivots = np.quantile(self.data.to_numpy(), quantiles, interpolation="nearest")
-        else:
-            pivots = np.quantile(self.data.to_numpy(), quantiles, method="closest_observation")
-        if desc:
-            pivots = pivots[::-1]
-        return DataBlock.make_block(data=pivots)
 
     def array_hash(self, seed: Optional[DataBlock[ArrowArrType]] = None) -> DataBlock[ArrowArrType]:
         assert isinstance(self.data, pa.ChunkedArray)

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -193,23 +193,27 @@ class vPartition:
             mask = mask.run_binary_operator(to_and.block, OperatorEnum.AND)
         return self.for_each_column_block(partial(DataBlock.filter, mask=mask))
 
-    def argsort(self, sort_keys: ExpressionList, desc: bool = False) -> DataBlock:
+    def argsort(self, sort_keys: ExpressionList, descending: Optional[List[bool]] = None) -> DataBlock:
         sorted = self.eval_expression_list(sort_keys)
         keys = list(sorted.columns.keys())
-        idx = DataBlock.argsort([sorted.columns[k].block for k in keys], descending=[desc for _ in keys])
+
+        if descending is None:
+            descending = [False for _ in keys]
+
+        idx = DataBlock.argsort([sorted.columns[k].block for k in keys], descending=descending)
         return idx
 
-    def sort(self, sort_keys: ExpressionList, desc: bool = False) -> vPartition:
-        idx = self.argsort(sort_keys=sort_keys, desc=desc)
+    def sort(self, sort_keys: ExpressionList, descending: Optional[List[bool]] = None) -> vPartition:
+        idx = self.argsort(sort_keys=sort_keys, descending=descending)
         return self.take(idx)
 
-    def search_sorted(self, keys: vPartition, input_reversed: bool = False) -> DataBlock:
+    def search_sorted(self, keys: vPartition, input_reversed: Optional[List[bool]] = None) -> DataBlock:
         assert self.columns.keys() == keys.columns.keys()
         col_ids = list(self.columns.keys())
         idx = DataBlock.search_sorted(
             [self.columns[k].block for k in col_ids],
             [keys.columns[k].block for k in col_ids],
-            input_reversed=[input_reversed for _ in col_ids],
+            input_reversed=input_reversed,
         )
         return idx
 

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -193,10 +193,25 @@ class vPartition:
             mask = mask.run_binary_operator(to_and.block, OperatorEnum.AND)
         return self.for_each_column_block(partial(DataBlock.filter, mask=mask))
 
-    def sort(self, sort_key: Expression, desc: bool = False) -> vPartition:
-        sort_tile = self.eval_expression(sort_key)
-        argsort_idx = sort_tile.apply(partial(DataBlock.argsort, desc=desc))
-        return self.take(argsort_idx.block)
+    def argsort(self, sort_keys: ExpressionList, desc: bool = False) -> DataBlock:
+        sorted = self.eval_expression_list(sort_keys)
+        keys = list(sorted.columns.keys())
+        idx = DataBlock.argsort([sorted.columns[k].block for k in keys], descending=[desc for _ in keys])
+        return idx
+
+    def sort(self, sort_keys: ExpressionList, desc: bool = False) -> vPartition:
+        idx = self.argsort(sort_keys=sort_keys, desc=desc)
+        return self.take(idx)
+
+    def search_sorted(self, keys: vPartition, input_reversed: bool = False) -> DataBlock:
+        assert self.columns.keys() == keys.columns.keys()
+        col_ids = list(self.columns.keys())
+        idx = DataBlock.search_sorted(
+            [self.columns[k].block for k in col_ids],
+            [keys.columns[k].block for k in col_ids],
+            input_reversed=[input_reversed for _ in col_ids],
+        )
+        return idx
 
     def take(self, indices: DataBlock) -> vPartition:
         return self.for_each_column_block(partial(DataBlock.take, indices=indices))
@@ -242,9 +257,9 @@ class vPartition:
     def split_by_index(self, num_partitions: int, target_partition_indices: DataBlock) -> List[vPartition]:
         assert len(target_partition_indices) == len(self)
         new_partition_to_columns: List[Dict[ColID, PyListTile]] = [{} for _ in range(num_partitions)]
-        argsort_targets = target_partition_indices.argsort()
+        argsort_targets = DataBlock.argsort([target_partition_indices])
         sorted_targets = target_partition_indices.take(argsort_targets)
-        sorted_targets_np = sorted_targets.to_polars().to_numpy()
+        sorted_targets_np = sorted_targets.to_numpy()
         pivots = np.where(np.diff(sorted_targets_np, prepend=np.nan))[0]
         target_partitions = sorted_targets_np[pivots]
 
@@ -259,6 +274,11 @@ class vPartition:
                 new_partition_to_columns[part_id][col_id] = nt
 
         return [vPartition(partition_id=i, columns=columns) for i, columns in enumerate(new_partition_to_columns)]
+
+    def quantiles(self, num: int) -> vPartition:
+        self_size = len(self)
+        sample_idx_np = np.linspace(self_size / num, self_size, num)[:-1].round().astype(np.int32)
+        return self.take(DataBlock.make_block(sample_idx_np))
 
     def join(
         self,

--- a/daft/runners/shuffle_ops.py
+++ b/daft/runners/shuffle_ops.py
@@ -98,10 +98,12 @@ class SortOp(ShuffleOp):
         if output_partitions == 1:
             return {PartID(0): input}
         sort_key = input.eval_expression(expr).block
-        argsort_idx = sort_key.argsort()
+        if desc is None:
+            desc = False
+        argsort_idx = sort_key.argsort(desc=desc)
         sorted_input = input.take(argsort_idx)
         sorted_keys = sort_key.take(argsort_idx)
-        target_idx = sorted_keys.search_sorted(boundaries, reverse=desc)
+        target_idx = sorted_keys.search_sorted(boundaries, input_reversed=desc)
         new_parts = sorted_input.split_by_index(num_partitions=output_partitions, target_partition_indices=target_idx)
         return {PartID(i): part for i, part in enumerate(new_parts)}
 

--- a/daft/runners/shuffle_ops.py
+++ b/daft/runners/shuffle_ops.py
@@ -90,25 +90,27 @@ class SortOp(ShuffleOp):
         output_partitions: int,
         exprs: Optional[ExpressionList] = None,
         boundaries: Optional[vPartition] = None,
-        desc: Optional[bool] = None,
+        descending: Optional[List[bool]] = None,
     ) -> Dict[PartID, vPartition]:
-        assert exprs is not None and boundaries is not None and desc is not None
+        assert exprs is not None and boundaries is not None and descending is not None
         assert len(boundaries) == (output_partitions - 1)
+        assert len(exprs) == len(descending)
         if output_partitions == 1:
             return {PartID(0): input}
-        if desc is None:
-            desc = False
         sort_keys = input.eval_expression_list(exprs)
-        target_idx = boundaries.search_sorted(sort_keys, input_reversed=desc)
+        target_idx = boundaries.search_sorted(sort_keys, input_reversed=descending)
         new_parts = input.split_by_index(num_partitions=output_partitions, target_partition_indices=target_idx)
         return {PartID(i): part for i, part in enumerate(new_parts)}
 
     @staticmethod
     def reduce_fn(
-        mapped_outputs: List[vPartition], exprs: Optional[ExpressionList] = None, desc: Optional[bool] = None
+        mapped_outputs: List[vPartition],
+        exprs: Optional[ExpressionList] = None,
+        descending: Optional[List[bool]] = None,
     ) -> vPartition:
-        assert exprs is not None and desc is not None
-        return vPartition.merge_partitions(mapped_outputs).sort(exprs, desc=desc)
+        assert exprs is not None and descending is not None
+        assert len(exprs) == len(descending)
+        return vPartition.merge_partitions(mapped_outputs).sort(exprs, descending=descending)
 
 
 class Shuffler(ShuffleOp):

--- a/daft/runners/shuffle_ops.py
+++ b/daft/runners/shuffle_ops.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
-from daft.expressions import Expression
 from daft.resource_request import ResourceRequest
 from daft.runners.blocks import ArrowArrType, DataBlock
 from daft.runners.partitioning import PartID, PartitionSet, vPartition
@@ -89,30 +88,27 @@ class SortOp(ShuffleOp):
     def map_fn(
         input: vPartition,
         output_partitions: int,
-        expr: Optional[Expression] = None,
-        boundaries: Optional[DataBlock] = None,
+        exprs: Optional[ExpressionList] = None,
+        boundaries: Optional[vPartition] = None,
         desc: Optional[bool] = None,
     ) -> Dict[PartID, vPartition]:
-        assert expr is not None and boundaries is not None and desc is not None
+        assert exprs is not None and boundaries is not None and desc is not None
         assert len(boundaries) == (output_partitions - 1)
         if output_partitions == 1:
             return {PartID(0): input}
-        sort_key = input.eval_expression(expr).block
         if desc is None:
             desc = False
-        argsort_idx = sort_key.argsort(desc=desc)
-        sorted_input = input.take(argsort_idx)
-        sorted_keys = sort_key.take(argsort_idx)
-        target_idx = sorted_keys.search_sorted(boundaries, input_reversed=desc)
-        new_parts = sorted_input.split_by_index(num_partitions=output_partitions, target_partition_indices=target_idx)
+        sort_keys = input.eval_expression_list(exprs)
+        target_idx = boundaries.search_sorted(sort_keys, input_reversed=desc)
+        new_parts = input.split_by_index(num_partitions=output_partitions, target_partition_indices=target_idx)
         return {PartID(i): part for i, part in enumerate(new_parts)}
 
     @staticmethod
     def reduce_fn(
-        mapped_outputs: List[vPartition], expr: Optional[Expression] = None, desc: Optional[bool] = None
+        mapped_outputs: List[vPartition], exprs: Optional[ExpressionList] = None, desc: Optional[bool] = None
     ) -> vPartition:
-        assert expr is not None and desc is not None
-        return vPartition.merge_partitions(mapped_outputs).sort(expr, desc=desc)
+        assert exprs is not None and desc is not None
+        return vPartition.merge_partitions(mapped_outputs).sort(exprs, desc=desc)
 
 
 class Shuffler(ShuffleOp):

--- a/tests/dataframe_cookbook/test_sorting.py
+++ b/tests/dataframe_cookbook/test_sorting.py
@@ -16,13 +16,13 @@ from tests.dataframe_cookbook.conftest import (
     "sort_keys",
     [
         pytest.param(["Unique Key"], id="NumSortKeys:1"),
-        pytest.param(["Borough", "Unique Key"], id="NumSortKeys:2", marks=pytest.mark.tdd),
+        pytest.param(["Borough", "Unique Key"], id="NumSortKeys:2"),
     ],
 )
 def test_get_sorted(sort_desc, daft_df, service_requests_csv_pd_df, repartition_nparts, sort_keys):
     """Sort by a column"""
     daft_df = daft_df.repartition(repartition_nparts)
-    daft_sorted_df = daft_df.sort(*[col(k) for k in sort_keys], desc=sort_desc)
+    daft_sorted_df = daft_df.sort([col(k) for k in sort_keys], desc=sort_desc)
 
     daft_sorted_pd_df = daft_sorted_df.to_pandas()
     assert_df_equals(
@@ -39,18 +39,43 @@ def test_get_sorted(sort_desc, daft_df, service_requests_csv_pd_df, repartition_
     "sort_keys",
     [
         pytest.param(["Unique Key"], id="NumSortKeys:1"),
-        pytest.param(["Borough", "Unique Key"], id="NumSortKeys:2", marks=pytest.mark.tdd),
+        pytest.param(["Borough", "Unique Key"], id="NumSortKeys:2"),
     ],
 )
 def test_get_sorted_top_n(sort_desc, daft_df, service_requests_csv_pd_df, repartition_nparts, sort_keys):
     """Sort by a column"""
     daft_df = daft_df.repartition(repartition_nparts)
-    daft_sorted_df = daft_df.sort(*[col(k) for k in sort_keys], desc=sort_desc).limit(100)
+    daft_sorted_df = daft_df.sort([col(k) for k in sort_keys], desc=sort_desc).limit(100)
     daft_sorted_pd_df = daft_sorted_df.to_pandas()
 
     assert_df_equals(
         daft_sorted_pd_df,
         service_requests_csv_pd_df.sort_values(by=sort_keys, ascending=not sort_desc).head(100),
+        assert_ordering=True,
+    )
+
+
+@parametrize_service_requests_csv_daft_df
+@parametrize_service_requests_csv_repartition
+@parametrize_sort_desc("sort_desc")
+@pytest.mark.parametrize(
+    "sort_keys",
+    [
+        pytest.param(["Borough", "Unique Key"], id="NumSortKeys:2"),
+    ],
+)
+def test_get_sorted_top_n_flipped_desc(sort_desc, daft_df, service_requests_csv_pd_df, repartition_nparts, sort_keys):
+    """Sort by a column"""
+    daft_df = daft_df.repartition(repartition_nparts)
+    desc_list = [sort_desc]
+    for i in range(len(sort_keys) - 1):
+        desc_list.append(not desc_list[-1])
+    daft_sorted_df = daft_df.sort([col(k) for k in sort_keys], desc=desc_list).limit(100)
+    daft_sorted_pd_df = daft_sorted_df.to_pandas()
+
+    assert_df_equals(
+        daft_sorted_pd_df,
+        service_requests_csv_pd_df.sort_values(by=sort_keys, ascending=[not b for b in desc_list]).head(100),
         assert_ordering=True,
     )
 

--- a/tests/internal/test_search_sorted.py
+++ b/tests/internal/test_search_sorted.py
@@ -191,7 +191,7 @@ def test_number_string_table_desc(str_len, num_chunks) -> None:
     sorted_table = pa.table([np.zeros(100), pa_data], names=["a", "b"])
     key_table = pa.table([pa_int_keys, pa_str_keys], names=["a", "b"])
 
-    pa_result = search_sorted(sorted_table, key_table, desc=[False, True])
+    pa_result = search_sorted(sorted_table, key_table, input_reversed=[False, True])
     assert np.all(result == pa_result.to_numpy())
 
 

--- a/tests/internal/test_search_sorted.py
+++ b/tests/internal/test_search_sorted.py
@@ -150,3 +150,64 @@ def test_multi_column_mixed_number_table(num_chunks) -> None:
     key_table = pa.table([pa_keys, pa_keys.cast(pa.float32()), pa_keys.cast(pa.uint64())], names=["a", "b", "c"])
     pa_result = search_sorted(sorted_table, key_table)
     assert np.all(result == pa_result.to_numpy())
+
+
+@pytest.mark.parametrize("str_len", [0, 1, 5])
+@pytest.mark.parametrize("num_chunks", range(1, 4))
+def test_number_string_table(str_len, num_chunks) -> None:
+    pa_int_keys = pa.chunked_array([np.zeros(10) for _ in range(num_chunks)])
+    pa_str_keys = pa.chunked_array(
+        [[gen_random_str(str_len) for _ in range(10)] for _ in range(num_chunks)],
+    )
+    keys = pa_str_keys.to_numpy()
+
+    data = np.array([gen_random_str(str_len + 1) for i in range(10)])
+    data.sort()
+    result = np.searchsorted(data, keys)
+    pa_data = pa.chunked_array([data])
+    sorted_table = pa.table([np.zeros(10), pa_data], names=["a", "b"])
+    key_table = pa.table([pa_int_keys, pa_str_keys], names=["a", "b"])
+
+    pa_result = search_sorted(sorted_table, key_table)
+    assert np.all(result == pa_result.to_numpy())
+
+
+@pytest.mark.parametrize("str_len", [0, 1, 5])
+@pytest.mark.parametrize("num_chunks", range(1, 4))
+def test_string_number_table(str_len, num_chunks) -> None:
+    pa_int_keys = pa.chunked_array([np.zeros(10) for _ in range(num_chunks)])
+    pa_str_keys = pa.chunked_array(
+        [[gen_random_str(str_len) for _ in range(10)] for _ in range(num_chunks)],
+    )
+    keys = pa_str_keys.to_numpy()
+
+    data = np.array([gen_random_str(str_len + 1) for i in range(10)])
+    data.sort()
+    result = np.searchsorted(data, keys)
+    pa_data = pa.chunked_array([data])
+    sorted_table = pa.table([pa_data, np.zeros(10)], names=["a", "b"])
+    key_table = pa.table([pa_str_keys, pa_int_keys], names=["a", "b"])
+
+    pa_result = search_sorted(sorted_table, key_table)
+    assert np.all(result == pa_result.to_numpy())
+
+
+@pytest.mark.parametrize("str_len", range(0, 10))
+@pytest.mark.parametrize("num_chunks", range(1, 4))
+def test_string_table(str_len, num_chunks) -> None:
+
+    pa_keys = pa.chunked_array(
+        [[gen_random_str(str_len) for _ in range(10)] for _ in range(num_chunks)],
+    )
+    keys = pa_keys.to_numpy()
+
+    data = np.array([gen_random_str(str_len + 1) for i in range(10)])
+    data.sort()
+    result = np.searchsorted(data, keys)
+    pa_data = pa.chunked_array([data])
+
+    sorted_table = pa.table([pa_data, pa_data, pa_data], names=["a", "b", "c"])
+    key_table = pa.table([pa_keys, pa_keys, pa_keys], names=["a", "b", "c"])
+
+    pa_result = search_sorted(sorted_table, key_table)
+    assert np.all(result == pa_result.to_numpy())

--- a/tests/runners/test_partitioning.py
+++ b/tests/runners/test_partitioning.py
@@ -178,7 +178,7 @@ def test_vpartition_sort() -> None:
 
         tiles[i] = PyListTile(column_id=i, column_name=f"col_{i}", partition_id=0, block=block)
     part = vPartition(columns=tiles, partition_id=0)
-    part = part.sort(expr)
+    part = part.sort(ExpressionList([expr]))
     arrow_table = pa.Table.from_pandas(part.to_pandas())
     assert arrow_table.column_names == [f"col_{i}" for i in range(col_id, col_id + 4)]
 
@@ -203,7 +203,7 @@ def test_vpartition_sort_desc() -> None:
 
         tiles[i] = PyListTile(column_id=i, column_name=f"col_{i}", partition_id=0, block=block)
     part = vPartition(columns=tiles, partition_id=0)
-    part = part.sort(expr, desc=True)
+    part = part.sort(ExpressionList([expr]), descending=[True])
     arrow_table = pa.Table.from_pandas(part.to_pandas())
     assert arrow_table.column_names == [f"col_{i}" for i in range(col_id, col_id + 4)]
 

--- a/tests/stress_tests/test_tpch.py
+++ b/tests/stress_tests/test_tpch.py
@@ -85,7 +85,6 @@ def test_tpch_q1(tmp_path, check_answer, get_df):
     daft_df = answers.q1(get_df)
     with start_transaction(op="task", name=f"tpch_q1:runner={get_context().runner_config.name.upper()}"):
         daft_pd_df = daft_df.to_pandas()
-    daft_pd_df = daft_pd_df.sort_values(by=["L_RETURNFLAG", "L_LINESTATUS"])  # WE don't have multicolumn sort
     check_answer(daft_pd_df, 1, tmp_path)
 
 
@@ -94,10 +93,6 @@ def test_tpch_q2(tmp_path, check_answer, get_df):
     # Multicol sorts not implemented yet
     with start_transaction(op="task", name=f"tpch_q2:runner={get_context().runner_config.name.upper()}"):
         daft_pd_df = daft_df.to_pandas()
-    daft_pd_df = daft_pd_df.sort_values(
-        by=["S_ACCTBAL", "N_NAME", "S_NAME", "P_PARTKEY"], ascending=[False, True, True, True]
-    )
-    daft_pd_df = daft_pd_df.head(100)
     check_answer(daft_pd_df, 2, tmp_path)
 
 
@@ -107,9 +102,6 @@ def test_tpch_q3(tmp_path, check_answer, get_df):
     # Multicol sorts not implemented yet
     with start_transaction(op="task", name=f"tpch_q3:runner={get_context().runner_config.name.upper()}"):
         daft_pd_df = daft_df.to_pandas()
-    daft_pd_df = daft_pd_df.sort_values(by=["revenue", "O_ORDERDATE"], ascending=[False, True])
-    daft_pd_df = daft_pd_df.head(10)
-    daft_pd_df = daft_pd_df[["O_ORDERKEY", "revenue", "O_ORDERDATE", "O_SHIPPRIORITY"]]
     check_answer(daft_pd_df, 3, tmp_path)
 
 
@@ -144,7 +136,6 @@ def test_tpch_q7(tmp_path, check_answer, get_df):
     # Multicol sorts not implemented yet
     with start_transaction(op="task", name=f"tpch_q7:runner={get_context().runner_config.name.upper()}"):
         daft_pd_df = daft_df.to_pandas()
-    daft_pd_df = daft_pd_df.sort_values(by=["supp_nation", "cust_nation", "l_year"])
     check_answer(daft_pd_df, 7, tmp_path)
 
 
@@ -161,7 +152,6 @@ def test_tpch_q9(tmp_path, check_answer, get_df):
 
     with start_transaction(op="task", name=f"tpch_q9:runner={get_context().runner_config.name.upper()}"):
         daft_pd_df = daft_df.to_pandas()
-    daft_pd_df = daft_pd_df.sort_values(by=["N_NAME", "o_year"], ascending=[True, False])
     check_answer(daft_pd_df, 9, tmp_path)
 
 


### PR DESCRIPTION
* Implements Arrow Table multicolumn Search Sorted needed for multicolumn partitioning
* Drops np quantile for vPartition Level one. Should be able to handle NULLs.
* Enables multiblock search sorted for vPartition
* Enabled DataFrame sort where multiple columns can be sorted with `desc` set for each of them.
* TPCH queries now don't depend on pandas for multi value sorting