### PR TITLE
GetItem semantic to select from DataFrame

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -437,6 +437,49 @@ class DataFrame:
         expressions = [col(c) if isinstance(c, str) else c for c in columns]
         return ExpressionList(expressions)
 
+    def __getitem__(
+        self, item: Union[slice, int, str, Iterable[Union[str, int]]]
+    ) -> Union[ColumnExpression, List[ColumnExpression]]:
+        result: Optional[ColumnExpression]
+
+        if isinstance(item, int):
+            exprs = self._plan.schema()
+            if item < -len(exprs.exprs) or item >= len(exprs.exprs):
+                raise ValueError(f"{item} out of bounds for {exprs.exprs}")
+            result = exprs.exprs[item]
+            assert result is not None
+            return result.to_column_expression()
+        elif isinstance(item, str):
+            exprs = self._plan.schema()
+            result = exprs.get_expression_by_name(item)
+            if result is None:
+                raise ValueError(f"{item} not found in DataFrame schema {exprs}")
+            assert result is not None
+            return result.to_column_expression()  # type: ignore
+        elif isinstance(item, Iterable):
+            exprs = self._plan.schema()
+            columns = []
+            for it in item:
+                if isinstance(it, str):
+                    result = exprs.get_expression_by_name(it)
+                    if result is None:
+                        raise ValueError(f"{it} not found in DataFrame schema {exprs}")
+                    columns.append(result)
+                elif isinstance(it, int):
+                    if it < -len(exprs.exprs) or it >= len(exprs.exprs):
+                        raise ValueError(f"{it} out of bounds for {exprs.exprs}")
+                    result = exprs.exprs[it]
+                    assert result is not None
+                    columns.append(result.to_column_expression())
+                else:
+                    raise ValueError(f"unknown indexing type: {it}")
+            return columns
+        elif isinstance(item, slice):
+            exprs = self._plan.schema()
+            return [val.to_column_expression() for val in exprs.exprs[item]]
+        else:
+            raise ValueError(f"Unknown type {type(item)} for indexing")
+
     def select(self, *columns: ColumnInputType) -> DataFrame:
         """Creates a new DataFrame that `selects` that columns that are passed in from the current DataFrame.
 

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -7,13 +7,13 @@ from daft.dataframe import DataFrame
 
 def test_create_dataframe(valid_data: List[Dict[str, float]]) -> None:
     df = DataFrame.from_pylist(valid_data)
-    assert df.column_names() == ["sepal_length", "sepal_width", "petal_length", "petal_width", "variety"]
+    assert df.column_names == ["sepal_length", "sepal_width", "petal_length", "petal_width", "variety"]
 
 
 def test_create_dataframe_pydict(valid_data: List[Dict[str, float]]) -> None:
     pydict = {k: [item[k] for item in valid_data] for k in valid_data[0].keys()}
     df = DataFrame.from_pydict(pydict)
-    assert df.column_names() == ["sepal_length", "sepal_width", "petal_length", "petal_width", "variety"]
+    assert df.column_names == ["sepal_length", "sepal_width", "petal_length", "petal_width", "variety"]
 
 
 def test_create_dataframe_csv(valid_data: List[Dict[str, float]]) -> None:
@@ -25,7 +25,7 @@ def test_create_dataframe_csv(valid_data: List[Dict[str, float]]) -> None:
         f.flush()
 
         df = DataFrame.from_csv(f.name)
-        assert df.column_names() == [
+        assert df.column_names == [
             "sepal_length",
             "sepal_width",
             "petal_length",

--- a/tests/dataframe/test_filter.py
+++ b/tests/dataframe/test_filter.py
@@ -28,7 +28,7 @@ def test_filter_pushdown_select(valid_data: List[Dict[str, float]], optimizer) -
     df = DataFrame.from_pylist(valid_data)
     unoptimized = df.select("sepal_length", "sepal_width").where(col("sepal_length") > 4.8)
     optimized = df.where(col("sepal_length") > 4.8).select("sepal_length", "sepal_width")
-    assert unoptimized.column_names() == ["sepal_length", "sepal_width"]
+    assert unoptimized.column_names == ["sepal_length", "sepal_width"]
     assert optimizer(unoptimized.plan()).is_eq(optimized.plan())
 
 
@@ -36,7 +36,7 @@ def test_filter_pushdown_with_column(valid_data: List[Dict[str, float]], optimiz
     df = DataFrame.from_pylist(valid_data)
     unoptimized = df.with_column("foo", col("sepal_length") + 1).where(col("sepal_length") > 4.8)
     optimized = df.where(col("sepal_length") > 4.8).with_column("foo", col("sepal_length") + 1)
-    assert unoptimized.column_names() == [*df.column_names(), "foo"]
+    assert unoptimized.column_names == [*df.column_names, "foo"]
     assert optimizer(unoptimized.plan()).is_eq(optimized.plan())
 
 
@@ -58,5 +58,5 @@ def test_filter_pushdown_sort(valid_data: List[Dict[str, float]], optimizer) -> 
     df = DataFrame.from_pylist(valid_data)
     unoptimized = df.sort("sepal_length").select("sepal_length", "sepal_width").where(col("sepal_length") > 4.8)
     optimized = df.where(col("sepal_length") > 4.8).sort("sepal_length").select("sepal_length", "sepal_width")
-    assert unoptimized.column_names() == ["sepal_length", "sepal_width"]
+    assert unoptimized.column_names == ["sepal_length", "sepal_width"]
     assert optimizer(unoptimized.plan()).is_eq(optimized.plan())

--- a/tests/dataframe/test_projection.py
+++ b/tests/dataframe/test_projection.py
@@ -67,3 +67,31 @@ def test_with_column(valid_data: List[Dict[str, float]]) -> None:
     expanded_df = df.with_column("foo", expr)
     # TODO(jay): Test that the expression with name "foo" is equal to the expected expression, except for the IDs of the columns
     assert expanded_df.column_names() == df.schema().column_names() + ["foo"]
+
+
+def test_dataframe_getitem_single(valid_data: List[Dict[str, float]]) -> None:
+    df = DataFrame.from_pylist(valid_data)
+    expanded_df = df.with_column("foo", df["sepal_length"] + df["sepal_width"])
+    # TODO(jay): Test that the expression with name "foo" is equal to the expected expression, except for the IDs of the columns
+    assert expanded_df.column_names() == df.schema().column_names() + ["foo"]
+    assert df.select(df["sepal_length"]).column_names() == ["sepal_length"]
+
+
+def test_dataframe_getitem_multiple(valid_data: List[Dict[str, float]]) -> None:
+    df = DataFrame.from_pylist(valid_data)
+    expanded_df = df.with_column("foo", sum(df["sepal_length", "sepal_width"]))
+    # TODO(jay): Test that the expression with name "foo" is equal to the expected expression, except for the IDs of the columns
+    assert expanded_df.column_names() == df.schema().column_names() + ["foo"]
+    assert df.select(*df["sepal_length", "sepal_width"]).column_names() == ["sepal_length", "sepal_width"]
+
+
+def test_dataframe_getitem_slice(valid_data: List[Dict[str, float]]) -> None:
+    df = DataFrame.from_pylist(valid_data)
+    slice_df = df.select(*df[:])
+    assert df.column_names() == slice_df.column_names()
+
+
+def test_dataframe_getitem_slice_rev(valid_data: List[Dict[str, float]]) -> None:
+    df = DataFrame.from_pylist(valid_data)
+    slice_df = df.select(*df[::-1])
+    assert df.column_names() == slice_df.column_names()[::-1]

--- a/tests/dataframe/test_scan.py
+++ b/tests/dataframe/test_scan.py
@@ -48,7 +48,7 @@ def test_projection_scan_pushdown(valid_data: List[Dict[str, float]], optimizer)
     df = DataFrame.from_pylist(valid_data)
     original_schema = df._plan.schema()
     df = df.select(*selected_columns)
-    assert df.column_names() == selected_columns
+    assert df.column_names == selected_columns
 
     optimized = optimizer(df.plan())
     expected = logical_plan.Scan(


### PR DESCRIPTION
* Allows for getitem selection from a DataFrame
`df['foo', 'bar']` to subselect columns as well as `df[0,1] or df[::-1]` 
* adds a column and column names property [changes method for column names to property]