### PR TITLE
Fix style CI isort issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     args: [--autofix]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
     name: isort (python)


### PR DESCRIPTION
CI's `isort` seems to be broken if any changes are made to the pre-commit config