### PR TITLE
Fix Ray compatibility tests

### DIFF
--- a/daft/runners/blocks.py
+++ b/daft/runners/blocks.py
@@ -567,18 +567,6 @@ def _should_truncate_chunk(arr: pa.Array) -> bool:
     return arr.get_total_buffer_size() > (arr.nbytes * 1.1)
 
 
-def _get_arrow_array_estimated_nbytes(arr: pa.Array) -> float:
-    """Returns the estimated number of bytes required to represent all elements of this Array
-
-    Unfortunately, `pa.Array.nbytes` was only introduced in Arrow>=7.0.0, and prior to that its behavior was
-    actually the behavior of the API `pa.Array.get_total_buffer_size()` that was introduced in Arrow 7.0.0.
-
-    To ensure consistent behavior across Arrow versions, we implement our own estimated_nbytes API here. This is
-    a very
-    """
-    return ((arr.type.bit_width) / 8) * len(arr)
-
-
 class ArrowDataBlock(DataBlock[ArrowArrType]):
     def __init__(self, data: ArrowArrType) -> None:
         assert not pa.types.is_nested(

--- a/tests/ray/test_datasets.py
+++ b/tests/ray/test_datasets.py
@@ -97,9 +97,7 @@ def test_ray_dataset_with_numpy(n_partitions: int):
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset(n_partitions: int):
     ds = ray.data.range(8)
-    ds = ds.map(lambda i: {"int": i, "np": np.ones((3, 3)), "np_variable": np.ones((i + 1, 3))}).repartition(
-        n_partitions
-    )
+    ds = ds.map(lambda i: {"int": i, "np": np.ones((3, 3))}).repartition(n_partitions)
 
     df = DataFrame.from_ray_dataset(ds)
     np.testing.assert_equal(
@@ -107,6 +105,5 @@ def test_from_ray_dataset(n_partitions: int):
         {
             "int": list(range(8)),
             "np": [np.ones((3, 3)) for i in range(8)],
-            "np_variable": [np.ones((i + 1, 3)) for i in range(8)],
         },
     )

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -15,6 +15,9 @@ arrow_string_types = [pa.string(), pa.large_string()]
 arrow_float_types = [pa.float32(), pa.float64()]
 
 
+PYARROW_GE_7_0_0 = tuple(int(s) for s in pa.__version__.split(".")) >= (7, 0, 0)
+
+
 def test_series_arrow_array_round_trip() -> None:
     arrow = pa.array([1, 2, 3, None, 5, None])
     s = Series.from_arrow(arrow)
@@ -381,6 +384,10 @@ def test_series_boolean_sorting() -> None:
     assert taken.to_pylist() == sorted_order[::-1]
 
 
+@pytest.mark.skipif(
+    not PYARROW_GE_7_0_0,
+    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
+)
 @pytest.mark.parametrize("dtype, size", itertools.product(arrow_int_types + arrow_float_types, [0, 1, 2, 8, 9, 16]))
 def test_series_numeric_size_bytes(dtype, size) -> None:
     pydata = list(range(size))
@@ -402,6 +409,10 @@ def test_series_numeric_size_bytes(dtype, size) -> None:
     assert s.size_bytes() == data.nbytes
 
 
+@pytest.mark.skipif(
+    not PYARROW_GE_7_0_0,
+    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
+)
 @pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
 def test_series_string_size_bytes(size) -> None:
 
@@ -424,6 +435,10 @@ def test_series_string_size_bytes(size) -> None:
     assert s.size_bytes() == data.nbytes
 
 
+@pytest.mark.skipif(
+    not PYARROW_GE_7_0_0,
+    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
+)
 @pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
 def test_series_boolean_size_bytes(size) -> None:
 
@@ -447,6 +462,10 @@ def test_series_boolean_size_bytes(size) -> None:
     assert s.size_bytes() == data.nbytes
 
 
+@pytest.mark.skipif(
+    not PYARROW_GE_7_0_0,
+    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
+)
 @pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
 def test_series_date_size_bytes(size) -> None:
     from datetime import date


### PR DESCRIPTION
Ray compatibility tests are breaking due to multiple reasons which are fixed in this PR

1. Recent changes to our Ray Dataset integrations are incompatible with older versions of Ray, specifially around the Ray Dataset's ArrowTensor type, which does not seem to work for tensors of differing shapes prior to v2.2.0
2. The `Dataset.dataset_format()` API which we use in our unit tests was only made public in Ray versions >2.2.0
3. PyArrow `Array.nbytes` has differing behavior from v0.0.7 onwards. We rely on the new behavior for Series unit tests, so those tests have to be skipped when we are on PyArrow <0.0.7, which is the case for Ray <2.2.0 that has the PyArrow dependency pinned