### PR TITLE
[CHORE] Add new trigger to run PR label enforcement after Release Drafter

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -2,6 +2,16 @@ name: Enforce Pull Request Labels
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
+  # Runs after the Release Drafter workflow runs on a non-main branch because that may have auto-labelled the PR
+  #
+  # NOTE: This is required because the Release Drafter workflow uses the `github-actions` bot to label the PR,
+  # and actions taken by the `github-actions` bot are not allowed to trigger new workflows.
+  workflow_run:
+    workflows: [Release Drafter]
+    types:
+    - completed
+    branches-ignore:
+    - main
 jobs:
   label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Actions taken by the `github-actions` bot cannot trigger workflows. Thus when the Release Drafter autolabeller adds a new label to our PRs (using the `github-actions` bot), the label enforcer workflow does not trigger.

This PR adds a new trigger condition to re-run the Enforce Pull Request workflow after the release drafter workflow is run, on any non-main branch.