### PR TITLE
Refactor code to retrieve visualization logic from a registry

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -73,5 +73,6 @@ from daft.datatype import DataType
 from daft.expressions import col, lit
 from daft.series import Series
 from daft.udf import polars_udf, udf
+from daft.viz import register_viz_hook
 
-__all__ = ["DataFrame", "col", "DataType", "lit", "udf", "polars_udf", "Series"]
+__all__ = ["DataFrame", "col", "DataType", "lit", "udf", "polars_udf", "Series", "register_viz_hook"]

--- a/daft/viz/__init__.py
+++ b/daft/viz/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
 from .dataframe_display import DataFrameDisplay
+from .html_viz_hooks import register_viz_hook
 
-__all__ = ["DataFrameDisplay"]
+__all__ = ["DataFrameDisplay", "register_viz_hook"]

--- a/daft/viz/html_viz_hooks.py
+++ b/daft/viz/html_viz_hooks.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import base64
+import io
+from typing import TYPE_CHECKING, Callable, TypeVar
+
+if TYPE_CHECKING:
+    import numpy as np
+    import PIL.Image
+
+
+HookClass = TypeVar("HookClass")
+
+_VIZ_HOOKS_REGISTRY = {}
+
+
+def register_viz_hook(klass: type[HookClass], hook: Callable[[HookClass], str]):
+    """Registers a visualization hook that returns the appropriate HTML for
+    visualizing a specific class in HTML"""
+    _VIZ_HOOKS_REGISTRY[klass] = hook
+
+
+def get_viz_hook(val: HookClass) -> Callable[[HookClass], str] | None:
+    for klass in _VIZ_HOOKS_REGISTRY:
+        if isinstance(val, klass):
+            return _VIZ_HOOKS_REGISTRY[klass]
+    return None
+
+
+###
+# Default hooks, registered at import-time
+###
+
+HAS_PILLOW = True
+try:
+    import PIL.Image
+except ImportError:
+    HAS_PILLOW = False
+
+HAS_NUMPY = True
+try:
+    import numpy as np
+except ImportError:
+    HAS_NUMPY = False
+
+if HAS_PILLOW:
+
+    def _viz_pil_image(val: PIL.Image.Image):
+        img = val.copy()
+        img.thumbnail((128, 128))
+        bio = io.BytesIO()
+        img.save(bio, "JPEG")
+        base64_img = base64.b64encode(bio.getvalue())
+        return f'<img style="max-height:128px;width:auto" src="data:image/png;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
+
+    register_viz_hook(PIL.Image.Image, _viz_pil_image)
+
+if HAS_NUMPY:
+
+    def _viz_numpy(val: np.ndarray):
+        return f"&ltnp.ndarray<br>shape={val.shape}<br>dtype={val.dtype}&gt"
+
+    register_viz_hook(np.ndarray, _viz_numpy)

--- a/daft/viz/repr.py
+++ b/daft/viz/repr.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import base64
-import io
+import html
 from typing import Any, Callable, Iterable
 
 from tabulate import tabulate
@@ -9,21 +8,7 @@ from tabulate import tabulate
 from daft.logical.schema import Schema
 from daft.runners.partitioning import vPartition
 from daft.types import ExpressionType
-
-try:
-    import PIL.Image
-
-    HAS_PILLOW = True
-except ImportError:
-    HAS_PILLOW = False
-
-try:
-    import numpy as np
-
-    HAS_NUMPY = True
-except ImportError:
-    HAS_NUMPY = False
-
+from daft.viz.html_viz_hooks import get_viz_hook
 
 DEFAULT_MAX_COL_WIDTH = 20
 DEFAULT_MAX_LINES = 3
@@ -44,16 +29,10 @@ def _stringify_object_default(val: Any, max_col_width: int, max_lines: int):
 
 def _stringify_object_html(val: Any, max_col_width: int, max_lines: int):
     """Stringifies Python objects, with custom handling for specific objects that Daft recognizes as media types"""
-    if HAS_PILLOW and isinstance(val, PIL.Image.Image):
-        img = val.copy()
-        img.thumbnail((128, 128))
-        bio = io.BytesIO()
-        img.save(bio, "JPEG")
-        base64_img = base64.b64encode(bio.getvalue())
-        return f'<img style="max-height:128px;width:auto" src="data:image/png;base64, {base64_img.decode("utf-8")}" alt="{str(val)}" />'
-    elif HAS_NUMPY and isinstance(val, np.ndarray):
-        return f"&ltnp.ndarray<br>shape={val.shape}<br>dtype={val.dtype}&gt"
-    return _truncate(str(val), max_col_width, max_lines)
+    viz_hook = get_viz_hook(val)
+    if viz_hook is not None:
+        return viz_hook(val)
+    return html.escape(_truncate(str(val), max_col_width, max_lines))
 
 
 def _stringify_vpartition(

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 
+import numpy as np
 import pandas as pd
 
 from daft import DataFrame
@@ -101,10 +102,10 @@ def test_empty_df_repr():
 
 
 def test_alias_repr():
-    df = DataFrame.from_pydict({"A": [1, 2, 3], "B": ["a", "b", "c"]})
-    df = df.select(df["A"].alias("A2"), df["B"])
+    df = DataFrame.from_pydict({"A": [1, 2, 3], "B": ["a", "b", "c"], "NP": [np.ones((i,)) for i in range(1, 4)]})
+    df = df.select(df["A"].alias("A2"), df["B"], df["NP"])
 
-    expected_data = {"A2": ("INTEGER", []), "B": ("STRING", [])}
+    expected_data = {"A2": ("INTEGER", []), "B": ("STRING", []), "NP": ("PY[ndarray]", [])}
     assert parse_str_table(df.__repr__(), expected_user_msg_regex=UNMATERIALIZED_REGEX) == expected_data
     assert parse_html_table(df._repr_html_(), expected_user_msg_regex=UNMATERIALIZED_REGEX) == expected_data
 
@@ -119,6 +120,14 @@ def test_alias_repr():
             "STRING",
             ["a", "b", "c"],
         ),
+        "NP": (
+            "PY[ndarray]",
+            [str(np.ones((i,))) for i in range(1, 4)],
+        ),
+    }
+    expected_data_html = {
+        **expected_data,
+        "NP": ("PY[ndarray]", [f"&ltnp.ndarray shape=({i},) dtype=float64&gt" for i in range(1, 4)]),
     }
     assert parse_str_table(df.__repr__()) == expected_data
-    assert parse_html_table(df._repr_html_()) == expected_data
+    assert parse_html_table(df._repr_html_()) == expected_data_html


### PR DESCRIPTION
* Visualization logic can be registered with Daft at runtime with `daft.viz.register_viz_hook`
* Refactors code for visualizing PIL and Numpy to now be registered with `register_viz_hook` at import-time of the module