### PR TITLE
Serialization support for Tables holding PyObjects

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -270,7 +270,10 @@ class Series:
         return SeriesDateNamespace.from_series(self)
 
     def __reduce__(self) -> tuple:
-        return (Series.from_arrow, (self.to_arrow(), self.name()))
+        if self.datatype()._is_python_type():
+            return (Series.from_pylist, (self.to_pylist(), self.name()))
+        else:
+            return (Series.from_arrow, (self.to_arrow(), self.name()))
 
 
 SomeSeriesNamespace = TypeVar("SomeSeriesNamespace", bound="SeriesNamespace")


### PR DESCRIPTION
After spending a while learning about Python serialization, turns out all that was missing was a small change to `Series.__reduce__` - all the other requirements had already been implemented.