### PR TITLE
[Missing Expression Kernels - 2/2] Add missing `str.length()`, `str.concat()`, and `float.is_nan()` kernels.

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -296,7 +296,8 @@ class ExpressionStringNamespace(ExpressionNamespace):
         return Expression._from_pyexpr(self._expr.utf8_startswith(prefix_expr._expr))
 
     def concat(self, other: str) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement string expression")
+        # Delegate to + operator implementation.
+        return Expression._from_pyexpr(self._expr) + other
 
     def length(self) -> Expression:
         raise NotImplementedError("[RUST-INT] Implement string expression")

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -300,7 +300,7 @@ class ExpressionStringNamespace(ExpressionNamespace):
         return Expression._from_pyexpr(self._expr) + other
 
     def length(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement string expression")
+        return Expression._from_pyexpr(self._expr.utf8_length())
 
 
 class ExpressionsProjection(Iterable[Expression]):

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -265,7 +265,7 @@ class ExpressionNamespace:
 
 class ExpressionFloatNamespace(ExpressionNamespace):
     def is_nan(self) -> Expression:
-        raise NotImplementedError("[RUST-INT] Implement float is_nan expression")
+        return Expression._from_pyexpr(self._expr.is_nan())
 
 
 class ExpressionDatetimeNamespace(ExpressionNamespace):

--- a/daft/series.py
+++ b/daft/series.py
@@ -251,6 +251,10 @@ class Series:
         return Series._from_pyseries(self._series.is_null())
 
     @property
+    def float(self) -> SeriesFloatNamespace:
+        return SeriesFloatNamespace.from_series(self)
+
+    @property
     def str(self) -> SeriesStringNamespace:
         return SeriesStringNamespace.from_series(self)
 
@@ -276,6 +280,11 @@ class SeriesNamespace:
         ns = cls.__new__(cls)
         ns._series = series._series
         return ns
+
+
+class SeriesFloatNamespace(SeriesNamespace):
+    def is_nan(self) -> Series:
+        return Series._from_pyseries(self._series.is_nan())
 
 
 class SeriesStringNamespace(SeriesNamespace):

--- a/daft/series.py
+++ b/daft/series.py
@@ -297,6 +297,12 @@ class SeriesStringNamespace(SeriesNamespace):
         assert self._series is not None and pattern._series is not None
         return Series._from_pyseries(self._series.utf8_contains(pattern._series))
 
+    def concat(self, other: Series) -> Series:
+        if not isinstance(other, Series):
+            raise ValueError(f"expected another Series but got {type(other)}")
+        assert self._series is not None and other._series is not None
+        return Series._from_pyseries(self._series) + other
+
 
 class SeriesDateNamespace(SeriesNamespace):
     def day(self) -> Series:

--- a/daft/series.py
+++ b/daft/series.py
@@ -303,6 +303,10 @@ class SeriesStringNamespace(SeriesNamespace):
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series) + other
 
+    def length(self) -> Series:
+        assert self._series is not None
+        return Series._from_pyseries(self._series.utf8_length())
+
 
 class SeriesDateNamespace(SeriesNamespace):
     def day(self) -> Series:

--- a/src/array/ops/float.rs
+++ b/src/array/ops/float.rs
@@ -1,11 +1,11 @@
-use std::sync::Arc;
-
 use crate::{
     array::DataArray,
-    datatypes::{BooleanType, DaftFloatType, DaftNumericType, DataType, Field, NullType},
+    datatypes::{BooleanArray, BooleanType, DaftFloatType, DaftNumericType, NullType},
     error::DaftResult,
 };
 use num_traits::Float;
+
+use crate::array::BaseArray;
 
 use super::DaftIsNan;
 
@@ -22,10 +22,7 @@ where
             arrow_array.values_iter().map(|v| v.is_nan()),
         )
         .with_validity(arrow_array.validity().cloned());
-        DataArray::<BooleanType>::new(
-            Arc::new(Field::new(self.field.name.clone(), DataType::Boolean)),
-            Arc::new(result_arrow_array),
-        )
+        Ok(BooleanArray::from((self.name(), result_arrow_array)))
     }
 }
 
