### PR TITLE
Add kernels for .list.join on a list[utf8] column

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -84,6 +84,11 @@ class Expression:
         return ExpressionUrlNamespace.from_expression(self)
 
     @property
+    def list(self) -> ExpressionListNamespace:
+        """Access methods that work on columns of lists"""
+        return ExpressionListNamespace.from_expression(self)
+
+    @property
     def image(self) -> ExpressionImageNamespace:
         """Access methods that work on columns of images"""
         return ExpressionImageNamespace.from_expression(self)
@@ -102,7 +107,7 @@ class Expression:
             return lit(obj)
 
     @staticmethod
-    def udf(func: Callable, expressions: list[Expression], return_dtype: DataType) -> Expression:
+    def udf(func: Callable, expressions: builtins.list[Expression], return_dtype: DataType) -> Expression:
         return Expression._from_pyexpr(_udf(func, [e._expr for e in expressions], return_dtype._dtype))
 
     def __bool__(self) -> bool:
@@ -560,6 +565,20 @@ class ExpressionStringNamespace(ExpressionNamespace):
             Expression: an UInt64 expression with the length of each string
         """
         return Expression._from_pyexpr(self._expr.utf8_length())
+
+
+class ExpressionListNamespace(ExpressionNamespace):
+    def join(self, delimiter: str | Expression) -> Expression:
+        """Joins every element of a list using the specified string delimiter
+
+        Args:
+            delimiter (str | Expression): the delimiter to use to join lists with
+
+        Returns:
+            Expression: a String expression which is every element of the list joined on the delimiter
+        """
+        delimiter_expr = Expression._to_expression(delimiter)
+        return Expression._from_pyexpr(self._expr.list_join(delimiter_expr._expr))
 
 
 class ExpressionsProjection(Iterable[Expression]):

--- a/docs/source/api_docs/expressions.rst
+++ b/docs/source/api_docs/expressions.rst
@@ -161,6 +161,19 @@ Example: ``e.image.resize()``
     daft.expressions.expressions.ExpressionImageNamespace.encode
 
 
+Nested
+******
+
+Operations on nested types (such as List and FixedSizeList), accessible through the ``Expression.list`` method accessor.
+
+Example: ``e1.str.concat(e2)``
+
+.. autosummary::
+    :toctree: expression_methods
+
+    daft.expressions.expressions.ExpressionListNamespace.join
+
+
 Changing Column Names/Types
 ###########################
 

--- a/src/array/ops/list.rs
+++ b/src/array/ops/list.rs
@@ -13,16 +13,26 @@ fn join_arrow_list_of_utf8s(
     list_element: Option<Box<dyn arrow2::array::Array>>,
     delimiter_str: &str,
 ) -> Option<String> {
-    list_element.map(|list_element| {
-        list_element
-            .as_any()
-            .downcast_ref::<arrow2::array::Utf8Array<i64>>()
-            .unwrap()
-            .iter()
-            .fold(String::from(""), |acc, str_item| {
-                acc + delimiter_str + str_item.unwrap_or("")
-            })
-    })
+    list_element
+        .map(|list_element| {
+            list_element
+                .as_any()
+                .downcast_ref::<arrow2::array::Utf8Array<i64>>()
+                .unwrap()
+                .iter()
+                .fold(String::from(""), |acc, str_item| {
+                    acc + str_item.unwrap_or("") + delimiter_str
+                })
+            // Remove trailing `delimiter_str`
+        })
+        .map(|result| {
+            let result_len = result.len();
+            if result_len > 0 {
+                result[..result_len - delimiter_str.len()].to_string()
+            } else {
+                result
+            }
+        })
 }
 
 impl ListArray {

--- a/src/array/ops/list.rs
+++ b/src/array/ops/list.rs
@@ -1,4 +1,4 @@
-use crate::datatypes::{FixedSizeListArray, ListArray, UInt64Array};
+use crate::datatypes::{FixedSizeListArray, ListArray, UInt64Array, Utf8Array};
 
 use crate::series::Series;
 
@@ -8,6 +8,22 @@ use arrow2::array::Array;
 use crate::error::DaftResult;
 
 use super::as_arrow::AsArrow;
+
+fn join_arrow_list_of_utf8s(
+    list_element: Option<Box<dyn arrow2::array::Array>>,
+    delimiter_str: &str,
+) -> Option<String> {
+    list_element.map(|list_element| {
+        list_element
+            .as_any()
+            .downcast_ref::<arrow2::array::Utf8Array<i64>>()
+            .unwrap()
+            .iter()
+            .fold(String::from(""), |acc, str_item| {
+                acc + delimiter_str + str_item.unwrap_or("")
+            })
+    })
+}
 
 impl ListArray {
     pub fn lengths(&self) -> DaftResult<UInt64Array> {
@@ -57,6 +73,37 @@ impl ListArray {
 
         Series::try_from((self.field.name.as_ref(), growable.as_box()))
     }
+
+    pub fn join(&self, delimiter: &Utf8Array) -> DaftResult<Utf8Array> {
+        let list_array = self.as_arrow();
+        assert_eq!(
+            list_array.values().data_type(),
+            &arrow2::datatypes::DataType::LargeUtf8
+        );
+
+        if delimiter.len() == 1 {
+            let delimiter_str = delimiter.get(0).unwrap();
+            let result = list_array
+                .iter()
+                .map(|list_element| join_arrow_list_of_utf8s(list_element, delimiter_str));
+            Ok(Utf8Array::from((
+                self.name(),
+                Box::new(arrow2::array::Utf8Array::from_iter(result)),
+            )))
+        } else {
+            assert_eq!(delimiter.len(), self.len());
+            let result = list_array.iter().zip(delimiter.as_arrow().iter()).map(
+                |(list_element, delimiter_element)| {
+                    let delimiter_str = delimiter_element.unwrap_or("");
+                    join_arrow_list_of_utf8s(list_element, delimiter_str)
+                },
+            );
+            Ok(Utf8Array::from((
+                self.name(),
+                Box::new(arrow2::array::Utf8Array::from_iter(result)),
+            )))
+        }
+    }
 }
 
 impl FixedSizeListArray {
@@ -97,5 +144,36 @@ impl FixedSizeListArray {
             }
         }
         Series::try_from((self.field.name.as_ref(), growable.as_box()))
+    }
+
+    pub fn join(&self, delimiter: &Utf8Array) -> DaftResult<Utf8Array> {
+        let list_array = self.as_arrow();
+        assert_eq!(
+            list_array.values().data_type(),
+            &arrow2::datatypes::DataType::LargeUtf8
+        );
+
+        if delimiter.len() == 1 {
+            let delimiter_str = delimiter.get(0).unwrap();
+            let result = list_array
+                .iter()
+                .map(|list_element| join_arrow_list_of_utf8s(list_element, delimiter_str));
+            Ok(Utf8Array::from((
+                self.name(),
+                Box::new(arrow2::array::Utf8Array::from_iter(result)),
+            )))
+        } else {
+            assert_eq!(delimiter.len(), self.len());
+            let result = list_array.iter().zip(delimiter.as_arrow().iter()).map(
+                |(list_element, delimiter_element)| {
+                    let delimiter_str = delimiter_element.unwrap_or("");
+                    join_arrow_list_of_utf8s(list_element, delimiter_str)
+                },
+            );
+            Ok(Utf8Array::from((
+                self.name(),
+                Box::new(arrow2::array::Utf8Array::from_iter(result)),
+            )))
+        }
     }
 }

--- a/src/dsl/functions/list/join.rs
+++ b/src/dsl/functions/list/join.rs
@@ -1,0 +1,64 @@
+use crate::{
+    datatypes::{DataType, Field},
+    dsl::Expr,
+    error::{DaftError, DaftResult},
+    schema::Schema,
+    series::{IntoSeries, Series},
+};
+
+use super::super::FunctionEvaluator;
+
+pub(super) struct JoinEvaluator {}
+
+impl FunctionEvaluator for JoinEvaluator {
+    fn fn_name(&self) -> &'static str {
+        "join"
+    }
+
+    fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
+        match inputs {
+            [input, delimiter] => {
+                let input_field = input.to_field(schema)?;
+                let delimiter_field = delimiter.to_field(schema)?;
+                if delimiter_field.dtype != DataType::Utf8 {
+                    return Err(DaftError::TypeError(format!(
+                        "Expected join delimiter to be of type {}, received: {}",
+                        DataType::Utf8,
+                        delimiter_field.dtype
+                    )));
+                }
+
+                match input_field.dtype {
+                    DataType::List(_) | DataType::FixedSizeList(_, _) => {
+                        let child_type = input_field.dtype.get_exploded_dtype().unwrap();
+                        if child_type != &DataType::Utf8 {
+                            return Err(DaftError::TypeError(format!("Expected input to be a list type with a Utf8 child, received child: {}", child_type)));
+                        }
+                        Ok(Field::new(input.name()?, DataType::Utf8))
+                    }
+                    _ => Err(DaftError::TypeError(format!(
+                        "Expected input to be a list type, received: {}",
+                        input_field.dtype
+                    ))),
+                }
+            }
+            _ => Err(DaftError::SchemaMismatch(format!(
+                "Expected 2 input args, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+
+    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+        match inputs {
+            [input, delimiter] => {
+                let delimiter = delimiter.utf8().unwrap();
+                Ok(input.join(delimiter)?.into_series())
+            }
+            _ => Err(DaftError::ValueError(format!(
+                "Expected 2 input args, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+}

--- a/src/dsl/functions/list/mod.rs
+++ b/src/dsl/functions/list/mod.rs
@@ -1,6 +1,8 @@
 mod explode;
+mod join;
 
 use explode::ExplodeEvaluator;
+use join::JoinEvaluator;
 use serde::{Deserialize, Serialize};
 
 use crate::dsl::Expr;
@@ -10,6 +12,7 @@ use super::FunctionEvaluator;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum ListExpr {
     Explode,
+    Join,
 }
 
 impl ListExpr {
@@ -18,6 +21,7 @@ impl ListExpr {
         use ListExpr::*;
         match self {
             Explode => &ExplodeEvaluator {},
+            Join => &JoinEvaluator {},
         }
     }
 }
@@ -26,5 +30,12 @@ pub fn explode(input: &Expr) -> Expr {
     Expr::Function {
         func: super::FunctionExpr::List(ListExpr::Explode),
         inputs: vec![input.clone()],
+    }
+}
+
+pub fn join(input: &Expr, delimiter: &Expr) -> Expr {
+    Expr::Function {
+        func: super::FunctionExpr::List(ListExpr::Join),
+        inputs: vec![input.clone(), delimiter.clone()],
     }
 }

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -336,6 +336,11 @@ impl PyExpr {
         use dsl::functions::image::resize;
         Ok(resize(&self.expr, w as u32, h as u32).into())
     }
+
+    pub fn list_join(&self, delimiter: &Self) -> PyResult<Self> {
+        use dsl::functions::list::join;
+        Ok(join(&self.expr, &delimiter.expr).into())
+    }
 }
 
 impl From<dsl::Expr> for PyExpr {

--- a/src/series/ops/list.rs
+++ b/src/series/ops/list.rs
@@ -1,5 +1,5 @@
 use crate::array::ops::as_arrow::AsArrow;
-use crate::datatypes::{DataType, UInt64Array};
+use crate::datatypes::{DataType, UInt64Array, Utf8Array};
 use crate::error::DaftError;
 use crate::{error::DaftResult, series::Series};
 
@@ -45,6 +45,17 @@ impl Series {
             }
             dt => Err(DaftError::TypeError(format!(
                 "lengths not implemented for {}",
+                dt
+            ))),
+        }
+    }
+
+    pub fn join(&self, delimiter: &Utf8Array) -> DaftResult<Utf8Array> {
+        match self.data_type() {
+            DataType::List(_) => self.list()?.join(delimiter),
+            DataType::FixedSizeList(..) => self.fixed_size_list()?.join(delimiter),
+            dt => Err(DaftError::TypeError(format!(
+                "Join not implemented for {}",
                 dt
             ))),
         }

--- a/tests/table/list/test_list_join.py
+++ b/tests/table/list/test_list_join.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+
+from daft.expressions import col
+from daft.table import Table
+
+
+def test_list_join():
+    table = Table.from_pydict({"col": [None, [], ["a"], [None], ["a", "a"], ["a", None], ["a", None, "a"]]})
+    result = table.eval_expression_list([col("col").list.join(",")])
+    assert result.to_pydict() == {"col": [None, "", "a", "", "a,a", "a,", "a,,a"]}
+
+
+def test_list_join_other_col():
+    table = Table.from_pydict(
+        {
+            "col": [None, [], ["a"], [None], ["a", "a"], ["a", None], ["a", None, "a"]],
+            "delimiter": ["1", "2", "3", "4", "5", "6", "7"],
+        }
+    )
+    result = table.eval_expression_list([col("col").list.join(col("delimiter"))])
+    assert result.to_pydict() == {"col": [None, "", "a", "", "a5a", "a6", "a77a"]}
+
+
+def test_list_join_bad_type():
+    table = Table.from_pydict({"col": [1, 2, 3]})
+    with pytest.raises(ValueError):
+        table.eval_expression_list([col("col").list.join(",")])
+
+    table = Table.from_pydict({"col": [[1, 2, 3], [4, 5, 6], []]})
+    with pytest.raises(ValueError):
+        table.eval_expression_list([col("col").list.join(",")])


### PR DESCRIPTION
* Adds the `.list` namespace on Expressions
* Adds implementation for a `.join` that only works if the nested child type is a string