### PR TITLE
Update requirement of tabulate to >=0.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "pyarrow >= 6.0.1",
   "fsspec[http]",
   "loguru",
-  "tabulate",
+  "tabulate >= 0.9.0",
   "psutil",
   "typing-extensions >= 4.0.0; python_version < '3.8'",
   "pickle5 >= 0.0.12; python_version < '3.8'"


### PR DESCRIPTION
Daft uses some functionality from `tabulate==0.9.0` for limiting the maximum number of characters per row, and needs to pin the requirement