### PR TITLE
Fix typo: CSV -> Parquet

### DIFF
--- a/docs/source/10-min.ipynb
+++ b/docs/source/10-min.ipynb
@@ -1529,7 +1529,7 @@
     "\n",
     "See: [Writing Data](df-writing-data)\n",
     "\n",
-    "Writing data will execute your DataFrame and write the results out to the specified backend. For example, to write data out to CSV:\n"
+    "Writing data will execute your DataFrame and write the results out to the specified backend. For example, to write data out to Parquet:\n"
    ]
   },
   {


### PR DESCRIPTION
I was reading the 10 minute tutorial (very nice by the way) and came across this little typo. :+1: