### PR TITLE
Fix size_bytes tests

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -223,6 +223,15 @@ class Series:
         return len(self._series)
 
     def size_bytes(self) -> int:
+        """Returns the total sizes of all buffers used for representing this Series.
+
+        In particular, this includes the:
+
+        1. Buffer(s) used for data (applies any slicing if that occurs!)
+        2. Buffer(s) used for offsets, if applicable (for variable-length arrow types)
+        3. Buffer(s) used for validity, if applicable (arrow can choose to omit the validity bitmask)
+        4. Recursively gets .size_bytes for any child arrays, if applicable (for nested types)
+        """
         return self._series.size_bytes()
 
     def __abs__(self) -> Series:

--- a/tests/series/test_size_bytes.py
+++ b/tests/series/test_size_bytes.py
@@ -113,11 +113,17 @@ def test_series_list_size_bytes(dtype, size, with_nulls) -> None:
 
     s = Series.from_arrow(data)
 
-    # Offset array has length (len + 1), and is increased in bit width from 32 to 64 when converting to large_list
-    conversion_to_large_list_bytes = (len(data) + 1) * 4
+    # Offset array is increased in bit width from 32 to 64 when converting to large_list
+    conversion_to_large_list_bytes = len(data) * 4
+
+    size_bytes = s.size_bytes()
+
+    # TODO(jay): There is an off-by-1 error in the arrow2 estimated_bytes_size API for List and LargeList:
+    # https://github.com/jorgecarleitao/arrow2/blob/64d8ec203f991468032025a13a4f971f1f2cfc14/src/compute/aggregate/memory.rs#LL76C1-L76C1
+    size_bytes = size_bytes + 4
 
     assert s.datatype() == DataType.from_arrow_type(list_dtype)
-    assert s.size_bytes() == get_total_buffer_size(data) + conversion_to_large_list_bytes
+    assert size_bytes == get_total_buffer_size(data) + conversion_to_large_list_bytes
 
 
 @pytest.mark.parametrize("dtype, size", itertools.product(ARROW_INT_TYPES + ARROW_FLOAT_TYPES, [0, 1, 2, 8, 9, 16]))

--- a/tests/series/test_size_bytes.py
+++ b/tests/series/test_size_bytes.py
@@ -13,187 +13,128 @@ from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES
 PYARROW_GE_7_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (7, 0, 0)
 
 
-@pytest.mark.skipif(
-    not PYARROW_GE_7_0_0,
-    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
-)
+def get_total_buffer_size(arr: pa.Array) -> int:
+    """Helper to get total buffer size because older versions of Arrow don't have the Array.get_total_buffer_size() method"""
+    return sum([buf.size if buf is not None else 0 for buf in arr.buffers()])
+
+
 @pytest.mark.parametrize("dtype, size", itertools.product(ARROW_INT_TYPES + ARROW_FLOAT_TYPES, [0, 1, 2, 8, 9, 16]))
-def test_series_numeric_size_bytes(dtype, size) -> None:
+@pytest.mark.parametrize("with_nulls", [True, False])
+def test_series_numeric_size_bytes(dtype, size, with_nulls) -> None:
     pydata = list(range(size))
-    data = pa.array(pydata, dtype)
+
+    if with_nulls and size > 0:
+        data = pa.array(pydata[:-1] + [None], dtype)
+    else:
+        data = pa.array(pydata, dtype)
 
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.from_arrow_type(dtype)
     assert s.size_bytes() == data.nbytes
 
-    ## with nulls
-    if size > 0:
-        pydata = pydata[:-1] + [None]
-    data = pa.array(pydata, dtype)
 
-    s = Series.from_arrow(data)
-
-    assert s.datatype() == DataType.from_arrow_type(dtype)
-    assert s.size_bytes() == data.nbytes
-
-
-@pytest.mark.skipif(
-    not PYARROW_GE_7_0_0,
-    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
-)
 @pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
-def test_series_string_size_bytes(size) -> None:
+@pytest.mark.parametrize("with_nulls", [True, False])
+def test_series_string_size_bytes(size, with_nulls) -> None:
     pydata = list(str(i) for i in range(size))
-    data = pa.array(pydata, pa.large_string())
+
+    if with_nulls and size > 0:
+        data = pa.array(pydata[:-1] + [None], pa.large_string())
+    else:
+        data = pa.array(pydata, pa.large_string())
 
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.string()
-    # TODO(Clark): This is required due to an off-by-one error in pyarrow's calculation of of the offset array length.
-    # We should fix this upstream and/or refactor these tests to not rely on pyarrow as the source-of-truth.
-    assert s.size_bytes() == data.nbytes + 8
-
-    ## with nulls
-    if size > 0:
-        pydata = pydata[:-1] + [None]
-    data = pa.array(pydata, pa.large_string())
-
-    s = Series.from_arrow(data)
-
-    assert s.datatype() == DataType.string()
-    assert s.size_bytes() == data.nbytes + 8
+    assert s.size_bytes() == get_total_buffer_size(data)
 
 
-@pytest.mark.skipif(
-    not PYARROW_GE_7_0_0,
-    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
-)
 @pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
