### PR TITLE
[RUST] Hashing of DataTypes

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -143,3 +143,6 @@ class DataType:
     def __setstate__(self, state: bytes) -> None:
         self._dtype = PyDataType.__new__(PyDataType)
         self._dtype.__setstate__(state)
+
+    def __hash__(self) -> int:
+        return self._dtype.__hash__()

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 // pub type TimeZone = String;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub enum DataType {
     // Start ArrowTypes
     /// Null type

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -6,7 +6,7 @@ use crate::{datatypes::dtype::DataType, error::DaftResult};
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub struct Field {
     pub name: String,
     pub dtype: DataType,

--- a/src/python/datatype.rs
+++ b/src/python/datatype.rs
@@ -126,6 +126,15 @@ impl PyDataType {
     pub fn __getstate__(&self, py: Python) -> PyResult<PyObject> {
         Ok(PyBytes::new(py, &bincode::serialize(&self.dtype).unwrap()).to_object(py))
     }
+
+    pub fn __hash__(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::Hash;
+        use std::hash::Hasher;
+        let mut hasher = DefaultHasher::new();
+        self.dtype.hash(&mut hasher);
+        hasher.finish()
+    }
 }
 
 impl From<DataType> for PyDataType {


### PR DESCRIPTION
Allows hashing of DataTypes using the Rust `Hash` trait. This is useful when testing in Python and lets us use DataTypes as keys for dictionaries, put DataTypes into sets etc.