### PR TITLE
[RUST] Fix binary typing kernel tests

### DIFF
--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -174,7 +174,8 @@ impl BinaryArray {
         let val = self.get(idx);
         match val {
             None => Ok("None".to_string()),
-            // TODO: proper display of bytes as string here
+            // TODO: [RUST-INT] proper display of bytes as string here, preferably similar to how Python displays it
+            // See discussion: https://stackoverflow.com/questions/54358833/how-does-bytes-repr-representation-work
             Some(v) => Ok(format!("b\"{:?}\"", v)),
         }
     }

--- a/tests/expressions/typing/conftest.py
+++ b/tests/expressions/typing/conftest.py
@@ -31,9 +31,9 @@ ALL_DTYPES = [
     (DataType.string(), pa.array(["1", "2", "3"], type=pa.string())),
     (DataType.bool(), pa.array([True, False, None], type=pa.bool_())),
     (DataType.null(), pa.array([None, None, None], type=pa.null())),
+    (DataType.binary(), pa.array([b"1", b"2", None], type=pa.binary())),
     # TODO: [RUST-INT][TYPING] Enable and perform fixes for these types
     # (DataType.date(), pa.array([datetime.date(2021, 1, 1), datetime.date(2021, 1, 2), None], type=pa.date32())),
-    # (DataType.binary(), pa.array([b"1", b"2", None], type=pa.binary())),
 ]
 
 ALL_DATATYPES_BINARY_PAIRS = list(itertools.product(ALL_DTYPES, repeat=2))
@@ -139,6 +139,7 @@ def is_comparable(dt: DataType):
         or dt == DataType.string()
         or dt == DataType.null()
         or dt == DataType.date()
+        or dt == DataType.binary()
     )
 
 

--- a/tests/expressions/typing/conftest.py
+++ b/tests/expressions/typing/conftest.py
@@ -139,7 +139,6 @@ def is_comparable(dt: DataType):
         or dt == DataType.string()
         or dt == DataType.null()
         or dt == DataType.date()
-        or dt == DataType.binary()
     )
 
 

--- a/tests/expressions/typing/test_arithmetic.py
+++ b/tests/expressions/typing/test_arithmetic.py
@@ -15,6 +15,12 @@ from tests.expressions.typing.conftest import (
 
 def plus_type_validation(lhs: DataType, rhs: DataType) -> bool:
     """Checks whether these input types are resolvable for the + operation"""
+
+    # Plus only works for certain types
+    for arg in (lhs, rhs):
+        if not (is_numeric(arg) or (arg == DataType.string()) or (arg == DataType.bool()) or (arg == DataType.null())):
+            return False
+
     return has_supertype(lhs, rhs)
 
 


### PR DESCRIPTION
* Designates binary types as "non-comparable" (see issue: #688)
* Makes binary types non-addable as well