### PR TITLE
[Images] [4/N] Add `Image` series --> Python (NumPy) series casting.

### DIFF
--- a/src/array/ops/as_arrow.rs
+++ b/src/array/ops/as_arrow.rs
@@ -10,6 +10,11 @@ use crate::{
     },
 };
 
+#[cfg(feature = "python")]
+use crate::array::pseudo_arrow::PseudoArrowArray;
+#[cfg(feature = "python")]
+use crate::datatypes::PythonArray;
+
 pub trait AsArrow {
     type Output;
 
@@ -92,8 +97,8 @@ impl AsArrow for StructArray {
 }
 
 #[cfg(feature = "python")]
-impl AsArrow for crate::datatypes::PythonArray {
-    type Output = crate::array::pseudo_arrow::PseudoArrowArray<pyo3::PyObject>;
+impl AsArrow for PythonArray {
+    type Output = PseudoArrowArray<pyo3::PyObject>;
 
     // downcasts a DataArray<T> to a PseudoArrowArray of PyObject.
     fn as_arrow(&self) -> &Self::Output {

--- a/src/array/ops/broadcast.rs
+++ b/src/array/ops/broadcast.rs
@@ -9,6 +9,11 @@ use crate::{
 
 use super::as_arrow::AsArrow;
 
+#[cfg(feature = "python")]
+use crate::array::pseudo_arrow::PseudoArrowArray;
+#[cfg(feature = "python")]
+use crate::datatypes::PythonArray;
+
 pub trait Broadcastable {
     fn broadcast(&self, num: usize) -> DaftResult<Self>
     where
@@ -292,9 +297,8 @@ impl Broadcastable for crate::datatypes::PythonArray {
             }
         };
 
-        let repeated_values_array: Box<dyn arrow2::array::Array> = Box::new(
-            crate::array::pseudo_arrow::PseudoArrowArray::new(repeated_values.into(), validity),
-        );
-        crate::datatypes::PythonArray::new(self.field.clone(), repeated_values_array)
+        let repeated_values_array: Box<dyn arrow2::array::Array> =
+            Box::new(PseudoArrowArray::new(repeated_values.into(), validity));
+        PythonArray::new(self.field.clone(), repeated_values_array)
     }
 }

--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -726,7 +726,7 @@ impl ImageArray {
                     );
                     let py_array = match arrow_array {
                         Some(arrow_array) => ffi::to_py_array(arrow_array, py, pyarrow)?
-                            .call_method0(py, pyo3::intern!(py, "to_numpy"))?
+                            .call_method1(py, pyo3::intern!(py, "to_numpy"), (false,))?
                             .call_method1(py, pyo3::intern!(py, "reshape"), (shape,))?,
                         None => PyArray3::<u8>::zeros(py, shape.into_dimension(), false)
                             .deref()

--- a/src/array/ops/image.rs
+++ b/src/array/ops/image.rs
@@ -297,7 +297,7 @@ impl ImageArray {
         ))
     }
 
-    fn as_image_obj<'a>(&'a self, idx: usize) -> Option<DaftImageBuffer<'a>> {
+    pub fn as_image_obj<'a>(&'a self, idx: usize) -> Option<DaftImageBuffer<'a>> {
         assert!(idx < self.len());
         if !self.physical.is_valid(idx) {
             return None;

--- a/src/array/ops/image.rs
+++ b/src/array/ops/image.rs
@@ -184,42 +184,42 @@ pub struct ImageArrayVecs<T> {
 }
 
 impl ImageArray {
-    fn image_mode(&self) -> &Option<ImageMode> {
+    pub fn image_mode(&self) -> &Option<ImageMode> {
         match self.logical_type() {
             DataType::Image(_, mode) => mode,
             _ => panic!("Expected dtype to be Image"),
         }
     }
 
-    fn data_array(&self) -> &arrow2::array::ListArray<i64> {
+    pub fn data_array(&self) -> &arrow2::array::ListArray<i64> {
         let p = self.physical.as_arrow();
         const IMAGE_DATA_IDX: usize = 0;
         let array = p.values().get(IMAGE_DATA_IDX).unwrap();
         array.as_ref().as_any().downcast_ref().unwrap()
     }
 
-    fn channel_array(&self) -> &arrow2::array::UInt16Array {
+    pub fn channel_array(&self) -> &arrow2::array::UInt16Array {
         let p = self.physical.as_arrow();
         const IMAGE_CHANNEL_IDX: usize = 1;
         let array = p.values().get(IMAGE_CHANNEL_IDX).unwrap();
         array.as_ref().as_any().downcast_ref().unwrap()
     }
 
-    fn height_array(&self) -> &arrow2::array::UInt32Array {
+    pub fn height_array(&self) -> &arrow2::array::UInt32Array {
         let p = self.physical.as_arrow();
         const IMAGE_HEIGHT_IDX: usize = 2;
         let array = p.values().get(IMAGE_HEIGHT_IDX).unwrap();
         array.as_ref().as_any().downcast_ref().unwrap()
     }
 
-    fn width_array(&self) -> &arrow2::array::UInt32Array {
+    pub fn width_array(&self) -> &arrow2::array::UInt32Array {
         let p = self.physical.as_arrow();
         const IMAGE_WIDTH_IDX: usize = 3;
         let array = p.values().get(IMAGE_WIDTH_IDX).unwrap();
         array.as_ref().as_any().downcast_ref().unwrap()
     }
 
-    fn mode_array(&self) -> &arrow2::array::UInt8Array {
+    pub fn mode_array(&self) -> &arrow2::array::UInt8Array {
         let p = self.physical.as_arrow();
         const IMAGE_MODE_IDX: usize = 4;
         let array = p.values().get(IMAGE_MODE_IDX).unwrap();

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -48,7 +48,7 @@ MODE_TO_OPENCV_COLOR_CONVERSION = {
 }
 
 
-def test_image_arrow_round_trip():
+def test_image_round_trip():
     data = [
         np.arange(12, dtype=np.uint8).reshape((2, 2, 3)),
         np.arange(12, 39, dtype=np.uint8).reshape((3, 3, 3)),
@@ -62,6 +62,16 @@ def test_image_arrow_round_trip():
 
     assert t.datatype() == target_dtype
 
+    # Test pylist roundtrip.
+    back_dtype = DataType.python()
+    back = t.cast(back_dtype)
+
+    assert back.datatype() == back_dtype
+
+    out = back.to_pylist()
+    np.testing.assert_equal(out, data)
+
+    # Test Arrow roundtrip.
     arrow_arr = t.to_arrow()
 
     assert isinstance(arrow_arr.type, DaftExtension)
@@ -94,7 +104,7 @@ def test_image_arrow_round_trip():
 )
 def test_image_decode_pil(mode, file_format):
     np_dtype = MODE_TO_NP_DTYPE[mode]
-    img_mode = ImageMode.from_mode_string(mode)
+    ImageMode.from_mode_string(mode)
     num_channels = MODE_TO_NUM_CHANNELS[mode]
     shape = (4, 4)
     if num_channels > 1:
@@ -109,12 +119,11 @@ def test_image_decode_pil(mode, file_format):
     t = s.image.decode()
     # TODO(Clark): Infer type-leve mode if all images are the same mode.
     assert t.datatype() == DataType.image()
-    for py_img in t.to_pylist():
-        assert py_img["channel"] == num_channels
-        assert py_img["height"] == shape[0]
-        assert py_img["width"] == shape[1]
-        assert py_img["mode"] == img_mode
-        np.testing.assert_equal(np.array(py_img["data"]).reshape(shape).astype(np_dtype), arr)
+    out = t.cast(DataType.python()).to_pylist()
+    expected_arrs = [arr, arr, arr]
+    if num_channels == 1:
+        expected_arrs = [np.expand_dims(arr, -1) for arr in expected_arrs]
+    np.testing.assert_equal(out, expected_arrs)
 
 
 @pytest.mark.parametrize(
@@ -146,7 +155,7 @@ def test_image_decode_pil(mode, file_format):
 )
 def test_image_decode_opencv(mode, file_format):
     np_dtype = MODE_TO_NP_DTYPE[mode]
-    img_mode = ImageMode.from_mode_string(mode)
+    ImageMode.from_mode_string(mode)
     num_channels = MODE_TO_NUM_CHANNELS[mode]
     shape = (4, 4, num_channels)
     arr = np.arange(np.prod(shape)).reshape(shape).astype(np_dtype)
@@ -163,12 +172,9 @@ def test_image_decode_opencv(mode, file_format):
     if np_dtype == np.uint8:
         # TODO(Clark): Infer type-leve mode if all images are the same mode.
         assert t.datatype() == DataType.image()
-    for py_img in t.to_pylist():
-        assert py_img["channel"] == num_channels
-        assert py_img["height"] == shape[0]
-        assert py_img["width"] == shape[1]
-        assert py_img["mode"] == img_mode
-        np.testing.assert_equal(np.array(py_img["data"]).reshape(shape).astype(np_dtype), arr)
+    out = t.cast(DataType.python()).to_pylist()
+    expected_arrs = [arr, arr, arr]
+    np.testing.assert_equal(out, expected_arrs)
 
 
 def test_image_resize():
@@ -188,20 +194,15 @@ def test_image_resize():
 
     resized = t.image.resize(5, 5)
 
-    as_py = resized.to_pylist()
-
     assert resized.datatype() == target_dtype
 
-    first_resized = np.array(as_py[0]["data"]).reshape(5, 5, 3)
-    assert np.all(first_resized[..., 0] == 1)
-    assert np.all(first_resized[..., 1] == 2)
-    assert np.all(first_resized[..., 2] == 3)
+    out = resized.cast(DataType.python()).to_pylist()
 
-    sec_resized = np.array(as_py[1]["data"]).reshape(5, 5, 3)
-    sec_resized_gt = np.asarray(Image.fromarray(second).resize((5, 5), resample=Image.BILINEAR))
-    assert np.all(sec_resized == sec_resized_gt)
+    def resize(arr):
+        # Use opencv as a resizing baseline.
+        return cv2.resize(arr, dsize=(5, 5), interpolation=cv2.INTER_LINEAR_EXACT)
 
-    assert as_py[2] == None
+    np.testing.assert_equal(out, [resize(first), resize(second), None])
 
 
 def test_image_resize_mixed_modes():
@@ -229,34 +230,19 @@ def test_image_resize_mixed_modes():
 
     resized = t.image.resize(5, 5)
 
-    as_py = resized.to_pylist()
+    out = resized.cast(DataType.python()).to_pylist()
 
-    assert resized.datatype() == target_dtype
+    def resize(arr):
+        # Use opencv as a resizing baseline.
+        arr = cv2.resize(arr, dsize=(5, 5), interpolation=cv2.INTER_LINEAR_EXACT)
+        if arr.ndim == 2:
+            arr = np.expand_dims(arr, -1)
+        return arr
 
-    first_resized = np.array(as_py[0]["data"]).reshape(5, 5, 3)
-    assert np.all(first_resized[..., 0] == 1)
-    assert np.all(first_resized[..., 1] == 2)
-    assert np.all(first_resized[..., 2] == 3)
-
-    second_resized = np.array(as_py[1]["data"]).reshape(5, 5, 4)
-    assert np.all(second_resized[..., 0] == 1)
-    assert np.all(second_resized[..., 1] == 2)
-    assert np.all(second_resized[..., 2] == 3)
-    assert np.all(second_resized[..., 3] == 4)
-
-    for i in range(2, 4):
-        resized_i = np.array(as_py[i]["data"]).reshape(5, 5, -1)
-        resized_i_gt = np.asarray(Image.fromarray(data[i]).resize((5, 5), resample=Image.BILINEAR)).reshape(5, 5, -1)
-        assert np.all(resized_i == resized_i_gt), f"{i} does not match"
-
-    # LA sampling doesn't work for some reason in PIL
-    resized_i = np.array(as_py[4]["data"]).reshape(5, 5, -1)
-    assert np.all(resized_i == 10)
-
-    assert as_py[-1] == None
+    np.testing.assert_equal(out, [resize(arr) if arr is not None else None for arr in data])
 
 
-def test_fixed_shape_image_arrow_round_trip():
+def test_fixed_shape_image_roundtrip():
     height = 2
     width = 2
     shape = (height, width, 3)
@@ -269,6 +255,16 @@ def test_fixed_shape_image_arrow_round_trip():
 
     assert t.datatype() == target_dtype
 
+    # Test pylist roundtrip.
+    back_dtype = DataType.python()
+    back = t.cast(back_dtype)
+
+    assert back.datatype() == back_dtype
+
+    out = back.to_pylist()
+    np.testing.assert_equal(out, data)
+
+    # Test Arrow roundtrip.
     arrow_arr = t.to_arrow()
 
     assert isinstance(arrow_arr.type, DaftExtension)


### PR DESCRIPTION
This PR adds an `Image` series --> Python egress path via the casting kernel, where elements in an `ImageArray` series are converted to NumPy ndarrays when hit with a `.cast(DataType::Python)`. This is added for both the fixed-shape image and variable-shape image arrays.

Automatic conversion of PIL images on `Series.from_pylist()` and to NumPy ndarrays on `Series.to_pylist()` is saved for a future PR.