### PR TITLE
Run code coverage per process to get better ray coverage

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -77,7 +77,7 @@ jobs:
         cargo llvm-cov clean --workspace
         maturin develop
         mkdir -p report-output && pytest --cov=daft
-        coverage combine -a || True
+        coverage combine -a || true
         coverage xml -o ./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.xml
         cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.lcov
       env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -76,7 +76,9 @@ jobs:
         export CARGO_INCREMENTAL=1
         cargo llvm-cov clean --workspace
         maturin develop
-        mkdir -p report-output && pytest --cov=./ --cov-report=xml:./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.xml
+        mkdir -p report-output && pytest --cov=daft
+        coverage combine -a
+        coverage xml -o ./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.xml
         cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.lcov
       env:
         DAFT_RUNNER: ${{ matrix.daft_runner }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -77,7 +77,7 @@ jobs:
         cargo llvm-cov clean --workspace
         maturin develop
         mkdir -p report-output && pytest --cov=daft
-        coverage combine -a || true
+        coverage combine -a --data-file='.coverage' || true
         coverage xml -o ./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.xml
         cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.lcov
       env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -77,7 +77,7 @@ jobs:
         cargo llvm-cov clean --workspace
         maturin develop
         mkdir -p report-output && pytest --cov=daft
-        coverage combine -a
+        coverage combine -a || True
         coverage xml -o ./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.xml
         cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.lcov
       env:

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -6,6 +6,22 @@ from typing import TYPE_CHECKING
 from daft.logging import setup_logger
 
 ###
+# Set up code coverage for when running code coverage with ray
+###
+if "COV_CORE_SOURCE" in os.environ:
+    try:
+        from pytest_cov.embed import init
+
+        init()
+    except Exception as exc:
+        import sys
+
+        sys.stderr.write(
+            "pytest-cov: Failed to setup subprocess coverage. "
+            "Environ: {!r} "
+            "Exception: {!r}\n".format({k: v for k, v in os.environ.items() if k.startswith("COV_CORE")}, exc)
+        )
+###
 # Setup logging
 ###
 


### PR DESCRIPTION
* init code coverage in daft init if we detect code coverage is being ran
* This should give us our code coverage for when we use the ray runner.