### PR TITLE
Rust Expressions / Table integration into Python

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ git-fetch-with-cli = true
 edition = "2021"
 name = "daft"
 version = "0.0.22"
+
+[profile.dev]
+overflow-checks = false

--- a/daft/expressions2.py
+++ b/daft/expressions2.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from daft.daft import PyExpr as _PyExpr
+from daft.daft import col as _col
+from daft.daft import lit as _lit
+from daft.datatype import DataType
+
+
+def lit(value: object) -> Expression:
+    return Expression._from_pyexpr(_lit(value))
+
+
+def col(name: str) -> Expression:
+    return Expression._from_pyexpr(_col(name))
+
+
+class Expression:
+    _expr: _PyExpr
+
+    def __init__(self) -> None:
+        raise NotImplementedError("We do not support creating a Expression via __init__ ")
+
+    @staticmethod
+    def _from_pyexpr(pyexpr) -> Expression:
+        expr = Expression.__new__(Expression)
+        expr._expr = pyexpr
+        return expr
+
+    @staticmethod
+    def _to_expression(obj: object) -> Expression:
+        if isinstance(obj, Expression):
+            return obj
+        else:
+            return lit(obj)
+
+    def __bool__(self) -> bool:
+        raise ValueError(
+            "Expressions don't have a truth value until executed. "
+            "If you reached this error using `and` / `or`, use `&` / `|` instead."
+        )
+
+    def __add__(self, other: object) -> Expression:
+        """Adds two numeric expressions (``e1 + e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr + expr._expr)
+
+    def __radd__(self, other: object) -> Expression:
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(expr._expr + self._expr)
+
+    def __sub__(self, other: object) -> Expression:
+        """Subtracts two numeric expressions (``e1 - e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr - expr._expr)
+
+    def __rsub__(self, other: object) -> Expression:
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(expr._expr - self._expr)
+
+    def __mul__(self, other: object) -> Expression:
+        """Multiplies two numeric expressions (``e1 * e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr * expr._expr)
+
+    def __rmul__(self, other: object) -> Expression:
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(expr._expr * self._expr)
+
+    def __truediv__(self, other: object) -> Expression:
+        """True divides two numeric expressions (``e1 / e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr / expr._expr)
+
+    def __rtruediv__(self, other: object) -> Expression:
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(expr._expr / self._expr)
+
+    def __mod__(self, other: Expression) -> Expression:
+        """Takes the mod of two numeric expressions (``e1 % e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr % expr._expr)
+
+    def __rmod__(self, other: Expression) -> Expression:
+        """Takes the mod of two numeric expressions (``e1 % e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(expr._expr % self._expr)
+
+    def __and__(self, other: Expression) -> Expression:
+        """Takes the logical AND of two expressions (``e1 & e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr & expr._expr)
+
+    def __rand__(self, other: Expression) -> Expression:
+        """Takes the logical reverse AND of two expressions (``e1 & e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(expr._expr & self._expr)
+
+    def __or__(self, other: Expression) -> Expression:
+        """Takes the logical OR of two expressions (``e1 | e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr | expr._expr)
+
+    def __ror__(self, other: Expression) -> Expression:
+        """Takes the logical reverse OR of two expressions (``e1 | e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(expr._expr | self._expr)
+
+    def __lt__(self, other: Expression) -> Expression:
+        """Compares if an expression is less than another (``e1 < e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr < expr._expr)
+
+    def __le__(self, other: Expression) -> Expression:
+        """Compares if an expression is less than or equal to another (``e1 <= e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr <= expr._expr)
+
+    def __eq__(self, other: Expression) -> Expression:  # type: ignore
+        """Compares if an expression is equal to another (``e1 == e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr == expr._expr)
+
+    def __ne__(self, other: Expression) -> Expression:  # type: ignore
+        """Compares if an expression is not equal to another (``e1 != e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr != expr._expr)
+
+    def __gt__(self, other: Expression) -> Expression:
+        """Compares if an expression is greater than another (``e1 > e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr > expr._expr)
+
+    def __ge__(self, other: Expression) -> Expression:
+        """Compares if an expression is greater than or equal to another (``e1 >= e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr >= expr._expr)
+
+    def alias(self, name: str) -> Expression:
+        assert isinstance(name, str)
+        expr = self._expr.alias(name)
+        return Expression._from_pyexpr(expr)
+
+    def cast(self, dtype: DataType) -> Expression:
+        assert isinstance(dtype, DataType)
+        expr = self._expr.cast(dtype._dtype)
+        return Expression._from_pyexpr(expr)
+
+    def name(self) -> str:
+        return self._expr.name()
+
+    def __repr__(self) -> str:
+        return repr(self._expr)

--- a/daft/table.py
+++ b/daft/table.py
@@ -26,6 +26,11 @@ class Table:
         return Table._from_pytable(pyt)
 
     @staticmethod
+    def empty() -> Table:
+        pyt = _PyTable.empty()
+        return Table._from_pytable(pyt)
+
+    @staticmethod
     def from_pydict(data: dict) -> Table:
         pya_table = pa.Table.from_pydict(data)
         return Table.from_arrow(pya_table)
@@ -50,6 +55,9 @@ class Table:
 
     def column_names(self) -> list[str]:
         return self._table.column_names()
+
+    def get_column(self, name: str) -> Series:
+        return Series._from_pyseries(self._table.get_column(name))
 
     def __len__(self) -> int:
         return len(self._table)

--- a/daft/table.py
+++ b/daft/table.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pyarrow as pa
 
 from daft.daft import PyTable as _PyTable
+from daft.expressions2 import Expression
 
 
 class Table:
@@ -30,6 +31,14 @@ class Table:
 
     def to_arrow(self) -> pa.Table:
         return pa.Table.from_batches([self._table.to_arrow_record_batch()])
+
+    def to_pydict(self) -> dict[str, list]:
+        return self.to_arrow().to_pydict()
+
+    def eval_expression_list(self, exprs: list[Expression]) -> Table:
+        assert all(isinstance(e, Expression) for e in exprs)
+        pyexprs = [e._expr for e in exprs]
+        return Table._from_pytable(self._table.eval_expression_list(pyexprs))
 
     def head(self, num: int) -> Table:
         return Table._from_pytable(self._table.head(num))

--- a/daft/table.py
+++ b/daft/table.py
@@ -4,6 +4,7 @@ import pyarrow as pa
 
 from daft.daft import PyTable as _PyTable
 from daft.expressions2 import Expression
+from daft.series import Series
 
 
 class Table:
@@ -42,6 +43,10 @@ class Table:
 
     def head(self, num: int) -> Table:
         return Table._from_pytable(self._table.head(num))
+
+    def take(self, indices: Series) -> Table:
+        assert isinstance(indices, Series)
+        return Table._from_pytable(self._table.take(indices._series))
 
     def column_names(self) -> list[str]:
         return self._table.column_names()

--- a/daft/table.py
+++ b/daft/table.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pyarrow as pa
+
+from daft.daft import PyTable as _PyTable
+
+
+class Table:
+    _table: _PyTable
+
+    def __init__(self) -> None:
+        raise NotImplementedError("We do not support creating a Table via __init__ ")
+
+    @staticmethod
+    def _from_pytable(pyt: _PyTable) -> Table:
+        tab = Table.__new__(Table)
+        tab._table = pyt
+        return tab
+
+    @staticmethod
+    def from_arrow(arrow_table: pa.Table) -> Table:
+        assert isinstance(arrow_table, pa.Table)
+        pyt = _PyTable.from_arrow_record_batches(arrow_table.to_batches())
+        return Table._from_pytable(pyt)
+
+    @staticmethod
+    def from_pydict(data: dict) -> Table:
+        pya_table = pa.Table.from_pydict(data)
+        return Table.from_arrow(pya_table)
+
+    def to_arrow(self) -> pa.Table:
+        return pa.Table.from_batches([self._table.to_arrow_record_batch()])
+
+    def head(self, num: int) -> Table:
+        return Table._from_pytable(self._table.head(num))
+
+    def column_names(self) -> list[str]:
+        return self._table.column_names()
+
+    def __len__(self) -> int:
+        return len(self._table)
+
+    def __repr__(self) -> str:
+        return repr(self._table)

--- a/src/array/from.rs
+++ b/src/array/from.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::datatypes::{
-    BooleanArray, DaftDataType, DaftNumericType, DataType, Field, Utf8Array, Utf8Type,
+    BinaryArray, BooleanArray, DaftDataType, DaftNumericType, DataType, Field, Utf8Array, Utf8Type,
 };
 
 use crate::array::DataArray;
@@ -62,6 +62,18 @@ impl<T: AsRef<str>> From<(&str, &[T])> for DataArray<Utf8Type> {
         let (name, slice) = item;
         let arrow_array = arrow2::array::Utf8Array::<i64>::from_slice(slice);
         DataArray::new(Field::new(name, DataType::Utf8).into(), arrow_array.arced()).unwrap()
+    }
+}
+
+impl From<(&str, &[u8])> for BinaryArray {
+    fn from(item: (&str, &[u8])) -> Self {
+        let (name, slice) = item;
+        let arrow_array = arrow2::array::BinaryArray::<i64>::from_slice([slice]);
+        DataArray::new(
+            Field::new(name, DataType::Binary).into(),
+            arrow_array.arced(),
+        )
+        .unwrap()
     }
 }
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -81,6 +81,11 @@ where
         let with_bitmap = self.data.with_validity(Some(Bitmap::from(validity)));
         DataArray::new(self.field.clone(), with_bitmap.into())
     }
+
+    pub fn head(&self, num: usize) -> DaftResult<Self> {
+        let sliced = self.data.slice(0, num);
+        Self::new(self.field.clone(), Arc::from(sliced))
+    }
 }
 
 impl<T: DaftDataType + 'static> BaseArray for DataArray<T> {

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -17,6 +17,8 @@ pub trait BaseArray: Any + Send + Sync {
 
     fn name(&self) -> &str;
 
+    fn rename(&self, name: &str) -> Box<dyn BaseArray>;
+
     fn field(&self) -> &Field;
 
     fn len(&self) -> usize;
@@ -103,6 +105,10 @@ impl<T: DaftDataType + 'static> BaseArray for DataArray<T> {
 
     fn name(&self) -> &str {
         self.field.name.as_str()
+    }
+
+    fn rename(&self, name: &str) -> Box<dyn BaseArray> {
+        Box::new(Self::new(Arc::new(self.field.rename(name)), self.data.clone()).unwrap())
     }
 
     fn field(&self) -> &Field {

--- a/src/array/ops/arithmetic.rs
+++ b/src/array/ops/arithmetic.rs
@@ -86,7 +86,6 @@ impl Add for &Utf8Array {
         Ok(Utf8Array::from((self.name(), result)))
     }
 }
-
 impl<T> Sub for &DataArray<T>
 where
     T: DaftNumericType,

--- a/src/array/ops/arithmetic.rs
+++ b/src/array/ops/arithmetic.rs
@@ -114,12 +114,72 @@ impl Div for &Float64Array {
     }
 }
 
