### PR TITLE
Fixes #299 to work without relying on expression IDs

### DIFF
--- a/daft/execution/logical_op_runners.py
+++ b/daft/execution/logical_op_runners.py
@@ -359,7 +359,10 @@ class LogicalGlobalOpRunner:
 
         def quantile_reduce_func(to_reduce: list[vPartition]) -> vPartition:
             merged = vPartition.merge_partitions(to_reduce, verify_partition_id=False)
-            merged_sorted = merged.sort(exprs, descending=descending)
+
+            # Skip evaluation of expressions by converting to ColumnExpression, since evaluation was done in sample_map_func
+            merged_sorted = merged.sort(exprs.to_column_expressions(), descending=descending)
+
             return merged_sorted.quantiles(num_partitions)
 
         prev_part = inputs[child_id]

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -208,10 +208,6 @@ class vPartition:
     def eval_expression(self, expr: Expression) -> PyListTile:
         expr_col_id = expr.get_id()
 
-        # Avoid recomputing expressions that have been computed before
-        if expr_col_id in self.columns and self.columns[expr_col_id].column_name == expr.name():
-            return self.columns[expr_col_id]
-
         expr_name = expr.name()
 
         assert expr_col_id is not None

--- a/tests/runners/test_partitioning.py
+++ b/tests/runners/test_partitioning.py
@@ -23,11 +23,11 @@ def test_vpartition_eval_expression() -> None:
     tiles = {}
     for c in expr.required_columns():
         block = DataBlock.make_block(np.ones(10))
-        tiles[c.name()] = PyListTile(column_id=c.name(), column_name=c.name(), partition_id=0, block=block)
+        tiles[c.get_id()] = PyListTile(column_id=c.get_id(), column_name=c.name(), partition_id=0, block=block)
     part = vPartition(columns=tiles, partition_id=0)
     result_tile = part.eval_expression(expr=expr)
     assert result_tile.partition_id == 0
-    assert result_tile.column_id == expr.name()
+    assert result_tile.column_id == expr.get_id()
     assert result_tile.column_name == expr.name()
     assert result_tile.block == DataBlock.make_block(np.ones(10) * 2)
 
@@ -45,7 +45,7 @@ def test_vpartition_eval_expression_list() -> None:
     tiles = {}
     for c in expr.required_columns():
         block = DataBlock.make_block(np.ones(10))
-        tiles[c.name()] = PyListTile(column_id=c.name(), column_name=c.name(), partition_id=0, block=block)
+        tiles[c.get_id()] = PyListTile(column_id=c.get_id(), column_name=c.name(), partition_id=0, block=block)
     part = vPartition(columns=tiles, partition_id=0)
     assert len(part) == 10
 
@@ -55,10 +55,10 @@ def test_vpartition_eval_expression_list() -> None:
     assert len(result_vpart.columns) == 4
     for i in range(4):
         expr = list_of_expr[i]
-        col_id = expr.name()
+        col_id = expr.get_id()
         result_tile = result_vpart.columns[col_id]
         assert result_vpart.partition_id == 0
-        assert result_tile.column_id == expr.name()
+        assert result_tile.column_id == expr.get_id()
         assert result_tile.column_name == expr.name()
         assert result_tile.block == DataBlock.make_block((np.ones(10) * 2) + i)
 
@@ -169,7 +169,7 @@ def test_vpartition_sort() -> None:
     expr = resolve_expr(expr)
 
     tiles = {}
-    col_id = expr.required_columns()[0].name()
+    col_id = expr.required_columns()[0].get_id()
 
     for i in range(col_id, col_id + 4):
         if i == col_id:
@@ -194,7 +194,7 @@ def test_vpartition_sort_desc() -> None:
     expr = resolve_expr(expr)
 
     tiles = {}
-    col_id = expr.required_columns()[0].name()
+    col_id = expr.required_columns()[0].get_id()
 
     for i in range(col_id, col_id + 4):
         if i == col_id:
@@ -242,7 +242,7 @@ def test_hash_partition(n) -> None:
     expr = resolve_expr(expr)
 
     tiles = {}
-    col_id = expr.required_columns()[0].name()
+    col_id = expr.required_columns()[0].get_id()
 
     for i in range(col_id, col_id + 4):
         block = DataBlock.make_block(np.arange(0, 2 * n, 1) % n)


### PR DESCRIPTION
* #299 fixes sorts by avoiding recomputations on Expressions that have IDs that already exist in the current vPartition
* However, moving forward Expressions will be ID-less
* This PR fixes sorts in a different way, no-opping expression evaluation in `quantile_reduce_func` during sort sampling