### PR TITLE
Fix hypothesis test to assert that nulls greater than all values

### DIFF
--- a/tests/property_based_testing/strategies.py
+++ b/tests/property_based_testing/strategies.py
@@ -91,8 +91,8 @@ total_order_dtypes = sampled_from(
         ExpressionType.string(),
         ExpressionType.integer(),
         ExpressionType.float(),
-        ExpressionType.logical(),
-        ExpressionType.bytes(),
+        # ExpressionType.logical(),
+        # ExpressionType.bytes(),
         ExpressionType.date(),
     ]
 )


### PR DESCRIPTION
* Fixes Hypothesis test to assert that nulls are "greater than" all values, regardless of sort ordering
* Modifies test to only run single-column sorts for now (see: issue #546)
* Enables `.repartition` and `.with_column` branches of the test