### PR TITLE
move RayPartitionSet import out of DataFrame top level and into ray_dataset_conversion

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -31,7 +31,6 @@ from daft.runners.partitioning import (
     vPartitionSchemaInferenceOptions,
 )
 from daft.runners.pyrunner import LocalPartitionSet
-from daft.runners.ray_runner import RayPartitionSet
 from daft.types import PythonExpressionType
 from daft.viz import DataFrameDisplay
 
@@ -1126,6 +1125,8 @@ class DataFrame:
         Returns:
             RayDataset: Ray dataset
         """
+        from daft.runners.ray_runner import RayPartitionSet
+
         self.collect()
         partition_set = self._result
         assert partition_set is not None


### PR DESCRIPTION
* Since ray is an optional dep, this should not be in the top level which causes import problems when not installed