### PR TITLE
[Missing Expression Kernels - 1/3] Add missing date kernels: `dt.month`, `dt.day`, and `dt.day_of_week`

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -269,17 +269,17 @@ class ExpressionFloatNamespace(ExpressionNamespace):
 
 
 class ExpressionDatetimeNamespace(ExpressionNamespace):
+    def day(self) -> Expression:
+        return Expression._from_pyexpr(self._expr.dt_day())
+
+    def month(self) -> Expression:
+        return Expression._from_pyexpr(self._expr.dt_month())
+
     def year(self) -> Expression:
         return Expression._from_pyexpr(self._expr.dt_year())
 
-    def month(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement date expression")
-
-    def day(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement date expression")
-
     def day_of_week(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement date expression")
+        return Expression._from_pyexpr(self._expr.dt_day_of_week())
 
 
 class ExpressionStringNamespace(ExpressionNamespace):

--- a/daft/series.py
+++ b/daft/series.py
@@ -299,5 +299,14 @@ class SeriesStringNamespace(SeriesNamespace):
 
 
 class SeriesDateNamespace(SeriesNamespace):
+    def day(self) -> Series:
+        return Series._from_pyseries(self._series.dt_day())
+
+    def month(self) -> Series:
+        return Series._from_pyseries(self._series.dt_month())
+
     def year(self) -> Series:
         return Series._from_pyseries(self._series.dt_year())
+
+    def day_of_week(self) -> Series:
+        return Series._from_pyseries(self._series.dt_day_of_week())

--- a/src/array/ops/date.rs
+++ b/src/array/ops/date.rs
@@ -1,12 +1,28 @@
 use crate::{
     array::BaseArray,
-    datatypes::{DateArray, Int32Array},
+    datatypes::{DateArray, Int32Array, UInt32Array},
     error::DaftResult,
 };
+use arrow2::compute::arithmetics::ArraySub;
 
 impl DateArray {
+    pub fn day(&self) -> DaftResult<UInt32Array> {
+        let day_arr = arrow2::compute::temporal::day(self.data.as_ref())?;
+        Ok((self.name(), Box::new(day_arr)).into())
+    }
+
+    pub fn month(&self) -> DaftResult<UInt32Array> {
+        let month_arr = arrow2::compute::temporal::month(self.data.as_ref())?;
+        Ok((self.name(), Box::new(month_arr)).into())
+    }
+
     pub fn year(&self) -> DaftResult<Int32Array> {
         let year_arr = arrow2::compute::temporal::year(self.data.as_ref())?;
         Ok((self.name(), Box::new(year_arr)).into())
+    }
+
+    pub fn day_of_week(&self) -> DaftResult<UInt32Array> {
+        let day_arr = arrow2::compute::temporal::weekday(self.data.as_ref())?;
+        Ok((self.name(), Box::new(day_arr.sub(&1))).into())
     }
 }

--- a/src/dsl/functions/temporal/day.rs
+++ b/src/dsl/functions/temporal/day.rs
@@ -1,0 +1,47 @@
+use crate::{
+    datatypes::{DataType, Field},
+    dsl::Expr,
+    error::{DaftError, DaftResult},
+    schema::Schema,
+    series::Series,
+};
+
+use super::super::FunctionEvaluator;
+
+pub(super) struct DayEvaluator {}
+
+impl FunctionEvaluator for DayEvaluator {
+    fn fn_name(&self) -> &'static str {
+        "day"
+    }
+
+    fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
+        if inputs.len() != 1 {
+            return Err(DaftError::SchemaMismatch(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            )));
+        }
+        let field = inputs.first().unwrap().to_field(schema)?;
+        if !field.dtype.is_temporal() {
+            return Err(DaftError::TypeError(format!(
+                "Expected input to day to be temporal, got {}",
+                field.dtype
+            )));
+        }
+        Ok(Field {
+            name: field.name,
+            dtype: DataType::UInt32,
+        })
+    }
+
+    fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
+        if inputs.len() != 1 {
+            return Err(DaftError::ValueError(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            )));
+        }
+        inputs.first().unwrap().dt_day()
+    }
+}

--- a/src/dsl/functions/temporal/day.rs
+++ b/src/dsl/functions/temporal/day.rs
@@ -36,12 +36,12 @@ impl FunctionEvaluator for DayEvaluator {
     }
 
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
-        if inputs.len() != 1 {
-            return Err(DaftError::ValueError(format!(
+        match inputs {
+            [input] => input.dt_day(),
+            _ => Err(DaftError::ValueError(format!(
                 "Expected 1 input arg, got {}",
                 inputs.len()
-            )));
+            ))),
         }
-        inputs.first().unwrap().dt_day()
     }
 }

