### PR TITLE
[Images] [1/N] Logical type for variable-shaped and fixed-shaped images.

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -5,22 +5,22 @@ from typing import TYPE_CHECKING
 
 from daft.logging import setup_logger
 
-###
-# Set up code coverage for when running code coverage with ray
-###
-if "COV_CORE_SOURCE" in os.environ:
-    try:
-        from pytest_cov.embed import init
+# ###
+# # Set up code coverage for when running code coverage with ray
+# ###
+# if "COV_CORE_SOURCE" in os.environ:
+#     try:
+#         from pytest_cov.embed import init
 
-        init()
-    except Exception as exc:
-        import sys
+#         init()
+#     except Exception as exc:
+#         import sys
 
-        sys.stderr.write(
-            "pytest-cov: Failed to setup subprocess coverage. "
-            "Environ: {!r} "
-            "Exception: {!r}\n".format({k: v for k, v in os.environ.items() if k.startswith("COV_CORE")}, exc)
-        )
+#         sys.stderr.write(
+#             "pytest-cov: Failed to setup subprocess coverage. "
+#             "Environ: {!r} "
+#             "Exception: {!r}\n".format({k: v for k, v in os.environ.items() if k.startswith("COV_CORE")}, exc)
+#         )
 ###
 # Setup logging
 ###

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -5,22 +5,22 @@ from typing import TYPE_CHECKING
 
 from daft.logging import setup_logger
 
-# ###
-# # Set up code coverage for when running code coverage with ray
-# ###
-# if "COV_CORE_SOURCE" in os.environ:
-#     try:
-#         from pytest_cov.embed import init
+###
+# Set up code coverage for when running code coverage with ray
+###
+if "COV_CORE_SOURCE" in os.environ:
+    try:
+        from pytest_cov.embed import init
 
-#         init()
-#     except Exception as exc:
-#         import sys
+        init()
+    except Exception as exc:
+        import sys
 
-#         sys.stderr.write(
-#             "pytest-cov: Failed to setup subprocess coverage. "
-#             "Environ: {!r} "
-#             "Exception: {!r}\n".format({k: v for k, v in os.environ.items() if k.startswith("COV_CORE")}, exc)
-#         )
+        sys.stderr.write(
+            "pytest-cov: Failed to setup subprocess coverage. "
+            "Environ: {!r} "
+            "Exception: {!r}\n".format({k: v for k, v in os.environ.items() if k.startswith("COV_CORE")}, exc)
+        )
 ###
 # Setup logging
 ###

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -1,0 +1,37 @@
+from enum import Enum
+from typing import Any
+
+class ImageMode(Enum):
+    """
+    Supported image modes for Daft's image type.
+    """
+
+    # 8-bit grayscale
+    L: int
+    # 8-bit grayscale + alpha
+    LA: int
+    # 8-bit RGB
+    RGB: int
+    # 8-bit RGB + alpha
+    RGBA: int
+    # 16-bit grayscale
+    L16: int
+    # 16-bit grayscale + alpha
+    LA16: int
+    # 16-bit RGB
+    RGB16: int
+    # 16-bit RGB + alpha
+    RGBA16: int
+    # 32-bit floating RGB
+    RGB32F: int
+    # 32-bit floating RGB + alpha
+    RGBA32F: int
+
+    @staticmethod
+    def from_mode_string(mode: str) -> ImageMode:
+        """
+        Create an ImageMode from its string representation.
+        """
+        ...
+
+def __getattr__(name) -> Any: ...

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -132,7 +132,9 @@ class DataType:
         return cls._from_pydatatype(PyDataType.embedding(name, dtype._dtype, size))
 
     @classmethod
-    def image(cls, mode: str | ImageMode, height: int | None = None, width: int | None = None) -> DataType:
+    def image(
+        cls, mode: str | ImageMode | None = None, height: int | None = None, width: int | None = None
+    ) -> DataType:
         if isinstance(mode, str):
             mode = ImageMode.from_mode_string(mode)
         if height is not None and width is not None:

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -118,18 +118,26 @@ class DataType:
         return cls._from_pydatatype(PyDataType.fixed_size_list(name, dtype._dtype, size))
 
     @classmethod
-    def embedding(cls, name: str, dtype: DataType, size: int) -> DataType:
-        if not isinstance(size, int) or size <= 0:
-            raise ValueError("The size for a embedding must be a positive integer, but got: ", size)
-        return cls._from_pydatatype(PyDataType.embedding(name, dtype._dtype, size))
-
-    @classmethod
     def struct(cls, fields: dict[str, DataType]) -> DataType:
         return cls._from_pydatatype(PyDataType.struct({name: datatype._dtype for name, datatype in fields.items()}))
 
     @classmethod
     def extension(cls, name: str, storage_dtype: DataType, metadata: str | None = None) -> DataType:
         return cls._from_pydatatype(PyDataType.extension(name, storage_dtype._dtype, metadata))
