### PR TITLE
Allow for creation of DataFrames from numpy/Pyarrow arrays in .from_pydict

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -4,6 +4,7 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, Union
 
+import numpy as np
 import pandas
 
 from daft import resource_request
@@ -254,7 +255,7 @@ class DataFrame:
 
     @classmethod
     @DataframePublicAPI
-    def from_pydict(cls, data: dict[str, list]) -> DataFrame:
+    def from_pydict(cls, data: dict[str, list | np.ndarray]) -> DataFrame:
         """Creates a DataFrame from a Python dictionary
 
         Example:
@@ -262,7 +263,7 @@ class DataFrame:
 
         Args:
             data: Key -> Sequence[item] of data. Each Key is created as a column, and must have a value that is
-                a Python list. Values must be equal in length across all keys.
+                a Python list or Numpy array. Values must be equal in length across all keys.
 
         Returns:
             DataFrame: DataFrame created from dictionary of columns
@@ -273,24 +274,7 @@ class DataFrame:
                 f"Expected all columns to be of the same length, but received columns with lengths: {column_lengths}"
             )
 
-        for header in data:
-            if not isinstance(data[header], list):
-                raise ValueError(
-                    f"Expected all columns to be of type list, but received {type(data[header])} for {header}"
-                )
-
-        column_types: dict[str, ExpressionType] = {}
-        for header in data:
-            found_types = {type(o) for o in data[header]} - {type(None)}
-            if len(found_types) == 0:
-                column_types[header] = ExpressionType.null()
-            elif len(found_types) == 1:
-                column_types[header] = ExpressionType.from_py_type(found_types.pop())
-            elif found_types == {int, float}:
-                column_types[header] = ExpressionType.float()
-            else:
-                column_types[header] = ExpressionType.python_object()
-
+        column_types: dict[str, ExpressionType] = {header: ExpressionType.infer_type(data[header]) for header in data}
         schema = Schema([Field(header, expr_type) for header, expr_type in column_types.items()])
         data_vpartition = vPartition.from_pydict(
             data={header: arr for header, arr in data.items()}, schema=schema, partition_id=0

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -4,9 +4,6 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar, Union
 
-import numpy as np
-import pandas
-
 from daft import resource_request
 from daft.api_annotations import DataframePublicAPI
 from daft.context import get_context
@@ -37,6 +34,9 @@ from daft.viz import DataFrameDisplay
 
 if TYPE_CHECKING:
     from ray.data.dataset import Dataset as RayDataset
+    import numpy as np
+    import pandas
+    import pyarrow as pa
 
 from daft.logical.field import Field
 from daft.logical.schema import Schema
@@ -255,7 +255,7 @@ class DataFrame:
 
     @classmethod
     @DataframePublicAPI
-    def from_pydict(cls, data: dict[str, list | np.ndarray]) -> DataFrame:
+    def from_pydict(cls, data: dict[str, list | np.ndarray | pa.Array]) -> DataFrame:
         """Creates a DataFrame from a Python dictionary
 
         Example:
@@ -263,7 +263,7 @@ class DataFrame:
 
         Args:
             data: Key -> Sequence[item] of data. Each Key is created as a column, and must have a value that is
-                a Python list or Numpy array. Values must be equal in length across all keys.
+                a Python list, Numpy array or PyArrow array. Values must be equal in length across all keys.
 
         Returns:
             DataFrame: DataFrame created from dictionary of columns

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -227,13 +227,12 @@ class vPartition:
         fields = schema.fields
         tiles = {}
         for f in fields.values():
+            # Coerce the column data into a list or PyArrow array depending on the provided schema
             col_name = f.name
             col_type = f.dtype
-
-            # Coerce the column data into a list or PyArrow array
             col_data: list | pa.Array
             if ExpressionType.is_py(col_type):
-                col_data = data[col_name]
+                col_data = list(data[col_name])
             elif isinstance(data[col_name], pa.Array):
                 col_data = data[col_name]
             else:

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -221,7 +221,7 @@ class vPartition:
         return vPartition(columns=tiles, partition_id=partition_id)
 
     @classmethod
-    def from_pydict(cls, data: dict[str, list[Any]], schema: Schema, partition_id: PartID) -> vPartition:
+    def from_pydict(cls, data: dict[str, list[Any] | np.ndarray], schema: Schema, partition_id: PartID) -> vPartition:
         fields = schema.fields
         tiles = {}
         for f in fields.values():

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -115,6 +115,7 @@ def test_create_dataframe_pydict_bad_columns() -> None:
 
 def test_load_pydict_types():
     data = {
+        # Lists
         "arrow_int": [None, 2, 3],
         "arrow_float": [None, 1.0, 3.0],
         "arrow_mixed_numbers": [None, 1.0, 3],
@@ -124,6 +125,11 @@ def test_load_pydict_types():
         "py_objs": [None, MyObj(), MyObj()],
         "heterogenous_py_objs": [None, MyObj(), MyObj2()],
         "numpy_arrays": [np.array([1]), np.array([2]), np.array([3])],
+        # Numpy arrays
+        "np_int": np.array([1, 2, 3], dtype=np.int64),
+        "np_string": np.array([None, "foo", "bar"], dtype=np.object_),
+        "np_object": np.array([None, MyObj(), MyObj()], dtype=np.object_),
+        "np_nested": np.ones((3, 3)),
     }
     daft_df = DataFrame.from_pydict(data)
 
@@ -140,6 +146,10 @@ def test_load_pydict_types():
         "py_objs": ExpressionType.from_py_type(MyObj),
         "heterogenous_py_objs": ExpressionType.python_object(),
         "numpy_arrays": ExpressionType.from_py_type(np.ndarray),
+        "np_int": ExpressionType.integer(),
+        "np_string": ExpressionType.string(),
+        "np_object": ExpressionType.from_py_type(MyObj),
+        "np_nested": ExpressionType.from_py_type(np.ndarray),
     }
 
     assert collected_data.keys() == data.keys() == expected.keys()

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -130,6 +130,9 @@ def test_load_pydict_types():
         "np_string": np.array([None, "foo", "bar"], dtype=np.object_),
         "np_object": np.array([None, MyObj(), MyObj()], dtype=np.object_),
         "np_nested": np.ones((3, 3)),
+        # Arrow arrays
+        "pa_int": pa.array([1, 2, 3]),
+        "pa_nested": pa.array([[1, 2, 3], [1, 2], [1]]),
     }
     daft_df = DataFrame.from_pydict(data)
 
@@ -150,6 +153,8 @@ def test_load_pydict_types():
         "np_string": ExpressionType.string(),
         "np_object": ExpressionType.from_py_type(MyObj),
         "np_nested": ExpressionType.from_py_type(np.ndarray),
+        "pa_int": ExpressionType.integer(),
+        "pa_nested": ExpressionType.from_py_type(list),
     }
 
     assert collected_data.keys() == data.keys() == expected.keys()

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -110,7 +110,7 @@ def test_create_dataframe_pydict_ragged_col_lens() -> None:
 def test_create_dataframe_pydict_bad_columns() -> None:
     with pytest.raises(ValueError) as e:
         DataFrame.from_pydict({"foo": "somestring"})
-    assert "Expected all columns to be of type list" in str(e.value)
+    assert "Expected inferred data to be of type list, np.ndarray or pa.Array" in str(e.value)
 
 
 def test_load_pydict_types():


### PR DESCRIPTION
* Our hypothesis tests create data using Arrow arrays, so `.from_pydict()` needs to be able to accept Arrow arrays
* Our benchmarking tests create data using Numpy arrays, so `.from_pydict()` needs to be able to accept numpy arrays