### PR TITLE
Simplify Analytics Client to single-threaded implementation

### DIFF
--- a/docs/source/docs/telemetry.rst
+++ b/docs/source/docs/telemetry.rst
@@ -8,7 +8,6 @@ We take the privacy of our users extremely seriously, and telemetry in Daft is b
 1. Easy to opt-out: to disable telemetry, set the following environment variable: ``DAFT_ANALYTICS_ENABLED=0``
 2. Non-identifiable: events are keyed by a session ID which is generated on import of Daft
 3. Metadata-only: we do not collect any of our users' proprietary code or data
-4. Easy to review: please get in touch with us at telemetry@eventualcomputing.com with specific session IDs that you would like to review or delete
 
 We **do not** sell or buy any of the data that is collected in telemetry.
 
@@ -23,5 +22,3 @@ In short, we collect the following:
 
 1. On import, we track system information such as the runner being used, version of Daft, OS, Python version, etc.
 2. On calls of public methods on the DataFrame object, we track metadata about the execution: the name of the method, the walltime for execution and the class of error raised (if any). Function parameters and stacktraces are not logged, ensuring that user data remains private.
-
-Collected data can be found as JSON files in your temporary directory under ``$TMPDIR/daft/<session_id>/analytics.log``. You can retrieve the temporary directory that Daft uses by running ``python -c 'import tempfile; print(tempfile.gettempdir())'`` in your terminal.

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -22,8 +22,8 @@ def mock_analytics() -> tuple[AnalyticsClient, MagicMock]:
     client = AnalyticsClient(
         daft.get_version(),
         daft.get_build_type(),
-        publisher_thread_sleep_interval_seconds=PUBLISHER_THREAD_SLEEP_INTERVAL_SECONDS,
         publish_payload_function=mock_publish,
+        buffer_capacity=1,
     )
 
     # Patch the publish method


### PR DESCRIPTION
- Remove daemon thread
- Use an in-memory list as a buffer, and flush events from the main thread