### PR TITLE
Fix links to ray.io latest docs

### DIFF
--- a/daft/convert.py
+++ b/daft/convert.py
@@ -112,7 +112,7 @@ def from_dask_dataframe(ddf: "dask.DataFrame") -> "DataFrame":
     """Creates a Daft DataFrame from a Dask DataFrame.
 
     The provided Dask DataFrame must have been created using
-    `Dask-on-Ray <https://docs.ray.io/en/latest/data/dask-on-ray.html>`__.
+    `Dask-on-Ray <https://docs.ray.io/en/latest/ray-more-libs/dask-on-ray.html>`__.
 
     .. NOTE::
         This function can only work if Daft is running using the RayRunner

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1123,7 +1123,7 @@ class DataFrame:
     ) -> "dask.DataFrame":
         """Converts the current Daft DataFrame to a Dask DataFrame.
 
-        The returned Dask DataFrame will use `Dask-on-Ray <https://docs.ray.io/en/latest/data/dask-on-ray.html>`__
+        The returned Dask DataFrame will use `Dask-on-Ray <https://docs.ray.io/en/latest/ray-more-libs/dask-on-ray.html>`__
         to execute operations on a Ray cluster.
 
         .. NOTE::

--- a/docs/source/release_notes/0.0.18.rst
+++ b/docs/source/release_notes/0.0.18.rst
@@ -4,7 +4,7 @@ Daft 0.0.18 Release Notes
 
 The Daft 0.0.18 adds bugfixes and new functionality - highlights:
 
-* `Ray Datasets <https://docs.ray.io/en/latest/data/dataset.html>`_ integration - Daft Dataframes can now feed into ML training on Ray easily using the ``.to_ray_dataset()`` method
+* `Ray Datasets <https://docs.ray.io/en/latest/data/data.html>`_ integration - Daft Dataframes can now feed into ML training on Ray easily using the ``.to_ray_dataset()`` method
 * Big performance improvements from fixes in join algorithm
 * ``.apply`` now infers the return type from the function's type annotation if available
 
@@ -15,7 +15,7 @@ New Features
 Ray Datasets Integration
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Daft Dataframes can now be converted easily into a `Ray Datasets <https://docs.ray.io/en/latest/data/dataset.html>`_, which makes it really easy to go from preprocessing/analyzing your data in Daft to ML training using the Ray ecosystem of tools, all on the same Ray cluster.
+Daft Dataframes can now be converted easily into a `Ray Datasets <https://docs.ray.io/en/latest/data/data.html>`_, which makes it really easy to go from preprocessing/analyzing your data in Daft to ML training using the Ray ecosystem of tools, all on the same Ray cluster.
 
 See: `#316 <https://github.com/Eventual-Inc/Daft/pull/316>`_
 


### PR DESCRIPTION
Fixes some links that were broken on the latest documentation on ray.io