### PR TITLE
[FEAT] Automatic Region Retrying for S3 Native Downloader

### DIFF
--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -68,8 +68,8 @@ lazy_static! {
 }
 
 impl HttpSource {
-    pub async fn get_client() -> Arc<Self> {
-        HTTP_CLIENT.clone()
+    pub async fn get_client() -> super::Result<Arc<Self>> {
+        Ok(HTTP_CLIENT.clone())
     }
 }
 

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use futures::{StreamExt, TryStreamExt};
+use lazy_static::lazy_static;
 use snafu::{IntoError, ResultExt, Snafu};
 
 use super::object_io::{GetResult, ObjectSource};
@@ -57,11 +60,16 @@ impl From<Error> for super::Error {
     }
 }
 
+lazy_static! {
+    static ref HTTP_CLIENT: Arc<HttpSource> = HttpSource {
+        client: reqwest::ClientBuilder::default().build().unwrap(),
+    }
+    .into();
+}
+
 impl HttpSource {
-    pub async fn new() -> Self {
-        HttpSource {
-            client: reqwest::ClientBuilder::default().build().unwrap(),
-        }
+    pub async fn get_client() -> Arc<Self> {
+        HTTP_CLIENT.clone()
     }
 }
 

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -62,10 +62,16 @@ pub(crate) enum Error {
         path: String,
         source: url::ParseError,
     },
+
     #[snafu(display("Not a File: \"{}\"", path))]
     NotAFile { path: String },
+
+    #[snafu(display("Failed to load Credentials for store: {store} {source}"))]
+    FailedToLoadCredentials { store: SourceType, source: DynError },
+
     #[snafu(display("Source not yet implemented: {}", store))]
     NotImplementedSource { store: String },
+
     #[snafu(display("Error joining spawned task: {}", source), context(false))]
     JoinError { source: tokio::task::JoinError },
 }
@@ -84,9 +90,9 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 async fn get_source(source_type: SourceType, config: &IOConfig) -> Result<Arc<dyn ObjectSource>> {
     Ok(match source_type {
-        SourceType::File => LocalSource::get_client().await as Arc<dyn ObjectSource>,
-        SourceType::Http => HttpSource::get_client().await as Arc<dyn ObjectSource>,
-        SourceType::S3 => S3LikeSource::get_client(&config.s3).await as Arc<dyn ObjectSource>,
+        SourceType::File => LocalSource::get_client().await? as Arc<dyn ObjectSource>,
+        SourceType::Http => HttpSource::get_client().await? as Arc<dyn ObjectSource>,
+        SourceType::S3 => S3LikeSource::get_client(&config.s3).await? as Arc<dyn ObjectSource>,
     })
 }
 

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -66,8 +66,11 @@ pub(crate) enum Error {
     #[snafu(display("Not a File: \"{}\"", path))]
     NotAFile { path: String },
 
+    #[snafu(display("Unable to load Credentials for store: {store} {source}"))]
+    UnableToLoadCredentials { store: SourceType, source: DynError },
+
     #[snafu(display("Failed to load Credentials for store: {store} {source}"))]
-    FailedToLoadCredentials { store: SourceType, source: DynError },
+    UnableToCreateClient { store: SourceType, source: DynError },
 
     #[snafu(display("Source not yet implemented: {}", store))]
     NotImplementedSource { store: String },

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -5,9 +5,9 @@ use super::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
 use snafu::{ResultExt, Snafu};
+use std::sync::Arc;
 use tokio::io::AsyncReadExt;
 use url::ParseError;
-
 pub(crate) struct LocalSource {}
 
 #[derive(Debug, Snafu)]
@@ -61,8 +61,8 @@ impl From<Error> for super::Error {
 }
 
 impl LocalSource {
-    pub async fn new() -> Self {
-        LocalSource {}
+    pub async fn get_client() -> Arc<Self> {
+        LocalSource {}.into()
     }
 }
 

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -61,8 +61,8 @@ impl From<Error> for super::Error {
 }
 
 impl LocalSource {
-    pub async fn get_client() -> Arc<Self> {
-        LocalSource {}.into()
+    pub async fn get_client() -> super::Result<Arc<Self>> {
+        Ok(LocalSource {}.into())
     }
 }
 


### PR DESCRIPTION
* Enables auto retrying and client creation when a s3 fetch is different than the current bucket.
* Enables multiple s3 client to support multi region workloads
* Enables credential checking when creating s3 client and propagation