### PR TITLE
Fixes DataFrame.write_* to be blocking calls

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -346,7 +346,13 @@ class DataFrame:
             storage_type=StorageType.PARQUET,
             compression=compression,
         )
-        return DataFrame(plan)
+
+        # Block and write, then retrieve data and return a new disconnected DataFrame
+        write_df = DataFrame(plan)
+        write_df.collect()
+        assert write_df._result is not None
+        data = write_df._result.to_pydict()
+        return DataFrame.from_pydict(data)
 
     def write_csv(self, root_dir: str, partition_cols: Optional[List[ColumnInputType]] = None) -> DataFrame:
         """Writes the DataFrame to CSV files using a `root_dir` and randomly generated UUIDs as the filepath and returns the filepaths.
@@ -374,7 +380,13 @@ class DataFrame:
             partition_cols=cols,
             storage_type=StorageType.CSV,
         )
-        return DataFrame(plan)
+
+        # Block and write, then retrieve data and return a new disconnected DataFrame
+        write_df = DataFrame(plan)
+        write_df.collect()
+        assert write_df._result is not None
+        data = write_df._result.to_pydict()
+        return DataFrame.from_pydict(data)
 
     ###
     # DataFrame operations

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import multiprocessing
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Dict, List, Optional, Type
-
-import pandas as pd
+from typing import Callable, ClassVar, Dict, List, Type
 
 from daft.execution.execution_plan import ExecutionPlan
 from daft.execution.logical_op_runners import (
@@ -21,7 +19,6 @@ from daft.logical.optimizer import (
     PushDownLimit,
     PushDownPredicates,
 )
-from daft.logical.schema import ExpressionList
 from daft.resource_request import ResourceRequest
 from daft.runners.partitioning import PartID, PartitionManager, PartitionSet, vPartition
 from daft.runners.profiler import profiler
@@ -40,12 +37,11 @@ from daft.runners.shuffle_ops import (
 class LocalPartitionSet(PartitionSet[vPartition]):
     _partitions: Dict[PartID, vPartition]
 
-    def to_pandas(self, schema: Optional[ExpressionList] = None) -> "pd.DataFrame":
+    def _get_all_vpartitions(self) -> List[vPartition]:
         partition_ids = sorted(list(self._partitions.keys()))
         assert partition_ids[0] == 0
         assert partition_ids[-1] + 1 == len(partition_ids)
-        part_dfs = [self._partitions[pid].to_pandas(schema=schema) for pid in partition_ids]
-        return pd.concat([pdf for pdf in part_dfs if not pdf.empty], ignore_index=True)
+        return [self._partitions[pid] for pid in partition_ids]
 
     def get_partition(self, idx: PartID) -> vPartition:
         return self._partitions[idx]

--- a/tests/dataframe_cookbook/test_write.py
+++ b/tests/dataframe_cookbook/test_write.py
@@ -8,32 +8,31 @@ from tests.dataframe_cookbook.conftest import SERVICE_REQUESTS_CSV
 def test_parquet_write(tmp_path):
     df = DataFrame.from_csv(SERVICE_REQUESTS_CSV)
 
-    pd_df = df.write_parquet(tmp_path).to_pandas()
-    assert len(pd_df) == 1
+    pd_df = df.write_parquet(tmp_path)
     read_back_pd_df = DataFrame.from_parquet(tmp_path.as_posix() + "/*.parquet").to_pandas()
-
     assert_df_equals(df.to_pandas(), read_back_pd_df)
+
+    assert len(pd_df.to_pandas()) == 1
 
 
 def test_parquet_write_with_partitioning(tmp_path):
     df = DataFrame.from_csv(SERVICE_REQUESTS_CSV)
 
-    pd_df = df.write_parquet(tmp_path, partition_cols=["Borough"]).to_pandas()
-    assert len(pd_df) == 5
-
+    pd_df = df.write_parquet(tmp_path, partition_cols=["Borough"])
     read_back_pd_df = DataFrame.from_parquet(tmp_path.as_posix() + "/**/*.parquet").to_pandas()
-
     assert_df_equals(df.exclude("Borough").to_pandas(), read_back_pd_df)
+
+    assert len(pd_df.to_pandas()) == 5
 
 
 def test_csv_write(tmp_path):
     df = DataFrame.from_csv(SERVICE_REQUESTS_CSV)
 
-    pd_df = df.write_csv(tmp_path).to_pandas()
-    assert len(pd_df) == 1
+    pd_df = df.write_csv(tmp_path)
     read_back_pd_df = DataFrame.from_csv(tmp_path.as_posix() + "/*.csv").to_pandas()
-
     assert_df_equals(df.to_pandas(), read_back_pd_df)
+
+    assert len(pd_df.to_pandas()) == 1
 
 
 @pytest.mark.skip()
@@ -41,7 +40,7 @@ def test_csv_write_with_partitioning(tmp_path):
     df = DataFrame.from_csv(SERVICE_REQUESTS_CSV)
 
     pd_df = df.write_csv(tmp_path, partition_cols=["Borough"]).to_pandas()
-    assert len(pd_df) == 5
-
     read_back_pd_df = DataFrame.from_csv(tmp_path.as_posix() + "/**/*.csv").to_pandas()
     assert_df_equals(df.exclude("Borough").to_pandas(), read_back_pd_df)
+
+    assert len(pd_df.to_pandas()) == 5


### PR DESCRIPTION
* `DataFrame.write_parquet` and `DataFrame.write_parquet` are now blocking and will execute the DataFrame when called
* The new DataFrame that is returned from these calls is "disconnected" from the old one, and is manually constructed after collecting the results to the driver