### PR TITLE
Fix quantile calculations in sort

### DIFF
--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -179,7 +179,7 @@ class vPartition:
         return self.for_each_column_block(partial(DataBlock.head, num=num))
 
     def sample(self, num: int) -> vPartition:
-        if len(self) == 0:
+        if len(self) <= num:
             return self
         sample_idx: DataBlock[ArrowArrType] = DataBlock.make_block(data=np.random.randint(0, len(self), num))
         return self.for_each_column_block(partial(DataBlock.take, indices=sample_idx))
@@ -280,7 +280,7 @@ class vPartition:
 
     def quantiles(self, num: int) -> vPartition:
         self_size = len(self)
-        sample_idx_np = np.linspace(self_size / num, self_size, num)[:-1].round().astype(np.int32)
+        sample_idx_np = np.minimum(np.linspace(self_size / num, self_size, num), self_size - 1).round().astype(np.int32)
         return self.take(DataBlock.make_block(sample_idx_np))
 
     def explode(self, columns: ExpressionList) -> vPartition:

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -280,7 +280,11 @@ class vPartition:
 
     def quantiles(self, num: int) -> vPartition:
         self_size = len(self)
-        sample_idx_np = np.minimum(np.linspace(self_size / num, self_size, num), self_size - 1).round().astype(np.int32)
+        if self_size == 0:
+            return self
+        sample_idx_np = (
+            np.minimum(np.linspace(self_size / num, self_size, num), self_size - 1).round().astype(np.int32)[:-1]
+        )
         return self.take(DataBlock.make_block(sample_idx_np))
 
     def explode(self, columns: ExpressionList) -> vPartition:

--- a/daft/runners/shuffle_ops.py
+++ b/daft/runners/shuffle_ops.py
@@ -95,7 +95,6 @@ class SortOp(ShuffleOp):
         descending: list[bool] | None = None,
     ) -> dict[PartID, vPartition]:
         assert exprs is not None and boundaries is not None and descending is not None
-        assert len(boundaries) == (output_partitions - 1)
         assert len(exprs) == len(descending)
         if output_partitions == 1:
             return {PartID(0): input}

--- a/tests/runners/test_partitioning.py
+++ b/tests/runners/test_partitioning.py
@@ -6,7 +6,7 @@ import pytest
 
 from daft.expressions import ColID, Expression, col
 from daft.logical.schema import ExpressionList
-from daft.runners.blocks import DataBlock
+from daft.runners.blocks import ArrowDataBlock, DataBlock
 from daft.runners.partitioning import PyListTile, vPartition
 
 
@@ -262,3 +262,11 @@ def test_hash_partition(n) -> None:
                 values_expected = pylist
             assert values_expected == pylist
         values_seen.update(pylist)
+
+
+def test_partition_quantiles_small_sample_large_partitions():
+    data = [1, 2, 3]
+    partition = vPartition({1: PyListTile(1, "foo", 1, ArrowDataBlock(pa.chunked_array([data])))}, 1)
+    quantiled_partition = partition.quantiles(10)
+    quantile_boundaries = quantiled_partition.columns[1].block.data.to_pylist()
+    assert sorted(quantile_boundaries) == quantile_boundaries, "quantile boundaries should be in sorted order"


### PR DESCRIPTION
Quantile computations are wrong if the number of partitions >> the number of samples points, causing segfaults when we index outside of the array's bounds