### PR TITLE
Extension Types for Ray Runner and Embedding Logical Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "pyo3-log",
  "rand",
  "serde",
+ "serde_json",
  "xxhash-rust",
 ]
 
@@ -863,6 +864,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.16",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -60,7 +60,7 @@ dependencies = [
  "multiversion",
  "num-traits",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "rustc_version",
  "simdutf8",
  "strength_reduce",
@@ -89,9 +89,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 
 [[package]]
 name = "bytemuck"
@@ -110,7 +110,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -167,6 +167,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "num-traits",
+ "numpy",
  "prettytable-rs",
  "pyo3",
  "rand",
@@ -346,9 +347,9 @@ checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -425,15 +426,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "lock_api"
@@ -455,6 +456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090126dc04f95dc0d1c1c91f61bdd474b3930ca064c1edc8a849da2c6cbe1e77"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "multiversion"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a87eede2251ca235e5573086d01d2ab6b59dfaea54c2be10f9320980f7e8f7"
+checksum = "8cda45dade5144c2c929bf2ed6c24bebbba784e9198df049ec87d722b9462bd1"
 dependencies = [
  "multiversion-macros",
  "target-features",
@@ -481,14 +492,36 @@ dependencies = [
 
 [[package]]
 name = "multiversion-macros"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1af1abf82261d780d114014eff4b555e47d823f3b84f893c4388572b40e089fb"
+checksum = "04bffdccbd4798b61dce08c97ce8c66a68976f95541aaf284a6e90c1d1c306e1"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
  "target-features",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -508,6 +541,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "numpy"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0fee4571867d318651c24f4a570c3f18408cf95f16ccb576b3ce85496a46e"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -570,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -639,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
@@ -677,6 +725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,13 +752,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -712,6 +766,18 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -724,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.12"
+version = "0.37.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
+checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
 dependencies = [
  "bitflags",
  "errno",
@@ -777,7 +843,7 @@ checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -817,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "a6f671d4b5ffdb8eadec19c0ae67fe2639df8684bd7bc4b83d986b8db549cf01"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -834,9 +900,9 @@ checksum = "24840de800c1707d75c800893dbd727a5e1501ce921944e602f0698167491e36"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.6"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
+checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "term"
@@ -866,7 +932,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]
@@ -901,9 +967,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -911,24 +977,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -936,22 +1002,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.16",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "array-init-cursor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,10 +172,12 @@ dependencies = [
  "fnv",
  "indexmap",
  "lazy_static",
+ "log",
  "num-traits",
  "numpy",
  "prettytable-rs",
  "pyo3",
+ "pyo3-log",
  "rand",
  "serde",
  "xxhash-rust",
@@ -618,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -660,6 +668,17 @@ checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9c8b57fe71fb5dcf38970ebedc2b1531cf1c14b1b9b4c560a182a57e115575c"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
 ]
 
 [[package]]
@@ -894,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "target-features"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24840de800c1707d75c800893dbd727a5e1501ce921944e602f0698167491e36"
+checksum = "06f6b473c37f9add4cf1df5b4d66a8ef58ab6c895f1a3b3f949cf3e21230140e"
 
 [[package]]
 name = "target-lexicon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ version = "1.4.0"
 version = "0.2"
 
 [dependencies.numpy]
-numpy = "0.18"
 optional = true
+version = "0.18"
 
 [dependencies.pyo3]
 features = ["extension-module", "abi3-py37"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ fnv = "1.0.7"
 prettytable-rs = "^0.10"
 pyo3-log = "0.8.1"
 rand = "^0.8"
+serde_json = "1.0.96"
 
 [dependencies.arrow2]
 branch = "clark/expand-casting-support"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 dyn-clone = "1.0.11"
 fnv = "1.0.7"
 prettytable-rs = "^0.10"
+pyo3-log = "0.8.1"
 rand = "^0.8"
 
 [dependencies.arrow2]
@@ -20,6 +21,10 @@ version = "1.9.2"
 
 [dependencies.lazy_static]
 version = "1.4.0"
+
+[dependencies.log]
+features = ["std"]
+version = "0.4.17"
 
 [dependencies.num-traits]
 version = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ version = "1.4.0"
 [dependencies.num-traits]
 version = "0.2"
 
+[dependencies.numpy]
+numpy = "0.18"
+optional = true
+
 [dependencies.pyo3]
 features = ["extension-module", "abi3-py37"]
 optional = true
@@ -39,7 +43,7 @@ version = "0.8.5"
 
 [features]
 default = ["python"]
-python = ["dep:pyo3"]
+python = ["dep:pyo3", "dep:numpy"]
 
 [lib]
 crate-type = ["cdylib"]

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -207,6 +207,11 @@ class DataType:
             return cls.python()
 
     @classmethod
+    def from_numpy_dtype(cls, np_type) -> DataType:
+        arrow_type = pa.from_numpy_dtype(np_type)
+        return cls.from_arrow_type(arrow_type)
+
+    @classmethod
     def python(cls) -> DataType:
         return cls._from_pydatatype(PyDataType.python())
 

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -118,6 +118,12 @@ class DataType:
         return cls._from_pydatatype(PyDataType.fixed_size_list(name, dtype._dtype, size))
 
     @classmethod
+    def embedding(cls, name: str, dtype: DataType, size: int) -> DataType:
+        if not isinstance(size, int) or size <= 0:
+            raise ValueError("The size for a embedding must be a positive integer, but got: ", size)
+        return cls._from_pydatatype(PyDataType.embedding(name, dtype._dtype, size))
+
+    @classmethod
     def struct(cls, fields: dict[str, DataType]) -> DataType:
         return cls._from_pydatatype(PyDataType.struct({name: datatype._dtype for name, datatype in fields.items()}))
 

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -4,6 +4,7 @@ import builtins
 
 import pyarrow as pa
 
+from daft.context import get_context
 from daft.daft import PyDataType
 
 _RAY_DATA_EXTENSIONS_AVAILABLE = True
@@ -185,6 +186,16 @@ class DataType:
             )
         elif isinstance(arrow_type, pa.BaseExtensionType):
             name = arrow_type.extension_name
+
+            if (get_context().runner_config.name == "ray") and (
+                type(arrow_type).__reduce__ == pa.BaseExtensionType.__reduce__
+            ):
+                raise ValueError(
+                    f"You are attempting to use a Extension Type: {arrow_type} with the default pyarrow `__reduce__` which breaks pickling for Extensions"
+                    "To fix this, implement your own `__reduce__` on your extension type"
+                    "For more details see this issue: "
+                    "https://github.com/apache/arrow/issues/35599"
+                )
             try:
                 metadata = arrow_type.__arrow_ext_serialize__().decode()
             except AttributeError:

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -4,7 +4,6 @@ import builtins
 
 import pyarrow as pa
 
-from daft.context import get_context
 from daft.daft import PyDataType
 
 _RAY_DATA_EXTENSIONS_AVAILABLE = True
@@ -185,12 +184,6 @@ class DataType:
                 f"used in non-Python Arrow implementations and Daft uses the Rust Arrow2 implementation: {arrow_type}"
             )
         elif isinstance(arrow_type, pa.BaseExtensionType):
-            if get_context().runner_config.name == "ray":
-                raise ValueError(
-                    f"pyarrow extension types are not supported for the Ray runner: {arrow_type}. If you need support "
-                    "for this, please let us know on this issue: "
-                    "https://github.com/Eventual-Inc/Daft/issues/933"
-                )
             name = arrow_type.extension_name
             try:
                 metadata = arrow_type.__arrow_ext_serialize__().decode()

--- a/daft/series.py
+++ b/daft/series.py
@@ -373,6 +373,10 @@ class Series:
     def dt(self) -> SeriesDateNamespace:
         return SeriesDateNamespace.from_series(self)
 
+    @property
+    def arr(self) -> SeriesArrayNamespace:
+        return SeriesArrayNamespace.from_series(self)
+
     def __reduce__(self) -> tuple:
         if self.datatype()._is_python_type():
             return (Series.from_pylist, (self.to_pylist(), self.name(), "force"))
@@ -443,3 +447,8 @@ class SeriesDateNamespace(SeriesNamespace):
 
     def day_of_week(self) -> Series:
         return Series._from_pyseries(self._series.dt_day_of_week())
+
+
+class SeriesArrayNamespace(SeriesNamespace):
+    def lengths(self) -> Series:
+        return Series._from_pyseries(self._series.arr_lengths())

--- a/src/array/ops/as_arrow.rs
+++ b/src/array/ops/as_arrow.rs
@@ -4,8 +4,9 @@ use arrow2::array;
 use crate::{
     array::DataArray,
     datatypes::{
-        logical::DateArray, BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray,
-        ListArray, StructArray, Utf8Array,
+        logical::{DateArray, EmbeddingArray},
+        BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray, ListArray, StructArray,
+        Utf8Array,
     },
 };
 
@@ -97,5 +98,14 @@ impl AsArrow for crate::datatypes::PythonArray {
     // downcasts a DataArray<T> to a PseudoArrowArray of PyObject.
     fn as_arrow(&self) -> &Self::Output {
         self.data().as_any().downcast_ref().unwrap()
+    }
+}
+
+impl AsArrow for EmbeddingArray {
+    type Output = array::FixedSizeListArray;
+
+    // downcasts a DataArray<T> to an Arrow DateArray.
+    fn as_arrow(&self) -> &Self::Output {
+        self.physical.data().as_any().downcast_ref().unwrap()
     }
 }

--- a/src/array/ops/as_arrow.rs
+++ b/src/array/ops/as_arrow.rs
@@ -104,7 +104,7 @@ impl AsArrow for crate::datatypes::PythonArray {
 impl AsArrow for EmbeddingArray {
     type Output = array::FixedSizeListArray;
 
-    // downcasts a DataArray<T> to an Arrow DateArray.
+    // downcasts a DataArray<T> to an Arrow FixedSizeListArray.
     fn as_arrow(&self) -> &Self::Output {
         self.physical.data().as_any().downcast_ref().unwrap()
     }

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -337,19 +337,17 @@ fn extract_python_to_vec<
                     values_vec.extend_from_slice(collected.as_slice());
                 }
             }
+        } else if let Some(list_size) = list_size {
+            values_vec.extend(iter::repeat(Tgt::default()).take(list_size));
         } else {
-            if let Some(list_size) = list_size {
-                values_vec.extend(iter::repeat(Tgt::default()).take(list_size));
-            } else {
-                let offset = offsets_vec.last().unwrap();
-                offsets_vec.push(*offset);
-            }
+            let offset = offsets_vec.last().unwrap();
+            offsets_vec.push(*offset);
         }
     }
