### PR TITLE
Add ray[default] to dev dependencies.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ serving = ["fastapi", "docker", "uvicorn", "cloudpickle", "boto3", "PyYAML"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "558f35ecc9272296f221ebc12c8408f6064045c0996638eb2bd726f4fb3565b8"
+content-hash = "76efd6fa68ed4635e91d656fe1d1536940506781448f10364d4f1336247797a4"
 
 [metadata.files]
 aiobotocore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ experimental = ["fastapi", "docker", "uvicorn", "cloudpickle", "boto3", "PyYAML"
 ipdb = "^0.13.9"
 pre-commit = "^2.20.0"
 Cython = "^0.29.32"
-ray = {version = ">=1.10.0", extras = ["default"]}
+ray = {version = "*", extras = ["default"]}  # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
 viztracer = "^0.15.4"
 Sphinx = "<5"
 sphinx-book-theme = "^0.3.3"


### PR DESCRIPTION
For the Ray python package, [the `"default"` package extra is required to provide the dashboard](https://docs.ray.io/en/latest/ray-overview/installation.html). 

This dashboard is really useful for Ray cluster debugging, so I added it to the `dev` dependencies only.


```
>>> import daft ; daft.context.set_runner_ray()
>>> df = daft.DataFrame.from_pydict({})
2022-12-05 15:47:14.216 | INFO     | daft.context:runner:79 - Using RayRunner
2022-12-05 15:47:16,995 INFO services.py:1470 -- View the Ray dashboard at http://127.0.0.1:8265
```

![image](https://user-images.githubusercontent.com/4212216/205770076-5d7a6cc1-6c51-4581-b3ce-307bc4527ec4.png)

I ran `poetry lock --no-update` as well.
