### PR TITLE
Naming and class refactors for physical plan

### DIFF
--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -84,25 +84,25 @@ class ExecutionStepBuilder(Generic[PartitionT]):
         self.resource_request = ResourceRequest.max_resources([self.resource_request, resource_request])
         return self
 
-    def build_materialization_request_single(self) -> ExecutionStepSingle[PartitionT]:
-        """Create an ExecutionStepSingle from this ExecutionStepBuilder.
+    def build_materialization_request_single(self) -> SingleOutputExecutionStep[PartitionT]:
+        """Create an SingleOutputExecutionStep from this ExecutionStepBuilder.
 
         Returns a "frozen" version of this ExecutionStep that cannot have instructions added.
         """
-        return ExecutionStepSingle[PartitionT](
+        return SingleOutputExecutionStep[PartitionT](
             inputs=self.inputs,
             instructions=self.instructions,
             num_results=1,
             resource_request=self.resource_request,
         )
 
-    def build_materialization_request_multi(self, num_results: int) -> ExecutionStepMulti[PartitionT]:
-        """Create an ExecutionStepMulti from this ExecutionStepBuilder.
+    def build_materialization_request_multi(self, num_results: int) -> MultiOutputExecutionStep[PartitionT]:
+        """Create an MultiOutputExecutionStep from this ExecutionStepBuilder.
 
         Same as as_materization_request, except the output of this ExecutionStep is a list of partitions.
         This is intended for execution steps that do a fanout.
         """
