### PR TITLE
Fixes and unit tests for aggregations on null items

### DIFF
--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -604,10 +604,12 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
 
     @staticmethod
     def _merge_blocks(blocks: List[DataBlock[ArrowArrType]]) -> DataBlock[ArrowArrType]:
+        block_types = {block.data.type for block in blocks}
+        assert len(block_types) == 1, f"Unable to merge blocks of different types: {block_types}"
         all_chunks = []
         for block in blocks:
             all_chunks.extend(block.data.chunks)
-        return DataBlock.make_block(pa.chunked_array(all_chunks))
+        return DataBlock.make_block(pa.chunked_array(all_chunks, type=block_types.pop()))
 
     def _make_empty(self) -> DataBlock[ArrowArrType]:
         return DataBlock.make_block(data=pa.chunked_array([[]], type=self.data.type))

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -648,7 +648,7 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
         if op == "sum":
             if len(self) == 0:
                 return ArrowDataBlock(data=pa.chunked_array([[]], type=self.data.type))
-            return ArrowDataBlock(data=pa.chunked_array([[pac.sum(self.data).as_py()]]))
+            return ArrowDataBlock(data=pa.chunked_array([[pac.sum(self.data, min_count=0).as_py()]]))
         elif op == "mean":
             if len(self) == 0:
                 return ArrowDataBlock(data=pa.chunked_array([[]], type=pa.float64()))
@@ -697,7 +697,7 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
                 exprs.append(pl.max(an))
                 agg_expected_arrow_type.append(arr.type)
             elif op == "count":
-                exprs.append(pl.count(an))
+                exprs.append(pl.col(an).is_not_null().sum().alias(an))
                 agg_expected_arrow_type.append(pa.int64())
             else:
                 raise NotImplementedError()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 import argparse
 import os
-from typing import List, Type, Union
+from typing import Dict, List, Type, Union
 
 import pandas as pd
 import pyarrow as pa
+import pyarrow.compute as pac
 import pytest
 
 from daft.context import get_context
@@ -139,3 +140,82 @@ def assert_df_equals(
         except AssertionError:
             print(f"Failed assertion for col: {col}")
             raise
+
+
+def assert_arrow_equals(
+    daft_columns: Dict[str, Union[pa.Array, pa.ChunkedArray]],
+    expected_columns: Dict[str, Union[pa.Array, pa.ChunkedArray]],
+    sort_key: Union[str, List[str]] = "id",
+    assert_ordering: bool = False,
+):
+    """Asserts that two dictionaries of columns are equal.
+    By default, we do not assert that the ordering is equal and will sort the columns according to `sort_key`.
+    However, if asserting on ordering is intended behavior, set `assert_ordering=True` and this function will
+    no longer run sorting before running the equality comparison.
+    """
+    if not assert_ordering:
+        sort_key_list: List[str] = [sort_key] if isinstance(sort_key, str) else sort_key
+        for key in sort_key_list:
+            assert key in daft_columns, (
+                f"DaFt Data missing key: {key}\nNOTE: This doesn't necessarily mean your code is "
+                "breaking, but our testing utilities require sorting on this key in order to compare your "
+                "Dataframe against the expected Data."
+            )
+            assert key in expected_columns, (
+                f"Expectred Data missing key: {key}\nNOTE: This doesn't necessarily mean your code is "
+                "breaking, but our testing utilities require sorting on this key in order to compare your "
+                "Dataframe against the expected Data."
+            )
+        daft_sort_indices = pac.sort_indices(
+            pa.Table.from_pydict(daft_columns), sort_keys=[(k, "ascending") for k in sort_key_list]
+        )
+        expected_sort_indices = pac.sort_indices(
+            pa.Table.from_pydict(expected_columns), sort_keys=[(k, "ascending") for k in sort_key_list]
+        )
+
+    assert sorted(daft_columns.keys()) == sorted(
+        expected_columns.keys()
+    ), f"Found {daft_columns.keys()} expected {expected_columns.keys()}"
+    for col in daft_columns.keys():
+
+        daft_arr: pa.Array
+        if isinstance(daft_columns[col], pa.ChunkedArray) and daft_columns[col].num_chunks > 0:
+            daft_arr = daft_columns[col].combine_chunks()
+        elif isinstance(daft_columns[col], pa.ChunkedArray):
+            daft_arr = pa.array([], type=daft_columns[col].type)
+        else:
+            daft_arr = daft_columns[col]
+        daft_arr = pac.array_take(daft_arr, daft_sort_indices)
+
+        expected_arr: pa.Array
+        if isinstance(expected_columns[col], pa.ChunkedArray) and expected_columns[col].num_chunks > 0:
+            expected_arr = expected_columns[col].combine_chunks()
+        elif isinstance(expected_columns[col], pa.ChunkedArray):
+            expected_arr = pa.array([], type=expected_columns[col].type)
+        else:
+            expected_arr = expected_columns[col]
+        expected_arr = pac.array_take(expected_arr, expected_sort_indices)
+
+        assert len(daft_arr) == len(expected_arr), f"{col} failed length check: {len(daft_arr)} vs {len(expected_arr)}"
+
+        # Float types NaNs do not equal each other, so we special-case floating arrays by checking that they are NaN in
+        # the same indices, and then filtering out the NaN indices when checking equality
+        assert expected_arr.type == daft_arr.type, f"{col} failed type check: {daft_arr.type} vs {expected_arr.type}"
+        nan_indices = None
+        if pa.types.is_floating(expected_arr.type):
+            assert pac.all(
+                pac.equal(pac.is_nan(daft_arr), pac.is_nan(expected_arr))
+            ), f"{col} failed NaN check: {daft_arr} vs {expected_arr}"
+            nan_indices = pac.is_nan(daft_arr)
+
+        arr_eq = pac.equal(daft_arr, expected_arr)
+        if nan_indices is not None:
+            arr_eq = pac.array_filter(arr_eq, pac.invert(nan_indices))
+
+        # No elements to compare
+        if pac.all(arr_eq).as_py() is None:
+            continue
+
+        assert pac.all(
+            arr_eq
+        ).as_py(), f"{col} failed equality check: {daft_arr} vs {expected_arr} (equality array={arr_eq})"

--- a/tests/dataframe_cookbook/test_filter.py
+++ b/tests/dataframe_cookbook/test_filter.py
@@ -33,7 +33,7 @@ COL_SUBSET = ["Unique Key", "Complaint Type", "Borough", "Descriptor"]
         ),
     ],
 )
