### PR TITLE
[bugfix] Fix Behavior in Search Sorted (Partitioning) for Nulls and NaNs

### DIFF
--- a/src/kernels/search_sorted.rs
+++ b/src/kernels/search_sorted.rs
@@ -198,11 +198,11 @@ fn build_compare_with_nan<'a>(
         let left: &PrimitiveArray<f32> = unsafe { left.as_any().downcast_ref().unwrap_unchecked() };
         let right: &PrimitiveArray<f32> =
             unsafe { right.as_any().downcast_ref().unwrap_unchecked() };
-        return Ok(Box::new(move |l, r| {
+        Ok(Box::new(move |l, r| {
             let lv = unsafe { left.value_unchecked(l) };
             let rv = unsafe { right.value_unchecked(r) };
             cmp_float::<f32>(&lv, &rv)
-        }));
+        }))
     } else if (left.data_type() == &DataType::Float64) && (right.data_type() == &DataType::Float64)
     {
         let left: &PrimitiveArray<f64> = unsafe { left.as_any().downcast_ref().unwrap_unchecked() };

--- a/src/kernels/search_sorted.rs
+++ b/src/kernels/search_sorted.rs
@@ -1,9 +1,9 @@
-use std::{any::TypeId, cmp::Ordering, iter::zip};
+use std::{cmp::Ordering, iter::zip};
 
 use arrow2::{
     array::ord::build_compare,
     array::Array,
-    array::{ord::DynComparator, PrimitiveArray, Utf8Array},
+    array::{PrimitiveArray, Utf8Array},
     datatypes::{DataType, PhysicalType},
     error::{Error, Result},
     types::{NativeType, Offset},
@@ -214,7 +214,7 @@ fn build_compare_with_nan<'a>(
             cmp_float::<f64>(&lv, &rv)
         }));
     } else {
-        return Ok(build_compare(left, right)?);
+        return build_compare(left, right);
     }
 }
 
@@ -227,12 +227,6 @@ fn build_compare_with_nulls<'a>(
     let left_is_valid = build_is_valid(left);
     let right_is_valid = build_is_valid(right);
 
