### PR TITLE
[RUST] Activate tests for date types

### DIFF
--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -55,7 +55,7 @@ where
 
         if !dtype.is_arrow() || !self.data_type().is_arrow() {
             return Err(DaftError::TypeError(format!(
-                "can not cast {:?} to type: {:?}",
+                "Can not cast {:?} to type: {:?}: not convertible to Arrow",
                 T::get_dtype(),
                 dtype
             )));
@@ -65,7 +65,7 @@ where
         let target_arrow_type = dtype.to_arrow()?;
         if !can_cast_types(&self_arrow_type, &target_arrow_type) {
             return Err(DaftError::TypeError(format!(
-                "can not cast {:?} to type: {:?}",
+                "can not cast {:?} to type: {:?}: Arrow types not castable",
                 T::get_dtype(),
                 dtype
             )));

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -1,8 +1,14 @@
-use arrow2::compute::cast::{can_cast_types, cast, CastOptions};
+use arrow2::compute::{
+    self,
+    cast::{can_cast_types, cast, CastOptions},
+};
 
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{DaftDataType, DataType},
+    datatypes::{
+        BinaryArray, BooleanArray, DaftDataType, DaftNumericType, DataType, DateArray, NullArray,
+        Utf8Array,
+    },
     error::{DaftError, DaftResult},
     series::Series,
 };
@@ -40,48 +46,107 @@ macro_rules! with_match_arrow_daft_types {(
     }
 })}
 
-impl<T> DataArray<T>
+fn arrow_cast<T>(to_cast: &DataArray<T>, dtype: &DataType) -> DaftResult<Series>
 where
     T: DaftDataType + 'static,
 {
+    if to_cast.data_type().eq(dtype) {
+        return Ok(
+            DataArray::<T>::try_from((to_cast.name(), to_cast.data().to_boxed()))?.into_series(),
+        );
+    }
+
+    let _arrow_type = dtype.to_arrow();
+
+    if !dtype.is_arrow() || !to_cast.data_type().is_arrow() {
+        return Err(DaftError::TypeError(format!(
+            "Can not cast {:?} to type: {:?}: not convertible to Arrow",
+            T::get_dtype(),
+            dtype
+        )));
+    }
+
+    let self_arrow_type = to_cast.data_type().to_arrow()?;
+    let target_arrow_type = dtype.to_arrow()?;
+    if !can_cast_types(&self_arrow_type, &target_arrow_type) {
+        return Err(DaftError::TypeError(format!(
+            "can not cast {:?} to type: {:?}: Arrow types not castable",
+            T::get_dtype(),
+            dtype
+        )));
+    }
+
+    let result_array = cast(
+        to_cast.data(),
+        &target_arrow_type,
+        CastOptions {
+            wrapped: true,
+            partial: false,
+        },
+    )?;
+
+    Ok(
+        with_match_arrow_daft_types!(dtype, |$T| DataArray::<$T>::try_from((to_cast.name(), result_array))?.into_series()),
+    )
+}
+
+impl<T> DataArray<T>
+where
+    T: DaftNumericType,
+{
     pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
-        if self.data_type().eq(dtype) {
-            return Ok(
-                DataArray::<T>::try_from((self.name(), self.data().to_boxed()))?.into_series(),
-            );
+        arrow_cast(self, dtype)
+    }
+}
+
+impl Utf8Array {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        arrow_cast(self, dtype)
+    }
+}
+
+impl BooleanArray {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        arrow_cast(self, dtype)
+    }
+}
+
+impl NullArray {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        arrow_cast(self, dtype)
+    }
+}
+
+impl BinaryArray {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        arrow_cast(self, dtype)
+    }
+}
+
+impl DateArray {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        // We need to handle casts that Arrow doesn't allow, but our type-system does
+        match dtype {
+            DataType::Utf8 => {
+                // TODO: we should move this into our own strftime kernel
+                let date_array = self.downcast();
+                let year_array = compute::temporal::year(date_array)?;
+                let month_array = compute::temporal::month(date_array)?;
+                let day_array = compute::temporal::day(date_array)?;
+                let date_str: arrow2::array::Utf8Array<i64> = year_array
+                    .iter()
+                    .zip(month_array.iter())
+                    .zip(day_array.iter())
+                    .map(|((y, m), d)| match (y, m, d) {
+                        (None, _, _) | (_, None, _) | (_, _, None) => None,
+                        (Some(y), Some(m), Some(d)) => Some(format!("{y}-{m}-{d}")),
+                    })
+                    .collect();
+                Ok(Utf8Array::from((self.name(), Box::new(date_str))).into_series())
+            }
+            DataType::Float32 => self.cast(&DataType::Int32)?.cast(&DataType::Float32),
+            DataType::Float64 => self.cast(&DataType::Int32)?.cast(&DataType::Float64),
+            _ => arrow_cast(self, dtype),
         }
-
-        let _arrow_type = dtype.to_arrow();
-
-        if !dtype.is_arrow() || !self.data_type().is_arrow() {
-            return Err(DaftError::TypeError(format!(
-                "Can not cast {:?} to type: {:?}: not convertible to Arrow",
-                T::get_dtype(),
-                dtype
-            )));
-        }
-
-        let self_arrow_type = self.data_type().to_arrow()?;
-        let target_arrow_type = dtype.to_arrow()?;
-        if !can_cast_types(&self_arrow_type, &target_arrow_type) {
-            return Err(DaftError::TypeError(format!(
-                "can not cast {:?} to type: {:?}: Arrow types not castable",
-                T::get_dtype(),
-                dtype
-            )));
-        }
-
-        let result_array = cast(
-            self.data(),
-            &target_arrow_type,
-            CastOptions {
-                wrapped: true,
-                partial: false,
-            },
-        )?;
-
-        Ok(
-            with_match_arrow_daft_types!(dtype, |$T| DataArray::<$T>::try_from((self.name(), result_array))?.into_series()),
-        )
     }
 }