-    if let Some(_) = list_size {
-        return Ok((values_vec, None));
+    if list_size.is_some() {
+        Ok((values_vec, None))
     } else {
-        return Ok((values_vec, Some(offsets_vec)));
+        Ok((values_vec, Some(offsets_vec)))
     }
 }
 

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -179,8 +179,8 @@ macro_rules! pycast_then_arrowcast {
 }
 
 #[cfg(feature = "python")]
-fn extract_numpy_array_to_fixed_size_list<'py, T: numpy::Element + arrow2::types::NativeType>(
-    py: Python<'py>,
+fn extract_numpy_array_to_fixed_size_list<T: numpy::Element + arrow2::types::NativeType>(
+    py: Python<'_>,
     python_objects: PythonArray,
     list_size: usize,
     inner_type: &DataType,
@@ -257,7 +257,6 @@ impl PythonArray {
     pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
         use crate::python::PySeries;
         use pyo3::prelude::*;
-        for x in self.as_arrow().iter() {}
         match dtype {
             DataType::Python => Ok(self.clone().into_series()),
 

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -328,7 +328,7 @@ fn extract_python_to_vec<
                     } else {
                         return Err(DaftError::ValueError(format!(
                             "Python Object is neither array-like or an iterable at index {}. Can not convert to a list. object type: {}",
-                            i, object.getattr(pyo3::intern!(py, "__class__"))?.to_string())));
+                            i, object.getattr(pyo3::intern!(py, "__class__"))?)));
                     };
 
                     if collected.is_err() {

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -314,9 +314,8 @@ fn extract_python_to_vec<
                         float_iter.collect::<PyResult<Vec<_>>>()
                     } else {
                         return Err(DaftError::ValueError(format!(
-                        "Python Object is neither array-like or an iterable at index {}. Can not convert to a list. object type: {}",
-                        i, object.getattr(pyo3::intern!(py, "__class__"))?.to_string()
-                    )));
+                            "Python Object is neither array-like or an iterable at index {}. Can not convert to a list. object type: {}",
+                            i, object.getattr(pyo3::intern!(py, "__class__"))?.to_string())));
                     };
 
                     if collected.is_err() {

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -21,6 +21,8 @@ use num_traits::{NumCast, ToPrimitive};
 
 use std::iter;
 
+use log;
+
 #[cfg(feature = "python")]
 use crate::datatypes::PythonArray;
 #[cfg(feature = "python")]
@@ -280,7 +282,13 @@ fn extract_numpy_array_to_fixed_size_list<
                             })
                             .map(|v| v.map(|v| v.0));
 
