### PR TITLE
Refactor resource requests out of Expressions

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -54,6 +54,7 @@ if not dev_build and not user_opted_out:
 
 from daft.dataframe import DataFrame
 from daft.expressions import col, lit
+from daft.resource_request import resources
 from daft.udf import polars_udf, udf
 
-__all__ = ["DataFrame", "col", "lit", "udf", "polars_udf"]
+__all__ = ["DataFrame", "col", "lit", "udf", "polars_udf", "resources"]

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -54,7 +54,6 @@ if not dev_build and not user_opted_out:
 
 from daft.dataframe import DataFrame
 from daft.expressions import col, lit
-from daft.resource_request import resources
 from daft.udf import polars_udf, udf
 
-__all__ = ["DataFrame", "col", "lit", "udf", "polars_udf", "resources"]
+__all__ = ["DataFrame", "col", "lit", "udf", "polars_udf"]

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, Union
 import pandas
 import pyarrow as pa
 
+from daft import resource_request
 from daft.api_annotations import DataframePublicAPI
 from daft.context import get_context
 from daft.dataframe.preview import DataFramePreview
@@ -679,7 +680,9 @@ class DataFrame:
             DataFrame: new DataFrame that will select the passed in columns
         """
         assert len(columns) > 0
-        projection = logical_plan.Projection(self._plan, self.__column_input_to_expression(columns))
+        projection = logical_plan.Projection(
+            self._plan, self.__column_input_to_expression(columns), custom_resource_request=None
+        )
         return DataFrame(projection)
 
     @DataframePublicAPI
@@ -721,7 +724,7 @@ class DataFrame:
         """
         names_to_skip = set(names)
         el = ExpressionList([col(e.name) for e in self._plan.schema() if e.name not in names_to_skip])
-        return DataFrame(logical_plan.Projection(self._plan, el))
+        return DataFrame(logical_plan.Projection(self._plan, el, custom_resource_request=None))
 
     @DataframePublicAPI
     def where(self, predicate: Expression) -> DataFrame:
@@ -740,7 +743,9 @@ class DataFrame:
         return DataFrame(plan)
 
     @DataframePublicAPI
-    def with_column(self, column_name: str, expr: Expression) -> DataFrame:
+    def with_column(
+        self, column_name: str, expr: Expression, resource_request: resource_request.ResourceRequest | None = None
+    ) -> DataFrame:
         """Adds a column to the current DataFrame with an Expression, equivalent to a ``select``
         with all current columns and the new one
 
@@ -750,13 +755,16 @@ class DataFrame:
         Args:
             column_name (str): name of new column
             expr (Expression): expression of the new column.
+            resource_request (resource_request.ResourceRequest): a custom resource request for the execution of this operation
 
         Returns:
             DataFrame: DataFrame with new column.
         """
         prev_schema_as_cols = self._plan.schema().to_column_expressions()
         projection = logical_plan.Projection(
-            self._plan, prev_schema_as_cols.union(ExpressionList([expr.alias(column_name)]), other_override=True)
+            self._plan,
+            prev_schema_as_cols.union(ExpressionList([expr.alias(column_name)]), other_override=True),
+            custom_resource_request=resource_request,
         )
         return DataFrame(projection)
 
@@ -1041,7 +1049,7 @@ class DataFrame:
 
         final_op: logical_plan.LogicalPlan
         if need_final_projection:
-            final_op = logical_plan.Projection(gagg_op, final_schema)
+            final_op = logical_plan.Projection(gagg_op, final_schema, custom_resource_request=None)
         else:
             final_op = gagg_op
 

--- a/daft/execution/logical_op_runners.py
+++ b/daft/execution/logical_op_runners.py
@@ -274,9 +274,7 @@ class LogicalGlobalOpRunner:
             raise NotImplementedError(f"{type(node)} not implemented")
 
     @abstractmethod
-    def map_partitions(
-        self, pset: PartitionSet, func: Callable[[vPartition], vPartition], resource_request: ResourceRequest
-    ) -> PartitionSet:
+    def map_partitions(self, pset: PartitionSet, func: Callable[[vPartition], vPartition]) -> PartitionSet:
         raise NotImplementedError()
 
     @abstractmethod
@@ -319,18 +317,15 @@ class LogicalGlobalOpRunner:
             else:
                 return part.head(0)
 
-        return self.map_partitions(prev_part, limit_map_func, limit.resource_request())
+        return self.map_partitions(prev_part, limit_map_func)
 
     def _handle_repartition(self, inputs: dict[int, PartitionSet], repartition: Repartition) -> PartitionSet:
         child_id = repartition._children()[0].id()
         repartitioner: ShuffleOp
         if repartition._scheme == PartitionScheme.RANDOM:
