### PR TITLE
[Feature] a State object to apply a logical plan for new data

### DIFF
--- a/daft/logical/state.py
+++ b/daft/logical/state.py
@@ -1,0 +1,165 @@
+import daft.logical.logical_plan
+import pathlib
+import cloudpickle
+import daft.types
+import typing
+import pyarrow as pa
+import daft.internal.treenode
+import daft.logical.schema
+import daft.expressions
+import daft.runners.partitioning
+from copy import deepcopy
+import daft
+import daft.context
+import daft.runners.pyrunner
+
+
+class State(object):
+    plan: daft.logical.logical_plan.LogicalPlan
+
+    def __init__(self, state=None, exprs_ids=None):
+        if hasattr(state, 'plan'):
+            state = state.plan()
+        self.plan = state
+        self.exprs_ids = exprs_ids
+        if state:
+            self.exprs_ids = [expr._id for expr in self.plan.schema().exprs if expr._id is not None]
+
+    def save(self, path):
+        pathlib.Path(path).write_bytes(cloudpickle.dumps(self))
+        return path
+
+    @classmethod
+    def from_dataframe(cls, df):
+        return cls(df.plan())
+
+    @classmethod
+    def load(cls, path):
+        return cloudpickle.loads(pathlib.Path(path).read_bytes())
+
+    def __repr__(self):
+        return self.plan.pretty_print()
+
+    @staticmethod
+    def get_block_data(data):
+        block_data: dict[str, tuple[daft.types.ExpressionType, typing.Any]] = {}
+        for header in data:
+            arr = data[header]
+
+            if isinstance(arr, pa.Array) or isinstance(arr, pa.ChunkedArray):
+                expr_type = daft.types.ExpressionType.from_arrow_type(arr.type)
+                block_data[header] = (expr_type, arr.to_pylist() if daft.types.ExpressionType.is_py(expr_type) else arr)
+                continue
+
+            try:
+                arrow_type = pa.infer_type(arr)
+            except pa.lib.ArrowInvalid:
+                arrow_type = None
+
+            if arrow_type is None or pa.types.is_nested(arrow_type):
+                found_types = {type(o) for o in data[header]} - {type(None)}
+                block_data[header] = (
+                    (daft.logical.schema.ExpressionType.python_object(), list(arr))
+                    if len(found_types) > 1
+                    else (daft.types.PythonExpressionType(found_types.pop()), list(arr))
+                )
+                continue
+
+            expr_type = daft.types.ExpressionType.from_arrow_type(arrow_type)
+            block_data[header] = (expr_type, list(arr) if daft.types.ExpressionType.is_py(expr_type) else pa.array(arr))
+        return block_data
+
+    def to_scan(self, data):
+        if isinstance(data, daft.DataFrame):
+            return data
+        block_data = self.get_block_data(data)
+        data_schema = daft.logical.schema.ExpressionList(
+            [daft.expressions.ColumnExpression(header, expr_type=expr_type) for header, (expr_type, _) in
+             block_data.items()]
+        ).resolve()
+        for expr, _id in zip(data_schema.exprs, self.exprs_ids):
+            expr._id = _id
+
+        data_vpartition = daft.runners.partitioning.vPartition.from_pydict(
+            data={header: arr for header, (_, arr) in block_data.items()}, schema=data_schema, partition_id=0
+        )
+
+        result_set = daft.runners.pyrunner.LocalPartitionSet({0: data_vpartition})
+        cache_entry = daft.context.get_context().runner().put_partition_set_into_cache(result_set)
+        return daft.logical.logical_plan.InMemoryScan(
+            cache_entry=cache_entry,
+            schema=data_schema,
+        )
+
+    @staticmethod
+    def _new_projection(node):
+        plan = daft.logical.logical_plan.LogicalPlan(node.schema(), partition_spec=node.partition_spec(),
+                                                     op_level=node.op_level())
+        return daft.logical.logical_plan.Projection(plan, node.schema())
+
+    @classmethod
+    def infer(cls, data):
+        """
+        TODO
+        * records (list of dicts)
+        * json
+        * pandas
+        * numpy
+        * pyarrow Table or Array
+        * polars DataFrame or Series
+        * path to file ?
+
+        """
+        if isinstance(data, daft.DataFrame):
+            return data
+        if isinstance(data, dict):
+            return daft.DataFrame.from_pydict(data)
+
+        raise NotImplementedError(f"Data type {type(data)} is not impemented yet")
+
+    def inference(self, data, filters: bool = False, remainder: bool = True, **kwargs):
+        """
+        param: data -
+        This function is used to apply transformations and modeling on new data.
+        We should infer dicts, records json etc, here, so we can deploy it in production.
+        """
+
+        new_data = State.infer(data).plan()  # get the InmemoryScan
+        state = deepcopy(self.plan)
+
+        # Naive implementation - we should use a better algorithm to include cases like joins, etc.
+        def dfs(node: daft.internal.treenode.TreeNode) -> None:
+            if not node._children():
+                return new_data
+            new_children = [dfs(child) for child in node._children()]
+            if isinstance(node, daft.logical.logical_plan.Filter) and not filters:
+                node = self._new_projection(node)
+            node = daft.logical.logical_plan.Projection.copy_with_new_children(node, new_children)
+
+            return node
+
+        state = dfs(state)
+        return daft.DataFrame(state)
+
+    def transform(self, data, **kwargs):
+        """
+        A common use case where we want to transform the data, including filters.
+        Main use-case is data cleaning before training a model.
+        """
+        return self.inference(data, filters=True, remainder=False, **kwargs)
+
+    # TODO
+    def fit(self, data, **kwargs):
+        """
+        Re-calculating the state with new data
+        """
+        self.state = data.plan()
+        return self
+
+    # TODO
+    def predict(self, data, **kwargs):
+        """
+        A discussion, is this a column we want the user to define explicitly? Or should we just return the last column added?
+        The column should return as numpy for now as it will integrate nicely with the current ecosystem.
+        """
+        return self.inference(data, filters=False, remainder=True, **kwargs)[self.plan.schema().exprs[-1].name()]

