### PR TITLE
Install polars with extra dependencies ["timezone"]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ tabulate = "^0.8.10"
 pandas = "^1.3.5"
 typing-extensions = { version = ">=4.0.0", python = "<3.8" }
 pickle5 = { version = "^0.0.12", python = "<3.8" }
-polars = "^0.14.12, <=0.14.19"
+polars = { extras = ["timezone"], version = "^0.14.12" }
 
 # Serving deps
 fastapi = {version="^0.79.0", optional=true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ tabulate = "^0.8.10"
 pandas = "^1.3.5"
 typing-extensions = { version = ">=4.0.0", python = "<3.8" }
 pickle5 = { version = "^0.0.12", python = "<3.8" }
-polars = "^0.14.12"
+polars = "^0.14.12, <=0.14.19"
 
 # Serving deps
 fastapi = {version="^0.79.0", optional=true}


### PR DESCRIPTION
The latest Polars release will break on import if `backports.zoneinfo` is not installed in Python < 3.9. We have to install it with the extras `["timezone"]` specified.