### PR TITLE
[rust] Refactor base array arc to box

### DIFF
--- a/src/array/from.rs
+++ b/src/array/from.rs
@@ -12,14 +12,14 @@ impl<T: DaftNumericType> From<(&str, Box<arrow2::array::PrimitiveArray<T::Native
 {
     fn from(item: (&str, Box<arrow2::array::PrimitiveArray<T::Native>>)) -> Self {
         let (name, array) = item;
-        DataArray::new(Field::new(name, T::get_dtype()).into(), array.arced()).unwrap()
+        DataArray::new(Field::new(name, T::get_dtype()).into(), array).unwrap()
     }
 }
 
 impl From<(&str, Box<arrow2::array::Utf8Array<i64>>)> for Utf8Array {
     fn from(item: (&str, Box<arrow2::array::Utf8Array<i64>>)) -> Self {
         let (name, array) = item;
-        DataArray::new(Field::new(name, DataType::Utf8).into(), array.arced()).unwrap()
+        DataArray::new(Field::new(name, DataType::Utf8).into(), array).unwrap()
     }
 }
 
@@ -29,8 +29,10 @@ where
 {
     fn from(item: (&str, &[T::Native])) -> Self {
         let (name, slice) = item;
-        let arrow_array = arrow2::array::PrimitiveArray::<T::Native>::from_slice(slice);
-        DataArray::new(Field::new(name, T::get_dtype()).into(), arrow_array.arced()).unwrap()
+        let arrow_array = Box::new(arrow2::array::PrimitiveArray::<T::Native>::from_slice(
+            slice,
+        ));
+        DataArray::new(Field::new(name, T::get_dtype()).into(), arrow_array).unwrap()
     }
 }
 
@@ -40,20 +42,16 @@ where
 {
     fn from(item: (&str, Vec<T::Native>)) -> Self {
         let (name, v) = item;
-        let arrow_array = arrow2::array::PrimitiveArray::<T::Native>::from_vec(v);
-        DataArray::new(Field::new(name, T::get_dtype()).into(), arrow_array.arced()).unwrap()
+        let arrow_array = Box::new(arrow2::array::PrimitiveArray::<T::Native>::from_vec(v));
+        DataArray::new(Field::new(name, T::get_dtype()).into(), arrow_array).unwrap()
     }
 }
 
 impl From<(&str, &[bool])> for BooleanArray {
     fn from(item: (&str, &[bool])) -> Self {
         let (name, slice) = item;
-        let arrow_array = arrow2::array::BooleanArray::from_slice(slice);
-        DataArray::new(
-            Field::new(name, DataType::Boolean).into(),
-            arrow_array.arced(),
-        )
-        .unwrap()
+        let arrow_array = Box::new(arrow2::array::BooleanArray::from_slice(slice));
+        DataArray::new(Field::new(name, DataType::Boolean).into(), arrow_array).unwrap()
     }
 }
 
@@ -62,7 +60,7 @@ impl From<(&str, arrow2::array::BooleanArray)> for BooleanArray {
         let (name, arrow_array) = item;
         DataArray::new(
             Field::new(name, DataType::Boolean).into(),
-            arrow_array.arced(),
+            Box::new(arrow_array),
         )
         .unwrap()
     }
@@ -71,20 +69,16 @@ impl From<(&str, arrow2::array::BooleanArray)> for BooleanArray {
 impl<T: AsRef<str>> From<(&str, &[T])> for DataArray<Utf8Type> {
     fn from(item: (&str, &[T])) -> Self {
         let (name, slice) = item;
-        let arrow_array = arrow2::array::Utf8Array::<i64>::from_slice(slice);
-        DataArray::new(Field::new(name, DataType::Utf8).into(), arrow_array.arced()).unwrap()
+        let arrow_array = Box::new(arrow2::array::Utf8Array::<i64>::from_slice(slice));
+        DataArray::new(Field::new(name, DataType::Utf8).into(), arrow_array).unwrap()
     }
 }
 
 impl From<(&str, &[u8])> for BinaryArray {
     fn from(item: (&str, &[u8])) -> Self {
         let (name, slice) = item;
-        let arrow_array = arrow2::array::BinaryArray::<i64>::from_slice([slice]);
-        DataArray::new(
-            Field::new(name, DataType::Binary).into(),
-            arrow_array.arced(),
-        )
-        .unwrap()
+        let arrow_array = Box::new(arrow2::array::BinaryArray::<i64>::from_slice([slice]));
+        DataArray::new(Field::new(name, DataType::Binary).into(), arrow_array).unwrap()
     }
 }
 
@@ -101,9 +95,6 @@ impl<T: DaftDataType> TryFrom<(&str, Box<dyn arrow2::array::Array>)> for DataArr
                 self_arrow_type
             )));
         }
-        DataArray::new(
-            Field::new(name, array.data_type().into()).into(),
-            Arc::from(array),
-        )
+        DataArray::new(Field::new(name, array.data_type().into()).into(), array)
     }
 }

