### PR TITLE
Clean up DataType userguide/API docs

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -33,6 +33,8 @@ else:
 
 
 class DataType:
+    """A Daft DataType defines the type of all the values in an Expression or DataFrame column"""
+
     _dtype: PyDataType
 
     def __init__(self) -> None:
@@ -49,76 +51,108 @@ class DataType:
 
     @classmethod
     def int8(cls) -> DataType:
+        """Create an 8-bit integer DataType"""
         return cls._from_pydatatype(PyDataType.int8())
 
     @classmethod
     def int16(cls) -> DataType:
+        """Create an 16-bit integer DataType"""
         return cls._from_pydatatype(PyDataType.int16())
 
     @classmethod
     def int32(cls) -> DataType:
+        """Create an 32-bit integer DataType"""
         return cls._from_pydatatype(PyDataType.int32())
 
     @classmethod
     def int64(cls) -> DataType:
+        """Create an 64-bit integer DataType"""
         return cls._from_pydatatype(PyDataType.int64())
 
     @classmethod
     def uint8(cls) -> DataType:
+        """Create an unsigned 8-bit integer DataType"""
         return cls._from_pydatatype(PyDataType.uint8())
 
     @classmethod
     def uint16(cls) -> DataType:
+        """Create an unsigned 16-bit integer DataType"""
         return cls._from_pydatatype(PyDataType.uint16())
 
     @classmethod
     def uint32(cls) -> DataType:
+        """Create an unsigned 32-bit integer DataType"""
         return cls._from_pydatatype(PyDataType.uint32())
 
     @classmethod
     def uint64(cls) -> DataType:
+        """Create an unsigned 64-bit integer DataType"""
         return cls._from_pydatatype(PyDataType.uint64())
 
     @classmethod
     def float32(cls) -> DataType:
+        """Create a 32-bit float DataType"""
         return cls._from_pydatatype(PyDataType.float32())
 
     @classmethod
     def float64(cls) -> DataType:
+        """Create a 64-bit float DataType"""
         return cls._from_pydatatype(PyDataType.float64())
 
     @classmethod
     def string(cls) -> DataType:
+        """Create a String DataType: A string of UTF8 characters"""
         return cls._from_pydatatype(PyDataType.string())
 
     @classmethod
     def bool(cls) -> DataType:
+        """Create the Boolean DataType: Either ``True`` or ``False``"""
         return cls._from_pydatatype(PyDataType.bool())
 
     @classmethod
     def binary(cls) -> DataType:
+        """Create a Binary DataType: A string of bytes"""
         return cls._from_pydatatype(PyDataType.binary())
 
     @classmethod
     def null(cls) -> DataType:
+        """Creates the Null DataType: Always the ``Null`` value"""
         return cls._from_pydatatype(PyDataType.null())
 
     @classmethod
     def date(cls) -> DataType:
+        """Create a Date DataType: A date with a year, month and day"""
         return cls._from_pydatatype(PyDataType.date())
 
     @classmethod
     def list(cls, name: str, dtype: DataType) -> DataType:
+        """Create a List DataType: Variable-length list, where each element in the list has type ``dtype``
+
+        Args:
+            dtype: DataType of each element in the list
+        """
         return cls._from_pydatatype(PyDataType.list(name, dtype._dtype))
 
     @classmethod
     def fixed_size_list(cls, name: str, dtype: DataType, size: int) -> DataType:
+        """Create a FixedSizeList DataType: Fixed-size list, where each element in the list has type ``dtype``
+        and each list has length ``size``.
+
+        Args:
+            dtype: DataType of each element in the list
+            size: length of each list
+        """
         if not isinstance(size, int) or size <= 0:
             raise ValueError("The size for a fixed-size list must be a positive integer, but got: ", size)
         return cls._from_pydatatype(PyDataType.fixed_size_list(name, dtype._dtype, size))
 
     @classmethod
     def struct(cls, fields: dict[str, DataType]) -> DataType:
+        """Create a Struct DataType: a nested type which has names mapped to child types
+
+        Args:
+            fields: Nested fields of the Struct
+        """
         return cls._from_pydatatype(PyDataType.struct({name: datatype._dtype for name, datatype in fields.items()}))
 
     @classmethod
@@ -127,6 +161,13 @@ class DataType:
 
     @classmethod
     def embedding(cls, name: str, dtype: DataType, size: int) -> DataType:
