### PR TITLE
[Integrations] Add `from_pandas()` and `from_arrow()`.

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1237,7 +1237,7 @@ class DataFrame:
         If results have not computed yet, collect will be called.
 
         Returns:
-            pandas.DataFrame: pandas DataFrame converted from a Daft DataFrame
+            pd.DataFrame: pandas DataFrame converted from a Daft DataFrame
 
             .. NOTE::
                 This call is **blocking** and will execute the DataFrame when called

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1337,8 +1337,8 @@ class DataFrame:
     def to_dask_dataframe(
         self,
         meta: Union[
-            "pandas.DataFrame",
-            "pandas.Series",
+            "pd.DataFrame",
+            "pd.Series",
             Dict[str, Any],
             Iterable[Any],
             Tuple[Any],

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -140,8 +140,7 @@ def _make_daft_partition_from_ray_dataset_blocks(ray_dataset_block: Any, daft_sc
 
 @ray.remote(num_returns=2)
 def _make_daft_partition_from_dask_dataframe_partitions(dask_df_partition: pd.DataFrame) -> tuple[Table, pa.Schema]:
-    # TODO(Clark): Port to Table.from_pandas() once that API exists.
-    vpart = Table.from_pydict(dask_df_partition.to_dict(orient="list"))
+    vpart = Table.from_pandas(dask_df_partition)
     return vpart, vpart.schema()
 
 

--- a/docs/source/api_docs/dataframe.rst
+++ b/docs/source/api_docs/dataframe.rst
@@ -43,6 +43,8 @@ From In-Memory Data
 
     daft.DataFrame.from_pylist
     daft.DataFrame.from_pydict
+    daft.DataFrame.from_arrow
+    daft.DataFrame.from_pandas
 
 From Integrations
 *****************

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -24,6 +24,14 @@ class MyObj2:
     pass
 
 
+class MyObjWithValue:
+    def __init__(self, value: int):
+        self.value = value
+
+    def __eq__(self, other: MyObjWithValue):
+        return isinstance(other, MyObjWithValue) and self.value == other.value
+
+
 COL_NAMES = [
     "sepal_length",
     "sepal_width",
@@ -150,7 +158,7 @@ def test_create_dataframe_pandas(valid_data: list[dict[str, float]]) -> None:
 
 def test_create_dataframe_pandas_py_object(valid_data: list[dict[str, float]]) -> None:
     pydict = {k: [item[k] for item in valid_data] for k in valid_data[0].keys()}
-    pydict["obj"] = [MyObj() for _ in range(len(valid_data))]
+    pydict["obj"] = [MyObjWithValue(i) for i in range(len(valid_data))]
     pd_df = pd.DataFrame(pydict)
     df = DataFrame.from_pandas(pd_df)
     assert set(df.column_names) == set(pd_df.columns)

--- a/tests/ray/test_datasets.py
+++ b/tests/ray/test_datasets.py
@@ -170,7 +170,7 @@ def test_from_ray_dataset_all_arrow(n_partitions: int):
 @pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_simple(n_partitions: int):
-    ds = ray.data.range(8).repartition(n_partitions)
+    ds = ray.data.range(8, parallelism=n_partitions)
 
     df = DataFrame.from_ray_dataset(ds)
     np.testing.assert_equal(df.to_pydict(), {"value": list(range(8))})


### PR DESCRIPTION
This PR adds `DataFrame.from_pandas()` and `DataFrame.from_arrow()`.

The fallback conversion strategy for `Table.from_pandas()` is as follows:
1. Try to convert the entire pandas DataFrame into an Arrow Table and go through the `Table.from_arrow()` route.
2. Convert the pandas DataFrame to a Python dict of `pd.Series`, and go through the the `Table.from_pydict()` path. For each column:
  a. Try to convert the `pd.Series` directly to an Arrow Array.
  b. Try to convert the `pd.Series` to a NumPy ndarray and go the `Series.from_numpy()` path.
  c. Convert the `pd.Series` to a Python list and go the `Series.from_pylist()` path.

Overall, this should keep the happy path where the pandas DataFrame --> Arrow Table conversion works fast, then fall back to trying to convert each column to a form that preserves the most typing information and that copies the least amount of data: first Arrow, then NumPy, then plain Python list.

I think that this should minimize copying and typing loss for each column.