### PR TITLE
[DataFrame Creation APIs] Move DataFrame creation APIs to module-level functions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,8 @@ In this example, we load images from an AWS S3 bucket and run a simple function 
 
 .. code:: python
 
-    from daft import DataFrame, lit
+    import daft
+    from daft import lit
 
     import io
     from PIL import Image
@@ -59,7 +60,7 @@ In this example, we load images from an AWS S3 bucket and run a simple function 
         return imgcopy
 
     # Load a dataframe from files in an S3 bucket
-    df = DataFrame.from_files("s3://daft-public-data/laion-sample-images/*")
+    df = daft.from_glob_path("s3://daft-public-data/laion-sample-images/*")
 
     # Get the AWS S3 url of each image
     df = df.select(lit("s3://").str.concat(df["name"]).alias("s3_url"))

--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -34,7 +34,6 @@ ALL_TABLES = [
 
 
 class MetricsBuilder:
-
     NUM_TPCH_QUESTIONS = 10
 
     HEADERS = [
@@ -114,7 +113,7 @@ class MetricsBuilder:
 
 def get_df_with_parquet_folder(parquet_folder: str) -> Callable[[str], DataFrame]:
     def _get_df(table_name: str) -> DataFrame:
-        return DataFrame.read_parquet(os.path.join(parquet_folder, table_name, "*.parquet"))
+        return daft.read_parquet(os.path.join(parquet_folder, table_name, "*.parquet"))
 
     return _get_df
 
@@ -178,6 +177,7 @@ def warmup_environment(requirements: str | None, parquet_folder: str):
         )
 
         logger.info("Warming up Ray cluster with a function...")
+
         # NOTE: installation of runtime_env is supposed to be eager but it seems to be happening async.
         # Here we farm out some work on Ray to warm up all the workers by downloading data.
         # Warm up n := num_cpus workers.

--- a/benchmarking/tpch/data_generation.py
+++ b/benchmarking/tpch/data_generation.py
@@ -10,7 +10,7 @@ from glob import glob
 
 from loguru import logger
 
-from daft.dataframe import DataFrame
+import daft
 
 SCHEMA = {
     "part": [
@@ -311,7 +311,7 @@ def gen_parquet(csv_files_location: str) -> str:
         table_parquet_path = os.path.join(PARQUET_FILE_PATH, tab_name)
         if not os.path.exists(table_parquet_path):
             logger.info(f"Generating Parquet Files for {tab_name}")
-            df = DataFrame.read_csv(
+            df = daft.read_csv(
                 os.path.join(csv_files_location, f"{tab_name}.tbl*"),
                 has_headers=False,
                 column_names=SCHEMA[tab_name],

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -68,11 +68,38 @@ if not dev_build and not user_opted_out:
 # Daft top-level imports
 ###
 
+from daft.convert import (
+    from_arrow,
+    from_dask_dataframe,
+    from_pandas,
+    from_pydict,
+    from_pylist,
+    from_ray_dataset,
+)
 from daft.dataframe import DataFrame
 from daft.datatype import DataType
 from daft.expressions import col, lit
+from daft.io import from_glob_path, read_csv, read_json, read_parquet
 from daft.series import Series
 from daft.udf import udf
 from daft.viz import register_viz_hook
 
-__all__ = ["DataFrame", "col", "DataType", "lit", "Series", "register_viz_hook", "udf"]
+__all__ = [
+    "from_pylist",
+    "from_pydict",
+    "from_arrow",
+    "from_pandas",
+    "from_ray_dataset",
+    "from_dask_dataframe",
+    "from_glob_path",
+    "read_csv",
+    "read_json",
+    "read_parquet",
+    "DataFrame",
+    "col",
+    "DataType",
+    "lit",
+    "Series",
+    "register_viz_hook",
+    "udf",
+]

--- a/daft/convert.py
+++ b/daft/convert.py
@@ -1,0 +1,125 @@
+# isort: dont-add-import: from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Union
+
+from daft.api_annotations import PublicAPI
+
+if TYPE_CHECKING:
+    import dask
+    import numpy as np
+    import pandas as pd
+    import pyarrow as pa
+    from ray.data.dataset import Dataset as RayDataset
+
+    from daft.dataframe import DataFrame
+
+
+InputListType = Union[list, "np.ndarray", "pa.Array", "pa.ChunkedArray"]
+
+
+@PublicAPI
+def from_pylist(data: List[Dict[str, Any]]) -> "DataFrame":
+    """Creates a DataFrame from a list of dictionaries.
+
+    Example:
+        >>> df = daft.from_pylist([{"foo": 1}, {"foo": 2}])
+
+    Args:
+        data: List of dictionaries, where each key is a column name.
+
+    Returns:
+        DataFrame: DataFrame created from list of dictionaries.
+    """
+    from daft import DataFrame
+
+    return DataFrame._from_pylist(data)
+
+
+@PublicAPI
+def from_pydict(data: Dict[str, InputListType]) -> "DataFrame":
+    """Creates a DataFrame from a Python dictionary.
+
+    Example:
+        >>> df = daft.from_pydict({"foo": [1, 2]})
+
+    Args:
+        data: Key -> Sequence[item] of data. Each Key is created as a column, and must have a value that is
+            a Python list, Numpy array or PyArrow array. Values must be equal in length across all keys.
+
+    Returns:
+        DataFrame: DataFrame created from dictionary of columns
+    """
+    from daft import DataFrame
+
+    return DataFrame._from_pydict(data)
+
+
+@PublicAPI
+def from_arrow(data: Union["pa.Table", List["pa.Table"]]) -> "DataFrame":
+    """Creates a DataFrame from a pyarrow Table.
+
+    Example:
+        >>> t = pa.table({"a": [1, 2, 3], "b": ["foo", "bar", "baz"]})
+        >>> df = daft.from_arrow(t)
+
+    Args:
+        data: pyarrow Table(s) that we wish to convert into a Daft DataFrame.
+
+    Returns:
+        DataFrame: DataFrame created from the provided pyarrow Table.
+    """
+    from daft import DataFrame
+
+    return DataFrame._from_arrow(data)
+
+
+@PublicAPI
+def from_pandas(data: Union["pd.DataFrame", List["pd.DataFrame"]]) -> "DataFrame":
+    """Creates a Daft DataFrame from a pandas DataFrame.
+
+    Example:
+        >>> pd_df = pd.DataFrame({"a": [1, 2, 3], "b": ["foo", "bar", "baz"]})
+        >>> df = daft.from_pandas(pd_df))
+
+    Args:
+        data: pandas DataFrame(s) that we wish to convert into a Daft DataFrame.
+
+    Returns:
+        DataFrame: Daft DataFrame created from the provided pandas DataFrame.
+    """
+    from daft import DataFrame
+
+    return DataFrame._from_pandas(data)
+
+
+@PublicAPI
+def from_ray_dataset(ds: "RayDataset") -> "DataFrame":
+    """Creates a DataFrame from a Ray Dataset.
+
+    .. NOTE::
+        This function can only work if Daft is running using the RayRunner.
+
+    Args:
+        ds: The Ray Dataset to create a Daft DataFrame from.
+    """
+    from daft import DataFrame
+
+    return DataFrame._from_ray_dataset(ds)
+
+
+@PublicAPI
+def from_dask_dataframe(ddf: "dask.DataFrame") -> "DataFrame":
+    """Creates a Daft DataFrame from a Dask DataFrame.
+
+    The provided Dask DataFrame must have been created using
+    `Dask-on-Ray <https://docs.ray.io/en/latest/data/dask-on-ray.html>`__.
+
+    .. NOTE::
+        This function can only work if Daft is running using the RayRunner
+
+    Args:
+        ddf: The Dask DataFrame to create a Daft DataFrame from.
+    """
+    from daft import DataFrame
+
+    return DataFrame._from_dask_dataframe(ddf)

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from daft.io._csv import read_csv
+from daft.io._json import read_json
+from daft.io.file_path import from_glob_path
+from daft.io.parquet import read_parquet
+
+__all__ = ["read_csv", "read_json", "from_glob_path", "read_parquet"]

--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -1,0 +1,44 @@
+# isort: dont-add-import: from __future__ import annotations
+
+from typing import List, Optional
+
+from daft.api_annotations import PublicAPI
+from daft.dataframe import DataFrame
+from daft.datasources import CSVSourceInfo
+from daft.io.common import _get_tabular_files_scan
+from daft.runners.partitioning import vPartitionSchemaInferenceOptions
+
+
+@PublicAPI
+def read_csv(
+    path: str,
+    has_headers: bool = True,
+    column_names: Optional[List[str]] = None,
+    delimiter: str = ",",
+) -> DataFrame:
+    """Creates a DataFrame from CSV file(s)
+
+    Example:
+        >>> df = daft.read_csv("/path/to/file.csv")
+        >>> df = daft.read_csv("/path/to/directory")
+        >>> df = daft.read_csv("/path/to/files-*.csv")
+        >>> df = daft.read_csv("s3://path/to/files-*.csv")
+
+    Args:
+        path (str): Path to CSV (allows for wildcards)
+        has_headers (bool): Whether the CSV has a header or not, defaults to True
+        column_names (Optional[List[str]]): Custom column names to assign to the DataFrame, defaults to None
+        delimiter (Str): Delimiter used in the CSV, defaults to ","
+
+    returns:
+        DataFrame: parsed DataFrame
+    """
+    plan = _get_tabular_files_scan(
+        path,
+        CSVSourceInfo(
+            delimiter=delimiter,
+            has_headers=has_headers,
+        ),
+        vPartitionSchemaInferenceOptions(inference_column_names=column_names),
+    )
+    return DataFrame(plan)

--- a/daft/io/_json.py
+++ b/daft/io/_json.py
@@ -1,0 +1,33 @@
+# isort: dont-add-import: from __future__ import annotations
+
+from daft.api_annotations import PublicAPI
+from daft.dataframe import DataFrame
+from daft.datasources import JSONSourceInfo
+from daft.io.common import _get_tabular_files_scan
+from daft.runners.partitioning import vPartitionSchemaInferenceOptions
+
+
+@PublicAPI
+def read_json(
+    path: str,
+) -> DataFrame:
+    """Creates a DataFrame from line-delimited JSON file(s)
+
+    Example:
+        >>> df = daft.read_json("/path/to/file.json")
+        >>> df = daft.read_json("/path/to/directory")
+        >>> df = daft.read_json("/path/to/files-*.json")
+        >>> df = daft.read_json("s3://path/to/files-*.json")
+
+    Args:
+        path (str): Path to JSON files (allows for wildcards)
+
+    returns:
+        DataFrame: parsed DataFrame
+    """
+    plan = _get_tabular_files_scan(
+        path,
+        JSONSourceInfo(),
+        vPartitionSchemaInferenceOptions(),
+    )
+    return DataFrame(plan)

--- a/daft/io/common.py
+++ b/daft/io/common.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from daft.context import get_context
+from daft.datasources import SourceInfo
+from daft.logical import logical_plan
+from daft.runners.partitioning import vPartitionSchemaInferenceOptions
+
+
+def _get_tabular_files_scan(
+    path: str,
+    source_info: SourceInfo,
+    schema_inference_options: vPartitionSchemaInferenceOptions,
+) -> logical_plan.TabularFilesScan:
+    """Returns a TabularFilesScan LogicalPlan for a given glob filepath."""
+    # Glob the path using the Runner
+    runner_io = get_context().runner().runner_io()
+    listing_details_partition_set = runner_io.glob_paths_details(path, source_info)
+
+    # TODO: We should have a more sophisticated schema inference mechanism (sample >1 file and resolve schemas across files)
+    # Infer schema from the first filepath in the listings PartitionSet
+    data_schema = runner_io.get_schema_from_first_filepath(
+        listing_details_partition_set, source_info, schema_inference_options
+    )
+
+    # Construct plan
+    cache_entry = get_context().runner().put_partition_set_into_cache(listing_details_partition_set)
+    filepath_plan = logical_plan.InMemoryScan(
+        cache_entry=cache_entry,
+        schema=runner_io.FS_LISTING_SCHEMA,
+        partition_spec=logical_plan.PartitionSpec(
+            logical_plan.PartitionScheme.UNKNOWN, listing_details_partition_set.num_partitions()
+        ),
+    )
+    return logical_plan.TabularFilesScan(
+        schema=data_schema,
+        predicate=None,
+        columns=None,
+        source_info=source_info,
+        filepaths_child=filepath_plan,
+        filepaths_column_name=runner_io.FS_LISTING_PATH_COLUMN_NAME,
+        # WARNING: This is currently hardcoded to be the same number of partitions as rows!! This is because we emit
+        # one partition per filepath. This will change in the future and our logic here should change accordingly.
+        num_partitions=len(listing_details_partition_set),
+    )

--- a/daft/io/file_path.py
+++ b/daft/io/file_path.py
@@ -1,0 +1,46 @@
+# isort: dont-add-import: from __future__ import annotations
+
+from daft.api_annotations import PublicAPI
+from daft.context import get_context
+from daft.dataframe import DataFrame
+from daft.logical import logical_plan
+
+
+@PublicAPI
+def from_glob_path(path: str) -> DataFrame:
+    """Creates a DataFrame of file paths and other metadata from a glob path.
+
+    This method supports wildcards:
+
+    1. "*" matches any number of any characters including none
+    2. "?" matches any single character
+    3. "[...]" matches any single character in the brackets
+    4. "**" recursively matches any number of layers of directories
+
+    The returned DataFrame will have the following columns:
+
+    1. path: the path to the file/directory
+    2. size: size of the object in bytes
+    3. type: either "file" or "directory"
+
+    Example:
+        >>> df = daft.from_glob_path("/path/to/files/*.jpeg")
+        >>> df = daft.from_glob_path("/path/to/files/**/*.jpeg")
+        >>> df = daft.from_glob_path("/path/to/files/**/image-?.jpeg")
+
+    Args:
+        path (str): Path to files on disk (allows wildcards).
+
+    Returns:
+        DataFrame: DataFrame containing the path to each file as a row, along with other metadata
+            parsed from the provided filesystem.
+    """
+    runner_io = get_context().runner().runner_io()
+    partition_set = runner_io.glob_paths_details(path)
+    cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
+    filepath_plan = logical_plan.InMemoryScan(
+        cache_entry=cache_entry,
+        schema=runner_io.FS_LISTING_SCHEMA,
+        partition_spec=logical_plan.PartitionSpec(logical_plan.PartitionScheme.UNKNOWN, partition_set.num_partitions()),
+    )
+    return DataFrame(filepath_plan)

--- a/daft/io/parquet.py
+++ b/daft/io/parquet.py
@@ -1,0 +1,31 @@
+# isort: dont-add-import: from __future__ import annotations
+
+from daft.api_annotations import PublicAPI
+from daft.dataframe import DataFrame
+from daft.datasources import ParquetSourceInfo
+from daft.io.common import _get_tabular_files_scan
+from daft.runners.partitioning import vPartitionSchemaInferenceOptions
+
+
+@PublicAPI
+def read_parquet(path: str) -> DataFrame:
+    """Creates a DataFrame from Parquet file(s)
+
+    Example:
+        >>> df = DataFrame.read_parquet("/path/to/file.parquet")
+        >>> df = DataFrame.read_parquet("/path/to/directory")
+        >>> df = DataFrame.read_parquet("/path/to/files-*.parquet")
+        >>> df = DataFrame.read_parquet("s3://path/to/files-*.parquet")
+
+    Args:
+        path (str): Path to Parquet file (allows for wildcards)
+
+    returns:
+        DataFrame: parsed DataFrame
+    """
+    plan = _get_tabular_files_scan(
+        path,
+        ParquetSourceInfo(),
+        vPartitionSchemaInferenceOptions(),
+    )
+    return DataFrame(plan)

--- a/docs/source/10-min.ipynb
+++ b/docs/source/10-min.ipynb
@@ -39,16 +39,18 @@
    },
    "outputs": [],
    "source": [
-    "from daft import DataFrame, DataType"
+    "import daft\n",
+    "from daft import DataType"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## DataFrame creation\n",
     "\n",
-    "See also: [API Reference: DataFrame Construction](df-construction)\n",
+    "See also: [API Reference: DataFrame Construction](df-input-output)\n",
     "\n",
     "We can create a DataFrame from a dictionary of columns - this is a dictionary where the keys are strings representing the columns' names and the values are equal-length lists representing the columns' values."
    ]
@@ -71,7 +73,7 @@
    "source": [
     "import datetime\n",
     "\n",
-    "df = DataFrame.from_pydict({\n",
+    "df = daft.from_pydict({\n",
     "    \"integers\": [1, 2, 3, 4],\n",
     "    \"floats\": [1.5, 2.5, 3.5, 4.5],\n",
     "    \"bools\": [True, True, False, False],\n",
@@ -83,15 +85,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "You can also load DataFrames from other sources, such as:\n",
     "\n",
-    "1. CSV files: `DataFrame.read_csv(\"s3://bucket/*.csv\")`\n",
-    "2. Parquet files: `DataFrame.read_parquet(\"/path/*.parquet\")`\n",
-    "3. JSON line-delimited files: `DataFrame.read_json(\"/path/*.parquet\")`\n",
-    "4. Files on disk: `DataFrame.from_glob_path(\"/path/*.jpeg\")`\n",
+    "1. CSV files: `daft.read_csv(\"s3://bucket/*.csv\")`\n",
+    "2. Parquet files: `daft.read_parquet(\"/path/*.parquet\")`\n",
+    "3. JSON line-delimited files: `daft.read_json(\"/path/*.parquet\")`\n",
+    "4. Files on disk: `daft.from_glob_path(\"/path/*.jpeg\")`\n",
     "\n",
     "Daft automatically supports local paths as well as paths to object storage such as AWS S3."
    ]
@@ -762,7 +765,7 @@
     }
    ],
    "source": [
-    "image_url_df = DataFrame.from_pydict({\n",
+    "image_url_df = daft.from_pydict({\n",
     "    \"urls\": [\n",
     "        \"http://farm9.staticflickr.com/8186/8119368305_4e622c8349_z.jpg\",\n",
     "        \"http://farm1.staticflickr.com/1/127244861_ab0c0381e7_z.jpg\",\n",
@@ -811,7 +814,7 @@
     "    def bark(self):\n",
     "        return f\"{self.name}!\"\n",
     "\n",
-    "py_df = DataFrame.from_pydict({\n",
+    "py_df = daft.from_pydict({\n",
     "    \"dogs\": [Dog(\"ruffles\"), Dog(\"waffles\"), Dog(\"doofus\")],\n",
     "    \"owner\": [\"russell\", \"william\", \"david\"],\n",
     "})"
@@ -1123,7 +1126,7 @@
     }
    ],
    "source": [
-    "missing_data_df = DataFrame.from_pydict({\n",
+    "missing_data_df = daft.from_pydict({\n",
     "    \"floats\": [1.5, None, float(\"nan\")],\n",
     "})\n",
     "missing_data_df = missing_data_df \\\n",
@@ -1331,7 +1334,7 @@
     }
    ],
    "source": [
-    "grouping_df = DataFrame.from_pydict(\n",
+    "grouping_df = daft.from_pydict(\n",
     "    {\n",
     "        \"A\": [\"foo\", \"bar\", \"foo\", \"bar\", \"foo\", \"bar\", \"foo\", \"foo\"],\n",
     "        \"B\": [\"a\", \"a\", \"b\", \"c\", \"b\", \"b\", \"a\", \"c\"],\n",

--- a/docs/source/api_docs/dataframe.rst
+++ b/docs/source/api_docs/dataframe.rst
@@ -13,52 +13,6 @@ DataFrame
     Most DataFrame methods are **lazy**, meaning that they do not execute computation immediately when invoked. Instead, these operations are enqueued in
     the DataFrame's internal query plan, and are only executed when `Execution`_ DataFrame methods are called.
 
-Construction
-############
-
-.. _df-construction:
-
-From Files
-**********
-
-.. _df-file-construction-api:
-
-.. autosummary::
-    :nosignatures:
-    :toctree: dataframe_methods
-
-    daft.DataFrame.read_csv
-    daft.DataFrame.read_json
-    daft.DataFrame.read_parquet
-    daft.DataFrame.from_glob_path
-
-From In-Memory Data
-*******************
-
-.. _df-memory-construction-api:
-
-.. autosummary::
-    :nosignatures:
-    :toctree: dataframe_methods
-
-    daft.DataFrame.from_pylist
-    daft.DataFrame.from_pydict
-    daft.DataFrame.from_arrow
-    daft.DataFrame.from_pandas
-
-From Integrations
-*****************
-
-.. _df-from-integrations:
-
-.. autosummary::
-    :nosignatures:
-    :toctree: dataframe_methods
-
-    daft.DataFrame.from_ray_dataset
-    daft.DataFrame.from_dask_dataframe
-
-
 .. _dataframe-api-operations:
 
 Data Manipulation

--- a/docs/source/api_docs/dataframe_methods/daft.DataFrame.from_glob_path.rst
+++ b/docs/source/api_docs/dataframe_methods/daft.DataFrame.from_glob_path.rst
@@ -1,6 +1,0 @@
-﻿daft.DataFrame.from\_glob\_path
-===============================
-
-.. currentmodule:: daft
-
-.. automethod:: DataFrame.from_glob_path

--- a/docs/source/api_docs/dataframe_methods/daft.DataFrame.from_pydict.rst
+++ b/docs/source/api_docs/dataframe_methods/daft.DataFrame.from_pydict.rst
@@ -1,6 +1,0 @@
-﻿daft.DataFrame.from\_pydict
-===========================
-
-.. currentmodule:: daft
-
-.. automethod:: DataFrame.from_pydict

--- a/docs/source/api_docs/dataframe_methods/daft.DataFrame.from_pylist.rst
+++ b/docs/source/api_docs/dataframe_methods/daft.DataFrame.from_pylist.rst
@@ -1,6 +1,0 @@
-﻿daft.DataFrame.from\_pylist
-===========================
-
-.. currentmodule:: daft
-
-.. automethod:: DataFrame.from_pylist

--- a/docs/source/api_docs/dataframe_methods/daft.DataFrame.read_csv.rst
+++ b/docs/source/api_docs/dataframe_methods/daft.DataFrame.read_csv.rst
@@ -1,6 +1,0 @@
-﻿daft.DataFrame.read\_csv
-========================
-
-.. currentmodule:: daft
-
-.. automethod:: DataFrame.read_csv

--- a/docs/source/api_docs/dataframe_methods/daft.DataFrame.read_json.rst
+++ b/docs/source/api_docs/dataframe_methods/daft.DataFrame.read_json.rst
@@ -1,6 +1,0 @@
-﻿daft.DataFrame.read\_json
-=========================
-
-.. currentmodule:: daft
-
-.. automethod:: DataFrame.read_json

--- a/docs/source/api_docs/dataframe_methods/daft.DataFrame.read_parquet.rst
+++ b/docs/source/api_docs/dataframe_methods/daft.DataFrame.read_parquet.rst
@@ -1,6 +1,0 @@
-﻿daft.DataFrame.read\_parquet
-============================
-
-.. currentmodule:: daft
-
-.. automethod:: DataFrame.read_parquet

--- a/docs/source/api_docs/dataframe_methods/daft.DataFrame.rst
+++ b/docs/source/api_docs/dataframe_methods/daft.DataFrame.rst
@@ -24,14 +24,6 @@
       ~DataFrame.exclude
       ~DataFrame.explain
       ~DataFrame.explode
-      ~DataFrame.from_csv
-      ~DataFrame.from_files
-      ~DataFrame.from_glob_path
-      ~DataFrame.from_json
-      ~DataFrame.from_parquet
-      ~DataFrame.from_pydict
-      ~DataFrame.from_pylist
-      ~DataFrame.from_ray_dataset
       ~DataFrame.groupby
       ~DataFrame.into_partitions
       ~DataFrame.join
@@ -41,9 +33,6 @@
       ~DataFrame.min
       ~DataFrame.num_partitions
       ~DataFrame.plan
-      ~DataFrame.read_csv
-      ~DataFrame.read_json
-      ~DataFrame.read_parquet
       ~DataFrame.repartition
       ~DataFrame.schema
       ~DataFrame.select

--- a/docs/source/api_docs/index.rst
+++ b/docs/source/api_docs/index.rst
@@ -3,6 +3,7 @@ API Documentation
 
 .. toctree::
 
+   input_output
    dataframe
    expressions
    groupby

--- a/docs/source/api_docs/input_output.rst
+++ b/docs/source/api_docs/input_output.rst
@@ -1,0 +1,117 @@
+.. _df-input-output:
+
+Input/Output
+============
+
+.. currentmodule:: daft
+
+In-Memory Data
+--------------
+
+.. _df-io-in-memory
+
+Python Objects
+~~~~~~~~~~~~~~
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+    daft.from_pylist
+    daft.from_pydict
+    daft.DataFrame.to_pydict
+
+Arrow
+~~~~~
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+    daft.from_arrow
+    daft.DataFrame.to_arrow
+
+Pandas
+~~~~~~
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+    daft.from_pandas
+    daft.DataFrame.to_pandas
+
+File Paths
+~~~~~~~~~~
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+    daft.from_glob_path
+
+Files
+-----
+
+.. _df-io-files
+
+Parquet
+~~~~~~~
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+    daft.read_parquet
+    daft.DataFrame.write_parquet
+
+CSV
+~~~
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+    daft.read_csv
+    daft.DataFrame.write_csv
+
+JSON
+~~~~
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+    daft.read_json
+    daft.DataFrame.write_json
+
+Integrations
+------------
+
+.. _df-io-integrations
+
+Ray Datasets
+~~~~~~~~~~~~
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+    daft.from_ray_dataset
+    daft.DataFrame.to_ray_dataset
+
+Dask
+~~~~
+
+.. autosummary::
+    :nosignatures:
+    :toctree: io_functions
+
+    daft.from_dask_dataframe
+    daft.DataFrame.to_dask_dataframe
+

--- a/docs/source/api_docs/io_functions/daft.from_arrow.rst
+++ b/docs/source/api_docs/io_functions/daft.from_arrow.rst
@@ -1,0 +1,6 @@
+daft.from\_arrow
+================
+
+.. currentmodule:: daft
+
+.. autofunction:: from_arrow

--- a/docs/source/api_docs/io_functions/daft.from_dask_dataframe.rst
+++ b/docs/source/api_docs/io_functions/daft.from_dask_dataframe.rst
@@ -1,0 +1,6 @@
+daft.from\_dask\_dataframe
+=======================
+
+.. currentmodule:: daft
+
+.. autofunction:: from_dask_dataframe

--- a/docs/source/api_docs/io_functions/daft.from_glob_path.rst
+++ b/docs/source/api_docs/io_functions/daft.from_glob_path.rst
@@ -1,0 +1,6 @@
+﻿daft.from\_glob\_path
+=====================
+
+.. currentmodule:: daft
+
+.. autofunction:: from_glob_path

--- a/docs/source/api_docs/io_functions/daft.from_pandas.rst
+++ b/docs/source/api_docs/io_functions/daft.from_pandas.rst
@@ -1,0 +1,6 @@
+daft.from\_pandas
+=================
+
+.. currentmodule:: daft
+
+.. autofunction:: from_pandas

--- a/docs/source/api_docs/io_functions/daft.from_pydict.rst
+++ b/docs/source/api_docs/io_functions/daft.from_pydict.rst
@@ -1,0 +1,6 @@
+﻿daft.from\_pydict
+=================
+
+.. currentmodule:: daft
+
+.. autofunction:: from_pydict

--- a/docs/source/api_docs/io_functions/daft.from_pylist.rst
+++ b/docs/source/api_docs/io_functions/daft.from_pylist.rst
@@ -1,0 +1,6 @@
+﻿daft.from\_pylist
+=================
+
+.. currentmodule:: daft
+
+.. autofunction:: from_pylist

--- a/docs/source/api_docs/io_functions/daft.from_ray_dataset.rst
+++ b/docs/source/api_docs/io_functions/daft.from_ray_dataset.rst
@@ -1,0 +1,6 @@
+daft.from\_ray\_dataset
+=======================
+
+.. currentmodule:: daft
+
+.. autofunction:: from_ray_dataset

--- a/docs/source/api_docs/io_functions/daft.read_csv.rst
+++ b/docs/source/api_docs/io_functions/daft.read_csv.rst
@@ -1,0 +1,6 @@
+﻿daft.read\_csv
+==============
+
+.. currentmodule:: daft
+
+.. autofunction:: read_csv

--- a/docs/source/api_docs/io_functions/daft.read_json.rst
+++ b/docs/source/api_docs/io_functions/daft.read_json.rst
@@ -1,0 +1,6 @@
+﻿daft.read\_json
+===============
+
+.. currentmodule:: daft
+
+.. autofunction:: read_json

--- a/docs/source/api_docs/io_functions/daft.read_parquet.rst
+++ b/docs/source/api_docs/io_functions/daft.read_parquet.rst
@@ -1,0 +1,6 @@
+﻿daft.read\_parquet
+==================
+
+.. currentmodule:: daft
+
+.. autofunction:: read_parquet

--- a/docs/source/learn/key_concepts.rst
+++ b/docs/source/learn/key_concepts.rst
@@ -49,10 +49,10 @@ Daft does not execute the computations defined on a DataFrame until explicitly i
 
 .. code:: python
 
-    from daft import DataFrame
+    import daft
 
     # Create a new dataframe with one column
-    df = DataFrame.from_pydict({"a": [1, 2, 3]})
+    df = daft.from_pydict({"a": [1, 2, 3]})
 
     # Create a new column which is column "a" incremented by 1
     df = df.with_column("b", df["a"] + 1)
@@ -104,10 +104,10 @@ Daft defines interesting types and operations over the data in your DataFrame. F
 
 .. code:: python
 
-    from daft import DataFrame
+    import daft
 
     # Create a new dataframe with just one column of URLs
-    df = DataFrame.from_pydict({"urls": ["https://www.google.com", "https://www.yahoo.com", "https://www.bing.com"]})
+    df = daft.from_pydict({"urls": ["https://www.google.com", "https://www.yahoo.com", "https://www.bing.com"]})
 
     # Create a new column which contains the downloaded bytes from each URL
     df = df.with_column("url_contents", df["urls"].url.download())
@@ -157,7 +157,7 @@ Daft then provides an extremely rich Expressions library to allow you to compose
 
 .. code:: python
 
-    from daft import col, DataType, DataFrame
+    from daft import col, DataType
 
     # Take the column named "a" and add 1 to each element
     col("a") + 1
@@ -169,7 +169,9 @@ Note that Expressions aren't very useful just by themselves! They are used in Da
 
 .. code:: python
 
-    df = DataFrame.from_pydict({"a": [1, 2, 3]})
+    import daft
+
+    df = daft.from_pydict({"a": [1, 2, 3]})
 
     df = df.select(
         col("a"),

--- a/docs/source/learn/user_guides/aggregations.rst
+++ b/docs/source/learn/user_guides/aggregations.rst
@@ -12,9 +12,9 @@ An aggregation can be applied on an entire DataFrame, for example to get the mea
 
 .. code:: python
 
-    from daft import DataFrame
+    import daft
 
-    df = DataFrame.from_pydict({
+    df = daft.from_pydict({
         "class": ["a", "a", "b", "b"],
         "score": [10, 20., 30., 40],
     })

--- a/docs/source/learn/user_guides/dataframe-operations.rst
+++ b/docs/source/learn/user_guides/dataframe-operations.rst
@@ -14,9 +14,9 @@ Select specific columns in a DataFrame using ``.select``, which also takes Expre
 
 .. code-block:: python
 
-    from daft import DataFrame
+    import daft
 
-    df = DataFrame.from_pydict({"A": [1, 2, 3], "B": [4, 5, 6]})
+    df = daft.from_pydict({"A": [1, 2, 3], "B": [4, 5, 6]})
 
     df.select("A").show()
 
@@ -101,7 +101,7 @@ We can limit the rows to the first ``N`` rows using ``.limit``:
 
 .. code-block:: python
 
-    df = DataFrame.from_pydict({
+    df = daft.from_pydict({
         "A": [1, 2, 3, 4, 5],
         "B": [6, 7, 8, 9, 10],
     })
@@ -152,8 +152,8 @@ Daft also supports multi-column joins key you have a join key comprising of mult
 
 .. code-block:: python
 
-    df1 = DataFrame.from_pydict({"A": [1, 2, 3], "B": [4, 5, 6]})
-    df2 = DataFrame.from_pydict({"A": [1, 2, 3], "C": [7, 8, 9]})
+    df1 = daft.from_pydict({"A": [1, 2, 3], "B": [4, 5, 6]})
+    df2 = daft.from_pydict({"A": [1, 2, 3], "C": [7, 8, 9]})
 
     df1.join(df2, on="A").show()
 
@@ -178,7 +178,7 @@ Rows in a DataFrame can be reordered based on some column using ``.sort``. Daft 
 
 .. code-block:: python
 
-    df = DataFrame.from_pydict({
+    df = daft.from_pydict({
         "A": [1, 2, 3],
         "B": [6, 7, 8],
     })
@@ -206,7 +206,7 @@ The ``df.explode`` method can be used to explode a column containing a list of v
 
 .. code:: python
 
-    df = DataFrame.from_pydict({
+    df = daft.from_pydict({
         "A": [1, 2, 3],
         "B": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
     })

--- a/docs/source/learn/user_guides/expressions.rst
+++ b/docs/source/learn/user_guides/expressions.rst
@@ -15,9 +15,9 @@ To do so, simply index a DataFrame with the string name of the column:
 
 .. code:: python
 
-    from daft import DataFrame
+    import daft
 
-    df = DataFrame.from_pydict({"A": [1, 2, 3]})
+    df = daft.from_pydict({"A": [1, 2, 3]})
 
     # Refers to column "A" in `df`
     df["A"]
@@ -99,7 +99,7 @@ Daft also lets you have columns of strings in a DataFrame. Let's take a look!
 
 .. code:: python
 
-    df = DataFrame.from_pydict({"B": ["foo", "bar", "baz"]})
+    df = daft.from_pydict({"B": ["foo", "bar", "baz"]})
     df.show()
 
 .. code:: none
@@ -171,7 +171,7 @@ Daft provides the ``Expression.url.*`` method namespace with functionality for w
 
 .. code:: python
 
-    df = DataFrame.from_pydict({
+    df = daft.from_pydict({
         "urls": [
             "https://www.google.com",
             "s3://daft-public-data/open-images/validation-images/0001eeaf4aed83f9.jpg",
@@ -207,7 +207,7 @@ Logical Expressions are an expression that refers to a column of type ``Boolean`
 
 .. code:: python
 
-    df = DataFrame.from_pydict({"C": [True, False, True]})
+    df = daft.from_pydict({"C": [True, False, True]})
     df["C"]
 
 Daft supports logical operations such as ``&`` (and) and ``|`` (or) between logical expressions.
@@ -221,7 +221,7 @@ For example, here we can compare if each element in column "A" is equal to eleme
 
 .. code:: python
 
-    df = DataFrame.from_pydict({"A": [1, 2, 3], "B": [1, 2, 4]})
+    df = daft.from_pydict({"A": [1, 2, 3], "B": [1, 2, 4]})
 
     df = df.with_column("A_eq_B", df["A"] == df["B"])
 
@@ -250,7 +250,7 @@ The ``.if_else`` method is a useful expression to have up your sleeve for choosi
 
 .. code:: python
 
-    df = DataFrame.from_pydict({"A": [1, 2, 3], "B": [0, 2, 4]})
+    df = daft.from_pydict({"A": [1, 2, 3], "B": [0, 2, 4]})
 
     # Pick values from column A if the value in column A is bigger
     # than the value in column B. Otherwise, pick values from column B.

--- a/docs/source/learn/user_guides/intro-dataframes.rst
+++ b/docs/source/learn/user_guides/intro-dataframes.rst
@@ -17,9 +17,9 @@ Let's create our first Dataframe from a Python dictionary of columns.
 
 .. code:: python
 
-    from daft import DataFrame
+    import daft
 
-    df = DataFrame.from_pydict({
+    df = daft.from_pydict({
         "A": [1, 2, 3, 4],
         "B": [1.5, 2.5, 3.5, 4.5],
         "C": [True, True, False, False],

--- a/docs/source/learn/user_guides/read-write.rst
+++ b/docs/source/learn/user_guides/read-write.rst
@@ -16,30 +16,31 @@ Additionally, Daft can read data from a variety of container file formats, inclu
 Daft supports file paths to a single file, a directory of files, and wildcards. It also supports paths to remote object storage such as AWS S3.
 
 .. code:: python
+    import daft
 
     # You can read a single CSV file from your local filesystem
-    df = DataFrame.read_csv("path/to/file.csv")
+    df = daft.read_csv("path/to/file.csv")
 
     # You can also read folders of CSV files, or include wildcards to select for patterns of file paths
-    df = DataFrame.read_csv("path/to/*.csv")
+    df = daft.read_csv("path/to/*.csv")
 
     # Other formats such as parquet and line-delimited JSON are also supported
-    df = DataFrame.read_parquet("path/to/*.parquet")
-    df = DataFrame.read_json("path/to/*.json")
+    df = daft.read_parquet("path/to/*.parquet")
+    df = daft.read_json("path/to/*.json")
 
     # Remote filesystems such as AWS S3 are also supported, and can be specified with their protocols
-    df = DataFrame.read_csv("s3://mybucket/path/to/*.csv")
+    df = daft.read_csv("s3://mybucket/path/to/*.csv")
 
-To learn more about each of these constructors, as well as the options that they support, consult the API documentation on :ref:`DataFrame construction from files <df-file-construction-api>`.
+To learn more about each of these constructors, as well as the options that they support, consult the API documentation on :ref:`creating DataFrames from files <df-io-files>`.
 
-From Filepaths
+From File Paths
 ^^^^^^^^^^^^^^
 
-However, if instead you are reading a set of files that are not container file formats, you can use the ``DataFrame.from_glob_path`` method which will read a DataFrame of globbed filepaths.
+However, if instead you are reading a set of files that are not container file formats, you can use the ``daft.from_glob_path`` method which will read a DataFrame of globbed filepaths.
 
 .. code:: python
 
-    df = DataFrame.from_glob_path("s3://mybucket/path/to/images/*.jpeg")
+    df = daft.from_glob_path("s3://mybucket/path/to/images/*.jpeg")
 
     # +----------+------+-----+
     # | name     | size | ... |
@@ -58,12 +59,12 @@ For testing, or small datasets that fit in memory, you may also create DataFrame
 .. code:: python
 
     # Create DataFrame using a dictionary of {column_name: list_of_values}
-    df = DataFrame.from_pydict({"A": [1, 2, 3], "B": ["foo", "bar", "baz"]})
+    df = daft.from_pydict({"A": [1, 2, 3], "B": ["foo", "bar", "baz"]})
 
     # Create DataFrame using a list of rows, where each row is a dictionary of {column_name: value}
-    df = DataFrame.from_pylist([{"A": 1, "B": "foo"}, {"A": 2, "B": "bar"}, {"A": 3, "B": "baz"}])
+    df = daft.from_pylist([{"A": 1, "B": "foo"}, {"A": 2, "B": "bar"}, {"A": 3, "B": "baz"}])
 
-To learn more, consult the API documentation on :ref:`DataFrame construction from in-memory datastructures <df-memory-construction-api>`.
+To learn more, consult the API documentation on :ref:`creating DataFrames from in-memory data structures <df-io-in-memory>`.
 
 Writing Data
 ------------

--- a/docs/source/learn/user_guides/udf.rst
+++ b/docs/source/learn/user_guides/udf.rst
@@ -7,10 +7,10 @@ Let's first create a dataframe that will be used as a running example throughout
 
 .. code:: python
 
-    from daft import DataFrame, DataType
+    import daft
     import numpy as np
 
-    df = DataFrame.from_pydict({
+    df = daft.from_pydict({
         # the `image` column contains images represented as 2D numpy arrays
         "image": [np.ones((128, 128)) for i in range(16)],
         # the `crop` column contains a box to crop from our image, represented as a list of integers: [x1, x2, y1, y2]
@@ -38,7 +38,7 @@ For example, the following example creates a new ``"flattened_image"`` column by
 
     df.with_column(
         "flattened_image",
-        df["image"].apply(lambda img: img.flatten(), return_dtype=DataType.python())
+        df["image"].apply(lambda img: img.flatten(), return_dtype=daft.DataType.python())
     ).show(2)
 
 .. code:: none
@@ -73,9 +73,7 @@ For example, let's try writing a function that will crop all our images in the `
 
 .. code:: python
 
-    from daft import udf
-
-    @udf(return_dtype=DataType.python())
+    @daft.udf(return_dtype=daft.DataType.python())
     def crop_images(images, crops, padding=0):
         cropped = []
         for img, crop in zip(images.to_pylist(), crops.to_pylist()):
@@ -163,7 +161,7 @@ between invocations of the class, for example downloading data or creating a mod
 
 .. code:: python
 
-    @udf(return_dtype=DataType.int64())
+    @daft.udf(return_dtype=daft.DataType.int64())
     class RunModel:
 
         def __init__(self):

--- a/tests/benchmarks/test_df_arithmetic.py
+++ b/tests/benchmarks/test_df_arithmetic.py
@@ -9,7 +9,7 @@ from daft import DataFrame
 @pytest.mark.aggregations
 @pytest.fixture(scope="module")
 def gen_aranged_df(num_samples=1_000_000) -> DataFrame:
-    return DataFrame.from_pydict(
+    return daft.from_pydict(
         {
             "i": ((np.arange(num_samples, dtype=np.int64) * 9582398353) % 100),
             "j": ((np.arange(num_samples, dtype=np.int64) * 847892347987) % 100),

--- a/tests/benchmarks/test_file_read.py
+++ b/tests/benchmarks/test_file_read.py
@@ -48,7 +48,7 @@ def test_csv_read(gen_simple_csvs, benchmark):
     csv_dir, num_rows = gen_simple_csvs
 
     def bench() -> DataFrame:
-        df = DataFrame.read_csv(csv_dir)
+        df = daft.read_csv(csv_dir)
         return df.collect()
 
     df = benchmark(bench)

--- a/tests/benchmarks/test_groups_and_aggs.py
+++ b/tests/benchmarks/test_groups_and_aggs.py
@@ -18,7 +18,7 @@ def test_agg_baseline(benchmark, num_samples) -> None:
 
     No groups, simplest aggregation (count).
     """
-    df = DataFrame.from_pydict({"mycol": np.arange(num_samples)}).collect()
+    df = daft.from_pydict({"mycol": np.arange(num_samples)}).collect()
 
     # Run the benchmark.
     def bench() -> DataFrame:
@@ -35,7 +35,7 @@ def test_agg_baseline(benchmark, num_samples) -> None:
 @pytest.mark.parametrize("num_samples", NUM_SAMPLES)
 def test_agg_multipart(benchmark, num_samples, num_partitions) -> None:
     """Evaluate the impact of multiple partitions."""
-    df = DataFrame.from_pydict({"mycol": np.arange(num_samples)}).into_partitions(num_partitions).collect()
+    df = daft.from_pydict({"mycol": np.arange(num_samples)}).into_partitions(num_partitions).collect()
 
     # Run the benchmark.
     def bench() -> DataFrame:
@@ -55,7 +55,7 @@ def test_comparable_agg(benchmark, num_samples) -> None:
     data = [str(uuid4()) for _ in range(num_samples)] + ["ffffffff-ffff-ffff-ffff-ffffffffffff"]
     random.shuffle(data)
 
-    df = DataFrame.from_pydict({"mycol": data}).collect()
+    df = daft.from_pydict({"mycol": data}).collect()
 
     # Run the benchmark.
     def bench() -> DataFrame:
@@ -72,7 +72,7 @@ def test_comparable_agg(benchmark, num_samples) -> None:
 def test_numeric_agg(benchmark, num_samples) -> None:
     """Test aggregation performance for numeric aggregation ops."""
 
-    df = DataFrame.from_pydict({"mycol": np.arange(num_samples)}).collect()
+    df = daft.from_pydict({"mycol": np.arange(num_samples)}).collect()
 
     # Run the benchmark.
     def bench() -> DataFrame:
@@ -96,7 +96,7 @@ def test_groupby(benchmark, num_samples, num_groups) -> None:
 
     np.random.shuffle(keys)
 
-    df = DataFrame.from_pydict(
+    df = daft.from_pydict(
         {
             "keys": keys,
             "data": np.arange(num_samples),
@@ -131,7 +131,7 @@ def test_groupby_string(benchmark, num_samples, num_groups) -> None:
 
     keys = [f"{i:09}" for i in keys]
 
-    df = DataFrame.from_pydict(
+    df = daft.from_pydict(
         {
             "keys": keys,
             "data": np.arange(num_samples),
@@ -166,7 +166,7 @@ def test_multicolumn_groupby(benchmark, num_columns, num_samples) -> None:
     keys = np.arange(num_samples) % num_groups
     np.random.shuffle(keys)
 
-    df = DataFrame.from_pydict(
+    df = daft.from_pydict(
         {
             "keys_a": keys * 7 % 10,
             "keys": keys,

--- a/tests/benchmarks/test_join.py
+++ b/tests/benchmarks/test_join.py
@@ -29,7 +29,7 @@ def test_join_simple(benchmark, num_samples, num_partitions) -> None:
     np.random.shuffle(right_arr)
 
     left_table = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "mycol": left_arr,
             }
@@ -38,7 +38,7 @@ def test_join_simple(benchmark, num_samples, num_partitions) -> None:
         .collect()
     )
     right_table = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "mycol": right_arr,
             }
@@ -75,7 +75,7 @@ def test_join_largekey(benchmark, num_samples, num_partitions) -> None:
     random.shuffle(right_keys)
 
     left_table = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "mycol": left_keys,
             }
@@ -84,7 +84,7 @@ def test_join_largekey(benchmark, num_samples, num_partitions) -> None:
         .collect()
     )
     right_table = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "mycol": right_keys,
             }
@@ -124,7 +124,7 @@ def test_join_withdata(benchmark, num_samples, num_partitions) -> None:
     long_B = "B" * 1024
 
     left_table = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "mykey": left_arr,
                 "left_data": [long_A for _ in range(num_samples)],
@@ -134,7 +134,7 @@ def test_join_withdata(benchmark, num_samples, num_partitions) -> None:
         .collect()
     )
     right_table = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "mykey": right_arr,
                 "right_data": [long_B for _ in range(num_samples)],
@@ -182,14 +182,14 @@ def test_broadcast_join(benchmark, left_bigger, num_partitions) -> None:
     big_arr = np.concatenate([np.arange(small_length) for _ in range(big_factor)])
     np.random.shuffle(big_arr)
 
-    small_table = DataFrame.from_pydict(
+    small_table = daft.from_pydict(
         {
             "keys": small_arr,
             "data": [str(x) for x in small_arr],
         }
     ).collect()
     big_table = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "keys": big_arr,
             }
@@ -233,7 +233,7 @@ def test_multicolumn_joins(benchmark, num_columns, num_samples, num_partitions) 
     np.random.shuffle(right_arr)
 
     left_table = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "nums_a": left_arr * 17 % 9,
                 "nums_b": left_arr * 17 % 10,
@@ -245,7 +245,7 @@ def test_multicolumn_joins(benchmark, num_columns, num_samples, num_partitions) 
         .collect()
     )
     right_table = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "nums_a": right_arr * 17 % 9,
                 "nums_b": right_arr * 17 % 10,

--- a/tests/benchmarks/test_repartition.py
+++ b/tests/benchmarks/test_repartition.py
@@ -14,7 +14,7 @@ NUM_PARTITIONS = 100
 @pytest.mark.parametrize("num_samples", [NUM_SAMPLES])
 def test_split(benchmark, num_samples, end_partitions) -> None:
     """Test performance of splitting into multiple partitions."""
-    df = DataFrame.from_pydict({"mycol": np.arange(num_samples)}).collect()
+    df = daft.from_pydict({"mycol": np.arange(num_samples)}).collect()
 
     # Run the benchmark.
     def bench() -> DataFrame:
@@ -28,7 +28,7 @@ def test_split(benchmark, num_samples, end_partitions) -> None:
 @pytest.mark.parametrize("num_samples", [NUM_SAMPLES])
 def test_coalesce(benchmark, num_samples, start_partitions) -> None:
     """Test performance of coalescing partitions."""
-    df = DataFrame.from_pydict({"mycol": np.arange(num_samples)}).into_partitions(start_partitions).collect()
+    df = daft.from_pydict({"mycol": np.arange(num_samples)}).into_partitions(start_partitions).collect()
 
     # Run the benchmark.
     def bench() -> DataFrame:
@@ -43,7 +43,7 @@ def test_coalesce(benchmark, num_samples, start_partitions) -> None:
 @pytest.mark.parametrize("num_samples", [NUM_SAMPLES])
 def test_repartition_random(benchmark, num_samples, start_partitions, end_partitions) -> None:
     """Test performance of random repartitioning."""
-    df = DataFrame.from_pydict({"mycol": np.arange(num_samples)}).into_partitions(start_partitions).collect()
+    df = daft.from_pydict({"mycol": np.arange(num_samples)}).into_partitions(start_partitions).collect()
 
     # Run the benchmark.
     def bench() -> DataFrame:
@@ -65,7 +65,7 @@ def test_repartition_hash(benchmark, num_samples, start_partitions, end_partitio
 
     np.random.shuffle(data)
 
-    df = DataFrame.from_pydict({"mycol": data}).into_partitions(start_partitions).collect()
+    df = daft.from_pydict({"mycol": data}).into_partitions(start_partitions).collect()
 
     # Run the benchmark.
     def bench() -> DataFrame:

--- a/tests/benchmarks/test_sort.py
+++ b/tests/benchmarks/test_sort.py
@@ -25,7 +25,7 @@ def test_sort_simple(benchmark, num_samples, num_partitions) -> None:
     np.random.shuffle(arr)
 
     df = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "mykey": arr,
             }
@@ -57,7 +57,7 @@ def test_sort_strings(benchmark, num_samples, num_partitions) -> None:
     random.shuffle(keys)
 
     df = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "mykey": keys,
             }
@@ -92,7 +92,7 @@ def test_sort_withdata(benchmark, num_samples, num_partitions) -> None:
     long_A = "A" * 1024
 
     df = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 "mykey": arr,
                 "data": [long_A for _ in range(num_samples)],
@@ -136,7 +136,7 @@ def test_multicolumn_sort(benchmark, num_columns, num_samples, num_partitions) -
     np.random.shuffle(arr)
 
     df = (
-        DataFrame.from_pydict(
+        daft.from_pydict(
             {
                 # all coprime
                 "nums_9": arr * 17 % 9,

--- a/tests/cookbook/conftest.py
+++ b/tests/cookbook/conftest.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 import pandas as pd
 import pytest
 
-from daft.dataframe import DataFrame
+import daft
 from daft.expressions import col
 from tests.cookbook.assets import COOKBOOK_DATA_CSV
 
@@ -15,7 +15,7 @@ CsvPathAndColumns = Tuple[str, List[str]]
 
 @pytest.fixture(scope="function")
 def daft_df():
-    return DataFrame.read_csv(COOKBOOK_DATA_CSV).select(*[col(c) for c in COLUMNS])
+    return daft.read_csv(COOKBOOK_DATA_CSV).select(*[col(c) for c in COLUMNS])
 
 
 @pytest.fixture(scope="function")

--- a/tests/cookbook/test_filter.py
+++ b/tests/cookbook/test_filter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from daft import DataFrame
+import daft
 from daft.expressions import col
 from tests.conftest import assert_df_equals
 
@@ -144,13 +144,13 @@ def test_chain_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartit
 
 def test_filter_on_projection():
     """Filter the dataframe with on top of a projection"""
-    df = DataFrame.from_pydict({"x": [1, 1, 1, 1, 1]})
+    df = daft.from_pydict({"x": [1, 1, 1, 1, 1]})
     df = df.select(col("x") * 2)
     df = df.where(col("x") == 1)
     result = df.to_pandas()
     assert len(result) == 0
 
-    df = DataFrame.from_pydict({"x": [1, 1, 1, 1, 1]})
+    df = daft.from_pydict({"x": [1, 1, 1, 1, 1]})
     df = df.select(col("x") * 2)
     df = df.where(col("x") == 2)
     result = df.to_pandas()

--- a/tests/cookbook/test_pandas_cookbook.py
+++ b/tests/cookbook/test_pandas_cookbook.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from daft.dataframe import DataFrame
+import daft
 from daft.datatype import DataType
 from daft.expressions import col, lit
 from tests.conftest import assert_df_equals
@@ -20,7 +20,7 @@ IF_THEN_DATA = {"AAA": [4, 5, 6, 7], "BBB": [10, 20, 30, 40], "CCC": [100, 50, -
 
 
 def test_if_then(repartition_nparts):
-    daft_df = DataFrame.from_pydict(IF_THEN_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(IF_THEN_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(IF_THEN_DATA)
     daft_df = daft_df.with_column("BBB", (col("AAA") >= 5).if_else(-1, col("BBB")))
     pd_df.loc[pd_df.AAA >= 5, "BBB"] = -1
@@ -29,7 +29,7 @@ def test_if_then(repartition_nparts):
 
 
 def test_if_then_2_cols(repartition_nparts):
-    daft_df = DataFrame.from_pydict(IF_THEN_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(IF_THEN_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(IF_THEN_DATA)
     daft_df = daft_df.with_column("BBB", (col("AAA") >= 5).if_else(2000, col("BBB"))).with_column(
         "CCC",
@@ -41,7 +41,7 @@ def test_if_then_2_cols(repartition_nparts):
 
 
 def test_if_then_numpy_where(repartition_nparts):
-    daft_df = DataFrame.from_pydict(IF_THEN_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(IF_THEN_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(IF_THEN_DATA)
     daft_df = daft_df.with_column("logic", (col("AAA") > 5).if_else("high", lit("low")))
     pd_df["logic"] = np.where(pd_df["AAA"] > 5, "high", "low")
@@ -57,7 +57,7 @@ SPLITTING_DATA = {"AAA": [4, 5, 6, 7], "BBB": [10, 20, 30, 40], "CCC": [100, 50,
 
 
 def test_split_frame_boolean_criterion(repartition_nparts):
-    daft_df = DataFrame.from_pydict(SPLITTING_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(SPLITTING_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(SPLITTING_DATA)
     daft_df = daft_df.where(col("AAA") <= 5)
     pd_df = pd_df[pd_df.AAA <= 5]
@@ -73,7 +73,7 @@ BUILDING_DATA = {"AAA": [4, 5, 6, 7], "BBB": [10, 20, 30, 40], "CCC": [100, 50, 
 
 
 def test_multi_criteria_and(repartition_nparts):
-    daft_df = DataFrame.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(BUILDING_DATA)
     daft_df = daft_df.where((col("BBB") < 25) & (col("CCC") >= -40)).select(col("AAA"))
     pd_df = pd.DataFrame({"AAA": pd_df.loc[(pd_df["BBB"] < 25) & (pd_df["CCC"] >= -40), "AAA"]})
@@ -82,7 +82,7 @@ def test_multi_criteria_and(repartition_nparts):
 
 
 def test_multi_criteria_or(repartition_nparts):
-    daft_df = DataFrame.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(BUILDING_DATA)
     daft_df = daft_df.where((col("BBB") > 25) | (col("CCC") >= -40)).select(col("AAA"))
     pd_df = pd.DataFrame({"AAA": pd_df.loc[(pd_df["BBB"] > 25) | (pd_df["CCC"] >= -40), "AAA"]})
@@ -91,7 +91,7 @@ def test_multi_criteria_or(repartition_nparts):
 
 
 def test_multi_criteria_or_assignment(repartition_nparts):
-    daft_df = DataFrame.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(BUILDING_DATA)
     daft_df = daft_df.with_column(
         "AAA", ((col("BBB") > 25) | (col("CCC") >= 75)).if_else(0.1, col("AAA").cast(DataType.float32()))
@@ -102,7 +102,7 @@ def test_multi_criteria_or_assignment(repartition_nparts):
 
 
 def test_select_rows_closest_to_certain_value_using_argsort(repartition_nparts):
-    daft_df = DataFrame.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(BUILDING_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(BUILDING_DATA)
     aValue = 43.0
     daft_df = daft_df.sort(abs(col("CCC") - aValue))
@@ -120,7 +120,7 @@ SELECTION_DATA = {"AAA": [4, 5, 6, 7], "BBB": [10, 20, 30, 40], "CCC": [100, 50,
 
 @pytest.mark.skip(reason="Requires F.row_number() and Expression.is_in(...)")
 def test_splitting_by_row_index(repartition_nparts):
-    daft_df = DataFrame.from_pydict(SELECTION_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(SELECTION_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(SELECTION_DATA)
     daft_df = daft_df.where((col("AAA") <= 6) & F.row_number().is_in([0, 2, 4]))
     pd_df = pd_df[(pd_df.AAA <= 6) & (pd_df.index.isin([0, 2, 4]))]
@@ -130,7 +130,7 @@ def test_splitting_by_row_index(repartition_nparts):
 
 @pytest.mark.skip(reason="Requires F.row_number()")
 def test_splitting_by_row_range(repartition_nparts):
-    daft_df = DataFrame.from_pydict(SELECTION_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(SELECTION_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(SELECTION_DATA)
     daft_df = daft_df.where((F.row_number() >= 0) & (F.row_number() < 3))
     pd_df = pd_df[0:3]
@@ -147,7 +147,7 @@ APPLYMAP_DATA = {"AAA": [1, 2, 1, 3], "BBB": [1, 1, 2, 2], "CCC": [2, 1, 3, 1]}
 
 @pytest.mark.skip(reason="Requires Expression.applymap((val) => result)")
 def test_efficiently_and_dynamically_creating_new_columns_using_applymap(repartition_nparts):
-    daft_df = DataFrame.from_pydict(APPLYMAP_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(APPLYMAP_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(APPLYMAP_DATA)
     source_cols = pd_df.columns
     categories = {1: "Alpha", 2: "Beta", 3: "Charlie"}
@@ -167,7 +167,7 @@ MIN_WITH_GROUPBY_DATA = {"AAA": [1, 1, 1, 2, 2, 2, 3, 3], "BBB": [2, 1, 3, 4, 5,
 
 @pytest.mark.skip(reason="Requires .first() aggregations")
 def test_keep_other_columns_when_using_min_with_groupby(repartition_nparts):
-    daft_df = DataFrame.from_pydict(APPLYMAP_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(APPLYMAP_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(APPLYMAP_DATA)
     daft_df = daft_df.groupby(col("AAA")).min(col("BBB"))
     pd_df = pd_df.sort_values(by="BBB").groupby("AAA", as_index=False).first()
@@ -204,7 +204,7 @@ GROUPBY_DATA = {
 
 
 def test_applying_to_different_items_in_group(repartition_nparts):
-    daft_df = DataFrame.from_pydict(GROUPBY_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(GROUPBY_DATA).repartition(repartition_nparts)
     pd_df = pd.DataFrame.from_dict(GROUPBY_DATA)
     daft_df = daft_df.with_column(
         "weight", (col("size") == "S").if_else(col("weight") * 1.5, col("weight").cast(DataType.float32()))
@@ -240,7 +240,7 @@ JOIN_DATA = {
 
 
 def test_self_join(repartition_nparts):
-    daft_df = DataFrame.from_pydict(JOIN_DATA).repartition(repartition_nparts)
+    daft_df = daft.from_pydict(JOIN_DATA).repartition(repartition_nparts)
     daft_df = daft_df.with_column("Test_1", col("Test_0") - 1)
     daft_df = daft_df.join(
         daft_df, left_on=[col("Bins"), col("Area"), col("Test_0")], right_on=[col("Bins"), col("Area"), col("Test_1")]

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -2,38 +2,38 @@ from __future__ import annotations
 
 import pytest
 
-from daft.dataframe import DataFrame
+import daft
 from tests.conftest import assert_df_equals
 from tests.cookbook.assets import COOKBOOK_DATA_CSV
 
 
 def test_parquet_write(tmp_path):
-    df = DataFrame.read_csv(COOKBOOK_DATA_CSV)
+    df = daft.read_csv(COOKBOOK_DATA_CSV)
 
     pd_df = df.write_parquet(tmp_path)
-    read_back_pd_df = DataFrame.read_parquet(tmp_path.as_posix() + "/*.parquet").to_pandas()
+    read_back_pd_df = daft.read_parquet(tmp_path.as_posix() + "/*.parquet").to_pandas()
     assert_df_equals(df.to_pandas(), read_back_pd_df)
 
     assert len(pd_df.to_pandas()) == 1
 
 
 def test_parquet_write_with_partitioning(tmp_path):
-    df = DataFrame.read_csv(COOKBOOK_DATA_CSV)
+    df = daft.read_csv(COOKBOOK_DATA_CSV)
 
     pd_df = df.write_parquet(tmp_path, partition_cols=["Borough"])
 
-    read_back_pd_df = DataFrame.read_parquet(tmp_path.as_posix() + "/**/*.parquet").to_pandas()
+    read_back_pd_df = daft.read_parquet(tmp_path.as_posix() + "/**/*.parquet").to_pandas()
     assert_df_equals(df.exclude("Borough").to_pandas(), read_back_pd_df)
 
     assert len(pd_df.to_pandas()) == 5
 
 
 def test_csv_write(tmp_path):
-    df = DataFrame.read_csv(COOKBOOK_DATA_CSV)
+    df = daft.read_csv(COOKBOOK_DATA_CSV)
 
     pd_df = df.write_csv(tmp_path)
 
-    read_back_pd_df = DataFrame.read_csv(tmp_path.as_posix() + "/*.csv").to_pandas()
+    read_back_pd_df = daft.read_csv(tmp_path.as_posix() + "/*.csv").to_pandas()
     assert_df_equals(df.to_pandas(), read_back_pd_df)
 
     assert len(pd_df.to_pandas()) == 1
@@ -41,10 +41,10 @@ def test_csv_write(tmp_path):
 
 @pytest.mark.skip()
 def test_csv_write_with_partitioning(tmp_path):
-    df = DataFrame.read_csv(COOKBOOK_DATA_CSV)
+    df = daft.read_csv(COOKBOOK_DATA_CSV)
 
     pd_df = df.write_csv(tmp_path, partition_cols=["Borough"]).to_pandas()
-    read_back_pd_df = DataFrame.read_csv(tmp_path.as_posix() + "/**/*.csv").to_pandas()
+    read_back_pd_df = daft.read_csv(tmp_path.as_posix() + "/**/*.csv").to_pandas()
     assert_df_equals(df.exclude("Borough").to_pandas(), read_back_pd_df)
 
     assert len(pd_df.to_pandas()) == 5

--- a/tests/dataframe/test_accessors.py
+++ b/tests/dataframe/test_accessors.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import pytest
 
-from daft import DataFrame
+import daft
 from daft.datatype import DataType
 from daft.logical.logical_plan import LogicalPlan
 
 
 @pytest.fixture(scope="function")
 def df():
-    return DataFrame.from_pydict({"foo": [1, 2, 3]})
+    return daft.from_pydict({"foo": [1, 2, 3]})
 
 
 def test_get_plan(df):

--- a/tests/dataframe/test_aggregations.py
+++ b/tests/dataframe/test_aggregations.py
@@ -4,7 +4,8 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from daft import DataFrame, col
+import daft
+from daft import col
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
 from daft.utils import freeze
@@ -13,7 +14,7 @@ from tests.utils import sort_arrow_table
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
 def test_agg_global(repartition_nparts):
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [1, 2, 3],
             "values": [1, None, 2],
@@ -44,7 +45,7 @@ def test_agg_global(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
 def test_agg_global_all_null(repartition_nparts):
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [0, 1, 2, 3],
             "values": [1, None, None, None],
@@ -80,7 +81,7 @@ def test_agg_global_all_null(repartition_nparts):
 
 
 def test_agg_global_empty():
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [0],
             "values": [1],
@@ -117,7 +118,7 @@ def test_agg_global_empty():
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 7])
 def test_agg_groupby(repartition_nparts):
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "group": [1, 1, 1, 2, 2, 2],
             "values": [1, None, 2, 2, None, 4],
@@ -162,7 +163,7 @@ def test_agg_groupby(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 5])
 def test_agg_groupby_all_null(repartition_nparts):
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [0, 1, 2, 3, 4],
             "group": [0, 1, 1, 2, 2],
@@ -201,7 +202,7 @@ def test_agg_groupby_all_null(repartition_nparts):
 
 
 def test_agg_groupby_null_type_column():
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [1, 2, 3, 4],
             "group": [1, 1, 2, 2],
@@ -220,7 +221,7 @@ def test_agg_groupby_null_type_column():
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 5])
 def test_null_groupby_keys(repartition_nparts):
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [0, 1, 2, 3, 4],
             "group": [0, 1, None, 2, None],
@@ -250,7 +251,7 @@ def test_null_groupby_keys(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
 def test_all_null_groupby_keys(repartition_nparts):
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [0, 1, 2],
             "group": [None, None, None],
@@ -279,7 +280,7 @@ def test_all_null_groupby_keys(repartition_nparts):
 
 
 def test_null_type_column_groupby_keys():
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [0, 1, 2],
             "group": [None, None, None],
@@ -292,7 +293,7 @@ def test_null_type_column_groupby_keys():
 
 
 def test_agg_groupby_empty():
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [0],
             "group": [0],

--- a/tests/dataframe/test_distinct.py
+++ b/tests/dataframe/test_distinct.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
-from daft import DataFrame
+import daft
 from daft.datatype import DataType
 from tests.utils import sort_arrow_table
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 5])
 def test_distinct_with_nulls(repartition_nparts):
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [1, None, None, None],
             "values": ["a1", "b1", "b1", "c1"],
@@ -29,7 +29,7 @@ def test_distinct_with_nulls(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 5])
 def test_distinct_with_all_nulls(repartition_nparts):
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [None, None, None, None],
             "values": ["a1", "b1", "b1", "c1"],
@@ -48,7 +48,7 @@ def test_distinct_with_all_nulls(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2])
 def test_distinct_with_empty(repartition_nparts):
-    daft_df = DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [1],
             "values": ["a1"],

--- a/tests/dataframe/test_explode.py
+++ b/tests/dataframe/test_explode.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
-from daft import DataFrame
+import daft
 from daft.expressions import col
 from daft.series import Series
 
@@ -16,7 +16,7 @@ from daft.series import Series
     ],
 )
 def test_explode(data):
-    df = DataFrame.from_pydict({"nested": data, "sidecar": ["a", "b", "c", "d"]})
+    df = daft.from_pydict({"nested": data, "sidecar": ["a", "b", "c", "d"]})
     df = df.explode(col("nested"))
     assert df.to_pydict() == {"nested": [1, 2, 3, 4, None, None], "sidecar": ["a", "a", "b", "b", "c", "d"]}
 
@@ -29,7 +29,7 @@ def test_explode(data):
     ],
 )
 def test_explode_multiple_cols(data):
-    df = DataFrame.from_pydict({"nested": data, "nested2": data, "sidecar": ["a", "b", "c", "d"]})
+    df = daft.from_pydict({"nested": data, "nested2": data, "sidecar": ["a", "b", "c", "d"]})
     df = df.explode(col("nested"), col("nested2"))
     # TODO: [RUST-INT][NESTED] Need to fix to allow multiple explodes
     with pytest.raises(ValueError):
@@ -37,6 +37,6 @@ def test_explode_multiple_cols(data):
 
 
 def test_explode_bad_col_type():
-    df = DataFrame.from_pydict({"a": [1, 2, 3]})
+    df = daft.from_pydict({"a": [1, 2, 3]})
     with pytest.raises(ValueError, match="Datatype cannot be exploded:"):
         df = df.explode(col("a"))

--- a/tests/dataframe/test_filter.py
+++ b/tests/dataframe/test_filter.py
@@ -4,31 +4,32 @@ from typing import Any
 
 import pytest
 
+import daft
 from daft import DataFrame
 
 
 def test_filter_missing_column(valid_data: list[dict[str, Any]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     with pytest.raises(ValueError):
         df.select("sepal_width").where(df["petal_length"] > 4.8)
 
 
 @pytest.mark.skip(reason="Requires Expression.float.is_nan()")
 def test_drop_na(missing_value_data: list[dict[str, Any]]) -> None:
-    df: DataFrame = DataFrame.from_pylist(missing_value_data)
+    df: DataFrame = daft.from_pylist(missing_value_data)
     df_len_no_col = len(df.drop_nan().collect())
     assert df_len_no_col == 2
 
-    df: DataFrame = DataFrame.from_pylist(missing_value_data)
+    df: DataFrame = daft.from_pylist(missing_value_data)
     df_len_col = len(df.drop_nan("sepal_width").collect())
     assert df_len_col == 2
 
 
 def test_drop_null(missing_value_data: list[dict[str, Any]]) -> None:
-    df: DataFrame = DataFrame.from_pylist(missing_value_data)
+    df: DataFrame = daft.from_pylist(missing_value_data)
     df_len_no_col = len(df.drop_null().collect())
     assert df_len_no_col == 2
 
-    df: DataFrame = DataFrame.from_pylist(missing_value_data)
+    df: DataFrame = daft.from_pylist(missing_value_data)
     df_len_col = len(df.drop_null("sepal_length").collect())
     assert df_len_col == 2

--- a/tests/dataframe/test_getitem.py
+++ b/tests/dataframe/test_getitem.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import pytest
 
+import daft
 from daft import DataFrame
 
 
 def test_dataframe_getitem_single(valid_data: list[dict[str, float]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     expanded_df = df.with_column("foo", df["sepal_length"] + df["sepal_width"])
     # TODO(jay): Test that the expression with name "foo" is equal to the expected expression, except for the IDs of the columns
 
@@ -16,7 +17,7 @@ def test_dataframe_getitem_single(valid_data: list[dict[str, float]]) -> None:
 
 
 def test_dataframe_getitem_single_bad(valid_data: list[dict[str, float]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     with pytest.raises(ValueError, match="not found"):
         df["foo"]
 
@@ -28,7 +29,7 @@ def test_dataframe_getitem_single_bad(valid_data: list[dict[str, float]]) -> Non
 
 
 def test_dataframe_getitem_multiple_bad(valid_data: list[dict[str, float]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     with pytest.raises(ValueError, match="not found"):
         df["foo", "bar"]
 
@@ -49,7 +50,7 @@ def test_dataframe_getitem_multiple_bad(valid_data: list[dict[str, float]]) -> N
 
 
 def test_dataframe_getitem_multiple(valid_data: list[dict[str, float]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     expanded_df = df.with_column("foo", sum(df["sepal_length", "sepal_width"].columns))
     # TODO(jay): Test that the expression with name "foo" is equal to the expected expression, except for the IDs of the columns
     assert expanded_df.column_names == df.column_names + ["foo"]
@@ -58,12 +59,12 @@ def test_dataframe_getitem_multiple(valid_data: list[dict[str, float]]) -> None:
 
 
 def test_dataframe_getitem_slice(valid_data: list[dict[str, float]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     slice_df = df[:]
     assert df.column_names == slice_df.column_names
 
 
 def test_dataframe_getitem_slice_rev(valid_data: list[dict[str, float]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     slice_df = df[::-1]
     assert df.column_names == slice_df.column_names[::-1]

--- a/tests/dataframe/test_joins.py
+++ b/tests/dataframe/test_joins.py
@@ -11,7 +11,7 @@ from tests.utils import sort_arrow_table
 
 @pytest.mark.parametrize("n_partitions", [1, 2, 4])
 def test_multicol_joins(n_partitions: int):
-    df = daft.DataFrame.from_pydict(
+    df = daft.from_pydict(
         {
             "A": [1, 2, 3],
             "B": ["a", "b", "c"],
@@ -35,8 +35,8 @@ def test_limit_after_join(n_partitions: int):
     data = {
         "A": [1, 2, 3],
     }
-    df1 = daft.DataFrame.from_pydict(data).repartition(n_partitions, "A")
-    df2 = daft.DataFrame.from_pydict(data).repartition(n_partitions, "A")
+    df1 = daft.from_pydict(data).repartition(n_partitions, "A")
+    df2 = daft.from_pydict(data).repartition(n_partitions, "A")
 
     joined = df1.join(df2, on="A").limit(1)
     joined_data = joined.to_pydict()
@@ -51,13 +51,13 @@ def test_limit_after_join(n_partitions: int):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
 def test_inner_join(repartition_nparts):
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [1, None, 3],
             "values_left": ["a1", "b1", "c1"],
         }
     ).repartition(repartition_nparts)
-    daft_df2 = daft.DataFrame.from_pydict(
+    daft_df2 = daft.from_pydict(
         {
             "id": [1, 2, 3],
             "values_right": ["a2", "b2", "c2"],
@@ -77,14 +77,14 @@ def test_inner_join(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
 def test_inner_join_multikey(repartition_nparts):
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [1, None, None],
             "id2": ["foo1", "foo2", None],
             "values_left": ["a1", "b1", "c1"],
         }
     ).repartition(repartition_nparts)
-    daft_df2 = daft.DataFrame.from_pydict(
+    daft_df2 = daft.from_pydict(
         {
             "id": [None, None, 1],
             "id2": ["foo2", None, "foo1"],
@@ -106,13 +106,13 @@ def test_inner_join_multikey(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
 def test_inner_join_all_null(repartition_nparts):
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [None, None, None],
             "values_left": ["a1", "b1", "c1"],
         }
     ).repartition(repartition_nparts)
-    daft_df2 = daft.DataFrame.from_pydict(
+    daft_df2 = daft.from_pydict(
         {
             "id": [1, 2, 3],
             "values_right": ["a2", "b2", "c2"],
@@ -131,13 +131,13 @@ def test_inner_join_all_null(repartition_nparts):
 
 
 def test_inner_join_null_type_column():
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [None, None, None],
             "values_left": ["a1", "b1", "c1"],
         }
     )
-    daft_df2 = daft.DataFrame.from_pydict(
+    daft_df2 = daft.from_pydict(
         {
             "id": [None, None, None],
             "values_right": ["a2", "b2", "c2"],

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -4,7 +4,7 @@ import re
 
 import pandas as pd
 
-from daft import DataFrame
+import daft
 
 ROW_DIVIDER_REGEX = re.compile(r"\+-+\+")
 SHOWING_N_ROWS_REGEX = re.compile(r".*\(Showing first (\d+) of (\d+) rows\).*")
@@ -69,7 +69,7 @@ def parse_html_table(
 
 
 def test_empty_repr():
-    df = DataFrame.from_pydict({})
+    df = daft.from_pydict({})
     assert df.__repr__() == "(No data to display: Dataframe has no columns)"
     assert df._repr_html_() == "<small>(No data to display: Dataframe has no columns)</small>"
 
@@ -79,7 +79,7 @@ def test_empty_repr():
 
 
 def test_empty_df_repr():
-    df = DataFrame.from_pydict({"A": [1, 2, 3], "B": ["a", "b", "c"]})
+    df = daft.from_pydict({"A": [1, 2, 3], "B": ["a", "b", "c"]})
     df = df.where(df["A"] > 10)
     expected_data = {"A": ("Int64", []), "B": ("Utf8", [])}
     assert parse_str_table(df.__repr__(), expected_user_msg_regex=UNMATERIALIZED_REGEX) == expected_data
@@ -101,7 +101,7 @@ def test_empty_df_repr():
 
 
 def test_alias_repr():
-    df = DataFrame.from_pydict({"A": [1, 2, 3], "B": ["a", "b", "c"]})
+    df = daft.from_pydict({"A": [1, 2, 3], "B": ["a", "b", "c"]})
     df = df.select(df["A"].alias("A2"), df["B"])
 
     expected_data = {"A2": ("Int64", []), "B": ("Utf8", [])}

--- a/tests/dataframe/test_select.py
+++ b/tests/dataframe/test_select.py
@@ -2,24 +2,24 @@ from __future__ import annotations
 
 import pytest
 
-from daft import DataFrame
+import daft
 
 
 def test_select_dataframe_missing_col(valid_data: list[dict[str, float]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
 
     with pytest.raises(ValueError):
         df = df.select("foo", "sepal_length")
 
 
 def test_select_dataframe(valid_data: list[dict[str, float]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     df = df.select("sepal_length", "sepal_width")
     assert df.column_names == ["sepal_length", "sepal_width"]
 
 
 def test_multiple_select_same_col(valid_data: list[dict[str, float]]):
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     df = df.select(df["sepal_length"], df["sepal_length"].alias("sepal_length_2"))
     pdf = df.to_pandas()
     assert len(pdf.columns) == 2

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from daft import DataFrame
+import daft
 
 
 def test_show_default(valid_data):
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     df_display = df.show()
 
     assert df_display.schema == df.schema()
@@ -14,7 +14,7 @@ def test_show_default(valid_data):
 
 
 def test_show_some(valid_data):
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     df_display = df.show(1)
 
     assert df_display.schema == df.schema()

--- a/tests/dataframe/test_sort.py
+++ b/tests/dataframe/test_sort.py
@@ -15,21 +15,21 @@ from daft.errors import ExpressionTypeError
 
 
 def test_disallowed_sort_bool():
-    df = daft.DataFrame.from_pydict({"A": [True, False]})
+    df = daft.from_pydict({"A": [True, False]})
 
     with pytest.raises(ExpressionTypeError):
         df.sort("A")
 
 
 def test_disallowed_sort_null():
-    df = daft.DataFrame.from_pydict({"A": [None, None]})
+    df = daft.from_pydict({"A": [None, None]})
 
     with pytest.raises(ExpressionTypeError):
         df.sort("A")
 
 
 def test_disallowed_sort_bytes():
-    df = daft.DataFrame.from_pydict({"A": [b"a", b"b"]})
+    df = daft.from_pydict({"A": [b"a", b"b"]})
 
     with pytest.raises(ExpressionTypeError):
         df.sort("A")
@@ -43,7 +43,7 @@ def test_disallowed_sort_bytes():
 @pytest.mark.parametrize("desc", [True, False])
 @pytest.mark.parametrize("n_partitions", [1, 3])
 def test_single_float_col_sort(desc: bool, n_partitions: int):
-    df = daft.DataFrame.from_pydict({"A": [1.0, None, 3.0, float("nan"), 2.0]})
+    df = daft.from_pydict({"A": [1.0, None, 3.0, float("nan"), 2.0]})
     df = df.repartition(n_partitions)
     df = df.sort("A", desc=desc)
     sorted_data = df.to_pydict()
@@ -61,7 +61,7 @@ def test_single_float_col_sort(desc: bool, n_partitions: int):
 @pytest.mark.skip(reason="Issue: https://github.com/Eventual-Inc/Daft/issues/546")
 @pytest.mark.parametrize("n_partitions", [1, 3])
 def test_multi_float_col_sort(n_partitions: int):
-    df = daft.DataFrame.from_pydict(
+    df = daft.from_pydict(
         {
             "A": [1.0, 1.0, None, None, float("nan"), float("nan"), float("nan")],
             "B": [1.0, 2.0, float("nan"), None, None, float("nan"), 1.0],
@@ -108,7 +108,7 @@ def test_multi_float_col_sort(n_partitions: int):
 @pytest.mark.parametrize("desc", [True, False])
 @pytest.mark.parametrize("n_partitions", [1, 3])
 def test_single_string_col_sort(desc: bool, n_partitions: int):
-    df = daft.DataFrame.from_pydict({"A": ["0", None, "1", "", "01"]})
+    df = daft.from_pydict({"A": ["0", None, "1", "", "01"]})
     df = df.repartition(n_partitions)
     df = df.sort("A", desc=desc)
     sorted_data = df.to_pydict()
@@ -127,7 +127,7 @@ def test_single_string_col_sort(desc: bool, n_partitions: int):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
 def test_int_sort_with_nulls(repartition_nparts):
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [2, None, 1],
             "values": ["a1", "b1", "c1"],
@@ -148,7 +148,7 @@ def test_int_sort_with_nulls(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
 def test_str_sort_with_nulls(repartition_nparts):
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [1, None, 2],
             "values": ["c1", None, "a1"],
@@ -168,7 +168,7 @@ def test_str_sort_with_nulls(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 4, 6])
 def test_sort_with_nulls_multikey(repartition_nparts):
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id1": [2, None, 2, None, 1],
             "id2": [2, None, 1, 1, None],
@@ -190,7 +190,7 @@ def test_sort_with_nulls_multikey(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
 def test_sort_with_all_nulls(repartition_nparts):
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [None, None, None],
             "values": ["c1", None, "a1"],
@@ -206,7 +206,7 @@ def test_sort_with_all_nulls(repartition_nparts):
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2])
 def test_sort_with_empty(repartition_nparts):
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [1],
             "values": ["a1"],
@@ -221,7 +221,7 @@ def test_sort_with_empty(repartition_nparts):
 
 
 def test_sort_with_all_null_type_column():
-    daft_df = daft.DataFrame.from_pydict(
+    daft_df = daft.from_pydict(
         {
             "id": [None, None, None],
             "values": ["a1", "b1", "c1"],

--- a/tests/dataframe/test_to_integrations.py
+++ b/tests/dataframe/test_to_integrations.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from daft.dataframe import DataFrame
+import daft
 from tests.utils import sort_arrow_table
 
 TEST_DATA_LEN = 16
@@ -42,7 +42,7 @@ TEST_DATA_SCHEMA = pa.schema(
 
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_arrow(n_partitions: int) -> None:
-    df = DataFrame.from_pydict(TEST_DATA).repartition(n_partitions)
+    df = daft.from_pydict(TEST_DATA).repartition(n_partitions)
     table = df.to_arrow()
     # String column is converted to large_string column in Daft.
     assert table.schema == TEST_DATA_SCHEMA
@@ -52,7 +52,7 @@ def test_to_arrow(n_partitions: int) -> None:
 
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_pandas(n_partitions: int) -> None:
-    df = DataFrame.from_pydict(TEST_DATA).repartition(n_partitions)
+    df = daft.from_pydict(TEST_DATA).repartition(n_partitions)
     pd_df = df.to_pandas().sort_values("integers").reset_index(drop=True)
     expected_df = pd.DataFrame(TEST_DATA).sort_values("integers").reset_index(drop=True)
     pd.testing.assert_frame_equal(pd_df, expected_df)

--- a/tests/dataframe/test_with_column.py
+++ b/tests/dataframe/test_with_column.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from daft import DataFrame
+import daft
 
 
 def test_with_column(valid_data: list[dict[str, float]]) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     expanded_df = df.with_column("bar", df["sepal_width"] + df["petal_length"])
     data = expanded_df.to_pydict()
     assert expanded_df.column_names == df.column_names + ["bar"]
@@ -12,7 +12,7 @@ def test_with_column(valid_data: list[dict[str, float]]) -> None:
 
 
 def test_stacked_with_columns(valid_data: list[dict[str, float]]):
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     df = df.select(df["sepal_length"])
     df = df.with_column("sepal_length_2", df["sepal_length"])
     df = df.with_column("sepal_length_3", df["sepal_length_2"])

--- a/tests/expressions/test_apply.py
+++ b/tests/expressions/test_apply.py
@@ -16,13 +16,13 @@ def add_1(x):
 
 
 def test_apply_module_func():
-    df = daft.DataFrame.from_pydict({"a": [1, 2, 3]})
+    df = daft.from_pydict({"a": [1, 2, 3]})
     df = df.with_column("a_plus_1", df["a"].apply(add_1, return_dtype=DataType.int32()))
     assert df.to_pydict() == {"a": [1, 2, 3], "a_plus_1": [2, 3, 4]}
 
 
 def test_apply_lambda():
-    df = daft.DataFrame.from_pydict({"a": [1, 2, 3]})
+    df = daft.from_pydict({"a": [1, 2, 3]})
     df = df.with_column("a_plus_1", df["a"].apply(lambda x: x + 1, return_dtype=DataType.int32()))
     assert df.to_pydict() == {"a": [1, 2, 3], "a_plus_1": [2, 3, 4]}
 
@@ -31,7 +31,7 @@ def test_apply_inline_func():
     def inline_add_1(x):
         return x + 1
 
-    df = daft.DataFrame.from_pydict({"a": [1, 2, 3]})
+    df = daft.from_pydict({"a": [1, 2, 3]})
     df = df.with_column("a_plus_1", df["a"].apply(inline_add_1, return_dtype=DataType.int32()))
     assert df.to_pydict() == {"a": [1, 2, 3], "a_plus_1": [2, 3, 4]}
 
@@ -42,7 +42,7 @@ class MyObj:
 
 
 def test_apply_obj():
-    df = daft.DataFrame.from_pydict({"obj": [MyObj(x=0), MyObj(x=0), MyObj(x=0)]})
+    df = daft.from_pydict({"obj": [MyObj(x=0), MyObj(x=0), MyObj(x=0)]})
 
     def inline_mutate_obj(obj):
         obj.x = 1

--- a/tests/integration/test_tpch.py
+++ b/tests/integration/test_tpch.py
@@ -7,8 +7,8 @@ import pandas as pd
 import pytest
 from fsspec.implementations.local import LocalFileSystem
 
+import daft
 from benchmarking.tpch import answers, data_generation
-from daft.dataframe import DataFrame
 from tests.assets import TPCH_DBGEN_DIR, TPCH_QUERIES
 from tests.conftest import assert_df_equals
 
@@ -47,7 +47,7 @@ def get_df(gen_tpch):
         except FileNotFoundError:
             fp = nonchunked_filepath
 
-        df = DataFrame.read_csv(
+        df = daft.read_csv(
             fp,
             has_headers=False,
             column_names=data_generation.SCHEMA[tbl_name],

--- a/tests/optimizer/test_drop_projections.py
+++ b/tests/optimizer/test_drop_projections.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+import daft
 from daft import col
-from daft.dataframe import DataFrame
 from daft.internal.rule_runner import Once, RuleBatch, RuleRunner
 from daft.logical.logical_plan import LogicalPlan
 from daft.logical.optimizer import DropProjections
@@ -24,7 +24,7 @@ def optimizer() -> RuleRunner[LogicalPlan]:
 
 
 def test_drop_projections(valid_data: list[dict[str, float]], optimizer) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     projection_df = df.select("petal_length", "petal_width", "sepal_length", "sepal_width", "variety")
     assert_plan_eq(optimizer(projection_df.plan()), df.plan())
 
@@ -43,6 +43,6 @@ def test_drop_projections(valid_data: list[dict[str, float]], optimizer) -> None
     ],
 )
 def test_cannot_drop_projections(valid_data: list[dict[str, float]], selection, optimizer) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     projection_df = df.select(*selection)
     assert_plan_eq(optimizer(projection_df.plan()), projection_df.plan())

--- a/tests/optimizer/test_fold_projections.py
+++ b/tests/optimizer/test_fold_projections.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+import daft
 from daft import col
-from daft.dataframe import DataFrame
 from daft.internal.rule_runner import Once, RuleBatch, RuleRunner
 from daft.logical.logical_plan import LogicalPlan
 from daft.logical.optimizer import FoldProjections
@@ -25,7 +25,7 @@ def optimizer() -> RuleRunner[LogicalPlan]:
 
 
 def test_fold_projections(valid_data: list[dict[str, float]], optimizer) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     df_unoptimized = df.select("sepal_length", "sepal_width").select("sepal_length")
     df_optimized = df.select("sepal_length")
     assert df_unoptimized.column_names == ["sepal_length"]
@@ -33,7 +33,7 @@ def test_fold_projections(valid_data: list[dict[str, float]], optimizer) -> None
 
 
 def test_fold_projections_aliases(valid_data: list[dict[str, float]], optimizer) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     df_unoptimized = df.select(col("sepal_length").alias("foo"), "sepal_width").select(col("foo").alias("sepal_width"))
     df_optimized = df.select(col("sepal_length").alias("foo").alias("sepal_width"))
 
@@ -42,13 +42,13 @@ def test_fold_projections_aliases(valid_data: list[dict[str, float]], optimizer)
 
 
 def test_cannot_fold_projections(valid_data: list[dict[str, float]], optimizer) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     df_unoptimized = df.select(col("sepal_length") + 1, "sepal_width").select("sepal_length")
     assert_plan_eq(optimizer(df_unoptimized.plan()), df_unoptimized.plan())
 
 
 def test_fold_projections_resource_requests(valid_data: list[dict[str, float]], optimizer) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     df_unoptimized = df.with_column(
         "bar", col("sepal_length"), resource_request=ResourceRequest(num_cpus=1)
     ).with_column("foo", col("sepal_length"), resource_request=ResourceRequest(num_gpus=1))

--- a/tests/optimizer/test_pushdown_clauses_into_scan.py
+++ b/tests/optimizer/test_pushdown_clauses_into_scan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+import daft
 from daft import DataFrame, col
 from daft.internal.rule_runner import Once, RuleBatch, RuleRunner
 from daft.logical.logical_plan import LogicalPlan, TabularFilesScan
@@ -15,7 +16,7 @@ def optimizer() -> RuleRunner[LogicalPlan]:
 
 
 def test_push_projection_scan_all_cols(valid_data_json_path: str, optimizer):
-    df_unoptimized_scan = DataFrame.from_json(valid_data_json_path)
+    df_unoptimized_scan = daft.read_json(valid_data_json_path)
     df_unoptimized = df_unoptimized_scan.select("sepal_length")
 
     # TODO: switch to using .read_parquet(columns=["sepal_length"]) once that's implemented
@@ -35,7 +36,7 @@ def test_push_projection_scan_all_cols(valid_data_json_path: str, optimizer):
 
 
 def test_push_projection_scan_all_cols_alias(valid_data_json_path: str, optimizer):
-    df_unoptimized_scan = DataFrame.from_json(valid_data_json_path)
+    df_unoptimized_scan = daft.read_json(valid_data_json_path)
     df_unoptimized = df_unoptimized_scan.select(col("sepal_length").alias("foo"))
 
     # TODO: switch to using .read_parquet(columns=["sepal_length"]) once that's implemented
@@ -56,7 +57,7 @@ def test_push_projection_scan_all_cols_alias(valid_data_json_path: str, optimize
 
 
 def test_push_projection_scan_some_cols_aliases(valid_data_json_path: str, optimizer):
-    df_unoptimized_scan = DataFrame.from_json(valid_data_json_path)
+    df_unoptimized_scan = daft.read_json(valid_data_json_path)
     df_unoptimized = df_unoptimized_scan.select(col("sepal_length").alias("foo"), col("sepal_width") + 1)
 
     # TODO: switch to using .read_parquet(columns=["sepal_length"]) once that's implemented

--- a/tests/optimizer/test_pushdown_limit.py
+++ b/tests/optimizer/test_pushdown_limit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from daft.dataframe import DataFrame
+import daft
 from daft.internal.rule_runner import FixedPointPolicy, RuleBatch, RuleRunner
 from daft.logical.logical_plan import LogicalPlan
 from daft.logical.optimizer import PushDownLimit
@@ -23,14 +23,14 @@ def optimizer() -> RuleRunner[LogicalPlan]:
 
 
 def test_limit_pushdown_repartition(valid_data: list[dict[str, float]], optimizer) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     unoptimized_df = df.repartition(3).limit(1)
     optimized_df = df.limit(1).repartition(3)
     assert_plan_eq(optimizer(unoptimized_df.plan()), optimized_df.plan())
 
 
 def test_limit_pushdown_projection(valid_data: list[dict[str, float]], optimizer) -> None:
-    df = DataFrame.from_pylist(valid_data)
+    df = daft.from_pylist(valid_data)
     unoptimized_df = df.select("variety").limit(1)
     optimized_df = df.limit(1).select("variety")
     assert_plan_eq(optimizer(unoptimized_df.plan()), optimized_df.plan())

--- a/tests/property_based_testing/test_sort.py
+++ b/tests/property_based_testing/test_sort.py
@@ -16,6 +16,7 @@ from hypothesis.strategies import (
     sampled_from,
 )
 
+import daft
 from daft import DataFrame
 from daft.datatype import DataType
 from tests.property_based_testing.strategies import (
@@ -68,7 +69,7 @@ class DataframeSortStateMachine(RuleBasedStateMachine):
                 num_rows_strategy=self.num_rows_strategy,
             )
         )
-        df = DataFrame.from_pydict(columns_dict_data)
+        df = daft.from_pydict(columns_dict_data)
         self.df = df
 
     @rule(data=data())
@@ -103,7 +104,6 @@ class DataframeSortStateMachine(RuleBasedStateMachine):
                 note(f"Comparing {current_tup} and {next_tup} for desc={sorted_on_desc}")
 
                 for current_val, next_val, desc in zip(current_tup, next_tup, sorted_on_desc):
-
                     a, b = (current_val, next_val) if desc else (next_val, current_val)
 
                     # Assert that a >= b, where the ordering is defined as: None > NaN > other values

--- a/tests/ray/test_dask.py
+++ b/tests/ray/test_dask.py
@@ -7,7 +7,8 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from daft import DataFrame, DataType
+import daft
+from daft import DataType
 from daft.context import get_context
 
 
@@ -28,7 +29,7 @@ DATA = {
 @pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_all_arrow(n_partitions: int):
-    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = daft.from_pydict(DATA).repartition(n_partitions)
     df = df.with_column("floatcol", df["intcol"].cast(DataType.float64()))
     ddf = df.to_dask_dataframe()
 
@@ -46,7 +47,7 @@ def test_to_dask_dataframe_all_arrow(n_partitions: int):
 @pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_all_arrow_with_schema(n_partitions: int):
-    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = daft.from_pydict(DATA).repartition(n_partitions)
     df = df.with_column("floatcol", df["intcol"].cast(DataType.float64()))
     ddf = df.to_dask_dataframe({"intcol": np.int64, "strcol": np.str_, "floatcol": np.float64})
 
@@ -64,7 +65,7 @@ def test_to_dask_dataframe_all_arrow_with_schema(n_partitions: int):
 @pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_with_py(n_partitions: int):
-    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = daft.from_pydict(DATA).repartition(n_partitions)
     df = df.with_column("pycol", df["intcol"].apply(lambda x: MyObj(x), DataType.python()))
     ddf = df.to_dask_dataframe()
 
@@ -82,7 +83,7 @@ def test_to_dask_dataframe_with_py(n_partitions: int):
 @pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_with_numpy(n_partitions: int):
-    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = daft.from_pydict(DATA).repartition(n_partitions)
     df = df.with_column("npcol", df["intcol"].apply(lambda _: np.ones((3, 3)), DataType.python()))
     ddf = df.to_dask_dataframe()
 
@@ -103,7 +104,7 @@ def test_to_dask_dataframe_with_numpy(n_partitions: int):
 @pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_with_numpy_variable_shaped(n_partitions: int):
-    df = DataFrame.from_pydict(DATA).repartition(n_partitions)
+    df = daft.from_pydict(DATA).repartition(n_partitions)
     df = df.with_column("npcol", df["intcol"].apply(lambda x: np.ones((x, 3)), DataType.python()))
     ddf = df.to_dask_dataframe()
 
@@ -128,7 +129,7 @@ def test_from_dask_dataframe_all_arrow(n_partitions: int):
     df["floatcol"] = df["intcol"].astype(float)
     ddf = dd.from_pandas(df, npartitions=n_partitions)
 
-    daft_df = DataFrame.from_dask_dataframe(ddf)
+    daft_df = daft.from_dask_dataframe(ddf)
     out_df = daft_df.to_pandas()
     pd.testing.assert_frame_equal(out_df, df)
 
@@ -140,6 +141,6 @@ def test_from_dask_dataframe_tensor(n_partitions: int):
     df["tensor"] = pd.Series([np.ones((2, 2)) for _ in range(len(df))], dtype=object)
     ddf = dd.from_pandas(df, npartitions=n_partitions)
 
-    daft_df = DataFrame.from_dask_dataframe(ddf)
+    daft_df = daft.from_dask_dataframe(ddf)
     out_df = daft_df.to_pandas()
     pd.testing.assert_frame_equal(out_df, df)

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -6,7 +6,7 @@ import uuid
 import pandas as pd
 import pytest
 
-from daft import DataFrame
+import daft
 from daft.expressions import col
 from tests.conftest import assert_df_equals
 
@@ -20,7 +20,7 @@ def files(tmpdir) -> list[str]:
 
 
 def test_download(files):
-    df = DataFrame.from_pydict({"filenames": [str(f) for f in files]})
+    df = daft.from_pydict({"filenames": [str(f) for f in files]})
     df = df.with_column("bytes", col("filenames").url.download())
     pd_df = pd.DataFrame.from_dict({"filenames": [str(f) for f in files]})
     pd_df["bytes"] = pd.Series([pathlib.Path(fn).read_bytes() for fn in files])
@@ -29,7 +29,7 @@ def test_download(files):
 
 def test_download_with_none(files):
     data = {"id": list(range(len(files) * 2)), "filenames": [str(f) for f in files] + [None for _ in range(len(files))]}
-    df = DataFrame.from_pydict(data)
+    df = daft.from_pydict(data)
     df = df.with_column("bytes", col("filenames").url.download())
     pd_df = pd.DataFrame.from_dict(data)
     pd_df["bytes"] = pd.Series([pathlib.Path(fn).read_bytes() if fn is not None else None for fn in files])
@@ -41,7 +41,7 @@ def test_download_with_broken_urls(files):
         "id": list(range(len(files) * 2)),
         "filenames": [str(f) for f in files] + [str(uuid.uuid4()) for _ in range(len(files))],
     }
-    df = DataFrame.from_pydict(data)
+    df = daft.from_pydict(data)
     df = df.with_column("bytes", col("filenames").url.download())
     pd_df = pd.DataFrame.from_dict(data)
     pd_df["bytes"] = pd.Series([pathlib.Path(fn).read_bytes() if pathlib.Path(fn).exists() else None for fn in files])
@@ -53,7 +53,7 @@ def test_download_with_duplicate_urls(files):
         "id": list(range(len(files) * 2)),
         "filenames": [str(f) for f in files] * 2,
     }
-    df = DataFrame.from_pydict(data)
+    df = daft.from_pydict(data)
     df = df.with_column("bytes", col("filenames").url.download())
     pd_df = pd.DataFrame.from_dict(data)
     pd_df["bytes"] = pd.Series(

--- a/tutorials/mnist.ipynb
+++ b/tutorials/mnist.ipynb
@@ -1,909 +1,910 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d1b56860-db41-4829-b395-176e11987cdc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install getdaft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
-    "!pip install Pillow torch torchvision"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c571e01d",
-   "metadata": {},
-   "source": [
-    "```{hint}\n",
-    "✨✨✨ **Run this notebook on Google Colab** ✨✨✨\n",
-    "\n",
-    "You can [run this notebook yourself with Google Colab](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/mnist.ipynb)!\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9b14abf5-a183-4bfb-9b15-a9a54b744fce",
-   "metadata": {},
-   "source": [
-    "# MNIST Daft Tutorial\n",
-    "\n",
-    "The MNIST Dataset is a \"large database of handwritten digits that is commonly used for training various image processing systems\"."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "252b5128-99c2-49dd-b624-6e4b21275959",
-   "metadata": {},
-   "source": [
-    "## Loading Data\n",
-    "\n",
-    "This is a JSON file containing all the data for the MNIST test set. Let's load it up into a Daft Dataframe!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "fc63a3ad-0e0a-4ab3-9cc0-cbec8bdd0632",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-04-21 11:44:02.554 | INFO     | daft.context:runner:88 - Using PyRunner\n"
-     ]
-    }
-   ],
-   "source": [
-    "from daft import DataFrame, col, udf, DataType\n",
-    "\n",
-    "URL = \"https://github.com/Eventual-Inc/mnist-json/raw/master/mnist_handwritten_test.json.gz\"\n",
-    "images_df = DataFrame.read_json(URL)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d52f6032-6619-4682-8305-2ed65bdc194c",
-   "metadata": {},
-   "source": [
-    "To peek at the dataset, simply have your notebook display the images_df that was just created."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "73a71adf-3b2e-4ec5-a0d2-34ad8eec734c",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "    <table class=\"dataframe\">\n",
-       "<tbody>\n",
-       "<tr><td>image<br>List[Int64]</td><td>label<br>Int64</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n",
-       "    <small>(No data to display: Dataframe not materialized)</small>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "+---------------+---------+\n",
-       "| image         | label   |\n",
-       "| List[Int64]   | Int64   |\n",
-       "+===============+=========+\n",
-       "+---------------+---------+\n",
-       "(No data to display: Dataframe not materialized)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "images_df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "4787caab-d7d1-4fd4-9a76-ffb08a404a31",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "    <table class=\"dataframe\">\n",
-       "<thead>\n",
-       "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               0</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n",
-       "    <small>(Showing first 10 rows)</small>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "+----------------------+---------+\n",
-       "| image                |   label |\n",
-       "| List[Int64]          |   Int64 |\n",
-       "+======================+=========+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       7 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       2 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       1 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       0 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       1 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       9 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       5 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       9 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         |\n",
-       "+----------------------+---------+\n",
-       "(Showing first 10 rows)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "images_df.show(10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "426f1bbb-e1c0-4fd6-b84e-cbb1ab309ff9",
-   "metadata": {},
-   "source": [
-    "You just loaded your first DaFt Dataframe! It consists of two columns:\n",
-    "1. The \"image\" column is a Python column of type `list` - where it looks like each row contains a list of digits representing the pixels of each image\n",
-    "2. The \"label\" column is an Integer column, consisting of just the label of that image."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9a7872e3-9860-4867-8a8c-61a69f69e334",
-   "metadata": {},
-   "source": [
-    "## Processing Columns with User-Defined Functions (UDF)\n",
-    "\n",
-    "It seems our JSON file has provided us with a one-dimensional array of pixels instead of two-dimensional images. We can easily modify data in this column by instructing Daft to run a method on every row in the column like so:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "af857589-b28a-4ee0-91cd-dc7a01ff4c07",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "\n",
-    "images_df = images_df.with_column(\n",
-    "    \"image_2d\",\n",
-    "    col(\"image\").apply(lambda l: np.array(l).reshape(28, 28), return_dtype=DataType.python()),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "d1212a7e-949a-4881-ba54-9d7e7eb31e6f",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "    <table class=\"dataframe\">\n",
-       "<thead>\n",
-       "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th><th>image_2d<br>Python                               </th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               0</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n",
-       "    <small>(Showing first 10 rows)</small>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "+----------------------+---------+----------------------+\n",
-       "| image                |   label | image_2d             |\n",
-       "| List[Int64]          |   Int64 | Python               |\n",
-       "+======================+=========+======================+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       7 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       0 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       5 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
-       "+----------------------+---------+----------------------+\n",
-       "(Showing first 10 rows)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "images_df.show(10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cd0d2664-12d8-4964-85cd-a67f8fee1384",
-   "metadata": {},
-   "source": [
-    "Great, but we can do one better - let's convert these two-dimensional arrays into Images. Computers speak in pixels and arrays, but humans do much better with visual patterns!\n",
-    "\n",
-    "To do this, we can leverage the `.apply` expression method. Similar to the `.as_py` method, this allows us to run a single function on all rows of a given column, but provides us with more flexibility as it takes as input any arbitrary function."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "e585303a-7c83-4a31-afbb-461c951481f7",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from PIL import Image\n",
-    "\n",
-    "images_df = images_df.with_column(\"pil_image\", col(\"image_2d\").apply(lambda arr: Image.fromarray(arr.astype(np.uint8)), return_dtype=DataType.python()))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "59b655ed-13aa-4764-acd4-a00beb91ec2f",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "    <table class=\"dataframe\">\n",
-       "<thead>\n",
-       "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th><th>image_2d<br>Python                               </th><th>pil_image<br>Python                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 </th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APA4Lea6nSC3hkmmc4SONSzMfQAdadc2dzZSmK7tpoJB/BKhU/kahoq1pupXuj6hDf6dcyW13CSY5YzhlyCDj8CRXXWvxe8b20SxtrH2lVOQbqCOU9OmWUn/APVXUfEfxBqCfDzSNJ16S2uNd1JxqEqpbohtIMYjQbQBlsEnv1HpXj9Fdx8OvDNlqNxe+IdeVh4e0VPPucLnznyNkQ/3j1/LjOa57xPr9z4n8R3usXQ2vcSZVB0jQcKo9gABWRRXSxeOdXt/A0nhGAW0WnSzGaZ1j/ey8g7SxOMZA6AHjrXNUV//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC36F50>\" />                                                    </td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APAY42lkWNBl2IVR6k17BB8L/BemalZaB4h8TXr+I7oKhtNNi3rDI3TcdpyB36HvwK8z8UaL/wAI74o1LRxOs4s52iEg/iAPGff196yaK9d+H1lbeCPCdz8SNZjWW5bdBpFtJw0jn5TIDn/eHToCe4ryvUb+51XUrnULyQyXNzK0srnuzHJqtRX0J4utvBHxCXSLez+INlo+m2dqqQ2EkQCIf7xLMoB24XB9Pc1wp8D+AdMc/wBrfEaCbazDy9Os2l3YHGHBIHPtj3riNfg0a31V00G8ubuw2qUkuYhG+ccgge9ZlFFFf//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37040>\" />                                                </td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+lALEAAkngAd62PFGgjw1rR0trrz5o4Ynn/d7PLkZAzR9TnbnGfboKxqK634a6PHrPjrT1uAhs7Mm9ut/TyovmOfrgD8awte1M614h1LVCGX7ZcyThWOSoZiQM+2cVn0V6J4RFvo/wu8X63NKi3F6qaVarxuYsQ0nvjaR+XevO6KKKKK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC36920>\" />                                                                                                                                                                                </td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               0</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+u6+Hnwx1Lx9cTlZmsLGGMn7W8JdWfOAijIz3yc8Y+lcdqFjPpt9NaXMbJJE5U7lIzg4yM9qrVJbwtcXMUKqzNI4QBRkkk44r6F8c/Em3+GdnD4I8KWyi5sYVWS4lXiEsA/TGHZg24nplu5zjC11T8SPgyfFupp5WtaK7RG4Cqi3SFl4J46AjA9QcferxOtDQr9NK8Q6ZqMiF0tLuKdlHUhXDEfpX0VqHgHwJ461y88a3niUy2Ny0P7uKdIY0KoqbXZgTzt6fKetcF8VfiLpOo6Ta+E/CStBpNsx+0MkflpKRjaqgdVzkkkcnB9z5FRRRRX//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC36FE0>\" />                            </td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tC60W7s9E0/Vpggtr95kgGTuPl7QxPGMZbA57Gohpl0dHOqhAbRZxbswYZDldwBHuAefY1Uq/oenDWNf07TDIIxd3McBc/w7mAz+tb3xG1NLvxZcadZxmHS9JJsLKDGAiIcM2PVm3MSeeea2PElpH4a+Enh/SWTN7rVwdXmc8FIwmyNfoQxP5151T4ZpLeeOeF2jljYOjqcFWByCK7GT4qeKJRvkk097njN02nQNMSO5YpyccV0Hx4u3uPFOipI/72PRoTNGDgRyFnJG3+E9OPTFeV0UVJPPNczvPcSvLM53PJIxZmPqSetR1//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37010>\" />                                        </td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+nIjSOqIpZmOAB1Jrb8V+EtT8GarFpuq+R9pkgSfEMm8KGzwfQgggj8sjBrCorvvg3oI1z4kaeZULW1jm8lO3IGz7uf8AgW2sTx54iPirxvqurhswzTFYOMful+VOO3ygE+5Nc5RXqvgG4Hh34TeM/EUIH22Yx6dC4bDRhupH/fYP/Aa8qooqVLidIJIEmkWGQgvGGIViOmR0OKior//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37070>\" />                                                                                                                                                </td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn8DJwOtbWveF9R8NxWB1PyYp7yHz1tRJmWJD08xf4SRyAefyNVtL0PUNZivpbOJWisYDcXEjuEWNB6knqTwB1JrOrc8HXGkWnjDS7jXU36XHOGuBgnjsSByQDg8eneu68W+F9I8QeIbrXm+I+iTR30jSjzN/moucBPLUEjCgAA4zjgVB8RYbPwLo1v4D0m6FxM7C71e52KGlfH7uPjkKvzHB/vCvMKK734O6JFrPxCtmnjEsOnxPfNDs3GUpjaoHruZT+Fc94ui1ZfE15PrcSw6jdSG4miDKTGXJO0gH5T7Hkd6w6Kmtru5spvOtbiWCXBXfE5VsHgjIqEkk5JyaK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC370A0>\" />            </td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tODw9q9zod1rUOnztplqVE11twiksFABPU5I6ZxmsyiivqLRLvU9Lm0Tw8ui2EngQ6RHJdX8ynyjuQu7MzYXlv4SP4sn28K+JegweHPH+qafaW8kFnvEturEEbGGflx/DkkD6c81yVFasniXWpfD8egyancNpUb70tS3yA/4c5x0rsdQuB48+G8V40gbXvDSeXcA8vcWZICv6koSAfQHPevOaKKuabqt9o9xJPYXDQSSwvBJgAh43GGUg8EEf0PUVTr/2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37130>\" />                                                                                            </td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tnw34W1nxbqJsNFszczqu9xvVQi5xkliBjmvRV/Z78QxRxPe6zo9qHzkNKxKnB/2QDzjoe9eWarp76TrF7p0kscr2lxJA0kRyrlGKkqfQ44rp/hh4Qi8aeMY7C53m0gha6nRDhnRSBtB7ZLAZ96k8Saj4ssfFl/fw6fqHh5yFiWC0RoRFCMbEyoAIwBz3PNcjeXF5cXDNfTTyzg4YzsWbPvnmq9XtI1nUtA1KPUNKvJbS7j+7JGcHHoR0I9jwa9/+FfxZvtfhv8AStf1ezj1bCtYz3MQVH4wVYKVyc4PUHk+lcJ8cvEeheIPE1l/Y8sNzNawGO6uoEwkjZyAD3xz69epry2iiiiv/9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC34970>\" /></td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+pIYJbiVYoInlkbgIilifwFSXlheadP5F9aT2s2M+XPGUb8iKr1f0S0s77XLG01C7FnZzTKk1wf8AlmpPLV9EXGh6zpyLpvwzTw7pljMqhdRa7WW5us4O4HDcdR39sVL47u08P/De9sPG2qW+p6jd2qx2dsi/OJlQKZA2ASu8CTJAwcjJzXzHRXtHwx0jTvBnhC6+JHiG3DupMelQswzI3IyB2JOQCegDHGOa8q8Qa9feJddu9W1CUvcXEhbGSQgzwq56ADgCsyiug1zxnq3iHQ9H0e9eIWekw+VAkSld3AAZueWwAM8fqa5+iv/Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37610>\" />                                        </td></tr>\n",
-       "</tbody>\n",
-       "</table>\n",
-       "    <small>(Showing first 10 rows)</small>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| image                |   label | image_2d             | pil_image        |\n",
-       "| List[Int64]          |   Int64 | Python               | Python           |\n",
-       "+======================+=========+======================+==================+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       7 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC36F50>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC37040>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC36920>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       0 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC36FE0>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC37010>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC37070>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC370A0>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC37130>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       5 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC34970>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
-       "|                      |         |                      | 0x10FC37610>     |\n",
-       "+----------------------+---------+----------------------+------------------+\n",
-       "(Showing first 10 rows)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "images_df.show(10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e6b633f4-3d9d-4c25-9075-bc815d8e357f",
-   "metadata": {},
-   "source": [
-    "Amazing! This looks great and we can finally get some idea of what the dataset truly looks like."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cd7e6774-9fb7-4827-a324-c116c8c812e1",
-   "metadata": {},
-   "source": [
-    "## Running a model with UDFs\n",
-    "\n",
-    "Next, let's try to run a deep learning model to classify each image. Models are expensive to initialize and load, so we want to do this as few times as possible, and share a model across multiple invocations.\n",
-    "\n",
-    "For the convenience of this quickstart tutorial, we pre-trained a model using a PyTorch-provided example script and saved the trained weights at https://github.com/Eventual-Inc/mnist-json/raw/master/mnist_cnn.pt.  We need to define the same deep learning model \"scaffold\" as the trained model that we want to load (this part is all PyTorch and is not specific at all to DaFt)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "5ff43066-8a42-4773-974f-160ca4a9bc49",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "###\n",
-    "# Model was trained using a script provided in PyTorch Examples: https://github.com/pytorch/examples/blob/main/mnist/main.py\n",
-    "###\n",
-    "\n",
-    "from __future__ import print_function\n",
-    "import argparse\n",
-    "import torch\n",
-    "import torch.nn as nn\n",
-    "import torch.nn.functional as F\n",
-    "import torch.optim as optim\n",
-    "import torch.hub\n",
-    "from torchvision import datasets, transforms\n",
-    "from torch.optim.lr_scheduler import StepLR\n",
-    "\n",
-    "class Net(nn.Module):\n",
-    "    def __init__(self):\n",
-    "        super(Net, self).__init__()\n",
-    "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
-    "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
-    "        self.dropout1 = nn.Dropout(0.25)\n",
-    "        self.dropout2 = nn.Dropout(0.5)\n",
-    "        self.fc1 = nn.Linear(9216, 128)\n",
-    "        self.fc2 = nn.Linear(128, 10)\n",
-    "\n",
-    "    def forward(self, x):\n",
-    "        x = self.conv1(x)\n",
-    "        x = F.relu(x)\n",
-    "        x = self.conv2(x)\n",
-    "        x = F.relu(x)\n",
-    "        x = F.max_pool2d(x, 2)\n",
-    "        x = self.dropout1(x)\n",
-    "        x = torch.flatten(x, 1)\n",
-    "        x = self.fc1(x)\n",
-    "        x = F.relu(x)\n",
-    "        x = self.dropout2(x)\n",
-    "        x = self.fc2(x)\n",
-    "        output = F.log_softmax(x, dim=1)\n",
-    "        return output"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "266c1cf8-bf9a-4990-8182-97b072f15b57",
-   "metadata": {},
-   "source": [
-    "Now comes the fun part - we can define a UDF using the `@udf` decorator. Notice that for a batch of data we only initialize our model once!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "fda097ea-4946-483c-bcc0-5271e0b033c3",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "@udf(return_dtype=DataType.int64())\n",
-    "class ClassifyImages:\n",
-    "    \n",
-    "    def __init__(self):\n",
-    "        # Perform expensive initializations - create the model, download model weights and load up the model with weights\n",
-    "        self.model = Net()\n",
-    "        state_dict = torch.hub.load_state_dict_from_url(\"https://github.com/Eventual-Inc/mnist-json/raw/master/mnist_cnn.pt\")\n",
-    "        self.model.load_state_dict(state_dict)\n",
-    "    \n",
-    "    def __call__(self, images_2d_col):\n",
-    "        images_arr = np.array(images_2d_col.to_pylist())\n",
-    "        normalized_image_2d = images_arr / 255\n",
-    "        normalized_image_2d = normalized_image_2d[:, np.newaxis, :, :]\n",
-    "        classifications = self.model(torch.from_numpy(normalized_image_2d).float())\n",
-    "        return classifications.detach().numpy().argmax(axis=1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3605d3a6-f9ce-4e81-9e0f-5190f981bbd4",
-   "metadata": {},
-   "source": [
-    "Using this UDF is really easy, we simply run it on the columns that we want to process:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "4f9fd9f8-a231-44fb-a519-0288f670a34a",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "    <table class=\"dataframe\">\n",
-       "<thead>\n",
-       "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th><th>image_2d<br>Python                               </th><th>pil_image<br>Python                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 </th><th style=\"text-align: right;\">  model_classification<br>Int64</th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APA4Lea6nSC3hkmmc4SONSzMfQAdadc2dzZSmK7tpoJB/BKhU/kahoq1pupXuj6hDf6dcyW13CSY5YzhlyCDj8CRXXWvxe8b20SxtrH2lVOQbqCOU9OmWUn/APVXUfEfxBqCfDzSNJ16S2uNd1JxqEqpbohtIMYjQbQBlsEnv1HpXj9Fdx8OvDNlqNxe+IdeVh4e0VPPucLnznyNkQ/3j1/LjOa57xPr9z4n8R3usXQ2vcSZVB0jQcKo9gABWRRXSxeOdXt/A0nhGAW0WnSzGaZ1j/ey8g7SxOMZA6AHjrXNUV//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCA800>\" />                                                    </td><td style=\"text-align: right;\">                              7</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APAY42lkWNBl2IVR6k17BB8L/BemalZaB4h8TXr+I7oKhtNNi3rDI3TcdpyB36HvwK8z8UaL/wAI74o1LRxOs4s52iEg/iAPGff196yaK9d+H1lbeCPCdz8SNZjWW5bdBpFtJw0jn5TIDn/eHToCe4ryvUb+51XUrnULyQyXNzK0srnuzHJqtRX0J4utvBHxCXSLez+INlo+m2dqqQ2EkQCIf7xLMoB24XB9Pc1wp8D+AdMc/wBrfEaCbazDy9Os2l3YHGHBIHPtj3riNfg0a31V00G8ubuw2qUkuYhG+ccgge9ZlFFFf//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCBFD0>\" />                                                </td><td style=\"text-align: right;\">                              2</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+lALEAAkngAd62PFGgjw1rR0trrz5o4Ynn/d7PLkZAzR9TnbnGfboKxqK634a6PHrPjrT1uAhs7Mm9ut/TyovmOfrgD8awte1M614h1LVCGX7ZcyThWOSoZiQM+2cVn0V6J4RFvo/wu8X63NKi3F6qaVarxuYsQ0nvjaR+XevO6KKKKK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCC9A50>\" />                                                                                                                                                                                </td><td style=\"text-align: right;\">                              1</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               0</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+u6+Hnwx1Lx9cTlZmsLGGMn7W8JdWfOAijIz3yc8Y+lcdqFjPpt9NaXMbJJE5U7lIzg4yM9qrVJbwtcXMUKqzNI4QBRkkk44r6F8c/Em3+GdnD4I8KWyi5sYVWS4lXiEsA/TGHZg24nplu5zjC11T8SPgyfFupp5WtaK7RG4Cqi3SFl4J46AjA9QcferxOtDQr9NK8Q6ZqMiF0tLuKdlHUhXDEfpX0VqHgHwJ461y88a3niUy2Ny0P7uKdIY0KoqbXZgTzt6fKetcF8VfiLpOo6Ta+E/CStBpNsx+0MkflpKRjaqgdVzkkkcnB9z5FRRRRX//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCC99C0>\" />                            </td><td style=\"text-align: right;\">                              0</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tC60W7s9E0/Vpggtr95kgGTuPl7QxPGMZbA57Gohpl0dHOqhAbRZxbswYZDldwBHuAefY1Uq/oenDWNf07TDIIxd3McBc/w7mAz+tb3xG1NLvxZcadZxmHS9JJsLKDGAiIcM2PVm3MSeeea2PElpH4a+Enh/SWTN7rVwdXmc8FIwmyNfoQxP5151T4ZpLeeOeF2jljYOjqcFWByCK7GT4qeKJRvkk097njN02nQNMSO5YpyccV0Hx4u3uPFOipI/72PRoTNGDgRyFnJG3+E9OPTFeV0UVJPPNczvPcSvLM53PJIxZmPqSetR1//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCAA10>\" />                                        </td><td style=\"text-align: right;\">                              4</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+nIjSOqIpZmOAB1Jrb8V+EtT8GarFpuq+R9pkgSfEMm8KGzwfQgggj8sjBrCorvvg3oI1z4kaeZULW1jm8lO3IGz7uf8AgW2sTx54iPirxvqurhswzTFYOMful+VOO3ygE+5Nc5RXqvgG4Hh34TeM/EUIH22Yx6dC4bDRhupH/fYP/Aa8qooqVLidIJIEmkWGQgvGGIViOmR0OKior//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCAC80>\" />                                                                                                                                                </td><td style=\"text-align: right;\">                              1</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn8DJwOtbWveF9R8NxWB1PyYp7yHz1tRJmWJD08xf4SRyAefyNVtL0PUNZivpbOJWisYDcXEjuEWNB6knqTwB1JrOrc8HXGkWnjDS7jXU36XHOGuBgnjsSByQDg8eneu68W+F9I8QeIbrXm+I+iTR30jSjzN/moucBPLUEjCgAA4zjgVB8RYbPwLo1v4D0m6FxM7C71e52KGlfH7uPjkKvzHB/vCvMKK734O6JFrPxCtmnjEsOnxPfNDs3GUpjaoHruZT+Fc94ui1ZfE15PrcSw6jdSG4miDKTGXJO0gH5T7Hkd6w6Kmtru5spvOtbiWCXBXfE5VsHgjIqEkk5JyaK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCACB0>\" />            </td><td style=\"text-align: right;\">                              4</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tODw9q9zod1rUOnztplqVE11twiksFABPU5I6ZxmsyiivqLRLvU9Lm0Tw8ui2EngQ6RHJdX8ynyjuQu7MzYXlv4SP4sn28K+JegweHPH+qafaW8kFnvEturEEbGGflx/DkkD6c81yVFasniXWpfD8egyancNpUb70tS3yA/4c5x0rsdQuB48+G8V40gbXvDSeXcA8vcWZICv6koSAfQHPevOaKKuabqt9o9xJPYXDQSSwvBJgAh43GGUg8EEf0PUVTr/2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCA9E0>\" />                                                                                            </td><td style=\"text-align: right;\">                              9</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tnw34W1nxbqJsNFszczqu9xvVQi5xkliBjmvRV/Z78QxRxPe6zo9qHzkNKxKnB/2QDzjoe9eWarp76TrF7p0kscr2lxJA0kRyrlGKkqfQ44rp/hh4Qi8aeMY7C53m0gha6nRDhnRSBtB7ZLAZ96k8Saj4ssfFl/fw6fqHh5yFiWC0RoRFCMbEyoAIwBz3PNcjeXF5cXDNfTTyzg4YzsWbPvnmq9XtI1nUtA1KPUNKvJbS7j+7JGcHHoR0I9jwa9/+FfxZvtfhv8AStf1ezj1bCtYz3MQVH4wVYKVyc4PUHk+lcJ8cvEeheIPE1l/Y8sNzNawGO6uoEwkjZyAD3xz69epry2iiiiv/9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCAF50>\" /></td><td style=\"text-align: right;\">                              6</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+pIYJbiVYoInlkbgIilifwFSXlheadP5F9aT2s2M+XPGUb8iKr1f0S0s77XLG01C7FnZzTKk1wf8AlmpPLV9EXGh6zpyLpvwzTw7pljMqhdRa7WW5us4O4HDcdR39sVL47u08P/De9sPG2qW+p6jd2qx2dsi/OJlQKZA2ASu8CTJAwcjJzXzHRXtHwx0jTvBnhC6+JHiG3DupMelQswzI3IyB2JOQCegDHGOa8q8Qa9feJddu9W1CUvcXEhbGSQgzwq56ADgCsyiug1zxnq3iHQ9H0e9eIWekw+VAkSld3AAZueWwAM8fqa5+iv/Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCAD40>\" />                                        </td><td style=\"text-align: right;\">                              9</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n",
-       "    <small>(Showing first 10 rows)</small>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| image                |   label | image_2d             | pil_image        |   model_classification |\n",
-       "| List[Int64]          |   Int64 | Python               | Python           |                  Int64 |\n",
-       "+======================+=========+======================+==================+========================+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       7 | [[  0   0   0   0    | <PIL.Image.Image |                      7 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCCA800>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |                      2 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCCBFD0>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    | <PIL.Image.Image |                      1 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCC9A50>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       0 | [[  0   0   0   0    | <PIL.Image.Image |                      0 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCC99C0>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |                      4 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCCAA10>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    | <PIL.Image.Image |                      1 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCCAC80>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |                      4 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCCACB0>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |                      9 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCCA9E0>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       5 | [[  0   0   0   0    | <PIL.Image.Image |                      6 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCCAF50>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |                      9 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x10FCCAD40>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "(Showing first 10 rows)"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "classified_images_df = images_df.with_column(\"model_classification\", ClassifyImages(col(\"image_2d\")))\n",
-    "\n",
-    "classified_images_df.show(10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2e6fb5fc-957d-414b-bfac-961ea64dad68",
-   "metadata": {},
-   "source": [
-    "Our model ran successfully, and produced a new classification column. These look pretty good - let's filter our Dataframe to show only rows that the model predicted wrongly."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "69344d63-7db4-496f-a0b2-949dfd947e4f",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "    <table class=\"dataframe\">\n",
-       "<thead>\n",
-       "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th><th>image_2d<br>Python                               </th><th>pil_image<br>Python                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         </th><th style=\"text-align: right;\">  model_classification<br>Int64</th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+u90r4YTvo8eseJNasfDthKN0P2vLTyr2ZYhzg8988dMUal8PdNfw5f634X8V2+uQaaA17G1pJayRqxABUNnd3z06dzxXBVe0fUv7I1i01EWtvdG2kEghuF3RuR2YdxT9b1zUvEWqS6hqd1JcXEhPLsSFGchVB6KOwruGsn8A/Da/i1HfHrPiaONYbXjMNsrBi7g9C3Kgdq82rqfAPhCPxp4hOnT6pBp0KRGV5ZSMsNwG1QSMsd1enXEHwf8Ah3rlsVkvNa1CKYElZFmS3PTLYwhxyccnIrkPHOm+G5r+XxAfHH9uG83MIEi23AbsDxtVRnuF6YA9PN6KKKK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F00D0>\" />        </td><td style=\"text-align: right;\">                              7</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               3</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+u38DeC9I8Y6dqMMviCLTtaiIa2huMCKVMc5b1zgcdPQ545rXtA1Lwzq82l6tbNb3UXVTyGHZge4PrWbRXoGhfCHX/Eml2moaTf6PcRzqGaNbv95BntIu3g+wzVj4qanYPaeHvD8OqHV9Q0aCSC81DbgOSwwgPfbgjP8AXNeb1u+DdN0vV/F2nWWtX0VlpskmZ5pZBGoUAnG48DOMZ967fQtF8LeBteg1vWPGNndzWkwlt7TQmNxvI5wzkAAdvf1rz/xJqkeueJ9U1WGEwx3l1JOsbHJUMxIB/Osuiiiiv//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F0FA0>\" />                                                </td><td style=\"text-align: right;\">                              2</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+trw74S17xZcSQ6Hpst48QBkKlVVc9MsxAH50/wAS+DPEHhB7dNd05rQ3ClosyI4YDrypOOo4NYVFe5/BrxBa6n4XuvAtvdXWk6tcSvPHf2sYJZPlJ5zkNgEZ6Yx36r8e9QsrHRtA8KR3sl9fWf72eaaTfKBtAG8+rZJ/AV4XU1raz313DaWsTzXEziOONBksxOABX0BqEWmfA74fmG3ZZfFuqxFPPXBMZxyRnoi9uOTjPt4Df393ql9Ne31xJcXUzbpJZGyzH3NV6mtLuewvYLy2k8u4t5FlifAO1lOQcHjqKu6/4i1bxPqjalrN493dsoXeyhQABgAKoAA+g96zKK//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F1180>\" /></td><td style=\"text-align: right;\">                              8</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+ug8LeFLjxLPcSNcJZaZZp5t7fyqSkCduB1Y9l6msa9it4b6eK1uDc26SMsU5jKeYoPDbTyMjnFQUV6H4s3eHvBXh/wAJWSyGXUIU1W/IQEzPIP3SDvhQD06k+tW7Dw9Z+BPBV1r3iW3P9t6nA9vpVg4w0asu1pnB6cMcAjjA7njzGivcPAfxA1XSPh/e69rN5FeQaViw0u2aJDI0hUEBnxuCAbenp7YryHXtf1PxLq0up6tdyXNzIerHhBkkKo7KMnAFZtFFFFf/2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F1A80>\" />                                                                            </td><td style=\"text-align: right;\">                              8</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tfSPC+ta9aXdzpVi92loAZliZS4B7hM7m/AGskgqSCCCOCDSVc0nS7vW9VttNsIjLc3D7EXOPqSewAySewFd/wCFfCvhvUtWW20vxJqtvqdihuZdU+yolpDsGSd2/cozwGPX0rnviNZ3tv451O4vLVYFvZmuoGRgySxsSVdWHBB68d81ytW9M1G40nUre/tSomgfcAwyreoI7gjII7gmt3W/F8d5p0mlaJpMGi6ZNJ5s8MEjO87ZyA7tyVU52rwB7nmpfD2tWOo6cvhfxJKV05nLWV91bT5T394mONy/iORzz+saTeaFq1zpl/H5d1bvtdQcj1BB7gggg9wRVKiiiv/Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F1FC0>\" />    </td><td style=\"text-align: right;\">                              9</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tXTvDmqarbG5toYktw4jE1zcR28bMf4Q0jKGPsCTVO/sLvS7+exvoHguoHKSxOMFWHaq1Fa/h+zn1zX9J0os8kT3CxhGchUQtlz/ALIxkkj60viu/GqeLNVvFcPHJdP5bAY/dg4T/wAdArHorpvB6zWh1bXIsA6bZOULIWBkl/dAcd8O7f8AAT6VzNFFXrTWNQsdMvtOtrp4rS/CC6iUDEoQkrk9eCT0qjRX/9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F24A0>\" />                                                                                                                    </td><td style=\"text-align: right;\">                              9</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+nwwy3EyQwxvLK5wqIpZmPoAOtdO/w48WRadNfTaT5MUMDXMqTXESSpGDgsYmYOBx6c9q5WivTrm/g+HdpocdhpjSLqVkl1daoshjmuFcZaKGTafKC9CVBJ46VzOveNrrVrKTTrGxttK0yRlaS3tgS05HQyyNlnI9zj2rl6nsrO41G9gsrSIy3M7iOKNerMTgCu/+Hj32uRS+HdXtUufC0G+W6muCU/s7jmSOT+BuPunIY547157OsaXEiwuXiDkI5GNwzwcVHTo5HhlSWJ2SRCGVlOCpHQg1t6x4z8Ra/Zraapqs9xbqwbyzhQzAYBbAG447nJrCor//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F2B60>\" />            </td><td style=\"text-align: right;\">                              8</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               6</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+nRxvNIscaM8jkKqqMliegAr0bTfg5qn9npqHiXVdO8N20gzGL+QCVh/uZGPoSD7Vwus2MGmaxdWVtfwahDC+1bqDOyQeoz/n0yOao17p4J8ISeCPAn/CeSaNPq+uTxh9OtY4i626MOJWA56c57DA4ySPH9f8Qar4l1aXUdXu5Li5c9W4CD+6o6AD0FZdFfVElxqFzr2leLU8XQ6b4Ihs4pDCJdvmFRyhTHckA9TxgDpXzn4x1a013xjq2qWEHk2t1ctJGhGDg9yOxPX8aw6KKKK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F2C80>\" />                                                                </td><td style=\"text-align: right;\">                              5</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+rFhZy6hqNtZQRtJNcSrEiL1YscACtvx7YaTpXjnVtP0NXWwtZvJRXYsQygB+TyfmDVzlFes/DLwVrVjZ3fjWTSLmU2luTpVv5JZrid/lRwvXYu7dnGO/Y1ifEz4fXXgu7sWxe3ST2ySXd48ZMX2li25VfGO2cHmuBre8Gf2Ivi/TX8RzCLSY5fMuCY2cMFBIUhQSQSADx0NehzfGSK5+JC63LFcro2nW8sem2MfAL7SFZ1BA5P1xxjpXA+JPHfiTxZJJ/a2qzywM+8WytthXnIAQccds5PvXOUUUUV//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F3220>\" />                                                </td><td style=\"text-align: right;\">                              2</td></tr>\n",
-       "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APAFVnYKoJYnAAHJNeoad8F7mHT4L7xd4i0zwzFcKWhiu3DTNjkgqWUZxjgEkZ5APFch408Jy+D9eOnm7jvbaSNZra8iXCTxn+Ickdcjgnp1rna2vCOoWGleL9Jv9Uh86xt7lJJk27vlB6474649qXWrzVfFXie7ne5uNYu5ZWCSxxsTIoPG1MZVcdFxxmur+JSHSPDXgrwxN5n2zT9Pe5uFkBDRvcMH8s+m3bjFec0V9WprmhfDDwRbX9rLp7aVNYRCxjhgK3V/PtyXdt2Mc5PHGTz0B8W8U+NvD3jrS/t2t6Zc2PiiIOon01FNvcjA2eYHbcu3AHBbv6gDzuiiiiv/2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F37F0>\" />    </td><td style=\"text-align: right;\">                              8</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n",
-       "    <small>(Showing first 10 rows)</small>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| image                |   label | image_2d             | pil_image        |   model_classification |\n",
-       "| List[Int64]          |   Int64 | Python               | Python           |                  Int64 |\n",
-       "+======================+=========+======================+==================+========================+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |                      7 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F00D0>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       3 | [[  0   0   0   0    | <PIL.Image.Image |                      2 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F0FA0>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |                      8 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F1180>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |                      8 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F1A80>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |                      9 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F1FC0>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       7 | [[  0   0   0   0    | <PIL.Image.Image |                      9 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F24A0>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       5 | [[  0   0   0   0    | <PIL.Image.Image |                      8 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F2B60>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       6 | [[  0   0   0   0    | <PIL.Image.Image |                      5 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F2C80>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |                      2 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F3220>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |                      8 |\n",
-       "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
-       "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
-       "|                      |         |                      | 0x1509F37F0>     |                        |\n",
-       "+----------------------+---------+----------------------+------------------+------------------------+\n",
-       "(Showing first 10 rows)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "classified_images_df.where(col(\"label\") != col(\"model_classification\")).show(10)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bb7ca72b-0743-451d-a3bf-e492a73ad7d6",
-   "metadata": {},
-   "source": [
-    "Some of these look hard indeed, even for a human!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5482e99e-cf3a-4d54-93e3-6e468db03eef",
-   "metadata": {},
-   "source": [
-    "## Analytics\n",
-    "\n",
-    "We just managed to run our model, but how well did it actually do? Dataframes expose a powerful set of operations in Groupbys/Aggregations to help us report on aggregates of our data.\n",
-    "\n",
-    "Let's group our data by the true labels and calculate how many mistakes our model made per label."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "8b60eef9-eeab-435e-9f5d-c775af9afe3f",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "    <table class=\"dataframe\">\n",
-       "<thead>\n",
-       "<tr><th style=\"text-align: right;\">  label<br>Int64</th><th style=\"text-align: right;\">  num_rows<br>UInt64</th><th style=\"text-align: right;\">  correct<br>Int64</th><th style=\"text-align: right;\">  wrong<br>Int64</th></tr>\n",
-       "</thead>\n",
-       "<tbody>\n",
-       "<tr><td style=\"text-align: right;\">               0</td><td style=\"text-align: right;\">                 980</td><td style=\"text-align: right;\">               957</td><td style=\"text-align: right;\">              23</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">               1</td><td style=\"text-align: right;\">                1135</td><td style=\"text-align: right;\">              1123</td><td style=\"text-align: right;\">              12</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">               2</td><td style=\"text-align: right;\">                1032</td><td style=\"text-align: right;\">               996</td><td style=\"text-align: right;\">              36</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">               3</td><td style=\"text-align: right;\">                1010</td><td style=\"text-align: right;\">               965</td><td style=\"text-align: right;\">              45</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">               4</td><td style=\"text-align: right;\">                 982</td><td style=\"text-align: right;\">               951</td><td style=\"text-align: right;\">              31</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">               5</td><td style=\"text-align: right;\">                 892</td><td style=\"text-align: right;\">               830</td><td style=\"text-align: right;\">              62</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">               6</td><td style=\"text-align: right;\">                 958</td><td style=\"text-align: right;\">               925</td><td style=\"text-align: right;\">              33</td></tr>\n",
-       "<tr><td style=\"text-align: right;\">               7</td><td style=\"text-align: right;\">                1028</td><td style=\"text-align: right;\">               971</td><td style=\"text-align: right;\">              57</td></tr>\n",
-       "</tbody>\n",
-       "</table>\n",
-       "    <small>(Showing first 8 rows)</small>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "+---------+------------+-----------+---------+\n",
-       "|   label |   num_rows |   correct |   wrong |\n",
-       "|   Int64 |     UInt64 |     Int64 |   Int64 |\n",
-       "+=========+============+===========+=========+\n",
-       "|       0 |        980 |       957 |      23 |\n",
-       "+---------+------------+-----------+---------+\n",
-       "|       1 |       1135 |      1123 |      12 |\n",
-       "+---------+------------+-----------+---------+\n",
-       "|       2 |       1032 |       996 |      36 |\n",
-       "+---------+------------+-----------+---------+\n",
-       "|       3 |       1010 |       965 |      45 |\n",
-       "+---------+------------+-----------+---------+\n",
-       "|       4 |        982 |       951 |      31 |\n",
-       "+---------+------------+-----------+---------+\n",
-       "|       5 |        892 |       830 |      62 |\n",
-       "+---------+------------+-----------+---------+\n",
-       "|       6 |        958 |       925 |      33 |\n",
-       "+---------+------------+-----------+---------+\n",
-       "|       7 |       1028 |       971 |      57 |\n",
-       "+---------+------------+-----------+---------+\n",
-       "(Showing first 8 rows)"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "analysis_df = classified_images_df \\\n",
-    "    .with_column(\"correct\", (col(\"model_classification\") == col(\"label\")).cast(DataType.int64())) \\\n",
-    "    .with_column(\"wrong\", (col(\"model_classification\") != col(\"label\")).cast(DataType.int64())) \\\n",
-    "    .groupby(col(\"label\")) \\\n",
-    "    .agg([\n",
-    "        (col(\"label\").alias(\"num_rows\"), \"count\"),\n",
-    "        (col(\"correct\"), \"sum\"),\n",
-    "        (col(\"wrong\"), \"sum\"),\n",
-    "    ]) \\\n",
-    "    .sort(col(\"label\"))\n",
-    "\n",
-    "analysis_df.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "05f7df20-6dbc-4115-9acf-8d863cac93af",
-   "metadata": {},
-   "source": [
-    "Pretty impressive, given that the model only actually trained for one epoch!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4acf0191-8bb2-4c50-9d19-7a6bc97840d2",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.9"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "e5d77f7bd5a748e4f6412a25f9708ab7af36936de941fc795d1a6b75eb2da082"
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "d1b56860-db41-4829-b395-176e11987cdc",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "!pip install getdaft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
+                "!pip install Pillow torch torchvision"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "c571e01d",
+            "metadata": {},
+            "source": [
+                "```{hint}\n",
+                "✨✨✨ **Run this notebook on Google Colab** ✨✨✨\n",
+                "\n",
+                "You can [run this notebook yourself with Google Colab](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/mnist.ipynb)!\n",
+                "```"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "9b14abf5-a183-4bfb-9b15-a9a54b744fce",
+            "metadata": {},
+            "source": [
+                "# MNIST Daft Tutorial\n",
+                "\n",
+                "The MNIST Dataset is a \"large database of handwritten digits that is commonly used for training various image processing systems\"."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "252b5128-99c2-49dd-b624-6e4b21275959",
+            "metadata": {},
+            "source": [
+                "## Loading Data\n",
+                "\n",
+                "This is a JSON file containing all the data for the MNIST test set. Let's load it up into a Daft Dataframe!"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "id": "fc63a3ad-0e0a-4ab3-9cc0-cbec8bdd0632",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "name": "stderr",
+                    "output_type": "stream",
+                    "text": [
+                        "2023-04-21 11:44:02.554 | INFO     | daft.context:runner:88 - Using PyRunner\n"
+                    ]
+                }
+            ],
+            "source": [
+                "import daft\n",
+                "from daft import col, udf, DataType\n",
+                "\n",
+                "URL = \"https://github.com/Eventual-Inc/mnist-json/raw/master/mnist_handwritten_test.json.gz\"\n",
+                "images_df = daft.read_json(URL)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "d52f6032-6619-4682-8305-2ed65bdc194c",
+            "metadata": {},
+            "source": [
+                "To peek at the dataset, simply have your notebook display the images_df that was just created."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "id": "73a71adf-3b2e-4ec5-a0d2-34ad8eec734c",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "    <table class=\"dataframe\">\n",
+                            "<tbody>\n",
+                            "<tr><td>image<br>List[Int64]</td><td>label<br>Int64</td></tr>\n",
+                            "</tbody>\n",
+                            "</table>\n",
+                            "    <small>(No data to display: Dataframe not materialized)</small>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "+---------------+---------+\n",
+                            "| image         | label   |\n",
+                            "| List[Int64]   | Int64   |\n",
+                            "+===============+=========+\n",
+                            "+---------------+---------+\n",
+                            "(No data to display: Dataframe not materialized)"
+                        ]
+                    },
+                    "execution_count": 2,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "images_df"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 3,
+            "id": "4787caab-d7d1-4fd4-9a76-ffb08a404a31",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "    <table class=\"dataframe\">\n",
+                            "<thead>\n",
+                            "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th></tr>\n",
+                            "</thead>\n",
+                            "<tbody>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               0</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td></tr>\n",
+                            "</tbody>\n",
+                            "</table>\n",
+                            "    <small>(Showing first 10 rows)</small>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "+----------------------+---------+\n",
+                            "| image                |   label |\n",
+                            "| List[Int64]          |   Int64 |\n",
+                            "+======================+=========+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       7 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       2 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       1 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       0 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       1 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       9 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       5 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       9 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         |\n",
+                            "+----------------------+---------+\n",
+                            "(Showing first 10 rows)"
+                        ]
+                    },
+                    "execution_count": 3,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "images_df.show(10)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "426f1bbb-e1c0-4fd6-b84e-cbb1ab309ff9",
+            "metadata": {},
+            "source": [
+                "You just loaded your first DaFt Dataframe! It consists of two columns:\n",
+                "1. The \"image\" column is a Python column of type `list` - where it looks like each row contains a list of digits representing the pixels of each image\n",
+                "2. The \"label\" column is an Integer column, consisting of just the label of that image."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "9a7872e3-9860-4867-8a8c-61a69f69e334",
+            "metadata": {},
+            "source": [
+                "## Processing Columns with User-Defined Functions (UDF)\n",
+                "\n",
+                "It seems our JSON file has provided us with a one-dimensional array of pixels instead of two-dimensional images. We can easily modify data in this column by instructing Daft to run a method on every row in the column like so:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 4,
+            "id": "af857589-b28a-4ee0-91cd-dc7a01ff4c07",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "import numpy as np\n",
+                "\n",
+                "images_df = images_df.with_column(\n",
+                "    \"image_2d\",\n",
+                "    col(\"image\").apply(lambda l: np.array(l).reshape(28, 28), return_dtype=DataType.python()),\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 5,
+            "id": "d1212a7e-949a-4881-ba54-9d7e7eb31e6f",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "    <table class=\"dataframe\">\n",
+                            "<thead>\n",
+                            "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th><th>image_2d<br>Python                               </th></tr>\n",
+                            "</thead>\n",
+                            "<tbody>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               0</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td></tr>\n",
+                            "</tbody>\n",
+                            "</table>\n",
+                            "    <small>(Showing first 10 rows)</small>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "+----------------------+---------+----------------------+\n",
+                            "| image                |   label | image_2d             |\n",
+                            "| List[Int64]          |   Int64 | Python               |\n",
+                            "+======================+=========+======================+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       7 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       0 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       5 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... |\n",
+                            "+----------------------+---------+----------------------+\n",
+                            "(Showing first 10 rows)"
+                        ]
+                    },
+                    "execution_count": 5,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "images_df.show(10)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "cd0d2664-12d8-4964-85cd-a67f8fee1384",
+            "metadata": {},
+            "source": [
+                "Great, but we can do one better - let's convert these two-dimensional arrays into Images. Computers speak in pixels and arrays, but humans do much better with visual patterns!\n",
+                "\n",
+                "To do this, we can leverage the `.apply` expression method. Similar to the `.as_py` method, this allows us to run a single function on all rows of a given column, but provides us with more flexibility as it takes as input any arbitrary function."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 6,
+            "id": "e585303a-7c83-4a31-afbb-461c951481f7",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "from PIL import Image\n",
+                "\n",
+                "images_df = images_df.with_column(\"pil_image\", col(\"image_2d\").apply(lambda arr: Image.fromarray(arr.astype(np.uint8)), return_dtype=DataType.python()))"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 7,
+            "id": "59b655ed-13aa-4764-acd4-a00beb91ec2f",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "    <table class=\"dataframe\">\n",
+                            "<thead>\n",
+                            "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th><th>image_2d<br>Python                               </th><th>pil_image<br>Python                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 </th></tr>\n",
+                            "</thead>\n",
+                            "<tbody>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APA4Lea6nSC3hkmmc4SONSzMfQAdadc2dzZSmK7tpoJB/BKhU/kahoq1pupXuj6hDf6dcyW13CSY5YzhlyCDj8CRXXWvxe8b20SxtrH2lVOQbqCOU9OmWUn/APVXUfEfxBqCfDzSNJ16S2uNd1JxqEqpbohtIMYjQbQBlsEnv1HpXj9Fdx8OvDNlqNxe+IdeVh4e0VPPucLnznyNkQ/3j1/LjOa57xPr9z4n8R3usXQ2vcSZVB0jQcKo9gABWRRXSxeOdXt/A0nhGAW0WnSzGaZ1j/ey8g7SxOMZA6AHjrXNUV//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC36F50>\" />                                                    </td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APAY42lkWNBl2IVR6k17BB8L/BemalZaB4h8TXr+I7oKhtNNi3rDI3TcdpyB36HvwK8z8UaL/wAI74o1LRxOs4s52iEg/iAPGff196yaK9d+H1lbeCPCdz8SNZjWW5bdBpFtJw0jn5TIDn/eHToCe4ryvUb+51XUrnULyQyXNzK0srnuzHJqtRX0J4utvBHxCXSLez+INlo+m2dqqQ2EkQCIf7xLMoB24XB9Pc1wp8D+AdMc/wBrfEaCbazDy9Os2l3YHGHBIHPtj3riNfg0a31V00G8ubuw2qUkuYhG+ccgge9ZlFFFf//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37040>\" />                                                </td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+lALEAAkngAd62PFGgjw1rR0trrz5o4Ynn/d7PLkZAzR9TnbnGfboKxqK634a6PHrPjrT1uAhs7Mm9ut/TyovmOfrgD8awte1M614h1LVCGX7ZcyThWOSoZiQM+2cVn0V6J4RFvo/wu8X63NKi3F6qaVarxuYsQ0nvjaR+XevO6KKKKK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC36920>\" />                                                                                                                                                                                </td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               0</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+u6+Hnwx1Lx9cTlZmsLGGMn7W8JdWfOAijIz3yc8Y+lcdqFjPpt9NaXMbJJE5U7lIzg4yM9qrVJbwtcXMUKqzNI4QBRkkk44r6F8c/Em3+GdnD4I8KWyi5sYVWS4lXiEsA/TGHZg24nplu5zjC11T8SPgyfFupp5WtaK7RG4Cqi3SFl4J46AjA9QcferxOtDQr9NK8Q6ZqMiF0tLuKdlHUhXDEfpX0VqHgHwJ461y88a3niUy2Ny0P7uKdIY0KoqbXZgTzt6fKetcF8VfiLpOo6Ta+E/CStBpNsx+0MkflpKRjaqgdVzkkkcnB9z5FRRRRX//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC36FE0>\" />                            </td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tC60W7s9E0/Vpggtr95kgGTuPl7QxPGMZbA57Gohpl0dHOqhAbRZxbswYZDldwBHuAefY1Uq/oenDWNf07TDIIxd3McBc/w7mAz+tb3xG1NLvxZcadZxmHS9JJsLKDGAiIcM2PVm3MSeeea2PElpH4a+Enh/SWTN7rVwdXmc8FIwmyNfoQxP5151T4ZpLeeOeF2jljYOjqcFWByCK7GT4qeKJRvkk097njN02nQNMSO5YpyccV0Hx4u3uPFOipI/72PRoTNGDgRyFnJG3+E9OPTFeV0UVJPPNczvPcSvLM53PJIxZmPqSetR1//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37010>\" />                                        </td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+nIjSOqIpZmOAB1Jrb8V+EtT8GarFpuq+R9pkgSfEMm8KGzwfQgggj8sjBrCorvvg3oI1z4kaeZULW1jm8lO3IGz7uf8AgW2sTx54iPirxvqurhswzTFYOMful+VOO3ygE+5Nc5RXqvgG4Hh34TeM/EUIH22Yx6dC4bDRhupH/fYP/Aa8qooqVLidIJIEmkWGQgvGGIViOmR0OKior//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37070>\" />                                                                                                                                                </td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn8DJwOtbWveF9R8NxWB1PyYp7yHz1tRJmWJD08xf4SRyAefyNVtL0PUNZivpbOJWisYDcXEjuEWNB6knqTwB1JrOrc8HXGkWnjDS7jXU36XHOGuBgnjsSByQDg8eneu68W+F9I8QeIbrXm+I+iTR30jSjzN/moucBPLUEjCgAA4zjgVB8RYbPwLo1v4D0m6FxM7C71e52KGlfH7uPjkKvzHB/vCvMKK734O6JFrPxCtmnjEsOnxPfNDs3GUpjaoHruZT+Fc94ui1ZfE15PrcSw6jdSG4miDKTGXJO0gH5T7Hkd6w6Kmtru5spvOtbiWCXBXfE5VsHgjIqEkk5JyaK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC370A0>\" />            </td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tODw9q9zod1rUOnztplqVE11twiksFABPU5I6ZxmsyiivqLRLvU9Lm0Tw8ui2EngQ6RHJdX8ynyjuQu7MzYXlv4SP4sn28K+JegweHPH+qafaW8kFnvEturEEbGGflx/DkkD6c81yVFasniXWpfD8egyancNpUb70tS3yA/4c5x0rsdQuB48+G8V40gbXvDSeXcA8vcWZICv6koSAfQHPevOaKKuabqt9o9xJPYXDQSSwvBJgAh43GGUg8EEf0PUVTr/2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37130>\" />                                                                                            </td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tnw34W1nxbqJsNFszczqu9xvVQi5xkliBjmvRV/Z78QxRxPe6zo9qHzkNKxKnB/2QDzjoe9eWarp76TrF7p0kscr2lxJA0kRyrlGKkqfQ44rp/hh4Qi8aeMY7C53m0gha6nRDhnRSBtB7ZLAZ96k8Saj4ssfFl/fw6fqHh5yFiWC0RoRFCMbEyoAIwBz3PNcjeXF5cXDNfTTyzg4YzsWbPvnmq9XtI1nUtA1KPUNKvJbS7j+7JGcHHoR0I9jwa9/+FfxZvtfhv8AStf1ezj1bCtYz3MQVH4wVYKVyc4PUHk+lcJ8cvEeheIPE1l/Y8sNzNawGO6uoEwkjZyAD3xz69epry2iiiiv/9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC34970>\" /></td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+pIYJbiVYoInlkbgIilifwFSXlheadP5F9aT2s2M+XPGUb8iKr1f0S0s77XLG01C7FnZzTKk1wf8AlmpPLV9EXGh6zpyLpvwzTw7pljMqhdRa7WW5us4O4HDcdR39sVL47u08P/De9sPG2qW+p6jd2qx2dsi/OJlQKZA2ASu8CTJAwcjJzXzHRXtHwx0jTvBnhC6+JHiG3DupMelQswzI3IyB2JOQCegDHGOa8q8Qa9feJddu9W1CUvcXEhbGSQgzwq56ADgCsyiug1zxnq3iHQ9H0e9eIWekw+VAkSld3AAZueWwAM8fqa5+iv/Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FC37610>\" />                                        </td></tr>\n",
+                            "</tbody>\n",
+                            "</table>\n",
+                            "    <small>(Showing first 10 rows)</small>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| image                |   label | image_2d             | pil_image        |\n",
+                            "| List[Int64]          |   Int64 | Python               | Python           |\n",
+                            "+======================+=========+======================+==================+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       7 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC36F50>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC37040>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC36920>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       0 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC36FE0>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC37010>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC37070>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC370A0>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC37130>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       5 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC34970>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |\n",
+                            "|                      |         |                      | 0x10FC37610>     |\n",
+                            "+----------------------+---------+----------------------+------------------+\n",
+                            "(Showing first 10 rows)"
+                        ]
+                    },
+                    "execution_count": 7,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "images_df.show(10)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "e6b633f4-3d9d-4c25-9075-bc815d8e357f",
+            "metadata": {},
+            "source": [
+                "Amazing! This looks great and we can finally get some idea of what the dataset truly looks like."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "cd7e6774-9fb7-4827-a324-c116c8c812e1",
+            "metadata": {},
+            "source": [
+                "## Running a model with UDFs\n",
+                "\n",
+                "Next, let's try to run a deep learning model to classify each image. Models are expensive to initialize and load, so we want to do this as few times as possible, and share a model across multiple invocations.\n",
+                "\n",
+                "For the convenience of this quickstart tutorial, we pre-trained a model using a PyTorch-provided example script and saved the trained weights at https://github.com/Eventual-Inc/mnist-json/raw/master/mnist_cnn.pt.  We need to define the same deep learning model \"scaffold\" as the trained model that we want to load (this part is all PyTorch and is not specific at all to DaFt)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 8,
+            "id": "5ff43066-8a42-4773-974f-160ca4a9bc49",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "###\n",
+                "# Model was trained using a script provided in PyTorch Examples: https://github.com/pytorch/examples/blob/main/mnist/main.py\n",
+                "###\n",
+                "\n",
+                "from __future__ import print_function\n",
+                "import argparse\n",
+                "import torch\n",
+                "import torch.nn as nn\n",
+                "import torch.nn.functional as F\n",
+                "import torch.optim as optim\n",
+                "import torch.hub\n",
+                "from torchvision import datasets, transforms\n",
+                "from torch.optim.lr_scheduler import StepLR\n",
+                "\n",
+                "class Net(nn.Module):\n",
+                "    def __init__(self):\n",
+                "        super(Net, self).__init__()\n",
+                "        self.conv1 = nn.Conv2d(1, 32, 3, 1)\n",
+                "        self.conv2 = nn.Conv2d(32, 64, 3, 1)\n",
+                "        self.dropout1 = nn.Dropout(0.25)\n",
+                "        self.dropout2 = nn.Dropout(0.5)\n",
+                "        self.fc1 = nn.Linear(9216, 128)\n",
+                "        self.fc2 = nn.Linear(128, 10)\n",
+                "\n",
+                "    def forward(self, x):\n",
+                "        x = self.conv1(x)\n",
+                "        x = F.relu(x)\n",
+                "        x = self.conv2(x)\n",
+                "        x = F.relu(x)\n",
+                "        x = F.max_pool2d(x, 2)\n",
+                "        x = self.dropout1(x)\n",
+                "        x = torch.flatten(x, 1)\n",
+                "        x = self.fc1(x)\n",
+                "        x = F.relu(x)\n",
+                "        x = self.dropout2(x)\n",
+                "        x = self.fc2(x)\n",
+                "        output = F.log_softmax(x, dim=1)\n",
+                "        return output"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "266c1cf8-bf9a-4990-8182-97b072f15b57",
+            "metadata": {},
+            "source": [
+                "Now comes the fun part - we can define a UDF using the `@udf` decorator. Notice that for a batch of data we only initialize our model once!"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 9,
+            "id": "fda097ea-4946-483c-bcc0-5271e0b033c3",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "@udf(return_dtype=DataType.int64())\n",
+                "class ClassifyImages:\n",
+                "    \n",
+                "    def __init__(self):\n",
+                "        # Perform expensive initializations - create the model, download model weights and load up the model with weights\n",
+                "        self.model = Net()\n",
+                "        state_dict = torch.hub.load_state_dict_from_url(\"https://github.com/Eventual-Inc/mnist-json/raw/master/mnist_cnn.pt\")\n",
+                "        self.model.load_state_dict(state_dict)\n",
+                "    \n",
+                "    def __call__(self, images_2d_col):\n",
+                "        images_arr = np.array(images_2d_col.to_pylist())\n",
+                "        normalized_image_2d = images_arr / 255\n",
+                "        normalized_image_2d = normalized_image_2d[:, np.newaxis, :, :]\n",
+                "        classifications = self.model(torch.from_numpy(normalized_image_2d).float())\n",
+                "        return classifications.detach().numpy().argmax(axis=1)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "3605d3a6-f9ce-4e81-9e0f-5190f981bbd4",
+            "metadata": {},
+            "source": [
+                "Using this UDF is really easy, we simply run it on the columns that we want to process:"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 10,
+            "id": "4f9fd9f8-a231-44fb-a519-0288f670a34a",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "    <table class=\"dataframe\">\n",
+                            "<thead>\n",
+                            "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th><th>image_2d<br>Python                               </th><th>pil_image<br>Python                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 </th><th style=\"text-align: right;\">  model_classification<br>Int64</th></tr>\n",
+                            "</thead>\n",
+                            "<tbody>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APA4Lea6nSC3hkmmc4SONSzMfQAdadc2dzZSmK7tpoJB/BKhU/kahoq1pupXuj6hDf6dcyW13CSY5YzhlyCDj8CRXXWvxe8b20SxtrH2lVOQbqCOU9OmWUn/APVXUfEfxBqCfDzSNJ16S2uNd1JxqEqpbohtIMYjQbQBlsEnv1HpXj9Fdx8OvDNlqNxe+IdeVh4e0VPPucLnznyNkQ/3j1/LjOa57xPr9z4n8R3usXQ2vcSZVB0jQcKo9gABWRRXSxeOdXt/A0nhGAW0WnSzGaZ1j/ey8g7SxOMZA6AHjrXNUV//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCA800>\" />                                                    </td><td style=\"text-align: right;\">                              7</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APAY42lkWNBl2IVR6k17BB8L/BemalZaB4h8TXr+I7oKhtNNi3rDI3TcdpyB36HvwK8z8UaL/wAI74o1LRxOs4s52iEg/iAPGff196yaK9d+H1lbeCPCdz8SNZjWW5bdBpFtJw0jn5TIDn/eHToCe4ryvUb+51XUrnULyQyXNzK0srnuzHJqtRX0J4utvBHxCXSLez+INlo+m2dqqQ2EkQCIf7xLMoB24XB9Pc1wp8D+AdMc/wBrfEaCbazDy9Os2l3YHGHBIHPtj3riNfg0a31V00G8ubuw2qUkuYhG+ccgge9ZlFFFf//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCBFD0>\" />                                                </td><td style=\"text-align: right;\">                              2</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+lALEAAkngAd62PFGgjw1rR0trrz5o4Ynn/d7PLkZAzR9TnbnGfboKxqK634a6PHrPjrT1uAhs7Mm9ut/TyovmOfrgD8awte1M614h1LVCGX7ZcyThWOSoZiQM+2cVn0V6J4RFvo/wu8X63NKi3F6qaVarxuYsQ0nvjaR+XevO6KKKKK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCC9A50>\" />                                                                                                                                                                                </td><td style=\"text-align: right;\">                              1</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               0</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+u6+Hnwx1Lx9cTlZmsLGGMn7W8JdWfOAijIz3yc8Y+lcdqFjPpt9NaXMbJJE5U7lIzg4yM9qrVJbwtcXMUKqzNI4QBRkkk44r6F8c/Em3+GdnD4I8KWyi5sYVWS4lXiEsA/TGHZg24nplu5zjC11T8SPgyfFupp5WtaK7RG4Cqi3SFl4J46AjA9QcferxOtDQr9NK8Q6ZqMiF0tLuKdlHUhXDEfpX0VqHgHwJ461y88a3niUy2Ny0P7uKdIY0KoqbXZgTzt6fKetcF8VfiLpOo6Ta+E/CStBpNsx+0MkflpKRjaqgdVzkkkcnB9z5FRRRRX//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCC99C0>\" />                            </td><td style=\"text-align: right;\">                              0</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tC60W7s9E0/Vpggtr95kgGTuPl7QxPGMZbA57Gohpl0dHOqhAbRZxbswYZDldwBHuAefY1Uq/oenDWNf07TDIIxd3McBc/w7mAz+tb3xG1NLvxZcadZxmHS9JJsLKDGAiIcM2PVm3MSeeea2PElpH4a+Enh/SWTN7rVwdXmc8FIwmyNfoQxP5151T4ZpLeeOeF2jljYOjqcFWByCK7GT4qeKJRvkk097njN02nQNMSO5YpyccV0Hx4u3uPFOipI/72PRoTNGDgRyFnJG3+E9OPTFeV0UVJPPNczvPcSvLM53PJIxZmPqSetR1//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCAA10>\" />                                        </td><td style=\"text-align: right;\">                              4</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               1</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+nIjSOqIpZmOAB1Jrb8V+EtT8GarFpuq+R9pkgSfEMm8KGzwfQgggj8sjBrCorvvg3oI1z4kaeZULW1jm8lO3IGz7uf8AgW2sTx54iPirxvqurhswzTFYOMful+VOO3ygE+5Nc5RXqvgG4Hh34TeM/EUIH22Yx6dC4bDRhupH/fYP/Aa8qooqVLidIJIEmkWGQgvGGIViOmR0OKior//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCAC80>\" />                                                                                                                                                </td><td style=\"text-align: right;\">                              1</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn8DJwOtbWveF9R8NxWB1PyYp7yHz1tRJmWJD08xf4SRyAefyNVtL0PUNZivpbOJWisYDcXEjuEWNB6knqTwB1JrOrc8HXGkWnjDS7jXU36XHOGuBgnjsSByQDg8eneu68W+F9I8QeIbrXm+I+iTR30jSjzN/moucBPLUEjCgAA4zjgVB8RYbPwLo1v4D0m6FxM7C71e52KGlfH7uPjkKvzHB/vCvMKK734O6JFrPxCtmnjEsOnxPfNDs3GUpjaoHruZT+Fc94ui1ZfE15PrcSw6jdSG4miDKTGXJO0gH5T7Hkd6w6Kmtru5spvOtbiWCXBXfE5VsHgjIqEkk5JyaK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCACB0>\" />            </td><td style=\"text-align: right;\">                              4</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tODw9q9zod1rUOnztplqVE11twiksFABPU5I6ZxmsyiivqLRLvU9Lm0Tw8ui2EngQ6RHJdX8ynyjuQu7MzYXlv4SP4sn28K+JegweHPH+qafaW8kFnvEturEEbGGflx/DkkD6c81yVFasniXWpfD8egyancNpUb70tS3yA/4c5x0rsdQuB48+G8V40gbXvDSeXcA8vcWZICv6koSAfQHPevOaKKuabqt9o9xJPYXDQSSwvBJgAh43GGUg8EEf0PUVTr/2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCA9E0>\" />                                                                                            </td><td style=\"text-align: right;\">                              9</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tnw34W1nxbqJsNFszczqu9xvVQi5xkliBjmvRV/Z78QxRxPe6zo9qHzkNKxKnB/2QDzjoe9eWarp76TrF7p0kscr2lxJA0kRyrlGKkqfQ44rp/hh4Qi8aeMY7C53m0gha6nRDhnRSBtB7ZLAZ96k8Saj4ssfFl/fw6fqHh5yFiWC0RoRFCMbEyoAIwBz3PNcjeXF5cXDNfTTyzg4YzsWbPvnmq9XtI1nUtA1KPUNKvJbS7j+7JGcHHoR0I9jwa9/+FfxZvtfhv8AStf1ezj1bCtYz3MQVH4wVYKVyc4PUHk+lcJ8cvEeheIPE1l/Y8sNzNawGO6uoEwkjZyAD3xz69epry2iiiiv/9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCAF50>\" /></td><td style=\"text-align: right;\">                              6</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+pIYJbiVYoInlkbgIilifwFSXlheadP5F9aT2s2M+XPGUb8iKr1f0S0s77XLG01C7FnZzTKk1wf8AlmpPLV9EXGh6zpyLpvwzTw7pljMqhdRa7WW5us4O4HDcdR39sVL47u08P/De9sPG2qW+p6jd2qx2dsi/OJlQKZA2ASu8CTJAwcjJzXzHRXtHwx0jTvBnhC6+JHiG3DupMelQswzI3IyB2JOQCegDHGOa8q8Qa9feJddu9W1CUvcXEhbGSQgzwq56ADgCsyiug1zxnq3iHQ9H0e9eIWekw+VAkSld3AAZueWwAM8fqa5+iv/Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x10FCCAD40>\" />                                        </td><td style=\"text-align: right;\">                              9</td></tr>\n",
+                            "</tbody>\n",
+                            "</table>\n",
+                            "    <small>(Showing first 10 rows)</small>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| image                |   label | image_2d             | pil_image        |   model_classification |\n",
+                            "| List[Int64]          |   Int64 | Python               | Python           |                  Int64 |\n",
+                            "+======================+=========+======================+==================+========================+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       7 | [[  0   0   0   0    | <PIL.Image.Image |                      7 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCCA800>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |                      2 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCCBFD0>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    | <PIL.Image.Image |                      1 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCC9A50>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       0 | [[  0   0   0   0    | <PIL.Image.Image |                      0 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCC99C0>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |                      4 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCCAA10>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       1 | [[  0   0   0   0    | <PIL.Image.Image |                      1 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCCAC80>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |                      4 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCCACB0>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |                      9 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCCA9E0>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       5 | [[  0   0   0   0    | <PIL.Image.Image |                      6 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCCAF50>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |                      9 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x10FCCAD40>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "(Showing first 10 rows)"
+                        ]
+                    },
+                    "execution_count": 10,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "classified_images_df = images_df.with_column(\"model_classification\", ClassifyImages(col(\"image_2d\")))\n",
+                "\n",
+                "classified_images_df.show(10)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "2e6fb5fc-957d-414b-bfac-961ea64dad68",
+            "metadata": {},
+            "source": [
+                "Our model ran successfully, and produced a new classification column. These look pretty good - let's filter our Dataframe to show only rows that the model predicted wrongly."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 11,
+            "id": "69344d63-7db4-496f-a0b2-949dfd947e4f",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "    <table class=\"dataframe\">\n",
+                            "<thead>\n",
+                            "<tr><th>image<br>List[Int64]                                        </th><th style=\"text-align: right;\">  label<br>Int64</th><th>image_2d<br>Python                               </th><th>pil_image<br>Python                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         </th><th style=\"text-align: right;\">  model_classification<br>Int64</th></tr>\n",
+                            "</thead>\n",
+                            "<tbody>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+u90r4YTvo8eseJNasfDthKN0P2vLTyr2ZYhzg8988dMUal8PdNfw5f634X8V2+uQaaA17G1pJayRqxABUNnd3z06dzxXBVe0fUv7I1i01EWtvdG2kEghuF3RuR2YdxT9b1zUvEWqS6hqd1JcXEhPLsSFGchVB6KOwruGsn8A/Da/i1HfHrPiaONYbXjMNsrBi7g9C3Kgdq82rqfAPhCPxp4hOnT6pBp0KRGV5ZSMsNwG1QSMsd1enXEHwf8Ah3rlsVkvNa1CKYElZFmS3PTLYwhxyccnIrkPHOm+G5r+XxAfHH9uG83MIEi23AbsDxtVRnuF6YA9PN6KKKK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F00D0>\" />        </td><td style=\"text-align: right;\">                              7</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               3</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+u38DeC9I8Y6dqMMviCLTtaiIa2huMCKVMc5b1zgcdPQ545rXtA1Lwzq82l6tbNb3UXVTyGHZge4PrWbRXoGhfCHX/Eml2moaTf6PcRzqGaNbv95BntIu3g+wzVj4qanYPaeHvD8OqHV9Q0aCSC81DbgOSwwgPfbgjP8AXNeb1u+DdN0vV/F2nWWtX0VlpskmZ5pZBGoUAnG48DOMZ967fQtF8LeBteg1vWPGNndzWkwlt7TQmNxvI5wzkAAdvf1rz/xJqkeueJ9U1WGEwx3l1JOsbHJUMxIB/Osuiiiiv//Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F0FA0>\" />                                                </td><td style=\"text-align: right;\">                              2</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               9</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+trw74S17xZcSQ6Hpst48QBkKlVVc9MsxAH50/wAS+DPEHhB7dNd05rQ3ClosyI4YDrypOOo4NYVFe5/BrxBa6n4XuvAtvdXWk6tcSvPHf2sYJZPlJ5zkNgEZ6Yx36r8e9QsrHRtA8KR3sl9fWf72eaaTfKBtAG8+rZJ/AV4XU1raz313DaWsTzXEziOONBksxOABX0BqEWmfA74fmG3ZZfFuqxFPPXBMZxyRnoi9uOTjPt4Df393ql9Ne31xJcXUzbpJZGyzH3NV6mtLuewvYLy2k8u4t5FlifAO1lOQcHjqKu6/4i1bxPqjalrN493dsoXeyhQABgAKoAA+g96zKK//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F1180>\" /></td><td style=\"text-align: right;\">                              8</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+ug8LeFLjxLPcSNcJZaZZp5t7fyqSkCduB1Y9l6msa9it4b6eK1uDc26SMsU5jKeYoPDbTyMjnFQUV6H4s3eHvBXh/wAJWSyGXUIU1W/IQEzPIP3SDvhQD06k+tW7Dw9Z+BPBV1r3iW3P9t6nA9vpVg4w0asu1pnB6cMcAjjA7njzGivcPAfxA1XSPh/e69rN5FeQaViw0u2aJDI0hUEBnxuCAbenp7YryHXtf1PxLq0up6tdyXNzIerHhBkkKo7KMnAFZtFFFFf/2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F1A80>\" />                                                                            </td><td style=\"text-align: right;\">                              8</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tfSPC+ta9aXdzpVi92loAZliZS4B7hM7m/AGskgqSCCCOCDSVc0nS7vW9VttNsIjLc3D7EXOPqSewAySewFd/wCFfCvhvUtWW20vxJqtvqdihuZdU+yolpDsGSd2/cozwGPX0rnviNZ3tv451O4vLVYFvZmuoGRgySxsSVdWHBB68d81ytW9M1G40nUre/tSomgfcAwyreoI7gjII7gmt3W/F8d5p0mlaJpMGi6ZNJ5s8MEjO87ZyA7tyVU52rwB7nmpfD2tWOo6cvhfxJKV05nLWV91bT5T394mONy/iORzz+saTeaFq1zpl/H5d1bvtdQcj1BB7gggg9wRVKiiiv/Z\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F1FC0>\" />    </td><td style=\"text-align: right;\">                              9</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               7</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+tXTvDmqarbG5toYktw4jE1zcR28bMf4Q0jKGPsCTVO/sLvS7+exvoHguoHKSxOMFWHaq1Fa/h+zn1zX9J0os8kT3CxhGchUQtlz/ALIxkkj60viu/GqeLNVvFcPHJdP5bAY/dg4T/wAdArHorpvB6zWh1bXIsA6bZOULIWBkl/dAcd8O7f8AAT6VzNFFXrTWNQsdMvtOtrp4rS/CC6iUDEoQkrk9eCT0qjRX/9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F24A0>\" />                                                                                                                    </td><td style=\"text-align: right;\">                              9</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               5</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+nwwy3EyQwxvLK5wqIpZmPoAOtdO/w48WRadNfTaT5MUMDXMqTXESSpGDgsYmYOBx6c9q5WivTrm/g+HdpocdhpjSLqVkl1daoshjmuFcZaKGTafKC9CVBJ46VzOveNrrVrKTTrGxttK0yRlaS3tgS05HQyyNlnI9zj2rl6nsrO41G9gsrSIy3M7iOKNerMTgCu/+Hj32uRS+HdXtUufC0G+W6muCU/s7jmSOT+BuPunIY547157OsaXEiwuXiDkI5GNwzwcVHTo5HhlSWJ2SRCGVlOCpHQg1t6x4z8Ra/Zraapqs9xbqwbyzhQzAYBbAG447nJrCor//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F2B60>\" />            </td><td style=\"text-align: right;\">                              8</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               6</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+nRxvNIscaM8jkKqqMliegAr0bTfg5qn9npqHiXVdO8N20gzGL+QCVh/uZGPoSD7Vwus2MGmaxdWVtfwahDC+1bqDOyQeoz/n0yOao17p4J8ISeCPAn/CeSaNPq+uTxh9OtY4i626MOJWA56c57DA4ySPH9f8Qar4l1aXUdXu5Li5c9W4CD+6o6AD0FZdFfVElxqFzr2leLU8XQ6b4Ihs4pDCJdvmFRyhTHckA9TxgDpXzn4x1a013xjq2qWEHk2t1ctJGhGDg9yOxPX8aw6KKKK//9k=\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F2C80>\" />                                                                </td><td style=\"text-align: right;\">                              5</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               4</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APn+rFhZy6hqNtZQRtJNcSrEiL1YscACtvx7YaTpXjnVtP0NXWwtZvJRXYsQygB+TyfmDVzlFes/DLwVrVjZ3fjWTSLmU2luTpVv5JZrid/lRwvXYu7dnGO/Y1ifEz4fXXgu7sWxe3ST2ySXd48ZMX2li25VfGO2cHmuBre8Gf2Ivi/TX8RzCLSY5fMuCY2cMFBIUhQSQSADx0NehzfGSK5+JC63LFcro2nW8sem2MfAL7SFZ1BA5P1xxjpXA+JPHfiTxZJJ/a2qzywM+8WytthXnIAQccds5PvXOUUUUV//2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F3220>\" />                                                </td><td style=\"text-align: right;\">                              2</td></tr>\n",
+                            "<tr><td>[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,...</td><td style=\"text-align: right;\">               2</td><td>&ltnp.ndarray<br>shape=(28, 28)<br>dtype=int64&gt</td><td><img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAAcABwBAREA/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/9oACAEBAAA/APAFVnYKoJYnAAHJNeoad8F7mHT4L7xd4i0zwzFcKWhiu3DTNjkgqWUZxjgEkZ5APFch408Jy+D9eOnm7jvbaSNZra8iXCTxn+Ickdcjgnp1rna2vCOoWGleL9Jv9Uh86xt7lJJk27vlB6474649qXWrzVfFXie7ne5uNYu5ZWCSxxsTIoPG1MZVcdFxxmur+JSHSPDXgrwxN5n2zT9Pe5uFkBDRvcMH8s+m3bjFec0V9WprmhfDDwRbX9rLp7aVNYRCxjhgK3V/PtyXdt2Mc5PHGTz0B8W8U+NvD3jrS/t2t6Zc2PiiIOon01FNvcjA2eYHbcu3AHBbv6gDzuiiiiv/2Q==\" alt=\"<PIL.Image.Image image mode=L size=28x28 at 0x1509F37F0>\" />    </td><td style=\"text-align: right;\">                              8</td></tr>\n",
+                            "</tbody>\n",
+                            "</table>\n",
+                            "    <small>(Showing first 10 rows)</small>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| image                |   label | image_2d             | pil_image        |   model_classification |\n",
+                            "| List[Int64]          |   Int64 | Python               | Python           |                  Int64 |\n",
+                            "+======================+=========+======================+==================+========================+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |                      7 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F00D0>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       3 | [[  0   0   0   0    | <PIL.Image.Image |                      2 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F0FA0>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       9 | [[  0   0   0   0    | <PIL.Image.Image |                      8 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F1180>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |                      8 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F1A80>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |                      9 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F1FC0>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       7 | [[  0   0   0   0    | <PIL.Image.Image |                      9 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F24A0>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       5 | [[  0   0   0   0    | <PIL.Image.Image |                      8 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F2B60>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       6 | [[  0   0   0   0    | <PIL.Image.Image |                      5 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F2C80>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       4 | [[  0   0   0   0    | <PIL.Image.Image |                      2 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F3220>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "| [0, 0, 0, 0, 0, 0,   |       2 | [[  0   0   0   0    | <PIL.Image.Image |                      8 |\n",
+                            "| 0, 0, 0, 0, 0, 0, 0, |         | 0   0   0   0   0    | image mode=L     |                        |\n",
+                            "| 0, 0, 0, 0, 0, 0,... |         | 0   0   0   0   0... | size=28x28 at    |                        |\n",
+                            "|                      |         |                      | 0x1509F37F0>     |                        |\n",
+                            "+----------------------+---------+----------------------+------------------+------------------------+\n",
+                            "(Showing first 10 rows)"
+                        ]
+                    },
+                    "execution_count": 11,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "classified_images_df.where(col(\"label\") != col(\"model_classification\")).show(10)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "bb7ca72b-0743-451d-a3bf-e492a73ad7d6",
+            "metadata": {},
+            "source": [
+                "Some of these look hard indeed, even for a human!"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "5482e99e-cf3a-4d54-93e3-6e468db03eef",
+            "metadata": {},
+            "source": [
+                "## Analytics\n",
+                "\n",
+                "We just managed to run our model, but how well did it actually do? Dataframes expose a powerful set of operations in Groupbys/Aggregations to help us report on aggregates of our data.\n",
+                "\n",
+                "Let's group our data by the true labels and calculate how many mistakes our model made per label."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 12,
+            "id": "8b60eef9-eeab-435e-9f5d-c775af9afe3f",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [
+                {
+                    "data": {
+                        "text/html": [
+                            "<div>\n",
+                            "    <table class=\"dataframe\">\n",
+                            "<thead>\n",
+                            "<tr><th style=\"text-align: right;\">  label<br>Int64</th><th style=\"text-align: right;\">  num_rows<br>UInt64</th><th style=\"text-align: right;\">  correct<br>Int64</th><th style=\"text-align: right;\">  wrong<br>Int64</th></tr>\n",
+                            "</thead>\n",
+                            "<tbody>\n",
+                            "<tr><td style=\"text-align: right;\">               0</td><td style=\"text-align: right;\">                 980</td><td style=\"text-align: right;\">               957</td><td style=\"text-align: right;\">              23</td></tr>\n",
+                            "<tr><td style=\"text-align: right;\">               1</td><td style=\"text-align: right;\">                1135</td><td style=\"text-align: right;\">              1123</td><td style=\"text-align: right;\">              12</td></tr>\n",
+                            "<tr><td style=\"text-align: right;\">               2</td><td style=\"text-align: right;\">                1032</td><td style=\"text-align: right;\">               996</td><td style=\"text-align: right;\">              36</td></tr>\n",
+                            "<tr><td style=\"text-align: right;\">               3</td><td style=\"text-align: right;\">                1010</td><td style=\"text-align: right;\">               965</td><td style=\"text-align: right;\">              45</td></tr>\n",
+                            "<tr><td style=\"text-align: right;\">               4</td><td style=\"text-align: right;\">                 982</td><td style=\"text-align: right;\">               951</td><td style=\"text-align: right;\">              31</td></tr>\n",
+                            "<tr><td style=\"text-align: right;\">               5</td><td style=\"text-align: right;\">                 892</td><td style=\"text-align: right;\">               830</td><td style=\"text-align: right;\">              62</td></tr>\n",
+                            "<tr><td style=\"text-align: right;\">               6</td><td style=\"text-align: right;\">                 958</td><td style=\"text-align: right;\">               925</td><td style=\"text-align: right;\">              33</td></tr>\n",
+                            "<tr><td style=\"text-align: right;\">               7</td><td style=\"text-align: right;\">                1028</td><td style=\"text-align: right;\">               971</td><td style=\"text-align: right;\">              57</td></tr>\n",
+                            "</tbody>\n",
+                            "</table>\n",
+                            "    <small>(Showing first 8 rows)</small>\n",
+                            "</div>"
+                        ],
+                        "text/plain": [
+                            "+---------+------------+-----------+---------+\n",
+                            "|   label |   num_rows |   correct |   wrong |\n",
+                            "|   Int64 |     UInt64 |     Int64 |   Int64 |\n",
+                            "+=========+============+===========+=========+\n",
+                            "|       0 |        980 |       957 |      23 |\n",
+                            "+---------+------------+-----------+---------+\n",
+                            "|       1 |       1135 |      1123 |      12 |\n",
+                            "+---------+------------+-----------+---------+\n",
+                            "|       2 |       1032 |       996 |      36 |\n",
+                            "+---------+------------+-----------+---------+\n",
+                            "|       3 |       1010 |       965 |      45 |\n",
+                            "+---------+------------+-----------+---------+\n",
+                            "|       4 |        982 |       951 |      31 |\n",
+                            "+---------+------------+-----------+---------+\n",
+                            "|       5 |        892 |       830 |      62 |\n",
+                            "+---------+------------+-----------+---------+\n",
+                            "|       6 |        958 |       925 |      33 |\n",
+                            "+---------+------------+-----------+---------+\n",
+                            "|       7 |       1028 |       971 |      57 |\n",
+                            "+---------+------------+-----------+---------+\n",
+                            "(Showing first 8 rows)"
+                        ]
+                    },
+                    "execution_count": 12,
+                    "metadata": {},
+                    "output_type": "execute_result"
+                }
+            ],
+            "source": [
+                "analysis_df = classified_images_df \\\n",
+                "    .with_column(\"correct\", (col(\"model_classification\") == col(\"label\")).cast(DataType.int64())) \\\n",
+                "    .with_column(\"wrong\", (col(\"model_classification\") != col(\"label\")).cast(DataType.int64())) \\\n",
+                "    .groupby(col(\"label\")) \\\n",
+                "    .agg([\n",
+                "        (col(\"label\").alias(\"num_rows\"), \"count\"),\n",
+                "        (col(\"correct\"), \"sum\"),\n",
+                "        (col(\"wrong\"), \"sum\"),\n",
+                "    ]) \\\n",
+                "    .sort(col(\"label\"))\n",
+                "\n",
+                "analysis_df.show()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "05f7df20-6dbc-4115-9acf-8d863cac93af",
+            "metadata": {},
+            "source": [
+                "Pretty impressive, given that the model only actually trained for one epoch!"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "4acf0191-8bb2-4c50-9d19-7a6bc97840d2",
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.9"
+        },
+        "vscode": {
+            "interpreter": {
+                "hash": "e5d77f7bd5a748e4f6412a25f9708ab7af36936de941fc795d1a6b75eb2da082"
+            }
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -1,317 +1,317 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "019805d9-4e9f-4306-8f18-a565cb1e8845",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 1000
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "019805d9-4e9f-4306-8f18-a565cb1e8845",
+            "metadata": {
+                "colab": {
+                    "base_uri": "https://localhost:8080/",
+                    "height": 1000
+                },
+                "id": "019805d9-4e9f-4306-8f18-a565cb1e8845",
+                "outputId": "f48e4a66-21cd-4b93-e8cb-261ae8c8aec8"
+            },
+            "outputs": [],
+            "source": [
+                "!pip install getdaft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
+                "!pip install min-dalle torch Pillow"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "9536868c",
+            "metadata": {
+                "tags": [
+                    "parameters"
+                ]
+            },
+            "outputs": [],
+            "source": [
+                "CI = False"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "8ff9d08a",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "# Flip this flag if you want to see the performance of running on CPU vs GPU\n",
+                "USE_GPU = False if CI else True\n",
+                "\n",
+                "PARQUET_PATH = \"https://huggingface.co/datasets/ChristophSchuhmann/improved_aesthetics_6.5plus/resolve/main/data/train-00000-of-00001-6f24a7497df494ae.parquet\""
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "d5a31f06",
+            "metadata": {},
+            "source": [
+                "```{hint}\n",
+                "✨✨✨ **Run this notebook on Google Colab** ✨✨✨\n",
+                "\n",
+                "You can [run this notebook yourself with Google Colab](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/text_to_image/text_to_image_generation.ipynb)!\n",
+                "```"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "78db424a-96b5-46f3-bd32-484f5c6b92a3",
+            "metadata": {
+                "id": "78db424a-96b5-46f3-bd32-484f5c6b92a3"
+            },
+            "source": [
+                "# Generating Images from Text with DALL-E\n",
+                "\n",
+                "In this tutorial, we will be using the DALL-E model to generate images from text. We will explore how to use GPUs with Daft to accelerate computations.\n",
+                "\n",
+                "To run this tutorial:\n",
+                "\n",
+                "1. You will need access to a GPU. If you are on Google Colab, you may switch to a GPU runtime by going to the menu `Runtime -> Change runtime type -> Hardware accelerator -> GPU -> Save`.\n",
+                "\n",
+                "Let's get started!"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "4da65a96-e4fe-4795-92d0-a5e631b58e33",
+            "metadata": {
+                "id": "4da65a96-e4fe-4795-92d0-a5e631b58e33"
+            },
+            "source": [
+                "## Setting Up\n",
+                "\n",
+                "First, let's load a Parquet file into Daft. This particular file is hosted in HuggingFace at a https URL."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "806451f8-68af-462a-af7b-ff5480425a3a",
+            "metadata": {
+                "id": "806451f8-68af-462a-af7b-ff5480425a3a",
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "import daft\n",
+                "from daft import col, udf, DataType\n",
+                "daft.context.set_runner_py(use_thread_pool=False)\n",
+                "\n",
+                "parquet_df = daft.read_parquet(PARQUET_PATH)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "a1e20f90",
+            "metadata": {},
+            "source": [
+                "Let's go ahead and `.collect()` this DataFrame. This will download the Parquet file and materialize the data in memory so that all our subsequent operations will be cached!"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "e1e3b619-beaf-465e-83f2-5ab71638dcc1",
+            "metadata": {
+                "colab": {
+                    "base_uri": "https://localhost:8080/",
+                    "height": 544
+                },
+                "id": "e1e3b619-beaf-465e-83f2-5ab71638dcc1",
+                "outputId": "e52133d2-5694-49a0-e385-758cf5b1b203",
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "parquet_df.collect()"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "b257cd91-db90-4803-afd9-9fdf571cf755",
+            "metadata": {
+                "id": "b257cd91-db90-4803-afd9-9fdf571cf755",
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "parquet_df = parquet_df.select(parquet_df[\"URL\"], parquet_df[\"TEXT\"], parquet_df[\"AESTHETIC_SCORE\"])"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "f28047df-bf05-47df-b4d4-3507a8f7d2ac",
+            "metadata": {
+                "id": "f28047df-bf05-47df-b4d4-3507a8f7d2ac"
+            },
+            "source": [
+                "## Downloading Images\n",
+                "\n",
+                "Like many datasets, instead of storing the actual images in the dataset's files it looks like the Dataset authors have instead opted to store a URL to the image.\n",
+                "\n",
+                "Let's use Daft's builtin functionality to download the images and open them as PIL Images - all in just a few lines of code!"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "f1e5cd84-4526-4a91-9fd5-f4e78f35965d",
+            "metadata": {
+                "id": "f1e5cd84-4526-4a91-9fd5-f4e78f35965d",
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "import io\n",
+                "import PIL.Image\n",
+                "\n",
+                "# Filter for images with longer descriptions\n",
+                "parquet_df_with_long_strings = parquet_df.where(parquet_df[\"TEXT\"].str.length() > 50)\n",
+                "\n",
+                "# Download images\n",
+                "images_df = parquet_df_with_long_strings.with_column(\n",
+                "    \"image\",\n",
+                "    parquet_df[\"URL\"].url.download().apply(\n",
+                "        lambda data: PIL.Image.open(io.BytesIO(data)) if data is not None else None,\n",
+                "        return_dtype=DataType.python(),\n",
+                "    ),\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "c1361728-8b1a-4e6e-9632-ddd17cad948b",
+            "metadata": {
+                "colab": {
+                    "base_uri": "https://localhost:8080/",
+                    "height": 802
+                },
+                "id": "c1361728-8b1a-4e6e-9632-ddd17cad948b",
+                "outputId": "1c2ce3a4-63a1-4f77-ce2e-e3ecea2a3e1f",
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "%%time\n",
+                "\n",
+                "images_df.show(5)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "6e6f59ee",
+            "metadata": {},
+            "source": [
+                "Great! Now we have a pretty good idea of what our dataset looks like."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "gCTmONUl81Vw",
+            "metadata": {
+                "id": "gCTmONUl81Vw"
+            },
+            "source": [
+                "# Running the Mini DALL-E model on a GPU using Daft UDFs\n",
+                "\n",
+                "Let's now run the Mini DALL-E model over the `\"TEXT\"` column, and generate images for those texts!\n",
+                "\n",
+                "Using GPUs with Daft UDFs is simple. Just specify `num_gpus=N`, where `N` is the number of GPUs that your UDF is going to use."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "b500e7f5",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "import torch\n",
+                "from min_dalle import MinDalle\n",
+                "\n",
+                "from daft.resource_request import ResourceRequest\n",
+                "\n",
+                "\n",
+                "@udf(return_dtype=DataType.python())\n",
+                "class GenerateImageFromText:\n",
+                "    def __init__(self):\n",
+                "        self.model = MinDalle(\n",
+                "            models_root='./pretrained',\n",
+                "            dtype=torch.float32,\n",
+                "            # Tell the min-dalle library to load model on GPU or GPU\n",
+                "            device=\"cuda\" if USE_GPU else \"cpu\",\n",
+                "            is_mega=False, \n",
+                "            is_reusable=True\n",
+                "        )\n",
+                "        \n",
+                "    def __call__(self, text_col):\n",
+                "        return [\n",
+                "            self.model.generate_image(\n",
+                "                t,\n",
+                "                seed=-1,\n",
+                "                grid_size=1,\n",
+                "                is_seamless=False,\n",
+                "                temperature=1,\n",
+                "                top_k=256,\n",
+                "                supercondition_factor=32,\n",
+                "            ) for t in text_col.to_pylist()\n",
+                "        ]\n",
+                "\n",
+                "resource_request = ResourceRequest(num_gpus=1) if USE_GPU else ResourceRequest()\n",
+                "images_df.with_column(\n",
+                "    \"generated_image\",\n",
+                "    GenerateImageFromText(images_df[\"TEXT\"]),\n",
+                "    resource_request=resource_request,\n",
+                ").show(1)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "5764ae83-9100-47c7-95d3-4880d9f1fe7c",
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "accelerator": "GPU",
+        "colab": {
+            "provenance": []
+        },
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.9"
+        },
+        "vscode": {
+            "interpreter": {
+                "hash": "e5d77f7bd5a748e4f6412a25f9708ab7af36936de941fc795d1a6b75eb2da082"
+            }
+        }
     },
-    "id": "019805d9-4e9f-4306-8f18-a565cb1e8845",
-    "outputId": "f48e4a66-21cd-4b93-e8cb-261ae8c8aec8"
-   },
-   "outputs": [],
-   "source": [
-    "!pip install getdaft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
-    "!pip install min-dalle torch Pillow"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9536868c",
-   "metadata": {
-    "tags": [
-     "parameters"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "CI = False"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8ff9d08a",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Flip this flag if you want to see the performance of running on CPU vs GPU\n",
-    "USE_GPU = False if CI else True\n",
-    "\n",
-    "PARQUET_PATH = \"https://huggingface.co/datasets/ChristophSchuhmann/improved_aesthetics_6.5plus/resolve/main/data/train-00000-of-00001-6f24a7497df494ae.parquet\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d5a31f06",
-   "metadata": {},
-   "source": [
-    "```{hint}\n",
-    "✨✨✨ **Run this notebook on Google Colab** ✨✨✨\n",
-    "\n",
-    "You can [run this notebook yourself with Google Colab](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/text_to_image/text_to_image_generation.ipynb)!\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "78db424a-96b5-46f3-bd32-484f5c6b92a3",
-   "metadata": {
-    "id": "78db424a-96b5-46f3-bd32-484f5c6b92a3"
-   },
-   "source": [
-    "# Generating Images from Text with DALL-E\n",
-    "\n",
-    "In this tutorial, we will be using the DALL-E model to generate images from text. We will explore how to use GPUs with Daft to accelerate computations.\n",
-    "\n",
-    "To run this tutorial:\n",
-    "\n",
-    "1. You will need access to a GPU. If you are on Google Colab, you may switch to a GPU runtime by going to the menu `Runtime -> Change runtime type -> Hardware accelerator -> GPU -> Save`.\n",
-    "\n",
-    "Let's get started!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4da65a96-e4fe-4795-92d0-a5e631b58e33",
-   "metadata": {
-    "id": "4da65a96-e4fe-4795-92d0-a5e631b58e33"
-   },
-   "source": [
-    "## Setting Up\n",
-    "\n",
-    "First, let's load a Parquet file into Daft. This particular file is hosted in HuggingFace at a https URL."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "806451f8-68af-462a-af7b-ff5480425a3a",
-   "metadata": {
-    "id": "806451f8-68af-462a-af7b-ff5480425a3a",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import daft\n",
-    "from daft import DataFrame, col, udf, DataType\n",
-    "daft.context.set_runner_py(use_thread_pool=False)\n",
-    "\n",
-    "parquet_df = DataFrame.read_parquet(PARQUET_PATH)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a1e20f90",
-   "metadata": {},
-   "source": [
-    "Let's go ahead and `.collect()` this DataFrame. This will download the Parquet file and materialize the data in memory so that all our subsequent operations will be cached!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e1e3b619-beaf-465e-83f2-5ab71638dcc1",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 544
-    },
-    "id": "e1e3b619-beaf-465e-83f2-5ab71638dcc1",
-    "outputId": "e52133d2-5694-49a0-e385-758cf5b1b203",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "parquet_df.collect()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b257cd91-db90-4803-afd9-9fdf571cf755",
-   "metadata": {
-    "id": "b257cd91-db90-4803-afd9-9fdf571cf755",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "parquet_df = parquet_df.select(parquet_df[\"URL\"], parquet_df[\"TEXT\"], parquet_df[\"AESTHETIC_SCORE\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f28047df-bf05-47df-b4d4-3507a8f7d2ac",
-   "metadata": {
-    "id": "f28047df-bf05-47df-b4d4-3507a8f7d2ac"
-   },
-   "source": [
-    "## Downloading Images\n",
-    "\n",
-    "Like many datasets, instead of storing the actual images in the dataset's files it looks like the Dataset authors have instead opted to store a URL to the image.\n",
-    "\n",
-    "Let's use Daft's builtin functionality to download the images and open them as PIL Images - all in just a few lines of code!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f1e5cd84-4526-4a91-9fd5-f4e78f35965d",
-   "metadata": {
-    "id": "f1e5cd84-4526-4a91-9fd5-f4e78f35965d",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import io\n",
-    "import PIL.Image\n",
-    "\n",
-    "# Filter for images with longer descriptions\n",
-    "parquet_df_with_long_strings = parquet_df.where(parquet_df[\"TEXT\"].str.length() > 50)\n",
-    "\n",
-    "# Download images\n",
-    "images_df = parquet_df_with_long_strings.with_column(\n",
-    "    \"image\",\n",
-    "    parquet_df[\"URL\"].url.download().apply(\n",
-    "        lambda data: PIL.Image.open(io.BytesIO(data)) if data is not None else None,\n",
-    "        return_dtype=DataType.python(),\n",
-    "    ),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c1361728-8b1a-4e6e-9632-ddd17cad948b",
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 802
-    },
-    "id": "c1361728-8b1a-4e6e-9632-ddd17cad948b",
-    "outputId": "1c2ce3a4-63a1-4f77-ce2e-e3ecea2a3e1f",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "\n",
-    "images_df.show(5)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6e6f59ee",
-   "metadata": {},
-   "source": [
-    "Great! Now we have a pretty good idea of what our dataset looks like."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "gCTmONUl81Vw",
-   "metadata": {
-    "id": "gCTmONUl81Vw"
-   },
-   "source": [
-    "# Running the Mini DALL-E model on a GPU using Daft UDFs\n",
-    "\n",
-    "Let's now run the Mini DALL-E model over the `\"TEXT\"` column, and generate images for those texts!\n",
-    "\n",
-    "Using GPUs with Daft UDFs is simple. Just specify `num_gpus=N`, where `N` is the number of GPUs that your UDF is going to use."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b500e7f5",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import torch\n",
-    "from min_dalle import MinDalle\n",
-    "\n",
-    "from daft.resource_request import ResourceRequest\n",
-    "\n",
-    "\n",
-    "@udf(return_dtype=DataType.python())\n",
-    "class GenerateImageFromText:\n",
-    "    def __init__(self):\n",
-    "        self.model = MinDalle(\n",
-    "            models_root='./pretrained',\n",
-    "            dtype=torch.float32,\n",
-    "            # Tell the min-dalle library to load model on GPU or GPU\n",
-    "            device=\"cuda\" if USE_GPU else \"cpu\",\n",
-    "            is_mega=False, \n",
-    "            is_reusable=True\n",
-    "        )\n",
-    "        \n",
-    "    def __call__(self, text_col):\n",
-    "        return [\n",
-    "            self.model.generate_image(\n",
-    "                t,\n",
-    "                seed=-1,\n",
-    "                grid_size=1,\n",
-    "                is_seamless=False,\n",
-    "                temperature=1,\n",
-    "                top_k=256,\n",
-    "                supercondition_factor=32,\n",
-    "            ) for t in text_col.to_pylist()\n",
-    "        ]\n",
-    "\n",
-    "resource_request = ResourceRequest(num_gpus=1) if USE_GPU else ResourceRequest()\n",
-    "images_df.with_column(\n",
-    "    \"generated_image\",\n",
-    "    GenerateImageFromText(images_df[\"TEXT\"]),\n",
-    "    resource_request=resource_request,\n",
-    ").show(1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5764ae83-9100-47c7-95d3-4880d9f1fe7c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "accelerator": "GPU",
-  "colab": {
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.9"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "e5d77f7bd5a748e4f6412a25f9708ab7af36936de941fc795d1a6b75eb2da082"
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/tutorials/text_to_image/using_cloud_with_ray.ipynb
+++ b/tutorials/text_to_image/using_cloud_with_ray.ipynb
@@ -1,218 +1,218 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "1b8a5f16-3d51-4690-80b3-95c7899c5474",
-   "metadata": {},
-   "source": [
-    "# Using Ray for Scaling Up\n",
-    "\n",
-    "Daft's default PyRunner is great for experimentation on your laptop, but when it comes times to running much more computationally expensive jobs that need to take advantage of large scale parallelism, you can run Daft on a [Ray](https://www.ray.io/) cluster instead.\n",
-    "\n",
-    "## What is a Ray Cluster, and why do I need it?\n",
-    "\n",
-    "Ray is a framework that exposes a Python interface for running distributed computation over a cluster of machines. Daft is built to use Ray as a backend for running dataframe operations, allowing it to scale to huge amounts of data and computation.\n",
-    "\n",
-    "However even if you do not have a big cluster to use Ray, you can run Ray locally on your laptop (in which case it would spin up a Ray cluster of just a single machine: your laptop), and using Daft's Ray backend would allow Daft to fully utilize your machine's cores.\n",
-    "\n",
-    "## Let's get started!\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bbe8f7c1-ae08-49b9-96c7-4b16cf48f479",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pip install getdaft[ray] --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
-    "!pip install Pillow"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "28d1d421",
-   "metadata": {
-    "tags": [
-     "parameters"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "CI = False"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cb73a22b",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "USE_RAY = False if CI else True\n",
-    "NUM_ROWS_LIMIT = 16 if CI else 160\n",
-    "PARQUET_URL = \"https://huggingface.co/datasets/ChristophSchuhmann/improved_aesthetics_6.5plus/resolve/main/data/train-00000-of-00001-6f24a7497df494ae.parquet\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8a3ef6f2-550b-4668-9d41-0417e98e22f7",
-   "metadata": {},
-   "source": [
-    "By default, Daft uses the \"Python Runner\" which runs all processing in a single Python process.\n",
-    "\n",
-    "To activate the RayRunner, you can either:\n",
-    "\n",
-    "1. Use the `DAFT_RUNNER=ray` and optionally the `DAFT_RAY_ADDRESS` environment variables\n",
-    "2. Call `daft.context.set_runner_ray(...)` at the start of your program.\n",
-    "\n",
-    "We'll demonstrate option 2 here!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d73050cd",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import daft\n",
-    "\n",
-    "if USE_RAY:\n",
-    "    RAY_ADDRESS = None\n",
-    "    daft.context.set_runner_ray(\n",
-    "        # You may provide Daft with the address to an existing Ray cluster if you have one!\n",
-    "        # If this is not provided, Daft will default to spinning up a single-node Ray cluster consisting of just your current local machine\n",
-    "        address=RAY_ADDRESS,\n",
-    "    )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5bb090a9",
-   "metadata": {},
-   "source": [
-    "Let's try to download the images from our previous [Text-to-Image Generatation tutorial](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/text_to_image/text_to_image_generation.ipynb) with the RayRunner instead."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "448057cd-52f7-449d-9c1c-6d6368de9cb2",
-   "metadata": {},
-   "source": [
-    "We limit the dataset to 160 rows and repartition it into 8 partitions for demonstration purposes. This just means that our data will be divided into 8 approximately equal-sized \"chunks\"."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f2639220-6c8f-48e2-9d8b-8301de21b8f2",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from daft import DataFrame, col, udf\n",
-    "\n",
-    "parquet_df = DataFrame.read_parquet(PARQUET_URL).limit(NUM_ROWS_LIMIT).repartition(8)\n",
-    "parquet_df.collect()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a601555b-ab09-4c6a-87dd-77a761b351b3",
-   "metadata": {},
-   "source": [
-    "## Download data from URLs\n",
-    "\n",
-    "Now, let's try downloading the data from the URLs with `.url.download()`!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "01bf3fde-5a64-49e3-8f32-cbf180905efe",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "images_df = parquet_df.with_column(\"images\", col(\"URL\").url.download())\n",
-    "images_df.collect()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d1ece805-b991-4b75-a3c0-ca00354365f2",
-   "metadata": {},
-   "source": [
-    "On Google Colab, it should take approximately 10 seconds, vs about 20 seconds with the Py Runner!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c2278cc6-f3c6-44da-9f38-684e220a43e1",
-   "metadata": {},
-   "source": [
-    "With exactly the same code, we were able to achieve a 2x speedup in execution - what happened here?\n",
-    "\n",
-    "It turns out that our workload is [IO Bound](https://en.wikipedia.org/wiki/I/O_bound) because most of the time is spent waiting for data to be downloaded from the URL.\n",
-    "\n",
-    "By default, the `.url.download()` UDF requests `num_cpus=1`. Since our Google Colab machine has 2 CPUs, the RayRunner is able to run two of these UDFs in parallel, hence achieving a 2x increase in throughput!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8430f756-f641-4bfa-9425-8d72e200d726",
-   "metadata": {},
-   "source": [
-    "## Remote Ray Clusters\n",
-    "\n",
-    "We have seen that using the RayRunner even locally provides us with some speedup already. However, the real power of distributed computing is in allowing us to access thousands of CPUs and GPUs in the cloud, on a remote Ray cluster.\n",
-    "\n",
-    "For example, UDFs that request for a single GPU with can run in parallel across hundreds of GPUs on a remote Ray cluster, effortlessly scaling your workloads up to take full advantage of the available hardware.\n",
-    "\n",
-    "To run Daft on large clusters, check out [Eventual](https://www.eventualcomputing.com) where you have access to a fully managed platform for running Daft at scale."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6f159a45-dbf5-4e19-b2c6-0d15474b270c",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.9"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "e5d77f7bd5a748e4f6412a25f9708ab7af36936de941fc795d1a6b75eb2da082"
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "id": "1b8a5f16-3d51-4690-80b3-95c7899c5474",
+            "metadata": {},
+            "source": [
+                "# Using Ray for Scaling Up\n",
+                "\n",
+                "Daft's default PyRunner is great for experimentation on your laptop, but when it comes times to running much more computationally expensive jobs that need to take advantage of large scale parallelism, you can run Daft on a [Ray](https://www.ray.io/) cluster instead.\n",
+                "\n",
+                "## What is a Ray Cluster, and why do I need it?\n",
+                "\n",
+                "Ray is a framework that exposes a Python interface for running distributed computation over a cluster of machines. Daft is built to use Ray as a backend for running dataframe operations, allowing it to scale to huge amounts of data and computation.\n",
+                "\n",
+                "However even if you do not have a big cluster to use Ray, you can run Ray locally on your laptop (in which case it would spin up a Ray cluster of just a single machine: your laptop), and using Daft's Ray backend would allow Daft to fully utilize your machine's cores.\n",
+                "\n",
+                "## Let's get started!\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "bbe8f7c1-ae08-49b9-96c7-4b16cf48f479",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "!pip install getdaft[ray] --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
+                "!pip install Pillow"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "28d1d421",
+            "metadata": {
+                "tags": [
+                    "parameters"
+                ]
+            },
+            "outputs": [],
+            "source": [
+                "CI = False"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "cb73a22b",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "USE_RAY = False if CI else True\n",
+                "NUM_ROWS_LIMIT = 16 if CI else 160\n",
+                "PARQUET_URL = \"https://huggingface.co/datasets/ChristophSchuhmann/improved_aesthetics_6.5plus/resolve/main/data/train-00000-of-00001-6f24a7497df494ae.parquet\""
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "8a3ef6f2-550b-4668-9d41-0417e98e22f7",
+            "metadata": {},
+            "source": [
+                "By default, Daft uses the \"Python Runner\" which runs all processing in a single Python process.\n",
+                "\n",
+                "To activate the RayRunner, you can either:\n",
+                "\n",
+                "1. Use the `DAFT_RUNNER=ray` and optionally the `DAFT_RAY_ADDRESS` environment variables\n",
+                "2. Call `daft.context.set_runner_ray(...)` at the start of your program.\n",
+                "\n",
+                "We'll demonstrate option 2 here!"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "d73050cd",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "import daft\n",
+                "\n",
+                "if USE_RAY:\n",
+                "    RAY_ADDRESS = None\n",
+                "    daft.context.set_runner_ray(\n",
+                "        # You may provide Daft with the address to an existing Ray cluster if you have one!\n",
+                "        # If this is not provided, Daft will default to spinning up a single-node Ray cluster consisting of just your current local machine\n",
+                "        address=RAY_ADDRESS,\n",
+                "    )"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "5bb090a9",
+            "metadata": {},
+            "source": [
+                "Let's try to download the images from our previous [Text-to-Image Generatation tutorial](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/text_to_image/text_to_image_generation.ipynb) with the RayRunner instead."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "448057cd-52f7-449d-9c1c-6d6368de9cb2",
+            "metadata": {},
+            "source": [
+                "We limit the dataset to 160 rows and repartition it into 8 partitions for demonstration purposes. This just means that our data will be divided into 8 approximately equal-sized \"chunks\"."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "f2639220-6c8f-48e2-9d8b-8301de21b8f2",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "from daft import col, udf\n",
+                "\n",
+                "parquet_df = daft.read_parquet(PARQUET_URL).limit(NUM_ROWS_LIMIT).repartition(8)\n",
+                "parquet_df.collect()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "a601555b-ab09-4c6a-87dd-77a761b351b3",
+            "metadata": {},
+            "source": [
+                "## Download data from URLs\n",
+                "\n",
+                "Now, let's try downloading the data from the URLs with `.url.download()`!"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "01bf3fde-5a64-49e3-8f32-cbf180905efe",
+            "metadata": {
+                "tags": []
+            },
+            "outputs": [],
+            "source": [
+                "images_df = parquet_df.with_column(\"images\", col(\"URL\").url.download())\n",
+                "images_df.collect()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "d1ece805-b991-4b75-a3c0-ca00354365f2",
+            "metadata": {},
+            "source": [
+                "On Google Colab, it should take approximately 10 seconds, vs about 20 seconds with the Py Runner!"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "c2278cc6-f3c6-44da-9f38-684e220a43e1",
+            "metadata": {},
+            "source": [
+                "With exactly the same code, we were able to achieve a 2x speedup in execution - what happened here?\n",
+                "\n",
+                "It turns out that our workload is [IO Bound](https://en.wikipedia.org/wiki/I/O_bound) because most of the time is spent waiting for data to be downloaded from the URL.\n",
+                "\n",
+                "By default, the `.url.download()` UDF requests `num_cpus=1`. Since our Google Colab machine has 2 CPUs, the RayRunner is able to run two of these UDFs in parallel, hence achieving a 2x increase in throughput!"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "8430f756-f641-4bfa-9425-8d72e200d726",
+            "metadata": {},
+            "source": [
+                "## Remote Ray Clusters\n",
+                "\n",
+                "We have seen that using the RayRunner even locally provides us with some speedup already. However, the real power of distributed computing is in allowing us to access thousands of CPUs and GPUs in the cloud, on a remote Ray cluster.\n",
+                "\n",
+                "For example, UDFs that request for a single GPU with can run in parallel across hundreds of GPUs on a remote Ray cluster, effortlessly scaling your workloads up to take full advantage of the available hardware.\n",
+                "\n",
+                "To run Daft on large clusters, check out [Eventual](https://www.eventualcomputing.com) where you have access to a fully managed platform for running Daft at scale."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "6f159a45-dbf5-4e19-b2c6-0d15474b270c",
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3 (ipykernel)",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.9"
+        },
+        "vscode": {
+            "interpreter": {
+                "hash": "e5d77f7bd5a748e4f6412a25f9708ab7af36936de941fc795d1a6b75eb2da082"
+            }
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }


### PR DESCRIPTION
This PR makes DataFrame creation APIs (e.g. `from_pydict()`, `read_parquet()`, etc.) module-level functions rather than `DataFrame` classmethods. This is more in keeping with other data libraries that have a single central data abstraction (such as our `DataFrame`) and allows users to create a DataFrame with less typing.

## API

### Before

```python
from daft import DataFrame

df = DataFrame.from_pydict(...)

## OR

import daft

df = daft.DataFrame.from_pydict(...)
```

### After

```python
import daft

df = daft.from_pydict(...)
```

## Docs Changes

This PR also adds a dedicated "Input/Output" API docs page, similar to [pandas](https://pandas.pydata.org/docs/reference/io.html), [Polars](https://pola-rs.github.io/polars/py-polars/html/reference/io.html), [SparkSQL](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/io.html), etc., with 3 top-level groupings (in-memory data, files, and integrations), with the APIs further grouped into e.g. the file type or the integration library, including both the input and the output APIs.

I did something [similar for Ray Datasets](https://docs.ray.io/en/latest/data/api/input_output.html) after user feedback around I/O API discoverability, and the reception after the change was all positive.

## Deprecated API Removal

This PR also removes the following deprecated APIs ahead of the 0.1.0 release:
- `DataFrame.from_files()`
- `DataFrame.from_csv()`
- `DataFrame.from_json()`
- `DataFrame.from_parquet()`