### PR TITLE
[CHORE] Add parquet benchmarking

### DIFF
--- a/benchmarking/parquet/README.md
+++ b/benchmarking/parquet/README.md
@@ -1,0 +1,20 @@
+# Parquet Benchmarks
+
+Goals:
+
+1. Find Parquet features that Daft underperforms on
+2. Compare Daft against other frameworks for reading Parquet files
+
+## Running the benchmarks:
+
+**Goal 1**: run only Daft reads and group by Parquet feature:
+
+```bash
+pytest benchmarking/parquet/ --benchmark-only --benchmark-group-by=group -k daft
+```
+
+**Goal 2**: run all the different frameworks' reads and group results by file path:
+
+```bash
+pytest benchmarking/parquet/ --benchmark-only --benchmark-group-by=param:path
+```

--- a/benchmarking/parquet/README.md
+++ b/benchmarking/parquet/README.md
@@ -3,18 +3,26 @@
 Goals:
 
 1. Find Parquet features that Daft underperforms on
-2. Compare Daft against other frameworks for reading Parquet files
+2. Compare Daft against other frameworks
 
 ## Running the benchmarks:
 
-**Goal 1**: run only Daft reads and group by Parquet feature:
+### Goal 1: Find Parquet features that Daft underperforms on
 
 ```bash
 pytest benchmarking/parquet/ --benchmark-only --benchmark-group-by=group -k daft
 ```
 
-**Goal 2**: run all the different frameworks' reads and group results by file path:
+### Goal 2: Compare Daft against other frameworks
 
 ```bash
 pytest benchmarking/parquet/ --benchmark-only --benchmark-group-by=param:path
+```
+
+### Check peak memory usage
+
+Ensure that you have `pytest-memray` installed.
+
+```bash
+pytest benchmarking/parquet/ --benchmark-only --memray
 ```

--- a/benchmarking/parquet/conftest.py
+++ b/benchmarking/parquet/conftest.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pyarrow.fs as pafs
+import pyarrow.parquet as papq
+import pytest
+
+import daft
+
+
+def daft_read(path: str, columns: list[str] | None = None) -> pa.Table:
+    df = daft.read_parquet(path)
+    if columns is not None:
+        df = df.select(*columns)
+    return df.to_arrow()
+
+
+def pyarrow_read(path: str, columns: list[str] | None = None) -> pa.Table:
+    fs = None
+    if path.startswith("s3://"):
+        fs = pafs.S3FileSystem()
+        path = path.replace("s3://", "")
+    return papq.read_table(path, columns=columns, filesystem=fs)
+
+
+@pytest.fixture(params=[daft_read, pyarrow_read], ids=["daft", "pyarrow"])
+def read_fn(request):
+    """Fixture which returns the function to read a PyArrow table from a path"""
+    return request.param

--- a/benchmarking/parquet/test_num_rowgroups.py
+++ b/benchmarking/parquet/test_num_rowgroups.py
@@ -7,16 +7,18 @@ import pytest
 @pytest.mark.parametrize(
     "path",
     [
-        "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part_1RG.parquet"
+        "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part_1RG.parquet",
         "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part.parquet",
-        "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part_18kRG.parquet"
-        "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part_180kRG.parquet",
+        # Disabled: too slow!
+        # "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part_18kRG.parquet"
+        # "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part_180kRG.parquet",
     ],
     ids=[
         "1",
         "2k",
-        "18k",
-        "180k",
+        # Disabled: too slow!
+        # "18k",
+        # "180k",
     ],
 )
 def test_read_parquet_num_rowgroups(path, read_fn, benchmark):

--- a/benchmarking/parquet/test_num_rowgroups.py
+++ b/benchmarking/parquet/test_num_rowgroups.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.benchmark(group="num_rowgroups")
+@pytest.mark.parametrize(
+    "path",
+    [
+        "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part_1RG.parquet"
+        "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part.parquet",
+        "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part_18kRG.parquet"
+        "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part_180kRG.parquet",
+    ],
+    ids=[
+        "1",
+        "2k",
+        "18k",
+        "180k",
+    ],
+)
+def test_read_parquet_num_rowgroups(path, read_fn, benchmark):
+    data = benchmark(read_fn, path, columns=["L_ORDERKEY"])
+
+    # Make sure the data is correct
+    assert data.column_names == ["L_ORDERKEY"]
+    assert len(data) == 18751674
+
+    # TODO(jay): Figure out how to track peak memory usage. Not sure yet how to aggregate this across calls.
+    benchmark.extra_info["peak_memory_usage"] = None

--- a/benchmarking/parquet/test_num_rowgroups.py
+++ b/benchmarking/parquet/test_num_rowgroups.py
@@ -27,6 +27,3 @@ def test_read_parquet_num_rowgroups(path, read_fn, benchmark):
     # Make sure the data is correct
     assert data.column_names == ["L_ORDERKEY"]
     assert len(data) == 18751674
-
-    # TODO(jay): Figure out how to track peak memory usage. Not sure yet how to aggregate this across calls.
-    benchmark.extra_info["peak_memory_usage"] = None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,7 @@ hypothesis==6.79.2
 pytest==7.4.0
 pytest-benchmark==4.0.0
 pytest-cov==4.1.0
+pytest-memray==1.4.1
 
 # Testing dependencies
 lxml==4.9.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,6 @@ hypothesis==6.79.2
 pytest==7.4.0
 pytest-benchmark==4.0.0
 pytest-cov==4.1.0
-pytest-memray==1.4.1
 
 # Testing dependencies
 lxml==4.9.2


### PR DESCRIPTION
# Summary

Adds Parquet benchmarking using `pytest-benchmark`

See: `benchmarking/parquet/README.md` for instructions.

## Screenshots

Some screenshots of the benchmarks in action:

**Benchmarking just Daft, grouped by the benchmarking "suite" (e.g. increasing number of rowgroups)**:

```
pytest benchmarking/parquet/ --benchmark-only --benchmark-group-by=group -k daft
```

<img width="1461" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/17691182/f3920610-9006-4ca7-81ec-e4bd5176ecec">


**Benchmarking Daft against other tools (grouped by Parquet file)**:

```
pytest benchmarking/parquet/ --benchmark-only --benchmark-group-by=param:path
```

<img width="1470" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/17691182/f464fdff-ba35-4c48-a505-ca8914cb053b">


**Running with memray enabled**:

If you want to see how all these tools perform in terms of peak memory usage as well

```
pytest benchmarking/parquet/ --benchmark-only --benchmark-group-by=param:path --memray
```

<img width="1465" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/17691182/56ee3024-b96d-4676-b929-5b7e2bfc83e2">
