### PR TITLE
Always translate LocalLimit logical plan to its own physical plan.

### DIFF
--- a/daft/execution/physical_plan_factory.py
+++ b/daft/execution/physical_plan_factory.py
@@ -77,9 +77,8 @@ def get_physical_plan(node: LogicalPlan) -> Iterator[None | ExecutionStep[Partit
             return physical_plan.file_write(child_plan, node)
 
         elif isinstance(node, logical_plan.LocalLimit):
-            # Ignore LocalLimit logical nodes; the GlobalLimit physical plan handles everything
-            # and will dynamically dispatch appropriate local limit instructions.
-            return child_plan
+            # Note that the GlobalLimit physical plan also dynamically dispatches its own LocalLimit instructions.
+            return physical_plan.local_limit(child_plan, node._num)
 
         elif isinstance(node, logical_plan.GlobalLimit):
             return physical_plan.global_limit(child_plan, node)


### PR DESCRIPTION
Currently, LocalLimit logical plan nodes are actually ignored in the physical plan factory. This was because they previously only existed under GlobalLimit, and the global limit physical plan already does its own local limit optimizations, so it would be redundant to translate the LocalLimit logical plan node too.

Soon, we may use LocalLimit separately from GlobalLimit in the logical plan (e.g. pushdown through sort), and thus it should be executed in the physical plan. This PR has the physical plan directly translate all LocalLimit logical nodes.

cc @samster25 