### PR TITLE
Refactor aggregation logic into a AggregationPlanBuilder class

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -32,6 +32,7 @@ from daft.execution.operators import ExpressionType
 from daft.expressions import Expression, col
 from daft.filesystem import get_filesystem_from_path
 from daft.logical import logical_plan
+from daft.logical.aggregation_plan_builder import AggregationPlanBuilder
 from daft.logical.schema import ExpressionList
 from daft.resource_request import ResourceRequest
 from daft.runners.partitioning import (
@@ -965,125 +966,26 @@ class DataFrame:
         return DataFrame(explode_op)
 
     def _agg(self, to_agg: List[Tuple[ColumnInputType, str]], group_by: Optional[ExpressionList] = None) -> "DataFrame":
-        assert len(to_agg) > 0, "no columns to aggregate."
-        exprs_to_agg = self.__column_input_to_expression(tuple(e for e, _ in to_agg))
-        ops = [op for _, op in to_agg]
-
-        function_lookup = {
-            "sum": Expression._sum,
-            "count": Expression._count,
-            "mean": Expression._mean,
-            "list": Expression._list,
-            "concat": Expression._concat,
-            "min": Expression._min,
-            "max": Expression._max,
-        }
-
-        if self.num_partitions() == 1:
-            agg_exprs = []
-
-            for e, op_name in zip(exprs_to_agg, ops):
-                assert op_name in function_lookup
-                agg_exprs.append((function_lookup[op_name](e).alias(e.name()), op_name))
-            plan = logical_plan.LocalAggregate(self._plan, agg=agg_exprs, group_by=group_by)
-            return DataFrame(plan)
-
-        intermediate_ops = {
-            "sum": ("sum",),
-            "list": ("list",),
-            "count": ("count",),
-            "mean": ("sum", "count"),
-            "min": ("min",),
-            "max": ("max",),
-        }
-
-        reduction_ops = {
-            "sum": ("sum",),
-            "list": ("concat",),
-            "count": ("sum",),
-            "mean": ("sum", "sum"),
-            "min": ("min",),
-            "max": ("max",),
-        }
-
-        finalizer_ops_funcs = {"mean": lambda x, y: (x + 0.0) / (y + 0.0)}
-
-        first_phase_ops: List[Tuple[Expression, str]] = []
-        second_phase_ops: List[Tuple[Expression, str]] = []
-        finalizer_phase_ops: List[Expression] = []
-        need_final_projection = False
-        for e, op in zip(exprs_to_agg, ops):
-            assert op in intermediate_ops
-            ops_to_add = intermediate_ops[op]
-
-            e_intermediate_name = []
-            for agg_op in ops_to_add:
-                name = f"{e.name()}_{agg_op}"
-                f = function_lookup[agg_op]
-                new_e = f(e).alias(name)
-                first_phase_ops.append((new_e, agg_op))
-                e_intermediate_name.append(new_e.name())
-
-            assert op in reduction_ops
-            ops_to_add = reduction_ops[op]
-            added_exprs = []
-            for agg_op, result_name in zip(ops_to_add, e_intermediate_name):
-                assert result_name is not None
-                col_e = col(result_name)
-                f = function_lookup[agg_op]
-                added: Expression = f(col_e)
-                if op in finalizer_ops_funcs:
-                    name = f"{result_name}_{agg_op}"
-                    added = added.alias(name)
-                else:
-                    added = added.alias(e.name())
-                second_phase_ops.append((added, agg_op))
-                added_exprs.append(added)
-
-            if op in finalizer_ops_funcs:
-                f = finalizer_ops_funcs[op]
-                operand_args = []
-                for ae in added_exprs:
-                    col_name = ae.name()
-                    assert col_name is not None
-                    operand_args.append(col(col_name))
-                final_name = e.name()
-                assert final_name is not None
-                new_e = f(*operand_args).alias(final_name)
-                finalizer_phase_ops.append(new_e)
-                need_final_projection = True
+        exprs_to_agg: list[tuple[Expression, str]] = list(
+            zip(self.__column_input_to_expression([c for c, _ in to_agg]), [op for _, op in to_agg])
+        )
+        builder = AggregationPlanBuilder(self._plan, group_by=group_by)
+        for expr, op in exprs_to_agg:
+            if op == "sum":
+                builder.add_sum(expr.name(), expr)
+            elif op == "min":
+                builder.add_min(expr.name(), expr)
+            elif op == "max":
+                builder.add_max(expr.name(), expr)
+            elif op == "count":
+                builder.add_count(expr.name(), expr)
+            elif op == "list":
+                builder.add_list(expr.name(), expr)
+            elif op == "mean":
+                builder.add_mean(expr.name(), expr)
             else:
-                for ae in added_exprs:
-                    col_name = ae.name()
-                    assert col_name is not None
-                    finalizer_phase_ops.append(col(col_name))
-
-        first_phase_lagg_op = logical_plan.LocalAggregate(self._plan, agg=first_phase_ops, group_by=group_by)
-        repart_op: logical_plan.LogicalPlan
-        if group_by is None:
-            repart_op = logical_plan.Coalesce(first_phase_lagg_op, 1)
-        else:
-            repart_op = logical_plan.Repartition(
-                first_phase_lagg_op,
-                num_partitions=self._plan.num_partitions(),
-                partition_by=group_by,
-                scheme=logical_plan.PartitionScheme.HASH,
-            )
-
-        gagg_op = logical_plan.LocalAggregate(repart_op, agg=second_phase_ops, group_by=group_by)
-
-        final_schema = ExpressionList(finalizer_phase_ops)
-
-        if group_by is not None:
-            final_schema = group_by.union(final_schema)
-
-        final_op: logical_plan.LogicalPlan
-        if need_final_projection:
-            final_op = logical_plan.Projection(gagg_op, final_schema)
-        else:
-            final_op = gagg_op
-
-        return DataFrame(final_op)
+                raise NotImplementedError(f"LogicalPlan construction for operation not implemented: {op}")
+        return DataFrame(builder.build())
 
     @DataframePublicAPI
     def sum(self, *cols: ColumnInputType) -> "DataFrame":

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -966,7 +966,7 @@ class DataFrame:
         return DataFrame(explode_op)
 
     def _agg(self, to_agg: List[Tuple[ColumnInputType, str]], group_by: Optional[ExpressionList] = None) -> "DataFrame":
-        exprs_to_agg: list[tuple[Expression, str]] = list(
+        exprs_to_agg: List[Tuple[Expression, str]] = list(
             zip(self.__column_input_to_expression([c for c, _ in to_agg]), [op for _, op in to_agg])
         )
         builder = AggregationPlanBuilder(self._plan, group_by=group_by)

--- a/daft/logical/aggregation_plan_builder.py
+++ b/daft/logical/aggregation_plan_builder.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from daft.expressions import Expression, col, lit
+from daft.logical import logical_plan
+from daft.logical.schema import ExpressionList
+
+AggregationOp = str
+ColName = str
+
+
+class AggregationPlanBuilder:
+    """Builder class to build the appropriate LogicalPlan tree for aggregations
+
+    See: `AggregationPlanBuilder.build()` for the high level logic on how this LogicalPlan is put together
+    """
+
+    def __init__(self, plan: logical_plan.LogicalPlan, group_by: ExpressionList | None):
+        self._plan = plan
+        self.group_by = group_by
+
+        # Aggregations to perform if the plan is just a single-partition
+        self._single_partition_shortcut_aggs: dict[ColName, tuple[Expression, AggregationOp]] = {}
+
+        # Aggregations to perform locally on each partition before the shuffle
+        self._preshuffle_aggs: dict[ColName, tuple[Expression, AggregationOp]] = {}
+
+        # Aggregations to perform locally on each partition after the shuffle
+        # NOTE: These are "global" aggregations, since the shuffle performs a global gather
+        self._postshuffle_aggs: dict[ColName, tuple[Expression, AggregationOp]] = {}
+
+        # Parameters for a final projection that is performed after "global" aggregations
+        self._final_projection_includes: dict[ColName, Expression] = {}
+        self._final_projection_excludes: set[ColName] = set()
+
+    def build(self) -> logical_plan.LogicalPlan:
+        """Builds a LogicalPlan for all the aggregations that have been added into the builder"""
+        if self._plan.num_partitions() == 1:
+            return self._build_for_single_partition_plan()
+        return self._build_for_multi_partition_plan()
+
+    def _build_for_single_partition_plan(self) -> logical_plan.LogicalPlan:
+        """Special-case for when the LogicalPlan has only one partition - there is no longer a need for
+        a shuffle step and everything can happen in a single LocalAggregate.
+        """
+        aggs = [(ex.alias(colname), op) for colname, (ex, op) in self._single_partition_shortcut_aggs.items()]
+        return logical_plan.LocalAggregate(self._plan, agg=aggs, group_by=self.group_by)
+
+    def _build_for_multi_partition_plan(self) -> logical_plan.LogicalPlan:
+        # 1. Pre-shuffle aggregations to reduce the size of the data before the shuffle
+        pre_shuffle_aggregations = [(ex.alias(colname), op) for colname, (ex, op) in self._preshuffle_aggs.items()]
+        preshuffle_agg_plan = logical_plan.LocalAggregate(
+            self._plan, agg=pre_shuffle_aggregations, group_by=self.group_by
+        )
+
+        # 2. Shuffle gather of all rows with the same key to the same partition
+        shuffle_plan: logical_plan.LogicalPlan
+        if self.group_by is None:
+            shuffle_plan = logical_plan.Coalesce(preshuffle_agg_plan, 1)
+        else:
+            shuffle_plan = logical_plan.Repartition(
+                preshuffle_agg_plan,
+                num_partitions=self._plan.num_partitions(),
+                partition_by=self.group_by,
+                scheme=logical_plan.PartitionScheme.HASH,
+            )
+
+        # 3. Perform post-shuffle aggregations (this is effectively now global aggregation)
+        post_shuffle_aggregations = [(ex.alias(colname), op) for colname, (ex, op) in self._postshuffle_aggs.items()]
+        postshuffle_agg_plan = logical_plan.LocalAggregate(
+            shuffle_plan, agg=post_shuffle_aggregations, group_by=self.group_by
+        )
+
+        # 4. Perform post-shuffle projections if necessary
+        postshuffle_projection_plan: logical_plan.LogicalPlan
+        if self._final_projection_includes or self._final_projection_excludes:
+            final_expressions = postshuffle_agg_plan.schema().to_column_expressions()
+            final_expressions = ExpressionList(
+                [e for e in final_expressions if e.name() not in self._final_projection_excludes]
+            )
+            final_expressions = final_expressions.union(
+                ExpressionList([expr.alias(colname) for colname, expr in self._final_projection_includes.items()])
+            )
+            postshuffle_projection_plan = logical_plan.Projection(postshuffle_agg_plan, final_expressions)
+        else:
+            postshuffle_projection_plan = postshuffle_agg_plan
+
+        return postshuffle_projection_plan
+
+    def _add_single_partition_shortcut_agg(
+        self,
+        result_colname: ColName,
+        expr: Expression,
+        op: AggregationOp,
+    ) -> None:
+        self._single_partition_shortcut_aggs[result_colname] = (expr, op)
+
+    def _add_2phase_agg(
+        self,
+        result_colname: ColName,
+        expr: Expression,
+        op_name: str,
+        local_op: AggregationOp,
+        global_op: AggregationOp,
+    ) -> None:
+        """Add a simple 2-phase aggregation:
+
+        1. Aggregate using local_op to produce an intermediate column
+        2. Shuffle
+        3. Aggregate using global_op on the intermediate column to produce result column
+        """
+        intermediate_colname = f"_local_{op_name}({result_colname})"
+        self._preshuffle_aggs[intermediate_colname] = (expr, local_op)
+        self._postshuffle_aggs[result_colname] = (col(intermediate_colname), global_op)
+
+    def add_sum(self, result_colname: ColName, expr: Expression) -> AggregationPlanBuilder:
+        self._add_single_partition_shortcut_agg(result_colname, Expression._sum(expr), "sum")
+        self._add_2phase_agg(result_colname, Expression._sum(expr), "sum", "sum", "sum")
+        return self
+
+    def add_min(self, result_colname: ColName, expr: Expression) -> AggregationPlanBuilder:
+        self._add_single_partition_shortcut_agg(result_colname, Expression._min(expr), "min")
+        self._add_2phase_agg(result_colname, Expression._min(expr), "min", "min", "min")
+        return self
+
+    def add_max(self, result_colname: ColName, expr: Expression) -> AggregationPlanBuilder:
+        self._add_single_partition_shortcut_agg(result_colname, Expression._max(expr), "max")
+        self._add_2phase_agg(result_colname, Expression._max(expr), "max", "max", "max")
+        return self
+
+    def add_count(self, result_colname: ColName, expr: Expression) -> AggregationPlanBuilder:
+        self._add_single_partition_shortcut_agg(result_colname, Expression._count(expr), "count")
+        self._add_2phase_agg(result_colname, Expression._count(expr), "count", "count", "sum")
+        return self
+
+    def add_list(self, result_colname: ColName, expr: Expression) -> AggregationPlanBuilder:
+        self._add_single_partition_shortcut_agg(result_colname, Expression._list(expr), "list")
+        self._add_2phase_agg(result_colname, Expression._list(expr), "list", "list", "concat")
+        return self
+
+    def add_concat(self, result_colname: ColName, expr: Expression) -> AggregationPlanBuilder:
+        self._add_single_partition_shortcut_agg(result_colname, Expression._concat(expr), "concat")
+        self._add_2phase_agg(result_colname, Expression._concat(expr), "concat", "concat", "concat")
+        return self
+
+    def add_mean(self, result_colname: ColName, expr: Expression) -> AggregationPlanBuilder:
+        self._add_single_partition_shortcut_agg(result_colname, Expression._mean(expr), "mean")
+
+        # Calculate intermediate sum and count
+        intermediate_sum_colname = f"_mean_intermediate_sum({result_colname})"
+        intermediate_count_colname = f"_mean_intermediate_count({result_colname})"
+        self._add_2phase_agg(intermediate_sum_colname, Expression._sum(expr), "sum", "sum", "sum")
+        self._add_2phase_agg(intermediate_count_colname, Expression._count(expr), "count", "count", "sum")
+
+        # Run projection to get mean using intermediate sun and count
+        # HACK: we add 0.0 because our current PyArrow-based type system returns an integer when dividing two integers
+        self._final_projection_includes[result_colname] = (col(intermediate_sum_colname) + lit(0.0)) / (
+            col(intermediate_count_colname) + lit(0.0)
+        )
+        self._final_projection_excludes.add(intermediate_sum_colname)
+        self._final_projection_excludes.add(intermediate_count_colname)
+
+        return self

--- a/tests/dataframe_cookbook/test_aggregations.py
+++ b/tests/dataframe_cookbook/test_aggregations.py
@@ -190,7 +190,7 @@ def test_min_groupby(daft_df, service_requests_csv_pd_df, repartition_nparts, ke
         pytest.param(["Borough", "Complaint Type"], id="NumGroupByKeys:2"),
     ],
 )
-def test_min_groupby(daft_df, service_requests_csv_pd_df, repartition_nparts, keys):
+def test_max_groupby(daft_df, service_requests_csv_pd_df, repartition_nparts, keys):
     """max across groups"""
     daft_df = (
         daft_df.repartition(repartition_nparts)


### PR DESCRIPTION
Our previous aggregation logic was getting hard to work with, entirely contained within the DataFrame `._agg` method.

This refactor cleans up the code and introduces a `AggregationPlanBuilder` builder class. This will help us introduce more complicated aggregations soon (count_distinct, count_keys etc).