-                        let collected = int_iter.collect::<PyResult<Vec<_>>>()?;
+                        let collected = int_iter.collect::<PyResult<Vec<_>>>();
+
+                        if collected.is_err() {
+                            log::warn!("Could not convert python object to fixed size list at index: {i} for input series: {}", python_objects.name())
+                        }
+                        let collected: Vec<Tgt> = collected?;
+
                         if collected.len() != list_size {
                             return Err(DaftError::ValueError(format!(
                                 "Expected Iterable Object to have {list_size} elements but got {} at index {}",
@@ -302,8 +310,11 @@ fn extract_numpy_array_to_fixed_size_list<
                                 })
                             })
                             .map(|v| v.map(|v| v.0));
-                        let collected = float_iter.collect::<PyResult<Vec<_>>>()?;
-
+                        let collected = float_iter.collect::<PyResult<Vec<_>>>();
+                        if collected.is_err() {
+                            log::warn!("Could not convert python object to fixed size list at index: {i} for input series: {}", python_objects.name())
+                        }
+                        let collected: Vec<Tgt> = collected?;
                         if collected.len() != list_size {
                             return Err(DaftError::ValueError(format!(
                                 "Expected Iterable Object to have {list_size} elements but got {} at index {}",

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -3,7 +3,7 @@ use arrow2::compute::{
     cast::{can_cast_types, cast, CastOptions},
 };
 
-use crate::datatypes::logical::LogicalArray;
+use crate::datatypes::logical::{EmbeddingArray, LogicalArray};
 use crate::series::IntoSeries;
 use crate::{
     array::DataArray,
@@ -212,5 +212,11 @@ impl PythonArray {
             // DataType::Timestamp(_, _) => $self.timestamp().unwrap().$method($($args),*),
             dt => unimplemented!("dtype {:?} not supported", dt),
         }
+    }
+}
+
+impl EmbeddingArray {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        self.physical.cast(dtype)
     }
 }

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -187,10 +187,9 @@ macro_rules! pycast_then_arrowcast {
 
 #[cfg(feature = "python")]
 fn append_values_from_numpy<
-    'a,
     Tgt: numpy::Element + NumCast + ToPrimitive + arrow2::types::NativeType,
 >(
-    pyarray: &'a PyAny,
+    pyarray: &PyAny,
     index: usize,
     from_numpy_dtype_fn: &PyAny,
     values_vec: &mut Vec<Tgt>,

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -278,7 +278,7 @@ fn extract_numpy_array_to_fixed_size_list<
                                     )
                                 })
                             })
