### PR TITLE
Fix colon URL downloads and default to strict mode for .url.download()

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -394,14 +394,14 @@ class ExpressionNamespace:
 
 class ExpressionUrlNamespace(ExpressionNamespace):
     def download(
-        self, max_worker_threads: int = 8, on_error: Literal["raise"] | Literal["null"] = "null"
+        self, max_worker_threads: int = 8, on_error: Literal["raise"] | Literal["null"] = "raise"
     ) -> Expression:
         """Treats each string as a URL, and downloads the bytes contents as a bytes column
 
         Args:
             max_worker_threads: The maximum number of threads to use for downloading URLs, defaults to 8
-            on_error: Behavior when a URL download error is encountered - "raise" to raise the error immediately, defaults to "null"
-                which will log the error but populate the result with a Null value
+            on_error: Behavior when a URL download error is encountered - "raise" to raise the error immediately or "null" to log
+                the error but fallback to a Null value. Defaults to "raise".
 
         Returns:
             UdfExpression: a BYTES expression which is the bytes contents of the URL, or None if an error occured during download

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -78,7 +78,7 @@ def get_protocol_from_path(path: str) -> str:
     matched_url = URL_REGEX.match(path)
     if matched_url is None:
         return "file"
-    return matched_url.group(0)
+    return matched_url.group(1)
 
 
 def get_filesystem_from_path(path: str, **kwargs) -> AbstractFileSystem:

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import re
 import sys
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
@@ -19,8 +18,6 @@ from fsspec import AbstractFileSystem, get_filesystem_class
 from loguru import logger
 
 from daft.datasources import ParquetSourceInfo, SourceInfo
-
-URL_REGEX = re.compile(r"([a-zA-Z\d_-]+):\/\/(.+)")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -75,10 +72,10 @@ def get_filesystem(protocol: str, **kwargs) -> AbstractFileSystem:
 
 
 def get_protocol_from_path(path: str) -> str:
-    matched_url = URL_REGEX.match(path)
-    if matched_url is None:
+    parsed_scheme = urlparse(path).scheme
+    if parsed_scheme == "" or parsed_scheme is None:
         return "file"
-    return matched_url.group(1)
+    return parsed_scheme
 
 
 def get_filesystem_from_path(path: str, **kwargs) -> AbstractFileSystem:

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import re
 import sys
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
@@ -18,6 +19,8 @@ from fsspec import AbstractFileSystem, get_filesystem_class
 from loguru import logger
 
 from daft.datasources import ParquetSourceInfo, SourceInfo
+
+URL_REGEX = re.compile(r"([a-zA-Z\d_-]+):\/\/(.+)")
 
 
 @dataclasses.dataclass(frozen=True)
@@ -71,11 +74,11 @@ def get_filesystem(protocol: str, **kwargs) -> AbstractFileSystem:
     return fs
 
 
-def get_protocol_from_path(path: str, **kwargs) -> str:
-    split = path.split(":")
-    assert len(split) <= 2, f"too many colons found in {path}"
-    protocol = split[0] if len(split) == 2 else "file"
-    return protocol
+def get_protocol_from_path(path: str) -> str:
+    matched_url = URL_REGEX.match(path)
+    if matched_url is None:
+        return "file"
+    return matched_url.group(0)
 
 
 def get_filesystem_from_path(path: str, **kwargs) -> AbstractFileSystem:

--- a/daft/udf_library/url_udfs.py
+++ b/daft/udf_library/url_udfs.py
@@ -48,14 +48,14 @@ def _warmup_fsspec_registry(urls_pylist: list[str | None]) -> None:
 
 
 @udf(return_dtype=DataType.binary())
-def download_udf(urls, max_worker_threads: int = 8, on_error: Literal["raise"] | Literal["null"] = "null"):
+def download_udf(urls, max_worker_threads: int = 8, on_error: Literal["raise"] | Literal["null"] = "raise"):
     """Downloads the contents of the supplied URLs.
 
     Args:
         urls: URLs as a UTF8 string series
         max_worker_threads: max number of worker threads to use, defaults to 8
