### PR TITLE
Better testing and validation of DataFrame.from_py* constructors

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -245,6 +245,8 @@ class DataFrame:
         """
         headers: set[str] = set()
         for row in data:
+            if not isinstance(row, dict):
+                raise ValueError(f"Expected list of dictionaries of {{column_name: value}}, received: {type(row)}")
             headers.update(row.keys())
         return cls.from_pydict(data={header: [row.get(header, None) for row in data] for header in headers})
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -282,6 +282,8 @@ class DataFrame:
                 column_types[header] = ExpressionType.null()
             elif len(found_types) == 1:
                 column_types[header] = ExpressionType.from_py_type(found_types.pop())
+            elif found_types == {int, float}:
+                column_types[header] = ExpressionType.float()
             else:
                 column_types[header] = ExpressionType.python_object()
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, Union
 
 import pandas
-import pyarrow as pa
 
 from daft import resource_request
 from daft.api_annotations import DataframePublicAPI
@@ -33,7 +32,6 @@ from daft.runners.partitioning import (
     vPartitionSchemaInferenceOptions,
 )
 from daft.runners.pyrunner import LocalPartitionSet
-from daft.types import PythonExpressionType
 from daft.viz import DataFrameDisplay
 
 if TYPE_CHECKING:
@@ -252,7 +250,7 @@ class DataFrame:
 
     @classmethod
     @DataframePublicAPI
-    def from_pydict(cls, data: dict[str, list | pa.Array]) -> DataFrame:
+    def from_pydict(cls, data: dict[str, list]) -> DataFrame:
         """Creates a DataFrame from a Python dictionary
 
         Example:
@@ -260,7 +258,7 @@ class DataFrame:
 
         Args:
             data: Key -> Sequence[item] of data. Each Key is created as a column, and must have a value that is
-                either a Python list or PyArrow array. Values must be equal in length across all keys.
+                a Python list. Values must be equal in length across all keys.
 
         Returns:
             DataFrame: DataFrame created from dictionary of columns
@@ -271,35 +269,25 @@ class DataFrame:
                 f"Expected all columns to be of the same length, but received columns with lengths: {column_lengths}"
             )
 
-        block_data: dict[str, tuple[ExpressionType, Any]] = {}
         for header in data:
