### PR TITLE
DataFrame Global Aggs API

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -825,6 +825,60 @@ class DataFrame:
         assert len(cols) > 0, "no columns were passed in"
         return self._agg([(c, "mean") for c in cols])
 
+    def min(self, *cols: ColumnInputType) -> DataFrame:
+        """Performs a global min on the DataFrame on a sequence of columns.
+
+        Args:
+            *cols (Union[str, Expression]): columns to min
+        Returns:
+            DataFrame: Globally aggregated min. Should be a single row.
+        """
+        assert len(cols) > 0, "no columns were passed in"
+        return self._agg([(c, "min") for c in cols])
+
+    def max(self, *cols: ColumnInputType) -> DataFrame:
+        """Performs a global max on the DataFrame on a sequence of columns.
+
+        Args:
+            *cols (Union[str, Expression]): columns to max
+        Returns:
+            DataFrame: Globally aggregated max. Should be a single row.
+        """
+        assert len(cols) > 0, "no columns were passed in"
+        return self._agg([(c, "max") for c in cols])
+
+    def count(self, *cols: ColumnInputType) -> DataFrame:
+        """Performs a global count on the DataFrame on a sequence of columns.
+
+        Args:
+            *cols (Union[str, Expression]): columns to count
+        Returns:
+            DataFrame: Globally aggregated count. Should be a single row.
+        """
+        assert len(cols) > 0, "no columns were passed in"
+        return self._agg([(c, "count") for c in cols])
+
+    def agg(self, to_agg: List[Tuple[ColumnInputType, str]]) -> DataFrame:
+        """Perform aggregations on this DataFrame. Allows for mixed aggregations for multiple columns
+        Will return a single row that aggregated the entire DataFrame.
+
+        Example:
+        >>> df = df.agg([
+        >>>     ('x', 'sum'),
+        >>>     ('x', 'mean'),
+        >>>     ('y', 'min'),
+        >>>     ('y', 'max'),
+        >>>     (col('x') + col('y'), 'max'),
+        >>> ])
+
+        Args:
+            to_agg (List[Tuple[ColumnInputType, str]]): list of (column, agg_type)
+
+        Returns:
+            DataFrame: DataFrame with aggregated results
+        """
+        return self._agg(to_agg, group_by=None)
+
     def groupby(self, *group_by: ColumnInputType) -> GroupedDataFrame:
         """Performs a GroupBy on the DataFrame for Aggregation.
 
@@ -892,6 +946,29 @@ class GroupedDataFrame:
         """
 
         return self.df._agg([(c, "mean") for c in cols], group_by=self.group_by)
+
+    def min(self, *cols: ColumnInputType) -> DataFrame:
+        """Perform grouped min on this GroupedDataFrame.
+
+        Args:
+            *cols (Union[str, Expression]): columns to min
+
+        Returns:
+            DataFrame: DataFrame with grouped min.
+        """
+        return self.df._agg([(c, "min") for c in cols], group_by=self.group_by)
+
+    def max(self, *cols: ColumnInputType) -> DataFrame:
+        """Performs grouped max on this GroupedDataFrame.
+
+        Args:
+            *cols (Union[str, Expression]): columns to max
+
+        Returns:
+            DataFrame: DataFrame with grouped max.
+        """
+
+        return self.df._agg([(c, "max") for c in cols], group_by=self.group_by)
 
     def agg(self, to_agg: List[Tuple[ColumnInputType, str]]) -> DataFrame:
         """Perform aggregations on this GroupedDataFrame. Allows for mixed aggregations.

--- a/daft/execution/operators.py
+++ b/daft/execution/operators.py
@@ -73,6 +73,17 @@ _BinaryNumericalTM = frozenset(
     }.items()
 )
 
+_ComparableTM = frozenset(
+    {
+        (ExpressionType.integer(),): ExpressionType.integer(),
+        (ExpressionType.logical(),): ExpressionType.logical(),
+        (ExpressionType.float(),): ExpressionType.float(),
+        (ExpressionType.string(),): ExpressionType.string(),
+        (ExpressionType.date(),): ExpressionType.date(),
+        (ExpressionType.bytes(),): ExpressionType.bytes(),
+    }.items()
+)
+
 _ComparisionTM = frozenset(
     {
         (ExpressionType.integer(), ExpressionType.integer()): ExpressionType.logical(),
@@ -84,6 +95,7 @@ _ComparisionTM = frozenset(
         (ExpressionType.bytes(), ExpressionType.bytes()): ExpressionType.logical(),
     }.items()
 )
+
 
 _BinaryLogicalTM = frozenset(
     {
@@ -168,6 +180,8 @@ _NBop = partial(_BOp, type_matrix=_BinaryNumericalTM)
 # Comparison Binary Ops
 _CBop = partial(_BOp, type_matrix=_ComparisionTM)
 
+_ComparibleUop = partial(_UOp, type_matrix=_ComparableTM)
+
 # Logical Binary Ops
 _LBop = partial(_BOp, type_matrix=_BinaryLogicalTM)
 
@@ -188,8 +202,8 @@ class OperatorEnum(Enum):
     # Reductions
     SUM = _NUop(name="sum", symbol="sum")
     MEAN = _NUop(name="mean", symbol="mean")
-    MIN = _NUop(name="min", symbol="min")
-    MAX = _NUop(name="max", symbol="max")
+    MIN = _ComparibleUop(name="min", symbol="min")
+    MAX = _ComparibleUop(name="max", symbol="max")
 
     COUNT = _UOp(name="count", symbol="count", type_matrix=_CountLogicalTM)
 

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -645,7 +645,6 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
             return DataBlock.make_block(data=pa.chunked_array([seed_arr]))
 
     def agg(self, op: str) -> DataBlock[ArrowArrType]:
-
         if op == "sum":
             if len(self) == 0:
                 return ArrowDataBlock(data=pa.chunked_array([[]], type=self.data.type))
@@ -658,7 +657,14 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
             if len(self) == 0:
                 return ArrowDataBlock(data=pa.chunked_array([[]], type=pa.int64()))
             return ArrowDataBlock(data=pa.chunked_array([[pac.count(self.data).as_py()]]))
-
+        elif op == "min":
+            if len(self) == 0:
+                return ArrowDataBlock(data=pa.chunked_array([[]], type=self.data.type))
+            return ArrowDataBlock(data=pa.chunked_array([[pac.min(self.data).as_py()]], type=self.data.type))
+        elif op == "max":
+            if len(self) == 0:
+                return ArrowDataBlock(data=pa.chunked_array([[]], type=self.data.type))
+            return ArrowDataBlock(data=pa.chunked_array([[pac.max(self.data).as_py()]], type=self.data.type))
         else:
             raise NotImplementedError(op)
 


### PR DESCRIPTION
* Enables `agg` method on DataFrame which allows for mixed aggregation without groups
* Enables min/max aggregation on other dtypes besides numeric
* Introduces Bug with min/max on string in a grouped aggregation. Must push a fix to Polars
* adds min/max syntactic sugar to DataFrame and GroupedDataFrame