### PR TITLE
Refactor @udf to return a UDF class instead of wrapped functions

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -72,7 +72,7 @@ from daft.dataframe import DataFrame
 from daft.datatype import DataType
 from daft.expressions import col, lit
 from daft.series import Series
-from daft.udf import polars_udf, udf
+from daft.udf import udf
 from daft.viz import register_viz_hook
 
-__all__ = ["DataFrame", "col", "DataType", "lit", "udf", "polars_udf", "Series", "register_viz_hook"]
+__all__ = ["DataFrame", "col", "DataType", "lit", "udf", "Series", "register_viz_hook"]

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -40,21 +40,140 @@ try:
 except ImportError:
     _PYARROW_AVAILABLE = False
 
-StatefulUDF = type  # stateful UDFs are provided as Python Classes
-StatelessUDF = Callable[..., Sequence]
-UDF = Union[StatefulUDF, StatelessUDF]
+_StatefulPythonFunction = type  # stateful UDFs are provided as Python Classes
+_StatelessPythonFunction = Callable[..., Sequence]
+_PythonFunction = Union[_StatefulPythonFunction, _StatelessPythonFunction]
 
 
 logger = logging.getLogger(__name__)
 
 
-def _initialize_func(func):
-    """Initializes a function if it is a class, otherwise noop"""
-    try:
-        return func() if isinstance(func, type) else func
-    except:
-        logger.error(f"Encountered error when initializing user-defined function {func.__name__}")
-        raise
+class UDF:
+    def __init__(self, f: _PythonFunction, input_columns: dict[str, type], return_dtype: type):
+        self._f = f
+        self._input_types = {
+            arg_name: UdfInputType.from_type_hint(type_hint) for arg_name, type_hint in input_columns.items()
+        }
+        self._func_ret_type = ExpressionType.from_py_type(return_dtype)
+
+        # Get function argument names, excluding `self` if it is a class method
+        call_method = f.__call__ if isinstance(f, type) else f
+        self._ordered_func_arg_names = list(inspect.signature(call_method).parameters.keys())
+        if isinstance(f, type):
+            self._ordered_func_arg_names = self._ordered_func_arg_names[1:]
+
+    @property
+    def func(self) -> _PythonFunction:
+        """Returns the wrapped function. Useful for local testing of your UDF.
+
+        Example:
+
+            >>> @udf(return_dtype=int, input_columns={"x": list})
+            >>> def my_udf(x: list, y: int):
+            >>>     return [i + y for i in x]
+            >>>
+            >>> assert my_udf.func([1, 2, 3], 1) == [2, 3, 4]
+
+        Returns:
+            _PythonFunction: The function (or class!) wrapped by the @udf decorator
+        """
+        return self._f
+
+    def _initialize_func(self):
+        """Initializes a function if it is a class, otherwise noop"""
+        try:
+            return self._f() if isinstance(self._f, type) else self._f
+        except:
+            logger.error(f"Encountered error when initializing user-defined function {self._f.__name__}")
+            raise
+
+    def _convert_argument(self, arg_name: str, arg: DataBlock, partition_length: int) -> Any:
+        """Converts a UDF argument input to the appropriate user-facing container type"""
+        if arg_name not in self._input_types:
+            assert arg.is_scalar(), f"Not a column type, this DataBlock should be a scalar literal"
+            return next(arg.iter_py())
+
+        input_type = self._input_types[arg_name]
+        if arg.is_scalar():
+            return next(arg.iter_py())
+        if input_type == UdfInputType.LIST:
+            arg_iterator = arg.iter_py()
+            return [next(arg_iterator) for _ in range(partition_length)]
+        elif input_type == UdfInputType.NUMPY:
+            return arg.to_numpy()
+        elif input_type == UdfInputType.PANDAS:
+            return pd.Series(arg.to_numpy())
+        elif input_type == UdfInputType.PYARROW:
+            return arg.to_arrow().combine_chunks()
+        elif input_type == UdfInputType.PYARROW_CHUNKED:
+            return arg.to_arrow()
+        elif input_type == UdfInputType.POLARS:
+            return arg.to_polars()
+        raise NotImplementedError(f"Unsupported UDF input type {input_type}")
+
+    def __call__(self, *args, **kwargs) -> UdfExpression:
+        """Call the UDF on arguments which can be Expressions, or normal Python values
+
+        Raises:
+            ValueError: if non-Expression objects are provided for parameters that are specified as `input_columns`
+
+        Returns:
+            UdfExpression: The resulting UDFExpression representing an execution of the UDF on its inputs
+        """
+        # Validate that arguments specified in input_columns receive Expressions as input
+        arg_names_and_args = list(zip(self._ordered_func_arg_names, args)) + list(kwargs.items())
+        for arg_name, arg in arg_names_and_args:
+            if arg_name in self._input_types and not isinstance(arg, Expression):
+                raise ValueError(
+                    f"`{arg_name}` is an input_column. UDF expects an Expression as input but received instead: {arg}"
+                )
+            if arg_name not in self._input_types and isinstance(arg, Expression):
+                raise ValueError(
+                    f"`{arg_name}` is not an input_column. UDF expects a non-Expression as input but received: {arg}"
+                )
+
+        @functools.wraps(self._f)
+        def pre_process_data_block_func(*args, **kwargs):
+            # TODO: The initialization of stateful UDFs is currently done on the execution on every partition here,
+            # but should instead be done on a higher level so that state initialization cost can be amortized across partitions.
+            # See: https://github.com/Eventual-Inc/Daft/issues/196
+            initialized_func = self._initialize_func()
+
+            # Calculate len of partition, or 0 if all datablocks are scalars
+            arg_lengths = [len(arg) if isinstance(arg, DataBlock) else 0 for arg in args]
+            kwarg_lengths = [len(kwargs[kwarg]) if isinstance(kwargs[kwarg], DataBlock) else 0 for kwarg in kwargs]
+            datablock_lengths = set(arg_lengths + kwarg_lengths)
+            datablock_lengths = datablock_lengths - {0}
+            assert (
+                len(datablock_lengths) <= 1
+            ), "All DataBlocks passed into a UDF must have the same length, or be scalar"
+            partition_length = datablock_lengths.pop() if len(datablock_lengths) > 0 else 0
+
+            # Convert DataBlock arguments to the correct type
+            converted_args = tuple(
+                self._convert_argument(arg_name, arg, partition_length)
+                for arg_name, arg in zip(self._ordered_func_arg_names, args)
+            )
+            converted_kwargs = {
+                kwarg_name: self._convert_argument(kwarg_name, arg, partition_length)
+                for kwarg_name, arg in kwargs.items()
+            }
+
+            try:
+                results = initialized_func(*converted_args, **converted_kwargs)
+            except:
+                logger.error(f"Encountered error when running user-defined function {self._f.__name__}")
+                raise
+
+            return results
+
+        out_expr = UdfExpression(
+            func=pre_process_data_block_func,
+            func_ret_type=self._func_ret_type,
+            func_args=args,
+            func_kwargs=kwargs,
+        )
+        return out_expr
 
 
 class UdfInputType(enum.Enum):