+
+    @classmethod
+    def embedding(cls, name: str, dtype: DataType, size: int) -> DataType:
+        if not isinstance(size, int) or size <= 0:
+            raise ValueError("The size for a embedding must be a positive integer, but got: ", size)
+        return cls._from_pydatatype(PyDataType.embedding(name, dtype._dtype, size))
+
+    @classmethod
+    def image(cls, name: str, dtype: DataType, shape: tuple | None = None) -> DataType:
+        if isinstance(shape, tuple) and (not shape or any(not isinstance(n, int) for n in shape)):
+            raise ValueError(
+                "The shape for a fixed-sized image type must be a non-empty tuple of ints, but got: ", shape
+            )
+        return cls._from_pydatatype(PyDataType.image(name, dtype._dtype, shape))
 
     @classmethod
     def from_arrow_type(cls, arrow_type: pa.lib.DataType) -> DataType:
@@ -259,7 +267,7 @@ class DaftExtension(pa.ExtensionType):
 
     @classmethod
     def __arrow_ext_deserialize__(cls, storage_type, serialized):
-        return DaftExtension(storage_type, serialized)
+        return cls(storage_type, serialized)
 
 
 pa.register_extension_type(DaftExtension(pa.null(), b""))

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -41,6 +41,7 @@ class ImageMode(str, Enum):
     B = "1"
     L = "L"
     P = "P"
+    LA = "LA"
     RGB = "RGB"
     RGBA = "RGBA"
     CMYK = "CMYK"
@@ -49,6 +50,12 @@ class ImageMode(str, Enum):
     HSV = "HSV"
     I = "I"
     F = "F"
+    L16 = "L16"
+    LA16 = "LA16"
+    RGB16 = "RGB16"
+    RGBA16 = "RGBA16"
+    RGB32F = "RGB32F"
+    RGBA32 = "RGBA32F"
 
     @classmethod
     def from_mode_string(cls, mode: str) -> ImageMode:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,6 +23,7 @@ numpy==1.24.3; python_version >= '3.8'
 pandas==1.3.5; python_version < '3.8'
 pandas==2.0.1; python_version >= '3.8'
 xxhash>=3.0.0
+Pillow==9.5.0
 
 # Ray
 ray[data, default]==2.4.0

