### PR TITLE
[Integrations] Add Dask DataFrame integration.

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1279,7 +1279,17 @@ class DataFrame:
         )
 
     @DataframePublicAPI
-    def to_dask_dataframe(self) -> "dask.DataFrame":
+    def to_dask_dataframe(
+        self,
+        meta: Union[
+            "pandas.DataFrame",
+            "pandas.Series",
+            Dict[str, Any],
+            Iterable[Any],
+            Tuple[Any],
+            None,
+        ] = None,
+    ) -> "dask.DataFrame":
         """Converts the current Daft DataFrame to a Dask DataFrame.
 
         The returned Dask DataFrame will use `Dask-on-Ray <https://docs.ray.io/en/latest/data/dask-on-ray.html>`__
@@ -1287,6 +1297,17 @@ class DataFrame:
 
         .. NOTE::
             This function can only work if Daft is running using the RayRunner.
+
+        Args:
+            meta: An empty pandas DataFrame or Series that matches the dtypes and column
+                names of the stream. This metadata is necessary for many algorithms in
+                dask dataframe to work. For ease of use, some alternative inputs are
+                also available. Instead of a DataFrame, a dict of ``{name: dtype}`` or
+                iterable of ``(name, dtype)`` can be provided (note that the order of
+                the names should match the order of the columns). Instead of a series, a
+                tuple of ``(name, dtype)`` can be used.
+                By default, this will be inferred from the underlying Daft DataFrame schema,
+                with this argument supplying an optional override.
 
         Returns:
             dask.DataFrame: A Dask DataFrame stored on a Ray cluster.
@@ -1300,7 +1321,7 @@ class DataFrame:
         # Dask is using a non-distributed scheduler.
         if not isinstance(partition_set, RayPartitionSet):
             raise ValueError("Cannot convert to Dask DataFrame if not running on Ray backend")
-        return partition_set.to_dask_dataframe()
+        return partition_set.to_dask_dataframe(meta)
 
     @classmethod
     @DataframePublicAPI

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     import numpy as np
     import pandas
     import pyarrow as pa
+    import dask
 
 from daft.logical.schema import Schema
 
@@ -1242,7 +1243,8 @@ class DataFrame:
         self.collect()
         partition_set = self._result
         assert partition_set is not None
-        assert isinstance(partition_set, RayPartitionSet), "Cannot convert to Ray Dataset if not running on Ray backend"
+        if not isinstance(partition_set, RayPartitionSet):
+            raise ValueError("Cannot convert to Ray Dataset if not running on Ray backend")
         return partition_set.to_ray_dataset()
 
     @classmethod
@@ -1256,9 +1258,8 @@ class DataFrame:
         Args:
             ds: the Ray Dataset to create a Daft DataFrame from
         """
-        assert (
-            get_context().runner_config.name == "ray"
-        ), "Daft needs to be running on the Ray Runner for this operation"
+        if get_context().runner_config.name != "ray":
+            raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO
 
@@ -1266,6 +1267,67 @@ class DataFrame:
         assert isinstance(ray_runner_io, RayRunnerIO)
 
         partition_set, schema = ray_runner_io.partition_set_from_ray_dataset(ds)
