### PR TITLE
Move fix for memory request 0 to the actual ray interface

### DIFF
--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -104,7 +104,7 @@ class PartitionTaskBuilder(Generic[PartitionT]):
         resource_request_final_cpu = ResourceRequest(
             num_cpus=self.resource_request.num_cpus or 1,
             num_gpus=self.resource_request.num_gpus,
-            memory_bytes=self.resource_request.memory_bytes or None,  # Lower versions of Ray do not accept 0
+            memory_bytes=self.resource_request.memory_bytes,
         )
 
         assert self.num_results == 1

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -352,9 +352,11 @@ def _get_ray_task_options(resource_request: ResourceRequest) -> dict[str, Any]:
         # Ray worker pool will thrash if a request comes in for fractional cpus,
         # so we floor the request to at least 1 cpu here.
         options["num_cpus"] = max(1, resource_request.num_cpus)
-    if resource_request.num_gpus is not None:
+    if resource_request.num_gpus:
         options["num_gpus"] = resource_request.num_gpus
-    if resource_request.memory_bytes is not None:
+    if resource_request.memory_bytes:
+        # Note that lower versions of Ray do not accept a value of 0 here,
+        # so the if-clause is load-bearing.
         options["memory"] = resource_request.memory_bytes
     return options
 


### PR DESCRIPTION
Lower versions of Ray do not accept a value of 0 for memory request.

This was already fixed but in the wrong place place and thus incomplete. I moved the fix to a correct place - the ray interface.