### PR TITLE
[PERF] Simple Read Planner and RangeReader for Native Parquet Reader

### DIFF
--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -345,6 +345,13 @@ class Table:
 
     @classmethod
     def read_parquet(
-        cls, path: str, row_groups: list | None = None, file_size: None | int = None, io_config: IOConfig | None = None
+        cls,
+        path: str,
+        columns: list[str] | None = None,
+        row_groups: list[int] | None = None,
+        file_size: None | int = None,
+        io_config: IOConfig | None = None,
     ) -> Table:
-        return Table._from_pytable(_read_parquet(uri=path, row_groups=row_groups, size=file_size, io_config=io_config))
+        return Table._from_pytable(
+            _read_parquet(uri=path, columns=columns, row_groups=row_groups, size=file_size, io_config=io_config)
+        )

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -422,8 +422,10 @@ mod tests {
         let parquet_file_path = "s3://daft-public-data/test_fixtures/parquet_small/0dad4c3f-da0d-49db-90d8-98684571391b-0.parquet";
         let parquet_expected_md5 = "929674747af64a98aceaa6d895863bd3";
 
-        let mut config = S3Config::default();
-        config.anonymous = true;
+        let config = S3Config {
+            anonymous: true,
+            ..Default::default()
+        };
         let client = S3LikeSource::get_client(&config).await?;
         let parquet_file = client.get(parquet_file_path, None).await?;
         let bytes = parquet_file.bytes().await?;

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -60,6 +60,12 @@ pub enum Error {
         row_group: i64,
         total_row_groups: i64,
     },
+
+    #[snafu(display("Error joining spawned task: {} for path: {}", source, path))]
+    JoinError {
+        path: String,
+        source: tokio::task::JoinError,
+    },
 }
 
 impl From<Error> for DaftError {

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -5,6 +5,7 @@ use snafu::Snafu;
 
 pub mod metadata;
 pub mod read;
+mod read_planner;
 
 #[cfg(feature = "python")]
 pub mod python;

--- a/src/daft-parquet/src/metadata.rs
+++ b/src/daft-parquet/src/metadata.rs
@@ -1,11 +1,13 @@
-use std::{sync::Arc, time::Instant};
+use std::{borrow::Cow, sync::Arc, time::Instant};
 
 use daft_io::IOClient;
 
 use parquet2::{metadata::FileMetaData, read::deserialize_metadata};
 use snafu::ResultExt;
 
-use crate::{Error, UnableToOpenFileSnafu, UnableToParseMetadataSnafu, UnableToReadBytesSnafu};
+use crate::{
+    Error, JoinSnafu, UnableToOpenFileSnafu, UnableToParseMetadataSnafu, UnableToReadBytesSnafu,
+};
 
 fn metadata_len(buffer: &[u8], len: usize) -> i32 {
     i32::from_le_bytes(buffer[len - 8..len - 4].try_into().unwrap())
@@ -50,10 +52,10 @@ pub async fn read_parquet_metadata(
         });
     }
 
-    let reader: &[u8] = if footer_len < buffer.len() {
+    let remaining;
+    if footer_len < buffer.len() {
         // the whole metadata is in the bytes we already read
-        let remaining = buffer.len() - footer_len;
-        &buffer[remaining..]
+        remaining = buffer.len() - footer_len;
     } else {
         // the end of file read by default is not long enough, read again including the metadata.
 
@@ -65,23 +67,28 @@ pub async fn read_parquet_metadata(
             .bytes()
             .await
             .context(UnableToReadBytesSnafu { path: uri })?;
-        let buffer = data.as_ref();
-        if buffer[buffer.len() - 4..] != PARQUET_MAGIC {
-            return Err(Error::InvalidParquetFile {
-                path: uri.into(),
-                footer: buffer[buffer.len() - 4..].into(),
-            });
-        }
-        let remaining = buffer.len() - footer_len;
-        &buffer[remaining..]
+        remaining = data.len() - footer_len;
     };
 
-    let max_size = reader.len() * 2 + 1024;
+    let buffer = data.as_ref();
 
-    let start = Instant::now();
-    let metadata =
-        deserialize_metadata(reader, max_size).context(UnableToParseMetadataSnafu { path: uri });
-    println!("time {:?}", start.elapsed().as_secs());
+    if buffer[buffer.len() - 4..] != PARQUET_MAGIC {
+        return Err(Error::InvalidParquetFile {
+            path: uri.into(),
+            footer: buffer[buffer.len() - 4..].into(),
+        });
+    }
+
+    let metadata = tokio::task::spawn_blocking(move || {
+        let reader = &data.as_ref()[remaining..];
+        let max_size = reader.len() * 2 + 1024;
+        deserialize_metadata(reader, max_size)
+    })
+    .await
+    .context(JoinSnafu {
+        path: uri.to_string(),
+    })?
+    .context(UnableToParseMetadataSnafu { path: uri });
 
     metadata
 }

--- a/src/daft-parquet/src/metadata.rs
+++ b/src/daft-parquet/src/metadata.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc, time::Instant};
+use std::sync::Arc;
 
 use daft_io::IOClient;
 