--- a/src/array/ops/compare_agg.rs
+++ b/src/array/ops/compare_agg.rs
@@ -93,3 +93,26 @@ impl DaftCompareAggable for &DataArray<NullType> {
         Self::min(self)
     }
 }
+
+impl DaftCompareAggable for &DataArray<DateType> {
+    type Output = DaftResult<DataArray<DateType>>;
+
+    fn min(&self) -> Self::Output {
+        let arrow_array: &arrow2::array::PrimitiveArray<i32> =
+            self.data().as_any().downcast_ref().unwrap();
+
+        let result = arrow2::compute::aggregate::min_primitive(arrow_array);
+        let res_arrow_array = arrow2::array::PrimitiveArray::<i32>::from([result]);
+
+        DataArray::new(self.field.clone(), Arc::new(res_arrow_array))
+    }
+    fn max(&self) -> Self::Output {
+        let arrow_array: &arrow2::array::PrimitiveArray<i32> =
+            self.data().as_any().downcast_ref().unwrap();
+
+        let result = arrow2::compute::aggregate::max_primitive(arrow_array);
+        let res_arrow_array = arrow2::array::PrimitiveArray::<i32>::from([result]);
+
+        DataArray::new(self.field.clone(), Arc::new(res_arrow_array))
+    }
+}

--- a/src/array/ops/compare_agg.rs
+++ b/src/array/ops/compare_agg.rs
@@ -93,26 +93,3 @@ impl DaftCompareAggable for &DataArray<NullType> {
         Self::min(self)
     }
 }
-
-impl DaftCompareAggable for &DataArray<DateType> {
-    type Output = DaftResult<DataArray<DateType>>;
-
-    fn min(&self) -> Self::Output {
-        let arrow_array: &arrow2::array::PrimitiveArray<i32> =
-            self.data().as_any().downcast_ref().unwrap();
-
-        let result = arrow2::compute::aggregate::min_primitive(arrow_array);
-        let res_arrow_array = arrow2::array::PrimitiveArray::<i32>::from([result]);
-
-        DataArray::new(self.field.clone(), Arc::new(res_arrow_array))
-    }
-    fn max(&self) -> Self::Output {
-        let arrow_array: &arrow2::array::PrimitiveArray<i32> =
-            self.data().as_any().downcast_ref().unwrap();
-
-        let result = arrow2::compute::aggregate::max_primitive(arrow_array);
-        let res_arrow_array = arrow2::array::PrimitiveArray::<i32>::from([result]);
-
-        DataArray::new(self.field.clone(), Arc::new(res_arrow_array))
-    }
-}

