### PR TITLE
[Types] [Nested Types - 1/N] Add support for `FixedSizeListArray`, `ListArray`, and general nested type scaffolding.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,10 +4,11 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
+ "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
@@ -24,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.14.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6f62e41078c967a4c063fcbdfd3801a2a9632276402c045311c4d73d0845f3"
+checksum = "c3c63cf31f1416ed2fab8f91e8488e10129f47bd89c553ec354a06751d5697f3"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -35,13 +36,16 @@ dependencies = [
  "either",
  "ethnum",
  "foreign_vec",
+ "getrandom",
  "hash_hasher",
+ "hashbrown 0.13.2",
  "itertools",
  "lexical-core",
  "multiversion",
  "num-traits",
  "regex",
  "regex-syntax",
+ "rustc_version",
  "simdutf8",
  "strength_reduce",
 ]
@@ -66,6 +70,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytemuck"
@@ -224,8 +234,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -241,6 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,7 +271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -300,6 +318,15 @@ name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -394,6 +421,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,22 +446,24 @@ dependencies = [
 
 [[package]]
 name = "multiversion"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025c962a3dd3cc5e0e520aa9c612201d127dcdf28616974961a649dca64f5373"
+checksum = "e6a87eede2251ca235e5573086d01d2ab6b59dfaea54c2be10f9320980f7e8f7"
 dependencies = [
  "multiversion-macros",
+ "target-features",
 ]
 
 [[package]]
 name = "multiversion-macros"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a3e2bde382ebf960c1f3e79689fa5941625fe9bf694a1cb64af3e85faff3af"
+checksum = "1af1abf82261d780d114014eff4b555e47d823f3b84f893c4388572b40e089fb"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "target-features",
 ]
 
 [[package]]
@@ -642,6 +680,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +719,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -727,6 +780,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-features"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24840de800c1707d75c800893dbd727a5e1501ce921944e602f0698167491e36"
 
 [[package]]
 name = "target-lexicon"
@@ -794,6 +853,60 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ rand = "^0.8"
 
 [dependencies.arrow2]
 features = ["compute"]
-version = "0.14.2"
+version = "0.17.0"
 
 [dependencies.bincode]
 version = "1.3.3"

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -79,16 +79,16 @@ class DataType:
         return cls._from_pydatatype(PyDataType.binary())
 
     @classmethod
-    def fixed_size_list(cls, name: str, dtype: DataType, size: int) -> DataType:
-        return cls._from_pydatatype(PyDataType.fixed_size_list(name, dtype._dtype, size))
-
-    @classmethod
     def null(cls) -> DataType:
         return cls._from_pydatatype(PyDataType.null())
 
     @classmethod
     def date(cls) -> DataType:
         return cls._from_pydatatype(PyDataType.date())
+
+    @classmethod
+    def fixed_size_list(cls, name: str, dtype: DataType, size: int) -> DataType:
+        return cls._from_pydatatype(PyDataType.fixed_size_list(name, dtype._dtype, size))
 
     @classmethod
     def from_arrow_type(cls, arrow_type: pa.lib.DataType) -> DataType:

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -92,6 +92,8 @@ class DataType:
 
     @classmethod
     def fixed_size_list(cls, name: str, dtype: DataType, size: int) -> DataType:
+        if not isinstance(size, int) or size <= 0:
+            raise ValueError("The size for a fixed-size list must be a positive integer, but got: ", size)
         return cls._from_pydatatype(PyDataType.fixed_size_list(name, dtype._dtype, size))
 
     @classmethod

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -26,104 +26,112 @@ class DataType:
         dt._dtype = pydt
         return dt
 
-    @staticmethod
-    def int8() -> DataType:
-        return DataType._from_pydatatype(PyDataType.int8())
+    @classmethod
+    def int8(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.int8())
 
-    @staticmethod
-    def int16() -> DataType:
-        return DataType._from_pydatatype(PyDataType.int16())
+    @classmethod
+    def int16(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.int16())
 
-    @staticmethod
-    def int32() -> DataType:
-        return DataType._from_pydatatype(PyDataType.int32())
+    @classmethod
+    def int32(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.int32())
 
-    @staticmethod
-    def int64() -> DataType:
-        return DataType._from_pydatatype(PyDataType.int64())
+    @classmethod
+    def int64(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.int64())
 
-    @staticmethod
-    def uint8() -> DataType:
-        return DataType._from_pydatatype(PyDataType.uint8())
+    @classmethod
+    def uint8(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.uint8())
 
-    @staticmethod
-    def uint16() -> DataType:
-        return DataType._from_pydatatype(PyDataType.uint16())
+    @classmethod
+    def uint16(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.uint16())
 
-    @staticmethod
-    def uint32() -> DataType:
-        return DataType._from_pydatatype(PyDataType.uint32())
+    @classmethod
+    def uint32(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.uint32())
 
-    @staticmethod
-    def uint64() -> DataType:
-        return DataType._from_pydatatype(PyDataType.uint64())
+    @classmethod
+    def uint64(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.uint64())
 
-    @staticmethod
-    def float32() -> DataType:
-        return DataType._from_pydatatype(PyDataType.float32())
+    @classmethod
+    def float32(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.float32())
 
-    @staticmethod
-    def float64() -> DataType:
-        return DataType._from_pydatatype(PyDataType.float64())
+    @classmethod
+    def float64(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.float64())
 
-    @staticmethod
-    def string() -> DataType:
-        return DataType._from_pydatatype(PyDataType.string())
+    @classmethod
+    def string(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.string())
 
-    @staticmethod
-    def bool() -> DataType:
-        return DataType._from_pydatatype(PyDataType.bool())
+    @classmethod
+    def bool(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.bool())
 
-    @staticmethod
-    def binary() -> DataType:
-        return DataType._from_pydatatype(PyDataType.binary())
+    @classmethod
+    def binary(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.binary())
 
-    @staticmethod
-    def null() -> DataType:
-        return DataType._from_pydatatype(PyDataType.null())
+    @classmethod
+    def fixed_size_list(cls, name: str, dtype: DataType, size: int) -> DataType:
+        return cls._from_pydatatype(PyDataType.fixed_size_list(name, dtype._dtype, size))
 
-    @staticmethod
-    def date() -> DataType:
-        return DataType._from_pydatatype(PyDataType.date())
+    @classmethod
+    def null(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.null())
 
-    @staticmethod
-    def from_arrow_type(arrow_type: pa.lib.DataType) -> DataType:
+    @classmethod
+    def date(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.date())
+
+    @classmethod
+    def from_arrow_type(cls, arrow_type: pa.lib.DataType) -> DataType:
         if pa.types.is_int8(arrow_type):
-            return DataType.int8()
+            return cls.int8()
         elif pa.types.is_int16(arrow_type):
-            return DataType.int16()
+            return cls.int16()
         elif pa.types.is_int32(arrow_type):
-            return DataType.int32()
+            return cls.int32()
         elif pa.types.is_int64(arrow_type):
-            return DataType.int64()
+            return cls.int64()
         elif pa.types.is_uint8(arrow_type):
-            return DataType.uint8()
+            return cls.uint8()
         elif pa.types.is_uint16(arrow_type):
-            return DataType.uint16()
+            return cls.uint16()
         elif pa.types.is_uint32(arrow_type):
-            return DataType.uint32()
+            return cls.uint32()
         elif pa.types.is_uint64(arrow_type):
-            return DataType.uint64()
+            return cls.uint64()
         elif pa.types.is_float32(arrow_type):
-            return DataType.float32()
+            return cls.float32()
         elif pa.types.is_float64(arrow_type):
-            return DataType.float64()
+            return cls.float64()
         elif pa.types.is_string(arrow_type) or pa.types.is_large_string(arrow_type):
-            return DataType.string()
+            return cls.string()
         elif pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
-            return DataType.binary()
+            return cls.binary()
         elif pa.types.is_boolean(arrow_type):
-            return DataType.bool()
+            return cls.bool()
+        elif pa.types.is_fixed_size_list(arrow_type):
+            assert isinstance(arrow_type, pa.FixedSizeListType)
+            field = arrow_type.value_field
+            return cls.fixed_size_list(field.name, cls.from_arrow_type(field.type), arrow_type.list_size)
         elif pa.types.is_null(arrow_type):