--- a/src/array/from.rs
+++ b/src/array/from.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::datatypes::{
     BinaryArray, BooleanArray, DaftDataType, DaftNumericType, DataType, Field, Utf8Array, Utf8Type,
 };

--- a/src/array/ops/broadcast.rs
+++ b/src/array/ops/broadcast.rs
@@ -91,8 +91,9 @@ impl BinaryArray {
                 let repeated_values: Vec<&[u8]> = std::iter::repeat(val).take(num).collect();
                 BinaryArray::new(
                     self.field.clone(),
-                    arrow2::array::BinaryArray::<i64>::from_slice(repeated_values.as_slice())
-                        .arced(),
+                    Box::new(arrow2::array::BinaryArray::<i64>::from_slice(
+                        repeated_values.as_slice(),
+                    )),
                 )
             }
             None => Ok(DataArray::full_null(self.name(), num)),

--- a/src/array/ops/compare_agg.rs
+++ b/src/array/ops/compare_agg.rs
@@ -21,18 +21,18 @@ where
         let primitive_arr = self.downcast();
 
         let result = arrow2::compute::aggregate::min_primitive(primitive_arr);
-        let arrow_array = arrow2::array::PrimitiveArray::from([result]);
+        let arrow_array = Box::new(arrow2::array::PrimitiveArray::from([result]));
 
-        DataArray::new(self.field.clone(), Arc::new(arrow_array))
+        DataArray::new(self.field.clone(), arrow_array)
     }
 
     fn max(&self) -> Self::Output {
         let primitive_arr = self.downcast();
 
         let result = arrow2::compute::aggregate::max_primitive(primitive_arr);
-        let arrow_array = arrow2::array::PrimitiveArray::from([result]);
+        let arrow_array = Box::new(arrow2::array::PrimitiveArray::from([result]));
 
-        DataArray::new(self.field.clone(), Arc::new(arrow_array))
+        DataArray::new(self.field.clone(), arrow_array)
     }
 }
 
@@ -45,7 +45,7 @@ impl DaftCompareAggable for &DataArray<Utf8Type> {
         let result = arrow2::compute::aggregate::min_string(arrow_array);
         let res_arrow_array = arrow2::array::Utf8Array::<i64>::from([result]);
 
-        DataArray::new(self.field.clone(), Arc::new(res_arrow_array))
+        DataArray::new(self.field.clone(), Box::new(res_arrow_array))
     }
     fn max(&self) -> Self::Output {
         let arrow_array: &arrow2::array::Utf8Array<i64> =
@@ -54,7 +54,7 @@ impl DaftCompareAggable for &DataArray<Utf8Type> {
         let result = arrow2::compute::aggregate::max_string(arrow_array);
         let res_arrow_array = arrow2::array::Utf8Array::<i64>::from([result]);
 
-        DataArray::new(self.field.clone(), Arc::new(res_arrow_array))
+        DataArray::new(self.field.clone(), Box::new(res_arrow_array))
     }
 }
 
@@ -67,7 +67,7 @@ impl DaftCompareAggable for &DataArray<BooleanType> {
         let result = arrow2::compute::aggregate::min_boolean(arrow_array);
         let res_arrow_array = arrow2::array::BooleanArray::from([result]);
 
-        DataArray::new(self.field.clone(), Arc::new(res_arrow_array))
+        DataArray::new(self.field.clone(), Box::new(res_arrow_array))
     }
     fn max(&self) -> Self::Output {
         let arrow_array: &arrow2::array::BooleanArray =
@@ -76,7 +76,7 @@ impl DaftCompareAggable for &DataArray<BooleanType> {
         let result = arrow2::compute::aggregate::max_boolean(arrow_array);
         let res_arrow_array = arrow2::array::BooleanArray::from([result]);
 
-        DataArray::new(self.field.clone(), Arc::new(res_arrow_array))
+        DataArray::new(self.field.clone(), Box::new(res_arrow_array))
     }
 }
 
@@ -85,7 +85,7 @@ impl DaftCompareAggable for &DataArray<NullType> {
 
     fn min(&self) -> Self::Output {
         let res_arrow_array = arrow2::array::NullArray::new(arrow2::datatypes::DataType::Null, 1);
-        DataArray::new(self.field.clone(), Arc::new(res_arrow_array))
+        DataArray::new(self.field.clone(), Box::new(res_arrow_array))
     }
 
     fn max(&self) -> Self::Output {

--- a/src/array/ops/compare_agg.rs
+++ b/src/array/ops/compare_agg.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2;
 
 use crate::{

--- a/src/array/ops/count.rs
+++ b/src/array/ops/count.rs
@@ -15,10 +15,11 @@ where
     fn count(&self) -> Self::Output {
         let arrow_array = &self.data;
         let count = arrow_array.len() - arrow_array.null_count();
-        let result_arrow_array = arrow2::array::PrimitiveArray::from([Some(count as u64)]);
+        let result_arrow_array =
+            Box::new(arrow2::array::PrimitiveArray::from([Some(count as u64)]));
         DataArray::<UInt64Type>::new(
             Arc::new(Field::new(self.field.name.clone(), DataType::UInt64)),
-            Arc::new(result_arrow_array),
+            result_arrow_array,
         )
     }
 }

--- a/src/array/ops/full.rs
+++ b/src/array/ops/full.rs
@@ -18,7 +18,7 @@ where
         }
         let arr = new_null_array(T::get_dtype().to_arrow().unwrap(), length);
 
-        DataArray::new(Arc::new(Field::new(name, T::get_dtype())), Arc::from(arr)).unwrap()
+        DataArray::new(Arc::new(Field::new(name, T::get_dtype())), arr).unwrap()
     }
 
     pub fn empty(name: &str) -> Self {
@@ -27,6 +27,6 @@ where
         }
         let arr = new_empty_array(T::get_dtype().to_arrow().unwrap());
 