-def test_series_boolean_size_bytes(size) -> None:
+@pytest.mark.parametrize("with_nulls", [True, False])
+def test_series_boolean_size_bytes(size, with_nulls) -> None:
     pydata = [True if i % 2 else False for i in range(size)]
 
-    data = pa.array(pydata, pa.bool_())
+    if with_nulls and size > 0:
+        data = pa.array(pydata[:-1] + [None], pa.bool_())
+    else:
+        data = pa.array(pydata, pa.bool_())
 
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.bool()
-    assert s.size_bytes() == data.nbytes
-
-    ## with nulls
-    if size > 0:
-        pydata = pydata[:-1] + [None]
-    data = pa.array(pydata, pa.bool_())
-
-    s = Series.from_arrow(data)
-
-    assert s.datatype() == DataType.bool()
-    assert s.size_bytes() == data.nbytes
+    assert s.size_bytes() == get_total_buffer_size(data)
 
 
-@pytest.mark.skipif(
-    not PYARROW_GE_7_0_0,
-    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
-)
 @pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
-def test_series_date_size_bytes(size) -> None:
+@pytest.mark.parametrize("with_nulls", [True, False])
+def test_series_date_size_bytes(size, with_nulls) -> None:
     from datetime import date
 
     pydata = [date(2023, 1, i + 1) for i in range(size)]
-    data = pa.array(pydata, pa.date32())
+
+    if with_nulls and size > 0:
+        data = pa.array(pydata[:-1] + [None], pa.date32())
+    else:
+        data = pa.array(pydata, pa.date32())
+
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.date()
-    assert s.size_bytes() == data.nbytes
-
-    ## with nulls
-    if size > 0:
-        pydata = pydata[:-1] + [None]
-    data = pa.array(pydata, pa.date32())
-    s = Series.from_arrow(data)
-
-    assert s.datatype() == DataType.date()
-    assert s.size_bytes() == data.nbytes
+    assert s.size_bytes() == get_total_buffer_size(data)
 
 
-@pytest.mark.skipif(
-    not PYARROW_GE_7_0_0,
-    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
-)
 @pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
-def test_series_binary_size_bytes(size) -> None:
+@pytest.mark.parametrize("with_nulls", [True, False])
+def test_series_binary_size_bytes(size, with_nulls) -> None:
     pydata = [str(i).encode("utf-8") for i in range(size)]
-    data = pa.array(pydata, pa.large_binary())
+
+    if with_nulls and size > 0:
+        data = pa.array(pydata[:-1] + [None], pa.large_binary())
+    else:
+        data = pa.array(pydata, pa.large_binary())
+
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.binary()
-    # TODO(Clark): This is required due to an off-by-one error in pyarrow's calculation of of the offset array length.
-    # We should fix this upstream and/or refactor these tests to not rely on pyarrow as the source-of-truth.
-    assert s.size_bytes() == data.nbytes + 8
-
-    ## with nulls
-    if size > 0:
-        pydata = pydata[:-1] + [None]
-    data = pa.array(pydata, pa.large_binary())
-    s = Series.from_arrow(data)
-
-    assert s.datatype() == DataType.binary()
-    assert s.size_bytes() == data.nbytes + 8
+    assert s.size_bytes() == get_total_buffer_size(data)
 
 
-@pytest.mark.skipif(
-    not PYARROW_GE_7_0_0,
-    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
-)
 @pytest.mark.parametrize("dtype, size", itertools.product(ARROW_INT_TYPES + ARROW_FLOAT_TYPES, [0, 1, 2, 8, 9, 16]))
-def test_series_list_size_bytes(dtype, size) -> None:
+@pytest.mark.parametrize("with_nulls", [True, False])
+def test_series_list_size_bytes(dtype, size, with_nulls) -> None:
     list_dtype = pa.list_(dtype)
     pydata = [[2 * i] if i % 2 == 0 else [2 * i, 2 * i + 1] for i in range(size)]
-    data = pa.array(pydata, list_dtype)
+
+    if with_nulls and size > 0:
+        data = pa.array(pydata[:-1] + [None], list_dtype)
+    else:
+        data = pa.array(pydata, list_dtype)
 
     s = Series.from_arrow(data)
 
-    assert s.datatype() == DataType.from_arrow_type(list_dtype)
-    # TODO(Clark): Investigate this discrepancy.
-    # TODO(Clark): Investigate this discrepancy between Arrow2 and pyarrow.
-    # We should fix this upstream and/or refactor these tests to not rely on pyarrow as the source-of-truth.
-    assert s.size_bytes() == data.nbytes + (size * 8) // 2
-
-    ## with nulls
-    if size > 0:
-        pydata = pydata[:-1] + [None]
-    data = pa.array(pydata, list_dtype)
-
-    s = Series.from_arrow(data)
+    # Offset array has length (len + 1), and is increased in bit width from 32 to 64 when converting to large_list
+    conversion_to_large_list_bytes = (len(data) + 1) * 4
 
     assert s.datatype() == DataType.from_arrow_type(list_dtype)
