### PR TITLE
Drop numpy split for pylist block and enhance pretty printing for explain()

### DIFF
--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import itertools
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import Enum, IntEnum
 from pprint import pformat
 from typing import Any, Generic, TypeVar
@@ -178,6 +178,12 @@ class LogicalPlan(TreeNode["LogicalPlan"]):
         for k, v in fields_to_print.items():
             if isinstance(v, ExpressionList):
                 v = v.exprs
+            elif isinstance(v, Schema):
+                v = v.to_column_expressions().exprs
+            elif isinstance(v, PartitionSpec):
+                v = asdict(v)
+                if isinstance(v["by"], ExpressionList):
+                    v["by"] = v["by"].exprs
             reduced_types[k] = v
         to_render: list[str] = [f"{self.__class__.__name__}\n"]
         space = "    "

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -452,7 +452,12 @@ class PyListDataBlock(DataBlock[List[T]]):
         return PyListDataBlock(data=[])
 
     def _split(self, pivots: np.ndarray) -> Sequence[list[T]]:
-        return [list(chunk) for chunk in np.split(self.data, pivots)[1:]]
+        if len(pivots) == 0:
+            return self.data
+
+        result = [self.data[s:e] for s,e in zip(pivots, pivots[1:])]
+        result.append(self.data[pivots[-1]:])
+        return result
 
     @staticmethod
     def _merge_blocks(blocks: list[DataBlock[list[T]]]) -> DataBlock[list[T]]:

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -455,8 +455,8 @@ class PyListDataBlock(DataBlock[List[T]]):
         if len(pivots) == 0:
             return self.data
 
-        result = [self.data[s:e] for s,e in zip(pivots, pivots[1:])]
-        result.append(self.data[pivots[-1]:])
+        result = [self.data[s:e] for s, e in zip(pivots, pivots[1:])]
+        result.append(self.data[pivots[-1] :])
         return result
 
     @staticmethod

--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -453,7 +453,7 @@ class PyListDataBlock(DataBlock[List[T]]):
 
     def _split(self, pivots: np.ndarray) -> Sequence[list[T]]:
         if len(pivots) == 0:
-            return self.data
+            return [self.data]
 
         result = [self.data[s:e] for s, e in zip(pivots, pivots[1:])]
         result.append(self.data[pivots[-1] :])


### PR DESCRIPTION
* drops np.split in favor an python list iteration due to numpy trying to coerce as_array methods to np
* reduce more types in pretty printer to ensure 80 character printing