### PR TITLE
Rust Wheel Publishing to PYPI and Anaconda Nightly

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,11 +18,18 @@ on:
 env:
   PACKAGE_NAME: getdaft
   PYTHON_VERSION: '3.7' # to build abi3 wheels
+  INTERPRETER: 3.7 3.8 3.9 3.10 3.11
 
 
 jobs:
-  macos:
-    runs-on: macos-latest
+  build-and-test:
+
+    name: platform wheels for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -44,18 +51,18 @@ jobs:
       uses: messense/maturin-action@v1
       with:
         target: x86_64
-        args: --release --out dist --sdist
-    - name: Install built wheel - x86_64
+        args: --release --out dist --interpreter ${{ env.INTERPRETER }}
+    - name: Install and test built wheel - x86_64
       run: |
-        pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
         pip install -r requirements-dev.txt
+        pip install dist/${{ env.PACKAGE_NAME }}-*-cp37-*.whl --force-reinstall
         rm -rf daft
         pytest -v
 
     - name: Build wheels - arm64
       uses: messense/maturin-action@v1
       with:
-        args: --release --out dist
+        args: --release --out dist --interpreter ${{ env.INTERPRETER }}
         target: aarch64
 
     - name: Upload wheels

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
     - build-and-test
-
+    steps:
     - uses: actions/download-artifact@v2
       with:
         name: wheels

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Install and test built wheel - x86_64
       run: |
         pip install -r requirements-dev.txt
-        pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+        pip install dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
         rm -rf daft
         pytest -v
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -85,7 +85,8 @@ jobs:
     - uses: actions/download-artifact@v2
       with:
         name: wheels
-
+        path: dist
+    - run: ls -R ./dist
     - name: Publish bdist package to PYPI
       if: ${{ success() && (env.IS_PUSH == 'true') }}
       run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,48 +22,48 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
-        target: [x86_64, aarch64]
+        os: [ubuntu] # [ubuntu, macos]
+        target: [x86_64] #[x86_64, aarch64]
         manylinux: [auto]
         include:
         - os: ubuntu
           platform: linux
-        - os: macos
-          target: aarch64
-          interpreter: 3.7 3.8 3.9 3.10 3.11
-        - os: ubuntu
-          platform: linux
-          target: i686
+        # - os: macos
+        #   target: aarch64
+        #   interpreter: 3.7 3.8 3.9 3.10 3.11
+        # - os: ubuntu
+        #   platform: linux
+        #   target: i686
           # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic
           # we use manylinux_2_24 container for aarch64 and armv7 targets instead,
-        - os: ubuntu
-          platform: linux
-          target: aarch64
-          container: messense/manylinux_2_24-cross:aarch64
-        - os: ubuntu
-          platform: linux
-          target: armv7
-          container: messense/manylinux_2_24-cross:armv7
-          interpreter: 3.7 3.8 3.9 3.10 3.11
-          # musllinux
-        - os: ubuntu
-          platform: linux
-          target: x86_64
-          manylinux: musllinux_1_1
-        - os: ubuntu
-          platform: linux
-          target: aarch64
-          manylinux: musllinux_1_1
-        - os: ubuntu
-          platform: linux
-          target: ppc64le
-          container: messense/manylinux_2_24-cross:ppc64le
-          interpreter: 3.7 3.8 3.9 3.10 3.11
-        - os: ubuntu
-          platform: linux
-          target: s390x
-          container: messense/manylinux_2_24-cross:s390x
-          interpreter: 3.7 3.8 3.9 3.10 3.11
+        # - os: ubuntu
+        #   platform: linux
+        #   target: aarch64
+        #   container: messense/manylinux_2_24-cross:aarch64
+        # - os: ubuntu
+        #   platform: linux
+        #   target: armv7
+        #   container: messense/manylinux_2_24-cross:armv7
+        #   interpreter: 3.7 3.8 3.9 3.10 3.11
+        #   # musllinux
+        # - os: ubuntu
+        #   platform: linux
+        #   target: x86_64
+        #   manylinux: musllinux_1_1
+        # - os: ubuntu
+        #   platform: linux
+        #   target: aarch64
+        #   manylinux: musllinux_1_1
+        # - os: ubuntu
+        #   platform: linux
+        #   target: ppc64le
+        #   container: messense/manylinux_2_24-cross:ppc64le
+        #   interpreter: 3.7 3.8 3.9 3.10 3.11
+        # - os: ubuntu
+        #   platform: linux
+        #   target: s390x
+        #   container: messense/manylinux_2_24-cross:s390x
+        #   interpreter: 3.7 3.8 3.9 3.10 3.11
     env:
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
       IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
