### PR TITLE
[FEAT] [Tensor] Add support for `Tensor` and `FixedShapeTensor` types.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.1"
-source = "git+https://github.com/Eventual-Inc/arrow2?branch=clark/expand-casting-support#fdd225bd05226a0fe5194cc247dc08cbd2cec8d9"
+source = "git+https://github.com/Eventual-Inc/arrow2?branch=clark/expand-casting-support#46bc134e386f597eed00a0396ea2de224d12943c"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1067,7 +1067,7 @@ class DataFrame:
         raise RuntimeError(message)
 
     @DataframePublicAPI
-    def to_pandas(self) -> "pd.DataFrame":
+    def to_pandas(self, cast_tensors_to_ray_tensor_dtype: bool = False) -> "pd.DataFrame":
         """Converts the current DataFrame to a pandas DataFrame.
         If results have not computed yet, collect will be called.
 
@@ -1081,11 +1081,13 @@ class DataFrame:
         result = self._result
         assert result is not None
 
-        pd_df = result.to_pandas(schema=self._plan.schema())
+        pd_df = result.to_pandas(
+            schema=self._plan.schema(), cast_tensors_to_ray_tensor_dtype=cast_tensors_to_ray_tensor_dtype
+        )
         return pd_df
 
     @DataframePublicAPI
-    def to_arrow(self) -> "pa.Table":
+    def to_arrow(self, cast_tensors_to_ray_tensor_dtype: bool = False) -> "pa.Table":
         """Converts the current DataFrame to a pyarrow Table.
         If results have not computed yet, collect will be called.
 
@@ -1099,7 +1101,7 @@ class DataFrame:
         result = self._result
         assert result is not None
 
-        return result.to_arrow()
+        return result.to_arrow(cast_tensors_to_ray_tensor_dtype)
 
     @DataframePublicAPI
     def to_pydict(self) -> Dict[str, List[Any]]:

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -440,6 +440,9 @@ class DataType:
     def _is_image_type(self) -> builtins.bool:
         return self._dtype.is_image()
 
+    def _is_fixed_shape_image_type(self) -> builtins.bool:
+        return self._dtype.is_fixed_shape_image()
+
     def _is_logical_type(self) -> builtins.bool:
         return self._dtype.is_logical()
 

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import builtins
+from typing import TYPE_CHECKING
 
-import numpy as np
 import pyarrow as pa
 
 from daft.context import get_context
 from daft.daft import ImageMode, PyDataType, PyTimeUnit
+
+if TYPE_CHECKING:
+    import numpy as np
 
 _RAY_DATA_EXTENSIONS_AVAILABLE = True
 _TENSOR_EXTENSION_TYPES = []

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -370,6 +370,9 @@ class DataType:
             scalar_dtype = cls.from_arrow_type(arrow_type.scalar_type)
             shape = arrow_type.shape if isinstance(arrow_type, ArrowTensorType) else None
             return cls.tensor(scalar_dtype, shape)
+        elif isinstance(arrow_type, getattr(pa, "FixedShapeTensorType", ())):
+            scalar_dtype = cls.from_arrow_type(arrow_type.value_type)
+            return cls.tensor(scalar_dtype, tuple(arrow_type.shape))
         elif isinstance(arrow_type, pa.PyExtensionType):
             # TODO(Clark): Add a native cross-lang extension type representation for PyExtensionTypes.
             raise ValueError(

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -74,13 +74,15 @@ class PartitionSet(Generic[PartitionT]):
         merged_partition = self._get_merged_vpartition()
         return merged_partition.to_pydict()
 
-    def to_pandas(self, schema: Schema | None = None) -> pd.DataFrame:
+    def to_pandas(self, schema: Schema | None = None, cast_tensors_to_ray_tensor_dtype: bool = False) -> pd.DataFrame:
         merged_partition = self._get_merged_vpartition()
-        return merged_partition.to_pandas(schema=schema)
+        return merged_partition.to_pandas(
+            schema=schema, cast_tensors_to_ray_tensor_dtype=cast_tensors_to_ray_tensor_dtype
+        )
 
-    def to_arrow(self) -> pa.Table:
+    def to_arrow(self, cast_tensors_to_ray_tensor_dtype: bool = False) -> pa.Table:
         merged_partition = self._get_merged_vpartition()
-        return merged_partition.to_arrow()
+        return merged_partition.to_arrow(cast_tensors_to_ray_tensor_dtype)
 
     def items(self) -> list[tuple[PartID, PartitionT]]:
         """

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -111,7 +111,7 @@ def _glob_path_into_details_vpartitions(
 @ray.remote
 def _make_ray_block_from_vpartition(partition: Table) -> RayDatasetBlock:
     try:
-        return partition.to_arrow()
+        return partition.to_arrow(cast_tensors_to_ray_tensor_dtype=True)
     except pa.ArrowInvalid:
         return partition.to_pylist()
 
@@ -471,9 +471,7 @@ class Scheduler:
                 next_step = next(phys_plan)
 
                 while True:  # Loop: Dispatch -> await.
-
                     while True:  # Loop: Dispatch (get tasks -> batch dispatch).
-
                         tasks_to_dispatch: list[PartitionTask] = []
 
                         dispatches_allowed = max_inflight_tasks - len(inflight_tasks)
@@ -481,7 +479,6 @@ class Scheduler:
 
                         # Loop: Get a batch of tasks.
                         while len(tasks_to_dispatch) < dispatches_allowed:
-
                             if next_step is None:
                                 # Blocked on already dispatched tasks; await some tasks.
                                 break

--- a/daft/series.py
+++ b/daft/series.py
@@ -83,13 +83,7 @@ class Series:
         elif isinstance(array, pa.ChunkedArray):
             array = ensure_chunked_array(array)
             arr_type = array.type
-            if _RAY_DATA_EXTENSIONS_AVAILABLE and isinstance(
-                arr_type, (ArrowTensorType, ArrowVariableShapedTensorType)
-            ):
-                from ray.air.util.transform_pyarrow import _concatenate_extension_column
-
-                combined_array = _concatenate_extension_column(array)
-            elif isinstance(arr_type, pa.BaseExtensionType):
+            if isinstance(arr_type, pa.BaseExtensionType):
                 combined_storage_array = array.cast(arr_type.storage_type).combine_chunks()
                 combined_array = arr_type.wrap_array(combined_storage_array)
             else:

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -13,12 +13,6 @@ from daft.expressions import Expression, ExpressionsProjection
 from daft.logical.schema import Schema
 from daft.series import Series
 
-_RAY_DATA_EXTENSIONS_AVAILABLE = True
-try:
-    pass
-except ImportError:
-    _RAY_DATA_EXTENSIONS_AVAILABLE = False
-
 _NUMPY_AVAILABLE = True
 try:
     import numpy as np

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -77,7 +77,7 @@ class PartialUDF:
             if self.udf.return_dtype == DataType.python():
                 return Series.from_pylist(result, name=name, pyobj="force")._series
             else:
-                return Series.from_pylist(result, name=name, pyobj="disallow").cast(self.udf.return_dtype)._series
+                return Series.from_pylist(result, name=name, pyobj="allow").cast(self.udf.return_dtype)._series
         elif _NUMPY_AVAILABLE and isinstance(result, np.ndarray):
             return Series.from_numpy(result, name=name).cast(self.udf.return_dtype)._series
         else:

--- a/daft/utils.py
+++ b/daft/utils.py
@@ -5,6 +5,10 @@ import random
 import statistics
 from typing import Any, Callable
 
+import pyarrow as pa
+
+ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
+
 
 def pydict_to_rows(pydict: dict[str, list]) -> list[frozenset[tuple[str, Any]]]:
     """Converts a dataframe pydict to a list of rows representation.
@@ -89,3 +93,10 @@ def map_operator_arrow_semantics(
     right_pylist: list,
 ) -> list:
     return [operator(l, r) if (l is not None and r is not None) else None for (l, r) in zip(left_pylist, right_pylist)]
+
+
+def pyarrow_supports_fixed_shape_tensor() -> bool:
+    """Whether pyarrow supports the fixed_shape_tensor canonical extension type."""
+    from daft.context import get_context
+
+    return hasattr(pa, "fixed_shape_tensor") and (not get_context().is_ray_runner or ARROW_VERSION >= (13, 0, 0))

--- a/src/daft-core/src/array/ops/as_arrow.rs
+++ b/src/daft-core/src/array/ops/as_arrow.rs
@@ -6,7 +6,7 @@ use crate::{
     datatypes::{
         logical::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
-            ImageArray, TimestampArray,
+            FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
         },
         BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray, ListArray, StructArray,
         Utf8Array,
@@ -76,3 +76,5 @@ impl_asarrow_logicalarray!(TimestampArray, array::PrimitiveArray<i64>);
 impl_asarrow_logicalarray!(EmbeddingArray, array::FixedSizeListArray);
 impl_asarrow_logicalarray!(ImageArray, array::StructArray);
 impl_asarrow_logicalarray!(FixedShapeImageArray, array::FixedSizeListArray);
+impl_asarrow_logicalarray!(TensorArray, array::StructArray);
+impl_asarrow_logicalarray!(FixedShapeTensorArray, array::FixedSizeListArray);

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1,14 +1,14 @@
 use super::as_arrow::AsArrow;
 use crate::{
-    array::DataArray,
+    array::{ops::image::ImageArraySidecarData, DataArray},
     datatypes::{
         logical::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
-            ImageArray, LogicalArray, TimestampArray,
+            FixedShapeTensorArray, ImageArray, LogicalArray, TensorArray, TimestampArray,
         },
-        DaftLogicalType,
+        DaftArrowBackedType, DaftLogicalType, DataType, Field, FixedShapeTensorType,
+        FixedSizeListArray, ImageMode, Utf8Array,
     },
-    datatypes::{DaftArrowBackedType, DataType, Field, Utf8Array},
     series::Series,
     with_match_arrow_daft_types, with_match_daft_logical_primitive_types,
     with_match_daft_logical_types,
@@ -24,8 +24,8 @@ use std::sync::Arc;
 
 #[cfg(feature = "python")]
 use {
-    crate::array::{ops::image::ImageArrayVecs, pseudo_arrow::PseudoArrowArray},
-    crate::datatypes::{FixedSizeListArray, ImageMode, ListArray, PythonArray},
+    crate::array::pseudo_arrow::PseudoArrowArray,
+    crate::datatypes::{ListArray, PythonArray, StructArray},
     crate::ffi,
     crate::with_match_numeric_daft_types,
     arrow2::array::Array,
@@ -154,53 +154,76 @@ where
             dtype
         )));
     }
-    let physical_type = dtype.to_physical();
-    let self_arrow_type = to_cast.data_type().to_arrow()?;
+    let target_physical_type = dtype.to_physical();
     let target_arrow_type = dtype.to_arrow()?;
-    if !can_cast_types(&self_arrow_type, &target_arrow_type) {
-        return Err(DaftError::TypeError(format!(
-            "can not cast {:?} to type: {:?}: Arrow types not castable",
-            to_cast.data_type(),
-            dtype
-        )));
-    }
+    let target_arrow_physical_type = target_physical_type.to_arrow()?;
+    let self_physical_type = to_cast.data_type().to_physical();
+    let self_arrow_type = to_cast.data_type().to_arrow()?;
+    let self_physical_arrow_type = self_physical_type.to_arrow()?;
 
