### PR TITLE
[RUST] Fix creation of tables for list type

### DIFF
--- a/src/array/ops/arithmetic.rs
+++ b/src/array/ops/arithmetic.rs
@@ -54,14 +54,14 @@ where
         (_, 1) => {
             let opt_rhs = rhs.get(0);
             match opt_rhs {
-                None => Ok(DataArray::full_null(lhs.name(), lhs.len())),
+                None => Ok(DataArray::full_null(lhs.name(), lhs.data_type(), lhs.len())),
                 Some(rhs) => lhs.apply(|lhs| operation(lhs, rhs)),
             }
         }
         (1, _) => {
             let opt_lhs = lhs.get(0);
             match opt_lhs {
-                None => Ok(DataArray::full_null(rhs.name(), rhs.len())),
+                None => Ok(DataArray::full_null(rhs.name(), lhs.data_type(), rhs.len())),
                 // NOTE: naming logic here is wrong, and assigns the rhs name. However, renaming is handled at the Series level so this
                 // error is obfuscated.
                 Some(lhs) => rhs.apply(|rhs| operation(lhs, rhs)),
@@ -162,14 +162,18 @@ where
                 (_, 1) => {
                     let opt_rhs = rhs.get(0);
                     match opt_rhs {
-                        None => Ok(DataArray::full_null(self.name(), self.len())),
+                        None => Ok(DataArray::full_null(
+                            self.name(),
+                            self.data_type(),
+                            self.len(),
+                        )),
                         Some(rhs) => self.apply(|lhs| lhs % rhs),
                     }
                 }
                 (1, _) => {
                     let opt_lhs = self.get(0);
                     Ok(match opt_lhs {
-                        None => DataArray::full_null(rhs.name(), rhs.len()),
+                        None => DataArray::full_null(rhs.name(), rhs.data_type(), rhs.len()),
                         Some(lhs) => {
                             let values_iter = rhs.downcast().iter().map(|v| v.map(|v| lhs % *v));
                             let arrow_array = unsafe {

--- a/src/array/ops/broadcast.rs
+++ b/src/array/ops/broadcast.rs
@@ -33,7 +33,7 @@ where
                     std::iter::repeat(*val).take(num).collect();
                 return Ok(DataArray::from((self.name(), repeated_values.as_slice())));
             }
-            None => Ok(DataArray::full_null(self.name(), num)),
+            None => Ok(DataArray::full_null(self.name(), self.data_type(), num)),
         }
     }
 }
@@ -52,7 +52,7 @@ impl Broadcastable for Utf8Array {
                 let repeated_values: Vec<&str> = std::iter::repeat(val).take(num).collect();
                 Ok(DataArray::from((self.name(), repeated_values.as_slice())))
             }
-            None => Ok(DataArray::full_null(self.name(), num)),
+            None => Ok(DataArray::full_null(self.name(), self.data_type(), num)),
         }
     }
 }
@@ -65,7 +65,7 @@ impl Broadcastable for NullArray {
                 self.name()
             )));
         }
-        Ok(DataArray::full_null(self.name(), num))
+        Ok(DataArray::full_null(self.name(), self.data_type(), num))
     }
 }
 
@@ -83,7 +83,7 @@ impl Broadcastable for BooleanArray {
                 let repeated_values: Vec<bool> = std::iter::repeat(val).take(num).collect();
                 Ok(DataArray::from((self.name(), repeated_values.as_slice())))
             }
-            None => Ok(DataArray::full_null(self.name(), num)),
+            None => Ok(DataArray::full_null(self.name(), self.data_type(), num)),
         }
     }
 }
@@ -107,7 +107,7 @@ impl Broadcastable for BinaryArray {
                     )),
                 )
             }
-            None => Ok(DataArray::full_null(self.name(), num)),
+            None => Ok(DataArray::full_null(self.name(), self.data_type(), num)),
         }
     }
 }
@@ -160,7 +160,7 @@ impl Broadcastable for ListArray {
                     self.name(), e,
                 ))),
             }
-            None => Ok(DataArray::full_null(self.name(), num)),
+            None => Ok(DataArray::full_null(self.name(), self.data_type(), num)),
         }
     }
 }