--- a/src/dsl/functions/temporal/day.rs
+++ b/src/dsl/functions/temporal/day.rs
@@ -16,23 +16,23 @@ impl FunctionEvaluator for DayEvaluator {
     }
 
     fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
-        if inputs.len() != 1 {
-            return Err(DaftError::SchemaMismatch(format!(
+        match inputs {
+            [input] => match input.to_field(schema) {
+                Ok(field) if field.dtype.is_temporal() => Ok(Field {
+                    name: field.name,
+                    dtype: DataType::UInt32,
+                }),
+                Ok(field) => Err(DaftError::TypeError(format!(
+                    "Expected input to day to be temporal, got {}",
+                    field.dtype
+                ))),
+                Err(e) => Err(e),
+            },
+            _ => Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
                 inputs.len()
-            )));
+            ))),
         }
-        let field = inputs.first().unwrap().to_field(schema)?;
-        if !field.dtype.is_temporal() {
-            return Err(DaftError::TypeError(format!(
-                "Expected input to day to be temporal, got {}",
-                field.dtype
-            )));
-        }
-        Ok(Field {
-            name: field.name,
-            dtype: DataType::UInt32,
-        })
     }
 
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {

--- a/src/dsl/functions/temporal/day_of_week.rs
+++ b/src/dsl/functions/temporal/day_of_week.rs
@@ -16,23 +16,23 @@ impl FunctionEvaluator for DayOfWeekEvaluator {
     }
 
     fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
-        if inputs.len() != 1 {
-            return Err(DaftError::SchemaMismatch(format!(
+        match inputs {
+            [input] => match input.to_field(schema) {
+                Ok(field) if field.dtype.is_temporal() => Ok(Field {
+                    name: field.name,
+                    dtype: DataType::UInt32,
+                }),
+                Ok(field) => Err(DaftError::TypeError(format!(
+                    "Expected input to day to be temporal, got {}",
+                    field.dtype
+                ))),
+                Err(e) => Err(e),
+            },
+            _ => Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
                 inputs.len()
-            )));
+            ))),
         }
-        let field = inputs.first().unwrap().to_field(schema)?;
-        if !field.dtype.is_temporal() {
-            return Err(DaftError::TypeError(format!(
-                "Expected input to day_of_week to be temporal, got {}",
-                field.dtype
-            )));
-        }
-        Ok(Field {
-            name: field.name,
-            dtype: DataType::UInt32,
-        })
     }
 
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {

--- a/src/dsl/functions/temporal/day_of_week.rs
+++ b/src/dsl/functions/temporal/day_of_week.rs
@@ -36,12 +36,12 @@ impl FunctionEvaluator for DayOfWeekEvaluator {
     }
 
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
-        if inputs.len() != 1 {
-            return Err(DaftError::ValueError(format!(
+        match inputs {
+            [input] => input.dt_day_of_week(),
+            _ => Err(DaftError::ValueError(format!(
                 "Expected 1 input arg, got {}",
                 inputs.len()
-            )));
+            ))),
         }
-        inputs.first().unwrap().dt_day_of_week()
     }
 }

--- a/src/dsl/functions/temporal/day_of_week.rs
+++ b/src/dsl/functions/temporal/day_of_week.rs
@@ -1,0 +1,47 @@
+use crate::{
+    datatypes::{DataType, Field},
+    dsl::Expr,
+    error::{DaftError, DaftResult},
+    schema::Schema,
+    series::Series,
+};
+
+use super::super::FunctionEvaluator;
+
+pub(super) struct DayOfWeekEvaluator {}
+
+impl FunctionEvaluator for DayOfWeekEvaluator {
+    fn fn_name(&self) -> &'static str {
+        "day_of_week"
+    }
+
+    fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
+        if inputs.len() != 1 {
+            return Err(DaftError::SchemaMismatch(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            )));
+        }
+        let field = inputs.first().unwrap().to_field(schema)?;
+        if !field.dtype.is_temporal() {
+            return Err(DaftError::TypeError(format!(
+                "Expected input to day_of_week to be temporal, got {}",
+                field.dtype
+            )));
+        }
+        Ok(Field {
+            name: field.name,
+            dtype: DataType::UInt32,
+        })
+    }
+
+    fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
+        if inputs.len() != 1 {
+            return Err(DaftError::ValueError(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            )));
+        }
+        inputs.first().unwrap().dt_day_of_week()
+    }
+}

