### PR TITLE
Allow .with_column to override an existing column name

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -526,7 +526,7 @@ class DataFrame:
         """
         prev_schema_as_cols = self._plan.schema().to_column_expressions()
         projection = logical_plan.Projection(
-            self._plan, prev_schema_as_cols.union(ExpressionList([expr.alias(column_name)]))
+            self._plan, prev_schema_as_cols.union(ExpressionList([expr.alias(column_name)]), other_override=True)
         )
         return DataFrame(projection)
 

--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -617,7 +617,7 @@ class Join(BinaryNode):
             num_partitions = min(left.num_partitions(), right.num_partitions())
             right_id_set = self._right_on.to_id_set()
             filtered_right = [e for e in right.schema() if e.get_id() not in right_id_set]
-            schema = left.schema().union(ExpressionList(filtered_right), strict=False, rename_dup="right.")
+            schema = left.schema().union(ExpressionList(filtered_right), rename_dup="right.")
 
         left = Repartition(left, partition_by=self._left_on, num_partitions=num_partitions, scheme=PartitionScheme.HASH)
         right = Repartition(

--- a/daft/logical/optimizer.py
+++ b/daft/logical/optimizer.py
@@ -71,7 +71,7 @@ class CombineFilters(Rule[LogicalPlan]):
 
     def _combine_filters(self, parent: Filter, child: Filter) -> Filter:
         logger.debug(f"combining {parent} into {child}")
-        new_predicate = parent._predicate.union(child._predicate, strict=False)
+        new_predicate = parent._predicate.union(child._predicate, rename_dup="right.")
         grand_child = child._children()[0]
         return Filter(grand_child, new_predicate)
 
@@ -109,7 +109,7 @@ class PushDownClausesIntoScan(Rule[LogicalPlan]):
         self.register_fn(Projection, Scan, self._push_down_projections_into_scan)
 
     def _push_down_predicates_into_scan(self, parent: Filter, child: Scan) -> Scan:
-        new_predicate = parent._predicate.union(child._predicate, strict=False)
+        new_predicate = parent._predicate.union(child._predicate, rename_dup="right.")
         child_schema = child.schema()
         assert new_predicate.required_columns().to_id_set().issubset(child_schema.to_id_set())
         return Scan(

--- a/tests/dataframe_cookbook/test_computations.py
+++ b/tests/dataframe_cookbook/test_computations.py
@@ -16,6 +16,20 @@ def test_add_one_to_column(daft_df, service_requests_csv_pd_df, repartition_npar
     assert_df_equals(daft_pd_df, service_requests_csv_pd_df)
 
 
+@parametrize_service_requests_csv_repartition
+@parametrize_service_requests_csv_daft_df
+def test_add_one_to_column_name_override(daft_df, service_requests_csv_pd_df, repartition_nparts):
+    """Creating a new column that is derived from (1 + other_column) and retrieving the top N results"""
+    daft_df = (
+        daft_df.repartition(repartition_nparts)
+        .with_column("Unique Key", col("Unique Key") + 1)
+        .with_column("Unique Key", col("Unique Key") + 1)
+    )
+    service_requests_csv_pd_df["Unique Key"] = service_requests_csv_pd_df["Unique Key"] + 2
+    daft_pd_df = daft_df.to_pandas()
+    assert_df_equals(daft_pd_df, service_requests_csv_pd_df)
+
+
 @parametrize_service_requests_csv_daft_df
 def test_add_one_to_column_limit(daft_df, service_requests_csv_pd_df):
     """Creating a new column that is derived from (1 + other_column) and retrieving the top N results"""


### PR DESCRIPTION
* `df.with_column("foo", ...)` now works even if `"foo"` is an existing column - it overrides the existing column in the dataframe