### PR TITLE
[Rust wheel publish] Set manylinux version to auto for max compatibility

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -53,12 +53,14 @@ jobs:
       uses: messense/maturin-action@v1
       with:
         target: x86_64
+        manylinux: auto
         args: --release --out dist --sdist
 
     - name: Build wheels - arm64
       uses: messense/maturin-action@v1
       with:
         target: aarch64
+        manylinux: auto
         args: --release --out dist
 
     - name: Install and test built wheel - x86_64


### PR DESCRIPTION
* Pip is having an issue picking up some of our wheels due the manylinux compatibility