### PR TITLE
Add if_else kernel to Series

### DIFF
--- a/daft/expressions2/expressions.py
+++ b/daft/expressions2/expressions.py
@@ -197,7 +197,7 @@ class Expression:
         return Expression._from_pyexpr(expr)
 
     def if_else(self, if_true: Expression, if_false: Expression) -> Expression:
-        raise NotImplementedError("[RUST-INT][TPCH] Implement expression")
+        return Expression._from_pyexpr(self._expr.if_else(if_true._expr, if_false._expr))
 
     def apply(self, func: Callable, return_dtype: DataType | None = None) -> Expression:
         raise NotImplementedError("[RUST-INT][UDF] Implement .apply")

--- a/daft/series.py
+++ b/daft/series.py
@@ -213,14 +213,14 @@ class Series:
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series ^ other._series)
 
-    def if_else(self, other: object, predicate: object) -> Series:
-        if not isinstance(other, Series):
-            raise ValueError(f"expected another Series but got {type(other)}")
-        if not isinstance(predicate, Series):
-            raise ValueError(f"expected another Series but got {type(predicate)}")
-        assert self._series is not None and other._series is not None and predicate._series is not None
-        return Series._from_pyseries(self._series.if_else(other._series, predicate._series))
-
+    def if_else(self, if_true: object, if_false: object) -> Series:
+        if not isinstance(if_true, Series):
+            raise ValueError(f"expected another Series but got {type(if_true)}")
+        if not isinstance(if_false, Series):
+            raise ValueError(f"expected another Series but got {type(if_false)}")
+        assert self._series is not None and if_true._series is not None and if_false._series is not None
+        # NOTE: Rust Series has a different ordering for if_else because of better static typing
+        return Series._from_pyseries(if_true._series.if_else(if_false._series, self._series))
 
     @property
     def str(self) -> SeriesStringNamespace:

--- a/daft/series.py
+++ b/daft/series.py
@@ -213,6 +213,15 @@ class Series:
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series ^ other._series)
 
