### PR TITLE
Fixes arrow table sorts for backward compatibility during testing

### DIFF
--- a/tests/dataframe/test_aggregations.py
+++ b/tests/dataframe/test_aggregations.py
@@ -8,6 +8,7 @@ from daft import DataFrame, col
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
 from daft.utils import freeze
+from tests.utils import sort_arrow_table
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
@@ -151,7 +152,9 @@ def test_agg_groupby(repartition_nparts):
     res_list = daft_cols.pop("list")
     exp_list = expected.pop("list")
 
-    assert pa.Table.from_pydict(daft_cols).sort_by("group") == pa.Table.from_pydict(expected).sort_by("group")
+    assert sort_arrow_table(pa.Table.from_pydict(daft_cols), "group") == sort_arrow_table(
+        pa.Table.from_pydict(expected), "group"
+    )
 
     arg_sort = np.argsort(daft_cols["group"])
     assert freeze([list(map(set, res_list))[i] for i in arg_sort]) == freeze(list(map(set, exp_list)))
@@ -192,7 +195,9 @@ def test_agg_groupby_all_null(repartition_nparts):
     daft_df.collect()
     daft_cols = daft_df.to_pydict()
 
-    assert pa.Table.from_pydict(daft_cols).sort_by("group") == pa.Table.from_pydict(expected).sort_by("group")
+    assert sort_arrow_table(pa.Table.from_pydict(daft_cols), "group") == sort_arrow_table(
+        pa.Table.from_pydict(expected), "group"
+    )
 
 
 def test_agg_groupby_null_type_column():
@@ -238,7 +243,9 @@ def test_null_groupby_keys(repartition_nparts):
         "mean": [0.0, 1.0, 2.0, 3.0],
     }
     daft_cols = daft_df.to_pydict()
-    assert pa.Table.from_pydict(daft_cols).sort_by("group") == pa.Table.from_pydict(expected).sort_by("group")
+    assert sort_arrow_table(pa.Table.from_pydict(daft_cols), "group") == sort_arrow_table(
+        pa.Table.from_pydict(expected), "group"
+    )
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
@@ -317,4 +324,6 @@ def test_agg_groupby_empty():
 
     daft_df.collect()
     daft_cols = daft_df.to_pydict()
-    assert pa.Table.from_pydict(daft_cols).sort_by("group") == pa.Table.from_pydict(expected).sort_by("group")
+    assert sort_arrow_table(pa.Table.from_pydict(daft_cols), "group") == sort_arrow_table(
+        pa.Table.from_pydict(expected), "group"
+    )

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -135,7 +135,7 @@ def test_create_dataframe_pydict_bad_columns() -> None:
 
 @pytest.mark.parametrize("multiple", [False, True])
 def test_create_dataframe_arrow(valid_data: list[dict[str, float]], multiple) -> None:
-    t = pa.Table.from_pylist(valid_data)
+    t = pa.Table.from_pydict({k: [valid_data[i][k] for i in range(len(valid_data))] for k in valid_data[0].keys()})
     if multiple:
         t = [t, t, t]
     df = DataFrame.from_arrow(t)

--- a/tests/dataframe/test_distinct.py
+++ b/tests/dataframe/test_distinct.py
@@ -5,6 +5,7 @@ import pytest
 
 from daft import DataFrame
 from daft.datatype import DataType
+from tests.utils import sort_arrow_table
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 5])
@@ -21,8 +22,8 @@ def test_distinct_with_nulls(repartition_nparts):
         "id": [1, None, None],
         "values": ["a1", "b1", "c1"],
     }
-    assert pa.Table.from_pydict(daft_df.to_pydict()).sort_by("values") == pa.Table.from_pydict(expected).sort_by(
-        "values"
+    assert sort_arrow_table(pa.Table.from_pydict(daft_df.to_pydict()), "values") == sort_arrow_table(
+        pa.Table.from_pydict(expected), "values"
     )
 
 
@@ -40,8 +41,8 @@ def test_distinct_with_all_nulls(repartition_nparts):
         "id": [None, None, None],
         "values": ["a1", "b1", "c1"],
     }
