### PR TITLE
Fix import of ray.data.extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ iceberg = ["icebridge"]
 ray = [
   # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
   "ray[data, default]>=2.0.0",
-  # Ray has a bug with grpcio 1.52.0: https://github.com/ray-project/ray/issues/32246
-  "grpcio<1.52.0"
+  # Explicitly install packaging. See issue: https://github.com/ray-project/ray/issues/34806
+  "packaging"
 ]
 serving = ["fastapi", "docker", "uvicorn", "cloudpickle", "boto3", "PyYAML"]
 


### PR DESCRIPTION
Problem 1: import of `ray.data.extensions` will fail if Ray is not installed (i.e. if Daft is installed without `[ray]`). This is solved by moving the import into a guarded import with a global boolean flag.

Problem 2: import of `ray.data.extensions` fails for Python versions < 3.10. See Ray issue: https://github.com/ray-project/ray/issues/34806