### PR TITLE
Add DAFT_PKG_BUILD_TYPE to python-publish CI job

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,6 +21,7 @@ env:
 
   IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
   IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+  DAFT_PKG_BUILD_TYPE: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0'))) && 'release' || 'nightly' }}
 
 jobs:
   build-and-test:


### PR DESCRIPTION
1. Build Daft with `DAFT_PKG_BUILD_TYPE=release` environment variable on release builds (with `v*` tags)
2. Build Daft with `DAFT_PKG_BUILD_TYPE=nightly` environment variable on other builds