-            arr = data[header]
-
-            if isinstance(arr, pa.Array) or isinstance(arr, pa.ChunkedArray):
-                expr_type = ExpressionType.from_arrow_type(arr.type)
-                block_data[header] = (expr_type, arr.to_pylist() if ExpressionType.is_py(expr_type) else arr)
-                continue
-
-            try:
-                arrow_type = pa.infer_type(arr)
-            except pa.lib.ArrowInvalid:
-                arrow_type = None
-
-            if arrow_type is None or pa.types.is_nested(arrow_type):
-                found_types = {type(o) for o in data[header]} - {type(None)}
-                block_data[header] = (
-                    (ExpressionType.python_object(), list(arr))
-                    if len(found_types) > 1
-                    else (PythonExpressionType(found_types.pop()), list(arr))
+            if not isinstance(data[header], list):
+                raise ValueError(
+                    f"Expected all columns to be of type list, but received {type(data[header])} for {header}"
                 )
-                continue
 
-            expr_type = ExpressionType.from_arrow_type(arrow_type)
-            block_data[header] = (expr_type, list(arr) if ExpressionType.is_py(expr_type) else pa.array(arr))
+        column_types: dict[str, ExpressionType] = {}
+        for header in data:
+            found_types = {type(o) for o in data[header]} - {type(None)}
+            if len(found_types) == 0:
+                column_types[header] = ExpressionType.null()
+            elif len(found_types) == 1:
+                column_types[header] = ExpressionType.from_py_type(found_types.pop())
+            else:
+                column_types[header] = ExpressionType.python_object()
 
-        schema = Schema([Field(header, expr_type) for header, (expr_type, _) in block_data.items()])
+        schema = Schema([Field(header, expr_type) for header, expr_type in column_types.items()])
         data_vpartition = vPartition.from_pydict(
-            data={header: arr for header, (_, arr) in block_data.items()}, schema=schema, partition_id=0
+            data={header: arr for header, arr in data.items()}, schema=schema, partition_id=0
         )
         result_pset = LocalPartitionSet({0: data_vpartition})
 

--- a/daft/execution/operators.py
+++ b/daft/execution/operators.py
@@ -242,6 +242,7 @@ class OperatorEnum(Enum):
         name="cast_int",
         type_matrix=frozenset(
             {
+                (ExpressionType.null(),): ExpressionType.integer(),
                 (ExpressionType.integer(),): ExpressionType.integer(),
                 (ExpressionType.float(),): ExpressionType.integer(),
                 (ExpressionType.logical(),): ExpressionType.integer(),
@@ -253,6 +254,7 @@ class OperatorEnum(Enum):
         name="cast_float",
         type_matrix=frozenset(
             {
+                (ExpressionType.null(),): ExpressionType.float(),
                 (ExpressionType.float(),): ExpressionType.float(),
                 (ExpressionType.integer(),): ExpressionType.float(),
                 (ExpressionType.python_object(),): ExpressionType.float(),
@@ -263,6 +265,7 @@ class OperatorEnum(Enum):
         name="cast_string",
         type_matrix=frozenset(
             {
+                (ExpressionType.null(),): ExpressionType.string(),
                 (ExpressionType.string(),): ExpressionType.string(),
                 (ExpressionType.integer(),): ExpressionType.string(),
                 (ExpressionType.logical(),): ExpressionType.string(),
@@ -275,6 +278,7 @@ class OperatorEnum(Enum):
         name="cast_logical",
         type_matrix=frozenset(
             {
+                (ExpressionType.null(),): ExpressionType.logical(),
                 (ExpressionType.logical(),): ExpressionType.logical(),
                 (ExpressionType.python_object(),): ExpressionType.logical(),
             }.items()
@@ -284,6 +288,7 @@ class OperatorEnum(Enum):
         name="cast_date",
         type_matrix=frozenset(
             {
+                (ExpressionType.null(),): ExpressionType.date(),
                 (ExpressionType.date(),): ExpressionType.date(),
                 (ExpressionType.python_object(),): ExpressionType.date(),
             }.items()
@@ -293,6 +298,7 @@ class OperatorEnum(Enum):
         name="cast_bytes",
         type_matrix=frozenset(
             {
+                (ExpressionType.null(),): ExpressionType.bytes(),
                 (ExpressionType.bytes(),): ExpressionType.bytes(),
                 (ExpressionType.python_object(),): ExpressionType.bytes(),
             }.items()

--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -453,7 +453,7 @@ class Sort(UnaryNode):
         for e in self._sort_by:
             dtype = e.resolve_type(input.schema())
             if dtype in {ExpressionType.null(), ExpressionType.bytes(), ExpressionType.logical()}:
-                raise ExpressionTypeError(f"Cannot sort on expression {e} with type: {e}")
+                raise ExpressionTypeError(f"Cannot sort on expression {e} with type: {dtype}")
 
         if isinstance(descending, bool):
             self._descending = [descending for _ in self._sort_by]

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -225,17 +225,13 @@ class vPartition:
         fields = schema.fields
         tiles = {}
         for f in fields.values():
-
             col_name = f.name
             col_type = f.dtype
-            col_data = data[col_name]
-
-            if ExpressionType.is_py(col_type):
-                col_data = list(col_data)
-            else:
-                if not isinstance(col_data, pa.Array) and not isinstance(col_data, pa.ChunkedArray):
-                    col_data = pa.array(col_data, type=col_type.to_arrow_type())
-
+            col_data = (
+                data[col_name]
+                if ExpressionType.is_py(col_type)
+                else pa.array(data[col_name], type=col_type.to_arrow_type())
+            )
             block = DataBlock.make_block(col_data)
             tiles[col_name] = PyListTile(column_name=col_name, partition_id=partition_id, block=block)
         return vPartition(columns=tiles, partition_id=partition_id)

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -38,6 +38,12 @@ def test_load_missing(read_method):
         getattr(DataFrame, read_method)(str(uuid.uuid4()))
 
 
+@pytest.mark.parametrize("data", [{"foo": [1, 2, 3]}, [{"foo": i} for i in range(3)], "foo"])
+def test_error_thrown_create_dataframe_constructor(data) -> None:
+    with pytest.raises(ValueError):
+        DataFrame(data)
+
+
 ###
 # List tests
 ###
@@ -95,10 +101,10 @@ def test_create_dataframe_pydict_ragged_col_lens() -> None:
     assert "Expected all columns to be of the same length" in str(e.value)
 
 
-@pytest.mark.parametrize("data", [{"foo": [1, 2, 3]}, [{"foo": i} for i in range(3)], "foo"])
-def test_error_thrown_create_dataframe_constructor(data) -> None:
-    with pytest.raises(ValueError):
-        DataFrame(data)
+def test_create_dataframe_pydict_bad_columns() -> None:
+    with pytest.raises(ValueError) as e:
+        DataFrame.from_pydict({"foo": "somestring"})
+    assert "Expected all columns to be of type list" in str(e.value)
 
 
 def test_load_pydict_types():

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -105,6 +105,7 @@ def test_load_pydict_types():
     data = {
         "arrow_int": [None, 2, 3],
         "arrow_float": [None, 1.0, 3.0],
+        "arrow_mixed_numbers": [None, 1.0, 3],
         "arrow_str": [None, "b", "c"],
         "arrow_struct": [None, {"foo": 1}, {"bar": 1}],
         "arrow_nulls": [None, None, None],
@@ -120,6 +121,7 @@ def test_load_pydict_types():
     expected = {
         "arrow_int": ExpressionType.integer(),
         "arrow_float": ExpressionType.float(),
+        "arrow_mixed_numbers": ExpressionType.float(),
         "arrow_str": ExpressionType.string(),
         "arrow_struct": ExpressionType.from_py_type(dict),
         "arrow_nulls": ExpressionType.null(),

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -79,6 +79,12 @@ def test_create_dataframe_list_empty_dicts() -> None:
     assert df.column_names == []
 
 
+def test_create_dataframe_list_non_dicts() -> None:
+    with pytest.raises(ValueError) as e:
+        DataFrame.from_pylist([1, 2, 3])
+    assert "Expected list of dictionaries of {column_name: value}" in str(e.value)
+
+
 ###
 # Dict tests
 ###

--- a/tests/dataframe_cookbook/test_explodes.py
+++ b/tests/dataframe_cookbook/test_explodes.py
@@ -4,7 +4,6 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
 import pytest
 
 from daft import DataFrame, col
@@ -54,7 +53,7 @@ def test_explode_single_col_pylist(nrepartitions):
 @pytest.mark.parametrize("nrepartitions", [1, 5])
 def test_explode_single_col_arrow(nrepartitions):
     data = {
-        "explode": pa.array([[1, 2, 3], [4, 5], [], None]),
+        "explode": [[1, 2, 3], [4, 5], [], None],
         "repeat": ["a", "b", "c", "d"],
         "repeat2": ["a", "b", "c", "d"],
     }

--- a/tests/null_tests/test_aggregations.py
+++ b/tests/null_tests/test_aggregations.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import pyarrow as pa
 import pytest
 
 from daft import DataFrame, col
@@ -239,7 +238,7 @@ def test_agg_groupby_null_type_column():
         {
             "id": [1, 2, 3, 4],
             "group": [1, 1, 2, 2],
-            "values": pa.array([None, None, None, None], type=pa.null()),
+            "values": [None, None, None, None],
         }
     )
     daft_df = daft_df.groupby(col("group"))
@@ -285,13 +284,14 @@ def test_all_null_groupby_keys(repartition_nparts):
     daft_df = DataFrame.from_pydict(
         {
             "id": [0, 1, 2],
-            "group": pa.array([None, None, None], type=pa.int64()),
+            "group": [None, None, None],
             "values": [1, 2, 3],
         }
     )
 
     daft_df = (
         daft_df.repartition(repartition_nparts)
+        .with_column("group", daft_df["group"].cast(int))
         .groupby(col("group"))
         .agg(
             [
@@ -312,7 +312,7 @@ def test_null_type_column_groupby_keys():
     daft_df = DataFrame.from_pydict(
         {
             "id": [0, 1, 2],
-            "group": pa.array([None, None, None], pa.null()),
+            "group": [None, None, None],
             "values": [1, 2, 3],
         }
     )

--- a/tests/null_tests/test_distinct.py
+++ b/tests/null_tests/test_distinct.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pyarrow as pa
 import pytest
 
 from daft import DataFrame
@@ -30,11 +29,11 @@ def test_distinct_with_nulls(repartition_nparts):
 def test_distinct_with_all_nulls(repartition_nparts):
     daft_df = DataFrame.from_pydict(
         {
-            "id": pa.array([None, None, None, None], type=pa.int64()),
+            "id": [None, None, None, None],
             "values": ["a1", "b1", "b1", "c1"],
         }
     ).repartition(repartition_nparts)
-    daft_df = daft_df.distinct()
+    daft_df = daft_df.with_column("id", daft_df["id"].cast(int)).distinct()
 
     expected = {
         "id": [None, None, None],

--- a/tests/null_tests/test_joins.py
+++ b/tests/null_tests/test_joins.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pyarrow as pa
 import pytest
 
 from daft import DataFrame
@@ -66,17 +65,17 @@ def test_inner_join_multikey(repartition_nparts):
 def test_inner_join_all_null(repartition_nparts):
     daft_df = DataFrame.from_pydict(
         {
-            "id": pa.array([None, None, None], type=pa.int64()),
+            "id": [None, None, None],
             "values_left": ["a1", "b1", "c1"],
         }
     ).repartition(repartition_nparts)
     daft_df2 = DataFrame.from_pydict(
         {
-            "id": pa.array([1, 2, 3], type=pa.int64()),
+            "id": [1, 2, 3],
             "values_right": ["a2", "b2", "c2"],
         }
     ).repartition(repartition_nparts)
-    daft_df = daft_df.join(daft_df2, on="id", how="inner")
+    daft_df = daft_df.with_column("id", daft_df["id"].cast(int)).join(daft_df2, on="id", how="inner")
 
     expected = {
         "id": [],
@@ -90,13 +89,13 @@ def test_inner_join_all_null(repartition_nparts):
 def test_inner_join_null_type_column():
     daft_df = DataFrame.from_pydict(
         {
-            "id": pa.array([None, None, None], type=pa.null()),
+            "id": [None, None, None],
             "values_left": ["a1", "b1", "c1"],
         }
     )
     daft_df2 = DataFrame.from_pydict(
         {
-            "id": pa.array([None, None, None], type=pa.null()),
+            "id": [None, None, None],
             "values_right": ["a2", "b2", "c2"],
         }
     )

--- a/tests/null_tests/test_sorts.py
+++ b/tests/null_tests/test_sorts.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pyarrow as pa
 import pytest
 
 from daft import DataFrame
@@ -69,11 +68,11 @@ def test_sort_with_nulls_multikey(repartition_nparts):
 def test_sort_with_all_nulls(repartition_nparts):
     daft_df = DataFrame.from_pydict(
         {
-            "id": pa.array([None, None, None], type=pa.int64()),
+            "id": [None, None, None],
             "values": ["c1", None, "a1"],
         }
     ).repartition(repartition_nparts)
-    daft_df = daft_df.sort(daft_df["id"])
+    daft_df = daft_df.with_column("id", daft_df["id"].cast(int)).sort(daft_df["id"])
     daft_df.collect()
 
     resultset = daft_df.to_pydict()
@@ -100,7 +99,7 @@ def test_sort_with_empty(repartition_nparts):
 def test_sort_with_all_null_type_column():
     daft_df = DataFrame.from_pydict(
         {
-            "id": pa.array([None, None, None], pa.null()),
+            "id": [None, None, None],
             "values": ["a1", "b1", "c1"],
         }
     )


### PR DESCRIPTION
* Refactors DataFrame.from_pydict to take in Python lists only, vastly simplifying the logic and helping testing
* Closes #507 - adds validation for `.from_pylist()`
* Adds validation for `.from_pydict()`