### PR TITLE
Add twine install to publishing steps

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -83,6 +83,11 @@ jobs:
     needs:
     - build-and-test
     steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+        architecture: x64
+    - run: pip install -U twine
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v2
       with:

--- a/docs/source/docs/release_notes/0.0.20.rst
+++ b/docs/source/docs/release_notes/0.0.20.rst
@@ -13,7 +13,7 @@ New Features
 Dynamic Scheduling
 ^^^^^^^^^^^^^^^^^^
 
-Great work by @charlesxlin to introduce a new Dynamic scheduler for running Daft dataframe queries. This version of the scheduler allows Daft to perform much more intelligent pull-based scheduling, dramatically speeding up operations such as `.limit(5).show()` which will now only require materializing the first partition, even in the presence of other global operations such as a `.where`.
+Great work by @xcharleslin to introduce a new Dynamic scheduler for running Daft dataframe queries. This version of the scheduler allows Daft to perform much more intelligent pull-based scheduling, dramatically speeding up operations such as `.limit(5).show()` which will now only require materializing the first partition, even in the presence of other global operations such as a `.where`.
 
 * Add tests for \#368 `#375 <https://github.com/Eventual-Inc/Daft/pull/375>`_
 * Implement dynamic scheduling. `#387 <https://github.com/Eventual-Inc/Daft/pull/387>`_


### PR DESCRIPTION
Publishing is currently failing on a missing `twine` package