### PR TITLE
Fix size_bytes for logical types

### DIFF
--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -171,7 +171,7 @@ impl PySeries {
     }
 
     pub fn size_bytes(&self) -> PyResult<usize> {
-        Ok(self.series.size_bytes())
+        Ok(self.series.size_bytes()?)
     }
 
     pub fn name(&self) -> PyResult<String> {

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -181,7 +181,7 @@ impl PyTable {
     }
 
     pub fn size_bytes(&self) -> PyResult<usize> {
-        Ok(self.table.size_bytes())
+        Ok(self.table.size_bytes()?)
     }
 
     pub fn column_names(&self) -> PyResult<Vec<String>> {

--- a/src/series/ops/len.rs
+++ b/src/series/ops/len.rs
@@ -1,3 +1,4 @@
+use crate::error::DaftResult;
 use crate::{series::Series, with_match_comparable_daft_types};
 
 impl Series {
@@ -5,10 +6,12 @@ impl Series {
         self.data_array.len()
     }
 
-    pub fn size_bytes(&self) -> usize {
-        with_match_comparable_daft_types!(self.data_type(), |$T| {
-            let downcasted = self.downcast::<$T>().unwrap();
-            downcasted.size_bytes()
+    pub fn size_bytes(&self) -> DaftResult<usize> {
+        let s = self.as_physical()?;
+
+        with_match_comparable_daft_types!(s.data_type(), |$T| {
+            let downcasted = s.downcast::<$T>().unwrap();
+            Ok(downcasted.size_bytes())
         })
     }
 }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -131,8 +131,10 @@ impl Table {
         self.take(&indices.into_series())
     }
 
-    pub fn size_bytes(&self) -> usize {
-        self.columns.iter().map(|s| s.size_bytes()).sum::<usize>()
+    pub fn size_bytes(&self) -> DaftResult<usize> {
+        let column_sizes: DaftResult<Vec<usize>> =
+            self.columns.iter().map(|s| s.size_bytes()).collect();
+        Ok(column_sizes?.iter().sum())
     }
 
     pub fn filter(&self, predicate: &[Expr]) -> DaftResult<Self> {

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -447,6 +447,27 @@ def test_series_boolean_size_bytes(size) -> None:
     assert s.size_bytes() == data.nbytes
 
 
+@pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
+def test_series_date_size_bytes(size) -> None:
+    from datetime import date
+
+    pydata = [date(2023, 1, 1), date(2023, 1, 2), date(2023, 1, 3)]
+    data = pa.array(pydata)
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.date()
+    assert s.size_bytes() == data.nbytes
+
+    ## with nulls
+    if size > 0:
+        pydata = pydata[:-1] + [None]
+    data = pa.array(pydata, pa.date32())
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.date()
+    assert s.size_bytes() == data.nbytes
+
+
 @pytest.mark.parametrize("dtype", arrow_int_types + arrow_float_types)
 def test_series_numeric_abs(dtype) -> None:
     if pa.types.is_unsigned_integer(dtype):


### PR DESCRIPTION
* `.size_bytes` currently panics if run on logical types (e.g. dates)
* This PR fixes that behavior by first casting into a Physical type