### PR TITLE
API Documentation refactors

### DIFF
--- a/daft/expressions.py
+++ b/daft/expressions.py
@@ -43,7 +43,7 @@ from daft.types import ExpressionType, PrimitiveExpressionType
 
 
 def col(name: str) -> ColumnExpression:
-    """Selects a column with a given name
+    """Creates an Expression referring to the column with the provided name
 
     Example:
         >>> col("x")
@@ -58,7 +58,7 @@ def col(name: str) -> ColumnExpression:
 
 
 def lit(val: Any) -> LiteralExpression:
-    """Selects a column with every item being the provided value
+    """Creates an Expression representing a column with every value set to the provided value
 
     Example:
         >>> col("x") + lit(1)
@@ -265,9 +265,18 @@ class Expression(TreeNode["Expression"]):
     # UnaryOps
 
     # Arithmetic
-    __neg__ = partialmethod(_unary_op, OperatorEnum.NEGATE)
-    __pos__ = partialmethod(_unary_op, OperatorEnum.POSITIVE)
-    __abs__ = partialmethod(_unary_op, OperatorEnum.ABS)
+
+    def __neg__(self) -> Expression:
+        """Negates a numeric expression (``-expr``)"""
+        return self._unary_op(OperatorEnum.NEGATE)
+
+    def __pos__(self) -> Expression:
+        """Positive of a numeric expression (``+expr``)"""
+        return self._unary_op(OperatorEnum.POSITIVE)
+
+    def __abs__(self) -> Expression:
+        """Absolute of a numeric expression (``abs(expr)``)"""
+        return self._unary_op(OperatorEnum.ABS)
 
     # Symbolic - not used during evaluation but useful for type resolution on the Expression
     _sum = partialmethod(_unary_op, OperatorEnum.SUM)
@@ -280,18 +289,40 @@ class Expression(TreeNode["Expression"]):
     _explode = partialmethod(_unary_op, OperatorEnum.EXPLODE)
 
     # Logical
-    __invert__ = partialmethod(_unary_op, OperatorEnum.INVERT)
+    def __invert__(self) -> Expression:
+        """Inverts a logical expression (``~e``)"""
+        return self._unary_op(OperatorEnum.INVERT)
 
     # BinaryOps
 
     # Arithmetic
-    __add__ = partialmethod(_binary_op, OperatorEnum.ADD)
-    __sub__ = partialmethod(_binary_op, OperatorEnum.SUB)
-    __mul__ = partialmethod(_binary_op, OperatorEnum.MUL)
-    __floordiv__ = partialmethod(_binary_op, OperatorEnum.FLOORDIV)
-    __truediv__ = partialmethod(_binary_op, OperatorEnum.TRUEDIV)
-    __pow__ = partialmethod(_binary_op, OperatorEnum.POW)
-    __mod__ = partialmethod(_binary_op, OperatorEnum.MOD)
+    def __add__(self, other: Expression) -> Expression:
+        """Adds two numeric expressions (``e1 + e2``)"""
+        return self._binary_op(OperatorEnum.ADD, other)
+
+    def __sub__(self, other: Expression) -> Expression:
+        """Subtracts two numeric expressions (``e1 - e2``)"""
+        return self._binary_op(OperatorEnum.SUB, other)
+
+    def __mul__(self, other: Expression) -> Expression:
+        """Multiplies two numeric expressions (``e1 * e2``)"""
+        return self._binary_op(OperatorEnum.MUL, other)
+
+    def __floordiv__(self, other: Expression) -> Expression:
+        """Floor divides two numeric expressions (``e1 // e2``)"""
+        return self._binary_op(OperatorEnum.FLOORDIV, other)
+
+    def __truediv__(self, other: Expression) -> Expression:
+        """True divides two numeric expressions (``e1 / e2``)"""
+        return self._binary_op(OperatorEnum.TRUEDIV, other)
+
+    def __pow__(self, other: Expression) -> Expression:
+        """Takes the power of two numeric expressions (``e1 ** e2``)"""
+        return self._binary_op(OperatorEnum.POW, other)
+
+    def __mod__(self, other: Expression) -> Expression:
+        """Takes the mod of two numeric expressions (``e1 % e2``)"""
+        return self._binary_op(OperatorEnum.MOD, other)
 
     # Reverse Arithmetic
     __radd__ = partialmethod(_reverse_binary_op, OperatorEnum.ADD)
