### PR TITLE
Runner IO code

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -58,8 +58,9 @@ def _get_tabular_files_scan(path: str, source_info: SourceInfo) -> logical_plan.
     runner_io = get_context().runner().runner_io()
     listing_details_partition_set = runner_io.glob_paths_details(path, source_info)
 
-    # Infer schema from the listings
-    data_schema = runner_io.get_schema(listing_details_partition_set, source_info)
+    # TODO: We should have a more sophisticated schema inference mechanism (sample >1 file and resolve schemas across files)
+    # Infer schema from the first filepath in the listings PartitionSet
+    data_schema = runner_io.get_schema_from_first_filepath(listing_details_partition_set, source_info)
 
     # Construct plan
     cache_entry = get_context().runner().put_partition_set_into_cache(listing_details_partition_set)

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Dict,
     Iterable,
     List,
@@ -35,14 +34,7 @@ from daft.logical import logical_plan
 from daft.logical.aggregation_plan_builder import AggregationPlanBuilder
 from daft.logical.schema import ExpressionList
 from daft.resource_request import ResourceRequest
-from daft.runners.partitioning import (
-    PartitionCacheEntry,
-    PartitionSet,
-    vPartition,
-    vPartitionParseCSVOptions,
-    vPartitionReadOptions,
-    vPartitionSchemaInferenceOptions,
-)
+from daft.runners.partitioning import PartitionCacheEntry, PartitionSet, vPartition
 from daft.runners.pyrunner import LocalPartitionSet
 from daft.viz import DataFrameDisplay
 
@@ -60,45 +52,32 @@ ColumnInputType = Union[Expression, str]
 InputListType = Union[list, "np.ndarray", "pa.Array", "pa.ChunkedArray"]
 
 
-def _get_tabular_files_scan(
-    path: str, get_schema: Callable[[str], Schema], source_info: SourceInfo
-) -> logical_plan.TabularFilesScan:
+def _get_tabular_files_scan(path: str, source_info: SourceInfo) -> logical_plan.TabularFilesScan:
     """Returns a TabularFilesScan LogicalPlan for a given glob filepath."""
-    # Glob the path and return as a DataFrame with a column containing the filepaths
-    partition_set_factory = get_context().runner().partition_set_factory()
-    partition_set, filepaths_schema = partition_set_factory.glob_paths_details(path, source_info)
-    cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
+    # Glob the path using the Runner
+    runner_io = get_context().runner().runner_io()
+    listing_details_partition_set = runner_io.glob_paths_details(path, source_info)
+
+    # Infer schema from the listings
+    data_schema = runner_io.get_schema(listing_details_partition_set, source_info)
+
+    # Construct plan
+    cache_entry = get_context().runner().put_partition_set_into_cache(listing_details_partition_set)
     filepath_plan = logical_plan.InMemoryScan(
         cache_entry=cache_entry,
-        schema=filepaths_schema,
-        partition_spec=logical_plan.PartitionSpec(logical_plan.PartitionScheme.UNKNOWN, partition_set.num_partitions()),
+        schema=runner_io.FS_LISTING_SCHEMA,
+        partition_spec=logical_plan.PartitionSpec(
+            logical_plan.PartitionScheme.UNKNOWN, listing_details_partition_set.num_partitions()
+        ),
     )
-    filepath_df = DataFrame(filepath_plan)
-
-    # Sample the first 10 filepaths and infer the schema
-    schema_df = filepath_df.limit(10).select(
-        col(partition_set_factory.FS_LISTING_PATH_COLUMN_NAME)
-        .apply(get_schema, return_dtype=ExpressionType.python(ExpressionList))
-        .alias("schema")
-    )
-    schema_df.collect()
-    schema_result = schema_df._result
-    assert schema_result is not None
-    sampled_schemas = schema_result.to_pydict()["schema"]
-
-    # TODO: infer schema from all sampled schemas instead of just taking the first one
-    schema = sampled_schemas[0]
-
-    # Return a TabularFilesScan node that will scan from the globbed filepaths filepaths
     return logical_plan.TabularFilesScan(
-        schema=schema,
+        schema=data_schema,
         predicate=None,
         columns=None,
         source_info=source_info,
         filepaths_child=filepath_plan,
-        filepaths_column_name=partition_set_factory.FS_LISTING_PATH_COLUMN_NAME,
-        # Hardcoded for now.
-        num_partitions=len(partition_set),
+        filepaths_column_name=runner_io.FS_LISTING_PATH_COLUMN_NAME,
+        num_partitions=filepath_plan.num_partitions(),
     )
 
 
