### PR TITLE
[I/O] Port to `pyarrow` filesystems by default.

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -5,22 +5,22 @@ from typing import TYPE_CHECKING
 
 from daft.logging import setup_logger
 
-###
-# Set up code coverage for when running code coverage with ray
-###
-if "COV_CORE_SOURCE" in os.environ:
-    try:
-        from pytest_cov.embed import init
+# ###
+# # Set up code coverage for when running code coverage with ray
+# ###
+# if "COV_CORE_SOURCE" in os.environ:
+#     try:
+#         from pytest_cov.embed import init
 
-        init()
-    except Exception as exc:
-        import sys
+#         init()
+#     except Exception as exc:
+#         import sys
 
-        sys.stderr.write(
-            "pytest-cov: Failed to setup subprocess coverage. "
-            "Environ: {!r} "
-            "Exception: {!r}\n".format({k: v for k, v in os.environ.items() if k.startswith("COV_CORE")}, exc)
-        )
+#         sys.stderr.write(
+#             "pytest-cov: Failed to setup subprocess coverage. "
+#             "Environ: {!r} "
+#             "Exception: {!r}\n".format({k: v for k, v in os.environ.items() if k.startswith("COV_CORE")}, exc)
+#         )
 ###
 # Setup logging
 ###

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -5,22 +5,22 @@ from typing import TYPE_CHECKING
 
 from daft.logging import setup_logger
 
-# ###
-# # Set up code coverage for when running code coverage with ray
-# ###
-# if "COV_CORE_SOURCE" in os.environ:
-#     try:
-#         from pytest_cov.embed import init
+###
+# Set up code coverage for when running code coverage with ray
+###
+if "COV_CORE_SOURCE" in os.environ:
+    try:
+        from pytest_cov.embed import init
 
-#         init()
-#     except Exception as exc:
-#         import sys
+        init()
+    except Exception as exc:
+        import sys
 
-#         sys.stderr.write(
-#             "pytest-cov: Failed to setup subprocess coverage. "
-#             "Environ: {!r} "
-#             "Exception: {!r}\n".format({k: v for k, v in os.environ.items() if k.startswith("COV_CORE")}, exc)
-#         )
+        sys.stderr.write(
+            "pytest-cov: Failed to setup subprocess coverage. "
+            "Environ: {!r} "
+            "Exception: {!r}\n".format({k: v for k, v in os.environ.items() if k.startswith("COV_CORE")}, exc)
+        )
 ###
 # Setup logging
 ###

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -18,6 +18,7 @@ import fsspec
 import pyarrow as pa
 from fsspec.implementations.http import HTTPFileSystem
 from fsspec.registry import get_filesystem_class
