### PR TITLE
Dynamic runners: Assert against negative limit()

### DIFF
--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -163,6 +163,7 @@ def global_limit(
     """Return the first n rows from the `child_plan`."""
 
     remaining_rows = global_limit._num
+    assert remaining_rows >= 0, f"Invalid value for limit: {remaining_rows}"
     remaining_partitions = global_limit.num_partitions()
 
     materializations: deque[MaterializationRequest[PartitionT]] = deque()


### PR DESCRIPTION
Raise an error if the user supplies a negative value to limit(). 

This is the only error regression against the existing runners and closes #440 .