-    let result_array = {
-        let target_arrow_physical = physical_type.to_arrow()?;
-        if target_arrow_physical == target_arrow_type {
-            cast(
-                to_cast.data(),
-                &target_arrow_type,
-                CastOptions {
-                    wrapped: true,
-                    partial: false,
-                },
-            )?
-        } else {
-            let arrow_logical = cast(
-                to_cast.data(),
-                &target_arrow_type,
-                CastOptions {
-                    wrapped: true,
-                    partial: false,
-                },
-            )?;
-            cast(
-                arrow_logical.as_ref(),
-                &target_arrow_physical,
-                CastOptions {
-                    wrapped: true,
-                    partial: false,
-                },
-            )?
+    let result_array = if target_arrow_physical_type == target_arrow_type {
+        if !can_cast_types(&self_arrow_type, &target_arrow_type) {
+            return Err(DaftError::TypeError(format!(
+                "can not cast {:?} to type: {:?}: Arrow types not castable, {:?}, {:?}",
+                to_cast.data_type(),
+                dtype,
+                self_arrow_type,
+                target_arrow_type,
+            )));
         }
+        cast(
+            to_cast.data(),
+            &target_arrow_type,
+            CastOptions {
+                wrapped: true,
+                partial: false,
+            },
+        )?
+    } else if can_cast_types(&self_arrow_type, &target_arrow_type) {
+        // Cast from logical Arrow2 type to logical Arrow2 type.
+        let arrow_logical = cast(
+            to_cast.data(),
+            &target_arrow_type,
+            CastOptions {
+                wrapped: true,
+                partial: false,
+            },
+        )?;
+        cast(
+            arrow_logical.as_ref(),
+            &target_arrow_physical_type,
+            CastOptions {
+                wrapped: true,
+                partial: false,
+            },
+        )?
+    } else if can_cast_types(&self_physical_arrow_type, &target_arrow_physical_type) {
+        // Cast from physical Arrow2 type to physical Arrow2 type.
+        cast(
+            to_cast.data(),
+            &target_arrow_physical_type,
+            CastOptions {
+                wrapped: true,
+                partial: false,
+            },
+        )?
+    } else {
+        return Err(DaftError::TypeError(format!(
+            "can not cast {:?} to type: {:?}: Arrow types not castable.\n{:?}, {:?},\nPhysical types: {:?}, {:?}",
+            to_cast.data_type(),
+            dtype,
+            self_arrow_type,
+            target_arrow_type,
+            self_physical_arrow_type,
+            target_arrow_physical_type,
+        )));
     };
 
     let new_field = Arc::new(Field::new(to_cast.name(), dtype.clone()));
 
     if dtype.is_logical() {
         with_match_daft_logical_types!(dtype, |$T| {
-            let physical = DataArray::try_from((Field::new(to_cast.name(), physical_type), result_array))?;
+            let physical = DataArray::try_from((Field::new(to_cast.name(), target_physical_type), result_array))?;
             return Ok(LogicalArray::<$T>::new(new_field.clone(), physical).into_series());
         })
     }
@@ -214,12 +237,11 @@ where
     T: DaftArrowBackedType,
 {
     pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
-        #[cfg(feature = "python")]
-        {
-            use crate::python::PySeries;
-            use pyo3::prelude::*;
-
-            if dtype == &DataType::Python {
+        match dtype {
+            #[cfg(feature = "python")]
+            DataType::Python => {
+                use crate::python::PySeries;
+                use pyo3::prelude::*;
                 // Convert something to Python.
 
                 // Use the existing logic on the Python side of the PyO3 layer
@@ -236,12 +258,10 @@ where
                         .getattr(pyo3::intern!(py, "_series"))?
                         .extract()
                 })?;
-
-                return Ok(new_pyseries.into());
+                Ok(new_pyseries.into())
             }
+            _ => arrow_cast(self, dtype),
         }
-
-        arrow_cast(self, dtype)
     }
 }
 
@@ -451,8 +471,8 @@ fn append_values_from_numpy<
     from_numpy_dtype_fn: &PyAny,
     enforce_dtype: Option<&DataType>,
     values_vec: &mut Vec<Tgt>,
-    shapes_vec: &mut Vec<Vec<u64>>,
-) -> DaftResult<usize> {
+    shapes_vec: &mut Vec<u64>,
+) -> DaftResult<(usize, usize)> {
     use crate::python::PyDataType;
     use std::num::Wrapping;
 
@@ -504,12 +524,17 @@ fn append_values_from_numpy<
             }
         };
         values_vec.extend(sl.iter().map(|v| <Wrapping<Tgt> as NumCast>::from(*v).unwrap().0));
-        shapes_vec.push(pyarray.shape().iter().map(|v| *v as u64).collect::<Vec<u64>>());
-        Ok((sl.len()))
+        shapes_vec.extend(pyarray.shape().iter().map(|v| *v as u64));
+        Ok((sl.len(), pyarray.shape().len()))
     })
 }
 
-type ArrayPayload<Tgt> = (Vec<Tgt>, Option<Vec<i64>>, Option<Vec<Vec<u64>>>);
+type ArrayPayload<Tgt> = (
+    Vec<Tgt>,
+    Option<Vec<i64>>,
+    Option<Vec<u64>>,
+    Option<Vec<i64>>,
+);
 
 #[cfg(feature = "python")]
 fn extract_python_to_vec<
@@ -528,12 +553,14 @@ fn extract_python_to_vec<
         Vec::with_capacity(list_size.unwrap_or(0) * python_objects.len());
 
     let mut offsets_vec: Vec<i64> = vec![];
-    let mut shapes_vec: Vec<Vec<u64>> = vec![];
+    let mut shapes_vec: Vec<u64> = vec![];
+    let mut shape_offsets_vec: Vec<i64> = vec![];
 
     if list_size.is_none() {
         offsets_vec.reserve(python_objects.len() + 1);
         offsets_vec.push(0);
-        shapes_vec.reserve(python_objects.len() + 1);
+        shape_offsets_vec.reserve(python_objects.len() + 1);
+        shape_offsets_vec.push(0);
     }
 
     let from_numpy_dtype = {
@@ -577,7 +604,7 @@ fn extract_python_to_vec<
                 // Path if object supports buffer/array protocols.
                 let np_as_array_fn = py.import("numpy")?.getattr(pyo3::intern!(py, "asarray"))?;
                 let pyarray = np_as_array_fn.call1((object,))?;
-                let num_values = append_values_from_numpy(
+                let (num_values, shape_size) = append_values_from_numpy(
                     pyarray,
                     i,
                     from_numpy_dtype,
@@ -594,6 +621,7 @@ fn extract_python_to_vec<
                     }
                 } else {
                     offsets_vec.push(offsets_vec.last().unwrap() + num_values as i64);
+                    shape_offsets_vec.push(shape_offsets_vec.last().unwrap() + shape_size as i64);
                 }
             } else {
                 // Path if object does not support buffer/array protocols.
@@ -653,7 +681,8 @@ fn extract_python_to_vec<
                     } else {
                         let offset = offsets_vec.last().unwrap() + collected.len() as i64;
                         offsets_vec.push(offset);
-                        shapes_vec.push(vec![1]);
+                        shapes_vec.extend(vec![1]);
+                        shape_offsets_vec.push(1i64);
                     }
                     values_vec.extend_from_slice(collected.as_slice());
                 } else {
@@ -668,14 +697,22 @@ fn extract_python_to_vec<
             let offset = offsets_vec.last().unwrap();
             offsets_vec.push(*offset);
             if let Some(shape_size) = shape_size {
-                shapes_vec.push(iter::repeat(1).take(shape_size).collect());
+                shapes_vec.extend(iter::repeat(1).take(shape_size));
+                shape_offsets_vec.push(shape_offsets_vec.last().unwrap() + shape_size as i64);
+            } else {
+                shape_offsets_vec.push(*shape_offsets_vec.last().unwrap());
             }
         }
     }
     if list_size.is_some() {
-        Ok((values_vec, None, None))
+        Ok((values_vec, None, None, None))
     } else {
-        Ok((values_vec, Some(offsets_vec), Some(shapes_vec)))
+        Ok((
+            values_vec,
+            Some(offsets_vec),
+            Some(shapes_vec),
+            Some(shape_offsets_vec),
+        ))
     }
 }
 
