### PR TITLE
[CHORE] Fix filepath for autogeneration of .list.join docs

### DIFF
--- a/docs/source/api_docs/expressions.rst
+++ b/docs/source/api_docs/expressions.rst
@@ -169,7 +169,7 @@ Operations on nested types (such as List and FixedSizeList), accessible through 
 Example: ``e1.str.concat(e2)``
 
 .. autosummary::
-    :toctree: expression_methods
+    :toctree: doc_gen/expression_methods
 
     daft.expressions.expressions.ExpressionListNamespace.join
 


### PR DESCRIPTION
This should fix the bad generation of `.rst` files for `ExpressionListNamespace.join`

cc @samster25 