### PR TITLE
Fix Series arithmetic naming logic

### DIFF
--- a/src/array/ops/arithmetic.rs
+++ b/src/array/ops/arithmetic.rs
@@ -60,6 +60,8 @@ where
             let opt_lhs = lhs.get(0);
             match opt_lhs {
                 None => Ok(DataArray::full_null(rhs.name(), rhs.len())),
+                // NOTE: naming logic here is wrong, and assigns the rhs name. However, renaming is handled at the Series level so this
+                // error is obfuscated.
                 Some(lhs) => rhs.apply(|rhs| operation(lhs, rhs)),
             }
         }

--- a/src/series/ops/arithmetic.rs
+++ b/src/series/ops/arithmetic.rs
@@ -22,7 +22,7 @@ macro_rules! impl_series_math_op {
                 with_match_numeric_daft_types!(lhs.data_type(), |$T| {
                     let lhs = lhs.downcast::<$T>()?;
                     let rhs = rhs.downcast::<$T>()?;
-                    Ok(lhs.$func_name(rhs)?.into_series())
+                    Ok(lhs.$func_name(rhs)?.into_series().rename(lhs.name()))
                 })
             }
         }
@@ -43,7 +43,7 @@ impl Add for &Series {
         with_match_numeric_and_utf_daft_types!(lhs.data_type(), |$T| {
             let lhs = lhs.downcast::<$T>()?;
             let rhs = rhs.downcast::<$T>()?;
-            Ok(lhs.add(rhs)?.into_series())
+            Ok(lhs.add(rhs)?.into_series().rename(lhs.name()))
         })
     }
 }