-            repartitioner = self._get_shuffle_op_klass(RepartitionRandomOp)(
-                expr_eval_resource_request=ResourceRequest.default()
-            )
+            repartitioner = self._get_shuffle_op_klass(RepartitionRandomOp)()
         elif repartition._scheme == PartitionScheme.HASH:
             repartitioner = self._get_shuffle_op_klass(RepartitionHashOp)(
-                expr_eval_resource_request=repartition.resource_request(),
                 map_args={"exprs": repartition._partition_by},
             )
         else:
@@ -363,11 +358,10 @@ class LogicalGlobalOpRunner:
             return merged_sorted.quantiles(num_partitions)
 
         prev_part = inputs[child_id]
-        sampled_partitions = self.map_partitions(prev_part, sample_map_func, sort.resource_request())
+        sampled_partitions = self.map_partitions(prev_part, sample_map_func)
         boundaries = self.reduce_partitions(sampled_partitions, quantile_reduce_func)
         sort_shuffle_op_klass = self._get_shuffle_op_klass(SortOp)
         sort_op = sort_shuffle_op_klass(
-            expr_eval_resource_request=sort.resource_request(),
             map_args={"exprs": exprs, "boundaries": boundaries, "descending": descending},
             reduce_args={"exprs": exprs, "descending": descending},
         )
@@ -382,7 +376,6 @@ class LogicalGlobalOpRunner:
         coalesce_op_klass = self._get_shuffle_op_klass(CoalesceOp)
 
         coalesce_op = coalesce_op_klass(
-            expr_eval_resource_request=ResourceRequest.default(),
             map_args={"num_input_partitions": prev_part.num_partitions()},
         )
         return coalesce_op.run(input=prev_part, num_target_partitions=num_partitions)

--- a/daft/logical/map_partition_ops.py
+++ b/daft/logical/map_partition_ops.py
@@ -3,16 +3,11 @@ from __future__ import annotations
 from abc import abstractmethod
 
 from daft.logical.schema import ExpressionList, Schema
-from daft.resource_request import ResourceRequest
 from daft.runners.partitioning import vPartition
 from daft.types import ExpressionType
 
 
 class MapPartitionOp:
-    @abstractmethod
-    def resource_request(self) -> ResourceRequest:
-        """Returns the resource request of running this MapPartitionOp on one vPartition"""
-
     @abstractmethod
     def get_output_schema(self) -> Schema:
         """Returns the output schema after running this MapPartitionOp"""
@@ -47,9 +42,6 @@ class ExplodeOp(MapPartitionOp):
                 raise ValueError(
                     f"Expected expression {c} to resolve to an explodable type such as PY, but received: {resolved_type}"
                 )
-
-    def resource_request(self) -> ResourceRequest:
-        return self.explode_columns.resource_request()
 
     def get_output_schema(self) -> Schema:
         return self.output_schema

--- a/daft/resource_request.py
+++ b/daft/resource_request.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import functools
 
@@ -36,3 +37,39 @@ class ResourceRequest:
             else:
                 max_resources[name] = max(getattr(self, name), getattr(other, name))
         return ResourceRequest(**max_resources)
+
+
+# Global singleton tracking the current context's resource request
+_CURRENT_RESOURCE_REQUEST = ResourceRequest.default()
+
+
+def _get_current_resource_request() -> ResourceRequest:
+    """Gets the current context's resource request"""
+    return _CURRENT_RESOURCE_REQUEST
+
+
+@contextlib.contextmanager
+def resources(num_cpus: int | float = 1.0, num_gpus: int | float = 0, memory_bytes: int | None = None):
+    """Sets the resources required to execute the Daft dataframe operations that it wraps
+
+    Example:
+
+        >>> with daft.resources(num_cpus=2, num_gpus=1):
+        >>>     df = df.with_column("model_results", run_model(df["features"]))
+
+    Args:
+        num_cpus: Number of CPUs required to execute the Daft dataframe operations that it wraps
+        num_gpus: Number of GPUs required to execute the Daft dataframe operations that it wraps
+        memory_bytes: Number of bytes of memory required to execute the Daft dataframe operations that it wraps
+    """
+    global _CURRENT_RESOURCE_REQUEST
+    old_resource_request = _CURRENT_RESOURCE_REQUEST
+    new_resource_request = ResourceRequest(
+        num_cpus=num_cpus,
+        num_gpus=num_gpus,
+        memory_bytes=memory_bytes,
+    )
+    try:
+        _CURRENT_RESOURCE_REQUEST = new_resource_request
+    finally:
+        _CURRENT_RESOURCE_REQUEST = old_resource_request

