### PR TITLE
Use ValueError instead of SchemaMismatch in FunctionExpr evaluation

### DIFF
--- a/src/dsl/functions/numeric/abs.rs
+++ b/src/dsl/functions/numeric/abs.rs
@@ -34,7 +34,7 @@ impl FunctionEvaluator for AbsEvaluator {
 
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
         if inputs.len() != 1 {
-            return Err(DaftError::SchemaMismatch(format!(
+            return Err(DaftError::ValueError(format!(
                 "Expected 1 input arg, got {}",
                 inputs.len()
             )));

--- a/src/dsl/functions/utf8/endswith.rs
+++ b/src/dsl/functions/utf8/endswith.rs
@@ -47,7 +47,7 @@ impl FunctionEvaluator for EndswithEvaluator {
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
         match inputs {
             [data, pattern] => data.utf8_endswith(pattern),
-            _ => Err(DaftError::SchemaMismatch(format!(
+            _ => Err(DaftError::ValueError(format!(
                 "Expected 2 input args, got {}",
                 inputs.len()
             ))),


### PR DESCRIPTION
SchemaMismatch error should be thrown only at schema-resolving-time.