+pub fn binary_with_nulls<T, F>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<T>,
+    op: F,
+) -> PrimitiveArray<T>
+where
+    T: arrow2::types::NativeType,
+    F: Fn(T, T) -> T,
+{
+    if lhs.len() != rhs.len() {
+        panic!("expected same length")
+    }
+    let values = lhs.iter().zip(rhs.iter()).map(|(l, r)| match (l, r) {
+        (None, _) => None,
+        (_, None) => None,
+        (Some(l), Some(r)) => Some(op(*l, *r)),
+    });
+    unsafe { PrimitiveArray::<T>::from_trusted_len_iter_unchecked(values) }
+}
+
+fn rem_with_nulls<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
+where
+    T: arrow2::types::NativeType + std::ops::Rem<Output = T>,
+{
+    binary_with_nulls(lhs, rhs, |a, b| a % b)
+}
+
 impl<T> Rem for &DataArray<T>
 where
     T: DaftNumericType,
 {
     type Output = DaftResult<DataArray<T>>;
     fn rem(self, rhs: Self) -> Self::Output {
-        arithmetic_helper(self, rhs, basic::rem, |l, r| l % r)
+        if rhs.data().null_count() == 0 {
+            arithmetic_helper(self, rhs, basic::rem, |l, r| l % r)
+        } else {
+            match (self.len(), rhs.len()) {
+                (a, b) if a == b => Ok(DataArray::from((
+                    self.name(),
+                    Box::new(rem_with_nulls(self.downcast(), rhs.downcast())),
+                ))),
+                // broadcast right path
+                (_, 1) => {
+                    let opt_rhs = rhs.get(0);
+                    Ok(match opt_rhs {
+                        None => DataArray::full_null(self.name(), self.len()),
+                        Some(rhs) => self.apply(|lhs| lhs % rhs),
+                    })
+                }
+                (1, _) => {
+                    let opt_lhs = self.get(0);
+                    Ok(match opt_lhs {
+                        None => DataArray::full_null(rhs.name(), rhs.len()),
+                        Some(lhs) => {
+                            let values_iter = rhs.downcast().iter().map(|v| v.map(|v| lhs % *v));
+                            let arrow_array = unsafe {
+                                PrimitiveArray::from_trusted_len_iter_unchecked(values_iter)
+                            };
+                            DataArray::from((self.name(), Box::new(arrow_array)))
+                        }
+                    })
+                }
+                (a, b) => Err(DaftError::ValueError(format!(
+                    "Cannot apply operation on arrays of different lengths: {a} vs {b}"
+                ))),
+            }
+        }
     }
 }

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -1,6 +1,6 @@
 use crate::{
-    array::DataArray,
-    datatypes::{BooleanArray, DaftNumericType, Utf8Array},
+    array::{BaseArray, DataArray},
+    datatypes::{BooleanArray, DaftIntegerType, DaftNumericType, Int64Array, Utf8Array},
     error::DaftResult,
 };
 