-    let comparator = match (left.data_type(), right.data_type()) {
-        (DataType::Float32, DataType::Float32) | (DataType::Float64, DataType::Float64) => {
-            Box::new(move |l, r| comparator(l, r))
-        }
-        _ => comparator,
-    };
     if reversed {
         Ok(Box::new(move |i: usize, j: usize| {
             match (left_is_valid(i), right_is_valid(j)) {

--- a/src/kernels/search_sorted.rs
+++ b/src/kernels/search_sorted.rs
@@ -34,8 +34,8 @@ where {
         let is_last_key_le = match (last_key, key_val) {
             (None, None) => false,
             (Some(last_key), Some(key_val)) => less(last_key, key_val),
-            (None, _) => false,
-            (_, None) => true,
+            (None, Some(_)) => false,
+            (Some(_), None) => true,
         };
         if is_last_key_le {
             right = array_size;
@@ -55,13 +55,13 @@ where {
                 mid_idx
             };
             let mid_val = unsafe { sorted_array.value_unchecked(corrected_idx) };
-            let is_key_val_le = match (key_val, sorted_array.is_valid(corrected_idx)) {
+            let is_key_val_lt = match (key_val, sorted_array.is_valid(corrected_idx)) {
                 (None, true) => false,
                 (None, false) => false,
                 (Some(key_val), true) => less(key_val, &mid_val),
                 (Some(_), false) => true,
             };
-            if is_key_val_le {
+            if is_key_val_lt {
                 right = mid_idx;
             } else {
                 left = mid_idx + 1;
@@ -93,7 +93,7 @@ fn search_sorted_utf_array<O: Offset>(
     for key_val in keys.iter() {
         let is_last_key_le = match (last_key, key_val) {
             (None, None) => false,
-            (Some(last_key), Some(key_val)) => last_key.le(key_val),
+            (Some(last_key), Some(key_val)) => last_key.lt(key_val),
             (None, _) => false,
             (_, None) => true,
         };
@@ -115,13 +115,13 @@ fn search_sorted_utf_array<O: Offset>(
                 mid_idx
             };
             let mid_val = unsafe { sorted_array.value_unchecked(corrected_idx) };
-            let is_key_val_le = match (key_val, sorted_array.is_valid(corrected_idx)) {
+            let is_key_val_lt = match (key_val, sorted_array.is_valid(corrected_idx)) {
                 (None, true) => false,
                 (None, false) => false,
-                (Some(key_val), true) => key_val.le(mid_val),
+                (Some(key_val), true) => key_val.lt(mid_val),
                 (_, false) => true,
             };
-            if is_key_val_le {
+            if is_key_val_lt {
                 right = mid_idx;
             } else {
                 left = mid_idx + 1;
@@ -306,10 +306,10 @@ pub fn search_sorted_multi_array(
         let mut right = sorted_array_size;
         while left < right {
             let mid_idx = left + ((right - left) >> 1);
-            if combined_comparator(mid_idx, key_idx).is_ge() {
-                right = mid_idx;
-            } else {
+            if combined_comparator(mid_idx, key_idx).is_lt() {
                 left = mid_idx + 1;
+            } else {
+                right = mid_idx;
             }
         }
         results.push(left.try_into().unwrap());

--- a/tests/internal/test_search_sorted.py
+++ b/tests/internal/test_search_sorted.py
@@ -75,10 +75,7 @@ def test_number_array_with_null_needle_reverse() -> None:
     pa_data = pa.chunked_array([[0, 1, 2, 2, 3, float("nan"), float("nan"), None, None][::-1]], type=pa.float32())
     pa_needle = pa.chunked_array([[-1, 2, float("nan"), None]], type=pa.float32())
     result = search_sorted(pa_data, pa_needle, input_reversed=True).to_numpy()
-    import ipdb
-
-    ipdb.set_trace()
-    assert np.all(result == np.array([9, 7, 4, 2]))
+    assert np.all(result == np.array([9, 7, 4, 0]))
 
 
 def test_multi_number_array_with_null_needle() -> None:
@@ -108,6 +105,33 @@ def test_number_array_with_nans() -> None:
     pa_needle = pa.chunked_array([[float("nan"), 2]], type=pa.float32())
     result = search_sorted(pa_data, pa_needle).to_numpy()
     assert np.all(result == np.array([2, 1]))
+
+
+def test_number_array_with_nans_reversed() -> None:
+    pa_data = pa.chunked_array([[2, float("nan")][::-1]], type=pa.float32())
+    pa_needle = pa.chunked_array([[float("nan"), 2]], type=pa.float32())
+    result = search_sorted(pa_data, pa_needle, input_reversed=True).to_numpy()
+    assert np.all(result == np.array([1, 2]))
+
+
+def test_multi_number_arrays_with_nans() -> None:
+    pa_data = pa.chunked_array([[2, float("nan")]], type=pa.float32())
+    data_table = pa.Table.from_pydict({"x": pa_data, "y": pa_data})
+
+    pa_needle = pa.chunked_array([[float("nan"), 2]], type=pa.float32())
+    needle_table = pa.Table.from_pydict({"x": pa_needle, "y": pa_needle})
+    result = search_sorted(data_table, needle_table).to_numpy()
+    assert np.all(result == np.array([2, 1]))
+
+
+def test_multi_number_arrays_with_nans_reversed() -> None:
+    pa_data = pa.chunked_array([[2, float("nan")][::-1]], type=pa.float32())
+    data_table = pa.Table.from_pydict({"x": pa_data, "y": pa_data})
+
+    pa_needle = pa.chunked_array([[float("nan"), 2]], type=pa.float32())
+    needle_table = pa.Table.from_pydict({"x": pa_needle, "y": pa_needle})
+    result = search_sorted(data_table, needle_table, input_reversed=True).to_numpy()
+    assert np.all(result == np.array([1, 2]))
 
 
 def test_str_array_with_empty_needle() -> None:

--- a/tests/internal/test_search_sorted.py
+++ b/tests/internal/test_search_sorted.py
@@ -14,13 +14,17 @@ float_types = [pa.float32(), pa.float64()]
 number_types = int_types + float_types
 
 
+def np_search_sorted(haystack, needles):
+    return np.searchsorted(haystack, needles, side="right")
+
+
 @pytest.mark.parametrize("num_chunks", range(1, 4))
 @pytest.mark.parametrize("dtype", number_types, ids=[repr(it) for it in number_types])
 def test_number_array(num_chunks, dtype) -> None:
     pa_keys = pa.chunked_array([np.array([4, 2, 1, 3], dtype=dtype.to_pandas_dtype()) for _ in range(num_chunks)])
     np_keys = pa_keys.to_numpy()
     np_sorted_arr = np.arange(100, dtype=dtype.to_pandas_dtype())
-    result = np.searchsorted(np_sorted_arr, np_keys)
+    result = np_search_sorted(np_sorted_arr, np_keys)
     pa_sorted_arr = pa.chunked_array([np_sorted_arr], type=dtype)
     pa_result = search_sorted(pa_sorted_arr, pa_keys)
 
@@ -34,7 +38,7 @@ def test_number_array(num_chunks, dtype) -> None:
 def test_number_array_with_nulls() -> None:
     keys = np.random.randint(0, 100, 1000)
     data = np.arange(100)
-    result = np.searchsorted(data, keys)
+    result = np_search_sorted(data, keys)
     pa_data = pa.chunked_array([data])
     pa_keys = pa.chunked_array([pa.chunked_array([keys] + [[None] * 10] + [keys]).combine_chunks()])
     pa_result = search_sorted(pa_data, pa_keys)
@@ -67,6 +71,38 @@ def test_number_array_with_null_needle() -> None:
     assert np.all(result == np.array([0, 4, 7, 9]))
 
 
+def test_number_array_with_null_needle_reverse() -> None:
+    pa_data = pa.chunked_array([[0, 1, 2, 2, 3, float("nan"), float("nan"), None, None][::-1]], type=pa.float32())
+    pa_needle = pa.chunked_array([[-1, 2, float("nan"), None]], type=pa.float32())
+    result = search_sorted(pa_data, pa_needle, input_reversed=True).to_numpy()
+    import ipdb
+
+    ipdb.set_trace()
+    assert np.all(result == np.array([9, 7, 4, 2]))
+
+
+def test_multi_number_array_with_null_needle() -> None:
+    pa_data = pa.chunked_array([[0, 1, 2, 2, 3, float("nan"), float("nan"), None, None]], type=pa.float32())
+
+    data_table = pa.Table.from_pydict({"x": pa_data, "y": pa_data})
+
+    pa_needle = pa.chunked_array([[-1, 2, float("nan"), None]], type=pa.float32())
+    needle_table = pa.Table.from_pydict({"x": pa_needle, "y": pa_needle})
+    result = search_sorted(data_table, needle_table).to_numpy()
+    assert np.all(result == np.array([0, 4, 7, 9]))
+
+
+def test_multi_number_array_with_null_needle_reverse() -> None:
+    pa_data = pa.chunked_array([[0, 1, 2, 2, 3, float("nan"), float("nan"), None, None][::-1]], type=pa.float32())
+
+    data_table = pa.Table.from_pydict({"x": pa_data, "y": pa_data})
+
+    pa_needle = pa.chunked_array([[-1, 2, float("nan"), None]], type=pa.float32())
+    needle_table = pa.Table.from_pydict({"x": pa_needle, "y": pa_needle})
+    result = search_sorted(data_table, needle_table, input_reversed=True).to_numpy()
+    assert np.all(result == np.array([9, 7, 4, 2]))
+
+
 def test_number_array_with_nans() -> None:
     pa_data = pa.chunked_array([[2, float("nan")]], type=pa.float32())
     pa_needle = pa.chunked_array([[float("nan"), 2]], type=pa.float32())
@@ -97,7 +133,7 @@ def test_string_array(str_len, num_chunks) -> None:
 
     data = np.array([gen_random_str(str_len + 1) for i in range(10)])
     data.sort()
-    result = np.searchsorted(data, keys)
+    result = np_search_sorted(data, keys)
     pa_data = pa.chunked_array([data])
     pa_result = search_sorted(pa_data, pa_keys)
     assert np.all(result == pa_result.to_numpy())
@@ -118,7 +154,7 @@ def test_string_array_with_nulls() -> None:
     keys = np.array(py_keys)
     data = np.array([gen_random_str(10 + 1) for i in range(10)])
     data.sort()
-    result = np.searchsorted(data, keys)
+    result = np_search_sorted(data, keys)
     pa_data = pa.chunked_array([data])
     pa_keys = pa.chunked_array([py_keys + [None] * 10 + py_keys])
     pa_result = search_sorted(pa_data, pa_keys)
@@ -153,7 +189,7 @@ def test_large_string_array(str_len, num_chunks) -> None:
     keys = pa_keys.cast(pa.string()).to_numpy()
     data = np.array([gen_random_str(10 + 1) for i in range(10)])
     data.sort()
-    result = np.searchsorted(data, keys)
+    result = np_search_sorted(data, keys)
     pa_data = pa.chunked_array([data]).cast(pa.large_string())
     pa_result = search_sorted(pa_data, pa_keys)
     pa_result = search_sorted(pa_data, pa_keys)
@@ -168,7 +204,7 @@ def test_large_string_array_with_nulls() -> None:
     keys = np.array(py_keys)
     data = np.array([gen_random_str(10 + 1) for i in range(10)])
     data.sort()
-    result = np.searchsorted(data, keys)
+    result = np_search_sorted(data, keys)
     pa_data = pa.chunked_array([data]).cast(pa.large_string())
     pa_keys = pa.chunked_array([py_keys + [None] * 10 + py_keys], type=pa.large_string())
     pa_result = search_sorted(pa_data, pa_keys)
@@ -185,7 +221,7 @@ def test_single_column_number_table(num_chunks, dtype) -> None:
     pa_keys = pa.chunked_array([np.array([4, 2, 1, 3], dtype=dtype.to_pandas_dtype()) for _ in range(num_chunks)])
     np_keys = pa_keys.to_numpy()
     np_sorted_arr = np.arange(100, dtype=dtype.to_pandas_dtype())
-    result = np.searchsorted(np_sorted_arr, np_keys)
+    result = np_search_sorted(np_sorted_arr, np_keys)
     pa_sorted_arr = pa.chunked_array([np_sorted_arr], type=dtype)
     pa_sorted_table = pa.table([pa_sorted_arr], ["a"])
     pa_table_keys = pa.table([pa_keys], ["a"])
@@ -210,7 +246,7 @@ def test_multi_column_number_table(num_chunks, dtype) -> None:
     np_keys = pa_keys.to_numpy()
     np_sorted_arr = np.arange(100, dtype=dtype.to_pandas_dtype())
 
-    result = np.searchsorted(np_sorted_arr, np_keys)
+    result = np_search_sorted(np_sorted_arr, np_keys)
 
     pa_sorted_arr = pa.chunked_array([np_sorted_arr], type=dtype)
 
@@ -241,7 +277,7 @@ def test_multi_column_mixed_number_table(num_chunks) -> None:
     np_keys = pa_keys.to_numpy()
     np_sorted_arr = np.arange(100, dtype=np.uint32())
 
-    result = np.searchsorted(np_sorted_arr, np_keys)
+    result = np_search_sorted(np_sorted_arr, np_keys)
 
     pa_sorted_arr = pa.chunked_array([np_sorted_arr], type=pa.uint32())
 
@@ -279,7 +315,7 @@ def test_number_string_table(str_len, num_chunks) -> None:
 
     data = np.array([gen_random_str(str_len + 1) for i in range(10)])
     data.sort()
-    result = np.searchsorted(data, keys)
+    result = np_search_sorted(data, keys)
     pa_data = pa.chunked_array([data])
     sorted_table = pa.table([np.zeros(10), pa_data], names=["a", "b"])
     key_table = pa.table([pa_int_keys, pa_str_keys], names=["a", "b"])
@@ -314,7 +350,7 @@ def test_number_string_table_desc(str_len, num_chunks) -> None:
 
     data = np.array([gen_random_str(str_len + 1) for i in range(100)])
     data.sort()
-    result = len(data) - np.searchsorted(data, keys)
+    result = len(data) - np_search_sorted(data, keys)
 
     data = data[::-1]
 
@@ -338,7 +374,7 @@ def test_string_number_table(str_len, num_chunks) -> None:
 
     data = np.array([gen_random_str(str_len + 1) for i in range(10)])
     data.sort()
-    result = np.searchsorted(data, keys)
+    result = np_search_sorted(data, keys)
     pa_data = pa.chunked_array([data])
     sorted_table = pa.table([pa_data, np.zeros(10)], names=["a", "b"])
     key_table = pa.table([pa_str_keys, pa_int_keys], names=["a", "b"])
@@ -359,7 +395,7 @@ def test_string_table(str_len, num_chunks) -> None:
 
     data = np.array([gen_random_str(str_len + 1) for i in range(10)])
     data.sort()
-    result = np.searchsorted(data, keys)
+    result = np_search_sorted(data, keys)
     pa_data = pa.chunked_array([data])
 
     sorted_table = pa.table([pa_data, pa_data, pa_data], names=["a", "b", "c"])
@@ -376,7 +412,7 @@ def test_string_table_with_nulls() -> None:
     keys = np.array(py_keys)
     data = np.array([gen_random_str(10 + 1) for i in range(10)])
     data.sort()
-    result = np.searchsorted(data, keys)
+    result = np_search_sorted(data, keys)
     pa_data = pa.chunked_array([data])
     pa_keys = pa.chunked_array([py_keys + [None] * 10 + py_keys])
     pa_data_table = pa.table([pa_data, pa_data], names=["a", "b"])

--- a/tests/internal/test_search_sorted.py
+++ b/tests/internal/test_search_sorted.py
@@ -39,7 +39,6 @@ def test_number_array_with_nulls() -> None:
     pa_keys = pa.chunked_array([pa.chunked_array([keys] + [[None] * 10] + [keys]).combine_chunks()])
     pa_result = search_sorted(pa_data, pa_keys)
     np_result = pa_result.to_numpy()
-
     assert np.all(result == np_result[:1000])
     assert np.all(result == np_result[1000 + 10 :])
     assert np.all(np_result[1000 : 1000 + 10] == np_result[1000])

--- a/tests/internal/test_search_sorted.py
+++ b/tests/internal/test_search_sorted.py
@@ -67,6 +67,13 @@ def test_number_array_with_null_needle() -> None:
     assert np.all(result == np.array([0, 4, 7, 9]))
 
 
+def test_number_array_with_nans() -> None:
+    pa_data = pa.chunked_array([[2, float("nan")]], type=pa.float32())
+    pa_needle = pa.chunked_array([[float("nan"), 2]], type=pa.float32())
+    result = search_sorted(pa_data, pa_needle).to_numpy()
+    assert np.all(result == np.array([2, 1]))
+
+
 def test_str_array_with_empty_needle() -> None:
     pa_data = pa.chunked_array([["a", "b", "c"]], type=pa.string())
     pa_needle = pa.chunked_array([["", None]], type=pa.string())

--- a/tests/internal/test_search_sorted.py
+++ b/tests/internal/test_search_sorted.py
@@ -61,6 +61,21 @@ def test_number_array_with_nulls() -> None:
     assert np.all(np_result_slice[1000 : 1000 + 10] == np_result_slice[1000])
 
 
+def test_number_array_with_null_needle() -> None:
+    pa_data = pa.chunked_array([[0, 1, 2, 2, 3, float("nan"), float("nan"), None, None]], type=pa.float32())
+    pa_needle = pa.chunked_array([[-1, 2, float("nan"), None]], type=pa.float32())
+    result = search_sorted(pa_data, pa_needle).to_numpy()
+    assert np.all(result == np.array([0, 4, 7, 9]))
+
+
+def test_str_array_with_empty_needle() -> None:
+    pa_data = pa.chunked_array([["a", "b", "c"]], type=pa.string())
+    pa_needle = pa.chunked_array([["", None]], type=pa.string())
+    search_sorted(pa_data, pa_needle)
+    result = search_sorted(pa_data, pa_needle).to_numpy()
+    assert np.all(result == np.array([0, 3]))
+
+
 def gen_random_str(k: int):
     return "".join(random.choices(string.ascii_uppercase + string.ascii_lowercase, k=k))
 


### PR DESCRIPTION
* Here we fix the behavior of nulls and nans in Search Sorted.
* fixed a bug for Nulls when sorting in reverse
* set ordering of nans to be `value < nan < null`
* fix bug when sorting in reverse that led to bisect left behavior rather than bisect right