### PR TITLE
Serialization of ArrowDataBlocks without rematerializing Array

### DIFF
--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -554,6 +554,9 @@ ArrowArrType = Union[pa.ChunkedArray, pa.Scalar]
 def _reconstruct_arrow_data_block(
     buffers: dict[int, pa.Buffer], array_metadata: list[dict[str, Any]]
 ) -> ArrowDataBlock:
+    """Helper to reconstruct an ArrowDataBlock from a collection of buffers and PyArrow Array metadata that
+    make up a ChunkedArray.
+    """
     chunks = [
         pa.Array.from_buffers(
             type=arr["type"],
@@ -582,6 +585,8 @@ class ArrowDataBlock(DataBlock[ArrowArrType]):
         elif len(self.data) == 0:
             return ArrowDataBlock, (self._make_empty().data,)
         else:
+            # ChunkedArray is serialized as a tuple of buffers and array metadata to avoid multiple
+            # copies of the same buffers if they are referenced by more than one array.
             buffers = {buf.address: buf for chunk in self.data.chunks for buf in chunk.buffers() if buf is not None}
             array_metadata = [
                 {


### PR DESCRIPTION
This is an alternative approach to #625 which should be put up for discussion.

Instead of materializing the Array, we could instead copy all the underlying buffers and metadata for reconstruction on the other end.

This feels less hacky, but has a disadvantage of never pruning arrays that may have been filtered on.