### PR TITLE
Add endswith kernel to Series

### DIFF
--- a/daft/expressions2/expressions.py
+++ b/daft/expressions2/expressions.py
@@ -266,8 +266,11 @@ class ExpressionStringNamespace(ExpressionNamespace):
     def contains(self, substr: str) -> Expression:
         raise NotImplementedError("[RUST-INT][TPCH] Implement string expression")
 
-    def endswith(self, suffix: str) -> Expression:
-        raise NotImplementedError("[RUST-INT][TPCH] Implement string expression")
+    def endswith(self, suffix: str | Expression) -> Expression:
+        if not isinstance(suffix, str) and not isinstance(suffix, Expression):
+            raise ValueError(f"Expected a suffix which is either a string or an Expression, received: {suffix}")
+        suffix_expr = lit(suffix) if isinstance(suffix, str) else suffix
+        return Expression._from_pyexpr(self._expr.utf8_endswith(suffix_expr._expr))
 
     def startswith(self, prefix: str) -> Expression:
         raise NotImplementedError("[RUST-INT] Implement string expression")

--- a/daft/expressions2/expressions.py
+++ b/daft/expressions2/expressions.py
@@ -267,9 +267,7 @@ class ExpressionStringNamespace(ExpressionNamespace):
         raise NotImplementedError("[RUST-INT][TPCH] Implement string expression")
 
     def endswith(self, suffix: str | Expression) -> Expression:
-        if not isinstance(suffix, str) and not isinstance(suffix, Expression):
-            raise ValueError(f"Expected a suffix which is either a string or an Expression, received: {suffix}")
-        suffix_expr = lit(suffix) if isinstance(suffix, str) else suffix
+        suffix_expr = Expression._to_expression(suffix)
         return Expression._from_pyexpr(self._expr.utf8_endswith(suffix_expr._expr))
 
     def startswith(self, prefix: str) -> Expression:

--- a/daft/series.py
+++ b/daft/series.py
@@ -229,3 +229,9 @@ class Series:
             raise TypeError(f"expected another Series but got {type(other)}")
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series ^ other._series)
+
+    def utf8_endswith(self, other: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series._from_pyseries(self._series.utf8_endswith(other._series))

--- a/daft/series.py
+++ b/daft/series.py
@@ -230,8 +230,23 @@ class Series:
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series ^ other._series)
 
-    def utf8_endswith(self, other: object) -> Series:
-        if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
-        assert self._series is not None and other._series is not None
-        return Series._from_pyseries(self._series.utf8_endswith(other._series))
+    @property
+    def str(self) -> SeriesStringNamespace:
+        series = SeriesStringNamespace.__new__(SeriesStringNamespace)
+        series._series = self._series
+        return series
+
+
+class SeriesNamespace:
+    _series: PySeries
+
+    def __init__(self) -> None:
+        raise NotImplementedError("We do not support creating a SeriesNamespace via __init__ ")
+
+
+class SeriesStringNamespace(SeriesNamespace):
+    def endswith(self, suffix: Series) -> Series:
+        if not isinstance(suffix, Series):
+            raise ValueError(f"expected another Series but got {type(suffix)}")
+        assert self._series is not None and suffix._series is not None
+        return Series._from_pyseries(self._series.utf8_endswith(suffix._series))

--- a/src/array/ops/mod.rs
+++ b/src/array/ops/mod.rs
@@ -20,6 +20,7 @@ mod search_sorted;
 mod sort;
 mod sum;
 mod take;