--- a/src/array/ops/as_arrow.rs
+++ b/src/array/ops/as_arrow.rs
@@ -4,7 +4,7 @@ use arrow2::array;
 use crate::{
     array::DataArray,
     datatypes::{
-        logical::{DateArray, EmbeddingArray},
+        logical::{DateArray, EmbeddingArray, FixedShapeImageArray, ImageArray},
         BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray, ListArray, StructArray,
         Utf8Array,
     },
@@ -104,7 +104,25 @@ impl AsArrow for crate::datatypes::PythonArray {
 impl AsArrow for EmbeddingArray {
     type Output = array::FixedSizeListArray;
 
-    // downcasts a DataArray<T> to an Arrow FixedSizeListArray.
+    // downcasts an EmbeddingArray to an Arrow FixedSizeListArray.
+    fn as_arrow(&self) -> &Self::Output {
+        self.physical.data().as_any().downcast_ref().unwrap()
+    }
+}
+
+impl AsArrow for ImageArray {
+    type Output = array::ListArray<i64>;
+
+    // downcasts an ImageArray to an Arrow ListArray.
+    fn as_arrow(&self) -> &Self::Output {
+        self.physical.data().as_any().downcast_ref().unwrap()
+    }
+}
+
+impl AsArrow for FixedShapeImageArray {
+    type Output = array::FixedSizeListArray;
+
+    // downcasts a FixedShapeImageArray to an Arrow FixedSizeListArray.
     fn as_arrow(&self) -> &Self::Output {
         self.physical.data().as_any().downcast_ref().unwrap()
     }

--- a/src/array/ops/as_arrow.rs
+++ b/src/array/ops/as_arrow.rs
@@ -111,9 +111,9 @@ impl AsArrow for EmbeddingArray {
 }
 
 impl AsArrow for ImageArray {
-    type Output = array::ListArray<i64>;
+    type Output = array::StructArray;
 
-    // downcasts an ImageArray to an Arrow ListArray.
+    // downcasts an ImageArray to an Arrow StructArray.
     fn as_arrow(&self) -> &Self::Output {
         self.physical.data().as_any().downcast_ref().unwrap()
     }

--- a/src/array/ops/filter.rs
+++ b/src/array/ops/filter.rs
@@ -1,7 +1,7 @@
 use crate::{
     array::DataArray,
     datatypes::{
-        logical::{DateArray, EmbeddingArray},
+        logical::{DateArray, EmbeddingArray, FixedShapeImageArray, ImageArray},
         BooleanArray, DaftArrowBackedType,
     },
     error::DaftResult,
@@ -81,6 +81,20 @@ impl DateArray {
 }
 
 impl EmbeddingArray {
+    pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
+        let new_array = self.physical.filter(mask)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+}
+
+impl ImageArray {
+    pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
+        let new_array = self.physical.filter(mask)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+}
+
+impl FixedShapeImageArray {
     pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
         let new_array = self.physical.filter(mask)?;
         Ok(Self::new(self.field.clone(), new_array))

--- a/src/array/ops/if_else.rs
+++ b/src/array/ops/if_else.rs
@@ -1,5 +1,5 @@
 use crate::array::DataArray;
-use crate::datatypes::logical::{DateArray, EmbeddingArray};
+use crate::datatypes::logical::{DateArray, EmbeddingArray, FixedShapeImageArray, ImageArray};
 use crate::datatypes::{
     BinaryArray, BooleanArray, DaftArrowBackedType, DaftNumericType, ExtensionArray, Field,
     FixedSizeListArray, ListArray, NullArray, StructArray, Utf8Array,
@@ -329,6 +329,20 @@ impl DateArray {
 }
 
 impl EmbeddingArray {
+    pub fn if_else(&self, other: &Self, predicate: &BooleanArray) -> DaftResult<Self> {
+        let new_array = self.physical.if_else(&other.physical, predicate)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+}
+
+impl ImageArray {
+    pub fn if_else(&self, other: &Self, predicate: &BooleanArray) -> DaftResult<Self> {
+        let new_array = self.physical.if_else(&other.physical, predicate)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+}
+
+impl FixedShapeImageArray {
     pub fn if_else(&self, other: &Self, predicate: &BooleanArray) -> DaftResult<Self> {
         let new_array = self.physical.if_else(&other.physical, predicate)?;
         Ok(Self::new(self.field.clone(), new_array))

--- a/src/array/ops/sort.rs
+++ b/src/array/ops/sort.rs
@@ -600,18 +600,18 @@ impl DateArray {
 
 impl EmbeddingArray {
     pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
-        todo!("impl sort for FixedSizeListArray")
+        todo!("impl sort for EmbeddingArray")
     }
 }
 
 impl ImageArray {
     pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
-        todo!("impl sort for ListArray")
+        todo!("impl sort for ImageArray")
     }
 }
 
 impl FixedShapeImageArray {
     pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
-        todo!("impl sort for FixedSizeListArray")
+        todo!("impl sort for FixedShapeImageArray")
     }
 }

--- a/src/array/ops/sort.rs
+++ b/src/array/ops/sort.rs
@@ -1,7 +1,7 @@
 use crate::{
     array::DataArray,
     datatypes::{
-        logical::{DateArray, EmbeddingArray},
+        logical::{DateArray, EmbeddingArray, FixedShapeImageArray, ImageArray},
         BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, ExtensionArray,
         FixedSizeListArray, Float32Array, Float64Array, ListArray, NullArray, StructArray,
         Utf8Array,
@@ -591,15 +591,27 @@ impl PythonArray {
     }
 }
 
+impl DateArray {
+    pub fn sort(&self, descending: bool) -> DaftResult<Self> {
+        let new_array = self.physical.sort(descending)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+}
+
 impl EmbeddingArray {
     pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
         todo!("impl sort for FixedSizeListArray")
     }
 }
 
-impl DateArray {
-    pub fn sort(&self, descending: bool) -> DaftResult<Self> {
-        let new_array = self.physical.sort(descending)?;
-        Ok(Self::new(self.field.clone(), new_array))
+impl ImageArray {
+    pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
+        todo!("impl sort for ListArray")
+    }
+}
+
+impl FixedShapeImageArray {
+    pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
+        todo!("impl sort for FixedSizeListArray")
     }
 }

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -506,7 +506,10 @@ impl ImageArray {
             .validity()
             .map_or(true, |validity| validity.get_bit(idx));
         if is_valid {
-            Some(unsafe { arrow_array.value_unchecked(idx) })
+            let data_array = arrow_array.values()[0]
+                .as_any()
+                .downcast_ref::<arrow2::array::ListArray<i64>>()?;
+            Some(unsafe { data_array.value_unchecked(idx) })
         } else {
             None
         }

--- a/src/array/ops/take.rs
+++ b/src/array/ops/take.rs
@@ -1,7 +1,7 @@
 use crate::{
     array::DataArray,
     datatypes::{
-        logical::{DateArray, EmbeddingArray},
+        logical::{DateArray, EmbeddingArray, FixedShapeImageArray, ImageArray},
         BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, ExtensionArray,
         FixedSizeListArray, ListArray, NullArray, StructArray, Utf8Array,
     },
@@ -461,6 +461,76 @@ impl DateArray {
 }
 
 impl EmbeddingArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<Box<dyn arrow2::array::Array>> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let arrow_array = self.as_arrow();
+        let is_valid = arrow_array
+            .validity()
+            .map_or(true, |validity| validity.get_bit(idx));
+        if is_valid {
+            Some(unsafe { arrow_array.value_unchecked(idx) })
+        } else {
+            None
+        }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let new_array = self.physical.take(idx)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            Some(v) => Ok(format!("{v:?}")),
+        }
+    }
+}
+
+impl ImageArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<Box<dyn arrow2::array::Array>> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let arrow_array = self.as_arrow();
+        let is_valid = arrow_array
+            .validity()
+            .map_or(true, |validity| validity.get_bit(idx));
+        if is_valid {
+            Some(unsafe { arrow_array.value_unchecked(idx) })
+        } else {
+            None
+        }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let new_array = self.physical.take(idx)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            Some(v) => Ok(format!("{v:?}")),
+        }
+    }
+}
+
+impl FixedShapeImageArray {
     #[inline]
     pub fn get(&self, idx: usize) -> Option<Box<dyn arrow2::array::Array>> {
         if idx >= self.len() {

--- a/src/datatypes/image_mode.rs
+++ b/src/datatypes/image_mode.rs
@@ -1,0 +1,127 @@
+use std::fmt::{Display, Formatter, Result};
+use std::str::FromStr;
+use std::string::ToString;
+
+#[cfg(feature = "python")]
+use pyo3::{exceptions::PyValueError, prelude::*};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    datatypes::DataType,
+    error::{DaftError, DaftResult},
+};
+
+/// Supported image modes for Daft's image type.
+///
+/// L       - 8-bit grayscale
+/// LA      - 8-bit grayscale + alpha
+/// RGB     - 8-bit RGB
+/// RGBA    - 8-bit RGB + alpha
+/// L16     - 16-bit grayscale
+/// LA16    - 16-bit grayscale + alpha
+/// RGB16   - 16-bit RGB
+/// RGBA16  - 16-bit RGB + alpha
+/// RGB32F  - 32-bit floating RGB
+/// RGBA32F - 32-bit floating RGB + alpha
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[cfg_attr(feature = "python", pyclass)]
+pub enum ImageMode {
+    L = 1,
+    LA = 2,
+    RGB = 3,
+    RGBA = 4,
+    L16 = 5,
+    LA16 = 6,
+    RGB16 = 7,
+    RGBA16 = 8,
+    RGB32F = 9,
+    RGBA32F = 10,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl ImageMode {
+    /// Create an ImageMode from its string representation.
+    #[staticmethod]
+    pub fn from_mode_string(mode: &str) -> PyResult<Self> {
+        Self::from_str(mode).map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    pub fn __str__(&self) -> PyResult<String> {
+        Ok(self.to_string())
+    }
+}
+
+impl ImageMode {
+    pub fn try_from_num_channels(num_channels: u16, dtype: &DataType) -> DaftResult<Self> {
+        use ImageMode::*;
+
+        match (num_channels, dtype) {
+            (1, DataType::UInt8) => Ok(L),
+            (1, DataType::UInt16) => Ok(L16),
+            (2, DataType::UInt8) => Ok(LA),
+            (2, DataType::UInt16) => Ok(LA16),
+            (3, DataType::UInt8) => Ok(RGB),
+            (3, DataType::UInt16) => Ok(RGB16),
+            (3, DataType::Float32) => Ok(RGB32F),
+            (4, DataType::UInt8) => Ok(RGBA),
+            (4, DataType::UInt16) => Ok(RGBA16),
+            (4, DataType::Float32) => Ok(RGBA32F),
+            (_, _) => Err(DaftError::ValueError(format!(
+                "Images with more than {} channels and dtype {} are not supported",
+                num_channels, dtype,
+            ))),
+        }
+    }
+    pub fn num_channels(&self) -> u16 {
+        use ImageMode::*;
+
+        match self {
+            L | L16 => 1,
+            LA | LA16 => 2,
+            RGB | RGB16 | RGB32F => 3,
+            RGBA | RGBA16 | RGBA32F => 4,
+        }
+    }
+    pub fn iterator() -> std::slice::Iter<'static, ImageMode> {
+        use ImageMode::*;
+
+        static MODES: [ImageMode; 10] =
+            [L, LA, RGB, RGBA, L16, LA16, RGB16, RGBA16, RGB32F, RGBA32F];
+        MODES.iter()
+    }
+}
+
+impl FromStr for ImageMode {
+    type Err = DaftError;
+
+    fn from_str(mode: &str) -> DaftResult<Self> {
+        use ImageMode::*;
+
+        match mode {
+            "L" => Ok(L),
+            "LA" => Ok(LA),
+            "RGB" => Ok(RGB),
+            "RGBA" => Ok(RGBA),
+            "L16" => Ok(L16),
+            "LA16" => Ok(LA16),
+            "RGB16" => Ok(RGB16),
+            "RGBA16" => Ok(RGBA16),
+            "RGB32F" => Ok(RGB32F),
+            "RGBA32F" => Ok(RGBA32F),
+            _ => Err(DaftError::TypeError(format!(
+                "Image mode {} is not supported; only the following modes are supported: {:?}",
+                mode,
+                ImageMode::iterator().as_slice()
+            ))),
+        }
+    }
+}
+
+impl Display for ImageMode {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        // Leverage Debug trait implementation, which will already return the enum variant as a string.
+        write!(f, "{:?}", self)
+    }
+}

--- a/src/datatypes/logical.rs
+++ b/src/datatypes/logical.rs
@@ -5,7 +5,7 @@ use crate::{
     error::DaftResult,
 };
 
-use super::{DataArray, DataType, EmbeddingType};
+use super::{DataArray, DataType, EmbeddingType, FixedShapeImageType, ImageType};
 
 pub struct LogicalArray<L: DaftLogicalType> {
     pub field: Arc<Field>,
@@ -94,3 +94,5 @@ impl<L: DaftLogicalType + 'static> LogicalArray<L> {
 
 pub type DateArray = LogicalArray<DateType>;
 pub type EmbeddingArray = LogicalArray<EmbeddingType>;
+pub type ImageArray = LogicalArray<ImageType>;
+pub type FixedShapeImageArray = LogicalArray<FixedShapeImageType>;

--- a/src/datatypes/matching.rs
+++ b/src/datatypes/matching.rs
@@ -232,6 +232,8 @@ macro_rules! with_match_daft_logical_types {(
     match $key_type {
         Date => __with_ty__! { DateType },
         Embedding(..) => __with_ty__! { EmbeddingType },
+        Image(..) => __with_ty__! { ImageType },
+        FixedShapeImage(..) => __with_ty__! { FixedShapeImageType },
         _ => panic!("{:?} not implemented for with_match_daft_logical_types", $key_type)
     }
 })}

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -10,7 +10,7 @@ use arrow2::{
     compute::{arithmetics::basic::NativeArithmetics, comparison::Simd8},
     types::{simd::Simd, NativeType},
 };
-pub use dtype::DataType;
+pub use dtype::{DataType, ImageMode};
 pub use field::Field;
 use num_traits::{Bounded, Float, FromPrimitive, Num, NumCast, ToPrimitive, Zero};
 pub use time_unit::TimeUnit;

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -1,5 +1,6 @@
 mod dtype;
 mod field;
+mod image_mode;
 mod matching;
 mod time_unit;
 
@@ -10,8 +11,9 @@ use arrow2::{
     compute::{arithmetics::basic::NativeArithmetics, comparison::Simd8},
     types::{simd::Simd, NativeType},
 };
-pub use dtype::{DataType, ImageMode};
+pub use dtype::DataType;
 pub use field::Field;
+pub use image_mode::ImageMode;
 use num_traits::{Bounded, Float, FromPrimitive, Num, NumCast, ToPrimitive, Zero};
 pub use time_unit::TimeUnit;
 pub mod logical;

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -107,7 +107,7 @@ impl_daft_logical_datatype!(DateType, Date, Int32Type);
 impl_daft_logical_datatype!(TimeType, Unknown, Int64Type);
 impl_daft_logical_datatype!(DurationType, Unknown, Int64Type);
 impl_daft_logical_datatype!(EmbeddingType, Unknown, FixedSizeListType);
-impl_daft_logical_datatype!(ImageType, Unknown, ListType);
+impl_daft_logical_datatype!(ImageType, Unknown, StructType);
 impl_daft_logical_datatype!(FixedShapeImageType, Unknown, FixedSizeListType);
 
 pub trait NumericNative:

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -107,6 +107,8 @@ impl_daft_logical_datatype!(DateType, Date, Int32Type);
 impl_daft_logical_datatype!(TimeType, Unknown, Int64Type);
 impl_daft_logical_datatype!(DurationType, Unknown, Int64Type);
 impl_daft_logical_datatype!(EmbeddingType, Unknown, FixedSizeListType);
+impl_daft_logical_datatype!(ImageType, Unknown, ListType);
+impl_daft_logical_datatype!(FixedShapeImageType, Unknown, FixedSizeListType);
 
 pub trait NumericNative:
     PartialOrd

--- a/src/python/datatype.rs
+++ b/src/python/datatype.rs
@@ -177,14 +177,13 @@ impl PyDataType {
     }
 
     #[staticmethod]
-    pub fn image(name: &str, data_type: Self, shape: Option<Vec<usize>>) -> PyResult<Self> {
+    pub fn image(data_type: Self, shape: Option<Vec<usize>>) -> PyResult<Self> {
         if !data_type.dtype.is_numeric() {
             return Err(PyValueError::new_err(format!(
                 "The data type for an image must be numeric, but got: {}",
                 data_type.dtype
             )));
         }
-        let field = Box::new(Field::new(name, data_type.dtype));
         match shape {
             Some(shape) => {
                 if shape.is_empty() {
@@ -193,9 +192,9 @@ impl PyDataType {
                         shape,
                     )));
                 }
-                Ok(DataType::FixedShapeImage(field, shape).into())
+                Ok(DataType::FixedShapeImage(Box::new(data_type.dtype), shape).into())
             }
-            None => Ok(DataType::Image(field).into()),
+            None => Ok(DataType::Image(Box::new(data_type.dtype)).into()),
         }
     }
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7,6 +7,7 @@ mod schema;
 mod series;
 mod table;
 
+use crate::datatypes::ImageMode;
 pub use datatype::PyDataType;
 pub use series::PySeries;
 
@@ -17,6 +18,7 @@ pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
     parent.add_class::<datatype::PyDataType>()?;
     parent.add_class::<schema::PySchema>()?;
     parent.add_class::<field::PyField>()?;
+    parent.add_class::<ImageMode>()?;
 
     parent.add_wrapped(wrap_pyfunction!(expr::col))?;
     parent.add_wrapped(wrap_pyfunction!(expr::lit))?;

--- a/src/series/array_impl/logical_array.rs
+++ b/src/series/array_impl/logical_array.rs
@@ -1,5 +1,4 @@
-use crate::datatypes::logical::DateArray;
-use crate::datatypes::logical::EmbeddingArray;
+use crate::datatypes::logical::{DateArray, EmbeddingArray, FixedShapeImageArray, ImageArray};
 
 use super::{ArrayWrapper, IntoSeries, Series};
 use crate::array::ops::GroupIndices;
@@ -142,3 +141,5 @@ macro_rules! impl_series_like_for_logical_array {
 
 impl_series_like_for_logical_array!(DateArray);
 impl_series_like_for_logical_array!(EmbeddingArray);
+impl_series_like_for_logical_array!(ImageArray);
+impl_series_like_for_logical_array!(FixedShapeImageArray);

--- a/src/series/ops/list.rs
+++ b/src/series/ops/list.rs
@@ -1,3 +1,4 @@
+use crate::array::ops::as_arrow::AsArrow;
 use crate::datatypes::{DataType, UInt64Array};
 use crate::error::DaftError;
 use crate::{error::DaftResult, series::Series};
@@ -18,10 +19,30 @@ impl Series {
     pub fn arr_lengths(&self) -> DaftResult<UInt64Array> {
         use DataType::*;
 
-        let p = self.as_physical()?;
-        match p.data_type() {
-            List(_) => p.list()?.lengths(),
-            FixedSizeList(..) => p.fixed_size_list()?.lengths(),
+        match self.data_type() {
+            List(_) => self.list()?.lengths(),
+            FixedSizeList(..) => self.fixed_size_list()?.lengths(),
+            Embedding(..) | FixedShapeImage(..) => self.as_physical()?.arr_lengths(),
+            Image(..) => {
+                let struct_array = self.as_physical()?;
+                let data_array = struct_array.struct_()?.as_arrow().values()[0]
+                    .as_any()
+                    .downcast_ref::<arrow2::array::ListArray<i64>>()
+                    .unwrap();
+                let offsets = data_array.offsets();
+
+                let mut lens = Vec::with_capacity(self.len());
+                for i in 0..self.len() {
+                    lens.push(
+                        (unsafe { offsets.get_unchecked(i + 1) - offsets.get_unchecked(i) }) as u64,
+                    )
+                }
+                let array = Box::new(
+                    arrow2::array::PrimitiveArray::from_vec(lens)
+                        .with_validity(data_array.validity().cloned()),
+                );
+                Ok(UInt64Array::from((self.name(), array)))
+            }
             dt => Err(DaftError::TypeError(format!(
                 "lengths not implemented for {}",
                 dt

--- a/tests/dataframe/test_logical_type.py
+++ b/tests/dataframe/test_logical_type.py
@@ -22,10 +22,10 @@ def test_embedding_type_df() -> None:
 
 
 def test_image_type_df() -> None:
-    data = [np.arange(4).reshape((1, 2, 2)), np.arange(4, 13).reshape((1, 3, 3)), None]
+    data = [np.arange(12).reshape((3, 2, 2)), np.arange(12, 39).reshape((3, 3, 3)), None]
     df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
 
-    target = DataType.image("F")
+    target = DataType.image("RGB")
     df = df.select(col("index"), col("image").cast(target))
     df = df.repartition(4, "index")
     df = df.sort("index")
@@ -35,11 +35,13 @@ def test_image_type_df() -> None:
 
 
 def test_fixed_shape_image_type_df() -> None:
-    shape = (3, 2, 2)
+    height = 2
+    width = 2
+    shape = (3, height, width)
     data = [np.arange(12).reshape(shape), np.arange(12, 24).reshape(shape), None]
     df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
 
-    target = DataType.image("RGB", shape[1:])
+    target = DataType.image("RGB", height, width)
     df = df.select(col("index"), col("image").cast(target))
     df = df.repartition(4, "index")
     df = df.sort("index")

--- a/tests/dataframe/test_logical_type.py
+++ b/tests/dataframe/test_logical_type.py
@@ -22,10 +22,10 @@ def test_embedding_type_df() -> None:
 
 
 def test_image_type_df() -> None:
-    data = [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3)), None]
+    data = [np.arange(4).reshape((1, 2, 2)), np.arange(4, 13).reshape((1, 3, 3)), None]
     df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
 
-    target = DataType.image(DataType.float32())
+    target = DataType.image("F")
     df = df.select(col("index"), col("image").cast(target))
     df = df.repartition(4, "index")
     df = df.sort("index")
@@ -35,11 +35,11 @@ def test_image_type_df() -> None:
 
 
 def test_fixed_shape_image_type_df() -> None:
-    shape = (2, 2, 1)
-    data = [np.arange(4).reshape(shape), np.arange(4, 8).reshape(shape), None]
+    shape = (3, 2, 2)
+    data = [np.arange(12).reshape(shape), np.arange(12, 24).reshape(shape), None]
     df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
 
-    target = DataType.image(DataType.float32(), shape)
+    target = DataType.image("RGB", shape[1:])
     df = df.select(col("index"), col("image").cast(target))
     df = df.repartition(4, "index")
     df = df.sort("index")

--- a/tests/dataframe/test_logical_type.py
+++ b/tests/dataframe/test_logical_type.py
@@ -19,3 +19,30 @@ def test_embedding_type_df() -> None:
     df = df.collect()
     arrow_table = df.to_arrow()
     assert isinstance(arrow_table["embeddings"].type, DaftExtension)
+
+
+def test_image_type_df() -> None:
+    data = [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3)), None]
+    df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
+
+    target = DataType.image("arr", DataType.float32())
+    df = df.select(col("index"), col("image").cast(target))
+    df = df.repartition(4, "index")
+    df = df.sort("index")
+    df = df.collect()
+    arrow_table = df.to_arrow()
+    assert isinstance(arrow_table["image"].type, DaftExtension)
+
+
+def test_fixed_shape_image_type_df() -> None:
+    shape = (2, 2)
+    data = [np.arange(4).reshape(shape), np.arange(4, 8).reshape(shape), None]
+    df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
+
+    target = DataType.image("arr", DataType.float32(), shape)
+    df = df.select(col("index"), col("image").cast(target))
+    df = df.repartition(4, "index")
+    df = df.sort("index")
+    df = df.collect()
+    arrow_table = df.to_arrow()
+    assert isinstance(arrow_table["image"].type, DaftExtension)

--- a/tests/dataframe/test_logical_type.py
+++ b/tests/dataframe/test_logical_type.py
@@ -25,7 +25,7 @@ def test_image_type_df() -> None:
     data = [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3)), None]
     df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
 
-    target = DataType.image("arr", DataType.float32())
+    target = DataType.image(DataType.float32())
     df = df.select(col("index"), col("image").cast(target))
     df = df.repartition(4, "index")
     df = df.sort("index")
@@ -35,11 +35,11 @@ def test_image_type_df() -> None:
 
 
 def test_fixed_shape_image_type_df() -> None:
-    shape = (2, 2)
+    shape = (2, 2, 1)
     data = [np.arange(4).reshape(shape), np.arange(4, 8).reshape(shape), None]
     df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
 
-    target = DataType.image("arr", DataType.float32(), shape)
+    target = DataType.image(DataType.float32(), shape)
     df = df.select(col("index"), col("image").cast(target))
     df = df.repartition(4, "index")
     df = df.sort("index")

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -191,17 +191,17 @@ def test_series_cast_python_to_embedding(dtype) -> None:
 
 @pytest.mark.parametrize("dtype", ARROW_FLOAT_TYPES + ARROW_INT_TYPES)
 def test_series_cast_python_to_image(dtype) -> None:
-    data = [np.arange(4).reshape((1, 2, 2)), np.arange(4, 13).reshape((1, 3, 3)), None]
+    data = [np.arange(12).reshape((3, 2, 2)), np.arange(12, 39).reshape((3, 3, 3)), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image("F")
+    target_dtype = DataType.image("RGB")
 
     t = s.cast(target_dtype)
 
     assert t.datatype() == target_dtype
     assert len(t) == len(data)
 
-    assert t.arr.lengths().to_pylist() == [4, 9, None]
+    assert t.arr.lengths().to_pylist() == [12, 27, None]
 
     pydata = t.to_pylist()
     assert pydata[-1] is None
@@ -212,11 +212,13 @@ def test_series_cast_python_to_image(dtype) -> None:
 
 @pytest.mark.parametrize("dtype", ARROW_FLOAT_TYPES + ARROW_INT_TYPES)
 def test_series_cast_python_to_fixed_shape_image(dtype) -> None:
-    shape = (3, 2, 2)
+    height = 2
+    width = 2
+    shape = (3, height, width)
     data = [np.arange(12).reshape(shape), np.arange(12, 24).reshape(shape), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image("RGB", shape[1:])
+    target_dtype = DataType.image("RGB", height, width)
 
     t = s.cast(target_dtype)
 

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -194,7 +194,7 @@ def test_series_cast_python_to_image(dtype) -> None:
     data = [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3)), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image("arr", DataType.float32())
+    target_dtype = DataType.image(DataType.float32())
 
     t = s.cast(target_dtype)
 
@@ -205,16 +205,18 @@ def test_series_cast_python_to_image(dtype) -> None:
 
     pydata = t.to_pylist()
     assert pydata[-1] is None
-    np.testing.assert_equal([data[0].ravel(), data[1].ravel()], pydata[:-1])
+    assert [data[0].ravel().tolist(), data[1].ravel().tolist()] == [row["data"] for row in pydata[:-1]]
+    # TODO(Clark): Fix the Daft --> pyarrow egress so it reconstitutes the NumPy ndarrays.
+    # np.testing.assert_equal([data[0].ravel(), data[1].ravel()], pydata[:-1])
 
 
 @pytest.mark.parametrize("dtype", ARROW_FLOAT_TYPES + ARROW_INT_TYPES)
 def test_series_cast_python_to_fixed_shape_image(dtype) -> None:
-    shape = (2, 2)
+    shape = (2, 2, 1)
     data = [np.arange(4).reshape(shape), np.arange(4, 8).reshape(shape), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image("arr", DataType.float32(), shape)
+    target_dtype = DataType.image(DataType.float32(), shape)
 
     t = s.cast(target_dtype)
 

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -187,3 +187,42 @@ def test_series_cast_python_to_embedding(dtype) -> None:
     assert list(map(int, itertools.chain.from_iterable(data[:-1]))) == list(
         map(int, itertools.chain.from_iterable(pydata[:-1]))
     )
+
+
+@pytest.mark.parametrize("dtype", ARROW_FLOAT_TYPES + ARROW_INT_TYPES)
+def test_series_cast_python_to_image(dtype) -> None:
+    data = [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3)), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("arr", DataType.float32())
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+    assert len(t) == len(data)
+
+    assert t.arr.lengths().to_pylist() == [4, 9, None]
+
+    pydata = t.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal([data[0].ravel(), data[1].ravel()], pydata[:-1])
+
+
+@pytest.mark.parametrize("dtype", ARROW_FLOAT_TYPES + ARROW_INT_TYPES)
+def test_series_cast_python_to_fixed_shape_image(dtype) -> None:
+    shape = (2, 2)
+    data = [np.arange(4).reshape(shape), np.arange(4, 8).reshape(shape), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("arr", DataType.float32(), shape)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+    assert len(t) == len(data)
+
+    assert t.arr.lengths().to_pylist() == [4, 4, None]
+
+    pydata = t.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal([data[0].ravel(), data[1].ravel()], pydata[:-1])

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -9,10 +9,10 @@ from daft.series import Series
 
 
 def test_image_arrow_round_trip():
-    data = [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3)), None]
+    data = [np.arange(4).reshape((1, 2, 2)), np.arange(4, 13).reshape((1, 3, 3)), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image(DataType.int32())
+    target_dtype = DataType.image("F")
 
     t = s.cast(target_dtype)
 
@@ -32,11 +32,11 @@ def test_image_arrow_round_trip():
 
 
 def test_fixed_shape_image_arrow_round_trip():
-    shape = (2, 2, 1)
-    data = [np.arange(4).reshape(shape), np.arange(4, 8).reshape(shape), None]
+    shape = (3, 2, 2)
+    data = [np.arange(12).reshape(shape), np.arange(12, 24).reshape(shape), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image(DataType.int32(), shape)
+    target_dtype = DataType.image("RGB", shape[1:])
 
     t = s.cast(target_dtype)
 

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -9,10 +9,10 @@ from daft.series import Series
 
 
 def test_image_arrow_round_trip():
-    data = [np.arange(4).reshape((1, 2, 2)), np.arange(4, 13).reshape((1, 3, 3)), None]
+    data = [np.arange(12).reshape((3, 2, 2)), np.arange(12, 39).reshape((3, 3, 3)), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image("F")
+    target_dtype = DataType.image("RGB")
 
     t = s.cast(target_dtype)
 
@@ -32,11 +32,13 @@ def test_image_arrow_round_trip():
 
 
 def test_fixed_shape_image_arrow_round_trip():
-    shape = (3, 2, 2)
+    height = 2
+    width = 2
+    shape = (3, height, width)
     data = [np.arange(12).reshape(shape), np.arange(12, 24).reshape(shape), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image("RGB", shape[1:])
+    target_dtype = DataType.image("RGB", height, width)
 
     t = s.cast(target_dtype)
 

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -12,7 +12,7 @@ def test_image_arrow_round_trip():
     data = [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3)), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image("arr", DataType.int32())
+    target_dtype = DataType.image(DataType.int32())
 
     t = s.cast(target_dtype)
 
@@ -32,11 +32,11 @@ def test_image_arrow_round_trip():
 
 
 def test_fixed_shape_image_arrow_round_trip():
-    shape = (2, 2)
+    shape = (2, 2, 1)
     data = [np.arange(4).reshape(shape), np.arange(4, 8).reshape(shape), None]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image("arr", DataType.int32(), shape)
+    target_dtype = DataType.image(DataType.int32(), shape)
 
     t = s.cast(target_dtype)
 

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+
+from daft.datatype import DaftExtension, DataType
+from daft.series import Series
+
+
+def test_image_arrow_round_trip():
+    data = [np.arange(4).reshape((2, 2)), np.arange(4, 13).reshape((3, 3)), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("arr", DataType.int32())
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    arrow_arr = t.to_arrow()
+
+    assert isinstance(arrow_arr.type, DaftExtension)
+    from_arrow = Series.from_arrow(t.to_arrow())
+
+    assert from_arrow.datatype() == t.datatype()
+    assert from_arrow.to_pylist() == t.to_pylist()
+
+    t_copy = copy.deepcopy(t)
+    assert t_copy.datatype() == t.datatype()
+    assert t_copy.to_pylist() == t.to_pylist()
+
+
+def test_fixed_shape_image_arrow_round_trip():
+    shape = (2, 2)
+    data = [np.arange(4).reshape(shape), np.arange(4, 8).reshape(shape), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("arr", DataType.int32(), shape)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    arrow_arr = t.to_arrow()
+
+    assert isinstance(arrow_arr.type, DaftExtension)
+    from_arrow = Series.from_arrow(t.to_arrow())
+
+    assert from_arrow.datatype() == t.datatype()
+    assert from_arrow.to_pylist() == t.to_pylist()
+
+    t_copy = copy.deepcopy(t)
+    assert t_copy.datatype() == t.datatype()
+    assert t_copy.to_pylist() == t.to_pylist()


### PR DESCRIPTION
This PR adds a logical type for variable-shaped and fixed-shape images.

# TODOs (This PR):

- [x] The internal representation for the variable-shaped `Image` type will actually need to be a `pa.struct({"data": pa.list_(data_dtype), "shapes": pa.list_(pa.uint64())})` or the like in order to be able to roundtrip with the Python representation.
- [x] Expose image mode instead of channel dimension.

## Follow-up Work (Future PRs)

1. Create the egress-side for Daft --> Python, taking tensor-ish Daft logical types and representing those arrays as NumPy ndarrays in Python land.
2. Add image processing compute kernels.
3. Add imagery tutorial to the docs.
4. Expand Python --> ImageArray support.