### PR TITLE
Very basic s3 parquet microbenchmark

### DIFF
--- a/tests/benchmarks/test_file_read.py
+++ b/tests/benchmarks/test_file_read.py
@@ -61,7 +61,7 @@ def test_csv_read(gen_simple_csvs, benchmark):
 @pytest.mark.parametrize("prune", [True, False])
 def test_s3_parquet_read_1x64mb(benchmark, prune):
     parquet_glob = "s3://daft-public-data/test_fixtures/parquet/*"
-    expected_rows = 3000000
+    expected_rows = 1500000
 
     def bench() -> DataFrame:
         df = daft.read_parquet(parquet_glob)


### PR DESCRIPTION
- 1 x 64mb parquet file
- 32 x 2mb parquet files
- Column pruning vs whole file

Data in s3://daft-public-data/test_fixtures so microbenchmark can be run from anywhere.