### PR TITLE
[rust] String multikey sorting bug fix

### DIFF
--- a/src/array/ops/sort.rs
+++ b/src/array/ops/sort.rs
@@ -485,16 +485,14 @@ impl Utf8Array {
             .downcast_ref::<arrow2::array::Utf8Array<i64>>()
             .unwrap();
 
-        let values = arrow_array.values();
-
         let result = if first_desc {
             multi_column_idx_sort(
                 arrow_array.validity(),
                 |a: &I::Native, b: &I::Native| {
                     let a = a.to_usize();
                     let b = b.to_usize();
-                    let l = unsafe { values.get_unchecked(a) };
-                    let r = unsafe { values.get_unchecked(b) };
+                    let l = unsafe { arrow_array.value_unchecked(a) };
+                    let r = unsafe { arrow_array.value_unchecked(b) };
                     match r.cmp(l) {
                         std::cmp::Ordering::Equal => others_cmp(a, b),
                         v => v,
@@ -510,8 +508,8 @@ impl Utf8Array {
                 |a: &I::Native, b: &I::Native| {
                     let a = a.to_usize();
                     let b = b.to_usize();
-                    let l = unsafe { values.get_unchecked(a) };
-                    let r = unsafe { values.get_unchecked(b) };
+                    let l = unsafe { arrow_array.value_unchecked(a) };
+                    let r = unsafe { arrow_array.value_unchecked(b) };
                     match l.cmp(r) {
                         std::cmp::Ordering::Equal => others_cmp(a, b),
                         v => v,

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -917,3 +917,25 @@ def test_table_concat_schema_mismatch() -> None:
 
     with pytest.raises(ValueError, match="Table concat requires all schemas to match"):
         Table.concat(mix_types_table)
+
+
+def test_string_table_sorting():
+    daft_table = Table.from_pydict(
+        {
+            "firstname": [
+                "bob",
+                "alice",
+                "eve",
+                None,
+                None,
+                "bob",
+                "alice",
+            ],
+            "lastname": ["a", "a", "a", "bond", None, None, "a"],
+        }
+    )
+    sorted_table = daft_table.sort([col("firstname"), col("lastname")])
+    assert sorted_table.to_pydict() == {
+        "firstname": ["alice", "alice", "bob", "bob", "eve", None, None],
+        "lastname": ["a", "a", "a", None, "a", "bond", None],
+    }


### PR DESCRIPTION
* Fixes bug when sorting multiple keys with string first. 
* Issue was using .values() on the arrow array which returns a Buffer of the string characters rather than the &str