### PR TITLE
Update Daft documentation for UDFs and remote execution

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -1,9 +1,9 @@
 from daft.dataframe import DataFrame
 from daft.expressions import col
 from daft.logging import setup_logger
-from daft.udf import udf
+from daft.udf import polars_udf, udf
 
-__all__ = ["DataFrame", "col", "udf"]
+__all__ = ["DataFrame", "col", "udf", "polars_udf"]
 
 setup_logger()
 

--- a/docs/source/api_docs.rst
+++ b/docs/source/api_docs.rst
@@ -7,3 +7,4 @@ API Documentation
    api_docs/expressions
    api_docs/groupby
    api_docs/udf
+   api_docs/context

--- a/docs/source/api_docs/context.rst
+++ b/docs/source/api_docs/context.rst
@@ -1,0 +1,5 @@
+Daft Context
+============
+
+.. autofunction:: daft.context.set_runner_ray
+.. autofunction:: daft.context.set_runner_py

--- a/docs/source/api_docs/udf.rst
+++ b/docs/source/api_docs/udf.rst
@@ -1,4 +1,5 @@
 User Defined Functions (UDFs)
 =============================
 
+.. autofunction:: daft.polars_udf
 .. autofunction:: daft.udf

--- a/docs/source/learn/user_guides.rst
+++ b/docs/source/learn/user_guides.rst
@@ -7,3 +7,4 @@ User Guides
     user_guides/expressions
     user_guides/udf
     user_guides/types_and_ops
+    user_guides/remote_cluster_execution

--- a/docs/source/learn/user_guides/remote_cluster_execution.rst
+++ b/docs/source/learn/user_guides/remote_cluster_execution.rst
@@ -1,0 +1,20 @@
+Remote Cluster Execution
+========================
+
+By default, Daft runs using your local machine's resources and your operations are thus limited by the CPUs, memory and GPUs available to you in your single local development machine.
+
+However, Daft has strong integrations with `Ray <https://www.ray.io>`_ which is a distributed computing framework for distributing computations across a cluster of machines. Here is a snippet showing how you can connect Daft to a Ray cluster:
+
+.. code:: python
+
+    import daft
+
+    daft.context.set_runner_ray()
+
+By default, if no address is specified Daft will spin up a Ray cluster locally on your machine. If you are running Daft on a powerful machine (such as an AWS P3 machine which is equipped with multiple GPUs) this is already very useful because Daft can parallelize its execution of computation across your CPUs and GPUs. However, if instead you already have your own Ray cluster running remotely, you can connect Daft to it by supplying an address:
+
+.. code:: python
+
+    daft.context.set_runner_ray(address="ray://url-to-mycluster")
+
+For more information about the ``address`` keyword argument, please see the `Ray documentation on initialization <https://docs.ray.io/en/latest/ray-core/package-ref.html#ray-init>`_.

--- a/docs/source/learn/user_guides/udf.rst
+++ b/docs/source/learn/user_guides/udf.rst
@@ -86,7 +86,7 @@ Daft provides an API for Stateful UDFs to do this. Stateful UDFs are just like S
 
 For example, to download and run a model on a column of images as shown in the :doc:`../quickstart` guide:
 
-.. code::python
+.. code:: python
 
     @udf(return_type=int)
     class ClassifyImages:
@@ -101,7 +101,7 @@ For example, to download and run a model on a column of images as shown in the :
 
 Running Stateful UDFs are exactly the same as running their Stateless cousins.
 
-.. code::python
+.. code:: python
 
     df = df.with_column("image_classifications", ClassifyImages(col("images")))
 
@@ -113,9 +113,9 @@ Sometimes, you may want to request for specific resources for your UDF. For exam
 
 Daft provides a simple API for indicating GPU and CPU requests.
 
-.. code::python
+.. code:: python
 
-    # Requires one GPU and two CPUs to run
+    # Requires one GPU and eight CPUs to run
     @udf(return_type=int, num_gpus=1, num_cpus=8)
     def func():
         model = get_model().cuda()


### PR DESCRIPTION
* Fix broken UDF docs codeblocks
* imports polars_udf on the toplevel daft package
* Adds new documentation for how to connect to a Ray cluster