### PR TITLE
Add PartitionMetadata. Interface tweaks for DynamicConstruction.

### DIFF
--- a/daft/execution/dynamic_schedule_factory.py
+++ b/daft/execution/dynamic_schedule_factory.py
@@ -24,6 +24,8 @@ PartitionT = TypeVar("PartitionT")
 
 class DynamicScheduleFactory(Generic[PartitionT]):
     def __init__(self):
+        # Normally this class would just be a holder for static methods;
+        # however, it seems mypy does not properly pass through type parameterization for static methods.
         pass
 
     def schedule_logical_node(self, node: LogicalPlan) -> DynamicSchedule[PartitionT]:

--- a/daft/runners/dynamic_runner.py
+++ b/daft/runners/dynamic_runner.py
@@ -68,5 +68,5 @@ class DynamicRunner(Runner):
 
     def _build_partitions(self, partspec: Construction[vPartition]) -> None:
         construct_fn = partspec.get_runnable()
-        results = construct_fn(partspec.inputs)
+        results, metas = construct_fn(*partspec.inputs)
         partspec.report_completed(results)

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -157,6 +157,11 @@ class PyListTile:
 
 
 @dataclass(frozen=True)
+class PartitionMetadata:
+    num_rows: int
+
+
+@dataclass(frozen=True)
 class vPartition:
     columns: dict[ColID, PyListTile]
     partition_id: PartID
@@ -177,6 +182,9 @@ class vPartition:
         if len(self.columns) == 0:
             return 0
         return len(next(iter(self.columns.values())))
+
+    def metadata(self) -> PartitionMetadata:
+        return PartitionMetadata(num_rows=len(self))
 
     def get_col_expressions(self) -> ExpressionList:
         """Generates column expressions that represent the vPartition's schema"""


### PR DESCRIPTION
PartitionMetadata as a separate abstraction will be used for DynamicRayRunner, which will need partition metadata to make decisions without having access to the partition objects themselves.

DynamicConstruction's get_runnable now also returns PartitionMetadatas. These can be awaited separately. 