### PR TITLE
pin the version of python used in publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   PACKAGE_NAME: getdaft
-  PYTHON_VERSION: '3.7' # to build abi3 wheels
+  PYTHON_VERSION: 3.7.16   # to build abi3 wheels
   DAFT_ANALYTICS_ENABLED: '0'
 
   IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}


### PR DESCRIPTION
* Pin python version used in publishing as a workaround to https://github.com/actions/setup-python/issues/682