--- a/src/dsl/functions/temporal/mod.rs
+++ b/src/dsl/functions/temporal/mod.rs
@@ -1,14 +1,23 @@
+mod day;
+mod day_of_week;
+mod month;
 mod year;
 
 use serde::{Deserialize, Serialize};
 
-use crate::dsl::{functions::temporal::year::YearEvaluator, Expr};
+use crate::dsl::functions::temporal::{
+    day::DayEvaluator, day_of_week::DayOfWeekEvaluator, month::MonthEvaluator, year::YearEvaluator,
+};
+use crate::dsl::Expr;
 
 use super::FunctionEvaluator;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum TemporalExpr {
+    Day,
+    Month,
     Year,
+    DayOfWeek,
 }
 
 impl TemporalExpr {
@@ -16,14 +25,38 @@ impl TemporalExpr {
     pub fn get_evaluator(&self) -> &dyn FunctionEvaluator {
         use TemporalExpr::*;
         match self {
+            Day => &DayEvaluator {},
+            Month => &MonthEvaluator {},
             Year => &YearEvaluator {},
+            DayOfWeek => &DayOfWeekEvaluator {},
         }
+    }
+}
+
+pub fn day(input: &Expr) -> Expr {
+    Expr::Function {
+        func: super::FunctionExpr::Temporal(TemporalExpr::Day),
+        inputs: vec![input.clone()],
+    }
+}
+
+pub fn month(input: &Expr) -> Expr {
+    Expr::Function {
+        func: super::FunctionExpr::Temporal(TemporalExpr::Month),
+        inputs: vec![input.clone()],
     }
 }
 
 pub fn year(input: &Expr) -> Expr {
     Expr::Function {
         func: super::FunctionExpr::Temporal(TemporalExpr::Year),
+        inputs: vec![input.clone()],
+    }
+}
+
+pub fn day_of_week(input: &Expr) -> Expr {
+    Expr::Function {
+        func: super::FunctionExpr::Temporal(TemporalExpr::DayOfWeek),
         inputs: vec![input.clone()],
     }
 }

--- a/src/dsl/functions/temporal/month.rs
+++ b/src/dsl/functions/temporal/month.rs
@@ -36,12 +36,12 @@ impl FunctionEvaluator for MonthEvaluator {
     }
 
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
-        if inputs.len() != 1 {
-            return Err(DaftError::ValueError(format!(
+        match inputs {
+            [input] => input.dt_month(),
+            _ => Err(DaftError::ValueError(format!(
                 "Expected 1 input arg, got {}",
                 inputs.len()
-            )));
+            ))),
         }
-        inputs.first().unwrap().dt_month()
     }
 }

--- a/src/dsl/functions/temporal/month.rs
+++ b/src/dsl/functions/temporal/month.rs
@@ -16,23 +16,23 @@ impl FunctionEvaluator for MonthEvaluator {
     }
 
     fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
-        if inputs.len() != 1 {
-            return Err(DaftError::SchemaMismatch(format!(
+        match inputs {
+            [input] => match input.to_field(schema) {
+                Ok(field) if field.dtype.is_temporal() => Ok(Field {
+                    name: field.name,
+                    dtype: DataType::UInt32,
+                }),
+                Ok(field) => Err(DaftError::TypeError(format!(
+                    "Expected input to month to be temporal, got {}",
+                    field.dtype
+                ))),
+                Err(e) => Err(e),
+            },
+            _ => Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
                 inputs.len()
-            )));
+            ))),
         }
-        let field = inputs.first().unwrap().to_field(schema)?;
-        if !field.dtype.is_temporal() {
-            return Err(DaftError::TypeError(format!(
-                "Expected input to month to be temporal, got {}",
-                field.dtype
-            )));
-        }
-        Ok(Field {
-            name: field.name,
-            dtype: DataType::UInt32,
-        })
     }
 
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {

--- a/src/dsl/functions/temporal/month.rs
+++ b/src/dsl/functions/temporal/month.rs
@@ -1,0 +1,47 @@
+use crate::{
+    datatypes::{DataType, Field},
+    dsl::Expr,
+    error::{DaftError, DaftResult},
+    schema::Schema,
+    series::Series,
+};
+
+use super::super::FunctionEvaluator;
+
+pub(super) struct MonthEvaluator {}
+
+impl FunctionEvaluator for MonthEvaluator {
+    fn fn_name(&self) -> &'static str {
+        "month"
+    }
+
+    fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
+        if inputs.len() != 1 {
+            return Err(DaftError::SchemaMismatch(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            )));
+        }
+        let field = inputs.first().unwrap().to_field(schema)?;
+        if !field.dtype.is_temporal() {
+            return Err(DaftError::TypeError(format!(
+                "Expected input to month to be temporal, got {}",
+                field.dtype
+            )));
+        }
+        Ok(Field {
+            name: field.name,
+            dtype: DataType::UInt32,
+        })
+    }
+
+    fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
+        if inputs.len() != 1 {
+            return Err(DaftError::ValueError(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            )));
+        }
+        inputs.first().unwrap().dt_month()
+    }
+}