--- a/daft/resource_request.py
+++ b/daft/resource_request.py
@@ -11,10 +11,6 @@ class ResourceRequest:
     num_gpus: int | float | None = None
     memory_bytes: int | float | None = None
 
-    @classmethod
-    def default(cls) -> ResourceRequest:
-        return ResourceRequest(num_cpus=None, num_gpus=None, memory_bytes=None)
-
     @staticmethod
     def max_resources(resource_requests: list[ResourceRequest | None]) -> ResourceRequest:
         """Gets the maximum of all resources in a list of ResourceRequests as a new ResourceRequest"""

--- a/daft/resource_request.py
+++ b/daft/resource_request.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import dataclasses
 import functools
 
@@ -8,25 +7,27 @@ import functools
 @dataclasses.dataclass(frozen=True)
 class ResourceRequest:
 
-    num_cpus: int | float | None
-    num_gpus: int | float | None
-    memory_bytes: int | float | None
+    num_cpus: int | float | None = None
+    num_gpus: int | float | None = None
+    memory_bytes: int | float | None = None
 
     @classmethod
     def default(cls) -> ResourceRequest:
         return ResourceRequest(num_cpus=None, num_gpus=None, memory_bytes=None)
 
     @staticmethod
-    def max_resources(resource_requests: list[ResourceRequest]) -> ResourceRequest:
-        """Gets the maximum of all resources in a list of ResourceRequests, including self, as a new ResourceRequest"""
+    def max_resources(resource_requests: list[ResourceRequest | None]) -> ResourceRequest:
+        """Gets the maximum of all resources in a list of ResourceRequests as a new ResourceRequest"""
         return functools.reduce(
             lambda acc, req: acc._max_for_each_resource(req),
             resource_requests,
             ResourceRequest(num_cpus=None, num_gpus=None, memory_bytes=None),
         )
 
-    def _max_for_each_resource(self, other: ResourceRequest) -> ResourceRequest:
+    def _max_for_each_resource(self, other: ResourceRequest | None) -> ResourceRequest:
         """Get a new ResourceRequest that consists of the maximum requests for each resource"""
+        if other is None:
+            return self
         resource_names = [f.name for f in dataclasses.fields(ResourceRequest)]
         max_resources = {}
         for name in resource_names:
@@ -37,39 +38,3 @@ class ResourceRequest:
             else:
                 max_resources[name] = max(getattr(self, name), getattr(other, name))
         return ResourceRequest(**max_resources)
-
-
-# Global singleton tracking the current context's resource request
-_CURRENT_RESOURCE_REQUEST = ResourceRequest.default()
-
-
-def _get_current_resource_request() -> ResourceRequest:
-    """Gets the current context's resource request"""
-    return _CURRENT_RESOURCE_REQUEST
-
-
-@contextlib.contextmanager
-def resources(num_cpus: int | float = 1.0, num_gpus: int | float = 0, memory_bytes: int | None = None):
-    """Sets the resources required to execute the Daft dataframe operations that it wraps
-
-    Example:
-
-        >>> with daft.resources(num_cpus=2, num_gpus=1):
-        >>>     df = df.with_column("model_results", run_model(df["features"]))
-
-    Args:
-        num_cpus: Number of CPUs required to execute the Daft dataframe operations that it wraps
-        num_gpus: Number of GPUs required to execute the Daft dataframe operations that it wraps
-        memory_bytes: Number of bytes of memory required to execute the Daft dataframe operations that it wraps
-    """
-    global _CURRENT_RESOURCE_REQUEST
-    old_resource_request = _CURRENT_RESOURCE_REQUEST
-    new_resource_request = ResourceRequest(
-        num_cpus=num_cpus,
-        num_gpus=num_gpus,
-        memory_bytes=memory_bytes,
-    )
-    try:
-        _CURRENT_RESOURCE_REQUEST = new_resource_request
-    finally:
-        _CURRENT_RESOURCE_REQUEST = old_resource_request

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -194,10 +194,7 @@ class LocalLogicalGlobalOpRunner(LogicalGlobalOpRunner):
         SortOp: PyRunnerSortOp,
     }
 
