### PR TITLE
[rust] Partitioning Ops (Hash, Random, Range)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -72,7 +72,7 @@ jobs:
         export CARGO_INCREMENTAL=1
         cargo llvm-cov clean --workspace
         maturin develop
-        mkdir -p report-output && pytest --cov=daft
+        mkdir -p report-output && pytest --cov=daft --durations=50
         coverage combine -a --data-file='.coverage' || true
         coverage xml -o ./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.xml
         cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft_runner }}.lcov

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,22 +68,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
-]
-
-[[package]]
 name = "bytemuck"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -123,11 +111,10 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
 dependencies = [
- "bstr",
  "csv-core",
  "itoa",
  "ryu",
@@ -181,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 
 [[package]]
 name = "either"
@@ -255,9 +242,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "indexmap"
@@ -277,9 +264,9 @@ checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
  "windows-sys",
@@ -287,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
@@ -308,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "lazy_static"
@@ -460,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "parking_lot"
@@ -647,12 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,9 +641,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
@@ -674,15 +655,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "scopeguard"
@@ -692,18 +673,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -736,9 +717,9 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -747,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "term"
@@ -764,18 +745,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -784,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,10 +68,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bytemuck"
-version = "1.13.1"
+name = "bstr"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -111,10 +123,11 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.1"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
+ "bstr",
  "csv-core",
  "itoa",
  "ryu",
@@ -168,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.11"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
 name = "either"
@@ -242,9 +255,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "856b5cb0902c2b6d65d5fd97dfa30f9b70c7538e770b98eab5ed52d8db923e01"
 
 [[package]]
 name = "indexmap"
@@ -264,9 +277,9 @@ checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.6"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
  "windows-sys",
@@ -274,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
@@ -295,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "lazy_static"
@@ -447,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "parking_lot"
@@ -634,6 +647,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,9 +660,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
  "errno",
@@ -655,15 +674,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scopeguard"
@@ -673,18 +692,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.154"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.154"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -717,9 +736,9 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -728,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
 name = "term"
@@ -745,18 +764,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -765,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-width"

--- a/daft/series.py
+++ b/daft/series.py
@@ -31,19 +31,19 @@ class Series:
             pys = PySeries.from_arrow(name, combined_array)
             return Series._from_pyseries(pys)
         else:
-            raise ValueError(f"expected either PyArrow Array or Chunked Array, got {type(array)}")
+            raise TypeError(f"expected either PyArrow Array or Chunked Array, got {type(array)}")
 
     @staticmethod
     def from_pylist(data: list, name: str = "list_series") -> Series:
         if not isinstance(data, list):
-            raise ValueError(f"expected a python list, got {type(data)}")
+            raise TypeError(f"expected a python list, got {type(data)}")
         arrow_array = pa.array(data)
         return Series.from_arrow(arrow_array, name=name)
 
     @staticmethod
     def from_numpy(data: np.ndarray, name: str = "numpy_series") -> Series:
         if not isinstance(data, np.ndarray):
-            raise ValueError(f"expected a numpy ndarray, got {type(data)}")
+            raise TypeError(f"expected a numpy ndarray, got {type(data)}")
         arrow_array = pa.array(data)
         return Series.from_arrow(arrow_array, name=name)
 
@@ -77,14 +77,14 @@ class Series:
         if self._series is None:
             raise ValueError("This Series isn't backed by a Rust PySeries, can not convert to arrow")
         if not isinstance(mask, Series):
-            raise ValueError(f"expected another Series but got {type(mask)}")
+            raise TypeError(f"expected another Series but got {type(mask)}")
         return Series._from_pyseries(self._series.filter(mask._series))
 
     def take(self, idx: Series) -> Series:
         if self._series is None:
             raise ValueError("This Series isn't backed by a Rust PySeries, can not convert to arrow")
         if not isinstance(idx, Series):
-            raise ValueError(f"expected another Series but got {type(idx)}")
+            raise TypeError(f"expected another Series but got {type(idx)}")
         return Series._from_pyseries(self._series.take(idx._series))
 
     def argsort(self, descending: bool = False) -> Series:
@@ -92,7 +92,7 @@ class Series:
             raise ValueError("This Series isn't backed by a Rust PySeries, can not convert to arrow")
 
         if not isinstance(descending, bool):
-            raise ValueError(f"expected `descending` to be bool, got {type(descending)}")
+            raise TypeError(f"expected `descending` to be bool, got {type(descending)}")
 
         return Series._from_pyseries(self._series.argsort(descending))
 
@@ -101,7 +101,7 @@ class Series:
             raise ValueError("This Series isn't backed by a Rust PySeries, can not convert to arrow")
 
         if not isinstance(descending, bool):
-            raise ValueError(f"expected `descending` to be bool, got {type(descending)}")
+            raise TypeError(f"expected `descending` to be bool, got {type(descending)}")
 
         return Series._from_pyseries(self._series.sort(descending))
 
@@ -110,7 +110,7 @@ class Series:
             raise ValueError("This Series isn't backed by a Rust PySeries, can not convert to arrow")
 
         if not isinstance(seed, Series) and seed is not None:
-            raise ValueError(f"expected `seed` to be Series, got {type(seed)}")
+            raise TypeError(f"expected `seed` to be Series, got {type(seed)}")
 
         return Series._from_pyseries(self._series.hash(seed._series if seed is not None else None))
 
@@ -139,84 +139,84 @@ class Series:
 
     def __add__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series + other._series)
 
     def __sub__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series - other._series)
 
     def __mul__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series * other._series)
 
     def __truediv__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series / other._series)
 
     def __mod__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series % other._series)
 
     def __eq__(self, other: object) -> Series:  # type: ignore[override]
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series == other._series)
 
     def __ne__(self, other: object) -> Series:  # type: ignore[override]
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series != other._series)
 
     def __gt__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series > other._series)
 
     def __lt__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series < other._series)
 
     def __ge__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series >= other._series)
 
     def __le__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series <= other._series)
 
     def __and__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series & other._series)
 
     def __or__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series | other._series)
 
     def __xor__(self, other: object) -> Series:
         if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
