### PR TITLE
Disable telemetry in CI jobs

### DIFF
--- a/.github/workflows/docs-github-pages-publish.yml
+++ b/.github/workflows/docs-github-pages-publish.yml
@@ -20,6 +20,9 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  DAFT_ANALYTICS_ENABLED: '0'
+
 jobs:
   # Single deploy job since we're just deploying
   deploy:

--- a/.github/workflows/notebook-checker.yml
+++ b/.github/workflows/notebook-checker.yml
@@ -5,6 +5,9 @@ on:
   - cron: 0 20 * * *
   workflow_dispatch:
 
+env:
+  DAFT_ANALYTICS_ENABLED: '0'
+
 jobs:
   notebook-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  DAFT_ANALYTICS_ENABLED: '0'
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,6 +18,7 @@ on:
 env:
   PACKAGE_NAME: getdaft
   PYTHON_VERSION: '3.7' # to build abi3 wheels
+  DAFT_ANALYTICS_ENABLED: '0'
 
   IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
   IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/ray-compatibility.yml
+++ b/.github/workflows/ray-compatibility.yml
@@ -7,6 +7,9 @@ on:
   - cron: 59 23 * * *
   workflow_dispatch:
 
+env:
+  DAFT_ANALYTICS_ENABLED: '0'
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Disables telemetry in CI jobs with the `DAFT_ANALYTICS_ENABLED=0` environment flag