-    def map_partitions(
-        self, pset: PartitionSet, func: Callable[[vPartition], vPartition], resource_request: ResourceRequest
-    ) -> PartitionSet:
-        # NOTE: resource_request is ignored since there isn't any actual distribution of workloads in PyRunner
+    def map_partitions(self, pset: PartitionSet, func: Callable[[vPartition], vPartition]) -> PartitionSet:
         return LocalPartitionSet({i: func(pset.get_partition(i)) for i in range(pset.num_partitions())})
 
     def reduce_partitions(self, pset: PartitionSet, func: Callable[[list[vPartition]], ReduceType]) -> ReduceType:

--- a/daft/runners/shuffle_ops.py
+++ b/daft/runners/shuffle_ops.py
@@ -6,7 +6,6 @@ from typing import Any
 
 import numpy as np
 
-from daft.resource_request import ResourceRequest
 from daft.runners.blocks import ArrowArrType, DataBlock
 from daft.runners.partitioning import PartID, PartitionSet, vPartition
 
@@ -16,13 +15,11 @@ from ..logical.schema import ExpressionList
 class ShuffleOp:
     def __init__(
         self,
-        expr_eval_resource_request: ResourceRequest,
         map_args: dict[str, Any] | None = None,
         reduce_args: dict[str, Any] | None = None,
     ) -> None:
         self._map_args = map_args
         self._reduce_args = reduce_args