-def test_sum(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts):
+def test_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts):
     """Filter the dataframe, retrieve the top N results and select a subset of columns"""
 
     daft_noise_complaints = daft_df_ops(daft_df.repartition(repartition_nparts))
@@ -88,7 +88,7 @@ def test_sum(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_npart
         ),
     ],
 )
-def test_sum(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts):
+def test_complex_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts):
     """Filter the dataframe with a complex filter and select a subset of columns"""
     daft_noise_complaints_brooklyn = daft_df_ops(daft_df.repartition(repartition_nparts))
 
@@ -136,7 +136,7 @@ def test_sum(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_npart
         ),
     ],
 )
-def test_sum(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts):
+def test_chain_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts):
     """Filter the dataframe with a chain of filters and select a subset of columns"""
     daft_noise_complaints_brooklyn = daft_df_ops(daft_df.repartition(repartition_nparts))
 

--- a/tests/null_tests/test_aggregations.py
+++ b/tests/null_tests/test_aggregations.py
@@ -1,0 +1,204 @@
+import pyarrow as pa
+import pytest
+
+from daft import DataFrame, col
+from tests.conftest import assert_arrow_equals
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
+def test_agg_global(repartition_nparts):
+    daft_df = DataFrame.from_pydict(
+        {
+            "id": [1, 2, 3],
+            "values": [1, None, 2],
+        }
+    )
+    daft_df = daft_df.repartition(repartition_nparts).agg(
+        [
+            (col("values").alias("sum"), "sum"),
+            (col("values").alias("mean"), "mean"),
+            (col("values").alias("min"), "min"),
+            (col("values").alias("max"), "max"),
+            (col("values").alias("count"), "count"),
+        ]
+    )
+    expected_arrow_table = {
+        "sum": pa.array([3]),
+        "mean": pa.array([1.5], type=pa.float64()),
+        "min": pa.array([1], type=pa.int64()),
+        "max": pa.array([2], type=pa.int64()),
+        "count": pa.array([2], type=pa.int64()),
+    }
+    daft_df.collect()
+    assert_arrow_equals(daft_df._result.to_pydict(), expected_arrow_table, sort_key="sum")
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
+def test_agg_global_all_null(repartition_nparts):
+    daft_df = DataFrame.from_pydict(
+        {
+            "id": [0, 1, 2, 3],
+            "values": [1, None, None, None],
+        }
+    )
+    daft_df = (
+        daft_df.where(col("id") != 0)
+        .repartition(repartition_nparts)
+        .agg(
+            [
+                (col("values").alias("sum"), "sum"),
+                (col("values").alias("mean"), "mean"),
+                (col("values").alias("min"), "min"),
+                (col("values").alias("max"), "max"),
+                (col("values").alias("count"), "count"),
+            ]
+        )
+    )
+    expected_arrow_table = {
+        "sum": pa.array([0]),
+        "mean": pa.array([float("nan")]),
+        "min": pa.array([None], type=pa.int64()),
+        "max": pa.array([None], type=pa.int64()),
+        "count": pa.array([0]),
+    }
+    daft_df.collect()
+    assert_arrow_equals(daft_df._result.to_pydict(), expected_arrow_table, sort_key="sum")
+
+
+def test_agg_global_empty():
+    daft_df = DataFrame.from_pydict(
+        {
+            "id": [0],
+            "values": [1],
+        }
+    )
+    daft_df = (
+        daft_df.where(col("id") != 0)
+        .repartition(2)
+        .agg(
+            [
+                (col("values").alias("sum"), "sum"),
+                (col("values").alias("mean"), "mean"),
+                (col("values").alias("min"), "min"),
+                (col("values").alias("max"), "max"),
+                (col("values").alias("count"), "count"),
+            ]
+        )
+    )
+    expected_arrow_table = {
+        "sum": pa.array([], type=pa.int64()),
+        "mean": pa.array([], type=pa.float64()),
+        "min": pa.array([], type=pa.int64()),
+        "max": pa.array([], type=pa.int64()),
+        "count": pa.array([], type=pa.int64()),
+    }
+    daft_df.collect()
+    assert_arrow_equals(daft_df._result.to_pydict(), expected_arrow_table, sort_key="sum")
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 7])
+def test_agg_groupby(repartition_nparts):
+    daft_df = DataFrame.from_pydict(
+        {
+            "group": [1, 1, 1, 2, 2, 2],
+            "values": [1, None, 2, 2, None, 4],
+        }
+    )
+    daft_df = (
+        daft_df.repartition(repartition_nparts)
+        .groupby("group")
+        .agg(
+            [
+                (col("values").alias("sum"), "sum"),
+                (col("values").alias("mean"), "mean"),
+                (col("values").alias("min"), "min"),
+                (col("values").alias("max"), "max"),
+                (col("values").alias("count"), "count"),
+            ]
+        )
+    )
+    expected_arrow_table = {
+        "group": pa.array([1, 2]),
+        "sum": pa.array([3, 6]),
+        "mean": pa.array([1.5, 3], type=pa.float64()),
+        "min": pa.array([1, 2], type=pa.int64()),
+        "max": pa.array([2, 4], type=pa.int64()),
+        "count": pa.array([2, 2], type=pa.int64()),
+    }
+    daft_df.collect()
+    assert_arrow_equals(daft_df._result.to_pydict(), expected_arrow_table, sort_key="group")
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 5])
+def test_agg_groupby_all_null(repartition_nparts):
+    daft_df = DataFrame.from_pydict(
+        {
+            "id": [0, 1, 2, 3, 4],
+            "group": [0, 1, 1, 2, 2],
+            "values": [1, None, None, None, None],
+        }
+    )
+    # Remove the first row so that all values are Null
+    daft_df = daft_df.where(col("id") != 0).repartition(repartition_nparts)
+    daft_df = (
+        daft_df.groupby(col("group"))
+        .agg(
+            [
+                (col("values").alias("sum"), "sum"),
+                (col("values").alias("mean"), "mean"),
+                (col("values").alias("min"), "min"),
+                (col("values").alias("max"), "max"),
+                (col("values").alias("count"), "count"),
+            ]
+        )
+        .sort(col("group"))
+    )
+
+    expected_arrow_table = {
+        "group": pa.array([1, 2]),
+        "sum": pa.array([0, 0]),
+        "mean": pa.array([float("nan"), float("nan")]),
+        "min": pa.array([None, None], type=pa.int64()),
+        "max": pa.array([None, None], type=pa.int64()),
+        "count": pa.array([0, 0]),
+    }
+
+    daft_df.collect()
+    assert_arrow_equals(daft_df._result.to_pydict(), expected_arrow_table, sort_key="group")
+
+
+def test_agg_groupby_empty():
+    daft_df = DataFrame.from_pydict(
+        {
+            "id": [0],
+            "group": [0],
+            "values": [1],
+        }
+    )
+    # Remove the first row so that dataframe is empty
+    daft_df = daft_df.where(col("id") != 0).repartition(2)
+    daft_df = (
+        daft_df.groupby(col("group"))
+        .agg(
+            [
+                (col("values").alias("sum"), "sum"),
+                (col("values").alias("mean"), "mean"),
+                (col("values").alias("min"), "min"),
+                (col("values").alias("max"), "max"),
+                (col("values").alias("count"), "count"),
+            ]
+        )
+        .sort(col("group"))
+    )
+
+    expected_arrow_table = {
+        "group": pa.array([], type=pa.int64()),
+        "sum": pa.array([], type=pa.int64()),
+        "mean": pa.array([], type=pa.float64()),
+        "min": pa.array([], type=pa.int64()),
+        "max": pa.array([], type=pa.int64()),
+        "count": pa.array([], type=pa.int64()),
+    }
+
+    daft_df.collect()
+    assert_arrow_equals(daft_df._result.to_pydict(), expected_arrow_table, sort_key="group")


### PR DESCRIPTION
* Fix issue in `merge_blocks` where merging empty blocks would throw an error because we do not properly propagate the block types
* Fix global sum when all values are null in a partition, to return 0 instead of null
* Fix groupby count to properly return number of non-null rows instead of a count of all rows