### PR TITLE
Add string grouping benchmarks

### DIFF
--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 import _pytest
 
 
-# Monkeypatch to use comma delimiters when showing parameter lists.
+# Monkeypatch to use dash delimiters when showing parameter lists.
 # https://github.com/pytest-dev/pytest/blob/31d0b51039fc295dfb14bfc5d2baddebe11bb746/src/_pytest/python.py#L1190
 # Related: https://github.com/pytest-dev/pytest/issues/3617
+# This allows us to perform pytest selection via the `-k` CLI flag
 def id(self):
-    return ",".join(self._idlist)
+    return "-".join(self._idlist)
 
 
 setattr(_pytest.python.CallSpec2, "id", property(id))
 
 
 def pytest_make_parametrize_id(config, val, argname):
-    return f"{argname}={val}"
+    if isinstance(val, int):
+        val = f"{val:_}"
+    return f"{argname}:{val}"

--- a/tests/benchmarks/test_groups_and_aggs.py
+++ b/tests/benchmarks/test_groups_and_aggs.py
@@ -8,7 +8,7 @@ import pytest
 
 from daft import DataFrame
 
-NUM_SAMPLES = [10_000_000, 100_000_000]
+NUM_SAMPLES = [1_000_000, 10_000_000]
 
 
 @pytest.mark.benchmark(group="aggregations")


### PR DESCRIPTION
* Adds string groupby benchmarks
* Changes delim in benchmarks to `-` and `:` so we can use `pytest -k`