### PR TITLE
[CHORE] New daft-plan crate; trait TreeDisplay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "daft-plan"
+version = "0.1.0"
+dependencies = [
+ "pyo3",
+]
+
+[[package]]
 name = "daft-table"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,8 @@ members = [
   "src/daft-io",
   "src/daft-parquet",
   "src/daft-dsl",
-  "src/daft-table"
+  "src/daft-table",
+  "src/daft-plan"
 ]
 
 [workspace.dependencies]

--- a/src/daft-plan/Cargo.toml
+++ b/src/daft-plan/Cargo.toml
@@ -1,0 +1,11 @@
+[dependencies]
+pyo3 = {workspace = true, optional = true}
+
+[features]
+default = ["python"]
+python = ["dep:pyo3"]
+
+[package]
+edition = {workspace = true}
+name = "daft-plan"
+version = {workspace = true}

--- a/src/daft-plan/src/display.rs
+++ b/src/daft-plan/src/display.rs
@@ -1,0 +1,67 @@
+use std::fmt;
+
+trait TreeDisplay {
+    // Required method: Print just the self node in a single line. No trailing newline.
+    fn fmt_oneline(&self, f: &mut fmt::Formatter) -> fmt::Result;
+
+    // Required method: Get the children of the self node.
+    fn get_children(&self) -> Vec<&Self>;
+
+    // Print the whole tree represented by this node.
+    fn fmt_tree(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.fmt_tree_gitstyle(0, f)
+    }
+
+    // Print the tree recursively, and illustrate the tree structure in the same style as `git log --graph`.
+    // `depth` is the number of forks in this node's ancestors.
+    fn fmt_tree_gitstyle(&self, depth: usize, f: &mut fmt::Formatter) -> fmt::Result {
+        // Print the current node.
+        // e.g. | | * <node contents>
+        self.fmt_depth(depth, f)?;
+        write!(f, "* ")?;
+        self.fmt_oneline(f)?;
+        writeln!(f)?;
+
+        // Recursively handle children.
+        let children = self.get_children();
+        match children[..] {
+            // No children - stop printing.
+            [] => Ok(()),
+            // One child - print leg, then print the child tree.
+            [child] => {
+                // Leg: e.g. | | |
+                self.fmt_depth(depth, f)?;
+                writeln!(f, "|")?;
+
+                // Child tree.
+                child.fmt_tree_gitstyle(depth, f)
+            }
+            // Two children - print legs, print right child indented, print left child.
+            [left, right] => {
+                // Legs: e.g. | | |\
+                self.fmt_depth(depth, f)?;
+                writeln!(f, "|\\")?;
+
+                // Right child tree, indented.
+                right.fmt_tree_gitstyle(depth + 1, f)?;
+
+                // Legs, e.g. | | |
+                self.fmt_depth(depth, f)?;
+                writeln!(f, "|")?;
+
+                // Left child tree.
+                left.fmt_tree_gitstyle(depth, f)
+            }
+            _ => unreachable!("Max two child nodes expected, got {}", children.len()),
+        }
+    }
+
+    fn fmt_depth(&self, depth: usize, f: &mut fmt::Formatter) -> fmt::Result {
+        // Print leading pipes for forks in ancestors that will be printed later.
+        // e.g. "| | "
+        for _ in 0..depth {
+            write!(f, "| ")?;
+        }
+        Ok(())
+    }
+}

--- a/src/daft-plan/src/lib.rs
+++ b/src/daft-plan/src/lib.rs
@@ -1,0 +1,1 @@
+mod display;


### PR DESCRIPTION
Beginning work on building logical plan in Rust.

- Create a new crate `daft-plan` to encapsulate all logical plan code.
- Create a trait TreeDisplay for debugging.

The default implementation of TreeDisplay uses a git-style graph to minimize indentation and make forking unambiguous:

```
   Compiling playground v0.0.1 (/playground)
    Finished dev [unoptimized + debuginfo] target(s) in 0.40s
     Running `target/debug/playground`

* Projection
|
* Join
|\
| * Repartition
| |
| * InMemoryScan
|
* Repartition
|
* Filter
|
* InMemoryScan
```

Contrast with the plan today:
```
┌─Projection
│
├──Join
│
└──┬──┬─Repartition
   │  │
   │  └──InMemoryScan
   │   
   └──┬─Repartition
      │
      ├──Filter
      │
      └──InMemoryScan
```

which is difficult to parse unambiguously without the labels:

```
┌─A
│
├──B
│
└──┬──┬─C
   │  │
   │  └──D
   │   
   └──┬─E
      │
      ├──F
      │
      └──G
```
- `└──┬──┬─C` looks like a join node, but it's not. 
- `├──B` and `├──F` look similar, but B is a join node and F is a linear node. 
- `└──┬─E` is a linear node but looks like it might be a join node. 