### PR TITLE
Cookbook test cleanups

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,6 @@ PyYAML
 
 ray[data, default]
 s3fs
-sentry-sdk>=1.9.5
 
 # needed for Docs
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 from itertools import chain
 
 import pandas as pd
@@ -16,43 +15,22 @@ from daft.types import ExpressionType
 def pytest_addoption(parser):
     parser.addoption("--run_conda", action="store_true", default=False, help="run tests that require conda")
     parser.addoption("--run_docker", action="store_true", default=False, help="run tests that require docker")
-    parser.addoption(
-        "--run_tdd", action="store_true", default=False, help="run tests that are marked for Test Driven Development"
-    )
-    parser.addoption(
-        "--run_tdd_all",
-        action="store_true",
-        default=False,
-        help="run tests that are marked for Test Driven Development (including low priority)",
-    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "conda: mark test as requiring conda to run")
     config.addinivalue_line("markers", "docker: mark test as requiring docker to run")
-    config.addinivalue_line("markers", "tdd: mark test as for TDD in active development")
-    config.addinivalue_line("markers", "tdd_all: mark test as for TDD but not in active development")
-    config.addinivalue_line("markers", "tpch: mark as a tpch test")
 
 
 def pytest_collection_modifyitems(config, items):
     marks = {
         "conda": pytest.mark.skip(reason="need --run_conda option to run"),
         "docker": pytest.mark.skip(reason="need --run_docker option to run"),
-        "tdd": pytest.mark.skip(reason="need --run_tdd option to run"),
-        "tdd_all": pytest.mark.skip(reason="need --run_tdd_all option to run"),
     }
     for item in items:
         for keyword in marks:
             if keyword in item.keywords and not config.getoption(f"--run_{keyword}"):
                 item.add_marker(marks[keyword])
