### PR TITLE
[Images] [7/N] Add image encoding support.

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -76,6 +76,7 @@ from daft.convert import (
     from_pylist,
     from_ray_dataset,
 )
+from daft.daft import ImageFormat
 from daft.dataframe import DataFrame
 from daft.datatype import DataType, ImageMode
 from daft.expressions import col, lit
@@ -99,6 +100,7 @@ __all__ = [
     "col",
     "DataType",
     "ImageMode",
+    "ImageFormat",
     "lit",
     "Series",
     "register_viz_hook",

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -48,4 +48,30 @@ class ImageMode(Enum):
         """
         ...
 
+class ImageFormat(Enum):
+    """
+    Supported image formats for Daft's image I/O.
+    """
+
+    PNG: int
+
+    JPEG: int
+
+    TIFF: int
+
+    WEBP: int
+
+    GIF: int
+
+    BMP: int
+
+    HDR: int
+
+    @staticmethod
+    def from_format_string(mode: str) -> ImageFormat:
+        """
+        Create an ImageFormat from its string representation.
+        """
+        ...
+
 def __getattr__(name) -> Any: ...

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -59,13 +59,9 @@ class ImageFormat(Enum):
 
     TIFF: int
 
-    WEBP: int
-
     GIF: int
 
     BMP: int
-
-    HDR: int
 
     @staticmethod
     def from_format_string(mode: str) -> ImageFormat:

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -199,7 +199,7 @@ class DataType:
                 Must be specified if the width is specified.
         """
         if isinstance(mode, str):
-            mode = ImageMode.from_mode_string(mode)
+            mode = ImageMode.from_mode_string(mode.upper())
         if height is not None and width is not None:
             if not isinstance(height, int) or height <= 0:
                 raise ValueError("Image height must be a positive integer, but got: ", height)

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -200,7 +200,7 @@ class DataType:
         """
         if isinstance(mode, str):
             mode = ImageMode.from_mode_string(mode.upper())
-        if not isinstance(mode, ImageMode):
+        if mode is not None and not isinstance(mode, ImageMode):
             raise ValueError(f"mode must be a string or ImageMode variant, but got: {mode}")
         if height is not None and width is not None:
             if not isinstance(height, int) or height <= 0:

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -200,6 +200,8 @@ class DataType:
         """
         if isinstance(mode, str):
             mode = ImageMode.from_mode_string(mode.upper())
+        if not isinstance(mode, ImageMode):
+            raise ValueError(f"mode must be a string or ImageMode variant, but got: {mode}")
         if height is not None and width is not None:
             if not isinstance(height, int) or height <= 0:
                 raise ValueError("Image height must be a positive integer, but got: ", height)

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -7,6 +7,7 @@ from typing import Callable, Iterable, Iterator, TypeVar, overload
 
 import fsspec
 
+from daft.daft import ImageFormat
 from daft.daft import PyExpr as _PyExpr
 from daft.daft import col as _col
 from daft.daft import lit as _lit
@@ -668,10 +669,45 @@ class ExpressionsProjection(Iterable[Expression]):
 
 
 class ExpressionImageNamespace(ExpressionNamespace):
+    """Expression operations for image columns."""
+
     def decode(self) -> Expression:
+        """
+        Decodes the binary data in this column into images.
+
+        This can only be applied to binary columns that contain encoded images (e.g. PNG, JPEG, etc.)
+
+        Returns:
+            Expression: An Image expression represnting an image column.
+        """
         return Expression._from_pyexpr(self._expr.image_decode())
 
+    def encode(self, image_format: str | ImageFormat) -> Expression:
+        """
+        Encode an image column as the provided image file format, returning a binary column
+        of encoded bytes.
+
+        Args:
+            image_format: The image file format into which the images will be encoded.
+
+        Returns:
+            Expression: A Binary expression representing a binary column of encoded image bytes.
+        """
+        if isinstance(image_format, str):
+            image_format = ImageFormat.from_format_string(image_format.upper())
+        return Expression._from_pyexpr(self._expr.image_encode(image_format))
+
     def resize(self, w: int, h: int) -> Expression:
+        """
+        Resize image into the provided width and height.
+
+        Args:
+            w: Desired width of the resized image.
+            h: Desired height of the resized image.
+
+        Returns:
+            Expression: An Image expression representing an image column of the resized images.
+        """
         if not isinstance(w, int):
             raise TypeError(f"expected int for w but got {type(w)}")
         if not isinstance(h, int):

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -695,6 +695,8 @@ class ExpressionImageNamespace(ExpressionNamespace):
         """
         if isinstance(image_format, str):
             image_format = ImageFormat.from_format_string(image_format.upper())
+        if not isinstance(image_format, ImageFormat):
+            raise ValueError(f"image_format must be a string or ImageFormat variant, but got: {image_format}")
         return Expression._from_pyexpr(self._expr.image_encode(image_format))
 
     def resize(self, w: int, h: int) -> Expression:

--- a/daft/series.py
+++ b/daft/series.py
@@ -5,7 +5,7 @@ from typing import TypeVar
 import pyarrow as pa
 
 from daft.arrow_utils import ensure_array, ensure_chunked_array
-from daft.daft import PySeries
+from daft.daft import ImageFormat, PySeries
 from daft.datatype import DataType
 
 _NUMPY_AVAILABLE = True
@@ -514,6 +514,11 @@ class SeriesArrayNamespace(SeriesNamespace):
 class SeriesImageNamespace(SeriesNamespace):
     def decode(self) -> Series:
         return Series._from_pyseries(self._series.image_decode())
+
+    def encode(self, image_format: str | ImageFormat) -> Series:
+        if isinstance(image_format, str):
+            image_format = ImageFormat.from_format_string(image_format.upper())
+        return Series._from_pyseries(self._series.image_encode(image_format))
 
     def resize(self, w: int, h: int) -> Series:
         if not isinstance(w, int):

--- a/daft/series.py
+++ b/daft/series.py
@@ -518,6 +518,8 @@ class SeriesImageNamespace(SeriesNamespace):
     def encode(self, image_format: str | ImageFormat) -> Series:
         if isinstance(image_format, str):
             image_format = ImageFormat.from_format_string(image_format.upper())
+        if not isinstance(image_format, ImageFormat):
+            raise ValueError(f"image_format must be a string or ImageFormat variant, but got: {image_format}")
         return Series._from_pyseries(self._series.image_encode(image_format))
 
     def resize(self, w: int, h: int) -> Series:

--- a/docs/source/api_docs/datatype.rst
+++ b/docs/source/api_docs/datatype.rst
@@ -133,6 +133,11 @@ Computer Vision
 
     ImageMode
 
+.. autosummary::
+    :nosignatures:
+
+    ImageFormat
+
 
 Miscellaneous
 ^^^^^^^^^^^^^
@@ -145,4 +150,5 @@ Miscellaneous
 .. toctree::
     :hidden:
 
+    datetype_image_format/daft.ImageFormat
     datatype_image_mode/daft.ImageMode

--- a/docs/source/api_docs/datetype_image_format/daft.ImageFormat.from_format_string.rst
+++ b/docs/source/api_docs/datetype_image_format/daft.ImageFormat.from_format_string.rst
@@ -1,0 +1,6 @@
+﻿daft.ImageFormat.from\_format\_string
+=====================================
+
+.. currentmodule:: daft
+
+.. automethod:: ImageFormat.from_format_string

--- a/docs/source/api_docs/datetype_image_format/daft.ImageFormat.rst
+++ b/docs/source/api_docs/datetype_image_format/daft.ImageFormat.rst
@@ -17,8 +17,5 @@
       ~ImageFormat.PNG
       ~ImageFormat.JPEG
       ~ImageFormat.TIFF
-      ~ImageFormat.WEBP
       ~ImageFormat.GIF
       ~ImageFormat.BMP
-      ~ImageFormat.HDR
-   

--- a/docs/source/api_docs/datetype_image_format/daft.ImageFormat.rst
+++ b/docs/source/api_docs/datetype_image_format/daft.ImageFormat.rst
@@ -1,0 +1,24 @@
+﻿daft.ImageFormat
+================
+
+.. currentmodule:: daft
+
+.. autoclass:: ImageFormat
+
+   .. autosummary::
+      :toctree:
+
+      ~ImageFormat.from_format_string
+
+   .. rubric:: Variants
+
+   .. autosummary::
+   
+      ~ImageFormat.PNG
+      ~ImageFormat.JPEG
+      ~ImageFormat.TIFF
+      ~ImageFormat.WEBP
+      ~ImageFormat.GIF
+      ~ImageFormat.BMP
+      ~ImageFormat.HDR
+   

--- a/docs/source/api_docs/expressions.rst
+++ b/docs/source/api_docs/expressions.rst
@@ -158,6 +158,7 @@ Example: ``e.image.resize()``
     daft.expressions.Expression.image
     daft.expressions.expressions.ExpressionImageNamespace.resize
     daft.expressions.expressions.ExpressionImageNamespace.decode
+    daft.expressions.expressions.ExpressionImageNamespace.encode
 
 
 Changing Column Names/Types

--- a/src/array/ops/image.rs
+++ b/src/array/ops/image.rs
@@ -120,7 +120,7 @@ impl<'a> DaftImageBuffer<'a> {
     }
 
     pub fn encode(&self, image_format: ImageFormat) -> DaftResult<Vec<u8>> {
-        let mut writer = std::io::Cursor::new(Vec::new());
+        let mut writer = std::io::BufWriter::new(std::io::Cursor::new(Vec::new()));
         image::write_buffer_with_format(
             &mut writer,
             self.as_u8_slice(),
@@ -135,7 +135,13 @@ impl<'a> DaftImageBuffer<'a> {
                 image_format, e
             ))
         })?;
-        Ok(writer.into_inner())
+        let out = writer.into_inner().map_err(|e| {
+            DaftError::ValueError(format!(
+                "Encoding image into file format {} failed: {}",
+                image_format, e
+            ))
+        })?;
+        Ok(out.into_inner())
     }
 
     pub fn resize(&self, w: u32, h: u32) -> Self {

--- a/src/array/ops/image.rs
+++ b/src/array/ops/image.rs
@@ -129,7 +129,12 @@ impl<'a> DaftImageBuffer<'a> {
             self.color(),
             image::ImageFormat::from(image_format),
         )
-        .map_err(|e| DaftError::ValueError(format!("Decoding image from bytes failed: {}", e)))?;
+        .map_err(|e| {
+            DaftError::ValueError(format!(
+                "Encoding image into file format {} failed: {}",
+                image_format, e
+            ))
+        })?;
         Ok(writer.into_inner())
     }
 

--- a/src/datatypes/image_format.rs
+++ b/src/datatypes/image_format.rs
@@ -13,10 +13,8 @@ use crate::error::{DaftError, DaftResult};
 /// | PNG
 /// | JPEG
 /// | TIFF
-/// | WEBP
 /// | GIF
 /// | BMP
-/// | HDR
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "python", pyclass)]
@@ -24,10 +22,8 @@ pub enum ImageFormat {
     PNG,
     JPEG,
     TIFF,
-    WEBP,
     GIF,
     BMP,
-    HDR,
 }
 
 #[cfg(feature = "python")]
@@ -53,7 +49,7 @@ impl ImageFormat {
     pub fn iterator() -> std::slice::Iter<'static, ImageFormat> {
         use ImageFormat::*;
 
-        static FORMATS: [ImageFormat; 7] = [PNG, JPEG, TIFF, WEBP, GIF, BMP, HDR];
+        static FORMATS: [ImageFormat; 5] = [PNG, JPEG, TIFF, GIF, BMP];
         FORMATS.iter()
     }
 }
@@ -68,10 +64,8 @@ impl FromStr for ImageFormat {
             "PNG" => Ok(PNG),
             "JPEG" => Ok(JPEG),
             "TIFF" => Ok(TIFF),
-            "WEBP" => Ok(WEBP),
             "GIF" => Ok(GIF),
             "BMP" => Ok(BMP),
-            "HDR" => Ok(HDR),
             _ => Err(DaftError::TypeError(format!(
                 "Image format {} is not supported; only the following formats are supported: {:?}",
                 format,
@@ -87,10 +81,8 @@ impl From<image::ImageFormat> for ImageFormat {
             image::ImageFormat::Png => ImageFormat::PNG,
             image::ImageFormat::Jpeg => ImageFormat::JPEG,
             image::ImageFormat::Tiff => ImageFormat::TIFF,
-            image::ImageFormat::WebP => ImageFormat::WEBP,
             image::ImageFormat::Gif => ImageFormat::GIF,
             image::ImageFormat::Bmp => ImageFormat::BMP,
-            image::ImageFormat::Hdr => ImageFormat::HDR,
             _ => unimplemented!("Image format {:?} is not supported", image_format),
         }
     }
@@ -102,10 +94,8 @@ impl From<ImageFormat> for image::ImageFormat {
             ImageFormat::PNG => image::ImageFormat::Png,
             ImageFormat::JPEG => image::ImageFormat::Jpeg,
             ImageFormat::TIFF => image::ImageFormat::Tiff,
-            ImageFormat::WEBP => image::ImageFormat::WebP,
             ImageFormat::GIF => image::ImageFormat::Gif,
             ImageFormat::BMP => image::ImageFormat::Bmp,
-            ImageFormat::HDR => image::ImageFormat::Hdr,
         }
     }
 }

--- a/src/datatypes/image_format.rs
+++ b/src/datatypes/image_format.rs
@@ -1,0 +1,118 @@
+use std::fmt::{Display, Formatter, Result};
+use std::str::FromStr;
+use std::string::ToString;
+
+#[cfg(feature = "python")]
+use pyo3::{exceptions::PyValueError, prelude::*};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{DaftError, DaftResult};
+
+/// Supported image formats for Daft's I/O layer.
+///
+/// | PNG
+/// | JPEG
+/// | TIFF
+/// | WEBP
+/// | GIF
+/// | BMP
+/// | HDR
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[cfg_attr(feature = "python", pyclass)]
+pub enum ImageFormat {
+    PNG,
+    JPEG,
+    TIFF,
+    WEBP,
+    GIF,
+    BMP,
+    HDR,
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl ImageFormat {
+    /// Create an ImageFormat from its string representation.
+    ///
+    /// Args:
+    ///     mode: String representation of the image format. This is the same as the enum
+    ///         attribute name, e.g. ``ImageFormat.from_mode_string("JPEG")`` would
+    ///         return ``ImageFormat.JPEG``.
+    #[staticmethod]
+    pub fn from_format_string(format: &str) -> PyResult<Self> {
+        Self::from_str(format).map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    pub fn __str__(&self) -> PyResult<String> {
+        Ok(self.to_string())
+    }
+}
+
+impl ImageFormat {
+    pub fn iterator() -> std::slice::Iter<'static, ImageFormat> {
+        use ImageFormat::*;
+
+        static FORMATS: [ImageFormat; 7] = [PNG, JPEG, TIFF, WEBP, GIF, BMP, HDR];
+        FORMATS.iter()
+    }
+}
+
+impl FromStr for ImageFormat {
+    type Err = DaftError;
+
+    fn from_str(format: &str) -> DaftResult<Self> {
+        use ImageFormat::*;
+
+        match format {
+            "PNG" => Ok(PNG),
+            "JPEG" => Ok(JPEG),
+            "TIFF" => Ok(TIFF),
+            "WEBP" => Ok(WEBP),
+            "GIF" => Ok(GIF),
+            "BMP" => Ok(BMP),
+            "HDR" => Ok(HDR),
+            _ => Err(DaftError::TypeError(format!(
+                "Image format {} is not supported; only the following formats are supported: {:?}",
+                format,
+                ImageFormat::iterator().as_slice()
+            ))),
+        }
+    }
+}
+
+impl From<image::ImageFormat> for ImageFormat {
+    fn from(image_format: image::ImageFormat) -> Self {
+        match image_format {
+            image::ImageFormat::Png => ImageFormat::PNG,
+            image::ImageFormat::Jpeg => ImageFormat::JPEG,
+            image::ImageFormat::Tiff => ImageFormat::TIFF,
+            image::ImageFormat::WebP => ImageFormat::WEBP,
+            image::ImageFormat::Gif => ImageFormat::GIF,
+            image::ImageFormat::Bmp => ImageFormat::BMP,
+            image::ImageFormat::Hdr => ImageFormat::HDR,
+            _ => unimplemented!("Image format {:?} is not supported", image_format),
+        }
+    }
+}
+
+impl From<ImageFormat> for image::ImageFormat {
+    fn from(image_format: ImageFormat) -> Self {
+        match image_format {
+            ImageFormat::PNG => image::ImageFormat::Png,
+            ImageFormat::JPEG => image::ImageFormat::Jpeg,
+            ImageFormat::TIFF => image::ImageFormat::Tiff,
+            ImageFormat::WEBP => image::ImageFormat::WebP,
+            ImageFormat::GIF => image::ImageFormat::Gif,
+            ImageFormat::BMP => image::ImageFormat::Bmp,
+            ImageFormat::HDR => image::ImageFormat::Hdr,
+        }
+    }
+}
+
+impl Display for ImageFormat {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        // Leverage Debug trait implementation, which will already return the enum variant as a string.
+        write!(f, "{:?}", self)
+    }
+}

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -1,5 +1,6 @@
 mod dtype;
 mod field;
+mod image_format;
 mod image_mode;
 mod matching;
 mod time_unit;
@@ -13,6 +14,7 @@ use arrow2::{
 };
 pub use dtype::DataType;
 pub use field::Field;
+pub use image_format::ImageFormat;
 pub use image_mode::ImageMode;
 use num_traits::{Bounded, Float, FromPrimitive, Num, NumCast, ToPrimitive, Zero};
 pub use time_unit::TimeUnit;

--- a/src/dsl/functions/image/encode.rs
+++ b/src/dsl/functions/image/encode.rs
@@ -1,0 +1,53 @@
+use crate::{
+    datatypes::{DataType, Field},
+    dsl::{functions::FunctionExpr, Expr},
+    error::{DaftError, DaftResult},
+    schema::Schema,
+    series::Series,
+};
+
+use super::{super::FunctionEvaluator, ImageExpr};
+
+pub struct EncodeEvaluator {}
+
+impl FunctionEvaluator for EncodeEvaluator {
+    fn fn_name(&self) -> &'static str {
+        "encode"
+    }
+
+    fn to_field(&self, inputs: &[Expr], schema: &Schema) -> DaftResult<Field> {
+        match inputs {
+            [input] => {
+                let field = input.to_field(schema)?;
+                match field.dtype {
+                    DataType::Image(..) => Ok(Field::new(field.name, DataType::Binary)),
+                    _ => Err(DaftError::TypeError(format!(
+                        "ImageEncode can only encode ImageArrays, got {}",
+                        field
+                    ))),
+                }
+            }
+            _ => Err(DaftError::SchemaMismatch(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+
+    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+        let image_format = match expr {
+            Expr::Function {
+                func: FunctionExpr::Image(ImageExpr::Encode { image_format }),
+                inputs: _,
+            } => image_format,
+            _ => panic!("Expected ImageResize Expr, got {expr}"),
+        };
+        match inputs {
+            [input] => input.image_encode(*image_format),
+            _ => Err(DaftError::ValueError(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+}

--- a/src/dsl/functions/image/encode.rs
+++ b/src/dsl/functions/image/encode.rs
@@ -40,7 +40,7 @@ impl FunctionEvaluator for EncodeEvaluator {
                 func: FunctionExpr::Image(ImageExpr::Encode { image_format }),
                 inputs: _,
             } => image_format,
-            _ => panic!("Expected ImageResize Expr, got {expr}"),
+            _ => panic!("Expected ImageEncode Expr, got {expr}"),
         };
         match inputs {
             [input] => input.image_encode(*image_format),

--- a/src/dsl/functions/image/mod.rs
+++ b/src/dsl/functions/image/mod.rs
@@ -1,17 +1,20 @@
 mod decode;
+mod encode;
 mod resize;
 
 use decode::DecodeEvaluator;
+use encode::EncodeEvaluator;
 use resize::ResizeEvaluator;
 use serde::{Deserialize, Serialize};
 
-use crate::dsl::Expr;
+use crate::{datatypes::ImageFormat, dsl::Expr};
 
 use super::FunctionEvaluator;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum ImageExpr {
     Decode(),
+    Encode { image_format: ImageFormat },
     Resize { w: u32, h: u32 },
 }
 
@@ -22,6 +25,7 @@ impl ImageExpr {
 
         match self {
             Decode() => &DecodeEvaluator {},
+            Encode { .. } => &EncodeEvaluator {},
             Resize { .. } => &ResizeEvaluator {},
         }
     }
@@ -30,6 +34,13 @@ impl ImageExpr {
 pub fn decode(input: &Expr) -> Expr {
     Expr::Function {
         func: super::FunctionExpr::Image(ImageExpr::Decode()),
+        inputs: vec![input.clone()],
+    }
+}
+
+pub fn encode(input: &Expr, image_format: ImageFormat) -> Expr {
+    Expr::Function {
+        func: super::FunctionExpr::Image(ImageExpr::Encode { image_format }),
         inputs: vec![input.clone()],
     }
 }

--- a/src/python/expr.rs
+++ b/src/python/expr.rs
@@ -2,7 +2,10 @@ use std::collections::HashSet;
 
 use super::field::PyField;
 use super::{datatype::PyDataType, schema::PySchema};
-use crate::dsl::{self, functions, optimization, Expr};
+use crate::{
+    datatypes::ImageFormat,
+    dsl::{self, functions, optimization, Expr},
+};
 use pyo3::{
     exceptions::PyValueError,
     prelude::*,
@@ -312,6 +315,11 @@ impl PyExpr {
     pub fn image_decode(&self) -> PyResult<Self> {
         use dsl::functions::image::decode;
         Ok(decode(&self.expr).into())
+    }
+
+    pub fn image_encode(&self, image_format: ImageFormat) -> PyResult<Self> {
+        use dsl::functions::image::encode;
+        Ok(encode(&self.expr, image_format).into())
     }
 
     pub fn image_resize(&self, w: i64, h: i64) -> PyResult<Self> {

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7,6 +7,7 @@ mod schema;
 mod series;
 mod table;
 
+use crate::datatypes::ImageFormat;
 use crate::datatypes::ImageMode;
 pub use datatype::PyDataType;
 pub use series::PySeries;
@@ -19,6 +20,7 @@ pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
     parent.add_class::<schema::PySchema>()?;
     parent.add_class::<field::PyField>()?;
     parent.add_class::<ImageMode>()?;
+    parent.add_class::<ImageFormat>()?;
 
     parent.add_wrapped(wrap_pyfunction!(expr::col))?;
     parent.add_wrapped(wrap_pyfunction!(expr::lit))?;

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -4,7 +4,7 @@ use pyo3::{exceptions::PyValueError, prelude::*, pyclass::CompareOp, types::PyLi
 
 use crate::{
     array::{ops::DaftLogical, pseudo_arrow::PseudoArrowArray, DataArray},
-    datatypes::{DataType, Field, PythonType, UInt64Type},
+    datatypes::{DataType, Field, ImageFormat, PythonType, UInt64Type},
     ffi,
     series::{self, IntoSeries, Series},
     utils::arrow::{cast_array_for_daft_if_needed, cast_array_from_daft_if_needed},
@@ -269,6 +269,11 @@ impl PySeries {
     pub fn image_decode(&self) -> PyResult<Self> {
         Ok(self.series.image_decode()?.into())
     }
+
+    pub fn image_encode(&self, image_format: ImageFormat) -> PyResult<Self> {
+        Ok(self.series.image_encode(image_format)?.into())
+    }
+
     pub fn image_resize(&self, w: i64, h: i64) -> PyResult<Self> {
         if w < 0 {
             return Err(PyValueError::new_err(format!(

--- a/src/series/ops/image.rs
+++ b/src/series/ops/image.rs
@@ -1,4 +1,4 @@
-use crate::datatypes::{DataType, ImageType};
+use crate::datatypes::{DataType, ImageFormat, ImageType};
 
 use crate::{
     error::{DaftError, DaftResult},
@@ -9,6 +9,15 @@ impl Series {
     pub fn image_decode(&self) -> DaftResult<Series> {
         match self.data_type() {
             DataType::Binary => Ok(self.binary()?.image_decode()?.into_series()),
+            dtype => Err(DaftError::ValueError(format!(
+                "Decoding in-memory data into images is only supported for binary arrays, but got {}", dtype
+            ))),
+        }
+    }
+
+    pub fn image_encode(&self, image_format: ImageFormat) -> DaftResult<Series> {
+        match self.data_type() {
+            DataType::Image(..) => Ok(self.downcast_logical::<ImageType>()?.encode(image_format)?.into_series()),
             dtype => Err(DaftError::ValueError(format!(
                 "Decoding in-memory data into images is only supported for binary arrays, but got {}", dtype
             ))),

--- a/src/series/ops/image.rs
+++ b/src/series/ops/image.rs
@@ -17,9 +17,13 @@ impl Series {
 
     pub fn image_encode(&self, image_format: ImageFormat) -> DaftResult<Series> {
         match self.data_type() {
-            DataType::Image(..) => Ok(self.downcast_logical::<ImageType>()?.encode(image_format)?.into_series()),
+            DataType::Image(..) => Ok(self
+                .downcast_logical::<ImageType>()?
+                .encode(image_format)?
+                .into_series()),
             dtype => Err(DaftError::ValueError(format!(
-                "Decoding in-memory data into images is only supported for binary arrays, but got {}", dtype
+                "Encoding images into bytes is only supported for image arrays, but got {}",
+                dtype
             ))),
         }
     }

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -101,6 +101,7 @@ def test_image_round_trip(give_mode):
     [
         ("L", "png"),
         ("L", "tiff"),
+        ("L", "jpeg"),
         ("LA", "png"),
         # Image crate doesn't support 2 samples per pixel.
         # ("LA", "tiff"),
@@ -108,6 +109,7 @@ def test_image_round_trip(give_mode):
         ("RGB", "tiff"),
         ("RGB", "bmp"),
         ("RGB", "gif"),
+        ("RGB", "jpeg"),
         ("RGBA", "png"),
         ("RGBA", "tiff"),
         ("RGBA", "gif"),
@@ -144,7 +146,11 @@ def test_image_encode_pil(mode, file_format):
             return np.asarray(img)
 
     pil_decoded_imgs = [pil_img_to_ndarray(img) for img in pil_imgs]
-    np.testing.assert_equal(pil_decoded_imgs, arrs)
+    if file_format == "jpeg":
+        # Do lossy check; JPEG format is encoded at 0.75 quality.
+        np.testing.assert_allclose(pil_decoded_imgs, arrs, rtol=1, atol=4)
+    else:
+        np.testing.assert_equal(pil_decoded_imgs, arrs)
 
 
 @pytest.mark.parametrize(

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -9,7 +9,7 @@ import pyarrow as pa
 import pytest
 from PIL import Image
 
-from daft.datatype import DaftExtension, DataType, ImageMode
+from daft.datatype import DaftExtension, DataType
 from daft.series import Series
 
 MODE_TO_NP_DTYPE = {
@@ -47,8 +47,18 @@ MODE_TO_OPENCV_COLOR_CONVERSION = {
     "RGBA32F": cv2.COLOR_RGBA2BGRA,
 }
 
+MODE_TO_OPENCV_COLOR_CONVERSION_DECODE = {
+    "RGB": cv2.COLOR_BGR2RGB,
+    "RGBA": cv2.COLOR_BGRA2RGBA,
+    "RGB16": cv2.COLOR_BGR2RGB,
+    "RGBA16": cv2.COLOR_BGRA2RGBA,
+    "RGB32F": cv2.COLOR_BGR2RGB,
+    "RGBA32F": cv2.COLOR_BGRA2RGBA,
+}
 
-def test_image_round_trip():
+
+@pytest.mark.parametrize("give_mode", [True, False])
+def test_image_round_trip(give_mode):
     data = [
         np.arange(12, dtype=np.uint8).reshape((2, 2, 3)),
         np.arange(12, 39, dtype=np.uint8).reshape((3, 3, 3)),
@@ -56,7 +66,8 @@ def test_image_round_trip():
     ]
     s = Series.from_pylist(data, pyobj="force")
 
-    target_dtype = DataType.image("RGB")
+    mode = "RGB" if give_mode else None
+    target_dtype = DataType.image(mode)
 
     t = s.cast(target_dtype)
 
@@ -102,9 +113,43 @@ def test_image_round_trip():
         # "L16", "LA16", "RGB16", "RGBA16", "RGB32F", "RGBA32F"
     ],
 )
+def test_image_encode_pil(mode, file_format):
+    np_dtype = MODE_TO_NP_DTYPE[mode]
+    num_channels = MODE_TO_NUM_CHANNELS[mode]
+    shape = (4, 4)
+    if num_channels > 1:
+        shape += (num_channels,)
+    arr = np.arange(np.prod(shape)).reshape(shape).astype(np_dtype)
+    arrs = [arr, arr, arr]
+
+    s = Series.from_pylist(arrs)
+    t = s.cast(DataType.image(mode))
+    assert t.datatype() == DataType.image(mode)
+
+    u = t.image.encode(file_format.upper())
+    pil_decoded_imgs = [np.asarray(Image.open(io.BytesIO(bytes_))) for bytes_ in u.to_pylist()]
+    np.testing.assert_equal(pil_decoded_imgs, arrs)
+
+
+@pytest.mark.parametrize(
+    ["mode", "file_format"],
+    [
+        ("L", "png"),
+        ("L", "tiff"),
+        ("LA", "png"),
+        # Image crate doesn't support 2 samples per pixel.
+        # ("LA", "tiff"),
+        ("RGB", "png"),
+        ("RGB", "tiff"),
+        ("RGB", "bmp"),
+        ("RGBA", "png"),
+        ("RGBA", "tiff"),
+        # Not supported by Daft or PIL.
+        # "L16", "LA16", "RGB16", "RGBA16", "RGB32F", "RGBA32F"
+    ],
+)
 def test_image_decode_pil(mode, file_format):
     np_dtype = MODE_TO_NP_DTYPE[mode]
-    ImageMode.from_mode_string(mode)
     num_channels = MODE_TO_NUM_CHANNELS[mode]
     shape = (4, 4)
     if num_channels > 1:
@@ -124,6 +169,100 @@ def test_image_decode_pil(mode, file_format):
     if num_channels == 1:
         expected_arrs = [np.expand_dims(arr, -1) for arr in expected_arrs]
     np.testing.assert_equal(out, expected_arrs)
+
+
+@pytest.mark.parametrize(
+    ["mode", "file_format"],
+    [
+        ("L", "png"),
+        ("L", "tiff"),
+        ("LA", "png"),
+        # Image crate doesn't support 2 samples per pixel.
+        # ("LA", "tiff"),
+        ("RGB", "png"),
+        ("RGB", "tiff"),
+        ("RGB", "bmp"),
+        ("RGBA", "png"),
+        ("RGBA", "tiff"),
+        # Not supported by Daft or PIL.
+        # "L16", "LA16", "RGB16", "RGBA16", "RGB32F", "RGBA32F"
+    ],
+)
+def test_image_encode_decode_pil_roundtrip(mode, file_format):
+    np_dtype = MODE_TO_NP_DTYPE[mode]
+    num_channels = MODE_TO_NUM_CHANNELS[mode]
+    shape = (4, 4)
+    if num_channels > 1:
+        shape += (num_channels,)
+    arr = np.arange(np.prod(shape)).reshape(shape).astype(np_dtype)
+    img = Image.fromarray(arr, mode=mode)
+    img_bytes = io.BytesIO()
+    img.save(img_bytes, file_format)
+    img_bytes = img_bytes.getvalue()
+    arrow_arr = pa.array([img_bytes, img_bytes, img_bytes], type=pa.binary())
+    s = Series.from_arrow(arrow_arr)
+    t = s.image.decode()
+    # TODO(Clark): Infer type-leve mode if all images are the same mode.
+    assert t.datatype() == DataType.image()
+
+    u = t.image.encode(file_format.upper())
+    pil_decoded_imgs = [np.asarray(Image.open(io.BytesIO(bytes_))) for bytes_ in u.to_pylist()]
+    np.testing.assert_equal(pil_decoded_imgs, [arr, arr, arr])
+
+
+@pytest.mark.parametrize(
+    ["mode", "file_format"],
+    [
+        ("L", "png"),
+        ("L", "tiff"),
+        # OpenCV doesn't support 2-channel images.
+        # ("LA", "png"),
+        ("RGB", "png"),
+        ("RGB", "tiff"),
+        ("RGB", "bmp"),
+        ("RGBA", "png"),
+        ("RGBA", "tiff"),
+        # Rust image crate doesn't support WebP encoding.
+        # ("RGBA", "webp"),
+        # TODO(Clark): Support uint16 images.
+        # ("L16", "png"),
+        # OpenCV doesn't support 2-channel images.
+        # ("LA16", "png"),
+        # TODO(Clark): Support uint16 images.
+        # ("RGB16", "png"),
+        # ("RGB16", "tiff"),
+        # ("RGBA16", "png"),
+        # ("RGBA16", "tiff"),
+        # Image crate doesn't support LogLuv HDR encoding.
+        # ("RGB32F", "tiff"),
+        # ("RGBA32F", "tiff"),
+    ],
+)
+def test_image_encode_opencv(mode, file_format):
+    np_dtype = MODE_TO_NP_DTYPE[mode]
+    num_channels = MODE_TO_NUM_CHANNELS[mode]
+    shape = (4, 4, num_channels)
+    arr = np.arange(np.prod(shape)).reshape(shape).astype(np_dtype)
+    arrs = [arr, arr, arr]
+
+    s = Series.from_pylist(arrs)
+    t = s.cast(DataType.image(mode))
+    assert t.datatype() == DataType.image(mode)
+    # TODO(Clark): Support constructing an Image type with an unknown mode by known dtype.
+    if np_dtype == np.uint8:
+        # TODO(Clark): Infer type-leve mode if all images are the same mode.
+        assert t.datatype() == DataType.image(mode)
+
+    u = t.image.encode(file_format.upper())
+    opencv_decoded_imgs = [
+        cv2.imdecode(np.frombuffer(bytes_, dtype=np.uint8), cv2.IMREAD_UNCHANGED) for bytes_ in u.to_pylist()
+    ]
+    if num_channels == 1:
+        opencv_decoded_imgs = [np.expand_dims(arr, -1) for arr in opencv_decoded_imgs]
+    color_conv = MODE_TO_OPENCV_COLOR_CONVERSION_DECODE.get(mode)
+    if color_conv is not None:
+        opencv_decoded_imgs = [cv2.cvtColor(arr, color_conv) for arr in opencv_decoded_imgs]
+    np.testing.assert_equal(opencv_decoded_imgs, arrs)
 
 
 @pytest.mark.parametrize(
@@ -155,7 +294,6 @@ def test_image_decode_pil(mode, file_format):
 )
 def test_image_decode_opencv(mode, file_format):
     np_dtype = MODE_TO_NP_DTYPE[mode]
-    ImageMode.from_mode_string(mode)
     num_channels = MODE_TO_NUM_CHANNELS[mode]
     shape = (4, 4, num_channels)
     arr = np.arange(np.prod(shape)).reshape(shape).astype(np_dtype)
@@ -175,6 +313,66 @@ def test_image_decode_opencv(mode, file_format):
     out = t.cast(DataType.python()).to_pylist()
     expected_arrs = [arr, arr, arr]
     np.testing.assert_equal(out, expected_arrs)
+
+
+@pytest.mark.parametrize(
+    ["mode", "file_format"],
+    [
+        ("L", "png"),
+        ("L", "tiff"),
+        # OpenCV doesn't support 2-channel images.
+        # ("LA", "png"),
+        ("RGB", "png"),
+        ("RGB", "tiff"),
+        ("RGB", "bmp"),
+        ("RGBA", "png"),
+        ("RGBA", "tiff"),
+        # Rust image crate doesn't support WebP encoding.
+        # ("RGBA", "webp"),
+        # TODO(Clark): Support uint16 images.
+        # ("L16", "png"),
+        # OpenCV doesn't support 2-channel images.
+        # ("LA16", "png"),
+        # TODO(Clark): Support uint16 images.
+        # ("RGB16", "png"),
+        # ("RGB16", "tiff"),
+        # ("RGBA16", "png"),
+        # ("RGBA16", "tiff"),
+        # Image crate doesn't support LogLuv HDR encoding.
+        # ("RGB32F", "tiff"),
+        # ("RGBA32F", "tiff"),
+    ],
+)
+def test_image_encode_decode_opencv_roundtrip(mode, file_format):
+    np_dtype = MODE_TO_NP_DTYPE[mode]
+    num_channels = MODE_TO_NUM_CHANNELS[mode]
+    shape = (4, 4, num_channels)
+    arr = np.arange(np.prod(shape)).reshape(shape).astype(np_dtype)
+    cv2_arr = arr
+    color_conv = MODE_TO_OPENCV_COLOR_CONVERSION.get(mode)
+    if color_conv is not None:
+        cv2_arr = cv2.cvtColor(arr, color_conv)
+    encoded_arr = cv2.imencode(f".{file_format}", cv2_arr)[1]
+    img_bytes = encoded_arr.tobytes()
+    arrow_arr = pa.array([img_bytes, img_bytes, img_bytes], type=pa.binary())
+
+    s = Series.from_arrow(arrow_arr)
+    t = s.image.decode()
+    # TODO(Clark): Support constructing an Image type with an unknown mode by known dtype.
+    if np_dtype == np.uint8:
+        # TODO(Clark): Infer type-leve mode if all images are the same mode.
+        assert t.datatype() == DataType.image()
+
+    u = t.image.encode(file_format.upper())
+    opencv_decoded_imgs = [
+        cv2.imdecode(np.frombuffer(bytes_, dtype=np.uint8), cv2.IMREAD_UNCHANGED) for bytes_ in u.to_pylist()
+    ]
+    if num_channels == 1:
+        opencv_decoded_imgs = [np.expand_dims(arr, -1) for arr in opencv_decoded_imgs]
+    color_conv = MODE_TO_OPENCV_COLOR_CONVERSION_DECODE.get(mode)
+    if color_conv is not None:
+        opencv_decoded_imgs = [cv2.cvtColor(arr, color_conv) for arr in opencv_decoded_imgs]
+    np.testing.assert_equal(opencv_decoded_imgs, [arr, arr, arr])
 
 
 def test_image_resize():


### PR DESCRIPTION
This PR adds support for encoding and image column into a binary column, containing bytes encoded into the specified file format.

This serves as a precursor to both more user-friendly reprs in Jupyer Notebooks and saving/uploading images to specified URIs.