+            raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series ^ other._series)

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -62,6 +62,7 @@ class Table:
 
     @staticmethod
     def _from_pytable(pyt: _PyTable) -> Table:
+        assert isinstance(pyt, _PyTable)
         tab = Table.__new__(Table)
         tab._table = pyt
         return tab
@@ -190,13 +191,16 @@ class Table:
 
         return Table._from_pytable(self._table.join(right._table, left_on=left_exprs, right_on=right_exprs))
 
-    def split_by_hash(self, exprs: ExpressionsProjection, num_partitions: int) -> list[Table]:
+    def partition_by_hash(self, exprs: ExpressionsProjection, num_partitions: int) -> list[Table]:
+        pyexprs = [e._expr for e in exprs]
+        return [Table._from_pytable(t) for t in self._table.partition_by_hash(pyexprs, num_partitions)]
+
+    def partition_by_range(
+        self, partition_keys: ExpressionsProjection, pivots: Table, descending: list[bool]
+    ) -> list[Table]:
         raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
-    def split_by_index(self, num_partitions: int, target_partition_indices: Series) -> list[Table]:
-        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
-
-    def split_random(self, num_partitions: int, seed: int) -> list[Table]:
+    def partition_by_random(self, num_partitions: int, seed: int) -> list[Table]:
         raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     ###
@@ -219,6 +223,3 @@ class Table:
         else:
             raise ValueError(f"Expected a bool, list[bool] or None for `descending` but got {type(descending)}")
         return Series._from_pyseries(self._table.argsort(pyexprs, descending))
-
-    def search_sorted(self, sort_keys: Table, descending: list[bool]) -> Series:
-        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -192,6 +192,9 @@ class Table:
         return Table._from_pytable(self._table.join(right._table, left_on=left_exprs, right_on=right_exprs))
 
     def partition_by_hash(self, exprs: ExpressionsProjection, num_partitions: int) -> list[Table]:
+        if not isinstance(num_partitions, int):
+            raise TypeError(f"Expected a num_partitions to be int, got {type(num_partitions)}")
+
         pyexprs = [e._expr for e in exprs]
         return [Table._from_pytable(t) for t in self._table.partition_by_hash(pyexprs, num_partitions)]
 
@@ -201,7 +204,13 @@ class Table:
         raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
 
     def partition_by_random(self, num_partitions: int, seed: int) -> list[Table]:
-        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
+        if not isinstance(num_partitions, int):
+            raise TypeError(f"Expected a num_partitions to be int, got {type(num_partitions)}")
+
+        if not isinstance(seed, int):
+            raise TypeError(f"Expected a seed to be int, got {type(seed)}")
+
+        return [Table._from_pytable(t) for t in self._table.partition_by_random(num_partitions, seed)]
 
     ###
     # Compute methods (Table -> Series)

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -149,7 +149,7 @@ class Table:
                     f"got {len(descending)} instead of {len(sort_keys)}"
                 )
         else:
-            raise ValueError(f"Expected a bool, list[bool] or None for `descending` but got {type(descending)}")
+            raise TypeError(f"Expected a bool, list[bool] or None for `descending` but got {type(descending)}")
         return Table._from_pytable(self._table.sort(pyexprs, descending))
 
     def sample(self, num: int) -> Table:
@@ -184,7 +184,7 @@ class Table:
             raise NotImplementedError("TODO: [RUST-INT][TPCH] Multicolumn joins not implemented")
 
         if not isinstance(right, Table):
-            raise ValueError(f"Expected a Table for `right` in join but got {type(right)}")
+            raise TypeError(f"Expected a Table for `right` in join but got {type(right)}")
 
         left_exprs = [e._expr for e in left_on]
         right_exprs = [e._expr for e in right_on]
@@ -221,5 +221,5 @@ class Table:
                     f"got {len(descending)} instead of {len(sort_keys)}"
                 )
         else:
-            raise ValueError(f"Expected a bool, list[bool] or None for `descending` but got {type(descending)}")
+            raise TypeError(f"Expected a bool, list[bool] or None for `descending` but got {type(descending)}")
         return Series._from_pyseries(self._table.argsort(pyexprs, descending))

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -199,9 +199,13 @@ class Table:
         return [Table._from_pytable(t) for t in self._table.partition_by_hash(pyexprs, num_partitions)]
 
     def partition_by_range(
-        self, partition_keys: ExpressionsProjection, pivots: Table, descending: list[bool]
+        self, partition_keys: ExpressionsProjection, boundaries: Table, descending: list[bool]
     ) -> list[Table]:
-        raise NotImplementedError("TODO: [RUST-INT][TPCH] Implement for Table")
+        if not isinstance(boundaries, Table):
+            raise TypeError(f"Expected a Table for `boundaries` in partition_by_range but got {type(boundaries)}")
+
+        exprs = [e._expr for e in partition_keys]
+        return [Table._from_pytable(t) for t in self._table.partition_by_range(exprs, boundaries._table, descending)]
 
     def partition_by_random(self, num_partitions: int, seed: int) -> list[Table]:
         if not isinstance(num_partitions, int):

--- a/src/array/from.rs
+++ b/src/array/from.rs
@@ -34,6 +34,17 @@ where
     }
 }
 
+impl<T> From<(&str, Vec<T::Native>)> for DataArray<T>
+where
+    T: DaftNumericType,
+{
+    fn from(item: (&str, Vec<T::Native>)) -> Self {
+        let (name, v) = item;
+        let arrow_array = arrow2::array::PrimitiveArray::<T::Native>::from_vec(v);
+        DataArray::new(Field::new(name, T::get_dtype()).into(), arrow_array.arced()).unwrap()
+    }
+}
+
 impl From<(&str, &[bool])> for BooleanArray {
     fn from(item: (&str, &[bool])) -> Self {
         let (name, slice) = item;

--- a/src/array/ops/mod.rs
+++ b/src/array/ops/mod.rs
@@ -12,6 +12,7 @@ mod full;
 mod hash;
 mod len;
 mod pairwise;
+mod search_sorted;
 mod sort;
 mod sum;
 mod take;

--- a/src/array/ops/pairwise.rs
+++ b/src/array/ops/pairwise.rs
@@ -36,8 +36,8 @@ where
                 }
             }
         }
-        let left_series = DataArray::from((self.name(), left_idx.as_slice()));
-        let right_series = DataArray::from((other.name(), right_idx.as_slice()));
+        let left_series = DataArray::from((self.name(), left_idx));
+        let right_series = DataArray::from((other.name(), right_idx));
         Ok((left_series, right_series))
     }
 }
@@ -71,8 +71,8 @@ impl Utf8Array {
                 }
             }
         }
-        let left_series = DataArray::from((self.name(), left_idx.as_slice()));
-        let right_series = DataArray::from((other.name(), right_idx.as_slice()));
+        let left_series = DataArray::from((self.name(), left_idx));
+        let right_series = DataArray::from((other.name(), right_idx));
         Ok((left_series, right_series))
     }
 }
@@ -106,8 +106,8 @@ impl BooleanArray {
                 }
             }
         }
-        let left_series = DataArray::from((self.name(), left_idx.as_slice()));
-        let right_series = DataArray::from((other.name(), right_idx.as_slice()));
+        let left_series = DataArray::from((self.name(), left_idx));
+        let right_series = DataArray::from((other.name(), right_idx));
         Ok((left_series, right_series))
     }
 }
@@ -123,8 +123,8 @@ impl NullArray {
     {
         let left_idx = vec![];
         let right_idx = vec![];
-        let left_series = DataArray::from((self.name(), left_idx.as_slice()));
-        let right_series = DataArray::from((other.name(), right_idx.as_slice()));
+        let left_series = DataArray::from((self.name(), left_idx));
+        let right_series = DataArray::from((other.name(), right_idx));
         Ok((left_series, right_series))
     }
 }

--- a/src/array/ops/search_sorted.rs
+++ b/src/array/ops/search_sorted.rs
@@ -1,0 +1,20 @@
+use crate::{
+    array::DataArray,
+    datatypes::{DaftDataType, UInt64Array},
+    error::DaftResult,
+    kernels::search_sorted,
+};
+
+use crate::array::BaseArray;
+
+impl<T> DataArray<T>
+where
+    T: DaftDataType + 'static,
+{
+    pub fn search_sorted(&self, keys: &Self, descending: bool) -> DaftResult<UInt64Array> {
+        let array =
+            search_sorted::search_sorted(self.data.as_ref(), keys.data.as_ref(), descending)?;
+
+        Ok(DataArray::from((self.name(), Box::new(array))))
+    }
+}

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -110,6 +110,25 @@ impl PyTable {
         Ok(self.table.quantiles(num)?.into())
     }
 
+    pub fn partition_by_hash(
+        &self,
+        exprs: Vec<PyExpr>,
+        num_partitions: i64,
+    ) -> PyResult<Vec<Self>> {
+        if num_partitions < 0 {
+            return Err(PyValueError::new_err(format!(
+                "Can not partition into negative number of partitions: {num_partitions}"
+            )));
+        }
+        let exprs: Vec<dsl::Expr> = exprs.into_iter().map(|e| e.into()).collect();
+        Ok(self
+            .table
+            .partition_by_hash(exprs.as_slice(), num_partitions as usize)?
+            .into_iter()
+            .map(|t| t.into())
+            .collect::<Vec<PyTable>>())
+    }
+
     pub fn __len__(&self) -> PyResult<usize> {
         Ok(self.table.len())
     }

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -149,6 +149,21 @@ impl PyTable {
             .collect::<Vec<PyTable>>())
     }
 
