### PR TITLE
Add optimization functions to expressions

### DIFF
--- a/daft/expressions2/expressions.py
+++ b/daft/expressions2/expressions.py
@@ -215,22 +215,6 @@ class Expression:
     def __repr__(self) -> builtins.str:
         return repr(self._expr)
 
-    def _input_mapping(self) -> builtins.str | None:
-        raise NotImplementedError(
-            "[RUST-INT][TPCH] Implement for checking if expression is a no-op and returning the input name it maps to if so"
-        )
-
-    def _required_columns(self) -> set[builtins.str]:
-        raise NotImplementedError("[RUST-INT][TPCH] Implement for getting required columns in an Expression")
-
-    def _is_column(self) -> bool:
-        raise NotImplementedError("[RUST-INT][TPCH] Implement for checking if this Expression is a Column")
-
-    def _replace_column_with_expression(self, column: builtins.str, new_expr: Expression) -> Expression:
-        raise NotImplementedError(
-            "[RUST-INT][TPCH] Implement replacing a Column with an Expression - used in optimizer"
-        )
-
     def _to_field(self, schema: Schema) -> Field:
         return Field._from_pyfield(self._expr.to_field(schema._schema))
 
@@ -240,6 +224,23 @@ class Expression:
     def __setstate__(self, state: bytes) -> None:
         self._expr = _PyExpr.__new__(_PyExpr)
         self._expr.__setstate__(state)
+
+    ###
+    # Helper methods required by optimizer:
+    # These should be removed from the Python API for Expressions when logical plans and optimizer are migrated to Rust
+    ###
+
+    def _input_mapping(self) -> builtins.str | None:
+        return self._expr._input_mapping()
+
+    def _required_columns(self) -> set[builtins.str]:
+        return self._expr._required_columns()
+
+    def _is_column(self) -> bool:
+        return self._expr._is_column()
+
+    def _replace_column_with_expression(self, column: builtins.str, new_expr: Expression) -> Expression:
+        return Expression._from_pyexpr(self._expr._replace_column_with_expression(column, new_expr._expr))
 
 
 SomeExpressionNamespace = TypeVar("SomeExpressionNamespace", bound="ExpressionNamespace")

--- a/src/dsl/mod.rs
+++ b/src/dsl/mod.rs
@@ -3,6 +3,7 @@ mod expr;
 mod lit;
 
 pub mod functions;
+pub mod optimization;
 pub use expr::binary_op;
 pub use expr::col;
 pub use expr::{AggExpr, Expr, Operator};

