### PR TITLE
Fix ExpressionExecutor eval's dispatching of OperatorEvaluator

### DIFF
--- a/daft/expressions.py
+++ b/daft/expressions.py
@@ -20,12 +20,7 @@ from typing import (
 
 from daft.errors import ExpressionTypeError
 from daft.execution import url_operators
-from daft.execution.operators import (
-    ExpressionOperator,
-    ExpressionType,
-    OperatorEnum,
-    PythonExpressionType,
-)
+from daft.execution.operators import ExpressionOperator, ExpressionType, OperatorEnum
 from daft.internal.treenode import TreeNode
 from daft.resource_request import ResourceRequest
 from daft.runners.blocks import (
@@ -91,7 +86,7 @@ class ExpressionExecutor:
             # Use a PyListDataBlock evaluator if any of the args are Python types
             op_evaluator = (
                 PyListDataBlock.evaluator
-                if any([isinstance(arg.resolved_type(), PythonExpressionType) for arg in expr._args])
+                if any(isinstance(block, PyListDataBlock) for block in eval_args)
                 else ArrowDataBlock.evaluator
             )
             op = expr._operator

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -678,15 +678,21 @@ def arrow_floordiv(arr, m):
 
 
 def arrow_str_contains(arr: pa.ChunkedArray, pattern: pa.StringScalar):
+    if pa.types.is_null(arr.type):
+        return arr
     substring_counts = pac.count_substring(arr, pattern=pattern.as_py())
     return pac.not_equal(substring_counts, pa.scalar(0))
 
 
 def arrow_str_endswith(arr: pa.ChunkedArray, pattern: pa.StringScalar):
+    if pa.types.is_null(arr.type):
+        return arr
     return pac.ends_with(arr, pattern=pattern.as_py())
 
 
 def arrow_str_startswith(arr: pa.ChunkedArray, pattern: pa.StringScalar):
+    if pa.types.is_null(arr.type):
+        return arr
     return pac.starts_with(arr, pattern=pattern.as_py())
 
 

--- a/tests/dataframe_cookbook/test_python_list_cols.py
+++ b/tests/dataframe_cookbook/test_python_list_cols.py
@@ -139,6 +139,20 @@ def test_python_dict_udf_merge_dicts(repartition_nparts, merge_dicts):
     assert_df_equals(daft_pd_df, pd_df, sort_key="id")
 
 
+@pytest.mark.parametrize("repartition_nparts", [1, 5, 6, 10, 11])
+def test_python_chained_expression_calls(repartition_nparts):
+    data = {"id": [i for i in range(10)], "dicts": [{"foo": str(i)} for i in range(10)]}
+    daft_df = (
+        DataFrame.from_pydict(data)
+        .repartition(repartition_nparts)
+        .with_column("foo_starts_with_1", col("dicts").as_py(dict)["foo"].str.startswith("1"))
+    )
+    pd_df = pd.DataFrame.from_dict(data)
+    pd_df["foo_starts_with_1"] = pd.Series([d["foo"] for d in pd_df["dicts"]]).str.startswith("1")
+    daft_pd_df = daft_df.to_pandas()
+    assert_df_equals(daft_pd_df, pd_df, sort_key="id")
+
+
 ###
 # Using np.ndarray as an object
 ###


### PR DESCRIPTION
* Instead of using the expression types for deciding which OperatorEvaluator to use, we use the runtime type of the block. This ensures that we will select the most efficient and correct kernel to use, even if our typing system is wrong

For instance, running `col("foo").as_py(Foo).name.str.contains("bar")` will fail, even if all the Foo objects actually do contain a string name.