-        return ExecutionStepMulti[PartitionT](
+        return MultiOutputExecutionStep[PartitionT](
             inputs=self.inputs,
             instructions=self.instructions,
             num_results=num_results,
@@ -119,7 +119,7 @@ class ExecutionStepBuilder(Generic[PartitionT]):
 
 
 @dataclass
-class ExecutionStepSingle(ExecutionStep[PartitionT]):
+class SingleOutputExecutionStep(ExecutionStep[PartitionT]):
     """An ExecutionStep that is ready to run. More instructions cannot be added.
 
     result: When available, the partition created from run the ExecutionStep.
@@ -129,7 +129,7 @@ class ExecutionStepSingle(ExecutionStep[PartitionT]):
 
 
 @dataclass
-class ExecutionStepMulti(ExecutionStep[PartitionT]):
+class MultiOutputExecutionStep(ExecutionStep[PartitionT]):
     """An ExecutionStep that is ready to run. More instructions cannot be added.
     This ExecutionStep will return a list of any number of partitions.
 

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -31,18 +31,21 @@ class ExecutionStep(Generic[PartitionT], ABC):
     The partition will be created by running a function pipeline (`instructions`) over some input partition(s) (`inputs`).
     Each function takes an entire set of inputs and produces a new set of partitions to pass into the next function.
 
-    This class should not be instantiated directly. See subclasses for usage:
-        - OpenExecutionQueue: to create a new ExecutionStep, and append functions to its pipeline.
-        - MaterializeRequest: to "freeze" an ExecutionStep and mark it for execution.
+    This class should not be instantiated directly. To create the appropriate ExecutionStep for your use-case, use the ExecutionStepBuilder.
     """
 
     inputs: list[PartitionT]
     instructions: list[Instruction]
     resource_request: ResourceRequest | None
+    num_results: int
+    _id: int = field(default_factory=lambda: next(ID_GEN))
+
+    def id(self) -> str:
+        return f"{self.__class__.__name__}_{self._id}"
 
     def __str__(self) -> str:
         return (
-            f"{self.__class__.__name__}\n"
+            f"{self.id()}\n"
             f"  Inputs: {self.inputs}\n"
             f"  Resource Request: {self.resource_request}\n"
             f"  Instructions: {[i.__class__.__name__ for i in self.instructions]}"
@@ -52,11 +55,21 @@ class ExecutionStep(Generic[PartitionT], ABC):
         return self.__str__()
 
 
-class OpenExecutionQueue(ExecutionStep[PartitionT]):
-    """This is an ExecutionStep that can still have functions added to its function pipeline."""
+class ExecutionStepBuilder(Generic[PartitionT]):
+    """Builds an ExecutionStep by adding instructions to its pipeline."""
 
-    def __copy__(self) -> OpenExecutionQueue[PartitionT]:
-        return OpenExecutionQueue[PartitionT](
+    def __init__(
+        self,
+        inputs: list[PartitionT],
+        instructions: list[Instruction] | None = None,
+        resource_request: ResourceRequest | None = None,
+    ) -> None:
+        self.inputs = inputs
+        self.instructions: list[Instruction] = [] if instructions is None else instructions
+        self.resource_request: ResourceRequest | None = resource_request
+
+    def __copy__(self) -> ExecutionStepBuilder[PartitionT]:
+        return ExecutionStepBuilder[PartitionT](
             inputs=self.inputs.copy(),
             instructions=self.instructions.copy(),
             resource_request=self.resource_request,  # ResourceRequest is immutable (dataclass with frozen=True)
@@ -66,57 +79,40 @@ class OpenExecutionQueue(ExecutionStep[PartitionT]):
         self,
         instruction: Instruction,
         resource_request: ResourceRequest | None,
-    ) -> OpenExecutionQueue[PartitionT]:
+    ) -> ExecutionStepBuilder[PartitionT]:
         """Append an instruction to this ExecutionStep's pipeline."""
         self.instructions.append(instruction)
         self.resource_request = ResourceRequest.max_resources([self.resource_request, resource_request])
         return self
 
-    def as_materialization_request(self) -> MaterializationRequest[PartitionT]:
-        """Create an MaterializationRequest from this ExecutionStep.
+    def build_materialization_request_single(self) -> ExecutionStepSingle[PartitionT]:
+        """Create an ExecutionStepSingle from this ExecutionStepBuilder.
 
         Returns a "frozen" version of this ExecutionStep that cannot have instructions added.
         """
-        return MaterializationRequest[PartitionT](
+        return ExecutionStepSingle[PartitionT](
             inputs=self.inputs,
             instructions=self.instructions,
             num_results=1,
             resource_request=self.resource_request,
         )
 
-    def as_materialization_request_multi(self, num_results: int) -> MaterializationRequestMulti[PartitionT]:
-        """Create an MaterializationRequestMulti from this ExecutionStep.
+    def build_materialization_request_multi(self, num_results: int) -> ExecutionStepMulti[PartitionT]:
+        """Create an ExecutionStepMulti from this ExecutionStepBuilder.
 
         Same as as_materization_request, except the output of this ExecutionStep is a list of partitions.
         This is intended for execution steps that do a fanout.
         """
-        return MaterializationRequestMulti[PartitionT](
+        return ExecutionStepMulti[PartitionT](
             inputs=self.inputs,
             instructions=self.instructions,
             num_results=num_results,
             resource_request=self.resource_request,
         )
 
-
-@dataclass
-class MaterializationRequestBase(ExecutionStep[PartitionT]):
-    """Common helpers for MaterializationRequest and MaterializationRequestMulti.
-    See those classes for more details.
-
-    num_results: The number of partitions that will be returned.
-    _id: A unique identifier for this ExecutionStep.
-    """
-
-    num_results: int
-    _id: int = field(default_factory=lambda: next(ID_GEN))
-
-    def id(self) -> str:
-        return f"{self.__class__.__name__}_{self._id}"
-
     def __str__(self) -> str:
-
         return (
-            f"{self.id()}\n"
+            f"ExecutionStepBuilder\n"
             f"  Inputs: {self.inputs}\n"
             f"  Resource Request: {self.resource_request}\n"
             f"  Instructions: {[i.__class__.__name__ for i in self.instructions]}"
@@ -124,27 +120,27 @@ class MaterializationRequestBase(ExecutionStep[PartitionT]):
 
 
 @dataclass
-class MaterializationRequest(MaterializationRequestBase[PartitionT]):
+class ExecutionStepSingle(ExecutionStep[PartitionT]):
     """An ExecutionStep that is ready to run. More instructions cannot be added.
 
     result: When available, the partition created from run the ExecutionStep.
     """
 
-    result: None | MaterializationResult[PartitionT] = None
+    result: None | MaterializedResult[PartitionT] = None
 
 
 @dataclass
-class MaterializationRequestMulti(MaterializationRequestBase[PartitionT]):
+class ExecutionStepMulti(ExecutionStep[PartitionT]):
     """An ExecutionStep that is ready to run. More instructions cannot be added.
     This ExecutionStep will return a list of any number of partitions.
 
     results: When available, the partitions created from run the ExecutionStep.
     """
 
-    results: None | list[MaterializationResult[PartitionT]] = None
+    results: None | list[MaterializedResult[PartitionT]] = None
 
 
-class MaterializationResult(Protocol[PartitionT]):
+class MaterializedResult(Protocol[PartitionT]):
     """A protocol for accessing the result partition of a ExecutionStep.
 
     Different Runners can fill in their own implementation here.

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 import sys
-from abc import ABC
 from dataclasses import dataclass, field
 from typing import Generic, TypeVar
 
@@ -25,7 +24,7 @@ ID_GEN = itertools.count()
 
 
 @dataclass
-class ExecutionStep(Generic[PartitionT], ABC):
+class ExecutionStep(Generic[PartitionT]):
     """An ExecutionStep describes a task that will run to create a partition.
 
     The partition will be created by running a function pipeline (`instructions`) over some input partition(s) (`inputs`).

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -99,7 +99,7 @@ class ExecutionStepBuilder(Generic[PartitionT]):
     def build_materialization_request_multi(self, num_results: int) -> MultiOutputExecutionStep[PartitionT]:
         """Create an MultiOutputExecutionStep from this ExecutionStepBuilder.
 
-        Same as as_materization_request, except the output of this ExecutionStep is a list of partitions.
+        Same as build_materialization_request_single, except the output of this ExecutionStep is a list of partitions.
         This is intended for execution steps that do a fanout.
         """
         return MultiOutputExecutionStep[PartitionT](

--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 
 import math
 from collections import deque
-from collections.abc import Generator, Iterator
-from typing import List, TypeVar, Union
+from typing import Generator, Iterator, List, TypeVar, Union
 
 from daft.execution import execution_step
 from daft.execution.execution_step import (

--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -106,8 +106,8 @@ def join(
 
     # Materialize the steps from the left and right sources to get partitions.
     # As the materializations complete, emit new steps to join each left and right partition.
-    left_requests: deque[ExecutionStepSingle] = deque()
-    right_requests: deque[ExecutionStepSingle] = deque()
+    left_requests: deque[ExecutionStepSingle[PartitionT]] = deque()
+    right_requests: deque[ExecutionStepSingle[PartitionT]] = deque()
 
     while True:
         # Emit new join steps if we have left and right partitions ready.
@@ -186,7 +186,7 @@ def global_limit(
     assert remaining_rows >= 0, f"Invalid value for limit: {remaining_rows}"
     remaining_partitions = global_limit.num_partitions()
 
-    materializations: deque[ExecutionStepSingle] = deque()
+    materializations: deque[ExecutionStepSingle[PartitionT]] = deque()
 
     # To dynamically schedule the global limit, we need to apply an appropriate limit to each child partition.
     # We don't know their exact sizes since they are pending execution, so we will have to iteratively execute them,
@@ -272,7 +272,7 @@ def coalesce(
     # For each output partition, the number of input partitions to merge in.
     merges_per_result = deque([stop - start for start, stop in zip(starts, stops)])
 
-    materializations: deque[ExecutionStepSingle] = deque()
+    materializations: deque[ExecutionStepSingle[PartitionT]] = deque()
 
     while True:
 

--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -16,15 +16,14 @@ from __future__ import annotations
 import math
 from collections import deque
 from collections.abc import Generator, Iterator
-from typing import TypeVar
+from typing import List, TypeVar, Union
 
 from daft.execution import execution_step
 from daft.execution.execution_step import (
     ExecutionStep,
+    ExecutionStepBuilder,
+    ExecutionStepSingle,
     Instruction,
-    MaterializationRequest,
-    MaterializationRequestBase,
-    OpenExecutionQueue,
     ReduceInstruction,
 )
 from daft.logical import logical_plan
@@ -33,18 +32,26 @@ PartitionT = TypeVar("PartitionT")
 T = TypeVar("T")
 
 
-def partition_read(partitions: Iterator[PartitionT]) -> Iterator[None | ExecutionStep[PartitionT]]:
+# A PhysicalPlan that is still being built - may yield both ExecutionStepBuilders and ExecutionSteps.
+InProgressPhysicalPlan = Iterator[Union[None, ExecutionStep[PartitionT], ExecutionStepBuilder[PartitionT]]]
+
+# A PhysicalPlan that is complete and will only yield ExecutionSteps.
+MaterializedPhysicalPlan = Generator[
+    Union[None, ExecutionStep[PartitionT]],
+    None,
+    List[PartitionT],
+]
+
+
+def partition_read(partitions: Iterator[PartitionT]) -> InProgressPhysicalPlan[PartitionT]:
     """Instantiate a (no-op) physical plan from existing partitions."""
-    yield from (
-        OpenExecutionQueue[PartitionT](inputs=[partition], instructions=[], resource_request=None)
-        for partition in partitions
-    )
+    yield from (ExecutionStepBuilder[PartitionT](inputs=[partition]) for partition in partitions)
 
 
 def file_read(
-    child_plan: Iterator[None | ExecutionStep[PartitionT]],
+    child_plan: InProgressPhysicalPlan[PartitionT],
     scan_info: logical_plan.TabularFilesScan,
-) -> Iterator[None | ExecutionStep[PartitionT]]:
+) -> InProgressPhysicalPlan[PartitionT]:
     """child_plan represents partitions with filenames.
 
     Yield a plan to read those filenames.
@@ -54,16 +61,16 @@ def file_read(
             execution_step.ReadFile(partition_id=index, logplan=scan_info),
             resource_request=None,
         )
-        if isinstance(step, OpenExecutionQueue)
+        if isinstance(step, ExecutionStepBuilder)
         else step
         for index, step in enumerate_open_executions(child_plan)
     )
 
 
 def file_write(
-    child_plan: Iterator[None | ExecutionStep[PartitionT]],
+    child_plan: InProgressPhysicalPlan[PartitionT],
     write_info: logical_plan.FileWrite,
-) -> Iterator[None | ExecutionStep[PartitionT]]:
+) -> InProgressPhysicalPlan[PartitionT]:
     """Write the results of `child_plan` into files described by `write_info`."""
 
     yield from (
@@ -71,36 +78,36 @@ def file_write(
             execution_step.WriteFile(partition_id=index, logplan=write_info),
             resource_request=None,
         )
-        if isinstance(step, OpenExecutionQueue)
+        if isinstance(step, ExecutionStepBuilder)
         else step
         for index, step in enumerate_open_executions(child_plan)
     )
 
 
 def pipeline_instruction(
-    child_plan: Iterator[None | ExecutionStep[PartitionT]],
+    child_plan: InProgressPhysicalPlan[PartitionT],
     pipeable_instruction: Instruction,
     resource_request: execution_step.ResourceRequest | None,
-) -> Iterator[None | ExecutionStep[PartitionT]]:
+) -> InProgressPhysicalPlan[PartitionT]:
     """Apply an instruction to the results of `child_plan`."""
 
     yield from (
-        step.add_instruction(pipeable_instruction, resource_request) if isinstance(step, OpenExecutionQueue) else step
+        step.add_instruction(pipeable_instruction, resource_request) if isinstance(step, ExecutionStepBuilder) else step
         for step in child_plan
     )
 
 
 def join(
-    left_plan: Iterator[None | ExecutionStep[PartitionT]],
-    right_plan: Iterator[None | ExecutionStep[PartitionT]],
+    left_plan: InProgressPhysicalPlan[PartitionT],
+    right_plan: InProgressPhysicalPlan[PartitionT],
     join: logical_plan.Join,
-) -> Iterator[None | ExecutionStep[PartitionT]]:
+) -> InProgressPhysicalPlan[PartitionT]:
     """Pairwise join the partitions from `left_child_plan` and `right_child_plan` together."""
 
     # Materialize the steps from the left and right sources to get partitions.
     # As the materializations complete, emit new steps to join each left and right partition.
-    left_requests: deque[MaterializationRequest] = deque()
-    right_requests: deque[MaterializationRequest] = deque()
+    left_requests: deque[ExecutionStepSingle] = deque()
+    right_requests: deque[ExecutionStepSingle] = deque()
 
     while True:
         # Emit new join steps if we have left and right partitions ready.
@@ -115,11 +122,9 @@ def join(
             assert next_left.result is not None  # for mypy only; guaranteed by while condition
             assert next_right.result is not None  # for mypy only; guaranteed by while condition
 
-            join_step = OpenExecutionQueue[PartitionT](
-                inputs=[next_left.result.partition(), next_right.result.partition()],
-                instructions=[execution_step.Join(join)],
-                resource_request=None,
-            )
+            join_step = ExecutionStepBuilder[PartitionT](
+                inputs=[next_left.result.partition(), next_right.result.partition()]
+            ).add_instruction(instruction=execution_step.Join(join), resource_request=None)
             yield join_step
 
         # Exhausted all ready inputs; execute a single child step to get more join inputs.
@@ -131,8 +136,8 @@ def join(
 
         try:
             step = next(next_plan)
-            if isinstance(step, OpenExecutionQueue):
-                step = step.as_materialization_request()
+            if isinstance(step, ExecutionStepBuilder):
+                step = step.build_materialization_request_single()
                 next_requests.append(step)
             yield step
 
@@ -148,9 +153,9 @@ def join(
 
 
 def local_limit(
-    child_plan: Iterator[None | ExecutionStep[PartitionT]],
+    child_plan: InProgressPhysicalPlan[PartitionT],
     limit: int,
-) -> Generator[None | ExecutionStep[PartitionT], None | int, None]:
+) -> Generator[None | ExecutionStep[PartitionT] | ExecutionStepBuilder[PartitionT], int, None]:
     """Apply a limit instruction to each partition in the child_plan.
 
     limit:
@@ -160,7 +165,7 @@ def local_limit(
     Send back: A new value to the limit (optional). This allows you to update the limit after each partition if desired.
     """
     for step in child_plan:
-        if not isinstance(step, OpenExecutionQueue):
+        if not isinstance(step, ExecutionStepBuilder):
             yield step
         else:
             maybe_new_limit = yield step.add_instruction(
@@ -172,16 +177,16 @@ def local_limit(
 
 
 def global_limit(
-    child_plan: Iterator[None | ExecutionStep[PartitionT]],
+    child_plan: InProgressPhysicalPlan[PartitionT],
     global_limit: logical_plan.GlobalLimit,
-) -> Iterator[None | ExecutionStep[PartitionT]]:
+) -> InProgressPhysicalPlan[PartitionT]:
     """Return the first n rows from the `child_plan`."""
 
     remaining_rows = global_limit._num
     assert remaining_rows >= 0, f"Invalid value for limit: {remaining_rows}"
     remaining_partitions = global_limit.num_partitions()
 
-    materializations: deque[MaterializationRequest[PartitionT]] = deque()
+    materializations: deque[ExecutionStepSingle] = deque()
 
     # To dynamically schedule the global limit, we need to apply an appropriate limit to each child partition.
     # We don't know their exact sizes since they are pending execution, so we will have to iteratively execute them,
@@ -201,10 +206,8 @@ def global_limit(
 
             limit = remaining_rows and min(remaining_rows, result.metadata().num_rows)
 
-            global_limit_step = OpenExecutionQueue[PartitionT](
-                inputs=[result.partition()],
-                instructions=[execution_step.LocalLimit(limit)],
-                resource_request=None,
+            global_limit_step = ExecutionStepBuilder[PartitionT](inputs=[result.partition()]).add_instruction(
+                instruction=execution_step.LocalLimit(limit), resource_request=None
             )
             yield global_limit_step
             remaining_partitions -= 1
@@ -222,9 +225,8 @@ def global_limit(
                         result_to_cancel.cancel()
 
                 yield from (
-                    OpenExecutionQueue[PartitionT](
-                        inputs=[result.partition()],
-                        instructions=[execution_step.LocalLimit(0)],
+                    ExecutionStepBuilder[PartitionT](inputs=[result.partition()]).add_instruction(
+                        instruction=execution_step.LocalLimit(0),
                         resource_request=None,
                     )
                     for _ in range(remaining_partitions)
@@ -240,8 +242,8 @@ def global_limit(
         try:
             child_step = child_plan.send(remaining_rows) if started else next(child_plan)
             started = True
-            if isinstance(child_step, OpenExecutionQueue):
-                child_step = child_step.as_materialization_request()
+            if isinstance(child_step, ExecutionStepBuilder):
+                child_step = child_step.build_materialization_request_single()
                 materializations.append(child_step)
             yield child_step
 
@@ -253,9 +255,9 @@ def global_limit(
 
 
 def coalesce(
-    child_plan: Iterator[None | ExecutionStep[PartitionT]],
+    child_plan: InProgressPhysicalPlan[PartitionT],
     coalesce: logical_plan.Coalesce,
-) -> Iterator[None | ExecutionStep[PartitionT]]:
+) -> InProgressPhysicalPlan[PartitionT]:
     """Coalesce the results of the child_plan into fewer partitions.
 
     The current implementation only does partition merging, no rebalancing.
@@ -270,7 +272,7 @@ def coalesce(
     # For each output partition, the number of input partitions to merge in.
     merges_per_result = deque([stop - start for start, stop in zip(starts, stops)])
 
-    materializations: deque[MaterializationRequest[PartitionT]] = deque()
+    materializations: deque[ExecutionStepSingle] = deque()
 
     while True:
 
@@ -284,9 +286,10 @@ def coalesce(
             ]
             if len(ready_to_coalesce) == num_partitions_to_merge:
                 # Coalesce the partition and emit it.
-                merge_step = OpenExecutionQueue[PartitionT](
-                    inputs=[_.partition() for _ in ready_to_coalesce],
-                    instructions=[execution_step.ReduceMerge()],
+                merge_step = ExecutionStepBuilder[PartitionT](
+                    inputs=[_.partition() for _ in ready_to_coalesce]
+                ).add_instruction(
+                    instruction=execution_step.ReduceMerge(),
                     resource_request=None,
                 )
                 [materializations.popleft() for _ in range(num_partitions_to_merge)]
@@ -297,8 +300,8 @@ def coalesce(
         # Materialize a single dependency.
         try:
             child_step = next(child_plan)
-            if isinstance(child_step, OpenExecutionQueue):
-                child_step = child_step.as_materialization_request()
+            if isinstance(child_step, ExecutionStepBuilder):
+                child_step = child_step.build_materialization_request_single()
                 materializations.append(child_step)
             yield child_step
 
@@ -310,10 +313,10 @@ def coalesce(
 
 
 def reduce(
-    fanout_plan: Iterator[None | ExecutionStep[PartitionT]],
+    fanout_plan: InProgressPhysicalPlan[PartitionT],
     num_partitions: int,
     reduce_instruction: ReduceInstruction,
-) -> Iterator[None | ExecutionStep[PartitionT]]:
+) -> InProgressPhysicalPlan[PartitionT]:
     """Reduce the result of fanout_plan.
 
     The child plan fanout_plan must produce a 2d list of partitions,
@@ -326,8 +329,8 @@ def reduce(
 
     # Dispatch all fanouts.
     for step in fanout_plan:
-        if isinstance(step, OpenExecutionQueue):
-            step = step.as_materialization_request_multi(num_partitions)
+        if isinstance(step, ExecutionStepBuilder):
+            step = step.build_materialization_request_multi(num_partitions)
             materializations.append(step)
         yield step
 
@@ -341,7 +344,7 @@ def reduce(
 
     # Yield all the reduces in order.
     while len(inputs_to_reduce[0]) > 0:
-        yield OpenExecutionQueue[PartitionT](
+        yield ExecutionStepBuilder[PartitionT](
             inputs=[result.partition() for result in (_.popleft() for _ in inputs_to_reduce)],
             instructions=[reduce_instruction],
             resource_request=None,
@@ -349,29 +352,32 @@ def reduce(
 
 
 def sort(
-    child_plan: Iterator[None | ExecutionStep[PartitionT]],
+    child_plan: InProgressPhysicalPlan[PartitionT],
     sort_info: logical_plan.Sort,
-) -> Iterator[None | ExecutionStep[PartitionT]]:
+) -> InProgressPhysicalPlan[PartitionT]:
     """Sort the result of `child_plan` according to `sort_info`."""
 
     # First, materialize the child plan.
-    source_materializations: deque[MaterializationRequest[PartitionT]] = deque()
+    source_materializations: deque[ExecutionStepSingle[PartitionT]] = deque()
     for step in child_plan:
-        if isinstance(step, OpenExecutionQueue):
-            step = step.as_materialization_request()
+        if isinstance(step, ExecutionStepBuilder):
+            step = step.build_materialization_request_single()
             source_materializations.append(step)
         yield step
 
     # Sample all partitions (to be used for calculating sort boundaries).
-    sample_materializations: deque[MaterializationRequest[PartitionT]] = deque()
+    sample_materializations: deque[ExecutionStepSingle[PartitionT]] = deque()
     for source in source_materializations:
         while source.result is None:
             yield None
-        sample = OpenExecutionQueue[PartitionT](
-            inputs=[source.result.partition()],
-            instructions=[execution_step.Sample(sort_by=sort_info._sort_by)],
-            resource_request=None,
-        ).as_materialization_request()
+        sample = (
+            ExecutionStepBuilder[PartitionT](inputs=[source.result.partition()])
+            .add_instruction(
+                instruction=execution_step.Sample(sort_by=sort_info._sort_by),
+                resource_request=None,
+            )
+            .build_materialization_request_single()
+        )
         sample_materializations.append(sample)
         yield sample
 
@@ -380,21 +386,24 @@ def sort(
         yield None
 
     # Reduce the samples to get sort boundaries.
-    boundaries = OpenExecutionQueue[PartitionT](
-        inputs=[
-            sample.result.partition()
-            for sample in consume_deque(sample_materializations)
-            if sample.result is not None  # for mypy only; guaranteed to be not None by while loop
-        ],
-        instructions=[
+    boundaries = (
+        ExecutionStepBuilder[PartitionT](
+            inputs=[
+                sample.result.partition()
+                for sample in consume_deque(sample_materializations)
+                if sample.result is not None  # for mypy only; guaranteed to be not None by while loop
+            ]
+        )
+        .add_instruction(
             execution_step.ReduceToQuantiles(
                 num_quantiles=sort_info.num_partitions(),
                 sort_by=sort_info._sort_by,
                 descending=sort_info._descending,
             ),
-        ],
-        resource_request=None,
-    ).as_materialization_request()
+            resource_request=None,
+        )
+        .build_materialization_request_single()
+    )
     yield boundaries
 
     # Wait for boundaries to materialize.
@@ -405,15 +414,12 @@ def sort(
 
     # Create a range fanout plan.
     range_fanout_plan = (
-        OpenExecutionQueue[PartitionT](
-            inputs=[boundaries_partition, source_partition],
-            instructions=[
-                execution_step.FanoutRange[PartitionT](
-                    num_outputs=sort_info.num_partitions(),
-                    sort_by=sort_info._sort_by,
-                    descending=sort_info._descending,
-                ),
-            ],
+        ExecutionStepBuilder[PartitionT](inputs=[boundaries_partition, source_partition]).add_instruction(
+            instruction=execution_step.FanoutRange[PartitionT](
+                num_outputs=sort_info.num_partitions(),
+                sort_by=sort_info._sort_by,
+                descending=sort_info._descending,
+            ),
             resource_request=None,
         )
         for source_partition in (
@@ -433,8 +439,8 @@ def sort(
 
 
 def materialize(
-    child_plan: Iterator[None | ExecutionStep[PartitionT]],
-) -> Generator[None | MaterializationRequestBase[PartitionT], None, list[PartitionT]]:
+    child_plan: InProgressPhysicalPlan[PartitionT],
+) -> MaterializedPhysicalPlan:
     """Materialize the child plan.
 
     Returns (via generator return): the completed plan's result partitions.
@@ -443,10 +449,10 @@ def materialize(
     materializations = list()
 
     for step in child_plan:
-        if isinstance(step, OpenExecutionQueue):
-            step = step.as_materialization_request()
+        if isinstance(step, ExecutionStepBuilder):
+            step = step.build_materialization_request_single()
             materializations.append(step)
-        assert isinstance(step, (MaterializationRequestBase, type(None)))
+        assert isinstance(step, (ExecutionStep, type(None)))
 
         yield step
 
@@ -457,15 +463,15 @@ def materialize(
 
 
 def enumerate_open_executions(
-    schedule: Iterator[None | ExecutionStep[PartitionT]],
-) -> Iterator[tuple[int, None | ExecutionStep[PartitionT]]]:
-    """Helper. Like enumerate() on an iterator, but only counts up if the result is an OpenExecutionQueue.
+    schedule: InProgressPhysicalPlan[PartitionT],
+) -> Iterator[tuple[int, None | ExecutionStep[PartitionT] | ExecutionStepBuilder[PartitionT]]]:
+    """Helper. Like enumerate() on an iterator, but only counts up if the result is an ExecutionStepBuilder.
 
-    Intended for counting the number of OpenExecutionQueues returned by the iterator.
+    Intended for counting the number of ExecutionStepBuilders returned by the iterator.
     """
     index = 0
     for item in schedule:
-        if isinstance(item, OpenExecutionQueue):
+        if isinstance(item, ExecutionStepBuilder):
             yield index, item
             index += 1
         else:

--- a/daft/runners/dynamic_runner.py
+++ b/daft/runners/dynamic_runner.py
@@ -8,9 +8,9 @@ import psutil
 from daft.execution import physical_plan_factory
 from daft.execution.execution_step import (
     ExecutionStep,
-    ExecutionStepMulti,
-    ExecutionStepSingle,
     MaterializedResult,
+    MultiOutputExecutionStep,
+    SingleOutputExecutionStep,
 )
 from daft.internal.gpu import cuda_device_count
 from daft.internal.rule_runner import FixedPointPolicy, Once, RuleBatch, RuleRunner
@@ -117,9 +117,9 @@ class DynamicRunner(Runner):
         partitions = partspec.inputs
         for instruction in partspec.instructions:
             partitions = instruction.run(partitions)
-        if isinstance(partspec, ExecutionStepMulti):
+        if isinstance(partspec, MultiOutputExecutionStep):
             partspec.results = [PyMaterializedResult(partition) for partition in partitions]
-        elif isinstance(partspec, ExecutionStepSingle):
+        elif isinstance(partspec, SingleOutputExecutionStep):
             [partition] = partitions
             partspec.result = PyMaterializedResult(partition)
         else:


### PR DESCRIPTION
1. `OpenExecutionQueue` -> `ExecutionStepBuilder`
2. `MaterializeResultBase` removed, its properties are promoted into `ExecutionStep`
3. `MaterializationRequest` -> `ExecutionStepSingle(ExecutionStep)`
4. `MaterializationRequestMulti` -> `ExecutionStepMulti(ExecutionStep)`
5. Added type alias `InProgressPhysicalPlan` which is an iterator that returns either `None | ExecutionStepBuilder | ExecutionStep` - we use this in the internals of physical_plan_factory when constructing the physical plan
6. Added type alias `MaterializedPhysicalPlan` which is a Generator that yields either `None | ExecutionStep` (cannot yield `ExecutionStepBuilder`) and stops with a `list[PartitionT]` - this is the final result that a client of physical_plan_factory will receive

Old inheritance hierarchy:

```
ExecutionStep
    - OpenExecutionQueue
    - MaterializeResultBase
        - MaterializationRequest
        - MaterializationRequestMulti
```

The new inheritance hierarchy is less nested, and the builder class does not inherit from the base class - looks like this:

```
ExecutionStep
    - ExecutionStepSingle
    - ExecutionStepMulti

ExecutionStepBuilder
```