@@ -302,15 +333,37 @@ class Expression(TreeNode["Expression"]):
     __rpow__ = partialmethod(_reverse_binary_op, OperatorEnum.POW)
 
     # Logical
-    __and__ = partialmethod(_binary_op, OperatorEnum.AND)
-    __or__ = partialmethod(_binary_op, OperatorEnum.OR)
+    def __and__(self, other: Expression) -> Expression:
+        """Takes the logical AND of two expressions (``e1 & e2``)"""
+        return self._binary_op(OperatorEnum.AND, other)
 
-    __lt__ = partialmethod(_binary_op, OperatorEnum.LT)
-    __le__ = partialmethod(_binary_op, OperatorEnum.LE)
-    __eq__ = partialmethod(_binary_op, OperatorEnum.EQ)  # type: ignore
-    __ne__ = partialmethod(_binary_op, OperatorEnum.NEQ)  # type: ignore
-    __gt__ = partialmethod(_binary_op, OperatorEnum.GT)
-    __ge__ = partialmethod(_binary_op, OperatorEnum.GE)
+    def __or__(self, other: Expression) -> Expression:
+        """Takes the logical OR of two expressions (``e1 | e2``)"""
+        return self._binary_op(OperatorEnum.OR, other)
+
+    def __lt__(self, other: Expression) -> Expression:
+        """Compares if an expression is less than another (``e1 < e2``)"""
+        return self._binary_op(OperatorEnum.LT, other)
+
+    def __le__(self, other: Expression) -> Expression:
+        """Compares if an expression is less than or equal to another (``e1 <= e2``)"""
+        return self._binary_op(OperatorEnum.LE, other)
+
+    def __eq__(self, other: Expression) -> Expression:  # type: ignore
+        """Compares if an expression is equal to another (``e1 == e2``)"""
+        return self._binary_op(OperatorEnum.EQ, other)
+
+    def __ne__(self, other: Expression) -> Expression:  # type: ignore
+        """Compares if an expression is not equal to another (``e1 != e2``)"""
+        return self._binary_op(OperatorEnum.NEQ, other)
+
+    def __gt__(self, other: Expression) -> Expression:
+        """Compares if an expression is greater than another (``e1 > e2``)"""
+        return self._binary_op(OperatorEnum.GT, other)
+
+    def __ge__(self, other: Expression) -> Expression:
+        """Compares if an expression is greater than or equal to another (``e1 >= e2``)"""
+        return self._binary_op(OperatorEnum.GE, other)
 
     # Reverse Logical
     __rand__ = partialmethod(_reverse_binary_op, OperatorEnum.AND)
@@ -427,7 +480,7 @@ class Expression(TreeNode["Expression"]):
         return True
 
     def if_else(self, if_true: Expression, if_false: Expression) -> Expression:
-        """Choose values from `if_true` and `if_false` based on the current expression as the condition.
+        """Conditionally choose values between two expressions using the current LOGICAL expression as a condition
 
         Example:
             >>> # x = [2, 2, 2]
@@ -450,7 +503,7 @@ class Expression(TreeNode["Expression"]):
         )
 
     def is_null(self) -> Expression:
-        """Checks if values in the Expression are Null (i.e. they are missing)
+        """Checks if values in the Expression are Null (a special value indicating missing data)
 
         Example:
             >>> # [1., None, NaN] -> [False, True, False]
@@ -465,7 +518,7 @@ class Expression(TreeNode["Expression"]):
         )
 
     def is_nan(self) -> Expression:
-        """Checks if values in the Expression are NaN (i.e. they are invalid)
+        """Checks if values are NaN (a special float value indicating not-a-number)
 
         Example:
             >>> # [1., None, NaN] -> [False, False, True]