+        """Create an Embedding DataType: embeddings are fixed size arrays, where each element
+        in the array has a **numeric** ``dtype`` and each array has a fixed length of ``size``.
+
+        Args:
+            dtype: DataType of each element in the list (must be numeric)
+            size: length of each list
+        """
         if not isinstance(size, int) or size <= 0:
             raise ValueError("The size for a embedding must be a positive integer, but got: ", size)
         return cls._from_pydatatype(PyDataType.embedding(name, dtype._dtype, size))
@@ -150,6 +191,7 @@ class DataType:
 
     @classmethod
     def from_arrow_type(cls, arrow_type: pa.lib.DataType) -> DataType:
+        """Maps a PyArrow DataType to a Daft DataType"""
         if pa.types.is_int8(arrow_type):
             return cls.int8()
         elif pa.types.is_int16(arrow_type):
@@ -229,11 +271,13 @@ class DataType:
 
     @classmethod
     def from_numpy_dtype(cls, np_type) -> DataType:
+        """Maps a Numpy datatype to a Daft DataType"""
         arrow_type = pa.from_numpy_dtype(np_type)
         return cls.from_arrow_type(arrow_type)
 
     @classmethod
     def python(cls) -> DataType:
+        """Create a Python DataType: a type which refers to an arbitrary Python object"""
         return cls._from_pydatatype(PyDataType.python())
 
     def _is_python_type(self) -> builtins.bool:

--- a/docs/source/api_docs/datatype.rst
+++ b/docs/source/api_docs/datatype.rst
@@ -1,0 +1,129 @@
+DataTypes
+=========
+
+.. currentmodule:: daft
+
+.. autosummary::
+    :nosignatures:
+    :toctree: datatype_methods
+
+    daft.DataType
+
+DataType Constructors
+#####################
+
+Construct Daft DataTypes using these constructor APIs.
+
+This is useful in many situations, such as casting, schema declaration and more.
+
+.. code:: python
+
+    import daft
+
+    dtype = daft.DataType.int64()
+    df = df.with_column("int64_column", df["int8_col"].cast(dtype))
+
+.. _api-datatypes-numeric:
+
+Numeric
+-------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: datatype_methods
+
+    daft.DataType.int8
+    daft.DataType.int16
+    daft.DataType.int32
+    daft.DataType.int64
+    daft.DataType.uint8
+    daft.DataType.uint16
+    daft.DataType.uint32
+    daft.DataType.uint64
+    daft.DataType.float32
+    daft.DataType.float64
+
+
+.. _api-datatypes-logical:
+
+Logical
+-------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: datatype_methods
+
+    daft.DataType.bool
+
+
+.. _api-datatypes-string:
+
+Strings
+-------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: datatype_methods
+
+    daft.DataType.binary
+    daft.DataType.string
+
+
+.. _api-datatypes-temporal:
+
+Temporal
+--------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: datatype_methods
+
+    daft.DataType.date
+
+
+.. _api-datatypes-nested:
+
+Nested
+------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: datatype_methods
+
+    daft.DataType.list
+    daft.DataType.fixed_size_list
+    daft.DataType.struct
+
+
+Python
+------
+
+.. autosummary::
+    :nosignatures:
+    :toctree: datatype_methods
+
+    daft.DataType.python
+
+
+.. _api-datatypes-complex:
+
+More Complex Types
+------------------
+
+Machine Learning
+^^^^^^^^^^^^^^^^
+
+.. autosummary::
+    :nosignatures:
+    :toctree: datatype_methods
+
+    daft.DataType.embedding
+
+
+Miscellaneous
+^^^^^^^^^^^^^
+.. autosummary::
+    :nosignatures:
+    :toctree: datatype_methods
+
+    daft.DataType.null

--- a/docs/source/api_docs/expressions.rst
+++ b/docs/source/api_docs/expressions.rst
@@ -103,6 +103,7 @@ Example: ``e1.str.concat(e2)``
     daft.expressions.expressions.ExpressionStringNamespace.startswith
     daft.expressions.expressions.ExpressionStringNamespace.length
 
+.. _api-expressions-temporal:
 
 Dates
 *****

--- a/docs/source/api_docs/index.rst
+++ b/docs/source/api_docs/index.rst
@@ -5,6 +5,7 @@ API Documentation
 
    input_output
    dataframe
+   datatype
    expressions
    groupby
    udf

--- a/docs/source/learn/user_guides.rst
+++ b/docs/source/learn/user_guides.rst
@@ -28,8 +28,8 @@ Daft is a Python dataframe library. A dataframe is just a table consisting of ro
     :maxdepth: 1
 
     user_guides/intro-dataframes
-    user_guides/expressions
     user_guides/datatypes
