### PR TITLE
[CHORE] [CI] use smarter github rust cache action

### DIFF
--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -21,19 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
-    - uses: actions/cache@v3
-      env:
-        cache-name: cache-cargo-profile
+    - uses: Swatinem/rust-cache@v2
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+        key: ${{ runner.os }}-profile
 
     - name: Set up Python ${{ env.PYTHON_VERSION }}
       uses: actions/setup-python@v4

--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
+      with:
+        cache: false
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-profile

--- a/.github/workflows/property-based-tests.yml
+++ b/.github/workflows/property-based-tests.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
+      with:
+        cache: false
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-build

--- a/.github/workflows/property-based-tests.yml
+++ b/.github/workflows/property-based-tests.yml
@@ -20,19 +20,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
-    - uses: actions/cache@v3
-      env:
-        cache-name: cache-cargo
+    - uses: Swatinem/rust-cache@v2
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+        key: ${{ runner.os }}-build
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,19 +34,9 @@ jobs:
     - uses: moonrepo/setup-rust@v0
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
-    - uses: actions/cache@v3
-      env:
-        cache-name: cache-cargo
+    - uses: Swatinem/rust-cache@v2
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+        key: ${{ runner.os }}-build
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -128,19 +118,9 @@ jobs:
     - run: python tools/patch_package_version.py
     - name: Install Rust toolchain
       uses: moonrepo/setup-rust@v0
-    - uses: actions/cache@v3
-      env:
-        cache-name: cache-cargo
+    - uses: Swatinem/rust-cache@v2
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-integration-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-integration-build-${{ env.cache-name }}-
-          ${{ runner.os }}-integration-build-
-          ${{ runner.os }}-
+        key: ${{ runner.os }}-integration-build
     # NOTE: we don't build with all the actual release optimizations to avoid hellish CI times
     - name: Build wheels
       run: maturin build --release --compatibility linux --out dist
@@ -293,19 +273,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
-    - uses: actions/cache@v3
-      env:
-        cache-name: cache-cargo
+    - uses: Swatinem/rust-cache@v2
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-rust-package-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-rust-package-${{ env.cache-name }}-
-          ${{ runner.os }}-rust-package-
-          ${{ runner.os }}-
+        key: ${{ runner.os }}-rust-build
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - name: Generate code coverage

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -116,8 +116,7 @@ jobs:
         architecture: x64
     - run: pip install -U twine toml maturin
     - run: python tools/patch_package_version.py
-    - name: Install Rust toolchain
-      uses: moonrepo/setup-rust@v0
+    - uses: moonrepo/setup-rust@v0
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-integration-build

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
+      with:
+        cache: false
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
     - uses: Swatinem/rust-cache@v2
@@ -117,6 +119,8 @@ jobs:
     - run: pip install -U twine toml maturin
     - run: python tools/patch_package_version.py
     - uses: moonrepo/setup-rust@v0
+      with:
+        cache: false
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-integration-build
@@ -272,6 +276,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
+      with:
+        cache: false
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-rust-build
@@ -352,20 +358,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
-    - uses: actions/cache@v3
-      env:
-        cache-name: cache-cargo
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
+        cache: false
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ runner.os }}-build
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -428,22 +425,12 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install pre-commit
-
     - uses: moonrepo/setup-rust@v0
-    - uses: actions/cache@v3
-      env:
-        cache-name: cache-cargo
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
+        cache: false
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ runner.os }}-build
     - uses: actions/cache@v3
       id: pre-commit-cache
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -45,9 +45,7 @@ jobs:
         architecture: x64
     - run: pip install -U twine toml
     - run: python tools/patch_package_version.py
-    - name: Install Rust toolchain
-      uses: moonrepo/setup-rust@v0
-
+    - uses: moonrepo/setup-rust@v0
     - name: Build wheels - x86
       if: ${{ matrix.compile_arch == 'x86_64' }}
       uses: messense/maturin-action@v1

--- a/.github/workflows/ray-compatibility.yml
+++ b/.github/workflows/ray-compatibility.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
+      with:
+        cache: false
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-build

--- a/.github/workflows/ray-compatibility.yml
+++ b/.github/workflows/ray-compatibility.yml
@@ -23,19 +23,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: moonrepo/setup-rust@v0
-    - uses: actions/cache@v3
-      env:
-        cache-name: cache-cargo
+    - uses: Swatinem/rust-cache@v2
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+        key: ${{ runner.os }}-build
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
* Our former cache of `./target` was steadily growing since we didn't purge out of date artifacts which this https://github.com/Swatinem/rust-cache does correctly.
* Move over all cargo caches to this paradigm