### PR TITLE
Python requirements cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
     - --no-sort-keys
     - '--indent=  '
   - id: check-added-large-files
-  - id: requirements-txt-fixer
   - id: check-merge-conflict
   - id: check-docstring-first
   - id: check-toml

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ hooks: venv
 
 .PHONY: build
 build: venv  ## Compile and install Daft for development
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --extras=all
 
 .PHONY: build-release
 build-release: venv  ## Compile and install a faster Daft binary

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -5,8 +5,6 @@ import sys
 from dataclasses import dataclass, field
 from typing import Generic, TypeVar
 
-import numpy as np
-
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
 else:
@@ -695,7 +693,7 @@ class FanoutSlices(FanoutInstruction):
             assert start >= 0, f"start must be positive, but got {start}"
             end = min(end, len(input))
 
-            indices_block = Series.from_numpy(np.arange(start, end))
+            indices_block = Series.from_numpy(list(range(start, end)))
             results.append(input.take(indices_block))
 
         return results

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -693,7 +693,7 @@ class FanoutSlices(FanoutInstruction):
             assert start >= 0, f"start must be positive, but got {start}"
             end = min(end, len(input))
 
-            indices_block = Series.from_numpy(list(range(start, end)))
+            indices_block = Series.from_pylist(list(range(start, end)))
             results.append(input.take(indices_block))
 
         return results

--- a/daft/internal/treenode.py
+++ b/daft/internal/treenode.py
@@ -71,7 +71,12 @@ class TreeNode(Generic[TreeNodeType]):
         return filename
 
     def to_dot(self) -> str:
-        import pydot
+        try:
+            import pydot
+        except ImportError:
+            raise ImportError(
+                "Error while importing pydot: please manually install `pip install pydot` for tree visualizations"
+            )
 
         graph: pydot.Graph = pydot.Dot("TreeNode", graph_type="digraph", bgcolor="white")  # type: ignore
         counter = 0

--- a/daft/internal/treenode.py
+++ b/daft/internal/treenode.py
@@ -11,8 +11,6 @@ if TYPE_CHECKING:
 
 TreeNodeType = TypeVar("TreeNodeType", bound="TreeNode")
 
-import pydot
-
 
 class TreeNode(Generic[TreeNodeType]):
     _registered_children: list[TreeNodeType]
@@ -73,6 +71,8 @@ class TreeNode(Generic[TreeNodeType]):
         return filename
 
     def to_dot(self) -> str:
+        import pydot
+
         graph: pydot.Graph = pydot.Dot("TreeNode", graph_type="digraph", bgcolor="white")  # type: ignore
         counter = 0
 

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 import weakref
 from abc import abstractmethod
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 from uuid import uuid4
 
-import pandas as pd
 import pyarrow as pa
 
 from daft.logical.schema import Schema
 from daft.table import Table
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 PartID = int
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,7 @@ dependencies = [
   "tabulate",
   "psutil",
   "typing-extensions >= 4.0.0; python_version < '3.8'",
-  "pickle5 >= 0.0.12; python_version < '3.8'",
-  # Breaking change in list aggregations in 0.16.1: https://github.com/pola-rs/polars/issues/6584
-  "polars[timezone] < 0.16.0"
+  "pickle5 >= 0.0.12; python_version < '3.8'"
 ]
 description = "A Distributed DataFrame library for large scale complex data processing."
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,12 @@ readme = "README.rst"
 requires-python = ">=3.7"
 
 [project.optional-dependencies]
-all = ["getdaft[aws, ray]"]
+all = ["getdaft[aws, ray, pandas, numpy, viz]"]
 aws = ["s3fs"]
 experimental = ["getdaft[serving, iceberg]"]
 iceberg = ["icebridge"]