-        self._expr_eval_resource_request = expr_eval_resource_request
 
     @staticmethod
     @abstractmethod

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -80,17 +80,16 @@ def udf(
     Args:
         f: Function to wrap as a UDF, accepts column inputs as Numpy arrays and returns a column of data as a Polars Series/Numpy array/Python list/Pandas series.
         return_type: The return type of the UDF
-        num_gpus: Deprecated - please use `with daft.resource_request(...):` instead
-        num_cpus: Deprecated - please use `with daft.resource_request(...):` instead
-        memory_bytes: Deprecated - please use `with daft.resource_request(...):` instead
+        num_gpus: Deprecated - please use `DataFrame.with_column(..., resource_request=...)` instead
+        num_cpus: Deprecated - please use `DataFrame.with_column(..., resource_request=...)` instead
+        memory_bytes: Deprecated - please use `DataFrame.with_column(..., resource_request=...)` instead
     """
     warnings.warn(
         "DEPRECATION WARNING: @udf will be deprecated in 0.1.0 in favor of @polars_udf which is much more efficient and handles Null/NaN semantics correctly"
     )
     if any(arg is not None for arg in [num_gpus, num_cpus, memory_bytes]):
         raise ValueError(
-            "The num_gpus, num_cpus, and memory_bytes kwargs have been deprecated for @udf. Please use `with daft.resource_request(...):` instead"
-            " to specify resource requests for dataframe operations"
+            "The num_gpus, num_cpus, and memory_bytes kwargs have been deprecated for @udf. Please use `DataFrame.with_column(..., resource_request=...)` instead"
         )
 
     func_ret_type = ExpressionType.from_py_type(return_type)
@@ -178,16 +177,15 @@ def polars_udf(
     Args:
         f: Function to wrap as a UDF, accepts column inputs as Polars Series and returns a column of data as a Polars Series/Numpy array/Python list/Pandas series.
         return_type: The return type of the UDF
-        num_gpus: Deprecated - please use `with daft.resource_request(...):` instead
-        num_cpus: Deprecated - please use `with daft.resource_request(...):` instead
-        memory_bytes: Deprecated - please use `with daft.resource_request(...):` instead
+        num_gpus: Deprecated - please use `DataFrame.with_column(..., resource_request=...)` instead
+        num_cpus: Deprecated - please use `DataFrame.with_column(..., resource_request=...)` instead
+        memory_bytes: Deprecated - please use `DataFrame.with_column(..., resource_request=...)` instead
     """
     if not _POLARS_AVAILABLE:
         raise ImportError("polars_udf requires polars to be installed")
     if any(arg is not None for arg in [num_gpus, num_cpus, memory_bytes]):
         raise ValueError(
-            "The num_gpus, num_cpus, and memory_bytes kwargs have been deprecated for @polars_udf. Please use `with daft.resource_request(...):` instead"
-            " to specify resource requests for dataframe operations"
+            "The num_gpus, num_cpus, and memory_bytes kwargs have been deprecated for @polars_udf. Please use `DataFrame.with_column(..., resource_request=...)` instead"
         )
 
     func_ret_type = ExpressionType.from_py_type(return_type)

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -7,7 +7,6 @@ from typing import Callable, Sequence, Union
 
 from daft.execution.operators import ExpressionType
 from daft.expressions import UdfExpression
-from daft.resource_request import ResourceRequest
 from daft.runners.blocks import DataBlock
 
 _POLARS_AVAILABLE = True
@@ -81,13 +80,18 @@ def udf(
     Args:
         f: Function to wrap as a UDF, accepts column inputs as Numpy arrays and returns a column of data as a Polars Series/Numpy array/Python list/Pandas series.
         return_type: The return type of the UDF
-        num_gpus: How many GPUs the UDF requires for execution, used for resource allocation when running in a distributed setting
-        num_cpus: How many CPUs the UDF requires for execution, used for resource allocation when running in a distributed setting
-        memory_bytes: How many bytes of memory this UDF requires for execution, used for resource allocation when running in a distributed setting
+        num_gpus: Deprecated - please use `with daft.resource_request(...):` instead
+        num_cpus: Deprecated - please use `with daft.resource_request(...):` instead
+        memory_bytes: Deprecated - please use `with daft.resource_request(...):` instead
     """
     warnings.warn(
         "DEPRECATION WARNING: @udf will be deprecated in 0.1.0 in favor of @polars_udf which is much more efficient and handles Null/NaN semantics correctly"
     )
+    if any(arg is not None for arg in [num_gpus, num_cpus, memory_bytes]):
+        raise ValueError(
+            "The num_gpus, num_cpus, and memory_bytes kwargs have been deprecated for @udf. Please use `with daft.resource_request(...):` instead"
+            " to specify resource requests for dataframe operations"
+        )
 
     func_ret_type = ExpressionType.from_py_type(return_type)
 
@@ -118,7 +122,6 @@ def udf(
                 func_ret_type=func_ret_type,
                 func_args=args,
                 func_kwargs=kwargs,
-                resource_request=ResourceRequest(num_cpus=num_cpus, num_gpus=num_gpus, memory_bytes=memory_bytes),
             )
             return out_expr
 
@@ -175,12 +178,17 @@ def polars_udf(
     Args:
         f: Function to wrap as a UDF, accepts column inputs as Polars Series and returns a column of data as a Polars Series/Numpy array/Python list/Pandas series.
         return_type: The return type of the UDF
-        num_gpus: How many GPUs the UDF requires for execution, used for resource allocation when running in a distributed setting
-        num_cpus: How many CPUs the UDF requires for execution, used for resource allocation when running in a distributed setting
-        memory_bytes: How many bytes of memory this UDF requires for execution, used for resource allocation when running in a distributed setting
+        num_gpus: Deprecated - please use `with daft.resource_request(...):` instead
+        num_cpus: Deprecated - please use `with daft.resource_request(...):` instead
+        memory_bytes: Deprecated - please use `with daft.resource_request(...):` instead
     """
     if not _POLARS_AVAILABLE:
         raise ImportError("polars_udf requires polars to be installed")
+    if any(arg is not None for arg in [num_gpus, num_cpus, memory_bytes]):
+        raise ValueError(
+            "The num_gpus, num_cpus, and memory_bytes kwargs have been deprecated for @polars_udf. Please use `with daft.resource_request(...):` instead"
+            " to specify resource requests for dataframe operations"
+        )
 
     func_ret_type = ExpressionType.from_py_type(return_type)
 
@@ -211,7 +219,6 @@ def polars_udf(
                 func_ret_type=func_ret_type,
                 func_args=args,
                 func_kwargs=kwargs,
-                resource_request=ResourceRequest(num_cpus=num_cpus, num_gpus=num_gpus, memory_bytes=memory_bytes),
             )
             return out_expr
 

--- a/docs/source/docs/learn/user_guides/udf.rst
+++ b/docs/source/docs/learn/user_guides/udf.rst
@@ -111,13 +111,21 @@ Resource Requests
 
 Sometimes, you may want to request for specific resources for your UDF. For example, some UDFs need one GPU to run as they will load a model onto the GPU.
 
-Daft provides a simple API for indicating GPU and CPU requests.
+As of Daft v0.0.22, resource requests are no longer in UDF definition. Instead, custom resources can be requested when you call ``.with_column``:
 
 .. code:: python
 
-    # Requires one GPU and eight CPUs to run
-    @udf(return_type=int, num_gpus=1, num_cpus=8)
+    from daft.resource_request import ResourceRequest
+
+    @udf(return_type=int)
     def func():
         model = get_model().cuda()
+
+    # Runs the UDF `func` with the specified resource requests
+    df = df.with_column(
+        "image_classifications",
+        func(df["images"]),
+        resource_request=ResourceRequest(num_gpus=1, num_cpus=8),
+    )
 
 In the above example, if ran Daft on a Ray cluster consisting of 8 GPUs and 64 CPUs, Daft would be able to run 8 replicas of your UDF in parallel, thus massively increasing the throughput of your UDF!

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -49,7 +49,7 @@ def my_udf(c):
 ###
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"py", "dynamic"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
 def test_requesting_too_many_cpus():
     df = DataFrame.from_pydict(DATA)
 
@@ -63,7 +63,7 @@ def test_requesting_too_many_cpus():
         df.to_pandas()
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"py", "dynamic"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
 def test_requesting_too_many_gpus():
     df = DataFrame.from_pydict(DATA)
     df = df.with_column(
@@ -74,7 +74,7 @@ def test_requesting_too_many_gpus():
         df.to_pandas()
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"py", "dynamic"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
 def test_requesting_too_much_memory():
     df = DataFrame.from_pydict(DATA)
 
@@ -88,7 +88,7 @@ def test_requesting_too_much_memory():
         df.to_pandas()
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"py", "dynamic"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 def test_with_column_pyrunner():
     df = DataFrame.from_pydict(DATA).repartition(5)
@@ -121,9 +121,7 @@ def noop_assert_gpu_available(c):
     return c
 
 
-@pytest.mark.skipif(
-    get_context().runner_config.name not in {"ray", "dynamicray"}, reason="requires RayRunner to be in use"
-)
+@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 @pytest.mark.parametrize("num_gpus", [None, 1])
 def test_with_column_rayrunner(num_gpus):
@@ -140,9 +138,7 @@ def test_with_column_rayrunner(num_gpus):
     assert_df_equals(df.to_pandas(), pd_df, sort_key="id")
 
 
-@pytest.mark.skipif(
-    get_context().runner_config.name not in {"ray", "dynamicray"}, reason="requires RayRunner to be in use"
-)
+@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 def test_with_column_max_resources_rayrunner():
     df = DataFrame.from_pydict(DATA).repartition(2)

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 import multiprocessing
 import os
 
-import pandas as pd
 import psutil
 import pytest
+import ray
 
 from daft import DataFrame, resource_request, udf
 from daft.context import get_context
 from daft.expressions import col
 from daft.internal.gpu import cuda_device_count
-from tests.conftest import assert_df_equals
 
 
 def no_gpu_available() -> bool:
@@ -19,21 +18,6 @@ def no_gpu_available() -> bool:
 
 
 DATA = {"id": [i for i in range(100)]}
-
-
-@udf(return_type=int)
-def assert_num_cuda_visible_devices(c, num_gpus: int = 0):
-    cuda_visible_devices = os.getenv("CUDA_VISIBLE_DEVICES")
-    # Env var not set: program is free to use any number of GPUs
-    if cuda_visible_devices is None:
-        result = cuda_device_count()
-    # Env var set to empty: program has no access to any GPUs
-    elif cuda_visible_devices == "":
-        result = 0
-    else:
-        result = len(cuda_visible_devices.split(","))
-    assert result == num_gpus
-    return c
 
 
 @udf(return_type=int)
@@ -60,7 +44,7 @@ def test_requesting_too_many_cpus():
     )
 
     with pytest.raises(RuntimeError):
-        df.to_pandas()
+        df.collect()
 
 
 @pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
@@ -71,7 +55,7 @@ def test_requesting_too_many_gpus():
     )
 
     with pytest.raises(RuntimeError):
-        df.to_pandas()
+        df.collect()
 
 
 @pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
@@ -85,12 +69,87 @@ def test_requesting_too_much_memory():
     )
 
     with pytest.raises(RuntimeError):