-            return DataType.null()
+            return cls.null()
         elif pa.types.is_date32(arrow_type):
-            return DataType.date()
+            return cls.date()
         else:
             raise NotImplementedError(f"we cant convert arrow type: {arrow_type} to a daft type")
 
-    @staticmethod
-    def python() -> DataType:
-        return DataType._from_pydatatype(PyDataType.python())
+    @classmethod
+    def python(cls) -> DataType:
+        return cls._from_pydatatype(PyDataType.python())
 
     def _is_python_type(self) -> builtins.bool:
         # NOTE: This is currently used in a few places still. We can get rid of it once these are refactored away. To be discussed.

--- a/src/array/from.rs
+++ b/src/array/from.rs
@@ -85,14 +85,6 @@ impl<T: DaftDataType> TryFrom<(&str, Box<dyn arrow2::array::Array>)> for DataArr
 
     fn try_from(item: (&str, Box<dyn arrow2::array::Array>)) -> DaftResult<Self> {
         let (name, array) = item;
-        let self_arrow_type = T::get_dtype().to_arrow().unwrap();
-        if !array.data_type().eq(&self_arrow_type) {
-            return Err(DaftError::TypeError(format!(
-                "mismatch in expected data type {:?} vs {:?}",
-                array.data_type(),
-                self_arrow_type
-            )));
-        }
         DataArray::new(Field::new(name, array.data_type().into()).into(), array)
     }
 }

--- a/src/array/iterator.rs
+++ b/src/array/iterator.rs
@@ -4,12 +4,14 @@ use crate::datatypes::{BooleanArray, DaftNumericType};
 
 use super::DataArray;
 
+use super::ops::downcast::Downcastable;
+
 impl<'a, T> IntoIterator for &'a DataArray<T>
 where
     T: DaftNumericType,
 {
     type Item = Option<&'a T::Native>;
-    type IntoIter = ZipValidity<'a, &'a T::Native, std::slice::Iter<'a, T::Native>>;
+    type IntoIter = ZipValidity<&'a T::Native, std::slice::Iter<'a, T::Native>, BitmapIter<'a>>;
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.downcast().into_iter()
@@ -18,7 +20,7 @@ where
 
 impl<'a> IntoIterator for &'a BooleanArray {
     type Item = Option<bool>;
-    type IntoIter = ZipValidity<'a, bool, BitmapIter<'a>>;
+    type IntoIter = ZipValidity<bool, BitmapIter<'a>, BitmapIter<'a>>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -92,7 +92,7 @@ where
                 "Trying to slice array with negative length, start: {start} vs end: {end}"
             )));
         }
-        let sliced = self.data.slice(start, end - start);
+        let sliced = self.data.sliced(start, end - start);
         Self::new(self.field.clone(), sliced)
     }
 

--- a/src/array/ops/arithmetic.rs
+++ b/src/array/ops/arithmetic.rs
@@ -8,6 +8,8 @@ use crate::{
     error::{DaftError, DaftResult},
     kernels::utf8::add_utf8_arrays,
 };
+
+use super::downcast::Downcastable;
 /// Helper function to perform arithmetic operations on a DataArray
 /// Takes both Kernel (array x array operation) and operation (scalar x scalar) functions
 /// The Kernel is used for when both arrays are non-unit length and the operation is used when broadcasting

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -6,8 +6,8 @@ use arrow2::compute::{
 use crate::{
     array::{BaseArray, DataArray},
     datatypes::{
-        BinaryArray, BooleanArray, DaftDataType, DaftNumericType, DataType, DateArray, NullArray,
-        Utf8Array,
+        BinaryArray, BooleanArray, DaftDataType, DaftNumericType, DataType, DateArray,
+        FixedSizeListArray, ListArray, NullArray, Utf8Array,
     },
     error::{DaftError, DaftResult},
     series::Series,
@@ -31,7 +31,7 @@ where
     if !dtype.is_arrow() || !to_cast.data_type().is_arrow() {
         return Err(DaftError::TypeError(format!(
             "Can not cast {:?} to type: {:?}: not convertible to Arrow",
-            T::get_dtype(),
+            to_cast.data_type(),
             dtype
         )));
     }
@@ -41,7 +41,7 @@ where
     if !can_cast_types(&self_arrow_type, &target_arrow_type) {
         return Err(DaftError::TypeError(format!(
             "can not cast {:?} to type: {:?}: Arrow types not castable",
-            T::get_dtype(),
+            to_cast.data_type(),
             dtype
         )));
     }
@@ -118,5 +118,17 @@ impl DateArray {
             DataType::Float64 => self.cast(&DataType::Int32)?.cast(&DataType::Float64),
             _ => arrow_cast(self, dtype),
         }
+    }
+}
+
+impl ListArray {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        arrow_cast(self, dtype)
+    }
+}
+
+impl FixedSizeListArray {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        arrow_cast(self, dtype)
     }
 }

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -14,6 +14,8 @@ use crate::{
     with_match_arrow_daft_types,
 };
 
+use super::downcast::Downcastable;
+
 fn arrow_cast<T>(to_cast: &DataArray<T>, dtype: &DataType) -> DaftResult<Series>
 where
     T: DaftDataType + 'static,

