### PR TITLE
Search Sorted Offset Fix for Arrow Views

### DIFF
--- a/daft/experimental/schema.py
+++ b/daft/experimental/schema.py
@@ -166,7 +166,7 @@ _T = TypeVar("_T")
 
 
 class DaftSchema(Generic[_T]):
-    primative_translation = {
+    primitive_translation = {
         int: TBT(0, pa.int64, int),
         float: TBT(0, pa.float32, float),
         str: TBT(0, pa.string, str),
@@ -263,8 +263,8 @@ class DaftSchema(Generic[_T]):
 
     @classmethod
     def parse_type(cls, name: str, t: Type) -> pa.Field:
-        if t in cls.primative_translation:
-            nargs, f, source_type, conversion = cls.primative_translation[t]
+        if t in cls.primitive_translation:
+            nargs, f, source_type, conversion = cls.primitive_translation[t]
             return pa.field(name, f()).with_metadata(cls.type_to_metadata(source_type, conversion))
 
         if get_origin(t) is not None:

--- a/daft/internal/kernels/hashing.cc
+++ b/daft/internal/kernels/hashing.cc
@@ -19,7 +19,7 @@ namespace bit_util = arrow::bit_util;
 #endif
 
 template <int64_t WordSize>
-struct HashingPrimativeArray {
+struct HashingPrimitiveArray {
   static void Exec(const arrow::ArrayData *arr, const arrow::ArrayData *seed, arrow::ArrayData *result) {
     const int64_t arr_len = arr->length;
     const int64_t bit_offset = arr->offset;
@@ -109,20 +109,20 @@ struct HashingBinaryArray {
   }
 };
 
-void hash_primative_array(const arrow::ArrayData *arr, const arrow::ArrayData *seed, arrow::ArrayData *result) {
+void hash_primitive_array(const arrow::ArrayData *arr, const arrow::ArrayData *seed, arrow::ArrayData *result) {
   switch (arrow::bit_width(arr->type->id()) >> 3) {
     case 1:
-      return HashingPrimativeArray<1>::Exec(arr, seed, result);
+      return HashingPrimitiveArray<1>::Exec(arr, seed, result);
     case 2:
-      return HashingPrimativeArray<2>::Exec(arr, seed, result);
+      return HashingPrimitiveArray<2>::Exec(arr, seed, result);
     case 4:
-      return HashingPrimativeArray<4>::Exec(arr, seed, result);
+      return HashingPrimitiveArray<4>::Exec(arr, seed, result);
     case 8:
-      return HashingPrimativeArray<8>::Exec(arr, seed, result);
+      return HashingPrimitiveArray<8>::Exec(arr, seed, result);
     case 16:
-      return HashingPrimativeArray<16>::Exec(arr, seed, result);
+      return HashingPrimitiveArray<16>::Exec(arr, seed, result);
     case 32:
-      return HashingPrimativeArray<32>::Exec(arr, seed, result);
+      return HashingPrimitiveArray<32>::Exec(arr, seed, result);
     default:
       ARROW_LOG(FATAL) << "Unknown bitwidth for arrow type" << arr->type->id();
   }
@@ -132,7 +132,7 @@ void hash_single_array(const arrow::ArrayData *arr, const arrow::ArrayData *seed
   ARROW_CHECK(arr != NULL);
   ARROW_CHECK(result != NULL);
   if (arrow::is_primitive(arr->type->id())) {
-    hash_primative_array(arr, seed, result);
+    hash_primitive_array(arr, seed, result);
   } else if (arrow::is_binary_like(arr->type->id())) {
     HashingBinaryArray<arrow::BinaryType::offset_type>::Exec(arr, seed, result);
   } else if (arrow::is_large_binary_like(arr->type->id())) {

--- a/daft/internal/kernels/memory_view.h
+++ b/daft/internal/kernels/memory_view.h
@@ -34,11 +34,11 @@ struct MemoryViewBase {
 #else
     namespace bit_util = arrow::bit_util;
 #endif
-    const auto bit_ptr = data_->GetValues<uint8_t>(0);
+    const auto bit_ptr = data_->GetValues<uint8_t>(0, 0);
     if (bit_ptr == NULL) {
       return false;
     }
-    return bit_util::GetBit(bit_ptr, idx);
+    return bit_util::GetBit(bit_ptr, idx + data_->offset);
   }
 
   virtual int Compare(const MemoryViewBase *other, const uint64_t left_idx, const uint64_t right_idx) const = 0;
@@ -65,11 +65,11 @@ struct BinaryMemoryView : public MemoryViewBase {
   ~BinaryMemoryView() = default;
   int Compare(const MemoryViewBase *other, const uint64_t left_idx, const uint64_t right_idx) const {
     using T = typename ArrowType::offset_type;
-    const T left_offset = *this->data_->template GetValues<T>(1, left_idx);
-    const T left_size = *this->data_->template GetValues<T>(1, left_idx + 1) - left_offset;
+    const T left_offset = *(this->data_->template GetValues<T>(1) + left_idx);
+    const T left_size = *(this->data_->template GetValues<T>(1) + left_idx + 1) - left_offset;
 
-    const T right_offset = *other->data_->template GetValues<T>(1, right_idx);
-    const T right_size = *other->data_->template GetValues<T>(1, right_idx + 1) - right_offset;
+    const T right_offset = *(other->data_->template GetValues<T>(1) + right_idx);
+    const T right_size = *(other->data_->template GetValues<T>(1) + right_idx + 1) - right_offset;
     return strcmpNoTerminator(this->data_->template GetValues<uint8_t>(2, left_offset),
                               other->data_->template GetValues<uint8_t>(2, right_offset), left_size, right_size);
   }

--- a/daft/internal/kernels/memory_view.h
+++ b/daft/internal/kernels/memory_view.h
@@ -46,9 +46,9 @@ struct MemoryViewBase {
 };
 
 template <typename ArrowType>
-struct PrimativeMemoryView : public MemoryViewBase {
-  PrimativeMemoryView(const std::shared_ptr<arrow::ArrayData> &data) : MemoryViewBase(data){};
-  ~PrimativeMemoryView() = default;
+struct PrimitiveMemoryView : public MemoryViewBase {
+  PrimitiveMemoryView(const std::shared_ptr<arrow::ArrayData> &data) : MemoryViewBase(data){};
+  ~PrimitiveMemoryView() = default;
   int Compare(const MemoryViewBase *other, const uint64_t left_idx, const uint64_t right_idx) const {
     using T = typename ArrowType::c_type;
     const T left_val = *(this->data_->template GetValues<T>(1) + left_idx);
@@ -85,9 +85,9 @@ struct CompositeView {
   }
 
   template <typename ArrowType>
-  void AddPrimativeMemoryView(const std::shared_ptr<arrow::ArrayData> &data) {
+  void AddPrimitiveMemoryView(const std::shared_ptr<arrow::ArrayData> &data) {
     static_assert(std::is_base_of<arrow::DataType, ArrowType>::value, "T is not derived from MemoryViewBase");
-    AddMemoryView<PrimativeMemoryView<ArrowType>>(data);
+    AddMemoryView<PrimitiveMemoryView<ArrowType>>(data);
   }
 
   template <typename ArrowType>

--- a/daft/internal/kernels/search_sorted.cc
+++ b/daft/internal/kernels/search_sorted.cc
@@ -408,12 +408,13 @@ std::shared_ptr<arrow::Array> search_sorted_multiple_columns(const std::vector<s
   uint64_t *result_ptr = result->GetMutableValues<uint64_t>(1);
   ARROW_CHECK(result_ptr != NULL);
 
-  uint8_t *result_bitmask_ptr = result->GetMutableValues<uint8_t>(0);
+  uint8_t *result_bitmask_ptr = result->GetMutableValues<uint8_t>(0, 0);
+  const size_t result_offset = result->offset;
 
   for (size_t key_idx = 0; key_idx < key_len; key_idx++, result_ptr++) {
     if (key_has_nulls) {
       const bool is_valid = keys_comp_view.isValid(key_idx);
-      bit_util::SetBitTo(result_bitmask_ptr, key_idx, is_valid);
+      bit_util::SetBitTo(result_bitmask_ptr, key_idx + result_offset, is_valid);
       if (!is_valid) {
         continue;
       }

--- a/daft/internal/kernels/search_sorted.cc
+++ b/daft/internal/kernels/search_sorted.cc
@@ -24,7 +24,7 @@ namespace bit_util = arrow::bit_util;
 #endif
 
 template <typename InType>
-struct SearchSortedPrimativeSingle {
+struct SearchSortedPrimitiveSingle {
   static void Exec(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result, const bool input_reversed) {
     if (keys->GetNullCount() == 0) {
       return KernelNonNull(arr, keys, result, input_reversed);
@@ -170,48 +170,48 @@ struct SearchSortedPrimativeSingle {
   }
 };
 
-void search_sorted_primative_single(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result,
+void search_sorted_primitive_single(const arrow::ArrayData *arr, const arrow::ArrayData *keys, arrow::ArrayData *result,
                                     const bool input_reversed) {
   switch (arr->type->id()) {
     case arrow::Type::INT8:
-      return SearchSortedPrimativeSingle<arrow::Int8Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::Int8Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::INT16:
-      return SearchSortedPrimativeSingle<arrow::Int16Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::Int16Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::INT32:
-      return SearchSortedPrimativeSingle<arrow::Int32Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::Int32Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::INT64:
-      return SearchSortedPrimativeSingle<arrow::Int64Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::Int64Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::UINT8:
-      return SearchSortedPrimativeSingle<arrow::UInt8Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::UInt8Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::UINT16:
-      return SearchSortedPrimativeSingle<arrow::UInt16Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::UInt16Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::UINT32:
-      return SearchSortedPrimativeSingle<arrow::UInt32Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::UInt32Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::UINT64:
-      return SearchSortedPrimativeSingle<arrow::UInt64Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::UInt64Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::FLOAT:
-      return SearchSortedPrimativeSingle<arrow::FloatType>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::FloatType>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::DOUBLE:
-      return SearchSortedPrimativeSingle<arrow::DoubleType>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::DoubleType>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::DATE32:
-      return SearchSortedPrimativeSingle<arrow::Date32Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::Date32Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::DATE64:
-      return SearchSortedPrimativeSingle<arrow::Date64Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::Date64Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::TIME32:
-      return SearchSortedPrimativeSingle<arrow::Time32Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::Time32Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::TIME64:
-      return SearchSortedPrimativeSingle<arrow::Time64Type>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::Time64Type>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::TIMESTAMP:
-      return SearchSortedPrimativeSingle<arrow::TimestampType>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::TimestampType>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::DURATION:
-      return SearchSortedPrimativeSingle<arrow::DurationType>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::DurationType>::Exec(arr, keys, result, input_reversed);
     case arrow::Type::INTERVAL_MONTHS:
-      return SearchSortedPrimativeSingle<arrow::MonthIntervalType>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::MonthIntervalType>::Exec(arr, keys, result, input_reversed);
     // Need custom less function for this since it uses a custom struct for the data structure
     // case arrow::Type::INTERVAL_MONTH_DAY_NANO:
-    //   return SearchSortedPrimativeSingle<arrow::MonthDayNanoIntervalType>::Exec(arr, keys, result);
+    //   return SearchSortedPrimitiveSingle<arrow::MonthDayNanoIntervalType>::Exec(arr, keys, result);
     case arrow::Type::INTERVAL_DAY_TIME:
-      return SearchSortedPrimativeSingle<arrow::DayTimeIntervalType>::Exec(arr, keys, result, input_reversed);
+      return SearchSortedPrimitiveSingle<arrow::DayTimeIntervalType>::Exec(arr, keys, result, input_reversed);
     default:
       ARROW_LOG(FATAL) << "Unknown arrow type" << arr->type->id();
   }
@@ -309,48 +309,48 @@ void search_sorted_binary_single(const arrow::ArrayData *arr, const arrow::Array
   }
 }
 
-void add_primative_memory_view_to_comp_view(daft::kernels::CompositeView &comp_view, const std::shared_ptr<arrow::ArrayData> arr) {
+void add_primitive_memory_view_to_comp_view(daft::kernels::CompositeView &comp_view, const std::shared_ptr<arrow::ArrayData> arr) {
   ARROW_CHECK(arrow::is_primitive(arr->type->id()));
   switch (arr->type->id()) {
     case arrow::Type::INT8:
-      return comp_view.AddPrimativeMemoryView<arrow::Int8Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::Int8Type>(arr);
     case arrow::Type::INT16:
-      return comp_view.AddPrimativeMemoryView<arrow::Int16Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::Int16Type>(arr);
     case arrow::Type::INT32:
-      return comp_view.AddPrimativeMemoryView<arrow::Int32Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::Int32Type>(arr);
     case arrow::Type::INT64:
-      return comp_view.AddPrimativeMemoryView<arrow::Int64Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::Int64Type>(arr);
     case arrow::Type::UINT8:
-      return comp_view.AddPrimativeMemoryView<arrow::UInt8Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::UInt8Type>(arr);
     case arrow::Type::UINT16:
-      return comp_view.AddPrimativeMemoryView<arrow::UInt16Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::UInt16Type>(arr);
     case arrow::Type::UINT32:
-      return comp_view.AddPrimativeMemoryView<arrow::UInt32Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::UInt32Type>(arr);
     case arrow::Type::UINT64:
-      return comp_view.AddPrimativeMemoryView<arrow::UInt64Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::UInt64Type>(arr);
     case arrow::Type::FLOAT:
-      return comp_view.AddPrimativeMemoryView<arrow::FloatType>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::FloatType>(arr);
     case arrow::Type::DOUBLE:
-      return comp_view.AddPrimativeMemoryView<arrow::DoubleType>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::DoubleType>(arr);
     case arrow::Type::DATE32:
-      return comp_view.AddPrimativeMemoryView<arrow::Date32Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::Date32Type>(arr);
     case arrow::Type::DATE64:
-      return comp_view.AddPrimativeMemoryView<arrow::Date64Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::Date64Type>(arr);
     case arrow::Type::TIME32:
-      return comp_view.AddPrimativeMemoryView<arrow::Time32Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::Time32Type>(arr);
     case arrow::Type::TIME64:
-      return comp_view.AddPrimativeMemoryView<arrow::Time64Type>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::Time64Type>(arr);
     case arrow::Type::TIMESTAMP:
-      return comp_view.AddPrimativeMemoryView<arrow::TimestampType>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::TimestampType>(arr);
     case arrow::Type::DURATION:
-      return comp_view.AddPrimativeMemoryView<arrow::DurationType>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::DurationType>(arr);
     case arrow::Type::INTERVAL_MONTHS:
-      return comp_view.AddPrimativeMemoryView<arrow::MonthIntervalType>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::MonthIntervalType>(arr);
     // Need custom less function for this since it uses a custom struct for the data structure
     // case arrow::Type::INTERVAL_MONTH_DAY_NANO:
-    //   return comp_view.AddPrimativeMemoryView<arrow::MonthDayNanoIntervalType>(arr);
+    //   return comp_view.AddPrimitiveMemoryView<arrow::MonthDayNanoIntervalType>(arr);
     case arrow::Type::INTERVAL_DAY_TIME:
-      return comp_view.AddPrimativeMemoryView<arrow::DayTimeIntervalType>(arr);
+      return comp_view.AddPrimitiveMemoryView<arrow::DayTimeIntervalType>(arr);
     default:
       break;
   }
@@ -373,7 +373,7 @@ std::shared_ptr<arrow::Array> search_sorted_multiple_columns(const std::vector<s
   for (auto arr : sorted) {
     ARROW_CHECK_EQ(arr->GetNullCount(), 0);
     if (arrow::is_primitive(arr->type->id())) {
-      add_primative_memory_view_to_comp_view(sorted_comp_view, arr);
+      add_primitive_memory_view_to_comp_view(sorted_comp_view, arr);
     } else if (arrow::is_base_binary_like(arr->type->id())) {
       add_binary_memory_view_to_comp_view(sorted_comp_view, arr);
     } else {
@@ -384,7 +384,7 @@ std::shared_ptr<arrow::Array> search_sorted_multiple_columns(const std::vector<s
   for (auto arr : keys) {
     key_has_nulls = key_has_nulls | (arr->GetNullCount() > 0);
     if (arrow::is_primitive(arr->type->id())) {
-      add_primative_memory_view_to_comp_view(keys_comp_view, arr);
+      add_primitive_memory_view_to_comp_view(keys_comp_view, arr);
     } else if (arrow::is_base_binary_like(arr->type->id())) {
       add_binary_memory_view_to_comp_view(keys_comp_view, arr);
     } else {
@@ -464,7 +464,7 @@ std::shared_ptr<arrow::Array> search_sorted_single_array(const arrow::Array *arr
       arrow::ArrayData::Make(std::make_shared<arrow::UInt64Type>(), size, result_buffers, keys->null_count());
   ARROW_CHECK(result.get() != NULL);
   if (arrow::is_primitive(arr->type()->id())) {
-    search_sorted_primative_single(arr->data().get(), keys->data().get(), result.get(), input_reversed);
+    search_sorted_primitive_single(arr->data().get(), keys->data().get(), result.get(), input_reversed);
   } else if (arrow::is_binary_like(arr->type()->id())) {
     search_sorted_binary_single<arrow::BinaryType::offset_type>(arr->data().get(), keys->data().get(), result.get(), input_reversed);
   } else if (arrow::is_large_binary_like(arr->type()->id())) {


### PR DESCRIPTION
* Fixes bug when running search sorted on a memory view
* This is due to inconsistent behavior for `GetValues` in Arrow.
* Rename Primative -> Primitive