### PR TITLE
Change envvar DAFT_PKG_BUILD_TYPE to RUST_DAFT_PKG_BUILD_TYPE

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,7 +21,7 @@ env:
 
   IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
   IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
-  DAFT_PKG_BUILD_TYPE: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0'))) && 'release' || 'nightly' }}
+  RUST_DAFT_PKG_BUILD_TYPE: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0'))) && 'release' || 'nightly' }}
 
 jobs:
   build-and-test:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ fn version() -> &'static str {
 
 const BUILD_TYPE_DEV: &str = "dev";
 const DAFT_BUILD_TYPE: &str = {
-    let env_build_type: Option<&str> = option_env!("DAFT_PKG_BUILD_TYPE");
+    let env_build_type: Option<&str> = option_env!("RUST_DAFT_PKG_BUILD_TYPE");
     match env_build_type {
         Some(val) => val,
         None => BUILD_TYPE_DEV,


### PR DESCRIPTION
The maturin build tool that we use corner-cases certain environment variable prefixes to be forwarded into the Docker container that is uses for building: https://github.com/PyO3/maturin-action/blob/main/src/index.ts#L507-L512

Here we change our environment variable to be prefixed with `RUST*` to circumvent this.