### PR TITLE
Skip Ray runner tests in property based testing

### DIFF
--- a/.github/workflows/property-based-tests.yml
+++ b/.github/workflows/property-based-tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7']
-        daft_runner: [py, ray, dynamic, dynamicray]
+        daft_runner: [py, dynamic]
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
The Ray runner is too slow for the tight loops in property based testing, so we skip it