### PR TITLE
[CHORE] Wait for 1 minute before running label check

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -8,6 +8,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+    - name: Sleep for 1 minute
+      run: sleep 60s
+      shell: bash
     - uses: mheap/github-action-required-labels@v5
       with:
         mode: minimum


### PR DESCRIPTION
The label check runs before our auto-labeller has the chance to label the PR.

This change makes it wait for 1 minute before running, so that the auto-labeller has a chance to run first.