@@ -23,6 +23,15 @@ where
         } else {
             None
         }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let result = arrow2::compute::take::take(self.data(), idx.downcast())?;
+        Self::try_from((self.name(), result))
     }
 
     pub fn str_value(&self, idx: usize) -> DaftResult<String> {
@@ -52,6 +61,15 @@ impl Utf8Array {
         }
     }
 
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let result = arrow2::compute::take::take(self.data(), idx.downcast())?;
+        Self::try_from((self.name(), result))
+    }
+
     pub fn str_value(&self, idx: usize) -> DaftResult<String> {
         let val = self.get(idx);
         match val {
@@ -77,6 +95,15 @@ impl BooleanArray {
         } else {
             None
         }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let result = arrow2::compute::take::take(self.data(), idx.downcast())?;
+        Self::try_from((self.name(), result))
     }
 
     pub fn str_value(&self, idx: usize) -> DaftResult<String> {

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{BooleanArray, DaftIntegerType, DaftNumericType, Int64Array, Utf8Array},
+    datatypes::{BooleanArray, DaftIntegerType, DaftNumericType, Utf8Array},
     error::DaftResult,
 };
 

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -148,6 +148,21 @@ impl DaftNumericType for Float64Type {
     type Native = f64;
 }
 
+pub trait DaftIntegerType: DaftNumericType
+where
+    Self::Native: arrow2::types::Index,
+{
+}
+
+impl DaftIntegerType for UInt8Type {}
+impl DaftIntegerType for UInt16Type {}
+impl DaftIntegerType for UInt32Type {}
+impl DaftIntegerType for UInt64Type {}
+impl DaftIntegerType for Int8Type {}
+impl DaftIntegerType for Int16Type {}
+impl DaftIntegerType for Int32Type {}
+impl DaftIntegerType for Int64Type {}
+
 pub type NullArray = DataArray<NullType>;
 pub type BooleanArray = DataArray<BooleanType>;
 pub type Int8Array = DataArray<Int8Type>;

--- a/src/dsl/lit.rs
+++ b/src/dsl/lit.rs
@@ -35,13 +35,13 @@ impl Display for LiteralValue {
         match self {
             Null => write!(f, "Null"),
             Boolean(val) => write!(f, "{val}"),
-            Utf8(val) => write!(f, "{val}"),
+            Utf8(val) => write!(f, "\"{val}\""),
             Binary(val) => write!(f, "Binary[{}]", val.len()),
             Int32(val) => write!(f, "{val}"),
             UInt32(val) => write!(f, "{val}"),
             Int64(val) => write!(f, "{val}"),
             UInt64(val) => write!(f, "{val}"),
-            Float64(val) => write!(f, "{val}"),
+            Float64(val) => write!(f, "{val:.1}"),
         }
     }
 }
