### PR TITLE
Convert input arguments in if_else to Expressions

### DIFF
--- a/daft/expressions2/expressions.py
+++ b/daft/expressions2/expressions.py
@@ -198,6 +198,8 @@ class Expression:
         return Expression._from_pyexpr(expr)
 
     def if_else(self, if_true: Expression, if_false: Expression) -> Expression:
+        if_true = Expression._to_expression(if_true)
+        if_false = Expression._to_expression(if_false)
         return Expression._from_pyexpr(self._expr.if_else(if_true._expr, if_false._expr))
 
     def apply(self, func: Callable, return_dtype: DataType | None = None) -> Expression:


### PR DESCRIPTION
* `if_else` fails if the input arguments are literals
* This PR adds a fix by running `Expression._to_expression` on its inputs before running