### PR TITLE
add http to fsspec package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.7"
 dependencies = [
     "numpy < 1.24",
     "pyarrow",
-    "fsspec",
+    "fsspec[http]",
     "protobuf>=3.19.0",
     "pydot",
     "loguru",


### PR DESCRIPTION
* right now the quickstart notebooks breaks on importing `aiobotocore` when doing the read_json call. 
* @jaychia 