+from loguru import logger
 from pyarrow.fs import (
     FileSystem,
     FSSpecHandler,
@@ -62,8 +63,6 @@ def _get_s3fs_kwargs() -> dict[str, Any]:
     try:
         import botocore.session
     except ImportError:
-        from loguru import logger
-
         logger.error(
             "Error when importing botocore. Install getdaft[aws] for the required 3rd party dependencies to interact with AWS S3 (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
         )
@@ -74,8 +73,6 @@ def _get_s3fs_kwargs() -> dict[str, Any]:
     # If accessing S3 without credentials, use anonymous access: https://github.com/Eventual-Inc/Daft/issues/503
     credentials_available = botocore.session.get_session().get_credentials() is not None
     if not credentials_available:
-        from loguru import logger
-
         logger.warning(
             "AWS credentials not found - using anonymous access to S3 which will fail if the bucket you are accessing is not a public bucket. See boto3 documentation for more details on configuring your AWS credentials: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html"
         )
@@ -93,8 +90,6 @@ def get_filesystem(protocol: str, **kwargs) -> fsspec.AbstractFileSystem:
     try:
         klass = fsspec.get_filesystem_class(protocol)
     except ImportError:
-        from loguru import logger
-
         logger.error(
             f"Error when importing dependencies for accessing data with: {protocol}. Please ensure that getdaft was installed with the appropriate extra dependencies (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
         )
@@ -221,8 +216,6 @@ def _resolve_path_and_filesystem(
             None, the provided filesystem will still be validated against the
             filesystem inferred from the provided path to ensure compatibility.
     """
-    from loguru import logger
-
     # Use pyarrow utility to resolve filesystem and this particular path.
     # If a non-None filesystem is provided to this utility, it will ensure that
     # it is compatible with the provided path.

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -17,7 +17,6 @@ from typing import Any
 import fsspec
 import pyarrow as pa
 from fsspec.implementations.http import HTTPFileSystem
-from loguru import logger
 from pyarrow.fs import FileSystem
 
 from daft.datasources import ParquetSourceInfo, SourceInfo
@@ -58,6 +57,8 @@ def _get_s3fs_kwargs() -> dict[str, Any]:
     try:
         import botocore.session
     except ImportError:
+        from loguru import logger
+
         logger.error(
             "Error when importing botocore. Install getdaft[aws] for the required 3rd party dependencies to interact with AWS S3 (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
         )
@@ -68,6 +69,8 @@ def _get_s3fs_kwargs() -> dict[str, Any]:
     # If accessing S3 without credentials, use anonymous access: https://github.com/Eventual-Inc/Daft/issues/503
     credentials_available = botocore.session.get_session().get_credentials() is not None
     if not credentials_available:
+        from loguru import logger
+
         logger.warning(
             "AWS credentials not found - using anonymous access to S3 which will fail if the bucket you are accessing is not a public bucket. See boto3 documentation for more details on configuring your AWS credentials: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html"
         )
@@ -85,6 +88,8 @@ def get_filesystem(protocol: str, **kwargs) -> fsspec.AbstractFileSystem:
     try:
         klass = fsspec.get_filesystem_class(protocol)
     except ImportError:
+        from loguru import logger
+
         logger.error(
             f"Error when importing dependencies for accessing data with: {protocol}. Please ensure that getdaft was installed with the appropriate extra dependencies (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
         )
@@ -125,6 +130,7 @@ def _resolve_paths_and_filesystem(
             compatibility.
     """
     import pyarrow as pa
+    from loguru import logger
     from pyarrow.fs import (
         FileSystem,
         FSSpecHandler,

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import dataclasses
+import pathlib
 import sys
+import urllib
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from urllib.parse import urlparse
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -15,9 +16,32 @@ from typing import Any
 
 import fsspec
 import pyarrow as pa
+from fsspec.implementations.http import HTTPFileSystem
 from loguru import logger
+from pyarrow.fs import FileSystem
 
 from daft.datasources import ParquetSourceInfo, SourceInfo
+
+_LOCAL_SCHEME = "local"
+_CACHED_FSES: dict[str, FileSystem] = {}
+
+
+def _get_fs_from_cache(protocol: str) -> FileSystem | None:
+    """
+    Get an instantiated pyarrow filesystem from the cache based on the URI protocol.
+
+    Returns None if no such cache entry exists.
+    """
+    global _CACHED_FSES
+
+    return _CACHED_FSES.get(protocol)
+
+
+def _put_fs_in_cache(protocol: str, fs: FileSystem) -> None:
+    """Put pyarrow filesystem in cache under provided protocol."""
+    global _CACHED_FSES
+
+    _CACHED_FSES[protocol] = fs
 
 
 @dataclasses.dataclass(frozen=True)
@@ -71,7 +95,7 @@ def get_filesystem(protocol: str, **kwargs) -> fsspec.AbstractFileSystem:
 
 
 def get_protocol_from_path(path: str) -> str:
-    parsed_scheme = urlparse(path).scheme
+    parsed_scheme = urllib.parse.urlparse(path, allow_fragments=False).scheme
     if parsed_scheme == "" or parsed_scheme is None:
         return "file"
     return parsed_scheme
@@ -83,6 +107,161 @@ def get_filesystem_from_path(path: str, **kwargs) -> fsspec.AbstractFileSystem:
     return fs
 
 
+def _resolve_paths_and_filesystem(
+    paths: str | pathlib.Path | list[str],
+    filesystem: pa.fs.FileSystem | None = None,
+) -> tuple[list[str], pa.fs.FileSystem]:
+    """
+    Resolves and normalizes all provided paths, infers a filesystem from the
+    paths, and ensures that all paths use the same filesystem.
+
+    Args:
+        paths: A single file/directory path or a list of file/directory paths.
+            A list of paths can contain both files and directories.
+        filesystem: The filesystem implementation that should be used for
+            reading these files. If None, a filesystem will be inferred. If not
+            None, the provided filesystem will still be validated against all
+            filesystems inferred from the provided paths to ensure
+            compatibility.
+    """
+    import pyarrow as pa
+    from pyarrow.fs import (
+        FileSystem,
+        FSSpecHandler,
+        PyFileSystem,
+        _resolve_filesystem_and_path,
+    )
+
+    if isinstance(paths, pathlib.Path):
+        paths = str(paths)
+    if isinstance(paths, str):
+        paths = [paths]
+    elif not isinstance(paths, list) or any(not isinstance(p, str) for p in paths):
+        raise ValueError(f"paths must be a path string or a list of path strings, got: {paths}")
+    elif len(paths) == 0:
+        raise ValueError("Must provide at least one path.")
+
+    if filesystem and not isinstance(filesystem, FileSystem):
+        err_msg = (
+            "The filesystem passed must be either pyarrow.fs.FileSystem or "
+            f"fsspec.spec.AbstractFileSystem. The provided filesystem was: {filesystem}"
+        )
+        if not isinstance(filesystem, fsspec.spec.AbstractFileSystem):
+            raise TypeError(err_msg) from None
+
+        filesystem = PyFileSystem(FSSpecHandler(filesystem))
+
+    resolved_paths = []
+    for path in paths:
+        path = _resolve_custom_scheme(path)
+        protocol = get_protocol_from_path(path)
+        cached_fs = _get_fs_from_cache(protocol)
+        if cached_fs is not None:
+            filesystem = cached_fs
+        try:
+            resolved_filesystem, resolved_path = _resolve_filesystem_and_path(path, filesystem)
+        except pa.lib.ArrowInvalid as e:
+            if "Cannot parse URI" in str(e):
+                resolved_filesystem, resolved_path = _resolve_filesystem_and_path(_encode_url(path), filesystem)
+                resolved_path = _decode_url(resolved_path)
+            elif "Unrecognized filesystem type in URI" in str(e):
+                # Fall back to fsspec.
+                logger.debug(f"pyarrow doesn't support paths with protocol {protocol}, falling back to fsspec.")
+                try:
+                    from fsspec.registry import get_filesystem_class
+                except ModuleNotFoundError:
+                    raise ImportError(f"Please install fsspec to read files with protocol {protocol}.") from None
+                try:
+                    fsspec_fs_cls = get_filesystem_class(protocol)
+                except ValueError:
+                    raise ValueError("pyarrow and fsspec don't recognize protocol {protocol} for path {path}.")
+                resolved_filesystem = PyFileSystem(FSSpecHandler(fsspec_fs_cls()))
+                resolved_path = path
+            else:
+                raise
+        _put_fs_in_cache(protocol, resolved_filesystem)
+        if filesystem is None:
+            filesystem = resolved_filesystem
+        # If filesystem is fsspec HTTPFileSystem, the protocol/scheme of paths
+        # should not be unwrapped/removed, because HTTPFileSystem expects full file
+        # paths including protocol/scheme. This is different behavior compared to
+        # filesystems implementated in pyarrow.
+        elif not (
+            isinstance(resolved_filesystem, PyFileSystem)
+            and isinstance(resolved_filesystem.handler, FSSpecHandler)
+            and isinstance(resolved_filesystem.handler.fs, HTTPFileSystem)
+        ):
+            resolved_path = _unwrap_protocol(resolved_path)
+        resolved_path = filesystem.normalize_path(resolved_path)
+        resolved_paths.append(resolved_path)
+
+    return resolved_paths, filesystem
+
+
+def _encode_url(path):
+    return urllib.parse.quote(path, safe="/:")
+
+
+def _decode_url(path):
+    return urllib.parse.unquote(path)
+
+
+def _unwrap_protocol(path):
+    """
+    Slice off any protocol prefixes on path.
+    """
+    if sys.platform == "win32" and _is_local_windows_path(path):
+        # Represent as posix path such that downstream functions properly handle it.
+        # This is executed when 'file://' is NOT included in the path.
+        return pathlib.Path(path).as_posix()
+
+    parsed = urllib.parse.urlparse(path, allow_fragments=False)  # support '#' in path
+    query = "?" + parsed.query if parsed.query else ""  # support '?' in path
+    netloc = parsed.netloc
+    if parsed.scheme == "s3" and "@" in parsed.netloc:
+        # If the path contains an @, it is assumed to be an anonymous
+        # credentialed path, and we need to strip off the credentials.
+        netloc = parsed.netloc.split("@")[-1]
+
+    parsed_path = parsed.path
+    # urlparse prepends the path with a '/'. This does not work on Windows
+    # so if this is the case strip the leading slash.
+    if (
+        sys.platform == "win32"
+        and not netloc
+        and len(parsed_path) >= 3
+        and parsed_path[0] == "/"  # The problematic leading slash
+        and parsed_path[1].isalpha()  # Ensure it is a drive letter.
+        and parsed_path[2:4] in (":", ":/")
+    ):
+        parsed_path = parsed_path[1:]
+
+    return netloc + parsed_path + query
+
+
+def _is_local_windows_path(path: str) -> bool:
+    """Determines if path is a Windows file-system location."""
+    if len(path) >= 1 and path[0] == "\\":
+        return True
+    if len(path) >= 3 and path[1] == ":" and (path[2] == "/" or path[2] == "\\") and path[0].isalpha():
+        return True
+    return False
+
+
+def _resolve_custom_scheme(path: str) -> str:
+    """Returns the resolved path if the given path follows a Ray-specific custom
+    scheme. Othewise, returns the path unchanged.
+
+    The supported custom schemes are: "local", "example".
+    """
+    import urllib.parse
+
+    parsed_uri = urllib.parse.urlparse(path)
+    if parsed_uri.scheme == _LOCAL_SCHEME:
+        path = parsed_uri.netloc + parsed_uri.path
+    return path
+
+
 ###
 # File globbing
 ###
@@ -92,7 +271,7 @@ def _ensure_path_protocol(protocol: str, returned_path: str) -> str:
     """This function adds the protocol that fsspec strips from returned results"""
     if protocol == "file":
         return returned_path
-    parsed_scheme = urlparse(returned_path).scheme
+    parsed_scheme = urllib.parse.urlparse(returned_path).scheme
     if parsed_scheme == "" or parsed_scheme is None:
         return f"{protocol}://{returned_path}"
     return returned_path

--- a/daft/table/table_io.py
+++ b/daft/table/table_io.py
@@ -4,7 +4,6 @@ import contextlib
 import pathlib
 from collections.abc import Generator
 from typing import IO, Union
-from urllib.parse import urlparse
 from uuid import uuid4
 
 import fsspec
@@ -13,9 +12,10 @@ from pyarrow import csv as pacsv
 from pyarrow import dataset as pads
 from pyarrow import json as pajson
 from pyarrow import parquet as papq
+from pyarrow.fs import FileSystem
 
 from daft.expressions import ExpressionsProjection
-from daft.filesystem import get_filesystem_from_path
+from daft.filesystem import _resolve_paths_and_filesystem
 from daft.runners.partitioning import (
     vPartitionParseCSVOptions,
     vPartitionReadOptions,
@@ -27,32 +27,34 @@ FileInput = Union[pathlib.Path, str, IO[bytes]]
 
 
 @contextlib.contextmanager
-def _get_file(
+def _open_stream(
     file: FileInput,
-    fs: fsspec.AbstractFileSystem | None,
-) -> Generator[FileInput, None, None]:
-    """Helper method to return an appropriate file handle
+    fs: FileSystem | fsspec.AbstractFileSystem | None,
+) -> Generator[pa.NativeFile, None, None]:
+    """Opens the provided file for reading, yield a pyarrow file handle."""
+    if isinstance(file, (pathlib.Path, str)):
+        paths, fs = _resolve_paths_and_filesystem(file, fs)
+        assert len(paths) == 1
+        path = paths[0]
+        with fs.open_input_stream(path) as f:
+            yield f
+    else:
+        yield file
 
-    1. If `fs` is not None, we fall-back onto the provided fsspec FileSystem and return an fsspec file handle
-    2. If `file` is a pathlib, we stringify it
-    3. If `file` is a string, we leave it unmodified
-    """
-    if isinstance(file, pathlib.Path):
-        file = str(file)
 
-    if isinstance(file, str):
-        # Use provided fsspec filesystem, slow but necessary for backward-compatibility
-        if fs is not None:
-            with fs.open(file, compression="infer") as f:
-                yield f
-        # Corner-case to handle `http` filepaths using fsspec because PyArrow cannot handle it
-        elif urlparse(file).scheme in {"http", "https"}:
-            fsspec_fs = get_filesystem_from_path(file)
-            with fsspec_fs.open(file, compression="infer") as f:
-                yield f
-        # Safely yield a string path, which can be correctly interpreted by PyArrow filesystem
-        else:
-            yield file
+@contextlib.contextmanager
+def _open_file(
+    file: FileInput,
+    fs: FileSystem | fsspec.AbstractFileSystem | None,
+) -> Generator[pa.NativeFile, None, None]:
+    """Opens the provided file for reading, yield a pyarrow file handle."""
+    if isinstance(file, (pathlib.Path, str)):
+        paths, fs = _resolve_paths_and_filesystem(file, fs)
+        assert len(paths) == 1
+        path = paths[0]
+        # TODO(Clark): Support (de)compression for random access files.
+        with fs.open_input_file(path) as f:
+            yield f
     else:
         yield file
 
@@ -73,7 +75,7 @@ def read_json(
     Returns:
         Table: Parsed Table from JSON
     """
-    with _get_file(file, fs) as f:
+    with _open_stream(file, fs) as f:
         table = pajson.read_json(f)
 
     if read_options.column_names is not None:
@@ -102,28 +104,35 @@ def read_parquet(
     Returns:
         Table: Parsed Table from Parquet
     """
-    with _get_file(file, fs) as f:
-        pqf = papq.ParquetFile(f)
-        # If no rows required, we manually construct an empty table with the right schema
-        if read_options.num_rows == 0:
-            arrow_schema = pqf.metadata.schema.to_arrow_schema()
-            table = pa.Table.from_arrays([pa.array([], type=field.type) for field in arrow_schema], schema=arrow_schema)
-        elif read_options.num_rows is not None:
-            # Read the file by rowgroup.
-            tables = []
-            rows_read = 0
-            for i in range(pqf.metadata.num_row_groups):
-                tables.append(pqf.read_row_group(i, columns=read_options.column_names))
-                rows_read += len(tables[i])
+    if not isinstance(file, (str, pathlib.Path)):
+        # BytesIO path.
+        return Table.from_arrow(papq.read_table(file, columns=read_options.column_names))
+
+    paths, fs = _resolve_paths_and_filesystem(file, fs)
+    assert len(paths) == 1
+    path = paths[0]
+    ds = papq.ParquetDataset(path, filesystem=fs, use_legacy_dataset=False, buffer_size=32 * 1024 * 1024)
+    # If no rows required, we manually construct an empty table with the right schema
+    if read_options.num_rows == 0:
+        arrow_schema = ds.schema
+        table = pa.Table.from_arrays([pa.array([], type=field.type) for field in arrow_schema], schema=arrow_schema)
+    elif read_options.num_rows is not None:
+        # Read the file by row group.
+        frags = [frag for fragment in ds.fragments for frag in fragment.split_by_row_group()]
+        tables = []
+        rows_read = 0
+        for frag in frags:
+            for batch in frag.to_batches(columns=read_options.column_names, batch_size=100000):
+                tables.append(pa.Table.from_batches([batch], schema=ds.schema))
+                rows_read += len(batch)
                 if rows_read >= read_options.num_rows:
                     break
-            table = pa.concat_tables(tables)
-            table = table.slice(length=read_options.num_rows)
-        else:
-            table = papq.read_table(
-                f,
-                columns=read_options.column_names,
-            )
+            if rows_read >= read_options.num_rows:
+                break
+        table = pa.concat_tables(tables)
+        table = table.slice(length=read_options.num_rows)
+    else:
+        table = ds.read(columns=read_options.column_names)
 
     return Table.from_arrow(table)
 
@@ -158,7 +167,7 @@ def read_csv(
     skip_header_row = full_column_names is not None and csv_options.has_headers
     pyarrow_skip_rows_after_names = (1 if skip_header_row else 0) + csv_options.skip_rows_after_header
 
-    with _get_file(file, fs) as f:
+    with _open_stream(file, fs) as f:
         table = pacsv.read_csv(
             f,
             parse_options=pacsv.ParseOptions(

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -388,11 +388,9 @@ def test_create_dataframe_csv_custom_fs(valid_data: list[dict[str, float]]) -> N
         # which would make this test pass without the passed filesystem being used.
         fs = LocalFileSystem(skip_instance_cache=True)
         mock_cache = MagicMock(return_value=None)
-        with (
-            patch.object(fs, "info", wraps=fs.info) as mock_info,
-            patch.object(fs, "open", wraps=fs.open) as mock_open,
-            patch("daft.filesystem._get_fs_from_cache", mock_cache),
-        ):
+        with patch.object(fs, "info", wraps=fs.info) as mock_info, patch.object(
+            fs, "open", wraps=fs.open
+        ) as mock_open, patch("daft.filesystem._get_fs_from_cache", mock_cache):
             df = daft.read_csv(f.name, fs=fs)
             # Check that info() is called on the passed filesystem.
             mock_info.assert_called()
@@ -510,11 +508,9 @@ def test_create_dataframe_json_custom_fs(valid_data: list[dict[str, float]]) -> 
         # which would make this test pass without the passed filesystem being used.
         fs = LocalFileSystem(skip_instance_cache=True)
         mock_cache = MagicMock(return_value=None)
-        with (
-            patch.object(fs, "info", wraps=fs.info) as mock_info,
-            patch.object(fs, "open", wraps=fs.open) as mock_open,
-            patch("daft.filesystem._get_fs_from_cache", mock_cache),
-        ):
+        with patch.object(fs, "info", wraps=fs.info) as mock_info, patch.object(
+            fs, "open", wraps=fs.open
+        ) as mock_open, patch("daft.filesystem._get_fs_from_cache", mock_cache):
             df = daft.read_json(f.name, fs=fs)
 
             # Check that info() is called on the passed filesystem.
@@ -586,11 +582,9 @@ def test_create_dataframe_parquet_custom_fs(valid_data: list[dict[str, float]]) 
         # which would make this test pass without the passed filesystem being used.
         fs = LocalFileSystem(skip_instance_cache=True)
         mock_cache = MagicMock(return_value=None)
-        with (
-            patch.object(fs, "info", wraps=fs.info) as mock_info,
-            patch.object(fs, "open", wraps=fs.open) as mock_open,
-            patch("daft.filesystem._get_fs_from_cache", mock_cache),
-        ):
+        with patch.object(fs, "info", wraps=fs.info) as mock_info, patch.object(
+            fs, "open", wraps=fs.open
+        ) as mock_open, patch("daft.filesystem._get_fs_from_cache", mock_cache):
             df = daft.read_parquet(f.name, fs=fs)
 
             # Check that info() is called on the passed filesystem.

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import tempfile
 import uuid
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pandas as pd
@@ -387,7 +387,12 @@ def test_create_dataframe_csv_custom_fs(valid_data: list[dict[str, float]]) -> N
         # fsspec would cache this instance and reuse it for Daft's default construction of filesystems,
         # which would make this test pass without the passed filesystem being used.
         fs = LocalFileSystem(skip_instance_cache=True)
-        with patch.object(fs, "info", wraps=fs.info) as mock_info, patch.object(fs, "open", wraps=fs.open) as mock_open:
+        mock_cache = MagicMock(return_value=None)
+        with (
+            patch.object(fs, "info", wraps=fs.info) as mock_info,
+            patch.object(fs, "open", wraps=fs.open) as mock_open,
+            patch("daft.filesystem._get_fs_from_cache", mock_cache),
+        ):
             df = daft.read_csv(f.name, fs=fs)
             # Check that info() is called on the passed filesystem.
             mock_info.assert_called()
@@ -504,7 +509,12 @@ def test_create_dataframe_json_custom_fs(valid_data: list[dict[str, float]]) -> 
         # fsspec would cache this instance and reuse it for Daft's default construction of filesystems,
         # which would make this test pass without the passed filesystem being used.
         fs = LocalFileSystem(skip_instance_cache=True)
-        with patch.object(fs, "info", wraps=fs.info) as mock_info, patch.object(fs, "open", wraps=fs.open) as mock_open:
+        mock_cache = MagicMock(return_value=None)
+        with (
+            patch.object(fs, "info", wraps=fs.info) as mock_info,
+            patch.object(fs, "open", wraps=fs.open) as mock_open,
+            patch("daft.filesystem._get_fs_from_cache", mock_cache),
+        ):
             df = daft.read_json(f.name, fs=fs)
 
             # Check that info() is called on the passed filesystem.
@@ -575,7 +585,12 @@ def test_create_dataframe_parquet_custom_fs(valid_data: list[dict[str, float]]) 
         # fsspec would cache this instance and reuse it for Daft's default construction of filesystems,
         # which would make this test pass without the passed filesystem being used.
         fs = LocalFileSystem(skip_instance_cache=True)
-        with patch.object(fs, "info", wraps=fs.info) as mock_info, patch.object(fs, "open", wraps=fs.open) as mock_open:
+        mock_cache = MagicMock(return_value=None)
+        with (
+            patch.object(fs, "info", wraps=fs.info) as mock_info,
+            patch.object(fs, "open", wraps=fs.open) as mock_open,
+            patch("daft.filesystem._get_fs_from_cache", mock_cache),
+        ):
             df = daft.read_parquet(f.name, fs=fs)
 
             # Check that info() is called on the passed filesystem.


### PR DESCRIPTION
This PR ports to our filesystem inference to create `pyarrow` `FileSystem` instances by default, only falling back to fsspec if the URI protocol is not supported. We also change our reading narrow waist to be around pyarrow `NativeFile` handles.