-        DataArray::new(Arc::new(Field::new(name, T::get_dtype())), Arc::from(arr)).unwrap()
+        DataArray::new(Arc::new(Field::new(name, T::get_dtype())), arr).unwrap()
     }
 }

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -4,7 +4,6 @@ use crate::error::DaftError;
 use crate::{array::DataArray, error::DaftResult};
 use arrow2::compute::if_then_else::if_then_else;
 use std::convert::identity;
-use std::sync::Arc;
 
 use crate::array::BaseArray;
 

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -50,7 +50,7 @@ macro_rules! broadcast_if_else{(
                     false => other_scalar,
                 }
             ).collect();
-            DataArray::new($if_true.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
+            DataArray::new($if_true.field.clone(), Box::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
         }
         // CASE: Broadcast truthy array
         (1, o, p)  if o == p => {
@@ -63,7 +63,7 @@ macro_rules! broadcast_if_else{(
                     false => $scalar_copy(other_val),
                 }
             ).collect();
-            DataArray::new($if_true.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
+            DataArray::new($if_true.field.clone(), Box::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
         }
         // CASE: Broadcast falsey array
         (s, 1, p)  if s == p => {
@@ -76,7 +76,7 @@ macro_rules! broadcast_if_else{(
                     false => other_scalar,
                 }
             ).collect();
-            DataArray::new($if_true.field.clone(), Arc::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
+            DataArray::new($if_true.field.clone(), Box::new(naive_if_else.with_validity(predicate_arr.validity().cloned())))
         }
         (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with mismatched lengths: self={s}, other={o}, predicate={p}")))
     }

--- a/src/array/ops/mean.rs
+++ b/src/array/ops/mean.rs
@@ -17,11 +17,11 @@ impl DaftMeanAggable for &DataArray<Float64Type> {
             0 => None,
             count_value => Some(sum_value / count_value as f64),
         };
-        let arrow_array = arrow2::array::PrimitiveArray::from([result]);
+        let arrow_array = Box::new(arrow2::array::PrimitiveArray::from([result]));
 
         DataArray::new(
             Arc::new(Field::new(self.field.name.clone(), DataType::Float64)),
-            Arc::new(arrow_array),
+            arrow_array,
         )
     }
 }

--- a/src/array/ops/null.rs
+++ b/src/array/ops/null.rs
@@ -14,7 +14,7 @@ where
 
     fn is_null(&self) -> Self::Output {
         let arrow_array = &self.data;
-        let result_arrow_array = match arrow_array.validity() {
+        let result_arrow_array = Box::new(match arrow_array.validity() {
             // If the bitmap is None, the arrow array doesn't have null values
             // (unless it's a NullArray - so check the null count)
             None => match arrow_array.null_count() {
@@ -26,10 +26,10 @@ where
                 !bitmap,
                 None,
             ),
-        };
+        });
         DataArray::<BooleanType>::new(
             Arc::new(Field::new(self.field.name.clone(), DataType::Boolean)),
-            Arc::new(result_arrow_array),
+            result_arrow_array,
         )
     }
 }

--- a/src/array/ops/sum.rs
+++ b/src/array/ops/sum.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2;
 
 use crate::{array::DataArray, datatypes::*, error::DaftResult};

--- a/src/array/ops/sum.rs
+++ b/src/array/ops/sum.rs
@@ -14,8 +14,8 @@ macro_rules! impl_daft_numeric_agg {
             fn sum(&self) -> Self::Output {
                 let primitive_arr = self.downcast();
                 let sum_value = arrow2::compute::aggregate::sum_primitive(primitive_arr);
-                let arrow_array = arrow2::array::PrimitiveArray::from([sum_value]);
-                DataArray::new(self.field.clone(), Arc::new(arrow_array))
+                let arrow_array = Box::new(arrow2::array::PrimitiveArray::from([sum_value]));
+                DataArray::new(self.field.clone(), arrow_array)
             }
         }
     };


### PR DESCRIPTION
* For DataArray use a Box to an Arrow Array over an Arc. This avoids another allocation since an Arc to a pointer to a rc and object as seen [here](https://docs.google.com/presentation/d/1q-c7UAyrUlM-eZyTo1pd8SZ0qwA_wYxmPZVOQkoDmH4/edit#slide=id.p).
* This results is about a 5% speed for large partition sizes