### PR TITLE
Daft nightly publishing prepend 0s to dev version to fix pip lexical ordering

### DIFF
--- a/tools/patch_package_version.py
+++ b/tools/patch_package_version.py
@@ -23,7 +23,7 @@ def calculate_version() -> str:
 
     if len(split_full_tag_version) > 1:
         _, distance, commit = split_full_tag_version
-        version = f"{MAJOR}.{MINOR}.{PATCH + 1}+dev{distance}.{commit[1:]}"
+        version = f"{MAJOR}.{MINOR}.{PATCH + 1}+dev{int(distance):04d}.{commit[1:]}"
     else:
         version = f"{MAJOR}.{MINOR}.{PATCH}"
     return version


### PR DESCRIPTION
* Prepends 0s to dev version to ensure pip installs the right one.