-        df.to_pandas()
+        df.collect()
+
+
+###
+# Assert RayRunner behavior for requests
+###
+
+
+@udf(return_type=int)
+def assert_resources(c, num_cpus=None, num_gpus=None, memory=None):
+    assigned_resources = ray.get_runtime_context().get_assigned_resources()
+
+    for resource, ray_resource_key in [(num_cpus, "CPU"), (num_gpus, "GPU"), (memory, "memory")]:
+        if resource is None:
+            assert ray_resource_key not in assigned_resources or assigned_resources[ray_resource_key] is None
+        else:
+            assert ray_resource_key in assigned_resources
+            assert assigned_resources[ray_resource_key] == resource
+
+    return c
+
+
+@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
+def test_with_column_rayrunner():
+    df = DataFrame.from_pydict(DATA).repartition(2)
+
+    df = df.with_column(
+        "resources_ok",
+        assert_resources(col("id"), num_cpus=2, num_gpus=None, memory=1_000_000),
+        resource_request=resource_request.ResourceRequest(num_cpus=2, memory_bytes=1_000_000, num_gpus=None),
+    )
+
+    df.collect()
+
+
+@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
+def test_with_column_folded_rayrunner():
+    df = DataFrame.from_pydict(DATA).repartition(2)
+
+    # Because of Projection Folding optimizations, the expected resource request is the max of the three .with_column requests
+    expected = dict(num_cpus=2, num_gpus=None, memory=5_000_000)
+    df = df.with_column(
+        "no_requests",
+        assert_resources(col("id"), **expected),
+    )
+    df = df.with_column(
+        "more_memory_request",
+        assert_resources(col("id"), **expected),
+        resource_request=resource_request.ResourceRequest(num_cpus=1, memory_bytes=5_000_000, num_gpus=None),
+    )
+    df = df.with_column(
+        "more_cpu_request",
+        assert_resources(col("id"), **expected),
+        resource_request=resource_request.ResourceRequest(num_cpus=2, memory_bytes=1_000_000, num_gpus=None),
+    )
+    df.collect()
+
+
+###
+# GPU tests - can only run if machine has a GPU
+###
+
+
+@udf(return_type=int)
+def assert_num_cuda_visible_devices(c, num_gpus: int = 0):
+    cuda_visible_devices = os.getenv("CUDA_VISIBLE_DEVICES")
+    # Env var not set: program is free to use any number of GPUs
+    if cuda_visible_devices is None:
+        result = cuda_device_count()
+    # Env var set to empty: program has no access to any GPUs
+    elif cuda_visible_devices == "":
+        result = 0
+    else:
+        result = len(cuda_visible_devices.split(","))
+    assert result == num_gpus
+    return c
 
 
 @pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