@@ -67,15 +67,15 @@ impl LiteralValue {
         use crate::datatypes::*;
         use LiteralValue::*;
         let result = match self {
-            Null => NullArray::full_null("lit", 1).into_series(),
-            Boolean(val) => BooleanArray::from(("lit", [*val].as_slice())).into_series(),
-            Utf8(val) => Utf8Array::from(("lit", [val.as_str()].as_slice())).into_series(),
-            Binary(_val) => panic!("Binary not supported yey"),
-            Int32(val) => Int32Array::from(("lit", [*val].as_slice())).into_series(),
-            UInt32(val) => UInt32Array::from(("lit", [*val].as_slice())).into_series(),
-            Int64(val) => Int64Array::from(("lit", [*val].as_slice())).into_series(),
-            UInt64(val) => UInt64Array::from(("lit", [*val].as_slice())).into_series(),
-            Float64(val) => Float64Array::from(("lit", [*val].as_slice())).into_series(),
+            Null => NullArray::full_null("literal", 1).into_series(),
+            Boolean(val) => BooleanArray::from(("literal", [*val].as_slice())).into_series(),
+            Utf8(val) => Utf8Array::from(("literal", [val.as_str()].as_slice())).into_series(),
+            Binary(val) => BinaryArray::from(("literal", val.as_slice())).into_series(),
+            Int32(val) => Int32Array::from(("literal", [*val].as_slice())).into_series(),
+            UInt32(val) => UInt32Array::from(("literal", [*val].as_slice())).into_series(),
+            Int64(val) => Int64Array::from(("literal", [*val].as_slice())).into_series(),
+            UInt64(val) => UInt64Array::from(("literal", [*val].as_slice())).into_series(),
+            Float64(val) => Float64Array::from(("literal", [*val].as_slice())).into_series(),
         };
         result
     }
@@ -106,6 +106,12 @@ macro_rules! make_literal {
             }
         }
     };
+}
+
+impl<'a> Literal for &'a [u8] {
+    fn lit(self) -> Expr {
+        Expr::Literal(LiteralValue::Binary(self.to_vec()))
+    }
 }
 
 make_literal!(bool, Boolean);

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -42,6 +42,9 @@ pub fn lit(item: &PyAny) -> PyResult<PyExpr> {
                 .expect("could not transform Python string to Rust Unicode"),
         )
         .into())
