### PR TITLE
Use Ray Datasets ArrowTensorExtension type when handling numpy arrays

### DIFF
--- a/tests/ray/test_datasets.py
+++ b/tests/ray/test_datasets.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 import pytest
 
 from daft import DataFrame
@@ -29,6 +30,8 @@ def test_ray_dataset_all_arrow(n_partitions: int):
     df = df.with_column("floatcol", df["intcol"].cast(float))
     ds = df.to_ray_dataset()
 
+    assert ds.dataset_format() == "arrow", "Ray Dataset format should be arrow"
+
     rows = [row for row in ds.iter_rows()]
     assert rows == [
         {"intcol": 1, "strcol": "a", "floatcol": 1.0},
@@ -44,9 +47,31 @@ def test_ray_dataset_with_py(n_partitions: int):
     df = df.with_column("pycol", df["intcol"].apply(lambda x: MyObj(x)))
     ds = df.to_ray_dataset()
 
+    assert ds.dataset_format() == "simple", "Ray Dataset format should be simple because it has Python objects"
+
     rows = [row for row in ds.iter_rows()]
     assert rows == [
         {"intcol": 1, "strcol": "a", "pycol": MyObj(1)},
         {"intcol": 2, "strcol": "b", "pycol": MyObj(2)},
         {"intcol": 3, "strcol": "c", "pycol": MyObj(3)},
     ]
+
+
+@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.parametrize("n_partitions", [1, 2])
+def test_ray_dataset_with_numpy(n_partitions: int):
+    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = df.with_column("npcol", df["intcol"].apply(lambda x: np.ones((x, 3))))
+    ds = df.to_ray_dataset()
+
+    assert ds.dataset_format() == "arrow", "Ray Dataset format should be arrow because it uses a Tensor extension type"
+
+    rows = [dict(row) for row in ds.iter_rows()]
+    np.testing.assert_equal(
+        rows,
+        [
+            {"intcol": 1, "strcol": "a", "npcol": np.ones((1, 3))},
+            {"intcol": 2, "strcol": "b", "npcol": np.ones((2, 3))},
+            {"intcol": 3, "strcol": "c", "npcol": np.ones((3, 3))},
+        ],
+    )


### PR DESCRIPTION
* Currently in `.to_ray_dataset()`, when any columns are columns of numpy arrays we use the "simple" Ray dataset format, which is a dictionary of Python objects
* This PR changes that behavior to use Arrow tables, using Ray Dataset's `ArrowTensorExtension`