### PR TITLE
Pin numpy < 1.24 to avoid partition bug for pylist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.rst"
 license = {file="LICENSE"}
 requires-python = ">=3.7"
 dependencies = [
-    "numpy",
+    "numpy < 1.24",
     "pyarrow",
     "fsspec",
     "protobuf>=3.19.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ icebridge
 ipdb
 maturin
 myst-nb>=0.16.0
-numpy
+numpy < 1.24
 pandas
 pre-commit
 pyarrow


### PR DESCRIPTION
* Numpy 1.24 has new behavior for np.split when dealing with list[np.ndarray]. Pin to a lower version until we factor it out