### PR TITLE
Add profiling to benchmarks/tpch. Improve profiler to prevent VizTracer nesting.

### DIFF
--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -25,6 +25,7 @@ import daft
 from benchmarking.tpch import answers, data_generation
 from daft import DataFrame
 from daft.context import get_context
+from daft.runners.profiler import profiler
 
 ALL_TABLES = [
     "part",
@@ -91,9 +92,11 @@ class MetricsBuilder:
     @contextlib.contextmanager
     def collect_metrics(self, qnum: int):
         logger.info(f"Running benchmarks for TPC-H q{qnum}")
-        start = time.time()
-        yield
-        walltime_s = time.time() - start
+        start = datetime.now()
+        profile_filename = f"tpch_q{qnum}_{datetime.replace(start, microsecond=0).isoformat()}.json"
+        with profiler(profile_filename):
+            yield
+        walltime_s = (datetime.now() - start).total_seconds()
         logger.info(f"Finished benchmarks for q{qnum}: {walltime_s}s")
         self._metrics[f"tpch_q{qnum}"] = walltime_s
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,11 +11,15 @@ ipdb
 maturin
 myst-nb>=0.16.0
 numpy < 1.24
+# orjson recommended for viztracer
+orjson
 pandas
 pre-commit
 pyarrow
 
 # Tooling
+
+
 
 # needed for testing
 pytest>=7.1.2


### PR DESCRIPTION
Add daft.runners.profiler to benchmarks.tpch. Now, you can run benchmark with DAFT_PROFILING=1 to generate a profile per question.

The profile will be in the form `tpch_q{num}_{timestamp}.json`.

----

Adding the profiler to TPCH introduces nested profiling, since there are already profiler calls lower in the Daft code. However, VizTracer does not seem to be nestable. It will complain loudly:

```
Warning! Overwrite tracer! You should not have two VizTracer recording at the same time!
```

and then sometimes segfault:
```
*** SIGSEGV received at time=1672950845 on cpu 2 ***
PC: @     0x7fc5f9ea6306  (unknown)  (unknown)
    @     0x7fc5f9c12320  (unknown)  (unknown)
[2023-01-05 12:34:05,190 E 2576853 2577214] logging.cc:361: *** SIGSEGV received at time=1672950845 on cpu 2 ***
[2023-01-05 12:34:05,190 E 2576853 2577214] logging.cc:361: PC: @     0x7fc5f9ea6306  (unknown)  (unknown)
[2023-01-05 12:34:05,191 E 2576853 2577214] logging.cc:361:     @     0x7fc5f9c12320  (unknown)  (unknown)
Fatal Python error: Segmentation fault

Stack (most recent call first):
<no Python frame>
zsh: segmentation fault (core dumped)
```

To work around this, I made Daft's viztracer wrapper its own context manager that no-ops if an existing VizTracer is already active.