### PR TITLE
Remove type annotation inference from UDFs

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -78,7 +78,7 @@ def _get_tabular_files_scan(
     # Sample the first 10 filepaths and infer the schema
     schema_df = filepath_df.limit(10).select(
         col(partition_set_factory.FS_LISTING_PATH_COLUMN_NAME)
-        .apply(get_schema, return_type=ExpressionList)
+        .apply(get_schema, return_dtype=ExpressionList)
         .alias("schema")
     )
     schema_df.collect()

--- a/daft/expressions.py
+++ b/daft/expressions.py
@@ -384,33 +384,36 @@ class Expression(TreeNode["Expression"]):
         """
         return AsPyExpression(self, ExpressionType.from_py_type(type_))
 
-    def apply(self, func: Callable, return_type: type | None = None) -> Expression:
+    def apply(self, func: Callable, return_dtype: type | None = None, return_type: Any = None) -> Expression:
         """Apply a function on a given expression
 
         Example:
             >>> def f(x_val: str) -> int:
             >>>     return int(x_val) if x_val.isnumeric() else 0
             >>>
-            >>> col("x").apply(f, return_type=int)
+            >>> col("x").apply(f, return_dtype=int)
 
         Args:
             func (Callable): Function to run per value of the expression
-            return_type (Optional[Type], optional): Return type of the function that was ran. This defaults to None and Daft will infer the return_type
+            return_dtype (Optional[Type], optional): Return type of the function that was ran. This defaults to None and Daft will infer the return_dtype
                 from the function's type annotations if available.
 
         Returns:
             Expression: New expression after having run the function on the expression
         """
+        if return_type is not None:
+            raise ValueError(f"The `return_type` keyword argument is deprecated, please use `return_dtype` instead.")
+
         inferred_type = get_type_hints(func).get("return", None)
-        return_type = inferred_type if inferred_type is not None else return_type
-        if return_type is None:
+        return_dtype = inferred_type if inferred_type is not None else return_dtype
+        if return_dtype is None:
             warnings.warn(
-                f"Supplied function {func} was not annotated with a return type and no `return_type` keyword argument specified in `.apply`."
-                "It is highly recommended to specify a return_type for Daft to perform optimizations and for access to vectorized expression operators."
+                f"Supplied function {func} was not annotated with a return type and no `return_dtype` keyword argument specified in `.apply`."
+                "It is highly recommended to specify a return_dtype for Daft to perform optimizations and for access to vectorized expression operators."
             )
 
         expression_type = (
-            ExpressionType.from_py_type(return_type) if return_type is not None else ExpressionType.python_object()
+            ExpressionType.from_py_type(return_dtype) if return_dtype is not None else ExpressionType.python_object()
         )
 
         def apply_func(f, data):

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -8,9 +8,9 @@ import sys
 from typing import Any, Callable, List, Sequence, Union
 
 if sys.version_info < (3, 8):
-    from typing_extensions import get_origin, get_type_hints
+    from typing_extensions import get_origin
 else:
-    from typing import get_type_hints, get_origin
+    from typing import get_origin
 
 from daft.execution.operators import ExpressionType
 from daft.expressions import UdfExpression
@@ -68,42 +68,21 @@ class UdfInputType(enum.Enum):
     PYARROW_CHUNKED = 5
     POLARS = 6
 
-
-def _get_input_types_from_annotation(func: Callable, type_hints: dict[str, type] | None) -> dict[str, UdfInputType]:
-    """Parses a function's type annotations to determine the input types for each argument"""
-    assert callable(func), f"Expected func to be callable, got {func}"
-
-    # If type_hints are not explicitly provided try to derive them from the function instead
-    if type_hints is None:
-        try:
-            type_hints = get_type_hints(func)
-        except TypeError as e:
-            raise TypeError(
-                f"Could not get type hints for function {func.__name__}. This is likely because you are using an advanced typing feature "
-                "that is not yet supported in your current version of Python (e.g. features from PEP 585 and PEP 604 in Python 3.7).\n"
-                "Please either only use compatible typing features for your Python version, or use the @udf(type_hints=...) keyword argument instead.\n"
-                f"Error message: {str(e)}"
-            )
-    param_types = {param: type_hints.get(param, None) for param in inspect.signature(func).parameters}
-
-    udf_input_types = {}
-    for name, annotation in param_types.items():
-        if annotation == list or annotation == List or get_origin(annotation) == list or get_origin(annotation) == List:
-            udf_input_types[name] = UdfInputType.LIST
-        elif _NUMPY_AVAILABLE and (annotation == np.ndarray or get_origin(annotation) == np.ndarray):
-            udf_input_types[name] = UdfInputType.NUMPY
-        elif _PANDAS_AVAILABLE and annotation == pd.Series:
-            udf_input_types[name] = UdfInputType.PANDAS
-        elif _PYARROW_AVAILABLE and annotation == pa.Array:
-            udf_input_types[name] = UdfInputType.PYARROW
-        elif _PYARROW_AVAILABLE and annotation == pa.ChunkedArray:
-            udf_input_types[name] = UdfInputType.PYARROW_CHUNKED
-        elif _POLARS_AVAILABLE and annotation == polars.Series:
-            udf_input_types[name] = UdfInputType.POLARS
-        else:
-            udf_input_types[name] = UdfInputType.UNKNOWN
-
-    return udf_input_types
+    @classmethod
+    def from_type_hint(cls, hint: type) -> UdfInputType:
+        if hint == list or hint == List or get_origin(hint) == list or get_origin(hint) == List:
+            return UdfInputType.LIST
+        elif _NUMPY_AVAILABLE and (hint == np.ndarray or get_origin(hint) == np.ndarray):
+            return UdfInputType.NUMPY
+        elif _PANDAS_AVAILABLE and hint == pd.Series:
+            return UdfInputType.PANDAS
+        elif _PYARROW_AVAILABLE and hint == pa.Array:
+            return UdfInputType.PYARROW
+        elif _PYARROW_AVAILABLE and hint == pa.ChunkedArray:
+            return UdfInputType.PYARROW_CHUNKED
+        elif _POLARS_AVAILABLE and hint == polars.Series:
+            return UdfInputType.POLARS
+        raise ValueError(f"UDF input array type {hint} is not supported")
 
 
 def _convert_argument(arg: Any, input_type: UdfInputType, partition_length: int) -> Any:
@@ -111,7 +90,7 @@ def _convert_argument(arg: Any, input_type: UdfInputType, partition_length: int)
     if isinstance(arg, DataBlock) and arg.is_scalar():
         return next(arg.iter_py())
     elif isinstance(arg, DataBlock):
-        if input_type == UdfInputType.UNKNOWN or input_type == UdfInputType.LIST:
+        if input_type == UdfInputType.LIST:
             arg_iterator = arg.iter_py()
             return [next(arg_iterator) for _ in range(partition_length)]
         elif input_type == UdfInputType.NUMPY:
@@ -132,68 +111,113 @@ def _convert_argument(arg: Any, input_type: UdfInputType, partition_length: int)
 def udf(
     f: Callable | None = None,
     *,
-    return_type: type,
-    type_hints: dict[str, type] | None = None,
-    num_gpus: int | float | None = None,
-    num_cpus: int | float | None = None,
-    memory_bytes: int | float | None = None,
+    return_dtype: type,
+    input_columns: dict[str, type],
+    **kwargs,
 ) -> Callable:
-    """Decorator for creating a UDF. This decorator wraps any custom Python code into a funciton that can be used to process
+    """Decorator for creating a UDF. This decorator wraps any custom Python code into a function that can be used to process
     columns of data in a Daft DataFrame.
+
+    Each UDF will process a **batch of columnar data**, and output a **batch of columnar data** as well. At runtime, Daft runs
+    your UDF on a partition of data at a time, and your UDF will receive input batches of length equal to the partition size.
 
     .. NOTE::
         UDFs are much slower than native Daft expressions because they run Python code instead of Daft's optimized Rust kernels.
         You should only use UDFs when performing operations that are not supported by Daft's native expressions, or when you
-        need to run custom Python code. For example, the following UDF will be much slower than ``df["x"] + 100``.
+        need to run custom Python code.
+
+        The following example UDF, while a simple example, will be much slower than ``df["x"] + 100`` since it is run as Python
+        instead of as a Rust addition kernel using the Expressions API.
 
     Example:
 
-    >>> @udf(return_type=int)
+    >>> @udf(
+    >>>     # Annotate the return dtype as an integer
+    >>>     return_dtype=int,
+    >>>     # Mark the `x` input parameter as a column, and tell Daft to pass it in as a list
+    >>>     input_columns={"x": list},
+    >>> )
     >>> def add_val(x, val=1):
     >>>    # Your custom Python code here
-    >>>    return [x + 1 for value in x]
+    >>>    return [x + val for value in x]
 
     To invoke your UDF, you can use the ``DataFrame.with_column`` method:
 
     >>> df = DataFrame.from_pydict({"x": [1, 2, 3]})
     >>> df = df.with_column("x_add_100", add_val(df["x"], val=100))
 
-    **Input/Return Types**
+    **UDF Function Outputs**
 
-    By default, Daft will pass columns of data into your function as Python lists. However, if this is a bottleneck for your
-    application, you may choose more optimized types for your inputs by annotating your function inputs with type hints.
+    The ``return_dtype`` argument specifies what type of column your UDF will return. For user convenience, you may specify a Python
+    type such as `str`, `int`, `float`, `bool` and `datetime.date`, which will be converted into a Daft dtype for you.
 
-    In the following example, we annotate the ``x`` input parameter as an ``np.ndarray``. Daft will now pass your data in as a Numpy
-    array which is much more efficient to work with than a Python list for numerical operations.
+    Python types that are not recognized as Daft types will be represented as a Daft Python object dtype. For example, if you specify
+    ``return_dtype=np.ndarray``, then your returned column will have type ``PY[np.ndarray]``.
 
-    >>> import numpy as np
-    >>>
-    >>> @udf(return_type=int)
-    >>> def add_val(x: np.ndarray, val: int = 1):
-    >>>     return x + val
+    >>> @udf(
+    >>>     # Annotate the return dtype as an numpy array
+    >>>     return_dtype=np.ndarray,
+    >>>     input_columns={"x": list},
+    >>> )
+    >>> def create_np_zero_arrays(x, dim=128):
+    >>>    return [np.zeros((dim,)) for i in range(len(x))]
 
-    Note also that Daft supports return types other than lists. In the above example, the returned value is a Numpy array as well.
-
-    Input and Return types supported by Daft UDFs and their respective type annotations:
+    Your UDF needs to return a batch of columnar data, and can do so as any one of the following array types:
 
     1. Numpy Arrays (``np.ndarray``)
     2. Pandas Series (``pd.Series``)
     3. Polars Series (``polars.Series``)
-    4. PyArrow Arrays (``pa.Array``)
+    4. PyArrow Arrays (``pa.Array``) or (``pa.ChunkedArray``)
+    5. Python lists (``list`` or ``typing.List``)
+
+    **UDF Function Inputs**
+
+    The ``input_columns`` argument is a dictionary. The keys specify which input parameters of your functions are columns.
+    The values specify the array container type that Daft should use when passing data into your function.
+
+    Here's an example where the same column is used multiple times in a UDF, but passed in as different types to illustrate
+    how this works!
+
+    >>> @udf(
+    >>>     return_dtype=int,
+    >>>     input_columns={"x_as_list": list, "x_as_numpy": np.ndarray, "x_as_pandas": pd.Series},
+    >>> )
+    >>> def example_func(x_as_list, x_as_numpy, x_as_pandas):
+    >>>     assert isinstance(x_as_list, list)
+    >>>     assert isinstance(x_as_numpy, np.ndarray)
+    >>>     assert isinstance(x_as_pandas, pd.Series)
+    >>>
+    >>> df = df.with_column("foo", example_func(df["x"], df["x"], df["x"]))
+
+    In the above example, when your DataFrame is executed, Daft will pass in batches of column data as equal-length arrays
+    into your function. The actual type of those arrays will take on the types indicated by ``input_columns``.
+
+    Input types supported by Daft UDFs and their respective type annotations:
+
+    1. Numpy Arrays (``np.ndarray``)
+    2. Pandas Series (``pd.Series``)
+    3. Polars Series (``polars.Series``)
+    4. PyArrow Arrays (``pa.Array``) or (``pa.ChunkedArray``)
     5. Python lists (``list`` or ``typing.List``)
 
     .. NOTE::
-        Type annotation can be finicky in Python, depending on the version of Python you are using and if you are using typing
-        functionality from future Python versions with ``from __future__ import annotations``. Daft will alert you if it cannot
-        infer types from your annotations, and you may choose to provide your types explicitly as a dictionary of input parameter
-        name to its type in the ``@udf(type_hints=...)`` keyword argument.
+        Certain array formats have some restrictions around the type of data that they can handle:
+
+        1. **Null Handling**: In Pandas and Numpy, nulls are represented as NaNs for numeric types, and Nones for non-numeric types.
+        Additionally, the existence of nulls will trigger a type casting from integer to float arrays. If null handling is important to
+        your use-case, we recommend using one of the other available options.
+
+        2. **Python Objects**: PyArrow array formats cannot support object-type columns.
+
+        We recommend using Python lists if performance is not a major consideration, and using the arrow-native formats such as
+        PyArrow arrays and Polars series if performance is important.
 
     **Stateful UDFs**
 
     UDFs can also be created on Classes, which allow for initialization on some expensive state that can be shared
     between invocations of the class, for example downloading data or creating a model.
 
-    >>> @udf(return_type=int)
+    >>> @udf(return_dtype=int, input_columns={"features_col": np.ndarray})
     >>> class RunModel:
     >>>     def __init__(self):
     >>>         # Perform expensive initializations
@@ -204,23 +228,34 @@ def udf(
 
     Args:
         f: Function to wrap as a UDF, accepts column inputs as Numpy arrays and returns a column of data as a Polars Series/Numpy array/Python list/Pandas series.
-        return_type: The return type of the UDF
-        type_hints: Optional dictionary of input parameter names to their types. If provided, this will override type hints provided using the function's type annotations.
-        num_gpus: Deprecated - please use `DataFrame.with_column(..., resource_request=...)` instead
-        num_cpus: Deprecated - please use `DataFrame.with_column(..., resource_request=...)` instead
-        memory_bytes: Deprecated - please use `DataFrame.with_column(..., resource_request=...)` instead
+        return_dtype: The return dtype of the UDF
+        input_columns: Optional dictionary of input parameter names to their types. If provided, this will override type hints provided using the function's type annotations.
     """
-    if any(arg is not None for arg in [num_gpus, num_cpus, memory_bytes]):
+    if "num_cpus" in kwargs:
         raise ValueError(
-            "The num_gpus, num_cpus, and memory_bytes kwargs have been deprecated for @udf. Please use `DataFrame.with_column(..., resource_request=...)` instead"
+            f"The `num_cpus` keyword argument has been deprecated. Please specify resource requirements when invoking your UDF in `.with_column` instead"
         )
+    if "num_gpus" in kwargs:
+        raise ValueError(
+            f"The `num_gpus` keyword argument has been deprecated. Please specify resource requirements when invoking your UDF in `.with_column` instead"
+        )
+    if "memory_bytes" in kwargs:
+        raise ValueError(
+            f"The `memory_bytes` keyword argument has been deprecated. Please specify resource requirements when invoking your UDF in `.with_column` instead"
+        )
+    if "return_type" in kwargs:
+        raise ValueError(f"The `return_type` keyword argument has been deprecated and renamed to return_dtype.")
+    if "type_hints" in kwargs:
+        raise ValueError(f"The `type_hints` keyword argument has been deprecated and renamed to input_columns.")
 
-    func_ret_type = ExpressionType.from_py_type(return_type)
+    func_ret_type = ExpressionType.from_py_type(return_dtype)
 
     def udf_decorator(func: UDF) -> Callable:
 
         call_method = func.__call__ if isinstance(func, type) else func
-        input_types = _get_input_types_from_annotation(call_method, type_hints)
+        input_types = {
+            arg_name: UdfInputType.from_type_hint(type_hint) for arg_name, type_hint in input_columns.items()
+        }
 
         # Get function argument names, excluding `self` if it is a class method
         ordered_func_arg_names = list(inspect.signature(call_method).parameters.keys())
@@ -248,11 +283,13 @@ def udf(
 
                 # Convert DataBlock arguments to the correct type
                 converted_args = tuple(
-                    _convert_argument(arg, input_types[arg_name], partition_length)
+                    _convert_argument(arg, input_types[arg_name], partition_length) if arg_name in input_types else arg
                     for arg_name, arg in zip(ordered_func_arg_names, args)
                 )
                 converted_kwargs = {
                     kwarg_name: _convert_argument(arg, input_types[kwarg_name], partition_length)
+                    if kwarg_name in input_types
+                    else arg
                     for kwarg_name, arg in kwargs.items()
                 }
 
@@ -281,5 +318,5 @@ def udf(
 
 def polars_udf(*args, **kwargs):
     raise NotImplementedError(
-        "Polars_udf is deprecated. Please use @udf instead and decorate your input arguments with `pl.Series`"
+        "Polars_udf is deprecated. Please use @udf instead and indicate `pl.Series` in your `input_columns`"
     )

--- a/daft/udf_library/url_udfs.py
+++ b/daft/udf_library/url_udfs.py
@@ -46,4 +46,4 @@ def _download_udf(urls: list[str | None], max_worker_threads: int = 8) -> list[b
 
 # HACK: Workaround for Ray pickling issues if we use the @polars_udf decorator instead.
 # There may be some issues around runtime imports and Ray pickling of decorated functions
-download_udf = udf(_download_udf, return_type=bytes, type_hints={"urls": List[Optional[str]]})
+download_udf = udf(_download_udf, return_dtype=bytes, input_columns={"urls": List[Optional[str]]})

--- a/docs/source/learn/10-min.ipynb
+++ b/docs/source/learn/10-min.ipynb
@@ -1129,7 +1129,7 @@
     "from daft import udf\n",
     "import polars as pl\n",
     "\n",
-    "@udf(return_type=datetime.date)\n",
+    "@udf(return_dtype=datetime.date, input_columns={\"f_date_data\": pl.Series, \"a_days_data\": pl.Series})\n",
     "def add_days(f_date_data: pl.Series, a_days_data: pl.Series):\n",
     "    return f_date_data + pl.duration(days=a_days_data)\n",
     "\n",
@@ -1190,7 +1190,7 @@
     }
    ],
    "source": [
-    "@udf(return_type=float)\n",
+    "@udf(return_dtype=float, input_columns={\"a_data\": np.ndarray, \"b_data\": np.ndarray})\n",
     "class RunExpensiveModel:\n",
     "\n",
     "    def __init__(self):\n",
@@ -1801,7 +1801,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4 (main, Jan 11 2023, 00:15:55) [Clang 13.0.0 (clang-1300.0.27.3)]"
+   "version": "3.8.16"
   },
   "vscode": {
    "interpreter": {

--- a/docs/source/learn/10-min.ipynb
+++ b/docs/source/learn/10-min.ipynb
@@ -924,9 +924,9 @@
     "```{note}\n",
     "It is good practice to supply Daft with the return type of your function.\n",
     "\n",
-    "You can do this using the ``return_type=`` keyword argument in ``.apply``, or by correctly type-annotating your function like in the ``list_to_numpy`` function below.\n",
+    "You can do this using the ``return_dtype=`` keyword argument in ``.apply``, or by correctly type-annotating your function like in the ``list_to_numpy`` function below.\n",
     "\n",
-    "Annotating the return type of your function correctly lets Daft effectively optimize your data and operations under the hood. For example, in this case we specify ``return_type=np.ndarray`` which tells Daft that each row in this column contains a Numpy array object.\n",
+    "Annotating the return type of your function correctly lets Daft effectively optimize your data and operations under the hood. For example, in this case we specify ``return_dtype=np.ndarray`` which tells Daft that each row in this column contains a Numpy array object.\n",
     "```"
    ]
   },

--- a/docs/source/learn/user_guides/udf.rst
+++ b/docs/source/learn/user_guides/udf.rst
@@ -27,7 +27,7 @@ For example, the following example creates a new ``"flattened_image"`` column by
 
     df.with_column(
         "flattened_image",
-        df["image"].apply(lambda img: img.flatten(), return_type=np.ndarray)
+        df["image"].apply(lambda img: img.flatten(), return_dtype=np.ndarray)
     )
 
 Note here that we use the ``return_type`` keyword argument to specify that our returned column type is of type ``np.ndarray``, so the new ``"flattened_image"``

--- a/docs/source/learn/user_guides/udf.rst
+++ b/docs/source/learn/user_guides/udf.rst
@@ -43,13 +43,13 @@ Multi-column per-partition functions using ``@udf``
 
 Daft provides the ``@udf`` decorator for defining your own UDFs that process multiple columns or multiple rows at a time.
 
-For example, let's try writing a function that will multiply all our images in our ``"image"`` column by its corresponding value in the ``"norm"`` column:
+For example, let's try writing a function that will crop all our images in the ``"image"`` column by its corresponding value in the ``"crop"`` column:
 
 .. code:: python
 
     from daft import udf
 
-    @udf(return_dtype=np.ndarray, input_columns={"images": list, "norm": list})
+    @udf(return_dtype=np.ndarray, input_columns={"images": list, "crops": list})
     def crop_images(images, crops, padding=0):
         cropped = []
         for img, crop in zip(images, crops):
@@ -93,7 +93,6 @@ array container types as well:
     1. **Null Handling**: In Pandas and Numpy, nulls are represented as NaNs for numeric types, and Nones for non-numeric types.
     Additionally, the existence of nulls will trigger a type casting from integer to float arrays. If null handling is important to
     your use-case, we recommend using one of the other available options.
-
     2. **Python Objects**: PyArrow array formats cannot support object-type columns.
 
     We recommend using Python lists if performance is not a major consideration, and using the arrow-native formats such as
@@ -138,7 +137,7 @@ Running Stateful UDFs are exactly the same as running their Stateless cousins.
 
 .. code:: python
 
-    df = df.with_column("image_classifications", ClassifyImages(col("images")))
+    df = df.with_column("image_classifications", RunModel(df["images"]))
 
 
 Resource Requests
@@ -155,7 +154,7 @@ Custom resources can be requested when you call ``.with_column``:
     # Runs the UDF `func` with the specified resource requests
     df = df.with_column(
         "image_classifications",
-        func(df["images"]),
+        RunModel(df["images"]),
         resource_request=ResourceRequest(num_gpus=1, num_cpus=8),
     )
 

--- a/tests/dataframe_cookbook/test_literals.py
+++ b/tests/dataframe_cookbook/test_literals.py
@@ -45,7 +45,7 @@ def test_pyobj_literal_column(daft_df, service_requests_csv_pd_df):
 
 def test_literal_column_computation(daft_df, service_requests_csv_pd_df):
     """Creating a new column that is derived from (1 + other_column) and retrieving the top N results"""
-    daft_df = daft_df.with_column("literal_col", lit({"foo": "bar"}).apply(lambda d: d["foo"], return_type=str))
+    daft_df = daft_df.with_column("literal_col", lit({"foo": "bar"}).apply(lambda d: d["foo"], return_dtype=str))
     daft_pd_df = daft_df.to_pandas()
     service_requests_csv_pd_df["literal_col"] = "bar"
     assert_df_equals(daft_pd_df, service_requests_csv_pd_df)

--- a/tests/dataframe_cookbook/test_python_list_cols.py
+++ b/tests/dataframe_cookbook/test_python_list_cols.py
@@ -26,7 +26,7 @@ def test_python_dict(repartition_nparts):
     assert_df_equals(daft_pd_df, pd_df, sort_key="id")
 
 
-@udf(return_type=dict)
+@udf(return_dtype=dict, input_columns={"dicts": list})
 def rename_key(dicts):
     new_dicts = []
     for d in dicts:
@@ -48,7 +48,7 @@ def test_python_dict_udf(repartition_nparts):
     assert_df_equals(daft_pd_df, pd_df, sort_key="id")
 
 
-@udf(return_type=dict)
+@udf(return_dtype=dict, input_columns={"dicts": list})
 def merge_dicts(dicts, to_merge):
     new_dicts = []
     for d in dicts:
@@ -77,7 +77,7 @@ def test_python_chained_expression_calls(repartition_nparts):
     daft_df = (
         DataFrame.from_pydict(data)
         .repartition(repartition_nparts)
-        .with_column("foo_starts_with_1", col("dicts").apply(lambda d: d["foo"], return_type=str).str.startswith("1"))
+        .with_column("foo_starts_with_1", col("dicts").apply(lambda d: d["foo"], return_dtype=str).str.startswith("1"))
     )
     pd_df = pd.DataFrame.from_dict(data)
     pd_df["foo_starts_with_1"] = pd.Series([d["foo"] for d in pd_df["dicts"]]).str.startswith("1")
@@ -142,17 +142,17 @@ def test_pyobj_add(repartition_nparts, op):
     assert_df_equals(daft_pd_df, pd_df, sort_key="id")
 
 
-@udf(return_type=int)
+@udf(return_dtype=int, input_columns={"features": list})
 def get_length(features):
     return [len(feature) for feature in features]
 
 
-@udf(return_type=np.ndarray)
+@udf(return_dtype=np.ndarray, input_columns={"features": list})
 def zeroes(features):
     return [np.zeros(feature.shape) for feature in features]
 
 
-@udf(return_type=np.ndarray)
+@udf(return_dtype=np.ndarray, input_columns={"lengths": list})
 def make_features(lengths):
     return [np.ones(length) for length in lengths]
 

--- a/tests/dataframe_cookbook/test_udf.py
+++ b/tests/dataframe_cookbook/test_udf.py
@@ -29,7 +29,7 @@ class MyObj:
 ###
 
 
-@udf(return_type=int)
+@udf(return_dtype=int, input_columns={"x": np.ndarray})
 def multiply_np(x: np.ndarray, num=2):
     return x * num
 
@@ -62,7 +62,7 @@ class MyModel:
         return data
 
 
-@udf(return_type=int)
+@udf(return_dtype=int, input_columns={"x": np.ndarray})
 class RunModelNumpy:
     def __init__(self) -> None:
         self._model = MyModel()
@@ -118,7 +118,7 @@ def test_apply_udf(daft_df, service_requests_csv_pd_df, repartition_nparts):
     assert_df_column_type(
         daft_df._result,
         "string_key",
-        object,  # no return_type specified for .apply, column has PY[object] type
+        object,  # no return_dtype specified for .apply, column has PY[object] type
     )
 
     # Running .str expressions will fail on PyObj columns
@@ -129,9 +129,9 @@ def test_apply_udf(daft_df, service_requests_csv_pd_df, repartition_nparts):
         daft_df_fail.to_pandas()
 
     # However, if we specify the return type then the blocks will be casted correctly to string types
-    daft_df_pass = daft_df.with_column("string_key", col("string_key").apply(lambda x: x, return_type=str)).with_column(
-        "string_key_starts_with_1", col("string_key").str.startswith("1")
-    )
+    daft_df_pass = daft_df.with_column(
+        "string_key", col("string_key").apply(lambda x: x, return_dtype=str)
+    ).with_column("string_key_starts_with_1", col("string_key").str.startswith("1"))
     service_requests_csv_pd_df["string_key_starts_with_1"] = service_requests_csv_pd_df["string_key"].str.startswith(
         "1"
     )

--- a/tests/expression_operators/test_cast.py
+++ b/tests/expression_operators/test_cast.py
@@ -158,7 +158,7 @@ def test_cast_py(before, method_to_run, to_type, expected):
         df = df.with_column(
             "before",
             df["before"].apply(
-                lambda obj: getattr(obj, method_to_run)() if obj is not None else None, return_type=object
+                lambda obj: getattr(obj, method_to_run)() if obj is not None else None, return_dtype=object
             ),
         )
 

--- a/tests/expression_operators/test_udf.py
+++ b/tests/expression_operators/test_udf.py
@@ -17,7 +17,19 @@ class MyObj:
         self._x = x
 
 
-@udf(return_type=int)
+@udf(
+    return_dtype=int,
+    input_columns={
+        "arg_untyped": list,
+        "arg_list": list,
+        "arg_typing_list": List,
+        "arg_typing_list_int": List[int],
+        "arg_numpy_array": np.ndarray,
+        "arg_polars_series": pl.Series,
+        "arg_pandas_series": pd.Series,
+        "arg_pyarrow_array": pa.Array,
+    },
+)
 def my_udf(
     # Test different arg containers
     arg_untyped,
@@ -132,7 +144,7 @@ def test_udf_typing_kwargs():
 ###
 
 
-@udf(return_type=int)
+@udf(return_dtype=int, input_columns={"b": np.ndarray})
 class MyUDF:
     def __init__(self):
         self._a = 1
@@ -153,8 +165,8 @@ def test_class_udf():
 ###
 
 
-@udf(return_type=int, type_hints={"a": np.ndarray})
-def my_udf_type_hints(a: list):
+@udf(return_dtype=int, input_columns={"a": np.ndarray})
+def my_udf_type_hints(a):
     assert isinstance(a, np.ndarray)
     return a
 
@@ -181,11 +193,11 @@ def test_udf_new_typing_annotations():
         return arg_list_int
 
     with pytest.raises(TypeError):
-        udf(my_udf_new_typing_annotations, return_type=int)
+        udf(my_udf_new_typing_annotations, return_dtype=int)
 
     my_udf_new_typing_annotations_udf = udf(
         my_udf_new_typing_annotations,
-        return_type=int,
+        return_dtype=int,
         type_hints={"arg_list_int": List[int], "arg_numpy_array_int": np.ndarray},
     )
     df = DataFrame.from_pydict({"a": [1, 2, 3]})

--- a/tests/property_based_testing/test_sort.py
+++ b/tests/property_based_testing/test_sort.py
@@ -199,7 +199,7 @@ class DataframeSortStateMachine(RuleBasedStateMachine):
             ExpressionType.float(): lambda e, other: e + other,
             ExpressionType.logical(): lambda e, other: e & other,
             ExpressionType.from_py_type(UserObject): lambda e, other: e.apply(
-                lambda x: x.add(other) if x is not None else None, return_type=UserObject
+                lambda x: x.add(other) if x is not None else None, return_dtype=UserObject
             ),
             # No meaningful binary operations supported for these yet
             ExpressionType.date(): lambda e, other: e.dt.year(),

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -20,7 +20,7 @@ def no_gpu_available() -> bool:
 DATA = {"id": [i for i in range(100)]}
 
 
-@udf(return_type=int)
+@udf(return_dtype=int, input_columns={"c": list})
 def my_udf(c):
     return [1] * len(c)
 
@@ -77,7 +77,7 @@ def test_requesting_too_much_memory():
 ###
 
 
-@udf(return_type=int)
+@udf(return_dtype=int, input_columns={"c": list})
 def assert_resources(c, num_cpus=None, num_gpus=None, memory=None):
     assigned_resources = ray.get_runtime_context().get_assigned_resources()
 
@@ -141,7 +141,7 @@ def test_with_column_folded_rayrunner():
 ###
 
 
-@udf(return_type=int)
+@udf(return_dtype=int, input_columns={"c": list})
 def assert_num_cuda_visible_devices(c, num_gpus: int = 0):
     cuda_visible_devices = os.getenv("CUDA_VISIBLE_DEVICES")
     # Env var not set: program is free to use any number of GPUs

--- a/tutorials/image_querying/top_n_red_color.ipynb
+++ b/tutorials/image_querying/top_n_red_color.ipynb
@@ -322,7 +322,7 @@
     "import io\n",
     "import PIL\n",
     "\n",
-    "@udf(return_type=PIL.Image.Image)\n",
+    "@udf(return_dtype=PIL.Image.Image, input_columns={\"bytes_columns\": list})\n",
     "def bytes_to_pil(bytes_column):\n",
     "    return [\n",
     "        PIL.Image.open(io.BytesIO(data)).resize((256, 256)) for data in bytes_column\n",
@@ -442,7 +442,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16 (default, Dec 25 2022, 07:11:03) \n[Clang 13.0.0 (clang-1300.0.27.3)]"
+   "version": "3.8.16"
   },
   "vscode": {
    "interpreter": {

--- a/tutorials/mnist.ipynb
+++ b/tutorials/mnist.ipynb
@@ -539,7 +539,7 @@
     }
    ],
    "source": [
-    "@udf(return_type=int)\n",
+    "@udf(return_type=int, input_columns={\"images_2d_col\": list})\n",
     "class ClassifyImages:\n",
     "\n",
     "    def __init__(self):\n",
@@ -905,7 +905,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16 (default, Dec 25 2022, 07:11:03) \n[Clang 13.0.0 (clang-1300.0.27.3)]"
+   "version": "3.8.16"
   },
   "vscode": {
    "interpreter": {

--- a/tutorials/mnist.ipynb
+++ b/tutorials/mnist.ipynb
@@ -232,7 +232,7 @@
     "\n",
     "images_df = images_df.with_column(\n",
     "    \"image_2d\",\n",
-    "    col(\"image\").apply(lambda l: np.array(l).reshape(28, 28), return_type=np.ndarray),\n",
+    "    col(\"image\").apply(lambda l: np.array(l).reshape(28, 28), return_dtype=np.ndarray),\n",
     ")"
    ]
   },
@@ -344,7 +344,7 @@
    "source": [
     "from PIL import Image\n",
     "\n",
-    "images_df = images_df.with_column(\"pil_image\", col(\"image_2d\").apply(lambda arr: Image.fromarray(arr.astype(np.uint8)), return_type=Image.Image))"
+    "images_df = images_df.with_column(\"pil_image\", col(\"image_2d\").apply(lambda arr: Image.fromarray(arr.astype(np.uint8)), return_dtype=Image.Image))"
    ]
   },
   {
@@ -539,7 +539,7 @@
     }
    ],
    "source": [
-    "@udf(return_type=int, input_columns={\"images_2d_col\": list})\n",
+    "@udf(return_dtype=int, input_columns={\"images_2d_col\": list})\n",
     "class ClassifyImages:\n",
     "\n",
     "    def __init__(self):\n",

--- a/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -235,7 +235,7 @@
     "from daft.resource_request import ResourceRequest\n",
     "\n",
     "# Tell Daft to use N number of GPUs with num_gpus=N\n",
-    "@udf(return_type=PIL.Image.Image)\n",
+    "@udf(return_dtype=PIL.Image.Image, input_columns={\"text_col\": list})\n",
     "class GenerateImageFromTextGPU:\n",
     "    \n",
     "    def __init__(self):\n",
@@ -290,7 +290,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4 (main, Jan 11 2023, 00:15:55) [Clang 13.0.0 (clang-1300.0.27.3)]"
+   "version": "3.8.16"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Closes #591 

* Remove type annotation inference from UDFs
* Rename `return_type=` to `return_dtype=`
* Rename `type_hints=` to `input_columns=` and make this non-optional
* Update documentation
* UDF invocation will fail if parameters marked as columns are not called on Expressions