### PR TITLE
Refactor Schema initialization in the codebase

### DIFF
--- a/daft/expressions.py
+++ b/daft/expressions.py
@@ -1047,10 +1047,8 @@ class ExpressionList(Iterable[Expression]):
     def to_schema(self, input_schema: Schema) -> Schema:
         from daft.logical.schema import Schema
 
-        result = []
-        for e in self.exprs:
-            result.append(e.to_field(input_schema))
-        return Schema(result)
+        fields = [e.to_field(input_schema) for e in self.exprs]
+        return Schema._from_name_and_types([(f.name, f.dtype) for f in fields])
 
     def union(
         self, other: ExpressionList, rename_dup: str | None = None, other_override: bool = False

--- a/daft/expressions.py
+++ b/daft/expressions.py
@@ -1048,7 +1048,7 @@ class ExpressionList(Iterable[Expression]):
         from daft.logical.schema import Schema
 
         fields = [e.to_field(input_schema) for e in self.exprs]
-        return Schema._from_name_and_types([(f.name, f.dtype) for f in fields])
+        return Schema._from_field_name_and_types([(f.name, f.dtype) for f in fields])
 
     def union(
         self, other: ExpressionList, rename_dup: str | None = None, other_override: bool = False

--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -228,7 +228,7 @@ class TabularFilesScan(UnaryNode):
             self._predicate = ExpressionList([])
 
         if columns is not None:
-            self._output_schema = Schema._from_name_and_types(
+            self._output_schema = Schema._from_field_name_and_types(
                 [(schema[col].name, schema[col].dtype) for col in columns]
             )
         else:
@@ -360,7 +360,7 @@ class FileWrite(UnaryNode):
                 field.dtype
             ), f"we can currently only write out primitive types, got: {field}"
 
-        schema = Schema._from_name_and_types([("file_path", ExpressionType.from_py_type(str))])
+        schema = Schema._from_field_name_and_types([("file_path", ExpressionType.from_py_type(str))])
 
         super().__init__(schema, input.partition_spec(), op_level=OpLevel.PARTITION)
         self._register_child(input)
@@ -634,7 +634,7 @@ class GlobalLimit(UnaryNode):
 
 class LocalCount(UnaryNode):
     def __init__(self, input: LogicalPlan) -> None:
-        schema = Schema._from_name_and_types([("count", ExpressionType.integer())])
+        schema = Schema._from_field_name_and_types([("count", ExpressionType.integer())])
         super().__init__(schema, partition_spec=input.partition_spec(), op_level=OpLevel.PARTITION)
         self._register_child(input)
 

--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -13,7 +13,6 @@ from daft.errors import ExpressionTypeError
 from daft.execution.operators import OperatorEnum
 from daft.expressions import CallExpression, Expression, ExpressionList, col
 from daft.internal.treenode import TreeNode
-from daft.logical.field import Field
 from daft.logical.map_partition_ops import ExplodeOp, MapPartitionOp
 from daft.logical.schema import Schema
 from daft.resource_request import ResourceRequest
@@ -229,7 +228,9 @@ class TabularFilesScan(UnaryNode):
             self._predicate = ExpressionList([])
 
         if columns is not None:
-            self._output_schema = Schema([schema[col] for col in columns])
+            self._output_schema = Schema._from_name_and_types(
+                [(schema[col].name, schema[col].dtype) for col in columns]
+            )
         else:
             self._output_schema = schema
 
@@ -359,7 +360,7 @@ class FileWrite(UnaryNode):
                 field.dtype
             ), f"we can currently only write out primitive types, got: {field}"
 
-        schema = Schema([Field("file_path", ExpressionType.from_py_type(str))])
+        schema = Schema._from_name_and_types([("file_path", ExpressionType.from_py_type(str))])
 
         super().__init__(schema, input.partition_spec(), op_level=OpLevel.PARTITION)
         self._register_child(input)
@@ -633,7 +634,7 @@ class GlobalLimit(UnaryNode):
 
 class LocalCount(UnaryNode):
     def __init__(self, input: LogicalPlan) -> None:
-        schema = Schema([Field("count", ExpressionType.integer())])
+        schema = Schema._from_name_and_types([("count", ExpressionType.integer())])
         super().__init__(schema, partition_spec=input.partition_spec(), op_level=OpLevel.PARTITION)
         self._register_child(input)
 

--- a/daft/logical/map_partition_ops.py
+++ b/daft/logical/map_partition_ops.py
@@ -32,7 +32,7 @@ class ExplodeOp(MapPartitionOp):
             else:
                 output_fields.append(f)
 
-        self.output_schema = Schema._from_name_and_types([(f.name, f.dtype) for f in output_fields])
+        self.output_schema = Schema._from_field_name_and_types([(f.name, f.dtype) for f in output_fields])
         self.explode_columns = explode_columns
 
         for c in self.explode_columns:

--- a/daft/logical/map_partition_ops.py
+++ b/daft/logical/map_partition_ops.py
@@ -32,7 +32,7 @@ class ExplodeOp(MapPartitionOp):
             else:
                 output_fields.append(f)
 
-        self.output_schema = Schema(output_fields)
+        self.output_schema = Schema._from_name_and_types([(f.name, f.dtype) for f in output_fields])
         self.explode_columns = explode_columns
 
         for c in self.explode_columns:

--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -14,7 +14,7 @@ class Schema:
         raise NotImplementedError(f"Initializing a schema with __init__ is not supported")
 
     @classmethod
-    def _from_name_and_types(self, fields: list[tuple[str, ExpressionType]]) -> Schema:
+    def _from_field_name_and_types(self, fields: list[tuple[str, ExpressionType]]) -> Schema:
         s = Schema.__new__(Schema)
         s.fields = {name: Field(name=name, dtype=dtype) for name, dtype in fields}
         return s
@@ -59,4 +59,4 @@ class Schema:
             assert f.name not in seen
             seen[f.name] = f
 
-        return Schema._from_name_and_types([(f.name, f.dtype) for f in seen.values()])
+        return Schema._from_field_name_and_types([(f.name, f.dtype) for f in seen.values()])

--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -1,23 +1,23 @@
 from __future__ import annotations
 
-from typing import Iterator, TypeVar
+from typing import Iterator
 
-from daft.expressions import Expression, ExpressionList, col
-
-ExpressionType = TypeVar("ExpressionType", bound=Expression)
-
+from daft.expressions import ExpressionList, col
 from daft.logical.field import Field
+from daft.types import ExpressionType
 
 
 class Schema:
     fields: dict[str, Field]
 
-    def __init__(self, fields: list[Field]) -> None:
-        self.fields = {}
-        for field in fields:
-            assert isinstance(field, Field), f"expect {Field}, got {type(field)}"
-            assert field.name not in self.fields
-            self.fields[field.name] = field
+    def __init__(self) -> None:
+        raise NotImplementedError(f"Initializing a schema with __init__ is not supported")
+
+    @classmethod
+    def _from_name_and_types(self, fields: list[tuple[str, ExpressionType]]) -> Schema:
+        s = Schema.__new__(Schema)
+        s.fields = {name: Field(name=name, dtype=dtype) for name, dtype in fields}
+        return s
 
     def __getitem__(self, key: str) -> Field:
         if key not in self.fields:
@@ -59,4 +59,4 @@ class Schema:
             assert f.name not in seen
             seen[f.name] = f
 
-        return Schema([f for f in seen.values()])
+        return Schema._from_name_and_types([(f.name, f.dtype) for f in seen.values()])

--- a/daft/logical/schema2.py
+++ b/daft/logical/schema2.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import Iterator, TypeVar
+from typing import Iterator
 
 from daft.daft import PyField as _PyField
 from daft.daft import PySchema as _PySchema
 from daft.datatype import DataType
 from daft.expressions2 import Expression, col
-
-ExpressionType = TypeVar("ExpressionType", bound=Expression)
 
 
 class Field:
@@ -46,6 +44,12 @@ class Schema:
     def _from_pyschema(schema: _PySchema) -> Schema:
         s = Schema.__new__(Schema)
         s._schema = schema
+        return s
+
+    @classmethod
+    def _from_field_name_and_types(self, fields: list[tuple[str, DataType]]) -> Schema:
+        s = Schema.__new__(Schema)
+        s._schema = _PySchema.from_field_name_and_types([(name, dtype._dtype) for name, dtype in fields])
         return s
 
     def __getitem__(self, key: str) -> Field:

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -198,7 +198,7 @@ class vPartition:
                     col_type = ExpressionType.python_object()
             field = Field(col_name, col_type)
             fields.append(field)
-        return Schema._from_name_and_types([(f.name, f.dtype) for f in fields])
+        return Schema._from_field_name_and_types([(f.name, f.dtype) for f in fields])
 
     def eval_expression(self, expr: Expression) -> PyListTile:
         expr_name = expr.name()
@@ -237,7 +237,7 @@ class vPartition:
         data: dict[str, list[Any] | np.ndarray | pa.Array | pa.ChunkedArray],
     ) -> vPartition:
         column_types = {header: ExpressionType.infer_type(data[header]) for header in data}
