### PR TITLE
[Arrow Types] Add automatic Python object fallback for unsupported Arrow types.

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -6,30 +6,6 @@ import pyarrow as pa
 
 from daft.daft import PyDataType
 
-_RAY_DATA_EXTENSIONS_AVAILABLE = True
-_TENSOR_EXTENSION_TYPES = []
-try:
-    import ray
-except ImportError:
-    _RAY_DATA_EXTENSIONS_AVAILABLE = False
-else:
-    _RAY_VERSION = tuple(int(s) for s in ray.__version__.split("."))
-    try:
-        # Variable-shaped tensor column support was added in Ray 2.1.0.
-        if _RAY_VERSION >= (2, 2, 0):
-            from ray.data.extensions import (
-                ArrowTensorType,
-                ArrowVariableShapedTensorType,
-            )
-
-            _TENSOR_EXTENSION_TYPES = [ArrowTensorType, ArrowVariableShapedTensorType]
-        else:
-            from ray.data.extensions import ArrowTensorType
-
-            _TENSOR_EXTENSION_TYPES = [ArrowTensorType]
-    except ImportError:
-        _RAY_DATA_EXTENSIONS_AVAILABLE = False
-
 
 class DataType:
     _dtype: PyDataType
@@ -164,12 +140,10 @@ class DataType:
             assert isinstance(arrow_type, pa.StructType)
             fields = [arrow_type[i] for i in range(arrow_type.num_fields)]
             return cls.struct({field.name: cls.from_arrow_type(field.type) for field in fields})
-        elif _RAY_DATA_EXTENSIONS_AVAILABLE and isinstance(arrow_type, tuple(_TENSOR_EXTENSION_TYPES)):
-            # TODO(Clark): Add an extension type Daft type to be able to represent this tensor extension
-            # type natively.
-            return cls.python()
         else:
-            raise NotImplementedError(f"we cant convert arrow type: {arrow_type} to a daft type")
+            # Fall back to a Python object type.
+            # TODO(Clark): Add native support for remaining Arrow types and extension types.
+            return cls.python()
 
     @classmethod
     def python(cls) -> DataType:

--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -32,6 +32,9 @@ class Field:
             return False
         return self._field.eq(other._field)
 
+    def __repr__(self) -> str:
+        return f"Field(name={self.name}, dtype={self.dtype})"
+
 
 class Schema:
     _schema: _PySchema

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -67,13 +67,6 @@ except ImportError:
 
 from daft.logical.schema import Schema
 
-_NUMPY_AVAILABLE = True
-try:
-    pass
-except ImportError:
-    _NUMPY_AVAILABLE = False
-
-
 RAY_VERSION = tuple(int(s) for s in ray.__version__.split("."))
 
 

--- a/daft/series.py
+++ b/daft/series.py
@@ -35,7 +35,10 @@ class Series:
 
     @staticmethod
     def from_arrow(array: pa.Array | pa.ChunkedArray, name: str = "arrow_series") -> Series:
-        if isinstance(array, pa.Array):
+        if DataType.from_arrow_type(array.type) == DataType.python():
+            # If the Arrow type is not natively supported, go through the Python list path.
+            return Series.from_pylist(array.to_pylist(), pyobj="force")
+        elif isinstance(array, pa.Array):
             array = ensure_array(array)
             pys = PySeries.from_arrow(name, array)
             return Series._from_pyseries(pys)

--- a/tests/table/test_from_py.py
+++ b/tests/table/test_from_py.py
@@ -24,8 +24,10 @@ PYTHON_TYPE_ARRAYS = {
     "list": [[1, 2], [3]],
     "struct": [{"a": 1, "b": 2.0}, {"b": 3.0}],
     "empty_struct": [{}, {}],
-    "tensor": list(np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])),
     "null": [None, None],
+    # The following types are not natively supported and will be cast to Python object types.
+    "tensor": list(np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])),
+    "timestamp": [datetime.datetime.now(), datetime.datetime.now()],
 }
 
 
@@ -39,8 +41,10 @@ INFERRED_TYPES = {
     "list": DataType.list("item", DataType.int64()),
     "struct": DataType.struct({"a": DataType.int64(), "b": DataType.float64()}),
     "empty_struct": DataType.struct({"": DataType.null()}),
-    "tensor": DataType.python(),
     "null": DataType.null(),
+    # The following types are not natively supported and will be cast to Python object types.
+    "tensor": DataType.python(),
+    "timestamp": DataType.python(),
 }
 
 
@@ -54,8 +58,10 @@ ROUNDTRIP_TYPES = {
     "list": pa.large_list(pa.int64()),
     "struct": pa.struct({"a": pa.int64(), "b": pa.float64()}),
     "empty_struct": pa.struct({"": pa.null()}),
-    "tensor": ArrowTensorType(shape=(2, 2), dtype=pa.int64()),
     "null": pa.null(),
+    # The following types are not natively supported and will be cast to Python object types.
+    "tensor": ArrowTensorType(shape=(2, 2), dtype=pa.int64()),
+    "timestamp": pa.timestamp("us"),
 }
 
 
@@ -78,9 +84,10 @@ ARROW_TYPE_ARRAYS = {
     "fixed_size_list": pa.array([[1, 2], [3, 4]], pa.list_(pa.int64(), 2)),
     "struct": pa.array(PYTHON_TYPE_ARRAYS["struct"], pa.struct([("a", pa.int64()), ("b", pa.float64())])),
     "empty_struct": pa.array(PYTHON_TYPE_ARRAYS["empty_struct"], pa.struct({"": pa.null()})),
-    # TODO(Clark): Uncomment once extension type support has been added.
-    # "tensor": ArrowTensorArray.from_numpy(PYTHON_TYPE_ARRAYS["tensor"]),
     "null": pa.array(PYTHON_TYPE_ARRAYS["null"], pa.null()),
+    # The following types are not natively supported and will be cast to Python object types.
+    "tensor": ArrowTensorArray.from_numpy(PYTHON_TYPE_ARRAYS["tensor"]),
+    "timestamp": pa.array(PYTHON_TYPE_ARRAYS["timestamp"]),
 }
 
 
@@ -103,9 +110,10 @@ ARROW_ROUNDTRIP_TYPES = {
     "fixed_size_list": pa.list_(pa.int64(), 2),
     "struct": pa.struct([("a", pa.int64()), ("b", pa.float64())]),
     "empty_struct": pa.struct({"": pa.null()}),
-    # TODO(Clark): Uncomment once extension type support has been added.
-    # "tensor": ArrowTensorType(shape=(2, 2), dtype=pa.int64()),
     "null": pa.null(),
+    # The following types are not natively supported and will be cast to Python object types.
+    "tensor": ArrowTensorType(shape=(2, 2), dtype=pa.int64()),
+    "timestamp": pa.timestamp("us"),
 }
 
 


### PR DESCRIPTION
This PR adds an automatic fallback to the Python object type for unsupported Arrow types, such as `pa.timestamp()` and extension types, including the Ray Datasets tensor extension type.