### PR TITLE
Add ExpressionsProjection to replace ExpressionList

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -769,10 +769,13 @@ class DataFrame:
         if not isinstance(resource_request, ResourceRequest):
             raise TypeError(f"resource_request should be a ResourceRequest, but got {type(resource_request)}")
 
-        prev_schema_as_cols = self._plan.schema().to_column_expressions()
+        prev_schema_as_cols = ExpressionList(
+            [e for e in self._plan.schema().to_column_expressions() if e.name() != column_name]
+        )
+        new_schema = prev_schema_as_cols.union(ExpressionList([expr.alias(column_name)]))
         projection = logical_plan.Projection(
             self._plan,
-            prev_schema_as_cols.union(ExpressionList([expr.alias(column_name)]), other_override=True),
+            new_schema,
             custom_resource_request=resource_request,
         )
         return DataFrame(projection)

--- a/daft/expressions2.py
+++ b/daft/expressions2.py
@@ -177,8 +177,6 @@ class ExpressionsProjection(Iterable[Expression]):
         # Check invariants
         seen: set[str] = set()
         for e in exprs:
-            if e.name() is None:
-                raise ValueError("Expressions must all have names")
             if e.name() in seen:
                 raise ValueError("Expressions must all have unique names")
             seen.add(e.name())

--- a/daft/expressions2.py
+++ b/daft/expressions2.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Iterable, Iterator
+
 from daft.daft import PyExpr as _PyExpr
 from daft.daft import col as _col
 from daft.daft import lit as _lit
@@ -150,3 +152,101 @@ class Expression:
 
     def __repr__(self) -> str:
         return repr(self._expr)
+
+    def _input_mapping(self) -> str | None:
+        raise NotImplementedError(
+            "[RUST-INT] Implement for checking if expression is a no-op and returning the input name it maps to if so"
+        )
+
+    def _is_eq(self, other: Expression) -> bool:
+        raise NotImplementedError("[RUST-INT] Implement for checking equality of Expressions")
+
+    def _required_columns(self) -> set[str]:
+        raise NotImplementedError("[RUST-INT] Implement for getting required columns in an Expression")
+
+
+class ExpressionsProjection(Iterable[Expression]):
+    """A collection of Expressions that can be projected onto a Table to produce another Table
+
+    Invariants:
+        1. All Expressions have names
+        2. All Expressions have unique names
+    """
+
+    def __init__(self, exprs: list[Expression]) -> None:
+        # Check invariants
+        seen: set[str] = set()
+        for e in exprs:
+            if e.name() is None:
+                raise ValueError("Expressions must all have names")
+            if e.name() in seen:
+                raise ValueError("Expressions must all have unique names")
+            seen.add(e.name())
+
+        self.exprs = {e.name(): e for e in exprs}
+
+    def __len__(self) -> int:
+        return len(self.exprs)
+
+    def __iter__(self) -> Iterator[Expression]:
+        return iter(self.exprs.values())
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ExpressionsProjection):
+            return False
+
+        return len(self.exprs) == len(other.exprs) and all(
+            (s.name() == o.name()) and (s._is_eq(o)) for s, o in zip(self.exprs.values(), other.exprs.values())
+        )
+
+    def required_columns(self) -> set[str]:
+        """Column names required to run this ExpressionsProjection"""
+        result: set[str] = set()
+        for e in self.exprs.values():
+            result |= e._required_columns()
+        return result
+
+    def union(self, other: ExpressionsProjection, rename_dup: str | None = None) -> ExpressionsProjection:
+        """Unions two Expressions. Output naming conflicts are handled with keyword arguments.
+
+        Args:
+            other (ExpressionList): other ExpressionList to union with this one
+            rename_dup (Optional[str], optional): when conflicts in naming happen, append this string to the conflicting column in `other`. Defaults to None.
+        """
+        unioned: dict[str, Expression] = {}
+        for expr in list(self) + list(other):
+            name = expr.name()
+
+            # Handle naming conflicts
+            if name in unioned:
+                if rename_dup is not None:
+                    while name in unioned:
+                        name = f"{rename_dup}{name}"
+                    expr = expr.alias(name)
+                else:
+                    raise ValueError(
+                        f"Duplicate name found with different expression. name: {name}, seen: {unioned[name]}, current: {expr}"
+                    )
+
+            unioned[name] = expr
+        return ExpressionsProjection(list(unioned.values()))
+
+    def to_name_set(self) -> set[str]:
+        return {e.name() for e in self}
+
+    def input_mapping(self) -> dict[str, str]:
+        """Returns a map of {output_name: input_name} for all expressions that are just no-ops/aliases of an existing input"""
+        result = {}
+        for e in self:
+            input_map = e._input_mapping()
+            if input_map is not None:
+                result[e.name()] = input_map
+        return result
+
+    def to_column_expressions(self) -> ExpressionsProjection:
+        return ExpressionsProjection([col(e.name()) for e in self])
+
+    def get_expression_by_name(self, name: str) -> Expression:
+        if name not in self.exprs:
+            raise ValueError(f"{name} not found in ExpressionsProjection")
+        return self.exprs[name]

