### PR TITLE
Fix alias evaluation

### DIFF
--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -209,7 +209,7 @@ class vPartition:
         expr_col_id = expr.get_id()
 
         # Avoid recomputing expressions that have been computed before
-        if expr_col_id in self.columns:
+        if expr_col_id in self.columns and self.columns[expr_col_id].column_name == expr.name():
             return self.columns[expr_col_id]
 
         expr_name = expr.name()

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import re
+
+from daft import DataFrame
+from daft.viz import DataFrameDisplay
+
+ROW_DIVIDER_REGEX = re.compile(r"\+-+\+")
+SHOWING_N_ROWS_REGEX = re.compile(r"\(Showing first (\d+) of (\d+) rows\)")
+
+
+def parse_str_table(table) -> dict[str, tuple[str, list[str]]]:
+    def _split_table_row(row: str) -> list[str]:
+        return [cell.strip() for cell in row.split("|")[1:-1]]
+
+    lines = table.split("\n")
+    assert len(lines) > 4
+    assert ROW_DIVIDER_REGEX.match(lines[0])
+    assert SHOWING_N_ROWS_REGEX.match(lines[-1])
+
+    column_names = _split_table_row(lines[1])
+    column_types = _split_table_row(lines[2])
+
+    data = []
+    for line in lines[4:-1]:
+        if ROW_DIVIDER_REGEX.match(line):
+            continue
+        data.append(_split_table_row(line))
+
+    return {column_names[i]: (column_types[i], [row[i] for row in data]) for i in range(len(column_names))}
+
+
+def test_alias_repr():
+    df = DataFrame.from_pydict({"A": [1, 2, 3]})
+    df = df.select(df["A"].alias("A2"))
+    df.collect()
+    display = DataFrameDisplay(df._preview, df.schema())
+    repr_str = display.__repr__()
+
+    assert parse_str_table(repr_str) == {
+        "A2": (
+            "INTEGER",
+            ["1", "2", "3"],
+        )
+    }


### PR DESCRIPTION
Closes #447 

Bug introduced by https://github.com/Eventual-Inc/Daft/pull/299/files#diff-8ce570b3f2f114483c776e449047082aaebf681b7f965f8ec989d12337a421bdR210-R214 which would skip evaluation of aliases because AliasExpressions have the same ID as its children nodes.

Add a test and fix for this bug