### PR TITLE
Enable Profiling of Daft on TPCH on rust-main

### DIFF
--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -1,7 +1,9 @@
-name: Run property based tests with Hypothesis
+name: Run Profiling on the TPCH Benchmark
 
 on:
   push:
+    branches: [rust-main]
+  pull_request:
     branches: [rust-main]
   workflow_dispatch:
 
@@ -69,17 +71,16 @@ jobs:
     - name: Generate TPCH Data
       run: python benchmarking/tpch/data_generation.py --scale_factor=${{ env.TPCH_SCALE_FACTOR }} --num_parts=${{ env.TPCH_NUM_PARTS }} --generate_parquet
 
-    
+
     - name: Run Profiling on TPCH Benchmark
-      run:  py-spy record --native -o tpch-${{GITHUB_RUN_ID}}.txt -f speedscope -- python benchmarking/tpch/__main__.py --scale_factor=${{ env.TPCH_SCALE_FACTOR }} --num_parts=${{ env.TPCH_NUM_PARTS }} --skip_warmup
-    env:
-      DAFT_DEVELOPER_USE_THREAD_POOL: '0'
-    
+      run: |
+        DAFT_DEVELOPER_USE_THREAD_POOL=0 py-spy record --native -o tpch-${{github.run_id}}.txt -f speedscope -- python benchmarking/tpch/__main__.py --scale_factor=${{ env.TPCH_SCALE_FACTOR }} --num_parts=${{ env.TPCH_NUM_PARTS }} --skip_warmup
+
     - name: Upload Profile
       uses: actions/upload-artifact@v2
       with:
         name: speedscope-profile
-        path: tpch-${{GITHUB_RUN_ID}}.txt
+        path: tpch-${{github.run_id}}.txt
 
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -1,0 +1,102 @@
+name: Run property based tests with Hypothesis
+
+on:
+  push:
+    branches: [rust-main]
+  workflow_dispatch:
+
+env:
+  DAFT_ANALYTICS_ENABLED: '0'
+  TPCH_SCALE_FACTOR: '4'
+  TPCH_NUM_PARTS: '32'
+
+
+jobs:
+  profile-daft:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7']
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - uses: actions/cache@v3
+      env:
+        cache-name: cache-cargo
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Setup Virtual Env
+      run: |
+        python -m venv venv
+        echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
+
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+        pip install -r requirements-dev.txt
+
+    - name: Build Rust Library
+      run: |
+        source activate
+        maturin develop --release
+
+    - uses: actions/cache@v3
+      env:
+        cache-name: profiling-cache-tpch-data
+      with:
+        path: data/tpch-dbgen
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.TPCH_SCALE_FACTOR }}-${{ env.TPCH_NUM_PARTS }}-${{ hashFiles('tests/integration/test_tpch.py', 'benchmarking/tpch/**') }}
+
+    - name: Generate TPCH Data
+      run: python benchmarking/tpch/data_generation.py --scale_factor=${{ env.TPCH_SCALE_FACTOR }} --num_parts=${{ env.TPCH_NUM_PARTS }} --generate_parquet
+
+    
+    - name: Run Profiling on TPCH Benchmark
+      run:  py-spy record --native -o tpch-${{GITHUB_RUN_ID}}.txt -f speedscope -- python benchmarking/tpch/__main__.py --scale_factor=${{ env.TPCH_SCALE_FACTOR }} --num_parts=${{ env.TPCH_NUM_PARTS }} --skip_warmup
+    env:
+      DAFT_DEVELOPER_USE_THREAD_POOL: '0'
+    
+    - name: Upload Profile
+      uses: actions/upload-artifact@v2
+      with:
+        name: speedscope-profile
+        path: tpch-${{GITHUB_RUN_ID}}.txt
+
+    - name: Send Slack notification on failure
+      uses: slackapi/slack-github-action@v1.23.0
+      if: failure()
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: [NIGHTLY] Property-Based Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -3,8 +3,6 @@ name: Run Profiling on the TPCH Benchmark
 on:
   push:
     branches: [rust-main]
-  pull_request:
-    branches: [rust-main]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -11,6 +11,7 @@ env:
   DAFT_ANALYTICS_ENABLED: '0'
   TPCH_SCALE_FACTOR: '4'
   TPCH_NUM_PARTS: '32'
+  PYTHON_VERSION: '3.7'
 
 
 jobs:
@@ -19,8 +20,6 @@ jobs:
     timeout-minutes: 15
     strategy:
       fail-fast: false
-      matrix:
-        python-version: ['3.7']
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
@@ -41,10 +40,10 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Setup Virtual Env
       run: |
@@ -71,10 +70,11 @@ jobs:
     - name: Generate TPCH Data
       run: python benchmarking/tpch/data_generation.py --scale_factor=${{ env.TPCH_SCALE_FACTOR }} --num_parts=${{ env.TPCH_NUM_PARTS }} --generate_parquet
 
-
     - name: Run Profiling on TPCH Benchmark
+      env:
+        DAFT_DEVELOPER_USE_THREAD_POOL: '0'
       run: |
-        DAFT_DEVELOPER_USE_THREAD_POOL=0 py-spy record --native -o tpch-${{github.run_id}}.txt -f speedscope -- python benchmarking/tpch/__main__.py --scale_factor=${{ env.TPCH_SCALE_FACTOR }} --num_parts=${{ env.TPCH_NUM_PARTS }} --skip_warmup
+        py-spy record --native -o tpch-${{github.run_id}}.txt -f speedscope -- python benchmarking/tpch/__main__.py --scale_factor=${{ env.TPCH_SCALE_FACTOR }} --num_parts=${{ env.TPCH_NUM_PARTS }} --skip_warmup
 
     - name: Upload Profile
       uses: actions/upload-artifact@v2

--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -231,8 +231,13 @@ if __name__ == "__main__":
         default=None,
         help="Path to pip-style requirements.txt file to bootstrap environment on remote Ray cluster",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--skip_warmup",
+        action="store_true",
+        help="Skip warming up data before benchmark",
+    )
 
+    args = parser.parse_args()
     if args.output_csv_headers:
         warnings.warn("Detected --output_csv_headers flag, but this flag is deprecated - CSVs always output headers")
 
@@ -248,7 +253,10 @@ if __name__ == "__main__":
     else:
         parquet_folder = generate_parquet_data(args.tpch_gen_folder, args.scale_factor, num_parts)
 
-    warmup_environment(args.requirements, parquet_folder)
+    if args.skip_warmup:
+        warnings.warn("Detected --skip_warmup flag, skipping warm up task")
+    else:
+        warmup_environment(args.requirements, parquet_folder)
 
     run_all_benchmarks(
         parquet_folder,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ orjson
 
 pandas
 pre-commit
+py-spy
 pyarrow
 pytest>=7.1.2
 pytest-benchmark


### PR DESCRIPTION
* Produce a flamegraph using py-spy in CI which will only run post-merges to `rust-main`
* Uploads a speedscope output file which can be used at `https://www.speedscope.app/`
* Adds flag to benchmarking code to enable skipping warmup
which would look something like this:
<img width="1282" alt="image" src="https://user-images.githubusercontent.com/2550285/230270297-925f2340-c027-4f3f-ad12-460c0203fd17.png">
