### PR TITLE
Refactor .from_pydict() to infer schema in the method

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -52,7 +52,6 @@ if TYPE_CHECKING:
     import pandas
     import pyarrow as pa
 
-from daft.logical.field import Field
 from daft.logical.schema import Schema
 
 UDFReturnType = TypeVar("UDFReturnType", covariant=True)
@@ -287,16 +286,14 @@ class DataFrame:
                 f"Expected all columns to be of the same length, but received columns with lengths: {column_lengths}"
             )
 
-        column_types: Dict[str, ExpressionType] = {header: ExpressionType.infer_type(data[header]) for header in data}
-        schema = Schema([Field(header, expr_type) for header, expr_type in column_types.items()])
-        data_vpartition = vPartition.from_pydict(data={header: arr for header, arr in data.items()}, schema=schema)
+        data_vpartition = vPartition.from_pydict(data={header: arr for header, arr in data.items()})
         result_pset = LocalPartitionSet({0: data_vpartition})
 
         cache_entry = get_context().runner().put_partition_set_into_cache(result_pset)
 
         plan = logical_plan.InMemoryScan(
             cache_entry=cache_entry,
-            schema=schema,
+            schema=data_vpartition.schema(),
         )
         return cls(plan)
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -286,7 +286,7 @@ class DataFrame:
                 f"Expected all columns to be of the same length, but received columns with lengths: {column_lengths}"
             )
 
-        data_vpartition = vPartition.from_pydict(data={header: arr for header, arr in data.items()})
+        data_vpartition = vPartition.from_pydict(data)
         result_pset = LocalPartitionSet({0: data_vpartition})
 
         cache_entry = get_context().runner().put_partition_set_into_cache(result_pset)

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -386,10 +386,8 @@ class LocalCount(Instruction):
 
     def _count(self, inputs: list[vPartition]) -> list[vPartition]:
         [input] = inputs
-        partition = vPartition.from_pydict(
-            {"count": [len(input)]},
-            schema=self.logplan._schema,
-        )
+        partition = vPartition.from_pydict({"count": [len(input)]})
+        assert partition.schema() == self.logplan.schema()
         return [partition]
 
     def run_partial_metadata(self, input_metadatas: list[PartialPartitionMetadata]) -> list[PartialPartitionMetadata]:

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -233,8 +233,11 @@ class vPartition:
 
     @classmethod
     def from_pydict(
-        cls, data: dict[str, list[Any] | np.ndarray | pa.Array | pa.ChunkedArray], schema: Schema
+        cls,
+        data: dict[str, list[Any] | np.ndarray | pa.Array | pa.ChunkedArray],
     ) -> vPartition:
+        column_types = {header: ExpressionType.infer_type(data[header]) for header in data}
+        schema = Schema([Field(header, expr_type) for header, expr_type in column_types.items()])
         fields = schema.fields
         tiles = {}
         for f in fields.values():

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 import psutil
+import pyarrow as pa
 
 from daft.datasources import SourceInfo
 from daft.execution import physical_plan, physical_plan_factory
@@ -89,17 +90,17 @@ class LocalPartitionSetFactory(PartitionSetFactory[vPartition]):
             raise FileNotFoundError(f"No files found at {source_path}")
 
         partition = vPartition.from_pydict(
-            data={
-                self.FS_LISTING_PATH_COLUMN_NAME: [f.path for f in files_info],
-                self.FS_LISTING_SIZE_COLUMN_NAME: [f.size for f in files_info],
-                self.FS_LISTING_TYPE_COLUMN_NAME: [f.type for f in files_info],
-                self.FS_LISTING_ROWS_COLUMN_NAME: [f.rows for f in files_info],
+            {
+                "path": pa.array([file_info.path for file_info in files_info], type=pa.string()),
+                "size": pa.array([file_info.size for file_info in files_info], type=pa.int64()),
+                "type": pa.array([file_info.type for file_info in files_info], type=pa.string()),
+                "rows": pa.array([file_info.rows for file_info in files_info], type=pa.int64()),
             },
         )
 
         # Make sure that the schema is consistent with what we expect
         schema = self._get_listing_paths_details_schema()
-        assert partition.schema() == schema
+        assert partition.schema() == schema, f"Schema should be expected: {schema}, but received: {partition.schema()}"
 
         pset = LocalPartitionSet(
             {

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -69,8 +69,6 @@ from daft.logical.schema import Schema
 def _glob_path_into_details_vpartitions(
     path: str, schema: Schema, source_info: SourceInfo | None
 ) -> list[tuple[PartID, vPartition]]:
-    assert len(schema) == 4
-    listing_path_name, listing_size_name, listing_type_name, listing_rows_name = ["path", "size", "type", "rows"]
     listing_infos = glob_path_with_stats(path, source_info)
     if len(listing_infos) == 0:
         raise FileNotFoundError(f"No files found at {path}")
@@ -78,13 +76,14 @@ def _glob_path_into_details_vpartitions(
     # Hardcoded to 1 partition
     partition = vPartition.from_pydict(
         {
-            listing_path_name: [file_info.path for file_info in listing_infos],
-            listing_size_name: [file_info.size for file_info in listing_infos],
-            listing_type_name: [file_info.type for file_info in listing_infos],
-            listing_rows_name: [file_info.rows for file_info in listing_infos],
+            "path": [file_info.path for file_info in listing_infos],
+            "size": [file_info.size for file_info in listing_infos],
+            "type": [file_info.type for file_info in listing_infos],
+            "rows": [file_info.rows for file_info in listing_infos],
         },
-        schema=schema,
     )
+    assert partition.schema() == schema, f"Constructed partition must have schema: {schema}"
+
     partition_ref = ray.put(partition)
     partition_refs = [(0, partition_ref)]
 

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -76,13 +76,13 @@ def _glob_path_into_details_vpartitions(
     # Hardcoded to 1 partition
     partition = vPartition.from_pydict(
         {
-            "path": [file_info.path for file_info in listing_infos],
-            "size": [file_info.size for file_info in listing_infos],
-            "type": [file_info.type for file_info in listing_infos],
-            "rows": [file_info.rows for file_info in listing_infos],
+            "path": pa.array([file_info.path for file_info in listing_infos], type=pa.string()),
+            "size": pa.array([file_info.size for file_info in listing_infos], type=pa.int64()),
+            "type": pa.array([file_info.type for file_info in listing_infos], type=pa.string()),
+            "rows": pa.array([file_info.rows for file_info in listing_infos], type=pa.int64()),
         },
     )
-    assert partition.schema() == schema, f"Constructed partition must have schema: {schema}"
+    assert partition.schema() == schema, f"Schema should be expected: {schema}, but received: {partition.schema()}"
 
     partition_ref = ray.put(partition)
     partition_refs = [(0, partition_ref)]

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -169,7 +169,9 @@ def test_load_pydict_types():
 
     assert collected_data.keys() == data.keys() == expected.keys()
     for colname, expected_schema_type in expected.items():
-        assert daft_df.schema()[colname].dtype == expected_schema_type
+        assert (
+            daft_df.schema()[colname].dtype == expected_schema_type
+        ), f"{colname} expected {expected_schema_type} but received {daft_df.schema()[colname].dtype}"
 
 
 ###


### PR DESCRIPTION
Refactor `.from_pydict()` such that schema inference is performed from inside the function, rather than provided as an external argument.