### PR TITLE
[FEAT] [Images] [9/N] Infer `Image` type for PIL images on ingress.

### DIFF
--- a/src/array/ops/cast.rs
+++ b/src/array/ops/cast.rs
@@ -437,7 +437,7 @@ fn extract_python_to_vec<
                 || supports_array_interface_protocol
                 || supports_array_protocol
             {
-                // Path if object is supports buffer/array protocols.
+                // Path if object supports buffer/array protocols.
                 let np_as_array_fn = py.import("numpy")?.getattr(pyo3::intern!(py, "asarray"))?;
                 let pyarray = np_as_array_fn.call1((object,))?;
                 let num_values = append_values_from_numpy(

--- a/src/datatypes/image_mode.rs
+++ b/src/datatypes/image_mode.rs
@@ -59,6 +59,26 @@ impl ImageMode {
 }
 
 impl ImageMode {
+    pub fn from_pil_mode_str(mode: &str) -> DaftResult<Self> {
+        use ImageMode::*;
+
+        match mode {
+            "L" => Ok(L),
+            "LA" => Ok(LA),
+            "RGB" => Ok(RGB),
+            "RGBA" => Ok(RGBA),
+            "1" | "P" | "CMYK" | "YCbCr" | "LAB" | "HSV" | "I" | "F" | "PA" | "RGBX" | "RGBa" | "La" | "I;16" | "I;16L" | "I;16B" | "I;16N" | "BGR;15" | "BGR;16" | "BGR;24" => Err(DaftError::TypeError(format!(
+                "PIL image mode {} is not supported; only the following modes are supported: {:?}",
+                mode,
+                ImageMode::iterator().as_slice()
+            ))),
+            _ => Err(DaftError::TypeError(format!(
+                "Image mode {} is not a valid PIL image mode; see https://pillow.readthedocs.io/en/stable/handbook/concepts.html#modes for valid PIL image modes. Of these, only the following modes are supported by Daft: {:?}",
+                mode,
+                ImageMode::iterator().as_slice()
+            ))),
+        }
+    }
     pub fn try_from_num_channels(num_channels: u16, dtype: &DataType) -> DaftResult<Self> {
         use ImageMode::*;
 

--- a/src/python/series.rs
+++ b/src/python/series.rs
@@ -1,7 +1,4 @@
-use std::{
-    ops::{Add, Div, Mul, Rem, Sub},
-    str::FromStr,
-};
+use std::ops::{Add, Div, Mul, Rem, Sub};
 
 use pyo3::{exceptions::PyValueError, prelude::*, pyclass::CompareOp, types::PyList};
 
@@ -327,15 +324,17 @@ fn infer_daft_dtype_for_sequence(
     py: pyo3::Python,
 ) -> PyResult<Option<DataType>> {
     let py_pil_image_type = py
-        .import("PIL.Image")
+        .import(pyo3::intern!(py, "PIL.Image"))
         .and_then(|m| m.getattr(pyo3::intern!(py, "Image")));
     let mut dtype: Option<DataType> = None;
     for obj in vec_pyobj.iter() {
         let obj = obj.as_ref(py);
         if let Ok(pil_image_type) = py_pil_image_type {
             if obj.is_instance(pil_image_type)? {
-                let mode_str = obj.getattr("mode")?.extract::<String>()?;
-                let mode = ImageMode::from_str(&mode_str)?;
+                let mode_str = obj
+                    .getattr(pyo3::intern!(py, "mode"))?
+                    .extract::<String>()?;
+                let mode = ImageMode::from_pil_mode_str(&mode_str)?;
                 match dtype {
                     Some(DataType::Image(Some(existing_mode))) => {
                         if existing_mode != mode {

--- a/tests/dataframe/test_logical_type.py
+++ b/tests/dataframe/test_logical_type.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
+from PIL import Image
 
 import daft
 from daft import DataType, Series, col
@@ -21,16 +23,22 @@ def test_embedding_type_df() -> None:
     assert isinstance(arrow_table["embeddings"].type, DaftExtension)
 
 
-def test_image_type_df() -> None:
+@pytest.mark.parametrize("from_pil_imgs", [True, False])
+def test_image_type_df(from_pil_imgs) -> None:
     data = [
-        np.arange(12, dtype=np.uint8).reshape((3, 2, 2)),
+        np.arange(12, dtype=np.uint8).reshape((2, 2, 3)),
         np.arange(12, 39, dtype=np.uint8).reshape((3, 3, 3)),
         None,
     ]
+    if from_pil_imgs:
+        data = [Image.fromarray(arr, mode="RGB") if arr is not None else None for arr in data]
     df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
 
-    target = DataType.image("RGB")
-    df = df.select(col("index"), col("image").cast(target))
+    image_expr = col("image")
+    if not from_pil_imgs:
+        target = DataType.image("RGB")
+        image_expr = image_expr.cast(target)
+    df = df.select(col("index"), image_expr)
     df = df.repartition(4, "index")
     df = df.sort("index")
     df = df.collect()

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
-from PIL import Image
 
 from daft.datatype import DataType, ImageMode, TimeUnit
 from daft.series import Series
@@ -187,28 +186,6 @@ def test_series_cast_python_to_embedding(dtype) -> None:
     pydata = t.to_pylist()
     assert pydata[-1] is None
     np.testing.assert_equal([np.asarray(arr, dtype=dtype.to_pandas_dtype()) for arr in data[:-1]], pydata[:-1])
-
-
-def test_series_cast_pil_to_image() -> None:
-    data = [
-        Image.fromarray(np.arange(12).reshape((2, 2, 3)).astype(np.uint8)),
-        Image.fromarray(np.arange(12, 39).reshape((3, 3, 3)).astype(np.uint8)),
-        None,
-    ]
-    s = Series.from_pylist(data, pyobj="force")
-
-    target_dtype = DataType.image("RGB")
-
-    t = s.cast(target_dtype)
-
-    assert t.datatype() == target_dtype
-    assert len(t) == len(data)
-
-    assert t.arr.lengths().to_pylist() == [12, 27, None]
-
-    pydata = t.to_pylist()
-    assert pydata[-1] is None
-    np.testing.assert_equal([np.asarray(data[0]), np.asarray(data[1])], pydata[:-1])
 
 
 def test_series_cast_numpy_to_image() -> None:

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -200,7 +200,6 @@ def test_image_pil_inference_mixed():
         np.ones(24, dtype=np.uint8).reshape((3, 4, 2)) * 10,  # LA
         None,
     ]
-    print([arr.shape if arr is not None else None for arr in arrs])
     imgs = [
         Image.fromarray(arr, mode=NUM_CHANNELS_TO_MODE[arr.shape[-1] if arr.ndim == 3 else 1])
         if arr is not None


### PR DESCRIPTION
This PR infers the `Image` type for PIL images provided to `Series.from_pylist()`, and therefore for `Table.from_pydict()` and `DataFrame.from_pydict()`.