### PR TITLE
Daft nightly fix -- add correct git clone for tag pickup

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -100,6 +100,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 0
+
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10'


### PR DESCRIPTION
* Perform git deep clone for tag up rather than a shallow clone.