--- a/src/array/ops/downcast.rs
+++ b/src/array/ops/downcast.rs
@@ -1,8 +1,9 @@
+use arrow2;
 use arrow2::array;
 
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{BinaryArray, BooleanArray, DaftNumericType, Utf8Array},
+    datatypes::{BinaryArray, BooleanArray, DaftNumericType, DateArray, Utf8Array},
 };
 
 impl<T> DataArray<T>
@@ -32,6 +33,13 @@ impl BooleanArray {
 impl BinaryArray {
     // downcasts a DataArray<T> to an Arrow BinaryArray.
     pub fn downcast(&self) -> &array::BinaryArray<i64> {
+        self.data().as_any().downcast_ref().unwrap()
+    }
+}
+
+impl DateArray {
+    // downcasts a DataArray<T> to an Arrow DateArray.
+    pub fn downcast(&self) -> &array::PrimitiveArray<i32> {
         self.data().as_any().downcast_ref().unwrap()
     }
 }

--- a/src/series/ops/agg.rs
+++ b/src/series/ops/agg.rs
@@ -60,16 +60,30 @@ impl Series {
     pub fn min(&self) -> DaftResult<Series> {
         use crate::array::ops::DaftCompareAggable;
 
-        with_match_comparable_daft_types!(self.data_type(), |$T| {
-            Ok(DaftCompareAggable::min(&self.downcast::<$T>()?)?.into_series())
-        })
+        let s = self.as_physical()?;
+
+        let result = with_match_comparable_daft_types!(s.data_type(), |$T| {
+            DaftCompareAggable::min(&s.downcast::<$T>()?)?.into_series()
+        });
+
+        if result.data_type() != self.data_type() {
+            return result.cast(self.data_type());
+        }
+        Ok(result)
     }
 
     pub fn max(&self) -> DaftResult<Series> {
         use crate::array::ops::DaftCompareAggable;
 
-        with_match_comparable_daft_types!(self.data_type(), |$T| {
-            Ok(DaftCompareAggable::max(&self.downcast::<$T>()?)?.into_series())
-        })
+        let s = self.as_physical()?;
+
+        let result = with_match_comparable_daft_types!(s.data_type(), |$T| {
+            DaftCompareAggable::max(&s.downcast::<$T>()?)?.into_series()
+        });
+
+        if result.data_type() != self.data_type() {
+            return result.cast(self.data_type());
+        }
+        Ok(result)
     }
 }

--- a/src/series/ops/cast.rs
+++ b/src/series/ops/cast.rs
@@ -16,14 +16,15 @@ macro_rules! apply_method_all_arrow_series {
             DataType::Int16 => $self.i16().unwrap().$method($($args),*),
             DataType::Int32 => $self.i32().unwrap().$method($($args),*),
             DataType::Int64 => $self.i64().unwrap().$method($($args),*),
-            DataType::Float16 => $self.f16().unwrap().$method($($args),*),
+            // DataType::Float16 => $self.f16().unwrap().$method($($args),*),
             DataType::Float32 => $self.f32().unwrap().$method($($args),*),
             DataType::Float64 => $self.f64().unwrap().$method($($args),*),
             DataType::Date => $self.date().unwrap().$method($($args),*),
-            DataType::Timestamp(_, _) => $self.timestamp().unwrap().$method($($args),*),
-            DataType::List(_) => $self.list().unwrap().$method($($args),*),
-            DataType::FixedSizeList(..) => $self.fixed_size_list().unwrap().$method($($args),*),
-            DataType::Struct(_) => $self.struct_().unwrap().$method($($args),*),
+            // TODO: Add implementations for these types
+            // DataType::Timestamp(_, _) => $self.timestamp().unwrap().$method($($args),*),
+            // DataType::List(_) => $self.list().unwrap().$method($($args),*),
+            // DataType::FixedSizeList(..) => $self.fixed_size_list().unwrap().$method($($args),*),
+            // DataType::Struct(_) => $self.struct_().unwrap().$method($($args),*),
             dt => panic!("dtype {:?} not supported", dt)
         }
     }