-def test_with_column_pyrunner():
+def test_with_column_pyrunner_gpu():
     df = DataFrame.from_pydict(DATA).repartition(5)
 
     # We do not do any masking of devices for the local PyRunner, even if the user requests fewer GPUs
@@ -101,30 +160,13 @@ def test_with_column_pyrunner():
         resource_request=resource_request.ResourceRequest(num_gpus=1),
     )
 
-    pd_df = pd.DataFrame.from_dict(DATA)
-    pd_df["foo"] = pd_df["id"]
-    assert_df_equals(df.to_pandas(), pd_df, sort_key="id")
-
-
-###
-# Assert RayRunner behavior for GPU requests:
-# Number of GPUs reported by each task should be exactly equal to the number requested.
-###
-
-
-@udf(return_type=int)
-def noop_assert_gpu_available(c):
-    cuda_visible_devices = os.getenv("CUDA_VISIBLE_DEVICES")
-    assert (
-        cuda_visible_devices is not None and cuda_visible_devices != "" and len(cuda_visible_devices.split(",")) == 1
-    ), "One and only one GPU must be made available"
-    return c
+    df.collect()
 
 
 @pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 @pytest.mark.parametrize("num_gpus", [None, 1])
-def test_with_column_rayrunner(num_gpus):
+def test_with_column_rayrunner_gpu(num_gpus):
     df = DataFrame.from_pydict(DATA).repartition(2)
 
     df = df.with_column(
@@ -133,14 +175,12 @@ def test_with_column_rayrunner(num_gpus):
         resource_request=resource_request.ResourceRequest(num_gpus=num_gpus),
     )
 
-    pd_df = pd.DataFrame.from_dict(DATA)
-    pd_df["num_cuda_visible_devices"] = pd_df["id"]
-    assert_df_equals(df.to_pandas(), pd_df, sort_key="id")
+    df.collect()
 
 
 @pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
-def test_with_column_max_resources_rayrunner():
+def test_with_column_max_resources_rayrunner_gpu():
     df = DataFrame.from_pydict(DATA).repartition(2)
 
     # Because of projection folding optimizations, both UDFs should run with num_gpus=1 even though 0_gpu_col requested for 0 GPUs
@@ -155,7 +195,4 @@ def test_with_column_max_resources_rayrunner():
         resource_request=resource_request.ResourceRequest(num_gpus=1),
     )
 
-    pd_df = pd.DataFrame.from_dict(DATA)
-    pd_df["0_gpu_col"] = pd_df["id"]
-    pd_df["1_gpu_col"] = pd_df["id"]
-    assert_df_equals(df.to_pandas(), pd_df, sort_key="id")
+    df.collect()

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -122,7 +122,7 @@ def test_with_column_folded_rayrunner():
     df = df.with_column(
         "more_cpu_request",
         assert_resources(col("id"), **expected),
-        resource_request=resource_request.ResourceRequest(num_cpus=2, memory_bytes=1_000_000, num_gpus=None),
+        resource_request=resource_request.ResourceRequest(num_cpus=2, memory_bytes=None, num_gpus=None),
     )
     df.collect()
 

