### PR TITLE
[rust] Implement Hash Joins for table

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -1,7 +1,6 @@
 pub mod from;
 pub mod iterator;
 pub mod ops;
-
 use std::{any::Any, marker::PhantomData, sync::Arc};
 
 use crate::{

--- a/src/array/ops/arrow2/comparison.rs
+++ b/src/array/ops/arrow2/comparison.rs
@@ -1,0 +1,106 @@
+use arrow2::{
+    array::{ord::build_compare, Array, PrimitiveArray},
+    datatypes::DataType,
+    error::Result,
+};
+use num_traits::Float;
+
+use crate::{
+    error::DaftResult,
+    kernels::search_sorted::{build_is_valid, cmp_float},
+    series::Series,
+};
+
+fn build_is_equal_float<F: Float + arrow2::types::NativeType>(
+    left: &dyn Array,
+    right: &dyn Array,
+    nan_equal: bool,
+) -> Box<dyn Fn(usize, usize) -> bool + Send + Sync> {
+    let left = left
+        .as_any()
+        .downcast_ref::<PrimitiveArray<F>>()
+        .unwrap()
+        .clone();
+    let right = right
+        .as_any()
+        .downcast_ref::<PrimitiveArray<F>>()
+        .unwrap()
+        .clone();
+    if nan_equal {
+        Box::new(move |i, j| cmp_float::<F>(&left.value(i), &right.value(j)).is_eq())
+    } else {
+        Box::new(move |i, j| left.value(i).eq(&right.value(j)))
+    }
+}
+
+fn build_is_equal_with_nan(
+    left: &dyn Array,
+    right: &dyn Array,
+    nulls_equal: bool,
+) -> Result<Box<dyn Fn(usize, usize) -> bool + Send + Sync>> {
+    if (left.data_type() == &DataType::Float32) && (right.data_type() == &DataType::Float32) {
+        Ok(build_is_equal_float::<f32>(left, right, nulls_equal))
+    } else if (left.data_type() == &DataType::Float64) && (right.data_type() == &DataType::Float64)
+    {
+        Ok(build_is_equal_float::<f64>(left, right, nulls_equal))
+    } else {
+        let comp = build_compare(left, right)?;
+        Ok(Box::new(move |i, j| comp(i, j).is_eq()))
+    }
+}
+
+pub fn build_is_equal(
+    left: &dyn Array,
+    right: &dyn Array,
+    nulls_equal: bool,
+    nan_equal: bool,
+) -> DaftResult<Box<dyn Fn(usize, usize) -> bool + Send + Sync>> {
+    let is_equal_fn = build_is_equal_with_nan(left, right, nan_equal)?;
+    let left_is_valid = build_is_valid(left);
+    let right_is_valid = build_is_valid(right);
+
+    if nulls_equal {
+        Ok(Box::new(move |i: usize, j: usize| {
+            match (left_is_valid(i), right_is_valid(j)) {
+                (true, true) => is_equal_fn(i, j),
+                (false, false) => true,
+                _ => false,
+            }
+        }))
+    } else {
+        Ok(Box::new(move |i: usize, j: usize| {
+            match (left_is_valid(i), right_is_valid(j)) {
+                (true, true) => is_equal_fn(i, j),
+                _ => false,
+            }
+        }))
+    }
+}
+
+pub fn build_multi_array_is_equal(
+    left: &[Series],
+    right: &[Series],
+    nulls_equal: bool,
+    nan_equal: bool,
+) -> DaftResult<Box<dyn Fn(usize, usize) -> bool + Send + Sync>> {
+    let mut fn_list = Vec::with_capacity(left.len());
+
+    for (l, r) in left.iter().zip(right.iter()) {
+        fn_list.push(build_is_equal(
+            l.array().data(),
+            r.array().data(),
+            nulls_equal,
+            nan_equal,
+        )?);
+    }
+
+    let combined_fn = Box::new(move |a_idx: usize, b_idx: usize| -> bool {
+        for f in fn_list.iter() {
+            if !f(a_idx, b_idx) {
+                return false;
+            }
+        }
+        true
+    });
+    Ok(combined_fn)
+}

--- a/src/array/ops/arrow2/mod.rs
+++ b/src/array/ops/arrow2/mod.rs
@@ -1,1 +1,2 @@
+pub mod comparison;
 pub mod sort;

--- a/src/array/ops/mod.rs
+++ b/src/array/ops/mod.rs
@@ -2,7 +2,7 @@ mod abs;
 mod apply;
 mod arange;
 mod arithmetic;
-mod arrow2;
+pub mod arrow2;
 mod broadcast;
 mod cast;
 mod compare_agg;

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -159,6 +159,11 @@ impl DataType {
     }
 
     #[inline]
+    pub fn is_null(&self) -> bool {
+        matches!(self, DataType::Null)
+    }
+
+    #[inline]
     pub fn is_castable(&self, cast_to: &DataType) -> bool {
         match (self.to_arrow(), cast_to.to_arrow()) {
             (Ok(self_arrow_type), Ok(cast_to_arrow_type)) => {

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter, Result};
+
 use arrow2::datatypes::Field as ArrowField;
 
 use crate::{datatypes::dtype::DataType, error::DaftResult};
@@ -35,5 +37,11 @@ impl From<&ArrowField> for Field {
             name: af.name.clone(),
             dtype: af.data_type().into(),
         }
+    }
+}
+
+impl Display for Field {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "{}#{}", self.name, self.dtype)
     }
 }

