### PR TITLE
Fix self join where column name can conflict

### DIFF
--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -300,7 +300,7 @@ class Join(Instruction):
             right,
             left_on=self.logplan._left_on,
             right_on=self.logplan._right_on,
-            output_schema=self.logplan.schema(),
+            output_projection=self.logplan._output_projection,
             how=self.logplan._how.value,
         )
         return [result]

--- a/daft/execution/logical_op_runners.py
+++ b/daft/execution/logical_op_runners.py
@@ -202,7 +202,7 @@ class LogicalPartitionOpRunner:
             right_partition,
             left_on=join._left_on,
             right_on=join._right_on,
-            output_schema=join.schema(),
+            output_projection=join._output_projection,
             how=join._how.value,
         )
 

--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -913,6 +913,7 @@ class Join(BinaryNode):
             unioned_expressions = left_columns.union(right_columns, rename_dup="right.")
             self._left_columns = left_columns
             self._right_columns = ExpressionList(unioned_expressions.exprs[len(self._left_columns.exprs) :])
+            self._output_projection = unioned_expressions
             output_schema = self._left_columns.to_schema(left.schema()).union(
                 self._right_columns.to_schema(right.schema())
             )

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -551,7 +551,7 @@ class vPartition:
         right: vPartition,
         left_on: ExpressionList,
         right_on: ExpressionList,
-        output_schema: Schema,
+        output_projection: ExpressionList,
         how: str = "inner",
     ) -> vPartition:
         assert how == "inner"
@@ -590,7 +590,7 @@ class vPartition:
         assert joined_block_idx == len(result_keys)
 
         output = vPartition(columns=result_columns, partition_id=self.partition_id)
-        return output.eval_expression_list(output_schema.to_column_expressions())
+        return output.eval_expression_list(output_projection)
 
     def _to_file(
         self,

--- a/tests/dataframe_cookbook/test_joins.py
+++ b/tests/dataframe_cookbook/test_joins.py
@@ -26,6 +26,23 @@ def test_simple_join(daft_df, service_requests_csv_pd_df, repartition_nparts):
 
 
 @parametrize_service_requests_csv_repartition
+def test_simple_self_join(daft_df, service_requests_csv_pd_df, repartition_nparts):
+    daft_df = daft_df.repartition(repartition_nparts)
+    daft_df = daft_df.select(col("Unique Key"), col("Borough"))
+
+    daft_df = daft_df.join(daft_df, col("Unique Key"))
+
+    service_requests_csv_pd_df = service_requests_csv_pd_df[["Unique Key", "Borough"]]
+    service_requests_csv_pd_df = (
+        service_requests_csv_pd_df.set_index("Unique Key")
+        .join(service_requests_csv_pd_df.set_index("Unique Key"), how="inner", rsuffix="right.")
+        .reset_index()
+    )
+    daft_pd_df = daft_df.to_pandas()
+    assert_df_equals(daft_pd_df, service_requests_csv_pd_df)
+
+
+@parametrize_service_requests_csv_repartition
 def test_simple_join_missing_rvalues(daft_df, service_requests_csv_pd_df, repartition_nparts):
     daft_df_right = daft_df.sort("Unique Key").limit(25).repartition(repartition_nparts)
     daft_df_left = daft_df.repartition(repartition_nparts)

--- a/tests/dataframe_cookbook/test_joins.py
+++ b/tests/dataframe_cookbook/test_joins.py
@@ -35,9 +35,10 @@ def test_simple_self_join(daft_df, service_requests_csv_pd_df, repartition_npart
     service_requests_csv_pd_df = service_requests_csv_pd_df[["Unique Key", "Borough"]]
     service_requests_csv_pd_df = (
         service_requests_csv_pd_df.set_index("Unique Key")
-        .join(service_requests_csv_pd_df.set_index("Unique Key"), how="inner", rsuffix="right.")
+        .join(service_requests_csv_pd_df.set_index("Unique Key"), how="inner", rsuffix="_right")
         .reset_index()
     )
+    service_requests_csv_pd_df = service_requests_csv_pd_df.rename({"Borough_right": "right.Borough"}, axis=1)
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, service_requests_csv_pd_df)
 


### PR DESCRIPTION
Fixes bug in self join where we get a key error when we join two dataframes that have name conflict for the non join keys
```
    daft_df = daft_df.select(col("Unique Key"), col("Borough"))
    daft_df = daft_df.join(daft_df, col("Unique Key"))
```
would yield:
```
/opt/hostedtoolcache/Python/3.7.15/x64/lib/python3.7/site-packages/daft/runners/partitioning.py in eval_expression(self, expr)
    198         required_blocks = {}
    199         for name in required_cols:
--> 200             block = self.columns[name].block
    201             required_blocks[name] = block
    202         exec = ExpressionExecutor()

KeyError: 'right.Borough'
```
