### PR TITLE
Add `cargo-check --no-default-features` to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,8 @@ repos:
   hooks:
   - id: fmt
   - id: cargo-check
+  - id: cargo-check
+    args: [--no-default-features]
   - id: clippy
 
 - repo: https://github.com/abravalheri/validate-pyproject


### PR DESCRIPTION
CI has a step that compiles with `--no-default-features`, so this PR adds it to the precommit as well.

(The existing cargo-check with no flags is preserved and also runs.)