@@ -688,7 +725,7 @@ fn extract_python_like_to_fixed_size_list<
     child_field: &Field,
     list_size: usize,
 ) -> DaftResult<FixedSizeListArray> {
-    let (values_vec, _, _) = extract_python_to_vec::<Tgt>(
+    let (values_vec, _, _, _) = extract_python_to_vec::<Tgt>(
         py,
         python_objects,
         &child_field.dtype,
@@ -726,7 +763,7 @@ fn extract_python_like_to_list<
     python_objects: &PythonArray,
     child_field: &Field,
 ) -> DaftResult<ListArray> {
-    let (values_vec, offsets, _) =
+    let (values_vec, offsets, _, _) =
         extract_python_to_vec::<Tgt>(py, python_objects, &child_field.dtype, None, None, None)?;
 
     let offsets = offsets.expect("Offsets should but non-None for dynamic list");
@@ -766,7 +803,7 @@ fn extract_python_like_to_image_array<
     // 3 dimensions - height x width x channel.
 
     let shape_size = 3;
-    let (values_vec, offsets, shapes) = extract_python_to_vec::<Tgt>(
+    let (values_vec, offsets, shapes, shape_offsets) = extract_python_to_vec::<Tgt>(
         py,
         python_objects,
         child_dtype,
@@ -777,23 +814,19 @@ fn extract_python_like_to_image_array<
 
     let offsets = offsets.expect("Offsets should but non-None for image struct array");
     let shapes = shapes.expect("Shapes should be non-None for image struct array");
+    let shape_offsets =
+        shape_offsets.expect("Shape offsets should be non-None for image struct array");
 
     let validity = python_objects.as_arrow().validity();
 
-    let num_rows = shapes.len();
+    let num_rows = offsets.len() - 1;
 
     let mut channels = Vec::<u16>::with_capacity(num_rows);
     let mut heights = Vec::<u32>::with_capacity(num_rows);
     let mut widths = Vec::<u32>::with_capacity(num_rows);
     let mut modes = Vec::<u8>::with_capacity(num_rows);
-    for (mut shape, is_valid) in iter::zip(
-        shapes.into_iter(),
-        validity
-            .unwrap_or(&arrow2::bitmap::Bitmap::from_iter(
-                iter::repeat(true).take(num_rows),
-            ))
-            .iter(),
-    ) {
+    for i in 0..num_rows {
+        let is_valid = validity.map_or(true, |v| v.get_bit(i));
         if !is_valid {
             // Handle invalid row by populating dummy data.
             channels.push(1);
@@ -802,6 +835,9 @@ fn extract_python_like_to_image_array<
             modes.push(mode_from_dtype.unwrap_or(ImageMode::L) as u8);
             continue;
         }
+        let shape_start = shape_offsets[i] as usize;
+        let shape_end = shape_offsets[i + 1] as usize;
+        let shape = &mut shapes[shape_start..shape_end].to_owned();
         if shape.len() == shape_size - 1 {
             shape.push(1);
         } else if shape.len() != shape_size {
@@ -837,16 +873,93 @@ fn extract_python_like_to_image_array<
     ImageArray::from_vecs(
         python_objects.name(),
         dtype.clone(),
-        ImageArrayVecs {
-            data: values_vec,
+        values_vec,
+        offsets,
+        ImageArraySidecarData {
             channels,
             heights,
             widths,
             modes,
-            offsets,
             validity: validity.cloned(),
         },
     )
+}
+
+#[cfg(feature = "python")]
+fn extract_python_like_to_tensor_array<
+    Tgt: numpy::Element + NumCast + ToPrimitive + arrow2::types::NativeType,
+>(
+    py: Python<'_>,
+    python_objects: &PythonArray,
+    dtype: &DataType,
+    child_dtype: &DataType,
+) -> DaftResult<TensorArray> {
+    let (data, offsets, shapes, shape_offsets) = extract_python_to_vec::<Tgt>(
+        py,
+        python_objects,
+        child_dtype,
+        Some(child_dtype),
+        None,
+        None,
+    )?;
+
+    let offsets = offsets.expect("Offsets should but non-None for image struct array");
+    let shapes = shapes.expect("Shapes should be non-None for image struct array");
+    let shape_offsets =
+        shape_offsets.expect("Shape offsets should be non-None for image struct array");
+
+    let validity = python_objects.as_arrow().validity();
+
+    let num_rows = shapes.len();
+    let name = python_objects.name();
+    if data.is_empty() {
+        // Create an all-null array if the data array is empty.
+        let physical_type = dtype.to_physical();
+        let null_struct_array = arrow2::array::new_null_array(physical_type.to_arrow()?, num_rows);
+        let daft_struct_array =
+            StructArray::new(Field::new(name, physical_type).into(), null_struct_array)?;
+        return Ok(TensorArray::new(
+            Field::new(name, dtype.clone()),
+            daft_struct_array,
+        ));
+    }
+    let offsets = arrow2::offset::OffsetsBuffer::try_from(offsets)?;
+    let arrow_dtype: arrow2::datatypes::DataType = Tgt::PRIMITIVE.into();
+
+    let data_dtype = arrow2::datatypes::DataType::LargeList(Box::new(
+        arrow2::datatypes::Field::new("data", arrow_dtype, true),
+    ));
+    let data_array = Box::new(arrow2::array::ListArray::<i64>::new(
+        data_dtype,
+        offsets,
+        Box::new(arrow2::array::PrimitiveArray::from_vec(data)),
+        validity.cloned(),
+    ));
+    let shapes_dtype = arrow2::datatypes::DataType::LargeList(Box::new(
+        arrow2::datatypes::Field::new("shape", arrow2::datatypes::DataType::UInt64, true),
+    ));
+    let shape_offsets = arrow2::offset::OffsetsBuffer::try_from(shape_offsets)?;
+    let shapes_array = Box::new(arrow2::array::ListArray::<i64>::new(
+        shapes_dtype,
+        shape_offsets,
+        Box::new(arrow2::array::PrimitiveArray::from_vec(shapes)),
+        validity.cloned(),
+    ));
+
+    let values: Vec<Box<dyn arrow2::array::Array>> = vec![data_array, shapes_array];
+    let physical_type = dtype.to_physical();
+    let struct_array = Box::new(arrow2::array::StructArray::new(
+        physical_type.to_arrow()?,
+        values,
+        validity.cloned(),
+    ));
+
+    let daft_struct_array =
+        crate::datatypes::StructArray::new(Field::new(name, physical_type).into(), struct_array)?;
+    Ok(TensorArray::new(
+        Field::new(name, dtype.clone()),
+        daft_struct_array,
+    ))
 }
 
 #[cfg(feature = "python")]
@@ -937,6 +1050,23 @@ impl PythonArray {
                     result.fixed_size_list()?.clone(),
                 );
                 Ok(image_array.into_series())
+            }
+            DataType::Tensor(inner_dtype) => {
+                with_match_numeric_daft_types!(**inner_dtype, |$T| {
+                    type Tgt = <$T as DaftNumericType>::Native;
+                    pyo3::Python::with_gil(|py| {
+                        let result = extract_python_like_to_tensor_array::<Tgt>(py, self, dtype, &inner_dtype)?;
+                        Ok(result.into_series())
+                    })
+                })
+            }
+            DataType::FixedShapeTensor(..) => {
+                let result = self.cast(&dtype.to_physical())?;
+                let tensor_array = FixedShapeTensorArray::new(
+                    Field::new(self.name(), dtype.clone()),
+                    result.fixed_size_list()?.clone(),
+                );
+                Ok(tensor_array.into_series())
             }
             // TODO: Add implementations for these types
             // DataType::Timestamp(_, _) => $self.timestamp().unwrap().$method($($args),*),
@@ -1060,6 +1190,272 @@ impl FixedShapeImageArray {
                     )?
                     .into_series())
                 })
+            }
+            (_, _) => self.physical.cast(dtype),
+        }
+    }
+}
+
+impl TensorArray {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        match dtype {
+            #[cfg(feature = "python")]
+            DataType::Python => Python::with_gil(|py| {
+                let mut ndarrays = Vec::with_capacity(self.len());
+                let da = self.data_array();
+                let sa = self.shape_array();
+                let pyarrow = py.import("pyarrow")?;
+                for (arrow_array, shape_array) in da.iter().zip(sa.iter()) {
+                    if let (Some(arrow_array), Some(shape_array)) = (arrow_array, shape_array) {
+                        let shape_array = shape_array
+                            .as_any()
+                            .downcast_ref::<arrow2::array::UInt64Array>()
+                            .unwrap();
+                        let shape = shape_array.values().to_vec();
+                        let py_array = ffi::to_py_array(arrow_array, py, pyarrow)?
+                            .call_method1(py, pyo3::intern!(py, "to_numpy"), (false,))?
+                            .call_method1(py, pyo3::intern!(py, "reshape"), (shape,))?;
+                        ndarrays.push(py_array);
+                    } else {
+                        ndarrays.push(py.None())
+                    }
+                }
+                let values_array =
+                    PseudoArrowArray::new(ndarrays.into(), self.as_arrow().validity().cloned());
+                Ok(PythonArray::new(
+                    Field::new(self.name(), dtype.clone()).into(),
+                    values_array.to_boxed(),
+                )?
+                .into_series())
+            }),
+            DataType::FixedShapeTensor(inner_dtype, shape) => {
+                let da = self.data_array();
+                let sa = self.shape_array();
+                if !sa.iter().all(|s| {
+                    s.map_or(true, |s| {
+                        s.as_any()
+                            .downcast_ref::<arrow2::array::PrimitiveArray<u64>>()
+                            .unwrap()
+                            .iter()
+                            .eq(shape.iter().map(Some))
+                    })
+                }) {
+                    return Err(DaftError::TypeError(format!(
+                        "Can not cast Tensor array to FixedShapeTensor array with type {:?}: Tensor array has shapes different than {:?}; shapes: {:?}",
+                        dtype,
+                        shape,
+                        sa,
+                    )));
+                }
+                let size = shape.iter().product::<u64>() as usize;
+                let new_da = arrow2::compute::cast::cast(
+                    da,
+                    &arrow2::datatypes::DataType::FixedSizeList(
+                        Box::new(arrow2::datatypes::Field::new(
+                            "data",
+                            inner_dtype.to_arrow()?,
+                            true,
+                        )),
+                        size,
+                    ),
+                    Default::default(),
+                )?;
+                let inner_field = Box::new(Field::new("data", *inner_dtype.clone()));
+                let new_field = Arc::new(Field::new(
+                    "data",
+                    DataType::FixedSizeList(inner_field, size),
+                ));
+                let result = FixedSizeListArray::new(new_field, new_da)?;
+                let tensor_array =
+                    FixedShapeTensorArray::new(Field::new(self.name(), dtype.clone()), result);
+                Ok(tensor_array.into_series())
+            }
+            DataType::Image(mode) => {
+                let sa = self.shape_array();
+                if !sa.iter().all(|s| {
+                    s.map_or(true, |s| {
+                        if s.len() != 3 && s.len() != 2 {
+                            // Images must have 2 or 3 dimensions: height x width or height x width x channel.
+                            // If image is 2 dimensions, 8-bit grayscale is assumed.
+                            return false;
+                        }
+                        if let Some(mode) = mode && s.as_any()
+                            .downcast_ref::<arrow2::array::PrimitiveArray<u64>>()
+                            .unwrap()
+                            .get(s.len() - 1)
+                            .unwrap() != mode.num_channels() as u64
+                        {
+                            // If type-level mode is defined, each image must have the implied number of channels.
+                            return false;
+                        }
+                        true
+                    })
+                }) {
+                    return Err(DaftError::TypeError(format!(
+                        "Can not cast Tensor array to Image array with type {:?}: Tensor array shapes are not compatible: {:?}",
+                        dtype,
+                        sa,
+                    )));
+                }
+                let num_rows = self.len();
+                let mut channels = Vec::<u16>::with_capacity(num_rows);
+                let mut heights = Vec::<u32>::with_capacity(num_rows);
+                let mut widths = Vec::<u32>::with_capacity(num_rows);
+                let mut modes = Vec::<u8>::with_capacity(num_rows);
+                let da = self.data_array();
+                let validity = da.validity();
+                for i in 0..num_rows {
+                    let is_valid = validity.map_or(true, |v| v.get_bit(i));
+                    if !is_valid {
+                        // Handle invalid row by populating dummy data.
+                        channels.push(1);
+                        heights.push(1);
+                        widths.push(1);
+                        modes.push(mode.unwrap_or(ImageMode::L) as u8);
+                        continue;
+                    }
+                    let shape = sa.value(i);
+                    let shape = shape
+                        .as_any()
+                        .downcast_ref::<arrow2::array::PrimitiveArray<u64>>()
+                        .unwrap();
+                    assert!(shape.validity().map_or(true, |v| v.iter().all(|b| b)));
+                    let mut shape = shape.values().to_vec();
+                    if shape.len() == 2 {
+                        // Add unit channel dimension to grayscale height x width image.
+                        shape.push(1);
+                    }
+                    if shape.len() != 3 {
+                        return Err(DaftError::ValueError(format!(
+                            "Image expected to have {} dimensions, but has {}. Image shape = {:?}",
+                            3,
+                            shape.len(),
+                            shape,
+                        )));
+                    }
+                    heights.push(
+                        shape[0]
+                            .try_into()
+                            .expect("Image height should fit into a uint16"),
+                    );
+                    widths.push(
+                        shape[1]
+                            .try_into()
+                            .expect("Image width should fit into a uint16"),
+                    );
+                    channels.push(
+                        shape[2]
+                            .try_into()
+                            .expect("Number of channels should fit into a uint8"),
+                    );
+
+                    modes.push(mode.unwrap_or(ImageMode::try_from_num_channels(
+                        shape[2].try_into().unwrap(),
+                        &DataType::UInt8,
+                    )?) as u8);
+                }
+                Ok(ImageArray::from_list_array(
+                    self.name(),
+                    dtype.clone(),
+                    Box::new(da.clone()),
+                    ImageArraySidecarData {
+                        channels,
+                        heights,
+                        widths,
+                        modes,
+                        validity: validity.cloned(),
+                    },
+                )?
+                .into_series())
+            }
+            DataType::FixedShapeImage(mode, height, width) => {
+                let num_channels = mode.num_channels();
+                let image_shape = vec![*height as u64, *width as u64, num_channels as u64];
+                let fixed_shape_tensor_dtype =
+                    DataType::FixedShapeTensor(Box::new(mode.get_dtype()), image_shape);
+                let fixed_shape_tensor_array =
+                    self.cast(&fixed_shape_tensor_dtype).or_else(|e| {
+                        if num_channels == 1 {
+                            // Fall back to height x width shape if unit channel.
+                            self.cast(&DataType::FixedShapeTensor(
+                                Box::new(mode.get_dtype()),
+                                vec![*height as u64, *width as u64],
+                            ))
+                            .or(Err(e))
+                        } else {
+                            Err(e)
+                        }
+                    })?;
+                let fixed_shape_tensor_array =
+                    fixed_shape_tensor_array.downcast_logical::<FixedShapeTensorType>()?;
+                let image_array = fixed_shape_tensor_array.cast(dtype)?;
+                Ok(image_array)
+            }
+            _ => self.physical.cast(dtype),
+        }
+    }
+}
+
+impl FixedShapeTensorArray {
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Series> {
+        match (dtype, self.logical_type()) {
+            #[cfg(feature = "python")]
+            (DataType::Python, DataType::FixedShapeTensor(_, shape)) => {
+                pyo3::Python::with_gil(|py| {
+                    let pyarrow = py.import("pyarrow")?;
+                    let mut np_shape: Vec<u64> = vec![self.len() as u64];
+                    np_shape.extend(shape);
+                    // Only go through FFI layer once instead of for every tensor element.
+                    // We create an (N, [shape..]) ndarray view on the entire tensor array buffer
+                    // sans the validity mask, and then create a subndarray view for each ndarray
+                    // element in the PythonArray.
+                    let py_array = ffi::to_py_array(
+                        self.as_arrow().values().with_validity(None),
+                        py,
+                        pyarrow,
+                    )?
+                    .call_method1(py, pyo3::intern!(py, "to_numpy"), (false,))?
+                    .call_method1(
+                        py,
+                        pyo3::intern!(py, "reshape"),
+                        (np_shape,),
+                    )?;
+                    let ndarrays = py_array
+                        .as_ref(py)
+                        .iter()?
+                        .map(|a| a.unwrap().to_object(py))
+                        .collect::<Vec<PyObject>>();
+                    let values_array =
+                        PseudoArrowArray::new(ndarrays.into(), self.as_arrow().validity().cloned());
+                    Ok(PythonArray::new(
+                        Field::new(self.name(), dtype.clone()).into(),
+                        values_array.to_boxed(),
+                    )?
+                    .into_series())
+                })
+            }
+            (
+                DataType::FixedShapeImage(mode, height, width),
+                DataType::FixedShapeTensor(_, tensor_shape),
+            ) => {
+                let num_channels = mode.num_channels();
+                let image_shape = vec![*height as u64, *width as u64, num_channels as u64];
+                if *tensor_shape != image_shape
+                    && (num_channels != 1 || *tensor_shape != vec![*height as u64, *width as u64])
+                {
+                    return Err(DaftError::TypeError(format!(
+                        "Can not cast FixedShapeTensor array with type {:?} to FixedShapeImage array with type {:?}: tensor shape is {:?} while desired image shape is {:?}",
+                        self.logical_type(),
+                        dtype,
+                        tensor_shape,
+                        image_shape,
+                    )));
+                }
+                let image_array = FixedShapeImageArray::new(
+                    Field::new(self.name(), dtype.clone()),
+                    self.physical.clone(),
+                );
+                Ok(image_array.into_series())
             }
             (_, _) => self.physical.cast(dtype),
         }

--- a/src/daft-core/src/array/ops/if_else.rs
+++ b/src/daft-core/src/array/ops/if_else.rs
@@ -1,7 +1,7 @@
 use crate::array::DataArray;
 use crate::datatypes::logical::{
-    DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray, ImageArray,
-    TimestampArray,
+    DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
+    FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
 };
 use crate::datatypes::{
     BinaryArray, BooleanArray, DaftArrowBackedType, DaftNumericType, ExtensionArray, Field,
@@ -342,3 +342,5 @@ impl_logicalarray_if_else!(TimestampArray);
 impl_logicalarray_if_else!(EmbeddingArray);
 impl_logicalarray_if_else!(ImageArray);
 impl_logicalarray_if_else!(FixedShapeImageArray);
+impl_logicalarray_if_else!(TensorArray);
+impl_logicalarray_if_else!(FixedShapeTensorArray);

--- a/src/daft-core/src/array/ops/mod.rs
+++ b/src/daft-core/src/array/ops/mod.rs
@@ -31,6 +31,7 @@ mod search_sorted;
 mod sort;
 mod sum;
 mod take;
+pub(crate) mod tensor;
 mod utf8;
 
 pub use sort::{build_multi_array_bicompare, build_multi_array_compare};

--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -3,7 +3,7 @@ use crate::{
     datatypes::{
         logical::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
-            ImageArray, TimestampArray,
+            FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
         },
         BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, ExtensionArray,
         FixedSizeListArray, Float32Array, Float64Array, ListArray, NullArray, StructArray,
@@ -637,5 +637,17 @@ impl ImageArray {
 impl FixedShapeImageArray {
     pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
         todo!("impl sort for FixedShapeImageArray")
+    }
+}
+
+impl TensorArray {
+    pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
+        todo!("impl sort for TensorArray")
+    }
+}
+
+impl FixedShapeTensorArray {
+    pub fn sort(&self, _descending: bool) -> DaftResult<Self> {
+        todo!("impl sort for FixedShapeTensorArray")
     }
 }

--- a/src/daft-core/src/array/ops/take.rs
+++ b/src/daft-core/src/array/ops/take.rs
@@ -3,7 +3,7 @@ use crate::{
     datatypes::{
         logical::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
-            ImageArray, TimestampArray,
+            FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
         },
         BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, ExtensionArray,
         FixedSizeListArray, ListArray, NullArray, StructArray, Utf8Array,
@@ -136,5 +136,92 @@ impl crate::datatypes::PythonArray {
             Box::new(PseudoArrowArray::new(new_values.into(), new_validity));
 
         DataArray::<PythonType>::new(self.field().clone().into(), arrow_array)
+    }
+}
+
+impl TensorArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<Box<dyn arrow2::array::Array>> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let arrow_array = self.as_arrow();
+        let is_valid = arrow_array
+            .validity()
+            .map_or(true, |validity| validity.get_bit(idx));
+        if is_valid {
+            let data_array = arrow_array.values()[0]
+                .as_any()
+                .downcast_ref::<arrow2::array::ListArray<i64>>()?;
+            Some(unsafe { data_array.value_unchecked(idx) })
+        } else {
+            None
+        }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let new_array = self.physical.take(idx)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            Some(v) => Ok(format!("{v:?}")),
+        }
+    }
+
+    pub fn html_value(&self, idx: usize) -> String {
+        let str_value = self.str_value(idx).unwrap();
+        html_escape::encode_text(&str_value)
+            .into_owned()
+            .replace('\n', "<br />")
+    }
+}
+
+impl FixedShapeTensorArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<Box<dyn arrow2::array::Array>> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let arrow_array = self.as_arrow();
+        let is_valid = arrow_array
+            .validity()
+            .map_or(true, |validity| validity.get_bit(idx));
+        if is_valid {
+            Some(unsafe { arrow_array.value_unchecked(idx) })
+        } else {
+            None
+        }
+    }
+
+    pub fn take<I>(&self, idx: &DataArray<I>) -> DaftResult<Self>
+    where
+        I: DaftIntegerType,
+        <I as DaftNumericType>::Native: arrow2::types::Index,
+    {
+        let new_array = self.physical.take(idx)?;
+        Ok(Self::new(self.field.clone(), new_array))
+    }
+
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            Some(v) => Ok(format!("{v:?}")),
+        }
+    }
+
+    pub fn html_value(&self, idx: usize) -> String {
+        let str_value = self.str_value(idx).unwrap();
+        html_escape::encode_text(&str_value)
+            .into_owned()
+            .replace('\n', "<br />")
     }
 }

