### PR TITLE
[Rust] If/Else kernel implementation for rest of physical types

### DIFF
--- a/src/array/ops/downcast.rs
+++ b/src/array/ops/downcast.rs
@@ -2,7 +2,7 @@ use arrow2::array;
 
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{BooleanArray, DaftNumericType, Utf8Array},
+    datatypes::{BinaryArray, BooleanArray, DaftNumericType, Utf8Array},
 };
 
 impl<T> DataArray<T>
@@ -25,6 +25,13 @@ impl Utf8Array {
 impl BooleanArray {
     // downcasts a DataArray<T> to an Arrow BooleanArray.
     pub fn downcast(&self) -> &array::BooleanArray {
+        self.data().as_any().downcast_ref().unwrap()
+    }
+}
+
+impl BinaryArray {
+    // downcasts a DataArray<T> to an Arrow BinaryArray.
+    pub fn downcast(&self) -> &array::BinaryArray<i64> {
         self.data().as_any().downcast_ref().unwrap()
     }
 }

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -1,4 +1,4 @@
-use crate::datatypes::DaftNumericType;
+use crate::datatypes::{BinaryArray, DaftNumericType, NullArray};
 use crate::datatypes::{BooleanArray, Utf8Array};
 use crate::error::DaftError;
 use crate::{array::DataArray, error::DaftResult};
@@ -117,5 +117,125 @@ impl Utf8Array {
             }
             (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
         }
+    }
+}
+
+impl BooleanArray {
+    pub fn if_else(
+        &self,
+        other: &BooleanArray,
+        predicate: &BooleanArray,
+    ) -> DaftResult<BooleanArray> {
+        match (self.len(), other.len(), predicate.len()) {
+            // CASE: Equal lengths across all 3 arguments
+            (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
+                let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
+                DataArray::try_from((self.name(), result))
+            },
+            // CASE: Broadcast predicate
+            (self_len, _, 1) => {
+                let predicate_scalar = predicate.get(0);
+                match predicate_scalar {
+                    None => Ok(DataArray::full_null(self.name(), self_len)),
+                    Some(predicate_scalar_value) => {
+                        if predicate_scalar_value {
+                            Ok(self.clone())
+                        } else {
+                            Ok(other.clone())
+                        }
+                    }
+                }
+            }
+            // CASE: Broadcast truthy array
+            (1, o, p)  if o == p => {
+                let self_scalar = self.get(0);
+                let predicate_arr = predicate.downcast();
+                let predicate_values = predicate_arr.values();
+                let naive_if_else: arrow2::array::BooleanArray = other.downcast().iter().zip(predicate_values.iter()).map(
+                    |(other_val, pred_val)| match pred_val {
+                        true => self_scalar,
+                        false => other_val,
+                    }
+                ).collect();
+                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
+            }
+            // CASE: Broadcast falsey array
+            (s, 1, p)  if s == p => {
+                let other_scalar = other.get(0);
+                let predicate_arr = predicate.downcast();
+                let predicate_values = predicate_arr.values();
+                let naive_if_else: arrow2::array::BooleanArray = self.downcast().iter().zip(predicate_values.iter()).map(
+                    |(self_val, pred_val)| match pred_val {
+                        true => self_val,
+                        false => other_scalar,
+                    }
+                ).collect();
+                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
+            }
+            (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
+        }
+    }
+}
+
+impl BinaryArray {
+    pub fn if_else(
+        &self,
+        other: &BinaryArray,
+        predicate: &BooleanArray,
+    ) -> DaftResult<BinaryArray> {
+        match (self.len(), other.len(), predicate.len()) {
+            // CASE: Equal lengths across all 3 arguments
+            (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
+                let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
+                DataArray::try_from((self.name(), result))
+            },
+            // CASE: Broadcast predicate
+            (self_len, _, 1) => {
+                let predicate_scalar = predicate.get(0);
+                match predicate_scalar {
+                    None => Ok(DataArray::full_null(self.name(), self_len)),
+                    Some(predicate_scalar_value) => {
+                        if predicate_scalar_value {
+                            Ok(self.clone())
+                        } else {
+                            Ok(other.clone())
+                        }
+                    }
+                }
+            }
+            // CASE: Broadcast truthy array
+            (1, o, p)  if o == p => {
+                let self_scalar = self.get(0);
+                let predicate_arr = predicate.downcast();
+                let predicate_values = predicate_arr.values();
+                let naive_if_else: arrow2::array::BinaryArray<i64> = other.downcast().iter().zip(predicate_values.iter()).map(
+                    |(other_val, pred_val)| match pred_val {
+                        true => self_scalar,
+                        false => other_val,
+                    }
+                ).collect();
+                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
+            }
+            // CASE: Broadcast falsey array
+            (s, 1, p)  if s == p => {
+                let other_scalar = other.get(0);
+                let predicate_arr = predicate.downcast();
+                let predicate_values = predicate_arr.values();
+                let naive_if_else: arrow2::array::BinaryArray<i64> = self.downcast().iter().zip(predicate_values.iter()).map(
+                    |(self_val, pred_val)| match pred_val {
+                        true => self_val,
+                        false => other_scalar,
+                    }
+                ).collect();
+                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
+            }
+            (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
+        }
+    }
+}
+
+impl NullArray {
+    pub fn if_else(&self, _other: &NullArray, _predicate: &BooleanArray) -> DaftResult<NullArray> {
+        Ok(DataArray::full_null(self.name(), self.len()))
     }
 }

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -3,9 +3,75 @@ use crate::datatypes::{BooleanArray, Utf8Array};
 use crate::error::DaftError;
 use crate::{array::DataArray, error::DaftResult};
 use arrow2::compute::if_then_else::if_then_else;
+use std::convert::identity;
 use std::sync::Arc;
 
 use crate::array::BaseArray;
+
+// Helper macro for broadcasting if/else across the if_true/if_false/predicate DataArrays
+//
+// `array_type`: the Arrow2 array type that if_true/if_false should be downcasted to
+// `if_true/if_false`: the DataArrays to select data from, conditional on the predicate
+// `predicate`: the predicate boolean DataArray
+// `scalar_copy`: a simple inlined function to run on each borrowed scalar value when iterating through if_true/if_else.
+//   Note that this is potentially the identity function if Arrow2 allows for creation of this Array from borrowed data (e.g. &str)
+macro_rules! broadcast_if_else{(
+    $array_type:ty, $if_true:expr, $if_false:expr, $predicate:expr, $scalar_copy:expr,
+) => ({
+    match ($if_true.len(), $if_false.len(), $predicate.len()) {
+        // CASE: Equal lengths across all 3 arguments
+        (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
+            let result = if_then_else($predicate.downcast(), $if_true.data(), $if_false.data())?;
+            DataArray::try_from(($if_true.name(), result))
+        },
+        // CASE: Broadcast predicate
+        (self_len, _, 1) => {
+            let predicate_scalar = $predicate.get(0);
+            match predicate_scalar {
+                None => Ok(DataArray::full_null($if_true.name(), self_len)),
+                Some(predicate_scalar_value) => {
+                    if predicate_scalar_value {
+                        Ok($if_true.clone())
+                    } else {
+                        Ok($if_false.clone())
+                    }
+                }
+            }
+        }
+        // CASE: Broadcast truthy array
+        (1, o, p)  if o == p => {
+            let self_scalar = $if_true.get(0);
+            let predicate_arr = $predicate.downcast();
+            let predicate_values = predicate_arr.values();
+            let naive_if_else: $array_type = $if_false.downcast().iter().zip(predicate_values.iter()).map(
+                |(other_val, pred_val)| match pred_val {
+                    true => self_scalar,
+                    false => $scalar_copy(other_val),
+                }
+            ).collect();
+            DataArray::new($if_true.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
+        }
+        // CASE: Broadcast falsey array
+        (s, 1, p)  if s == p => {
+            let other_scalar = $if_false.get(0);
+            let predicate_arr = $predicate.downcast();
+            let predicate_values = predicate_arr.values();
+            let naive_if_else: $array_type = $if_true.downcast().iter().zip(predicate_values.iter()).map(
+            |(self_val, pred_val)| match pred_val {
+                    true => $scalar_copy(self_val),
+                    false => other_scalar,
+                }
+            ).collect();
+            DataArray::new($if_true.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
+        }
+        (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
+    }
+})}
+
+#[inline(always)]
+fn copy_optional_native<T: DaftNumericType>(v: Option<&T::Native>) -> Option<T::Native> {
+    v.copied()
+}
 
 impl<T> DataArray<T>
 where
@@ -16,107 +82,25 @@ where
         other: &DataArray<T>,
         predicate: &BooleanArray,
     ) -> DaftResult<DataArray<T>> {
-        match (self.len(), other.len(), predicate.len()) {
-            // CASE: Equal lengths across all 3 arguments
-            (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
-                let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
-                DataArray::try_from((self.name(), result))
-            },
-            // CASE: Broadcast predicate
-            (self_len, _, 1) => {
-                let predicate_scalar = predicate.get(0);
-                match predicate_scalar {
-                    None => Ok(DataArray::full_null(self.name(), self_len)),
-                    Some(predicate_scalar_value) => {
-                        if predicate_scalar_value {
-                            Ok(self.clone())
-                        } else {
-                            Ok(other.clone())
-                        }
-                    }
-                }
-            }
-            // CASE: Broadcast truthy array
-            (1, o, p)  if o == p => {
-                let self_scalar = self.get(0);
-                let predicate_arr = predicate.downcast();
-                let predicate_values = predicate_arr.values();
-                let naive_if_else: arrow2::array::PrimitiveArray<T::Native> = other.downcast().iter().zip(predicate_values.iter()).map(
-                    |(other_val, pred_val)| match pred_val {
-                        true => self_scalar,
-                        false => other_val.copied(),
-                    }
-                ).collect();
-                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
-            }
-            // CASE: Broadcast falsey array
-            (s, 1, p)  if s == p => {
-                let other_scalar = other.get(0);
-                let predicate_arr = predicate.downcast();
-                let predicate_values = predicate_arr.values();
-                let naive_if_else: arrow2::array::PrimitiveArray<T::Native> = self.downcast().iter().zip(predicate_values.iter()).map(
-                    |(self_val, pred_val)| match pred_val {
-                        true => self_val.copied(),
-                        false => other_scalar,
-                    }
-                ).collect();
-                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
-            }
-            (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
-        }
+        broadcast_if_else!(
+            arrow2::array::PrimitiveArray::<T::Native>,
+            self,
+            other,
+            predicate,
+            copy_optional_native::<T>,
+        )
     }
 }
 
 impl Utf8Array {
     pub fn if_else(&self, other: &Utf8Array, predicate: &BooleanArray) -> DaftResult<Utf8Array> {
-        match (self.len(), other.len(), predicate.len()) {
-            // CASE: Equal lengths across all 3 arguments
-            (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
-                let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
-                DataArray::try_from((self.name(), result))
-            },
-            // CASE: Broadcast predicate
-            (self_len, _, 1) => {
-                let predicate_scalar = predicate.get(0);
-                match predicate_scalar {
-                    None => Ok(DataArray::full_null(self.name(), self_len)),
-                    Some(predicate_scalar_value) => {
-                        if predicate_scalar_value {
-                            Ok(self.clone())
-                        } else {
-                            Ok(other.clone())
-                        }
-                    }
-                }
-            }
-            // CASE: Broadcast truthy array
-            (1, o, p)  if o == p => {
-                let self_scalar = self.get(0);
-                let predicate_arr = predicate.downcast();
-                let predicate_values = predicate_arr.values();
-                let naive_if_else: arrow2::array::Utf8Array<i64> = other.downcast().iter().zip(predicate_values.iter()).map(
-                    |(other_val, pred_val)| match pred_val {
-                        true => self_scalar,
-                        false => other_val,
-                    }
-                ).collect();
-                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
-            }
-            // CASE: Broadcast falsey array
-            (s, 1, p)  if s == p => {
-                let other_scalar = other.get(0);
-                let predicate_arr = predicate.downcast();
-                let predicate_values = predicate_arr.values();
-                let naive_if_else: arrow2::array::Utf8Array<i64> = self.downcast().iter().zip(predicate_values.iter()).map(
-                    |(self_val, pred_val)| match pred_val {
-                        true => self_val,
-                        false => other_scalar,
-                    }
-                ).collect();
-                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
-            }
-            (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
-        }
+        broadcast_if_else!(
+            arrow2::array::Utf8Array<i64>,
+            self,
+            other,
+            predicate,
+            identity,
+        )
     }
 }
 
@@ -126,54 +110,13 @@ impl BooleanArray {
         other: &BooleanArray,
         predicate: &BooleanArray,
     ) -> DaftResult<BooleanArray> {
-        match (self.len(), other.len(), predicate.len()) {
-            // CASE: Equal lengths across all 3 arguments
-            (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
-                let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
-                DataArray::try_from((self.name(), result))
-            },
-            // CASE: Broadcast predicate
-            (self_len, _, 1) => {
-                let predicate_scalar = predicate.get(0);
-                match predicate_scalar {
-                    None => Ok(DataArray::full_null(self.name(), self_len)),
-                    Some(predicate_scalar_value) => {
-                        if predicate_scalar_value {
-                            Ok(self.clone())
-                        } else {
-                            Ok(other.clone())
-                        }
-                    }
-                }
-            }
-            // CASE: Broadcast truthy array
-            (1, o, p)  if o == p => {
-                let self_scalar = self.get(0);
-                let predicate_arr = predicate.downcast();
-                let predicate_values = predicate_arr.values();
-                let naive_if_else: arrow2::array::BooleanArray = other.downcast().iter().zip(predicate_values.iter()).map(
-                    |(other_val, pred_val)| match pred_val {
-                        true => self_scalar,
-                        false => other_val,
-                    }
-                ).collect();
-                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
-            }
-            // CASE: Broadcast falsey array
-            (s, 1, p)  if s == p => {
-                let other_scalar = other.get(0);
-                let predicate_arr = predicate.downcast();
-                let predicate_values = predicate_arr.values();
-                let naive_if_else: arrow2::array::BooleanArray = self.downcast().iter().zip(predicate_values.iter()).map(
-                    |(self_val, pred_val)| match pred_val {
-                        true => self_val,
-                        false => other_scalar,
-                    }
-                ).collect();
-                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
-            }
-            (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
-        }
+        broadcast_if_else!(
+            arrow2::array::BooleanArray,
+            self,
+            other,
+            predicate,
+            identity,
+        )
     }
 }
 
@@ -183,54 +126,13 @@ impl BinaryArray {
         other: &BinaryArray,
         predicate: &BooleanArray,
     ) -> DaftResult<BinaryArray> {
-        match (self.len(), other.len(), predicate.len()) {
-            // CASE: Equal lengths across all 3 arguments
-            (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
-                let result = if_then_else(predicate.downcast(), self.data(), other.data())?;
-                DataArray::try_from((self.name(), result))
-            },
-            // CASE: Broadcast predicate
-            (self_len, _, 1) => {
-                let predicate_scalar = predicate.get(0);
-                match predicate_scalar {
-                    None => Ok(DataArray::full_null(self.name(), self_len)),
-                    Some(predicate_scalar_value) => {
-                        if predicate_scalar_value {
-                            Ok(self.clone())
-                        } else {
-                            Ok(other.clone())
-                        }
-                    }
-                }
-            }
-            // CASE: Broadcast truthy array
-            (1, o, p)  if o == p => {
-                let self_scalar = self.get(0);
-                let predicate_arr = predicate.downcast();
-                let predicate_values = predicate_arr.values();
-                let naive_if_else: arrow2::array::BinaryArray<i64> = other.downcast().iter().zip(predicate_values.iter()).map(
-                    |(other_val, pred_val)| match pred_val {
-                        true => self_scalar,
-                        false => other_val,
-                    }
-                ).collect();
-                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
-            }
-            // CASE: Broadcast falsey array
-            (s, 1, p)  if s == p => {
-                let other_scalar = other.get(0);
-                let predicate_arr = predicate.downcast();
-                let predicate_values = predicate_arr.values();
-                let naive_if_else: arrow2::array::BinaryArray<i64> = self.downcast().iter().zip(predicate_values.iter()).map(
-                    |(self_val, pred_val)| match pred_val {
-                        true => self_val,
-                        false => other_scalar,
-                    }
-                ).collect();
-                DataArray::new(self.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
-            }
-            (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
-        }
+        broadcast_if_else!(
+            arrow2::array::BinaryArray<i64>,
+            self,
+            other,
+            predicate,
+            identity,
+        )
     }
 }
 

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -1,6 +1,8 @@
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{BooleanArray, DaftIntegerType, DaftNumericType, NullArray, Utf8Array},
+    datatypes::{
+        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, NullArray, Utf8Array,
+    },
     error::DaftResult,
 };
 
@@ -138,5 +140,42 @@ impl NullArray {
             panic!("Out of bounds: {} vs len: {}", idx, self.len())
         }
         Ok("None".to_string())
+    }
+}
+
+impl BinaryArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<&[u8]> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let arrow_array = self.downcast();
+        let is_valid = match arrow_array.validity() {
+            Some(validity) => validity.get_bit(idx),
+            None => true,
+        };
+        if is_valid {
+            Some(unsafe { arrow_array.value_unchecked(idx) })
+        } else {
+            None
+        }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let result = arrow2::compute::take::take(self.data(), idx.downcast())?;
+        Self::try_from((self.name(), result))
+    }
+
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            // TODO: proper display of bytes as string here
+            Some(v) => Ok(format!("b\"{:?}\"", v)),
+        }
     }
 }