--- a/src/kernels/search_sorted.rs
+++ b/src/kernels/search_sorted.rs
@@ -174,7 +174,7 @@ macro_rules! with_match_primitive_type {(
 })}
 
 type IsValid = Box<dyn Fn(usize) -> bool + Send + Sync>;
-fn build_is_valid(array: &dyn Array) -> IsValid {
+pub fn build_is_valid(array: &dyn Array) -> IsValid {
     if let Some(validity) = array.validity() {
         let validity = validity.clone();
         Box::new(move |x| unsafe { validity.get_bit_unchecked(x) })

--- a/src/python/schema.rs
+++ b/src/python/schema.rs
@@ -36,8 +36,8 @@ impl PySchema {
         Ok(self.schema.get_field(name)?.clone().into())
     }
 
-    pub fn names(&self) -> PyResult<Vec<String>> {
-        Ok(self.schema.names()?)
+    pub fn names(&self) -> Vec<String> {
+        self.schema.names()
     }
 
     pub fn union(&self, other: &PySchema) -> PyResult<PySchema> {

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -184,8 +184,8 @@ impl PyTable {
         Ok(self.table.size_bytes()?)
     }
 
-    pub fn column_names(&self) -> PyResult<Vec<String>> {
-        Ok(self.table.column_names()?)
+    pub fn column_names(&self) -> Vec<String> {
+        self.table.column_names()
     }
 
     pub fn get_column(&self, name: &str) -> PyResult<PySeries> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -59,8 +59,8 @@ impl Schema {
         }
     }
 
-    pub fn names(&self) -> DaftResult<Vec<String>> {
-        return Ok(self.fields.keys().cloned().collect());
+    pub fn names(&self) -> Vec<String> {
+        self.fields.keys().cloned().collect()
     }
 
     pub fn union(&self, other: &Schema) -> DaftResult<Schema> {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -67,7 +67,7 @@ impl Table {
         self.columns.len()
     }
 
-    pub fn column_names(&self) -> DaftResult<Vec<String>> {
+    pub fn column_names(&self) -> Vec<String> {
         self.schema.names()
     }
 
@@ -216,6 +216,14 @@ impl Table {
     pub fn get_column<S: AsRef<str>>(&self, name: S) -> DaftResult<&Series> {
         let i = self.schema.get_index(name.as_ref())?;
         Ok(self.columns.get(i).unwrap())
+    }
+
+    pub fn get_columns<S: AsRef<str>>(&self, names: &[S]) -> DaftResult<Self> {
+        let series_by_name = names
+            .iter()
+            .map(|s| self.get_column(s).cloned())
+            .collect::<DaftResult<Vec<_>>>()?;
+        Self::from_columns(series_by_name)
     }
 
     pub fn get_column_by_index(&self, idx: usize) -> DaftResult<&Series> {

--- a/src/table/ops/joins/hash_join.rs
+++ b/src/table/ops/joins/hash_join.rs
@@ -1,0 +1,90 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    hash::{BuildHasherDefault, Hasher},
+};
+
+use crate::{
+    array::BaseArray,
+    datatypes::UInt64Array,
+    error::{DaftError, DaftResult},
+    series::Series,
+    table::Table,
+};
+
+#[derive(Default)]
+pub struct IdentityHasher {
+    hash: u64,
+}
+
+impl Hasher for IdentityHasher {
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        unreachable!("IdentityHasher should be used by u64")
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.hash = i;
+    }
+}
+
+pub type IdentityBuildHasher = BuildHasherDefault<IdentityHasher>;
+
+pub(super) fn hash_inner_join(left: &Table, right: &Table) -> DaftResult<(Series, Series)> {
+    if left.num_columns() != right.num_columns() {
+        return Err(DaftError::ValueError(format!(
+            "Mismatch of join on clauses: left: {:?} vs right: {:?}",
+            left.num_columns(),
+            right.num_columns()
+        )));
+    }
+    if left.num_columns() == 0 {
+        return Err(DaftError::ValueError(
+            "No columns were passed in to join on".to_string(),
+        ));
+    }
+
+    let hashes = left.hash_rows()?;
+    let mut probe_table =
+        HashMap::<u64, Vec<u64>, IdentityBuildHasher>::with_hasher(Default::default());
+
+    for (i, h) in hashes.downcast().values_iter().enumerate() {
+        // let entry = probe_table.raw_entry_mut().from_hash(h, ||);
+        let entry = probe_table.entry(*h);
+        match entry {
+            Entry::Vacant(entry) => {
+                entry.insert(vec![i as u64]);
+            }
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().push(i as u64);
+            }
+        }
+    }
+
+    let r_hashes = right.hash_rows()?;
+    let mut left_idx = vec![];
+    let mut right_idx = vec![];
+    use crate::array::ops::build_multi_array_bicompare;
+    let comp = build_multi_array_bicompare(
+        left.columns.as_slice(),
+        right.columns.as_slice(),
+        vec![false; left.num_columns()].as_slice(),
+    )?;
+
+    for (i, h) in r_hashes.downcast().values_iter().enumerate() {
+        if let Some(indices) = probe_table.get(h) {
+            for j in indices {
+                if comp(*j as usize, i).is_eq() {
+                    left_idx.push(*j);
+                    right_idx.push(i as u64);
+                }
+            }
+        }
+    }
+    let left_series = UInt64Array::from(("left_indices", left_idx));
+    let right_series = UInt64Array::from(("right_indices", right_idx));
+    Ok((left_series.into_series(), right_series.into_series()))
+}

--- a/src/table/ops/joins/mod.rs
+++ b/src/table/ops/joins/mod.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{dsl::Expr, error::DaftResult, schema::Schema, table::Table};
 
+mod hash_join;
 mod naive_join;
 
 impl Table {
@@ -9,7 +10,7 @@ impl Table {
         let ltable = self.eval_expression_list(left_on)?;
         let rtable = right.eval_expression_list(right_on)?;
 
-        let (lidx, ridx) = naive_join::naive_inner_join(&ltable, &rtable)?;
+        let (lidx, ridx) = hash_join::hash_inner_join(&ltable, &rtable)?;
 
         let mut join_fields = ltable
             .schema

--- a/src/table/ops/joins/mod.rs
+++ b/src/table/ops/joins/mod.rs
@@ -1,25 +1,57 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::{dsl::Expr, error::DaftResult, schema::Schema, table::Table};
+use crate::{
+    dsl::Expr,
+    error::{DaftError, DaftResult},
+    schema::Schema,
+    table::Table,
+    utils::supertype::try_get_supertype,
+};
 
 mod hash_join;
 mod naive_join;
+
+fn match_types_for_tables(left: &Table, right: &Table) -> DaftResult<(Table, Table)> {
+    let mut lseries = vec![];
+    let mut rseries = vec![];
+
+    for (ls, rs) in left.columns.iter().zip(right.columns.iter()) {
+        let st = try_get_supertype(ls.data_type(), rs.data_type());
+        if let Ok(st) = st {
+            lseries.push(ls.cast(&st)?);
+            rseries.push(rs.cast(&st)?);
+        } else {
+            return Err(DaftError::SchemaMismatch(format!(
+                "Can not perform join between due to mismatch of types of left: {} vs right: {}",
+                ls.field(),
+                rs.field()
+            )));
+        }
+    }
+    Ok((Table::from_columns(lseries)?, Table::from_columns(rseries)?))
+}
 
 impl Table {
     pub fn join(&self, right: &Self, left_on: &[Expr], right_on: &[Expr]) -> DaftResult<Self> {
         let ltable = self.eval_expression_list(left_on)?;
         let rtable = right.eval_expression_list(right_on)?;
 
+        let (ltable, rtable) = match_types_for_tables(&ltable, &rtable)?;
+
         let (lidx, ridx) = hash_join::hash_inner_join(&ltable, &rtable)?;
 
         let mut join_fields = ltable
-            .schema
-            .fields
-            .clone()
-            .into_values()
-            .collect::<Vec<_>>();
+            .column_names()
+            .iter()
+            .map(|s| self.schema.get_field(s).cloned())
+            .collect::<DaftResult<Vec<_>>>()?;
 
-        let mut join_series = ltable.take(&lidx)?.columns;
+        let mut join_series = self
+            .get_columns(ltable.column_names().as_slice())?
+            .take(&lidx)?
+            .columns;
+        drop(ltable);
+        drop(rtable);
 
         let mut names_so_far = HashSet::new();
 
@@ -36,6 +68,8 @@ impl Table {
                 names_so_far.insert(field.name.clone());
             }
         }
+
+        drop(lidx);
 
         // Zip the names of the left and right expressions into a HashMap
         let left_names = left_on.iter().map(|e| e.name());
@@ -71,6 +105,7 @@ impl Table {
             names_so_far.insert(curr_name.clone());
         }
 
+        drop(ridx);
         Table::new(Schema::new(join_fields), join_series)
     }
 }

--- a/src/table/ops/joins/naive_join.rs
+++ b/src/table/ops/joins/naive_join.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 
 pub(super) fn naive_inner_join(left: &Table, right: &Table) -> DaftResult<(Series, Series)> {
+    #![allow(dead_code)]
     if left.num_columns() != right.num_columns() {
         return Err(DaftError::ValueError(format!(
             "Mismatch of join on clauses: left: {:?} vs right: {:?}",

--- a/tests/table/test_joins.py
+++ b/tests/table/test_joins.py
@@ -7,6 +7,7 @@ import pytest
 from daft import utils
 from daft.datatype import DataType
 from daft.expressions import col
+from daft.series import Series
 from daft.table import Table
 
 daft_int_types = [
@@ -174,6 +175,26 @@ def test_table_join_multicolumn_cross() -> None:
             ]
         )
     )
+
+
+def test_table_join_multicolumn_all_nulls() -> None:
+    left_table = Table.from_pydict(
+        {
+            "a": Series.from_pylist([None, None, None]).cast(DataType.int64()),
+            "b": Series.from_pylist([None, None, None]).cast(DataType.string()),
+            "c": [1, 2, 3],
+        }
+    )
+    right_table = Table.from_pydict(
+        {
+            "x": Series.from_pylist([None, None, None]).cast(DataType.int64()),
+            "y": Series.from_pylist([None, None, None]).cast(DataType.string()),
+            "z": [1, 2, 3],
+        }
+    )
+
+    result = left_table.join(right_table, left_on=[col("a"), col("b")], right_on=[col("x"), col("y")])
+    assert set(utils.freeze(utils.pydict_to_rows(result.to_pydict()))) == set(utils.freeze([]))
 
 
 def test_table_join_no_columns() -> None:


### PR DESCRIPTION
* Implements simple and naive hash joins for table which is upto 300x faster in some cases
* implements is_equal operator function since our other comparator assumes total ordering and can not parameterize if nulls and nans are equal
*  refactor agg grouper to use is_equal rather than old comparator 