### PR TITLE
Fix schema inference of reads from Parquet and empty vPartitions

### DIFF
--- a/daft/runners/runner_io.py
+++ b/daft/runners/runner_io.py
@@ -110,7 +110,7 @@ def sample_schema(
         sampled_partition = vPartition.from_parquet(
             path=filepath,
             read_options=vPartitionReadOptions(
-                num_rows=100,  # sample 100 rows for schema inference
+                num_rows=0,  # sample 100 rows for schema inference
                 column_names=None,  # read all columns
             ),
             schema_options=schema_inference_options,


### PR DESCRIPTION
* Change Parquet schema inference to use 0 rows
* Schema inference logic is then changed to use the inferred schema from the Arrow schema rather than from the parsed data