### PR TITLE
Downgrade isort 5.12.0 -> 5.11.5 for py37 compatibility.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
     args: [--autofix]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.12.0
+  rev: 5.11.5
   hooks:
   - id: isort
     name: isort (python)


### PR DESCRIPTION
It seems isort will run, but not install, if py>=38 is not available :thinking: 