### PR TITLE
[RUST] Fix range partitioning for empty/all-null partition keys

### DIFF
--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -56,8 +56,8 @@ class Table:
     ###
 
     @staticmethod
-    def empty() -> Table:
-        pyt = _PyTable.empty()
+    def empty(schema: Schema | None = None) -> Table:
+        pyt = _PyTable.empty(None) if schema is None else _PyTable.empty(schema._schema)
         return Table._from_pytable(pyt)
 
     @staticmethod

--- a/src/python/schema.rs
+++ b/src/python/schema.rs
@@ -12,6 +12,7 @@ use crate::schema;
 use crate::schema::Schema;
 
 #[pyclass]
+#[derive(Clone)]
 pub struct PySchema {
     pub schema: schema::SchemaRef,
 }

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -260,8 +260,12 @@ impl PyTable {
     }
 
     #[staticmethod]
-    pub fn empty() -> PyResult<Self> {
-        Ok(table::Table::empty()?.into())
+    pub fn empty(schema: Option<PySchema>) -> PyResult<Self> {
+        Ok(table::Table::empty(match schema {
+            Some(s) => Some(s.schema),
+            None => None,
+        })?
+        .into())
     }
 }
 

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -9,6 +9,7 @@ use crate::dsl::{AggExpr, Expr};
 use crate::error::{DaftError, DaftResult};
 use crate::schema::{Schema, SchemaRef};
 use crate::series::Series;
+use crate::with_match_daft_types;
 
 mod ops;
 #[derive(Clone)]
@@ -53,8 +54,19 @@ impl Table {
         })
     }
 
-    pub fn empty() -> DaftResult<Self> {
-        Self::new(Schema::empty(), vec![])
+    pub fn empty(schema: Option<SchemaRef>) -> DaftResult<Self> {
+        match schema {
+            Some(schema) => {
+                let mut columns: Vec<Series> = Vec::with_capacity(schema.names().len());
+                for (field_name, field) in schema.fields.iter() {
+                    with_match_daft_types!(field.dtype, |$T| {
+                        columns.push(DataArray::<$T>::full_null(field_name, 0).into_series())
+                    })
+                }
+                Ok(Table { schema, columns })
+            }
+            None => Self::new(Schema::empty(), vec![]),
+        }
     }
 
     pub fn from_columns(columns: Vec<Series>) -> DaftResult<Self> {


### PR DESCRIPTION
Bug description:
* When a partitioning key contains all null or is empty, the computed boundaries used for range partitioning is empty
* This causes issues in our code which assumes N_OUTPUT_PARTITIONS number of partitions to be returned

This commit fixes this behavior by padding the results with empty tables, ensuring that we always return the number of partitions requested