### PR TITLE
[CHORE] Add release-drafter files

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -50,10 +50,10 @@ autolabeler:
   - /.*\[BREAKING\].*/
 - label: enhancement
   title:
-  - /.*\[FEATURE\].*/
+  - /.*\[FEAT\].*/
 - label: performance
   title:
-  - /.*\[PERFORMANCE\].*/
+  - /.*\[PERF\].*/
 - label: bug
   title:
   - /.*\[BUG\].*/

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,69 @@
+name-template: v$NEXT_PATCH_VERSION
+tag-template: v$NEXT_PATCH_VERSION
+categories:
+- title: 🏆 Highlights
+  labels:
+  - highlight
+- title: 💥 Breaking Changes
+  labels:
+  - breaking
+- title: ✨ New Features
+  labels:
+  - enhancement
+- title: 🚀 Performance Improvements
+  labels:
+  - performance
+- title: 👾 Bug Fixes
+  labels:
+  - bug
+- title: 📖 Documentation
+  labels:
+  - documentation
+- title: 🧰 Maintenance
+  labels:
+  - chore
+- title: ⬆️ Dependencies
+  collapse-after: 3
+  labels:
+  - dependencies
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: \<*_&   # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+
+template: |
+  ## Changes
+
+  $CHANGES
+
+footer: |
+  ## Contributors
+
+  Here's a BIG thank you to all our contributors who made this release possible!
+
+  $CONTRIBUTORS
+
+
+autolabeler:
+- label: breaking
+  title:
+  - /.*\[BREAKING\].*/
+- label: enhancement
+  title:
+  - /.*\[FEATURE\].*/
+- label: performance
+  title:
+  - /.*\[PERFORMANCE\].*/
+- label: bug
+  title:
+  - /.*\[BUG\].*/
+- label: chore
+  title:
+  - /.*\[CHORE\].*/
+- label: documentation
+  title:
+  - /.*\[DOC\].*/
+  files:
+  - '*.rst'
+  - '*.html'
+  - '*.ipynb'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,43 @@
+# Adapted from: https://github.com/release-drafter/release-drafter#readme
+
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+    - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds workflow and config for release-drafter (https://github.com/release-drafter/release-drafter)

This will keep a running release changelog draft as we add PRs.

PRs are categorized based on their labels. We currently check for the following labels:

1. `highlight` - manually add this label to a PR to surface it as a highlight of the release
2. `breaking` - add `[BREAKING]` to your PR title
3. `enhancement` - add `[FEAT]` to your PR title
4. `performance` - add `[PERF]` to your PR title
5. `bug` - add `[BUG]` to your PR title
6. `chore` - add `[CHORE]` to your PR title (for things such as changes to our build, pure cleanups etc)
7. `documentation` - add `[DOC]` to your PR title, but should be automatically picked up as well if you change any `*.rst/html/ipynb` files