--- a/src/series/ops/if_else.rs
+++ b/src/series/ops/if_else.rs
@@ -6,11 +6,21 @@ use crate::{
 impl Series {
     pub fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series> {
         let (if_true, if_false) = match_types_on_series(self, other)?;
-        with_match_physical_daft_types!(if_true.data_type(), |$T| {
+
+        let if_true_original_dtype = if_true.data_type();
+        let if_true = if_true.as_physical()?;
+        let if_false = if_false.as_physical()?;
+
+        let result = with_match_physical_daft_types!(if_true.data_type(), |$T| {
             let if_true_array = if_true.downcast::<$T>()?;
             let if_false_array = if_false.downcast::<$T>()?;
             let predicate_array = predicate.downcast::<datatypes::BooleanType>()?;
-            Ok(if_true_array.if_else(if_false_array, predicate_array)?.into_series())
-        })
+            if_true_array.if_else(if_false_array, predicate_array)?.into_series()
+        });
+
+        if result.data_type() != if_true_original_dtype {
+            return result.cast(if_true_original_dtype);
+        }
+        Ok(result)
     }
 }

--- a/src/utils/supertype.rs
+++ b/src/utils/supertype.rs
@@ -118,8 +118,12 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
 
             (Float64, Float32) => Some(Float64),
 
+            (Date, UInt8) => Some(Int64),
+            (Date, UInt16) => Some(Int64),
             (Date, UInt32) => Some(Int64),
             (Date, UInt64) => Some(Int64),
+            (Date, Int8) => Some(Int32),
+            (Date, Int16) => Some(Int32),
             (Date, Int32) => Some(Int32),
             (Date, Int64) => Some(Int64),
             (Date, Float32) => Some(Float32),

--- a/tests/expressions/typing/conftest.py
+++ b/tests/expressions/typing/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import itertools
 import sys
 
@@ -32,8 +33,7 @@ ALL_DTYPES = [
     (DataType.bool(), pa.array([True, False, None], type=pa.bool_())),
     (DataType.null(), pa.array([None, None, None], type=pa.null())),
     (DataType.binary(), pa.array([b"1", b"2", None], type=pa.binary())),
-    # TODO: [RUST-INT][TYPING] Enable and perform fixes for these types
-    # (DataType.date(), pa.array([datetime.date(2021, 1, 1), datetime.date(2021, 1, 2), None], type=pa.date32())),
+    (DataType.date(), pa.array([datetime.date(2021, 1, 1), datetime.date(2021, 1, 2), None], type=pa.date32())),
 ]
 
 ALL_DATATYPES_BINARY_PAIRS = list(itertools.product(ALL_DTYPES, repeat=2))

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -319,7 +319,7 @@ test_table_count_cases = [
 def test_table_count(idx_dtype, case) -> None:
     input, expected = case
     if idx_dtype == DataType.date():
-        input = [datetime.datetime.utcfromtimestamp(_) if _ is not None else None for _ in input]
+        input = [datetime.date(2020 + x, 1 + x, 1 + x) if x is not None else None for x in input]
     daft_table = Table.from_pydict({"input": input})
     daft_table = daft_table.eval_expression_list([col("input").cast(idx_dtype)])
     daft_table = daft_table.eval_expression_list([col("input").alias("count")._count()])


### PR DESCRIPTION
* Adds custom logic for date casts, because Arrow doesn't like casting dates to many types
* Fixes our `Series.min/max` logic to cast to physical
* Fixes our `Series.if_else` logic to cast to physical
* Adds some more Date entries to our Supertype table, so that Dates are supertypeable with all numeric types

```
            (Date, UInt8) => Some(Int64),
            (Date, UInt16) => Some(Int64),
            (Date, Int8) => Some(Int32),
            (Date, Int16) => Some(Int32),
```