### PR TITLE
Fixes for anaconda publishing and enable CRON publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, macos-11]
         python: [cp37, cp38, cp39, cp310]
     env:
-      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0') }}
+      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
       IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
     steps:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -8,7 +8,7 @@ on:
   #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
   #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
   #        │  │ │ │ │
-  - cron: 0 21 * * *
+  - cron: 0 5 * * *
 
   push:
     tags:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,6 +21,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 0
 
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -95,6 +95,8 @@ jobs:
         python-version: '3.10'
     - name: Install poetry
       run: python -m pip install poetry==1.2.0 twine && poetry self add "poetry-dynamic-versioning[plugin]"
+    - name: Patch local toml with SemVar
+      run: poetry dynamic-versioning
     - name: Build wheels
       run: poetry build -f sdist
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -76,7 +76,6 @@ jobs:
         upload_wheels
 
   build_sdist_wheels:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0'))
     name: source wheel
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,10 +1,20 @@
 name: daft-publish
 
 on:
+  schedule:
+  #        ┌───────────── minute (0 - 59)
+  #        │  ┌───────────── hour (0 - 23)
+  #        │  │ ┌───────────── day of the month (1 - 31)
+  #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+  #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+  #        │  │ │ │ │
+  - cron: 0 21 * * *
+
   push:
     tags:
     - v*
   workflow_dispatch:
+
 
 jobs:
   build_bdist_wheels:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -81,6 +81,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+
+    env:
+      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
+      IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4


### PR DESCRIPTION
* Fixes for poetry versioning for daft python package building
* enable cron schedule for nightly publishing to https://anaconda.org/daft-nightly/getdaft
* enable tagged version publishing to https://anaconda.org/daft/getdaft