### PR TITLE
Add passthrough __getitem__ to GroupedDataFrame.

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1097,6 +1097,9 @@ class GroupedDataFrame:
             if e.resolved_type() == ExpressionType.null():
                 raise ExpressionTypeError(f"Cannot groupby on null type expression: {e}")
 
+    def __getitem__(self, item: slice | int | str | Iterable[str | int]) -> ColumnExpression | DataFrame:
+        return self.df.__getitem__(item)
+
     def sum(self, *cols: ColumnInputType) -> DataFrame:
         """Perform grouped sum on this GroupedDataFrame.
 


### PR DESCRIPTION
Closes #285

GroupedDataFrame["A"] now calls DataFrame["A"] on the underlying DataFrame. 

This allows true column references to be used in `.agg` as shown here:

![image](https://user-images.githubusercontent.com/4212216/204433702-49f77fa1-bf9a-435f-baf2-644af7cdcc47.png)
