### PR TITLE
Allow for Runner to be set more than once

### DIFF
--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -367,6 +367,15 @@ class RayRunner(Runner):
             ]
         )
 
+    def __del__(self) -> None:
+        logger.info("Shutting down Ray connection")
+        try:
+            ray.shutdown()
+        # ImportError: sys.meta_path is None, Python is likely shutting down is thrown when
+        # ray.shutdown() is called as the Python kernel is shutting down. This is expected.
+        except ImportError:
+            pass
+
     def put_partition_set_into_cache(self, pset: PartitionSet) -> PartitionCacheEntry:
         if isinstance(pset, LocalPartitionSet):
             pset = RayPartitionSet({pid: ray.put(val) for pid, val in pset._partitions.items()})

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import daft
+from daft.context import (
+    _DynamicRayRunnerConfig,
+    _get_runner_config_from_env,
+    _RayRunnerConfig,
+)
+
+
+def test_reset_runner():
+    """Test resetting the runner"""
+    config = _get_runner_config_from_env()
+    if config.name == "py":
+        daft.context.set_runner_py()
+    elif config.name == "ray":
+        assert isinstance(config, _RayRunnerConfig)
+        daft.context.set_runner_ray(address=config.address)
+    elif config.name == "dynamic":
+        daft.context.set_runner_dynamic()
+    elif config.name == "dynamicray":
+        assert isinstance(config, _DynamicRayRunnerConfig)
+        daft.context.set_runner_dynamic_ray(address=config.address)
+    else:
+        raise NotImplementedError(f"Test not implemented for runner: {config.name}")
+
+    # Run some daft code to trigger runner creation
+    df = daft.DataFrame.from_pydict({"a": [1, 2, 3]})
+    df.collect()


### PR DESCRIPTION
Allows `daft.context.set_runner_*` to be called more than once per Python session, for demos and tutorials