-
-
-def run_tdd():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--run_tdd", action="store_true")
-    args, _ = parser.parse_known_args()
-    return args.run_tdd
 
 
 def assert_df_column_type(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import os
 from itertools import chain
 
 import pandas as pd
@@ -9,30 +8,9 @@ import pyarrow as pa
 import pyarrow.compute as pac
 import pytest
 
-from daft.context import get_context
 from daft.runners.blocks import ArrowDataBlock, PyListDataBlock
 from daft.runners.partitioning import PartitionSet
 from daft.types import ExpressionType
-
-
-@pytest.fixture(scope="session", autouse=True)
-def sentry_telemetry():
-    if os.getenv("CI"):
-        import sentry_sdk
-
-        sentry_sdk.init(
-            dsn="https://7e05ae17fdad482a82cd2e79e94d9f51@o1383722.ingest.sentry.io/6701254",
-            # Set traces_sample_rate to 1.0 to capture 100%
-            # of transactions for performance monitoring.
-            # We recommend adjusting this value in production.
-            traces_sample_rate=1.0,
-            # traces_sampler=True,
-        )
-        sentry_sdk.set_tag("CI", os.environ["CI"])
-        sentry_sdk.set_tag("DAFT_RUNNER", get_context().runner_config.name)
-    else:
-        ...
-    yield
 
 
 def pytest_addoption(parser):

--- a/tests/dataframe_cookbook/test_pandas_cookbook.py
+++ b/tests/dataframe_cookbook/test_pandas_cookbook.py
@@ -237,6 +237,7 @@ GROUPBY_DATA_PARTITIONING = [1, 2, 7, 8]
 #     assert_df_equals(daft_df, pd_df, sort_key="animal")
 
 
+@pytest.mark.skip(reason="Issue: #441")
 @pytest.mark.parametrize(
     "repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in GROUPBY_DATA_PARTITIONING]
 )
@@ -281,6 +282,7 @@ JOIN_DATA = {
 JOIN_DATA_PARTITIONING = [1, 3, 7, 8]
 
 
+@pytest.mark.skip(reason="Issue: #442")
 @pytest.mark.parametrize("repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in JOIN_DATA_PARTITIONING])
 def test_self_join(repartition_nparts):
     daft_df = DataFrame.from_pydict(JOIN_DATA).repartition(repartition_nparts)

--- a/tests/dataframe_cookbook/test_pandas_cookbook.py
+++ b/tests/dataframe_cookbook/test_pandas_cookbook.py
@@ -19,37 +19,34 @@ IF_THEN_DATA = {"AAA": [4, 5, 6, 7], "BBB": [10, 20, 30, 40], "CCC": [100, 50, -
 IF_THEN_PARTITIONING = [1, 2, 3, 4, 5]
 
 
-@pytest.mark.tdd_all("Expression.where(...)")
 @pytest.mark.parametrize("repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in IF_THEN_PARTITIONING])
 def test_if_then(repartition_nparts):
     daft_df = DataFrame.from_pydict(IF_THEN_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(IF_THEN_DATA)
-    daft_df = daft_df.with_column("BBB", col("BBB").where(col("AAA") >= 5, -1))
+    daft_df = daft_df.with_column("BBB", (col("AAA") >= 5).if_else(-1, col("BBB")))
     pd_df.loc[pd_df.AAA >= 5, "BBB"] = -1
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, pd_df, sort_key="AAA")
 
 
-@pytest.mark.tdd_all("Requires In-Memory scans and Expression.where(...)")
 @pytest.mark.parametrize("repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in IF_THEN_PARTITIONING])
 def test_if_then_2_cols(repartition_nparts):
     daft_df = DataFrame.from_pydict(IF_THEN_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(IF_THEN_DATA)
-    daft_df = daft_df.with_column("BBB", col("BBB").where(col("AAA") >= 5, 2000)).with_column(
+    daft_df = daft_df.with_column("BBB", (col("AAA") >= 5).if_else(2000, col("BBB"))).with_column(
         "CCC",
-        col("CCC").where(col("AAA") >= 5, 2000),
+        (col("AAA") >= 5).if_else(2000, col("CCC")),
     )
     pd_df.loc[pd_df.AAA >= 5, ["BBB", "CCC"]] = 2000
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, pd_df, sort_key="AAA")
 
 
-@pytest.mark.tdd_all("Requires In-Memory scans and Expression.where(...)")
 @pytest.mark.parametrize("repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in IF_THEN_PARTITIONING])
 def test_if_then_numpy_where(repartition_nparts):
     daft_df = DataFrame.from_pydict(IF_THEN_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(IF_THEN_DATA)
-    daft_df = daft_df.with_column("logic", lit("low").where(col("AAA") > 5, "high"))
+    daft_df = daft_df.with_column("logic", (col("AAA") > 5).if_else("high", lit("low")))
     pd_df["logic"] = np.where(pd_df["AAA"] > 5, "high", "low")
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, pd_df, sort_key="AAA")
@@ -107,20 +104,18 @@ def test_multi_criteria_or(repartition_nparts):
     assert_df_equals(daft_pd_df, pd_df, sort_key="AAA")
 
 
-@pytest.mark.tdd_all("Requires Expression.where(...)")
 @pytest.mark.parametrize(
     "repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in BUILDING_DATA_PARTITIONING]
 )
 def test_multi_criteria_or_assignment(repartition_nparts):
     daft_df = DataFrame.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(BUILDING_DATA)
-    daft_df = daft_df.with_column("AAA", col("AAA").where((col("BBB") > 25) | (col("CCC") >= 75), 0.1))
+    daft_df = daft_df.with_column("AAA", ((col("BBB") > 25) | (col("CCC") >= 75)).if_else(0.1, col("AAA").cast(float)))
     pd_df.loc[(pd_df["BBB"] > 25) | (pd_df["CCC"] >= 75), "AAA"] = 0.1
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, pd_df, sort_key="AAA")
 
 
-@pytest.mark.tdd_all("Requires Expression.abs()")
 @pytest.mark.parametrize(
     "repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in BUILDING_DATA_PARTITIONING]
 )
@@ -128,7 +123,7 @@ def test_select_rows_closest_to_certain_value_using_argsort(repartition_nparts):
     daft_df = DataFrame.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(BUILDING_DATA)
     aValue = 43.0
-    daft_df = daft_df.sort((col("CCC") - aValue).abs())
+    daft_df = daft_df.sort(abs(col("CCC") - aValue))
     pd_df = pd_df.loc[(pd_df.CCC - aValue).abs().argsort()]
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, pd_df, sort_key="AAA")
@@ -142,7 +137,7 @@ SELECTION_DATA = {"AAA": [4, 5, 6, 7], "BBB": [10, 20, 30, 40], "CCC": [100, 50,
 SELECTION_DATA_PARTITIONING = [1, 2, 3, 4, 5]
 
 
-@pytest.mark.tdd_all("Requires F.row_number() and Expression.is_in(...)")
+@pytest.mark.skip(reason="Requires F.row_number() and Expression.is_in(...)")
 @pytest.mark.parametrize(
     "repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in SELECTION_DATA_PARTITIONING]
 )
@@ -155,7 +150,7 @@ def test_splitting_by_row_index(repartition_nparts):
     assert_df_equals(daft_pd_df, pd_df, sort_key="AAA")
 
 
-@pytest.mark.tdd_all("Requires F.row_number()")
+@pytest.mark.skip(reason="Requires F.row_number()")
 @pytest.mark.parametrize(
     "repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in SELECTION_DATA_PARTITIONING]
 )
@@ -176,7 +171,7 @@ APPLYMAP_DATA = {"AAA": [1, 2, 1, 3], "BBB": [1, 1, 2, 2], "CCC": [2, 1, 3, 1]}
 APPLYMAP_DATA_PARTITIONING = [1, 2, 3, 4, 5]
 
 
-@pytest.mark.tdd_all("Requires Expression.applymap((val) => result)")
+@pytest.mark.skip(reason="Requires Expression.applymap((val) => result)")
 @pytest.mark.parametrize(
     "repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in APPLYMAP_DATA_PARTITIONING]
 )
@@ -200,7 +195,7 @@ MIN_WITH_GROUPBY_DATA = {"AAA": [1, 1, 1, 2, 2, 2, 3, 3], "BBB": [2, 1, 3, 4, 5,
 MIN_WITH_GROUPBY_DATA_PARTITIONING = [1, 2, 3, 8, 9]
 
 
-@pytest.mark.tdd_all("Requires .groupby() and .min()")
+@pytest.mark.skip(reason="Requires .first() aggregations")
 @pytest.mark.parametrize(
     "repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in APPLYMAP_DATA_PARTITIONING]
 )
@@ -242,18 +237,23 @@ GROUPBY_DATA_PARTITIONING = [1, 2, 7, 8]
 #     assert_df_equals(daft_df, pd_df, sort_key="animal")
 
 
-@pytest.mark.tdd_all("Requires Expression.where(), .groupby(), .agg() and Expression.agg.*")
 @pytest.mark.parametrize(
     "repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in GROUPBY_DATA_PARTITIONING]
 )
 def test_applying_to_different_items_in_group(repartition_nparts):
     daft_df = DataFrame.from_pydict(GROUPBY_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(GROUPBY_DATA)
-    daft_df = daft_df.with_column("weight", col("weight").where(col("size") == "S", col("weight") * 1.5))
-    daft_df = daft_df.with_column("weight", col("weight").where(col("size") == "M", col("weight") * 1.25))
-    daft_df = daft_df.with_column("weight", col("weight").where(col("size") == "L", col("weight")))
+    daft_df = daft_df.with_column(
+        "weight", (col("size") == "S").if_else(col("weight") * 1.5, col("weight").cast(float))
+    )
+    daft_df = daft_df.with_column("weight", (col("size") == "M").if_else(col("weight") * 1.25, col("weight")))
+    daft_df = daft_df.with_column("weight", (col("size") == "L").if_else(col("weight"), col("weight")))
     daft_df = daft_df.groupby(col("animal")).agg(
-        col("weight").agg.mean(), lit("L").alias("size"), lit(True).alias("adult")
+        [
+            (col("weight"), "mean"),
+            (lit("L").alias("size"), "min"),
+            (lit(True).alias("adult"), "min"),
+        ],
     )
 
     def GrowUp(x):
@@ -281,15 +281,16 @@ JOIN_DATA = {
 JOIN_DATA_PARTITIONING = [1, 3, 7, 8]
 
 
-@pytest.mark.tdd_all("Requires multi-column joins")
 @pytest.mark.parametrize("repartition_nparts", [pytest.param(n, id=f"Repartition:{n}") for n in JOIN_DATA_PARTITIONING])
 def test_self_join(repartition_nparts):
     daft_df = DataFrame.from_pydict(JOIN_DATA).repartition(repartition_nparts)
-    pd_df = pd.DataFrame.from_dict(JOIN_DATA)
     daft_df = daft_df.with_column("Test_1", col("Test_0") - 1).with_column("key", col("Test_0"))
     daft_df_right = daft_df.with_column("key", col("Test_1"))
-    daft_df = daft_df.join(daft_df_right, [col("Bins"), col("Area"), col("key")], left_suffix="_L", right_suffix="_R")
+    daft_df = daft_df.join(daft_df_right, [col("Bins"), col("Area"), col("key")])
+    daft_df = daft_df.exclude("key")
+    daft_pd_df = daft_df.to_pandas()
 
+    pd_df = pd.DataFrame.from_dict(JOIN_DATA)
     pd_df["Test_1"] = pd_df["Test_0"] - 1
     pd_df = pd.merge(
         pd_df,

--- a/tests/dataframe_cookbook/test_pandas_cookbook.py
+++ b/tests/dataframe_cookbook/test_pandas_cookbook.py
@@ -113,7 +113,7 @@ def test_multi_criteria_or_assignment(repartition_nparts):
     daft_df = daft_df.with_column("AAA", ((col("BBB") > 25) | (col("CCC") >= 75)).if_else(0.1, col("AAA").cast(float)))
     pd_df.loc[(pd_df["BBB"] > 25) | (pd_df["CCC"] >= 75), "AAA"] = 0.1
     daft_pd_df = daft_df.to_pandas()
-    assert_df_equals(daft_pd_df, pd_df, sort_key="AAA")
+    assert_df_equals(daft_pd_df, pd_df, sort_key="BBB")
 
 
 @pytest.mark.parametrize(

--- a/tests/stress_tests/test_tpch.py
+++ b/tests/stress_tests/test_tpch.py
@@ -8,7 +8,6 @@ import sqlite3
 import pandas as pd
 import pytest
 from fsspec.implementations.local import LocalFileSystem
-from sentry_sdk import start_transaction
 
 from benchmarking.tpch import answers, data_generation
 from daft.context import get_context

--- a/tests/stress_tests/test_tpch.py
+++ b/tests/stress_tests/test_tpch.py
@@ -10,7 +10,6 @@ import pytest
 from fsspec.implementations.local import LocalFileSystem
 
 from benchmarking.tpch import answers, data_generation
-from daft.context import get_context
 from daft.dataframe import DataFrame
 from tests.assets.assets import TPCH_DBGEN_DIR, TPCH_QUERIES
 from tests.conftest import assert_df_equals
@@ -84,77 +83,59 @@ def check_answer(gen_tpch):
 
 def test_tpch_q1(tmp_path, check_answer, get_df):
     daft_df = answers.q1(get_df)
-    with start_transaction(op="task", name=f"tpch_q1:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 1, tmp_path)
 
 
 def test_tpch_q2(tmp_path, check_answer, get_df):
     daft_df = answers.q2(get_df)
-    with start_transaction(op="task", name=f"tpch_q2:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 2, tmp_path)
 
 
 def test_tpch_q3(tmp_path, check_answer, get_df):
     daft_df = answers.q3(get_df)
-    with start_transaction(op="task", name=f"tpch_q3:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 3, tmp_path)
 
 
 def test_tpch_q4(tmp_path, check_answer, get_df):
     daft_df = answers.q4(get_df)
-
-    with start_transaction(op="task", name=f"tpch_q4:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
-
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 4, tmp_path)
 
 
 def test_tpch_q5(tmp_path, check_answer, get_df):
     daft_df = answers.q5(get_df)
-
-    with start_transaction(op="task", name=f"tpch_q5:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 5, tmp_path)
 
 
 def test_tpch_q6(tmp_path, check_answer, get_df):
     daft_df = answers.q6(get_df)
-
-    with start_transaction(op="task", name=f"tpch_q6:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 6, tmp_path)
 
 
 def test_tpch_q7(tmp_path, check_answer, get_df):
     daft_df = answers.q7(get_df)
-
-    with start_transaction(op="task", name=f"tpch_q7:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 7, tmp_path)
 
 
 def test_tpch_q8(tmp_path, check_answer, get_df):
     daft_df = answers.q8(get_df)
-
-    with start_transaction(op="task", name=f"tpch_q8:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 8, tmp_path)
 
 
 def test_tpch_q9(tmp_path, check_answer, get_df):
     daft_df = answers.q9(get_df)
-
-    with start_transaction(op="task", name=f"tpch_q9:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 9, tmp_path)
 
 
 def test_tpch_q10(tmp_path, check_answer, get_df):
     daft_df = answers.q10(get_df)
-
-    with start_transaction(op="task", name=f"tpch_q10:runner={get_context().runner_config.name.upper()}"):
-        daft_pd_df = daft_df.to_pandas()
+    daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 10, tmp_path)


### PR DESCRIPTION
- Removes Sentry (#435)
- Cleans up Pandas cookbook tests: enables tests that Daft can now handle and skips the rest with a `.skip` instead of a `tdd` flag