--- a/src/array/ops/compare_agg.rs
+++ b/src/array/ops/compare_agg.rs
@@ -8,6 +8,8 @@ use crate::{
 
 use super::DaftCompareAggable;
 
+use super::downcast::Downcastable;
+
 impl<T> DaftCompareAggable for &DataArray<T>
 where
     T: DaftDataType + DaftNumericType,

--- a/src/array/ops/comparison.rs
+++ b/src/array/ops/comparison.rs
@@ -9,6 +9,8 @@ use crate::{
 use std::ops::Not;
 
 use super::{DaftCompare, DaftLogical};
+
+use super::downcast::Downcastable;
 use arrow2::{compute::comparison, scalar::PrimitiveScalar};
 
 fn arrow_bitmap_validity(

--- a/src/array/ops/downcast.rs
+++ b/src/array/ops/downcast.rs
@@ -4,7 +4,8 @@ use arrow2::array;
 use crate::{
     array::{BaseArray, DataArray},
     datatypes::{
-        BinaryArray, BooleanArray, DaftNumericType, DateArray, FixedSizeListArray, Utf8Array,
+        BinaryArray, BooleanArray, DaftNumericType, DateArray, FixedSizeListArray, ListArray,
+        Utf8Array,
     },
 };
 
@@ -62,10 +63,19 @@ impl Downcastable for DateArray {
     }
 }
 
+impl Downcastable for ListArray {
+    type Output = array::ListArray<i64>;
+
+    // downcasts a DataArray<T> to an Arrow ListArray.
+    fn downcast(&self) -> &Self::Output {
+        self.data().as_any().downcast_ref().unwrap()
+    }
+}
+
 impl Downcastable for FixedSizeListArray {
     type Output = array::FixedSizeListArray;
 
-    // downcasts a DataArray<T> to an Arrow Array.
+    // downcasts a DataArray<T> to an Arrow FixedSizeListArray.
     fn downcast(&self) -> &Self::Output {
         self.data().as_any().downcast_ref().unwrap()
     }

--- a/src/array/ops/downcast.rs
+++ b/src/array/ops/downcast.rs
@@ -3,43 +3,69 @@ use arrow2::array;
 
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{BinaryArray, BooleanArray, DaftNumericType, DateArray, Utf8Array},
+    datatypes::{
+        BinaryArray, BooleanArray, DaftNumericType, DateArray, FixedSizeListArray, Utf8Array,
+    },
 };
 
-impl<T> DataArray<T>
+pub trait Downcastable {
+    type Output;
+
+    fn downcast(&self) -> &Self::Output;
+}
+
+impl<T> Downcastable for DataArray<T>
 where
     T: DaftNumericType,
 {
+    type Output = array::PrimitiveArray<T::Native>;
+
     // downcasts a DataArray<T> to an Arrow PrimitiveArray.
-    pub fn downcast(&self) -> &array::PrimitiveArray<T::Native> {
+    fn downcast(&self) -> &Self::Output {
         self.data().as_any().downcast_ref().unwrap()
     }
 }
 
-impl Utf8Array {
+impl Downcastable for Utf8Array {
+    type Output = array::Utf8Array<i64>;
+
     // downcasts a DataArray<T> to an Arrow Utf8Array.
-    pub fn downcast(&self) -> &array::Utf8Array<i64> {
+    fn downcast(&self) -> &Self::Output {
         self.data().as_any().downcast_ref().unwrap()
     }
 }
 
-impl BooleanArray {
+impl Downcastable for BooleanArray {
+    type Output = array::BooleanArray;
+
     // downcasts a DataArray<T> to an Arrow BooleanArray.
-    pub fn downcast(&self) -> &array::BooleanArray {
+    fn downcast(&self) -> &Self::Output {
         self.data().as_any().downcast_ref().unwrap()
     }
 }
 
-impl BinaryArray {
+impl Downcastable for BinaryArray {
+    type Output = array::BinaryArray<i64>;
+
     // downcasts a DataArray<T> to an Arrow BinaryArray.
-    pub fn downcast(&self) -> &array::BinaryArray<i64> {
+    fn downcast(&self) -> &Self::Output {
         self.data().as_any().downcast_ref().unwrap()
     }
 }
 
-impl DateArray {
+impl Downcastable for DateArray {
+    type Output = array::PrimitiveArray<i32>;
+
     // downcasts a DataArray<T> to an Arrow DateArray.
-    pub fn downcast(&self) -> &array::PrimitiveArray<i32> {
+    fn downcast(&self) -> &Self::Output {
+        self.data().as_any().downcast_ref().unwrap()
+    }
+}
+
+impl Downcastable for FixedSizeListArray {
+    type Output = array::FixedSizeListArray;
+    // downcasts a DataArray<T> to an Arrow Array.
+    fn downcast(&self) -> &Self::Output {
         self.data().as_any().downcast_ref().unwrap()
     }
 }

--- a/src/array/ops/downcast.rs
+++ b/src/array/ops/downcast.rs
@@ -64,6 +64,7 @@ impl Downcastable for DateArray {
 
 impl Downcastable for FixedSizeListArray {
     type Output = array::FixedSizeListArray;
+
     // downcasts a DataArray<T> to an Arrow Array.
     fn downcast(&self) -> &Self::Output {
         self.data().as_any().downcast_ref().unwrap()
@@ -71,9 +72,11 @@ impl Downcastable for FixedSizeListArray {
 }
 
 #[cfg(feature = "python")]
-impl crate::datatypes::PythonArray {
+impl Downcastable for crate::datatypes::PythonArray {
+    type Output = crate::array::vec_backed::VecBackedArray<pyo3::PyObject>;
+
     // downcasts a DataArray<T> to a VecBackedArray of PyObject.
-    pub fn downcast(&self) -> &crate::array::vec_backed::VecBackedArray<pyo3::PyObject> {
+    fn downcast(&self) -> &Self::Output {
         self.data().as_any().downcast_ref().unwrap()
     }
 }

--- a/src/array/ops/filter.rs
+++ b/src/array/ops/filter.rs
@@ -3,7 +3,8 @@ use arrow2::array::Array;
 use crate::{
     array::DataArray,
     datatypes::{
-        BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray, NullArray, Utf8Array,
+        BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray, ListArray, NullArray,
+        Utf8Array,
     },
     error::DaftResult,
 };
@@ -47,6 +48,13 @@ impl NullArray {
     pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
         let set_bits = mask.len() - mask.downcast().values().unset_bits();
         Ok(NullArray::full_null(self.name(), set_bits))
+    }
+}
+
+impl ListArray {
+    pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
+        let result = arrow2::compute::filter::filter(self.downcast(), mask.downcast())?;
+        DataArray::try_from((self.name(), result))
     }
 }
 

--- a/src/array/ops/float.rs
+++ b/src/array/ops/float.rs
@@ -9,6 +9,8 @@ use crate::array::BaseArray;
 
 use super::DaftIsNan;
 
+use super::downcast::Downcastable;
+
 impl<T> DaftIsNan for &DataArray<T>
 where
     T: DaftFloatType,

--- a/src/array/ops/hash.rs
+++ b/src/array/ops/hash.rs
@@ -7,6 +7,8 @@ use crate::{
 
 use crate::array::BaseArray;
 
+use super::downcast::Downcastable;
+
 impl<T> DataArray<T>
 where
     T: DaftNumericType,

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -1,14 +1,13 @@
+use crate::array::{BaseArray, DataArray};
 use crate::datatypes::{
-    BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray, NullArray, PythonArray,
-    Utf8Array,
+    BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray, ListArray, NullArray,
+    PythonArray, Utf8Array,
 };
-use crate::error::DaftError;
-use crate::{array::DataArray, error::DaftResult};
+use crate::error::{DaftError, DaftResult};
 use arrow2::compute::if_then_else::if_then_else;
 use std::convert::identity;
 
-use crate::array::BaseArray;
-
+use super::broadcast::Broadcastable;
 use super::downcast::Downcastable;
 
 // Helper macro for broadcasting if/else across the if_true/if_false/predicate DataArrays
@@ -169,17 +168,84 @@ impl PythonArray {
     }
 }
 
-fn from_arrow_if_then_else(
-    predicate: &BooleanArray,
-    if_true: &FixedSizeListArray,
-    if_false: &FixedSizeListArray,
-) -> DaftResult<FixedSizeListArray> {
+// fn from_arrow_if_then_else<T>(
+//     predicate: &BooleanArray,
+//     if_true: &DataArray<T>,
+//     if_false: &DataArray<T>,
+// ) -> DaftResult<DataArray<T>>
+// where
+//     T: DaftDataType,
+// {
+//     let result = if_then_else(
+//         predicate.downcast(),
+//         if_true.downcast(),
+//         if_false.downcast(),
+//     )?;
+//     DataArray::try_from((if_true.name(), result))
+// }
+
+fn from_arrow_if_then_else<T>(predicate: &BooleanArray, if_true: &T, if_false: &T) -> DaftResult<T>
+where
+    T: BaseArray
+        + Downcastable
+        + for<'a> TryFrom<(&'a str, Box<dyn arrow2::array::Array>), Error = DaftError>,
+    <T as Downcastable>::Output: arrow2::array::Array,
+{
     let result = if_then_else(
         predicate.downcast(),
         if_true.downcast(),
         if_false.downcast(),
     )?;
-    DataArray::try_from((if_true.name(), result))
+    T::try_from((if_true.name(), result))
+}
+
+fn nested_if_then_else<T>(predicate: &BooleanArray, if_true: &T, if_false: &T) -> DaftResult<T>
+where
+    T: BaseArray
+        + Broadcastable
+        + Downcastable
+        + for<'a> TryFrom<(&'a str, Box<dyn arrow2::array::Array>), Error = DaftError>,
+    <T as Downcastable>::Output: arrow2::array::Array,
+{
+    // TODO(Clark): Support streaming broadcasting, i.e. broadcasting without inflating scalars to full array length.
+    match (predicate.len(), if_true.len(), if_false.len()) {
+        (predicate_len, if_true_len, if_false_len)
+            if predicate_len == if_true_len && if_true_len == if_false_len => from_arrow_if_then_else(predicate, if_true, if_false),
+        (1, if_true_len, 1) => from_arrow_if_then_else(
+            &predicate.broadcast(if_true_len)?,
+            if_true,
+            &if_false.broadcast(if_true_len)?,
+        ),
+        (1, 1, if_false_len) => from_arrow_if_then_else(
+            &predicate.broadcast(if_false_len)?,
+            &if_true.broadcast(if_false_len)?,
+            if_false,
+        ),
+        (predicate_len, 1, 1) => from_arrow_if_then_else(
+            predicate,
+            &if_true.broadcast(predicate_len)?,
+            &if_false.broadcast(predicate_len)?,
+        ),
+        (predicate_len, if_true_len, 1) if predicate_len == if_true_len => from_arrow_if_then_else(
+            predicate,
+            if_true,
+            &if_false.broadcast(predicate_len)?,
+        ),
+        (predicate_len, 1, if_false_len) if predicate_len == if_false_len => from_arrow_if_then_else(
+            predicate,
+            &if_true.broadcast(predicate_len)?,
+            if_false,
+        ),
+        (p, s, o) => {
+            Err(DaftError::ValueError(format!("Cannot run if_else against arrays with non-broadcastable lengths: if_true={s}, if_false={o}, predicate={p}")))
+        }
+    }
+}
+
+impl ListArray {
+    pub fn if_else(&self, other: &ListArray, predicate: &BooleanArray) -> DaftResult<ListArray> {
+        nested_if_then_else(predicate, self, other)
+    }
 }
 
 impl FixedSizeListArray {
@@ -188,38 +254,6 @@ impl FixedSizeListArray {
         other: &FixedSizeListArray,
         predicate: &BooleanArray,
     ) -> DaftResult<FixedSizeListArray> {
-        // TODO(Clark): Support streaming broadcasting, i.e. broadcasting without inflating scalars to full array length.
-        match (predicate.len(), self.len(), other.len()) {
-            (predicate_len, self_len, other_len)
-                if predicate_len == self_len && self_len == other_len => from_arrow_if_then_else(predicate, self, other),
-            (1, self_len, 1) => from_arrow_if_then_else(
-                &predicate.broadcast(self_len)?,
-                self,
-                &other.broadcast(self_len)?,
-            ),
-            (1, 1, other_len) => from_arrow_if_then_else(
-                &predicate.broadcast(other_len)?,
-                &self.broadcast(other_len)?,
-                other,
-            ),
-            (predicate_len, 1, 1) => from_arrow_if_then_else(
-                predicate,
-                &self.broadcast(predicate_len)?,
-                &other.broadcast(predicate_len)?,
-            ),
-            (predicate_len, self_len, 1) if predicate_len == self_len => from_arrow_if_then_else(
-                predicate,
-                self,
-                &other.broadcast(predicate_len)?,
-            ),
-            (predicate_len, 1, other_len) if predicate_len == other_len => from_arrow_if_then_else(
-                predicate,
-                &self.broadcast(predicate_len)?,
-                other,
-            ),
-            (p, s, o) => {
-                Err(DaftError::ValueError(format!("Cannot run if_else against arrays with non-broadcastable lengths: self={s}, other={o}, predicate={p}")))
-            }
-        }
+        nested_if_then_else(predicate, self, other)
     }
 }

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -168,22 +168,6 @@ impl PythonArray {
     }
 }
 
-// fn from_arrow_if_then_else<T>(
-//     predicate: &BooleanArray,
-//     if_true: &DataArray<T>,
-//     if_false: &DataArray<T>,
-// ) -> DaftResult<DataArray<T>>
-// where
-//     T: DaftDataType,
-// {
-//     let result = if_then_else(
-//         predicate.downcast(),
-//         if_true.downcast(),
-//         if_false.downcast(),
-//     )?;
-//     DataArray::try_from((if_true.name(), result))
-// }
-
 fn from_arrow_if_then_else<T>(predicate: &BooleanArray, if_true: &T, if_false: &T) -> DaftResult<T>
 where
     T: BaseArray

--- a/src/array/ops/len.rs
+++ b/src/array/ops/len.rs
@@ -1,8 +1,6 @@
-use arrow2::bitmap::Bitmap;
-
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{BinaryArray, BooleanArray, DaftDataType, DaftNumericType, NullArray, Utf8Array},
+    datatypes::DaftDataType,
 };
 
 impl<T> DataArray<T>
@@ -14,81 +12,11 @@ where
     }
 }
 
-fn validity_byte_size(bitmask: Option<&Bitmap>) -> usize {
-    match bitmask {
-        None => 0,
-        Some(b) => (b.len() + 8 - 1) / 8,
-    }
-}
-
 impl<T> DataArray<T>
 where
-    T: DaftNumericType,
+    T: DaftDataType + 'static,
 {
     pub fn size_bytes(&self) -> usize {
-        use core::mem::size_of;
-        let bytes_per_elem = size_of::<T::Native>();
-        let numerical_data_size = self.len() * bytes_per_elem;
-        numerical_data_size + validity_byte_size(self.data().validity())
-    }
-}
-
-impl BooleanArray {
-    pub fn size_bytes(&self) -> usize {
-        let bitmask_size = (self.len() + 8 - 1) / 8;
-        bitmask_size + validity_byte_size(self.data().validity())
-    }
-}
-
-impl Utf8Array {
-    pub fn size_bytes(&self) -> usize {
-        use core::mem::size_of;
-
-        let arrow_array = self.downcast();
-        let buffer_size = (arrow_array.offsets().last().unwrap()
-            - arrow_array.offsets().first().unwrap()) as usize;
-        let offset_size = self.len() * size_of::<i64>();
-
-        buffer_size + offset_size + validity_byte_size(self.data().validity())
-    }
-}
-
-impl BinaryArray {
-    pub fn size_bytes(&self) -> usize {
-        use core::mem::size_of;
-
-        let arrow_array = self.downcast();
-        let buffer_size = (arrow_array.offsets().last().unwrap()
-            - arrow_array.offsets().first().unwrap()) as usize;
-        let offset_size = self.len() * size_of::<i64>();
-
-        buffer_size + offset_size + validity_byte_size(self.data().validity())
-    }
-}
-
-impl NullArray {
-    pub fn size_bytes(&self) -> usize {
-        0
-    }
-}
-
-#[cfg(feature = "python")]
-impl crate::datatypes::PythonArray {
-    pub fn size_bytes(&self) -> usize {
-        use pyo3::prelude::*;
-        use pyo3::types::PyList;
-
-        let vector = self.downcast().vec();
-        Python::with_gil(|py| {
-            let daft_utils = PyModule::import(py, "daft.utils").unwrap();
-            let estimate_size_bytes_pylist =
-                daft_utils.getattr("estimate_size_bytes_pylist").unwrap();
-            let size_bytes: usize = estimate_size_bytes_pylist
-                .call1((PyList::new(py, vector),))
-                .unwrap()
-                .extract()
-                .unwrap();
-            size_bytes
-        })
+        arrow2::compute::aggregate::estimated_bytes_size(self.data())
     }
 }

--- a/src/array/ops/mean.rs
+++ b/src/array/ops/mean.rs
@@ -6,6 +6,8 @@ use crate::{array::DataArray, datatypes::*, error::DaftResult};
 
 use super::{DaftCountAggable, DaftMeanAggable, DaftSumAggable};
 
+use super::downcast::Downcastable;
+
 impl DaftMeanAggable for &DataArray<Float64Type> {
     type Output = DaftResult<DataArray<Float64Type>>;
 

--- a/src/array/ops/mod.rs
+++ b/src/array/ops/mod.rs
@@ -3,7 +3,7 @@ mod apply;
 mod arange;
 mod arithmetic;
 pub mod arrow2;
-mod broadcast;
+pub(crate) mod broadcast;
 mod cast;
 mod compare_agg;
 mod comparison;

--- a/src/array/ops/mod.rs
+++ b/src/array/ops/mod.rs
@@ -10,7 +10,7 @@ mod comparison;
 mod concat;
 mod count;
 mod date;
-mod downcast;
+pub(crate) mod downcast;
 mod filter;
 mod float;
 mod full;

--- a/src/array/ops/pairwise.rs
+++ b/src/array/ops/pairwise.rs
@@ -4,6 +4,8 @@ use crate::{
     error::DaftResult,
 };
 
+use super::downcast::Downcastable;
+
 impl<T> DataArray<T>
 where
     T: DaftNumericType,

--- a/src/array/ops/sort.rs
+++ b/src/array/ops/sort.rs
@@ -17,6 +17,8 @@ use arrow2::{
 
 use super::arrow2::sort::primitive::common::multi_column_idx_sort;
 
+use super::downcast::Downcastable;
+
 pub fn build_multi_array_compare(
     arrays: &[Series],
     descending: &[bool],

--- a/src/array/ops/sum.rs
+++ b/src/array/ops/sum.rs
@@ -4,6 +4,8 @@ use crate::{array::DataArray, datatypes::*, error::DaftResult};
 
 use super::DaftSumAggable;
 
+use super::downcast::Downcastable;
+
 macro_rules! impl_daft_numeric_agg {
     ($T:ident) => {
         impl DaftSumAggable for &DataArray<$T> {

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -1,8 +1,8 @@
 use crate::{
     array::{BaseArray, DataArray},
     datatypes::{
-        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeListArray, NullArray,
-        Utf8Array,
+        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeListArray, ListArray,
+        NullArray, Utf8Array,
     },
     error::DaftResult,
 };
@@ -149,6 +149,44 @@ impl NullArray {
 impl BinaryArray {
     #[inline]
     pub fn get(&self, idx: usize) -> Option<&[u8]> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let arrow_array = self.downcast();
+        let is_valid = match arrow_array.validity() {
+            Some(validity) => validity.get_bit(idx),
+            None => true,
+        };
+        if is_valid {
+            Some(unsafe { arrow_array.value_unchecked(idx) })
+        } else {
+            None
+        }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let result = arrow2::compute::take::take(self.data(), idx.downcast())?;
+        Self::try_from((self.name(), result))
+    }
+
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            // TODO: [RUST-INT] proper display of bytes as string here, preferably similar to how Python displays it
+            // See discussion: https://stackoverflow.com/questions/54358833/how-does-bytes-repr-representation-work
+            Some(v) => Ok(format!("b\"{:?}\"", v)),
+        }
+    }
+}
+
+impl ListArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<Box<dyn arrow2::array::Array>> {
         if idx >= self.len() {
             panic!("Out of bounds: {} vs len: {}", idx, self.len())
         }

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -1,10 +1,13 @@
 use crate::{
     array::{BaseArray, DataArray},
     datatypes::{
-        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, NullArray, Utf8Array,
+        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeListArray, NullArray,
+        Utf8Array,
     },
     error::DaftResult,
 };
+
+use super::downcast::Downcastable;
 
 impl<T> DataArray<T>
 where
@@ -146,6 +149,44 @@ impl NullArray {
 impl BinaryArray {
     #[inline]
     pub fn get(&self, idx: usize) -> Option<&[u8]> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let arrow_array = self.downcast();
+        let is_valid = match arrow_array.validity() {
+            Some(validity) => validity.get_bit(idx),
+            None => true,
+        };
+        if is_valid {
+            Some(unsafe { arrow_array.value_unchecked(idx) })
+        } else {
+            None
+        }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let result = arrow2::compute::take::take(self.data(), idx.downcast())?;
+        Self::try_from((self.name(), result))
+    }
+
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            // TODO: [RUST-INT] proper display of bytes as string here, preferably similar to how Python displays it
+            // See discussion: https://stackoverflow.com/questions/54358833/how-does-bytes-repr-representation-work
+            Some(v) => Ok(format!("b\"{:?}\"", v)),
+        }
+    }
+}
+
+impl FixedSizeListArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<Box<dyn arrow2::array::Array>> {
         if idx >= self.len() {
             panic!("Out of bounds: {} vs len: {}", idx, self.len())
         }

--- a/src/array/ops/utf8.rs
+++ b/src/array/ops/utf8.rs
@@ -4,6 +4,8 @@ use arrow2;
 
 use crate::error::{DaftError, DaftResult};
 
+use super::downcast::Downcastable;
+
 impl Utf8Array {
     pub fn endswith(&self, pattern: &Utf8Array) -> DaftResult<BooleanArray> {
         self.binary_broadcasted_compare(pattern, |data: &str, pat: &str| data.ends_with(pat))

--- a/src/array/vec_backed.rs
+++ b/src/array/vec_backed.rs
@@ -72,8 +72,11 @@ impl<T: Send + Sync + Clone + 'static> Array for VecBackedArray<T> {
     }
 
     fn sliced(&self, offset: usize, length: usize) -> Box<dyn Array> {
-        let values = self.values[offset..(offset + length)].to_vec();
-        Box::new(VecBackedArray { values })
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        unsafe { self.sliced_unchecked(offset, length) }
     }
 
     unsafe fn sliced_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/vec_backed.rs
+++ b/src/array/vec_backed.rs
@@ -59,12 +59,24 @@ impl<T: Send + Sync + Clone + 'static> Array for VecBackedArray<T> {
         !self.is_null(i)
     }
 
-    fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
+    fn slice(&mut self, offset: usize, length: usize) {
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        self.values = self.values[offset..(offset + length)].to_vec();
+    }
+
+    fn sliced(&self, offset: usize, length: usize) -> Box<dyn Array> {
         let values = self.values[offset..(offset + length)].to_vec();
         Box::new(VecBackedArray { values })
     }
 
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
+    unsafe fn sliced_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
         let values = self
             .values
             .get_unchecked(offset..(offset + length))

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -109,7 +109,7 @@ impl DataType {
             DataType::FixedSizeList(field, size) => {
                 Ok(ArrowType::FixedSizeList(Box::new(field.to_arrow()?), *size))
             }
-            DataType::List(field) => Ok(ArrowType::List(Box::new(field.to_arrow()?))),
+            DataType::List(field) => Ok(ArrowType::LargeList(Box::new(field.to_arrow()?))),
             DataType::Struct(fields) => Ok({
                 let fields: DaftResult<Vec<arrow2::datatypes::Field>> =
                     fields.iter().map(|f| f.to_arrow()).collect();

--- a/src/datatypes/matching.rs
+++ b/src/datatypes/matching.rs
@@ -59,8 +59,8 @@ macro_rules! with_match_physical_daft_types {(
         Float64 => __with_ty__! { Float64Type },
         Binary => __with_ty__! { BinaryType },
         Utf8 => __with_ty__! { Utf8Type },
+        FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
         // TODO: [RUST-INT][NESTED]: implement for nested types
-        // FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
         // List(_) => __with_ty__! { ListType },
         // Struct(_) => __with_ty__! { StructType },
         #[cfg(feature = "python")]

--- a/src/datatypes/matching.rs
+++ b/src/datatypes/matching.rs
@@ -60,8 +60,8 @@ macro_rules! with_match_physical_daft_types {(
         Binary => __with_ty__! { BinaryType },
         Utf8 => __with_ty__! { Utf8Type },
         FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
+        List(_) => __with_ty__! { ListType },
         // TODO: [RUST-INT][NESTED]: implement for nested types
-        // List(_) => __with_ty__! { ListType },
         // Struct(_) => __with_ty__! { StructType },
         #[cfg(feature = "python")]
         Python => __with_ty__! { PythonType },

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -23,7 +23,24 @@ pub trait DaftDataType: Sync + Send {
         Self: Sized;
 }
 
-macro_rules! impl_daft_datatype {
+pub trait DaftArrowBackedType: Send + Sync + DaftDataType {}
+
+macro_rules! impl_daft_arrow_datatype {
+    ($ca:ident, $variant:ident) => {
+        pub struct $ca {}
+
+        impl DaftDataType for $ca {
+            #[inline]
+            fn get_dtype() -> DataType {
+                DataType::$variant
+            }
+        }
+
+        impl DaftArrowBackedType for $ca {}
+    };
+}
+
+macro_rules! impl_daft_non_arrow_datatype {
     ($ca:ident, $variant:ident) => {
         pub struct $ca {}
 
@@ -36,29 +53,29 @@ macro_rules! impl_daft_datatype {
     };
 }
 
-impl_daft_datatype!(NullType, Null);
-impl_daft_datatype!(BooleanType, Boolean);
-impl_daft_datatype!(Int8Type, Int8);
-impl_daft_datatype!(Int16Type, Int16);
-impl_daft_datatype!(Int32Type, Int32);
-impl_daft_datatype!(Int64Type, Int64);
-impl_daft_datatype!(UInt8Type, UInt8);
-impl_daft_datatype!(UInt16Type, UInt16);
-impl_daft_datatype!(UInt32Type, UInt32);
-impl_daft_datatype!(UInt64Type, UInt64);
-impl_daft_datatype!(Float16Type, Float16);
-impl_daft_datatype!(Float32Type, Float32);
-impl_daft_datatype!(Float64Type, Float64);
-impl_daft_datatype!(TimestampType, Unknown);
-impl_daft_datatype!(DateType, Date);
-impl_daft_datatype!(TimeType, Unknown);
-impl_daft_datatype!(DurationType, Unknown);
-impl_daft_datatype!(BinaryType, Binary);
-impl_daft_datatype!(Utf8Type, Utf8);
-impl_daft_datatype!(FixedSizeListType, Unknown);
-impl_daft_datatype!(ListType, Unknown);
-impl_daft_datatype!(StructType, Unknown);
-impl_daft_datatype!(PythonType, Python);
+impl_daft_arrow_datatype!(NullType, Null);
+impl_daft_arrow_datatype!(BooleanType, Boolean);
+impl_daft_arrow_datatype!(Int8Type, Int8);
+impl_daft_arrow_datatype!(Int16Type, Int16);
+impl_daft_arrow_datatype!(Int32Type, Int32);
+impl_daft_arrow_datatype!(Int64Type, Int64);
+impl_daft_arrow_datatype!(UInt8Type, UInt8);
+impl_daft_arrow_datatype!(UInt16Type, UInt16);
+impl_daft_arrow_datatype!(UInt32Type, UInt32);
+impl_daft_arrow_datatype!(UInt64Type, UInt64);
+impl_daft_arrow_datatype!(Float16Type, Float16);
+impl_daft_arrow_datatype!(Float32Type, Float32);
+impl_daft_arrow_datatype!(Float64Type, Float64);
+impl_daft_arrow_datatype!(TimestampType, Unknown);
+impl_daft_arrow_datatype!(DateType, Date);
+impl_daft_arrow_datatype!(TimeType, Unknown);
+impl_daft_arrow_datatype!(DurationType, Unknown);
+impl_daft_arrow_datatype!(BinaryType, Binary);
+impl_daft_arrow_datatype!(Utf8Type, Utf8);
+impl_daft_arrow_datatype!(FixedSizeListType, Unknown);
+impl_daft_arrow_datatype!(ListType, Unknown);
+impl_daft_arrow_datatype!(StructType, Unknown);
+impl_daft_non_arrow_datatype!(PythonType, Python);
 
 pub trait NumericNative:
     PartialOrd

--- a/src/python/datatype.rs
+++ b/src/python/datatype.rs
@@ -110,8 +110,18 @@ impl PyDataType {
     }
 
     #[staticmethod]
-    pub fn fixed_size_list(name: &str, data_type: Self, size: usize) -> PyResult<Self> {
-        Ok(DataType::FixedSizeList(Box::new(Field::new(name, data_type.dtype)), size).into())
+    pub fn fixed_size_list(name: &str, data_type: Self, size: i64) -> PyResult<Self> {
+        if size <= 0 {
+            return Err(PyValueError::new_err(format!(
+                "The size for fixed-size list types must be a positive integer, but got: {}",
+                size
+            )));
+        }
+        Ok(DataType::FixedSizeList(
+            Box::new(Field::new(name, data_type.dtype)),
+            usize::try_from(size)?,
+        )
+        .into())
     }
 
     #[staticmethod]

--- a/src/python/datatype.rs
+++ b/src/python/datatype.rs
@@ -105,6 +105,11 @@ impl PyDataType {
     }
 
     #[staticmethod]
+    pub fn list(name: &str, data_type: Self) -> PyResult<Self> {
+        Ok(DataType::List(Box::new(Field::new(name, data_type.dtype))).into())
+    }
+
+    #[staticmethod]
     pub fn fixed_size_list(name: &str, data_type: Self, size: usize) -> PyResult<Self> {
         Ok(DataType::FixedSizeList(Box::new(Field::new(name, data_type.dtype)), size).into())
     }

--- a/src/python/datatype.rs
+++ b/src/python/datatype.rs
@@ -1,4 +1,4 @@
-use crate::datatypes::DataType;
+use crate::datatypes::{DataType, Field};
 use pyo3::{
     exceptions::PyValueError,
     prelude::*,
@@ -102,6 +102,11 @@ impl PyDataType {
     #[staticmethod]
     pub fn date() -> PyResult<Self> {
         Ok(DataType::Date.into())
+    }
+
+    #[staticmethod]
+    pub fn fixed_size_list(name: &str, data_type: Self, size: usize) -> PyResult<Self> {
+        Ok(DataType::FixedSizeList(Box::new(Field::new(name, data_type.dtype)), size).into())
     }
 
     #[staticmethod]

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -34,6 +34,13 @@ impl PySeries {
                 arrow2::datatypes::DataType::LargeBinary,
             )
             .boxed(),
+            arrow2::datatypes::DataType::List(field) => cast::cast(
+                arrow_array.as_ref(),
+                &arrow2::datatypes::DataType::LargeList(field.clone()),
+                Default::default(),
+            )
+            .unwrap()
+            .to_boxed(),
             _ => arrow_array,
         };
         let series = series::Series::try_from((name, arrow_array))?;

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 use super::datatype::PyDataType;
+use crate::array::ops::downcast::Downcastable;
 
 #[pyclass]
 #[derive(Clone)]

--- a/src/series/ops/broadcast.rs
+++ b/src/series/ops/broadcast.rs
@@ -1,5 +1,6 @@
 use crate::{error::DaftResult, series::Series, with_match_physical_daft_types};
 
+use crate::array::ops::broadcast::Broadcastable;
 use crate::array::BaseArray;
 
 impl Series {

--- a/src/series/ops/cast.rs
+++ b/src/series/ops/cast.rs
@@ -20,10 +20,10 @@ macro_rules! apply_method_all_arrow_series {
             DataType::Float32 => $self.f32().unwrap().$method($($args),*),
             DataType::Float64 => $self.f64().unwrap().$method($($args),*),
             DataType::Date => $self.date().unwrap().$method($($args),*),
+            DataType::List(_) => $self.list().unwrap().$method($($args),*),
+            DataType::FixedSizeList(..) => $self.fixed_size_list().unwrap().$method($($args),*),
             // TODO: Add implementations for these types
             // DataType::Timestamp(_, _) => $self.timestamp().unwrap().$method($($args),*),
-            // DataType::List(_) => $self.list().unwrap().$method($($args),*),
-            // DataType::FixedSizeList(..) => $self.fixed_size_list().unwrap().$method($($args),*),
             // DataType::Struct(_) => $self.struct_().unwrap().$method($($args),*),
             dt => panic!("dtype {:?} not supported", dt)
         }

--- a/src/series/ops/downcast.rs
+++ b/src/series/ops/downcast.rs
@@ -10,14 +10,13 @@ impl Series {
     where
         T: DaftDataType + 'static,
     {
-        if self.data_type().eq(&T::get_dtype()) {
-            Ok(self.array().as_any().downcast_ref().unwrap())
-        } else {
-            Err(DaftError::SchemaMismatch(format!(
+        match self.array().as_any().downcast_ref() {
+            Some(arr) => Ok(arr),
+            None => Err(DaftError::SchemaMismatch(format!(
                 "{:?} not {:?}",
                 self.data_type(),
                 T::get_dtype()
-            )))
+            ))),
         }
     }
 

--- a/src/table/ops/agg.rs
+++ b/src/table/ops/agg.rs
@@ -7,6 +7,8 @@ use crate::{
     table::Table,
 };
 
+use crate::array::ops::downcast::Downcastable;
+
 impl Table {
     pub fn agg(&self, to_agg: &[Expr], group_by: &[Expr]) -> DaftResult<Table> {
         // Dispatch depending on whether we're doing groupby or just a global agg.

--- a/src/table/ops/joins/hash_join.rs
+++ b/src/table/ops/joins/hash_join.rs
@@ -11,6 +11,8 @@ use crate::{
     table::Table,
 };
 
+use crate::array::ops::downcast::Downcastable;
+
 #[derive(Default)]
 pub struct IdentityHasher {
     hash: u64,

--- a/src/table/ops/partition.rs
+++ b/src/table/ops/partition.rs
@@ -11,6 +11,8 @@ use crate::{
     table::Table,
 };
 
+use crate::array::ops::downcast::Downcastable;
+
 impl Table {
     fn partition_by_index(
         &self,

--- a/src/utils/supertype.rs
+++ b/src/utils/supertype.rs
@@ -192,9 +192,9 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
             //     let inner_st = inner(&inner_left_field.dtype, &inner_right_field.dtype)?;
             //     Some(DataType::FixedSizeList(Box::new(Field::new(inner_left_field.name.clone(), inner_st)), *inner_left_size))
             // }
-            (FixedSizeList(inner_left_field, inner_left_size), List(inner_right_field)) => {
-                let inner_st = inner(&inner_left_field.dtype, &inner_right_field.dtype)?;
-                Some(DataType::FixedSizeList(Box::new(Field::new(inner_left_field.name.clone(), inner_st)), *inner_left_size))
+            (FixedSizeList(inner_left_field, _inner_left_size), List(inner_right_field)) => {
+                let inner_st = get_supertype(&inner_left_field.dtype, &inner_right_field.dtype)?;
+                Some(DataType::List(Box::new(Field::new(inner_left_field.name.clone(), inner_st))))
             }
 
             // every known type can be casted to a string except binary

--- a/src/utils/supertype.rs
+++ b/src/utils/supertype.rs
@@ -187,15 +187,20 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
             //TODO(sammy): add time, struct related dtypes
             (Boolean, Float32) => Some(Float32),
             (Boolean, Float64) => Some(Float64),
+            (List(inner_left_field), List(inner_right_field)) => {
+                let inner_st = get_supertype(&inner_left_field.dtype, &inner_right_field.dtype)?;
+                Some(DataType::List(Box::new(Field::new(inner_left_field.name.clone(), inner_st))))
+            }
             // TODO(Clark): Add support for getting supertype for two fixed size lists once Arrow2 supports such a cast.
             // (FixedSizeList(inner_left_field, inner_left_size), FixedSizeList(inner_right_field, inner_right_size)) if inner_left_size == inner_right_size => {
             //     let inner_st = inner(&inner_left_field.dtype, &inner_right_field.dtype)?;
             //     Some(DataType::FixedSizeList(Box::new(Field::new(inner_left_field.name.clone(), inner_st)), *inner_left_size))
             // }
-            (FixedSizeList(inner_left_field, _inner_left_size), List(inner_right_field)) => {
-                let inner_st = get_supertype(&inner_left_field.dtype, &inner_right_field.dtype)?;
-                Some(DataType::List(Box::new(Field::new(inner_left_field.name.clone(), inner_st))))
-            }
+            // TODO(Clark): Add support for getting supertype for a fixed size list and a list once Arrow2 supports such a cast.
+            // (FixedSizeList(inner_left_field, _inner_left_size), List(inner_right_field)) => {
+            //     let inner_st = get_supertype(&inner_left_field.dtype, &inner_right_field.dtype)?;
+            //     Some(DataType::List(Box::new(Field::new(inner_left_field.name.clone(), inner_st))))
+            // }
 
             // every known type can be casted to a string except binary
             (dt, Utf8) if dt.ne(&Binary) => Some(Utf8),

--- a/src/utils/supertype.rs
+++ b/src/utils/supertype.rs
@@ -1,4 +1,5 @@
 use crate::datatypes::DataType;
+use crate::datatypes::Field;
 use crate::datatypes::TimeUnit;
 use crate::error::DaftError;
 use crate::error::DaftResult;
@@ -186,6 +187,15 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
             //TODO(sammy): add time, struct related dtypes
             (Boolean, Float32) => Some(Float32),
             (Boolean, Float64) => Some(Float64),
+            // TODO(Clark): Add support for getting supertype for two fixed size lists once Arrow2 supports such a cast.
+            // (FixedSizeList(inner_left_field, inner_left_size), FixedSizeList(inner_right_field, inner_right_size)) if inner_left_size == inner_right_size => {
+            //     let inner_st = inner(&inner_left_field.dtype, &inner_right_field.dtype)?;
+            //     Some(DataType::FixedSizeList(Box::new(Field::new(inner_left_field.name.clone(), inner_st)), *inner_left_size))
+            // }
+            (FixedSizeList(inner_left_field, inner_left_size), List(inner_right_field)) => {
+                let inner_st = inner(&inner_left_field.dtype, &inner_right_field.dtype)?;
+                Some(DataType::FixedSizeList(Box::new(Field::new(inner_left_field.name.clone(), inner_st)), *inner_left_size))
+            }
 
             // every known type can be casted to a string except binary
             (dt, Utf8) if dt.ne(&Binary) => Some(Utf8),

--- a/tests/series/test_filter.py
+++ b/tests/series/test_filter.py
@@ -64,6 +64,21 @@ def test_series_filter_on_binary() -> None:
     assert result.to_pylist() == expected
 
 
+@pytest.mark.parametrize("dtype", ARROW_INT_TYPES + ARROW_FLOAT_TYPES)
+def test_series_filter_on_fixed_size_list_array(dtype) -> None:
+    data = pa.array([[1, 2], [3, None], None, [8, 9], [None, 11]], type=pa.list_(dtype, 2))
+
+    s = Series.from_arrow(data)
+    pymask = [False, True, True, None, False]
+    mask = Series.from_pylist(pymask)
+
+    result = s.filter(mask)
+
+    assert s.datatype() == result.datatype()
+    expected = [val for val, keep in zip(s.to_pylist(), pymask) if keep]
+    assert result.to_pylist() == expected
+
+
 @pytest.mark.parametrize("dtype", ARROW_INT_TYPES + ARROW_FLOAT_TYPES + ARROW_STRING_TYPES)
 def test_series_filter_broadcast(dtype) -> None:
     data = pa.array([1, 2, 3, None, 5, None])

--- a/tests/series/test_filter.py
+++ b/tests/series/test_filter.py
@@ -65,6 +65,21 @@ def test_series_filter_on_binary() -> None:
 
 
 @pytest.mark.parametrize("dtype", ARROW_INT_TYPES + ARROW_FLOAT_TYPES)
+def test_series_filter_on_list_array(dtype) -> None:
+    data = pa.array([[1], [2, None], None, [5, 6, 7], [8]], type=pa.list_(dtype))
+
+    s = Series.from_arrow(data)
+    pymask = [False, True, True, None, False]
+    mask = Series.from_pylist(pymask)
+
+    result = s.filter(mask)
+
+    assert s.datatype() == result.datatype()
+    expected = [val for val, keep in zip(s.to_pylist(), pymask) if keep]
+    assert result.to_pylist() == expected
+
+
+@pytest.mark.parametrize("dtype", ARROW_INT_TYPES + ARROW_FLOAT_TYPES)
 def test_series_filter_on_fixed_size_list_array(dtype) -> None:
     data = pa.array([[1, 2], [3, None], None, [8, 9], [None, 11]], type=pa.list_(dtype, 2))
 

--- a/tests/series/test_if_else.py
+++ b/tests/series/test_if_else.py
@@ -104,6 +104,47 @@ def test_series_if_else_binary(if_true, if_false) -> None:
 
 
 @pytest.mark.parametrize(
+    ["if_true", "if_false", "expected"],
+    [
+        # Same length, same type
+        (
+            pa.array([[1, 2], [None, 4], None, [7, 8]], type=pa.list_(pa.int64(), 2)),
+            pa.array([[9, 10], [None, 12], None, [15, 16]], type=pa.list_(pa.int64(), 2)),
+            [[1, 2], [None, 12], None, [7, 8]],
+        ),
+        # TODO(Clark): Uncomment this case when Arrow2 supports broadcasting between different FixedSizeListArrays.
+        # Same length, different super-castable type
+        # (pa.array([[1, 2], [None, 4], None, [7, 8]], type=pa.list_(pa.int64(), 2)), pa.array([[9, 10], [None, 12], None, [15, 16]], type=pa.list_(pa.int32(), 2))),
+        # Broadcast left
+        (
+            pa.array([[1, 2]], type=pa.list_(pa.int64(), 2)),
+            pa.array([[9, 10], [None, 12], None, [15, 16]], type=pa.list_(pa.int64(), 2)),
+            [[1, 2], [None, 12], None, [1, 2]],
+        ),
+        # Broadcast right
+        (
+            pa.array([[1, 2], [None, 4], None, [7, 8]], type=pa.list_(pa.int64(), 2)),
+            pa.array([[9, 10]], type=pa.list_(pa.int64(), 2)),
+            [[1, 2], [9, 10], None, [7, 8]],
+        ),
+        # Broadcast both
+        (
+            pa.array([[1, 2]], type=pa.list_(pa.int64(), 2)),
+            pa.array([[9, 10]], type=pa.list_(pa.int64(), 2)),
+            [[1, 2], [9, 10], None, [1, 2]],
+        ),
+    ],
+)
+def test_series_if_else_fixed_size_list(if_true, if_false, expected) -> None:
+    if_true_series = Series.from_arrow(if_true)
+    if_false_series = Series.from_arrow(if_false)
+    predicate_series = Series.from_arrow(pa.array([True, False, None, True]))
+    result = predicate_series.if_else(if_true_series, if_false_series)
+    assert result.datatype() == DataType.fixed_size_list("item", DataType.int64(), 2)
+    assert result.to_pylist() == expected
+
+
+@pytest.mark.parametrize(
     ["if_true", "if_false"],
     [
         # Same length, same type

--- a/tests/series/test_size_bytes.py
+++ b/tests/series/test_size_bytes.py
@@ -50,7 +50,7 @@ def test_series_string_size_bytes(size) -> None:
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.string()
-    assert s.size_bytes() == data.nbytes
+    assert s.size_bytes() == data.nbytes + 8
 
     ## with nulls
     if size > 0:
@@ -60,7 +60,7 @@ def test_series_string_size_bytes(size) -> None:
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.string()
-    assert s.size_bytes() == data.nbytes
+    assert s.size_bytes() == data.nbytes + 8
 
 
 @pytest.mark.skipif(
@@ -126,7 +126,7 @@ def test_series_binary_size_bytes(size) -> None:
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.binary()
-    assert s.size_bytes() == data.nbytes
+    assert s.size_bytes() == data.nbytes + 8
 
     ## with nulls
     if size > 0:
@@ -135,4 +135,30 @@ def test_series_binary_size_bytes(size) -> None:
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.binary()
+    assert s.size_bytes() == data.nbytes + 8
+
+
+@pytest.mark.skipif(
+    not PYARROW_GE_7_0_0,
+    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
+)
+@pytest.mark.parametrize("dtype, size", itertools.product(ARROW_INT_TYPES + ARROW_FLOAT_TYPES, [0, 1, 2, 8, 9, 16]))
+def test_series_fixed_size_list_size_bytes(dtype, size) -> None:
+    list_dtype = pa.list_(dtype, 2)
+    pydata = [[2 * i, 2 * i + 1] for i in range(size)]
+    data = pa.array(pydata, list_dtype)
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.from_arrow_type(list_dtype)
+    assert s.size_bytes() == data.nbytes
+
+    ## with nulls
+    if size > 0:
+        pydata = pydata[:-1] + [None]
+    data = pa.array(pydata, list_dtype)
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.from_arrow_type(list_dtype)
     assert s.size_bytes() == data.nbytes

--- a/tests/series/test_size_bytes.py
+++ b/tests/series/test_size_bytes.py
@@ -50,6 +50,8 @@ def test_series_string_size_bytes(size) -> None:
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.string()
+    # TODO(Clark): This is required due to an off-by-one error in pyarrow's calculation of of the offset array length.
+    # We should fix this upstream and/or refactor these tests to not rely on pyarrow as the source-of-truth.
     assert s.size_bytes() == data.nbytes + 8
 
     ## with nulls
@@ -126,6 +128,8 @@ def test_series_binary_size_bytes(size) -> None:
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.binary()
+    # TODO(Clark): This is required due to an off-by-one error in pyarrow's calculation of of the offset array length.
+    # We should fix this upstream and/or refactor these tests to not rely on pyarrow as the source-of-truth.
     assert s.size_bytes() == data.nbytes + 8
 
     ## with nulls
@@ -136,6 +140,35 @@ def test_series_binary_size_bytes(size) -> None:
 
     assert s.datatype() == DataType.binary()
     assert s.size_bytes() == data.nbytes + 8
+
+
+@pytest.mark.skipif(
+    not PYARROW_GE_7_0_0,
+    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
+)
+@pytest.mark.parametrize("dtype, size", itertools.product(ARROW_INT_TYPES + ARROW_FLOAT_TYPES, [0, 1, 2, 8, 9, 16]))
+def test_series_list_size_bytes(dtype, size) -> None:
+    list_dtype = pa.list_(dtype)
+    pydata = [[2 * i] if i % 2 == 0 else [2 * i, 2 * i + 1] for i in range(size)]
+    data = pa.array(pydata, list_dtype)
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.from_arrow_type(list_dtype)
+    # TODO(Clark): Investigate this discrepancy.
+    # TODO(Clark): Investigate this discrepancy between Arrow2 and pyarrow.
+    # We should fix this upstream and/or refactor these tests to not rely on pyarrow as the source-of-truth.
+    assert s.size_bytes() == data.nbytes + (size * 8) // 2
+
+    ## with nulls
+    if size > 0:
+        pydata = pydata[:-1] + [None]
+    data = pa.array(pydata, list_dtype)
+
+    s = Series.from_arrow(data)
+
+    assert s.datatype() == DataType.from_arrow_type(list_dtype)
+    assert s.size_bytes() == data.nbytes + (size * 8) // 2
 
 
 @pytest.mark.skipif(

--- a/tests/series/test_take.py
+++ b/tests/series/test_take.py
@@ -56,6 +56,22 @@ def test_series_binary_take() -> None:
     assert result.to_pylist() == expected
 
 
+def test_series_list_take() -> None:
+    data = pa.array([[1, 2], [None], None, [7, 8, 9], [10, None], [11]], type=pa.list_(pa.int64()))
+
+    s = Series.from_arrow(data)
+    pyidx = [2, 0, None, 5]
+    idx = Series.from_pylist(pyidx)
+
+    result = s.take(idx)
+    assert result.datatype() == s.datatype()
+    assert len(result) == 4
+
+    original_data = s.to_pylist()
+    expected = [original_data[i] if i is not None else None for i in pyidx]
+    assert result.to_pylist() == expected
+
+
 def test_series_fixed_size_list_take() -> None:
     data = pa.array([[1, 2], [None, 4], None, [7, 8], [9, None], [11, 12]], type=pa.list_(pa.int64(), 2))
 

--- a/tests/series/test_take.py
+++ b/tests/series/test_take.py
@@ -54,3 +54,19 @@ def test_series_binary_take() -> None:
     original_data = s.to_pylist()
     expected = [original_data[i] if i is not None else None for i in pyidx]
     assert result.to_pylist() == expected
+
+
+def test_series_fixed_size_list_take() -> None:
+    data = pa.array([[1, 2], [None, 4], None, [7, 8], [9, None], [11, 12]], type=pa.list_(pa.int64(), 2))
+
+    s = Series.from_arrow(data)
+    pyidx = [2, 0, None, 5]
+    idx = Series.from_pylist(pyidx)
+
+    result = s.take(idx)
+    assert result.datatype() == s.datatype()
+    assert len(result) == 4
+
+    original_data = s.to_pylist()
+    expected = [original_data[i] if i is not None else None for i in pyidx]
+    assert result.to_pylist() == expected


### PR DESCRIPTION
This PR adds support for our first nested type, `FixedSizeListArray`, `ListArray`, and adds some general nested type scaffolding for other nested types, like `ListArray` and `StructArray`.

## Drivebys

- Updates Arrow2 from 0.14.2 to 0.17.0 - the big breaking changes were around `ZipValidity` and `Array::slice()`.
- Ported our `DataArray::size_bytes()` to use Arrow2's `estimate_bytes_size()`.
- Changed some `staticmethod`s to `classmethod`s on the Python side.

## TODOs

- [x] Add support for `ListArray`s.

## Future PR TODOs
- [ ] Add support for `StructArray`s.
- [ ] Add more test coverage.
- [ ] Close gap on kernel support (e.g. make these nested types opaque passthroughs for certain kernels).