--- a/docs/source/_static/custom-function-signatures.css
+++ b/docs/source/_static/custom-function-signatures.css
@@ -1,0 +1,13 @@
+/* Taken from suggested solutions in: https://github.com/sphinx-doc/sphinx/issues/1514 */
+
+/* Newlines (\a) and spaces (\20) before each parameter */
+.sig-param::before {
+    content: "\a\20\20\20\20";
+    white-space: pre;
+}
+
+/* Newline after the last parameter (so the closing bracket is on a new line) */
+dt em.sig-param:last-of-type::after {
+    content: "\a";
+    white-space: pre;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,7 @@ nb_execution_mode = "off"
 
 html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
-html_css_files = ["header.css", "landing-page.css"]
+html_css_files = ["header.css", "landing-page.css", "custom-function-signatures.css"]
 html_theme_options = {
     # This is the footer of the primary sidebar as HTML
     "extra_navbar": "",

--- a/docs/source/docs/api_docs/context.rst
+++ b/docs/source/docs/api_docs/context.rst
@@ -1,5 +1,5 @@
-Daft Context
-============
+Configuration
+=============
 
 .. autofunction:: daft.context.set_runner_ray
 .. autofunction:: daft.context.set_runner_py

--- a/docs/source/docs/api_docs/dataframe.rst
+++ b/docs/source/docs/api_docs/dataframe.rst
@@ -1,92 +1,179 @@
 DataFrame
 =========
 
-.. autoclass:: daft.DataFrame
+.. currentmodule:: daft
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    DataFrame
+
+.. NOTE::
+    Most DataFrame methods are **lazy**, meaning that they do not execute computation immediately when invoked. Instead, these operations are enqueued in
+    the DataFrame's internal query plan, and are only executed when `Execution`_ DataFrame methods are called.
 
 Construction
 ############
 
+From Files
+**********
+
 .. _df-file-construction-api:
 
-.. automethod:: daft.DataFrame.read_csv
-.. automethod:: daft.DataFrame.read_json
-.. automethod:: daft.DataFrame.read_parquet
-.. automethod:: daft.DataFrame.from_files
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
 
-.. _df-memory-construction-api:
+    daft.DataFrame.read_csv
+    daft.DataFrame.read_json
+    daft.DataFrame.read_parquet
+    daft.DataFrame.from_files
 
-.. automethod:: daft.DataFrame.from_pylist
-.. automethod:: daft.DataFrame.from_pydict
+From In-Memory Data
+*******************
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.from_pylist
+    daft.DataFrame.from_pydict
+
 
 .. _dataframe-api-operations:
 
-Operations
-##########
+Data Manipulation
+#################
 
 Manipulating Columns
 ********************
+
 .. _df-select:
-.. automethod:: daft.DataFrame.select
 .. _df-with-column:
-.. automethod:: daft.DataFrame.with_column
-.. automethod:: daft.DataFrame.exclude
-.. automethod:: daft.DataFrame.explode
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.select
+    daft.DataFrame.with_column
+    daft.DataFrame.exclude
+    daft.DataFrame.explode
 
 Filtering Rows
 **************
-.. automethod:: daft.DataFrame.distinct
+
 .. _df-where:
-.. automethod:: daft.DataFrame.where
 .. _df-limit:
-.. automethod:: daft.DataFrame.limit
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.distinct
+    daft.DataFrame.where
+    daft.DataFrame.limit
 
 Reordering
 **********
+
 .. _df-sort:
-.. automethod:: daft.DataFrame.sort
-.. automethod:: daft.DataFrame.repartition
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.sort
+    daft.DataFrame.repartition
 
 Combining
 *********
+
 .. _df-join:
-.. automethod:: daft.DataFrame.join
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.join
 
 Aggregations
 ************
+
 .. _df-groupby:
-.. automethod:: daft.DataFrame.groupby
 .. _df-sum:
-.. automethod:: daft.DataFrame.sum
 .. _df-mean:
-.. automethod:: daft.DataFrame.mean
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.groupby
+    daft.DataFrame.sum
+    daft.DataFrame.mean
+    daft.DataFrame.count
+    daft.DataFrame.min
+    daft.DataFrame.max
 
 Execution
 #########
+
+.. NOTE::
+    These methods will execute the operations in your DataFrame and **are blocking**.
+
+Materialization
+***************
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.collect
 
 Visualization
 *************
 
 .. _df-show:
-.. automethod:: daft.DataFrame.show
-.. _df-to-pandas:
-.. automethod:: daft.DataFrame.to_pandas
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.show
+
 
 .. _df-write-data:
 
 Writing Data
 ************
 
-.. automethod:: daft.DataFrame.write_parquet
-.. automethod:: daft.DataFrame.write_csv
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.write_parquet
+    daft.DataFrame.write_csv
 
 Integrations
 ************
 
-.. automethod:: daft.DataFrame.to_ray_dataset
+.. _df-to-pandas:
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.to_pandas
+    daft.DataFrame.to_ray_dataset
 
 Schema and Lineage
 ##################
 
-.. automethod:: daft.DataFrame.explain
-.. automethod:: daft.DataFrame.schema
-.. autoproperty:: daft.DataFrame.column_names
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.explain
+    daft.DataFrame.schema
+    daft.DataFrame.column_names

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.collect.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.collect.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.collect
+======================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.collect

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.column_names.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.column_names.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.column\_names
+============================
+
+.. currentmodule:: daft
+
+.. autoproperty:: DataFrame.column_names

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.count.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.count.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.count
+====================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.count

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.distinct.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.distinct.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.distinct
+=======================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.distinct

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.exclude.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.exclude.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.exclude
+======================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.exclude

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.explain.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.explain.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.explain
+======================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.explain

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.explode.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.explode.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.explode
+======================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.explode

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_files.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_files.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.from\_files
+==========================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.from_files

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_pydict.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_pydict.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.from\_pydict
+===========================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.from_pydict

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_pylist.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_pylist.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.from\_pylist
+===========================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.from_pylist

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.groupby.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.groupby.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.groupby
+======================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.groupby

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.join.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.join.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.join
+===================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.join

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.limit.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.limit.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.limit
+====================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.limit

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.max.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.max.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.max
+==================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.max

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.mean.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.mean.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.mean
+===================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.mean

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.min.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.min.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.min
+==================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.min

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.read_csv.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.read_csv.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.read\_csv
+========================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.read_csv

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.read_json.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.read_json.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.read\_json
+=========================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.read_json

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.read_parquet.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.read_parquet.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.read\_parquet
+============================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.read_parquet

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.repartition.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.repartition.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.repartition
+==========================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.repartition

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.rst
@@ -1,0 +1,64 @@
+﻿daft.DataFrame
+==============
+
+.. currentmodule:: daft
+
+.. autoclass:: DataFrame
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~DataFrame.__init__
+      ~DataFrame.agg
+      ~DataFrame.collect
+      ~DataFrame.count
+      ~DataFrame.distinct
+      ~DataFrame.exclude
+      ~DataFrame.explain
+      ~DataFrame.explode
+      ~DataFrame.from_csv
+      ~DataFrame.from_files
+      ~DataFrame.from_json
+      ~DataFrame.from_parquet
+      ~DataFrame.from_pydict
+      ~DataFrame.from_pylist
+      ~DataFrame.groupby
+      ~DataFrame.join
+      ~DataFrame.limit
+      ~DataFrame.max
+      ~DataFrame.mean
+      ~DataFrame.min
+      ~DataFrame.num_partitions
+      ~DataFrame.plan
+      ~DataFrame.read_csv
+      ~DataFrame.read_json
+      ~DataFrame.read_parquet
+      ~DataFrame.repartition
+      ~DataFrame.schema
+      ~DataFrame.select
+      ~DataFrame.show
+      ~DataFrame.sort
+      ~DataFrame.sum
+      ~DataFrame.to_pandas
+      ~DataFrame.to_pydict
+      ~DataFrame.to_ray_dataset
+      ~DataFrame.where
+      ~DataFrame.with_column
+      ~DataFrame.write_csv
+      ~DataFrame.write_parquet
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~DataFrame.column_names
+      ~DataFrame.columns

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.schema.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.schema.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.schema
+=====================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.schema

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.select.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.select.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.select
+=====================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.select

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.show.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.show.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.show
+===================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.show

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.sort.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.sort.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.sort
+===================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.sort

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.sum.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.sum.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.sum
+==================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.sum

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.to_pandas.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.to_pandas.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.to\_pandas
+=========================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.to_pandas

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.to_ray_dataset.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.to_ray_dataset.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.to\_ray\_dataset
+===============================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.to_ray_dataset

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.where.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.where.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.where
+====================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.where

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.with_column.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.with_column.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.with\_column
+===========================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.with_column

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.write_csv.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.write_csv.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.write\_csv
+=========================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.write_csv

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.write_parquet.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.write_parquet.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.write\_parquet
+=============================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.write_parquet

--- a/docs/source/docs/api_docs/expression_methods/daft.DataFrame.__getitem__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.DataFrame.__getitem__.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.\_\_getitem\_\_
+==============================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.__getitem__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.DatetimeMethodAccessor.day.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.DatetimeMethodAccessor.day.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.DatetimeMethodAccessor.day
+===========================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: DatetimeMethodAccessor.day

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.DatetimeMethodAccessor.day_of_week.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.DatetimeMethodAccessor.day_of_week.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.DatetimeMethodAccessor.day\_of\_week
+=====================================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: DatetimeMethodAccessor.day_of_week

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.DatetimeMethodAccessor.month.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.DatetimeMethodAccessor.month.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.DatetimeMethodAccessor.month
+=============================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: DatetimeMethodAccessor.month

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.DatetimeMethodAccessor.year.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.DatetimeMethodAccessor.year.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.DatetimeMethodAccessor.year
+============================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: DatetimeMethodAccessor.year

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__abs__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__abs__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_abs\_\_
+=======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__abs__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__add__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__add__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_add\_\_
+=======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__add__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__and__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__and__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_and\_\_
+=======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__and__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__eq__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__eq__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_eq\_\_
+======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__eq__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__floordiv__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__floordiv__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_floordiv\_\_
+============================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__floordiv__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__ge__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__ge__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_ge\_\_
+======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__ge__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__gt__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__gt__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_gt\_\_
+======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__gt__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__invert__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__invert__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_invert\_\_
+==========================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__invert__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__le__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__le__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_le\_\_
+======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__le__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__lt__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__lt__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_lt\_\_
+======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__lt__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__mod__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__mod__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_mod\_\_
+=======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__mod__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__mul__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__mul__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_mul\_\_
+=======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__mul__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__ne__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__ne__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_ne\_\_
+======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__ne__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__neg__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__neg__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_neg\_\_
+=======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__neg__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__or__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__or__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_or\_\_
+======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__or__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__pos__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__pos__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_pos\_\_
+=======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__pos__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__pow__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__pow__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_pow\_\_
+=======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__pow__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__sub__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__sub__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_sub\_\_
+=======================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__sub__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__truediv__.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.__truediv__.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.\_\_truediv\_\_
+===========================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.__truediv__

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.alias.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.alias.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.alias
+=================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.alias

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.apply.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.apply.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.apply
+=================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.apply

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.as_py.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.as_py.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.as\_py
+==================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.as_py

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.cast.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.cast.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.cast
+================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.cast

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.if_else.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.if_else.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.if\_else
+====================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.if_else

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.is_nan.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.is_nan.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.is\_nan
+===================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.is_nan

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.is_null.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.is_null.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.Expression.is\_null
+====================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: Expression.is_null

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.Expression.rst
@@ -1,0 +1,49 @@
+﻿daft.expressions.Expression
+===========================
+
+.. currentmodule:: daft.expressions
+
+.. autoclass:: Expression
+
+
+   .. automethod:: __init__
+
+
+   .. rubric:: Methods
+
+   .. autosummary::
+
+      ~Expression.__init__
+      ~Expression.alias
+      ~Expression.apply
+      ~Expression.apply_and_trickle_down
+      ~Expression.as_py
+      ~Expression.cast
+      ~Expression.get_id
+      ~Expression.has_call
+      ~Expression.has_id
+      ~Expression.if_else
+      ~Expression.is_eq
+      ~Expression.is_nan
+      ~Expression.is_null
+      ~Expression.is_same
+      ~Expression.name
+      ~Expression.post_order
+      ~Expression.required_columns
+      ~Expression.resolved_type
+      ~Expression.resource_request
+      ~Expression.to_column_expression
+      ~Expression.to_dot
+      ~Expression.to_dot_file
+
+
+
+
+
+   .. rubric:: Attributes
+
+   .. autosummary::
+
+      ~Expression.dt
+      ~Expression.str
+      ~Expression.url

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.concat.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.concat.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.StringMethodAccessor.concat
+============================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: StringMethodAccessor.concat

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.contains.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.contains.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.StringMethodAccessor.contains
+==============================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: StringMethodAccessor.contains

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.endswith.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.endswith.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.StringMethodAccessor.endswith
+==============================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: StringMethodAccessor.endswith

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.length.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.length.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.StringMethodAccessor.length
+============================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: StringMethodAccessor.length

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.startswith.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.StringMethodAccessor.startswith.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.StringMethodAccessor.startswith
+================================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: StringMethodAccessor.startswith

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.UrlMethodAccessor.download.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.UrlMethodAccessor.download.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.UrlMethodAccessor.download
+===========================================
+
+.. currentmodule:: daft.expressions
+
+.. automethod:: UrlMethodAccessor.download

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.col.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.col.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.col
+====================
+
+.. currentmodule:: daft.expressions
+
+.. autofunction:: col

--- a/docs/source/docs/api_docs/expression_methods/daft.expressions.lit.rst
+++ b/docs/source/docs/api_docs/expression_methods/daft.expressions.lit.rst
@@ -1,0 +1,6 @@
+﻿daft.expressions.lit
+====================
+
+.. currentmodule:: daft.expressions
+
+.. autofunction:: lit

--- a/docs/source/docs/api_docs/expressions.rst
+++ b/docs/source/docs/api_docs/expressions.rst
@@ -1,175 +1,143 @@
 Expressions
 ===========
 
-.. autoclass:: daft.expressions.Expression
+.. currentmodule:: daft
+
+.. autosummary::
+    :nosignatures:
+    :toctree: expression_methods
+
+    daft.expressions.Expression
 
 Expression Constructors
 #######################
 
-.. autofunction:: daft.expressions.col
-.. autofunction:: daft.expressions.lit
+.. autosummary::
+    :nosignatures:
+    :toctree: expression_methods
+
+    daft.DataFrame.__getitem__
+    daft.expressions.col
+    daft.expressions.lit
 
 Operators
 #########
 
-Operators allow for creating new expressions from existing ones. Not all operators can be run on all types. For a list of expression types and their operations, see: https://docs.getdaft.io/daft/user-guides/daft-types-and-operations
-
-Unary
-*****
-
-.. py:module:: daft.expressions
-
-.. py:method:: Expression.__neg__()
-
-    Takes the negated value of a numeric expression.
-
-    >>> -col("x")
-
-.. py:method:: Expression.__pos__()
-
-    Takes the positive value of a numeric expression.
-
-    >>> +col("x")
-
-.. py:method:: Expression.__abs__()
-
-    Takes the absolute value of a numeric expression.
-
-    >>> abs(col("x"))
-
-.. py:method:: Expression.__invert__()
-
-    Inverts a LOGICAL expression.
-
-    >>> ~col("x")
-
-Binary
-******
-
-.. py:method:: Expression.__add__(other: Expression)
-
-    Adds two numeric expressions.
-
-    >>> col("x") + col("y")
-
-.. py:method:: Expression.__sub__(other: Expression)
-
-    Subtracts two numeric expressions.
-
-    >>> col("x") - col("y")
-
-.. py:method:: Expression.__mul__(other: Expression)
-
-    Subtracts two numeric expressions.
-
-    >>> col("x") * col("y")
-
-.. py:method:: Expression.__floordiv__(other: Expression)
-
-    Takes the floor division of two numeric expressions.
-
-    >>> col("x") // col("y")
-
-.. py:method:: Expression.__truediv__(other: Expression)
-
-    Takes the true division of two numeric expressions.
-
-    >>> col("x") / col("y")
-
-.. py:method:: Expression.__pow__(other: Expression)
-
-    Takes the power of two numeric expressions.
-
-    >>> col("x") ** col("y")
-
-.. py:method:: Expression.__mod__(other: Expression)
-
-    Takes the mod of two numeric expressions.
-
-    >>> col("x") % col("y")
-
-.. py:method:: Expression.__and__(other: Expression)
-
-    Takes the conjunction of two LOGICAL expressions.
-
-    >>> col("x") & col("y")
-
-.. py:method:: Expression.__or__(other: Expression)
-
-    Takes the disjunction of two LOGICAL expressions.
-
-    >>> col("x") | col("y")
-
-.. py:method:: Expression.__lt__(other: Expression)
-
-    Compares two Expressions to check if the first is less than the second.
-
-    >>> col("x") < col("y")
-
-.. py:method:: Expression.__le__(other: Expression)
-
-    Compares two Expressions to check if the first is less or equal to the second.
-
-    >>> col("x") <= col("y")
-
-.. py:method:: Expression.__eq__(other: Expression)
-
-    Compares two Expressions to check if they are equal.
-
-    >>> col("x") == col("y")
-
-.. py:method:: Expression.__ne__(other: Expression)
-
-    Compares two Expressions to check if they are not equal.
-
-    >>> col("x") != col("y")
-
-.. py:method:: Expression.__gt__(other: Expression)
-
-    Compares two Expressions to check if the first is greater than the second.
-
-    >>> col("x") > col("y")
-
-.. py:method:: Expression.__ge__(other: Expression)
-
-    Compares two Expressions to check if the first is greater than or equal to the second.
-
-    >>> col("x") >= col("y")
-
-.. automethod:: daft.expressions.Expression.is_null
-.. automethod:: daft.expressions.Expression.is_nan
-
-Ternary
+Numeric
 *******
 
-.. automethod:: daft.expressions.Expression.if_else
+Operations on numbers (floats and integers)
 
-Changing Column Names/Types
-###########################
-.. automethod:: daft.expressions.Expression.alias
-.. automethod:: daft.expressions.Expression.cast
+.. autosummary::
+    :toctree: expression_methods
 
-Running Python Functions
-########################
-.. automethod:: daft.expressions.Expression.as_py
-.. automethod:: daft.expressions.Expression.apply
+    daft.expressions.Expression.__neg__
+    daft.expressions.Expression.__pos__
+    daft.expressions.Expression.__abs__
+    daft.expressions.Expression.__add__
+    daft.expressions.Expression.__sub__
+    daft.expressions.Expression.__mul__
+    daft.expressions.Expression.__floordiv__
+    daft.expressions.Expression.__truediv__
+    daft.expressions.Expression.__pow__
+    daft.expressions.Expression.__mod__
+    daft.expressions.Expression.is_nan
 
-Accessors
-#########
+Logical
+*******
+
+Operations on logical expressions (True/False booleans)
+
+.. autosummary::
+    :toctree: expression_methods
+
+    daft.expressions.Expression.__invert__
+    daft.expressions.Expression.__and__
+    daft.expressions.Expression.__or__
+    daft.expressions.Expression.if_else
+
+Comparisons
+***********
+
+Comparing expressions and values, returning a logical expression
+
+.. autosummary::
+    :toctree: expression_methods
+
+    daft.expressions.Expression.__lt__
+    daft.expressions.Expression.__le__
+    daft.expressions.Expression.__eq__
+    daft.expressions.Expression.__ne__
+    daft.expressions.Expression.__gt__
+    daft.expressions.Expression.__ge__
+    daft.expressions.Expression.is_null
 
 .. _expression-accessor-properties:
 
-Expression Accessor Properties
-******************************
-.. autoproperty:: daft.expressions.Expression.str
-.. autoproperty:: daft.expressions.Expression.url
-.. autoproperty:: daft.expressions.Expression.dt
+Strings
+*******
 
-Accessor APIs
-*************
-.. autoclass:: daft.expressions.StringMethodAccessor
-    :members:
-.. autoclass:: daft.expressions.UrlMethodAccessor
-    :members:
-.. autoclass:: daft.expressions.DatetimeMethodAccessor
-    :members:
+Operations on strings, accessible through the ``Expression.str`` method accessor.
+
+Example: ``e1.str.concat(e2)``
+
+.. autosummary::
+    :toctree: expression_methods
+
+    daft.expressions.StringMethodAccessor.concat
+    daft.expressions.StringMethodAccessor.contains
+    daft.expressions.StringMethodAccessor.endswith
+    daft.expressions.StringMethodAccessor.startswith
+    daft.expressions.StringMethodAccessor.length
+
+
+Dates
+*****
+
+Operations on datetimes, accessible through the ``Expression.dt`` method accessor:
+
+Example: ``e.dt.day()``
+
+.. autosummary::
+    :nosignatures:
+    :toctree: expression_methods
+
+    daft.expressions.DatetimeMethodAccessor.day
+    daft.expressions.DatetimeMethodAccessor.month
+    daft.expressions.DatetimeMethodAccessor.year
+    daft.expressions.DatetimeMethodAccessor.day_of_week
+
+
+URLs
+****
+
+Operations on URLs, accessible through the ``Expression.url`` method accessor:
+
+Example: ``e.url.download()``
+
+.. autosummary::
+    :nosignatures:
+    :toctree: expression_methods
+
+    daft.expressions.UrlMethodAccessor.download
+
+
+Changing Column Names/Types
+###########################
+
+.. autosummary::
+    :nosignatures:
+    :toctree: expression_methods
+
+    daft.expressions.Expression.alias
+    daft.expressions.Expression.cast
+
+Running Python Functions
+########################
+
+.. autosummary::
+    :nosignatures:
+    :toctree: expression_methods
+
+    daft.expressions.Expression.as_py
+    daft.expressions.Expression.apply


### PR DESCRIPTION
1. Places each function parameter as its own line for readability in API docs
2. Clean up API docs by generating a stub page for each function/method, and having `/dataframes` and `/expressions` be a page of summaries that group useful methods and functionality together.