### PR TITLE
Expressions and Schema refactors for v2 compatibility

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -625,7 +625,7 @@ class DataFrame:
             schema = self._plan.schema()
             if item < -len(schema) or item >= len(schema):
                 raise ValueError(f"{item} out of bounds for {schema}")
-            result = schema.to_column_expressions().exprs[item]
+            result = schema.to_column_expressions()[item]
             assert result is not None
             return result
         elif isinstance(item, str):
@@ -646,7 +646,7 @@ class DataFrame:
                 elif isinstance(it, int):
                     if it < -len(schema) or it >= len(schema):
                         raise ValueError(f"{it} out of bounds for {schema}")
-                    result = col_exprs.exprs[it]
+                    result = col_exprs[it]
                     assert result is not None
                     columns.append(result)
                 else:
@@ -655,7 +655,7 @@ class DataFrame:
         elif isinstance(item, slice):
             schema = self._plan.schema()
             columns_exprs: ExpressionList = schema.to_column_expressions()
-            selected_columns = columns_exprs.exprs[item]
+            selected_columns = columns_exprs[item]
             return self.select(*selected_columns)
         else:
             raise ValueError(f"unknown indexing type: {type(item)}")

--- a/daft/logical/map_partition_ops.py
+++ b/daft/logical/map_partition_ops.py
@@ -26,7 +26,7 @@ class ExplodeOp(MapPartitionOp):
         self.input_schema = input_schema
         output_fields = []
         explode_schema = input_schema.resolve_expressions(explode_columns)
-        for f in input_schema.fields.values():
+        for f in input_schema:
             if f.name in explode_schema.column_names():
                 output_fields.append(explode_schema[f.name])
             else:

--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -8,7 +8,7 @@ from daft.types import ExpressionType
 
 
 class Schema:
-    fields: dict[str, Field]
+    _fields: dict[str, Field]
 
     def __init__(self) -> None:
         raise NotImplementedError(f"Initializing a schema with __init__ is not supported")
@@ -16,46 +16,46 @@ class Schema:
     @classmethod
     def _from_field_name_and_types(self, fields: list[tuple[str, ExpressionType]]) -> Schema:
         s = Schema.__new__(Schema)
-        s.fields = {name: Field(name=name, dtype=dtype) for name, dtype in fields}
+        s._fields = {name: Field(name=name, dtype=dtype) for name, dtype in fields}
         return s
 
     def __getitem__(self, key: str) -> Field:
-        if key not in self.fields:
-            raise ValueError(f"{key} was not found in Schema of fields {self.fields.keys()}")
-        return self.fields[key]
+        if key not in self._fields:
+            raise ValueError(f"{key} was not found in Schema of fields {self._fields.keys()}")
+        return self._fields[key]
 
     def __len__(self) -> int:
-        return len(self.fields)
+        return len(self._fields)
 
     def __iter__(self) -> Iterator[Field]:
-        return iter(self.fields.values())
+        return iter(self._fields.values())
 
     def __eq__(self, other: object) -> bool:
-        return isinstance(other, Schema) and self.fields == other.fields
+        return isinstance(other, Schema) and self._fields == other._fields
 
     def column_names(self) -> list[str]:
-        return list(self.fields.keys())
+        return list(self._fields.keys())
 
     def to_name_set(self) -> set[str]:
         return set(self.column_names())
 
     def __repr__(self) -> str:
-        return repr([(field.name, field.dtype) for field in self.fields.values()])
+        return repr([(field.name, field.dtype) for field in self._fields.values()])
 
     def _repr_html_(self) -> str:
-        return repr([(field.name, field.dtype) for field in self.fields.values()])
+        return repr([(field.name, field.dtype) for field in self._fields.values()])
 
     def to_column_expressions(self) -> ExpressionList:
-        return ExpressionList([col(f.name) for f in self.fields.values()])
+        return ExpressionList([col(f.name) for f in self._fields.values()])
 
     def union(self, other: Schema) -> Schema:
         assert isinstance(other, Schema), f"expected Schema, got {type(other)}"
         seen = {}
-        for f in self.fields.values():
+        for f in self._fields.values():
             assert f.name not in seen
             seen[f.name] = f
 
-        for f in other.fields.values():
+        for f in other._fields.values():
             assert f.name not in seen
             seen[f.name] = f
 

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -238,9 +238,8 @@ class vPartition:
     ) -> vPartition:
         column_types = {header: ExpressionType.infer_type(data[header]) for header in data}
         schema = Schema._from_field_name_and_types(list(column_types.items()))
-        fields = schema.fields
         tiles = {}
-        for f in fields.values():
+        for f in schema:
             # Coerce the column data into a list or PyArrow array depending on the provided schema
             col_name = f.name
             col_type = f.dtype
@@ -401,7 +400,7 @@ class vPartition:
 
     def to_pandas(self, schema: Schema | None = None) -> pd.DataFrame:
         if schema is not None:
-            output_schema = [f.name for f in schema.fields.values()]
+            output_schema = [f.name for f in schema]
         else:
             output_schema = [tile for tile in self.columns.keys()]
 

--- a/tests/test_expressions_projection.py
+++ b/tests/test_expressions_projection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from daft.expressions2 import ExpressionsProjection, col
+from daft.expressions2 import Expression, ExpressionsProjection, col
 
 
 def test_expressions_projection_error_dup_name():
@@ -138,3 +138,20 @@ def test_get_expression_by_name():
     exprs = [col("x")]
     ep = ExpressionsProjection(exprs)
     assert ep.get_expression_by_name("x").name() == "x"
+
+
+def test_expressions_projection_indexing():
+    exprs = [
+        col("x"),
+        col("y") + 1,
+        col("z").alias("a"),
+    ]
+    ep = ExpressionsProjection(exprs)
+    assert isinstance(ep[0], Expression)
+    assert ep[0].name() == "x"
+    assert isinstance(ep[:2], list)
+    assert [e.name() for e in ep[:2]] == ["x", "y"]
+
+    # TODO: [RUST-INT] enable once we have Expression._is_eq
+    # assert ep[0]._is_eq(col("x"))
+    # assert all([result._is_eq(expected) for result, expected in zip(ep[:2], list(col("x"), col("y") + 1))])


### PR DESCRIPTION
* Refactors all usage of `ExpressionList.exprs` to instead iterate and create a list, and make the `.exprs` a private var
* Refactors all usage of `ExpressionList.exprs[idx/slice]` to instead use `ExpressionList.__getitem__`
* Refactors all usage of `Schema.fields` to instead use `Schema.__iter__` for accessing fields