-        schema = Schema._from_name_and_types(list(column_types.items()))
+        schema = Schema._from_field_name_and_types(list(column_types.items()))
         fields = schema.fields
         tiles = {}
         for f in fields.values():
@@ -842,7 +842,7 @@ class PartitionSetFactory(Generic[PartitionT]):
 
     def _get_listing_paths_schema(self) -> Schema:
         """Construct the schema for a DataFrame of path listing"""
-        return Schema._from_name_and_types(
+        return Schema._from_field_name_and_types(
             [
                 (self.FS_LISTING_PATH_COLUMN_NAME, ExpressionType.string()),
             ]
@@ -850,7 +850,7 @@ class PartitionSetFactory(Generic[PartitionT]):
 
     def _get_listing_paths_details_schema(self) -> Schema:
         """Construct the schema for a DataFrame of detailed path listing"""
-        return Schema._from_name_and_types(
+        return Schema._from_field_name_and_types(
             [
                 (self.FS_LISTING_PATH_COLUMN_NAME, ExpressionType.string()),
                 (self.FS_LISTING_SIZE_COLUMN_NAME, ExpressionType.integer()),

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -198,7 +198,7 @@ class vPartition:
                     col_type = ExpressionType.python_object()
             field = Field(col_name, col_type)
             fields.append(field)
-        return Schema(fields)
+        return Schema._from_name_and_types([(f.name, f.dtype) for f in fields])
 
     def eval_expression(self, expr: Expression) -> PyListTile:
         expr_name = expr.name()
@@ -237,7 +237,7 @@ class vPartition:
         data: dict[str, list[Any] | np.ndarray | pa.Array | pa.ChunkedArray],
     ) -> vPartition:
         column_types = {header: ExpressionType.infer_type(data[header]) for header in data}
-        schema = Schema([Field(header, expr_type) for header, expr_type in column_types.items()])
+        schema = Schema._from_name_and_types(list(column_types.items()))
         fields = schema.fields
         tiles = {}
         for f in fields.values():
@@ -842,20 +842,20 @@ class PartitionSetFactory(Generic[PartitionT]):
 
     def _get_listing_paths_schema(self) -> Schema:
         """Construct the schema for a DataFrame of path listing"""
-        return Schema(
+        return Schema._from_name_and_types(
             [
-                Field(self.FS_LISTING_PATH_COLUMN_NAME, ExpressionType.string()),
+                (self.FS_LISTING_PATH_COLUMN_NAME, ExpressionType.string()),
             ]
         )
 
     def _get_listing_paths_details_schema(self) -> Schema:
         """Construct the schema for a DataFrame of detailed path listing"""
-        return Schema(
+        return Schema._from_name_and_types(
             [
-                Field(self.FS_LISTING_PATH_COLUMN_NAME, ExpressionType.string()),
-                Field(self.FS_LISTING_SIZE_COLUMN_NAME, ExpressionType.integer()),
-                Field(self.FS_LISTING_TYPE_COLUMN_NAME, ExpressionType.string()),
-                Field(self.FS_LISTING_ROWS_COLUMN_NAME, ExpressionType.integer()),
+                (self.FS_LISTING_PATH_COLUMN_NAME, ExpressionType.string()),
+                (self.FS_LISTING_SIZE_COLUMN_NAME, ExpressionType.integer()),
+                (self.FS_LISTING_TYPE_COLUMN_NAME, ExpressionType.string()),
+                (self.FS_LISTING_ROWS_COLUMN_NAME, ExpressionType.integer()),
             ]
         )
 

--- a/tests/logical/test_logical_plan.py
+++ b/tests/logical/test_logical_plan.py
@@ -11,7 +11,7 @@ from daft.types import ExpressionType
 
 @pytest.fixture(scope="function")
 def schema():
-    return Schema._from_name_and_types(
+    return Schema._from_field_name_and_types(
         list(
             map(
                 lambda col_name: (col_name, ExpressionType.from_py_type(int)),

--- a/tests/logical/test_logical_plan.py
+++ b/tests/logical/test_logical_plan.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pytest
 
 from daft.expressions import ExpressionList, col
-from daft.logical.field import Field
 from daft.logical.logical_plan import Filter, InMemoryScan, Projection
 from daft.logical.schema import Schema
 from daft.runners.partitioning import PartitionCacheEntry
@@ -12,10 +11,10 @@ from daft.types import ExpressionType
 
 @pytest.fixture(scope="function")
 def schema():
-    return Schema(
+    return Schema._from_name_and_types(
         list(
             map(
-                lambda col_name: Field(col_name, ExpressionType.from_py_type(int)),
+                lambda col_name: (col_name, ExpressionType.from_py_type(int)),
                 ["a", "b", "c"],
             )
         )

--- a/tests/logical/test_schema2.py
+++ b/tests/logical/test_schema2.py
@@ -4,6 +4,7 @@ import pytest
 
 from daft.datatype import DataType
 from daft.expressions2 import col
+from daft.logical.schema2 import Schema
 from daft.table import Table
 
 DATA = {
@@ -92,3 +93,14 @@ def test_union():
 
     assert unioned_schema.column_names() == list(DATA.keys()) + list(new_data.keys())
     assert list(unioned_schema) == list(schema) + list(new_table.schema())
+
+
+def test_from_field_name_and_types():
+    schema = Schema._from_field_name_and_types([("foo", DataType.int16())])
+    assert schema["foo"].name == "foo"
+    assert schema["foo"].dtype == DataType.int16()
+
+
+def test_from_empty_field_name_and_types():
+    schema = Schema._from_field_name_and_types([])
+    assert len(schema) == 0


### PR DESCRIPTION
`Schema()` is currently initialized with `Fields` in its `__init__`. However, in `schema2.py` this will no longer be allowed since the new schemas are Rust datastructures.

This refactor changes all locations where we do this intialization to a call to `Schema._from_field_name_and_types` instead, which takes in a simple Python list of tuples, so that integration will be easier.
