### PR TITLE
Expressions2: Count on NullArray returns 0

### DIFF
--- a/src/array/ops/count.rs
+++ b/src/array/ops/count.rs
@@ -14,10 +14,7 @@ where
 
     fn count(&self) -> Self::Output {
         let arrow_array = &self.data;
-        let count = match arrow_array.validity() {
-            None => arrow_array.len(),
-            Some(bitmap) => arrow_array.len() - bitmap.unset_bits(),
-        };
+        let count = arrow_array.len() - arrow_array.null_count();
         let result_arrow_array = arrow2::array::PrimitiveArray::from([Some(count as u64)]);
         DataArray::<UInt64Type>::new(
             Arc::new(Field::new(self.field.name.clone(), DataType::UInt64)),

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -328,15 +328,14 @@ def test_table_count(idx_dtype, case) -> None:
     assert res == expected
 
 
-@pytest.mark.parametrize("length", [1, 10])
+@pytest.mark.parametrize("length", [0, 1, 10])
 def test_table_count_nulltype(length) -> None:
-    """Count on NullType in Arrow counts the nulls (instead of ignoring them)."""
     daft_table = Table.from_pydict({"input": [None] * length})
     daft_table = daft_table.eval_expression_list([col("input").cast(DataType.null())])
     daft_table = daft_table.eval_expression_list([col("input").alias("count")._count()])
 
     res = daft_table.to_pydict()["count"]
-    assert res == [length]
+    assert res == [0]
 
 
 test_table_minmax_numerics_cases = [


### PR DESCRIPTION
Previous behaviour (returning length) was based on incorrect interpretation of arrow bitmap semantics.