### PR TITLE
[CHORE] Add a GitHub action to enforce labels are added to the PR before merging

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -15,7 +15,11 @@ jobs:
         labels: performance, enhancement, bug, chore, documentation, dependencies
         add_comment: true
         message: |
-          This PR is being prevented from merging because you need at least one of the required labels: [enhancement | performance | bug | chore | documentation | dependencies].
+          This PR is being prevented from merging because you need at least one of the required labels:
+
+          ```
+          enhancement | performance | bug | chore | documentation | dependencies
+          ```
 
           The canonical and easiest way of adding them is to add the following prefixes to your PR title:
 

--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -1,0 +1,28 @@
+name: Enforce Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - uses: mheap/github-action-required-labels@v5
+      with:
+        mode: minimum
+        count: 1
+        labels: performance, enhancement, bug, chore, documentation, dependencies
+        add_comment: true
+        message: |
+          This PR is being prevented from merging because you need at least one of the required labels: [enhancement | performance | bug | chore | documentation | dependencies].
+
+          The canonical and easiest way of adding them is to add the following prefixes to your PR title:
+
+          * [FEAT]: adds the `enhancement` label
+          * [PERF]: adds the `performance` label
+          * [BUG]: adds the `bug` label
+          * [CHORE]: adds the `chore` label
+          * [DOCS]: adds the `documentation` label
+
+          Thanks for helping us categorize and manage our PRs!

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ on:
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, edited]
   # pull_request_target event is required for autolabeler to support PRs from forks
   # pull_request_target:
   #   types: [opened, reopened, synchronize]


### PR DESCRIPTION
Adds a new GitHub Action which will prevent the merging of a PR unless it has one of the following labels:

```
[enhancement | performance | bug | chore | documentation | dependencies]
```