+        cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
+        return cls(
+            logical_plan.InMemoryScan(
+                cache_entry=cache_entry,
+                schema=schema,
+                partition_spec=logical_plan.PartitionSpec(
+                    logical_plan.PartitionScheme.UNKNOWN, partition_set.num_partitions()
+                ),
+            )
+        )
+
+    @DataframePublicAPI
+    def to_dask_dataframe(self) -> "dask.DataFrame":
+        """Converts the current Daft DataFrame to a Dask DataFrame.
+
+        The returned Dask DataFrame will use `Dask-on-Ray <https://docs.ray.io/en/latest/data/dask-on-ray.html>`__
+        to execute operations on a Ray cluster.
+
+        .. NOTE::
+            This function can only work if Daft is running using the RayRunner.
+
+        Returns:
+            dask.DataFrame: A Dask DataFrame stored on a Ray cluster.
+        """
+        from daft.runners.ray_runner import RayPartitionSet
+
+        self.collect()
+        partition_set = self._result
+        assert partition_set is not None
+        # TODO(Clark): Support Dask DataFrame conversion for the local runner if
+        # Dask is using a non-distributed scheduler.
+
+        if not isinstance(partition_set, RayPartitionSet):
+            raise ValueError("Cannot convert to Dask DataFrame if not running on Ray backend")
+        return partition_set.to_dask_dataframe()
+
+    @classmethod
+    @DataframePublicAPI
+    def from_dask_dataframe(cls, ddf: "dask.DataFrame") -> "DataFrame":
+        """Creates a Daft DataFrame from a Dask DataFrame.
+
+        The provided Dask DataFrame must have been created using
+        `Dask-on-Ray <https://docs.ray.io/en/latest/data/dask-on-ray.html>`__.
+
+        .. NOTE::
+            This function can only work if Daft is running using the RayRunner
+
+        Args:
+            ddf: The Dask DataFrame to create a Daft DataFrame from.
+        """
+        # TODO(Clark): Support Dask DataFrame conversion for the local runner if
+        # Dask is using a non-distributed scheduler.
+        if get_context().runner_config.name != "ray":
+            raise ValueError("Daft needs to be running on the Ray Runner for this operation")
+
+        from daft.runners.ray_runner import RayRunnerIO
+
+        ray_runner_io = get_context().runner().runner_io()
+        assert isinstance(ray_runner_io, RayRunnerIO)
+
+        partition_set, schema = ray_runner_io.partition_set_from_dask_dataframe(ddf)
         cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
         return cls(
             logical_plan.InMemoryScan(

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1298,7 +1298,6 @@ class DataFrame:
         assert partition_set is not None
         # TODO(Clark): Support Dask DataFrame conversion for the local runner if
         # Dask is using a non-distributed scheduler.
-
         if not isinstance(partition_set, RayPartitionSet):
             raise ValueError("Cannot convert to Dask DataFrame if not running on Ray backend")
         return partition_set.to_dask_dataframe()

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterable
 
 import pyarrow as pa
 from loguru import logger
@@ -202,7 +202,10 @@ class RayPartitionSet(PartitionSet[ray.ObjectRef]):
         # instead of Arrow tables as the codepath for Dataset creation is the same.
         return from_arrow_refs(blocks)
 
-    def to_dask_dataframe(self) -> dask.DataFrame:
+    def to_dask_dataframe(
+        self,
+        meta: (pd.DataFrame | pd.Series | dict[str, Any] | Iterable[Any] | tuple[Any] | None) = None,
+    ) -> dask.DataFrame:
         import dask
         import dask.dataframe as dd
         from ray.util.dask import ray_dask_get
@@ -216,7 +219,7 @@ class RayPartitionSet(PartitionSet[ray.ObjectRef]):
         ddf_parts = [
             _make_dask_dataframe_partition_from_vpartition(self._partitions[k]) for k in self._partitions.keys()
         ]
-        return dd.from_delayed(ddf_parts)
+        return dd.from_delayed(ddf_parts, meta=meta)
 
     def get_partition(self, idx: PartID) -> ray.ObjectRef:
         return self._partitions[idx]

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -54,6 +54,8 @@ from daft.runners.runner import Runner
 from daft.table import Table
 
 if TYPE_CHECKING:
+    import dask
+    import pandas as pd
     from ray.data.block import Block as RayDatasetBlock
     from ray.data.dataset import Dataset as RayDataset
 
@@ -136,6 +138,25 @@ def _make_daft_partition_from_ray_dataset_blocks(ray_dataset_block: Any, daft_sc
     return partition
 
 
+@ray.remote(num_returns=2)
+def _make_daft_partition_from_dask_dataframe_partitions(dask_df_partition: pd.DataFrame) -> tuple[Table, pa.Schema]:
+    # TODO(Clark): Port to Table.from_pandas() once that API exists.
+    vpart = Table.from_pydict(dask_df_partition.to_dict(orient="list"))
+    return vpart, vpart.schema()
+
+
+def _to_pandas_ref(df: pd.DataFrame | ray.ObjectRef[pd.DataFrame]) -> ray.ObjectRef[pd.DataFrame]:
+    """Ensures that the provided pandas DataFrame partition is in the Ray object store."""
+    import pandas as pd
+
+    if isinstance(df, pd.DataFrame):
+        return ray.put(df)
+    elif isinstance(df, ray.ObjectRef):
+        return df
+    else:
+        raise ValueError("Expected a Ray object ref or a Pandas DataFrame, " f"got {type(df)}")
+
+
 @ray.remote
 def remote_len_partition(p: Table) -> int:
     return len(p)
@@ -180,6 +201,22 @@ class RayPartitionSet(PartitionSet[ray.ObjectRef]):
         # NOTE: although the Ray method is called `from_arrow_refs`, this method works also when the blocks are List[T] types
         # instead of Arrow tables as the codepath for Dataset creation is the same.
         return from_arrow_refs(blocks)
+
+    def to_dask_dataframe(self) -> dask.DataFrame:
+        import dask
+        import dask.dataframe as dd
+        from ray.util.dask import ray_dask_get
+
+        dask.config.set(scheduler=ray_dask_get)
+
+        @dask.delayed
+        def _make_dask_dataframe_partition_from_vpartition(partition: Table) -> pd.DataFrame:
+            return partition.to_pandas()
+
+        ddf_parts = [
+            _make_dask_dataframe_partition_from_vpartition(self._partitions[k]) for k in self._partitions.keys()
+        ]
+        return dd.from_delayed(ddf_parts)
 
     def get_partition(self, idx: PartID) -> ray.ObjectRef:
         return self._partitions[idx]
@@ -268,7 +305,24 @@ class RayRunnerIO(runner_io.RunnerIO[ray.ObjectRef]):
         daft_vpartitions = [
             _make_daft_partition_from_ray_dataset_blocks.remote(block, daft_schema) for block in block_refs
         ]
-        return RayPartitionSet({part_id: part for part_id, part in enumerate(daft_vpartitions)}), daft_schema
+        return RayPartitionSet(dict(enumerate(daft_vpartitions))), daft_schema
+
+    def partition_set_from_dask_dataframe(
+        self,
+        ddf: dask.DataFrame,
+    ) -> tuple[RayPartitionSet, Schema]:
+        import dask
+        from ray.util.dask import ray_dask_get
+
+        partitions = ddf.to_delayed()
+        if not partitions:
+            raise ValueError("Can't convert an empty Dask DataFrame (with no partitions) to a Daft DataFrame.")
+        persisted_partitions = dask.persist(*partitions, scheduler=ray_dask_get)
+        parts = [_to_pandas_ref(next(iter(part.dask.values()))) for part in persisted_partitions]
+        daft_vpartitions, schemas = zip(*map(_make_daft_partition_from_dask_dataframe_partitions.remote, parts))
+        schemas = ray.get(list(schemas))
+        # TODO(Clark): Validate that all schemas are the same.
+        return RayPartitionSet(dict(enumerate(daft_vpartitions))), schemas[0]
 
 
 def _get_ray_task_options(resource_request: ResourceRequest) -> dict[str, Any]:

--- a/docs/source/api_docs/dataframe.rst
+++ b/docs/source/api_docs/dataframe.rst
@@ -44,6 +44,18 @@ From In-Memory Data
     daft.DataFrame.from_pylist
     daft.DataFrame.from_pydict
 
+From Integrations
+*****************
+
+.. _df-from-integrations:
+
+.. autosummary::
+    :nosignatures:
+    :toctree: dataframe_methods
+
+    daft.DataFrame.from_ray_dataset
+    daft.DataFrame.from_dask_dataframe
+
 
 .. _dataframe-api-operations:
 
@@ -167,7 +179,7 @@ Writing Data
 Integrations
 ************
 
-.. _df-to-pandas:
+.. _df-to-integrations:
 
 .. autosummary::
     :nosignatures:
@@ -175,6 +187,7 @@ Integrations
 
     daft.DataFrame.to_pandas
     daft.DataFrame.to_ray_dataset
+    daft.DataFrame.to_dask_dataframe
 
 Schema and Lineage
 ##################

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 boto3
 cloudpickle
+dask
 docker
 fastapi
 

--- a/tests/ray/test_dask.py
+++ b/tests/ray/test_dask.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Any
+
+import dask
+import numpy as np
+import pandas as pd
+import pytest
+import ray
+
+from daft import DataFrame, DataType
+from daft.context import get_context
+
+RAY_VERSION = tuple(int(s) for s in ray.__version__.split("."))
+
+
+class MyObj:
+    def __init__(self, x: int):
+        self._x = x
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, MyObj) and self._x == other._x
+
+
+DATA = {
+    "intcol": [1, 2, 3],
+    "strcol": ["a", "b", "c"],
+}
+
+
+@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.parametrize("n_partitions", [1, 2])
+def test_to_dask_dataframe_all_arrow(n_partitions: int):
+    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = df.with_column("floatcol", df["intcol"].cast(DataType.float64()))
+    ddf = df.to_dask_dataframe()
+
+    rows = sorted(ddf.compute().to_dict("records"), key=lambda r: r["intcol"])
+    assert rows == sorted(
+        [
+            {"intcol": 1, "strcol": "a", "floatcol": 1.0},
+            {"intcol": 2, "strcol": "b", "floatcol": 2.0},
+            {"intcol": 3, "strcol": "c", "floatcol": 3.0},
+        ],
+        key=lambda r: r["intcol"],
+    )
+
+
+@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.parametrize("n_partitions", [1, 2])
+def test_to_dask_dataframe_with_py(n_partitions: int):
+    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = df.with_column("pycol", df["intcol"].apply(lambda x: MyObj(x), DataType.python()))
+    ddf = df.to_dask_dataframe()
+
+    rows = sorted(ddf.compute().to_dict("records"), key=lambda r: r["intcol"])
+    assert rows == sorted(
+        [
+            {"intcol": 1, "strcol": "a", "pycol": MyObj(1)},
+            {"intcol": 2, "strcol": "b", "pycol": MyObj(2)},
+            {"intcol": 3, "strcol": "c", "pycol": MyObj(3)},
+        ],
+        key=lambda r: r["intcol"],
+    )
+
+
+@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.parametrize("n_partitions", [1, 2])
+def test_to_dask_dataframe_with_numpy(n_partitions: int):
+    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = df.with_column("npcol", df["intcol"].apply(lambda _: np.ones((3, 3)), DataType.python()))
+    ddf = df.to_dask_dataframe()
+
+    rows = sorted(ddf.compute().to_dict("records"), key=lambda r: r["intcol"])
+    np.testing.assert_equal(
+        rows,
+        sorted(
+            [
+                {"intcol": 1, "strcol": "a", "npcol": np.ones((3, 3))},
+                {"intcol": 2, "strcol": "b", "npcol": np.ones((3, 3))},
+                {"intcol": 3, "strcol": "c", "npcol": np.ones((3, 3))},
+            ],
+            key=lambda r: r["intcol"],
+        ),
+    )
+
+
+@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.parametrize("n_partitions", [1, 2])
+def test_to_dask_dataframe_with_numpy_variable_shaped(n_partitions: int):
+    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = df.with_column("npcol", df["intcol"].apply(lambda x: np.ones((x, 3)), DataType.python()))
+    ddf = df.to_dask_dataframe()
+
+    rows = sorted(ddf.compute().to_dict("records"), key=lambda r: r["intcol"])
+    np.testing.assert_equal(
+        rows,
+        sorted(
+            [
+                {"intcol": 1, "strcol": "a", "npcol": np.ones((1, 3))},
+                {"intcol": 2, "strcol": "b", "npcol": np.ones((2, 3))},
+                {"intcol": 3, "strcol": "c", "npcol": np.ones((3, 3))},
+            ],
+            key=lambda r: r["intcol"],
+        ),
+    )
+
+
+@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.parametrize("n_partitions", [1, 2])
+def test_from_dask_dataframe_all_arrow(n_partitions: int):
+    df = pd.DataFrame(DATA)
+    df["floatcol"] = df["intcol"].astype(float)
+    ddf = dask.dataframe.from_pandas(df, npartitions=n_partitions)
+
+    daft_df = DataFrame.from_dask_dataframe(ddf)
+    out_df = daft_df.to_pandas()
+    pd.testing.assert_frame_equal(out_df, df)
+
+
+@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.parametrize("n_partitions", [1, 2])
+def test_from_dask_dataframe_tensor(n_partitions: int):
+    df = pd.DataFrame(DATA)
+    df["tensor"] = pd.Series([np.ones((2, 2)) for _ in range(len(df))], dtype=object)
+    ddf = dask.dataframe.from_pandas(df, npartitions=n_partitions)
+
+    daft_df = DataFrame.from_dask_dataframe(ddf)
+    out_df = daft_df.to_pandas()
+    pd.testing.assert_frame_equal(out_df, df)

--- a/tests/ray/test_dask.py
+++ b/tests/ray/test_dask.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import dask
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
@@ -111,7 +111,7 @@ def test_to_dask_dataframe_with_numpy_variable_shaped(n_partitions: int):
 def test_from_dask_dataframe_all_arrow(n_partitions: int):
     df = pd.DataFrame(DATA)
     df["floatcol"] = df["intcol"].astype(float)
-    ddf = dask.dataframe.from_pandas(df, npartitions=n_partitions)
+    ddf = dd.from_pandas(df, npartitions=n_partitions)
 
     daft_df = DataFrame.from_dask_dataframe(ddf)
     out_df = daft_df.to_pandas()
@@ -123,7 +123,7 @@ def test_from_dask_dataframe_all_arrow(n_partitions: int):
 def test_from_dask_dataframe_tensor(n_partitions: int):
     df = pd.DataFrame(DATA)
     df["tensor"] = pd.Series([np.ones((2, 2)) for _ in range(len(df))], dtype=object)
-    ddf = dask.dataframe.from_pandas(df, npartitions=n_partitions)
+    ddf = dd.from_pandas(df, npartitions=n_partitions)
 
     daft_df = DataFrame.from_dask_dataframe(ddf)
     out_df = daft_df.to_pandas()

--- a/tests/ray/test_dask.py
+++ b/tests/ray/test_dask.py
@@ -6,12 +6,9 @@ import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 import pytest
-import ray
 
 from daft import DataFrame, DataType
 from daft.context import get_context
-
-RAY_VERSION = tuple(int(s) for s in ray.__version__.split("."))
 
 
 class MyObj:

--- a/tests/ray/test_datasets.py
+++ b/tests/ray/test_datasets.py
@@ -35,10 +35,11 @@ def test_to_ray_dataset_all_arrow(n_partitions: int):
     df = df.with_column("floatcol", df["intcol"].cast(DataType.float64()))
     ds = df.to_ray_dataset()
 
-    if RAY_VERSION >= (2, 2, 0):
-        assert ds.dataset_format() == "arrow", "Ray Dataset format should be arrow"
-    elif RAY_VERSION >= (2, 0, 0):
-        assert ds._dataset_format() == "arrow", "Ray Dataset format should be arrow"
+    if RAY_VERSION < (2, 4, 0):
+        if RAY_VERSION >= (2, 2, 0):
+            assert ds.dataset_format() == "arrow", "Ray Dataset format should be arrow"
+        elif RAY_VERSION >= (2, 0, 0):
+            assert ds._dataset_format() == "arrow", "Ray Dataset format should be arrow"
 
     rows = sorted([row.as_pydict() for row in ds.iter_rows()], key=lambda r: r["intcol"])
     assert rows == sorted(
@@ -58,10 +59,11 @@ def test_to_ray_dataset_with_py(n_partitions: int):
     df = df.with_column("pycol", df["intcol"].apply(lambda x: MyObj(x), DataType.python()))
     ds = df.to_ray_dataset()
 
-    if RAY_VERSION >= (2, 2, 0):
-        assert ds.dataset_format() == "simple", "Ray Dataset format should be simple because it has Python objects"
-    elif RAY_VERSION >= (2, 0, 0):
-        assert ds._dataset_format() == "simple", "Ray Dataset format should be simple because it has Python objects"
+    if RAY_VERSION < (2, 4, 0):
+        if RAY_VERSION >= (2, 2, 0):
+            assert ds.dataset_format() == "simple", "Ray Dataset format should be simple because it has Python objects"
+        elif RAY_VERSION >= (2, 0, 0):
+            assert ds._dataset_format() == "simple", "Ray Dataset format should be simple because it has Python objects"
 
     rows = sorted([row for row in ds.iter_rows()], key=lambda r: r["intcol"])
     assert rows == sorted(
@@ -81,14 +83,15 @@ def test_to_ray_dataset_with_numpy(n_partitions: int):
     df = df.with_column("npcol", df["intcol"].apply(lambda _: np.ones((3, 3)), DataType.python()))
     ds = df.to_ray_dataset()
 
-    if RAY_VERSION >= (2, 2, 0):
-        assert (
-            ds.dataset_format() == "arrow"
-        ), "Ray Dataset format should be arrow because it uses a Tensor extension type"
-    elif RAY_VERSION >= (2, 0, 0):
-        assert (
-            ds._dataset_format() == "arrow"
-        ), "Ray Dataset format should be arrow because it uses a Tensor extension type"
+    if RAY_VERSION < (2, 4, 0):
+        if RAY_VERSION >= (2, 2, 0):
+            assert (
+                ds.dataset_format() == "arrow"
+            ), "Ray Dataset format should be arrow because it uses a Tensor extension type"
+        elif RAY_VERSION >= (2, 0, 0):
+            assert (
+                ds._dataset_format() == "arrow"
+            ), "Ray Dataset format should be arrow because it uses a Tensor extension type"
 
     rows = sorted([row.as_pydict() for row in ds.iter_rows()], key=lambda r: r["intcol"])
     np.testing.assert_equal(
@@ -111,14 +114,15 @@ def test_to_ray_dataset_with_numpy_variable_shaped(n_partitions: int):
     df = df.with_column("npcol", df["intcol"].apply(lambda x: np.ones((x, 3)), DataType.python()))
     ds = df.to_ray_dataset()
 
-    if RAY_VERSION >= (2, 2, 0):
-        assert (
-            ds.dataset_format() == "arrow"
-        ), "Ray Dataset format should be arrow because it uses a Tensor extension type"
-    elif RAY_VERSION >= (2, 0, 0):
-        assert (
-            ds._dataset_format() == "simple"
-        ), "In old versions of Ray, we drop down to `simple` format because ArrowTensorType is not compatible with ragged tensors"
+    if RAY_VERSION < (2, 4, 0):
+        if RAY_VERSION >= (2, 2, 0):
+            assert (
+                ds.dataset_format() == "arrow"
+            ), "Ray Dataset format should be arrow because it uses a Tensor extension type"
+        elif RAY_VERSION >= (2, 0, 0):
+            assert (
+                ds._dataset_format() == "simple"
+            ), "In old versions of Ray, we drop down to `simple` format because ArrowTensorType is not compatible with ragged tensors"
 
     rows = sorted([row.as_pydict() for row in ds.iter_rows()], key=lambda r: r["intcol"])
     np.testing.assert_equal(
@@ -143,10 +147,11 @@ def test_from_ray_dataset_all_arrow(n_partitions: int):
     table = pa.table(DATA)
     ds = ray.data.from_arrow(table).map_batches(add_float, batch_format="pyarrow").repartition(n_partitions)
 
-    if RAY_VERSION >= (2, 2, 0):
-        assert ds.dataset_format() == "arrow", "Ray Dataset format should be arrow"
-    elif RAY_VERSION >= (2, 0, 0):
-        assert ds._dataset_format() == "arrow", "Ray Dataset format should be arrow"
+    if RAY_VERSION < (2, 4, 0):
+        if RAY_VERSION >= (2, 2, 0):
+            assert ds.dataset_format() == "arrow", "Ray Dataset format should be arrow"
+        elif RAY_VERSION >= (2, 0, 0):
+            assert ds._dataset_format() == "arrow", "Ray Dataset format should be arrow"
 
     df = DataFrame.from_ray_dataset(ds)
     out_table = df.to_arrow()
@@ -198,10 +203,11 @@ def test_from_ray_dataset_pandas(n_partitions: int):
 
     ds = ray.data.from_pandas(pd_df).map_batches(add_float).repartition(n_partitions)
 
-    if RAY_VERSION >= (2, 2, 0):
-        assert ds.dataset_format() == "pandas", "Ray Dataset format should be pandas"
-    elif RAY_VERSION >= (2, 0, 0):
-        assert ds._dataset_format() == "pandas", "Ray Dataset format should be pandas"
+    if RAY_VERSION < (2, 4, 0):
+        if RAY_VERSION >= (2, 2, 0):
+            assert ds.dataset_format() == "pandas", "Ray Dataset format should be pandas"
+        elif RAY_VERSION >= (2, 0, 0):
+            assert ds._dataset_format() == "pandas", "Ray Dataset format should be pandas"
 
     df = DataFrame.from_ray_dataset(ds)
     expected_df = add_float(pd_df)


### PR DESCRIPTION
This PR adds a Dask DataFrame integration, allowing for converting a Dask DataFrame to a Daft DataFrame:
```python
df = daft.DataFrame.from_dask_dataframe()
```
and for converting a Daft DataFrame to a Dask DataFrame:
```python
ddf = df.to_dask_dataframe()
```

This is currently only supported for the Ray runner; we could add support for converting a local Daft DataFrame to a local Dask DataFrame, and vice versa, in a future PR.

## Drivebys

- Fix `daft.Table.to_pandas()` so it properly handles Python object columns.
- Raise `ValueError`s if a Ray runner isn't configured for the Ray Datasets integration rather than raising an `AssertionError`.

## TODOs

- [ ] **[P1]** Port `DataFrame.from_dask_dataframe()` to use `Table.from_pandas()` once that API is added; currently we convert the Pandas DataFrame to a column dictionary and go through the `Table.from_pydict()` API, which is less efficient.
- [ ] **[P2]** Support local Python runner + local Dask schedulers.