### PR TITLE
Add pytest benchmarking for benchmark suites with a simple agg test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,10 @@ ignore_missing_imports = true
 module = 'daft.*'
 warn_return_any = false
 enable-error-code = ["attr-defined"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "--benchmark-skip"
+testpaths = [
+    "tests",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,6 +23,7 @@ pyarrow
 
 # needed for testing
 pytest>=7.1.2
+pytest-benchmark
 PyYAML
 
 ray[data, default]

--- a/tests/benchmarks/test_aggregations.py
+++ b/tests/benchmarks/test_aggregations.py
@@ -8,27 +8,27 @@ from daft import DataFrame
 
 @pytest.mark.aggregations
 @pytest.fixture(scope="module")
-def gen_aranged_df(num_samples=100_000_000) -> DataFrame:
-    return DataFrame.from_pydict({"x": np.arange(num_samples, dtype=np.int32)})
+def gen_aranged_df(num_samples=1_000_000_000) -> DataFrame:
+    return DataFrame.from_pydict({"x": np.arange(num_samples, dtype=np.int32)}).collect()
 
 
 @pytest.mark.benchmark(group="aggregations")
-def test_single_column_sum(gen_aranged_df, benchmark) -> None:
+def test_single_int32_column_sum(gen_aranged_df, benchmark) -> None:
     def bench_sum() -> DataFrame:
         return gen_aranged_df.sum("x").collect()
 
     result = benchmark(bench_sum)
-    total_count = 100_000_000 - 1
+    total_count = 1_000_000_000 - 1
     total_sum = total_count * (total_count + 1) / 2
     assert (result.to_pandas()["x"] == total_sum).all()
 
 
 @pytest.mark.benchmark(group="aggregations")
-def test_single_column_mean(gen_aranged_df, benchmark) -> None:
+def test_single_int32_column_mean(gen_aranged_df, benchmark) -> None:
     def bench_mean() -> DataFrame:
         return gen_aranged_df.mean("x").collect()
 
     result = benchmark(bench_mean)
-    total_count = 100_000_000 - 1
+    total_count = 1_000_000_000 - 1
     total_mean = total_count / 2.0
     assert (result.to_pandas()["x"] == total_mean).all()

--- a/tests/benchmarks/test_aggregations.py
+++ b/tests/benchmarks/test_aggregations.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from daft import DataFrame
+
+
+@pytest.mark.aggregations
+@pytest.fixture(scope="module")
+def gen_aranged_df(num_samples=100_000_000) -> DataFrame:
+    return DataFrame.from_pydict({"x": np.arange(num_samples, dtype=np.int32)})
+
+
+@pytest.mark.benchmark(group="aggregations")
+def test_single_column_sum(gen_aranged_df, benchmark) -> None:
+    def bench_sum() -> DataFrame:
+        return gen_aranged_df.sum("x").collect()
+
+    result = benchmark(bench_sum)
+    total_count = 100_000_000 - 1
+    total_sum = total_count * (total_count + 1) / 2
+    assert (result.to_pandas()["x"] == total_sum).all()
+
+
+@pytest.mark.benchmark(group="aggregations")
+def test_single_column_mean(gen_aranged_df, benchmark) -> None:
+    def bench_mean() -> DataFrame:
+        return gen_aranged_df.mean("x").collect()
+
+    result = benchmark(bench_mean)
+    total_count = 100_000_000 - 1
+    total_mean = total_count / 2.0
+    assert (result.to_pandas()["x"] == total_mean).all()


### PR DESCRIPTION
* Adds pytest benchmarking to run regression suites which is disabled by default in pyproject.toml
* To run benchmarks: run `pytest --benchmark-only` which will yield an output like:
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/2550285/213106989-04b7c53b-3114-4445-a4b2-593db11dc76c.png">

* to produce a json report run: `pytest --benchmark-only --benchmark-json=out.json`
Which looks like:
<img width="627" alt="image" src="https://user-images.githubusercontent.com/2550285/213107941-8ca5e339-90bc-4030-9b3a-dfaca0a37e4b.png">