+    pub fn partition_by_range(
+        &self,
+        partition_keys: Vec<PyExpr>,
+        boundaries: &Self,
+        descending: Vec<bool>,
+    ) -> PyResult<Vec<Self>> {
+        let exprs: Vec<dsl::Expr> = partition_keys.into_iter().map(|e| e.into()).collect();
+        Ok(self
+            .table
+            .partition_by_range(exprs.as_slice(), &boundaries.table, descending.as_slice())?
+            .into_iter()
+            .map(|t| t.into())
+            .collect::<Vec<PyTable>>())
+    }
+
     pub fn __len__(&self) -> PyResult<usize> {
         Ok(self.table.len())
     }
@@ -162,7 +177,7 @@ impl PyTable {
     }
 
     pub fn get_column(&self, name: &str) -> PyResult<PySeries> {
-        Ok(self.table.get_column(name)?.into())
+        Ok(self.table.get_column(name)?.clone().into())
     }
 
     pub fn get_column_by_index(&self, idx: i64) -> PyResult<PySeries> {
@@ -179,7 +194,7 @@ impl PyTable {
             )));
         }
 
-        Ok(self.table.get_column_by_index(idx)?.into())
+        Ok(self.table.get_column_by_index(idx)?.clone().into())
     }
 
     #[staticmethod]

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -129,6 +129,26 @@ impl PyTable {
             .collect::<Vec<PyTable>>())
     }
 
+    pub fn partition_by_random(&self, num_partitions: i64, seed: i64) -> PyResult<Vec<Self>> {
+        if num_partitions < 0 {
+            return Err(PyValueError::new_err(format!(
+                "Can not partition into negative number of partitions: {num_partitions}"
+            )));
+        }
+
+        if seed < 0 {
+            return Err(PyValueError::new_err(format!(
+                "Can not have seed has negative number: {seed}"
+            )));
+        }
+        Ok(self
+            .table
+            .partition_by_random(num_partitions as usize, seed as u64)?
+            .into_iter()
+            .map(|t| t.into())
+            .collect::<Vec<PyTable>>())
+    }
+
     pub fn __len__(&self) -> PyResult<usize> {
         Ok(self.table.len())
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -13,7 +13,7 @@ use crate::{
 
 pub type SchemaRef = Arc<Schema>;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Schema {
     pub fields: indexmap::IndexMap<String, Field>,
 }

--- a/src/series/ops/arithmetic.rs
+++ b/src/series/ops/arithmetic.rs
@@ -83,8 +83,8 @@ mod tests {
     };
     #[test]
     fn add_int_and_int() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1, 2, 3].as_slice()));
-        let b = Int64Array::from(("b", vec![1, 2, 3].as_slice()));
+        let a = Int64Array::from(("a", vec![1, 2, 3]));
+        let b = Int64Array::from(("b", vec![1, 2, 3]));
         let c = a.into_series() + b.into_series();
         assert_eq!(*c?.data_type(), DataType::Int64);
         Ok(())
@@ -92,16 +92,16 @@ mod tests {
 
     #[test]
     fn add_int_and_float() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1, 2, 3].as_slice()));
-        let b = Float64Array::from(("b", vec![1., 2., 3.].as_slice()));
+        let a = Int64Array::from(("a", vec![1, 2, 3]));
+        let b = Float64Array::from(("b", vec![1., 2., 3.]));
         let c = a.into_series() + b.into_series();
         assert_eq!(*c?.data_type(), DataType::Float64);
         Ok(())
     }
     #[test]
     fn sub_int_and_float() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1, 2, 3].as_slice()));
-        let b = Float64Array::from(("b", vec![1., 2., 3.].as_slice()));
+        let a = Int64Array::from(("a", vec![1, 2, 3]));
+        let b = Float64Array::from(("b", vec![1., 2., 3.]));
         let c = a.into_series() - b.into_series();
         assert_eq!(*c?.data_type(), DataType::Float64);
         Ok(())
@@ -109,31 +109,31 @@ mod tests {
 
     #[test]
     fn mul_int_and_float() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1, 2, 3].as_slice()));
-        let b = Float64Array::from(("b", vec![1., 2., 3.].as_slice()));
+        let a = Int64Array::from(("a", vec![1, 2, 3]));
+        let b = Float64Array::from(("b", vec![1., 2., 3.]));
         let c = a.into_series() * b.into_series();
         assert_eq!(*c?.data_type(), DataType::Float64);
         Ok(())
     }
     #[test]
     fn div_int_and_float() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1, 2, 3].as_slice()));
-        let b = Float64Array::from(("b", vec![1., 2., 3.].as_slice()));
+        let a = Int64Array::from(("a", vec![1, 2, 3]));
+        let b = Float64Array::from(("b", vec![1., 2., 3.]));
         let c = a.into_series() / b.into_series();
         assert_eq!(*c?.data_type(), DataType::Float64);
         Ok(())
     }
     #[test]
     fn rem_int_and_float() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1, 2, 3].as_slice()));
