### PR TITLE
Add resolve_schema functionality to expressions2

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -28,11 +28,10 @@ from daft.datasources import (
 )
 from daft.errors import ExpressionTypeError
 from daft.execution.operators import ExpressionType
-from daft.expressions import Expression, col
+from daft.expressions import Expression, ExpressionList, col
 from daft.filesystem import get_filesystem_from_path
 from daft.logical import logical_plan
 from daft.logical.aggregation_plan_builder import AggregationPlanBuilder
-from daft.logical.schema import ExpressionList
 from daft.resource_request import ResourceRequest
 from daft.runners.partitioning import (
     PartitionCacheEntry,
@@ -1143,7 +1142,7 @@ class GroupedDataFrame:
     group_by: ExpressionList
 
     def __post_init__(self):
-        resolved_groupby_schema = self.df._plan.schema().resolve_expressions(self.group_by)
+        resolved_groupby_schema = self.group_by.resolve_schema(self.df._plan.schema())
         for field, e in zip(resolved_groupby_schema, self.group_by):
             if field.dtype == ExpressionType.null():
                 raise ExpressionTypeError(f"Cannot groupby on null type expression: {e}")

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -11,10 +11,9 @@ else:
     from typing import Protocol
 
 import daft
-from daft.expressions import Expression, col
+from daft.expressions import Expression, ExpressionList, col
 from daft.logical import logical_plan
 from daft.logical.map_partition_ops import MapPartitionOp
-from daft.logical.schema import ExpressionList
 from daft.resource_request import ResourceRequest
 from daft.runners.partitioning import (
     PartialPartitionMetadata,

--- a/daft/experimental/serving/endpoint.py
+++ b/daft/experimental/serving/endpoint.py
@@ -6,8 +6,8 @@ from daft.experimental.serving.backend import (
 )
 from daft.experimental.serving.definitions import Endpoint
 from daft.experimental.serving.env import DaftEnv
+from daft.expressions import ExpressionList
 from daft.logical.logical_plan import HTTPResponse, LogicalPlan
-from daft.logical.schema import ExpressionList
 
 
 class HTTPEndpoint:

--- a/daft/expressions.py
+++ b/daft/expressions.py
@@ -6,7 +6,6 @@ import warnings
 from abc import abstractmethod
 from functools import partial, partialmethod
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Iterable,
@@ -38,6 +37,8 @@ import pyarrow as pa
 from daft.errors import ExpressionTypeError
 from daft.execution.operators import ExpressionOperator, OperatorEnum
 from daft.internal.treenode import TreeNode
+from daft.logical.field import Field
+from daft.logical.schema import Schema
 from daft.runners.blocks import (
     ArrowDataBlock,
     DataBlock,
@@ -45,11 +46,6 @@ from daft.runners.blocks import (
     zip_blocks_as_py,
 )
 from daft.types import DatatypeInference, ExpressionType, PrimitiveExpressionType
-
-if TYPE_CHECKING:
-    from daft.logical.schema import Schema
-
-from daft.logical.field import Field
 
 
 def col(name: str) -> ColumnExpression:
@@ -1131,3 +1127,7 @@ class ExpressionList(Iterable[Expression]):
             if n == name:
                 return self._exprs[i]
         raise ValueError(f"{name} not found in ExpressionList")
+
+    def resolve_schema(self, schema: Schema) -> Schema:
+        fields = [e.to_field(schema) for e in self]
+        return Schema._from_field_name_and_types([(f.name, f.dtype) for f in fields])

--- a/daft/expressions.py
+++ b/daft/expressions.py
@@ -1036,6 +1036,10 @@ class ExpressionList(Iterable[Expression]):
             self.names.append(e_name)
             name_set.add(e_name)
 
+    @classmethod
+    def from_schema(cls, schema: Schema) -> ExpressionList:
+        return cls([col(field.name) for field in schema])
+
     def __len__(self) -> int:
         return len(self._exprs)
 

--- a/daft/expressions2/expressions.py
+++ b/daft/expressions2/expressions.py
@@ -8,6 +8,7 @@ from daft.daft import col as _col
 from daft.daft import lit as _lit
 from daft.datatype import DataType
 from daft.expressions2.testing import expr_structurally_equal
+from daft.logical.schema2 import Schema
 
 
 def lit(value: object) -> Expression:
@@ -287,6 +288,10 @@ class ExpressionsProjection(Iterable[Expression]):
             seen.add(e.name())
 
         self._output_name_to_exprs = {e.name(): e for e in exprs}
+
+    @classmethod
+    def from_schema(cls, schema: Schema) -> ExpressionsProjection:
+        return cls([col(field.name) for field in schema])
 
     def __len__(self) -> int:
         return len(self._output_name_to_exprs)

--- a/daft/expressions2/expressions.py
+++ b/daft/expressions2/expressions.py
@@ -204,7 +204,7 @@ class Expression:
         )
 
     def _to_field(self, schema: Schema) -> Field:
-        raise NotImplementedError("TODO!!!")
+        return Field._from_pyfield(self._expr.to_field(schema._schema))
 
 
 class ExpressionNamespace:

--- a/daft/expressions2/expressions.py
+++ b/daft/expressions2/expressions.py
@@ -8,7 +8,7 @@ from daft.daft import col as _col
 from daft.daft import lit as _lit
 from daft.datatype import DataType
 from daft.expressions2.testing import expr_structurally_equal
-from daft.logical.schema2 import Schema
+from daft.logical.schema2 import Field, Schema
 
 
 def lit(value: object) -> Expression:
@@ -203,6 +203,9 @@ class Expression:
             "[RUST-INT][TPCH] Implement replacing a Column with an Expression - used in optimizer"
         )
 
+    def _to_field(self, schema: Schema) -> Field:
+        raise NotImplementedError("TODO!!!")
+
 
 class ExpressionNamespace:
     _expr: _PyExpr
@@ -371,3 +374,7 @@ class ExpressionsProjection(Iterable[Expression]):
         if name not in self._output_name_to_exprs:
             raise ValueError(f"{name} not found in ExpressionsProjection")
         return self._output_name_to_exprs[name]
+
+    def resolve_schema(self, schema: Schema) -> Schema:
+        fields = [e._to_field(schema) for e in self]
+        return Schema._from_field_name_and_types([(f.name, f.dtype) for f in fields])

--- a/daft/logical/aggregation_plan_builder.py
+++ b/daft/logical/aggregation_plan_builder.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from daft.expressions import Expression, col, lit
+from daft.expressions import Expression, ExpressionList, col, lit
 from daft.logical import logical_plan
-from daft.logical.schema import ExpressionList
 
 AggregationOp = str
 ColName = str

--- a/daft/logical/aggregation_plan_builder.py
+++ b/daft/logical/aggregation_plan_builder.py
@@ -73,7 +73,7 @@ class AggregationPlanBuilder:
         # 4. Perform post-shuffle projections if necessary
         postshuffle_projection_plan: logical_plan.LogicalPlan
         if self._final_projection_includes or self._final_projection_excludes:
-            final_expressions = postshuffle_agg_plan.schema().to_column_expressions()
+            final_expressions = ExpressionList.from_schema(postshuffle_agg_plan.schema())
             final_expressions = ExpressionList(
                 [e for e in final_expressions if e.name() not in self._final_projection_excludes]
             )

--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -179,7 +179,7 @@ class LogicalPlan(TreeNode["LogicalPlan"]):
             if isinstance(v, ExpressionList):
                 v = list(v)
             elif isinstance(v, Schema):
-                v = list(v.to_column_expressions())
+                v = list([col(field.name) for field in v])
             elif isinstance(v, PartitionSpec):
                 v = asdict(v)
                 if isinstance(v["by"], ExpressionList):
@@ -966,7 +966,7 @@ class Join(BinaryNode):
         elif how == JoinType.INNER:
             num_partitions = max(left.num_partitions(), right.num_partitions())
             right_drop_set = {r.name() for l, r in zip(left_on, right_on) if l.name() == r.name()}
-            left_columns = left.schema().to_column_expressions()
+            left_columns = ExpressionList.from_schema(left.schema())
             right_columns = ExpressionList([col(f.name) for f in right.schema() if f.name not in right_drop_set])
             unioned_expressions = left_columns.union(right_columns, rename_dup="right.")
             self._left_columns = left_columns

--- a/daft/logical/map_partition_ops.py
+++ b/daft/logical/map_partition_ops.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from abc import abstractmethod
 
-from daft.logical.schema import ExpressionList, Schema
+from daft.expressions import ExpressionList
+from daft.logical.schema import Schema
 from daft.runners.partitioning import vPartition
 
 
@@ -24,7 +25,7 @@ class ExplodeOp(MapPartitionOp):
         super().__init__()
         self.input_schema = input_schema
         output_fields = []
-        explode_schema = input_schema.resolve_expressions(explode_columns)
+        explode_schema = explode_columns.resolve_schema(input_schema)
         for f in input_schema:
             if f.name in explode_schema.column_names():
                 output_fields.append(explode_schema[f.name])
@@ -35,7 +36,7 @@ class ExplodeOp(MapPartitionOp):
         self.explode_columns = explode_columns
 
         # Resolve expressions to validate that explode_columns is a valid operation
-        self.input_schema.resolve_expressions(self.explode_columns)
+        self.explode_columns.resolve_schema(self.input_schema)
 
     def get_output_schema(self) -> Schema:
         return self.output_schema

--- a/daft/logical/optimizer.py
+++ b/daft/logical/optimizer.py
@@ -5,7 +5,7 @@ import copy
 from loguru import logger
 
 from daft import resource_request
-from daft.expressions import col
+from daft.expressions import ExpressionList, col
 from daft.internal.rule import Rule
 from daft.logical.logical_plan import (
     Coalesce,
@@ -22,7 +22,6 @@ from daft.logical.logical_plan import (
     TabularFilesScan,
     UnaryNode,
 )
-from daft.logical.schema import ExpressionList
 
 
 class PushDownPredicates(Rule[LogicalPlan]):

--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Iterator
 
-from daft.expressions import ExpressionList, col
+from daft.expressions import ExpressionList
 from daft.logical.field import Field
 from daft.types import ExpressionType
 
@@ -44,9 +44,6 @@ class Schema:
 
     def _repr_html_(self) -> str:
         return repr([(field.name, field.dtype) for field in self._fields.values()])
-
-    def to_column_expressions(self) -> ExpressionList:
-        return ExpressionList([col(f.name) for f in self._fields.values()])
 
     def union(self, other: Schema) -> Schema:
         assert isinstance(other, Schema), f"expected Schema, got {type(other)}"

--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Iterator
 
-from daft.expressions import ExpressionList
 from daft.logical.field import Field
 from daft.types import ExpressionType
 
@@ -57,7 +56,3 @@ class Schema:
             seen[f.name] = f
 
         return Schema._from_field_name_and_types([(f.name, f.dtype) for f in seen.values()])
-
-    def resolve_expressions(self, exprs: ExpressionList) -> Schema:
-        fields = [e.to_field(self) for e in exprs]
-        return Schema._from_field_name_and_types([(f.name, f.dtype) for f in fields])

--- a/daft/logical/schema2.py
+++ b/daft/logical/schema2.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 from daft.daft import PyField as _PyField
 from daft.daft import PySchema as _PySchema
 from daft.datatype import DataType
-from daft.expressions2 import ExpressionsProjection, col
+
+if TYPE_CHECKING:
+    from daft.expressions2 import ExpressionsProjection
 
 
 class Field:
@@ -86,11 +88,9 @@ class Schema:
     def __repr__(self) -> str:
         return repr([(field.name, field.dtype) for field in self])
 
-    def to_column_expressions(self) -> ExpressionsProjection:
-        return ExpressionsProjection([col(f.name) for f in self])
-
     def resolve_expressions(self, expressions: ExpressionsProjection) -> Schema:
         """Create a new Schema by resolving the Expressions against an existing Schema"""
+
         raise NotImplementedError(
             "[RUST-INT][TPCH] Requires an API for construction of a new Schema from resolving Expressions against an existing one"
         )

--- a/daft/logical/schema2.py
+++ b/daft/logical/schema2.py
@@ -7,7 +7,7 @@ from daft.daft import PySchema as _PySchema
 from daft.datatype import DataType
 
 if TYPE_CHECKING:
-    from daft.expressions2 import ExpressionsProjection
+    pass
 
 
 class Field:
@@ -87,13 +87,6 @@ class Schema:
 
     def __repr__(self) -> str:
         return repr([(field.name, field.dtype) for field in self])
-
-    def resolve_expressions(self, expressions: ExpressionsProjection) -> Schema:
-        """Create a new Schema by resolving the Expressions against an existing Schema"""
-
-        raise NotImplementedError(
-            "[RUST-INT][TPCH] Requires an API for construction of a new Schema from resolving Expressions against an existing one"
-        )
 
     def union(self, other: Schema) -> Schema:
         if not isinstance(other, Schema):

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -1,3 +1,5 @@
+use super::field::PyField;
+use super::{datatype::PyDataType, schema::PySchema};
 use crate::dsl;
 use pyo3::{
     exceptions::PyValueError,
@@ -5,8 +7,6 @@ use pyo3::{
     pyclass::CompareOp,
     types::{PyBool, PyBytes, PyFloat, PyInt, PyString, PyTuple},
 };
-
-use super::datatype::PyDataType;
 
 #[pyfunction]
 pub fn col(name: &str) -> PyResult<PyExpr> {
@@ -129,6 +129,10 @@ impl PyExpr {
 
     pub fn name(&self) -> PyResult<&str> {
         Ok(self.expr.name()?)
+    }
+
+    pub fn to_field(&self, schema: &PySchema) -> PyResult<PyField> {
+        Ok(self.expr.to_field(&schema.schema)?.into())
     }
 
     pub fn __repr__(&self) -> PyResult<String> {

--- a/src/python/field.rs
+++ b/src/python/field.rs
@@ -1,0 +1,36 @@
+use pyo3::prelude::*;
+
+use super::datatype::PyDataType;
+use crate::datatypes;
+
+#[pyclass]
+pub struct PyField {
+    pub field: datatypes::Field,
+}
+
+#[pymethods]
+impl PyField {
+    pub fn name(&self) -> PyResult<String> {
+        Ok(self.field.name.clone())
+    }
+
+    pub fn dtype(&self) -> PyResult<PyDataType> {
+        Ok(self.field.dtype.clone().into())
+    }
+
+    pub fn eq(&self, other: &PyField) -> PyResult<bool> {
+        Ok(self.field.eq(&other.field))
+    }
+}
+
+impl From<datatypes::Field> for PyField {
+    fn from(field: datatypes::Field) -> Self {
+        PyField { field }
+    }
+}
+
+impl From<PyField> for datatypes::Field {
+    fn from(item: PyField) -> Self {
+        item.field
+    }
+}

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -2,6 +2,7 @@ use pyo3::prelude::*;
 mod datatype;
 mod error;
 mod expr;
+mod field;
 mod schema;
 mod series;
 mod table;
@@ -12,7 +13,7 @@ pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
     parent.add_class::<series::PySeries>()?;
     parent.add_class::<datatype::PyDataType>()?;
     parent.add_class::<schema::PySchema>()?;
-    parent.add_class::<schema::PyField>()?;
+    parent.add_class::<field::PyField>()?;
 
     parent.add_wrapped(wrap_pyfunction!(expr::col))?;
     parent.add_wrapped(wrap_pyfunction!(expr::lit))?;

--- a/src/python/schema.rs
+++ b/src/python/schema.rs
@@ -3,18 +3,13 @@ use std::sync::Arc;
 use pyo3::prelude::*;
 
 use super::datatype::PyDataType;
+use super::field::PyField;
 use crate::datatypes;
-use crate::python::datatype;
 use crate::schema;
 
 #[pyclass]
 pub struct PySchema {
     pub schema: schema::SchemaRef,
-}
-
-#[pyclass]
-pub struct PyField {
-    pub field: datatypes::Field,
 }
 
 #[pymethods]
@@ -48,33 +43,6 @@ impl PySchema {
         Ok(PySchema {
             schema: schema.into(),
         })
-    }
-}
-
-#[pymethods]
-impl PyField {
-    pub fn name(&self) -> PyResult<String> {
-        Ok(self.field.name.clone())
-    }
-
-    pub fn dtype(&self) -> PyResult<datatype::PyDataType> {
-        Ok(self.field.dtype.clone().into())
-    }
-
-    pub fn eq(&self, other: &PyField) -> PyResult<bool> {
-        Ok(self.field.eq(&other.field))
-    }
-}
-
-impl From<datatypes::Field> for PyField {
-    fn from(field: datatypes::Field) -> Self {
-        PyField { field }
-    }
-}
-
-impl From<PyField> for datatypes::Field {
-    fn from(item: PyField) -> Self {
-        item.field
     }
 }
 

--- a/tests/experimental/test_serving.py
+++ b/tests/experimental/test_serving.py
@@ -16,8 +16,7 @@ from daft.experimental.serving.backends import (
     MultiprocessingEndpointBackend,
 )
 from daft.experimental.serving.env import DaftEnv, get_docker_client
-from daft.expressions import col
-from daft.logical.schema import ExpressionList
+from daft.expressions import ExpressionList, col
 
 TEST_BACKEND_CONFIG = {
     "mp": {"type": "multiprocessing"},

--- a/tests/logical/test_logical_plan.py
+++ b/tests/logical/test_logical_plan.py
@@ -70,14 +70,14 @@ def test_projection_new_columns_logical_plan(schema) -> None:
 
     Projection(
         scan,
-        schema.to_column_expressions().union(ExpressionList([(col("a") + col("b")).alias("d")])),
+        ExpressionList.from_schema(schema).union(ExpressionList([(col("a") + col("b")).alias("d")])),
         custom_resource_request=None,
     )
     projection = Projection(scan, ExpressionList([col("b")]), custom_resource_request=None)
     proj_schema = projection.schema()
     hstacked_on_proj = Projection(
         projection,
-        proj_schema.to_column_expressions().union(
+        ExpressionList.from_schema(proj_schema).union(
             ExpressionList([(col("b") + 1).alias("a"), (col("b") + 2).alias("c")])
         ),
         custom_resource_request=None,
@@ -105,7 +105,7 @@ def test_scan_projection_filter_projection_chain(schema) -> None:
 
     hstacked = Projection(
         scan,
-        schema.to_column_expressions().union(ExpressionList([(col("a") + col("b")).alias("d")])),
+        ExpressionList.from_schema(schema).union(ExpressionList([(col("a") + col("b")).alias("d")])),
         custom_resource_request=None,
     )
     assert hstacked.schema().column_names() == ["a", "b", "c", "d"]

--- a/tests/logical/test_schema2.py
+++ b/tests/logical/test_schema2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from daft.datatype import DataType
-from daft.expressions2 import col
+from daft.expressions2 import ExpressionsProjection, col
 from daft.logical.schema2 import Schema
 from daft.table import Table
 
@@ -68,7 +68,7 @@ def test_repr():
 
 def test_to_col_expr():
     schema = TABLE.schema()
-    schema_col_exprs = schema.to_column_expressions()
+    schema_col_exprs = ExpressionsProjection.from_schema(schema)
     expected_col_exprs = [col(n) for n in schema.column_names()]
 
     assert len(schema_col_exprs) == len(expected_col_exprs)

--- a/tests/optimizer/test_pushdown_predicates.py
+++ b/tests/optimizer/test_pushdown_predicates.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 import pytest
 
 from daft.dataframe import DataFrame
-from daft.expressions import col
+from daft.expressions import ExpressionList, col
 from daft.internal.rule_runner import Once, RuleBatch, RuleRunner
 from daft.logical.logical_plan import Filter, Join, LogicalPlan
 from daft.logical.optimizer import PushDownPredicates
-from daft.logical.schema import ExpressionList
 from tests.optimizer.conftest import assert_plan_eq
 
 

--- a/tests/runners/test_partitioning.py
+++ b/tests/runners/test_partitioning.py
@@ -4,8 +4,7 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from daft.expressions import Expression, col
-from daft.logical.schema import ExpressionList
+from daft.expressions import Expression, ExpressionList, col
 from daft.runners.blocks import ArrowDataBlock, DataBlock
 from daft.runners.partitioning import PyListTile, vPartition
 


### PR DESCRIPTION
* Fixes a circular dependency between schema.py and expressions.py - we now follow the semantics in our Rust code, Expressions depends on Schema but not the other way around
* Adds `ExpressionsProjection.resolve_schema` functionality, leveraging our underlying Rust `Expr`'s `.to_field(schema)`.