@@ -200,7 +200,7 @@ impl Broadcastable for FixedSizeListArray {
                     ),
                 }
             }
-            None => Ok(DataArray::full_null(self.name(), num)),
+            None => Ok(DataArray::full_null(self.name(), self.data_type(), num)),
         }
     }
 }

--- a/src/array/ops/comparison.rs
+++ b/src/array/ops/comparison.rs
@@ -2,7 +2,7 @@ use num_traits::{NumCast, ToPrimitive};
 
 use crate::{
     array::{BaseArray, DataArray},
-    datatypes::{BooleanArray, DaftNumericType, NullArray, Utf8Array},
+    datatypes::{BooleanArray, DaftNumericType, DataType, NullArray, Utf8Array},
     error::{DaftError, DaftResult},
 };
 
@@ -45,14 +45,22 @@ where
                 if let Some(value) = rhs.get(0) {
                     Ok(self.equal(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     Ok(rhs.equal(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -77,14 +85,22 @@ where
                 if let Some(value) = rhs.get(0) {
                     Ok(self.not_equal(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     Ok(rhs.not_equal(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -109,14 +125,22 @@ where
                 if let Some(value) = rhs.get(0) {
                     Ok(self.lt(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     Ok(rhs.gt(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -141,14 +165,22 @@ where
                 if let Some(value) = rhs.get(0) {
                     Ok(self.lte(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     Ok(rhs.gte(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -173,14 +205,22 @@ where
                 if let Some(value) = rhs.get(0) {
                     Ok(self.gt(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     Ok(rhs.lt(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -205,14 +245,22 @@ where
                 if let Some(value) = rhs.get(0) {
                     Ok(self.gte(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     Ok(rhs.lte(value))
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -308,14 +356,22 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
                 if let Some(value) = rhs.get(0) {
                     self.equal(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.equal(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -340,14 +396,22 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
                 if let Some(value) = rhs.get(0) {
                     self.not_equal(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.not_equal(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -372,14 +436,22 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
                 if let Some(value) = rhs.get(0) {
                     self.lt(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -404,14 +476,22 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
                 if let Some(value) = rhs.get(0) {
                     self.lte(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.gte(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -436,14 +516,22 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
                 if let Some(value) = rhs.get(0) {
                     self.gt(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.lt(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -468,14 +556,22 @@ impl DaftCompare<&BooleanArray> for BooleanArray {
                 if let Some(value) = rhs.get(0) {
                     self.gte(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.lte(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -575,14 +671,22 @@ impl DaftLogical<&BooleanArray> for BooleanArray {
                 if let Some(value) = rhs.get(0) {
                     self.and(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.and(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -614,14 +718,22 @@ impl DaftLogical<&BooleanArray> for BooleanArray {
                 if let Some(value) = rhs.get(0) {
                     self.or(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.or(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -653,14 +765,22 @@ impl DaftLogical<&BooleanArray> for BooleanArray {
                 if let Some(value) = rhs.get(0) {
                     self.xor(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.xor(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -676,9 +796,17 @@ macro_rules! null_array_comparision_method {
     ($func_name:ident) => {
         fn $func_name(&self, rhs: &NullArray) -> Self::Output {
             match (self.len(), rhs.len()) {
-                (x, y) if x == y => Ok(BooleanArray::full_null(self.name(), x)),
-                (l_size, 1) => Ok(BooleanArray::full_null(self.name(), l_size)),
-                (1, r_size) => Ok(BooleanArray::full_null(self.name(), r_size)),
+                (x, y) if x == y => Ok(BooleanArray::full_null(self.name(), &DataType::Boolean, x)),
+                (l_size, 1) => Ok(BooleanArray::full_null(
+                    self.name(),
+                    &DataType::Boolean,
+                    l_size,
+                )),
+                (1, r_size) => Ok(BooleanArray::full_null(
+                    self.name(),
+                    &DataType::Boolean,
+                    r_size,
+                )),
                 (l, r) => Err(DaftError::ValueError(format!(
                     "trying to compare different length arrays: {}: {l} vs {}: {r}",
                     self.name(),
@@ -757,14 +885,22 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
                 if let Some(value) = rhs.get(0) {
                     self.equal(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.equal(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -789,14 +925,22 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
                 if let Some(value) = rhs.get(0) {
                     self.not_equal(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.not_equal(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -821,14 +965,22 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
                 if let Some(value) = rhs.get(0) {
                     self.lt(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -853,14 +1005,22 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
                 if let Some(value) = rhs.get(0) {
                     self.lte(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.gte(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -885,14 +1045,22 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
                 if let Some(value) = rhs.get(0) {
                     self.gt(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.lt(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(
@@ -917,14 +1085,22 @@ impl DaftCompare<&Utf8Array> for Utf8Array {
                 if let Some(value) = rhs.get(0) {
                     self.gte(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), l_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        l_size,
+                    ))
                 }
             }
             (1, r_size) => {
                 if let Some(value) = self.get(0) {
                     rhs.lte(value)
                 } else {
-                    Ok(BooleanArray::full_null(self.name(), r_size))
+                    Ok(BooleanArray::full_null(
+                        self.name(),
+                        &DataType::Boolean,
+                        r_size,
+                    ))
                 }
             }
             (l, r) => Err(DaftError::ValueError(format!(

--- a/src/array/ops/filter.rs
+++ b/src/array/ops/filter.rs
@@ -47,7 +47,11 @@ impl BooleanArray {
 impl NullArray {
     pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
         let set_bits = mask.len() - mask.downcast().values().unset_bits();
-        Ok(NullArray::full_null(self.name(), set_bits))
+        Ok(NullArray::full_null(
+            self.name(),
+            self.data_type(),
+            set_bits,
+        ))
     }
 }
 

--- a/src/array/ops/full.rs
+++ b/src/array/ops/full.rs
@@ -1,10 +1,8 @@
 use std::sync::Arc;
 
-use arrow2::array::{new_empty_array, new_null_array};
-
 use crate::{
     array::DataArray,
-    datatypes::{DaftDataType, Field},
+    datatypes::{DaftDataType, DataType, Field},
 };
 
 impl<T> DataArray<T>
@@ -12,21 +10,33 @@ where
     T: DaftDataType,
 {
     /// Creates a DataArray<T> of size `length` that is filled with all nulls.
-    pub fn full_null(name: &str, length: usize) -> Self {
-        if !T::get_dtype().is_arrow() {
-            panic!("Only arrow types are supported for null arrays");
+    pub fn full_null(name: &str, dtype: &DataType, length: usize) -> Self {
+        let arrow_dtype = dtype.to_arrow();
+        match arrow_dtype {
+            Ok(arrow_dtype) => DataArray::<T>::new(
+                Arc::new(Field {
+                    name: name.to_string(),
+                    dtype: dtype.clone(),
+                }),
+                arrow2::array::new_null_array(arrow_dtype, length),
+            )
+            .unwrap(),
+            Err(e) => panic!("Cannot create DataArray from non-arrow dtype: {e}"),
         }
-        let arr = new_null_array(T::get_dtype().to_arrow().unwrap(), length);
-
-        DataArray::new(Arc::new(Field::new(name, T::get_dtype())), arr).unwrap()
     }
 
-    pub fn empty(name: &str) -> Self {
-        if !T::get_dtype().is_arrow() {
-            panic!("Only arrow types are supported for empty arrays");
+    pub fn empty(name: &str, dtype: &DataType) -> Self {
+        let arrow_dtype = dtype.to_arrow();
+        match arrow_dtype {
+            Ok(arrow_dtype) => DataArray::<T>::new(
+                Arc::new(Field {
+                    name: name.to_string(),
+                    dtype: dtype.clone(),
+                }),
+                arrow2::array::new_empty_array(arrow_dtype),
+            )
+            .unwrap(),
+            Err(e) => panic!("Cannot create DataArray from non-arrow dtype: {e}"),
         }
-        let arr = new_empty_array(T::get_dtype().to_arrow().unwrap());
-
-        DataArray::new(Arc::new(Field::new(name, T::get_dtype())), arr).unwrap()
     }
 }

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -30,7 +30,7 @@ macro_rules! broadcast_if_else{(
         (self_len, _, 1) => {
             let predicate_scalar = $predicate.get(0);
             match predicate_scalar {
-                None => Ok(DataArray::full_null($if_true.name(), self_len)),
+                None => Ok(DataArray::full_null($if_true.name(), $if_true.data_type(), self_len)),
                 Some(predicate_scalar_value) => {
                     if predicate_scalar_value {
                         Ok($if_true.clone())
@@ -154,7 +154,11 @@ impl BinaryArray {
 
 impl NullArray {
     pub fn if_else(&self, _other: &NullArray, _predicate: &BooleanArray) -> DaftResult<NullArray> {
-        Ok(DataArray::full_null(self.name(), self.len()))
+        Ok(DataArray::full_null(
+            self.name(),
+            self.data_type(),
+            self.len(),
+        ))
     }
 }
 

--- a/src/array/ops/utf8.rs
+++ b/src/array/ops/utf8.rs
@@ -56,7 +56,11 @@ impl Utf8Array {
             (self_len, 1) => {
                 let other_scalar_value = other.get(0);
                 match other_scalar_value {
-                    None => Ok(BooleanArray::full_null(self.name(), self_len)),
+                    None => Ok(BooleanArray::full_null(
+                        self.name(),
+                        self.data_type(),
+                        self_len,
+                    )),
                     Some(other_v) => {
                         let arrow_result: arrow2::array::BooleanArray = self_arrow
                             .into_iter()
@@ -70,7 +74,11 @@ impl Utf8Array {
             (1, other_len) => {
                 let self_scalar_value = self.get(0);
                 match self_scalar_value {
-                    None => Ok(BooleanArray::full_null(self.name(), other_len)),
+                    None => Ok(BooleanArray::full_null(
+                        self.name(),
+                        self.data_type(),
+                        other_len,
+                    )),
                     Some(self_v) => {
                         let arrow_result: arrow2::array::BooleanArray = other_arrow
                             .into_iter()

--- a/src/dsl/lit.rs
+++ b/src/dsl/lit.rs
@@ -67,7 +67,7 @@ impl LiteralValue {
         use crate::datatypes::*;
         use LiteralValue::*;
         let result = match self {
-            Null => NullArray::full_null("literal", 1).into_series(),
+            Null => NullArray::full_null("literal", &DataType::Null, 1).into_series(),
             Boolean(val) => BooleanArray::from(("literal", [*val].as_slice())).into_series(),
             Utf8(val) => Utf8Array::from(("literal", [val.as_str()].as_slice())).into_series(),
             Binary(val) => BinaryArray::from(("literal", val.as_slice())).into_series(),

--- a/src/series/ops/arithmetic.rs
+++ b/src/series/ops/arithmetic.rs
@@ -147,7 +147,7 @@ mod tests {
     #[test]
     fn add_int_and_int_full_null() -> DaftResult<()> {
         let a = Int64Array::from(("a", vec![1, 2, 3]));
-        let b = Int64Array::full_null("b", 3);
+        let b = Int64Array::full_null("b", &DataType::Int64, 3);
         let c = a.into_series() + b.into_series();
         assert_eq!(*c?.data_type(), DataType::Int64);
         Ok(())

--- a/src/series/ops/broadcast.rs
+++ b/src/series/ops/broadcast.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn broadcast_int_null() -> DaftResult<()> {
-        let a = Int64Array::full_null("a", 1).into_series();
+        let a = Int64Array::full_null("a", &DataType::Int64, 1).into_series();
         let a = a.broadcast(10)?;
         assert_eq!(a.len(), 10);
         assert_eq!(*a.data_type(), DataType::Int64);
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn broadcast_utf8_null() -> DaftResult<()> {
-        let a = Utf8Array::full_null("a", 1).into_series();
+        let a = Utf8Array::full_null("a", &DataType::Utf8, 1).into_series();
         let a = a.broadcast(10)?;
         assert_eq!(a.len(), 10);
         assert_eq!(*a.data_type(), DataType::Utf8);

--- a/src/series/ops/full.rs
+++ b/src/series/ops/full.rs
@@ -4,7 +4,7 @@ use crate::{datatypes::DataType, error::DaftResult, series::Series, with_match_d
 impl Series {
     pub fn empty(name: &str, datatype: &DataType) -> DaftResult<Self> {
         with_match_daft_types!(datatype, |$T| {
-            Ok(DataArray::<$T>::empty(name).into_series())
+            Ok(DataArray::<$T>::empty(name, datatype).into_series())
         })
     }
 }

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -60,7 +60,7 @@ impl Table {
                 let mut columns: Vec<Series> = Vec::with_capacity(schema.names().len());
                 for (field_name, field) in schema.fields.iter() {
                     with_match_daft_types!(field.dtype, |$T| {
-                        columns.push(DataArray::<$T>::full_null(field_name, 0).into_series())
+                        columns.push(DataArray::<$T>::full_null(field_name, &field.dtype, 0).into_series())
                     })
                 }
                 Ok(Table { schema, columns })
@@ -124,7 +124,7 @@ impl Table {
         }
 
         if num == 0 {
-            let indices = UInt64Array::empty("idx");
+            let indices = UInt64Array::empty("idx", &DataType::UInt64);
             return self.take(&indices.into_series());
         }
 

--- a/tests/table/test_table_io.py
+++ b/tests/table/test_table_io.py
@@ -35,11 +35,11 @@ TEST_DATA = {
     "integers": [i for i in range(TEST_DATA_LEN)],
     "floats": [float(i) for i in range(TEST_DATA_LEN)],
     "bools": [True for i in range(TEST_DATA_LEN)],
+    "fixed_sized_arrays": [[i for _ in range(4)] for i in range(TEST_DATA_LEN)],
     # NOTE: [RUST-INT][NESTED] Implement for nested types.
     # NOTE: Structs are currently breaking in test_parquet_reads_limit_rows! Something weird is happening during conversion to a Rust Array
     # where the slice offset is not being respected specifically for struct types.
     # "structs": [{"foo": i} for i in range(TEST_DATA_LEN)],
-    # "fixed_sized_arrays": [[i for _ in range(4)] for i in range(TEST_DATA_LEN)],
     # "var_sized_arrays": [[i for _ in range(i)] for i in range(TEST_DATA_LEN)],
 }
 
@@ -70,9 +70,9 @@ JSON_EXPECTED_DATA = {
     "integers": TEST_DATA["integers"],
     "floats": TEST_DATA["floats"],
     "bools": TEST_DATA["bools"],
+    "fixed_sized_arrays": TEST_DATA["fixed_sized_arrays"],
     # [RUST-INT][NESTED] Enable for nested types
     # "structs": TEST_DATA["structs"],
-    # "fixed_sized_arrays": TEST_DATA["fixed_sized_arrays"],
     # "var_sized_arrays": TEST_DATA["var_sized_arrays"],
 }
 
@@ -133,9 +133,9 @@ PARQUET_EXPECTED_DATA = {
     "integers": TEST_DATA["integers"],
     "floats": TEST_DATA["floats"],
     "bools": TEST_DATA["bools"],
+    "fixed_sized_arrays": TEST_DATA["fixed_sized_arrays"],
     # [RUST-INT][NESTED] Enable for nested types
     # "structs": TEST_DATA["structs"],
-    # "fixed_sized_arrays": TEST_DATA["fixed_sized_arrays"],
     # "var_sized_arrays": TEST_DATA["var_sized_arrays"],
 }
 
@@ -187,9 +187,9 @@ CSV_EXPECTED_DATA = {
     "integers": TEST_DATA["integers"],
     "floats": TEST_DATA["floats"],
     "bools": TEST_DATA["bools"],
+    "fixed_sized_arrays": [str(l) for l in TEST_DATA["fixed_sized_arrays"]],
     # [RUST-INT][NESTED] Enable for nested types
     # "structs": [str(s) for s in TEST_DATA["structs"]],
-    # "fixed_sized_arrays": [str(l) for l in TEST_DATA["fixed_sized_arrays"]],
     # "var_sized_arrays": [str(l) for l in TEST_DATA["var_sized_arrays"]],
 }
 


### PR DESCRIPTION
* Creation of tables from parquet/csv/json may pass in an Arrow array with type `List` instead of `LargeList` - we need to perform a cast at runtime to account for this
* Changes to `DataArray::full_null` and `DataArray::empty` to accept a `DataType` argument and construct the array using the `DataType` instead of the `DaftDataType`. This is required because `DaftDataType` doesn't contain the child-type information required to create the appropriate (null/empty) arrow arrays.