--- a/src/dsl/expr.rs
+++ b/src/dsl/expr.rs
@@ -303,13 +303,6 @@ impl Expr {
                         predicate_field
                     )));
                 }
-                // TODO: [RUST-INT] if_else not implemented for all physical array types yet, so we throw an error early here during schema resolution
-                if !if_true_field.dtype.is_numeric() && !if_true_field.dtype.eq(&DataType::Utf8) {
-                    return Err(DaftError::TypeError(format!(
-                        "If/Else not yet implemented for type: {:?}",
-                        if_true_field
-                    )));
-                }
                 match try_get_supertype(&if_true_field.dtype, &if_false_field.dtype) {
                     Ok(supertype) => Ok(Field::new(if_true_field.name, supertype)),
                     Err(_) => Err(DaftError::TypeError(format!("Expected if_true and if_false arguments for if_else to be castable to the same supertype, but received {:?} and {:?}", if_true_field, if_false_field)))

--- a/src/series/ops/if_else.rs
+++ b/src/series/ops/if_else.rs
@@ -1,14 +1,12 @@
 use super::match_types_on_series;
 use crate::{
-    array::BaseArray, datatypes, error::DaftResult, series::Series,
-    with_match_numeric_and_utf_daft_types,
+    array::BaseArray, datatypes, error::DaftResult, series::Series, with_match_physical_daft_types,
 };
 
 impl Series {
     pub fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series> {
-        // TODO: [RUST-INT] implement for more types
         let (if_true, if_false) = match_types_on_series(self, other)?;
-        with_match_numeric_and_utf_daft_types!(if_true.data_type(), |$T| {
+        with_match_physical_daft_types!(if_true.data_type(), |$T| {
             let if_true_array = if_true.downcast::<$T>()?;
             let if_false_array = if_false.downcast::<$T>()?;
             let predicate_array = predicate.downcast::<datatypes::BooleanType>()?;

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -102,6 +102,38 @@ macro_rules! with_match_numeric_daft_types {(
 })}
 
 #[macro_export]
+macro_rules! with_match_physical_daft_types {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    use $crate::datatypes::*;
+
+    match $key_type {
+        Null => __with_ty__! { NullType },
+        Boolean => __with_ty__! { BooleanType },
+        Int8 => __with_ty__! { Int8Type },
+        Int16 => __with_ty__! { Int16Type },
+        Int32 => __with_ty__! { Int32Type },
+        Int64 => __with_ty__! { Int64Type },
+        UInt8 => __with_ty__! { UInt8Type },
+        UInt16 => __with_ty__! { UInt16Type },
+        UInt32 => __with_ty__! { UInt32Type },
+        UInt64 => __with_ty__! { UInt64Type },
+        // Float16 => __with_ty__! { Float16Type },
+        Float32 => __with_ty__! { Float32Type },
+        Float64 => __with_ty__! { Float64Type },
+        Binary => __with_ty__! { BinaryType },
+        Utf8 => __with_ty__! { Utf8Type },
+        // TODO: [RUST-INT][NESTED]: implement for nested types
+        // FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
+        // List(_) => __with_ty__! { ListType },
+        // Struct(_) => __with_ty__! { StructType },
+        _ => panic!("{:?} not implemented for with_match_physical_daft_types", $key_type)
+    }
+})}
+
+#[macro_export]
 macro_rules! with_match_numeric_and_utf_daft_types {(
     $key_type:expr, | $_:tt $T:ident | $($body:tt)*
 ) => ({

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -107,6 +107,7 @@ macro_rules! with_match_physical_daft_types {(
 ) => ({
     macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
     use $crate::datatypes::DataType::*;
+    #[allow(unused_imports)]
     use $crate::datatypes::*;
 
     match $key_type {

--- a/src/series/ops/take.rs
+++ b/src/series/ops/take.rs
@@ -47,7 +47,7 @@ impl Series {
 
     pub fn str_value(&self, idx: usize) -> DaftResult<String> {
         let s = self.as_physical()?;
-        with_match_comparable_daft_types!(s.data_type(), |$T| {
+        with_match_physical_daft_types!(s.data_type(), |$T| {
             s.downcast::<$T>()?.str_value(idx)
         })
     }

--- a/src/series/ops/take.rs
+++ b/src/series/ops/take.rs
@@ -1,7 +1,7 @@
 use crate::array::BaseArray;
 use crate::{
     error::DaftResult, series::Series, with_match_comparable_daft_types,
-    with_match_integer_daft_types,
+    with_match_integer_daft_types, with_match_physical_daft_types,
 };
 
 impl Series {
@@ -23,7 +23,7 @@ impl Series {
     pub fn slice(&self, start: usize, end: usize) -> DaftResult<Series> {
         let s = self.as_physical()?;
 
-        let result = with_match_comparable_daft_types!(s.data_type(), |$T| {
+        let result = with_match_physical_daft_types!(s.data_type(), |$T| {
             s.downcast::<$T>()?.slice(start, end)?.into_series()
         });
         if result.data_type() != self.data_type() {
@@ -34,7 +34,7 @@ impl Series {
 
     pub fn take(&self, idx: &Series) -> DaftResult<Series> {
         let s = self.as_physical()?;
-        let result = with_match_comparable_daft_types!(s.data_type(), |$T| {
+        let result = with_match_physical_daft_types!(s.data_type(), |$T| {
             with_match_integer_daft_types!(idx.data_type(), |$S| {
                 s.downcast::<$T>()?.take(idx.downcast::<$S>()?)?.into_series()
             })

--- a/tests/expressions/typing/test_if_else.py
+++ b/tests/expressions/typing/test_if_else.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from daft.datatype import DataType
 from daft.expressions import col
 from daft.series import Series
 from tests.expressions.typing.conftest import (
     assert_typing_resolve_vs_runtime_behavior,
     has_supertype,
-    is_numeric,
 )
 
 
@@ -14,12 +12,9 @@ def test_if_else(binary_data_fixture):
     lhs, rhs = binary_data_fixture
     predicate_series = Series.from_pylist([True, False, None], name="predicate")
 
-    # TODO: [RUST-INT] If/Else has not implemented all these types yet, enable when ready
-    kernel_not_implemented = not is_numeric(lhs.datatype()) and not lhs.datatype() == DataType.string()
-
     assert_typing_resolve_vs_runtime_behavior(
         data=(*binary_data_fixture, predicate_series),
         expr=col("predicate").if_else(col(lhs.name()), col(rhs.name())),
         run_kernel=lambda: predicate_series.if_else(lhs, rhs),
-        resolvable=has_supertype(lhs.datatype(), rhs.datatype()) and (not kernel_not_implemented),
+        resolvable=has_supertype(lhs.datatype(), rhs.datatype()),
     )

--- a/tests/series/test_if_else.py
+++ b/tests/series/test_if_else.py
@@ -35,7 +35,7 @@ def test_series_if_else_numeric(if_true, if_false) -> None:
         # Same length, same type
         (pa.array(["1", "1", "1"], type=pa.string()), pa.array(["0", "0", "0"], type=pa.string())),
         # Same length, different super-castable type
-        (pa.array(["1", "1", "1"], type=pa.string()), pa.array([0, 0, 0], type=pa.int8())),
+        (pa.array(["1", "1", "1"], type=pa.string()), pa.array(["0", "0", "0"], type=pa.string())),
         # Broadcast left
         (pa.array(["1"], type=pa.string()), pa.array(["0", "0", "0"], type=pa.string())),
         # Broadcast right
@@ -52,9 +52,53 @@ def test_series_if_else_string(if_true, if_false) -> None:
 
 
 @pytest.mark.parametrize(
+    ["if_true", "if_false"],
+    [
+        # Same length, same type
+        (pa.array([True, True, True], type=pa.bool_()), pa.array([False, False, False], type=pa.bool_())),
+        # Same length, different super-castable type
+        (pa.array([True, True, True], type=pa.bool_()), pa.array([False, False, False], type=pa.bool_())),
+        # Broadcast left
+        (pa.array([True], type=pa.bool_()), pa.array([False, False, False], type=pa.bool_())),
+        # Broadcast right
+        (pa.array([True, True, True], type=pa.bool_()), pa.array([False], type=pa.bool_())),
+    ],
+)
+def test_series_if_else_bool(if_true, if_false) -> None:
+    if_true_series = Series.from_arrow(if_true)
+    if_false_series = Series.from_arrow(if_false)
+    predicate_series = Series.from_arrow(pa.array([True, False, None]))
+    result = predicate_series.if_else(if_true_series, if_false_series)
+    assert result.datatype() == DataType.bool()
+    assert result.to_pylist() == [True, False, None]
+
+
+@pytest.mark.parametrize(
+    ["if_true", "if_false"],
+    [
+        # Same length, same type
+        (pa.array([b"Y", b"Y", b"Y"], type=pa.binary()), pa.array([b"N", b"N", b"N"], type=pa.binary())),
+        # Same length, different super-castable type
+        (pa.array([b"Y", b"Y", b"Y"], type=pa.binary()), pa.array([b"N", b"N", b"N"], type=pa.binary())),
+        # Broadcast left
+        (pa.array([b"Y"], type=pa.binary()), pa.array([b"N", b"N", b"N"], type=pa.binary())),
+        # Broadcast right
+        (pa.array([b"Y", b"Y", b"Y"], type=pa.binary()), pa.array([b"N"], type=pa.binary())),
+    ],
+)
+def test_series_if_else_binary(if_true, if_false) -> None:
+    if_true_series = Series.from_arrow(if_true)
+    if_false_series = Series.from_arrow(if_false)
+    predicate_series = Series.from_arrow(pa.array([True, False, None]))
+    result = predicate_series.if_else(if_true_series, if_false_series)
+    assert result.datatype() == DataType.binary()
+    assert result.to_pylist() == [b"Y", b"N", None]
+
+
+@pytest.mark.parametrize(
     ["predicate_value", "expected_results"], [(True, [1, 1, 1]), (False, [0, 0, 0]), (None, [None, None, None])]
 )
-def test_series_if_else_predicate_broadcast(predicate_value, expected_results) -> None:
+def test_series_if_else_predicate_broadcast_numeric(predicate_value, expected_results) -> None:
     if_true_series = Series.from_arrow(pa.array([1, 1, 1], type=pa.int64()))
     if_false_series = Series.from_arrow(pa.array([0, 0, 0], type=pa.int64()))
     predicate_series = Series.from_arrow(pa.array([predicate_value], type=pa.bool_()))
@@ -73,6 +117,32 @@ def test_series_if_else_predicate_broadcast_strings(predicate_value, expected_re
     predicate_series = Series.from_arrow(pa.array([predicate_value], type=pa.bool_()))
     result = predicate_series.if_else(if_true_series, if_false_series)
     assert result.datatype() == DataType.string()
+    assert result.to_pylist() == expected_results
+
+
+@pytest.mark.parametrize(
+    ["predicate_value", "expected_results"],
+    [(True, [True, True, True]), (False, [False, False, False]), (None, [None, None, None])],
+)
+def test_series_if_else_predicate_broadcast_bools(predicate_value, expected_results) -> None:
+    if_true_series = Series.from_arrow(pa.array([True, True, True], type=pa.bool_()))
+    if_false_series = Series.from_arrow(pa.array([False, False, False], type=pa.bool_()))
+    predicate_series = Series.from_arrow(pa.array([predicate_value], type=pa.bool_()))
+    result = predicate_series.if_else(if_true_series, if_false_series)
+    assert result.datatype() == DataType.bool()
+    assert result.to_pylist() == expected_results
+
+
+@pytest.mark.parametrize(
+    ["predicate_value", "expected_results"],
+    [(True, [b"Y", b"Y", b"Y"]), (False, [b"N", b"N", b"N"]), (None, [None, None, None])],
+)
+def test_series_if_else_predicate_broadcast_binary(predicate_value, expected_results) -> None:
+    if_true_series = Series.from_arrow(pa.array([b"Y", b"Y", b"Y"], type=pa.binary()))
+    if_false_series = Series.from_arrow(pa.array([b"N", b"N", b"N"], type=pa.binary()))
+    predicate_series = Series.from_arrow(pa.array([predicate_value], type=pa.bool_()))
+    result = predicate_series.if_else(if_true_series, if_false_series)
+    assert result.datatype() == DataType.binary()
     assert result.to_pylist() == expected_results
 
 

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -53,6 +53,17 @@ def test_series_pylist_round_trip_null() -> None:
     assert words["None"] == 2
 
 
+def test_series_pylist_round_trip_binary() -> None:
+    data = pa.array([b"a", b"b", b"c", None, b"d", None])
+
+    s = Series.from_arrow(data)
+
+    words = Counter(repr(s).split())
+    assert s.name() in words
+    assert words[s.name()] == 1
+    assert words["None"] == 2
+
+
 @pytest.mark.parametrize("dtype", ARROW_FLOAT_TYPES + ARROW_INT_TYPES + ARROW_STRING_TYPES)
 def test_series_pickling(dtype) -> None:
     s = Series.from_pylist([1, 2, 3, None]).cast(DataType.from_arrow_type(dtype))

--- a/tests/series/test_take.py
+++ b/tests/series/test_take.py
@@ -9,7 +9,7 @@ from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES, ARROW_STRING_TYPES
 
 
 @pytest.mark.parametrize("dtype", ARROW_INT_TYPES + ARROW_FLOAT_TYPES + ARROW_STRING_TYPES)
-def test_series_take_numeric(dtype) -> None:
+def test_series_take(dtype) -> None:
     data = pa.array([1, 2, 3, None, 5, None])
 
     s = Series.from_arrow(data.cast(dtype))
@@ -38,3 +38,19 @@ def test_series_date_take() -> None:
     taken = s.take(Series.from_pylist([5, 4, 3, 2, 1, 0]))
     assert taken.datatype() == DataType.date()
     assert taken.to_pylist() == days[::-1]
+
+
+def test_series_binary_take() -> None:
+    data = pa.array([b"1", b"2", b"3", None, b"5", None])
+
+    s = Series.from_arrow(data)
+    pyidx = [2, 0, None, 5]
+    idx = Series.from_pylist(pyidx)
+
+    result = s.take(idx)
+    assert result.datatype() == s.datatype()
+    assert len(result) == 4
+
+    original_data = s.to_pylist()
+    expected = [original_data[i] if i is not None else None for i in pyidx]
+    assert result.to_pylist() == expected


### PR DESCRIPTION
* Previously, If/Else only worked for numeric and string types. Our tests and schema resolution code had blocks to skip types that were not supported
* This PR implements kernels for the other physical types and enables tests