+    user_guides/expressions
     user_guides/read-write
     user_guides/dataframe-operations
     user_guides/aggregations

--- a/docs/source/learn/user_guides/datatypes.rst
+++ b/docs/source/learn/user_guides/datatypes.rst
@@ -1,68 +1,125 @@
 Datatypes
 =========
 
-All columns in a Daft DataFrame have a DataType \(dtype\). All items in a column are of the same dtype, or they can be the special Null value \(indicating a missing value\).
+All columns in a Daft DataFrame have a DataType \(also often abbreviated as ``dtype``\).
 
-+-------------------------+----------------------------------------------------------------------------------------------+
-| DataType                | Description                                                                                  |
-+=========================+==============================================================================================+
-| **Simple Types**                                                                                                       |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Null``                | Always the ``Null`` value                                                                    |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Boolean``             | Either ``True`` or ``False``                                                                 |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| **Numeric**                                                                                                            |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``UInt8``               | 8-bit unsigned integer                                                                       |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``UInt16``              | 16-bit unsigned integer                                                                      |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``UInt32``              | 32-bit unsigned integer                                                                      |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``UInt64``              | 64-bit unsigned integer                                                                      |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Int8``                | 8-bit signed integer                                                                         |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Int16``               | 16-bit signed integer                                                                        |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Int32``               | 32-bit signed integer                                                                        |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Int64``               | 64-bit signed integer                                                                        |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Float32``             | 32-bit float                                                                                 |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Float64``             | 64-bit float                                                                                 |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| **Temporal**                                                                                                           |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Date``                | A date with a year, month and day                                                            |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Timestamp(U, Z)``     | (Coming soon) timestamp with a unit of resolution (``U``) and an optional timezone (``Z``)   |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Duration(U)``         | (Coming soon) a duration of time with a unit of resolution (``U``)                           |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Time(U)``             | (Coming soon) Time since midnight with a unit of resolution (``U``)                          |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| **Nested**                                                                                                             |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``List(D)``             | Variable-length list of dtype (``D``)                                                        |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``FixedSizeList(D, N)`` | Fixed-size list of dtype (``D``) and constant length (``N``)                                 |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Struct(M)``           | Struct with a mapping (``M``) of field names to dtypes                                       |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| **Python**                                                                                                             |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Python``              | Python objects                                                                               |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| **Images**                                                                                                             |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Image``               | (Coming soon) Images                                                                         |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``FixedSizeImage(W, H)``| (Coming soon) Images of a fixed size of width ``W`` and height ``H``                         |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| **Machine Learning**                                                                                                   |
-+-------------------------+----------------------------------------------------------------------------------------------+
-| ``Embeddings(D, S)``    | Fixed-sized array of ``S`` number of elements, each of numerical dtype ``D``                 |
-+-------------------------+----------------------------------------------------------------------------------------------+
+All elements of a column are of the same dtype, or they can be the special Null value \(indicating a missing value\).
+
+Daft provides simple DataTypes that are ubiquituous in many DataFrames such as numbers, strings and dates - all the way up to more complex types like images and embeddings.
+
+.. NOTE::
+
+    For a full overview on all the DataTypes that Daft supports, see the :doc:`DataType API Reference <../../api_docs/datatype>`.
+
+Numeric DataTypes
+-----------------
+
+Numeric DataTypes allows Daft to represent numbers. These numbers can differ in terms of the number of bits used to represent them (8, 16, 32 or 64 bits) and the semantic meaning of those bits
+(float vs integer vs unsigned integers).
+
+Examples:
+
+1. ``DataType.int8()``: represents an 8-bit signed integer (-128 to 127)
+2. ``DataType.float32()``: represents a 32-bit float (a float number with about 7 decimal digits of precision)
+
+Columns/expressions with these datatypes can be operated on with many numeric expressions such as ``+`` and ``*``.
+
+See also:
+
+* :ref:`Numeric DataTypes <api-datatypes-numeric>`
+* :ref:`Numeric Expressions <userguide-numeric-expressions>`
+
+Logical DataTypes
+-----------------
+
+The ``DataType.bool()`` DataType represents values which are boolean values: ``True``, ``False`` or ``Null``.
+
+Columns/expressions with this dtype can be operated on using logical expressions such as ``&`` and ``if_else``.
+
+See also:
+
+* :ref:`Logical DataTypes <api-datatypes-logical>`
+* :ref:`Logical Expressions <userguide-logical-expressions>`
+
+String Types
+------------
+
+Daft has string types, which represent a variable-length string of characters.
+
+As a convenience method, string types also support the ``+`` Expression, which has been overloaded to support concatenation of elements between two ``DataType.string()`` columns.
+
+1. ``DataType.string()``: represents a string of UTF-8 characters
+2. ``DataType.binary()``: represents a string of bytes
+
+See also:
+
+* :ref:`String DataTypes <api-datatypes-string>`
+* :ref:`String Expressions <userguide-string-expressions>`
+
+Temporal
+--------
+
+Temporal dtypes represent data that have to do with time.
+
+Examples:
+
+1. ``DataType.date()``: represents a Date (year, month and day)
+2. ``DataType.duration()``: [COMING SOON] represents the duration between two instances in time
+
+NOTE: Many temporal types are still a work-in-progress!
+
+See also:
+
+* :ref:`Temporal DataTypes <api-datatypes-temporal>`
+* :ref:`Temporal Expressions <api-expressions-temporal>`
+
+Nested
+------
+
+Nested DataTypes wrap other DataTypes, allowing you to compose types into complex datastructures.
+
+Examples:
+
+1. ``DataType.list(child_dtype)``: represents a list where each element is of the child dtype
+2. ``DataType.struct({"field_name": child_dtype})``: represents a structure that has children dtypes, each mapped to a field name
+
+See also:
+
+* :ref:`Nested DataTypes <api-datatypes-nested>`
+
+Python
+------
+
+The ``DataType.python()`` dtype represent items that are Python objects.
+
+.. WARNING::
+
+    Daft does not impose any invariants about what *Python types* these objects are. To Daft, these are just generic Python objects!
+
+Python is AWESOME because it's so flexible, but it's also slow and memory inefficient! Thus we recommend:
+
+1. **Cast early!**: Casting your Python data into native Daft DataTypes if possible - this results in much more efficient downstream data serialization and computation.
+2. **Use Python UDFs**: If there is no suitable Daft representation for your Python objects, use Python UDFs to process your Python data and extract the relevant data to be returned as native Daft DataTypes!
+
+.. NOTE::
+
+    If you work with Python class for a generalizable use-case (e.g. images, documents, protobufs), it may be that these types are good candidates for "promotion" into a native Daft type!
+    Please get in touch with the Daft team and we would love to work together on building your type into canonical Daft types.
+
+Other Complex Types
+-------------------
+
+Daft supports many more interesting complex DataTypes, for example:
+
+* ``DataType.embedding()``: Embeddings used in Machine Learning
+* ``DataType.image()``: 2D Images!
+
+Daft abstracts away the in-memory representation of your data, as well as provides kernels for many common operations on top of this type of data (e.g. resizing an image).
+
+For more complex algorithms, you can also drop into a Python UDF to process this data using your custom Python libraries.
+
+Please add suggestions for new DataTypes to our Github Discussions page!
+
+See also:
+
+* :ref:`Complex Types <api-datatypes-complex>`

