### PR TITLE
Add more Rust python binding requirements for TPC-H

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -121,13 +121,13 @@ class DataType:
 
     @staticmethod
     def python(py_class: type) -> DataType:
-        raise NotImplementedError("[RUST-INT] implement Python types for DataType")
+        raise NotImplementedError("[RUST-INT][PY] implement Python types for DataType")
 
     def _is_python_type(self) -> builtins.bool:
         # NOTE: This is currently used in a few places still. We can get rid of it once these are refactored away. To be discussed.
         # 1. Visualizations - we can get rid of it if we do all our repr and repr_html logic in a Series instead of in Python
         # 2. Hypothesis test data generation - we can get rid of it if we allow for creation of Series from a Python list and DataType
-        raise NotImplementedError("[RUST-INT] Implement checking whether this dtype is a Python type")
+        raise NotImplementedError("[RUST-INT][PY] Implement checking whether this dtype is a Python type")
 
     def __repr__(self) -> str:
         return f"DataType({self._dtype})"

--- a/daft/expressions2/expressions.py
+++ b/daft/expressions2/expressions.py
@@ -162,17 +162,19 @@ class Expression:
 
     def _input_mapping(self) -> str | None:
         raise NotImplementedError(
-            "[RUST-INT] Implement for checking if expression is a no-op and returning the input name it maps to if so"
+            "[RUST-INT][TPCH] Implement for checking if expression is a no-op and returning the input name it maps to if so"
         )
 
     def _required_columns(self) -> set[str]:
-        raise NotImplementedError("[RUST-INT] Implement for getting required columns in an Expression")
+        raise NotImplementedError("[RUST-INT][TPCH] Implement for getting required columns in an Expression")
 
     def _is_column(self) -> bool:
-        raise NotImplementedError("[RUST-INT] Implement for checking if this Expression is a Column")
+        raise NotImplementedError("[RUST-INT][TPCH] Implement for checking if this Expression is a Column")
 
     def _replace_column_with_expression(self, column: str, new_expr: Expression) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement replacing a Column with an Expression - used in optimizer")
+        raise NotImplementedError(
+            "[RUST-INT][TPCH] Implement replacing a Column with an Expression - used in optimizer"
+        )
 
 
 class ExpressionNamespace:
@@ -190,25 +192,25 @@ class ExpressionNamespace:
 
 class ExpressionAggNamespace(ExpressionNamespace):
     def sum(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement expression aggregation")
+        raise NotImplementedError("[RUST-INT][TPCH] Implement expression aggregation")
 
     def mean(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement expression aggregation")
+        raise NotImplementedError("[RUST-INT][TPCH] Implement expression aggregation")
 
     def min(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement expression aggregation")
+        raise NotImplementedError("[RUST-INT][TPCH] Implement expression aggregation")
 
     def max(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement expression aggregation")
+        raise NotImplementedError("[RUST-INT][TPCH] Implement expression aggregation")
 
     def count(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement expression aggregation")
+        raise NotImplementedError("[RUST-INT][TPCH] Implement expression aggregation")
 
     def list(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement expression aggregation")
+        raise NotImplementedError("[RUST-INT][NESTED] Implement expression aggregation")
 
     def concat(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement expression aggregation")
+        raise NotImplementedError("[RUST-INT][NESTED] Implement expression aggregation")
 
 
 class ExpressionsProjection(Iterable[Expression]):

--- a/daft/logical/schema2.py
+++ b/daft/logical/schema2.py
@@ -92,7 +92,7 @@ class Schema:
     def resolve_expressions(self, expressions: ExpressionsProjection) -> Schema:
         """Create a new Schema by resolving the Expressions against an existing Schema"""
         raise NotImplementedError(
-            "[RUST-INT] Requires an API for construction of a new Schema from resolving Expressions against an existing one"
+            "[RUST-INT][TPCH] Requires an API for construction of a new Schema from resolving Expressions against an existing one"
         )
 
     def union(self, other: Schema) -> Schema:

--- a/daft/table.py
+++ b/daft/table.py
@@ -43,7 +43,7 @@ class Table:
         return Series._from_pyseries(self._table.get_column(name))
 
     def size_bytes(self) -> int:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     def __len__(self) -> int:
         return len(self._table)
@@ -89,26 +89,25 @@ class Table:
 
     @classmethod
     def concat(cls, to_merge: list[Table]) -> Table:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     ###
     # Exporting methods
     ###
 
     def to_arrow(self) -> pa.Table:
-        # TODO: [RUST-INT] throw error for Python object types
+        # TODO: [RUST-INT][PY] throw error for Python object types
         return pa.Table.from_batches([self._table.to_arrow_record_batch()])
 
     def to_pydict(self) -> dict[str, list]:
-        # TODO: [RUST-INT] support for Python object types
+        # TODO: [RUST-INT][PY] support for Python object types
         return self.to_arrow().to_pydict()
 
     def to_pandas(self, schema: Schema | None = None) -> pd.DataFrame:
         if not _PANDAS_AVAILABLE:
             raise ImportError("Unable to import Pandas - please ensure that it is installed.")
 
-        # TODO: [RUST-INT] it should be possible to go from .to_arrow(*arrow_columns) + .to_pydict(*py_columns)
-        # to Pandas for more accurate type conversions
+        # TODO: [RUST-INT][TPCH] implement and test better - this is used in test validations
         pd_df = pd.DataFrame(self.to_pydict())
         if schema is not None:
             pd_df = pd_df[schema.column_names()]
@@ -153,16 +152,16 @@ class Table:
         return Table._from_pytable(self._table.sort(pyexprs, descending))
 
     def sample(self, num: int) -> Table:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     def agg(self, to_agg: list[tuple[Expression, str]], group_by: ExpressionsProjection | None = None) -> Table:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     def quantiles(self, num: int) -> Table:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     def explode(self, columns: ExpressionsProjection) -> Table:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][NESTED] Implement for Table")
 
     def join(
         self,
@@ -172,16 +171,16 @@ class Table:
         output_projection: ExpressionsProjection,
         how: str = "inner",
     ) -> Table:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     def split_by_hash(self, exprs: ExpressionsProjection, num_partitions: int) -> list[Table]:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     def split_by_index(self, num_partitions: int, target_partition_indices: Series) -> list[Table]:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     def split_random(self, num_partitions: int, seed: int) -> list[Table]:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     ###
     # Compute methods (Table -> Series)
@@ -205,4 +204,4 @@ class Table:
         return Series._from_pyseries(self._table.argsort(pyexprs, descending))
 
     def search_sorted(self, sort_keys: Table, descending: list[bool]) -> Series:
-        raise NotImplementedError("TODO: [RUST-INT] Implement for Table")
+        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")

--- a/daft/table_io.py
+++ b/daft/table_io.py
@@ -22,7 +22,7 @@ def read_parquet(
     path: str,
     read_options: vPartitionReadOptions = vPartitionReadOptions(),
 ) -> Table:
-    raise NotImplementedError("[RUST-INT] Implement tableio")
+    raise NotImplementedError("[RUST-INT][TPCH] Implement tableio")
 
 
 def read_csv(


### PR DESCRIPTION
This PR tags our code with areas that need to be implemented to run our TPC-H queries on our Rust backend, as well as adding more Expression APIs to allow us to do so.

Tags:

1. `[RUST-INT][TPCH]`: required functionality for running TPC-H tests
2. `[RUST-INT][PY]`: functionality relating to Python types
3. `[RUST-INT][UDF]`: functionality relating to UDFs
4. `[RUST-INT][NESTED]`: functionality relating to nested types (e.g. explodes)
5. `[RUST-INT]`: other functionality that is nice to have and rounds out our Expressions API