### PR TITLE
Add DataFrame.from_ray_dataset

### DIFF
--- a/daft/types.py
+++ b/daft/types.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 from dataclasses import dataclass
 from enum import Enum
+from typing import Hashable
 
 _NUMPY_AVAILABLE = True
 try:
@@ -114,7 +115,7 @@ class ExpressionType:
             return ExpressionType.python(list)
         elif pa.types.is_struct(datatype):
             return ExpressionType.python(dict)
-        if datatype not in _PYARROW_TYPE_TO_EXPRESSION_TYPE:
+        if not isinstance(datatype, Hashable) or datatype not in _PYARROW_TYPE_TO_EXPRESSION_TYPE:
             return ExpressionType.python_object()
         return _PYARROW_TYPE_TO_EXPRESSION_TYPE[datatype]
 


### PR DESCRIPTION
Adds an API to create a DataFrame from a Ray dataset. This is useful when using Daft together with Ray, to allow for analysis of experimental results (e.g. an output Dataset from running evaluation-during-training).