--- a/tests/logical/test_state.py
+++ b/tests/logical/test_state.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import polars as pl
+import numpy as np
+import daft
+from tempfile import TemporaryDirectory
+from daft.logical.state import State
+
+"""
+A state holds the logical plan and metadat needed to run the logical plan on new data.
+This can save a lot of time when implementing ML pipelines.
+
+The state.inference(df, filters:bool=False, reminder:bool=True) will apply all the calculations which was saved 
+to the state on the df, ignoring filter (as we almost always want at inference time) 
+and let new columns which were not introduce to the state to propagate and stay, so we may return them if needed.    
+"""
+
+
+def test_state_infer():
+    """
+    An infer function to deal with standard IO can help to build services quicker and easier.
+    Any standard input coming for query, needs to first turned into a daft.DataFrame.
+
+    Every user, who solves any problem will need to implement it themselves every time with small variation.
+    """
+    df = daft.DataFrame.read_csv('tests/assets/iris.csv').limit(1).to_pandas()
+
+    state = State.from_dataframe(df)
+    # Inference use cases
+    isinstance(state.infer(df.to_dict(orient='records')), daft.DataFrame)  # [{"key":value}]
+    isinstance(state.infer(df.to_json(orient='records')), daft.DataFrame)  # '[{"key":value}]'
+    isinstance(state.infer(df.to_dict(orient='list')), daft.DataFrame)  # {"column":[value_1, value_2]}
+    # Integrations use cases
+    isinstance(state.infer(pl.from_pandas(df).to_arrow()), daft.DataFrame)  # pyarrow.Table
+    isinstance(state.infer(df.values), daft.DataFrame)  # numpy
+
+
+def test_state_inference():
+    @daft.polars_udf(return_type=float)
+    class RunExpensiveModel:
+
+        def __init__(self):
+            # Initialize and cache an "expensive" model between invocations of the UDF
+            self.model = np.array([1.23, 4.56])
+
+        def __call__(self, a_data: pl.Series, b_data: pl.Series):
+            print(a_data, b_data)
+            return np.matmul(self.model, np.array([a_data.to_numpy(), b_data.to_numpy()]))
+
+    df = daft.DataFrame.read_csv('tests/assets/iris.csv')
+    train, test = df.limit(10), df.limit(10)  # test should be different train
+
+    train = train.with_column('model_results',
+                              RunExpensiveModel(daft.col('sepal.length'), daft.col('sepal.width')).alias(
+                                  'model_output'))
+    state = State.from_dataframe(train)
+    temepdir = TemporaryDirectory()
+    state_path = temepdir.name + 'state.pkl'
+    state.save(state_path)
+    state = State.from_file(state)
+    for data in (test, test.to_dict(orient='records'), df.to_dict(orient='records'), df.to_json(orient='records'),
+                 df.to_dict(orient='list'), pl.from_pandas(df).to_arrow(), df.values):
+        assert 'model_results' in state.inference(data, filters=False, remainder=True).column_names
+
+
+def test_state_inference_filters():
+    """
+    Use cases where we want to get predictions for the entire data.
+    Avoid cleaning missing values and outliers in production and metric evaluations. 
+    """
+    df = daft.DataFrame.read_csv('tests/assets/iris.csv')
+    filtered = df[df['sepal.length'] > 5]  # filter
+    state = State.from_dataframe(filtered)
+    assert len(state.inference(df, filters=False)) == len(df)
+    assert len(state.inference(df, filters=True)) == len(filtered)
+
+
+def test_state_inference_reminder():
+    """
+    Use cases where we send additional information to the inference function, which we want to keep.
+    For example, an identifier for each row, or a timestamp.
+    """
+    df = daft.DataFrame.read_csv('tests/assets/iris.csv').to_pandas()
+    filtered = df.select('sepal.length', 'sepal.width')
+    state = State.from_dataframe(filtered)
+    assert len(state.inference(df, remainder=True).columns) == len(df.columns)
+    assert len(state.inference(df, remainder=False).columns) == len(filtered.columns)


