### PR TITLE
[ci] [daft publish] pin urllib to < 2 for conda

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -145,7 +145,7 @@ jobs:
 
     - name: Install anaconda client
       shell: bash -el {0}
-      run: conda install -q -y anaconda-client
+      run: conda install -q -y anaconda-client "urllib3<2.0"
 
     - name: Upload wheels to anaconda nightly
       if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}


### PR DESCRIPTION
* Fix for issue when trying to publish nightly wheel: https://github.com/Eventual-Inc/Daft/actions/runs/5053346792