### PR TITLE
Fixes Joins when we have duplicate names from each source

### DIFF
--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -956,9 +956,9 @@ class Join(BinaryNode):
             raise NotImplementedError()
         elif how == JoinType.INNER:
             num_partitions = max(left.num_partitions(), right.num_partitions())
-            right_id_set = self._right_on.to_name_set()
+            right_drop_set = {r.name() for l, r in zip(left_on, right_on) if l.name() == r.name()}
             left_columns = left.schema().to_column_expressions()
-            right_columns = ExpressionList([col(f.name) for f in right.schema() if f.name not in right_id_set])
+            right_columns = ExpressionList([col(f.name) for f in right.schema() if f.name not in right_drop_set])
             unioned_expressions = left_columns.union(right_columns, rename_dup="right.")
             self._left_columns = left_columns
             self._right_columns = ExpressionList(unioned_expressions.exprs[len(self._left_columns.exprs) :])

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -600,23 +600,21 @@ class vPartition:
 
         for lk, rk in zip(left_key_ids, right_key_ids):
             if lk != rk:
-                if rk in result_columns:
-                    target_name = f"right.{rk}"
-                else:
-                    target_name = k
-                assert target_name not in result_columns
-                result_columns[target_name] = PyListTile(
-                    column_name=target_name, partition_id=self.partition_id, block=result_columns[lk].block
+                while rk in result_columns:
+                    rk = f"right.{rk}"
+
+                assert rk not in result_columns
+                result_columns[rk] = PyListTile(
+                    column_name=rk, partition_id=self.partition_id, block=result_columns[lk].block
                 )
 
         for k in right_nonjoin_ids:
-            if k in result_columns:
-                target_name = f"right.{k}"
-            else:
-                target_name = k
-            assert target_name not in result_columns
-            result_columns[target_name] = PyListTile(
-                column_name=target_name, partition_id=self.partition_id, block=joined_blocks[joined_block_idx]
+
+            while k in result_columns:
+                k = f"right.{k}"
+            assert k not in result_columns
+            result_columns[k] = PyListTile(
+                column_name=k, partition_id=self.partition_id, block=joined_blocks[joined_block_idx]
             )
             joined_block_idx += 1
 

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -568,6 +568,9 @@ class vPartition:
         left_key_ids = list(left_key_part.columns.keys())
 
         right_key_part = right.eval_expression_list(right_on)
+
+        right_key_ids = list(right_key_part.columns.keys())
+
         left_key_list = [left_key_part.columns[le.name()].block for le in left_on]
         right_key_list = [right_key_part.columns[re.name()].block for re in right_on]
 
@@ -585,21 +588,41 @@ class vPartition:
         joined_block_idx = 0
         result_columns = {}
         for k in left_key_ids:
+            assert k not in result_columns
             result_columns[k] = left_key_part.columns[k].replace_block(block=joined_blocks[joined_block_idx])
+
             joined_block_idx += 1
 
         for k in left_nonjoin_ids:
+            assert k not in result_columns
             result_columns[k] = self.columns[k].replace_block(block=joined_blocks[joined_block_idx])
             joined_block_idx += 1
 
+        for lk, rk in zip(left_key_ids, right_key_ids):
+            if lk != rk:
+                if rk in result_columns:
+                    target_name = f"right.{rk}"
+                else:
+                    target_name = k
+                assert target_name not in result_columns
+                result_columns[target_name] = PyListTile(
+                    column_name=target_name, partition_id=self.partition_id, block=result_columns[lk].block
+                )
+
         for k in right_nonjoin_ids:
-            result_columns[k] = right.columns[k].replace_block(block=joined_blocks[joined_block_idx])
+            if k in result_columns:
+                target_name = f"right.{k}"
+            else:
+                target_name = k
+            assert target_name not in result_columns
+            result_columns[target_name] = PyListTile(
+                column_name=target_name, partition_id=self.partition_id, block=joined_blocks[joined_block_idx]
+            )
             joined_block_idx += 1
 
         assert joined_block_idx == len(result_keys)
-
-        output = vPartition(columns=result_columns, partition_id=self.partition_id)
-        return output.eval_expression_list(output_projection)
+        output_ordering = output_projection.to_column_expressions()
+        return vPartition(columns=result_columns, partition_id=self.partition_id).eval_expression_list(output_ordering)
 
     def _to_file(
         self,


### PR DESCRIPTION
* Closes: https://github.com/Eventual-Inc/Daft/issues/442
* Fixes 2 bugs:
- When we join and left and right have different names but the same value
- in vPartition Join: when we are joining, we can clobber names from the left side with the right blocks.