### PR TITLE
[BUG] Reenable HTML viz hooks for np.ndarray and PIL Images

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -106,7 +106,7 @@ class Series:
         except pa.lib.ArrowInvalid:
             if pyobj == "disallow":
                 raise
-            pys = PySeries.from_pylist(name, data)
+            pys = PySeries.from_pylist(name, data, pyobj=pyobj)
             return Series._from_pyseries(pys)
 
     @classmethod

--- a/daft/series.py
+++ b/daft/series.py
@@ -97,7 +97,7 @@ class Series:
             raise ValueError(f"pyobj: expected either 'allow', 'disallow', or 'force', but got {pyobj})")
 
         if pyobj == "force":
-            pys = PySeries.from_pylist(name, data)
+            pys = PySeries.from_pylist(name, data, pyobj=pyobj)
             return Series._from_pyseries(pys)
 
         try:

--- a/daft/viz/html_viz_hooks.py
+++ b/daft/viz/html_viz_hooks.py
@@ -14,13 +14,13 @@ HookClass = TypeVar("HookClass")
 _VIZ_HOOKS_REGISTRY = {}
 
 
-def register_viz_hook(klass: type[HookClass], hook: Callable[[HookClass], str]):
+def register_viz_hook(klass: type[HookClass], hook: Callable[[object], str]):
     """Registers a visualization hook that returns the appropriate HTML for
     visualizing a specific class in HTML"""
     _VIZ_HOOKS_REGISTRY[klass] = hook
 
 
-def get_viz_hook(val: HookClass) -> Callable[[HookClass], str] | None:
+def get_viz_hook(val: object) -> Callable[[object], str] | None:
     for klass in _VIZ_HOOKS_REGISTRY:
         if isinstance(val, klass):
             return _VIZ_HOOKS_REGISTRY[klass]
@@ -45,7 +45,7 @@ except ImportError:
 
 if HAS_PILLOW:
 
-    def _viz_pil_image(val: PIL.Image.Image):
+    def _viz_pil_image(val: PIL.Image.Image) -> str:
         img = val.copy()
         img.thumbnail((128, 128))
         bio = io.BytesIO()
@@ -57,7 +57,7 @@ if HAS_PILLOW:
 
 if HAS_NUMPY:
 
-    def _viz_numpy(val: np.ndarray):
+    def _viz_numpy(val: np.ndarray) -> str:
         return f"&ltnp.ndarray<br>shape={val.shape}<br>dtype={val.dtype}&gt"
 
     register_viz_hook(np.ndarray, _viz_numpy)

--- a/tests/dataframe/test_logical_type.py
+++ b/tests/dataframe/test_logical_type.py
@@ -32,7 +32,7 @@ def test_image_type_df(from_pil_imgs) -> None:
     ]
     if from_pil_imgs:
         data = [Image.fromarray(arr, mode="RGB") if arr is not None else None for arr in data]
-    df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="force")})
+    df = daft.from_pydict({"index": np.arange(len(data)), "image": Series.from_pylist(data, pyobj="allow")})
 
     image_expr = col("image")
     if not from_pil_imgs:

--- a/tests/series/test_image.py
+++ b/tests/series/test_image.py
@@ -178,7 +178,7 @@ def test_image_pil_inference(fixed_shape, mode):
             if arr is not None:
                 arr[..., -1] = 255
     imgs = [Image.fromarray(arr, mode=mode) if arr is not None else None for arr in arrs]
-    s = Series.from_pylist(imgs, pyobj="force")
+    s = Series.from_pylist(imgs, pyobj="allow")
     assert s.datatype() == DataType.image(mode)
     out = s.to_pylist()
     if num_channels == 1:
@@ -206,7 +206,12 @@ def test_image_pil_inference_mixed():
         else None
         for arr in arrs
     ]
+
+    # Forcing should still create Python Series
     s = Series.from_pylist(imgs, pyobj="force")
+    assert s.datatype() == DataType.python()
+
+    s = Series.from_pylist(imgs, pyobj="allow")
     assert s.datatype() == DataType.image()
     out = s.to_pylist()
     arrs[3] = np.expand_dims(arrs[3], axis=-1)


### PR DESCRIPTION
Closes: #1077 and #1075 

* Adds a fix for `Series.from_pylist(..., pyobj="force")` when the list is a list of PIL Images (cc @clarkzinzow)
* Re-enables our HTML viz hooks in Python, for Python objects when calling into the HTML repr for Python arrays