--- a/src/daft-core/src/array/ops/tensor.rs
+++ b/src/daft-core/src/array/ops/tensor.rs
@@ -1,0 +1,17 @@
+use crate::{array::ops::as_arrow::AsArrow, datatypes::logical::TensorArray};
+
+impl TensorArray {
+    pub fn data_array(&self) -> &arrow2::array::ListArray<i64> {
+        let p = self.physical.as_arrow();
+        const DATA_IDX: usize = 0;
+        let array = p.values().get(DATA_IDX).unwrap();
+        array.as_ref().as_any().downcast_ref().unwrap()
+    }
+
+    pub fn shape_array(&self) -> &arrow2::array::ListArray<i64> {
+        let p = self.physical.as_arrow();
+        const SHAPE_IDX: usize = 1;
+        let array = p.values().get(SHAPE_IDX).unwrap();
+        array.as_ref().as_any().downcast_ref().unwrap()
+    }
+}

--- a/src/daft-core/src/datatypes/dtype.rs
+++ b/src/daft-core/src/datatypes/dtype.rs
@@ -302,7 +302,12 @@ impl DataType {
 
     #[inline]
     pub fn is_image(&self) -> bool {
-        matches!(self, DataType::Image(..) | DataType::FixedShapeImage(..))
+        matches!(self, DataType::Image(..))
+    }
+
+    #[inline]
+    pub fn is_fixed_shape_image(&self) -> bool {
+        matches!(self, DataType::FixedShapeImage(..))
     }
 
     #[inline]

--- a/src/daft-core/src/datatypes/dtype.rs
+++ b/src/daft-core/src/datatypes/dtype.rs
@@ -85,6 +85,10 @@ pub enum DataType {
     Image(Option<ImageMode>),
     /// A logical type for images with the same size (height x width).
     FixedShapeImage(ImageMode, u32, u32),
+    /// A logical type for tensors with variable shapes.
+    Tensor(Box<DataType>),
+    /// A logical type for tensors with the same shape.
+    FixedShapeTensor(Box<DataType>, Vec<u64>),
     Python,
     Unknown,
 }
@@ -153,14 +157,18 @@ impl DataType {
                 Box::new(dtype.to_arrow()?),
                 metadata.clone(),
             )),
