### PR TITLE
[rust] Series including kernels for comparisons, arithmetic and broadcasting, etc

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -54,6 +54,7 @@ if not dev_build and not user_opted_out:
 
 from daft.dataframe import DataFrame
 from daft.expressions import col, lit
+from daft.series import Series
 from daft.udf import polars_udf, udf
 
-__all__ = ["DataFrame", "col", "lit", "udf", "polars_udf"]
+__all__ = ["DataFrame", "col", "lit", "udf", "polars_udf", "Series"]

--- a/daft/series.py
+++ b/daft/series.py
@@ -33,6 +33,11 @@ class Series:
         arrow_array = pa.array(data)
         return Series.from_arrow(arrow_array, name=name)
 
+    def name(self) -> str:
+        if self._series is None:
+            raise ValueError("This Series isn't backed by a Rust PySeries, can not get name")
+        return self._series.name()
+
     def to_arrow(self) -> pa.Array:
         if self._series is None:
             raise ValueError("This Series isn't backed by a Rust PySeries, can not convert to arrow")

--- a/daft/series.py
+++ b/daft/series.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import pyarrow as pa
+
+from daft.daft import PySeries
+
+
+class Series:
+    _series: PySeries | None
+
+    @staticmethod
+    def from_pyseries(pyseries: PySeries) -> Series:
+        s = Series()
+        s._series = pyseries
+        return s
+
+    @staticmethod
+    def from_arrow(array: pa.Array | pa.ChunkedArray, name: str = "arrow_series") -> Series:
+        if isinstance(array, pa.Array):
+            pys = PySeries.from_arrow(name, array)
+            return Series.from_pyseries(pys)
+        elif isinstance(array, pa.ChunkedArray):
+            combined_array = array.combine_chunks()
+            pys = PySeries.from_arrow(name, combined_array)
+            return Series.from_pyseries(pys)
+        else:
+            raise ValueError(f"expected either PyArrow Array or Chunked Array, got {type(array)}")
+
+    @staticmethod
+    def from_pylist(data: list, name: str = "list_series") -> Series:
+        if not isinstance(data, list):
+            raise ValueError(f"expected a python list, got {type(data)}")
+        arrow_array = pa.array(data)
+        return Series.from_arrow(arrow_array, name=name)
+
+    def to_arrow(self) -> pa.Array:
+        if self._series is None:
+            raise ValueError("This Series isn't backed by a Rust PySeries, can not convert to arrow")
+        return self._series.to_arrow()
+
+    def to_pylist(self) -> list:
+        if self._series is None:
+            raise ValueError("This Series isn't backed by a Rust PySeries, can not convert to arrow")
+        return self._series.to_arrow().to_pylist()
+
+    def __repr__(self) -> str:
+        return repr(self._series)
+
+    def __bool__(self) -> bool:
+        raise ValueError(
+            "Series don't have a truth value." "If you reached this error using `and` / `or`, use `&` / `|` instead."
+        )
+
+    def __add__(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series + other._series)
+
+    def __sub__(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series - other._series)
+
+    def __mul__(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series * other._series)
+
+    def __truediv__(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series / other._series)
+
+    def __mod__(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series % other._series)
+
+    def __eq__(self, other: object) -> Series:  # type: ignore[override]
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series == other._series)
+
+    def __ne__(self, other: object) -> Series:  # type: ignore[override]
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series != other._series)
+
+    def __gt__(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series > other._series)
+
+    def __lt__(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series < other._series)
+
+    def __ge__(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series >= other._series)
+
+    def __le__(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series.from_pyseries(self._series <= other._series)

--- a/src/array/from.rs
+++ b/src/array/from.rs
@@ -46,6 +46,17 @@ impl From<(&str, &[bool])> for BooleanArray {
     }
 }
 
+impl From<(&str, arrow2::array::BooleanArray)> for BooleanArray {
+    fn from(item: (&str, arrow2::array::BooleanArray)) -> Self {
+        let (name, arrow_array) = item;
+        DataArray::new(
+            Field::new(name, DataType::Boolean).into(),
+            arrow_array.arced(),
+        )
+        .unwrap()
+    }
+}
+
 impl<T: AsRef<str>> From<(&str, &[T])> for DataArray<Utf8Type> {
     fn from(item: (&str, &[T])) -> Self {
         let (name, slice) = item;

--- a/src/array/iterator.rs
+++ b/src/array/iterator.rs
@@ -1,0 +1,27 @@
+use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
+
+use crate::datatypes::{BooleanArray, DaftNumericType};
+
+use super::DataArray;
+
+impl<'a, T> IntoIterator for &'a DataArray<T>
+where
+    T: DaftNumericType,
+{
+    type Item = Option<&'a T::Native>;
+    type IntoIter = ZipValidity<'a, &'a T::Native, std::slice::Iter<'a, T::Native>>;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.downcast().into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a BooleanArray {
+    type Item = Option<bool>;
+    type IntoIter = ZipValidity<'a, bool, BitmapIter<'a>>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.downcast().into_iter()
+    }
+}

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -36,11 +36,17 @@ impl std::fmt::Debug for dyn BaseArray {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DataArray<T: DaftDataType> {
     field: Arc<Field>,
     data: Arc<dyn arrow2::array::Array>,
     marker_: PhantomData<T>,
+}
+
+impl<T: DaftDataType> Clone for DataArray<T> {
+    fn clone(&self) -> Self {
+        DataArray::new(self.field.clone(), self.data.clone()).unwrap()
+    }
 }
 
 impl<T> DataArray<T>

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -1,4 +1,5 @@
 pub mod from;
+pub mod iterator;
 pub mod ops;
 
 use std::{any::Any, marker::PhantomData, sync::Arc};
@@ -60,6 +61,19 @@ where
             data,
             marker_: PhantomData,
         })
+    }
+
+    pub fn with_validity(&self, validity: &[bool]) -> DaftResult<Self> {
+        if validity.len() != self.data.len() {
+            return Err(DaftError::ValueError(format!(
+                "validity mask length does not match DataArray length, {} vs {}",
+                validity.len(),
+                self.data.len()
+            )));
+        }
+        use arrow2::bitmap::Bitmap;
+        let with_bitmap = self.data.with_validity(Some(Bitmap::from(validity)));
+        DataArray::new(self.field.clone(), with_bitmap.into())
     }
 }
 

--- a/src/array/ops/arange.rs
+++ b/src/array/ops/arange.rs
@@ -11,8 +11,7 @@ where
     pub fn arange<S: AsRef<str>>(name: S, start: i64, end: i64, step: usize) -> DaftResult<Self> {
         if start > end {
             return Err(crate::error::DaftError::ValueError(format!(
-                "invalid range, start greater than end, {} vs {}",
-                start, end
+                "invalid range, start greater than end, {start} vs {end}"
             )));
         }
         let data: Vec<i64> = (start..end).step_by(step).collect();

--- a/src/array/ops/arange.rs
+++ b/src/array/ops/arange.rs
@@ -1,0 +1,25 @@
+use crate::{
+    array::DataArray,
+    datatypes::{DaftNumericType, Int64Array},
+    error::DaftResult,
+};
+
+impl<T> DataArray<T>
+where
+    T: DaftNumericType,
+{
+    pub fn arange<S: AsRef<str>>(name: S, start: i64, end: i64, step: usize) -> DaftResult<Self> {
+        if start > end {
+            return Err(crate::error::DaftError::ValueError(format!(
+                "invalid range, start greater than end, {} vs {}",
+                start, end
+            )));
+        }
+        let data: Vec<i64> = (start..end).step_by(step).collect();
+        let arrow_array = Box::new(arrow2::array::PrimitiveArray::<i64>::from_vec(data));
+        let data_array = Int64Array::from((name.as_ref(), arrow_array));
+        let casted_array = data_array.cast(&T::get_dtype())?;
+        let downcasted = casted_array.downcast::<T>()?;
+        Ok(downcasted.clone())
+    }
+}

--- a/src/array/ops/arithmetic.rs
+++ b/src/array/ops/arithmetic.rs
@@ -4,7 +4,7 @@ use arrow2::{array::PrimitiveArray, compute::arithmetics::basic};
 
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{DaftNumericType, Utf8Array},
+    datatypes::{DaftNumericType, Float64Array, Utf8Array},
     kernels::utf8::add_utf8_arrays,
 };
 /// Helper function to perform arithmetic operations on a DataArray
@@ -104,11 +104,8 @@ where
     }
 }
 
