### PR TITLE
Remove ExprResolveTypeError in favor of a plain TypeError

### DIFF
--- a/src/dsl/functions/utf8/endswith.rs
+++ b/src/dsl/functions/utf8/endswith.rs
@@ -6,8 +6,8 @@ use crate::{
     series::Series,
 };
 
-use super::{super::FunctionEvaluator, super::FunctionExpr, Utf8Expr};
-use std::sync::Arc;
+use super::super::FunctionEvaluator;
+
 pub(super) struct EndswithEvaluator {}
 
 impl FunctionEvaluator for EndswithEvaluator {
@@ -23,17 +23,10 @@ impl FunctionEvaluator for EndswithEvaluator {
                 if !matches!(data_field.dtype, DataType::Utf8)
                     || !matches!(pattern_field.dtype, DataType::Utf8)
                 {
-                    return Err(DaftError::ExprResolveTypeError {
-                        expectation: "data input to endswith to be utf8".into(),
-                        expr: Arc::new(Expr::Function {
-                            func: FunctionExpr::Utf8(Utf8Expr::EndsWith),
-                            inputs: inputs.to_vec(),
-                        }),
-                        child_fields_to_expr: vec![
-                            (data_field, Arc::new(data.clone())),
-                            (pattern_field, Arc::new(pattern.clone())),
-                        ],
-                    });
+                    return Err(DaftError::TypeError(format!(
+                        "Expects inputs to endwith to be utf8, but received {:?} and {:?}",
+                        data_field, pattern_field
+                    )));
                 }
                 Ok(Field::new(data_field.name, DataType::Boolean))
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,5 @@
 use std::fmt::{Display, Formatter, Result};
 
-use crate::{datatypes::Field, dsl::Expr};
-use std::sync::Arc;
-
 #[derive(Debug)]
 pub enum DaftError {
     NotFound(String),
@@ -11,15 +8,6 @@ pub enum DaftError {
     ComputeError(String),
     ArrowError(String),
     ValueError(String),
-    // ExprResolveTypeError: Typing error when resolving expressions against schemas
-    //
-    // This variant has custom Display logic for presenting a more user-friendly error message which shows
-    // exactly which operation, arguments and dtypes of those arguments caused the issue.
-    ExprResolveTypeError {
-        expectation: String,
-        expr: Arc<Expr>,
-        child_fields_to_expr: Vec<(Field, Arc<Expr>)>,
-    },
 }
 
 impl From<arrow2::error::Error> for DaftError {
@@ -33,28 +21,6 @@ pub type DaftResult<T> = std::result::Result<T, DaftError>;
 impl Display for DaftError {
     // `f` is a buffer, and this method must write the formatted string into it
     fn fmt(&self, f: &mut Formatter) -> Result {
-        // Override this method if the error propagated should have custom display for better user-level error messages
-        match self {
-            Self::ExprResolveTypeError {
-                expectation,
-                expr,
-                child_fields_to_expr,
-            } => {
-                writeln!(
-                    f,
-                    "Expects {expectation}, but failed type resolution: {expr}",
-                )?;
-                writeln!(f, "where expression arguments are:")?;
-                for (field, expr) in child_fields_to_expr.iter() {
-                    writeln!(
-                        f,
-                        "  `{}` resolves to {}: {}",
-                        field.name, field.dtype, expr
-                    )?;
-                }
-                Ok(())
-            }
-            _ => write!(f, "{self:?}"),
-        }
+        write!(f, "{self:?}")
     }
 }


### PR DESCRIPTION
* ExprResolveTypeError is too complicated and difficult to use, slowing down kernel development velocity
* This PR removes ExprResolveTypeError, but we open a new issue for better expression schema resolution errors