### PR TITLE
Update docs to reflect yanked 0.0.12 version

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,4 +3,4 @@ Release Notes
 
 .. toctree::
 
-    v0.0.12 <release_notes/0.0.12>
+    v0.0.13 <release_notes/0.0.13>

--- a/docs/source/release_notes/0.0.13.rst
+++ b/docs/source/release_notes/0.0.13.rst
@@ -1,7 +1,7 @@
-Daft 0.0.12 Release Notes
+Daft 3 Release Notes
 =========================
 
-The Daft 0.0.12 release fixes some issues with typing and adds new functionality for loading from files on disk. The highlights are:
+The Daft 0.0.13 release fixes some issues with typing and adds new functionality for loading from files on disk. The highlights are:
 
 * Improved unified API + User documentation published on www.getdaft.io
 * Adds support for multi-column ``DataFrame.sort``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "getdaft"
-version = "0.0.12" # needed for poetry but ignored
+version = "0.0.13" # needed for poetry but ignored
 description = "A Distributed DataFrame library for large scale complex data processing."
 authors = ["Eventual Inc <daft@eventualcomputing.com>"]
 maintainers = [


### PR DESCRIPTION
* v0.0.12 was yanked from PyPi due to some build issues
* Docs are updated to start the changelog at 0.0.13 instead