@@ -71,7 +71,8 @@ impl Div for &Series {
         Ok(lhs
             .downcast::<Float64Type>()?
             .div(rhs.downcast::<Float64Type>()?)?
-            .into_series())
+            .into_series()
+            .rename(lhs.name()))
     }
 }
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -275,7 +275,7 @@ impl Table {
         }?;
         if expected_field.name != series.field().name {
             return Err(DaftError::ComputeError(format!(
-                "Mismatch of expected expression name and name from computed series, {} vs {}",
+                "Mismatch of expected expression name and name from computed series ({} vs {}) for expression: {expr}",
                 expected_field.name,
                 series.field().name
             )));

--- a/tests/series/test_arithmetic.py
+++ b/tests/series/test_arithmetic.py
@@ -17,24 +17,28 @@ def test_arithmetic_numbers_array(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([1, 4, 1, 5, None, None])
 
-    l = Series.from_arrow(l_arrow.cast(l_dtype))
-    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    l = Series.from_arrow(l_arrow.cast(l_dtype), name="left")
+    r = Series.from_arrow(r_arrow.cast(r_dtype), name="right")
 
-    add = (l + r).to_pylist()
-    assert add == [2, 6, 4, None, None, None]
+    add = l + r
+    assert add.name() == l.name()
+    assert add.to_pylist() == [2, 6, 4, None, None, None]
 
     if pa.types.is_signed_integer(l_dtype) or pa.types.is_signed_integer(r_dtype):
         sub = (l - r).to_pylist()
         assert sub == [0, -2, 2, None, None, None]
 
-    mul = (l * r).to_pylist()
-    assert mul == [1, 8, 3, None, None, None]
+    mul = l * r
+    assert mul.name() == l.name()
+    assert mul.to_pylist() == [1, 8, 3, None, None, None]
 
-    div = (l / r).to_pylist()
-    assert div == [1.0, 0.5, 3.0, None, None, None]
+    div = l / r
+    assert div.name() == l.name()
+    assert div.to_pylist() == [1.0, 0.5, 3.0, None, None, None]
 
-    # mod = (l % r).to_pylist()
-    # assert mod == [0, 2, 0, None, None, None]
+    # mod = (l % r)
+    # assert mod.name() == l.name()
+    # assert mod.to_pylist() == [0, 2, 0, None, None, None]
 
 
 @pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
@@ -42,24 +46,29 @@ def test_arithmetic_numbers_left_scalar(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1])
     r_arrow = pa.array([1, 4, 1, 5, None, None])
 
-    l = Series.from_arrow(l_arrow.cast(l_dtype))
-    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    l = Series.from_arrow(l_arrow.cast(l_dtype), name="left")
+    r = Series.from_arrow(r_arrow.cast(r_dtype), name="right")
 
-    add = (l + r).to_pylist()
-    assert add == [2, 5, 2, 6, None, None]
+    add = l + r
+    assert add.name() == l.name()
+    assert add.to_pylist() == [2, 5, 2, 6, None, None]
 
     if pa.types.is_signed_integer(l_dtype) or pa.types.is_signed_integer(r_dtype):
-        sub = (l - r).to_pylist()
-        assert sub == [0, -3, 0, -4, None, None]
+        sub = l - r
+        assert sub.name() == l.name()
+        assert sub.to_pylist() == [0, -3, 0, -4, None, None]
 
-    mul = (l * r).to_pylist()
-    assert mul == [1, 4, 1, 5, None, None]
+    mul = l * r
+    assert mul.name() == l.name()
+    assert mul.to_pylist() == [1, 4, 1, 5, None, None]
 
-    div = (l / r).to_pylist()
-    assert div == [1.0, 0.25, 1.0, 0.2, None, None]
+    div = l / r
+    assert div.name() == l.name()
+    assert div.to_pylist() == [1.0, 0.25, 1.0, 0.2, None, None]
 
-    mod = (l % r).to_pylist()
-    assert mod == [0, 1, 0, 1, None, None]
+    mod = l % r
+    assert mod.name() == l.name()
+    assert mod.to_pylist() == [0, 1, 0, 1, None, None]
 
 
 @pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
@@ -67,24 +76,29 @@ def test_arithmetic_numbers_right_scalar(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([1])
 
-    l = Series.from_arrow(l_arrow.cast(l_dtype))
-    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    l = Series.from_arrow(l_arrow.cast(l_dtype), name="left")
+    r = Series.from_arrow(r_arrow.cast(r_dtype), name="right")
 
-    add = (l + r).to_pylist()
-    assert add == [2, 3, 4, None, 6, None]
+    add = l + r
+    assert add.name() == l.name()
+    assert add.to_pylist() == [2, 3, 4, None, 6, None]
 
     if pa.types.is_signed_integer(l_dtype) or pa.types.is_signed_integer(r_dtype):
-        sub = (l - r).to_pylist()
-        assert sub == [0, 1, 2, None, 4, None]
+        sub = l - r
+        assert sub.name() == l.name()
+        assert sub.to_pylist() == [0, 1, 2, None, 4, None]
 
-    mul = (l * r).to_pylist()
-    assert mul == [1, 2, 3, None, 5, None]
+    mul = l * r
+    assert mul.name() == l.name()
+    assert mul.to_pylist() == [1, 2, 3, None, 5, None]
 
-    div = (l / r).to_pylist()
-    assert div == [1.0, 2.0, 3.0, None, 5.0, None]
+    div = l / r
+    assert div.name() == l.name()
+    assert div.to_pylist() == [1.0, 2.0, 3.0, None, 5.0, None]
 
-    mod = (l % r).to_pylist()
-    assert mod == [0, 0, 0, None, 0, None]
+    mod = l % r
+    assert mod.name() == l.name()
+    assert mod.to_pylist() == [0, 0, 0, None, 0, None]
 
 
 @pytest.mark.parametrize("l_dtype, r_dtype", itertools.product(arrow_int_types + arrow_float_types, repeat=2))
@@ -92,24 +106,29 @@ def test_arithmetic_numbers_null_scalar(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([None], type=r_dtype)
 
-    l = Series.from_arrow(l_arrow.cast(l_dtype))
-    r = Series.from_arrow(r_arrow)
+    l = Series.from_arrow(l_arrow.cast(l_dtype), name="left")
+    r = Series.from_arrow(r_arrow, name="right")
 
-    add = (l + r).to_pylist()
-    assert add == [None, None, None, None, None, None]
+    add = l + r
+    assert add.name() == l.name()
+    assert add.to_pylist() == [None, None, None, None, None, None]
 
     if pa.types.is_signed_integer(l_dtype) or pa.types.is_signed_integer(r_dtype):
-        sub = (l - r).to_pylist()
-        assert sub == [None, None, None, None, None, None]
+        sub = l - r
+        assert sub.name() == l.name()
+        assert sub.to_pylist() == [None, None, None, None, None, None]
 
-    mul = (l * r).to_pylist()
-    assert mul == [None, None, None, None, None, None]
+    mul = l * r
+    assert mul.name() == l.name()
+    assert mul.to_pylist() == [None, None, None, None, None, None]
 
-    div = (l / r).to_pylist()
-    assert div == [None, None, None, None, None, None]
+    div = l / r
+    assert div.name() == l.name()
+    assert div.to_pylist() == [None, None, None, None, None, None]
 
-    mod = (l % r).to_pylist()
-    assert mod == [None, None, None, None, None, None]
+    mod = l % r
+    assert mod.name() == l.name()
+    assert mod.to_pylist() == [None, None, None, None, None, None]
 
 
 @pytest.mark.parametrize(
@@ -119,11 +138,12 @@ def test_add_for_int_and_string_array(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([1, 4, 1, 5, None, None])
 
-    l = Series.from_arrow(l_arrow.cast(l_dtype))
-    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    l = Series.from_arrow(l_arrow.cast(l_dtype), name="left")
+    r = Series.from_arrow(r_arrow.cast(r_dtype), name="right")
 
-    add = (l + r).to_pylist()
-    assert add == ["11", "24", "31", None, None, None]
+    add = l + r
+    assert add.name() == l.name()
+    assert add.to_pylist() == ["11", "24", "31", None, None, None]
 
 
 @pytest.mark.parametrize(
@@ -133,11 +153,12 @@ def test_add_for_int_and_string_left_scalar(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1])
     r_arrow = pa.array([1, 4, 1, 5, None, None])
 
-    l = Series.from_arrow(l_arrow.cast(l_dtype))
-    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    l = Series.from_arrow(l_arrow.cast(l_dtype), name="left")
+    r = Series.from_arrow(r_arrow.cast(r_dtype), name="right")
 
-    add = (l + r).to_pylist()
-    assert add == ["11", "14", "11", "15", None, None]
+    add = l + r
+    assert add.name() == l.name()
+    assert add.to_pylist() == ["11", "14", "11", "15", None, None]
 
 
 @pytest.mark.parametrize(
@@ -147,11 +168,12 @@ def test_add_for_int_and_string_right_scalar(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([1])
 
-    l = Series.from_arrow(l_arrow.cast(l_dtype))
-    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    l = Series.from_arrow(l_arrow.cast(l_dtype), name="left")
+    r = Series.from_arrow(r_arrow.cast(r_dtype), name="right")
 
-    add = (l + r).to_pylist()
-    assert add == ["11", "21", "31", None, "51", None]
+    add = l + r
+    assert add.name() == l.name()
+    assert add.to_pylist() == ["11", "21", "31", None, "51", None]
 
 
 @pytest.mark.parametrize(
@@ -161,17 +183,18 @@ def test_add_for_int_and_string_null_scalar(l_dtype, r_dtype) -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([None], type=pa.string())
 
-    l = Series.from_arrow(l_arrow.cast(l_dtype))
-    r = Series.from_arrow(r_arrow.cast(r_dtype))
+    l = Series.from_arrow(l_arrow.cast(l_dtype), name="left")
+    r = Series.from_arrow(r_arrow.cast(r_dtype), name="right")
 
-    add = (l + r).to_pylist()
-    assert add == [None, None, None, None, None, None]
+    add = l + r
+    assert add.name() == l.name()
+    assert add.to_pylist() == [None, None, None, None, None, None]
 
 
 def test_comparisons_bad_right_value() -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
 
-    l = Series.from_arrow(l_arrow)
+    l = Series.from_arrow(l_arrow, name="left")
     r = [1, 2, 3, None, 5, None]
 
     with pytest.raises(TypeError, match="another Series"):
@@ -194,8 +217,8 @@ def test_arithmetic_numbers_array_mismatch_length() -> None:
     l_arrow = pa.array([1, 2, 3, None, 5, None])
     r_arrow = pa.array([1, 4, 1, 5, None])
 
-    l = Series.from_arrow(l_arrow)
-    r = Series.from_arrow(r_arrow)
+    l = Series.from_arrow(l_arrow, name="left")
+    r = Series.from_arrow(r_arrow, name="right")
 
     with pytest.raises(ValueError, match="different lengths"):
         l + r


### PR DESCRIPTION
* When broadcasting, series arithmetic logic is wrong when assigning names to the resulting series
* In general, it seems to be a bad idea to have `name()` be an array-level attribute, because of the potential mismatch in naming logic between `to_field()` and `evaluate()`. This is just one example of a place where this may cause errors.