@@ -71,6 +71,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 0
 
     - name: set up python
       uses: actions/setup-python@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,138 +19,197 @@ on:
 jobs:
   build_bdist_wheels:
     name: platform wheels for ${{ matrix.python }}-${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-11]
-        python: [cp37, cp38, cp39, cp310]
+        os: [ubuntu, macos]
+        target: [x86_64, aarch64]
+        manylinux: [auto]
+        include:
+        - os: ubuntu
+          platform: linux
+        - os: macos
+          target: aarch64
+          interpreter: 3.7 3.8 3.9 3.10 3.11
+        - os: ubuntu
+          platform: linux
+          target: i686
+          # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic
+          # we use manylinux_2_24 container for aarch64 and armv7 targets instead,
+        - os: ubuntu
+          platform: linux
+          target: aarch64
+          container: messense/manylinux_2_24-cross:aarch64
+        - os: ubuntu
+          platform: linux
+          target: armv7
+          container: messense/manylinux_2_24-cross:armv7
+          interpreter: 3.7 3.8 3.9 3.10 3.11
+          # musllinux
+        - os: ubuntu
+          platform: linux
+          target: x86_64
+          manylinux: musllinux_1_1
+        - os: ubuntu
+          platform: linux
+          target: aarch64
+          manylinux: musllinux_1_1
+        - os: ubuntu
+          platform: linux
+          target: ppc64le
+          container: messense/manylinux_2_24-cross:ppc64le
+          interpreter: 3.7 3.8 3.9 3.10 3.11
+        - os: ubuntu
+          platform: linux
+          target: s390x
+          container: messense/manylinux_2_24-cross:s390x
+          interpreter: 3.7 3.8 3.9 3.10 3.11
     env:
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
       IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ${{ matrix.os }}-latest
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: true
-        fetch-depth: 0
 