-            DataType::Embedding(..) | DataType::Image(..) | DataType::FixedShapeImage(..) => {
+            DataType::Embedding(..)
+            | DataType::Image(..)
+            | DataType::FixedShapeImage(..)
+            | DataType::Tensor(..)
+            | DataType::FixedShapeTensor(..) => {
                 let physical = Box::new(self.to_physical());
-                let embedding_extension = DataType::Extension(
+                let logical_extension = DataType::Extension(
                     DAFT_SUPER_EXTENSION_NAME.into(),
                     physical,
                     Some(self.to_json()?),
                 );
-                embedding_extension.to_arrow()
+                logical_extension.to_arrow()
             }
             _ => Err(DaftError::TypeError(format!(
                 "Can not convert {self:?} into arrow type"
@@ -206,8 +214,21 @@ impl DataType {
                 Box::new(Field::new("data", mode.get_dtype())),
                 usize::try_from(mode.num_channels() as u32 * height * width).unwrap(),
             ),
-            t if t.is_physical() => self.clone(),
-            _ => unreachable!(),
+            Tensor(dtype) => Struct(vec![
+                Field::new("data", List(Box::new(Field::new("data", *dtype.clone())))),
+                Field::new(
+                    "shape",
+                    List(Box::new(Field::new("shape", DataType::UInt64))),
+                ),
+            ]),
+            FixedShapeTensor(dtype, shape) => FixedSizeList(
+                Box::new(Field::new("data", *dtype.clone())),
+                usize::try_from(shape.iter().product::<u64>()).unwrap(),
+            ),
+            _ => {
+                assert!(self.is_physical());
+                self.clone()
+            }
         }
     }
 
@@ -270,6 +291,21 @@ impl DataType {
     }
 
     #[inline]
+    pub fn is_tensor(&self) -> bool {
+        matches!(self, DataType::Tensor(..))
+    }
+
+    #[inline]
+    pub fn is_fixed_shape_tensor(&self) -> bool {
+        matches!(self, DataType::FixedShapeTensor(..))
+    }
+
+    #[inline]
+    pub fn is_image(&self) -> bool {
+        matches!(self, DataType::Image(..) | DataType::FixedShapeImage(..))
+    }
+
+    #[inline]
     pub fn is_null(&self) -> bool {
         match self {
             DataType::Null => true,
@@ -303,6 +339,8 @@ impl DataType {
                 | DataType::Embedding(..)
                 | DataType::Image(..)
                 | DataType::FixedShapeImage(..)
+                | DataType::Tensor(..)
+                | DataType::FixedShapeTensor(..)
         )
     }
 

--- a/src/daft-core/src/datatypes/logical.rs
+++ b/src/daft-core/src/datatypes/logical.rs
@@ -5,7 +5,7 @@ use common_error::DaftResult;
 
 use super::{
     DataArray, DataType, Decimal128Type, DurationType, EmbeddingType, FixedShapeImageType,
-    ImageType, TimestampType,
+    FixedShapeTensorType, ImageType, TensorType, TimestampType,
 };
 pub struct LogicalArray<L: DaftLogicalType> {
     pub field: Arc<Field>,
@@ -114,6 +114,8 @@ pub type EmbeddingArray = LogicalArray<EmbeddingType>;
 pub type ImageArray = LogicalArray<ImageType>;
 pub type FixedShapeImageArray = LogicalArray<FixedShapeImageType>;
 pub type TimestampArray = LogicalArray<TimestampType>;
+pub type TensorArray = LogicalArray<TensorType>;
+pub type FixedShapeTensorArray = LogicalArray<FixedShapeTensorType>;
 
 pub trait DaftImageryType: DaftLogicalType {}
 

--- a/src/daft-core/src/datatypes/matching.rs
+++ b/src/daft-core/src/datatypes/matching.rs
@@ -237,6 +237,8 @@ macro_rules! with_match_daft_logical_types {(
         Embedding(..) => __with_ty__! { EmbeddingType },
         Image(..) => __with_ty__! { ImageType },
         FixedShapeImage(..) => __with_ty__! { FixedShapeImageType },
+        Tensor(..) => __with_ty__! { TensorType },
+        FixedShapeTensor(..) => __with_ty__! { FixedShapeTensorType },
         _ => panic!("{:?} not implemented for with_match_daft_logical_types", $key_type)
     }
 })}

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -117,6 +117,8 @@ impl_daft_logical_datatype!(DurationType, Unknown, Int64Type);
 impl_daft_logical_datatype!(EmbeddingType, Unknown, FixedSizeListType);
 impl_daft_logical_datatype!(ImageType, Unknown, StructType);
 impl_daft_logical_datatype!(FixedShapeImageType, Unknown, FixedSizeListType);
+impl_daft_logical_datatype!(TensorType, Unknown, StructType);
+impl_daft_logical_datatype!(FixedShapeTensorType, Unknown, FixedSizeListType);
 
 pub trait NumericNative:
     PartialOrd

--- a/src/daft-core/src/ffi.rs
+++ b/src/daft-core/src/ffi.rs
@@ -51,6 +51,22 @@ pub fn to_py_array(array: ArrayRef, py: Python, pyarrow: &PyModule) -> PyResult<
     Ok(array.to_object(py))
 }
 
+pub fn to_py_schema(
+    dtype: &arrow2::datatypes::DataType,
+    py: Python,
+    pyarrow: &PyModule,
+) -> PyResult<PyObject> {
+    let schema = Box::new(ffi::export_field_to_c(&Field::new("", dtype.clone(), true)));
+    let schema_ptr: *const ffi::ArrowSchema = &*schema;
+
+    let field = pyarrow.getattr(pyo3::intern!(py, "Field"))?.call_method1(
+        pyo3::intern!(py, "_import_from_c"),
+        (schema_ptr as Py_uintptr_t,),
+    )?;
+
+    Ok(field.to_object(py))
+}
+
 fn fix_child_array_slice_offsets(array: ArrayRef) -> ArrayRef {
     /* Zero-copy slices of arrow2 struct/fixed-size list arrays are currently not correctly
     converted to pyarrow struct/fixed-size list arrays when going over the FFI boundary;

--- a/src/daft-core/src/lib.rs
+++ b/src/daft-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(let_chains)]
+
 pub mod array;
 pub mod datatypes;
 #[cfg(feature = "python")]

--- a/src/daft-core/src/python/datatype.rs
+++ b/src/daft-core/src/python/datatype.rs
@@ -1,4 +1,7 @@
-use crate::datatypes::{DataType, Field, ImageMode, TimeUnit};
+use crate::{
+    datatypes::{DataType, Field, ImageMode, TimeUnit},
+    ffi,
+};
 use pyo3::{
     class::basic::CompareOp,
     exceptions::PyValueError,
@@ -268,8 +271,88 @@ impl PyDataType {
     }
 
     #[staticmethod]
+    pub fn tensor(dtype: Self, shape: Option<Vec<u64>>) -> PyResult<Self> {
+        // TODO(Clark): Add support for non-numeric (e.g. string) tensor columns.
+        if !dtype.dtype.is_numeric() {
+            return Err(PyValueError::new_err(format!(
+                "The data type for a tensor column must be numeric, but got: {}",
+                dtype.dtype
+            )));
+        }
+        let dtype = Box::new(dtype.dtype);
+        match shape {
+            Some(shape) => Ok(DataType::FixedShapeTensor(dtype, shape).into()),
+            None => Ok(DataType::Tensor(dtype).into()),
+        }
+    }
+
+    #[staticmethod]
     pub fn python() -> PyResult<Self> {
         Ok(DataType::Python.into())
+    }
+
+    pub fn to_arrow(&self, cast_tensor_type_for_ray: Option<bool>) -> PyResult<PyObject> {
+        Python::with_gil(|py| {
+            let pyarrow = py.import(pyo3::intern!(py, "pyarrow"))?;
+            let cast_tensor_to_ray_type = cast_tensor_type_for_ray.unwrap_or(false);
+            match (&self.dtype, cast_tensor_to_ray_type) {
+                (DataType::FixedShapeTensor(dtype, shape), false) => pyarrow
+                    .getattr(pyo3::intern!(py, "fixed_shape_tensor"))
+                    .map_or_else(
+                        // Fall back to default Daft super extension representation if installed pyarrow doesn't have the
+                        // canonical tensor extension type.
+                        |_| ffi::to_py_schema(&self.dtype.to_arrow()?, py, pyarrow),
+                        |fst| {
+                            Ok(fst
+                                .call1((
+                                    Self {
+                                        dtype: *dtype.clone(),
+                                    }
+                                    .to_arrow(None)?,
+                                    pyo3::types::PyTuple::new(py, shape.clone()),
+                                ))?
+                                .to_object(py))
+                        },
+                    ),
+                (DataType::FixedShapeTensor(dtype, shape), true) => Ok(py
+                    .import(pyo3::intern!(py, "ray.data.extensions"))?
+                    .getattr(pyo3::intern!(py, "ArrowTensorType"))?
+                    .call1((
+                        pyo3::types::PyTuple::new(py, shape.clone()),
+                        Self {
+                            dtype: *dtype.clone(),
+                        }
+                        .to_arrow(None)?,
+                    ))?
+                    .to_object(py)),
+                // We don't export variable-shaped tensors as Ray's variable-shaped tensor type since the
+                // latter requires all tensor elements to have the same number of dimensions, which is a
+                // constraint that Daft does not have.
+                // (DataType::Tensor(dtype), true) => Ok(py
+                //     .import(pyo3::intern!(py, "ray.data.extensions"))?
+                //     .getattr(pyo3::intern!(py, "ArrowVariableShapedTensorType"))?
+                //     .call1((Self {
+                //         dtype: *dtype.clone(),
+                //         ndim: ???,
+                //     }
+                //     .to_arrow(None)?,))?
+                //     .to_object(py)),
+                (_, _) => ffi::to_py_schema(&self.dtype.to_arrow()?, py, pyarrow)?
+                    .getattr(py, pyo3::intern!(py, "type")),
+            }
+        })
+    }
+
+    pub fn is_image(&self) -> PyResult<bool> {
+        Ok(self.dtype.is_image())
+    }
+
+    pub fn is_tensor(&self) -> PyResult<bool> {
+        Ok(self.dtype.is_tensor())
+    }
+
+    pub fn is_fixed_shape_tensor(&self) -> PyResult<bool> {
+        Ok(self.dtype.is_fixed_shape_tensor())
     }
 
     pub fn is_logical(&self) -> PyResult<bool> {
@@ -283,6 +366,11 @@ impl PyDataType {
         } else {
             Ok(false)
         }
+    }
+
+    #[staticmethod]
+    pub fn from_json(serialized: &str) -> PyResult<Self> {
+        Ok(DataType::from_json(serialized)?.into())
     }
 
     pub fn __setstate__(&mut self, py: Python, state: PyObject) -> PyResult<()> {

--- a/src/daft-core/src/python/datatype.rs
+++ b/src/daft-core/src/python/datatype.rs
@@ -352,6 +352,10 @@ impl PyDataType {
         Ok(self.dtype.is_image())
     }
 
+    pub fn is_fixed_shape_image(&self) -> PyResult<bool> {
+        Ok(self.dtype.is_fixed_shape_image())
+    }
+
     pub fn is_tensor(&self) -> PyResult<bool> {
         Ok(self.dtype.is_tensor())
     }

--- a/src/daft-core/src/python/datatype.rs
+++ b/src/daft-core/src/python/datatype.rs
@@ -330,18 +330,6 @@ impl PyDataType {
                         .to_arrow(None)?,
                     ))?
                     .to_object(py)),
-                // We don't export variable-shaped tensors as Ray's variable-shaped tensor type since the
-                // latter requires all tensor elements to have the same number of dimensions, which is a
-                // constraint that Daft does not have.
-                // (DataType::Tensor(dtype), true) => Ok(py
-                //     .import(pyo3::intern!(py, "ray.data.extensions"))?
-                //     .getattr(pyo3::intern!(py, "ArrowVariableShapedTensorType"))?
-                //     .call1((Self {
-                //         dtype: *dtype.clone(),
-                //         ndim: ???,
-                //     }
-                //     .to_arrow(None)?,))?
-                //     .to_object(py)),
                 (_, _) => ffi::to_py_schema(&self.dtype.to_arrow()?, py, pyarrow)?
                     .getattr(py, pyo3::intern!(py, "type")),
             }

--- a/src/daft-core/src/python/series.rs
+++ b/src/daft-core/src/python/series.rs
@@ -367,7 +367,7 @@ fn infer_daft_dtype_for_sequence(
                     break;
                 }
             }
-        } else if let Ok(np_ndarray_type) = np_ndarray_type && let Ok(np_generic_type) = np_generic_type && obj.is_instance(pyo3::types::PyTuple::new(py, vec![np_ndarray_type, np_generic_type]))? {
+        } else if let Ok(np_ndarray_type) = np_ndarray_type && let Ok(np_generic_type) = np_generic_type && (obj.is_instance(np_ndarray_type)? || obj.is_instance(np_generic_type)?) {
             let np_dtype = obj.getattr(pyo3::intern!(py, "dtype"))?;
             let inferred_inner_dtype = from_numpy_dtype.call1((np_dtype,)).map(|dt| dt.getattr(pyo3::intern!(py, "_dtype")).unwrap().extract::<PyDataType>().unwrap().dtype);
             let shape: Vec<u64> = obj.getattr(pyo3::intern!(py, "shape"))?.extract()?;

--- a/src/daft-core/src/series/array_impl/binary_ops.rs
+++ b/src/daft-core/src/series/array_impl/binary_ops.rs
@@ -10,7 +10,8 @@ use crate::{
 };
 
 use crate::datatypes::logical::{
-    DateArray, DurationArray, EmbeddingArray, FixedShapeImageArray, ImageArray, TimestampArray,
+    DateArray, DurationArray, EmbeddingArray, FixedShapeImageArray, FixedShapeTensorArray,
+    ImageArray, TensorArray, TimestampArray,
 };
 use crate::datatypes::{
     BinaryArray, BooleanArray, ExtensionArray, FixedSizeListArray, Float32Array, Float64Array,
@@ -262,3 +263,5 @@ impl SeriesBinaryOps for ArrayWrapper<TimestampArray> {
 impl SeriesBinaryOps for ArrayWrapper<EmbeddingArray> {}
 impl SeriesBinaryOps for ArrayWrapper<ImageArray> {}
 impl SeriesBinaryOps for ArrayWrapper<FixedShapeImageArray> {}
+impl SeriesBinaryOps for ArrayWrapper<TensorArray> {}
+impl SeriesBinaryOps for ArrayWrapper<FixedShapeTensorArray> {}

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -1,6 +1,6 @@
 use crate::datatypes::logical::{
-    DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray, ImageArray,
-    TimestampArray,
+    DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
+    FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
 };
 use crate::datatypes::BooleanArray;
 
@@ -224,3 +224,5 @@ impl_series_like_for_logical_array!(EmbeddingArray);
 impl_series_like_for_logical_array!(ImageArray);
 impl_series_like_for_logical_array!(FixedShapeImageArray);
 impl_series_like_for_logical_array!(TimestampArray);
+impl_series_like_for_logical_array!(TensorArray);
+impl_series_like_for_logical_array!(FixedShapeTensorArray);

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -20,6 +20,7 @@ from daft.api_annotations import APITypeError
 from daft.context import get_context
 from daft.dataframe import DataFrame
 from daft.datatype import DataType
+from daft.utils import pyarrow_supports_fixed_shape_tensor
 from tests.conftest import UuidType
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
@@ -186,12 +187,8 @@ def test_create_dataframe_arrow_tensor_ray(valid_data: list[dict[str, float]]) -
 
 
 @pytest.mark.skipif(
-    ARROW_VERSION < (12, 0, 0),
+    not pyarrow_supports_fixed_shape_tensor(),
     reason=f"Arrow version {ARROW_VERSION} doesn't support the canonical tensor extension type.",
-)
-@pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
-    reason="Pickling canonical tensor extension type is not supported by pyarrow",
 )
 def test_create_dataframe_arrow_tensor_canonical(valid_data: list[dict[str, float]]) -> None:
     pydict = {k: [item[k] for item in valid_data] for k in valid_data[0].keys()}

--- a/tests/dataframe/test_logical_type.py
+++ b/tests/dataframe/test_logical_type.py
@@ -9,6 +9,7 @@ from PIL import Image
 import daft
 from daft import DataType, Series, col
 from daft.datatype import DaftExtension
+from daft.utils import pyarrow_supports_fixed_shape_tensor
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
 
@@ -96,7 +97,7 @@ def test_fixed_shape_tensor_type_df() -> None:
     df = df.sort("index")
     df = df.collect()
     arrow_table = df.to_arrow()
-    if ARROW_VERSION >= (12, 0, 0):
+    if pyarrow_supports_fixed_shape_tensor():
         assert arrow_table["tensor"].type == pa.fixed_shape_tensor(pa.int64(), shape)
     else:
         assert isinstance(arrow_table["tensor"].type, DaftExtension)

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -146,17 +146,17 @@ def test_udf_equality():
     assert not expr_structurally_equal(udf1("x"), udf1("y"))
 
 
-def test_udf_return_numpy():
-    @udf(return_dtype=DataType.python())
+def test_udf_return_tensor():
+    @udf(return_dtype=DataType.tensor(DataType.float64()))
     def np_udf(x):
-        return [np.ones((3,)) * i for i in x.to_pylist()]
+        return [np.ones((3, 3)) * i for i in x.to_pylist()]
 
     expr = np_udf(col("x"))
     table = Table.from_pydict({"x": [0, 1, 2]})
     result = table.eval_expression_list([expr])
     assert len(result.to_pydict()["x"]) == 3
     for i in range(3):
-        np.testing.assert_array_equal(result.to_pydict()["x"][i], np.ones((3,)) * i)
+        np.testing.assert_array_equal(result.to_pydict()["x"][i], np.ones((3, 3)) * i)
 
 
 @pytest.mark.skip(

--- a/tests/ray/test_datasets.py
+++ b/tests/ray/test_datasets.py
@@ -91,7 +91,8 @@ def test_to_ray_dataset_with_py(n_partitions: int):
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_with_numpy(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
-    df = df.with_column("npcol", df["intcol"].apply(lambda _: np.ones((3, 3)), DataType.python()))
+    shape = (3, 3)
+    df = df.with_column("npcol", df["intcol"].apply(lambda _: np.ones(shape), DataType.tensor(DataType.int64(), shape)))
     ds = df.to_ray_dataset()
 
     if RAY_VERSION < (2, 4, 0):
@@ -123,7 +124,7 @@ def test_to_ray_dataset_with_numpy(n_partitions: int):
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_with_numpy_variable_shaped(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
-    df = df.with_column("npcol", df["intcol"].apply(lambda x: np.ones((x, 3)), DataType.python()))
+    df = df.with_column("npcol", df["intcol"].apply(lambda x: np.ones((x, 3)), DataType.tensor(DataType.int64())))
     ds = df.to_ray_dataset()
 
     if RAY_VERSION < (2, 4, 0):

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -253,6 +253,269 @@ def test_series_cast_python_to_fixed_shape_image() -> None:
     np.testing.assert_equal(data[:-1], pydata[:-1])
 
 
+def test_series_cast_numpy_to_tensor() -> None:
+    data = [
+        np.arange(12, dtype=np.uint8).reshape((2, 2, 3)),
+        np.arange(12, 39, dtype=np.uint8).reshape((3, 3, 3)),
+        None,
+    ]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.tensor(DataType.uint8())
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+    assert len(t) == len(data)
+
+    pydata = t.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(data[:-1], pydata[:-1])
+
+
+def test_series_cast_numpy_to_fixed_shape_tensor() -> None:
+    shape = (2, 2)
+    data = [
+        np.arange(4, dtype=np.uint8).reshape(shape),
+        np.arange(4, 8, dtype=np.uint8).reshape(shape),
+        None,
+    ]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.tensor(DataType.uint8(), shape)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+    assert len(t) == len(data)
+
+    pydata = t.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(data[:-1], pydata[:-1])
+
+
+def test_series_cast_image_to_fixed_shape_image() -> None:
+    height = 2
+    width = 2
+    shape = (height, width, 3)
+    data = [np.arange(12, dtype=np.uint8).reshape(shape), np.arange(12, 24, dtype=np.uint8).reshape(shape), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("RGB")
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    target_dtype = DataType.image("RGB", height, width)
+    u = t.cast(target_dtype)
+
+    assert u.datatype() == target_dtype
+    assert len(u) == len(data)
+
+    pydata = u.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(pydata[:-1], data[:-1])
+
+
+def test_series_cast_image_to_tensor() -> None:
+    data = [
+        np.arange(12, dtype=np.uint8).reshape((2, 2, 3)),
+        np.arange(12, 39, dtype=np.uint8).reshape((3, 3, 3)),
+        None,
+    ]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("RGB")
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    target_dtype = DataType.tensor(DataType.uint8())
+
+    u = t.cast(target_dtype)
+
+    assert u.datatype() == target_dtype
+    assert len(u) == len(data)
+
+    pydata = u.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(data[:-1], pydata[:-1])
+
+
+def test_series_cast_image_to_fixed_shape_tensor() -> None:
+    height = 2
+    width = 2
+    shape = (height, width, 3)
+    data = [np.arange(12, dtype=np.uint8).reshape(shape), np.arange(12, 24, dtype=np.uint8).reshape(shape), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("RGB")
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    target_dtype = DataType.tensor(DataType.uint8(), shape)
+    u = t.cast(target_dtype)
+
+    assert u.datatype() == target_dtype
+    assert len(u) == len(data)
+
+    pydata = u.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(pydata[:-1], data[:-1])
+
+
+def test_series_cast_fixed_shape_image_to_image() -> None:
+    height = 2
+    width = 2
+    shape = (height, width, 3)
+    data = [np.arange(12, dtype=np.uint8).reshape(shape), np.arange(12, 24, dtype=np.uint8).reshape(shape), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("RGB", height, width)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    target_dtype = DataType.image("RGB")
+    u = t.cast(target_dtype)
+
+    assert u.datatype() == target_dtype
+    assert len(u) == len(data)
+
+    pydata = u.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(pydata[:-1], data[:-1])
+
+
+def test_series_cast_fixed_shape_image_to_fixed_shape_tensor() -> None:
+    height = 2
+    width = 2
+    shape = (height, width, 3)
+    data = [np.arange(12, dtype=np.uint8).reshape(shape), np.arange(12, 24, dtype=np.uint8).reshape(shape), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("RGB", height, width)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    target_dtype = DataType.tensor(DataType.uint8(), shape)
+    u = t.cast(target_dtype)
+
+    assert u.datatype() == target_dtype
+    assert len(u) == len(data)
+
+    pydata = u.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(pydata[:-1], data[:-1])
+
+
+def test_series_cast_fixed_shape_image_to_tensor() -> None:
+    height = 2
+    width = 2
+    shape = (height, width, 3)
+    data = [np.arange(12, dtype=np.uint8).reshape(shape), np.arange(12, 24, dtype=np.uint8).reshape(shape), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.image("RGB", height, width)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    target_dtype = DataType.tensor(DataType.uint8())
+    u = t.cast(target_dtype)
+
+    assert u.datatype() == target_dtype
+    assert len(u) == len(data)
+
+    pydata = u.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(pydata[:-1], data[:-1])
+
+
+def test_series_cast_fixed_shape_tensor_to_tensor() -> None:
+    shape = (2, 2, 3)
+    data = [np.arange(12, dtype=np.uint8).reshape(shape), np.arange(12, 24, dtype=np.uint8).reshape(shape), None]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.tensor(DataType.uint8(), shape)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    target_dtype = DataType.tensor(DataType.uint8())
+    u = t.cast(target_dtype)
+
+    assert u.datatype() == target_dtype
+    assert len(u) == len(data)
+
+    pydata = u.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(pydata[:-1], data[:-1])
+
+
+def test_series_cast_embedding_to_fixed_shape_tensor() -> None:
+    shape = (4,)
+    data = [
+        np.arange(4, dtype=np.uint8).reshape(shape),
+        np.arange(4, 8, dtype=np.uint8).reshape(shape),
+        None,
+    ]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.embedding("arr", DataType.uint8(), 4)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    target_dtype = DataType.tensor(DataType.uint8(), shape)
+
+    u = t.cast(target_dtype)
+
+    assert u.datatype() == target_dtype
+    assert len(u) == len(data)
+
+    pydata = u.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(data[:-1], pydata[:-1])
+
+
+def test_series_cast_embedding_to_tensor() -> None:
+    shape = (4,)
+    data = [
+        np.arange(4, dtype=np.uint8).reshape(shape),
+        np.arange(4, 8, dtype=np.uint8).reshape(shape),
+        None,
+    ]
+    s = Series.from_pylist(data, pyobj="force")
+
+    target_dtype = DataType.embedding("arr", DataType.uint8(), 4)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    target_dtype = DataType.tensor(DataType.uint8())
+
+    u = t.cast(target_dtype)
+
+    assert u.datatype() == target_dtype
+    assert len(u) == len(data)
+
+    pydata = u.to_pylist()
+    assert pydata[-1] is None
+    np.testing.assert_equal(data[:-1], pydata[:-1])
+
+
 @pytest.mark.parametrize(
     "timeunit",
     [

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -190,7 +190,7 @@ def test_series_cast_python_to_embedding(dtype) -> None:
 
 def test_series_cast_numpy_to_image() -> None:
     data = [
-        np.arange(12, dtype=np.uint8).reshape((3, 2, 2)),
+        np.arange(12, dtype=np.uint8).reshape((2, 2, 3)),
         np.arange(12, 39, dtype=np.uint8).reshape((3, 3, 3)),
         None,
     ]
@@ -236,7 +236,7 @@ def test_series_cast_python_to_fixed_shape_image() -> None:
     height = 2
     width = 2
     shape = (height, width, 3)
-    data = [np.arange(12).reshape(shape), np.arange(12, 24).reshape(shape), None]
+    data = [np.arange(12, dtype=np.uint8).reshape(shape), np.arange(12, 24, dtype=np.uint8).reshape(shape), None]
     s = Series.from_pylist(data, pyobj="force")
 
     target_dtype = DataType.image("RGB", height, width)

--- a/tests/series/test_concat.py
+++ b/tests/series/test_concat.py
@@ -9,6 +9,7 @@ from ray.data.extensions import ArrowTensorArray
 
 from daft import DataType, Series
 from daft.context import get_context
+from daft.utils import pyarrow_supports_fixed_shape_tensor
 from tests.conftest import *
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES, ARROW_STRING_TYPES
 
@@ -113,12 +114,8 @@ def test_series_concat_tensor_array_ray(chunks) -> None:
 
 
 @pytest.mark.skipif(
-    ARROW_VERSION < (12, 0, 0),
+    not pyarrow_supports_fixed_shape_tensor(),
     reason=f"Arrow version {ARROW_VERSION} doesn't support the canonical tensor extension type.",
-)
-@pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
-    reason="Pickling canonical tensor extension type is not supported by pyarrow",
 )
 @pytest.mark.parametrize("chunks", [1, 2, 3, 10])
 def test_series_concat_tensor_array_canonical(chunks) -> None:

--- a/tests/series/test_concat.py
+++ b/tests/series/test_concat.py
@@ -137,8 +137,8 @@ def test_series_concat_tensor_array_canonical(chunks) -> None:
 
     concated = Series.concat(series)
 
-    assert concated.datatype() == DataType.extension(
-        "arrow.fixed_shape_tensor", DataType.from_arrow_type(ext_arrays[0].type.storage_type), '{"shape":[2,2]}'
+    assert concated.datatype() == DataType.tensor(
+        DataType.from_arrow_type(ext_arrays[0].type.storage_type.value_type), (2, 2)
     )
     expected = [chunk[i] for chunk in chunks for i in range(len(chunk))]
     concated_arrow = concated.to_arrow()

--- a/tests/series/test_concat.py
+++ b/tests/series/test_concat.py
@@ -107,7 +107,7 @@ def test_series_concat_tensor_array_ray(chunks) -> None:
 
     concated = Series.concat(series)
 
-    assert concated.datatype() == DataType.python()
+    assert concated.datatype() == DataType.tensor(DataType.int64(), element_shape)
     expected = [chunk[i] for chunk in chunks for i in range(len(chunk))]
     np.testing.assert_equal(concated.to_pylist(), expected)
 

--- a/tests/series/test_filter.py
+++ b/tests/series/test_filter.py
@@ -7,6 +7,7 @@ import pytest
 from daft.context import get_context
 from daft.datatype import DataType
 from daft.series import Series
+from daft.utils import pyarrow_supports_fixed_shape_tensor
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES, ARROW_STRING_TYPES
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
@@ -134,18 +135,15 @@ def test_series_filter_on_extension_array(uuid_ext_type) -> None:
 
 
 @pytest.mark.skipif(
-    ARROW_VERSION < (12, 0, 0),
+    not pyarrow_supports_fixed_shape_tensor(),
     reason=f"Arrow version {ARROW_VERSION} doesn't support the canonical tensor extension type.",
-)
-@pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
-    reason="Pickling canonical tensor extension type is not supported by pyarrow",
 )
 def test_series_filter_on_canonical_tensor_extension_array() -> None:
     arr = np.arange(20).reshape((5, 2, 2))
     data = pa.FixedShapeTensorArray.from_numpy_ndarray(arr)
 
     s = Series.from_arrow(data)
+    assert s.datatype() == DataType.tensor(DataType.int64(), (2, 2))
     pymask = [False, True, True, None, False]
     mask = Series.from_pylist(pymask)
 

--- a/tests/series/test_filter.py
+++ b/tests/series/test_filter.py
@@ -153,7 +153,7 @@ def test_series_filter_on_canonical_tensor_extension_array() -> None:
 
     assert s.datatype() == result.datatype()
     expected = [val for val, keep in zip(s.to_pylist(), pymask) if keep]
-    assert result.to_pylist() == expected
+    np.testing.assert_equal(result.to_pylist(), expected)
 
 
 @pytest.mark.parametrize("dtype", ARROW_INT_TYPES + ARROW_FLOAT_TYPES + ARROW_STRING_TYPES)

--- a/tests/series/test_if_else.py
+++ b/tests/series/test_if_else.py
@@ -7,6 +7,7 @@ import pytest
 from daft import Series
 from daft.context import get_context
 from daft.datatype import DataType
+from daft.utils import pyarrow_supports_fixed_shape_tensor
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
 
@@ -348,12 +349,8 @@ def test_series_if_else_extension_type(uuid_ext_type, if_true_storage, if_false_
 
 
 @pytest.mark.skipif(
-    ARROW_VERSION < (12, 0, 0),
+    not pyarrow_supports_fixed_shape_tensor(),
     reason=f"Arrow version {ARROW_VERSION} doesn't support the canonical tensor extension type.",
-)
-@pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
-    reason="Pickling canonical tensor extension type is not supported by pyarrow",
 )
 @pytest.mark.parametrize(
     ["if_true", "if_false", "expected"],

--- a/tests/series/test_if_else.py
+++ b/tests/series/test_if_else.py
@@ -397,8 +397,8 @@ def test_series_if_else_canonical_tensor_extension_type(if_true, if_false, expec
 
     result = predicate_series.if_else(if_true_series, if_false_series)
 
-    assert result.datatype() == DataType.extension(
-        "arrow.fixed_shape_tensor", DataType.from_arrow_type(if_true_arrow.type.storage_type), '{"shape":[2,2]}'
+    assert result.datatype() == DataType.tensor(
+        DataType.from_arrow_type(if_true_arrow.type.storage_type.value_type), (2, 2)
     )
     result_arrow = result.to_arrow()
     np.testing.assert_equal(result_arrow.to_numpy_ndarray(), expected)

--- a/tests/series/test_size_bytes.py
+++ b/tests/series/test_size_bytes.py
@@ -233,7 +233,5 @@ def test_series_canonical_tensor_extension_type_size_bytes(dtype, size, with_nul
 
     s = Series.from_arrow(data)
 
-    assert s.datatype() == DataType.extension(
-        "arrow.fixed_shape_tensor", DataType.from_arrow_type(data.type.storage_type), '{"shape":[2,2]}'
-    )
+    assert s.datatype() == DataType.tensor(DataType.from_arrow_type(data.type.storage_type.value_type), (2, 2))
     assert s.size_bytes() == get_total_buffer_size(data)

--- a/tests/series/test_size_bytes.py
+++ b/tests/series/test_size_bytes.py
@@ -10,6 +10,7 @@ import pytest
 from daft.context import get_context
 from daft.datatype import DataType
 from daft.series import Series
+from daft.utils import pyarrow_supports_fixed_shape_tensor
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
@@ -209,12 +210,8 @@ def test_series_extension_type_size_bytes(uuid_ext_type, size, with_nulls) -> No
 
 
 @pytest.mark.skipif(
-    ARROW_VERSION < (12, 0, 0),
+    not pyarrow_supports_fixed_shape_tensor(),
     reason=f"Arrow version {ARROW_VERSION} doesn't support the canonical tensor extension type.",
-)
-@pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
-    reason="Pickling canonical tensor extension type is not supported by pyarrow",
 )
 @pytest.mark.parametrize("dtype, size", itertools.product(ARROW_INT_TYPES + ARROW_FLOAT_TYPES, [0, 1, 2, 8, 9, 16]))
 @pytest.mark.parametrize("with_nulls", [True, False])

--- a/tests/series/test_take.py
+++ b/tests/series/test_take.py
@@ -7,6 +7,7 @@ import pytest
 from daft.context import get_context
 from daft.datatype import DataType
 from daft.series import Series
+from daft.utils import pyarrow_supports_fixed_shape_tensor
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES, ARROW_STRING_TYPES
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
@@ -145,12 +146,8 @@ def test_series_extension_type_take(uuid_ext_type) -> None:
 
 
 @pytest.mark.skipif(
-    ARROW_VERSION < (12, 0, 0),
+    not pyarrow_supports_fixed_shape_tensor(),
     reason=f"Arrow version {ARROW_VERSION} doesn't support the canonical tensor extension type.",
-)
-@pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
-    reason="Pickling canonical tensor extension type is not supported by pyarrow",
 )
 def test_series_canonical_tensor_extension_type_take() -> None:
     pydata = np.arange(24).reshape((6, 4)).tolist()

--- a/tests/series/test_take.py
+++ b/tests/series/test_take.py
@@ -156,13 +156,12 @@ def test_series_canonical_tensor_extension_type_take() -> None:
     pydata = np.arange(24).reshape((6, 4)).tolist()
     pydata[2] = None
     storage = pa.array(pydata, pa.list_(pa.int64(), 4))
-    tensor_type = pa.fixed_shape_tensor(pa.int64(), (2, 2))
+    shape = (2, 2)
+    tensor_type = pa.fixed_shape_tensor(pa.int64(), shape)
     data = pa.FixedShapeTensorArray.from_storage(tensor_type, storage)
 
     s = Series.from_arrow(data)
-    assert s.datatype() == DataType.extension(
-        "arrow.fixed_shape_tensor", DataType.from_arrow_type(tensor_type.storage_type), '{"shape":[2,2]}'
-    )
+    assert s.datatype() == DataType.tensor(DataType.from_arrow_type(tensor_type.storage_type.value_type), shape)
     pyidx = [2, 0, None, 5]
     idx = Series.from_pylist(pyidx)
 
@@ -172,7 +171,7 @@ def test_series_canonical_tensor_extension_type_take() -> None:
 
     original_data = s.to_pylist()
     expected = [original_data[i] if i is not None else None for i in pyidx]
-    assert result.to_pylist() == expected
+    np.testing.assert_equal(result.to_pylist(), expected)
 
 
 def test_series_deeply_nested_take() -> None:

--- a/tests/series/test_tensor.py
+++ b/tests/series/test_tensor.py
@@ -8,6 +8,7 @@ import pytest
 
 from daft.datatype import DaftExtension, DataType
 from daft.series import Series
+from daft.utils import pyarrow_supports_fixed_shape_tensor
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
@@ -79,7 +80,7 @@ def test_fixed_shape_tensor_roundtrip(dtype):
     # Test Arrow roundtrip.
     arrow_arr = t.to_arrow()
 
-    if ARROW_VERSION >= (12, 0, 0):
+    if pyarrow_supports_fixed_shape_tensor():
         assert arrow_arr.type == pa.fixed_shape_tensor(dtype, shape)
     else:
         assert isinstance(arrow_arr.type, DaftExtension)

--- a/tests/series/test_tensor.py
+++ b/tests/series/test_tensor.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+from daft.datatype import DaftExtension, DataType
+from daft.series import Series
+from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES
+
+
+@pytest.mark.parametrize("dtype", ARROW_INT_TYPES + ARROW_FLOAT_TYPES)
+def test_tensor_roundtrip(dtype):
+    np_dtype = dtype.to_pandas_dtype()
+    data = [
+        np.arange(8, dtype=np_dtype).reshape((2, 2, 2)),
+        np.arange(8, 32, dtype=np_dtype).reshape((2, 2, 3, 2)),
+        None,
+    ]
+    s = Series.from_pylist(data, pyobj="allow")
+
+    daft_dtype = DataType.tensor(DataType.from_arrow_type(dtype))
+
+    assert s.datatype() == daft_dtype
+
+    # Test pylist roundtrip.
+    back_dtype = DataType.python()
+    back = s.cast(back_dtype)
+
+    assert back.datatype() == back_dtype
+
+    out = back.to_pylist()
+    np.testing.assert_equal(out, data)
+
+    # Test Arrow roundtrip.
+    arrow_arr = s.to_arrow()
+
+    assert isinstance(arrow_arr.type, DaftExtension)
+    from_arrow = Series.from_arrow(arrow_arr)
+
+    assert from_arrow.datatype() == s.datatype()
+    np.testing.assert_equal(from_arrow.to_pylist(), s.to_pylist())
+
+    s_copy = copy.deepcopy(s)
+    assert s_copy.datatype() == s.datatype()
+    np.testing.assert_equal(s_copy.to_pylist(), s.to_pylist())
+
+
+@pytest.mark.parametrize("dtype", ARROW_INT_TYPES + ARROW_FLOAT_TYPES)
+def test_fixed_shape_tensor_roundtrip(dtype):
+    np_dtype = dtype.to_pandas_dtype()
+    shape = (3, 2, 2)
+    data = [
+        np.arange(12, dtype=np_dtype).reshape(shape),
+        np.arange(12, 24, dtype=np_dtype).reshape(shape),
+        None,
+    ]
+    s = Series.from_pylist(data, pyobj="allow")
+
+    target_dtype = DataType.tensor(DataType.from_arrow_type(dtype), shape)
+
+    t = s.cast(target_dtype)
+
+    assert t.datatype() == target_dtype
+
+    # Test pylist roundtrip.
+    back_dtype = DataType.python()
+    back = t.cast(back_dtype)
+
+    assert back.datatype() == back_dtype
+
+    out = back.to_pylist()
+    np.testing.assert_equal(out, data)
+
+    # Test Arrow roundtrip.
+    arrow_arr = t.to_arrow()
+
+    assert isinstance(arrow_arr.type, DaftExtension)
+    from_arrow = Series.from_arrow(t.to_arrow())
+
+    assert from_arrow.datatype() == t.datatype()
+    np.testing.assert_equal(from_arrow.to_pylist(), t.to_pylist())
+
+    t_copy = copy.deepcopy(t)
+    assert t_copy.datatype() == t.datatype()
+    np.testing.assert_equal(t_copy.to_pylist(), t.to_pylist())
+
+
+@pytest.mark.parametrize("dtype", ARROW_INT_TYPES + ARROW_FLOAT_TYPES)
+@pytest.mark.parametrize("fixed_shape", [True, False])
+def test_tensor_numpy_inference(dtype, fixed_shape):
+    np_dtype = dtype.to_pandas_dtype()
+    if fixed_shape:
+        shape = (2, 2)
+        arr = np.arange(np.prod(shape), dtype=np_dtype).reshape(shape)
+        arrs = [arr, arr, None]
+    else:
+        shape1 = (2, 2)
+        shape2 = (3, 3)
+        arr1 = np.arange(np.prod(shape1), dtype=np_dtype).reshape(shape1)
+        arr2 = np.arange(np.prod(shape1), np.prod(shape1) + np.prod(shape2), dtype=np_dtype).reshape(shape2)
+        arrs = [arr1, arr2, None]
+    s = Series.from_pylist(arrs, pyobj="allow")
+    assert s.datatype() == DataType.tensor(DataType.from_arrow_type(dtype))
+    out = s.to_pylist()
+    np.testing.assert_equal(out, arrs)

--- a/tests/table/test_from_py.py
+++ b/tests/table/test_from_py.py
@@ -8,7 +8,6 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pac
 import pytest
-from ray.data.extensions import ArrowTensorArray, ArrowTensorType
 
 from daft import DataType, TimeUnit
 from daft.context import get_context
@@ -28,11 +27,10 @@ PYTHON_TYPE_ARRAYS = {
     "struct": [{"a": 1, "b": 2.0}, {"b": 3.0}],
     "empty_struct": [{}, {}],
     "null": [None, None],
+    "tensor": [np.ones((2, 2), np.int64), np.ones((3, 3), np.int64)],
     # The following types are not natively supported and will be cast to Python object types.
-    "tensor": list(np.arange(8).reshape(2, 2, 2)),
     "timestamp": [datetime.datetime.now(), datetime.datetime.now()],
 }
-
 
 PYTHON_INFERRED_TYPES = {
     "int": DataType.int64(),
@@ -45,9 +43,8 @@ PYTHON_INFERRED_TYPES = {
     "struct": DataType.struct({"a": DataType.int64(), "b": DataType.float64()}),
     "empty_struct": DataType.struct({"": DataType.null()}),
     "null": DataType.null(),
+    "tensor": DataType.tensor(DataType.int64()),
     # The following types are not natively supported and will be cast to Python object types.
-    # TODO(Clark): Change the tensor inferred type to be the canonical fixed-shape tensor extension type.
-    "tensor": DataType.python(),
     "timestamp": DataType.timestamp(TimeUnit.us()),
 }
 
@@ -67,8 +64,8 @@ ROUNDTRIP_TYPES = {
     "struct": pa.struct({"a": pa.int64(), "b": pa.float64()}),
     "empty_struct": pa.struct({"": pa.null()}),
     "null": pa.null(),
+    "tensor": PYTHON_INFERRED_TYPES["tensor"].to_arrow_dtype(),
     # The following types are not natively supported and will be cast to Python object types.
-    "tensor": ArrowTensorType(shape=(2, 2), dtype=pa.int64()),
     "timestamp": pa.timestamp("us"),
 }
 
@@ -93,8 +90,22 @@ ARROW_TYPE_ARRAYS = {
     "struct": pa.array(PYTHON_TYPE_ARRAYS["struct"], pa.struct([("a", pa.int64()), ("b", pa.float64())])),
     "empty_struct": pa.array(PYTHON_TYPE_ARRAYS["empty_struct"], pa.struct({"": pa.null()})),
     "null": pa.array(PYTHON_TYPE_ARRAYS["null"], pa.null()),
+    "tensor": pa.ExtensionArray.from_storage(
+        ROUNDTRIP_TYPES["tensor"],
+        pa.array(
+            [
+                {"data": PYTHON_TYPE_ARRAYS["tensor"][0].ravel(), "shape": [2, 2]},
+                {"data": PYTHON_TYPE_ARRAYS["tensor"][1].ravel(), "shape": [3, 3]},
+            ],
+            pa.struct(
+                {
+                    "data": pa.large_list(pa.field("data", pa.int64())),
+                    "shape": pa.large_list(pa.field("shape", pa.uint64())),
+                }
+            ),
+        ),
+    ),
     # The following types are not natively supported and will be cast to Python object types.
-    "tensor": ArrowTensorArray.from_numpy(PYTHON_TYPE_ARRAYS["tensor"]),
     "timestamp": pa.array(PYTHON_TYPE_ARRAYS["timestamp"]),
 }
 
@@ -119,16 +130,20 @@ ARROW_ROUNDTRIP_TYPES = {
     "struct": pa.struct([("a", pa.int64()), ("b", pa.float64())]),
     "empty_struct": pa.struct({"": pa.null()}),
     "null": pa.null(),
+    "tensor": PYTHON_INFERRED_TYPES["tensor"].to_arrow_dtype(),
     # The following types are not natively supported and will be cast to Python object types.
-    "tensor": ArrowTensorType(shape=(2, 2), dtype=pa.int64()),
     "timestamp": pa.timestamp("us"),
 }
 
 if ARROW_VERSION >= (12, 0, 0) and get_context().runner_config.name != "ray":
-    ARROW_ROUNDTRIP_TYPES["canonical_tensor"] = pa.fixed_shape_tensor(pa.int64(), (2, 2))
-    ARROW_TYPE_ARRAYS["canonical_tensor"] = pa.FixedShapeTensorArray.from_numpy_ndarray(
-        np.array(PYTHON_TYPE_ARRAYS["tensor"])
-    )
+    arrow_tensor_dtype = pa.fixed_shape_tensor(pa.int64(), (2, 2))
+    # NOTE: We don't infer fixed-shape tensors when constructing a table from Python objects, since
+    # the shapes may be variable across partitions.
+    # PYTHON_TYPE_ARRAYS["canonical_tensor"] = list(np.arange(8).reshape(2, 2, 2))
+    # PYTHON_INFERRED_TYPES["canonical_tensor"] = DataType.tensor(DataType.int64(), (2, 2))
+    # ROUNDTRIP_TYPES["canonical_tensor"] = arrow_tensor_dtype
+    ARROW_ROUNDTRIP_TYPES["canonical_tensor"] = arrow_tensor_dtype
+    ARROW_TYPE_ARRAYS["canonical_tensor"] = pa.FixedShapeTensorArray.from_numpy_ndarray(np.arange(8).reshape(2, 2, 2))
 
 
 def _with_uuid_ext_type(uuid_ext_type) -> tuple[dict, dict]:
@@ -153,7 +168,7 @@ def test_from_pydict_roundtrip() -> None:
     arrs = {}
     for col_name, col in PYTHON_TYPE_ARRAYS.items():
         if col_name == "tensor":
-            arrs[col_name] = ArrowTensorArray.from_numpy(col)
+            arrs[col_name] = ARROW_TYPE_ARRAYS[col_name]
         else:
             arrs[col_name] = pa.array(col, type=schema.field(col_name).type)
     expected_table = pa.table(arrs, schema=schema)
@@ -190,9 +205,6 @@ def test_from_pandas_roundtrip() -> None:
     assert set(table.column_names()) == set(PYTHON_TYPE_ARRAYS.keys())
     for field in table.schema():
         assert field.dtype == PANDAS_INFERRED_TYPES[field.name]
-    # pyarrow --> pandas doesn't preserve the datetime type for the "date" column, so we need to
-    # convert it before the comparison.
-    df["date"] = pd.to_datetime(df["date"]).astype("datetime64[s]")
     # pyarrow --> pandas will insert explicit Nones within the struct fields.
     df["struct"][1]["a"] = None
     df["empty_struct"][0][""] = None

--- a/tests/table/test_from_py.py
+++ b/tests/table/test_from_py.py
@@ -13,6 +13,7 @@ from daft import DataType, TimeUnit
 from daft.context import get_context
 from daft.series import Series
 from daft.table import Table
+from daft.utils import pyarrow_supports_fixed_shape_tensor
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
 
@@ -135,7 +136,7 @@ ARROW_ROUNDTRIP_TYPES = {
     "timestamp": pa.timestamp("us"),
 }
 
-if ARROW_VERSION >= (12, 0, 0) and get_context().runner_config.name != "ray":
+if pyarrow_supports_fixed_shape_tensor():
     arrow_tensor_dtype = pa.fixed_shape_tensor(pa.int64(), (2, 2))
     # NOTE: We don't infer fixed-shape tensors when constructing a table from Python objects, since
     # the shapes may be variable across partitions.


### PR DESCRIPTION
This PR adds basic support for `Tensor` and `FixedShapeTensor` types, allowing us to represent arbitrary n-dimensional arrays in dataframe columns.

### Heterogeneous/ragged tensor type

```python
    data = [
        np.arange(8,).reshape((2, 2, 2)),
        np.arange(8, 32).reshape((2, 2, 3, 2)),
        None,
    ]
    s = Series.from_pylist(data, pyobj="force")
    s = s.cast(DataType.tensor(DateType::Int64))
```

### Homogeneous/fixed-shape tensor type

```python
    shape = (3, 2, 2)
    data = [
        np.arange(12, dtype=np_dtype).reshape(shape),
        np.arange(12, 24, dtype=np_dtype).reshape(shape),
        None,
    ]
    s = Series.from_pylist(data, pyobj="force")
    s = s.cast(DataType.tensor(DateType::Int64, shape))
```

### TODOs

- [x] DataFrame-level test coverage.
- [x] Add repr for tensor types.
- [x] Convert NumPy ndarrays to `Tensor` type on Python ingress (`Series.from_pylist()`).
- [x] Convert `Tensor` type to NumPy ndarrays on Python egress (`Series.to_pylist()`).
- [x] Casting between tensor types.
- [x] Casting to/from image types.
- [x]  Convert pyarrow `fixed_shape_tensor` extension type to `FixedShapeTensor` type on Arrow ingress.
- [x] Convert `FixedShapeTensor` type to pyarrow `fixed_shape_tensor` extension type on Arrow egress.
- [x] Casting to/from embedding type.
- [ ] Add some basic kernels that delegate to the `ndarray` crate.