-    assert s.size_bytes() == data.nbytes + (size * 8) // 2
+    assert s.size_bytes() == get_total_buffer_size(data) + conversion_to_large_list_bytes
 
 
-@pytest.mark.skipif(
-    not PYARROW_GE_7_0_0,
-    reason="Array.nbytes behavior changed in versions >= 7.0.0. Old behavior is incompatible with our tests and is renamed to Array.get_total_buffer_size()",
-)
 @pytest.mark.parametrize("dtype, size", itertools.product(ARROW_INT_TYPES + ARROW_FLOAT_TYPES, [0, 1, 2, 8, 9, 16]))
-def test_series_fixed_size_list_size_bytes(dtype, size) -> None:
+@pytest.mark.parametrize("with_nulls", [True, False])
+def test_series_fixed_size_list_size_bytes(dtype, size, with_nulls) -> None:
     list_dtype = pa.list_(dtype, 2)
     pydata = [[2 * i, 2 * i + 1] for i in range(size)]
-    data = pa.array(pydata, list_dtype)
+
+    if with_nulls and size > 0:
+        data = pa.array(pydata[:-1] + [None], list_dtype)
+    else:
+        data = pa.array(pydata, list_dtype)
 
     s = Series.from_arrow(data)
 
     assert s.datatype() == DataType.from_arrow_type(list_dtype)
-    assert s.size_bytes() == data.nbytes
-
-    ## with nulls
-    if size > 0:
-        pydata = pydata[:-1] + [None]
-    data = pa.array(pydata, list_dtype)
-
-    s = Series.from_arrow(data)
-
-    assert s.datatype() == DataType.from_arrow_type(list_dtype)
-    assert s.size_bytes() == data.nbytes
+    assert s.size_bytes() == get_total_buffer_size(data)
 
 
 @pytest.mark.parametrize("size", [0, 1, 2, 8, 9, 16])
@@ -212,11 +153,11 @@ def test_series_struct_size_bytes(size, with_nulls) -> None:
     else:
         data = pa.array(pydata, type=dtype)
 
-    # Additional bytes are allocated for converting the nested string child array to a large_string array
-    additional_bytes_for_large_string_offsets = (len(data) + 1) * 4
-
     s = Series.from_arrow(data)
     assert s.datatype() == DataType.from_arrow_type(dtype)
+
+    # Offset buffer for child array "c" has length (len + 1), and is increased in bit width from 32 to 64 when converting to large_string
+    conversion_to_large_string_bytes = (len(data) + 1) * 4
 
     # If nulls were injected, check validity bitmaps were were properly propagated to children
     if with_nulls and size > 0:
@@ -224,10 +165,11 @@ def test_series_struct_size_bytes(size, with_nulls) -> None:
         child_arrays_without_validity_buffer = len(
             [child for child in child_arrays if any([b is None for b in child.buffers()])]
         )
+        additional_validity_buffer_bytes = child_arrays_without_validity_buffer * math.ceil(size / 8)
         assert s.size_bytes() == (
             data.get_total_buffer_size()
             + child_arrays_without_validity_buffer * math.ceil(size / 8)
-            + additional_bytes_for_large_string_offsets
+            + conversion_to_large_string_bytes
         )
     else:
-        assert s.size_bytes() == data.get_total_buffer_size() + additional_bytes_for_large_string_offsets
+        assert s.size_bytes() == data.get_total_buffer_size() + conversion_to_large_string_bytes

--- a/tests/series/test_size_bytes.py
+++ b/tests/series/test_size_bytes.py
@@ -173,9 +173,7 @@ def test_series_struct_size_bytes(size, with_nulls) -> None:
         )
         additional_validity_buffer_bytes = child_arrays_without_validity_buffer * math.ceil(size / 8)
         assert s.size_bytes() == (
-            data.get_total_buffer_size()
-            + child_arrays_without_validity_buffer * math.ceil(size / 8)
-            + conversion_to_large_string_bytes
+            data.get_total_buffer_size() + additional_validity_buffer_bytes + conversion_to_large_string_bytes
         )
     else:
         assert s.size_bytes() == data.get_total_buffer_size() + conversion_to_large_string_bytes


### PR DESCRIPTION
Fixes the testing logic for our size_bytes tests

# Summary

Updated `Series.size_bytes` for correct description of its intended behavior:

> Returns the total sizes of all buffers used for representing this Series.
>
> In particular, this includes the:
>
> 1. Buffer(s) used for data (applies any slicing if that occurs!)
> 2. Buffer(s) used for offsets, if applicable (for variable-length arrow types)
> 3. Buffer(s) used for validity, if applicable (arrow can choose to omit the validity bitmask)
> 4. Recursively gets .size_bytes for any child arrays, if applicable (for nested types)

Also updated tests to reflect this behavior, including additional calculations in places that require it:

1. Any automatic casting of `list -> large_list`, `string -> large_string` etc requires adding additional bytes for the upsized offsets array
2. Our logic for creating and pushing down validity bitmaps to children of structarrays when crossing the pyarrow -> arrow2 ffi layer has to assign buffers for the children arrays

Lastly, there is a off-by-one bug in arrow2 that requires us to manually fix `size_bytes` for List/LargeList right now.
