### PR TITLE
[CHORE] unpin numpy version for py<3.8

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,8 +19,8 @@ lxml==4.9.2
 dask==2022.2.0; python_version < '3.8'
 dask==2023.5.0; python_version == '3.8'
 dask==2023.6.0; python_version >= '3.9'
-numpy; python_version < '3.8'
-numpy==1.25.0; python_version >= '3.8'
+numpy; python_version < '3.9'
+numpy==1.25.0; python_version >= '3.9'
 pandas==1.3.5; python_version < '3.8'
 pandas==2.0.2; python_version >= '3.8'
 xxhash>=3.0.0


### PR DESCRIPTION
Unpins numpy for Python 3.8, which has been dropped by Numpy 1.25.0