### PR TITLE
Remove partition_id from vPartition

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -289,9 +289,7 @@ class DataFrame:
 
         column_types: Dict[str, ExpressionType] = {header: ExpressionType.infer_type(data[header]) for header in data}
         schema = Schema([Field(header, expr_type) for header, expr_type in column_types.items()])
-        data_vpartition = vPartition.from_pydict(
-            data={header: arr for header, arr in data.items()}, schema=schema, partition_id=0
-        )
+        data_vpartition = vPartition.from_pydict(data={header: arr for header, arr in data.items()}, schema=schema)
         result_pset = LocalPartitionSet({0: data_vpartition})
 
         cache_entry = get_context().runner().put_partition_set_into_cache(result_pset)
@@ -332,7 +330,6 @@ class DataFrame:
         def get_schema(filepath: str) -> Schema:
             return vPartition.from_json(
                 filepath,
-                partition_id=0,
                 schema_options=vPartitionSchemaInferenceOptions(
                     schema=None,
                     inference_column_names=None,  # has no effect on inferring schema from JSON
@@ -386,7 +383,6 @@ class DataFrame:
         def get_schema(filepath: str) -> Schema:
             return vPartition.from_csv(
                 path=filepath,
-                partition_id=0,
                 csv_options=vPartitionParseCSVOptions(
                     delimiter=delimiter,
                     has_headers=has_headers,
@@ -440,7 +436,6 @@ class DataFrame:
         def get_schema(filepath: str) -> Schema:
             return vPartition.from_parquet(
                 filepath,
-                partition_id=0,
                 schema_options=vPartitionSchemaInferenceOptions(
                     schema=None,
                     inference_column_names=None,  # has no effect on schema inferencing Parquet

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -338,7 +338,7 @@ class DataFrame:
                     num_rows=100,  # sample 100 rows for inferring schema
                     column_names=None,  # read all columns
                 ),
-            ).get_schema()
+            ).schema()
 
         plan = _get_tabular_files_scan(
             path,
@@ -397,7 +397,7 @@ class DataFrame:
                     num_rows=100,  # sample 100 rows for schema inference
                     column_names=None,  # read all columns
                 ),
-            ).get_schema()
+            ).schema()
 
         plan = _get_tabular_files_scan(
             path,
@@ -444,7 +444,7 @@ class DataFrame:
                     num_rows=0,  # sample 0 rows since Parquet has metadata
                     column_names=None,  # read all columns
                 ),
-            ).get_schema()
+            ).schema()
 
         plan = _get_tabular_files_scan(
             path,

--- a/daft/execution/logical_op_runners.py
+++ b/daft/execution/logical_op_runners.py
@@ -113,7 +113,6 @@ class LogicalPartitionOpRunner:
         assert col_name is not None
         columns[col_name] = PyListTile(
             col_name,
-            partition_id=partition_id,
             block=DataBlock.make_block(file_names),
         )
         return vPartition(

--- a/daft/execution/logical_op_runners.py
+++ b/daft/execution/logical_op_runners.py
@@ -21,7 +21,7 @@ class LogicalPartitionOpRunner:
     # TODO(charles): move to ExecutionStep
 
     def _handle_tabular_files_scan(
-        self, inputs: dict[int, vPartition], scan: TabularFilesScan, partition_id: int, index: int | None = None
+        self, inputs: dict[int, vPartition], scan: TabularFilesScan, index: int | None = None
     ) -> vPartition:
         child_id = scan._children()[0].id()
         prev_partition = inputs[child_id]
@@ -44,11 +44,10 @@ class LogicalPartitionOpRunner:
 
         if scan._source_info.scan_type() == StorageType.CSV:
             assert isinstance(scan._source_info, CSVSourceInfo)
-            return vPartition.merge_partitions(
+            return vPartition.concat(
                 [
                     vPartition.from_csv(
                         path=fp,
-                        partition_id=partition_id,
                         csv_options=vPartitionParseCSVOptions(
                             delimiter=scan._source_info.delimiter,
                             has_headers=scan._source_info.has_headers,
@@ -63,11 +62,10 @@ class LogicalPartitionOpRunner:
             )
         elif scan._source_info.scan_type() == StorageType.JSON:
             assert isinstance(scan._source_info, JSONSourceInfo)
-            return vPartition.merge_partitions(
+            return vPartition.concat(
                 [
                     vPartition.from_json(
                         path=fp,
-                        partition_id=partition_id,
                         schema_options=schema_options,
                         read_options=read_options,
                     )
@@ -76,11 +74,10 @@ class LogicalPartitionOpRunner:
             )
         elif scan._source_info.scan_type() == StorageType.PARQUET:
             assert isinstance(scan._source_info, ParquetSourceInfo)
-            return vPartition.merge_partitions(
+            return vPartition.concat(
                 [
                     vPartition.from_parquet(
                         path=fp,
-                        partition_id=partition_id,
                         schema_options=schema_options,
                         read_options=read_options,
                     )
@@ -90,7 +87,7 @@ class LogicalPartitionOpRunner:
         else:
             raise NotImplementedError(f"PyRunner has not implemented scan: {scan._source_info.scan_type()}")
 
-    def _handle_file_write(self, inputs: dict[int, vPartition], file_write: FileWrite, partition_id: int) -> vPartition:
+    def _handle_file_write(self, inputs: dict[int, vPartition], file_write: FileWrite) -> vPartition:
         child_id = file_write._children()[0].id()
         assert file_write._storage_type == StorageType.PARQUET or file_write._storage_type == StorageType.CSV
         if file_write._storage_type == StorageType.PARQUET:
@@ -115,7 +112,4 @@ class LogicalPartitionOpRunner:
             col_name,
             block=DataBlock.make_block(file_names),
         )
-        return vPartition(
-            columns,
-            partition_id=partition_id,
-        )
+        return vPartition(columns)

--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -464,6 +464,17 @@ def sort(
     )
 
 
+def fanout_random(child_plan: InProgressPhysicalPlan[PartitionT], node: logical_plan.Repartition):
+    """Splits the results of `child_plan` randomly into a list of `node.num_partitions()` number of partitions"""
+    seed = 0
+    for step in child_plan:
+        if isinstance(step, PartitionTaskBuilder):
+            instruction = execution_step.FanoutRandom(node.num_partitions(), seed)
+            step = step.add_instruction(instruction)
+        yield step
+        seed += 1
+
+
 def materialize(
     child_plan: InProgressPhysicalPlan[PartitionT],
 ) -> MaterializedPhysicalPlan:

--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -69,7 +69,7 @@ def file_read(
             file_sizes_bytes = vpartition.to_pydict()["size"]
 
             # Emit one partition for each file (NOTE: hardcoded for now).
-            for i in range(vpartition.metadata().num_rows):
+            for i in range(len(vpartition)):
 
                 file_read_step = PartitionTaskBuilder[PartitionT](inputs=[done_task.partition()]).add_instruction(
                     instruction=execution_step.ReadFile(

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -144,6 +144,13 @@ class PartitionMetadata:
     num_rows: int
     size_bytes: int
 
+    @classmethod
+    def from_table(cls, table: vPartition) -> PartitionMetadata:
+        return PartitionMetadata(
+            num_rows=len(table),
+            size_bytes=table.size_bytes(),
+        )
+
 
 @dataclass(frozen=True)
 class vPartition:
@@ -164,11 +171,8 @@ class vPartition:
             return 0
         return len(next(iter(self.columns.values())))
 
-    def metadata(self) -> PartitionMetadata:
-        return PartitionMetadata(
-            num_rows=len(self),
-            size_bytes=sum(tile.size_bytes() for tile in self.columns.values()),
-        )
+    def size_bytes(self) -> int:
+        return sum(tile.size_bytes() for tile in self.columns.values())
 
     def get_schema(self) -> Schema:
         """Generates column expressions that represent the vPartition's schema"""

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -174,7 +174,7 @@ class vPartition:
     def size_bytes(self) -> int:
         return sum(tile.size_bytes() for tile in self.columns.values())
 
-    def get_schema(self) -> Schema:
+    def schema(self) -> Schema:
         """Generates column expressions that represent the vPartition's schema"""
         fields = []
         for _, tile in self.columns.items():

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -49,7 +49,7 @@ class LocalPartitionSet(PartitionSet[vPartition]):
         ids_and_partitions = self.items()
         assert ids_and_partitions[0][0] == 0
         assert ids_and_partitions[-1][0] + 1 == len(ids_and_partitions)
-        return vPartition.merge_partitions([part for id, part in ids_and_partitions], verify_partition_id=False)
+        return vPartition.concat([part for id, part in ids_and_partitions])
 
     def get_partition(self, idx: PartID) -> vPartition:
         return self._partitions[idx]
@@ -100,7 +100,6 @@ class LocalPartitionSetFactory(PartitionSetFactory[vPartition]):
                         self.FS_LISTING_ROWS_COLUMN_NAME: [f.rows for f in files_info],
                     },
                     schema=schema,
-                    partition_id=0,
                 ),
             }
         )

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -275,7 +275,7 @@ class PyMaterializedResult(MaterializedResult[vPartition]):
         return self._partition
 
     def metadata(self) -> PartitionMetadata:
-        return self._partition.metadata()
+        return PartitionMetadata.from_table(self._partition)
 
     def cancel(self) -> None:
         return None

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -195,7 +195,7 @@ def build_partitions(
     for instruction in instruction_stack:
         partitions = instruction.run(partitions)
 
-    metadatas = [p.metadata() for p in partitions]
+    metadatas = [PartitionMetadata.from_table(p) for p in partitions]
 
     return [metadatas, *partitions]
 
@@ -233,7 +233,7 @@ def reduce_and_fanout(
 
 @ray.remote
 def get_meta(partition: vPartition) -> PartitionMetadata:
-    return partition.metadata()
+    return PartitionMetadata.from_table(partition)
 
 
 @ray.remote(num_cpus=1)

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -84,7 +84,6 @@ def _glob_path_into_details_vpartitions(
             listing_rows_name: [file_info.rows for file_info in listing_infos],
         },
         schema=schema,
-        partition_id=0,
     )
     partition_ref = ray.put(partition)
     partition_refs = [(0, partition_ref)]
@@ -122,7 +121,7 @@ class RayPartitionSet(PartitionSet[ray.ObjectRef]):
         assert ids_and_partitions[0][0] == 0
         assert ids_and_partitions[-1][0] + 1 == len(ids_and_partitions)
         all_partitions = ray.get([part for id, part in ids_and_partitions])
-        return vPartition.merge_partitions(all_partitions, verify_partition_id=False)
+        return vPartition.concat(all_partitions)
 
     def to_ray_dataset(self) -> RayDataset:
         if not _RAY_FROM_ARROW_REFS_AVAILABLE:

--- a/daft/runners/shuffle_ops.py
+++ b/daft/runners/shuffle_ops.py
@@ -33,12 +33,7 @@ class ShuffleOp:
 
 class RepartitionRandomOp(ShuffleOp):
     @staticmethod
-    def map_fn(input: vPartition, output_partitions: int, seed: int | None = None) -> dict[PartID, vPartition]:
-        if seed is None:
-            seed = input.partition_id
-        else:
-            seed += input.partition_id
-
+    def map_fn(input: vPartition, output_partitions: int, seed: int = 0) -> dict[PartID, vPartition]:
         rng = np.random.default_rng(seed=seed)
         target_idx: DataBlock[ArrowArrType] = DataBlock.make_block(
             data=rng.integers(low=0, high=output_partitions, size=len(input))
@@ -48,7 +43,7 @@ class RepartitionRandomOp(ShuffleOp):
 
     @staticmethod
     def reduce_fn(mapped_outputs: list[vPartition]) -> vPartition:
-        return vPartition.merge_partitions(mapped_outputs)
+        return vPartition.concat(mapped_outputs)
 
 
 class RepartitionHashOp(ShuffleOp):
@@ -62,7 +57,7 @@ class RepartitionHashOp(ShuffleOp):
 
     @staticmethod
     def reduce_fn(mapped_outputs: list[vPartition]) -> vPartition:
-        return vPartition.merge_partitions(mapped_outputs)
+        return vPartition.concat(mapped_outputs)
 
 
 class SortOp(ShuffleOp):
@@ -91,4 +86,4 @@ class SortOp(ShuffleOp):
     ) -> vPartition:
         assert exprs is not None and descending is not None
         assert len(exprs) == len(descending)
-        return vPartition.merge_partitions(mapped_outputs).sort(exprs, descending=descending)
+        return vPartition.concat(mapped_outputs).sort(exprs, descending=descending)

--- a/tests/runners/test_partitioning.py
+++ b/tests/runners/test_partitioning.py
@@ -16,7 +16,7 @@ def test_vpartition_eval_expression() -> None:
     for c in expr.required_columns():
         block = DataBlock.make_block(np.ones(10))
         tiles[c] = PyListTile(column_name=c, block=block)
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     result_tile = part.eval_expression(expr=expr)
     assert result_tile.column_name == expr.name()
     assert result_tile.block == DataBlock.make_block(np.ones(10) * 2)
@@ -34,7 +34,7 @@ def test_vpartition_eval_expression_list() -> None:
     for c in expr.required_columns():
         block = DataBlock.make_block(np.ones(10))
         tiles[c] = PyListTile(column_name=c, block=block)
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     assert len(part) == 10
 
     result_vpart = part.eval_expression_list(exprs=expr_list)
@@ -45,7 +45,6 @@ def test_vpartition_eval_expression_list() -> None:
         expr = list_of_expr[i]
         col_name = expr.name()
         result_tile = result_vpart.columns[col_name]
-        assert result_vpart.partition_id == 0
         assert result_tile.column_name == expr.name()
         assert result_tile.block == DataBlock.make_block((np.ones(10) * 2) + i)
 
@@ -55,7 +54,7 @@ def test_vpartition_to_arrow_table() -> None:
     for i in range(4):
         block = DataBlock.make_block(np.ones(10) * i)
         tiles[f"col_{i}"] = PyListTile(column_name=f"col_{i}", block=block)
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     arrow_table = pa.Table.from_pandas(part.to_pandas())
     assert arrow_table.column_names == [f"col_{i}" for i in range(4)]
 
@@ -65,7 +64,7 @@ def test_vpartition_to_arrow_table() -> None:
 
 def test_vpartition_from_arrow_table() -> None:
     arrow_table = pa.table([np.ones(10) * i for i in range(4)], names=[f"col_{i}" for i in range(4)])
-    vpart = vPartition.from_arrow_table(arrow_table, partition_id=0)
+    vpart = vPartition.from_arrow_table(arrow_table)
     assert len(vpart) == 10
     for i, (col_name, tile) in enumerate(vpart.columns.items()):
         assert tile.block == DataBlock.make_block(data=np.ones(10) * i)
@@ -79,7 +78,7 @@ def test_vpartition_uneven_tiles() -> None:
         tiles[f"col_{i}"] = PyListTile(column_name=f"col_{i}", block=block)
 
     with pytest.raises(ValueError):
-        part = vPartition(columns=tiles, partition_id=0)
+        part = vPartition(columns=tiles)
 
 
 def test_vpartition_head() -> None:
@@ -87,7 +86,7 @@ def test_vpartition_head() -> None:
     for i in range(4):
         block = DataBlock.make_block(np.ones(10) * i)
         tiles[f"col_{i}"] = PyListTile(column_name=f"col_{i}", block=block)
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     part = part.head(3)
     arrow_table = pa.Table.from_pandas(part.to_pandas())
     assert arrow_table.column_names == [f"col_{i}" for i in range(4)]
@@ -101,7 +100,7 @@ def test_vpartition_sample() -> None:
     for i in range(4):
         block = DataBlock.make_block(np.ones(10) * i)
         tiles[f"col_{i}"] = PyListTile(column_name=f"col_{i}", block=block)
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     part = part.sample(3)
     arrow_table = pa.Table.from_pandas(part.to_pandas())
     assert arrow_table.column_names == [f"col_{i}" for i in range(4)]
@@ -120,7 +119,7 @@ def test_vpartition_filter() -> None:
         block = DataBlock.make_block(np.arange(0, 10, 1))
         tiles[f"col_{i}"] = PyListTile(column_name=f"col_{i}", block=block)
 
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     part = part.filter(ExpressionList([expr]))
     arrow_table = pa.Table.from_pandas(part.to_pandas())
     assert arrow_table.column_names == [f"col_{i}" for i in range(4)]
@@ -141,7 +140,7 @@ def test_vpartition_sort() -> None:
             block = DataBlock.make_block(np.arange(0, 10, 1))
 
         tiles[f"col_{i}"] = PyListTile(column_name=f"col_{i}", block=block)
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     part = part.sort(ExpressionList([expr]))
     arrow_table = pa.Table.from_pandas(part.to_pandas())
     assert arrow_table.column_names == [f"col_{i}" for i in range(4)]
@@ -164,7 +163,7 @@ def test_vpartition_sort_desc() -> None:
             block = DataBlock.make_block(np.arange(0, 10, 1))
 
         tiles[f"col_{i}"] = PyListTile(column_name=f"col_{i}", block=block)
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     part = part.sort(ExpressionList([expr]), descending=[True])
     arrow_table = pa.Table.from_pandas(part.to_pandas())
     assert arrow_table.column_names == [f"col_{i}" for i in range(4)]
@@ -181,7 +180,7 @@ def test_split_by_index_even(n) -> None:
     for i in range(0, 4):
         block = DataBlock.make_block(np.arange(0, 100, 1))
         tiles[f"col_{i}"] = PyListTile(column_name=f"col_{i}", block=block)
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     new_parts = part.split_by_index(n, DataBlock.make_block(data=np.arange(0, 100, 1) % n))
     assert len(new_parts) == n
 
@@ -190,7 +189,6 @@ def test_split_by_index_even(n) -> None:
         remainder = 100 % n
         if remainder > 0 and i < remainder:
             expected_size += 1
-        assert new_part.partition_id == i
         assert len(new_part) == expected_size
         for col in new_part.columns.values():
             pylist = col.block.iter_py()
@@ -207,11 +205,10 @@ def test_hash_partition(n) -> None:
 
         tiles[f"col_{i}"] = PyListTile(column_name=f"col_{i}", block=block)
 
-    part = vPartition(columns=tiles, partition_id=0)
+    part = vPartition(columns=tiles)
     new_parts = part.split_by_hash(ExpressionList([col("col_0")]), n)
     values_seen = set()
     for i, new_part in enumerate(new_parts):
-        assert new_part.partition_id == i
         values_expected = None
         for ncol in new_part.columns.values():
             pylist = list(ncol.block.iter_py())
@@ -225,7 +222,7 @@ def test_hash_partition(n) -> None:
 
 def test_partition_quantiles_small_sample_large_partitions():
     data = [1, 2, 3]
-    partition = vPartition({"foo": PyListTile("foo", ArrowDataBlock(pa.chunked_array([data])))}, 1)
+    partition = vPartition({"foo": PyListTile("foo", ArrowDataBlock(pa.chunked_array([data])))})
     quantiled_partition = partition.quantiles(10)
     quantile_boundaries = quantiled_partition.columns["foo"].block.data.to_pylist()
     assert sorted(quantile_boundaries) == quantile_boundaries, "quantile boundaries should be in sorted order"


### PR DESCRIPTION
* We don't actually use `.partition_id` anywhere
* Removing it makes transitioning over from `vPartition -> Table` much easier since they now map 1:1