### PR TITLE
[rust] size_bytes for Table and Series

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -127,6 +127,12 @@ class Series:
             raise ValueError("This Series isn't backed by a Rust PySeries, can not convert to arrow")
         return len(self._series)
 
+    def size_bytes(self) -> int:
+        if self._series is None:
+            raise ValueError("This Series isn't backed by a Rust PySeries, can not get size bytes")
+
+        return self._series.size_bytes()
+
     def __add__(self, other: object) -> Series:
         if not isinstance(other, Series):
             raise ValueError(f"expected another Series but got {type(other)}")

--- a/daft/table.py
+++ b/daft/table.py
@@ -43,7 +43,7 @@ class Table:
         return Series._from_pyseries(self._table.get_column(name))
 
     def size_bytes(self) -> int:
-        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
+        return self._table.size_bytes()
 
     def __len__(self) -> int:
         return len(self._table)

--- a/src/array/ops/len.rs
+++ b/src/array/ops/len.rs
@@ -1,3 +1,5 @@
+use arrow2::bitmap::Bitmap;
+
 use crate::{
     array::{BaseArray, DataArray},
     datatypes::{BooleanArray, DaftDataType, DaftNumericType, NullArray, Utf8Array},
@@ -12,6 +14,13 @@ where
     }
 }
 
+fn validity_byte_size(bitmask: Option<&Bitmap>) -> usize {
+    match bitmask {
+        None => 0,
+        Some(b) => (b.len() + 8 - 1) / 8,
+    }
+}
+
 impl<T> DataArray<T>
 where
     T: DaftNumericType,
@@ -20,18 +29,14 @@ where
         use core::mem::size_of;
         let bytes_per_elem = size_of::<T::Native>();
         let numerical_data_size = self.len() * bytes_per_elem;
-        let bitmask_data_size = match self.data().validity() {
-            None => 0,
-            Some(_) => (self.len() + 8 - 1) / 8,
-        };
-
-        numerical_data_size + bitmask_data_size
+        numerical_data_size + validity_byte_size(self.data().validity())
     }
 }
 
 impl BooleanArray {
     pub fn size_bytes(&self) -> usize {
-        (self.len() + 8 - 1) / 8
+        let bitmask_size = (self.len() + 8 - 1) / 8;
+        bitmask_size + validity_byte_size(self.data().validity())
     }
 }
 
@@ -42,12 +47,9 @@ impl Utf8Array {
         let arrow_array = self.downcast();
         let buffer_size = (arrow_array.offsets().last().unwrap()
             - arrow_array.offsets().first().unwrap()) as usize;
-        let offset_size = (self.len() + 1) * size_of::<i64>();
-        let bitmask_data_size = match self.data().validity() {
-            None => 0,
-            Some(_) => (self.len() + 8 - 1) / 8,
-        };
-        buffer_size + offset_size + bitmask_data_size
+        let offset_size = self.len() * size_of::<i64>();
+
+        buffer_size + offset_size + validity_byte_size(self.data().validity())
     }
 }
 

--- a/src/array/ops/len.rs
+++ b/src/array/ops/len.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::DaftDataType,
+    datatypes::{BooleanArray, DaftDataType, DaftNumericType, NullArray, Utf8Array},
 };
 
 impl<T> DataArray<T>
@@ -9,5 +9,50 @@ where
 {
     pub fn len(&self) -> usize {
         self.data().len()
+    }
+}
+
+impl<T> DataArray<T>
+where
+    T: DaftNumericType,
+{
+    pub fn size_bytes(&self) -> usize {
+        use core::mem::size_of;
+        let bytes_per_elem = size_of::<T::Native>();
+        let numerical_data_size = self.len() * bytes_per_elem;
+        let bitmask_data_size = match self.data().validity() {
+            None => 0,
+            Some(_) => (self.len() + 8 - 1) / 8,
+        };
+
+        numerical_data_size + bitmask_data_size
+    }
+}
+
+impl BooleanArray {
+    pub fn size_bytes(&self) -> usize {
+        (self.len() + 8 - 1) / 8
+    }
+}
+
+impl Utf8Array {
+    pub fn size_bytes(&self) -> usize {
+        use core::mem::size_of;
+
+        let arrow_array = self.downcast();
+        let buffer_size = (arrow_array.offsets().last().unwrap()
+            - arrow_array.offsets().first().unwrap()) as usize;
+        let offset_size = (self.len() + 1) * size_of::<i64>();
+        let bitmask_data_size = match self.data().validity() {
+            None => 0,
+            Some(_) => (self.len() + 8 - 1) / 8,
+        };
+        buffer_size + offset_size + bitmask_data_size
+    }
+}
+
+impl NullArray {
+    pub fn size_bytes(&self) -> usize {
+        0
     }
 }

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -140,6 +140,10 @@ impl PySeries {
         Ok(self.series.len())
     }
 
+    pub fn size_bytes(&self) -> PyResult<usize> {
+        Ok(self.series.size_bytes())
+    }
+
     pub fn name(&self) -> PyResult<String> {
         Ok(self.series.name().to_string())
     }

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -94,6 +94,10 @@ impl PyTable {
         Ok(self.table.len())
     }
 
+    pub fn size_bytes(&self) -> PyResult<usize> {
+        Ok(self.table.size_bytes())
+    }
+
     pub fn column_names(&self) -> PyResult<Vec<String>> {
         Ok(self.table.column_names()?)
     }

--- a/src/series/mod.rs
+++ b/src/series/mod.rs
@@ -37,10 +37,6 @@ impl Series {
         Self::new(Arc::from(self.data_array.rename(name.as_ref())))
     }
 