@@ -323,23 +302,8 @@ class DataFrame:
         returns:
             DataFrame: parsed DataFrame
         """
-
-        def get_schema(filepath: str) -> Schema:
-            return vPartition.from_json(
-                filepath,
-                schema_options=vPartitionSchemaInferenceOptions(
-                    schema=None,
-                    inference_column_names=None,  # has no effect on inferring schema from JSON
-                ),
-                read_options=vPartitionReadOptions(
-                    num_rows=100,  # sample 100 rows for inferring schema
-                    column_names=None,  # read all columns
-                ),
-            ).schema()
-
         plan = _get_tabular_files_scan(
             path,
-            get_schema,
             JSONSourceInfo(),
         )
         return cls(plan)
@@ -377,28 +341,8 @@ class DataFrame:
             DataFrame: parsed DataFrame
         """
 
-        def get_schema(filepath: str) -> Schema:
-            return vPartition.from_csv(
-                path=filepath,
-                csv_options=vPartitionParseCSVOptions(
-                    delimiter=delimiter,
-                    has_headers=has_headers,
-                    skip_rows_before_header=0,
-                    skip_rows_after_header=0,
-                ),
-                schema_options=vPartitionSchemaInferenceOptions(
-                    schema=None,
-                    inference_column_names=column_names,  # pass in user-provided column names
-                ),
-                read_options=vPartitionReadOptions(
-                    num_rows=100,  # sample 100 rows for schema inference
-                    column_names=None,  # read all columns
-                ),
-            ).schema()
-
         plan = _get_tabular_files_scan(
             path,
-            get_schema,
             CSVSourceInfo(
                 delimiter=delimiter,
                 has_headers=has_headers,
@@ -429,23 +373,8 @@ class DataFrame:
         returns:
             DataFrame: parsed DataFrame
         """
-
-        def get_schema(filepath: str) -> Schema:
-            return vPartition.from_parquet(
-                filepath,
-                schema_options=vPartitionSchemaInferenceOptions(
-                    schema=None,
-                    inference_column_names=None,  # has no effect on schema inferencing Parquet
-                ),
-                read_options=vPartitionReadOptions(
-                    num_rows=0,  # sample 0 rows since Parquet has metadata
-                    column_names=None,  # read all columns
-                ),
-            ).schema()
-
         plan = _get_tabular_files_scan(
             path,
-            get_schema,
             ParquetSourceInfo(),
         )
         return cls(plan)
@@ -502,12 +431,12 @@ class DataFrame:
             DataFrame: DataFrame containing the path to each file as a row, along with other metadata
                 parsed from the provided filesystem
         """
-        partition_set_factory = get_context().runner().partition_set_factory()
-        partition_set, filepaths_schema = partition_set_factory.glob_paths_details(path)
+        runner_io = get_context().runner().runner_io()
+        partition_set = runner_io.glob_paths_details(path)
         cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
         filepath_plan = logical_plan.InMemoryScan(
             cache_entry=cache_entry,
-            schema=filepaths_schema,
+            schema=runner_io.FS_LISTING_SCHEMA,
             partition_spec=logical_plan.PartitionSpec(
                 logical_plan.PartitionScheme.UNKNOWN, partition_set.num_partitions()
             ),

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -34,6 +34,7 @@ from daft.runners.partitioning import (
     PartitionMetadata,
     PartitionSet,
     vPartition,
+    vPartitionSchemaInferenceOptions,
 )
 from daft.runners.profiler import profiler
 from daft.runners.runner import Runner
@@ -112,7 +113,10 @@ class PyRunnerIO(runner_io.RunnerIO[vPartition]):
         return pset
 
     def get_schema_from_first_filepath(
-        self, listing_details_partitions: PartitionSet[vPartition], source_info: SourceInfo
+        self,
+        listing_details_partitions: PartitionSet[vPartition],
+        source_info: SourceInfo,
+        schema_inference_options: vPartitionSchemaInferenceOptions,
     ) -> Schema:
         # Naively retrieve the first filepath in the PartitionSet
         nonempty_partitions = [
@@ -124,7 +128,7 @@ class PyRunnerIO(runner_io.RunnerIO[vPartition]):
             raise ValueError("No files to get schema from")
         first_filepath = nonempty_partitions[0].to_pydict()[PyRunnerIO.FS_LISTING_PATH_COLUMN_NAME][0]
 
-        return runner_io.sample_schema(first_filepath, source_info)
+        return runner_io.sample_schema(first_filepath, source_info, schema_inference_options)
 
 
 class LocalLogicalPartitionOpRunner(LogicalPartitionOpRunner):

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -45,7 +45,6 @@ from daft.runners.partitioning import (
     PartitionCacheEntry,
     PartitionMetadata,
     PartitionSet,
-    PartitionSetFactory,
     vPartition,
 )
 from daft.runners.profiler import profiler

--- a/daft/runners/runner.py
+++ b/daft/runners/runner.py
@@ -7,8 +7,8 @@ from daft.runners.partitioning import (
     PartitionCacheEntry,
     PartitionSet,
     PartitionSetCache,
-    PartitionSetFactory,
 )
+from daft.runners.runner_io import RunnerIO
 
 
 class Runner:
@@ -22,7 +22,7 @@ class Runner:
         return self._part_set_cache.put_partition_set(pset=pset)
 
     @abstractmethod
-    def partition_set_factory(self) -> PartitionSetFactory:
+    def runner_io(self) -> RunnerIO:
         ...
 
     @abstractmethod

--- a/daft/runners/runner_io.py
+++ b/daft/runners/runner_io.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Generic, TypeVar
+
+from daft.datasources import SourceInfo
+from daft.logical.schema import Schema
+from daft.runners.partitioning import PartitionSet
+from daft.types import ExpressionType
+
+PartitionT = TypeVar("PartitionT")
+
+
+class RunnerIO(Generic[PartitionT]):
+    """Reading and writing data from the Runner.
+
+    This is an abstract class and each runner must write their own implementation.
+
+    This is a generic class and each runner needs to parametrize their implementation with the appropriate
+    PartitionT that it uses for in-memory data representation.
+    """
+
+    FS_LISTING_PATH_COLUMN_NAME = "path"
+    FS_LISTING_SIZE_COLUMN_NAME = "size"
+    FS_LISTING_TYPE_COLUMN_NAME = "type"
+    FS_LISTING_ROWS_COLUMN_NAME = "rows"
+    FS_LISTING_SCHEMA = Schema._from_field_name_and_types(
+        [
+            (FS_LISTING_SIZE_COLUMN_NAME, ExpressionType.integer()),
+            (FS_LISTING_PATH_COLUMN_NAME, ExpressionType.string()),
+            (FS_LISTING_TYPE_COLUMN_NAME, ExpressionType.string()),
+            (FS_LISTING_ROWS_COLUMN_NAME, ExpressionType.integer()),
+        ]
+    )
+
+    @abstractmethod
+    def glob_paths_details(
+        self,
+        source_path: str,
+        source_info: SourceInfo | None = None,
+    ) -> PartitionSet[PartitionT]:
+        """Globs the specified filepath to construct Partitions containing file and dir metadata
+
+        Args:
+            source_path (str): path to glob
+
+        Returns:
+            PartitionSet[PartitionT]: Partitions containing the listings' metadata
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_schema(self, listing_details_partitions: PartitionSet[PartitionT], source_info: SourceInfo) -> Schema:
+        raise NotImplementedError()

--- a/daft/runners/runner_io.py
+++ b/daft/runners/runner_io.py
@@ -63,12 +63,19 @@ class RunnerIO(Generic[PartitionT]):
 
     @abstractmethod
     def get_schema_from_first_filepath(
-        self, listing_details_partitions: PartitionSet[PartitionT], source_info: SourceInfo
+        self,
+        listing_details_partitions: PartitionSet[PartitionT],
+        source_info: SourceInfo,
+        schema_inference_options: vPartitionSchemaInferenceOptions,
     ) -> Schema:
         raise NotImplementedError()
 
 
-def sample_schema(filepath: str, source_info: SourceInfo) -> Schema:
+def sample_schema(
+    filepath: str,
+    source_info: SourceInfo,
+    schema_inference_options: vPartitionSchemaInferenceOptions,
+) -> Schema:
     """Helper method that samples a schema from the specified source"""
 
     sampled_partition: vPartition
@@ -82,10 +89,7 @@ def sample_schema(filepath: str, source_info: SourceInfo) -> Schema:
                 skip_rows_before_header=0,
                 skip_rows_after_header=0,
             ),
-            schema_options=vPartitionSchemaInferenceOptions(
-                schema=None,
-                inference_column_names=None,  # TODO: pass in user-provided column names
-            ),
+            schema_options=schema_inference_options,
             read_options=vPartitionReadOptions(
                 num_rows=100,  # sample 100 rows for schema inference
                 column_names=None,  # read all columns
@@ -99,6 +103,7 @@ def sample_schema(filepath: str, source_info: SourceInfo) -> Schema:
                 num_rows=100,  # sample 100 rows for schema inference
                 column_names=None,  # read all columns
             ),
+            schema_options=schema_inference_options,
         )
     elif source_info.scan_type() == StorageType.PARQUET:
         assert isinstance(source_info, ParquetSourceInfo)
@@ -108,6 +113,7 @@ def sample_schema(filepath: str, source_info: SourceInfo) -> Schema:
                 num_rows=100,  # sample 100 rows for schema inference
                 column_names=None,  # read all columns
             ),
+            schema_options=schema_inference_options,
         )
     else:
         raise NotImplementedError(f"Schema inference for {source_info} not implemented")


### PR DESCRIPTION
* Refactors `PartitionSetFactory` into `RunnerIO`, which is responsible for executing code on the Runner (Py or Ray) that performs I/O outside of the DataFrame API
* The two use-cases right now are: 
    * `glob_paths_details`: subsumes functionality from `PartitionSetFactory` to list filepaths and details about those files
    * `get_schema_from_first_filepath`: samples Schema objects from filepaths