### PR TITLE
Add DataFrame.from_glob_path, deprecating DataFrame.from_files

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -50,7 +50,7 @@ def _get_tabular_files_scan(
     """Returns a TabularFilesScan LogicalPlan for a given glob filepath."""
     # Glob the path and return as a DataFrame with a column containing the filepaths
     partition_set_factory = get_context().runner().partition_set_factory()
-    partition_set, filepaths_schema = partition_set_factory.glob_filepaths(path)
+    partition_set, filepaths_schema = partition_set_factory.glob_paths(path)
     cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
     filepath_plan = logical_plan.InMemoryScan(
         cache_entry=cache_entry,
@@ -61,7 +61,9 @@ def _get_tabular_files_scan(
 
     # Sample the first 10 filepaths and infer the schema
     schema_df = filepath_df.limit(10).select(
-        col(partition_set_factory.FILEPATH_COLUMN_NAME).apply(get_schema, return_type=ExpressionList).alias("schema")
+        col(partition_set_factory.FS_LISTING_PATH_COLUMN_NAME)
+        .apply(get_schema, return_type=ExpressionList)
+        .alias("schema")
     )
     schema_df.collect()
     schema_result = schema_df._result
@@ -79,7 +81,7 @@ def _get_tabular_files_scan(
         columns=None,
         source_info=source_info,
         filepaths_child=filepath_plan,
-        filepaths_column_name=partition_set_factory.FILEPATH_COLUMN_NAME,
+        filepaths_column_name=partition_set_factory.FS_LISTING_PATH_COLUMN_NAME,
     )
 
 
@@ -477,12 +479,18 @@ class DataFrame:
     def from_glob_path(cls, path: str) -> DataFrame:
         """Creates a DataFrame of file paths and other metadata from a glob path
 
-        This method supports wilcards:
+        This method supports wildcards:
 
         1. "*" matches any number of any characters including none
         2. "?" matches any single character
         3. "[...]" matches any single character in the brackets
         4. "**" recursively matches any number of layers of directories
+
+        The returned DataFrame will have the following columns:
+
+        1. path: the path to the file/directory
+        2. size: size of the object in bytes
+        3. type: either "file" or "directory"
 
         Example:
             >>> df = DataFrame.from_glob_path("/path/to/files/*.jpeg")
@@ -497,7 +505,7 @@ class DataFrame:
                 parsed from the provided filesystem
         """
         partition_set_factory = get_context().runner().partition_set_factory()
-        partition_set, filepaths_schema = partition_set_factory.glob_file_details(path)
+        partition_set, filepaths_schema = partition_set_factory.glob_paths_details(path)
         cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
         filepath_plan = logical_plan.InMemoryScan(
             cache_entry=cache_entry,

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -466,7 +466,7 @@ class DataFrame:
                 parsed from the provided filesystem
         """
         warnings.warn(
-            f"DataFrame.from_files will be deprecated in 0.1.0 in favor of DataFrame.from_glob_filepath, which presents a more predictable set of columns for each backend and runs the file globbing on the runner instead of the driver"
+            f"DataFrame.from_files will be deprecated in 0.1.0 in favor of DataFrame.from_glob_path, which presents a more predictable set of columns for each backend and runs the file globbing on the runner instead of the driver"
         )
         fs = get_filesystem_from_path(path)
         file_details = fs.glob(path, detail=True)
@@ -474,12 +474,20 @@ class DataFrame:
 
     @classmethod
     @DataframePublicAPI
-    def from_glob_filepath(cls, path: str) -> DataFrame:
+    def from_glob_path(cls, path: str) -> DataFrame:
         """Creates a DataFrame of file paths and other metadata from a glob path
 
+        This method supports wilcards:
+
+        1. "*" matches any number of any characters including none
+        2. "?" matches any single character
+        3. "[...]" matches any single character in the brackets
+        4. "**" recursively matches any number of layers of directories
+
         Example:
-            >>> df = DataFrame.from_files("/path/to/files/*.jpeg")
-            >>> df = DataFrame.from_files("/path/to/files/**/*.jpeg")
+            >>> df = DataFrame.from_glob_path("/path/to/files/*.jpeg")
+            >>> df = DataFrame.from_glob_path("/path/to/files/**/*.jpeg")
+            >>> df = DataFrame.from_glob_path("/path/to/files/**/image-?.jpeg")
 
         Args:
             path (str): path to files on disk (allows wildcards)

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -1,7 +1,15 @@
 from __future__ import annotations
 
+import dataclasses
+
 from fsspec import AbstractFileSystem, get_filesystem_class
 from loguru import logger
+
+
+@dataclasses.dataclass(frozen=True)
+class FileInfo:
+    path: str
+    size: int
 
 
 def get_filesystem(protocol: str, **kwargs) -> AbstractFileSystem:
@@ -29,15 +37,51 @@ def get_filesystem_from_path(path: str, **kwargs) -> AbstractFileSystem:
     return fs
 
 
+def _fix_returned_path(protocol: str, returned_path: str) -> str:
+    """This function adds the protocol that fsspec strips from returned results"""
+    return returned_path if protocol == "file" else f"{protocol}://{returned_path}"
+
+
+def _path_is_glob(path: str) -> bool:
+    # fsspec glob supports *, ? and [..] patterns
+    # See: : https://filesystem-spec.readthedocs.io/en/latest/api.html
+    return any([char in path for char in ["*", "?", "["]])
+
+
 def glob_path(path: str) -> list[str]:
     fs = get_filesystem_from_path(path)
     protocol = get_protocol_from_path(path)
-    if fs.isdir(path):
-        return [f"{protocol}://{path}" if protocol != "file" else path for path in fs.ls(path)]
-    elif fs.isfile(path):
+
+    if _path_is_glob(path):
+        globbed_data = fs.glob(path, detail=False)
+        return [_fix_returned_path(protocol, path) for path in globbed_data]
+
+    if fs.isfile(path):
         return [path]
-    try:
-        expanded = fs.expand_path(path, recursive=True)
-    except FileNotFoundError:
-        expanded = []
-    return [f"{protocol}://{path}" if protocol != "file" else path for path in expanded]
+    elif fs.isdir(path):
+        files_info = fs.ls(path, detail=False)
+        return [_fix_returned_path(protocol, path) for path in files_info]
+    raise FileNotFoundError(f"File or directory not found: {path}")
+
+
+def glob_path_with_stats(path: str) -> list[FileInfo]:
+    fs = get_filesystem_from_path(path)
+    protocol = get_protocol_from_path(path)
+
+    if _path_is_glob(path):
+        globbed_data = fs.glob(path, detail=True)
+        return [
+            FileInfo(path=_fix_returned_path(protocol, path), size=details["size"])
+            for path, details in globbed_data.items()
+        ]
+
+    if fs.isfile(path):
+        file_info = fs.info(path)
+        return [FileInfo(path=_fix_returned_path(protocol, file_info["name"]), size=file_info["size"])]
+    elif fs.isdir(path):
+        files_info = fs.ls(path, detail=True)
+        return [
+            FileInfo(path=_fix_returned_path(protocol, file_info["name"]), size=file_info["size"])
+            for file_info in files_info
+        ]
+    raise FileNotFoundError(f"File or directory not found: {path}")

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import dataclasses
+from typing import Literal
 
 from fsspec import AbstractFileSystem, get_filesystem_class
 from loguru import logger
 
 
 @dataclasses.dataclass(frozen=True)
-class FileInfo:
+class ListingInfo:
     path: str
     size: int
+    type: Literal["file"] | Literal["directory"]
 
 
 def get_filesystem(protocol: str, **kwargs) -> AbstractFileSystem:
@@ -64,24 +66,30 @@ def glob_path(path: str) -> list[str]:
     raise FileNotFoundError(f"File or directory not found: {path}")
 
 
-def glob_path_with_stats(path: str) -> list[FileInfo]:
+def glob_path_with_stats(path: str) -> list[ListingInfo]:
     fs = get_filesystem_from_path(path)
     protocol = get_protocol_from_path(path)
 
     if _path_is_glob(path):
         globbed_data = fs.glob(path, detail=True)
         return [
-            FileInfo(path=_fix_returned_path(protocol, path), size=details["size"])
+            ListingInfo(path=_fix_returned_path(protocol, path), size=details["size"], type=details["type"])
             for path, details in globbed_data.items()
         ]
 
     if fs.isfile(path):
         file_info = fs.info(path)
-        return [FileInfo(path=_fix_returned_path(protocol, file_info["name"]), size=file_info["size"])]
+        return [
+            ListingInfo(
+                path=_fix_returned_path(protocol, file_info["name"]), size=file_info["size"], type=file_info["type"]
+            )
+        ]
     elif fs.isdir(path):
         files_info = fs.ls(path, detail=True)
         return [
-            FileInfo(path=_fix_returned_path(protocol, file_info["name"]), size=file_info["size"])
+            ListingInfo(
+                path=_fix_returned_path(protocol, file_info["name"]), size=file_info["size"], type=file_info["type"]
+            )
             for file_info in files_info
         ]
     raise FileNotFoundError(f"File or directory not found: {path}")

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -815,9 +815,41 @@ class PartitionSetFactory(Generic[PartitionT]):
     """Factory class for creating PartitionSets."""
 
     FILEPATH_COLUMN_NAME = "filepath"
+    FILE_SIZE_COLUMN_NAME = "size"
+
+    def _get_filepaths_schema(self) -> ExpressionList:
+        return ExpressionList(
+            [
+                ColumnExpression(self.FILEPATH_COLUMN_NAME, ExpressionType.string()),
+            ]
+        ).resolve()
+
+    def _get_file_details_schema(self) -> ExpressionList:
+        return ExpressionList(
+            [
+                ColumnExpression(self.FILEPATH_COLUMN_NAME, ExpressionType.string()),
+                ColumnExpression(self.FILE_SIZE_COLUMN_NAME, ExpressionType.integer()),
+            ]
+        ).resolve()
 
     @abstractmethod
     def glob_filepaths(
+        self,
+        source_path: str,
+    ) -> tuple[PartitionSet[PartitionT], ExpressionList]:
+        """Globs the specified filepath to construct a PartitionSet of file paths
+
+        Args:
+            source_path (str): path to glob
+
+        Returns:
+            PartitionSet[PartitionT]: PartitionSet containing the files' paths
+            ExpressionList: Schema of the PartitionSet that was constructed
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def glob_file_details(
         self,
         source_path: str,
     ) -> tuple[PartitionSet[PartitionT], ExpressionList]:

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -814,52 +814,56 @@ class PartitionSetCache:
 class PartitionSetFactory(Generic[PartitionT]):
     """Factory class for creating PartitionSets."""
 
-    FILEPATH_COLUMN_NAME = "filepath"
-    FILE_SIZE_COLUMN_NAME = "size"
+    FS_LISTING_PATH_COLUMN_NAME = "path"
+    FS_LISTING_SIZE_COLUMN_NAME = "size"
+    FS_LISTING_TYPE_COLUMN_NAME = "type"
 
-    def _get_filepaths_schema(self) -> ExpressionList:
+    def _get_listing_paths_schema(self) -> ExpressionList:
+        """Construct the schema for a DataFrame of path listing"""
         return ExpressionList(
             [
-                ColumnExpression(self.FILEPATH_COLUMN_NAME, ExpressionType.string()),
+                ColumnExpression(self.FS_LISTING_PATH_COLUMN_NAME, ExpressionType.string()),
             ]
         ).resolve()
 
-    def _get_file_details_schema(self) -> ExpressionList:
+    def _get_listing_paths_details_schema(self) -> ExpressionList:
+        """Construct the schema for a DataFrame of detailed path listing"""
         return ExpressionList(
             [
-                ColumnExpression(self.FILEPATH_COLUMN_NAME, ExpressionType.string()),
-                ColumnExpression(self.FILE_SIZE_COLUMN_NAME, ExpressionType.integer()),
+                ColumnExpression(self.FS_LISTING_PATH_COLUMN_NAME, ExpressionType.string()),
+                ColumnExpression(self.FS_LISTING_SIZE_COLUMN_NAME, ExpressionType.integer()),
+                ColumnExpression(self.FS_LISTING_TYPE_COLUMN_NAME, ExpressionType.string()),
             ]
         ).resolve()
 
     @abstractmethod
-    def glob_filepaths(
+    def glob_paths(
         self,
         source_path: str,
     ) -> tuple[PartitionSet[PartitionT], ExpressionList]:
-        """Globs the specified filepath to construct a PartitionSet of file paths
+        """Globs the specified filepath to construct a PartitionSet of file or dir paths
 
         Args:
             source_path (str): path to glob
 
         Returns:
-            PartitionSet[PartitionT]: PartitionSet containing the files' paths
+            PartitionSet[PartitionT]: PartitionSet containing the listings' paths
             ExpressionList: Schema of the PartitionSet that was constructed
         """
         raise NotImplementedError()
 
     @abstractmethod
-    def glob_file_details(
+    def glob_paths_details(
         self,
         source_path: str,
     ) -> tuple[PartitionSet[PartitionT], ExpressionList]:
-        """Globs the specified filepath to construct a PartitionSet of file metadata
+        """Globs the specified filepath to construct a PartitionSet of file and dir metadata
 
         Args:
             source_path (str): path to glob
 
         Returns:
-            PartitionSet[PartitionT]: PartitionSet containing the files' metadata
+            PartitionSet[PartitionT]: PartitionSet containing the listings' metadata
             ExpressionList: Schema of the PartitionSet that was constructed
         """
         raise NotImplementedError()

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -12,8 +12,7 @@ from daft.execution.logical_op_runners import (
     LogicalPartitionOpRunner,
     ReduceType,
 )
-from daft.expressions import ColumnExpression
-from daft.filesystem import glob_path
+from daft.filesystem import glob_path, glob_path_with_stats
 from daft.internal.gpu import cuda_device_count
 from daft.internal.rule_runner import FixedPointPolicy, Once, RuleBatch, RuleRunner
 from daft.logical import logical_plan
@@ -45,7 +44,6 @@ from daft.runners.shuffle_ops import (
     Shuffler,
     SortOp,
 )
-from daft.types import ExpressionType
 
 
 @dataclass
@@ -97,14 +95,38 @@ class LocalPartitionSetFactory(PartitionSetFactory[vPartition]):
         if len(filepaths) == 0:
             raise FileNotFoundError(f"No files found at {source_path}")
 
-        schema = ExpressionList([ColumnExpression(self.FILEPATH_COLUMN_NAME, ExpressionType.string())]).resolve()
+        schema = self._get_filepaths_schema()
         pset = LocalPartitionSet(
             {
-                i: vPartition.from_pydict(
-                    data={self.FILEPATH_COLUMN_NAME: [filepaths[i]]}, schema=schema, partition_id=i
-                )
-                for i in range(len(filepaths))  # Hardcoded to 1 path per partition
+                i: vPartition.from_pydict(data={self.FILEPATH_COLUMN_NAME: [path]}, schema=schema, partition_id=i)
+                for i, path in enumerate(filepaths)  # Hardcoded to 1 path per partition
             },
+        )
+        return pset, schema
+
+    def glob_file_details(
+        self,
+        source_path: str,
+    ) -> tuple[LocalPartitionSet, ExpressionList]:
+        files_info = glob_path_with_stats(source_path)
+        print(files_info)
+
+        if len(files_info) == 0:
+            raise FileNotFoundError(f"No files found at {source_path}")
+
+        schema = self._get_file_details_schema()
+        pset = LocalPartitionSet(
+            {
+                # Hardcoded to 1 partition
+                0: vPartition.from_pydict(
+                    data={
+                        self.FILEPATH_COLUMN_NAME: [f.path for f in files_info],
+                        self.FILE_SIZE_COLUMN_NAME: [f.size for f in files_info],
+                    },
+                    schema=schema,
+                    partition_id=0,
+                ),
+            }
         )
         return pset, schema
 

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -109,7 +109,6 @@ class LocalPartitionSetFactory(PartitionSetFactory[vPartition]):
         source_path: str,
     ) -> tuple[LocalPartitionSet, ExpressionList]:
         files_info = glob_path_with_stats(source_path)
-        print(files_info)
 
         if len(files_info) == 0:
             raise FileNotFoundError(f"No files found at {source_path}")

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -86,7 +86,7 @@ class LocalPartitionSet(PartitionSet[vPartition]):
 
 
 class LocalPartitionSetFactory(PartitionSetFactory[vPartition]):
-    def glob_filepaths(
+    def glob_paths(
         self,
         source_path: str,
     ) -> tuple[LocalPartitionSet, ExpressionList]:
@@ -95,16 +95,18 @@ class LocalPartitionSetFactory(PartitionSetFactory[vPartition]):
         if len(filepaths) == 0:
             raise FileNotFoundError(f"No files found at {source_path}")
 
-        schema = self._get_filepaths_schema()
+        schema = self._get_listing_paths_schema()
         pset = LocalPartitionSet(
             {
-                i: vPartition.from_pydict(data={self.FILEPATH_COLUMN_NAME: [path]}, schema=schema, partition_id=i)
+                i: vPartition.from_pydict(
+                    data={self.FS_LISTING_PATH_COLUMN_NAME: [path]}, schema=schema, partition_id=i
+                )
                 for i, path in enumerate(filepaths)  # Hardcoded to 1 path per partition
             },
         )
         return pset, schema
 
-    def glob_file_details(
+    def glob_paths_details(
         self,
         source_path: str,
     ) -> tuple[LocalPartitionSet, ExpressionList]:
@@ -113,14 +115,15 @@ class LocalPartitionSetFactory(PartitionSetFactory[vPartition]):
         if len(files_info) == 0:
             raise FileNotFoundError(f"No files found at {source_path}")
 
-        schema = self._get_file_details_schema()
+        schema = self._get_listing_paths_details_schema()
         pset = LocalPartitionSet(
             {
                 # Hardcoded to 1 partition
                 0: vPartition.from_pydict(
                     data={
-                        self.FILEPATH_COLUMN_NAME: [f.path for f in files_info],
-                        self.FILE_SIZE_COLUMN_NAME: [f.size for f in files_info],
+                        self.FS_LISTING_PATH_COLUMN_NAME: [f.path for f in files_info],
+                        self.FS_LISTING_SIZE_COLUMN_NAME: [f.size for f in files_info],
+                        self.FS_LISTING_TYPE_COLUMN_NAME: [f.type for f in files_info],
                     },
                     schema=schema,
                     partition_id=0,

--- a/docs/source/docs/api_docs/dataframe.rst
+++ b/docs/source/docs/api_docs/dataframe.rst
@@ -28,7 +28,7 @@ From Files
     daft.DataFrame.read_csv
     daft.DataFrame.read_json
     daft.DataFrame.read_parquet
-    daft.DataFrame.from_files
+    daft.DataFrame.from_glob_path
 
 From In-Memory Data
 *******************

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_files.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_files.rst
@@ -1,6 +1,0 @@
-﻿daft.DataFrame.from\_files
-==========================
-
-.. currentmodule:: daft
-
-.. automethod:: DataFrame.from_files

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_glob_path.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.from_glob_path.rst
@@ -1,0 +1,6 @@
+﻿daft.DataFrame.from\_glob\_path
+===============================
+
+.. currentmodule:: daft
+
+.. automethod:: DataFrame.from_glob_path

--- a/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.rst
+++ b/docs/source/docs/api_docs/dataframe_methods/daft.DataFrame.rst
@@ -23,6 +23,7 @@
       ~DataFrame.explode
       ~DataFrame.from_csv
       ~DataFrame.from_files
+      ~DataFrame.from_glob_path
       ~DataFrame.from_json
       ~DataFrame.from_parquet
       ~DataFrame.from_pydict

--- a/docs/source/docs/learn/10-min.ipynb
+++ b/docs/source/docs/learn/10-min.ipynb
@@ -59,6 +59,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -67,7 +68,7 @@
     "1. CSV files: `DataFrame.read_csv(\"s3://bucket/*.csv\")`\n",
     "2. Parquet files: `DataFrame.read_parquet(\"/path/*.parquet\")`\n",
     "3. JSON line-delimited files: `DataFrame.read_json(\"/path/*.parquet\")`\n",
-    "4. Files on disk: `DataFrame.from_files(\"/path/*.jpeg\")`\n",
+    "4. Files on disk: `DataFrame.from_glob_path(\"/path/*.jpeg\")`\n",
     "\n",
     "Daft automatically supports local paths as well as paths to object storage such as AWS S3."
    ]

--- a/tutorials/image_querying/top_n_red_color.ipynb
+++ b/tutorials/image_querying/top_n_red_color.ipynb
@@ -65,7 +65,7 @@
    "source": [
     "from daft import DataFrame, lit\n",
     "\n",
-    "df = DataFrame.from_files(\"s3://daft-public-data/open-images/validation-images/*\")\n",
+    "df = DataFrame.from_glob_path(\"s3://daft-public-data/open-images/validation-images/*\")\n",
     "\n",
     "if distributed:\n",
     "    df = df.limit(10000)\n",
@@ -201,7 +201,7 @@
    "id": "539db555-f70f-4d7d-8c1f-8af7d3ba0213",
    "metadata": {},
    "source": [
-    "Let's prune the columns to just the \"name\" column, which is the only one we need at the moment:"
+    "Let's prune the columns to just the \"filepath\" column, which is the only one we need at the moment:"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = df.select(\"name\")"
+    "df = df.select(\"filepath\")"
    ]
   },
   {
@@ -244,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = df.with_column(\"image\", lit(\"s3://\").str.concat(df[\"name\"]).url.download())"
+    "df = df.with_column(\"image\", df[\"filepath\"].url.download())"
    ]
   },
   {
@@ -379,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107010fc-990c-47d0-a2c2-900569529145",
+   "id": "826eabd2-54e8-4147-a5c6-e97c9d0a9e04",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -401,7 +401,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Adds a new `DataFrame.from_glob_path` method
* New method returns a dataframe with 3 columns only: path, size and type
* New method runs file globbing operations inside of the runner instead of on the driver
* Deprecates the old `DataFrame.from_files` method in favor of `DataFrame.from_glob_path`

Closes #426 