-    pub fn len(&self) -> usize {
-        self.data_array.len()
-    }
-
     pub fn field(&self) -> &Field {
         self.data_array.field()
     }

--- a/src/series/ops/len.rs
+++ b/src/series/ops/len.rs
@@ -1,0 +1,14 @@
+use crate::{series::Series, with_match_comparable_daft_types};
+
+impl Series {
+    pub fn len(&self) -> usize {
+        self.data_array.len()
+    }
+
+    pub fn size_bytes(&self) -> usize {
+        with_match_comparable_daft_types!(self.data_type(), |$T| {
+            let downcasted = self.downcast::<$T>().unwrap();
+            downcasted.size_bytes()
+        })
+    }
+}

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -10,6 +10,7 @@ pub mod downcast;
 pub mod filter;
 pub mod full;
 pub mod hash;
+pub mod len;
 pub mod pairwise;
 pub mod sort;
 pub mod take;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -90,6 +90,10 @@ impl Table {
         })
     }
 
+    pub fn size_bytes(&self) -> usize {
+        self.columns.iter().map(|s| s.size_bytes()).sum::<usize>()
+    }
+
     pub fn filter(&self, predicate: &[Expr]) -> DaftResult<Self> {
         if predicate.is_empty() {
             Ok(self.clone())

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -314,7 +314,8 @@ def test_series_boolean_sorting() -> None:
 
 @pytest.mark.parametrize("dtype, size", itertools.product(arrow_int_types + arrow_float_types, [0, 1, 2, 8, 9, 16]))
 def test_series_numeric_size_bytes(dtype, size) -> None:
-    data = pa.array(list(range(size)), dtype)
+    pydata = list(range(size))
+    data = pa.array(pydata, dtype)
 
     s = Series.from_arrow(data)
 
@@ -322,7 +323,9 @@ def test_series_numeric_size_bytes(dtype, size) -> None:
     assert s.size_bytes() == data.nbytes
 
     ## with nulls
-    data = pa.array(list(range(size - 1)) + [None], dtype)
+    if size > 0:
+        pydata = pydata[:-1] + [None]
+    data = pa.array(pydata, dtype)
 
     s = Series.from_arrow(data)
 
@@ -332,17 +335,44 @@ def test_series_numeric_size_bytes(dtype, size) -> None:
 
 @pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
 def test_series_string_size_bytes(size) -> None:
-    data = pa.array(list(range(size)), pa.large_string())
+
+    pydata = list(str(i) for i in range(size))
+    data = pa.array(pydata, pa.large_string())
 
     s = Series.from_arrow(data)
 
-    assert s.datatype() == DataType.from_arrow_type(pa.large_string())
+    assert s.datatype() == DataType.string()
     assert s.size_bytes() == data.nbytes
 
     ## with nulls
-    data = pa.array(list(range(size - 1)) + [None], pa.large_string())
+    if size > 0:
+        pydata = pydata[:-1] + [None]
+    data = pa.array(pydata, pa.large_string())
 
     s = Series.from_arrow(data)
 
-    assert s.datatype() == DataType.from_arrow_type(pa.large_string())
+    assert s.datatype() == DataType.string()
+    assert s.size_bytes() == data.nbytes
+
+
+@pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
+def test_series_boolean_size_bytes(size) -> None:
+
+    pydata = [True if i % 2 else False for i in range(size)]
+
+    data = pa.array(pydata, pa.bool_())
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.bool()
+    assert s.size_bytes() == data.nbytes
+
+    ## with nulls
+    if size > 0:
+        pydata = pydata[:-1] + [None]
+    data = pa.array(pydata, pa.bool_())
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.bool()
     assert s.size_bytes() == data.nbytes

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -310,3 +310,39 @@ def test_series_boolean_sorting() -> None:
     taken = s.take(s_argsorted)
     assert len(taken) == len(s)
     assert taken.to_pylist() == sorted_order[::-1]
+
+
+@pytest.mark.parametrize("dtype, size", itertools.product(arrow_int_types + arrow_float_types, [0, 1, 2, 8, 9, 16]))
+def test_series_numeric_size_bytes(dtype, size) -> None:
+    data = pa.array(list(range(size)), dtype)
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.from_arrow_type(dtype)
+    assert s.size_bytes() == data.nbytes
+
+    ## with nulls
+    data = pa.array(list(range(size - 1)) + [None], dtype)
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.from_arrow_type(dtype)
+    assert s.size_bytes() == data.nbytes
+
+
+@pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
+def test_series_string_size_bytes(size) -> None:
+    data = pa.array(list(range(size)), pa.large_string())
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.from_arrow_type(pa.large_string())
+    assert s.size_bytes() == data.nbytes
+
+    ## with nulls
+    data = pa.array(list(range(size - 1)) + [None], pa.large_string())
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.from_arrow_type(pa.large_string())
+    assert s.size_bytes() == data.nbytes

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -505,3 +505,10 @@ def test_table_boolean_multiple_col_sorting(second_dtype, data) -> None:
         daft_table.argsort([col("a"), col("b")], descending=[not a_desc, not b_desc]).to_pylist()
         == argsort_order.to_pylist()[::-1]
     )
+
+
+def test_table_size_bytes() -> None:
+    data = Table.from_pydict({"a": [1, 2, 3, 4, None], "b": [False, True, False, True, None]}).eval_expression_list(
+        [col("a").cast(DataType.int64()), col("b")]
+    )
+    assert data.size_bytes() == (5 * 8 + 1) + (1 + 1)


### PR DESCRIPTION
* Adds `size_byte` which gives the min number of bytes a table or series requires in memory