### PR TITLE
[RUST] Add PartialEq implementation for PartialUDF

### DIFF
--- a/src/dsl/functions/python/partial_udf.rs
+++ b/src/dsl/functions/python/partial_udf.rs
@@ -57,11 +57,8 @@ impl<'de> Deserialize<'de> for PartialUDF {
     }
 }
 
-impl<Rhs> PartialEq<Rhs> for PartialUDF {
-    fn eq(&self, _other: &Rhs) -> bool {
-        Python::with_gil(|_py| {
-            // TODO: Call __eq__
-            todo!();
-        })
+impl PartialEq for PartialUDF {
+    fn eq(&self, other: &Self) -> bool {
+        Python::with_gil(|py| self.0.as_ref(py).eq(other.0.as_ref(py)).unwrap())
     }
 }

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -6,6 +6,7 @@ import pytest
 from daft import col
 from daft.datatype import DataType
 from daft.expressions import Expression
+from daft.expressions.testing import expr_structurally_equal
 from daft.series import Series
 from daft.table import Table
 from daft.udf import udf
@@ -98,6 +99,15 @@ def test_full_udf_call():
 
     with pytest.raises(TypeError):
         full_udf()
+
+
+def test_udf_equality():
+    @udf(return_dtype=DataType.int64())
+    def udf1(x):
+        pass
+
+    assert expr_structurally_equal(udf1("x"), udf1("x"))
+    assert not expr_structurally_equal(udf1("x"), udf1("y"))
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
* Fills in the PartialEq implementation for PartialUDF which allows for comparison of two UDFExpressions