### PR TITLE
Add test fixes for Pandas 2.0

### DIFF
--- a/tests/dataframe_cookbook/test_aggregations.py
+++ b/tests/dataframe_cookbook/test_aggregations.py
@@ -176,7 +176,7 @@ def test_min_groupby(daft_df, service_requests_csv_pd_df, repartition_nparts, ke
         .min(col("Unique Key"), col("Created Date"))
     )
     service_requests_csv_pd_df = (
-        service_requests_csv_pd_df.groupby(keys)["Unique Key", "Created Date"].min().reset_index()
+        service_requests_csv_pd_df.groupby(keys)[["Unique Key", "Created Date"]].min().reset_index()
     )
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, service_requests_csv_pd_df, sort_key=keys)
@@ -198,7 +198,7 @@ def test_max_groupby(daft_df, service_requests_csv_pd_df, repartition_nparts, ke
         .max(col("Unique Key"), col("Created Date"))
     )
     service_requests_csv_pd_df = (
-        service_requests_csv_pd_df.groupby(keys)["Unique Key", "Created Date"].max().reset_index()
+        service_requests_csv_pd_df.groupby(keys)[["Unique Key", "Created Date"]].max().reset_index()
     )
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, service_requests_csv_pd_df, sort_key=keys)

--- a/tests/expression_operators/test_datetime.py
+++ b/tests/expression_operators/test_datetime.py
@@ -14,7 +14,7 @@ def test_datetime_year():
     df = DataFrame.from_pydict(data)
     df = df.with_column("year", col("dt").dt.year())
     pd_df = pd.DataFrame.from_dict(data)
-    pd_df["year"] = pd.to_datetime(pd_df["dt"]).dt.year
+    pd_df["year"] = pd.to_datetime(pd_df["dt"]).dt.year.astype("int64")
     assert_df_equals(df.to_pandas(), pd_df, sort_key="dt")
 
 
@@ -23,7 +23,7 @@ def test_datetime_month():
     df = DataFrame.from_pydict(data)
     df = df.with_column("month", col("dt").dt.month())
     pd_df = pd.DataFrame.from_dict(data)
-    pd_df["month"] = pd.to_datetime(pd_df["dt"]).dt.month
+    pd_df["month"] = pd.to_datetime(pd_df["dt"]).dt.month.astype("int64")
     assert_df_equals(df.to_pandas(), pd_df, sort_key="dt")
 
 
@@ -32,7 +32,7 @@ def test_datetime_day():
     df = DataFrame.from_pydict(data)
     df = df.with_column("day", col("dt").dt.day())
     pd_df = pd.DataFrame.from_dict(data)
-    pd_df["day"] = pd.to_datetime(pd_df["dt"]).dt.day
+    pd_df["day"] = pd.to_datetime(pd_df["dt"]).dt.day.astype("int64")
     assert_df_equals(df.to_pandas(), pd_df, sort_key="dt")
 
 
@@ -41,5 +41,5 @@ def test_datetime_day_of_week():
     df = DataFrame.from_pydict(data)
     df = df.with_column("day_of_week", col("dt").dt.day_of_week())
     pd_df = pd.DataFrame.from_dict(data)
-    pd_df["day_of_week"] = pd.to_datetime(pd_df["dt"]).dt.day_of_week
+    pd_df["day_of_week"] = pd.to_datetime(pd_df["dt"]).dt.day_of_week.astype("int64")
     assert_df_equals(df.to_pandas(), pd_df, sort_key="dt")


### PR DESCRIPTION
* Pandas 2.0 landed on April 3 2023 which broke some tests
* The types in some datetime operations were changed from int64 to int32
* Indexing API for `df[c1, c2]` was deprecated, and we have to do `df[[c1, c2]]` now