+    def if_else(self, other: object, predicate: object) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        if not isinstance(predicate, Series):
+            raise ValueError(f"expected another Series but got {type(predicate)}")
+        assert self._series is not None and other._series is not None and predicate._series is not None
+        return Series._from_pyseries(self._series.if_else(other._series, predicate._series))
+
+
     @property
     def str(self) -> SeriesStringNamespace:
         return SeriesStringNamespace.from_series(self)

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -8,7 +8,11 @@ impl<T> DataArray<T>
 where
     T: DaftDataType + 'static,
 {
-    pub fn if_else(self, other: DataArray<T>, predicate: BooleanArray) -> DaftResult<DataArray<T>> {
+    pub fn if_else(
+        &self,
+        other: &DataArray<T>,
+        predicate: &BooleanArray,
+    ) -> DaftResult<DataArray<T>> {
         let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
         DataArray::try_from((self.name(), result))
     }

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -1,0 +1,16 @@
+use crate::datatypes::DaftDataType;
+use crate::{array::DataArray, datatypes::BooleanArray, error::DaftResult};
+use arrow2::compute::if_then_else::if_then_else;
+
+use crate::array::BaseArray;
+
+impl BooleanArray {
+    pub fn if_else<T: DaftDataType + 'static>(
+        &self,
+        if_true: &DataArray<T>,
+        if_false: &DataArray<T>,
+    ) -> DaftResult<DataArray<T>> {
+        let result = if_then_else(self.downcast(), if_true.data(), if_false.data())?;
+        DataArray::try_from((self.name(), result))
+    }
+}

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -4,13 +4,12 @@ use arrow2::compute::if_then_else::if_then_else;
 
 use crate::array::BaseArray;
 
-impl BooleanArray {
-    pub fn if_else<T: DaftDataType + 'static>(
-        &self,
-        if_true: &DataArray<T>,
-        if_false: &DataArray<T>,
-    ) -> DaftResult<DataArray<T>> {
-        let result = if_then_else(self.downcast(), if_true.data(), if_false.data())?;
+impl<T> DataArray<T>
+where
+    T: DaftDataType + 'static,
+{
+    pub fn if_else(self, other: DataArray<T>, predicate: BooleanArray) -> DaftResult<DataArray<T>> {
+        let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
         DataArray::try_from((self.name(), result))
     }
 }

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -1,19 +1,109 @@
-use crate::datatypes::DaftDataType;
-use crate::{array::DataArray, datatypes::BooleanArray, error::DaftResult};
+use crate::datatypes::DaftNumericType;
+use crate::datatypes::{BooleanArray, Utf8Array};
+use crate::error::DaftError;
+use crate::{array::DataArray, error::DaftResult};
 use arrow2::compute::if_then_else::if_then_else;
+use std::sync::Arc;
 
 use crate::array::BaseArray;
 
 impl<T> DataArray<T>
 where
-    T: DaftDataType + 'static,
+    T: DaftNumericType,
 {
     pub fn if_else(
         &self,
         other: &DataArray<T>,
         predicate: &BooleanArray,
     ) -> DaftResult<DataArray<T>> {
-        let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
-        DataArray::try_from((self.name(), result))
+        match (self.len(), other.len(), predicate.len()) {
+            (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
+                let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
+                DataArray::try_from((self.name(), result))
+            },
+            (self_len, _, 1) => {
+                let predicate_scalar = predicate.get(0);
+                match predicate_scalar {
+                    None => Ok(DataArray::full_null(self.name(), self_len)),
+                    Some(predicate_scalar_value) => {
+                        if predicate_scalar_value {
+                            Ok(self.clone())
+                        } else {
+                            Ok(other.clone())
+                        }
+                    }
+                }
+            }
+            (1, o, p)  if o == p => {
+                let self_scalar = self.get(0);
+                let new_arr: arrow2::array::PrimitiveArray<T::Native> = other.downcast().iter().zip(predicate.downcast().iter()).map(
+                    |(other_val, pred_val)| match pred_val {
+                        None => None,
+                        Some(true) => self_scalar,
+                        Some(false) => other_val.copied()
+                    }
+                ).collect();
+                DataArray::new(self.field.clone(), Arc::new(new_arr))
+            }
+            (s, 1, p)  if s == p => {
+                let other_scalar = other.get(0);
+                let new_arr: arrow2::array::PrimitiveArray<T::Native> = self.downcast().iter().zip(predicate.downcast().iter()).map(
+                    |(self_val, pred_val)| match pred_val {
+                        None => None,
+                        Some(true) => self_val.copied(),
+                        Some(false) => other_scalar
+                    }
+                ).collect();
+                DataArray::new(self.field.clone(), Arc::new(new_arr))
+            }
+            (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
+        }
+    }
+}
+
+impl Utf8Array {
+    pub fn if_else(&self, other: &Utf8Array, predicate: &BooleanArray) -> DaftResult<Utf8Array> {
+        match (self.len(), other.len(), predicate.len()) {
+            (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
+                let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
+                DataArray::try_from((self.name(), result))
+            },
+            (self_len, _, 1) => {
+                let predicate_scalar = predicate.get(0);
+                match predicate_scalar {
+                    None => Ok(DataArray::full_null(self.name(), self_len)),
+                    Some(predicate_scalar_value) => {
+                        if predicate_scalar_value {
+                            Ok(self.clone())
+                        } else {
+                            Ok(other.clone())
+                        }
+                    }
+                }
+            }
+            (1, o, p)  if o == p => {
+                let self_scalar = self.get(0);
+                let new_arr: arrow2::array::Utf8Array<i64> = other.downcast().iter().zip(predicate.downcast().iter()).map(
+                    |(other_val, pred_val)| match pred_val {
+                        None => None,
+                        Some(true) => self_scalar,
+                        Some(false) => other_val,
+                    }
+                ).collect();
+                DataArray::new(self.field.clone(), Arc::new(new_arr))
+            }
+            (s, 1, p)  if s == p => {
+                let other_scalar = other.get(0);
+                let new_arr: arrow2::array::Utf8Array<i64> = self.downcast().iter().zip(predicate.downcast().iter()).map(
+                    |(self_val, pred_val)| match pred_val {
+                        None => None,
+                        Some(true) => self_val,
+                        Some(false) => other_scalar,
+                    }
+                ).collect();
+                DataArray::new(self.field.clone(), Arc::new(new_arr))
+            }
+            (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
+        }
     }
 }

--- a/src/array/ops/mod.rs
+++ b/src/array/ops/mod.rs
@@ -14,6 +14,7 @@ mod downcast;
 mod filter;
 mod full;
 mod hash;
+mod if_else;
 mod len;
 mod mean;
 mod pairwise;

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -83,6 +83,10 @@ impl PyExpr {
         Ok(self.expr.cast(&dtype.into()).into())
     }
 
+    pub fn if_else(&self, if_true: &Self, if_false: &Self) -> PyResult<Self> {
+        Ok(self.expr.if_else(&if_true.expr, &if_false.expr).into())
+    }
+
     pub fn count(&self) -> PyResult<Self> {
         Ok(self.expr.count().into())
     }

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -197,6 +197,13 @@ impl PySeries {
     pub fn dt_year(&self) -> PyResult<Self> {
         Ok(self.series.dt_year()?.into())
     }
+
+    pub fn if_else(&self, other: &Self, predicate: &Self) -> PyResult<Self> {
+        Ok(self
+            .series
+            .if_else(&other.series, &predicate.series)?
+            .into())
+    }
 }
 
 impl From<series::Series> for PySeries {

--- a/src/series/ops/if_else.rs
+++ b/src/series/ops/if_else.rs
@@ -1,0 +1,14 @@
+use crate::{
+    array::BaseArray, datatypes, error::DaftResult, series::Series, with_match_daft_types,
+};
+
+impl Series {
+    pub fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series> {
+        with_match_daft_types!(self.data_type(), |$T| {
+            let self_array = self.downcast::<$T>()?;
+            let other_array = other.downcast::<$T>()?;
+            let predicate_array = predicate.downcast::<datatypes::BooleanType>()?;
+            Ok(self_array.if_else(other_array, predicate_array)?.into_series())
+        })
+    }
+}

--- a/src/series/ops/if_else.rs
+++ b/src/series/ops/if_else.rs
@@ -1,10 +1,12 @@
 use crate::{
-    array::BaseArray, datatypes, error::DaftResult, series::Series, with_match_daft_types,
+    array::BaseArray, datatypes, error::DaftResult, series::Series,
+    with_match_numeric_and_utf_daft_types,
 };
 
 impl Series {
     pub fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series> {
-        with_match_daft_types!(self.data_type(), |$T| {
+        // TODO: [RUST-INT] implement for more types
+        with_match_numeric_and_utf_daft_types!(self.data_type(), |$T| {
             let self_array = self.downcast::<$T>()?;
             let other_array = other.downcast::<$T>()?;
             let predicate_array = predicate.downcast::<datatypes::BooleanType>()?;

--- a/src/series/ops/if_else.rs
+++ b/src/series/ops/if_else.rs
@@ -1,3 +1,4 @@
+use super::match_types_on_series;
 use crate::{
     array::BaseArray, datatypes, error::DaftResult, series::Series,
     with_match_numeric_and_utf_daft_types,
@@ -6,11 +7,12 @@ use crate::{
 impl Series {
     pub fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series> {
         // TODO: [RUST-INT] implement for more types
-        with_match_numeric_and_utf_daft_types!(self.data_type(), |$T| {
-            let self_array = self.downcast::<$T>()?;
-            let other_array = other.downcast::<$T>()?;
+        let (if_true, if_false) = match_types_on_series(self, other)?;
+        with_match_numeric_and_utf_daft_types!(if_true.data_type(), |$T| {
+            let if_true_array = if_true.downcast::<$T>()?;
+            let if_false_array = if_false.downcast::<$T>()?;
             let predicate_array = predicate.downcast::<datatypes::BooleanType>()?;
-            Ok(self_array.if_else(other_array, predicate_array)?.into_series())
+            Ok(if_true_array.if_else(if_false_array, predicate_array)?.into_series())
         })
     }
 }

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -15,6 +15,7 @@ pub mod downcast;
 pub mod filter;
 pub mod full;
 pub mod hash;
+pub mod if_else;
 pub mod len;
 pub mod pairwise;
 pub mod search_sorted;

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -272,6 +272,16 @@ impl Table {
                 func.evaluate(evaluated_inputs.as_slice())
             }
             Literal(lit_value) => Ok(lit_value.to_series()),
+            IfElse {
+                if_true,
+                if_false,
+                predicate,
+            } => {
+                let if_true_series = self.eval_expression(if_true)?;
+                let if_false_series = self.eval_expression(if_false)?;
+                let predicate_series = self.eval_expression(predicate)?;
+                Ok(if_true_series.if_else(&if_false_series, &predicate_series)?)
+            }
         }?;
         if expected_field.name != series.field().name {
             return Err(DaftError::ComputeError(format!(

--- a/tests/series/test_if_else.py
+++ b/tests/series/test_if_else.py
@@ -24,7 +24,7 @@ def test_series_if_else_numeric(if_true, if_false) -> None:
     if_true_series = Series.from_arrow(if_true)
     if_false_series = Series.from_arrow(if_false)
     predicate_series = Series.from_arrow(pa.array([True, False, None]))
-    result = if_true_series.if_else(if_false_series, predicate_series)
+    result = predicate_series.if_else(if_true_series, if_false_series)
     assert result.datatype() == DataType.int64()
     assert result.to_pylist() == [1, 0, None]
 
@@ -33,7 +33,7 @@ def test_series_if_else_predicate_broadcast() -> None:
     if_true_series = Series.from_arrow(pa.array([1, 1, 1], type=pa.int64()))
     if_false_series = Series.from_arrow(pa.array([0, 0, 0], type=pa.int64()))
     predicate_series = Series.from_arrow(pa.array([True], type=pa.bool_()))
-    result = if_true_series.if_else(if_false_series, predicate_series)
+    result = predicate_series.if_else(if_true_series, if_false_series)
     assert result.datatype() == DataType.int64()
     assert result.to_pylist() == [1, 1, 1]
 
@@ -42,7 +42,7 @@ def test_series_if_else_predicate_broadcast_null() -> None:
     if_true_series = Series.from_arrow(pa.array([1, 1, 1], type=pa.int64()))
     if_false_series = Series.from_arrow(pa.array([0, 0, 0], type=pa.int64()))
     predicate_series = Series.from_arrow(pa.array([None], type=pa.bool_()))
-    result = if_true_series.if_else(if_false_series, predicate_series)
+    result = predicate_series.if_else(if_true_series, if_false_series)
     assert result.datatype() == DataType.int64()
     assert result.to_pylist() == [None, None, None]
 
@@ -53,7 +53,7 @@ def test_series_if_else_wrong_types() -> None:
     predicate_series = Series.from_arrow(pa.array([None], type=pa.bool_()))
 
     with pytest.raises(ValueError):
-        if_true_series.if_else(object(), predicate_series)
+        predicate_series.if_else(object(), if_false_series)
 
     with pytest.raises(ValueError):
-        if_true_series.if_else(if_false_series, object())
+        predicate_series.if_else(if_true_series, object())

--- a/tests/series/test_if_else.py
+++ b/tests/series/test_if_else.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+from daft import Series
+from daft.datatype import DataType
+
+
+@pytest.mark.parametrize(
+    ["if_true", "if_false"],
+    [
+        # Same length, same type
+        (pa.array([1, 1, 1], type=pa.int64()), pa.array([0, 0, 0], type=pa.int64())),
+        # Same length, different super-castable type
+        (pa.array([1, 1, 1], type=pa.int64()), pa.array([0, 0, 0], type=pa.int8())),
+        # Broadcast left
+        (pa.array([1], type=pa.int64()), pa.array([0, 0, 0], type=pa.int64())),
+        # Broadcast right
+        (pa.array([1, 1, 1], type=pa.int64()), pa.array([0], type=pa.int64())),
+    ],
+)
+def test_series_if_else_numeric(if_true, if_false) -> None:
+    if_true_series = Series.from_arrow(if_true)
+    if_false_series = Series.from_arrow(if_false)
+    predicate_series = Series.from_arrow(pa.array([True, False, None]))
+    result = if_true_series.if_else(if_false_series, predicate_series)
+    assert result.datatype() == DataType.int64()
+    assert result.to_pylist() == [1, 0, None]
+
+
+def test_series_if_else_predicate_broadcast() -> None:
+    if_true_series = Series.from_arrow(pa.array([1, 1, 1], type=pa.int64()))
+    if_false_series = Series.from_arrow(pa.array([0, 0, 0], type=pa.int64()))
+    predicate_series = Series.from_arrow(pa.array([True], type=pa.bool_()))
+    result = if_true_series.if_else(if_false_series, predicate_series)
+    assert result.datatype() == DataType.int64()
+    assert result.to_pylist() == [1, 1, 1]
+
+
+def test_series_if_else_predicate_broadcast_null() -> None:
+    if_true_series = Series.from_arrow(pa.array([1, 1, 1], type=pa.int64()))
+    if_false_series = Series.from_arrow(pa.array([0, 0, 0], type=pa.int64()))
+    predicate_series = Series.from_arrow(pa.array([None], type=pa.bool_()))
+    result = if_true_series.if_else(if_false_series, predicate_series)
+    assert result.datatype() == DataType.int64()
+    assert result.to_pylist() == [None, None, None]
+
+
+def test_series_if_else_wrong_types() -> None:
+    if_true_series = Series.from_arrow(pa.array([1, 1, 1], type=pa.int64()))
+    if_false_series = Series.from_arrow(pa.array([0, 0, 0], type=pa.int64()))
+    predicate_series = Series.from_arrow(pa.array([None], type=pa.bool_()))
+
+    with pytest.raises(ValueError):
+        if_true_series.if_else(object(), predicate_series)
+
+    with pytest.raises(ValueError):
+        if_true_series.if_else(if_false_series, object())

--- a/tests/series/test_if_else.py
+++ b/tests/series/test_if_else.py
@@ -29,22 +29,51 @@ def test_series_if_else_numeric(if_true, if_false) -> None:
     assert result.to_pylist() == [1, 0, None]
 
 
-def test_series_if_else_predicate_broadcast() -> None:
-    if_true_series = Series.from_arrow(pa.array([1, 1, 1], type=pa.int64()))
-    if_false_series = Series.from_arrow(pa.array([0, 0, 0], type=pa.int64()))
-    predicate_series = Series.from_arrow(pa.array([True], type=pa.bool_()))
+@pytest.mark.parametrize(
+    ["if_true", "if_false"],
+    [
+        # Same length, same type
+        (pa.array(["1", "1", "1"], type=pa.string()), pa.array(["0", "0", "0"], type=pa.string())),
+        # Same length, different super-castable type
+        (pa.array(["1", "1", "1"], type=pa.string()), pa.array([0, 0, 0], type=pa.int8())),
+        # Broadcast left
+        (pa.array(["1"], type=pa.string()), pa.array(["0", "0", "0"], type=pa.string())),
+        # Broadcast right
+        (pa.array(["1", "1", "1"], type=pa.string()), pa.array(["0"], type=pa.string())),
+    ],
+)
+def test_series_if_else_string(if_true, if_false) -> None:
+    if_true_series = Series.from_arrow(if_true)
+    if_false_series = Series.from_arrow(if_false)
+    predicate_series = Series.from_arrow(pa.array([True, False, None]))
     result = predicate_series.if_else(if_true_series, if_false_series)
-    assert result.datatype() == DataType.int64()
-    assert result.to_pylist() == [1, 1, 1]
+    assert result.datatype() == DataType.string()
+    assert result.to_pylist() == ["1", "0", None]
 
 
-def test_series_if_else_predicate_broadcast_null() -> None:
+@pytest.mark.parametrize(
+    ["predicate_value", "expected_results"], [(True, [1, 1, 1]), (False, [0, 0, 0]), (None, [None, None, None])]
+)
+def test_series_if_else_predicate_broadcast(predicate_value, expected_results) -> None:
     if_true_series = Series.from_arrow(pa.array([1, 1, 1], type=pa.int64()))
     if_false_series = Series.from_arrow(pa.array([0, 0, 0], type=pa.int64()))
-    predicate_series = Series.from_arrow(pa.array([None], type=pa.bool_()))
+    predicate_series = Series.from_arrow(pa.array([predicate_value], type=pa.bool_()))
     result = predicate_series.if_else(if_true_series, if_false_series)
     assert result.datatype() == DataType.int64()
-    assert result.to_pylist() == [None, None, None]
+    assert result.to_pylist() == expected_results
+
+
+@pytest.mark.parametrize(
+    ["predicate_value", "expected_results"],
+    [(True, ["1", "1", "1"]), (False, ["0", "0", "0"]), (None, [None, None, None])],
+)
+def test_series_if_else_predicate_broadcast_strings(predicate_value, expected_results) -> None:
+    if_true_series = Series.from_arrow(pa.array(["1", "1", "1"], type=pa.string()))
+    if_false_series = Series.from_arrow(pa.array(["0", "0", "0"], type=pa.string()))
+    predicate_series = Series.from_arrow(pa.array([predicate_value], type=pa.bool_()))
+    result = predicate_series.if_else(if_true_series, if_false_series)
+    assert result.datatype() == DataType.string()
+    assert result.to_pylist() == expected_results
 
 
 def test_series_if_else_wrong_types() -> None:

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -1061,3 +1061,9 @@ def test_table_filter_with_date_years() -> None:
     result = new_table.to_pydict()
     assert result["days"] == [date(4000, 1, 1), date(2022, 1, 1)]
     assert result["enum"] == [1, 4]
+
+
+def test_table_if_else() -> None:
+    table = Table.from_arrow(pa.Table.from_pydict({"ones": [1, 1, 1], "zeros": [0, 0, 0], "pred": [True, False, None]}))
+    result_table = table.eval_expression_list([col("pred").if_else(col("ones"), col("zeros"))])
+    result_table.to_pydict() == {"ones": [1, 0, None]}


### PR DESCRIPTION
Adds an `if_else` kernel that works with only numeric arrays and utf8 arrays for now

* Note that on the Rust series/array level, the syntax is: `if_true.if_else(if_false, predicate)` because we can use the static type of `if_true` to determine what kernel to dispatch
* However, on the Python series/expression level, the syntax is: `predicate.if_else(if_true, if_false)` because this is the current API. Under the hood we re-order the arguments when calling into Rust