-    assert pa.Table.from_pydict(daft_df.to_pydict()).sort_by("values") == pa.Table.from_pydict(expected).sort_by(
-        "values"
+    assert sort_arrow_table(pa.Table.from_pydict(daft_df.to_pydict()), "values") == sort_arrow_table(
+        pa.Table.from_pydict(expected), "values"
     )
 
 

--- a/tests/dataframe/test_joins.py
+++ b/tests/dataframe/test_joins.py
@@ -6,6 +6,7 @@ import pytest
 import daft
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
+from tests.utils import sort_arrow_table
 
 
 @pytest.mark.parametrize("n_partitions", [1, 2, 4])
@@ -69,7 +70,9 @@ def test_inner_join(repartition_nparts):
         "values_left": ["a1", "c1"],
         "values_right": ["a2", "c2"],
     }
-    assert pa.Table.from_pydict(daft_df.to_pydict()).sort_by("id") == pa.Table.from_pydict(expected).sort_by("id")
+    assert sort_arrow_table(pa.Table.from_pydict(daft_df.to_pydict()), "id") == sort_arrow_table(
+        pa.Table.from_pydict(expected), "id"
+    )
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
@@ -96,7 +99,9 @@ def test_inner_join_multikey(repartition_nparts):
         "values_left": ["a1"],
         "values_right": ["c2"],
     }
-    assert pa.Table.from_pydict(daft_df.to_pydict()).sort_by("id") == pa.Table.from_pydict(expected).sort_by("id")
+    assert sort_arrow_table(pa.Table.from_pydict(daft_df.to_pydict()), "id") == sort_arrow_table(
+        pa.Table.from_pydict(expected), "id"
+    )
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
@@ -120,7 +125,9 @@ def test_inner_join_all_null(repartition_nparts):
         "values_left": [],
         "values_right": [],
     }
-    assert pa.Table.from_pydict(daft_df.to_pydict()).sort_by("id") == pa.Table.from_pydict(expected).sort_by("id")
+    assert sort_arrow_table(pa.Table.from_pydict(daft_df.to_pydict()), "id") == sort_arrow_table(
+        pa.Table.from_pydict(expected), "id"
+    )
 
 
 def test_inner_join_null_type_column():

--- a/tests/dataframe/test_to_integrations.py
+++ b/tests/dataframe/test_to_integrations.py
@@ -7,6 +7,7 @@ import pyarrow as pa
 import pytest
 
 from daft.dataframe import DataFrame
+from tests.utils import sort_arrow_table
 
 TEST_DATA_LEN = 16
 FIXED_SIZE_LIST_ARRAY_LENGTH = 4
@@ -45,8 +46,8 @@ def test_to_arrow(n_partitions: int) -> None:
     table = df.to_arrow()
     # String column is converted to large_string column in Daft.
     assert table.schema == TEST_DATA_SCHEMA
-    expected_table = pa.table(TEST_DATA, schema=table.schema).sort_by("integers")
-    assert table.sort_by("integers").equals(expected_table)
+    expected_table = sort_arrow_table(pa.table(TEST_DATA, schema=table.schema), "integers")
+    assert sort_arrow_table(table, "integers").equals(expected_table)
 
 
 @pytest.mark.parametrize("n_partitions", [1, 2])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pyarrow.compute as pac
+
+
+def sort_arrow_table(tbl: pa.Table, sort_by: str):
+    """In arrow versions < 7, pa.Table does not support sorting yet so we add a helper method here"""
+    sort_indices = pac.sort_indices(tbl.column(sort_by))
+    return pac.take(tbl, sort_indices)


### PR DESCRIPTION
Pyarrow only introduced `pa.Table.sort_by` in PyArrow > 7.0

This PR adds a `tests.utils.sort_arrow_table` utility to replace all calls in our tests of `pa.Table.sort_by` for backward compatibility.

**Drive-by:**
Also fixes `test_create_dataframe_arrow` which uses `pa.Table.from_pylist` which is similarly not available in earlier versions of PyArrow.