--- a/daft/logical/map_partition_ops.py
+++ b/daft/logical/map_partition_ops.py
@@ -25,7 +25,7 @@ class ExplodeOp(MapPartitionOp):
         super().__init__()
         self.input_schema = input_schema
         output_fields = []
-        explode_schema = explode_columns.to_schema(input_schema)
+        explode_schema = input_schema.resolve_expressions(explode_columns)
         for f in input_schema.fields.values():
             if f.name in explode_schema.column_names():
                 output_fields.append(explode_schema[f.name])

--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -60,3 +60,7 @@ class Schema:
             seen[f.name] = f
 
         return Schema._from_field_name_and_types([(f.name, f.dtype) for f in seen.values()])
+
+    def resolve_expressions(self, exprs: ExpressionList) -> Schema:
+        fields = [e.to_field(self) for e in exprs]
+        return Schema._from_field_name_and_types([(f.name, f.dtype) for f in fields])

--- a/daft/logical/schema2.py
+++ b/daft/logical/schema2.py
@@ -48,13 +48,20 @@ class Schema:
 
     @classmethod
     def _from_field_name_and_types(self, fields: list[tuple[str, DataType]]) -> Schema:
+        assert isinstance(fields, list), f"Expected a list of field tuples, received: {fields}"
+        for field in fields:
+            assert isinstance(field, tuple), f"Expected a tuple, received: {field}"
+            assert len(field) == 2, f"Expected a tuple of length 2, received: {field}"
+            name, dtype = field
+            assert isinstance(name, str), f"Expected a string name, received: {name}"
+            assert isinstance(dtype, DataType), f"Expected a DataType dtype, received: {dtype}"
+
         s = Schema.__new__(Schema)
         s._schema = _PySchema.from_field_name_and_types([(name, dtype._dtype) for name, dtype in fields])
         return s
 
     def __getitem__(self, key: str) -> Field:
-        if not isinstance(key, str):
-            raise ValueError(f"Expected str for key, but received: {type(key)}")
+        assert isinstance(key, str), f"Expected str for key, but received: {type(key)}"
         if key not in self._schema.names():
             raise ValueError(f"{key} was not found in Schema of fields {self._schema.field_names()}")
         pyfield = self._schema[key]

--- a/daft/logical/schema2.py
+++ b/daft/logical/schema2.py
@@ -5,7 +5,7 @@ from typing import Iterator
 from daft.daft import PyField as _PyField
 from daft.daft import PySchema as _PySchema
 from daft.datatype import DataType
-from daft.expressions2 import Expression, col
+from daft.expressions2 import ExpressionsProjection, col
 
 
 class Field:
@@ -86,8 +86,14 @@ class Schema:
     def __repr__(self) -> str:
         return repr([(field.name, field.dtype) for field in self])
 
-    def to_column_expressions(self) -> list[Expression]:
-        return [col(f.name) for f in self]
+    def to_column_expressions(self) -> ExpressionsProjection:
+        return ExpressionsProjection([col(f.name) for f in self])
+
+    def resolve_expressions(self, expressions: ExpressionsProjection) -> Schema:
+        """Create a new Schema by resolving the Expressions against an existing Schema"""
+        raise NotImplementedError(
+            "[RUST-INT] Requires an API for construction of a new Schema from resolving Expressions against an existing one"
+        )
 
     def union(self, other: Schema) -> Schema:
         if not isinstance(other, Schema):

--- a/daft/table.py
+++ b/daft/table.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pyarrow as pa
 
 from daft.daft import PyTable as _PyTable
-from daft.expressions2 import Expression
+from daft.expressions2 import Expression, ExpressionsProjection
 from daft.logical.schema2 import Schema
 from daft.series import Series
 
@@ -45,7 +45,7 @@ class Table:
     def to_pydict(self) -> dict[str, list]:
         return self.to_arrow().to_pydict()
 
-    def eval_expression_list(self, exprs: list[Expression]) -> Table:
+    def eval_expression_list(self, exprs: ExpressionsProjection) -> Table:
         assert all(isinstance(e, Expression) for e in exprs)
         pyexprs = [e._expr for e in exprs]
         return Table._from_pytable(self._table.eval_expression_list(pyexprs))
@@ -57,12 +57,12 @@ class Table:
         assert isinstance(indices, Series)
         return Table._from_pytable(self._table.take(indices._series))
 
-    def filter(self, exprs: list[Expression]) -> Table:
+    def filter(self, exprs: ExpressionsProjection) -> Table:
         assert all(isinstance(e, Expression) for e in exprs)
         pyexprs = [e._expr for e in exprs]
         return Table._from_pytable(self._table.filter(pyexprs))
 
-    def sort(self, sort_keys: list[Expression], descending: bool | list[bool] | None = None) -> Table:
+    def sort(self, sort_keys: ExpressionsProjection, descending: bool | list[bool] | None = None) -> Table:
         assert all(isinstance(e, Expression) for e in sort_keys)
         pyexprs = [e._expr for e in sort_keys]
         if descending is None:
@@ -79,7 +79,7 @@ class Table:
             raise ValueError(f"Expected a bool, list[bool] or None for `descending` but got {type(descending)}")
         return Table._from_pytable(self._table.sort(pyexprs, descending))
 
-    def argsort(self, sort_keys: list[Expression], descending: bool | list[bool] | None = None) -> Series:
+    def argsort(self, sort_keys: ExpressionsProjection, descending: bool | list[bool] | None = None) -> Series:
         assert all(isinstance(e, Expression) for e in sort_keys)
         pyexprs = [e._expr for e in sort_keys]
         if descending is None:

--- a/tests/logical/test_schema2.py
+++ b/tests/logical/test_schema2.py
@@ -28,12 +28,6 @@ def test_schema_column_names():
     assert schema.column_names() == list(DATA.keys())
 
 
-def test_schema_bad_type_getitem():
-    schema = TABLE.schema()
-    with pytest.raises(ValueError):
-        schema[1]
-
-
 def test_schema_field_types():
     schema = TABLE.schema()
     for key in EXPECTED_TYPES:

--- a/tests/test_expressions_projection.py
+++ b/tests/test_expressions_projection.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import pytest
+
+from daft.expressions2 import ExpressionsProjection, col
+
+
+def test_expressions_projection_error_dup_name():
+    with pytest.raises(ValueError):
+        ep = ExpressionsProjection(
+            [
+                col("x"),
+                col("y").alias("x"),
+            ]
+        )
+
+
+def test_expressions_projection_empty():
+    ep = ExpressionsProjection([])
+
+    # Test len
+    assert len(ep) == 0
+
+    # Test iter
+    assert list(ep) == []
+
+    # Test eq
+    assert ep == ep
+    assert ep != ExpressionsProjection([col("x")])
+
+    # Test required_columns
+    assert ep.required_columns() == set()
+
+    # Test to_name_set()
+    assert ep.to_name_set() == set()
+
+    # Test to_column_expression()
+    assert ep.to_column_expressions() == ExpressionsProjection([])
+
+
+def test_expressions_projection():
+    exprs = [
+        col("x"),
+        col("y") + 1,
+        col("z").alias("a"),
+    ]
+    ep = ExpressionsProjection(exprs)
+
+    # Test len
+    assert len(ep) == 3
+
+    # Test iter
+    for e1, e2 in zip(ep, exprs):
+        assert e1.name() == e2.name()
+
+    # Test eq
+    # TODO: [RUST-INT] Needs Expression._is_eq
+    # assert ep == ep
+    # assert ep != ExpressionsProjection([])
+
+    # Test required_columns
+    # TODO: [RUST-INT] Needs Expression._required_columns
+    # assert ep.required_columns() == ["x", "y", "z"]
+
+    # Test to_name_set()
+    assert ep.to_name_set() == {"x", "y", "a"}
+
+    # Test to_column_expression()
+    # TODO: [RUST-INT] Needs Expression._is_eq
+    # assert ep.to_column_expressions() == ExpressionsProjection([col("x"), col("y"), col("a")])
+
+
+def test_expressions_union():
+    exprs1 = [
+        col("x"),
+        col("y"),
+    ]
+    ep1 = ExpressionsProjection(exprs1)
+
+    exprs2 = [
+        col("z"),
+    ]
+    ep2 = ExpressionsProjection(exprs2)
+
+    assert ep1.union(ep2).to_name_set() == {"x", "y", "z"}
+
+
+def test_expressions_union_dup_err():
+    exprs1 = [
+        col("x"),
+        col("y"),
+    ]
+    ep1 = ExpressionsProjection(exprs1)
+
+    exprs2 = [
+        col("x"),
+    ]
+    ep2 = ExpressionsProjection(exprs2)
+
+    with pytest.raises(ValueError):
+        assert ep1.union(ep2)
+
+
+def test_expressions_union_dup_rename():
+    exprs1 = [
+        col("x"),
+        col("y"),
+    ]
+    ep1 = ExpressionsProjection(exprs1)
+
+    exprs2 = [
+        col("x"),
+    ]
+    ep2 = ExpressionsProjection(exprs2)
+    assert ep1.union(ep2, rename_dup="foo.").union(ep2, rename_dup="foo.").to_name_set() == {
+        "x",
+        "y",
+        "foo.x",
+        "foo.foo.x",
+    }
+
+
+@pytest.mark.skip(reason="[RUST-INT] Needs Expression._input_mapping")
+def test_input_mapping():
+    exprs = [
+        col("x"),
+        col("y") + 1,
+        col("z").alias("a"),
+    ]
+    ep = ExpressionsProjection(exprs)
+    assert ep.input_mapping() == {
+        "x": "x",
+        "a": "z",
+    }
+
+
+def test_get_expression_by_name():
+    exprs = [col("x")]
+    ep = ExpressionsProjection(exprs)
+    assert ep.get_expression_by_name("x").name() == "x"


### PR DESCRIPTION
* Add `ExpressionsProjection` abstraction to `expressions2.py` to replace `ExpressionList`
* Some other minor refactors as well to facilitate this:
    * We had a circular dependency in `.to_schema()` in ExpressionList. This has been refactored and moved into `Schema.resolve_expressions()` such that Schema has a dependency on Expressions, but not the other way around.
    * Simplify the `ExpressionList.union()` function and remove the `other_override` kwarg. The client has to do this themselves now.