@@ -85,32 +204,7 @@ class UdfInputType(enum.Enum):
         raise ValueError(f"UDF input array type {hint} is not supported")
 
 
-def _convert_argument(arg: DataBlock, input_type: UdfInputType | None, partition_length: int) -> Any:
-    """Converts a UDF argument input to the appropriate user-facing container type"""
-    if input_type is None:
-        assert arg.is_scalar(), f"Not a column type, this DataBlock should be a scalar literal"
-        return next(arg.iter_py())
-
-    if arg.is_scalar():
-        return next(arg.iter_py())
-    if input_type == UdfInputType.LIST:
-        arg_iterator = arg.iter_py()
-        return [next(arg_iterator) for _ in range(partition_length)]
-    elif input_type == UdfInputType.NUMPY:
-        return arg.to_numpy()
-    elif input_type == UdfInputType.PANDAS:
-        return pd.Series(arg.to_numpy())
-    elif input_type == UdfInputType.PYARROW:
-        return arg.to_arrow().combine_chunks()
-    elif input_type == UdfInputType.PYARROW_CHUNKED:
-        return arg.to_arrow()
-    elif input_type == UdfInputType.POLARS:
-        return arg.to_polars()
-    raise NotImplementedError(f"Unsupported UDF input type {input_type}")
-
-
 def udf(
-    f: Callable | None = None,
     *,
     return_dtype: type,
     input_columns: dict[str, type],
@@ -249,86 +343,11 @@ def udf(
     if "type_hints" in kwargs:
         raise ValueError(f"The `type_hints` keyword argument has been deprecated and renamed to input_columns.")
 
-    func_ret_type = ExpressionType.from_py_type(return_dtype)
+    def _udf(f: _PythonFunction) -> UDF:
+        return UDF(
+            f,
+            input_columns,
+            return_dtype,
+        )
 
-    def udf_decorator(func: UDF) -> Callable:
-
-        call_method = func.__call__ if isinstance(func, type) else func
-        input_types = {
-            arg_name: UdfInputType.from_type_hint(type_hint) for arg_name, type_hint in input_columns.items()
-        }
-
-        # Get function argument names, excluding `self` if it is a class method
-        ordered_func_arg_names = list(inspect.signature(call_method).parameters.keys())
-        if isinstance(func, type):
-            ordered_func_arg_names = ordered_func_arg_names[1:]
-
-        @functools.wraps(func)
-        def wrapped_func(*args, **kwargs):
-
-            # Validate that arguments specified in input_columns receive Expressions as input
-            arg_names_and_args = list(zip(ordered_func_arg_names, args)) + list(kwargs.items())
-            for arg_name, arg in arg_names_and_args:
-                if arg_name in input_types and not isinstance(arg, Expression):
-                    raise ValueError(
-                        f"Argument `{arg_name}` is an input_column expects an Expression but received instead: {arg}"
-                    )
-                if arg_name not in input_types and isinstance(arg, Expression):
-                    raise ValueError(
-                        f"Argument `{arg_name}` is not an input_column but received an Expression as input: {arg}"
-                    )
-
-            @functools.wraps(func)
-            def pre_process_data_block_func(*args, **kwargs):
-                # TODO: The initialization of stateful UDFs is currently done on the execution on every partition here,
-                # but should instead be done on a higher level so that state initialization cost can be amortized across partitions.
-                # See: https://github.com/Eventual-Inc/Daft/issues/196
-                initialized_func = _initialize_func(func)
-
-                # Calculate len of partition, or 0 if all datablocks are scalars
-                arg_lengths = [len(arg) if isinstance(arg, DataBlock) else 0 for arg in args]
-                kwarg_lengths = [len(kwargs[kwarg]) if isinstance(kwargs[kwarg], DataBlock) else 0 for kwarg in kwargs]
-                datablock_lengths = set(arg_lengths + kwarg_lengths)
-                datablock_lengths = datablock_lengths - {0}
-                assert (
-                    len(datablock_lengths) <= 1
-                ), "All DataBlocks passed into a UDF must have the same length, or be scalar"
-                partition_length = datablock_lengths.pop() if len(datablock_lengths) > 0 else 0
-
-                # Convert DataBlock arguments to the correct type
-                converted_args = tuple(
-                    _convert_argument(arg, input_types.get(arg_name), partition_length)
-                    for arg_name, arg in zip(ordered_func_arg_names, args)
-                )
-                converted_kwargs = {
-                    kwarg_name: _convert_argument(arg, input_types.get(kwarg_name), partition_length)
-                    for kwarg_name, arg in kwargs.items()
-                }
-
-                try:
-                    results = initialized_func(*converted_args, **converted_kwargs)
-                except:
-                    logger.error(f"Encountered error when running user-defined function {func.__name__}")
-                    raise
-
-                return results
-
-            out_expr = UdfExpression(
-                func=pre_process_data_block_func,
-                func_ret_type=func_ret_type,
-                func_args=args,
-                func_kwargs=kwargs,
-            )
-            return out_expr
-
-        return wrapped_func
-
-    if f is None:
-        return udf_decorator
-    return udf_decorator(f)
-
-
-def polars_udf(*args, **kwargs):
-    raise NotImplementedError(
-        "Polars_udf is deprecated. Please use @udf instead and indicate `pl.Series` in your `input_columns`"
-    )
+    return _udf


### PR DESCRIPTION
* UDF class has a `.func` convenience accessor to access the underlying function. Users can now access a function they wrapped with `@udf` simply by calling `f.func(...)` and use it normally
* Removes `@polars_udf`