### PR TITLE
[FEAT] Automatically cast logical types to Python objects on `Series.to_pylist()`.

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -379,6 +379,9 @@ class DataType:
 
         return self == DataType.python()
 
+    def _is_logical_type(self) -> builtins.bool:
+        return self._dtype.is_logical()
+
     def __repr__(self) -> str:
         return self._dtype.__repr__()
 

--- a/daft/series.py
+++ b/daft/series.py
@@ -228,6 +228,8 @@ class Series:
         """
         if self.datatype()._is_python_type():
             return self._series.to_pylist()
+        elif self.datatype()._is_logical_type():
+            return self._series.cast(DataType.python()._dtype).to_pylist()
         else:
             return self._series.to_arrow().to_pylist()
 

--- a/src/python/datatype.rs
+++ b/src/python/datatype.rs
@@ -270,6 +270,10 @@ impl PyDataType {
         Ok(DataType::Python.into())
     }
 
+    pub fn is_logical(&self) -> PyResult<bool> {
+        Ok(self.dtype.is_logical())
+    }
+
     pub fn is_equal(&self, other: &PyAny) -> PyResult<bool> {
         if other.is_instance_of::<PyDataType>()? {
             let other = other.extract::<PyDataType>()?;

--- a/tests/cookbook/test_image.py
+++ b/tests/cookbook/test_image.py
@@ -41,24 +41,24 @@ def test_image_resize_mixed_modes():
 
     as_py = df.to_pydict()["resized"]
 
-    first_resized = np.array(as_py[0]["data"]).reshape(5, 5, 3)
+    first_resized = as_py[0]
     assert np.all(first_resized[..., 0] == 1)
     assert np.all(first_resized[..., 1] == 2)
     assert np.all(first_resized[..., 2] == 3)
 
-    second_resized = np.array(as_py[1]["data"]).reshape(5, 5, 4)
+    second_resized = as_py[1]
     assert np.all(second_resized[..., 0] == 1)
     assert np.all(second_resized[..., 1] == 2)
     assert np.all(second_resized[..., 2] == 3)
     assert np.all(second_resized[..., 3] == 4)
 
     for i in range(2, 4):
-        resized_i = np.array(as_py[i]["data"]).reshape(5, 5, -1)
+        resized_i = as_py[i]
         resized_i_gt = np.asarray(Image.fromarray(data[i]).resize((5, 5), resample=Image.BILINEAR)).reshape(5, 5, -1)
         assert np.all(resized_i == resized_i_gt), f"{i} does not match"
 
     # LA sampling doesn't work for some reason in PIL
-    resized_i = np.array(as_py[4]["data"]).reshape(5, 5, -1)
+    resized_i = as_py[4]
     assert np.all(resized_i == 10)
 
     assert as_py[-1] == None

--- a/tests/series/test_embedding.py
+++ b/tests/series/test_embedding.py
@@ -25,8 +25,8 @@ def test_embedding_arrow_round_trip():
     from_arrow = Series.from_arrow(t.to_arrow())
 
     assert from_arrow.datatype() == t.datatype()
-    assert from_arrow.to_pylist() == t.to_pylist()
+    np.testing.assert_equal(from_arrow.to_pylist(), t.to_pylist())
 
     t_copy = copy.deepcopy(t)
     assert t_copy.datatype() == t.datatype()
-    assert t_copy.to_pylist() == t.to_pylist()
+    np.testing.assert_equal(t_copy.to_pylist(), t.to_pylist())

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -89,11 +89,11 @@ def test_image_round_trip(give_mode):
     from_arrow = Series.from_arrow(t.to_arrow())
 
     assert from_arrow.datatype() == t.datatype()
-    assert from_arrow.to_pylist() == t.to_pylist()
+    np.testing.assert_equal(from_arrow.to_pylist(), t.to_pylist())
 
     t_copy = copy.deepcopy(t)
     assert t_copy.datatype() == t.datatype()
-    assert t_copy.to_pylist() == t.to_pylist()
+    np.testing.assert_equal(t_copy.to_pylist(), t.to_pylist())
 
 
 @pytest.mark.parametrize(
@@ -491,11 +491,11 @@ def test_fixed_shape_image_roundtrip():
     from_arrow = Series.from_arrow(t.to_arrow())
 
     assert from_arrow.datatype() == t.datatype()
-    assert from_arrow.to_pylist() == t.to_pylist()
+    np.testing.assert_equal(from_arrow.to_pylist(), t.to_pylist())
 
     t_copy = copy.deepcopy(t)
     assert t_copy.datatype() == t.datatype()
-    assert t_copy.to_pylist() == t.to_pylist()
+    np.testing.assert_equal(t_copy.to_pylist(), t.to_pylist())
 
 
 def test_bad_cast_image():


### PR DESCRIPTION
This PR automatically casts logical types (dates, timestamps, images, embeddings) into their Python representation when `Series.to_pylist()` is called. This results in a representation that's much easier to work with in Python UDFs and when egressing from Daft.

### Before

You'd need to manually cast logical series to the `Python` type before calling `.to_pylist()`, otherwise you'd get our internal Arrow representation:
```python
list_of_sensible_objs = s.cast(DataType.python()).to_pylist()
```

### After

Now, this is done automatically for the user.
```python
list_of_sensible_objs = s.to_pylist()
```