--- a/tutorials/image_querying/top_n_red_color.ipynb
+++ b/tutorials/image_querying/top_n_red_color.ipynb
@@ -308,7 +308,7 @@
     "import io\n",
     "import PIL\n",
     "\n",
-    "@udf(num_cpus=2, return_type=PIL.Image.Image)\n",
+    "@udf(return_type=PIL.Image.Image)\n",
     "def bytes_to_pil(bytes_column):\n",
     "    return [\n",
     "        PIL.Image.open(io.BytesIO(data)).resize((256, 256)) for data in bytes_column\n",
@@ -428,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16 (default, Dec 25 2022, 07:11:03) \n[Clang 13.0.0 (clang-1300.0.27.3)]"
+   "version": "3.10.4 (main, Jan 11 2023, 00:15:55) [Clang 13.0.0 (clang-1300.0.27.3)]"
   },
   "vscode": {
    "interpreter": {

--- a/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -205,11 +205,13 @@
     "import torch\n",
     "from min_dalle import MinDalle\n",
     "\n",
+    "from daft.resource_request import ResourceRequest\n",
+    "\n",
     "# Flip this flag if you want to see the performance of running on CPU vs GPU\n",
     "USE_GPU = False\n",
     "\n",
     "# Tell Daft to use N number of GPUs with num_gpus=N\n",
-    "@udf(return_type=PIL.Image.Image, num_gpus=1 if USE_GPU else None)\n",
+    "@udf(return_type=PIL.Image.Image)\n",
     "class GenerateImageFromTextGPU:\n",
     "    \n",
     "    def __init__(self):\n",
@@ -235,7 +237,12 @@
     "            ) for t in text_col\n",
     "        ]\n",
     "\n",
-    "%time images_df.with_column(\"generated_image\", GenerateImageFromTextGPU(images_df[\"TEXT\"])).show(1)"
+    "resource_request = ResourceRequest(num_gpus=1) if USE_GPU else None\n",
+    "images_df.with_column(\n",
+    "    \"generated_image\",\n",
+    "    GenerateImageFromTextGPU(images_df[\"TEXT\"]),\n",
+    "    resource_request=resource_request,\n",
+    ").show(1)"
    ]
   }
  ],

--- a/tutorials/text_to_image/using_cloud_with_ray.ipynb
+++ b/tutorials/text_to_image/using_cloud_with_ray.ipynb
@@ -34,9 +34,9 @@
    "id": "8a3ef6f2-550b-4668-9d41-0417e98e22f7",
    "metadata": {},
    "source": [
-    "First, we will run our code without changing the runner. By default, Daft uses the \"Python Runner\" which runs all processing in a single Python process.\n",
+    "By default, Daft uses the \"Python Runner\" which runs all processing in a single Python process.\n",
     "\n",
-    "Let's try to download the images from our previous [Text-to-Image Generatation tutorial](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/text_to_image/text_to_image_generation.ipynb) with the PyRunner."
+    "Let's try to download the images from our previous [Text-to-Image Generatation tutorial](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/text_to_image/text_to_image_generation.ipynb) with the RayRunner instead."
    ]
   },
   {
@@ -211,6 +211,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8430f756-f641-4bfa-9425-8d72e200d726",
    "metadata": {},
@@ -219,7 +220,7 @@
     "\n",
     "We have seen that using the RayRunner even locally provides us with some speedup already. However, the real power of distributed computing is in allowing us to access thousands of CPUs and GPUs in the cloud, on a remote Ray cluster.\n",
     "\n",
-    "For example, UDFs that request for a single GPU with `@udf(num_gpus=1)` can run in parallel across hundreds of GPUs on a remote Ray cluster, effortlessly scaling your workloads up to take full advantage of the available hardware.\n",
+    "For example, UDFs that request for a single GPU with can run in parallel across hundreds of GPUs on a remote Ray cluster, effortlessly scaling your workloads up to take full advantage of the available hardware.\n",
     "\n",
     "To run Daft on large clusters, check out [Eventual](https://www.eventualcomputing.com) where you have access to a fully managed platform for running Daft at scale."
    ]


### PR DESCRIPTION
1. Expressions no longer have an associated `.resource_request()` function, only LogicalPlans.
2. `@udf(...)` no longer allows users to specify resource requests in the UDF
3. The only DataFrame method that allows for custom resource requests is `.with_column("x", expr, resource_request=...)`

