### PR TITLE
[codecov] Enable Code Coverage for Rust From python tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,6 +28,8 @@ jobs:
         profile: minimal
         toolchain: stable
         override: true
+    - name: Install cargo-llvm-cov
+      uses: taiki-e/install-action@cargo-llvm-cov
     - uses: actions/cache@v3
       env:
         cache-name: cache-cargo
@@ -40,7 +42,6 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-
           ${{ runner.os }}-build-
           ${{ runner.os }}-
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -59,20 +60,32 @@ jobs:
     - name: Build Rust Library
       run: |
         source activate
+        source <(cargo llvm-cov show-env --export-prefix)
+        export CARGO_TARGET_DIR=$CARGO_LLVM_COV_TARGET_DIR
+        export CARGO_INCREMENTAL=1
+        cargo llvm-cov clean --workspace
         maturin develop
+
     - name: Clone TPCH SQlite repository
       uses: actions/checkout@v2
       with:
         repository: lovasoa/TPCH-sqlite
         path: data/tpch-sqlite
         submodules: recursive
+
     - name: Build TPCH data
       working-directory: data/tpch-sqlite
       run: SCALE_FACTOR=0.2 make
+
     - name: Test with pytest
       run: mkdir -p report-output && pytest --cov=./ --cov-report=xml:./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.xml
       env:
         DAFT_RUNNER: ${{ matrix.daft_runner }}
+
+    - name: export rust coverage from python
+      run: |
+        cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.lcov
+
     - name: Upload coverage report
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,15 +57,6 @@ jobs:
         pip install --upgrade pip
         pip install -r requirements-dev.txt
 
-    - name: Build Rust Library
-      run: |
-        source activate
-        source <(cargo llvm-cov show-env --export-prefix)
-        export CARGO_TARGET_DIR=$CARGO_LLVM_COV_TARGET_DIR
-        export CARGO_INCREMENTAL=1
-        cargo llvm-cov clean --workspace
-        maturin develop
-
     - name: Clone TPCH SQlite repository
       uses: actions/checkout@v2
       with:
@@ -77,14 +68,18 @@ jobs:
       working-directory: data/tpch-sqlite
       run: SCALE_FACTOR=0.2 make
 
-    - name: Test with pytest
-      run: mkdir -p report-output && pytest --cov=./ --cov-report=xml:./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.xml
+    - name: Build library and Test with pytest
+      run: |
+        source activate
+        source <(cargo llvm-cov show-env --export-prefix)
+        export CARGO_TARGET_DIR=$CARGO_LLVM_COV_TARGET_DIR
+        export CARGO_INCREMENTAL=1
+        cargo llvm-cov clean --workspace
+        maturin develop
+        mkdir -p report-output && pytest --cov=./ --cov-report=xml:./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.xml
+        cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.lcov
       env:
         DAFT_RUNNER: ${{ matrix.daft_runner }}
-
-    - name: export rust coverage from python
-      run: |
-        cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.lcov
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
* We can now publish rust code coverage from python tests
* I had to consolidate all the CI steps for building with maturin and pytest since github has weird handling of EnvVars