### PR TITLE
[ci] Github Actions: Daft Profiling: increase timeout, bump python version and set target-cpu to native

### DIFF
--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -9,13 +9,13 @@ env:
   DAFT_ANALYTICS_ENABLED: '0'
   TPCH_SCALE_FACTOR: '4'
   TPCH_NUM_PARTS: '32'
-  PYTHON_VERSION: '3.7'
+  PYTHON_VERSION: '3.8'
 
 
 jobs:
   profile-daft:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
     steps:
@@ -51,11 +51,11 @@ jobs:
 
     - name: Build Rust Library
       env:
-        RUSTFLAGS: -g
+        RUSTFLAGS: -Ctarget-cpu=native
 
       run: |
         source activate
-        maturin develop --release
+        maturin develop --profile dev-bench
 
     - uses: actions/cache@v3
       env:


### PR DESCRIPTION
* Bump timeout to 20 minutes
* Bump python version to 3.8
* Use dev-bench profile instead of custom -g flag
* set cpu-target to native