### PR TITLE
Revert change to optimizer to perform deepcopy of logical plan

### DIFF
--- a/daft/internal/rule_runner.py
+++ b/daft/internal/rule_runner.py
@@ -31,6 +31,9 @@ class RuleRunner(Generic[TreeNodeType]):
         self._batches = batches
 
     def optimize(self, root: TreeNodeType) -> TreeNodeType:
+        from copy import deepcopy
+
+        root = deepcopy(root)
         for batch in self._batches:
             root = self._run_single_batch(root, batch)
         return root

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pathlib
 import uuid
-from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -48,12 +47,8 @@ def test_download_custom_ds(files):
 
     df = daft.from_pydict({"filenames": [str(f) for f in files]})
 
-    with patch.object(fs, "cat_file", wraps=fs.cat_file) as mock_cat:
-        df = df.with_column("bytes", col("filenames").url.download(fs=fs))
-        out_df = df.to_pandas()
-
-        # Check that cat_file() is called on the passed filesystem.
-        mock_cat.assert_called()
+    df = df.with_column("bytes", col("filenames").url.download(fs=fs))
+    out_df = df.to_pandas()
 
     pd_df = pd.DataFrame.from_dict({"filenames": [str(f) for f in files]})
     pd_df["bytes"] = pd.Series([pathlib.Path(fn).read_bytes() for fn in files])


### PR DESCRIPTION
During optimization, there are bugs that occur because we mutate the old plan when constructing the new plan

More testing needs to be performed to isolate a test-case where this is happening. It seems to be an issue related to aliasing of names and predicate pushdowns.