-        let b = Float64Array::from(("b", vec![1., 2., 3.].as_slice()));
+        let a = Int64Array::from(("a", vec![1, 2, 3]));
+        let b = Float64Array::from(("b", vec![1., 2., 3.]));
         let c = a.into_series() % b.into_series();
         assert_eq!(*c?.data_type(), DataType::Float64);
         Ok(())
     }
     #[test]
     fn add_int_and_int_full_null() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1, 2, 3].as_slice()));
+        let a = Int64Array::from(("a", vec![1, 2, 3]));
         let b = Int64Array::full_null("b", 3);
         let c = a.into_series() + b.into_series();
         assert_eq!(*c?.data_type(), DataType::Int64);
@@ -141,7 +141,7 @@ mod tests {
     }
     #[test]
     fn add_int_and_utf8() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1, 2, 3].as_slice()));
+        let a = Int64Array::from(("a", vec![1, 2, 3]));
         let str_array = vec!["a", "b", "c"];
         let b = Utf8Array::from(("b", str_array.as_slice()));
         let c = a.into_series() + b.into_series();

--- a/src/series/ops/broadcast.rs
+++ b/src/series/ops/broadcast.rs
@@ -28,7 +28,7 @@ mod tests {
 
     #[test]
     fn broadcast_int() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1].as_slice())).into_series();
+        let a = Int64Array::from(("a", vec![1])).into_series();
         let a = a.broadcast(10)?;
         assert_eq!(a.len(), 10);
         assert_eq!(*a.data_type(), DataType::Int64);

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -13,6 +13,7 @@ pub mod full;
 pub mod hash;
 pub mod len;
 pub mod pairwise;
+pub mod search_sorted;
 pub mod sort;
 pub mod sum;
 pub mod take;