-        on_error: Behavior when a URL download error is encountered - "raise" to raise the error immediately, defaults to "null"
-            which will log the error but populate the result with a Null value
+        on_error: Behavior when a URL download error is encountered - "raise" to raise the error immediately or "null" to log
+            the error but fallback to a Null value. Defaults to "raise".
     """
 
     from loguru import logger

--- a/daft/udf_library/url_udfs.py
+++ b/daft/udf_library/url_udfs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -7,6 +8,11 @@ from daft import filesystem
 from daft.datatype import DataType
 from daft.series import Series
 from daft.udf import udf
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
 
 thread_local = threading.local()
 
@@ -42,8 +48,15 @@ def _warmup_fsspec_registry(urls_pylist: list[str | None]) -> None:
 
 
 @udf(return_dtype=DataType.binary())
-def download_udf(urls, max_worker_threads: int = 8):
-    """Downloads the contents of the supplied URLs."""
+def download_udf(urls, max_worker_threads: int = 8, on_error: Literal["raise"] | Literal["null"] = "null"):
+    """Downloads the contents of the supplied URLs.
+
+    Args:
+        urls: URLs as a UTF8 string series
+        max_worker_threads: max number of worker threads to use, defaults to 8
+        on_error: Behavior when a URL download error is encountered - "raise" to raise the error immediately, defaults to "null"
+            which will log the error but populate the result with a Null value
+    """
 
     from loguru import logger
 
@@ -58,6 +71,13 @@ def download_udf(urls, max_worker_threads: int = 8):
         try:
             results[future_to_idx[future]] = future.result()
         except Exception as e:
-            logger.error(f"Encountered error during download from URL {urls_pylist[future_to_idx[future]]}: {str(e)}")
+            if on_error == "raise":
+                raise
+            elif on_error == "null":
+                logger.error(
+                    f"Encountered error during download from URL {urls_pylist[future_to_idx[future]]} and falling back to Null: {str(e)}"
+                )
+            else:
+                raise NotImplemented(f"Unimplemented on_error option: {on_error}.\n\nEncountered error: {e}")
 
     return Series.from_pylist(results)

--- a/daft/udf_library/url_udfs.py
+++ b/daft/udf_library/url_udfs.py
@@ -22,7 +22,9 @@ def _worker_thread_initializer() -> None:
     thread_local.filesystems_cache = {}
 
 
-def _download(path: str | None) -> bytes | None:
+def _download(path: str | None, on_error: Literal["raise"] | Literal["null"]) -> bytes | None:
+    from loguru import logger
+
     if path is None:
         return None
     protocol = filesystem.get_protocol_from_path(path)
@@ -30,7 +32,16 @@ def _download(path: str | None) -> bytes | None:
     if fs is None:
         fs = filesystem.get_filesystem(protocol)
         thread_local.filesystems_cache[protocol] = fs
-    return fs.cat_file(path)
+    try:
+        return fs.cat_file(path)
+    except Exception as e:
+        if on_error == "raise":
+            raise
+        elif on_error == "null":
+            logger.error(f"Encountered error during download from URL {path} and falling back to Null\n\n{e}: {str(e)}")
+            return None
+        else:
+            raise NotImplemented(f"Unimplemented on_error option: {on_error}.\n\nEncountered error: {e}")
 
 
 def _warmup_fsspec_registry(urls_pylist: list[str | None]) -> None:
@@ -66,18 +77,8 @@ def download_udf(urls, max_worker_threads: int = 8, on_error: Literal["raise"] |
 
     executor = ThreadPoolExecutor(max_workers=max_worker_threads, initializer=_worker_thread_initializer)
     results: list[bytes | None] = [None for _ in range(len(urls))]
-    future_to_idx = {executor.submit(_download, urls_pylist[i]): i for i in range(len(urls))}
+    future_to_idx = {executor.submit(_download, urls_pylist[i], on_error): i for i in range(len(urls))}
     for future in as_completed(future_to_idx):
-        try:
-            results[future_to_idx[future]] = future.result()
-        except Exception as e:
-            if on_error == "raise":
-                raise
-            elif on_error == "null":
-                logger.error(
-                    f"Encountered error during download from URL {urls_pylist[future_to_idx[future]]} and falling back to Null: {str(e)}"
-                )
-            else:
-                raise NotImplemented(f"Unimplemented on_error option: {on_error}.\n\nEncountered error: {e}")
+        results[future_to_idx[future]] = future.result()
 
     return Series.from_pylist(results)

--- a/daft/udf_library/url_udfs.py
+++ b/daft/udf_library/url_udfs.py
@@ -69,8 +69,6 @@ def download_udf(urls, max_worker_threads: int = 8, on_error: Literal["raise"] |
             the error but fallback to a Null value. Defaults to "raise".
     """
 
-    from loguru import logger
-
     urls_pylist = urls.to_arrow().to_pylist()
 
     _warmup_fsspec_registry(urls_pylist)

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -51,7 +51,7 @@ def test_download_with_broken_urls(files):
         "filenames": [str(f) for f in files] + [str(uuid.uuid4()) for _ in range(len(files))],
     }
     df = daft.from_pydict(data)
-    df = df.with_column("bytes", col("filenames").url.download())
+    df = df.with_column("bytes", col("filenames").url.download(on_error="null"))
     pd_df = pd.DataFrame.from_dict(data)
     pd_df["bytes"] = pd.Series([pathlib.Path(fn).read_bytes() if pathlib.Path(fn).exists() else None for fn in files])
     assert_df_equals(df.to_pandas(), pd_df, sort_key="id")

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -57,6 +57,18 @@ def test_download_with_broken_urls(files):
     assert_df_equals(df.to_pandas(), pd_df, sort_key="id")
 
 
+def test_download_with_broken_urls_reraise_errors(files):
+    data = {
+        "id": list(range(len(files) * 2)),
+        "filenames": [str(f) for f in files] + [str(uuid.uuid4()) for _ in range(len(files))],
+    }
+    df = daft.from_pydict(data)
+    df = df.with_column("bytes", col("filenames").url.download(on_error="raise"))
+
+    with pytest.raises(FileNotFoundError):
+        df.collect()
+
+
 def test_download_with_duplicate_urls(files):
     data = {
         "id": list(range(len(files) * 2)),

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -11,9 +11,18 @@ from daft.expressions import col
 from tests.conftest import assert_df_equals
 
 
+def _get_filename():
+    name = str(uuid.uuid4())
+
+    # Inject colons into the name
+    name += ":foo:bar"
+
+    return name
+
+
 @pytest.fixture(scope="function")
 def files(tmpdir) -> list[str]:
-    filepaths = [pathlib.Path(tmpdir) / str(uuid.uuid4()) for _ in range(10)]
+    filepaths = [pathlib.Path(tmpdir) / _get_filename() for _ in range(10)]
     for fp in filepaths:
         fp.write_bytes(fp.name.encode("utf-8"))
     return filepaths


### PR DESCRIPTION
* Adds a fix for URLs with multiple colons
* Adds a "strict" mode for `.url.download()` using the kwarg `on_error="raise"`. We default to this behavior now because the other behavior `"null"` could cause idempotency issues and unexpected user behavior.
* Fixes the try/catch block to be reduce its surface area - just to catch the `fsspec.cat_file` call