### PR TITLE
[FEAT] Enable reading a list of URLs in read_* APIs

### DIFF
--- a/daft/api_annotations.py
+++ b/daft/api_annotations.py
@@ -64,6 +64,7 @@ def type_check_function(func: Callable[..., Any], *args: Any, **kwargs: Any) -> 
         # T is a generic type, like `typing.List`
         origin_T = get_origin(T)
         if isinstance(origin_T, type):
+            print(type(T), origin_T, T)
             return isinstance(value, origin_T)
 
         # T is a higher order type, like `typing.Union`

--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -47,6 +47,8 @@ def read_csv(
             "`df.select(*[col(old).alias(new) for old, new in zip(df.column_names, MY_COL_NAMES)])`. Please submit an issue if this is a "
             "blocker for your workflow!"
         )
+    if isinstance(path, list) and len(path) == 0:
+        raise ValueError(f"Cannot read DataFrame from from empty list of CSV filepaths")
 
     plan = _get_tabular_files_scan(
         path,

--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -1,6 +1,6 @@
 # isort: dont-add-import: from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 import fsspec
 
@@ -13,7 +13,7 @@ from daft.io.common import _get_tabular_files_scan
 
 @PublicAPI
 def read_csv(
-    path: str,
+    path: Union[str, List[str]],
     schema_hints: Optional[Dict[str, DataType]] = None,
     fs: Optional[fsspec.AbstractFileSystem] = None,
     has_headers: bool = True,

--- a/daft/io/_json.py
+++ b/daft/io/_json.py
@@ -35,6 +35,9 @@ def read_json(
     returns:
         DataFrame: parsed DataFrame
     """
+    if isinstance(path, list) and len(path) == 0:
+        raise ValueError(f"Cannot read DataFrame from from empty list of JSON filepaths")
+
     plan = _get_tabular_files_scan(
         path,
         schema_hints,

--- a/daft/io/_json.py
+++ b/daft/io/_json.py
@@ -1,6 +1,6 @@
 # isort: dont-add-import: from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 import fsspec
 
@@ -13,7 +13,7 @@ from daft.io.common import _get_tabular_files_scan
 
 @PublicAPI
 def read_json(
-    path: str,
+    path: Union[str, List[str]],
     schema_hints: Optional[Dict[str, DataType]] = None,
     fs: Optional[fsspec.AbstractFileSystem] = None,
 ) -> DataFrame:

--- a/daft/io/common.py
+++ b/daft/io/common.py
@@ -17,7 +17,7 @@ def _get_schema_from_hints(hints: dict[str, DataType]) -> Schema:
 
 
 def _get_tabular_files_scan(
-    path: str,
+    path: str | list[str],
     schema_hints: dict[str, DataType] | None,
     source_info: SourceInfo,
     fs: fsspec.AbstractFileSystem | None,
@@ -25,7 +25,9 @@ def _get_tabular_files_scan(
     """Returns a TabularFilesScan LogicalPlan for a given glob filepath."""
     # Glob the path using the Runner
     runner_io = get_context().runner().runner_io()
-    listing_details_partition_set = runner_io.glob_paths_details(path, source_info, fs)
+
+    paths = path if isinstance(path, list) else [str(path)]
+    listing_details_partition_set = runner_io.glob_paths_details(paths, source_info, fs)
 
     # Infer schema if no hints provided
     inferred_or_provided_schema = (

--- a/daft/io/file_path.py
+++ b/daft/io/file_path.py
@@ -42,7 +42,7 @@ def from_glob_path(path: str, fs: Optional[fsspec.AbstractFileSystem] = None) ->
             parsed from the provided filesystem.
     """
     runner_io = get_context().runner().runner_io()
-    partition_set = runner_io.glob_paths_details(path, fs=fs)
+    partition_set = runner_io.glob_paths_details([path], fs=fs)
     cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
     filepath_plan = logical_plan.InMemoryScan(
         cache_entry=cache_entry,

--- a/daft/io/parquet.py
+++ b/daft/io/parquet.py
@@ -35,6 +35,9 @@ def read_parquet(
     returns:
         DataFrame: parsed DataFrame
     """
+    if isinstance(path, list) and len(path) == 0:
+        raise ValueError(f"Cannot read DataFrame from from empty list of Parquet filepaths")
+
     plan = _get_tabular_files_scan(
         path,
         schema_hints,

--- a/daft/io/parquet.py
+++ b/daft/io/parquet.py
@@ -1,6 +1,6 @@
 # isort: dont-add-import: from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 import fsspec
 
@@ -13,7 +13,7 @@ from daft.io.common import _get_tabular_files_scan
 
 @PublicAPI
 def read_parquet(
-    path: str,
+    path: Union[str, List[str]],
     schema_hints: Optional[Dict[str, DataType]] = None,
     fs: Optional[fsspec.AbstractFileSystem] = None,
 ) -> DataFrame:

--- a/daft/runners/runner_io.py
+++ b/daft/runners/runner_io.py
@@ -46,7 +46,7 @@ class RunnerIO(Generic[PartitionT]):
     @abstractmethod
     def glob_paths_details(
         self,
-        source_path: str,
+        source_path: list[str],
         source_info: SourceInfo | None = None,
         fs: fsspec.AbstractFileSystem | None = None,
     ) -> PartitionSet[PartitionT]:


### PR DESCRIPTION
Adds the ability to pass in a list of URLs into our `read_*` APIs.

For example:

```python
daft.read_parquet(["s3://my-bucket/file.pq", "s3://my-other-bucket/file2.pq"])
```

Note that our schema inference is naive and will sample from just the first file! Users can override this behavior by explicitly passing in `schema_hints={...}`.

Closes: #1081 