### PR TITLE
Fix temporal unit tests for older versions of pyarrow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["maturin>=0.14,<0.15"]
 [project]
 authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]
 dependencies = [
-  "pyarrow",
+  "pyarrow >= 6.0.1",
   "fsspec[http]",
   "loguru",
   "tabulate",

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -8,6 +8,8 @@ import pytest
 
 import daft
 
+PYARROW_GE_7_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (7, 0, 0)
+
 
 def test_temporal_arithmetic() -> None:
     now = datetime.now()
@@ -41,32 +43,38 @@ def test_temporal_arithmetic() -> None:
 
 @pytest.mark.parametrize("format", ["csv", "parquet"])
 def test_temporal_file_roundtrip(format) -> None:
-    pa_table = pa.Table.from_pydict(
-        {
-            "date32": pa.array([1], pa.date32()),
-            "date64": pa.array([1], pa.date64()),
+    data = {
+        "date32": pa.array([1], pa.date32()),
+        "date64": pa.array([1], pa.date64()),
+        # Not supported by pyarrow CSV reader yet.
+        # "time32_s": pa.array([1], pa.time32("s")),
+        # "time32_ms": pa.array([1], pa.time32("ms")),
+        # "time64_us": pa.array([1], pa.time64("us")),
+        # "time64_ns": pa.array([1], pa.time64("ns")),
+        # "duration_s": pa.array([1], pa.duration("s")),
+        # "duration_ms": pa.array([1], pa.duration("ms")),
+        # "duration_us": pa.array([1], pa.duration("us")),
+        # "duration_ns": pa.array([1], pa.duration("ns")),
+        # Nanosecond resolution not yet supported (since we currently use Python temporal objects).
+        # "timestamp_ns": pa.array([1], pa.timestamp("ns")),
+        # "timestamp_ns_tz": pa.array([1], pa.timestamp("ns", tz='UTC')),
+        # pyarrow doesn't support writing interval type.
+        # "interval": pa.array([pa.scalar((1, 1, 1), type=pa.month_day_nano_interval()).as_py()]),
+    }
+
+    # CSV writing of these files only supported by pyarrow CSV writer in PyArrow >= 7.0.0
+    if format == "csv" and PYARROW_GE_7_0_0:
+        data = {
+            **data,
             "timestamp_s": pa.array([1], pa.timestamp("s")),
             "timestamp_ms": pa.array([1], pa.timestamp("ms")),
             "timestamp_us": pa.array([1], pa.timestamp("us")),
             "timestamp_s_tz": pa.array([1], pa.timestamp("s", tz="UTC")),
             "timestamp_ms_tz": pa.array([1], pa.timestamp("ms", tz="UTC")),
             "timestamp_us_tz": pa.array([1], pa.timestamp("us", tz="UTC")),
-            # Not supported by pyarrow CSV reader yet.
-            # "time32_s": pa.array([1], pa.time32("s")),
-            # "time32_ms": pa.array([1], pa.time32("ms")),
-            # "time64_us": pa.array([1], pa.time64("us")),
-            # "time64_ns": pa.array([1], pa.time64("ns")),
-            # "duration_s": pa.array([1], pa.duration("s")),
-            # "duration_ms": pa.array([1], pa.duration("ms")),
-            # "duration_us": pa.array([1], pa.duration("us")),
-            # "duration_ns": pa.array([1], pa.duration("ns")),
-            # Nanosecond resolution not yet supported (since we currently use Python temporal objects).
-            # "timestamp_ns": pa.array([1], pa.timestamp("ns")),
-            # "timestamp_ns_tz": pa.array([1], pa.timestamp("ns", tz='UTC')),
-            # pyarrow doesn't support writing interval type.
-            # "interval": pa.array([pa.scalar((1, 1, 1), type=pa.month_day_nano_interval()).as_py()]),
         }
-    )
+
+    pa_table = pa.Table.from_pydict(data)
 
     df = daft.from_arrow(pa_table)
 


### PR DESCRIPTION
* Only adds timestamp types for the `test_temporal_file_roundtrip` test if using a large enough PyArrow version (>=7.0.0)
* Pins `pyarrow >= 6.0.1` because we use a kwarg `existing_data_behavior="overwrite_or_ignore"` when writing data in `table_io.py`