### PR TITLE
[RUST] Remove extraneous calls to combine_chunks in favor of using Table::concat

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -116,6 +116,8 @@ class DataType:
             return DataType.bool()
         elif pa.types.is_null(arrow_type):
             return DataType.null()
+        elif pa.types.is_date32(arrow_type):
+            return DataType.date()
         else:
             raise NotImplementedError(f"we cant convert arrow type: {arrow_type} to a daft type")
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,12 +1,12 @@
 use arrow2::compute::cast;
 use arrow2::{array::Array, datatypes::Field, ffi};
 
-use pyo3::exceptions::PyValueError;
 use pyo3::ffi::Py_uintptr_t;
 use pyo3::prelude::*;
 use pyo3::{PyAny, PyObject, PyResult, Python};
 
 use crate::error::DaftResult;
+use crate::schema::SchemaRef;
 use crate::series::Series;
 use crate::table::Table;
 
@@ -34,42 +34,41 @@ pub fn array_to_rust(arrow_array: &PyAny) -> PyResult<ArrayRef> {
     }
 }
 
-pub fn record_batches_to_table(batches: &[&PyAny]) -> PyResult<Table> {
+pub fn record_batches_to_table(batches: &[&PyAny], schema: SchemaRef) -> PyResult<Table> {
     if batches.is_empty() {
-        return Err(PyValueError::new_err(
-            "received an empty list of arrow record batches. Can not infer a schema.",
-        ));
-    }
-    if batches.len() > 1 {
-        return Err(PyValueError::new_err(
-            "we can only handle a single record batch right now",
-        ));
+        return Ok(Table::empty(Some(schema))?);
     }
 
-    let schema = batches.get(0).unwrap().getattr("schema").unwrap();
-    let names = schema.getattr("names")?.extract::<Vec<String>>()?;
-    let rb = *batches.get(0).unwrap();
-    let columns: DaftResult<Vec<Series>> = (0..names.len())
-        .map(|i| {
-            let array = rb.call_method1("column", (i,)).unwrap();
-            let arr = array_to_rust(array).unwrap();
-            let arr = match arr.data_type() {
-                arrow2::datatypes::DataType::Utf8 => {
-                    cast::utf8_to_large_utf8(arr.as_ref().as_any().downcast_ref().unwrap()).boxed()
-                }
-                arrow2::datatypes::DataType::Binary => cast::binary_to_large_binary(
-                    arr.as_ref().as_any().downcast_ref().unwrap(),
-                    arrow2::datatypes::DataType::LargeBinary,
-                )
-                .boxed(),
-                _ => arr,
-            };
+    let names = schema.names();
 
-            Series::try_from((names.get(i).unwrap().as_str(), arr))
-        })
-        .collect();
+    let mut tables: Vec<Table> = Vec::with_capacity(batches.len());
+    for rb in batches {
+        let columns: DaftResult<Vec<Series>> = (0..names.len())
+            .map(|i| {
+                let array = rb.call_method1("column", (i,)).unwrap();
+                let arr = array_to_rust(array).unwrap();
+                let arr = match arr.data_type() {
+                    arrow2::datatypes::DataType::Utf8 => {
+                        cast::utf8_to_large_utf8(arr.as_ref().as_any().downcast_ref().unwrap())
+                            .boxed()
+                    }
+                    arrow2::datatypes::DataType::Binary => cast::binary_to_large_binary(
+                        arr.as_ref().as_any().downcast_ref().unwrap(),
+                        arrow2::datatypes::DataType::LargeBinary,
+                    )
+                    .boxed(),
+                    _ => arr,
+                };
 
-    Ok(Table::from_columns(columns?)?)
+                Series::try_from((names.get(i).unwrap().as_str(), arr))
+            })
+            .collect();
+        tables.push(Table::from_columns(columns?)?)
+    }
+
+    Ok(Table::concat(
+        tables.iter().collect::<Vec<&Table>>().as_slice(),
+    )?)
 }
 
 pub fn to_py_array(array: ArrayRef, py: Python, pyarrow: &PyModule) -> PyResult<PyObject> {

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -215,8 +215,11 @@ impl PyTable {
     }
 
     #[staticmethod]
-    pub fn from_arrow_record_batches(record_batches: Vec<&PyAny>) -> PyResult<Self> {
-        let table = ffi::record_batches_to_table(record_batches.as_slice())?;
+    pub fn from_arrow_record_batches(
+        record_batches: Vec<&PyAny>,
+        schema: &PySchema,
+    ) -> PyResult<Self> {
+        let table = ffi::record_batches_to_table(record_batches.as_slice(), schema.schema.clone())?;
         Ok(PyTable { table })
     }
 


### PR DESCRIPTION
* We observed that our calls to combine_chunks was 6% of time spent in TPC-H tests
* We previously called it twice, making that 12% of time spent
* This PR removes those calls, and instead uses `Table::concat` in Rust to combine rowgroups into one Table

NOTE: In the future, we can have chunked Tables which will make this operation even cheaper!