@@ -34,12 +31,10 @@ impl DaftIsNan for &DataArray<NullType> {
 
     fn is_nan(&self) -> Self::Output {
         // Entire array is null; since we don't consider nulls to be NaNs, return an all null (invalid) boolean array.
-        DataArray::<BooleanType>::new(
-            Arc::new(Field::new(self.field.name.clone(), DataType::Boolean)),
-            Arc::new(
-                arrow2::array::BooleanArray::from_slice(vec![false; self.len()])
-                    .with_validity(Some(arrow2::bitmap::Bitmap::from(vec![false; self.len()]))),
-            ),
-        )
+        Ok(BooleanArray::from((
+            self.name(),
+            arrow2::array::BooleanArray::from_slice(vec![false; self.len()])
+                .with_validity(Some(arrow2::bitmap::Bitmap::from(vec![false; self.len()]))),
+        )))
     }
 }

--- a/src/array/ops/float.rs
+++ b/src/array/ops/float.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use crate::{
+    array::DataArray,
+    datatypes::{BooleanType, DataType, Field, Float32Type, Float64Type, NullType},
+    error::DaftResult,
+};
+
+use super::DaftIsNan;
+
+impl DaftIsNan for &DataArray<NullType> {
+    type Output = DaftResult<DataArray<BooleanType>>;
+
+    fn is_nan(&self) -> Self::Output {
+        // Entire array is null; since we don't consider nulls to be NaNs, return an all null (invalid) boolean array.
+        DataArray::<BooleanType>::new(
+            Arc::new(Field::new(self.field.name.clone(), DataType::Boolean)),
+            Arc::new(
+                arrow2::array::BooleanArray::from_slice(vec![false; self.len()])
+                    .with_validity(Some(arrow2::bitmap::Bitmap::from(vec![false; self.len()]))),
+            ),
+        )
+    }
+}
+
+macro_rules! impl_daft_float_is_nan {
+    ($T:ident) => {
+        impl DaftIsNan for &DataArray<$T> {
+            type Output = DaftResult<DataArray<BooleanType>>;
+
+            fn is_nan(&self) -> Self::Output {
+                let arrow_array = self.downcast();
+                let result_arrow_array = arrow2::array::BooleanArray::from_trusted_len_values_iter(
+                    arrow_array.values_iter().map(|v| v.is_nan()),
+                )
+                .with_validity(arrow_array.validity().cloned());
+                DataArray::<BooleanType>::new(
+                    Arc::new(Field::new(self.field.name.clone(), DataType::Boolean)),
+                    Arc::new(result_arrow_array),
+                )
+            }
+        }
+    };
+}
+
+impl_daft_float_is_nan!(Float32Type);
+impl_daft_float_is_nan!(Float64Type);

--- a/src/array/ops/mod.rs
+++ b/src/array/ops/mod.rs
@@ -12,6 +12,7 @@ mod count;
 mod date;
 mod downcast;
 mod filter;
+mod float;
 mod full;
 mod hash;
 mod if_else;
@@ -65,6 +66,11 @@ pub trait DaftLogical<Rhs> {
 pub trait DaftIsNull {
     type Output;
     fn is_null(&self) -> Self::Output;
+}
+
+pub trait DaftIsNan {
+    type Output;
+    fn is_nan(&self) -> Self::Output;
 }
 
 pub trait DaftCountAggable {

--- a/src/array/ops/utf8.rs
+++ b/src/array/ops/utf8.rs
@@ -1,6 +1,9 @@
 use crate::array::BaseArray;
-use crate::datatypes::{BooleanArray, UInt64Array, Utf8Array};
+use crate::datatypes::{
+    BooleanArray, DataArray, DataType, Field, UInt64Array, UInt64Type, Utf8Array,
+};
 use arrow2;
+use std::sync::Arc;
 
 use crate::error::{DaftError, DaftResult};
 
@@ -27,7 +30,10 @@ impl Utf8Array {
             })
             .collect::<arrow2::array::UInt64Array>()
             .with_validity(self_arrow.validity().cloned());
-        Ok(UInt64Array::from((self.name(), Box::new(arrow_result))))
+        DataArray::<UInt64Type>::new(
+            Arc::new(Field::new(self.field.name.clone(), DataType::UInt64)),
+            Arc::new(arrow_result),
+        )
     }
 
     fn binary_broadcasted_compare<ScalarKernel>(

--- a/src/array/ops/utf8.rs
+++ b/src/array/ops/utf8.rs
@@ -1,9 +1,6 @@
 use crate::array::BaseArray;
-use crate::datatypes::{
-    BooleanArray, DataArray, DataType, Field, UInt64Array, UInt64Type, Utf8Array,
-};
+use crate::datatypes::{BooleanArray, UInt64Array, Utf8Array};
 use arrow2;
-use std::sync::Arc;
 
 use crate::error::{DaftError, DaftResult};
 
@@ -30,10 +27,7 @@ impl Utf8Array {
             })
             .collect::<arrow2::array::UInt64Array>()
             .with_validity(self_arrow.validity().cloned());