--- a/src/dsl/optimization.rs
+++ b/src/dsl/optimization.rs
@@ -1,0 +1,118 @@
+use super::expr::{AggExpr, Expr};
+
+pub fn get_required_columns(e: &Expr) -> Vec<String> {
+    // Returns all the column names required by this expression
+    match e {
+        Expr::Alias(child, _) => get_required_columns(child),
+        Expr::Agg(agg) => match agg {
+            AggExpr::Count(child) => get_required_columns(child),
+            AggExpr::Sum(child) => get_required_columns(child),
+            AggExpr::Mean(child) => get_required_columns(child),
+            AggExpr::Min(child) => get_required_columns(child),
+            AggExpr::Max(child) => get_required_columns(child),
+        },
+        Expr::BinaryOp { left, right, .. } => {
+            let mut req_cols = get_required_columns(left);
+            req_cols.extend(get_required_columns(right));
+            req_cols
+        }
+        Expr::Cast(child, _) => get_required_columns(child),
+        Expr::Column(name) => vec![name.to_string()],
+        Expr::Function { inputs, .. } => {
+            let child_required_columns: Vec<Vec<String>> =
+                inputs.iter().map(get_required_columns).collect();
+            child_required_columns.concat()
+        }
+        Expr::Not(child) => get_required_columns(child),
+        Expr::IsNull(child) => get_required_columns(child),
+        Expr::Literal(_) => vec![],
+        Expr::IfElse {
+            if_true,
+            if_false,
+            predicate,
+        } => {
+            let mut req_cols = get_required_columns(if_true);
+            req_cols.extend(get_required_columns(if_false));
+            req_cols.extend(get_required_columns(predicate));
+            req_cols
+        }
+    }
+}
+
+pub fn requires_computation(e: &Expr) -> bool {
+    // Returns whether or not this expression runs any computation on the underlying data
+    match e {
+        Expr::Alias(child, _) => requires_computation(child),
+        Expr::Column(..) | Expr::Literal(_) => false,
+        Expr::Agg(..)
+        | Expr::BinaryOp { .. }
+        | Expr::Cast(..)
+        | Expr::Function { .. }
+        | Expr::Not(..)
+        | Expr::IsNull(..)
+        | Expr::IfElse { .. } => true,
+    }
+}
+
+pub fn replace_column_with_expression(expr: &Expr, column_name: &str, new_expr: &Expr) -> Expr {
+    // Constructs a new deep-copied Expr which is `expr` but with all occurrences of Column(column_name) recursively
+    // replaced with `new_expr`
+    match expr {
+        // BASE CASE: found a matching column
+        Expr::Column(name) if name.as_ref().eq(column_name) => new_expr.clone(),
+
+        // BASE CASE: reached non-matching leaf node
+        Expr::Column(..) => expr.clone(),
+        Expr::Literal(_) => expr.clone(),
+
+        // RECURSIVE CASE: recursively replace for matching column
+        Expr::Alias(child, name) => Expr::Alias(
+            replace_column_with_expression(child, column_name, new_expr).into(),
+            (*name).clone(),
+        ),
+        Expr::Agg(agg) => match agg {
+            AggExpr::Count(child) => Expr::Agg(AggExpr::Count(
+                replace_column_with_expression(child, column_name, new_expr).into(),
+            )),
+            AggExpr::Sum(child) => Expr::Agg(AggExpr::Sum(
+                replace_column_with_expression(child, column_name, new_expr).into(),
+            )),
+            AggExpr::Mean(child) => Expr::Agg(AggExpr::Mean(
+                replace_column_with_expression(child, column_name, new_expr).into(),
+            )),
+            AggExpr::Min(child) => Expr::Agg(AggExpr::Min(
+                replace_column_with_expression(child, column_name, new_expr).into(),
+            )),
+            AggExpr::Max(child) => Expr::Agg(AggExpr::Max(
+                replace_column_with_expression(child, column_name, new_expr).into(),
+            )),
+        },
+        Expr::BinaryOp { left, right, op } => Expr::BinaryOp {
+            op: *op,
+            left: replace_column_with_expression(left, column_name, new_expr).into(),
+            right: replace_column_with_expression(right, column_name, new_expr).into(),
+        },
+        Expr::Cast(child, name) => Expr::Cast(
+            replace_column_with_expression(child, column_name, new_expr).into(),
+            (*name).clone(),
+        ),
+        Expr::Function { inputs, func } => Expr::Function {
+            func: func.clone(),
+            inputs: inputs
+                .iter()
+                .map(|e| replace_column_with_expression(e, column_name, new_expr))
+                .collect(),
+        },
+        Expr::Not(child) => replace_column_with_expression(child, column_name, new_expr),
+        Expr::IsNull(child) => replace_column_with_expression(child, column_name, new_expr),
+        Expr::IfElse {
+            if_true,
+            if_false,
+            predicate,
+        } => Expr::IfElse {
+            if_true: replace_column_with_expression(if_true, column_name, new_expr).into(),
+            if_false: replace_column_with_expression(if_false, column_name, new_expr).into(),
+            predicate: replace_column_with_expression(predicate, column_name, new_expr).into(),
+        },
+    }
+}

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -1,6 +1,8 @@
+use std::collections::HashSet;
+
 use super::field::PyField;
 use super::{datatype::PyDataType, schema::PySchema};
-use crate::dsl::{self, functions};
+use crate::dsl::{self, functions, optimization, Expr};
 use pyo3::{
     exceptions::PyValueError,
     prelude::*,
@@ -78,6 +80,37 @@ impl PyExpr {
                 args.len()
             ))),
         }
+    }
+
+    pub fn _input_mapping(&self) -> PyResult<Option<String>> {
+        let required_columns = optimization::get_required_columns(&self.expr);
+        let requires_computation = optimization::requires_computation(&self.expr);
+
+        // Return the required column only if:
+        //   1. There is only one required column
+        //   2. No computation is run on this required column
+        match (&required_columns[..], requires_computation) {
+            ([required_col], false) => Ok(Some(required_col.clone())),
+            _ => Ok(None),
+        }
+    }
+
+    pub fn _required_columns(&self) -> PyResult<HashSet<String>> {
+        let mut hs = HashSet::new();
+        for name in optimization::get_required_columns(&self.expr) {
+            hs.insert(name);
+        }
+        Ok(hs)
+    }
+
+    pub fn _is_column(&self) -> PyResult<bool> {
+        Ok(matches!(self.expr, Expr::Column(..)))
+    }
+
+    pub fn _replace_column_with_expression(&self, column: &str, new_expr: &Self) -> PyResult<Self> {
+        Ok(PyExpr {
+            expr: optimization::replace_column_with_expression(&self.expr, column, &new_expr.expr),
+        })
     }
 
     pub fn alias(&self, name: &str) -> PyResult<Self> {


### PR DESCRIPTION
* Implements expression methods that are used during query optimization
* It's a little annoying that we have to define logic to reconstruct every expression every single time. One possible optimization that can be made here is if we have each expression define a `.to_children` method which will return an ordered Vec of its children, and a `.from_children` which takes as input an ordered Vec of modified children. But that optimization is left as an exercise for another PR.
* Testing is performed in `tests/optimizer`, but does not run on `main` because `expressions2` is not yet integrated with main. All optimizer tests pass on our Rust integration branch.