### PR TITLE
Support empty dataframes, with and without schema info.

### DIFF
--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -92,7 +92,8 @@ class vPartition:
                 raise ValueError(f"mismatch of column id: {col_id} vs {tile.column_id}")
 
     def __len__(self) -> int:
-        assert len(self.columns) > 0
+        if len(self.columns) == 0:
+            return 0
         return len(next(iter(self.columns.values())))
 
     def eval_expression(self, expr: Expression) -> PyListTile:

--- a/daft/viz/repr.py
+++ b/daft/viz/repr.py
@@ -97,7 +97,7 @@ def vpartition_repr_html(
         max_lines=max_lines,
     )
 
-    headers=[f"{name}<br>{daft_schema[name].daft_type}" for name in daft_schema.column_names()]
+    headers = [f"{name}<br>{daft_schema[name].daft_type}" for name in daft_schema.column_names()]
 
     # Workaround for https://github.com/astanin/python-tabulate/issues/224
     # tabulate library doesn't render header if there are no rows;
@@ -118,7 +118,7 @@ def vpartition_repr_html(
         )
 
     # tabulate generates empty HTML string for empty table.
-    if tabulate_html_string == '':
+    if tabulate_html_string == "":
         tabulate_html_string = "<table></table>"
 
     # Appending class="dataframe" here helps Google Colab with applying CSS
@@ -148,15 +148,12 @@ def vpartition_repr(
         max_lines=max_lines,
     )
 
-    # Workaround for https://github.com/astanin/python-tabulate/issues/223
-    # If table has no rows, specifying maxcolwidths always raises error.
-    if len(vpartition) == 0:
-        max_col_width = None
-
     return tabulate(
         data_stringified,
         headers=[f"{name}\n{daft_schema[name].daft_type}" for name in daft_schema.column_names()],
         tablefmt="grid",
         missingval="None",
-        maxcolwidths=max_col_width,
+        # Workaround for https://github.com/astanin/python-tabulate/issues/223
+        # If table has no rows, specifying maxcolwidths always raises error.
+        maxcolwidths=max_col_width if len(vpartition) else None,
     )


### PR DESCRIPTION
Closes #307 .

## Before:

_(show(0) on dataframe)_
![image](https://user-images.githubusercontent.com/4212216/204409177-0996e2a2-b92c-4a81-a34f-800eae372ff7.png)

_(show() on empty dataframe with schema)_
![image](https://user-images.githubusercontent.com/4212216/204409329-f0345c02-804a-4c4b-bedd-79dd86f9d4c9.png)

_(show() on empty dataframe with empty schema)_
![image](https://user-images.githubusercontent.com/4212216/204409453-543be3ad-ea86-4d13-891a-f071c5e5592f.png)

## After:
![image](https://user-images.githubusercontent.com/4212216/204409574-6931783b-232a-41e2-8e7c-73c82e161fb0.png)

![image](https://user-images.githubusercontent.com/4212216/204409743-49c7c4b8-7348-4899-ae00-f8b944dbf540.png)

![image](https://user-images.githubusercontent.com/4212216/204409777-3a09a006-3f14-4041-b04a-7a851679d42b.png)
