### PR TITLE
Fix deprecated call to DataFrame.from_glob_path

### DIFF
--- a/daft/io/parquet.py
+++ b/daft/io/parquet.py
@@ -12,10 +12,10 @@ def read_parquet(path: str) -> DataFrame:
     """Creates a DataFrame from Parquet file(s)
 
     Example:
-        >>> df = DataFrame.read_parquet("/path/to/file.parquet")
-        >>> df = DataFrame.read_parquet("/path/to/directory")
-        >>> df = DataFrame.read_parquet("/path/to/files-*.parquet")
-        >>> df = DataFrame.read_parquet("s3://path/to/files-*.parquet")
+        >>> df = daft.read_parquet("/path/to/file.parquet")
+        >>> df = daft.read_parquet("/path/to/directory")
+        >>> df = daft.read_parquet("/path/to/files-*.parquet")
+        >>> df = daft.read_parquet("s3://path/to/files-*.parquet")
 
     Args:
         path (str): Path to Parquet file (allows for wildcards)

--- a/tutorials/image_querying/top_n_red_color.ipynb
+++ b/tutorials/image_querying/top_n_red_color.ipynb
@@ -107,9 +107,9 @@
    },
    "outputs": [],
    "source": [
-    "from daft import DataFrame, lit, DataType\n",
+    "import daft\n",
     "\n",
-    "df = DataFrame.from_glob_path(\"s3://daft-public-data/open-images/validation-images/*\")\n",
+    "df = daft.from_glob_path(\"s3://daft-public-data/open-images/validation-images/*\")\n",
     "\n",
     "if USE_RAY:\n",
     "    df = df.limit(10000)\n",
@@ -340,7 +340,7 @@
    },
    "outputs": [],
    "source": [
-    "from daft import udf\n",
+    "from daft import udf, DataType\n",
     "\n",
     "import io\n",
     "import PIL\n",


### PR DESCRIPTION
* Fixes a bad call to DataFrame.from_glob_path in our tutorials
* Also fixes some stale documentation on `daft.read_parquet`