+mod utf8;
 
 pub trait DaftCompare<Rhs> {
     type Output;

--- a/src/array/ops/utf8.rs
+++ b/src/array/ops/utf8.rs
@@ -1,0 +1,65 @@
+use arrow2::array::{BooleanArray, Utf8Array};
+
+use crate::error::{DaftError, DaftResult};
+
+#[allow(dead_code)] //TODO: remove-me
+pub fn endswith_utf8_arrays(
+    data: &Utf8Array<i64>,
+    pattern: &Utf8Array<i64>,
+) -> DaftResult<BooleanArray> {
+    match (data.len(), pattern.len()) {
+        // Broadcast case:
+        (data_len, 1) => match pattern.validity() {
+            Some(validity) if !validity.get_bit(0) => Ok(BooleanArray::new_null(
+                arrow2::datatypes::DataType::Boolean,
+                data_len,
+            )),
+            _ => {
+                let pattern_val = pattern.value(0);
+                Ok(data
+                    .into_iter()
+                    .map(|val| Some(val?.ends_with(pattern_val)))
+                    .collect())
+            }
+        },
+        // Mismatched len case:
+        (data_len, pattern_len) if data_len != pattern_len => Err(DaftError::ComputeError(
+            format!("lhs and rhs have different length arrays: {data_len} vs {pattern_len}"),
+        )),
+        // Matching len case:
+        _ => Ok(data
+            .into_iter()
+            .zip(pattern.into_iter())
+            .map(|(val, pat)| Some(val?.ends_with(pat?)))
+            .collect()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_endswith_utf_arrays_broadcast() -> DaftResult<()> {
+        let data = Utf8Array::<i64>::from(vec!["x_foo".into(), "y_foo".into(), "z_bar".into()]);
+        let pattern = Utf8Array::<i64>::from(vec!["foo".into()]);
+        let result = endswith_utf8_arrays(&data, &pattern)?;
+        assert_eq!(result.len(), 3);
+        assert!(result.value(0));
+        assert!(result.value(1));
+        assert!(!result.value(2));
+        Ok(())
+    }
+
+    #[test]
+    fn check_endswith_utf_arrays() -> DaftResult<()> {
+        let data = Utf8Array::<i64>::from(vec!["x_foo".into(), "y_foo".into(), "z_bar".into()]);
+        let pattern = Utf8Array::<i64>::from(vec!["foo".into(), "wrong".into(), "bar".into()]);
+        let result = endswith_utf8_arrays(&data, &pattern)?;
+        assert_eq!(result.len(), 3);
+        assert!(result.value(0));
+        assert!(!result.value(1));
+        assert!(result.value(2));
+        Ok(())
+    }
+}

--- a/src/array/ops/utf8.rs
+++ b/src/array/ops/utf8.rs
@@ -1,6 +1,6 @@
 use crate::array::BaseArray;
 use crate::datatypes::{BooleanArray, Utf8Array};
-use arrow2::array as arrow2_array;
+use arrow2;
 
 use crate::error::{DaftError, DaftResult};
 
@@ -8,47 +8,49 @@ impl Utf8Array {
     pub fn endswith(&self, pattern: &Utf8Array) -> DaftResult<BooleanArray> {
         let data_arrow = self.downcast();
         let pattern_arrow = pattern.downcast();
-        let result_arrow = match (self.len(), pattern.len()) {
+        match (self.len(), pattern.len()) {
             // Broadcast pattern case:
             (data_len, 1) => match pattern_arrow.validity() {
-                Some(validity) if !validity.get_bit(0) => Ok(arrow2_array::BooleanArray::new_null(
-                    arrow2::datatypes::DataType::Boolean,
-                    data_len,
-                )),
+                Some(validity) if !validity.get_bit(0) => {
+                    Ok(BooleanArray::full_null(self.name(), data_len))
+                }
                 _ => {
                     let pattern_val = pattern_arrow.value(0);
-                    Ok(data_arrow
+                    let arrow_result: arrow2::array::BooleanArray = data_arrow
                         .into_iter()
                         .map(|val| Some(val?.ends_with(pattern_val)))
-                        .collect())
+                        .collect();
+                    Ok(BooleanArray::from((self.name(), arrow_result)))
                 }
             },
             // Broadcast data case
             (1, pattern_len) => match data_arrow.validity() {
-                Some(validity) if !validity.get_bit(0) => Ok(arrow2_array::BooleanArray::new_null(
-                    arrow2::datatypes::DataType::Boolean,
-                    pattern_len,
-                )),
+                Some(validity) if !validity.get_bit(0) => {
+                    Ok(BooleanArray::full_null(self.name(), pattern_len))
+                }
                 _ => {
                     let data_val = data_arrow.value(0);
-                    Ok(pattern_arrow
+                    let arrow_result: arrow2::array::BooleanArray = pattern_arrow
                         .into_iter()
                         .map(|pat| Some(data_val.ends_with(pat?)))
-                        .collect())
+                        .collect();
+                    Ok(BooleanArray::from((self.name(), arrow_result)))
                 }
             },
             // Matching len case:
-            (data_len, pattern_len) if data_len == pattern_len => Ok(data_arrow
-                .into_iter()
-                .zip(pattern_arrow.into_iter())
-                .map(|(val, pat)| Some(val?.ends_with(pat?)))
-                .collect()),
+            (data_len, pattern_len) if data_len == pattern_len => {
+                let arrow_result: arrow2::array::BooleanArray = data_arrow
+                    .into_iter()
+                    .zip(pattern_arrow.into_iter())
+                    .map(|(val, pat)| Some(val?.ends_with(pat?)))
+                    .collect();
+                Ok(BooleanArray::from((self.name(), arrow_result)))
+            }
             // Mismatched len case:
             (data_len, pattern_len) => Err(DaftError::ComputeError(format!(
                 "lhs and rhs have different length arrays: {data_len} vs {pattern_len}"
             ))),
-        };
-        Ok((self.name(), result_arrow?).into())
+        }
     }
 }
 
@@ -60,7 +62,7 @@ mod tests {
     fn check_endswith_utf_arrays_broadcast() -> DaftResult<()> {
         let data = Utf8Array::from((
             "data",
-            Box::new(arrow2_array::Utf8Array::<i64>::from(vec![
+            Box::new(arrow2::array::Utf8Array::<i64>::from(vec![
                 "x_foo".into(),
                 "y_foo".into(),
                 "z_bar".into(),
@@ -68,7 +70,7 @@ mod tests {
         ));
         let pattern = Utf8Array::from((
             "pattern",
-            Box::new(arrow2_array::Utf8Array::<i64>::from(vec!["foo".into()])),
+            Box::new(arrow2::array::Utf8Array::<i64>::from(vec!["foo".into()])),
         ));
         let result = &data.endswith(&pattern)?;
         assert_eq!(result.len(), 3);
@@ -82,7 +84,7 @@ mod tests {
     fn check_endswith_utf_arrays() -> DaftResult<()> {
         let data = Utf8Array::from((
             "data",
-            Box::new(arrow2_array::Utf8Array::<i64>::from(vec![
+            Box::new(arrow2::array::Utf8Array::<i64>::from(vec![
                 "x_foo".into(),
                 "y_foo".into(),
                 "z_bar".into(),
@@ -90,7 +92,7 @@ mod tests {
         ));
         let pattern = Utf8Array::from((
             "pattern",
-            Box::new(arrow2_array::Utf8Array::<i64>::from(vec![
+            Box::new(arrow2::array::Utf8Array::<i64>::from(vec![
                 "foo".into(),
                 "wrong".into(),
                 "bar".into(),

--- a/src/array/ops/utf8.rs
+++ b/src/array/ops/utf8.rs
@@ -1,51 +1,54 @@
-use arrow2::array::{BooleanArray, Utf8Array};
+use crate::array::BaseArray;
+use crate::datatypes::{BooleanArray, Utf8Array};
+use arrow2::array as arrow2_array;
 
 use crate::error::{DaftError, DaftResult};
 
-#[allow(dead_code)] //TODO: remove-me
-pub fn endswith_utf8_arrays(
-    data: &Utf8Array<i64>,
-    pattern: &Utf8Array<i64>,
-) -> DaftResult<BooleanArray> {
-    match (data.len(), pattern.len()) {
-        // Broadcast pattern case:
-        (data_len, 1) => match pattern.validity() {
-            Some(validity) if !validity.get_bit(0) => Ok(BooleanArray::new_null(
-                arrow2::datatypes::DataType::Boolean,
-                data_len,
-            )),
-            _ => {
-                let pattern_val = pattern.value(0);
-                Ok(data
-                    .into_iter()
-                    .map(|val| Some(val?.ends_with(pattern_val)))
-                    .collect())
-            }
-        },
-        // Broadcast data case
-        (1, pattern_len) => match data.validity() {
-            Some(validity) if !validity.get_bit(0) => Ok(BooleanArray::new_null(
-                arrow2::datatypes::DataType::Boolean,
-                pattern_len,
-            )),
-            _ => {
-                let data_val = data.value(0);
-                Ok(pattern
-                    .into_iter()
-                    .map(|pat| Some(data_val.ends_with(pat?)))
-                    .collect())
-            }
-        },
-        // Matching len case:
-        (data_len, pattern_len) if data_len == pattern_len => Ok(data
-            .into_iter()
-            .zip(pattern.into_iter())
-            .map(|(val, pat)| Some(val?.ends_with(pat?)))
-            .collect()),
-        // Mismatched len case:
-        (data_len, pattern_len) => Err(DaftError::ComputeError(format!(
-            "lhs and rhs have different length arrays: {data_len} vs {pattern_len}"
-        ))),
+impl Utf8Array {
+    pub fn endswith(&self, pattern: &Utf8Array) -> DaftResult<BooleanArray> {
+        let data_arrow = self.downcast();
+        let pattern_arrow = pattern.downcast();
+        let result_arrow = match (self.len(), pattern.len()) {
+            // Broadcast pattern case:
+            (data_len, 1) => match pattern_arrow.validity() {
+                Some(validity) if !validity.get_bit(0) => Ok(arrow2_array::BooleanArray::new_null(
+                    arrow2::datatypes::DataType::Boolean,
+                    data_len,
+                )),
+                _ => {
+                    let pattern_val = pattern_arrow.value(0);
+                    Ok(data_arrow
+                        .into_iter()
+                        .map(|val| Some(val?.ends_with(pattern_val)))
+                        .collect())
+                }
+            },
+            // Broadcast data case
+            (1, pattern_len) => match data_arrow.validity() {
+                Some(validity) if !validity.get_bit(0) => Ok(arrow2_array::BooleanArray::new_null(
+                    arrow2::datatypes::DataType::Boolean,
+                    pattern_len,
+                )),
+                _ => {
+                    let data_val = data_arrow.value(0);
+                    Ok(pattern_arrow
+                        .into_iter()
+                        .map(|pat| Some(data_val.ends_with(pat?)))
+                        .collect())
+                }
+            },
+            // Matching len case:
+            (data_len, pattern_len) if data_len == pattern_len => Ok(data_arrow
+                .into_iter()
+                .zip(pattern_arrow.into_iter())
+                .map(|(val, pat)| Some(val?.ends_with(pat?)))
+                .collect()),
+            // Mismatched len case:
+            (data_len, pattern_len) => Err(DaftError::ComputeError(format!(
+                "lhs and rhs have different length arrays: {data_len} vs {pattern_len}"
+            ))),
+        };
+        Ok((self.name(), result_arrow?).into())
     }
 }
 
@@ -55,25 +58,49 @@ mod tests {
 
     #[test]
     fn check_endswith_utf_arrays_broadcast() -> DaftResult<()> {
-        let data = Utf8Array::<i64>::from(vec!["x_foo".into(), "y_foo".into(), "z_bar".into()]);
-        let pattern = Utf8Array::<i64>::from(vec!["foo".into()]);
-        let result = endswith_utf8_arrays(&data, &pattern)?;
+        let data = Utf8Array::from((
+            "data",
+            Box::new(arrow2_array::Utf8Array::<i64>::from(vec![
+                "x_foo".into(),
+                "y_foo".into(),
+                "z_bar".into(),
+            ])),
+        ));
+        let pattern = Utf8Array::from((
+            "pattern",
+            Box::new(arrow2_array::Utf8Array::<i64>::from(vec!["foo".into()])),
+        ));
+        let result = &data.endswith(&pattern)?;
         assert_eq!(result.len(), 3);
-        assert!(result.value(0));
-        assert!(result.value(1));
-        assert!(!result.value(2));
+        assert!(result.downcast().value(0));
+        assert!(result.downcast().value(1));
+        assert!(!result.downcast().value(2));
         Ok(())
     }
 
     #[test]
     fn check_endswith_utf_arrays() -> DaftResult<()> {
-        let data = Utf8Array::<i64>::from(vec!["x_foo".into(), "y_foo".into(), "z_bar".into()]);
-        let pattern = Utf8Array::<i64>::from(vec!["foo".into(), "wrong".into(), "bar".into()]);
-        let result = endswith_utf8_arrays(&data, &pattern)?;
+        let data = Utf8Array::from((
+            "data",
+            Box::new(arrow2_array::Utf8Array::<i64>::from(vec![
+                "x_foo".into(),
+                "y_foo".into(),
+                "z_bar".into(),
+            ])),
+        ));
+        let pattern = Utf8Array::from((
+            "pattern",
+            Box::new(arrow2_array::Utf8Array::<i64>::from(vec![
+                "foo".into(),
+                "wrong".into(),
+                "bar".into(),
+            ])),
+        ));
+        let result = &data.endswith(&pattern)?;
         assert_eq!(result.len(), 3);
-        assert!(result.value(0));
-        assert!(!result.value(1));
-        assert!(result.value(2));
+        assert!(result.downcast().value(0));
+        assert!(!result.downcast().value(1));
+        assert!(result.downcast().value(2));
         Ok(())
     }
 }

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -153,6 +153,10 @@ impl DataType {
             _ => false,
         }
     }
+
+    pub fn is_utf8(&self) -> bool {
+        matches!(self, DataType::Utf8)
+    }
 }
 
 impl From<&ArrowType> for DataType {

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -153,10 +153,6 @@ impl DataType {
             _ => false,
         }
     }
-
-    pub fn is_utf8(&self) -> bool {
-        matches!(self, DataType::Utf8)
-    }
 }
 
 impl From<&ArrowType> for DataType {

--- a/src/dsl/functions/mod.rs
+++ b/src/dsl/functions/mod.rs
@@ -1,7 +1,9 @@
 pub mod numeric;
+pub mod utf8;
 
 use numeric::NumericExpr;
 use serde::{Deserialize, Serialize};
+use utf8::Utf8Expr;
 
 use crate::{datatypes::Field, error::DaftResult, schema::Schema, series::Series};
 
@@ -10,6 +12,7 @@ use super::Expr;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FunctionExpr {
     Numeric(NumericExpr),
+    Utf8(Utf8Expr),
 }
 
 pub trait FunctionEvaluator {
@@ -24,6 +27,7 @@ impl FunctionExpr {
         use FunctionExpr::*;
         match self {
             Numeric(expr) => expr.get_evaluator(),
+            Utf8(expr) => expr.get_evaluator(),
         }
     }
 }

--- a/src/dsl/functions/utf8/endswith.rs
+++ b/src/dsl/functions/utf8/endswith.rs
@@ -1,0 +1,55 @@
+use crate::{
+    datatypes::{DataType, Field},
+    dsl::Expr,
+    error::{DaftError, DaftResult},
+    schema::Schema,
+    series::Series,
+};
+
+use super::super::FunctionEvaluator;
+
+pub(super) struct EndswithEvaluator {}
+
+impl FunctionEvaluator for EndswithEvaluator {
+    fn fn_name(&self) -> &'static str {
+        "endswith"
+    }
+
+    fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
+        match inputs {
+            [data, pattern] => {
+                let data_field = data.to_field(schema)?;
+                let pattern_field = pattern.to_field(schema)?;
+                if !data_field.dtype.is_utf8() {
+                    // TODO: Change to SchemaResolveTypeError
+                    return Err(DaftError::TypeError(format!(
+                        "Expected data input to endswith to be utf8, got {}",
+                        data_field.dtype
+                    )));
+                }
+                if !pattern_field.dtype.is_utf8() {
+                    // TODO: Change to SchemaResolveTypeError
+                    return Err(DaftError::TypeError(format!(
+                        "Expected pattern input to endswith to be utf8, got {}",
+                        pattern_field.dtype
+                    )));
+                }
+                Ok(Field::new(data_field.name, DataType::Boolean))
+            }
+            _ => Err(DaftError::SchemaMismatch(format!(
+                "Expected 2 input args, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+
+    fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
+        match inputs {
+            [data, pattern] => Ok(data.utf8_endswith(pattern)?),
+            _ => Err(DaftError::SchemaMismatch(format!(
+                "Expected 2 input args, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+}

--- a/src/dsl/functions/utf8/endswith.rs
+++ b/src/dsl/functions/utf8/endswith.rs
@@ -46,7 +46,7 @@ impl FunctionEvaluator for EndswithEvaluator {
 
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
         match inputs {
-            [data, pattern] => Ok(data.utf8_endswith(pattern)?),
+            [data, pattern] => data.utf8_endswith(pattern),
             _ => Err(DaftError::SchemaMismatch(format!(
                 "Expected 2 input args, got {}",
                 inputs.len()

--- a/src/dsl/functions/utf8/mod.rs
+++ b/src/dsl/functions/utf8/mod.rs
@@ -1,0 +1,30 @@
+mod endswith;
+
+use endswith::EndswithEvaluator;
+use serde::{Deserialize, Serialize};
+
+use crate::dsl::Expr;
+
+use super::FunctionEvaluator;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Utf8Expr {
+    EndsWith,
+}
+
+impl Utf8Expr {
+    #[inline]
+    pub fn get_evaluator(&self) -> &dyn FunctionEvaluator {
+        use Utf8Expr::*;
+        match self {
+            EndsWith => &EndswithEvaluator {},
+        }
+    }
+}
+
+pub fn endswith(data: &Expr, pattern: &Expr) -> Expr {
+    Expr::Function {
+        func: super::FunctionExpr::Utf8(Utf8Expr::EndsWith),
+        inputs: vec![data.clone(), pattern.clone()],
+    }
+}

--- a/src/kernels/utf8.rs
+++ b/src/kernels/utf8.rs
@@ -1,6 +1,6 @@
 // ****************************************************************************************
 // IMPLEMENTOR NOTE: This file will soon be deprecated and functionality should be moved to
-// src/array/ops/utf-8.py instead
+// src/array/ops/utf8.py instead
 // ****************************************************************************************
 
 use arrow2::array::Utf8Array;

--- a/src/kernels/utf8.rs
+++ b/src/kernels/utf8.rs
@@ -1,4 +1,4 @@
-use arrow2::array::{BooleanArray, Utf8Array};
+use arrow2::array::Utf8Array;
 
 use crate::error::{DaftError, DaftResult};
 
@@ -73,39 +73,6 @@ pub fn add_utf8_arrays(lhs: &Utf8Array<i64>, rhs: &Utf8Array<i64>) -> DaftResult
         })
         .collect();
     Ok(result)
-}
-
-#[allow(dead_code)] // TODO: Integrate and remove me!
-pub fn endswith_utf8_arrays(
-    data: &Utf8Array<i64>,
-    pattern: &Utf8Array<i64>,
-) -> DaftResult<BooleanArray> {
-    match (data.len(), pattern.len()) {
-        // Broadcast case:
-        (data_len, 1) => match pattern.validity() {
-            Some(validity) if !validity.get_bit(0) => Ok(BooleanArray::new_null(
-                arrow2::datatypes::DataType::Boolean,
-                data_len,
-            )),
-            _ => {
-                let pattern_val = pattern.value(0);
-                Ok(data
-                    .into_iter()
-                    .map(|val| Some(val?.ends_with(pattern_val)))
-                    .collect())
-            }
-        },
-        // Mismatched len case:
-        (data_len, pattern_len) if data_len != pattern_len => Err(DaftError::ComputeError(
-            format!("lhs and rhs have different length arrays: {data_len} vs {pattern_len}"),
-        )),
-        // Matching len case:
-        _ => Ok(data
-            .into_iter()
-            .zip(pattern.into_iter())
-            .map(|(val, pat)| Some(val?.ends_with(pat?)))
-            .collect()),
-    }
 }
 
 #[cfg(test)]

--- a/src/kernels/utf8.rs
+++ b/src/kernels/utf8.rs
@@ -1,4 +1,4 @@
-use arrow2::array::Utf8Array;
+use arrow2::array::{BooleanArray, Utf8Array};
 
 use crate::error::{DaftError, DaftResult};
 
@@ -75,6 +75,39 @@ pub fn add_utf8_arrays(lhs: &Utf8Array<i64>, rhs: &Utf8Array<i64>) -> DaftResult
     Ok(result)
 }
 
+#[allow(dead_code)] // TODO: Integrate and remove me!
+pub fn endswith_utf8_arrays(
+    data: &Utf8Array<i64>,
+    pattern: &Utf8Array<i64>,
+) -> DaftResult<BooleanArray> {
+    match (data.len(), pattern.len()) {
+        // Broadcast case:
+        (data_len, 1) => match pattern.validity() {
+            Some(validity) if !validity.get_bit(0) => Ok(BooleanArray::new_null(
+                arrow2::datatypes::DataType::Boolean,
+                data_len,
+            )),
+            _ => {
+                let pattern_val = pattern.value(0);
+                Ok(data
+                    .into_iter()
+                    .map(|val| Some(val?.ends_with(pattern_val)))
+                    .collect())
+            }
+        },
+        // Mismatched len case:
+        (data_len, pattern_len) if data_len != pattern_len => Err(DaftError::ComputeError(
+            format!("lhs and rhs have different length arrays: {data_len} vs {pattern_len}"),
+        )),
+        // Matching len case:
+        _ => Ok(data
+            .into_iter()
+            .zip(pattern.into_iter())
+            .map(|(val, pat)| Some(val?.ends_with(pat?)))
+            .collect()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -112,6 +145,30 @@ mod tests {
         assert_eq!(result.value(0), "a1");
         assert_eq!(result.value(1), "b1");
         assert_eq!(result.value(2), "c1");
+        Ok(())
+    }
+
+    #[test]
+    fn check_endswith_utf_arrays_broadcast() -> DaftResult<()> {
+        let data = Utf8Array::<i64>::from(vec!["x_foo".into(), "y_foo".into(), "z_bar".into()]);
+        let pattern = Utf8Array::<i64>::from(vec!["foo".into()]);
+        let result = endswith_utf8_arrays(&data, &pattern)?;
+        assert_eq!(result.len(), 3);
+        assert!(result.value(0));
+        assert!(result.value(1));
+        assert!(!result.value(2));
+        Ok(())
+    }
+
+    #[test]
+    fn check_endswith_utf_arrays() -> DaftResult<()> {
+        let data = Utf8Array::<i64>::from(vec!["x_foo".into(), "y_foo".into(), "z_bar".into()]);
+        let pattern = Utf8Array::<i64>::from(vec!["foo".into(), "wrong".into(), "bar".into()]);
+        let result = endswith_utf8_arrays(&data, &pattern)?;
+        assert_eq!(result.len(), 3);
+        assert!(result.value(0));
+        assert!(!result.value(1));
+        assert!(result.value(2));
         Ok(())
     }
 }

--- a/src/kernels/utf8.rs
+++ b/src/kernels/utf8.rs
@@ -1,6 +1,6 @@
 // ****************************************************************************************
 // IMPLEMENTOR NOTE: This file will soon be deprecated and functionality should be moved to
-// src/array/ops/utf8.py instead
+// src/array/ops/utf8.rs instead
 // ****************************************************************************************
 
 use arrow2::array::Utf8Array;

--- a/src/kernels/utf8.rs
+++ b/src/kernels/utf8.rs
@@ -1,3 +1,8 @@
+// ****************************************************************************************
+// IMPLEMENTOR NOTE: This file will soon be deprecated and functionality should be moved to
+// src/array/ops/utf-8.py instead
+// ****************************************************************************************
+
 use arrow2::array::Utf8Array;
 
 use crate::error::{DaftError, DaftResult};
@@ -112,30 +117,6 @@ mod tests {
         assert_eq!(result.value(0), "a1");
         assert_eq!(result.value(1), "b1");
         assert_eq!(result.value(2), "c1");
-        Ok(())
-    }
-
-    #[test]
-    fn check_endswith_utf_arrays_broadcast() -> DaftResult<()> {
-        let data = Utf8Array::<i64>::from(vec!["x_foo".into(), "y_foo".into(), "z_bar".into()]);
-        let pattern = Utf8Array::<i64>::from(vec!["foo".into()]);
-        let result = endswith_utf8_arrays(&data, &pattern)?;
-        assert_eq!(result.len(), 3);
-        assert!(result.value(0));
-        assert!(result.value(1));
-        assert!(!result.value(2));
-        Ok(())
-    }
-
-    #[test]
-    fn check_endswith_utf_arrays() -> DaftResult<()> {
-        let data = Utf8Array::<i64>::from(vec!["x_foo".into(), "y_foo".into(), "z_bar".into()]);
-        let pattern = Utf8Array::<i64>::from(vec!["foo".into(), "wrong".into(), "bar".into()]);
-        let result = endswith_utf8_arrays(&data, &pattern)?;
-        assert_eq!(result.len(), 3);
-        assert!(result.value(0));
-        assert!(!result.value(1));
-        assert!(result.value(2));
         Ok(())
     }
 }

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -177,6 +177,11 @@ impl PyExpr {
     pub fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
         Ok(PyBytes::new(py, &bincode::serialize(&self.expr).unwrap()).to_object(py))
     }
+
+    pub fn utf8_endswith(&self, pattern: &Self) -> PyResult<Self> {
+        use dsl::functions::utf8::endswith;
+        Ok(endswith(&self.expr, &pattern.expr).into())
+    }
 }
 
 impl From<dsl::Expr> for PyExpr {

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -162,6 +162,10 @@ impl PySeries {
     pub fn data_type(&self) -> PyResult<PyDataType> {
         Ok(self.series.data_type().clone().into())
     }
+
+    pub fn utf8_endswith(&self, pattern: &Self) -> PyResult<Self> {
+        Ok(self.series.utf8_endswith(&pattern.series)?.into())
+    }
 }
 
 impl From<series::Series> for PySeries {

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -19,6 +19,7 @@ pub mod pairwise;
 pub mod search_sorted;
 pub mod sort;
 pub mod take;
+pub mod utf8;
 
 fn match_types_on_series(l: &Series, r: &Series) -> DaftResult<(Series, Series)> {
     let mut lhs = l.clone();

--- a/src/series/ops/utf8.rs
+++ b/src/series/ops/utf8.rs
@@ -1,0 +1,18 @@
+use crate::{
+    error::{DaftError, DaftResult},
+    series::Series,
+};
+
+use crate::array::BaseArray;
+use crate::datatypes::*;
+
+impl Series {
+    pub fn utf8_endswith(&self, pattern: &Series) -> DaftResult<Series> {
+        match self.data_type() {
+            DataType::Utf8 => Ok(self.utf8()?.endswith(pattern.utf8()?)?.into_series()),
+            dt => Err(DaftError::TypeError(format!(
+                "Endswith not implemented for type {dt}"
+            ))),
+        }
+    }
+}

--- a/tests/series/test_utf8.py
+++ b/tests/series/test_utf8.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+from daft import Series
+
+
+def test_series_endswith() -> None:
+    s = Series.from_arrow(pa.array(["x_foo", "y_foo", "z_bar"]))
+    pattern = Series.from_arrow(pa.array(["foo", "bar", "bar"]))
+    result = s.utf8_endswith(pattern)
+    assert result.to_pylist() == [True, False, True]
+
+
+def test_series_endswith_pattern_broadcast() -> None:
+    s = Series.from_arrow(pa.array(["x_foo", "y_foo", "z_bar"]))
+    pattern = Series.from_arrow(pa.array(["foo"]))
+    result = s.utf8_endswith(pattern)
+    assert result.to_pylist() == [True, True, False]
+
+
+def test_series_endswith_pattern_broadcast_null() -> None:
+    s = Series.from_arrow(pa.array(["x_foo", "y_foo", "z_bar"]))
+    pattern = Series.from_arrow(pa.array([None], type=pa.string()))
+    result = s.utf8_endswith(pattern)
+    assert result.to_pylist() == [None, None, None]
+
+
+def test_series_endswith_data_broadcast() -> None:
+    s = Series.from_arrow(pa.array(["x_foo"]))
+    pattern = Series.from_arrow(pa.array(["foo", "bar", "baz"]))
+    result = s.utf8_endswith(pattern)
+    assert result.to_pylist() == [True, False, False]
+
+
+def test_series_endswith_data_broadcast_null() -> None:
+    s = Series.from_arrow(pa.array([None], type=pa.string()))
+    pattern = Series.from_arrow(pa.array(["foo", "bar", "baz"]))
+    result = s.utf8_endswith(pattern)
+    assert result.to_pylist() == [None, None, None]
+
+
+def test_series_endswith_nulls() -> None:
+    s = Series.from_arrow(pa.array([None, None, "z_bar"]))
+    pattern = Series.from_arrow(pa.array([None, "bar", None]))
+    result = s.utf8_endswith(pattern)
+    assert result.to_pylist() == [None, None, None]
+
+
+def test_series_endswith_empty() -> None:
+    s = Series.from_arrow(pa.array([], type=pa.string()))
+    pattern = Series.from_arrow(pa.array([], type=pa.string()))
+    result = s.utf8_endswith(pattern)
+    assert result.to_pylist() == []
+
+
+@pytest.mark.parametrize(
+    "bad_series",
+    [
+        # Wrong number of elements, not broadcastable
+        Series.from_arrow(pa.array([], type=pa.string())),
+        Series.from_arrow(pa.array(["foo", "bar"], type=pa.string())),
+        # Bad input type
+        object(),
+    ],
+)
+def test_series_endswith_invalid_inputs(bad_series) -> None:
+    s = Series.from_arrow(pa.array(["x_foo", "y_foo", "z_bar"]))
+    with pytest.raises(ValueError):
+        s.utf8_endswith(bad_series)

--- a/tests/series/test_utf8.py
+++ b/tests/series/test_utf8.py
@@ -9,49 +9,49 @@ from daft import Series
 def test_series_endswith() -> None:
     s = Series.from_arrow(pa.array(["x_foo", "y_foo", "z_bar"]))
     pattern = Series.from_arrow(pa.array(["foo", "bar", "bar"]))
-    result = s.utf8_endswith(pattern)
+    result = s.str.endswith(pattern)
     assert result.to_pylist() == [True, False, True]
 
 
 def test_series_endswith_pattern_broadcast() -> None:
     s = Series.from_arrow(pa.array(["x_foo", "y_foo", "z_bar"]))
     pattern = Series.from_arrow(pa.array(["foo"]))
-    result = s.utf8_endswith(pattern)
+    result = s.str.endswith(pattern)
     assert result.to_pylist() == [True, True, False]
 
 
 def test_series_endswith_pattern_broadcast_null() -> None:
     s = Series.from_arrow(pa.array(["x_foo", "y_foo", "z_bar"]))
     pattern = Series.from_arrow(pa.array([None], type=pa.string()))
-    result = s.utf8_endswith(pattern)
+    result = s.str.endswith(pattern)
     assert result.to_pylist() == [None, None, None]
 
 
 def test_series_endswith_data_broadcast() -> None:
     s = Series.from_arrow(pa.array(["x_foo"]))
     pattern = Series.from_arrow(pa.array(["foo", "bar", "baz"]))
-    result = s.utf8_endswith(pattern)
+    result = s.str.endswith(pattern)
     assert result.to_pylist() == [True, False, False]
 
 
 def test_series_endswith_data_broadcast_null() -> None:
     s = Series.from_arrow(pa.array([None], type=pa.string()))
     pattern = Series.from_arrow(pa.array(["foo", "bar", "baz"]))
-    result = s.utf8_endswith(pattern)
+    result = s.str.endswith(pattern)
     assert result.to_pylist() == [None, None, None]
 
 
 def test_series_endswith_nulls() -> None:
     s = Series.from_arrow(pa.array([None, None, "z_bar"]))
     pattern = Series.from_arrow(pa.array([None, "bar", None]))
-    result = s.utf8_endswith(pattern)
+    result = s.str.endswith(pattern)
     assert result.to_pylist() == [None, None, None]
 
 
 def test_series_endswith_empty() -> None:
     s = Series.from_arrow(pa.array([], type=pa.string()))
     pattern = Series.from_arrow(pa.array([], type=pa.string()))
-    result = s.utf8_endswith(pattern)
+    result = s.str.endswith(pattern)
     assert result.to_pylist() == []
 
 
@@ -68,4 +68,4 @@ def test_series_endswith_empty() -> None:
 def test_series_endswith_invalid_inputs(bad_series) -> None:
     s = Series.from_arrow(pa.array(["x_foo", "y_foo", "z_bar"]))
     with pytest.raises(ValueError):
-        s.utf8_endswith(bad_series)
+        s.str.endswith(bad_series)

--- a/tests/table/utf8/test_endswith.py
+++ b/tests/table/utf8/test_endswith.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from daft.expressions2 import col, lit
+from daft.table import Table
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        col("col").str.endswith("foo"),
+        col("col").str.endswith(lit("foo")),
+        col("col").str.endswith(col("emptystrings") + lit("foo")),
+    ],
+)
+def test_endswith(expr):
+    table = Table.from_pydict({"col": ["x_foo", "y_foo", "z_bar"], "emptystrings": ["", "", ""]})
+    result = table.eval_expression_list([expr])
+    assert result.to_pydict() == {"col": [True, True, False]}

--- a/tests/test_runtime_matches_static_types.py
+++ b/tests/test_runtime_matches_static_types.py
@@ -67,6 +67,7 @@ ALL_KERNELS = [
     KernelSpec(name="ge", num_args=2, func=ops.ge),
     KernelSpec(name="gt", num_args=2, func=ops.gt),
     KernelSpec(name="cast", num_args=1, func=_cast, kwarg_variants=[{"cast_to": dt for dt in ALL_DTYPES}]),
+    KernelSpec(name="str_ends_with", num_args=2, func=lambda data, pattern: data.str.endswith(pattern)),
     # TODO: [RUST-INT][TPCH] Activate tests once these kernels have been implemented
     # KernelSpec(name="sum", num_args=1, func=lambda e: e.agg.sum()),
 ]


### PR DESCRIPTION
1. Adds a `.utf8_endswith` kernel to Series + unit tests on the Series level
2. Adds a `.str.endswith` to Expressions + quick unit test on the Table for some corner-cases (using `lit` vs `"foo"` vs `Expression` as the pattern)
3. Checks type resolution logic by adding to the tests into our `test_runtime_matches_static_types.py` test