--- a/src/dsl/functions/temporal/year.rs
+++ b/src/dsl/functions/temporal/year.rs
@@ -36,12 +36,12 @@ impl FunctionEvaluator for YearEvaluator {
     }
 
     fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
-        if inputs.len() != 1 {
-            return Err(DaftError::ValueError(format!(
+        match inputs {
+            [input] => input.dt_year(),
+            _ => Err(DaftError::ValueError(format!(
                 "Expected 1 input arg, got {}",
                 inputs.len()
-            )));
+            ))),
         }
-        inputs.first().unwrap().dt_year()
     }
 }

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -214,9 +214,24 @@ impl PyExpr {
         Ok(format!("{}", self.expr))
     }
 
+    pub fn dt_day(&self) -> PyResult<Self> {
+        use functions::temporal::day;
+        Ok(day(&self.expr).into())
+    }
+
+    pub fn dt_month(&self) -> PyResult<Self> {
+        use functions::temporal::month;
+        Ok(month(&self.expr).into())
+    }
+
     pub fn dt_year(&self) -> PyResult<Self> {
         use functions::temporal::year;
         Ok(year(&self.expr).into())
+    }
+
+    pub fn dt_day_of_week(&self) -> PyResult<Self> {
+        use functions::temporal::day_of_week;
+        Ok(day_of_week(&self.expr).into())
     }
 
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -219,8 +219,20 @@ impl PySeries {
         Ok(self.series.utf8_contains(&pattern.series)?.into())
     }
 
