### PR TITLE
Fix Ray grpcio issues in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,12 @@ all = ["daft[aws, ray]"]
 aws = ["s3fs"]
 experimental = ["daft[serving, iceberg]"]
 iceberg = ["icebridge"]
-ray = ["ray[data, default]>=1.10.0"]  # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
+ray = [
+  # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
+  "ray[data, default]>=1.10.0",
+  # Ray has a bug with grpcio 1.52.0: https://github.com/ray-project/ray/issues/32246
+  "grpcio<=1.51.1"
+]
 serving = ["fastapi", "docker", "uvicorn", "cloudpickle", "boto3", "PyYAML"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ ray = [
   # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
   "ray[data, default]>=1.10.0",
   # Ray has a bug with grpcio 1.52.0: https://github.com/ray-project/ray/issues/32246
-  "grpcio<=1.51.1"
+  "grpcio<1.52.0"
 ]
 serving = ["fastapi", "docker", "uvicorn", "cloudpickle", "boto3", "PyYAML"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,9 @@ docker
 
 # For aws and serving
 fastapi
+
+# Pinned for Ray
+grpcio==1.51.1
 hypothesis
 icebridge
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,39 +1,31 @@
 boto3
 cloudpickle
 docker
-
-# For aws and serving
 fastapi
+
+# Pin due to Ray issue: https://github.com/ray-project/ray/issues/32246
+grpcio<1.52.0
+
 hypothesis
 icebridge
-
-# DevTools
 ipdb
 lxml
 maturin
 myst-nb>=0.16.0
 numpy < 1.24
+
 # orjson recommended for viztracer
 orjson
+
 pandas
 pre-commit
 pyarrow
-
-# Tooling
-
-
-
-# needed for testing
 pytest>=7.1.2
 pytest-benchmark
 pytest-cov
 PyYAML
-
 ray[data, default]
 s3fs
-
-# needed for Docs
-
 Sphinx <= 5
 sphinx-book-theme>=0.3.3
 sphinx-reredirects>=0.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,9 +4,6 @@ docker
 
 # For aws and serving
 fastapi
-
-# Pinned for Ray
-grpcio==1.51.1
 hypothesis
 icebridge
 


### PR DESCRIPTION
Ray is having issues with the new `1.52.0` release of `grpcio`: https://github.com/ray-project/ray/issues/32246

We pin our version of grpcio as a temporary workaround.