### PR TITLE
[CHORE] Cache build artifacts in target folder

### DIFF
--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -28,6 +28,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          target
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-

--- a/.github/workflows/property-based-tests.yml
+++ b/.github/workflows/property-based-tests.yml
@@ -27,6 +27,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          target
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,6 +41,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          target
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
@@ -134,6 +135,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          target
         key: ${{ runner.os }}-integration-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-integration-build-${{ env.cache-name }}-
@@ -229,6 +231,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          target
         key: ${{ runner.os }}-rust-package-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-rust-package-${{ env.cache-name }}-
@@ -318,6 +321,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          target
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-
@@ -395,6 +399,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          target
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-

--- a/.github/workflows/ray-compatibility.yml
+++ b/.github/workflows/ray-compatibility.yml
@@ -30,6 +30,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
+          target
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-


### PR DESCRIPTION
Previously we were only caching `~/.cargo/registry` and `~/.cargo/git`, which would cache the source files being pulled by cargo.

This PR takes it a step further by caching the build data itself in `target/` so that we can speed up CI times.