+    pub fn dt_day(&self) -> PyResult<Self> {
+        Ok(self.series.dt_day()?.into())
+    }
+
+    pub fn dt_month(&self) -> PyResult<Self> {
+        Ok(self.series.dt_month()?.into())
+    }
+
     pub fn dt_year(&self) -> PyResult<Self> {
         Ok(self.series.dt_year()?.into())
+    }
+
+    pub fn dt_day_of_week(&self) -> PyResult<Self> {
+        Ok(self.series.dt_day_of_week()?.into())
     }
 
     pub fn if_else(&self, other: &Self, predicate: &Self) -> PyResult<Self> {

--- a/src/series/ops/date.rs
+++ b/src/series/ops/date.rs
@@ -7,6 +7,30 @@ use crate::{
 };
 
 impl Series {
+    pub fn dt_day(&self) -> DaftResult<Self> {
+        if !matches!(self.data_type(), DataType::Date) {
+            return Err(DaftError::ComputeError(format!(
+                "Can only run day() operation on DateType, got {}",
+                self.data_type()
+            )));
+        }
+
+        let downcasted = self.downcast::<DateType>()?;
+        Ok(downcasted.day()?.into_series())
+    }
+
+    pub fn dt_month(&self) -> DaftResult<Self> {
+        if !matches!(self.data_type(), DataType::Date) {
+            return Err(DaftError::ComputeError(format!(
+                "Can only run month() operation on DateType, got {}",
+                self.data_type()
+            )));
+        }
+
+        let downcasted = self.downcast::<DateType>()?;
+        Ok(downcasted.month()?.into_series())
+    }
+
     pub fn dt_year(&self) -> DaftResult<Self> {
         if !matches!(self.data_type(), DataType::Date) {
             return Err(DaftError::ComputeError(format!(
@@ -17,5 +41,17 @@ impl Series {
 
         let downcasted = self.downcast::<DateType>()?;
         Ok(downcasted.year()?.into_series())
+    }
+
+    pub fn dt_day_of_week(&self) -> DaftResult<Self> {
+        if !matches!(self.data_type(), DataType::Date) {
+            return Err(DaftError::ComputeError(format!(
+                "Can only run day_of_week() operation on DateType, got {}",
+                self.data_type()
+            )));
+        }
+
+        let downcasted = self.downcast::<DateType>()?;
+        Ok(downcasted.day_of_week()?.into_series())
     }
 }

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -82,11 +82,38 @@ def test_repr_functions_abs() -> None:
     assert repr_out == repr(copied)
 
 
+def test_repr_functions_day() -> None:
+    a = col("a")
+    y = a.dt.day()
+    repr_out = repr(y)
+    assert repr_out == "day(col(a))"
+    copied = copy.deepcopy(y)
+    assert repr_out == repr(copied)
+
+
+def test_repr_functions_month() -> None:
+    a = col("a")
+    y = a.dt.month()
+    repr_out = repr(y)
+    assert repr_out == "month(col(a))"
+    copied = copy.deepcopy(y)
+    assert repr_out == repr(copied)
+
+
 def test_repr_functions_year() -> None:
     a = col("a")
     y = a.dt.year()
     repr_out = repr(y)
     assert repr_out == "year(col(a))"
+    copied = copy.deepcopy(y)
+    assert repr_out == repr(copied)
+
+
+def test_repr_functions_day_of_week() -> None:
+    a = col("a")
+    y = a.dt.day_of_week()
+    repr_out = repr(y)
+    assert repr_out == "day_of_week(col(a))"
     copied = copy.deepcopy(y)
     assert repr_out == repr(copied)
 

--- a/tests/expressions/typing/test_dt.py
+++ b/tests/expressions/typing/test_dt.py
@@ -10,7 +10,10 @@ from tests.expressions.typing.conftest import assert_typing_resolve_vs_runtime_b
 @pytest.mark.parametrize(
     "op",
     [
+        pytest.param(lambda x: x.dt.day(), id="day"),
+        pytest.param(lambda x: x.dt.month(), id="month"),
         pytest.param(lambda x: x.dt.year(), id="year"),
+        pytest.param(lambda x: x.dt.day_of_week(), id="day_of_week"),
     ],
 )
 def test_dt_extraction_ops(unary_data_fixture, op):

--- a/tests/series/test_temporal_ops.py
+++ b/tests/series/test_temporal_ops.py
@@ -4,6 +4,44 @@ from daft.datatype import DataType
 from daft.series import Series
 
 
+def test_series_date_day_operation() -> None:
+    from datetime import date
+
+    def date_maker(d):
+        if d is None:
+            return None
+        return date(2023, 1, d)
+
+    input = [1, 5, 14, None, 23, None, 28]
+
+    input_dates = list(map(date_maker, input))
+    s = Series.from_pylist(input_dates)
+    days = s.dt.day()
+
+    assert days.datatype() == DataType.uint32()
+
+    assert input == days.to_pylist()
+
+
+def test_series_date_month_operation() -> None:
+    from datetime import date
+
+    def date_maker(m):
+        if m is None:
+            return None
+        return date(2023, m, 1)
+
+    input = list(range(1, 10)) + [None, 11, 12]
+
+    input_dates = list(map(date_maker, input))
+    s = Series.from_pylist(input_dates)
+    months = s.dt.month()
+
+    assert months.datatype() == DataType.uint32()
+
+    assert input == months.to_pylist()
+
+
 def test_series_date_year_operation() -> None:
     from datetime import date
 
@@ -14,10 +52,30 @@ def test_series_date_year_operation() -> None:
 
     input = [1, 1969, 2023 + 5, 2023 + 4, 2023 + 1, None, 2023 + 2, None]
 
-    days = list(map(date_maker, input))
-    s = Series.from_pylist(days)
+    input_dates = list(map(date_maker, input))
+    s = Series.from_pylist(input_dates)
     years = s.dt.year()
 
     assert years.datatype() == DataType.int32()
 
     assert input == years.to_pylist()
+
+
+def test_series_date_day_of_week_operation() -> None:
+    from datetime import date
+
+    def date_maker(d):
+        if d is None:
+            return None
+        return date(2023, 4, d)
+
+    # 04/03/2023 is a Monday.
+    input = [3, 4, 5, None, 6, 7, None, 8, 9]
+
+    input_dates = list(map(date_maker, input))
+    s = Series.from_pylist(input_dates)
+    day_of_weeks = s.dt.day_of_week()
+
+    assert day_of_weeks.datatype() == DataType.uint32()
+
+    assert [0, 1, 2, None, 3, 4, None, 5, 6] == day_of_weeks.to_pylist()


### PR DESCRIPTION
This PR adds the missing date kernels, `dt.month`, `dt.day`, and `dt.day_of_week`, to the Rust expression path.

This is the first of two PRs for https://github.com/Eventual-Inc/Daft/issues/759.