-        DataArray::<UInt64Type>::new(
-            Arc::new(Field::new(self.field.name.clone(), DataType::UInt64)),
-            Arc::new(arrow_result),
-        )
+        Ok(UInt64Array::from((self.name(), Box::new(arrow_result))))
     }
 
     fn binary_broadcasted_compare<ScalarKernel>(

--- a/src/dsl/functions/float/is_nan.rs
+++ b/src/dsl/functions/float/is_nan.rs
@@ -1,0 +1,48 @@
+use crate::{
+    datatypes::{DataType, Field},
+    dsl::Expr,
+    error::{DaftError, DaftResult},
+    schema::Schema,
+    series::Series,
+};
+
+use super::super::FunctionEvaluator;
+
+pub(super) struct IsNanEvaluator {}
+
+impl FunctionEvaluator for IsNanEvaluator {
+    fn fn_name(&self) -> &'static str {
+        "is_nan"
+    }
+
+    fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
+        match inputs {
+            [data] => match data.to_field(schema) {
+                Ok(data_field) => match &data_field.dtype {
+                    DataType::Float16 | DataType::Float32 | DataType::Float64 => {
+                        Ok(Field::new(data_field.name, DataType::Boolean))
+                    }
+                    _ => Err(DaftError::TypeError(format!(
+                        "Expects input to is_nan to be float, but received {:?}",
+                        data_field
+                    ))),
+                },
+                Err(e) => Err(e),
+            },
+            _ => Err(DaftError::SchemaMismatch(format!(
+                "Expected 1 input args, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+
+    fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
+        match inputs {
+            [data] => data.is_nan(),
+            _ => Err(DaftError::ValueError(format!(
+                "Expected 1 input args, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+}

--- a/src/dsl/functions/float/mod.rs
+++ b/src/dsl/functions/float/mod.rs
@@ -1,0 +1,30 @@
+mod is_nan;
+
+use is_nan::IsNanEvaluator;
+use serde::{Deserialize, Serialize};
+
+use crate::dsl::Expr;
+
+use super::FunctionEvaluator;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum FloatExpr {
+    IsNan,
+}
+
+impl FloatExpr {
+    #[inline]
+    pub fn get_evaluator(&self) -> &dyn FunctionEvaluator {
+        use FloatExpr::*;
+        match self {
+            IsNan => &IsNanEvaluator {},
+        }
+    }
+}
+
+pub fn is_nan(data: &Expr) -> Expr {
+    Expr::Function {
+        func: super::FunctionExpr::Float(FloatExpr::IsNan),
+        inputs: vec![data.clone()],
+    }
+}

--- a/src/dsl/functions/mod.rs
+++ b/src/dsl/functions/mod.rs
@@ -1,7 +1,9 @@
+pub mod float;
 pub mod numeric;
 pub mod temporal;
 pub mod utf8;
 
+use float::FloatExpr;
 use numeric::NumericExpr;
 use serde::{Deserialize, Serialize};
 use utf8::Utf8Expr;
@@ -15,6 +17,7 @@ use super::Expr;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum FunctionExpr {
     Numeric(NumericExpr),
+    Float(FloatExpr),
     Utf8(Utf8Expr),
     Temporal(TemporalExpr),
 }
@@ -31,6 +34,7 @@ impl FunctionExpr {
         use FunctionExpr::*;
         match self {
             Numeric(expr) => expr.get_evaluator(),
+            Float(expr) => expr.get_evaluator(),
             Utf8(expr) => expr.get_evaluator(),
             Temporal(expr) => expr.get_evaluator(),
         }

--- a/src/dsl/functions/utf8/endswith.rs
+++ b/src/dsl/functions/utf8/endswith.rs
@@ -17,19 +17,20 @@ impl FunctionEvaluator for EndswithEvaluator {
 
     fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
         match inputs {
-            [data, pattern] => {
-                let data_field = data.to_field(schema)?;
-                let pattern_field = pattern.to_field(schema)?;
-                if !matches!(data_field.dtype, DataType::Utf8)
-                    || !matches!(pattern_field.dtype, DataType::Utf8)
-                {
-                    return Err(DaftError::TypeError(format!(
-                        "Expects inputs to endwith to be utf8, but received {:?} and {:?}",
-                        data_field, pattern_field
-                    )));
+            [data, pattern] => match (data.to_field(schema), pattern.to_field(schema)) {
+                (Ok(data_field), Ok(pattern_field)) => {
+                    match (&data_field.dtype, &pattern_field.dtype) {
+                        (DataType::Utf8, DataType::Utf8) => {
+                            Ok(Field::new(data_field.name, DataType::Boolean))
+                        }
+                        _ => Err(DaftError::TypeError(format!(
+                            "Expects inputs to endswith to be utf8, but received {:?} and {:?}",
+                            data_field, pattern_field
+                        ))),
+                    }
                 }
-                Ok(Field::new(data_field.name, DataType::Boolean))
-            }
+                (Err(e), _) | (_, Err(e)) => Err(e),
+            },
             _ => Err(DaftError::SchemaMismatch(format!(
                 "Expected 2 input args, got {}",
                 inputs.len()

--- a/src/dsl/functions/utf8/length.rs
+++ b/src/dsl/functions/utf8/length.rs
@@ -1,0 +1,46 @@
+use crate::{
+    datatypes::{DataType, Field},
+    dsl::Expr,
+    error::{DaftError, DaftResult},
+    schema::Schema,
+    series::Series,
+};
+
+use super::super::FunctionEvaluator;
+
+pub(super) struct LengthEvaluator {}
+
+impl FunctionEvaluator for LengthEvaluator {
+    fn fn_name(&self) -> &'static str {
+        "length"
+    }
+
+    fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
+        match inputs {
+            [data] => match data.to_field(schema) {
+                Ok(data_field) => match &data_field.dtype {
+                    DataType::Utf8 => Ok(Field::new(data_field.name, DataType::UInt64)),
+                    _ => Err(DaftError::TypeError(format!(
+                        "Expects input to length to be utf8, but received {:?}",
+                        data_field
+                    ))),
+                },
+                Err(e) => Err(e),
+            },
+            _ => Err(DaftError::SchemaMismatch(format!(
+                "Expected 1 input args, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+
+    fn evaluate(&self, inputs: &[Series]) -> DaftResult<Series> {
+        match inputs {
+            [data] => data.utf8_length(),
+            _ => Err(DaftError::ValueError(format!(
+                "Expected 1 input args, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+}

--- a/src/dsl/functions/utf8/mod.rs
+++ b/src/dsl/functions/utf8/mod.rs
@@ -1,9 +1,11 @@
 mod contains;
 mod endswith;
+mod length;
 mod startswith;
 
 use contains::ContainsEvaluator;
 use endswith::EndswithEvaluator;
+use length::LengthEvaluator;
 use serde::{Deserialize, Serialize};
 use startswith::StartswithEvaluator;
 
@@ -16,6 +18,7 @@ pub enum Utf8Expr {
     EndsWith,
     StartsWith,
     Contains,
+    Length,
 }
 
 impl Utf8Expr {
@@ -26,6 +29,7 @@ impl Utf8Expr {
             EndsWith => &EndswithEvaluator {},
             StartsWith => &StartswithEvaluator {},
             Contains => &ContainsEvaluator {},
+            Length => &LengthEvaluator {},
         }
     }
 }
@@ -48,5 +52,12 @@ pub fn contains(data: &Expr, pattern: &Expr) -> Expr {
     Expr::Function {
         func: super::FunctionExpr::Utf8(Utf8Expr::Contains),
         inputs: vec![data.clone(), pattern.clone()],
+    }
+}
+
+pub fn length(data: &Expr) -> Expr {
+    Expr::Function {
+        func: super::FunctionExpr::Utf8(Utf8Expr::Length),
+        inputs: vec![data.clone()],
     }
 }

--- a/src/dsl/functions/utf8/startswith.rs
+++ b/src/dsl/functions/utf8/startswith.rs
@@ -17,19 +17,20 @@ impl FunctionEvaluator for StartswithEvaluator {
 
     fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
         match inputs {
-            [data, pattern] => {
-                let data_field = data.to_field(schema)?;
-                let pattern_field = pattern.to_field(schema)?;
-                if !matches!(data_field.dtype, DataType::Utf8)
-                    || !matches!(pattern_field.dtype, DataType::Utf8)
-                {
-                    return Err(DaftError::TypeError(format!(
-                        "Expects inputs to endwith to be utf8, but received {:?} and {:?}",
-                        data_field, pattern_field
-                    )));
+            [data, pattern] => match (data.to_field(schema), pattern.to_field(schema)) {
+                (Ok(data_field), Ok(pattern_field)) => {
+                    match (&data_field.dtype, &pattern_field.dtype) {
+                        (DataType::Utf8, DataType::Utf8) => {
+                            Ok(Field::new(data_field.name, DataType::Boolean))
+                        }
+                        _ => Err(DaftError::TypeError(format!(
+                            "Expects inputs to startswith to be utf8, but received {:?} and {:?}",
+                            data_field, pattern_field
+                        ))),
+                    }
                 }
-                Ok(Field::new(data_field.name, DataType::Boolean))
-            }
+                (Err(e), _) | (_, Err(e)) => Err(e),
+            },
             _ => Err(DaftError::SchemaMismatch(format!(
                 "Expected 2 input args, got {}",
                 inputs.len()

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -262,6 +262,11 @@ impl PyExpr {
         use dsl::functions::utf8::contains;
         Ok(contains(&self.expr, &pattern.expr).into())
     }
+
+    pub fn utf8_length(&self) -> PyResult<Self> {
+        use dsl::functions::utf8::length;
+        Ok(length(&self.expr).into())
+    }
 }
 
 impl From<dsl::Expr> for PyExpr {

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -214,6 +214,11 @@ impl PyExpr {
         Ok(format!("{}", self.expr))
     }
 
+    pub fn is_nan(&self) -> PyResult<Self> {
+        use functions::float::is_nan;
+        Ok(is_nan(&self.expr).into())
+    }
+
     pub fn dt_day(&self) -> PyResult<Self> {
         use functions::temporal::day;
         Ok(day(&self.expr).into())

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -223,6 +223,10 @@ impl PySeries {
         Ok(self.series.utf8_length()?.into())
     }
 
+    pub fn is_nan(&self) -> PyResult<Self> {
+        Ok(self.series.is_nan()?.into())
+    }
+
     pub fn dt_day(&self) -> PyResult<Self> {
         Ok(self.series.dt_day()?.into())
     }

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -219,6 +219,10 @@ impl PySeries {
         Ok(self.series.utf8_contains(&pattern.series)?.into())
     }
 
+    pub fn utf8_length(&self) -> PyResult<Self> {
+        Ok(self.series.utf8_length()?.into())
+    }
+
     pub fn dt_day(&self) -> PyResult<Self> {
         Ok(self.series.dt_day()?.into())
     }

--- a/src/series/ops/float.rs
+++ b/src/series/ops/float.rs
@@ -1,0 +1,13 @@
+use crate::{error::DaftResult, series::Series, with_match_float_and_null_daft_types};
+
+use crate::array::BaseArray;
+
+impl Series {
+    pub fn is_nan(&self) -> DaftResult<Series> {
+        use crate::array::ops::DaftIsNan;
+
+        with_match_float_and_null_daft_types!(self.data_type(), |$T| {
+            Ok(DaftIsNan::is_nan(&self.downcast::<$T>()?)?.into_series())
+        })
+    }
+}

--- a/src/series/ops/mod.rs
+++ b/src/series/ops/mod.rs
@@ -13,6 +13,7 @@ pub mod concat;
 pub mod date;
 pub mod downcast;
 pub mod filter;
+pub mod float;
 pub mod full;
 pub mod hash;
 pub mod if_else;
@@ -205,5 +206,22 @@ macro_rules! with_match_integer_daft_types {(
         UInt32 => __with_ty__! { UInt32Type },
         UInt64 => __with_ty__! { UInt64Type },
         _ => panic!("Only Integer Types are supported, {:?} not implemented", $key_type)
+    }
+})}
+
+#[macro_export]
+macro_rules! with_match_float_and_null_daft_types {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    use $crate::datatypes::*;
+
+    match $key_type {
+        Null => __with_ty__! { NullType },
+        // Float16 => __with_ty__! { Float16Type },
+        Float32 => __with_ty__! { Float32Type },
+        Float64 => __with_ty__! { Float64Type },
+        _ => panic!("Only Float Types are supported, {:?} not implemented", $key_type)
     }
 })}

--- a/src/series/ops/utf8.rs
+++ b/src/series/ops/utf8.rs
@@ -33,4 +33,14 @@ impl Series {
             ))),
         }
     }
+
+    pub fn utf8_length(&self) -> DaftResult<Series> {
+        match self.data_type() {
+            DataType::Utf8 => Ok(self.utf8()?.length()?.into_series()),
+            DataType::Null => Ok(self.clone()),
+            dt => Err(DaftError::TypeError(format!(
+                "Length not implemented for type {dt}"
+            ))),
+        }
+    }
 }

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -124,3 +124,13 @@ def test_expr_structurally_equal() -> None:
     e3 = (col("a")._max() == col("b").alias("moo") - 4).is_null()
     assert expr_structurally_equal(e1, e2)
     assert not expr_structurally_equal(e2, e3)
+
+
+def test_str_concat_delegation() -> None:
+    a = col("a")
+    b = "foo"
+    c = a.str.concat(b)
+    expected = a + lit(b)
+    assert expr_structurally_equal(c, expected)
+    output = repr(c)
+    assert output == 'col(a) + lit("foo")'

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -134,3 +134,10 @@ def test_str_concat_delegation() -> None:
     assert expr_structurally_equal(c, expected)
     output = repr(c)
     assert output == 'col(a) + lit("foo")'
+
+
+def test_float_is_nan() -> None:
+    a = col("a")
+    c = a.float.is_nan()
+    output = repr(c)
+    assert output == "is_nan(col(a))"

--- a/tests/expressions/typing/test_float.py
+++ b/tests/expressions/typing/test_float.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from daft.datatype import DataType
+from daft.expressions import col
+from tests.expressions.typing.conftest import assert_typing_resolve_vs_runtime_behavior
+
+
+def test_float_is_nan(unary_data_fixture):
+    assert_typing_resolve_vs_runtime_behavior(
+        data=[unary_data_fixture],
+        expr=col(unary_data_fixture.name()).float.is_nan(),
+        run_kernel=unary_data_fixture.float.is_nan,
+        resolvable=unary_data_fixture.datatype() in (DataType.float32(), DataType.float64()),
+    )

--- a/tests/expressions/typing/test_str.py
+++ b/tests/expressions/typing/test_str.py
@@ -13,10 +13,17 @@ from tests.expressions.typing.conftest import assert_typing_resolve_vs_runtime_b
         pytest.param(lambda data, pat: data.str.contains(pat), id="contains"),
         pytest.param(lambda data, pat: data.str.startswith(pat), id="startswith"),
         pytest.param(lambda data, pat: data.str.endswith(pat), id="endswith"),
+        pytest.param(lambda data, pat: data.str.concat(pat), id="concat"),
     ],
 )
-def test_str_compares(binary_data_fixture, op):
+def test_str_compares(binary_data_fixture, op, request):
     lhs, rhs = binary_data_fixture
+    if "concat" in request.node.callspec.id and (
+        lhs.datatype() != DataType.string() or rhs.datatype() != DataType.string()
+    ):
+        # Only test concat with strings, since other types will have their own semantics
+        # for the underlying + operator.
+        return
     assert_typing_resolve_vs_runtime_behavior(
         data=binary_data_fixture,
         expr=op(col(lhs.name()), col(rhs.name())),

--- a/tests/expressions/typing/test_str.py
+++ b/tests/expressions/typing/test_str.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import pyarrow as pa
 import pytest
 
 from daft.datatype import DataType
 from daft.expressions import col
+from daft.series import Series
 from tests.expressions.typing.conftest import assert_typing_resolve_vs_runtime_behavior
 
 
@@ -29,4 +31,14 @@ def test_str_compares(binary_data_fixture, op, request):
         expr=op(col(lhs.name()), col(rhs.name())),
         run_kernel=lambda: op(lhs, rhs),
         resolvable=(lhs.datatype() == DataType.string()) and (rhs.datatype() == DataType.string()),
+    )
+
+
+def test_str_length():
+    s = Series.from_arrow(pa.array(["1", "2", "3"]), name="arg")
+    assert_typing_resolve_vs_runtime_behavior(
+        data=[s],
+        expr=col(s.name()).str.length(),
+        run_kernel=s.str.length,
+        resolvable=True,
     )

--- a/tests/series/test_float.py
+++ b/tests/series/test_float.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import numpy as np
+import pyarrow as pa
+
+from daft import Series
+
+
+def test_float_is_nan() -> None:
+    s = Series.from_arrow(pa.array([1.0, np.nan, 3.0, float("nan")]))
+    result = s.float.is_nan()
+    assert result.to_pylist() == [False, True, False, True]
+
+
+def test_float_is_nan_with_nulls() -> None:
+    s = Series.from_arrow(pa.array([1.0, None, np.nan, 3.0, None, float("nan")]))
+    result = s.float.is_nan()
+    assert result.to_pylist() == [False, None, True, False, None, True]
+
+
+def test_float_is_nan_empty() -> None:
+    s = Series.from_arrow(pa.array([], type=pa.float64()))
+    result = s.float.is_nan()
+    assert result.to_pylist() == []
+
+
+def test_float_is_nan_all_null() -> None:
+    s = Series.from_arrow(pa.array([None, None, None]))
+    result = s.float.is_nan()
+    assert result.to_pylist() == [None, None, None]

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -100,3 +100,27 @@ def test_series_utf8_compare_invalid_inputs(funcname, bad_series) -> None:
     s = Series.from_arrow(pa.array(["x_foo", "y_foo", "z_bar"]))
     with pytest.raises(ValueError):
         getattr(s.str, funcname)(bad_series)
+
+
+def test_series_utf8_length() -> None:
+    s = Series.from_arrow(pa.array(["foo", "barbaz", "quux"]))
+    result = s.str.length()
+    assert result.to_pylist() == [3, 6, 4]
+
+
+def test_series_utf8_length_with_nulls() -> None:
+    s = Series.from_arrow(pa.array(["foo", None, "barbaz", "quux"]))
+    result = s.str.length()
+    assert result.to_pylist() == [3, None, 6, 4]
+
+
+def test_series_utf8_length_empty() -> None:
+    s = Series.from_arrow(pa.array([], type=pa.string()))
+    result = s.str.length()
+    assert result.to_pylist() == []
+
+
+def test_series_utf8_length_all_null() -> None:
+    s = Series.from_arrow(pa.array([None, None, None]))
+    result = s.str.length()
+    assert result.to_pylist() == [None, None, None]

--- a/tests/table/test_table.py
+++ b/tests/table/test_table.py
@@ -1174,6 +1174,13 @@ def test_table_filter_with_date_days_of_week() -> None:
     assert result["enum"] == [1, 4]
 
 
+def test_table_float_is_nan() -> None:
+    table = Table.from_pydict({"a": [1.0, np.nan, 3.0, None, float("nan")]})
+    result_table = table.eval_expression_list([col("a").float.is_nan()])
+    # Note that null entries are _not_ treated as float NaNs.
+    assert result_table.to_pydict() == {"a": [False, True, False, None, True]}
+
+
 def test_table_if_else() -> None:
     table = Table.from_arrow(pa.Table.from_pydict({"ones": [1, 1, 1], "zeros": [0, 0, 0], "pred": [True, False, None]}))
     result_table = table.eval_expression_list([col("pred").if_else(col("ones"), col("zeros"))])

--- a/tests/table/utf8/test_length.py
+++ b/tests/table/utf8/test_length.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from daft.expressions import col
+from daft.table import Table
+
+
+def test_utf8_length():
+    table = Table.from_pydict({"col": ["foo", None, "barbaz", "quux"]})
+    result = table.eval_expression_list([col("col").str.length()])
+    assert result.to_pydict() == {"col": [3, None, 6, 4]}


### PR DESCRIPTION
This PR adds the missing `str.length()`, `str.concat()`, and `float.is_nan()` kernels to the Rust expression path.

**Drivebys:** ports `to_field()` methods for `str.contains()`, `str.startswith()`, and `str.endswith()` to structural matching.

This PR is the second of two PRs, a follow-up for: https://github.com/Eventual-Inc/Daft/pull/771

Closes https://github.com/Eventual-Inc/Daft/issues/759