### PR TITLE
fix concats for extension array for old versions of pyarrow

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -44,7 +44,13 @@ class Series:
             return Series._from_pyseries(pys)
         elif isinstance(array, pa.ChunkedArray):
             array = ensure_chunked_array(array)
-            combined_array = array.combine_chunks()
+            arr_type = array.type
+            if isinstance(arr_type, pa.BaseExtensionType):
+                combined_storage_array = array.cast(arr_type.storage_type).combine_chunks()
+                combined_array = arr_type.wrap_array(combined_storage_array)
+            else:
+                combined_array = array.combine_chunks()
+
             pys = PySeries.from_arrow(name, combined_array)
             return Series._from_pyseries(pys)
         else:

--- a/src/datatypes/dtype.rs
+++ b/src/datatypes/dtype.rs
@@ -364,7 +364,7 @@ impl Display for DataType {
     // `f` is a buffer, and this method must write the formatted string into it
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
-            DataType::List(nested) => write!(f, "List[{}]", nested.dtype),
+            DataType::List(nested) => write!(f, "List[{}:{}]", nested.name, nested.dtype),
             DataType::FixedSizeList(inner, size) => {
                 write!(f, "FixedSizeList[{}; {}]", inner.dtype, size)
             }

--- a/tests/series/test_concat.py
+++ b/tests/series/test_concat.py
@@ -167,7 +167,10 @@ def test_series_concat_extension_type(uuid_ext_type, chunks) -> None:
     concated_arrow = concated.to_arrow()
     assert isinstance(concated_arrow.type, UuidType)
     assert concated_arrow.type == uuid_ext_type
-    assert concated_arrow == pa.concat_arrays(ext_arrays)
+
+    expected = uuid_ext_type.wrap_array(pa.concat_arrays(storage_arrays))
+
+    assert concated_arrow == expected
 
 
 @pytest.mark.parametrize("chunks", [1, 2, 3, 10])


### PR DESCRIPTION
* Fix `from_arrow` for Extension ChunkedArrays for pyarrow <= 7.0
* Fix tests for list dtype comparisions since it checks for the field name