-impl<T> Div for &DataArray<T>
-where
-    T: DaftNumericType,
-{
-    type Output = DataArray<T>;
+impl Div for &Float64Array {
+    type Output = Float64Array;
     fn div(self, rhs: Self) -> Self::Output {
         arithmetic_helper(self, rhs, basic::div, |l, r| l / r)
     }

--- a/src/array/ops/comparison.rs
+++ b/src/array/ops/comparison.rs
@@ -2,7 +2,7 @@ use num_traits::{NumCast, ToPrimitive};
 
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{BooleanArray, DaftNumericType},
+    datatypes::{BooleanArray, DaftNumericType, Utf8Array},
 };
 
 use super::DaftCompare;
@@ -283,6 +283,502 @@ where
         let rhs: T::Native =
             NumCast::from(rhs).expect("could not cast to underlying DataArray type");
         self.compare_to_scalar(rhs, comparison::gt_eq_scalar)
+    }
+}
+
+impl DaftCompare<&BooleanArray> for BooleanArray {
+    type Output = BooleanArray;
+
+    fn equal(&self, rhs: &BooleanArray) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::eq(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.equal(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.equal(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn not_equal(&self, rhs: &BooleanArray) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::neq(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.not_equal(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.not_equal(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn lt(&self, rhs: &BooleanArray) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::lt(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.lt(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.gt(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn lte(&self, rhs: &BooleanArray) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::lt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.lte(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.gte(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn gt(&self, rhs: &BooleanArray) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::gt(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.gt(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.lt(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn gte(&self, rhs: &BooleanArray) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::gt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.gte(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.lte(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+}
+
+impl DaftCompare<bool> for BooleanArray {
+    type Output = BooleanArray;
+
+    fn equal(&self, rhs: bool) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::boolean::eq_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn not_equal(&self, rhs: bool) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::boolean::neq_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn lt(&self, rhs: bool) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::boolean::lt_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn lte(&self, rhs: bool) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::boolean::lt_eq_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn gt(&self, rhs: bool) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::boolean::gt_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn gte(&self, rhs: bool) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::boolean::gt_eq_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+}
+
+impl DaftCompare<&Utf8Array> for Utf8Array {
+    type Output = BooleanArray;
+
+    fn equal(&self, rhs: &Utf8Array) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::eq(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.equal(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.equal(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn not_equal(&self, rhs: &Utf8Array) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::neq(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.not_equal(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.not_equal(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn lt(&self, rhs: &Utf8Array) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::lt(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.lt(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.gt(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn lte(&self, rhs: &Utf8Array) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::lt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.lte(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.gte(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn gt(&self, rhs: &Utf8Array) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::gt(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.gt(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.lt(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+
+    fn gte(&self, rhs: &Utf8Array) -> Self::Output {
+        match (self.len(), rhs.len()) {
+            (x, y) if x == y => {
+                let validity =
+                    arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
+                BooleanArray::from((
+                    self.name(),
+                    comparison::gt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
+                ))
+            }
+            (l_size, 1) => {
+                if let Some(value) = rhs.get(0) {
+                    self.gte(value)
+                } else {
+                    BooleanArray::full_null(self.name(), l_size)
+                }
+            }
+            (1, r_size) => {
+                if let Some(value) = self.get(0) {
+                    rhs.lte(value)
+                } else {
+                    BooleanArray::full_null(self.name(), r_size)
+                }
+            }
+            (l, r) => panic!(
+                "trying to compare different length arrays: {}: {l} vs {}: {r}",
+                self.name(),
+                rhs.name()
+            ),
+        }
+    }
+}
+
+impl DaftCompare<&str> for Utf8Array {
+    type Output = BooleanArray;
+
+    fn equal(&self, rhs: &str) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::utf8::eq_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn not_equal(&self, rhs: &str) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::utf8::neq_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn lt(&self, rhs: &str) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::utf8::lt_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn lte(&self, rhs: &str) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::utf8::lt_eq_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn gt(&self, rhs: &str) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::utf8::gt_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
+    }
+
+    fn gte(&self, rhs: &str) -> Self::Output {
+        let validity = self.downcast().validity().cloned();
+        let arrow_result =
+            comparison::utf8::gt_eq_scalar(self.downcast(), rhs).with_validity(validity);
+
+        BooleanArray::from((self.name(), arrow_result))
     }
 }
 

--- a/src/array/ops/comparison.rs
+++ b/src/array/ops/comparison.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::DaftCompare;
 use arrow2::{
-    compute::comparison::{self, Simd8, Simd8PartialEq, Simd8PartialOrd},
+    compute::comparison::{self},
     scalar::PrimitiveScalar,
 };
 
@@ -69,10 +69,7 @@ where
 
         let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
 
-        let validity = match self.downcast().validity() {
-            Some(bitmap) => Some(bitmap.clone()),
-            None => None,
-        };
+        let validity = self.downcast().validity().cloned();
 
         let arrow_result = comparison::eq_scalar(self.downcast(), &scalar).with_validity(validity);
         DataArray::from((self.name(), arrow_result))
@@ -84,10 +81,7 @@ where
 
         let arrow_array = self.downcast();
         let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
-        let validity = match self.downcast().validity() {
-            Some(bitmap) => Some(bitmap.clone()),
-            None => None,
-        };
+        let validity = self.downcast().validity().cloned();
 
         let arrow_result = comparison::neq_scalar(arrow_array, &scalar).with_validity(validity);
         DataArray::from((self.name(), arrow_result))
@@ -100,10 +94,7 @@ where
         let arrow_array = self.downcast();
         let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
 
-        let validity = match self.downcast().validity() {
-            Some(bitmap) => Some(bitmap.clone()),
-            None => None,
-        };
+        let validity = self.downcast().validity().cloned();
         let arrow_result = comparison::lt_scalar(arrow_array, &scalar).with_validity(validity);
         DataArray::from((self.name(), arrow_result))
     }
@@ -115,10 +106,7 @@ where
         let arrow_array = self.downcast();
         let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
 
-        let validity = match self.downcast().validity() {
-            Some(bitmap) => Some(bitmap.clone()),
-            None => None,
-        };
+        let validity = self.downcast().validity().cloned();
         let arrow_result = comparison::lt_eq_scalar(arrow_array, &scalar).with_validity(validity);
         DataArray::from((self.name(), arrow_result))
     }
@@ -130,10 +118,7 @@ where
         let arrow_array = self.downcast();
         let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
 
-        let validity = match arrow_array.validity() {
-            Some(bitmap) => Some(bitmap.clone()),
-            None => None,
-        };
+        let validity = arrow_array.validity().cloned();
         let arrow_result = comparison::gt_scalar(arrow_array, &scalar).with_validity(validity);
         DataArray::from((self.name(), arrow_result))
     }
@@ -145,10 +130,7 @@ where
         let arrow_array = self.downcast();
         let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
 
-        let validity = match arrow_array.validity() {
-            Some(bitmap) => Some(bitmap.clone()),
-            None => None,
-        };
+        let validity = arrow_array.validity().cloned();
         let arrow_result = comparison::gt_eq_scalar(arrow_array, &scalar).with_validity(validity);
         DataArray::from((self.name(), arrow_result))
     }
@@ -156,8 +138,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::array::{BaseArray, DataArray};
-    use crate::datatypes::{DaftDataType, DaftNumericType, DataType, Int16Type};
+    use crate::array::BaseArray;
+
     use crate::{array::ops::DaftCompare, datatypes::Int64Array, error::DaftResult};
 
     #[test]

--- a/src/array/ops/comparison.rs
+++ b/src/array/ops/comparison.rs
@@ -1,5 +1,3 @@
-use std::ops::Not;
-
 use num_traits::{NumCast, ToPrimitive};
 
 use crate::{
@@ -8,10 +6,7 @@ use crate::{
 };
 
 use super::DaftCompare;
-use arrow2::{
-    compute::comparison::{self},
-    scalar::{PrimitiveScalar, Scalar},
-};
+use arrow2::{compute::comparison, scalar::PrimitiveScalar};
 
 // fn comparison_helper<T, >(
 //     lhs: &DataArray<T>,
@@ -54,7 +49,7 @@ fn arrow_bitmap_validity(
         (None, None) => None,
         (Some(l), None) => Some(l.clone()),
         (None, Some(r)) => Some(r.clone()),
-        (Some(l), Some(r)) => Some(arrow2::bitmap::and(&l, &r)),
+        (Some(l), Some(r)) => Some(arrow2::bitmap::and(l, r)),
     }
 }
 

--- a/src/array/ops/comparison.rs
+++ b/src/array/ops/comparison.rs
@@ -3,6 +3,7 @@ use num_traits::{NumCast, ToPrimitive};
 use crate::{
     array::{BaseArray, DataArray},
     datatypes::{BooleanArray, DaftNumericType, Utf8Array},
+    error::{DaftError, DaftResult},
 };
 
 use super::DaftCompare;
@@ -24,37 +25,37 @@ impl<T> DaftCompare<&DataArray<T>> for DataArray<T>
 where
     T: DaftNumericType,
 {
-    type Output = BooleanArray;
+    type Output = DaftResult<BooleanArray>;
 
     fn equal(&self, rhs: &DataArray<T>) -> Self::Output {
         match (self.len(), rhs.len()) {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::eq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    self.equal(value)
+                    Ok(self.equal(value))
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
-                    rhs.equal(value)
+                    Ok(rhs.equal(value))
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -63,30 +64,30 @@ where
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::neq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    self.not_equal(value)
+                    Ok(self.not_equal(value))
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
-                    rhs.not_equal(value)
+                    Ok(rhs.not_equal(value))
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -95,30 +96,30 @@ where
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::lt(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    self.lt(value)
+                    Ok(self.lt(value))
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
-                    rhs.gt(value)
+                    Ok(rhs.gt(value))
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -127,30 +128,30 @@ where
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::lt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    self.lte(value)
+                    Ok(self.lte(value))
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
-                    rhs.gte(value)
+                    Ok(rhs.gte(value))
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -159,30 +160,30 @@ where
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::gt(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    self.gt(value)
+                    Ok(self.gt(value))
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
-                    rhs.lt(value)
+                    Ok(rhs.lt(value))
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -191,30 +192,30 @@ where
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::gt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    self.gte(value)
+                    Ok(self.gte(value))
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
-                    rhs.lte(value)
+                    Ok(rhs.lte(value))
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 }
@@ -287,37 +288,37 @@ where
 }
 
 impl DaftCompare<&BooleanArray> for BooleanArray {
-    type Output = BooleanArray;
+    type Output = DaftResult<BooleanArray>;
 
     fn equal(&self, rhs: &BooleanArray) -> Self::Output {
         match (self.len(), rhs.len()) {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::eq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.equal(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.equal(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -326,30 +327,30 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::neq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.not_equal(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.not_equal(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -358,30 +359,30 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::lt(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.lt(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -390,30 +391,30 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::lt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.lte(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.gte(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -422,30 +423,30 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::gt(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.gt(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.lt(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -454,43 +455,43 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::gt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.gte(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.lte(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 }
 
 impl DaftCompare<bool> for BooleanArray {
-    type Output = BooleanArray;
+    type Output = DaftResult<BooleanArray>;
 
     fn equal(&self, rhs: bool) -> Self::Output {
         let validity = self.downcast().validity().cloned();
         let arrow_result =
             comparison::boolean::eq_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn not_equal(&self, rhs: bool) -> Self::Output {
@@ -498,7 +499,7 @@ impl DaftCompare<bool> for BooleanArray {
         let arrow_result =
             comparison::boolean::neq_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn lt(&self, rhs: bool) -> Self::Output {
@@ -506,7 +507,7 @@ impl DaftCompare<bool> for BooleanArray {
         let arrow_result =
             comparison::boolean::lt_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn lte(&self, rhs: bool) -> Self::Output {
@@ -514,7 +515,7 @@ impl DaftCompare<bool> for BooleanArray {
         let arrow_result =
             comparison::boolean::lt_eq_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn gt(&self, rhs: bool) -> Self::Output {
@@ -522,7 +523,7 @@ impl DaftCompare<bool> for BooleanArray {
         let arrow_result =
             comparison::boolean::gt_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn gte(&self, rhs: bool) -> Self::Output {
@@ -530,42 +531,42 @@ impl DaftCompare<bool> for BooleanArray {
         let arrow_result =
             comparison::boolean::gt_eq_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 }
 
 impl DaftCompare<&Utf8Array> for Utf8Array {
-    type Output = BooleanArray;
+    type Output = DaftResult<BooleanArray>;
 
     fn equal(&self, rhs: &Utf8Array) -> Self::Output {
         match (self.len(), rhs.len()) {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::eq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.equal(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.equal(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -574,30 +575,30 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::neq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.not_equal(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.not_equal(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -606,30 +607,30 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::lt(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.lt(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -638,30 +639,30 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::lt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.lte(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.gte(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -670,30 +671,30 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::gt(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.gt(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.lt(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 
@@ -702,43 +703,43 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
             (x, y) if x == y => {
                 let validity =
                     arrow_bitmap_validity(self.downcast().validity(), rhs.downcast().validity());
-                BooleanArray::from((
+                Ok(BooleanArray::from((
                     self.name(),
                     comparison::gt_eq(self.downcast(), rhs.downcast()).with_validity(validity),
-                ))
+                )))
             }
             (l_size, 1) => {
                 if let Some(value) = rhs.get(0) {
                     self.gte(value)
                 } else {
-                    BooleanArray::full_null(self.name(), l_size)
+                    Ok(BooleanArray::full_null(self.name(), l_size))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.lte(value)
                 } else {
-                    BooleanArray::full_null(self.name(), r_size)
+                    Ok(BooleanArray::full_null(self.name(), r_size))
                 }
             }
-            (l, r) => panic!(
+            (l, r) => Err(DaftError::ValueError(format!(
                 "trying to compare different length arrays: {}: {l} vs {}: {r}",
                 self.name(),
                 rhs.name()
-            ),
+            ))),
         }
     }
 }
 
 impl DaftCompare<&str> for Utf8Array {
-    type Output = BooleanArray;
+    type Output = DaftResult<BooleanArray>;
 
     fn equal(&self, rhs: &str) -> Self::Output {
         let validity = self.downcast().validity().cloned();
         let arrow_result =
             comparison::utf8::eq_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn not_equal(&self, rhs: &str) -> Self::Output {
@@ -746,7 +747,7 @@ impl DaftCompare<&str> for Utf8Array {
         let arrow_result =
             comparison::utf8::neq_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn lt(&self, rhs: &str) -> Self::Output {
@@ -754,7 +755,7 @@ impl DaftCompare<&str> for Utf8Array {
         let arrow_result =
             comparison::utf8::lt_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn lte(&self, rhs: &str) -> Self::Output {
@@ -762,7 +763,7 @@ impl DaftCompare<&str> for Utf8Array {
         let arrow_result =
             comparison::utf8::lt_eq_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn gt(&self, rhs: &str) -> Self::Output {
@@ -770,7 +771,7 @@ impl DaftCompare<&str> for Utf8Array {
         let arrow_result =
             comparison::utf8::gt_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 
     fn gte(&self, rhs: &str) -> Self::Output {
@@ -778,7 +779,7 @@ impl DaftCompare<&str> for Utf8Array {
         let arrow_result =
             comparison::utf8::gt_eq_scalar(self.downcast(), rhs).with_validity(validity);
 
-        BooleanArray::from((self.name(), arrow_result))
+        Ok(BooleanArray::from((self.name(), arrow_result)))
     }
 }
 
@@ -868,11 +869,11 @@ mod tests {
     fn equal_int64_array_with_same_array() -> DaftResult<()> {
         let array = Int64Array::arange("a", 1, 4, 1)?;
         assert_eq!(array.len(), 3);
-        let result: Vec<_> = array.equal(&array).into_iter().collect();
+        let result: Vec<_> = array.equal(&array)?.into_iter().collect();
         assert_eq!(result[..], [Some(true), Some(true), Some(true)]);
 
         let array = array.with_validity(&[true, false, true])?;
-        let result: Vec<_> = array.equal(&array).into_iter().collect();
+        let result: Vec<_> = array.equal(&array)?.into_iter().collect();
         assert_eq!(result[..], [Some(true), None, Some(true)]);
         Ok(())
     }
@@ -881,11 +882,11 @@ mod tests {
     fn not_equal_int64_array_with_same_array() -> DaftResult<()> {
         let array = Int64Array::arange("a", 1, 4, 1)?;
         assert_eq!(array.len(), 3);
-        let result: Vec<_> = array.not_equal(&array).into_iter().collect();
+        let result: Vec<_> = array.not_equal(&array)?.into_iter().collect();
         assert_eq!(result[..], [Some(false), Some(false), Some(false)]);
 
         let array = array.with_validity(&[true, false, true])?;
-        let result: Vec<_> = array.not_equal(&array).into_iter().collect();
+        let result: Vec<_> = array.not_equal(&array)?.into_iter().collect();
         assert_eq!(result[..], [Some(false), None, Some(false)]);
         Ok(())
     }
@@ -894,15 +895,15 @@ mod tests {
     fn lt_int64_array_with_array() -> DaftResult<()> {
         let lhs = Int64Array::arange("a", 1, 4, 1)?;
         let rhs = Int64Array::arange("a", 0, 6, 2)?;
-        let result: Vec<_> = lhs.lt(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.lt(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [Some(false), Some(false), Some(true)]);
 
         let lhs = lhs.with_validity(&[true, false, true])?;
-        let result: Vec<_> = lhs.lt(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.lt(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [Some(false), None, Some(true)]);
 
         let rhs = rhs.with_validity(&[false, true, true])?;
-        let result: Vec<_> = lhs.lt(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.lt(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [None, None, Some(true)]);
         Ok(())
     }
@@ -911,15 +912,15 @@ mod tests {
     fn lte_int64_array_with_array() -> DaftResult<()> {
         let lhs = Int64Array::arange("a", 1, 4, 1)?;
         let rhs = Int64Array::arange("a", 0, 6, 2)?;
-        let result: Vec<_> = lhs.lte(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.lte(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [Some(false), Some(true), Some(true)]);
 
         let lhs = lhs.with_validity(&[true, false, true])?;
-        let result: Vec<_> = lhs.lte(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.lte(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [Some(false), None, Some(true)]);
 
         let rhs = rhs.with_validity(&[false, true, true])?;
-        let result: Vec<_> = lhs.lte(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.lte(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [None, None, Some(true)]);
         Ok(())
     }
@@ -928,15 +929,15 @@ mod tests {
     fn gt_int64_array_with_array() -> DaftResult<()> {
         let lhs = Int64Array::arange("a", 1, 4, 1)?;
         let rhs = Int64Array::arange("a", 0, 6, 2)?;
-        let result: Vec<_> = lhs.gt(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.gt(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [Some(true), Some(false), Some(false)]);
 
         let lhs = lhs.with_validity(&[true, false, true])?;
-        let result: Vec<_> = lhs.gt(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.gt(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [Some(true), None, Some(false)]);
 
         let rhs = rhs.with_validity(&[false, true, true])?;
-        let result: Vec<_> = lhs.gt(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.gt(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [None, None, Some(false)]);
         Ok(())
     }
@@ -945,15 +946,15 @@ mod tests {
     fn gte_int64_array_with_array() -> DaftResult<()> {
         let lhs = Int64Array::arange("a", 1, 4, 1)?;
         let rhs = Int64Array::arange("a", 0, 6, 2)?;
-        let result: Vec<_> = lhs.gte(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.gte(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [Some(true), Some(true), Some(false)]);
 
         let lhs = lhs.with_validity(&[true, false, true])?;
-        let result: Vec<_> = lhs.gte(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.gte(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [Some(true), None, Some(false)]);
 
         let rhs = rhs.with_validity(&[false, true, true])?;
-        let result: Vec<_> = lhs.gte(&rhs).into_iter().collect();
+        let result: Vec<_> = lhs.gte(&rhs)?.into_iter().collect();
         assert_eq!(result[..], [None, None, Some(false)]);
         Ok(())
     }

--- a/src/array/ops/comparison.rs
+++ b/src/array/ops/comparison.rs
@@ -156,22 +156,85 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::array::{BaseArray, DataArray};
+    use crate::datatypes::{DaftDataType, DaftNumericType, DataType, Int16Type};
     use crate::{array::ops::DaftCompare, datatypes::Int64Array, error::DaftResult};
 
     #[test]
-    fn equal_int_array_with_scalar() -> DaftResult<()> {
-        let array = Int64Array::from(("a", vec![1, 2, 3].as_slice()));
+    fn equal_int64_array_with_scalar() -> DaftResult<()> {
+        let array = Int64Array::arange("a", 1, 4, 1)?;
+        assert_eq!(array.len(), 3);
         let result: Vec<_> = array.equal(2).into_iter().collect();
         assert_eq!(result[..], [Some(false), Some(true), Some(false)]);
+
+        let array = array.with_validity(&[true, false, true])?;
+        let result: Vec<_> = array.equal(2).into_iter().collect();
+        assert_eq!(result[..], [Some(false), None, Some(false)]);
         Ok(())
     }
 
     #[test]
-    fn equal_int_array_with_null_with_scalar() -> DaftResult<()> {
-        let array = Int64Array::from(("a", vec![1, 2, 3].as_slice()))
-            .with_validity(&[true, false, true])?;
-        let result: Vec<_> = array.equal(2).into_iter().collect();
-        assert_eq!(result[..], [Some(false), None, Some(false)]);
+    fn not_equal_int64_array_with_scalar() -> DaftResult<()> {
+        let array = Int64Array::arange("a", 1, 4, 1)?;
+        assert_eq!(array.len(), 3);
+        let result: Vec<_> = array.not_equal(2).into_iter().collect();
+        assert_eq!(result[..], [Some(true), Some(false), Some(true)]);
+
+        let array = array.with_validity(&[true, false, true])?;
+        let result: Vec<_> = array.not_equal(2).into_iter().collect();
+        assert_eq!(result[..], [Some(true), None, Some(true)]);
+        Ok(())
+    }
+
+    #[test]
+    fn lt_int64_array_with_scalar() -> DaftResult<()> {
+        let array = Int64Array::arange("a", 1, 4, 1)?;
+        assert_eq!(array.len(), 3);
+        let result: Vec<_> = array.lt(2).into_iter().collect();
+        assert_eq!(result[..], [Some(true), Some(false), Some(false)]);
+
+        let array = array.with_validity(&[true, false, true])?;
+        let result: Vec<_> = array.lt(2).into_iter().collect();
+        assert_eq!(result[..], [Some(true), None, Some(false)]);
+        Ok(())
+    }
+
+    #[test]
+    fn lte_int64_array_with_scalar() -> DaftResult<()> {
+        let array = Int64Array::arange("a", 1, 4, 1)?;
+        assert_eq!(array.len(), 3);
+        let result: Vec<_> = array.lte(2).into_iter().collect();
+        assert_eq!(result[..], [Some(true), Some(true), Some(false)]);
+
+        let array = array.with_validity(&[true, false, true])?;
+        let result: Vec<_> = array.lte(2).into_iter().collect();
+        assert_eq!(result[..], [Some(true), None, Some(false)]);
+        Ok(())
+    }
+
+    #[test]
+    fn gt_int64_array_with_scalar() -> DaftResult<()> {
+        let array = Int64Array::arange("a", 1, 4, 1)?;
+        assert_eq!(array.len(), 3);
+        let result: Vec<_> = array.gt(2).into_iter().collect();
+        assert_eq!(result[..], [Some(false), Some(false), Some(true)]);
+
+        let array = array.with_validity(&[true, false, true])?;
+        let result: Vec<_> = array.gt(2).into_iter().collect();
+        assert_eq!(result[..], [Some(false), None, Some(true)]);
+        Ok(())
+    }
+
+    #[test]
+    fn gte_int64_array_with_scalar() -> DaftResult<()> {
+        let array = Int64Array::arange("a", 1, 4, 1)?;
+        assert_eq!(array.len(), 3);
+        let result: Vec<_> = array.gte(2).into_iter().collect();
+        assert_eq!(result[..], [Some(false), Some(true), Some(true)]);
+
+        let array = array.with_validity(&[true, false, true])?;
+        let result: Vec<_> = array.gte(2).into_iter().collect();
+        assert_eq!(result[..], [Some(false), None, Some(true)]);
         Ok(())
     }
 }

--- a/src/array/ops/comparison.rs
+++ b/src/array/ops/comparison.rs
@@ -1,0 +1,144 @@
+use num_traits::{NumCast, ToPrimitive};
+
+use crate::{
+    array::{BaseArray, DataArray},
+    datatypes::{BooleanArray, DaftNumericType},
+};
+
+use super::DaftCompare;
+use arrow2::{
+    compute::comparison::{self, Simd8, Simd8PartialEq, Simd8PartialOrd},
+    scalar::PrimitiveScalar,
+};
+
+// fn comparison_helper<T, Kernel, F>(
+//     lhs: &DataArray<T>,
+//     rhs: &DataArray<T>,
+//     kernel: Kernel,
+//     operation: F,
+// ) -> DataArray<T>
+// where
+//     T: DaftNumericType,
+//     Kernel: Fn(&PrimitiveArray<T::Native>, &PrimitiveArray<T::Native>) -> PrimitiveArray<T::Native>,
+//     F: Fn(T::Native, T::Native) -> T::Native,
+// {
+//     let ca = match (lhs.len(), rhs.len()) {
+//         (a, b) if a == b => {
+//             DataArray::from((lhs.name(), Box::new(kernel(lhs.downcast(), rhs.downcast()))))
+//         }
+//         // broadcast right path
+//         (_, 1) => {
+//             let opt_rhs = rhs.get(0);
+//             match opt_rhs {
+//                 None => DataArray::full_null(lhs.name(), lhs.len()),
+//                 Some(rhs) => lhs.apply(|lhs| operation(lhs, rhs)),
+//             }
+//         }
+//         (1, _) => {
+//             let opt_lhs = lhs.get(0);
+//             match opt_lhs {
+//                 None => DataArray::full_null(rhs.name(), rhs.len()),
+//                 Some(lhs) => rhs.apply(|rhs| operation(lhs, rhs)),
+//             }
+//         }
+//         _ => panic!("Cannot apply operation on arrays of different lengths"),
+//     };
+//     ca
+// }
+
+// impl<T> DaftCompare<&DataArray<T>> for DataArray<T>
+// where
+//     T: DaftNumericType,
+// {
+//     type Output = BooleanArray;
+
+//     fn equal(&self, rhs: &DataArray<T>) -> Self::Output {}
+// }
+
+impl<T, Scalar> DaftCompare<Scalar> for DataArray<T>
+where
+    T: DaftNumericType,
+    Scalar: ToPrimitive,
+{
+    type Output = BooleanArray;
+
+    fn equal(&self, rhs: Scalar) -> Self::Output {
+        let rhs: T::Native =
+            NumCast::from(rhs).expect("could not cast to underlying DataArray type");
+        let arrow_array = self.downcast();
+        let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
+        let arrow_result = comparison::eq_scalar_and_validity(self.downcast(), &scalar);
+        DataArray::from((self.name(), arrow_result))
+    }
+
+    fn not_equal(&self, rhs: Scalar) -> Self::Output {
+        let rhs: T::Native =
+            NumCast::from(rhs).expect("could not cast to underlying DataArray type");
+
+        let arrow_array = self.downcast();
+        let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
+
+        let arrow_result = comparison::neq_scalar_and_validity(arrow_array, &scalar);
+        DataArray::from((self.name(), arrow_result))
+    }
+
+    fn lt(&self, rhs: Scalar) -> Self::Output {
+        let rhs: T::Native =
+            NumCast::from(rhs).expect("could not cast to underlying DataArray type");
+
+        let arrow_array = self.downcast();
+        let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
+
+        let validity = match self.downcast().validity() {
+            Some(bitmap) => Some(bitmap.clone()),
+            None => None,
+        };
+        let arrow_result = comparison::lt_scalar(arrow_array, &scalar).with_validity(validity);
+        DataArray::from((self.name(), arrow_result))
+    }
+
+    fn lte(&self, rhs: Scalar) -> Self::Output {
+        let rhs: T::Native =
+            NumCast::from(rhs).expect("could not cast to underlying DataArray type");
+
+        let arrow_array = self.downcast();
+        let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
+
+        let validity = match self.downcast().validity() {
+            Some(bitmap) => Some(bitmap.clone()),
+            None => None,
+        };
+        let arrow_result = comparison::lt_eq_scalar(arrow_array, &scalar).with_validity(validity);
+        DataArray::from((self.name(), arrow_result))
+    }
+
+    fn gt(&self, rhs: Scalar) -> Self::Output {
+        let rhs: T::Native =
+            NumCast::from(rhs).expect("could not cast to underlying DataArray type");
+
+        let arrow_array = self.downcast();
+        let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
+
+        let validity = match arrow_array.validity() {
+            Some(bitmap) => Some(bitmap.clone()),
+            None => None,
+        };
+        let arrow_result = comparison::gt_scalar(arrow_array, &scalar).with_validity(validity);
+        DataArray::from((self.name(), arrow_result))
+    }
+
+    fn gte(&self, rhs: Scalar) -> Self::Output {
+        let rhs: T::Native =
+            NumCast::from(rhs).expect("could not cast to underlying DataArray type");
+
+        let arrow_array = self.downcast();
+        let scalar = PrimitiveScalar::new(arrow_array.data_type().clone(), Some(rhs));
+
+        let validity = match arrow_array.validity() {
+            Some(bitmap) => Some(bitmap.clone()),
+            None => None,
+        };
+        let arrow_result = comparison::gt_eq_scalar(arrow_array, &scalar).with_validity(validity);
+        DataArray::from((self.name(), arrow_result))
+    }
+}

--- a/src/array/ops/comparison.rs
+++ b/src/array/ops/comparison.rs
@@ -8,39 +8,6 @@ use crate::{
 use super::DaftCompare;
 use arrow2::{compute::comparison, scalar::PrimitiveScalar};
 
-// fn comparison_helper<T, >(
-//     lhs: &DataArray<T>,
-//     rhs: &DataArray<T>,
-//     array_func: impl Fn(&dyn arrow2::array::Array, &dyn arrow2::array::Array) -> arrow2::array::BooleanArray,
-//     array_func: impl Fn(&dyn arrow2::array::Array, &dyn arrow2::array::Array) -> arrow2::array::BooleanArray,
-
-// ) -> BooleanArray
-// where
-//     T: DaftNumericType,{
-//     let ca = match (lhs.len(), rhs.len()) {
-//         (a, b) if a == b => {
-//             BooleanArray::from((lhs.name(), array_func(lhs.downcast(), rhs.downcast())))
-//         }
-//         // broadcast right path
-//         (_, 1) => {
-//             let opt_rhs = rhs.get(0);
-//             match opt_rhs {
-//                 None => DataArray::full_null(lhs.name(), lhs.len()),
-//                 Some(rhs) => ),
-//             }
-//         }
-//         (1, _) => {
-//             let opt_lhs = lhs.get(0);
-//             match opt_lhs {
-//                 None => DataArray::full_null(rhs.name(), rhs.len()),
-//                 Some(lhs) => rhs.apply(|rhs| operation(lhs, rhs)),
-//             }
-//         }
-//         _ => panic!("Cannot apply operation on arrays of different lengths"),
-//     };
-//     ca
-// }
-
 fn arrow_bitmap_validity(
     l_bitmap: Option<&arrow2::bitmap::Bitmap>,
     r_bitmap: Option<&arrow2::bitmap::Bitmap>,

--- a/src/array/ops/downcast.rs
+++ b/src/array/ops/downcast.rs
@@ -2,7 +2,7 @@ use arrow2::array;
 
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{DaftNumericType, Utf8Array},
+    datatypes::{BooleanArray, DaftNumericType, Utf8Array},
 };
 
 impl<T> DataArray<T>
@@ -18,6 +18,13 @@ where
 impl Utf8Array {
     // downcasts a DataArray<T> to an Arrow Utf8Array.
     pub fn downcast(&self) -> &array::Utf8Array<i64> {
+        self.data().as_any().downcast_ref().unwrap()
+    }
+}
+
+impl BooleanArray {
+    // downcasts a DataArray<T> to an Arrow BooleanArray.
+    pub fn downcast(&self) -> &array::BooleanArray {
         self.data().as_any().downcast_ref().unwrap()
     }
 }

--- a/src/array/ops/mod.rs
+++ b/src/array/ops/mod.rs
@@ -1,4 +1,5 @@
 mod apply;
+mod arange;
 mod arithmetic;
 mod broadcast;
 mod cast;

--- a/src/array/ops/mod.rs
+++ b/src/array/ops/mod.rs
@@ -2,7 +2,30 @@ mod apply;
 mod arithmetic;
 mod broadcast;
 mod cast;
+mod comparison;
 mod downcast;
 mod full;
 mod len;
 mod take;
+
+pub trait DaftCompare<Rhs> {
+    type Output;
+
+    /// equality.
+    fn equal(&self, rhs: Rhs) -> Self::Output;
+
+    /// inequality.
+    fn not_equal(&self, rhs: Rhs) -> Self::Output;
+
+    /// Greater than
+    fn gt(&self, rhs: Rhs) -> Self::Output;
+
+    /// Greater than or equal
+    fn gte(&self, rhs: Rhs) -> Self::Output;
+
+    /// Less than
+    fn lt(&self, rhs: Rhs) -> Self::Output;
+
+    /// Less than or equal
+    fn lte(&self, rhs: Rhs) -> Self::Output;
+}

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::DataArray,
-    datatypes::{DaftNumericType, Utf8Array},
+    datatypes::{BooleanArray, DaftNumericType, Utf8Array},
     error::DaftResult,
 };
 
@@ -57,6 +57,33 @@ impl Utf8Array {
         match val {
             None => Ok("None".to_string()),
             Some(v) => Ok(format!("\"{v}\"")),
+        }
+    }
+}
+
+impl BooleanArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<bool> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let arrow_array = self.downcast();
+        let is_valid = match arrow_array.validity() {
+            Some(validity) => validity.get_bit(idx),
+            None => true,
+        };
+        if is_valid {
+            Some(unsafe { arrow_array.value_unchecked(idx) })
+        } else {
+            None
+        }
+    }
+
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            Some(v) => Ok(format!("{v}")),
         }
     }
 }

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -29,7 +29,7 @@ where
         let val = self.get(idx);
         match val {
             None => Ok("None".to_string()),
-            Some(v) => Ok(v.to_string()),
+            Some(v) => Ok(format!("{v}")),
         }
     }
 }

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -11,7 +11,7 @@ use arrow2::{
 };
 pub use dtype::DataType;
 pub use field::Field;
-use num_traits::{Bounded, FromPrimitive, Num, NumCast, Zero};
+use num_traits::{Bounded, FromPrimitive, Num, NumCast, ToPrimitive, Zero};
 pub use time_unit::TimeUnit;
 
 /// Trait to wrap DataType Enum
@@ -74,6 +74,7 @@ pub trait NumericNative:
     + Rem<Output = Self>
     + Bounded
     + FromPrimitive
+    + ToPrimitive
     + NativeArithmetics
 {
     type DAFTTYPE: DaftNumericType;

--- a/src/dsl/arithmetic.rs
+++ b/src/dsl/arithmetic.rs
@@ -31,7 +31,7 @@ macro_rules! impl_expr_op {
 impl_expr_op!(Add, add, Plus);
 impl_expr_op!(Sub, sub, Minus);
 impl_expr_op!(Mul, mul, Multiply);
-impl_expr_op!(Div, div, Divide);
+impl_expr_op!(Div, div, TrueDivide);
 impl_expr_op!(Rem, rem, Modulus);
 
 #[cfg(test)]

--- a/src/dsl/expr.rs
+++ b/src/dsl/expr.rs
@@ -60,6 +60,9 @@ impl Expr {
                     | Operator::Or => {
                         Field::new(left.to_field(schema)?.name.as_str(), DataType::Boolean)
                     }
+                    Operator::TrueDivide => {
+                        Field::new(left.to_field(schema)?.name.as_str(), DataType::Float64)
+                    }
                     _ => Field::new(
                         left.to_field(schema)?.name.as_str(),
                         try_get_supertype(&left.get_type(schema)?, &right.get_type(schema)?)?,
@@ -111,7 +114,6 @@ pub enum Operator {
     Plus,
     Minus,
     Multiply,
-    Divide,
     TrueDivide,
     FloorDivide,
     Modulus,
@@ -133,9 +135,8 @@ impl Display for Operator {
             Plus => "+",
             Minus => "-",
             Multiply => "*",
-            Divide => "//",
             TrueDivide => "/",
-            FloorDivide => "floor_div",
+            FloorDivide => "//",
             Modulus => "%",
             And => "&",
             Or => "|",

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -40,23 +40,23 @@ impl PySeries {
     }
 
     pub fn __add__(&self, other: &Self) -> PyResult<Self> {
-        Ok((&self.series).add(&other.series).into())
+        Ok((&self.series).add(&other.series)?.into())
     }
 
     pub fn __sub__(&self, other: &Self) -> PyResult<Self> {
-        Ok((&self.series).sub(&other.series).into())
+        Ok((&self.series).sub(&other.series)?.into())
     }
 
     pub fn __mul__(&self, other: &Self) -> PyResult<Self> {
-        Ok((&self.series).mul(&other.series).into())
+        Ok((&self.series).mul(&other.series)?.into())
     }
 
     pub fn __truediv__(&self, other: &Self) -> PyResult<Self> {
-        Ok((&self.series).div(&other.series).into())
+        Ok((&self.series).div(&other.series)?.into())
     }
 
     pub fn __mod__(&self, other: &Self) -> PyResult<Self> {
-        Ok((&self.series).rem(&other.series).into())
+        Ok((&self.series).rem(&other.series)?.into())
     }
 
     pub fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<Self> {

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -74,6 +74,10 @@ impl PySeries {
     pub fn __repr__(&self) -> PyResult<String> {
         Ok(format!("{}", self.series))
     }
+
+    pub fn name(&self) -> PyResult<String> {
+        Ok(self.series.name().to_string())
+    }
 }
 
 impl From<series::Series> for PySeries {

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -1,10 +1,66 @@
-use pyo3::prelude::*;
+use std::ops::{Add, Div, Mul, Rem, Sub};
 
-use crate::series;
+use pyo3::{prelude::*, pyclass::CompareOp};
+
+use crate::{array::BaseArray, ffi, series};
 
 #[pyclass]
 pub struct PySeries {
     pub series: series::Series,
+}
+
+#[pymethods]
+impl PySeries {
+    #[staticmethod]
+    pub fn from_arrow(name: &str, pyarrow_array: &PyAny) -> PyResult<Self> {
+        let arrow_array = ffi::array_to_rust(pyarrow_array)?;
+        let series = series::Series::try_from((name, arrow_array))?;
+        Ok(series.into())
+    }
+
+    pub fn to_arrow(&self) -> PyResult<PyObject> {
+        let arrow_array = self.series.array().data().to_boxed();
+        Python::with_gil(|py| {
+            let pyarrow = py.import("pyarrow")?;
+            ffi::to_py_array(arrow_array, py, pyarrow)
+        })
+    }
+
+    pub fn __add__(&self, other: &Self) -> PyResult<Self> {
+        Ok((&self.series).add(&other.series).into())
+    }
+
+    pub fn __sub__(&self, other: &Self) -> PyResult<Self> {
+        Ok((&self.series).sub(&other.series).into())
+    }
+
+    pub fn __mul__(&self, other: &Self) -> PyResult<Self> {
+        Ok((&self.series).mul(&other.series).into())
+    }
+
+    pub fn __truediv__(&self, other: &Self) -> PyResult<Self> {
+        Ok((&self.series).div(&other.series).into())
+    }
+
+    pub fn __mod__(&self, other: &Self) -> PyResult<Self> {
+        Ok((&self.series).rem(&other.series).into())
+    }
+
+    pub fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<Self> {
+        use crate::array::ops::DaftCompare;
+        match op {
+            CompareOp::Lt => Ok((self.series.lt(&other.series)?).into_series().into()),
+            CompareOp::Le => Ok((self.series.lte(&other.series)?).into_series().into()),
+            CompareOp::Eq => Ok((self.series.equal(&other.series)?).into_series().into()),
+            CompareOp::Ne => Ok((self.series.not_equal(&other.series)?).into_series().into()),
+            CompareOp::Gt => Ok((self.series.gt(&other.series)?).into_series().into()),
+            CompareOp::Ge => Ok((self.series.gte(&other.series)?).into_series().into()),
+        }
+    }
+
+    pub fn __repr__(&self) -> PyResult<String> {
+        Ok(format!("{}", self.series))
+    }
 }
 
 impl From<series::Series> for PySeries {

--- a/src/series/mod.rs
+++ b/src/series/mod.rs
@@ -1,7 +1,10 @@
 mod from;
 mod ops;
 
-use std::sync::Arc;
+use std::{
+    fmt::{Display, Formatter, Result},
+    sync::Arc,
+};
 
 use crate::{
     array::BaseArray,
@@ -36,6 +39,45 @@ impl Series {
 
     pub fn field(&self) -> &Field {
         self.data_array.field()
+    }
+}
+
+impl Display for Series {
+    // `f` is a buffer, and this method must write the formatted string into it
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        let mut table = prettytable::Table::new();
+
+        let header =
+            prettytable::Cell::new(format!("{}\n{:?}", self.name(), self.data_type()).as_str())
+                .with_style(prettytable::Attr::Bold);
+        table.add_row(prettytable::Row::new(vec![header]));
+
+        let head_rows;
+        let tail_rows;
+
+        if self.len() > 10 {
+            head_rows = 5;
+            tail_rows = 5;
+        } else {
+            head_rows = self.len();
+            tail_rows = 0;
+        }
+
+        for i in 0..head_rows {
+            let row = vec![self.str_value(i).unwrap()];
+            table.add_row(row.into());
+        }
+        if tail_rows != 0 {
+            let row = vec!["..."];
+            table.add_row(row.into());
+        }
+
+        for i in 0..tail_rows {
+            let row = vec![self.str_value(i).unwrap()];
+            table.add_row(row.into());
+        }
+
+        write!(f, "{table}")
     }
 }
 

--- a/src/series/ops/arithmetic.rs
+++ b/src/series/ops/arithmetic.rs
@@ -2,6 +2,7 @@ use std::ops::{Add, Div, Mul, Rem, Sub};
 
 use super::match_types_on_series;
 use crate::array::BaseArray;
+use crate::datatypes::Float64Type;
 use crate::series::Series;
 use crate::with_match_numeric_and_utf_daft_types;
 use crate::with_match_numeric_daft_types;
@@ -48,8 +49,27 @@ impl Add for Series {
     }
 }
 
+impl Div for &Series {
+    type Output = Series;
+    fn div(self, rhs: Self) -> Self::Output {
+        let lhs = self.cast(&crate::datatypes::DataType::Float64).unwrap();
+        let rhs = rhs.cast(&crate::datatypes::DataType::Float64).unwrap();
+
+        lhs.downcast::<Float64Type>()
+            .unwrap()
+            .div(rhs.downcast::<Float64Type>().unwrap())
+            .into_series()
+    }
+}
+
+impl Div for Series {
+    type Output = Series;
+    fn div(self, rhs: Self) -> Self::Output {
+        (&self).add(&rhs)
+    }
+}
+
 impl_series_math_op!(Sub, sub);
-impl_series_math_op!(Div, div);
 impl_series_math_op!(Mul, mul);
 impl_series_math_op!(Rem, rem);
 

--- a/src/series/ops/arithmetic.rs
+++ b/src/series/ops/arithmetic.rs
@@ -1,71 +1,10 @@
 use std::ops::{Add, Div, Mul, Rem, Sub};
 
-use crate::{
-    array::BaseArray, error::DaftResult, series::Series, utils::supertype::try_get_supertype,
-};
-
-fn match_types_on_series(l: &Series, r: &Series) -> DaftResult<(Series, Series)> {
-    let mut lhs = l.clone();
-    let mut rhs = r.clone();
-    let supertype = try_get_supertype(lhs.data_type(), rhs.data_type())?;
-    if !lhs.data_type().eq(&supertype) {
-        lhs = lhs.cast(&supertype)?;
-    }
-
-    if !rhs.data_type().eq(&supertype) {
-        rhs = rhs.cast(&supertype)?;
-    }
-    Ok((lhs, rhs))
-}
-
-#[macro_export]
-macro_rules! with_match_numeric_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    use $crate::datatypes::*;
-
-    match $key_type {
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        // Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        _ => panic!("{:?} not implemented", $key_type)
-    }
-})}
-
-#[macro_export]
-macro_rules! with_match_numeric_and_utf_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    use $crate::datatypes::*;
-
-    match $key_type {
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        // Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        Utf8 => __with_ty__! { Utf8Type },
-        _ => panic!("{:?} not implemented", $key_type)
-    }
-})}
+use super::match_types_on_series;
+use crate::array::BaseArray;
+use crate::series::Series;
+use crate::with_match_numeric_and_utf_daft_types;
+use crate::with_match_numeric_daft_types;
 
 macro_rules! impl_series_math_op {
     ($op:ident, $func_name:ident) => {

--- a/src/series/ops/comparision.rs
+++ b/src/series/ops/comparision.rs
@@ -12,7 +12,7 @@ impl DaftCompare<&Series> for Series {
         with_match_comparable_daft_types!(lhs.data_type(), |$T| {
             let lhs = lhs.downcast::<$T>()?;
             let rhs = rhs.downcast::<$T>()?;
-            Ok(lhs.equal(rhs))
+            lhs.equal(rhs)
         })
     }
 
@@ -21,7 +21,7 @@ impl DaftCompare<&Series> for Series {
         with_match_comparable_daft_types!(lhs.data_type(), |$T| {
             let lhs = lhs.downcast::<$T>()?;
             let rhs = rhs.downcast::<$T>()?;
-            Ok(lhs.not_equal(rhs))
+            lhs.not_equal(rhs)
         })
     }
 
@@ -30,7 +30,7 @@ impl DaftCompare<&Series> for Series {
         with_match_comparable_daft_types!(lhs.data_type(), |$T| {
             let lhs = lhs.downcast::<$T>()?;
             let rhs = rhs.downcast::<$T>()?;
-            Ok(lhs.lt(rhs))
+            lhs.lt(rhs)
         })
     }
 
@@ -39,7 +39,7 @@ impl DaftCompare<&Series> for Series {
         with_match_comparable_daft_types!(lhs.data_type(), |$T| {
             let lhs = lhs.downcast::<$T>()?;
             let rhs = rhs.downcast::<$T>()?;
-            Ok(lhs.lte(rhs))
+            lhs.lte(rhs)
         })
     }
 
@@ -48,7 +48,7 @@ impl DaftCompare<&Series> for Series {
         with_match_comparable_daft_types!(lhs.data_type(), |$T| {
             let lhs = lhs.downcast::<$T>()?;
             let rhs = rhs.downcast::<$T>()?;
-            Ok(lhs.gt(rhs))
+            lhs.gt(rhs)
         })
     }
 
@@ -57,7 +57,7 @@ impl DaftCompare<&Series> for Series {
         with_match_comparable_daft_types!(lhs.data_type(), |$T| {
             let lhs = lhs.downcast::<$T>()?;
             let rhs = rhs.downcast::<$T>()?;
-            Ok(lhs.gte(rhs))
+            lhs.gte(rhs)
         })
     }
 }

--- a/src/series/ops/comparision.rs
+++ b/src/series/ops/comparision.rs
@@ -1,0 +1,63 @@
+use crate::{
+    array::ops::DaftCompare, datatypes::BooleanArray, error::DaftResult, series::Series,
+    with_match_comparable_daft_types,
+};
+
+use super::match_types_on_series;
+
+impl DaftCompare<&Series> for Series {
+    type Output = DaftResult<BooleanArray>;
+    fn equal(&self, rhs: &Series) -> Self::Output {
+        let (lhs, rhs) = match_types_on_series(self, rhs)?;
+        with_match_comparable_daft_types!(lhs.data_type(), |$T| {
+            let lhs = lhs.downcast::<$T>()?;
+            let rhs = rhs.downcast::<$T>()?;
+            Ok(lhs.equal(rhs))
+        })
+    }
+
+    fn not_equal(&self, rhs: &Series) -> Self::Output {
+        let (lhs, rhs) = match_types_on_series(self, rhs)?;
+        with_match_comparable_daft_types!(lhs.data_type(), |$T| {
+            let lhs = lhs.downcast::<$T>()?;
+            let rhs = rhs.downcast::<$T>()?;
+            Ok(lhs.not_equal(rhs))
+        })
+    }
+
+    fn lt(&self, rhs: &Series) -> Self::Output {
+        let (lhs, rhs) = match_types_on_series(self, rhs)?;
+        with_match_comparable_daft_types!(lhs.data_type(), |$T| {
+            let lhs = lhs.downcast::<$T>()?;
+            let rhs = rhs.downcast::<$T>()?;
+            Ok(lhs.lt(rhs))
+        })
+    }
+
+    fn lte(&self, rhs: &Series) -> Self::Output {
+        let (lhs, rhs) = match_types_on_series(self, rhs)?;
+        with_match_comparable_daft_types!(lhs.data_type(), |$T| {
+            let lhs = lhs.downcast::<$T>()?;
+            let rhs = rhs.downcast::<$T>()?;
+            Ok(lhs.lte(rhs))
+        })
+    }
+
+    fn gt(&self, rhs: &Series) -> Self::Output {
+        let (lhs, rhs) = match_types_on_series(self, rhs)?;
+        with_match_comparable_daft_types!(lhs.data_type(), |$T| {
+            let lhs = lhs.downcast::<$T>()?;
+            let rhs = rhs.downcast::<$T>()?;
+            Ok(lhs.gt(rhs))
+        })
+    }
+
+    fn gte(&self, rhs: &Series) -> Self::Output {
+        let (lhs, rhs) = match_types_on_series(self, rhs)?;
+        with_match_comparable_daft_types!(lhs.data_type(), |$T| {
+            let lhs = lhs.downcast::<$T>()?;
+            let rhs = rhs.downcast::<$T>()?;
+            Ok(lhs.gte(rhs))
+        })
+    }
+}

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -5,6 +5,7 @@ use super::Series;
 pub mod arithmetic;
 pub mod broadcast;
 pub mod cast;
+pub mod comparision;
 pub mod downcast;
 pub mod take;
 
@@ -55,6 +56,32 @@ macro_rules! with_match_numeric_and_utf_daft_types {(
     use $crate::datatypes::*;
 
     match $key_type {
+        Int8 => __with_ty__! { Int8Type },
+        Int16 => __with_ty__! { Int16Type },
+        Int32 => __with_ty__! { Int32Type },
+        Int64 => __with_ty__! { Int64Type },
+        UInt8 => __with_ty__! { UInt8Type },
+        UInt16 => __with_ty__! { UInt16Type },
+        UInt32 => __with_ty__! { UInt32Type },
+        UInt64 => __with_ty__! { UInt64Type },
+        // Float16 => __with_ty__! { Float16Type },
+        Float32 => __with_ty__! { Float32Type },
+        Float64 => __with_ty__! { Float64Type },
+        Utf8 => __with_ty__! { Utf8Type },
+        _ => panic!("{:?} not implemented", $key_type)
+    }
+})}
+
+#[macro_export]
+macro_rules! with_match_comparable_daft_types {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    use $crate::datatypes::*;
+
+    match $key_type {
+        Boolean => __with_ty__! { BooleanType },
         Int8 => __with_ty__! { Int8Type },
         Int16 => __with_ty__! { Int16Type },
         Int32 => __with_ty__! { Int32Type },

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -1,5 +1,72 @@
+use crate::{error::DaftResult, utils::supertype::try_get_supertype};
+
+use super::Series;
+
 pub mod arithmetic;
 pub mod broadcast;
 pub mod cast;
 pub mod downcast;
 pub mod take;
+
+fn match_types_on_series(l: &Series, r: &Series) -> DaftResult<(Series, Series)> {
+    let mut lhs = l.clone();
+    let mut rhs = r.clone();
+    let supertype = try_get_supertype(lhs.data_type(), rhs.data_type())?;
+    if !lhs.data_type().eq(&supertype) {
+        lhs = lhs.cast(&supertype)?;
+    }
+
+    if !rhs.data_type().eq(&supertype) {
+        rhs = rhs.cast(&supertype)?;
+    }
+    Ok((lhs, rhs))
+}
+
+#[macro_export]
+macro_rules! with_match_numeric_daft_types {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    use $crate::datatypes::*;
+
+    match $key_type {
+        Int8 => __with_ty__! { Int8Type },
+        Int16 => __with_ty__! { Int16Type },
+        Int32 => __with_ty__! { Int32Type },
+        Int64 => __with_ty__! { Int64Type },
+        UInt8 => __with_ty__! { UInt8Type },
+        UInt16 => __with_ty__! { UInt16Type },
+        UInt32 => __with_ty__! { UInt32Type },
+        UInt64 => __with_ty__! { UInt64Type },
+        // Float16 => __with_ty__! { Float16Type },
+        Float32 => __with_ty__! { Float32Type },
+        Float64 => __with_ty__! { Float64Type },
+        _ => panic!("{:?} not implemented", $key_type)
+    }
+})}
+
+#[macro_export]
+macro_rules! with_match_numeric_and_utf_daft_types {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    use $crate::datatypes::*;
+
+    match $key_type {
+        Int8 => __with_ty__! { Int8Type },
+        Int16 => __with_ty__! { Int16Type },
+        Int32 => __with_ty__! { Int32Type },
+        Int64 => __with_ty__! { Int64Type },
+        UInt8 => __with_ty__! { UInt8Type },
+        UInt16 => __with_ty__! { UInt16Type },
+        UInt32 => __with_ty__! { UInt32Type },
+        UInt64 => __with_ty__! { UInt64Type },
+        // Float16 => __with_ty__! { Float16Type },
+        Float32 => __with_ty__! { Float32Type },
+        Float64 => __with_ty__! { Float64Type },
+        Utf8 => __with_ty__! { Utf8Type },
+        _ => panic!("{:?} not implemented", $key_type)
+    }
+})}

--- a/src/series/ops/take.rs
+++ b/src/series/ops/take.rs
@@ -1,8 +1,8 @@
-use crate::{error::DaftResult, series::Series, with_match_numeric_and_utf_daft_types};
+use crate::{error::DaftResult, series::Series, with_match_comparable_daft_types};
 
 impl Series {
     pub fn str_value(&self, idx: usize) -> DaftResult<String> {
-        with_match_numeric_and_utf_daft_types!(self.data_type(), |$T| {
+        with_match_comparable_daft_types!(self.data_type(), |$T| {
             self.downcast::<$T>()?.str_value(idx)
         })
     }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -91,11 +91,11 @@ impl Table {
                 let rhs = self.eval_expression(right)?;
                 use crate::dsl::Operator::*;
                 match op {
-                    Plus => Ok(lhs + rhs),
-                    Minus => Ok(lhs - rhs),
-                    TrueDivide => Ok(lhs / rhs),
-                    Multiply => Ok(lhs * rhs),
-                    Modulus => Ok(lhs % rhs),
+                    Plus => lhs + rhs,
+                    Minus => lhs - rhs,
+                    TrueDivide => lhs / rhs,
+                    Multiply => lhs * rhs,
+                    Modulus => lhs % rhs,
                     _ => panic!("{op:?} not supported"),
                 }
             }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -93,7 +93,7 @@ impl Table {
                 match op {
                     Plus => Ok(lhs + rhs),
                     Minus => Ok(lhs - rhs),
-                    Divide => Ok(lhs / rhs),
+                    TrueDivide => Ok(lhs / rhs),
                     Multiply => Ok(lhs * rhs),
                     Modulus => Ok(lhs % rhs),
                     _ => panic!("{op:?} not supported"),

--- a/tests/series/test_arithmetic.py
+++ b/tests/series/test_arithmetic.py
@@ -13,7 +13,7 @@ arrow_float_types = [pa.float32(), pa.float64()]
 
 
 @pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
-def test_arithmetic_numbers(l_dtype, r_dtype) -> None:
+def test_arithmetic_numbers_array(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([1, 4, 1, 5, None, None])
 
@@ -34,10 +34,76 @@ def test_arithmetic_numbers(l_dtype, r_dtype) -> None:
     assert div == [1.0, 0.5, 3.0, None, None, None]
 
 
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
+def test_arithmetic_numbers_left_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1])
+    r_arrow = pa.array([1, 4, 1, 5, None, None])
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+
+    add = (l + r).to_pylist()
+    assert add == [2, 5, 2, 6, None, None]
+
+    if pa.types.is_signed_integer(l_dtype) or pa.types.is_signed_integer(r_dtype):
+        sub = (l - r).to_pylist()
+        assert sub == [0, -3, 0, -4, None, None]
+
+    mul = (l * r).to_pylist()
+    assert mul == [1, 4, 1, 5, None, None]
+
+    div = (l / r).to_pylist()
+    assert div == [1.0, 0.25, 1.0, 0.2, None, None]
+
+
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
+def test_arithmetic_numbers_right_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([1])
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+
+    add = (l + r).to_pylist()
+    assert add == [2, 3, 4, None, 6, None]
+
+    if pa.types.is_signed_integer(l_dtype) or pa.types.is_signed_integer(r_dtype):
+        sub = (l - r).to_pylist()
+        assert sub == [0, 1, 2, None, 4, None]
+
+    mul = (l * r).to_pylist()
+    assert mul == [1, 2, 3, None, 5, None]
+
+    div = (l / r).to_pylist()
+    assert div == [1.0, 2.0, 3.0, None, 5.0, None]
+
+
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
+def test_arithmetic_numbers_null_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([None], type=r_dtype)
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow)
+
+    add = (l + r).to_pylist()
+    assert add == [None, None, None, None, None, None]
+
+    if pa.types.is_signed_integer(l_dtype) or pa.types.is_signed_integer(r_dtype):
+        sub = (l - r).to_pylist()
+        assert sub == [None, None, None, None, None, None]
+
+    mul = (l * r).to_pylist()
+    assert mul == [None, None, None, None, None, None]
+
+    div = (l / r).to_pylist()
+    assert div == [None, None, None, None, None, None]
+
+
 @pytest.mark.parametrize(
     "l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_string_types, arrow_string_types)
 )
-def test_add_for_int_and_string(l_dtype, r_dtype) -> None:
+def test_add_for_int_and_string_array(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([1, 4, 1, 5, None, None])
 
@@ -46,3 +112,45 @@ def test_add_for_int_and_string(l_dtype, r_dtype) -> None:
 
     add = (l + r).to_pylist()
     assert add == ["11", "24", "31", None, None, None]
+
+
+@pytest.mark.parametrize(
+    "l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_string_types, arrow_string_types)
+)
+def test_add_for_int_and_string_left_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1])
+    r_arrow = pa.array([1, 4, 1, 5, None, None])
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+
+    add = (l + r).to_pylist()
+    assert add == ["11", "14", "11", "15", None, None]
+
+
+@pytest.mark.parametrize(
+    "l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_string_types, arrow_string_types)
+)
+def test_add_for_int_and_string_right_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([1])
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+
+    add = (l + r).to_pylist()
+    assert add == ["11", "21", "31", None, "51", None]
+
+
+@pytest.mark.parametrize(
+    "l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_string_types, arrow_string_types)
+)
+def test_add_for_int_and_string_null_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([None], type=pa.string())
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+
+    add = (l + r).to_pylist()
+    assert add == [None, None, None, None, None, None]

--- a/tests/series/test_arithmetic.py
+++ b/tests/series/test_arithmetic.py
@@ -33,6 +33,9 @@ def test_arithmetic_numbers_array(l_dtype, r_dtype) -> None:
     div = (l / r).to_pylist()
     assert div == [1.0, 0.5, 3.0, None, None, None]
 
+    # mod = (l % r).to_pylist()
+    # assert mod == [0, 2, 0, None, None, None]
+
 
 @pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
 def test_arithmetic_numbers_left_scalar(l_dtype, r_dtype) -> None:
@@ -54,6 +57,9 @@ def test_arithmetic_numbers_left_scalar(l_dtype, r_dtype) -> None:
 
     div = (l / r).to_pylist()
     assert div == [1.0, 0.25, 1.0, 0.2, None, None]
+
+    # mod = (l % r).to_pylist()
+    # assert mod == [0, 1, 0, 1, None, None]
 
 
 @pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
@@ -77,6 +83,9 @@ def test_arithmetic_numbers_right_scalar(l_dtype, r_dtype) -> None:
     div = (l / r).to_pylist()
     assert div == [1.0, 2.0, 3.0, None, 5.0, None]
 
+    mod = (l % r).to_pylist()
+    assert mod == [0, 0, 0, None, 0, None]
+
 
 @pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
 def test_arithmetic_numbers_null_scalar(l_dtype, r_dtype) -> None:
@@ -98,6 +107,9 @@ def test_arithmetic_numbers_null_scalar(l_dtype, r_dtype) -> None:
 
     div = (l / r).to_pylist()
     assert div == [None, None, None, None, None, None]
+
+    mod = (l % r).to_pylist()
+    assert mod == [None, None, None, None, None, None]
 
 
 @pytest.mark.parametrize(
@@ -154,3 +166,26 @@ def test_add_for_int_and_string_null_scalar(l_dtype, r_dtype) -> None:
 
     add = (l + r).to_pylist()
     assert add == [None, None, None, None, None, None]
+
+
+def test_arithmetic_numbers_array_mismatch_length() -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([1, 4, 1, 5, None])
+
+    l = Series.from_arrow(l_arrow)
+    r = Series.from_arrow(r_arrow)
+
+    with pytest.raises(ValueError, match="different lengths"):
+        l + r
+
+    with pytest.raises(ValueError, match="different lengths"):
+        l - r
+
+    with pytest.raises(ValueError, match="different lengths"):
+        l * r
+
+    with pytest.raises(ValueError, match="different lengths"):
+        l / r
+
+    with pytest.raises(ValueError, match="different lengths"):
+        l % r

--- a/tests/series/test_arithmetic.py
+++ b/tests/series/test_arithmetic.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import itertools
+
+import pyarrow as pa
+import pytest
+
+from daft import Series
+
+arrow_int_types = [pa.int8(), pa.uint8(), pa.int16(), pa.uint16(), pa.int32(), pa.uint32(), pa.int64(), pa.uint64()]
+arrow_string_types = [pa.string(), pa.large_string()]
+arrow_float_types = [pa.float32(), pa.float64()]
+
+
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
+def test_arithmetic_numbers(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([1, 4, 1, 5, None, None])
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+
+    add = (l + r).to_pylist()
+    assert add == [2, 6, 4, None, None, None]
+
+    if pa.types.is_signed_integer(l_dtype) or pa.types.is_signed_integer(r_dtype):
+        sub = (l - r).to_pylist()
+        assert sub == [0, -2, 2, None, None, None]
+
+    mul = (l * r).to_pylist()
+    assert mul == [1, 8, 3, None, None, None]
+
+    div = (l / r).to_pylist()
+    assert div == [1.0, 0.5, 3.0, None, None, None]
+
+
+@pytest.mark.parametrize(
+    "l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_string_types, arrow_string_types)
+)
+def test_add_for_int_and_string(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([1, 4, 1, 5, None, None])
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+
+    add = (l + r).to_pylist()
+    assert add == ["11", "24", "31", None, None, None]

--- a/tests/series/test_arithmetic.py
+++ b/tests/series/test_arithmetic.py
@@ -168,6 +168,28 @@ def test_add_for_int_and_string_null_scalar(l_dtype, r_dtype) -> None:
     assert add == [None, None, None, None, None, None]
 
 
+def test_comparisons_bad_right_value() -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+
+    l = Series.from_arrow(l_arrow)
+    r = [1, 2, 3, None, 5, None]
+
+    with pytest.raises(ValueError, match="another Series"):
+        l + r
+
+    with pytest.raises(ValueError, match="another Series"):
+        l - r
+
+    with pytest.raises(ValueError, match="another Series"):
+        l / r
+
+    with pytest.raises(ValueError, match="another Series"):
+        l * r
+
+    with pytest.raises(ValueError, match="another Series"):
+        l % r
+
+
 def test_arithmetic_numbers_array_mismatch_length() -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([1, 4, 1, 5, None])

--- a/tests/series/test_comparisions.py
+++ b/tests/series/test_comparisions.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import itertools
+
+import pyarrow as pa
+import pytest
+
+from daft import Series
+
+arrow_int_types = [pa.int8(), pa.uint8(), pa.int16(), pa.uint16(), pa.int32(), pa.uint32(), pa.int64(), pa.uint64()]
+arrow_string_types = [pa.string(), pa.large_string()]
+arrow_float_types = [pa.float32(), pa.float64()]
+
+
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_string_types, repeat=2))
+def test_comparisons_int_and_str(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([1, 3, 1, 5, None, None])
+    # eq, lt, gt, None, None, None
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    lt = (l < r).to_pylist()
+    assert lt == [False, True, False, None, None, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [True, True, False, None, None, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [True, False, False, None, None, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [False, True, True, None, None, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [True, False, True, None, None, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [False, False, True, None, None, None]
+
+
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
+def test_comparisons_int_and_float(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([1, 3, 1, 5, None, None])
+    # eq, lt, gt, None, None, None
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    lt = (l < r).to_pylist()
+    assert lt == [False, True, False, None, None, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [True, True, False, None, None, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [True, False, False, None, None, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [False, True, True, None, None, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [True, False, True, None, None, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [False, False, True, None, None, None]

--- a/tests/series/test_comparisions.py
+++ b/tests/series/test_comparisions.py
@@ -202,6 +202,87 @@ def test_comparisons_int_and_float_right_null_scalar(l_dtype, r_dtype) -> None:
     assert gt == [None, None, None, None, None, None]
 
 
+def test_comparisons_boolean_array() -> None:
+    l_arrow = pa.array([False, False, None, True, None])
+    r_arrow = pa.array([True, False, True, None, None])
+    # lt, eq, lt, None
+
+    l = Series.from_arrow(l_arrow)
+    r = Series.from_arrow(r_arrow)
+
+    lt = (l < r).to_pylist()
+    assert lt == [True, False, None, None, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [True, True, None, None, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [False, True, None, None, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [True, False, None, None, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [False, True, None, None, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [False, False, None, None, None]
+
+
+def test_comparisons_boolean_array_right_scalar() -> None:
+    l_arrow = pa.array([False, True, None])
+    r_arrow = pa.array([True])
+    # lt, eq, lt, None
+
+    l = Series.from_arrow(l_arrow)
+    r = Series.from_arrow(r_arrow)
+
+    lt = (l < r).to_pylist()
+    assert lt == [True, False, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [True, True, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [False, True, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [True, False, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [False, True, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [False, False, None]
+
+
+def test_comparisons_boolean_array_right_scalar() -> None:
+    l_arrow = pa.array([True])
+    r_arrow = pa.array([False, True, None])
+    # lt, eq, lt, None
+
+    l = Series.from_arrow(l_arrow)
+    r = Series.from_arrow(r_arrow)
+
+    lt = (l < r).to_pylist()
+    assert lt == [False, False, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [False, True, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [False, True, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [True, False, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [True, True, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [True, False, None]
+
+
 def test_comparisons_bad_right_value() -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
 

--- a/tests/series/test_comparisions.py
+++ b/tests/series/test_comparisions.py
@@ -64,3 +64,28 @@ def test_comparisons_int_and_float(l_dtype, r_dtype) -> None:
 
     gt = (l > r).to_pylist()
     assert gt == [False, False, True, None, None, None]
+
+
+def test_comparisons_bad_right_value() -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+
+    l = Series.from_arrow(l_arrow)
+    r = [1, 2, 3, None, 5, None]
+
+    with pytest.raises(ValueError, match="another Series"):
+        (l < r)
+
+    with pytest.raises(ValueError, match="another Series"):
+        le = l <= r
+
+    with pytest.raises(ValueError, match="another Series"):
+        eq = l == r
+
+    with pytest.raises(ValueError, match="another Series"):
+        neq = l != r
+
+    with pytest.raises(ValueError, match="another Series"):
+        ge = l >= r
+
+    with pytest.raises(ValueError, match="another Series"):
+        (l > r)

--- a/tests/series/test_comparisions.py
+++ b/tests/series/test_comparisions.py
@@ -39,6 +39,88 @@ def test_comparisons_int_and_str(l_dtype, r_dtype) -> None:
     assert gt == [False, False, True, None, None, None]
 
 
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_string_types, repeat=2))
+def test_comparisons_int_and_str_left_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([2])
+    r_arrow = pa.array([1, 2, 3, None])
+    # gt, eq, lt
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+
+    lt = (l < r).to_pylist()
+    assert lt == [False, False, True, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [False, True, True, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [False, True, False, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [True, False, True, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [True, True, False, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [True, False, False, None]
+
+
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_string_types, repeat=2))
+def test_comparisons_int_and_str_right_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([2])
+    # lt, eq, gt, None, gt, None
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    lt = (l < r).to_pylist()
+    assert lt == [True, False, False, None, False, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [True, True, False, None, False, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [False, True, False, None, False, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [True, False, True, None, True, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [False, True, True, None, True, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [False, False, True, None, True, None]
+
+
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_string_types, repeat=2))
+def test_comparisons_int_and_str_right_null_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([None], type=r_dtype)
+    # lt, eq, gt, None, gt, None
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow)
+    lt = (l < r).to_pylist()
+    assert lt == [None, None, None, None, None, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [None, None, None, None, None, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [None, None, None, None, None, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [None, None, None, None, None, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [None, None, None, None, None, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [None, None, None, None, None, None]
+
+
 @pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
 def test_comparisons_int_and_float(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
@@ -64,6 +146,60 @@ def test_comparisons_int_and_float(l_dtype, r_dtype) -> None:
 
     gt = (l > r).to_pylist()
     assert gt == [False, False, True, None, None, None]
+
+
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
+def test_comparisons_int_and_float_right_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([2])
+    # lt, eq, gt, None, gt, None
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    lt = (l < r).to_pylist()
+    assert lt == [True, False, False, None, False, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [True, True, False, None, False, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [False, True, False, None, False, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [True, False, True, None, True, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [False, True, True, None, True, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [False, False, True, None, True, None]
+
+
+@pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
+def test_comparisons_int_and_float_right_null_scalar(l_dtype, r_dtype) -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([None], type=r_dtype)
+    # lt, eq, gt, None, gt, None
+
+    l = Series.from_arrow(l_arrow.cast(l_dtype))
+    r = Series.from_arrow(r_arrow)
+    lt = (l < r).to_pylist()
+    assert lt == [None, None, None, None, None, None]
+
+    le = (l <= r).to_pylist()
+    assert le == [None, None, None, None, None, None]
+
+    eq = (l == r).to_pylist()
+    assert eq == [None, None, None, None, None, None]
+
+    neq = (l != r).to_pylist()
+    assert neq == [None, None, None, None, None, None]
+
+    ge = (l >= r).to_pylist()
+    assert ge == [None, None, None, None, None, None]
+
+    gt = (l > r).to_pylist()
+    assert gt == [None, None, None, None, None, None]
 
 
 def test_comparisons_bad_right_value() -> None:

--- a/tests/series/test_comparisions.py
+++ b/tests/series/test_comparisions.py
@@ -73,19 +73,19 @@ def test_comparisons_bad_right_value() -> None:
     r = [1, 2, 3, None, 5, None]
 
     with pytest.raises(ValueError, match="another Series"):
-        (l < r)
+        l < r
 
     with pytest.raises(ValueError, match="another Series"):
-        le = l <= r
+        l <= r
 
     with pytest.raises(ValueError, match="another Series"):
-        eq = l == r
+        l == r
 
     with pytest.raises(ValueError, match="another Series"):
-        neq = l != r
+        l != r
 
     with pytest.raises(ValueError, match="another Series"):
-        ge = l >= r
+        l >= r
 
     with pytest.raises(ValueError, match="another Series"):
-        (l > r)
+        l > r

--- a/tests/series/test_comparisions.py
+++ b/tests/series/test_comparisions.py
@@ -306,3 +306,29 @@ def test_comparisons_bad_right_value() -> None:
 
     with pytest.raises(ValueError, match="another Series"):
         l > r
+
+
+def test_arithmetic_numbers_array_mismatch_length() -> None:
+    l_arrow = pa.array([1, 2, 3, None, 5, None])
+    r_arrow = pa.array([1, 4, 1, 5, None])
+
+    l = Series.from_arrow(l_arrow)
+    r = Series.from_arrow(r_arrow)
+
+    with pytest.raises(ValueError, match="different length"):
+        l < r
+
+    with pytest.raises(ValueError, match="different length"):
+        l <= r
+
+    with pytest.raises(ValueError, match="different length"):
+        l == r
+
+    with pytest.raises(ValueError, match="different length"):
+        l != r
+
+    with pytest.raises(ValueError, match="different length"):
+        l > r
+
+    with pytest.raises(ValueError, match="different length"):
+        l >= r

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pyarrow as pa
+
+from daft import Series
+
+
+def test_series_arrow_array_round_trip() -> None:
+    arrow = pa.array([1, 2, 3, None, 5, None])
+    s = Series.from_arrow(arrow)
+    back_to_arrow = s.to_arrow()
+    assert arrow == back_to_arrow
+
+
+def test_series_arrow_chunked_array_round_trip() -> None:
+    arrow = pa.chunked_array([[1, 2, 3], [None, 5, None]])
+    s = Series.from_arrow(arrow)
+    back_to_arrow = s.to_arrow()
+    assert arrow.combine_chunks() == back_to_arrow
+
+
+def test_series_pylist_round_trip() -> None:
+    data = [1, 2, 3, 4, None]
+    s = Series.from_pylist(data)
+    back_to_list = s.to_pylist()
+    assert data == back_to_list

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+from collections import Counter
+
 import pyarrow as pa
+import pytest
 
 from daft import Series
+
+arrow_int_types = [pa.int8(), pa.uint8(), pa.int16(), pa.uint16(), pa.int32(), pa.uint32(), pa.int64(), pa.uint64()]
+arrow_string_types = [pa.string(), pa.large_string()]
+arrow_float_types = [pa.float32(), pa.float64()]
 
 
 def test_series_arrow_array_round_trip() -> None:
@@ -24,3 +31,15 @@ def test_series_pylist_round_trip() -> None:
     s = Series.from_pylist(data)
     back_to_list = s.to_pylist()
     assert data == back_to_list
+
+
+@pytest.mark.parametrize("dtype", arrow_int_types + arrow_float_types + arrow_string_types)
+def test_series_pylist_round_trip(dtype) -> None:
+    data = pa.array([1, 2, 3, None, 5, None])
+
+    s = Series.from_arrow(data.cast(dtype))
+
+    words = Counter(repr(s).split())
+    assert s.name() in words
+    assert words[s.name()] == 1
+    assert words["None"] == 2


### PR DESCRIPTION
* Implements Series in rust, pyo3 and Python
* Implements arange kernel for numerics
* Implements into_iter method
* Update arithmetic kernels for array to return a result instead of panicking
* Implement comparisons kernels for arrays [numeric, boolean, utf] via the DaftCompare Trait
* Downcast kernel for Boolean Array
* Depreciate "Divide" and now only have TrueDivide and FloorDivide
* Implement PySeries Methods for comparison and arithmetic operations 
* Provide access to Array kernels in Series via macros
* Implement Series in Python that wraps PySeries
* Testing for Series in Python that covers all the types for comparison and arithmetic operations as well as repr and creation methods like from_arrow and from_pylist
* repr method for Series using pretty table
<img width="271" alt="image" src="https://user-images.githubusercontent.com/2550285/217929229-6d553308-f5ea-459e-94e6-be3be62d59d3.png">
 