-    - uses: actions/setup-python@v4
+    - name: set up python
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
+        architecture: ${{ matrix.python-architecture || 'x64' }}
 
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==2.9.0 poetry==1.2.0 twine && poetry self add "poetry-dynamic-versioning[plugin]"
-    - name: Patch local toml with SemVar
-      run: poetry dynamic-versioning
-    - name: Build wheels
-      run: python -m cibuildwheel --output-dir ./wheelhouse
-      env:
-        CIBW_BUILD: ${{ matrix.python }}-*
+    - run: pip install -U twine
+
+    - name: Patch local cargo toml
+      run: python tools/patch_package_version.py
+
+    - name: build sdist
+      if: ${{ matrix.os == 'ubuntu' && matrix.target == 'x86_64' && matrix.manylinux == 'auto' }}
+      uses: messense/maturin-action@v1
+      with:
+        command: sdist
+        args: --out dist
+        rust-toolchain: stable
+
+    - name: build wheels
+      uses: messense/maturin-action@v1
+      with:
+        target: ${{ matrix.target }}
+        manylinux: ${{ matrix.manylinux || 'auto' }}
+        container: ${{ matrix.container }}
+        args: --release --out dist --interpreter ${{ matrix.interpreter || '3.7 3.8 3.9 3.10 3.11 pypy3.7 pypy3.8 pypy3.9' }}
+        rust-toolchain: stable
+
+    - run: ${{ matrix.ls || 'ls -lh' }} dist/
+
+    - run: twine check dist/*
     - uses: actions/upload-artifact@v3
       with:
-        name: ${{ matrix.python }}-${{ matrix.os }}_bdist_wheels
-        path: ./wheelhouse/*.whl
-    - name: Publish bdist package to PYPI
-      if: ${{ success() && (env.IS_PUSH == 'true') }}
-      run: python -m twine upload --skip-existing --disable-progress-bar ./wheelhouse/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-update-conda: true
-        # Really doesn't matter what version we upload with
-        # just the version we test with
-        python-version: '3.8'
-        channels: conda-forge
-        channel-priority: true
-        mamba-version: '*'
+        name: pypi_files
+        path: dist
 
-    - name: Install anaconda client
-      shell: bash -el {0}
-      run: conda install -q -y anaconda-client
+  #   - name: Publish bdist package to PYPI
+  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
+  #     run: python -m twine upload --skip-existing --disable-progress-bar ./wheelhouse/*
+  #     env:
+  #       TWINE_USERNAME: __token__
+  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  #   - uses: conda-incubator/setup-miniconda@v2
+  #     with:
+  #       auto-update-conda: true
+  #       # Really doesn't matter what version we upload with
+  #       # just the version we test with
+  #       python-version: '3.8'
+  #       channels: conda-forge
+  #       channel-priority: true
+  #       mamba-version: '*'
 
-    - name: Upload wheels to anaconda nightly
-      if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
-      shell: bash -el {0}
-      env:
-        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-      run: |
-        source ci/upload_wheels.sh
-        set_upload_vars
-        # trigger an upload to
-        # https://anaconda.org/daft-nightly/getdaft
-        # for cron jobs or "Run workflow" (restricted to main branch).
-        # Tags will upload to
-        # https://anaconda.org/daft/getdaft
-        # The tokens were originally generated at anaconda.org
-        upload_wheels
+  #   - name: Install anaconda client
+  #     shell: bash -el {0}
+  #     run: conda install -q -y anaconda-client
 
-  build_sdist_wheels:
-    name: source wheel
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
+  #   - name: Upload wheels to anaconda nightly
+  #     if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
+  #     shell: bash -el {0}
+  #     env:
+  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+  #     run: |
+  #       source ci/upload_wheels.sh
+  #       set_upload_vars
+  #       # trigger an upload to
+  #       # https://anaconda.org/daft-nightly/getdaft
+  #       # for cron jobs or "Run workflow" (restricted to main branch).
+  #       # Tags will upload to
+  #       # https://anaconda.org/daft/getdaft
+  #       # The tokens were originally generated at anaconda.org
+  #       upload_wheels
 
-    env:
-      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
-      IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+  # build_sdist_wheels:
+  #   name: source wheel
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
 
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-        fetch-depth: 0
+  #   env:
+  #     IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
+  #     IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
-    - name: Install poetry
-      run: python -m pip install poetry==1.2.0 twine && poetry self add "poetry-dynamic-versioning[plugin]"
-    - name: Patch local toml with SemVar
-      run: poetry dynamic-versioning
-    - name: Build wheels
-      run: poetry build -f sdist
-    - uses: actions/upload-artifact@v3
-      with:
-        name: source_wheels
-        path: ./dist/*
-    - name: Publish sdist package to PYPI
-      if: ${{ success() && (env.IS_PUSH == 'true') }}
-      run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      # Used to push the built sdist
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        auto-update-conda: true
-        # Really doesn't matter what version we upload with
-        # just the version we test with
-        python-version: '3.8'
-        channels: conda-forge
-        channel-priority: true
-        mamba-version: '*'
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #     with:
+  #       submodules: true
+  #       fetch-depth: 0
 
-    - name: Install anaconda client
-      shell: bash -el {0}
-      run: conda install -q -y anaconda-client
+  #   - uses: actions/setup-python@v4
+  #     with:
+  #       python-version: '3.11'
 
-    - name: Upload wheels to anaconda nightly
-      if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
-      shell: bash -el {0}
-      env:
-        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-      run: |
-        source ci/upload_wheels.sh
-        set_upload_vars
-        # trigger an upload to
-        # https://anaconda.org/daft-nightly/getdaft
-        # for cron jobs or "Run workflow" (restricted to main branch).
-        # Tags will upload to
-        # https://anaconda.org/daft/getdaft
-        # The tokens were originally generated at anaconda.org
-        upload_wheels
+
+  #   - name: Patch local cargo toml
+  #     run: python tools/patch_package_version.py
+
+
+  #   - name: Build wheels
+  #     run: poetry build -f sdist
+  #   - uses: actions/upload-artifact@v3
+  #     with:
+  #       name: source_wheels
+  #       path: ./dist/*
+  #   - name: Publish sdist package to PYPI
+  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
+  #     run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
+  #     env:
+  #       TWINE_USERNAME: __token__
+  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  #     # Used to push the built sdist
+  #   - uses: conda-incubator/setup-miniconda@v2
+  #     with:
+  #       auto-update-conda: true
+  #       # Really doesn't matter what version we upload with
+  #       # just the version we test with
+  #       python-version: '3.8'
+  #       channels: conda-forge
+  #       channel-priority: true
+  #       mamba-version: '*'
+
+  #   - name: Install anaconda client
+  #     shell: bash -el {0}
+  #     run: conda install -q -y anaconda-client
+
+  #   - name: Upload wheels to anaconda nightly
+  #     if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
+  #     shell: bash -el {0}
+  #     env:
+  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+  #     run: |
+  #       source ci/upload_wheels.sh
+  #       set_upload_vars
+  #       # trigger an upload to
+  #       # https://anaconda.org/daft-nightly/getdaft
+  #       # for cron jobs or "Run workflow" (restricted to main branch).
+  #       # Tags will upload to
+  #       # https://anaconda.org/daft/getdaft
+  #       # The tokens were originally generated at anaconda.org
+  #       upload_wheels

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,101 +15,55 @@ on:
     - v*
   workflow_dispatch:
 
+env:
+  PACKAGE_NAME: getdaft
+  PYTHON_VERSION: '3.7' # to build abi3 wheels
+
 
 jobs:
-  build_bdist_wheels:
-    name: build on ${{ matrix.platform || matrix.os }} (${{ matrix.target }} - ${{ matrix.manylinux || 'auto' }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu] # [ubuntu, macos]
-        target: [x86_64] #[x86_64, aarch64]
-        manylinux: [auto]
-        include:
-        - os: ubuntu
-          platform: linux
-        # - os: macos
-        #   target: aarch64
-        #   interpreter: 3.7 3.8 3.9 3.10 3.11
-        # - os: ubuntu
-        #   platform: linux
-        #   target: i686
-          # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic
-          # we use manylinux_2_24 container for aarch64 and armv7 targets instead,
-        # - os: ubuntu
-        #   platform: linux
-        #   target: aarch64
-        #   container: messense/manylinux_2_24-cross:aarch64
-        # - os: ubuntu
-        #   platform: linux
-        #   target: armv7
-        #   container: messense/manylinux_2_24-cross:armv7
-        #   interpreter: 3.7 3.8 3.9 3.10 3.11
-        #   # musllinux
-        # - os: ubuntu
-        #   platform: linux
-        #   target: x86_64
-        #   manylinux: musllinux_1_1
-        # - os: ubuntu
-        #   platform: linux
-        #   target: aarch64
-        #   manylinux: musllinux_1_1
-        # - os: ubuntu
-        #   platform: linux
-        #   target: ppc64le
-        #   container: messense/manylinux_2_24-cross:ppc64le
-        #   interpreter: 3.7 3.8 3.9 3.10 3.11
-        # - os: ubuntu
-        #   platform: linux
-        #   target: s390x
-        #   container: messense/manylinux_2_24-cross:s390x
-        #   interpreter: 3.7 3.8 3.9 3.10 3.11
-    env:
-      IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
-      IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ${{ matrix.os }}-latest
-
+  macos:
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
         fetch-depth: 0
-
-    - name: set up python
-      uses: actions/setup-python@v4
+    - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
-        architecture: ${{ matrix.python-architecture || 'x64' }}
-
+        python-version: ${{ env.PYTHON_VERSION }}
+        architecture: x64
     - run: pip install -U twine toml
-
-    - name: Patch local cargo toml
-      run: python tools/patch_package_version.py
-
-    - name: build sdist
-      if: ${{ matrix.os == 'ubuntu' && matrix.target == 'x86_64' && matrix.manylinux == 'auto' }}
+    - run: python tools/patch_package_version.py
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        default: true
+    - name: Build wheels - x86_64
       uses: messense/maturin-action@v1
       with:
-        command: sdist
-        args: --out dist
-        rust-toolchain: stable
+        target: x86_64
+        args: --release --out dist --sdist
+    - name: Install built wheel - x86_64
+      run: |
+        pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
+        pip install -r requirements-dev.txt
+        rm -rf daft
+        pytest -v
 
-    - name: build wheels
+    - name: Build wheels - arm64
       uses: messense/maturin-action@v1
       with:
-        target: ${{ matrix.target }}
-        manylinux: ${{ matrix.manylinux || 'auto' }}
-        container: ${{ matrix.container }}
-        args: --release --out dist --interpreter ${{ matrix.interpreter || '3.7 3.8 3.9 3.10 3.11 pypy3.7 pypy3.8 pypy3.9' }}
-        rust-toolchain: stable
+        args: --release --out dist
+        target: aarch64
 
-    - run: ${{ matrix.ls || 'ls -lh' }} dist/
-
-    - run: twine check dist/*
-    - uses: actions/upload-artifact@v3
+    - name: Upload wheels
+      uses: actions/upload-artifact@v2
       with:
-        name: pypi_files
+        name: wheels
         path: dist
+
 
   #   - name: Publish bdist package to PYPI
   #     if: ${{ success() && (env.IS_PUSH == 'true') }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build_bdist_wheels:
-    name: platform wheels for ${{ matrix.python }}-${{ matrix.os }}
+    name: build on ${{ matrix.platform || matrix.os }} (${{ matrix.target }} - ${{ matrix.manylinux || 'auto' }})
     strategy:
       fail-fast: false
       matrix:
@@ -78,7 +78,7 @@ jobs:
         python-version: '3.11'
         architecture: ${{ matrix.python-architecture || 'x64' }}
 
-    - run: pip install -U twine
+    - run: pip install -U twine toml
 
     - name: Patch local cargo toml
       run: python tools/patch_package_version.py

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -81,6 +81,7 @@ jobs:
     needs:
     - build-and-test
     steps:
+    - uses: actions/checkout@v3
     - uses: actions/download-artifact@v2
       with:
         name: wheels

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,8 +18,6 @@ on:
 env:
   PACKAGE_NAME: getdaft
   PYTHON_VERSION: '3.7' # to build abi3 wheels
-  INTERPRETER: 3.7 3.8 3.9 3.10 3.11
-
 
 jobs:
   build-and-test:
@@ -47,23 +45,25 @@ jobs:
         toolchain: stable
         profile: minimal
         default: true
+
     - name: Build wheels - x86_64
       uses: messense/maturin-action@v1
       with:
         target: x86_64
-        args: --release --out dist --interpreter ${{ env.INTERPRETER }}
+        args: --release --out dist --sdist
+
+    - name: Build wheels - arm64
+      uses: messense/maturin-action@v1
+      with:
+        target: aarch64
+        args: --release --out dist
+
     - name: Install and test built wheel - x86_64
       run: |
         pip install -r requirements-dev.txt
         pip install dist/${{ env.PACKAGE_NAME }}-*-cp37-*.whl --force-reinstall
         rm -rf daft
         pytest -v
-
-    - name: Build wheels - arm64
-      uses: messense/maturin-action@v1
-      with:
-        args: --release --out dist --interpreter ${{ env.INTERPRETER }}
-        target: aarch64
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,6 +19,9 @@ env:
   PACKAGE_NAME: getdaft
   PYTHON_VERSION: '3.7' # to build abi3 wheels
 
+  IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
+  IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+
 jobs:
   build-and-test:
 
@@ -61,7 +64,7 @@ jobs:
     - name: Install and test built wheel - x86_64
       run: |
         pip install -r requirements-dev.txt
-        pip install dist/${{ env.PACKAGE_NAME }}-*-cp37-*.whl --force-reinstall
+        pip install dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
         rm -rf daft
         pytest -v
 
@@ -72,108 +75,50 @@ jobs:
         path: dist
 
 
-  #   - name: Publish bdist package to PYPI
-  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
-  #     run: python -m twine upload --skip-existing --disable-progress-bar ./wheelhouse/*
-  #     env:
-  #       TWINE_USERNAME: __token__
-  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-  #   - uses: conda-incubator/setup-miniconda@v2
-  #     with:
-  #       auto-update-conda: true
-  #       # Really doesn't matter what version we upload with
-  #       # just the version we test with
-  #       python-version: '3.8'
-  #       channels: conda-forge
-  #       channel-priority: true
-  #       mamba-version: '*'
+  publish:
+    name: Publish wheels to PYPI and Anaconda
+    runs-on: ubuntu-latest
+    needs:
+    - build-and-test
 
-  #   - name: Install anaconda client
-  #     shell: bash -el {0}
-  #     run: conda install -q -y anaconda-client
+    - uses: actions/download-artifact@v2
+      with:
+        name: wheels
 
-  #   - name: Upload wheels to anaconda nightly
-  #     if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
-  #     shell: bash -el {0}
-  #     env:
-  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-  #     run: |
-  #       source ci/upload_wheels.sh
-  #       set_upload_vars
-  #       # trigger an upload to
-  #       # https://anaconda.org/daft-nightly/getdaft
-  #       # for cron jobs or "Run workflow" (restricted to main branch).
-  #       # Tags will upload to
-  #       # https://anaconda.org/daft/getdaft
-  #       # The tokens were originally generated at anaconda.org
-  #       upload_wheels
+    - name: Publish bdist package to PYPI
+      if: ${{ success() && (env.IS_PUSH == 'true') }}
+      run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
-  # build_sdist_wheels:
-  #   name: source wheel
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        # Really doesn't matter what version we upload with
+        # just the version we test with
+        python-version: '3.8'
+        channels: conda-forge
+        channel-priority: true
+        mamba-version: '*'
 
-  #   env:
-  #     IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
-  #     IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    - name: Install anaconda client
+      shell: bash -el {0}
+      run: conda install -q -y anaconda-client
 
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #     with:
-  #       submodules: true
-  #       fetch-depth: 0
-
-  #   - uses: actions/setup-python@v4
-  #     with:
-  #       python-version: '3.11'
-
-
-  #   - name: Patch local cargo toml
-  #     run: python tools/patch_package_version.py
-
-
-  #   - name: Build wheels
-  #     run: poetry build -f sdist
-  #   - uses: actions/upload-artifact@v3
-  #     with:
-  #       name: source_wheels
-  #       path: ./dist/*
-  #   - name: Publish sdist package to PYPI
-  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
-  #     run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
-  #     env:
-  #       TWINE_USERNAME: __token__
-  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-  #     # Used to push the built sdist
-  #   - uses: conda-incubator/setup-miniconda@v2
-  #     with:
-  #       auto-update-conda: true
-  #       # Really doesn't matter what version we upload with
-  #       # just the version we test with
-  #       python-version: '3.8'
-  #       channels: conda-forge
-  #       channel-priority: true
-  #       mamba-version: '*'
-
-  #   - name: Install anaconda client
-  #     shell: bash -el {0}
-  #     run: conda install -q -y anaconda-client
-
-  #   - name: Upload wheels to anaconda nightly
-  #     if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
-  #     shell: bash -el {0}
-  #     env:
-  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-  #     run: |
-  #       source ci/upload_wheels.sh
-  #       set_upload_vars
-  #       # trigger an upload to
-  #       # https://anaconda.org/daft-nightly/getdaft
-  #       # for cron jobs or "Run workflow" (restricted to main branch).
-  #       # Tags will upload to
-  #       # https://anaconda.org/daft/getdaft
-  #       # The tokens were originally generated at anaconda.org
-  #       upload_wheels
+    - name: Upload wheels to anaconda nightly
+      if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
+      shell: bash -el {0}
+      env:
+        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+      run: |
+        source ci/upload_wheels.sh
+        set_upload_vars
+        # trigger an upload to
+        # https://anaconda.org/daft-nightly/getdaft
+        # for cron jobs or "Run workflow" (restricted to main branch).
+        # Tags will upload to
+        # https://anaconda.org/daft/getdaft
+        # The tokens were originally generated at anaconda.org
+        upload_wheels

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
+        os: [ubuntu] #,macos]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -55,18 +55,18 @@ jobs:
         target: x86_64
         args: --release --out dist --sdist
 
-    - name: Build wheels - arm64
-      uses: messense/maturin-action@v1
-      with:
-        target: aarch64
-        args: --release --out dist
+    # - name: Build wheels - arm64
+    #   uses: messense/maturin-action@v1
+    #   with:
+    #     target: aarch64
+    #     args: --release --out dist
 
-    - name: Install and test built wheel - x86_64
-      run: |
-        pip install -r requirements-dev.txt
-        pip install dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
-        rm -rf daft
-        pytest -v
+    # - name: Install and test built wheel - x86_64
+    #   run: |
+    #     pip install -r requirements-dev.txt
+    #     pip install dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
+    #     rm -rf daft
+    #     pytest -v
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu] #,macos]
+        os: [ubuntu, macos]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -55,18 +55,18 @@ jobs:
         target: x86_64
         args: --release --out dist --sdist
 
-    # - name: Build wheels - arm64
-    #   uses: messense/maturin-action@v1
-    #   with:
-    #     target: aarch64
-    #     args: --release --out dist
+    - name: Build wheels - arm64
+      uses: messense/maturin-action@v1
+      with:
+        target: aarch64
+        args: --release --out dist
 
-    # - name: Install and test built wheel - x86_64
-    #   run: |
-    #     pip install -r requirements-dev.txt
-    #     pip install dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
-    #     rm -rf daft
-    #     pytest -v
+    - name: Install and test built wheel - x86_64
+      run: |
+        pip install -r requirements-dev.txt
+        pip install dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
+        rm -rf daft
+        pytest -v
 
     - name: Upload wheels
       uses: actions/upload-artifact@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "daft"
-version = "0.0.20"
+version = "0.0.20+dev11.g913a4e9"
 dependencies = [
  "arrow2",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ features = [ "compute",]
 
 [dependencies.pyo3]
 version = "0.17.3"
-features = [ "extension-module",]
+features = [ "extension-module", "abi3-py37"]
 
 [dependencies.xxhash-rust]
 version = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,23 @@
-[dependencies]
-pyo3 = { version = "0.17.3", features = ["extension-module"] }
-arrow2 = { version = "0.14.2", features = ["compute"]}
+[dependencies.arrow2]
+version = "0.14.2"
+features = [ "compute",]
+
+[dependencies.pyo3]
+version = "0.17.3"
+features = [ "extension-module",]
 
 [dependencies.xxhash-rust]
 version = "0.8.5"
-features = ["xxh3", "const_xxh3"]
+features = [ "xxh3", "const_xxh3",]
 
 [lib]
 name = "daft"
-crate-type = ["cdylib"]
+crate-type = [ "cdylib",]
 
 [net]
 git-fetch-with-cli = true
 
 [package]
 name = "daft"
-version = "0.0.20"
+version = "0.0.20+dev11.g913a4e9"
 edition = "2021"

--- a/ci/upload_wheels.sh
+++ b/ci/upload_wheels.sh
@@ -25,10 +25,10 @@ upload_wheels() {
         if [ -z ${TOKEN} ]; then
             echo no token set, not uploading
         else
-            if compgen -G "./dist/*.gz"; then
+            if compgen -G "./dist/*"; then
                 echo "Found in dist"
                 anaconda -q -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./dist/*.gz
-            elif compgen -G "./wheelhouse/*.whl"; then
+            elif compgen -G "./wheelhouse/*"; then
                 echo "Found in wheelhouse"
                 anaconda -q -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./wheelhouse/*.whl
             else

--- a/ci/upload_wheels.sh
+++ b/ci/upload_wheels.sh
@@ -27,10 +27,10 @@ upload_wheels() {
         else
             if compgen -G "./dist/*"; then
                 echo "Found in dist"
-                anaconda -q -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./dist/*.gz
+                anaconda -q -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./dist/*
             elif compgen -G "./wheelhouse/*"; then
                 echo "Found in wheelhouse"
-                anaconda -q -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./wheelhouse/*.whl
+                anaconda -q -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./wheelhouse/*
             else
                 echo "Files do not exist"
                 return 1

--- a/ci/upload_wheels.sh
+++ b/ci/upload_wheels.sh
@@ -25,12 +25,11 @@ upload_wheels() {
         if [ -z ${TOKEN} ]; then
             echo no token set, not uploading
         else
-            # sdists are located under dist folder when built through setup.py
             if compgen -G "./dist/*.gz"; then
-                echo "Found sdist"
+                echo "Found in dist"
                 anaconda -q -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./dist/*.gz
             elif compgen -G "./wheelhouse/*.whl"; then
-                echo "Found wheel"
+                echo "Found in wheelhouse"
                 anaconda -q -t ${TOKEN} upload --skip -u ${ANACONDA_ORG} ./wheelhouse/*.whl
             else
                 echo "Files do not exist"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ readme = "README.rst"
 license = {file="LICENSE"}
 requires-python = ">=3.7"
 dependencies = [
-    "ray>=1.10.0",
     "numpy",
     "pyarrow",
     "fsspec",
@@ -35,7 +34,7 @@ aws = ["boto3", "s3fs"]
 serving = ["fastapi", "docker", "uvicorn", "cloudpickle", "boto3", "PyYAML"]
 iceberg = ["icebridge"]
 experimental = ["daft[serving, iceberg]"]
-ray = ["ray[data, default]"] # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
+ray = ["ray[data, default]>=1.10.0"] # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
 all = ["daft[aws, ray]"]
 
 [project.urls]

--- a/tools/patch_package_version.py
+++ b/tools/patch_package_version.py
@@ -38,6 +38,7 @@ def patch_cargo_toml_version(version: str):
     package["version"] = version
     with open("Cargo.toml", "w") as out_file:
         toml.dump(source, out_file)
+    print(f"Patched {CARGO_TOML} to version: {version}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Use maturin instead of cibuilwheel to build prod wheels
* Use abi3 wheels instead of specific version ones
* Custom script to patch Cargo version for wheel version