### PR TITLE
Set show to default to showing 8 rows

### DIFF
--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -9,7 +9,7 @@ def test_show_all(valid_data):
 
     assert df_display.schema == df.schema()
     assert len(df_display.preview.preview_partition) == len(valid_data)
-    assert df_display.preview.dataframe_num_rows == len(valid_data)
+    assert df_display.preview.dataframe_num_rows is None
 
 
 def test_show_some(valid_data):
@@ -18,5 +18,4 @@ def test_show_some(valid_data):
 
     assert df_display.schema == df.schema()
     assert len(df_display.preview.preview_partition) == 1
-    # Show does not know the total size of the dataset when applying a limit
     assert df_display.preview.dataframe_num_rows is None


### PR DESCRIPTION
Closes: #607 

* Set show to default to showing 8 rows
* Refactor to simplify logic and avoid multiple calls to limit the dataframe