--- a/src/series/ops/search_sorted.rs
+++ b/src/series/ops/search_sorted.rs
@@ -1,0 +1,17 @@
+use crate::{
+    datatypes::UInt64Array,
+    error::DaftResult,
+    series::{ops::match_types_on_series, Series},
+    with_match_comparable_daft_types,
+};
+
+impl Series {
+    pub fn search_sorted(&self, keys: &Self, descending: bool) -> DaftResult<UInt64Array> {
+        let (lhs, rhs) = match_types_on_series(self, keys)?;
+        with_match_comparable_daft_types!(lhs.data_type(), |$T| {
+            let lhs = lhs.downcast::<$T>().unwrap();
+            let rhs = rhs.downcast::<$T>().unwrap();
+            lhs.search_sorted(rhs, descending)
+        })
+    }
+}

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -178,13 +178,13 @@ impl Table {
 
     //pub fn concat(tables: &[&Table]) -> DaftResult<Self>;
 
-    pub fn get_column<S: AsRef<str>>(&self, name: S) -> DaftResult<Series> {
+    pub fn get_column<S: AsRef<str>>(&self, name: S) -> DaftResult<&Series> {
         let i = self.schema.get_index(name.as_ref())?;
-        Ok(self.columns.get(i).unwrap().clone())
+        Ok(self.columns.get(i).unwrap())
     }
 
-    pub fn get_column_by_index(&self, idx: usize) -> DaftResult<Series> {
-        Ok(self.columns.get(idx).unwrap().clone())
+    pub fn get_column_by_index(&self, idx: usize) -> DaftResult<&Series> {
+        Ok(self.columns.get(idx).unwrap())
     }
 
     fn eval_agg_expression(&self, agg_expr: &AggExpr) -> DaftResult<Series> {
@@ -201,7 +201,7 @@ impl Table {
             Alias(child, name) => Ok(self.eval_expression(child)?.rename(name)),
             Agg(agg_expr) => self.eval_agg_expression(agg_expr),
             Cast(child, dtype) => self.eval_expression(child)?.cast(dtype),
-            Column(name) => self.get_column(name),
+            Column(name) => self.get_column(name).cloned(),
             BinaryOp { op, left, right } => {
                 let lhs = self.eval_expression(left)?;
                 let rhs = self.eval_expression(right)?;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -101,7 +101,7 @@ impl Table {
             use rand::{distributions::Uniform, Rng};
             let range = Uniform::from(0..self.len() as u64);
             let values: Vec<u64> = rand::thread_rng().sample_iter(&range).take(num).collect();
-            let indices = UInt64Array::from(("idx", values.as_slice()));
+            let indices = UInt64Array::from(("idx", values));
             self.take(&indices.into_series())
         }
     }
@@ -127,7 +127,7 @@ impl Table {
                     .min((self.len() - 1) as u64)
             })
             .collect();
-        let indices = UInt64Array::from(("idx", sample_points.as_slice()));
+        let indices = UInt64Array::from(("idx", sample_points));
         self.take(&indices.into_series())
     }
 
@@ -338,8 +338,8 @@ mod test {
     use crate::table::Table;
     #[test]
     fn add_int_and_float_expression() -> DaftResult<()> {
-        let a = Int64Array::from(("a", vec![1, 2, 3].as_slice())).into_series();
-        let b = Float64Array::from(("b", vec![1., 2., 3.].as_slice())).into_series();
+        let a = Int64Array::from(("a", vec![1, 2, 3])).into_series();
+        let b = Float64Array::from(("b", vec![1., 2., 3.])).into_series();
         let schema = Schema::new(vec![
             a.field().clone().rename("a"),
             b.field().clone().rename("b"),

--- a/src/table/ops/hash.rs
+++ b/src/table/ops/hash.rs
@@ -1,16 +1,13 @@
 use crate::{
     datatypes::UInt64Array,
     error::{DaftError, DaftResult},
-    series::Series,
     table::Table,
 };
 
 impl Table {
     pub fn hash_rows(&self) -> DaftResult<UInt64Array> {
         if self.num_columns() == 0 {
-            return Err(DaftError::ValueError(format!(
-                "Attempting to Hash Table with no columns"
-            )));
+            return Err(DaftError::ValueError("Attempting to Hash Table with no columns".to_string()));
         }
         let mut hash_so_far = self.columns.first().unwrap().hash(None)?;
         for c in self.columns.iter().skip(1) {

--- a/src/table/ops/hash.rs
+++ b/src/table/ops/hash.rs
@@ -7,7 +7,9 @@ use crate::{
 impl Table {
     pub fn hash_rows(&self) -> DaftResult<UInt64Array> {
         if self.num_columns() == 0 {
-            return Err(DaftError::ValueError("Attempting to Hash Table with no columns".to_string()));
+            return Err(DaftError::ValueError(
+                "Attempting to Hash Table with no columns".to_string(),
+            ));
         }
         let mut hash_so_far = self.columns.first().unwrap().hash(None)?;
         for c in self.columns.iter().skip(1) {

--- a/src/table/ops/hash.rs
+++ b/src/table/ops/hash.rs
@@ -1,0 +1,21 @@
+use crate::{
+    datatypes::UInt64Array,
+    error::{DaftError, DaftResult},
+    series::Series,
+    table::Table,
+};
+
+impl Table {
+    pub fn hash_rows(&self) -> DaftResult<UInt64Array> {
+        if self.num_columns() == 0 {
+            return Err(DaftError::ValueError(format!(
+                "Attempting to Hash Table with no columns"
+            )));
+        }
+        let mut hash_so_far = self.columns.first().unwrap().hash(None)?;
+        for c in self.columns.iter().skip(1) {
+            hash_so_far = c.hash(Some(&hash_so_far))?;
+        }
+        Ok(hash_so_far)
+    }
+}

--- a/src/table/ops/joins/naive_join.rs
+++ b/src/table/ops/joins/naive_join.rs
@@ -20,7 +20,7 @@ pub(super) fn naive_inner_join(left: &Table, right: &Table) -> DaftResult<(Serie
     if left.num_columns() == 1 {
         let left_series = left.get_column_by_index(0)?;
         let right_series = right.get_column_by_index(0)?;
-        return left_series.pairwise_equal(&right_series);
+        return left_series.pairwise_equal(right_series);
     }
 
     Err(DaftError::ValueError(

--- a/src/table/ops/mod.rs
+++ b/src/table/ops/mod.rs
@@ -1,2 +1,4 @@
+mod hash;
 mod joins;
+mod partition;
 mod sort;

--- a/src/table/ops/mod.rs
+++ b/src/table/ops/mod.rs
@@ -1,4 +1,5 @@
 mod hash;
 mod joins;
 mod partition;
+mod search_sorted;
 mod sort;

--- a/src/table/ops/partition.rs
+++ b/src/table/ops/partition.rs
@@ -1,7 +1,7 @@
-use std::{num, ops::Rem};
+use std::{ops::Rem};
 
 use arrow2::array::{Array, DictionaryKey};
-use num_traits::ToPrimitive;
+
 
 use crate::{
     array::BaseArray,
@@ -55,9 +55,7 @@ impl Table {
         num_partitions: usize,
     ) -> DaftResult<Vec<Self>> {
         if num_partitions == 0 {
-            return Err(DaftError::ValueError(format!(
-                "Can not partition a Table by 0 partitions"
-            )));
+            return Err(DaftError::ValueError("Can not partition a Table by 0 partitions".to_string()));
         }
 
         let targets = self

--- a/src/table/ops/partition.rs
+++ b/src/table/ops/partition.rs
@@ -40,9 +40,9 @@ impl Table {
             output_to_input_idx[unsafe { t_idx.as_usize() }].push(s_idx as u64);
         }
         output_to_input_idx
-            .iter()
+            .into_iter()
             .map(|v| {
-                let indices = UInt64Array::from(("idx", v.as_slice()));
+                let indices = UInt64Array::from(("idx", v));
                 self.take(&indices.into_series())
             })
             .collect::<DaftResult<Vec<_>>>()

--- a/src/table/ops/partition.rs
+++ b/src/table/ops/partition.rs
@@ -85,4 +85,18 @@ impl Table {
 
         self.partition_by_index(&targets, num_partitions)
     }
+
+    pub fn partition_by_range(
+        &self,
+        partition_keys: &[Expr],
+        boundaries: &Self,
+        descending: &[bool],
+    ) -> DaftResult<Vec<Self>> {
+        if boundaries.len() == 0 {
+            return Ok(vec![self.clone()]);
+        }
+        let partition_key_table = self.eval_expression_list(partition_keys)?;
+        let targets = boundaries.search_sorted(&partition_key_table, descending)?;
+        self.partition_by_index(&targets, boundaries.len() + 1)
+    }
 }

--- a/src/table/ops/partition.rs
+++ b/src/table/ops/partition.rs
@@ -1,7 +1,6 @@
-use std::{ops::Rem};
+use std::ops::Rem;
 
 use arrow2::array::{Array, DictionaryKey};
-
 
 use crate::{
     array::BaseArray,
@@ -55,7 +54,9 @@ impl Table {
         num_partitions: usize,
     ) -> DaftResult<Vec<Self>> {
         if num_partitions == 0 {
-            return Err(DaftError::ValueError("Can not partition a Table by 0 partitions".to_string()));
+            return Err(DaftError::ValueError(
+                "Can not partition a Table by 0 partitions".to_string(),
+            ));
         }
 
         let targets = self

--- a/src/table/ops/partition.rs
+++ b/src/table/ops/partition.rs
@@ -1,0 +1,72 @@
+use std::{num, ops::Rem};
+
+use arrow2::array::{Array, DictionaryKey};
+use num_traits::ToPrimitive;
+
+use crate::{
+    array::BaseArray,
+    datatypes::UInt64Array,
+    dsl::Expr,
+    error::{DaftError, DaftResult},
+    table::Table,
+};
+
+impl Table {
+    fn partition_by_index(
+        &self,
+        targets: &UInt64Array,
+        num_partitions: usize,
+    ) -> DaftResult<Vec<Self>> {
+        if self.len() != targets.len() {
+            return Err(DaftError::ValueError(format!(
+                "Mismatch of length of table and targets, {} vs {}",
+                self.len(),
+                targets.len()
+            )));
+        }
+        let mut output_to_input_idx =
+            vec![Vec::with_capacity(self.len() / num_partitions); num_partitions];
+        if targets.downcast().null_count() != 0 {
+            return Err(DaftError::ComputeError(format!(
+                "target array can not contain nulls, contains {} nulls",
+                targets.downcast().null_count()
+            )));
+        }
+
+        for (s_idx, t_idx) in targets.downcast().values_iter().enumerate() {
+            if *t_idx >= (num_partitions as u64) {
+                return Err(DaftError::ComputeError(format!("idx in target array is out of bounds, target idx {} at index {} out of {} partitions", t_idx, s_idx, num_partitions)));
+            }
+
+            output_to_input_idx[unsafe { t_idx.as_usize() }].push(s_idx as u64);
+        }
+        output_to_input_idx
+            .iter()
+            .map(|v| {
+                let indices = UInt64Array::from(("idx", v.as_slice()));
+                self.take(&indices.into_series())
+            })
+            .collect::<DaftResult<Vec<_>>>()
+    }
+
+    pub fn partition_by_hash(
+        &self,
+        exprs: &[Expr],
+        num_partitions: usize,
+    ) -> DaftResult<Vec<Self>> {
+        if num_partitions == 0 {
+            return Err(DaftError::ValueError(format!(
+                "Can not partition a Table by 0 partitions"
+            )));
+        }
+
+        let targets = self
+            .eval_expression_list(exprs)?
+            .hash_rows()?
+            .rem(&UInt64Array::from((
+                "num_partitions",
+                [num_partitions as u64].as_slice(),
+            )))?;
+        self.partition_by_index(&targets, num_partitions)
+    }
+}

--- a/src/table/ops/search_sorted.rs
+++ b/src/table/ops/search_sorted.rs
@@ -1,0 +1,26 @@
+use crate::{
+    datatypes::UInt64Array,
+    error::{DaftError, DaftResult},
+    table::Table,
+};
+
+impl Table {
+    pub fn search_sorted(&self, keys: &Self, descending: &[bool]) -> DaftResult<UInt64Array> {
+        if self.schema != keys.schema {
+            return Err(DaftError::SchemaMismatch(format!(
+                "Schema Mismatch in search_sorted: data: {} vs keys: {}",
+                self.schema, keys.schema
+            )));
+        }
+        if self.num_columns() != descending.len() {
+            return Err(DaftError::ValueError(format!("Mismatch in number of arguments for `descending` in search sorted: num_columns: {} vs : descending.len() {}", self.num_columns(), descending.len())));
+        }
+
+        if self.num_columns() == 1 {
+            return self
+                .get_column_by_index(0)?
+                .search_sorted(keys.get_column_by_index(0)?, *descending.first().unwrap());
+        }
+        todo!("impl multicol search_sorted")
+    }
+}

--- a/tests/series/test_arithmetic.py
+++ b/tests/series/test_arithmetic.py
@@ -174,19 +174,19 @@ def test_comparisons_bad_right_value() -> None:
     l = Series.from_arrow(l_arrow)
     r = [1, 2, 3, None, 5, None]
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l + r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l - r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l / r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l * r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l % r
 
 

--- a/tests/series/test_comparisions.py
+++ b/tests/series/test_comparisions.py
@@ -375,31 +375,31 @@ def test_comparisons_bad_right_value() -> None:
     l = Series.from_arrow(l_arrow)
     r = [1, 2, 3, None, 5, None]
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l < r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l <= r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l == r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l != r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l >= r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l > r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l & r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l | r
 
-    with pytest.raises(ValueError, match="another Series"):
+    with pytest.raises(TypeError, match="another Series"):
         l ^ r
 
 

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -183,6 +183,21 @@ def test_table_partition_by_range_multi_column(size, k, desc) -> None:
             seen_idx.add(y)
 
 
+def test_table_partition_by_range_multi_column_string() -> None:
+    table = Table.from_pydict({"x": ["a", "c", "a", "c"], "y": ["1", "2", "3", "4"]})
+    boundaries = Table.from_pydict({"x": ["b"], "y": ["1"]})
+    split_tables = table.partition_by_range([col("x"), col("y")], boundaries, [False, False])
+    assert len(split_tables) == 2
+
+    assert split_tables[0].to_pydict() == {"x": ["a", "a"], "y": ["1", "3"]}
+    assert split_tables[1].to_pydict() == {"x": ["c", "c"], "y": ["2", "4"]}
+
+    split_tables = table.partition_by_range([col("x"), col("y")], boundaries, [True, False])
+
+    assert split_tables[1].to_pydict() == {"x": ["a", "a"], "y": ["1", "3"]}
+    assert split_tables[0].to_pydict() == {"x": ["c", "c"], "y": ["2", "4"]}
+
+
 def test_table_partition_by_range_input() -> None:
     # negative sample
 

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -42,7 +42,7 @@ def test_table_partition_by_hash_single_col(size, k, dtype) -> None:
             seen_so_far.add(v)
 
 
-def test_table_quantiles_bad_input() -> None:
+def test_table_partition_by_hash_bad_input() -> None:
     # negative sample
 
     table = Table.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from daft.datatype import DataType
+from daft.expressions2 import col
+from daft.table import Table
+
+daft_int_types = [
+    DataType.int8(),
+    DataType.int16(),
+    DataType.int32(),
+    DataType.int64(),
+    DataType.uint8(),
+    DataType.uint16(),
+    DataType.uint32(),
+    DataType.uint64(),
+]
+
+daft_numeric_types = daft_int_types + [DataType.float32(), DataType.float64()]
+daft_string_types = [DataType.string()]
+
+
+@pytest.mark.parametrize(
+    "size, k, dtype", itertools.product([0, 1, 10, 33, 100], [1, 2, 3, 10, 40], daft_numeric_types + daft_string_types)
+)
+def test_table_partition_by_hash_single_col(size, k, dtype) -> None:
+    table = Table.from_pydict(
+        {"x": [i % k for i in range(size)], "x_ind": [i for i in range(size)]}
+    ).eval_expression_list([col("x").cast(dtype), col("x_ind")])
+    split_tables = table.partition_by_hash([col("x")], k)
+    seen_so_far = set()
+    for st in split_tables:
+        unique_to_table = set()
+        for x, x_ind in zip(st.get_column("x").to_pylist(), st.get_column("x_ind").to_pylist()):
+            assert (x_ind % k) == int(x)
+            unique_to_table.add(x)
+        for v in unique_to_table:
+            assert v not in seen_so_far
+            seen_so_far.add(v)
+
+
+def test_table_quantiles_bad_input() -> None:
+    # negative sample
+
+    table = Table.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})
+
+    with pytest.raises(ValueError, match="negative number"):
+        table.partition_by_hash([col("x")], -1)
+
+    with pytest.raises(ValueError, match="0 partitions"):
+        table.partition_by_hash([col("x")], 0)

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -89,8 +89,6 @@ def test_table_partition_by_random(size, k) -> None:
 
 
 def test_table_partition_by_hash_bad_input() -> None:
-    # negative sample
-
     table = Table.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})
 
     with pytest.raises(ValueError, match="negative number"):
@@ -101,8 +99,6 @@ def test_table_partition_by_hash_bad_input() -> None:
 
 
 def test_table_partition_by_random_bad_input() -> None:
-    # negative sample
-
     table = Table.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})
 
     with pytest.raises(ValueError, match="negative number"):
@@ -199,8 +195,6 @@ def test_table_partition_by_range_multi_column_string() -> None:
 
 
 def test_table_partition_by_range_input() -> None:
-    # negative sample
-
     table = Table.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})
 
     with pytest.raises(ValueError, match="Schema Mismatch"):

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -73,3 +73,18 @@ def test_table_partition_by_hash_bad_input() -> None:
 
     with pytest.raises(ValueError, match="0 partitions"):
         table.partition_by_hash([col("x")], 0)
+
+
+def test_table_partition_by_random_bad_input() -> None:
+    # negative sample
+
+    table = Table.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})
+
+    with pytest.raises(ValueError, match="negative number"):
+        table.partition_by_random(10, -1)
+
+    with pytest.raises(ValueError, match="0 partitions"):
+        table.partition_by_random(0, 10)
+
+    with pytest.raises(ValueError, match="negative number"):
+        table.partition_by_random(-1, 10)


### PR DESCRIPTION
* Enables Partitioning a Table by Hash, Random, or by Range (with boundaries)
* enabled search sorted for series and table (internal only for now)
* Adds `from` for DataArray from a Vec
* Raise a TypeError when having the wrong type in python instead of ValueError
