### PR TITLE
Use a simple disk-based cache for remote file scans

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -48,6 +48,15 @@ def _get_runner_config_from_env() -> _RunnerConfig:
     return _PyRunnerConfig()
 
 
+def _get_cache_location_from_env() -> pathlib.Path | None:
+    envvar = os.getenv("DAFT_CACHE")
+    if envvar is None:
+        return DEFAULT_DAFT_CACHE_LOCATION
+    elif envvar == "":
+        return None
+    return pathlib.Path(envvar)
+
+
 # Global Runner singleton, initialized when accessed through the DaftContext
 _RUNNER: Runner | None = None
 
@@ -58,7 +67,7 @@ class DaftContext:
 
     runner_config: _RunnerConfig = dataclasses.field(default_factory=_get_runner_config_from_env)
     disallow_set_runner: bool = False
-    cache_location: pathlib.Path | None = DEFAULT_DAFT_CACHE_LOCATION
+    cache_location: pathlib.Path | None = dataclasses.field(default_factory=_get_cache_location_from_env)
 
     def runner(self) -> Runner:
         global _RUNNER

--- a/daft/context.py
+++ b/daft/context.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import dataclasses
 import os
+import pathlib
+import tempfile
 from typing import TYPE_CHECKING, ClassVar
 
 from loguru import logger
 
 if TYPE_CHECKING:
     from daft.runners.runner import Runner
+
+
+DEFAULT_DAFT_CACHE_LOCATION = pathlib.Path(tempfile.gettempdir()) / "daft"
 
 
 class _RunnerConfig:
@@ -53,6 +58,7 @@ class DaftContext:
 
     runner_config: _RunnerConfig = dataclasses.field(default_factory=_get_runner_config_from_env)
     disallow_set_runner: bool = False
+    cache_location: pathlib.Path | None = DEFAULT_DAFT_CACHE_LOCATION
 
     def runner(self) -> Runner:
         global _RUNNER
@@ -87,6 +93,26 @@ _DaftContext = DaftContext()
 
 
 def get_context() -> DaftContext:
+    return _DaftContext
+
+
+def set_daft_cache(cache_location: pathlib.Path | None) -> DaftContext:
+    """Sets the location of the Daft cache
+
+    By default Daft will use /tmp/daft as the cache location, but it may be useful for applications
+    to set a better location for example to take advantage of SSD scratch space.
+
+    Args:
+        cache_location (Optional[pathlib.Path]): Location for caching Daft data
+
+    Returns:
+        DaftContext: Daft context after setting the cache location
+    """
+    global _DaftContext
+    _DaftContext = dataclasses.replace(
+        _DaftContext,
+        cache_location=cache_location,
+    )
     return _DaftContext
 
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -66,7 +66,11 @@ def _get_filepaths(path: str):
         return [f"{protocol}://{path}" if protocol != "file" else path for path in fs.ls(path)]
     elif fs.isfile(path):
         return [path]
-    return [f"{protocol}://{path}" if protocol != "file" else path for path in fs.expand_path(path, recursive=True)]
+    try:
+        expanded = fs.expand_path(path, recursive=True)
+    except FileNotFoundError:
+        return []
+    return [f"{protocol}://{path}" if protocol != "file" else path for path in expanded]
 
 
 class DataFrame:

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -23,9 +23,9 @@ def get_filesystem_from_path(path: str, **kwargs) -> AbstractFileSystem:
     protocol = get_protocol_from_path(path)
     fs = get_filesystem(protocol, **kwargs)
 
-    # If a cache location is set, use as a simple disk-based cache
+    # If a cache location is set and the protocol is not a local file, use as a simple disk-based cache
     cache_location = get_context().cache_location
-    if cache_location is not None:
+    if protocol != "file" and cache_location is not None:
         fs = SimpleCacheFileSystem(fs=fs, cache_storage=str(cache_location / "simple-cache-file-system"))
 
     return fs

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from fsspec import AbstractFileSystem, get_filesystem_class
+from fsspec.implementations.cached import SimpleCacheFileSystem
+
+from daft.context import get_context
 
 
 def get_filesystem(protocol: str, **kwargs) -> AbstractFileSystem:
@@ -18,4 +21,11 @@ def get_protocol_from_path(path: str, **kwargs) -> str:
 
 def get_filesystem_from_path(path: str, **kwargs) -> AbstractFileSystem:
     protocol = get_protocol_from_path(path)
-    return get_filesystem(protocol, **kwargs)
+    fs = get_filesystem(protocol, **kwargs)
+
+    # If a cache location is set, use as a simple disk-based cache
+    cache_location = get_context().cache_location
+    if cache_location is not None:
+        fs = SimpleCacheFileSystem(fs=fs, cache_storage=str(cache_location / "simple-cache-file-system"))
+
+    return fs


### PR DESCRIPTION
When scanning remote files, we use a simple disk-based cache that will cache whole files as they are read.

The location of this cache can be controlled with either the `DAFT_CACHE` environment variable, or with `daft.context.set_daft_cache` at runtime. The cache can be disabled by setting either `DAFT_CACHE=` or `daft.context.set_daft_cache(None)`.