### PR TITLE
Pin polars to versions <= 0.15.18 due to issue #6584

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
   "psutil",
   "typing-extensions >= 4.0.0; python_version < '3.8'",
   "pickle5 >= 0.0.12; python_version < '3.8'",
-  # Polars issue with list aggregations in 0.16.1: https://github.com/pola-rs/polars/issues/6584
-  "polars[timezone] <= 0.15.18"
+  # Breaking change in list aggregations in 0.16.1: https://github.com/pola-rs/polars/issues/6584
+  "polars[timezone] < 0.16.0"
 ]
 description = "A Distributed DataFrame library for large scale complex data processing."
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
   "psutil",
   "typing-extensions >= 4.0.0; python_version < '3.8'",
   "pickle5 >= 0.0.12; python_version < '3.8'",
-  "polars[timezone]"
+  # Polars issue with list aggregations in 0.16.1: https://github.com/pola-rs/polars/issues/6584
+  "polars[timezone] <= 0.15.18"
 ]
 description = "A Distributed DataFrame library for large scale complex data processing."
 dynamic = ["version"]


### PR DESCRIPTION
Polars issue https://github.com/pola-rs/polars/issues/6584 is currently breaking our local aggregations. We pin our polars version here temporarily until this is fixed.