### PR TITLE
Add `DataFrame.from_files` function

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -320,6 +320,25 @@ class DataFrame:
         )
         return cls(plan)
 
+    @classmethod
+    def from_files(cls, path: str) -> DataFrame:
+        """Creates a DataFrame from files in storage, where each file is one row of the DataFrame
+
+        Args:
+            path (str): path to files on disk (allows wildcards)
+
+        Returns:
+            DataFrame: DataFrame containing the path to each file as a row, along with other metadata
+                parsed from the provided filesystem
+        """
+        fs = get_filesystem_from_path(path)
+        file_details = fs.glob(path, detail=True)
+        return cls.from_pylist(list(file_details.values()))
+
+    ###
+    # Write methods
+    ###
+
     def write_parquet(
         self, root_dir: str, compression: str = "snappy", partition_cols: Optional[List[ColumnInputType]] = None
     ) -> DataFrame:


### PR DESCRIPTION
* Loads each file's metadata as one row. File metadata consists of name, size and anything else the underlying filesystem provides when we list files.

NOTE: File listing is potentially a very slow operation, and users should manually chunk (zip files up) where possible. Exploding zipped files into one file per row in the future could be a pretty useful operation!