@@ -79,7 +79,7 @@ pub async fn read_parquet_metadata(
         });
     }
 
-    let metadata = tokio::task::spawn_blocking(move || {
+    tokio::task::spawn_blocking(move || {
         let reader = &data.as_ref()[remaining..];
         let max_size = reader.len() * 2 + 1024;
         deserialize_metadata(reader, max_size)
@@ -88,9 +88,7 @@ pub async fn read_parquet_metadata(
     .context(JoinSnafu {
         path: uri.to_string(),
     })?
-    .context(UnableToParseMetadataSnafu { path: uri });
-
-    metadata
+    .context(UnableToParseMetadataSnafu { path: uri })
 }
 
 #[cfg(test)]

--- a/src/daft-parquet/src/metadata.rs
+++ b/src/daft-parquet/src/metadata.rs
@@ -1,7 +1,4 @@
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Instant};
 
 use daft_io::IOClient;
 

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -9,6 +9,7 @@ pub mod pylib {
     pub fn read_parquet(
         py: Python,
         uri: &str,
+        columns: Option<Vec<&str>>,
         row_groups: Option<Vec<i64>>,
         size: Option<usize>,
         io_config: Option<PyIOConfig>,
@@ -16,7 +17,14 @@ pub mod pylib {
         py.allow_threads(|| {
             let io_client = get_io_client(io_config.unwrap_or_default().config.into())?;
 
-            Ok(crate::read::read_parquet(uri, row_groups.as_deref(), size, io_client)?.into())
+            Ok(crate::read::read_parquet(
+                uri,
+                columns.as_deref(),
+                row_groups.as_deref(),
+                size,
+                io_client,
+            )?
+            .into())
         })
     }
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -254,7 +254,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parquet_read_planner() -> DaftResult<()> {
-        let file = "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part.parquet";
+        let file = "s3://daft-public-data/test_fixtures/parquet_small/0dad4c3f-da0d-49db-90d8-98684571391b-0.parquet";
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
@@ -263,7 +263,7 @@ mod tests {
         let size = io_client.single_url_get_size(file.into()).await?;
         let metadata =
             crate::metadata::read_parquet_metadata(file, size, io_client.clone()).await?;
-        let mut plan = plan_read_row_groups(file, Some(&["L_ORDERKEY"]), Some(&[1, 2]), &metadata)?;
+        let mut plan = plan_read_row_groups(file, Some(&["P_PARTKEY"]), Some(&[1, 2]), &metadata)?;
 
         plan.add_pass(Box::new(CoalescePass {
             max_hole_size: 1024 * 1024,
@@ -272,7 +272,7 @@ mod tests {
         plan.run_passes()?;
         let memory = plan.collect(io_client.clone()).await?;
         let _table =
-            read_row_groups_from_ranges(&memory, Some(&["L_ORDERKEY"]), Some(&[1, 2]), &metadata)?;
+            read_row_groups_from_ranges(&memory, Some(&["P_PARTKEY"]), Some(&[1, 2]), &metadata)?;
         Ok(())
     }
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -12,10 +12,12 @@ use parquet2::{
     metadata::FileMetaData,
     read::{BasicDecompressor, PageReader},
 };
+use snafu::ResultExt;
 
 use crate::{
     metadata::read_parquet_metadata,
     read_planner::{self, CoalescePass, RangesContainer, ReadPlanBuilder, SplitLargeRequestPass},
+    JoinSnafu,
 };
 
 fn plan_read_row_groups(
@@ -47,7 +49,7 @@ fn plan_read_row_groups(
     };
 
     let num_row_groups = metadata.row_groups.len();
-    let mut read_plan = read_planner::ReadPlanBuilder::new(uri);
+    let mut read_plan = read_planner::ReadPlanBuilder::new(&uri);
     let row_groups = match row_groups {
         Some(rg) => rg.to_vec(),
         None => (0i64..num_row_groups as i64).collect(),
@@ -204,7 +206,9 @@ pub fn read_parquet(
             Some(size) => size,
             None => io_client.single_url_get_size(uri.into()).await?,
         };
+
         let metadata = read_parquet_metadata(uri, size, io_client.clone()).await?;
+
         let mut plan = plan_read_row_groups(uri, columns, row_groups, &metadata)?;
 
         plan.add_pass(Box::new(SplitLargeRequestPass {
@@ -217,8 +221,6 @@ pub fn read_parquet(
             max_request_size: 16 * 1024 * 1024,
         }));
         plan.run_passes()?;
-        println!("plan: {}", plan);
-
         DaftResult::Ok((metadata, plan.collect(io_client).await?))
     })?;
 
@@ -270,11 +272,9 @@ mod tests {
             max_request_size: 16 * 1024 * 1024,
         }));
         plan.run_passes()?;
-        println!("{}", plan);
         let memory = plan.collect(io_client.clone()).await?;
         let table =
             read_row_groups_from_ranges(&memory, Some(&["L_ORDERKEY"]), Some(&[1, 2]), &metadata)?;
-        println!("{}", table);
         Ok(())
     }
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -256,8 +256,8 @@ mod tests {
     async fn test_parquet_read_planner() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part.parquet";
 
-        let io_config = IOConfig::default();
-        // io_config.s3.anonymous = true;
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
         let size = io_client.single_url_get_size(file.into()).await?;

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeMap, HashSet},
-    fmt::format,
     sync::Arc,
 };
 
@@ -244,16 +243,14 @@ mod tests {
     }
 
     use crate::{
-        read::plan_read_row_groups,
-        read::read_row_groups_from_ranges,
-        read_planner::{CoalescePass, ReadPlanBuilder},
+        read::plan_read_row_groups, read::read_row_groups_from_ranges, read_planner::CoalescePass,
     };
-    use std::io::Read;
+
     #[tokio::test]
     async fn test_parquet_read_planner() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/parquet-dev/daft_tpch_100g_32part.parquet";
 
-        let mut io_config = IOConfig::default();
+        let io_config = IOConfig::default();
         // io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -12,12 +12,10 @@ use parquet2::{
     metadata::FileMetaData,
     read::{BasicDecompressor, PageReader},
 };
-use snafu::ResultExt;
 
 use crate::{
     metadata::read_parquet_metadata,
     read_planner::{self, CoalescePass, RangesContainer, ReadPlanBuilder, SplitLargeRequestPass},
-    JoinSnafu,
 };
 
 fn plan_read_row_groups(
@@ -49,7 +47,7 @@ fn plan_read_row_groups(
     };
 
     let num_row_groups = metadata.row_groups.len();
-    let mut read_plan = read_planner::ReadPlanBuilder::new(&uri);
+    let mut read_plan = read_planner::ReadPlanBuilder::new(uri);
     let row_groups = match row_groups {
         Some(rg) => rg.to_vec(),
         None => (0i64..num_row_groups as i64).collect(),
@@ -273,7 +271,7 @@ mod tests {
         }));
         plan.run_passes()?;
         let memory = plan.collect(io_client.clone()).await?;
-        let table =
+        let _table =
             read_row_groups_from_ranges(&memory, Some(&["L_ORDERKEY"]), Some(&[1, 2]), &metadata)?;
         Ok(())
     }

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt::Display, io::Read, ops::Range, sync::Arc};
+use std::{fmt::Display, io::Read, ops::Range, sync::Arc};
 
 use common_error::DaftResult;
 use daft_io::IOClient;
@@ -117,7 +117,7 @@ pub(crate) struct RangesContainer {
 impl RangesContainer {
     pub fn get_range_reader<'a>(&'a self, range: Range<usize>) -> DaftResult<MultiRead<'a>> {
         let mut current_pos = range.start;
-        let mut curr_index = 0;
+        let mut curr_index;
         let start_point = self.ranges.binary_search_by_key(&current_pos, |(v, _)| *v);
 
         let mut slice_vec: Vec<&'a [u8]> = vec![];

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -125,10 +125,10 @@ impl RangesContainer {
                 let index = index - 1;
                 let (byte_start, bytes_at_index) = &self.ranges[index];
                 let end = byte_start + bytes_at_index.len();
-                println!("curr pos: {current_pos}, byte_start: {byte_start}, byte_end: {end}");
+                println!("curr pos: {current_pos}, byte_start: {byte_start}, byte_end: {end}, Range: {range:?}");
                 assert!(current_pos >= *byte_start && current_pos < end);
                 let start_offset = current_pos - byte_start;
-                let end_offset = bytes_at_index.len().min(range.end - current_pos);
+                let end_offset = bytes_at_index.len().min(range.end - byte_start);
                 let curr_slice = &bytes_at_index.as_slice()[start_offset..end_offset];
                 slice_vec.push(curr_slice);
                 current_pos += curr_slice.len();
@@ -139,7 +139,7 @@ impl RangesContainer {
             let (byte_start, bytes_at_index) = &self.ranges[curr_index];
             assert_eq!(*byte_start, current_pos);
             let start_offset = 0;
-            let end_offset = bytes_at_index.len().min(range.end - current_pos);
+            let end_offset = bytes_at_index.len().min(range.end - byte_start);
             let curr_slice = &bytes_at_index.as_slice()[start_offset..end_offset];
             slice_vec.push(curr_slice);
             current_pos += curr_slice.len();

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -1,0 +1,85 @@
+use std::{fmt::Display, ops::Range};
+
+type RangeList = Vec<Range<usize>>;
+
+pub trait ReadPlanPass {
+    fn run(&self, ranges: &RangeList) -> crate::Result<(bool, RangeList)>;
+}
+
+pub struct CoalescePass {
+    pub max_hole_size: usize,
+}
+
+impl ReadPlanPass for CoalescePass {
+    fn run(&self, ranges: &RangeList) -> crate::Result<(bool, RangeList)> {
+        let mut ranges = ranges.clone();
+        let before_num_ranges = ranges.len();
+        // sort by start
+        ranges.sort_by_key(|v| v.start);
+
+        // filter out zero length
+        ranges.retain(|v| v.end > v.start);
+
+        if ranges.is_empty() {
+            return Ok((before_num_ranges != ranges.len(), ranges));
+        }
+
+        let mut curr_start = ranges.first().unwrap().start;
+        let mut curr_end = ranges.first().unwrap().end;
+        let mut new_ranges = vec![];
+        for range in ranges.iter().skip(1) {
+            if (range.start + self.max_hole_size) >= curr_end {
+                curr_end = range.end.max(curr_end);
+            } else {
+                new_ranges.push(curr_start..curr_end);
+                curr_start = range.start;
+                curr_end = range.end;
+            }
+        }
+        new_ranges.push(curr_start..curr_end);
+        Ok((before_num_ranges != new_ranges.len(), new_ranges))
+    }
+}
+
+pub(crate) struct ReadPlanBuilder {
+    ranges: RangeList,
+    passes: Vec<Box<dyn ReadPlanPass>>,
+}
+
+impl ReadPlanBuilder {
+    pub fn new() -> Self {
+        ReadPlanBuilder {
+            ranges: vec![],
+            passes: vec![],
+        }
+    }
+
+    pub fn add_range(&mut self, start: usize, end: usize) {
+        self.ranges.push(start..end);
+    }
+
+    pub fn add_pass(&mut self, pass: Box<dyn ReadPlanPass>) {
+        self.passes.push(pass);
+    }
+
+    pub fn run_passes(&mut self) -> super::Result<()> {
+        for pass in self.passes.iter() {
+            let (changed, ranges) = pass.run(&self.ranges)?;
+            if changed {
+                self.ranges = ranges;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Display for ReadPlanBuilder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "ReadPlanBuilder: {} ranges", self.ranges.len())?;
+        for range in self.ranges.iter() {
+            writeln!(f, "{}-{}", range.start, range.end)?;
+        }
+        Ok(())
+    }
+}

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -176,7 +176,7 @@ impl RangesContainer {
                 let index = index - 1;
                 let (byte_start, bytes_at_index) = &self.ranges[index];
                 let end = byte_start + bytes_at_index.len();
-                assert!(current_pos >= *byte_start && current_pos < end);
+                assert!(current_pos >= *byte_start && current_pos < end, "range: {range:?}, current_pos: {current_pos}, bytes_start: {byte_start}, end: {end}");
                 let start_offset = current_pos - byte_start;
                 let end_offset = bytes_at_index.len().min(range.end - byte_start);
                 let curr_slice = &bytes_at_index.as_slice()[start_offset..end_offset];

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -1,4 +1,7 @@
-use std::{fmt::Display, ops::Range};
+use std::{collections::BTreeMap, fmt::Display, io::Read, ops::Range, sync::Arc};
+
+use common_error::DaftResult;
+use daft_io::IOClient;
 
 type RangeList = Vec<Range<usize>>;
 
@@ -8,6 +11,7 @@ pub trait ReadPlanPass {
 
 pub struct CoalescePass {
     pub max_hole_size: usize,
+    pub max_request_size: usize,
 }
 
 impl ReadPlanPass for CoalescePass {
@@ -28,7 +32,9 @@ impl ReadPlanPass for CoalescePass {
         let mut curr_end = ranges.first().unwrap().end;
         let mut new_ranges = vec![];
         for range in ranges.iter().skip(1) {
-            if range.start <= (curr_end + self.max_hole_size) {
+            if (range.start <= (curr_end + self.max_hole_size))
+                && ((range.end.max(curr_end) - curr_start) < self.max_request_size)
+            {
                 curr_end = range.end.max(curr_end);
             } else {
                 new_ranges.push(curr_start..curr_end);
@@ -42,13 +48,15 @@ impl ReadPlanPass for CoalescePass {
 }
 
 pub(crate) struct ReadPlanBuilder {
+    source: String,
     ranges: RangeList,
     passes: Vec<Box<dyn ReadPlanPass>>,
 }
 
 impl ReadPlanBuilder {
-    pub fn new() -> Self {
+    pub fn new(source: &str) -> Self {
         ReadPlanBuilder {
+            source: source.into(),
             ranges: vec![],
             passes: vec![],
         }
@@ -71,6 +79,118 @@ impl ReadPlanBuilder {
         }
 
         Ok(())
+    }
+
+    pub async fn collect(self, io_client: Arc<IOClient>) -> DaftResult<RangesContainer> {
+        let mut stored_ranges = Vec::with_capacity(self.ranges.len());
+        for range in self.ranges.iter() {
+            // multithread this
+            let get_result = io_client
+                .single_url_get(self.source.clone(), Some(range.clone()))
+                .await?;
+            let bytes = get_result.bytes().await?;
+            stored_ranges.push((range.start, bytes.to_vec()));
+        }
+        stored_ranges.sort_by_key(|(start, _)| *start);
+        Ok(RangesContainer {
+            ranges: stored_ranges,
+        })
+    }
+}
+
+pub(crate) struct RangesContainer {
+    ranges: Vec<(usize, Vec<u8>)>,
+}
+
+impl RangesContainer {
+    pub fn get_range_reader<'a>(&'a self, range: Range<usize>) -> DaftResult<MultiRead<'a>> {
+        let mut current_pos = range.start;
+        let mut curr_index = 0;
+        let start_point = self.ranges.binary_search_by_key(&current_pos, |(v, _)| *v);
+
+        let mut slice_vec: Vec<&'a [u8]> = vec![];
+        match start_point {
+            Ok(index) => {
+                let (byte_start, bytes_at_index) = &self.ranges[index];
+                assert_eq!(*byte_start, current_pos);
+                let start_offset = 0;
+                let end_offset = bytes_at_index.len().min(range.end - current_pos);
+                let curr_slice = &bytes_at_index.as_slice()[start_offset..end_offset];
+                slice_vec.push(curr_slice);
+                current_pos += curr_slice.len();
+                curr_index = index + 1;
+            }
+            Err(index) => {
+                assert!(index > 0);
+                let index = index - 1;
+                let (byte_start, bytes_at_index) = &self.ranges[index];
+                let end = byte_start + bytes_at_index.len();
+                println!("curr pos: {current_pos}, byte_start: {byte_start}, byte_end: {end}");
+                assert!(current_pos >= *byte_start && current_pos < end);
+                let start_offset = current_pos - byte_start;
+                let end_offset = bytes_at_index.len().min(range.end - current_pos);
+                let curr_slice = &bytes_at_index.as_slice()[start_offset..end_offset];
+                slice_vec.push(curr_slice);
+                current_pos += curr_slice.len();
+                curr_index = index + 1;
+            }
+        };
+        while current_pos < range.end && curr_index < self.ranges.len() {
+            let (byte_start, bytes_at_index) = &self.ranges[curr_index];
+            assert_eq!(*byte_start, current_pos);
+            let start_offset = 0;
+            let end_offset = bytes_at_index.len().min(range.end - current_pos);
+            let curr_slice = &bytes_at_index.as_slice()[start_offset..end_offset];
+            slice_vec.push(curr_slice);
+            current_pos += curr_slice.len();
+            curr_index += 1;
+        }
+
+        assert_eq!(current_pos, range.end);
+
+        Ok(MultiRead::new(slice_vec))
+    }
+}
+
+pub(crate) struct MultiRead<'a> {
+    sources: Vec<&'a [u8]>,
+    pos_in_sources: usize,
+    pos_in_current: usize,
+}
+
+impl<'a> MultiRead<'a> {
+    fn new(sources: Vec<&'a [u8]>) -> MultiRead<'a> {
+        for s in sources.iter() {
+            println!("len of slice: {}", s.len());
+        }
+
+        MultiRead {
+            sources,
+            pos_in_sources: 0,
+            pos_in_current: 0,
+        }
+    }
+}
+
+impl Read for MultiRead<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        println!("buf len {}", buf.len());
+
+        let current = loop {
+            if self.pos_in_sources >= self.sources.len() {
+                return Ok(0); // EOF
+            }
+            let current = self.sources[self.pos_in_sources];
+            if self.pos_in_current < current.len() {
+                break current;
+            }
+            self.pos_in_current = 0;
+            self.pos_in_sources += 1;
+        };
+        let read_size = buf.len().min(current.len() - self.pos_in_current);
+        buf[..read_size].copy_from_slice(&current[self.pos_in_current..][..read_size]);
+        self.pos_in_current += read_size;
+        Ok(read_size)
     }
 }
 

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -28,7 +28,7 @@ impl ReadPlanPass for CoalescePass {
         let mut curr_end = ranges.first().unwrap().end;
         let mut new_ranges = vec![];
         for range in ranges.iter().skip(1) {
-            if (range.start + self.max_hole_size) >= curr_end {
+            if range.start <= (curr_end + self.max_hole_size) {
                 curr_end = range.end.max(curr_end);
             } else {
                 new_ranges.push(curr_start..curr_end);
@@ -78,7 +78,13 @@ impl Display for ReadPlanBuilder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "ReadPlanBuilder: {} ranges", self.ranges.len())?;
         for range in self.ranges.iter() {
-            writeln!(f, "{}-{}", range.start, range.end)?;
+            writeln!(
+                f,
+                "{}-{}, {}",
+                range.start,
+                range.end,
+                range.end - range.start
+            )?;
         }
         Ok(())
     }

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -260,10 +260,6 @@ impl Read for MultiRead<'_> {
             self.pos_in_sources += 1;
             self.bytes_read += slice.len();
         }
-        println!(
-            "bytes read to end: {}",
-            self.bytes_read - starting_bytes_read
-        );
         Ok(self.bytes_read - starting_bytes_read)
     }
 }


### PR DESCRIPTION
* Enables simple read planning (coalesce and parallelize) for parquet using the metadata to construct a read plan
* Enables Parallel fetching for s3 requests
* Enables non contiguous range reader 