### PR DESCRIPTION
:warning: **work in progress**: The tests are not passing, and some functions lack implementation. 

# State object
**Goal**:  One of the most common use cases of any ML solution is eventually getting prediction in production.
In almost any server, we must turn the JSON/dict input data into a DataFrame, and run all of our feature-engineering and modelling on it, and return one or more columns.

As this is done manually every single time, I suggest implementing an object which practically does it behind the scenes using the logical plan which is already inplace.

We can save the state to file and load it into a server and get predictions without implementing mountains of pipeline code.

## Usage
```                                                                                                                                
@daft.polars_udf(return_type=float)
 class ModelExample:
    def __init__(self):
        # Initialize and cache an "expensive" model between invocations of the UDF
        self.model = load_model()

    def __call__(self, feature1: pl.Series, feature2: pl.Series):
        return self.model(np.array([feature1.to_numpy(), feature1.to_numpy()])

df = daft.DataFrame.read_csv('tests/assets/iris.csv')
train, test = df.ml.train_test_split(0.8)

train = train.with_column('model_results',
                          ModelExample(daft.col('sepal.length'), daft.col('sepal.width')).alias(
                              'model_output'))
state = State.from_dataframe(train)
assert 'model_output' in state.infer(test).columns
```
* Feature work - auto-generated [FastAPI app](http://fastapi.tiangolo.com)
* Feature work - auto-generated server
  * [Ray-serve](https://docs.ray.io/en/latest/serve/index.html)
  * [Gunicorn](https://gunicorn.org)
  * [MLFlow](https://www.mlflow.org)
  * [modal.com function](http://modal.com/)

