### PR TITLE
[RUST] Python feature flag

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -208,7 +208,7 @@ jobs:
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate code coverage
-      run: mkdir -p report-output && cargo llvm-cov --all-features --workspace --lcov --output-path ./report-output/lcov.info
+      run: mkdir -p report-output && cargo llvm-cov --no-default-features --workspace --lcov --output-path ./report-output/lcov.info
     - name: Upload coverage report
       uses: actions/upload-artifact@v2
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ version = "0.2"
 
 [dependencies.pyo3]
 features = ["extension-module", "abi3-py37"]
+optional = true
 version = "0.17.3"
 
 [dependencies.serde]
@@ -27,6 +28,10 @@ version = "1.0.152"
 [dependencies.xxhash-rust]
 features = ["xxh3", "const_xxh3"]
 version = "0.8.5"
+
+[features]
+default = ["python"]
+python = ["dep:pyo3"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/kernels/hashing.rs
+++ b/src/kernels/hashing.rs
@@ -8,11 +8,6 @@ use arrow2::{
 
 use xxhash_rust::xxh3::{xxh3_64, xxh3_64_with_seed};
 
-use pyo3::exceptions::PyValueError;
-use pyo3::prelude::*;
-
-use crate::ffi;
-
 fn hash_primitive<T: NativeType>(
     array: &PrimitiveArray<T>,
     seed: Option<&PrimitiveArray<u64>>,
@@ -178,44 +173,4 @@ pub fn hash(array: &dyn Array, seed: Option<&PrimitiveArray<u64>>) -> Result<Pri
             )))
         }
     })
-}
-
-#[pyfunction]
-pub fn hash_pyarrow_array(
-    pyarray: &PyAny,
-    py: Python,
-    pyarrow: &PyModule,
-    seed: Option<&PyAny>,
-) -> PyResult<PyObject> {
-    let rarray = ffi::array_to_rust(pyarray)?;
-    let hashed;
-    if let Some(seed) = seed {
-        let rseed = ffi::array_to_rust(seed)?;
-        if rseed.len() != rarray.len() {
-            return Err(PyValueError::new_err(format!(
-                "seed length does not match array length: {} vs {}",
-                rseed.len(),
-                rarray.len()
-            )));
-        }
-        if *rseed.data_type() != DataType::UInt64 {
-            return Err(PyValueError::new_err(format!(
-                "seed data type expected to be UInt64, got {:?}",
-                *rseed.data_type()
-            )));
-        }
-
-        let downcasted_seed = rseed
-            .as_ref()
-            .as_any()
-            .downcast_ref::<PrimitiveArray<u64>>()
-            .unwrap();
-        hashed = py.allow_threads(move || hash(rarray.as_ref(), Some(downcasted_seed)));
-    } else {
-        hashed = py.allow_threads(move || hash(rarray.as_ref(), None));
-    }
-    match hashed {
-        Err(e) => Err(PyValueError::new_err(e.to_string())),
-        Ok(s) => ffi::to_py_array(Box::new(s), py, pyarrow),
-    }
 }

--- a/src/kernels/mod.rs
+++ b/src/kernels/mod.rs
@@ -1,21 +1,3 @@
 pub mod hashing;
-pub mod utf8;
-
 pub mod search_sorted;
-
-use pyo3::prelude::*;
-
-pub fn register_kernels(py: Python, parent: &PyModule) -> PyResult<()> {
-    let kernels_mod = PyModule::new(py, "kernels")?;
-    kernels_mod.add_function(wrap_pyfunction!(hashing::hash_pyarrow_array, kernels_mod)?)?;
-    kernels_mod.add_function(wrap_pyfunction!(
-        search_sorted::search_sorted_pyarrow_array,
-        kernels_mod
-    )?)?;
-    kernels_mod.add_function(wrap_pyfunction!(
-        search_sorted::search_sorted_multiple_pyarrow_array,
-        kernels_mod
-    )?)?;
-    parent.add_submodule(kernels_mod)?;
-    Ok(())
-}
+pub mod utf8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,22 +2,18 @@ mod array;
 mod datatypes;
 mod dsl;
 mod error;
-mod ffi;
 mod kernels;
-mod python;
 mod schema;
 mod series;
 mod table;
 mod utils;
 
-use pyo3::prelude::*;
+#[cfg(feature = "python")]
+mod ffi;
+#[cfg(feature = "python")]
+mod python;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-#[pyfunction]
-fn version() -> &'static str {
-    VERSION
-}
-
 const BUILD_TYPE_DEV: &str = "dev";
 const DAFT_BUILD_TYPE: &str = {
     let env_build_type: Option<&str> = option_env!("RUST_DAFT_PKG_BUILD_TYPE");
@@ -27,16 +23,28 @@ const DAFT_BUILD_TYPE: &str = {
     }
 };
 
-#[pyfunction]
-fn build_type() -> &'static str {
-    DAFT_BUILD_TYPE
-}
+#[cfg(feature = "python")]
+pub mod pylib {
 
-#[pymodule]
-fn daft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    kernels::register_kernels(_py, m)?;
-    python::register_modules(_py, m)?;
-    m.add_wrapped(wrap_pyfunction!(version))?;
-    m.add_wrapped(wrap_pyfunction!(build_type))?;
-    Ok(())
+    use super::python;
+    use super::{DAFT_BUILD_TYPE, VERSION};
+    use pyo3::prelude::*;
+
+    #[pyfunction]
+    fn version() -> &'static str {
+        VERSION
+    }
+
+    #[pyfunction]
+    fn build_type() -> &'static str {
+        DAFT_BUILD_TYPE
+    }
+
+    #[pymodule]
+    fn daft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+        python::register_modules(_py, m)?;
+        m.add_wrapped(wrap_pyfunction!(version))?;
+        m.add_wrapped(wrap_pyfunction!(build_type))?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
Hides our Python functionality behind a `python` Cargo feature flag

1. All PyO3-related functionality should be localized to `src/python/**`
2. Deleted Python-related functionality in `src/kernels` which was dead code that we don't call anymore
3. Added compilation feature flags to avoid compiling Python-related modules where required