### PR TITLE
Pin Daft requirements to Ray >= 1.10.0

### DIFF
--- a/.github/workflows/ray-compatibility.yml
+++ b/.github/workflows/ray-compatibility.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8']
-        daft_runner: ray
         ray-version: [2.1.0, 2.0.0, 1.13.0, 1.12.0, 1.11.0, 1.10.0, 1.9.0, 1.8.0]
 
     steps:
@@ -50,4 +49,4 @@ jobs:
     - name: Test with pytest
       run: poetry run pytest
       env:
-        DAFT_RUNNER: ${{ matrix.daft_runner }}
+        DAFT_RUNNER: ray

--- a/.github/workflows/ray-compatibility.yml
+++ b/.github/workflows/ray-compatibility.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8']
-        ray-version: [2.1.0, 2.0.0, 1.13.0, 1.12.0, 1.11.0, 1.10.0, 1.9.0, 1.8.0]
+        ray-version: [2.1.0, 2.0.0, 1.13.0, 1.12.0, 1.11.0, 1.10.0]
 
     steps:
     - uses: actions/checkout@v3

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ serving = ["fastapi", "docker", "uvicorn", "cloudpickle", "boto3", "PyYAML"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "b2679001d60a9bfe825ada177c679cecd7bc639ed02ba772527a8ce955f90231"
+content-hash = "58231cc6003b2cb0f08bf55ed672c16903ce82e78b139b1edbb50722788a2662"
 
 [metadata.files]
 aiobotocore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ generate-setup-file = true
 
 [tool.poetry.dependencies]
 python = "^3.7.1"
-ray = ">=1.8.0"
+ray = ">=1.10.0"
 numpy = "^1.16.6"
 pyarrow = "^6"
 fsspec = "*"


### PR DESCRIPTION
Closes #336 

Ray versions before 1.10.0 do not have the kwarg `@ray.remote(scheduling_strategy="SPREAD")` which we use in the reduce phase for our shuffle operations.

Moreover, Ray documentation for versions below 1.11.0 is hard to find. Thus we are pinning Daft to  ray>=1.10.0