-                            .map(|v| v.and_then(|v| Ok(v.0)));
+                            .map(|v| v.map(|v| v.0));
 
                         let collected = int_iter.collect::<PyResult<Vec<_>>>()?;
                         if collected.len() != list_size {
@@ -301,7 +301,7 @@ fn extract_numpy_array_to_fixed_size_list<
                                     )
                                 })
                             })
-                            .map(|v| v.and_then(|v| Ok(v.0)));
+                            .map(|v| v.map(|v| v.0));
                         let collected = float_iter.collect::<PyResult<Vec<_>>>()?;
 
                         if collected.len() != list_size {

--- a/src/array/ops/filter.rs
+++ b/src/array/ops/filter.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::DataArray,
-    datatypes::{logical::DateArray, BooleanArray, DaftArrowBackedType},
+    datatypes::{logical::{DateArray, EmbeddingArray}, BooleanArray, DaftArrowBackedType},
     error::DaftResult,
 };
 
@@ -71,6 +71,13 @@ impl crate::datatypes::PythonArray {
 }
 
 impl DateArray {
+    pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
+        let new_array = self.physical.filter(mask)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+}
+
+impl EmbeddingArray {
     pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
         let new_array = self.physical.filter(mask)?;
         Ok(Self::new(self.field.clone(), new_array))

--- a/src/array/ops/filter.rs
+++ b/src/array/ops/filter.rs
@@ -1,6 +1,9 @@
 use crate::{
     array::DataArray,
-    datatypes::{logical::{DateArray, EmbeddingArray}, BooleanArray, DaftArrowBackedType},
+    datatypes::{
+        logical::{DateArray, EmbeddingArray},
+        BooleanArray, DaftArrowBackedType,
+    },
     error::DaftResult,
 };
 

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -1,5 +1,5 @@
 use crate::array::DataArray;
-use crate::datatypes::logical::DateArray;
+use crate::datatypes::logical::{DateArray, EmbeddingArray};
 use crate::datatypes::{
     BinaryArray, BooleanArray, DaftArrowBackedType, DaftNumericType, ExtensionArray, Field,
     FixedSizeListArray, ListArray, NullArray, StructArray, Utf8Array,
@@ -322,7 +322,14 @@ impl ExtensionArray {
 }
 
 impl DateArray {
-    pub fn if_else(&self, other: &DateArray, predicate: &BooleanArray) -> DaftResult<DateArray> {
+    pub fn if_else(&self, other: &Self, predicate: &BooleanArray) -> DaftResult<Self> {
+        let new_array = self.physical.if_else(&other.physical, predicate)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+}
+
+impl EmbeddingArray {
+    pub fn if_else(&self, other: &Self, predicate: &BooleanArray) -> DaftResult<Self> {
         let new_array = self.physical.if_else(&other.physical, predicate)?;
         Ok(Self::new(self.field.clone(), new_array))
     }

--- a/src/array/ops/sort.rs
+++ b/src/array/ops/sort.rs
@@ -1,9 +1,9 @@
 use crate::{
     array::DataArray,
     datatypes::{
-        logical::DateArray, BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType,
-        ExtensionArray, FixedSizeListArray, Float32Array, Float64Array, ListArray, NullArray,
-        StructArray, Utf8Array,
+        logical::{DateArray, EmbeddingArray},
+        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeListArray,
+        Float32Array, Float64Array, ListArray, NullArray, StructArray, Utf8Array, ExtensionArray
     },
     error::DaftResult,
     kernels::search_sorted::{build_compare_with_nulls, cmp_float},
@@ -587,6 +587,12 @@ impl ExtensionArray {
 impl PythonArray {
     pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
         todo!("impl sort for python array")
+    }
+}
+
+impl EmbeddingArray {
+    pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
+        todo!("impl sort for FixedSizeListArray")
     }
 }
 

--- a/src/array/ops/sort.rs
+++ b/src/array/ops/sort.rs
@@ -2,8 +2,9 @@ use crate::{
     array::DataArray,
     datatypes::{
         logical::{DateArray, EmbeddingArray},
-        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeListArray,
-        Float32Array, Float64Array, ListArray, NullArray, StructArray, Utf8Array, ExtensionArray
+        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, ExtensionArray,
+        FixedSizeListArray, Float32Array, Float64Array, ListArray, NullArray, StructArray,
+        Utf8Array,
     },
     error::DaftResult,
     kernels::search_sorted::{build_compare_with_nulls, cmp_float},

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -1,8 +1,9 @@
 use crate::{
     array::DataArray,
     datatypes::{
-        logical::DateArray, BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType,
-        ExtensionArray, FixedSizeListArray, ListArray, NullArray, StructArray, Utf8Array,
+        logical::{DateArray, EmbeddingArray},
+        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeListArray, ListArray,
+        NullArray, StructArray, Utf8Array, ExtensionArray
     },
     error::DaftResult,
 };
@@ -455,6 +456,41 @@ impl DateArray {
         match val {
             None => Ok("None".to_string()),
             Some(v) => Ok(format!("{v}")),
+        }
+    }
+}
+
+impl EmbeddingArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<Box<dyn arrow2::array::Array>> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let arrow_array = self.as_arrow();
+        let is_valid = arrow_array
+            .validity()
+            .map_or(true, |validity| validity.get_bit(idx));
+        if is_valid {
+            Some(unsafe { arrow_array.value_unchecked(idx) })
+        } else {
+            None
+        }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let new_array = self.physical.take(idx)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            Some(v) => Ok(format!("{v:?}")),
         }
     }
 }

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -2,8 +2,8 @@ use crate::{
     array::DataArray,
     datatypes::{
         logical::{DateArray, EmbeddingArray},
-        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeListArray, ListArray,
-        NullArray, StructArray, Utf8Array, ExtensionArray
+        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, ExtensionArray,
+        FixedSizeListArray, ListArray, NullArray, StructArray, Utf8Array,
     },
     error::DaftResult,
 };

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -185,25 +185,25 @@ impl DataType {
 
     #[inline]
     pub fn is_integer(&self) -> bool {
-        match self {
+        matches!(
+            self,
             DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64 => true,
-            _ => false,
-        }
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+        )
     }
 
     #[inline]
     pub fn is_floating(&self) -> bool {
-        match self {
-            DataType::Float16 | DataType::Float32 | DataType::Float64 => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            DataType::Float16 | DataType::Float32 | DataType::Float64
+        )
     }
 
     #[inline]

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -293,11 +293,11 @@ impl DataType {
 
     pub fn to_json(&self) -> DaftResult<String> {
         let payload = DataTypePayload::new(self);
-        Ok(serde_json::to_string(&payload).unwrap())
+        Ok(serde_json::to_string(&payload)?)
     }
 
     pub fn from_json(input: &str) -> DaftResult<Self> {
-        let val: DataTypePayload = serde_json::from_str(input).unwrap();
+        let val: DataTypePayload = serde_json::from_str(input)?;
         Ok(val.datatype)
     }
 }

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -125,9 +125,14 @@ impl DataType {
                 Box::new(dtype.to_arrow()?),
                 metadata.clone(),
             )),
-            // TODO: Embedding should be exported as an extension type
-            DataType::Embedding(field, size) => {
-                Ok(ArrowType::FixedSizeList(Box::new(field.to_arrow()?), *size))
+            DataType::Embedding(_field, size) => {
+                let physical = Box::new(self.to_physical());
+                let embedding_extension = DataType::Extension(
+                    "daft.embedding".into(),
+                    physical,
+                    Some(format!("{{\"size\": \"{size}\"}}")),
+                );
+                embedding_extension.to_arrow()
             }
             _ => Err(DaftError::TypeError(format!(
                 "Can not convert {self:?} into arrow type"

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -75,7 +75,8 @@ pub enum DataType {
     /// Extension type.
     Extension(String, Box<DataType>, Option<String>),
     // Stop ArrowTypes
-    DaftType(Box<DataType>),
+    /// A Embedding Logical Type
+    Embedding(Box<Field>, usize),
     Python,
     Unknown,
 }

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -184,6 +184,29 @@ impl DataType {
     }
 
     #[inline]
+    pub fn is_integer(&self) -> bool {
+        match self {
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64 => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn is_floating(&self) -> bool {
+        match self {
+            DataType::Float16 | DataType::Float32 | DataType::Float64 => true,
+            _ => false,
+        }
+    }
+
+    #[inline]
     pub fn is_temporal(&self) -> bool {
         match self {
             DataType::Date => true,

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -97,6 +97,7 @@ impl DataTypePayload {
         }
     }
 }
+const DAFT_SUPER_EXTENSION_NAME: &str = "daft.super_extension";
 
 impl DataType {
     pub fn new_null() -> DataType {
@@ -145,7 +146,7 @@ impl DataType {
             DataType::Embedding(..) => {
                 let physical = Box::new(self.to_physical());
                 let embedding_extension = DataType::Extension(
-                    "daft.super_extension".into(),
+                    DAFT_SUPER_EXTENSION_NAME.into(),
                     physical,
                     Some(self.to_json()?),
                 );
@@ -340,12 +341,13 @@ impl From<&ArrowType> for DataType {
                 DataType::Struct(fields)
             }
             ArrowType::Extension(name, dtype, metadata) => {
-                if let Some(metadata) = metadata {
-                    if let Ok(daft_extension) = Self::from_json(metadata.as_str()) {
-                        return daft_extension;
+                if name == DAFT_SUPER_EXTENSION_NAME {
+                    if let Some(metadata) = metadata {
+                        if let Ok(daft_extension) = Self::from_json(metadata.as_str()) {
+                            return daft_extension;
+                        }
                     }
                 }
-
                 DataType::Extension(
                     name.clone(),
                     Box::new(dtype.as_ref().into()),

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -237,16 +237,6 @@ impl DataType {
             ))),
         }
     }
-
-    #[inline]
-    pub fn is_castable(&self, cast_to: &DataType) -> bool {
-        match (self.to_arrow(), cast_to.to_arrow()) {
-            (Ok(self_arrow_type), Ok(cast_to_arrow_type)) => {
-                arrow2::compute::cast::can_cast_types(&self_arrow_type, &cast_to_arrow_type)
-            }
-            _ => false,
-        }
-    }
 }
 
 impl From<&ArrowType> for DataType {
@@ -301,6 +291,9 @@ impl Display for DataType {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
             DataType::List(nested) => write!(f, "List[{}]", nested.dtype),
+            DataType::FixedSizeList(inner, size) => {
+                write!(f, "FixedSizeList[{}; {}]", inner.dtype, size)
+            }
             DataType::Struct(fields) => {
                 let fields: String = fields
                     .iter()

--- a/src/datatypes/logical.rs
+++ b/src/datatypes/logical.rs
@@ -14,7 +14,8 @@ pub struct LogicalArray<L: DaftLogicalType> {
 }
 
 impl<L: DaftLogicalType + 'static> LogicalArray<L> {
-    pub fn new(field: Arc<Field>, physical: DataArray<L::PhysicalType>) -> Self {
+    pub fn new<F: Into<Arc<Field>>>(field: F, physical: DataArray<L::PhysicalType>) -> Self {
+        let field = field.into();
         assert!(
             field.dtype.is_logical(),
             "Can only construct Logical Arrays on Logical Types, got {}",
@@ -37,7 +38,7 @@ impl<L: DaftLogicalType + 'static> LogicalArray<L> {
 
     pub fn empty(name: &str, dtype: &DataType) -> Self {
         let field = Field::new(name, dtype.clone());
-        Self::new(field.into(), DataArray::empty(name, &dtype.to_physical()))
+        Self::new(field, DataArray::empty(name, &dtype.to_physical()))
     }
 
     pub fn name(&self) -> &str {
@@ -47,7 +48,7 @@ impl<L: DaftLogicalType + 'static> LogicalArray<L> {
     pub fn rename(&self, name: &str) -> Self {
         let new_field = self.field.rename(name);
         let new_array = self.physical.rename(name);
-        Self::new(new_field.into(), new_array)
+        Self::new(new_field, new_array)
     }
 
     pub fn field(&self) -> &Field {

--- a/src/datatypes/logical.rs
+++ b/src/datatypes/logical.rs
@@ -5,7 +5,7 @@ use crate::{
     error::DaftResult,
 };
 
-use super::{DataArray, DataType};
+use super::{DataArray, DataType, EmbeddingType};
 
 pub struct LogicalArray<L: DaftLogicalType> {
     pub field: Arc<Field>,
@@ -92,3 +92,4 @@ impl<L: DaftLogicalType + 'static> LogicalArray<L> {
 }
 
 pub type DateArray = LogicalArray<DateType>;
+pub type EmbeddingArray = LogicalArray<EmbeddingType>;

--- a/src/datatypes/matching.rs
+++ b/src/datatypes/matching.rs
@@ -231,6 +231,7 @@ macro_rules! with_match_daft_logical_types {(
 
     match $key_type {
         Date => __with_ty__! { DateType },
+        Embedding(..) => __with_ty__! { EmbeddingType },
         _ => panic!("{:?} not implemented for with_match_daft_logical_types", $key_type)
     }
 })}

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -106,6 +106,7 @@ impl_daft_logical_datatype!(TimestampType, Unknown, Int64Type);
 impl_daft_logical_datatype!(DateType, Date, Int32Type);
 impl_daft_logical_datatype!(TimeType, Unknown, Int64Type);
 impl_daft_logical_datatype!(DurationType, Unknown, Int64Type);
+impl_daft_logical_datatype!(EmbeddingType, Unknown, FixedSizeListType);
 
 pub trait NumericNative:
     PartialOrd

--- a/src/dsl/expr.rs
+++ b/src/dsl/expr.rs
@@ -331,11 +331,7 @@ impl Expr {
                                 return Ok(Field::new(left_field.name.as_str(), supertype));
                             }
                         }
-                        if !left_field.dtype.is_castable(&DataType::Float64)
-                            || !right_field.dtype.is_castable(&DataType::Float64)
-                            || !left_field.dtype.is_numeric()
-                            || !right_field.dtype.is_numeric()
-                        {
+                        if !left_field.dtype.is_numeric() || !right_field.dtype.is_numeric() {
                             return Err(DaftError::TypeError(format!("Expected left and right arguments for {op} to both be numeric and castable to {}, but received {left_field} and {right_field}", DataType::Float64)));
                         }
                         Ok(Field::new(left_field.name.as_str(), DataType::Float64))

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,7 @@
-use std::fmt::{Display, Formatter, Result};
+use std::{
+    fmt::{Display, Formatter, Result},
+    io,
+};
 
 #[derive(Debug)]
 pub enum DaftError {
@@ -10,6 +13,7 @@ pub enum DaftError {
     ValueError(String),
     #[cfg(feature = "python")]
     PyO3Error(pyo3::PyErr),
+    IoError(io::Error),
 }
 
 impl From<arrow2::error::Error> for DaftError {
@@ -22,6 +26,12 @@ impl From<arrow2::error::Error> for DaftError {
 impl From<pyo3::PyErr> for DaftError {
     fn from(error: pyo3::PyErr) -> Self {
         DaftError::PyO3Error(error)
+    }
+}
+
+impl From<serde_json::Error> for DaftError {
+    fn from(error: serde_json::Error) -> Self {
+        DaftError::IoError(error.into())
     }
 }
 
@@ -39,6 +49,7 @@ impl Display for DaftError {
             Self::ValueError(s) => write!(f, "DaftError::ValueError {s}"),
             #[cfg(feature = "python")]
             Self::PyO3Error(e) => write!(f, "DaftError::PyO3Error {e}"),
+            Self::IoError(e) => write!(f, "DaftError::IoError {e}"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod ffi;
 #[cfg(feature = "python")]
 mod python;
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 const BUILD_TYPE_DEV: &str = "dev";
 const DAFT_BUILD_TYPE: &str = {
     let env_build_type: Option<&str> = option_env!("RUST_DAFT_PKG_BUILD_TYPE");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod ffi;
 #[cfg(feature = "python")]
 mod python;
 
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 const BUILD_TYPE_DEV: &str = "dev";
 const DAFT_BUILD_TYPE: &str = {
     let env_build_type: Option<&str> = option_env!("RUST_DAFT_PKG_BUILD_TYPE");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@ pub mod pylib {
 
     #[pymodule]
     fn daft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+        pyo3_log::init();
+
         python::register_modules(_py, m)?;
         m.add_wrapped(wrap_pyfunction!(version))?;
         m.add_wrapped(wrap_pyfunction!(build_type))?;

--- a/src/python/datatype.rs
+++ b/src/python/datatype.rs
@@ -125,6 +125,28 @@ impl PyDataType {
     }
 
     #[staticmethod]
+    pub fn embedding(name: &str, data_type: Self, size: i64) -> PyResult<Self> {
+        if size <= 0 {
+            return Err(PyValueError::new_err(format!(
+                "The size for embedding types must be a positive integer, but got: {}",
+                size
+            )));
+        }
+        if !data_type.dtype.is_numeric() {
+            return Err(PyValueError::new_err(format!(
+                "The data type for an embedding must be numeric, but got: {}",
+                data_type.dtype
+            )));
+        }
+
+        Ok(DataType::Embedding(
+            Box::new(Field::new(name, data_type.dtype)),
+            usize::try_from(size)?,
+        )
+        .into())
+    }
+
+    #[staticmethod]
     pub fn r#struct(fields: &PyDict) -> PyResult<Self> {
         Ok(DataType::Struct(
             fields

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7,6 +7,7 @@ mod schema;
 mod series;
 mod table;
 
+pub use datatype::PyDataType;
 pub use series::PySeries;
 
 pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -262,6 +262,10 @@ impl PySeries {
         Ok(self.series.dt_day_of_week()?.into())
     }
 
+    pub fn arr_lengths(&self) -> PyResult<Self> {
+        Ok(self.series.arr_lengths()?.into_series().into())
+    }
+
     pub fn if_else(&self, other: &Self, predicate: &Self) -> PyResult<Self> {
         Ok(self
             .series

--- a/src/series/array_impl/logical_array.rs
+++ b/src/series/array_impl/logical_array.rs
@@ -1,4 +1,5 @@
 use crate::datatypes::logical::DateArray;
+use crate::datatypes::logical::EmbeddingArray;
 
 use super::{ArrayWrapper, IntoSeries, Series};
 use crate::array::ops::GroupIndices;
@@ -140,3 +141,4 @@ macro_rules! impl_series_like_for_logical_array {
 }
 
 impl_series_like_for_logical_array!(DateArray);
+impl_series_like_for_logical_array!(EmbeddingArray);

--- a/src/series/ops/list.rs
+++ b/src/series/ops/list.rs
@@ -15,11 +15,13 @@ impl Series {
         }
     }
 
-    pub fn lengths(&self) -> DaftResult<UInt64Array> {
+    pub fn arr_lengths(&self) -> DaftResult<UInt64Array> {
         use DataType::*;
-        match self.data_type() {
-            List(_) => self.list()?.lengths(),
-            FixedSizeList(..) => self.fixed_size_list()?.lengths(),
+
+        let p = self.as_physical()?;
+        match p.data_type() {
+            List(_) => p.list()?.lengths(),
+            FixedSizeList(..) => p.fixed_size_list()?.lengths(),
             dt => Err(DaftError::TypeError(format!(
                 "lengths not implemented for {}",
                 dt

--- a/src/table/ops/explode.rs
+++ b/src/table/ops/explode.rs
@@ -59,11 +59,11 @@ impl Table {
                 }
             }
         }
-        let first_len = evaluated_columns.first().unwrap().lengths()?;
+        let first_len = evaluated_columns.first().unwrap().arr_lengths()?;
         if evaluated_columns
             .iter()
             .skip(1)
-            .any(|c| c.lengths().unwrap().ne(&first_len))
+            .any(|c| c.arr_lengths().unwrap().ne(&first_len))
         {
             return Err(DaftError::ValueError(
                 "In multicolumn explode, list length did not match".to_string(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,8 @@ class UuidType(pa.ExtensionType):
         return UuidType, ()
 
     @classmethod
-    def __arrow_ext_deserialize__(self, storage_type, serialized):
-        return UuidType()
+    def __arrow_ext_deserialize__(cls, storage_type, serialized):
+        return cls()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,9 @@ class UuidType(pa.ExtensionType):
     def __arrow_ext_serialize__(self):
         return b""
 
+    def __reduce__(self):
+        return UuidType, ()
+
     @classmethod
     def __arrow_ext_deserialize__(self, storage_type, serialized):
         return UuidType()

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -198,10 +198,6 @@ def test_create_dataframe_arrow_tensor_canonical(valid_data: list[dict[str, floa
     assert df.to_arrow() == expected
 
 
-@pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
-    reason="pyarrow extension types aren't supported on Ray clusters.",
-)
 def test_create_dataframe_arrow_extension_type(valid_data: list[dict[str, float]], uuid_ext_type: UuidType) -> None:
     pydict = {k: [item[k] for item in valid_data] for k in valid_data[0].keys()}
     storage = pa.array([f"{i}".encode() for i in range(len(valid_data))])
@@ -216,22 +212,6 @@ def test_create_dataframe_arrow_extension_type(valid_data: list[dict[str, float]
     expected = t.cast(t.schema.set(t.schema.get_field_index("variety"), casted_field))
     # Check roundtrip.
     assert df.to_arrow() == expected
-
-
-# TODO(Clark): Remove this test once pyarrow extension types are supported for Ray clusters.
-@pytest.mark.skipif(
-    get_context().runner_config.name != "ray",
-    reason="This test requires the Ray runner.",
-)
-def test_create_dataframe_arrow_extension_type_fails_for_ray(
-    valid_data: list[dict[str, float]], uuid_ext_type: UuidType
-) -> None:
-    pydict = {k: [item[k] for item in valid_data] for k in valid_data[0].keys()}
-    storage = pa.array([f"{i}".encode() for i in range(len(valid_data))])
-    pydict["obj"] = pa.ExtensionArray.from_storage(uuid_ext_type, storage)
-    t = pa.Table.from_pydict(pydict)
-    with pytest.raises(ValueError):
-        daft.from_arrow(t).to_arrow()
 
 
 class PyExtType(pa.PyExtensionType):

--- a/tests/dataframe/test_logical_type.py
+++ b/tests/dataframe/test_logical_type.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+import daft
+from daft import DataType, Series, col
+from daft.datatype import DaftExtension
+
+
+def test_embedding_type_df() -> None:
+    data = [[1, 2, 3], np.arange(3), ["1", "2", "3"], [1, "2", 3.0], pd.Series([1.1, 2, 3]), (1, 2, 3), None]
+    df = daft.from_pydict({"index": np.arange(len(data)), "embeddings": Series.from_pylist(data, pyobj="force")})
+
+    target = DataType.embedding("arr", DataType.float32(), 3)
+    df = df.select(col("index"), col("embeddings").cast(target))
+    df = df.repartition(4, "index")
+    df = df.sort("index")
+    df = df.collect()
+    arrow_table = df.to_arrow()
+    assert isinstance(arrow_table["embeddings"].type, DaftExtension)

--- a/tests/series/test_embedding.py
+++ b/tests/series/test_embedding.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pandas as pd
+
+from daft.datatype import DaftExtension, DataType
+from daft.series import Series
+
+
+def test_embedding_arrow_round_trip():
+    data = [[1, 2, 3], np.arange(3), ["1", "2", "3"], [1, "2", 3.0], pd.Series([1.1, 2, 3]), (1, 2, 3), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.embedding("arr", DataType.int32(), 3)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    arrow_arr = t.to_arrow()
+
+    assert isinstance(arrow_arr.type, DaftExtension)
+    from_arrow = Series.from_arrow(t.to_arrow())
+
+    assert from_arrow.datatype() == t.datatype()
+    assert from_arrow.to_pylist() == t.to_pylist()
+
+    t_copy = copy.deepcopy(t)
+    assert t_copy.datatype() == t.datatype()
+    assert t_copy.to_pylist() == t.to_pylist()


### PR DESCRIPTION
* Enables Embedding Logical Type
* Enables running of extension types in Ray
* Enables LogicalType exports to ExtensionArrays and Back via Daft Super Types
* Enables Casts from python to [list, fixed_sized_list, embedding]
* Enables pyo3 logging for rust -> python logging
* Enables arr.lengths namespace for list like operations