--- a/docs/source/learn/user_guides/expressions.rst
+++ b/docs/source/learn/user_guides/expressions.rst
@@ -56,6 +56,8 @@ You may find yourself needing to hardcode a "single value" oftentimes as an expr
 
 This special ``lit`` expression we just created evaluates always to the value ``42``.
 
+.. _userguide-numeric-expressions:
+
 Numeric Expressions
 -------------------
 
@@ -91,6 +93,8 @@ Since column "A" is an integer, we can run numeric computation such as addition,
 Notice that the returned types of these operations are also well-typed according to their input types. For example, calling ``df["A"] > 1`` returns a column of type ``Boolean``.
 
 Both The Float and Int types are numeric types, and inherit many of the same arithmetic Expression operations. You may find the full list of numeric operations in the :ref:`Expressions API reference <api-numeric-expression-operations>`.
+
+.. _userguide-string-expressions:
 
 String Expressions
 ------------------
@@ -200,7 +204,9 @@ Daft provides the ``Expression.url.*`` method namespace with functionality for w
 
 This works well for URLs which are HTTP paths to non-HTML files (e.g. jpeg), local filepaths or even paths to a file in an object store such as AWS S3 as well!
 
-Boolean Expressions
+.. _userguide-logical-expressions:
+
+Logical Expressions
 -------------------
 
 Logical Expressions are an expression that refers to a column of type ``Boolean``, and can only take on the values True or False.


### PR DESCRIPTION
Cleanups to the DataType userguide and API docs:

1. Adds DataType API docs where we autogenerate stubs for the DataType class
2. Cleanup the DataType userguide to be more of a walkthrough the main categories of DataTypes rather than just a list, and link to the DataType API docs where appropriate