### PR TITLE
[Table-Read-Schema 2/3] Add table casting logic

### DIFF
--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -62,6 +62,12 @@ class Schema:
         s._schema = _PySchema.from_field_name_and_types([(name, dtype._dtype) for name, dtype in fields])
         return s
 
+    @classmethod
+    def _from_fields(self, fields: list[Field]) -> Schema:
+        s = Schema.__new__(Schema)
+        s._schema = _PySchema.from_fields([f._field for f in fields])
+        return s
+
     def __getitem__(self, key: str) -> Field:
         assert isinstance(key, str), f"Expected str for key, but received: {type(key)}"
         if key not in self._schema.names():

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -211,6 +211,10 @@ class Table:
     # Compute methods (Table -> Table)
     ###
 
+    def cast_to_schema(self, schema: Schema) -> Table:
+        """Casts a Table into the provided schema"""
+        return Table._from_pytable(self._table.cast_to_schema(schema._schema))
+
     def eval_expression_list(self, exprs: ExpressionsProjection) -> Table:
         assert all(isinstance(e, Expression) for e in exprs)
         pyexprs = [e._expr for e in exprs]

--- a/daft/table/table_io.py
+++ b/daft/table/table_io.py
@@ -55,9 +55,7 @@ def _cast_table_to_schema(table: Table, read_options: TableReadOptions, schema: 
     if read_options.column_names is not None:
         pruned_schema = Schema._from_fields([schema[name] for name in read_options.column_names])
 
-    # TODO(jaychia): impl
-    pruned_schema
-    # table = table.cast_to_schema(pruned_schema)
+    table = table.cast_to_schema(pruned_schema)
     return table
 
 

--- a/daft/table/table_io.py
+++ b/daft/table/table_io.py
@@ -49,7 +49,15 @@ def _cast_table_to_schema(table: Table, read_options: TableReadOptions, schema: 
     This helper function takes care of all that, ensuring that the resulting Table has all column types matching
     their corresponding dtype in `schema`, and column ordering/inclusion matches `read_options.column_names` (if provided).
     """
-    # TODO(jaychia): Currently a no-op
+    pruned_schema = schema
+
+    # If reading only a subset of fields, prune the schema
+    if read_options.column_names is not None:
+        pruned_schema = Schema._from_fields([schema[name] for name in read_options.column_names])
+
+    # TODO(jaychia): impl
+    pruned_schema
+    # table = table.cast_to_schema(pruned_schema)
     return table
 
 

--- a/src/python/field.rs
+++ b/src/python/field.rs
@@ -8,6 +8,7 @@ use super::datatype::PyDataType;
 use crate::datatypes::{self, DataType, Field};
 
 #[pyclass]
+#[derive(Clone)]
 pub struct PyField {
     pub field: datatypes::Field,
 }

--- a/src/python/schema.rs
+++ b/src/python/schema.rs
@@ -64,6 +64,13 @@ impl PySchema {
         })
     }
 
+    #[staticmethod]
+    pub fn from_fields(fields: Vec<PyField>) -> PyResult<PySchema> {
+        Ok(PySchema {
+            schema: schema::Schema::new(fields.iter().map(|f| f.field.clone()).collect())?.into(),
+        })
+    }
+
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {
         match state.extract::<&PyBytes>(py) {
             Ok(s) => {

--- a/src/python/table.rs
+++ b/src/python/table.rs
@@ -30,6 +30,10 @@ impl PyTable {
         })
     }
 
+    pub fn cast_to_schema(&self, schema: &PySchema) -> PyResult<Self> {
+        Ok(self.table.cast_to_schema(&schema.schema)?.into())
+    }
+
     pub fn eval_expression_list(&self, py: Python, exprs: Vec<PyExpr>) -> PyResult<Self> {
         let converted_exprs: Vec<dsl::Expr> = exprs.into_iter().map(|e| e.into()).collect();
         py.allow_threads(|| {

--- a/src/table/mod.rs
+++ b/src/table/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter, Result};
 
 use num_traits::ToPrimitive;
@@ -7,7 +8,7 @@ use crate::array::ops::GroupIndices;
 use crate::datatypes::logical::LogicalArray;
 use crate::datatypes::{BooleanType, DataType, Field, UInt64Array};
 use crate::dsl::functions::FunctionEvaluator;
-use crate::dsl::{AggExpr, Expr};
+use crate::dsl::{col, null_lit, AggExpr, Expr};
 use crate::error::{DaftError, DaftResult};
 use crate::schema::{Schema, SchemaRef};
 use crate::series::{IntoSeries, Series};
@@ -345,7 +346,6 @@ impl Table {
             .iter()
             .map(|s| s.field().clone())
             .collect::<Vec<Field>>();
-        use std::collections::HashSet;
         let mut seen: HashSet<String> = HashSet::new();
         for field in fields.iter() {
             let name = &field.name;
@@ -362,6 +362,24 @@ impl Table {
     pub fn as_physical(&self) -> DaftResult<Self> {
         let new_series: DaftResult<Vec<_>> = self.columns.iter().map(|s| s.as_physical()).collect();
         Table::from_columns(new_series?)
+    }
+
+    pub fn cast_to_schema(&self, schema: &Schema) -> DaftResult<Self> {
+        let current_col_names = HashSet::<_>::from_iter(self.column_names());
+        let exprs: Vec<_> = schema
+            .fields
+            .iter()
+            .map(|(name, field)| {
+                if current_col_names.contains(name) {
+                    // For any fields already in the table, perform a cast
+                    col(name.clone()).cast(&field.dtype)
+                } else {
+                    // For any fields in schema that are not in self.schema, create all-null arrays
+                    null_lit().alias(name.clone()).cast(&field.dtype)
+                }
+            })
+            .collect();
+        self.eval_expression_list(&exprs)
     }
 
     pub fn repr_html(&self) -> String {

--- a/tests/table/table_io/test_read_time_cast.py
+++ b/tests/table/table_io/test_read_time_cast.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+import daft
+from daft import DataType
+from daft.logical.schema import Schema
+from daft.table import Table, table_io
+from tests.table.table_io.test_parquet import _parquet_write_helper
+
+
+@pytest.mark.parametrize(
+    ["data", "schema", "expected"],
+    [
+        # Test that a cast occurs (in this case, int64 -> int8)
+        (
+            pa.Table.from_pydict({"foo": pa.array([1, 2, 3], type=pa.int64())}),
+            Schema._from_field_name_and_types([("foo", DataType.int8())]),
+            Table.from_pydict({"foo": daft.Series.from_arrow(pa.array([1, 2, 3], type=pa.int8()))}),
+        ),
+        # Test what happens if a cast should occur, but fails at runtime (in this case, a potentially bad cast from utf8->int64)
+        (
+            pa.Table.from_pydict({"foo": pa.array(["1", "2", "FAIL"], type=pa.string())}),
+            Schema._from_field_name_and_types([("foo", DataType.int64())]),
+            # NOTE: cast failures will become a Null value
+            Table.from_pydict({"foo": daft.Series.from_arrow(pa.array([1, 2, None], type=pa.int64()))}),
+        ),
+        # Test reordering of columns
+        (
+            pa.Table.from_pydict({"foo": pa.array([1, 2, 3]), "bar": pa.array([1, 2, 3])}),
+            Schema._from_field_name_and_types([("bar", DataType.int64()), ("foo", DataType.int64())]),
+            Table.from_pydict({"bar": pa.array([1, 2, 3]), "foo": pa.array([1, 2, 3])}),
+        ),
+        # Test automatic insertion of null values for missing column
+        (
+            pa.Table.from_pydict({"foo": pa.array([1, 2, 3])}),
+            Schema._from_field_name_and_types([("bar", DataType.int64()), ("foo", DataType.int64())]),
+            Table.from_pydict({"bar": pa.array([None, None, None], type=pa.int64()), "foo": pa.array([1, 2, 3])}),
+        ),
+    ],
+)
+def test_parquet_cast_at_read_time(data, schema, expected):
+    f = _parquet_write_helper(data)
+    table = table_io.read_parquet(f, schema)
+    assert table.schema() == schema
+    assert table.to_arrow() == expected.to_arrow()


### PR DESCRIPTION
* Adds table casting logic to coerce the table that was read to the schema that was required
* Adds also a strong assertion after reading the tables on each table's schema so that we catch any reading issues early, rather than silently letting it through which will cause VERY weird issues down the line

Note that after this PR, certain reads may throw errors (e.g. reading two JSONs with incompatible nested struct fields). This is expected, and if we want to support those use-cases we need to fix our `cast` implementation for those types!