+numpy = ["numpy"]
+pandas = ["pandas"]
 ray = [
   # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
   "ray[data, default]>=2.0.0",
@@ -36,6 +38,7 @@ ray = [
   "grpcio<1.52.0"
 ]
 serving = ["fastapi", "docker", "uvicorn", "cloudpickle", "boto3", "PyYAML"]
+viz = ["pydot"]
 
 [project.urls]
 homepage = "https://www.getdaft.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,9 @@ readme = "README.rst"
 requires-python = ">=3.7"
 
 [project.optional-dependencies]
-all = ["daft[aws, ray]"]
+all = ["getdaft[aws, ray]"]
 aws = ["s3fs"]
-experimental = ["daft[serving, iceberg]"]
+experimental = ["getdaft[serving, iceberg]"]
 iceberg = ["icebridge"]
 ray = [
   # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]
 dependencies = [
   "pyarrow",
   "fsspec[http]",
-  "pydot",
   "loguru",
   "tabulate",
   "psutil",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires = ["maturin>=0.14,<0.15"]
 [project]
 authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]
 dependencies = [
-  "numpy < 1.24",
   "pyarrow",
   "fsspec[http]",
   "protobuf>=3.19.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
   "pydot",
   "loguru",
   "tabulate",
-  "pandas",
   "psutil",
   "typing-extensions >= 4.0.0; python_version < '3.8'",
   "pickle5 >= 0.0.12; python_version < '3.8'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]
 dependencies = [
   "pyarrow",
   "fsspec[http]",
-  "protobuf>=3.19.0",
   "pydot",
   "loguru",
   "tabulate",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ pandas
 xxhash>=3.0.0
 
 # Ray
-grpcio<1.52.0  # Pin due to Ray issue: https://github.com/ray-project/ray/issues/32246
+grpcio
 ray[data, default]
 
 # Documentation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,33 +1,33 @@
 # Development/Build utilities
+ipdb
 maturin
 pre-commit
-ipdb
 
 # Tracing
 # TODO: Do we need orjson and viztracer still?
 orjson  # orjson recommended for viztracer
-viztracer
 py-spy
+viztracer
 
 # Testing frameworks
+hypothesis
 pytest>=7.1.2
 pytest-benchmark
 pytest-cov
-hypothesis
 
 # Testing dependencies
-pandas
+dask
 lxml
 numpy < 1.24
+pandas
 xxhash>=3.0.0
-dask
 
 # Ray
-ray[data, default]
 grpcio<1.52.0  # Pin due to Ray issue: https://github.com/ray-project/ray/issues/32246
+ray[data, default]
 
 # Documentation
-Sphinx <= 5
 myst-nb>=0.16.0
+Sphinx <= 5
 sphinx-book-theme>=0.3.3,<1.0.0
 sphinx-reredirects>=0.1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ maturin
 pre-commit
 
 # Tracing
-# TODO: Do we need orjson and viztracer still?
 orjson  # orjson recommended for viztracer
 py-spy
 viztracer
@@ -18,7 +17,7 @@ pytest-cov
 # Testing dependencies
 dask
 lxml
-numpy < 1.24
+numpy
 pandas
 xxhash>=3.0.0
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,36 +1,33 @@
-boto3
-cloudpickle
-dask
-docker
-fastapi
-
-# Pin due to Ray issue: https://github.com/ray-project/ray/issues/32246
-grpcio<1.52.0
-
-hypothesis
-icebridge
-ipdb
-lxml
+# Development/Build utilities
 maturin
-myst-nb>=0.16.0
-numpy < 1.24
-
-# orjson recommended for viztracer
-orjson
-
-pandas
 pre-commit
+ipdb
+
+# Tracing
+# TODO: Do we need orjson and viztracer still?
+orjson  # orjson recommended for viztracer
+viztracer
 py-spy
-pyarrow
+
+# Testing frameworks
 pytest>=7.1.2
 pytest-benchmark
 pytest-cov
-PyYAML
+hypothesis
+
+# Testing dependencies
+pandas
+lxml
+numpy < 1.24
+xxhash>=3.0.0
+dask
+
+# Ray
 ray[data, default]
-s3fs
+grpcio<1.52.0  # Pin due to Ray issue: https://github.com/ray-project/ray/issues/32246
+
+# Documentation
 Sphinx <= 5
+myst-nb>=0.16.0
 sphinx-book-theme>=0.3.3,<1.0.0
 sphinx-reredirects>=0.1.1
-uvicorn
-viztracer
-xxhash>=3.0.0


### PR DESCRIPTION
Output of a fresh `maturin develop`:

```
...
Installing collected packages: urllib3, tabulate, psutil, numpy, multidict, loguru, idna, fsspec, frozenlist, charset-normalizer, certifi, attrs, async-timeout, yarl, requests, pyarrow, aiosignal, aiohttp
```

Some notes:

1. I removed `pydot` as a dependency, and moved `import pydot` into our TreeNode visualization method. This means that this will fail if called at runtime - cc @samster25 to make sure this is fine?
2. `numpy` is still installed as a transitive dependency of pyarrow.
3. All of `aiohttp, aiosignal, async-timeout, attrs, certifi, charset-normalizer, frozenlist, idna, multidict, requests, urllib, yarl` are transitive dependencies of `fsspec[http]`. We can get rid of this only if we remove our dependency on fsspec.

If we remove the fsspec dependency, then we only end up installing:

```
loguru-0.7.0 numpy-1.24.3 psutil-5.9.5 pyarrow-11.0.0 tabulate-0.9.0
```

**Remaining Todos**

1. `loguru` should be cleaned up, but this requires cleaning up the way we do logging everywhere. Will do as a follow-on PR.
2. It could be nice to remove our dependency on`fsspec`. We use this for reading our tabular files and also for our `.url.download()` UDF.