+    } else if let Ok(pybytes) = item.downcast::<PyBytes>() {
+        let bytes = pybytes.as_bytes();
+        Ok(dsl::lit(bytes).into())
     } else if item.is_none() {
         Ok(dsl::null_lit().into())
     } else {
@@ -122,6 +125,10 @@ impl PyExpr {
             CompareOp::Gt => Ok(binary_op(Operator::Gt, &self.expr, &other.expr).into()),
             CompareOp::Ge => Ok(binary_op(Operator::GtEq, &self.expr, &other.expr).into()),
         }
+    }
+
+    pub fn name(&self) -> PyResult<&str> {
+        Ok(self.expr.name()?)
     }
 
     pub fn __repr__(&self) -> PyResult<String> {

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -1,3 +1,4 @@
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use crate::dsl;
@@ -25,7 +26,13 @@ impl PyTable {
         Ok(format!("{}", self.table))
     }
 
-    pub fn head(&self, num: usize) -> PyResult<Self> {
+    pub fn head(&self, num: i64) -> PyResult<Self> {
+        if num < 0 {
+            return Err(PyValueError::new_err(format!(
+                "Can not head table with negative number: {num}"
+            )));
+        }
+        let num = num as usize;
         Ok(self.table.head(num)?.into())
     }
 

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -26,11 +26,11 @@ impl PyTable {
     }
 
     pub fn head(&self, num: usize) -> PyResult<Self> {
-        return Ok(self.table.head(num)?.into());
+        Ok(self.table.head(num)?.into())
     }
 
     pub fn __len__(&self) -> PyResult<usize> {
-        return Ok(self.table.len());
+        Ok(self.table.len())
     }
 
     pub fn column_names(&self) -> PyResult<Vec<String>> {

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -25,6 +25,18 @@ impl PyTable {
         Ok(format!("{}", self.table))
     }
 
+    pub fn head(&self, num: usize) -> PyResult<Self> {
+        return Ok(self.table.head(num)?.into());
+    }
+
+    pub fn __len__(&self) -> PyResult<usize> {
+        return Ok(self.table.len());
+    }
+
+    pub fn column_names(&self) -> PyResult<Vec<String>> {
+        Ok(self.table.column_names()?)
+    }
+
     #[staticmethod]
     pub fn from_arrow_record_batches(record_batches: Vec<&PyAny>) -> PyResult<Self> {
         let table = ffi::record_batches_to_table(record_batches.as_slice())?;

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -7,6 +7,8 @@ use crate::table;
 
 use crate::python::expr::PyExpr;
 
+use super::series::PySeries;
+
 #[pyclass]
 pub struct PyTable {
     pub table: table::Table,
@@ -20,6 +22,10 @@ impl PyTable {
             .table
             .eval_expression_list(converted_exprs.as_slice())?
             .into())
+    }
+
+    pub fn take(&self, idx: &PySeries) -> PyResult<Self> {
+        Ok(self.table.take(&idx.series)?.into())
     }
 
     pub fn __repr__(&self) -> PyResult<String> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt::{Display, Formatter, Result},
+    iter,
     sync::Arc,
 };
 
@@ -44,6 +45,10 @@ impl Schema {
             None => Err(DaftError::NotFound(name.into())),
             Some(val) => Ok(val),
         }
+    }
+
+    pub fn names(&self) -> DaftResult<Vec<String>> {
+        return Ok(self.fields.keys().cloned().collect());
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,5 @@
 use std::{
     fmt::{Display, Formatter, Result},
-    iter,
     sync::Arc,
 };
 

--- a/src/series/mod.rs
+++ b/src/series/mod.rs
@@ -33,6 +33,10 @@ impl Series {
         self.data_array.name()
     }
 
+    pub fn rename(&self, name: &str) -> Self {
+        Self::new(Arc::from(self.data_array.rename(name)))
+    }
+
     pub fn len(&self) -> usize {
         self.data_array.len()
     }

--- a/src/series/ops/arithmetic.rs
+++ b/src/series/ops/arithmetic.rs
@@ -66,7 +66,7 @@ impl Div for &Series {
 impl Div for Series {
     type Output = DaftResult<Series>;
     fn div(self, rhs: Self) -> Self::Output {
-        (&self).add(&rhs)
+        (&self).div(&rhs)
     }
 }
 

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -97,3 +97,24 @@ macro_rules! with_match_comparable_daft_types {(
         _ => panic!("{:?} not implemented", $key_type)
     }
 })}
+
+#[macro_export]
+macro_rules! with_match_integer_daft_types {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    use $crate::datatypes::*;
+
+    match $key_type {
+        Int8 => __with_ty__! { Int8Type },
+        Int16 => __with_ty__! { Int16Type },
+        Int32 => __with_ty__! { Int32Type },
+        Int64 => __with_ty__! { Int64Type },
+        UInt8 => __with_ty__! { UInt8Type },
+        UInt16 => __with_ty__! { UInt16Type },
+        UInt32 => __with_ty__! { UInt32Type },
+        UInt64 => __with_ty__! { UInt64Type },
+        _ => panic!("{:?} not implemented", $key_type)
+    }
+})}

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -78,6 +78,7 @@ macro_rules! with_match_comparable_daft_types {(
 ) => ({
     macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use $crate::datatypes::DataType::*;
+    #[allow(unused_imports)]
     use $crate::datatypes::*;
 
     match $key_type {

--- a/src/series/ops/take.rs
+++ b/src/series/ops/take.rs
@@ -1,5 +1,4 @@
-use crate::array::{BaseArray, DataArray};
-use crate::datatypes::{DaftIntegerType, DaftNumericType};
+use crate::array::BaseArray;
 use crate::{
     error::DaftResult, series::Series, with_match_comparable_daft_types,
     with_match_integer_daft_types,

--- a/src/series/ops/take.rs
+++ b/src/series/ops/take.rs
@@ -1,5 +1,9 @@
-use crate::array::BaseArray;
-use crate::{error::DaftResult, series::Series, with_match_comparable_daft_types};
+use crate::array::{BaseArray, DataArray};
+use crate::datatypes::{DaftIntegerType, DaftNumericType};
+use crate::{
+    error::DaftResult, series::Series, with_match_comparable_daft_types,
+    with_match_integer_daft_types,
+};
 
 impl Series {
     pub fn head(&self, num: usize) -> DaftResult<Series> {
@@ -9,6 +13,14 @@ impl Series {
 
         with_match_comparable_daft_types!(self.data_type(), |$T| {
             Ok(self.downcast::<$T>()?.head(num)?.into_series())
+        })
+    }
+
+    pub fn take(&self, idx: &Series) -> DaftResult<Series> {
+        with_match_comparable_daft_types!(self.data_type(), |$T| {
+            with_match_integer_daft_types!(idx.data_type(), |$S| {
+                Ok(self.downcast::<$T>()?.take(idx.downcast::<$S>()?)?.into_series())
+            })
         })
     }
 

--- a/src/series/ops/take.rs
+++ b/src/series/ops/take.rs
@@ -1,6 +1,17 @@
+use crate::array::BaseArray;
 use crate::{error::DaftResult, series::Series, with_match_comparable_daft_types};
 
 impl Series {
+    pub fn head(&self, num: usize) -> DaftResult<Series> {
+        if num >= self.len() {
+            return Ok(self.clone());
+        }
+
+        with_match_comparable_daft_types!(self.data_type(), |$T| {
+            Ok(self.downcast::<$T>()?.head(num)?.into_series())
+        })
+    }
+
     pub fn str_value(&self, idx: usize) -> DaftResult<String> {
         with_match_comparable_daft_types!(self.data_type(), |$T| {
             self.downcast::<$T>()?.str_value(idx)

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -57,6 +57,11 @@ impl Table {
     pub fn num_columns(&self) -> usize {
         self.columns.len()
     }
+
+    pub fn column_names(&self) -> DaftResult<Vec<String>> {
+        self.schema.names()
+    }
+
     pub fn len(&self) -> usize {
         if self.num_columns() == 0 {
             0
@@ -64,7 +69,22 @@ impl Table {
             self.get_column_by_index(0).unwrap().len()
         }
     }
-    //pub fn head(&self, num: usize) -> DaftResult<Table>;
+
+    pub fn head(&self, num: usize) -> DaftResult<Table> {
+        if num >= self.len() {
+            return Ok(Table {
+                schema: self.schema.clone(),
+                columns: self.columns.clone(),
+            });
+        }
+
+        let new_series: DaftResult<Vec<_>> = self.columns.iter().map(|s| s.head(num)).collect();
+        Ok(Table {
+            schema: self.schema.clone(),
+            columns: new_series?,
+        })
+    }
+
     //pub fn sample(&self, num: usize) -> DaftResult<Table>;
     //pub fn filter(&self, predicate: &[&Expr]) -> DaftResult<Table>;
     //pub fn sort(&self, sort_keys: &[&Expr], descending: &[bool]) -> DaftResult<Table>;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -48,6 +48,10 @@ impl Table {
         })
     }
 
+    pub fn empty() -> DaftResult<Self> {
+        Self::new(Schema::empty(), vec![])
+    }
+
     pub fn from_columns(columns: Vec<Series>) -> DaftResult<Self> {
         let fields = columns.iter().map(|s| s.field().clone()).collect();
         let schema = Schema::new(fields);

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,7 +1,8 @@
 use std::fmt::{Display, Formatter, Result};
 use std::sync::Arc;
 
-use crate::datatypes::Field;
+use crate::array::DataArray;
+use crate::datatypes::{DaftIntegerType, DaftNumericType, Field};
 use crate::dsl::Expr;
 use crate::error::{DaftError, DaftResult};
 use crate::schema::Schema;
@@ -85,11 +86,16 @@ impl Table {
         })
     }
 
-    //pub fn sample(&self, num: usize) -> DaftResult<Table>;
-    //pub fn filter(&self, predicate: &[&Expr]) -> DaftResult<Table>;
+    // pub fn filter(&self, predicate: &[&Expr]) -> DaftResult<Table>;
     //pub fn sort(&self, sort_keys: &[&Expr], descending: &[bool]) -> DaftResult<Table>;
     //pub fn argsort(&self, sort_keys: &[&Expr], descending: &[bool]) -> DaftResult<Series>;
-    //pub fn take(&self, idx: &Series) -> DaftResult<Table>;
+    pub fn take(&self, idx: &Series) -> DaftResult<Table> {
+        let new_series: DaftResult<Vec<_>> = self.columns.iter().map(|s| s.take(idx)).collect();
+        Ok(Table {
+            schema: self.schema.clone(),
+            columns: new_series?,
+        })
+    }
     //pub fn concat(tables: &[&Table]) -> DaftResult<Table>;
 
     pub fn get_column<S: AsRef<str>>(&self, name: S) -> DaftResult<Series> {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -133,6 +133,17 @@ impl Table {
             .iter()
             .map(|s| s.field().clone())
             .collect::<Vec<Field>>();
+        use std::collections::HashSet;
+        let mut seen: HashSet<String> = HashSet::new();
+        for field in fields.iter() {
+            let name = &field.name;
+            if seen.contains(name) {
+                return Err(DaftError::ValueError(format!(
+                    "Duplicate name found when evaluating expressions: {name}"
+                )));
+            }
+            seen.insert(name.clone());
+        }
         let schema = Schema::new(fields);
         Table::new(schema, result_series)
     }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,8 +1,7 @@
 use std::fmt::{Display, Formatter, Result};
 use std::sync::Arc;
 
-use crate::array::DataArray;
-use crate::datatypes::{DaftIntegerType, DaftNumericType, Field};
+use crate::datatypes::Field;
 use crate::dsl::Expr;
 use crate::error::{DaftError, DaftResult};
 use crate::schema::Schema;

--- a/tests/series/test_arithmetic.py
+++ b/tests/series/test_arithmetic.py
@@ -58,8 +58,8 @@ def test_arithmetic_numbers_left_scalar(l_dtype, r_dtype) -> None:
     div = (l / r).to_pylist()
     assert div == [1.0, 0.25, 1.0, 0.2, None, None]
 
-    # mod = (l % r).to_pylist()
-    # assert mod == [0, 1, 0, 1, None, None]
+    mod = (l % r).to_pylist()
+    assert mod == [0, 1, 0, 1, None, None]
 
 
 @pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -81,14 +81,14 @@ def test_table_eval_expressions_conflict() -> None:
         daft_table.eval_expression_list(exprs)
 
 
-@pytest.mark.parametrize("dtype", daft_int_types)
-def test_table_take(dtype) -> None:
+@pytest.mark.parametrize("idx_dtype", daft_int_types)
+def test_table_take_int(idx_dtype) -> None:
     pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
     daft_table = Table.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 
-    indices = Series.from_pylist([0, 1]).cast(dtype)
+    indices = Series.from_pylist([0, 1]).cast(idx_dtype)
 
     taken = daft_table.take(indices)
     assert len(taken) == 2
@@ -96,7 +96,7 @@ def test_table_take(dtype) -> None:
 
     assert taken.to_pydict() == {"a": [1, 2], "b": [5, 6]}
 
-    indices = Series.from_pylist([3, 2]).cast(dtype)
+    indices = Series.from_pylist([3, 2]).cast(idx_dtype)
 
     taken = daft_table.take(indices)
     assert len(taken) == 2
@@ -104,10 +104,74 @@ def test_table_take(dtype) -> None:
 
     assert taken.to_pydict() == {"a": [4, 3], "b": [8, 7]}
 
-    indices = Series.from_pylist([3, 2, 2, 2, 3]).cast(dtype)
+    indices = Series.from_pylist([3, 2, 2, 2, 3]).cast(idx_dtype)
 
     taken = daft_table.take(indices)
     assert len(taken) == 5
     assert taken.column_names() == ["a", "b"]
 
     assert taken.to_pydict() == {"a": [4, 3, 3, 3, 4], "b": [8, 7, 7, 7, 8]}
+
+
+@pytest.mark.parametrize("idx_dtype", daft_int_types)
+def test_table_take_str(idx_dtype) -> None:
+    pa_table = pa.Table.from_pydict({"a": ["1", "2", "3", "4"], "b": ["5", "6", "7", "8"]})
+    daft_table = Table.from_arrow(pa_table)
+    assert len(daft_table) == 4
+    assert daft_table.column_names() == ["a", "b"]
+
+    indices = Series.from_pylist([0, 1]).cast(idx_dtype)
+
+    taken = daft_table.take(indices)
+    assert len(taken) == 2
+    assert taken.column_names() == ["a", "b"]
+
+    assert taken.to_pydict() == {"a": ["1", "2"], "b": ["5", "6"]}
+
+    indices = Series.from_pylist([3, 2]).cast(idx_dtype)
+
+    taken = daft_table.take(indices)
+    assert len(taken) == 2
+    assert taken.column_names() == ["a", "b"]
+
+    assert taken.to_pydict() == {"a": ["4", "3"], "b": ["8", "7"]}
+
+    indices = Series.from_pylist([3, 2, 2, 2, 3]).cast(idx_dtype)
+
+    taken = daft_table.take(indices)
+    assert len(taken) == 5
+    assert taken.column_names() == ["a", "b"]
+
+    assert taken.to_pydict() == {"a": ["4", "3", "3", "3", "4"], "b": ["8", "7", "7", "7", "8"]}
+
+
+@pytest.mark.parametrize("idx_dtype", daft_int_types)
+def test_table_take_bool(idx_dtype) -> None:
+    pa_table = pa.Table.from_pydict({"a": [False, True, False, True], "b": [True, False, True, False]})
+    daft_table = Table.from_arrow(pa_table)
+    assert len(daft_table) == 4
+    assert daft_table.column_names() == ["a", "b"]
+
+    indices = Series.from_pylist([0, 1]).cast(idx_dtype)
+
+    taken = daft_table.take(indices)
+    assert len(taken) == 2
+    assert taken.column_names() == ["a", "b"]
+
+    assert taken.to_pydict() == {"a": [False, True], "b": [True, False]}
+
+    indices = Series.from_pylist([3, 2]).cast(idx_dtype)
+
+    taken = daft_table.take(indices)
+    assert len(taken) == 2
+    assert taken.column_names() == ["a", "b"]
+
+    assert taken.to_pydict() == {"a": [True, False], "b": [False, True]}
+
+    indices = Series.from_pylist([3, 2, 2, 2, 3]).cast(idx_dtype)
+
+    taken = daft_table.take(indices)
+    assert len(taken) == 5
+    assert taken.column_names() == ["a", "b"]
+
+    assert taken.to_pydict() == {"a": [True, False, False, False, True], "b": [False, True, True, True, False]}

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pyarrow as pa
+
+from daft.daft import PyTable
+
+
+def test_from_arrow_round_trip() -> None:
+    pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+    daft_table = PyTable.from_arrow_record_batches(pa_table.to_batches())
+    assert len(daft_table) == 4
+    assert daft_table.column_names() == ["a", "b"]
+    read_back = pa.Table.from_batches([daft_table.to_arrow_record_batch()])
+    assert pa_table == read_back
+
+
+def test_table_head() -> None:
+    pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+    daft_table = PyTable.from_arrow_record_batches(pa_table.to_batches())
+    assert len(daft_table) == 4
+    assert daft_table.column_names() == ["a", "b"]
+
+    # subslice
+    headed = daft_table.head(3)
+    assert len(headed) == 3
+    assert headed.column_names() == ["a", "b"]
+    pa_headed = pa.Table.from_batches([headed.to_arrow_record_batch()])
+    assert pa_table[:3] == pa_headed
+
+    # overslice
+    headed = daft_table.head(5)
+    assert len(headed) == 4
+    assert headed.column_names() == ["a", "b"]
+    pa_headed = pa.Table.from_batches([headed.to_arrow_record_batch()])
+    assert pa_table == pa_headed

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -3,21 +3,21 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
-from daft.daft import PyTable
+from daft.table import Table
 
 
 def test_from_arrow_round_trip() -> None:
     pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-    daft_table = PyTable.from_arrow_record_batches(pa_table.to_batches())
+    daft_table = Table.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
-    read_back = pa.Table.from_batches([daft_table.to_arrow_record_batch()])
+    read_back = daft_table.to_arrow()
     assert pa_table == read_back
 
 
 def test_table_head() -> None:
     pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-    daft_table = PyTable.from_arrow_record_batches(pa_table.to_batches())
+    daft_table = Table.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 
@@ -25,14 +25,14 @@ def test_table_head() -> None:
     headed = daft_table.head(3)
     assert len(headed) == 3
     assert headed.column_names() == ["a", "b"]
-    pa_headed = pa.Table.from_batches([headed.to_arrow_record_batch()])
+    pa_headed = headed.to_arrow()
     assert pa_table[:3] == pa_headed
 
     # overslice
     headed = daft_table.head(5)
     assert len(headed) == 4
     assert headed.column_names() == ["a", "b"]
-    pa_headed = pa.Table.from_batches([headed.to_arrow_record_batch()])
+    pa_headed = headed.to_arrow()
     assert pa_table == pa_headed
 
     # negative slice

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -207,7 +207,6 @@ def test_table_numeric_expressions(data_dtype, op) -> None:
 
 @pytest.mark.parametrize("data_dtype, op", itertools.product(daft_numeric_types, OPS))
 def test_table_numeric_expressions_with_nulls(data_dtype, op) -> None:
-
     a, b = [5, 6, None, 8, None], [1, 2, 3, None, None]
     pa_table = pa.Table.from_pydict({"a": a, "b": b})
 

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -181,3 +181,44 @@ def test_table_take_bool(idx_dtype) -> None:
     assert taken.column_names() == ["a", "b"]
 
     assert taken.to_pydict() == {"a": [True, False, False, False, True], "b": [False, True, True, True, False]}
+
+
+import operator as ops
+
+OPS = [ops.add, ops.sub, ops.mul, ops.truediv, ops.mod, ops.lt, ops.le, ops.eq, ops.ne, ops.ge, ops.gt]
+
+
+@pytest.mark.parametrize("data_dtype, op", itertools.product(daft_numeric_types, OPS))
+def test_table_numeric_expressions(data_dtype, op) -> None:
+
+    a, b = [5, 6, 7, 8], [1, 2, 3, 4]
+    pa_table = pa.Table.from_pydict({"a": a, "b": b})
+
+    daft_table = Table.from_arrow(pa_table)
+    daft_table = daft_table.eval_expression_list(
+        [op(col("a").cast(data_dtype), col("b").cast(data_dtype)).alias("result")]
+    )
+
+    assert len(daft_table) == 4
+    assert daft_table.column_names() == ["result"]
+    pyresult = [op(l, r) for l, r in zip(a, b)]
+    assert daft_table.get_column("result").to_pylist() == pyresult
+
+
+@pytest.mark.parametrize("data_dtype, op", itertools.product(daft_numeric_types, OPS))
+def test_table_numeric_expressions_with_nulls(data_dtype, op) -> None:
+
+    a, b = [5, 6, None, 8, None], [1, 2, 3, None, None]
+    pa_table = pa.Table.from_pydict({"a": a, "b": b})
+
+    daft_table = Table.from_arrow(pa_table)
+    daft_table = daft_table.eval_expression_list(
+        [op(col("a").cast(data_dtype), col("b").cast(data_dtype)).alias("result")]
+    )
+
+    assert len(daft_table) == 5
+    assert daft_table.column_names() == ["result"]
+    pyresult = [op(l, r) for l, r in zip(a[:2], b[:2])]
+    assert daft_table.get_column("result").to_pylist()[:2] == pyresult
+
+    assert daft_table.get_column("result").to_pylist()[2:] == [None, None, None]

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -3,8 +3,21 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
+from daft.datatype import DataType
 from daft.expressions2 import col
+from daft.series import Series
 from daft.table import Table
+
+daft_int_types = [
+    DataType.int8(),
+    DataType.int16(),
+    DataType.int32(),
+    DataType.int64(),
+    DataType.uint8(),
+    DataType.uint16(),
+    DataType.uint32(),
+    DataType.uint64(),
+]
 
 
 def test_from_arrow_round_trip() -> None:
@@ -66,3 +79,35 @@ def test_table_eval_expressions_conflict() -> None:
 
     with pytest.raises(ValueError, match="Duplicate name"):
         daft_table.eval_expression_list(exprs)
+
+
+@pytest.mark.parametrize("dtype", daft_int_types)
+def test_table_take(dtype) -> None:
+    pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+    daft_table = Table.from_arrow(pa_table)
+    assert len(daft_table) == 4
+    assert daft_table.column_names() == ["a", "b"]
+
+    indices = Series.from_pylist([0, 1]).cast(dtype)
+
+    taken = daft_table.take(indices)
+    assert len(taken) == 2
+    assert taken.column_names() == ["a", "b"]
+
+    assert taken.to_pydict() == {"a": [1, 2], "b": [5, 6]}
+
+    indices = Series.from_pylist([3, 2]).cast(dtype)
+
+    taken = daft_table.take(indices)
+    assert len(taken) == 2
+    assert taken.column_names() == ["a", "b"]
+
+    assert taken.to_pydict() == {"a": [4, 3], "b": [8, 7]}
+
+    indices = Series.from_pylist([3, 2, 2, 2, 3]).cast(dtype)
+
+    taken = daft_table.take(indices)
+    assert len(taken) == 5
+    assert taken.column_names() == ["a", "b"]
+
+    assert taken.to_pydict() == {"a": [4, 3, 3, 3, 4], "b": [8, 7, 7, 7, 8]}

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pyarrow as pa
+import pytest
 
 from daft.daft import PyTable
 
@@ -33,3 +34,7 @@ def test_table_head() -> None:
     assert headed.column_names() == ["a", "b"]
     pa_headed = pa.Table.from_batches([headed.to_arrow_record_batch()])
     assert pa_table == pa_headed
+
+    # negative slice
+    with pytest.raises(ValueError, match="negative number"):
+        headed = daft_table.head(-1)

--- a/tests/test_expressions2.py
+++ b/tests/test_expressions2.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from daft.datatype import DataType
+from daft.expressions2 import lit
+from daft.table import Table
+
+
+@pytest.mark.parametrize(
+    "data, expected_dtype",
+    [
+        (1, DataType.int32()),
+        (2**32, DataType.int64()),
+        (1 << 63, DataType.uint64()),
+        (1.2, DataType.float64()),
+        ("a", DataType.string()),
+        (b"a", DataType.binary()),
+        (True, DataType.bool()),
+        (None, DataType.null()),
+    ],
+)
+def test_make_lit(data, expected_dtype) -> None:
+    l = lit(data)
+    assert l.name() == "literal"
+    empty_table = Table.empty()
+    lit_table = empty_table.eval_expression_list([l])
+    series = lit_table.get_column("literal")
+    assert series.datatype() == expected_dtype


### PR DESCRIPTION
* Python daft.expressions2.Expression: Replacement for daft expressions that are backed by rust
* Python: Daft.Table: a local Table Implementation backed by our rust table
* [rust + python] Series / Table take kernels
* [rust + python] Series / Table head kernels
* bugfix for series div that hit the add kernel instead
* handle the panic when we perform a `rem` kernel with a null on the `rhs` side
* Handle python bytes literals
* Test cases for making literals from python
* Add remaining comparisons to eval_expression for table
* Add Table::empty creator for easier debugging
* Allow renaming a series