### PR TITLE
[FEAT] Consolidate to list namespace

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -614,6 +614,14 @@ class ExpressionListNamespace(ExpressionNamespace):
         delimiter_expr = Expression._to_expression(delimiter)
         return Expression._from_pyexpr(self._expr.list_join(delimiter_expr._expr))
 
+    def lengths(self) -> Expression:
+        """Gets the length of each list
+
+        Returns:
+            Expression: a UInt64 expression which is the length of each list
+        """
+        return Expression._from_pyexpr(self._expr.list_lengths())
+
 
 class ExpressionsProjection(Iterable[Expression]):
     """A collection of Expressions that can be projected onto a Table to produce another Table

--- a/daft/series.py
+++ b/daft/series.py
@@ -480,8 +480,8 @@ class Series:
         return SeriesDateNamespace.from_series(self)
 
     @property
-    def arr(self) -> SeriesArrayNamespace:
-        return SeriesArrayNamespace.from_series(self)
+    def list(self) -> SeriesListNamespace:
+        return SeriesListNamespace.from_series(self)
 
     @property
     def image(self) -> SeriesImageNamespace:
@@ -559,9 +559,9 @@ class SeriesDateNamespace(SeriesNamespace):
         return Series._from_pyseries(self._series.dt_day_of_week())
 
 
-class SeriesArrayNamespace(SeriesNamespace):
+class SeriesListNamespace(SeriesNamespace):
     def lengths(self) -> Series:
-        return Series._from_pyseries(self._series.arr_lengths())
+        return Series._from_pyseries(self._series.list_lengths())
 
 
 class SeriesImageNamespace(SeriesNamespace):

--- a/docs/source/api_docs/expressions.rst
+++ b/docs/source/api_docs/expressions.rst
@@ -172,6 +172,7 @@ Example: ``e1.list.join(e2)``
     :toctree: doc_gen/expression_methods
 
     daft.expressions.expressions.ExpressionListNamespace.join
+    daft.expressions.expressions.ExpressionListNamespace.lengths
 
 
 Changing Column Names/Types

--- a/docs/source/api_docs/expressions.rst
+++ b/docs/source/api_docs/expressions.rst
@@ -166,7 +166,7 @@ Nested
 
 Operations on nested types (such as List and FixedSizeList), accessible through the ``Expression.list`` method accessor.
 
-Example: ``e1.str.concat(e2)``
+Example: ``e1.list.join(e2)``
 
 .. autosummary::
     :toctree: doc_gen/expression_methods

--- a/src/daft-core/src/python/series.rs
+++ b/src/daft-core/src/python/series.rs
@@ -270,8 +270,8 @@ impl PySeries {
         Ok(self.series.dt_day_of_week()?.into())
     }
 
-    pub fn arr_lengths(&self) -> PyResult<Self> {
-        Ok(self.series.arr_lengths()?.into_series().into())
+    pub fn list_lengths(&self) -> PyResult<Self> {
+        Ok(self.series.list_lengths()?.into_series().into())
     }
 
     pub fn image_decode(&self) -> PyResult<Self> {

--- a/src/daft-core/src/series/ops/list.rs
+++ b/src/daft-core/src/series/ops/list.rs
@@ -18,13 +18,13 @@ impl Series {
         }
     }
 
-    pub fn arr_lengths(&self) -> DaftResult<UInt64Array> {
+    pub fn list_lengths(&self) -> DaftResult<UInt64Array> {
         use DataType::*;
 
         match self.data_type() {
             List(_) => self.list()?.lengths(),
             FixedSizeList(..) => self.fixed_size_list()?.lengths(),
-            Embedding(..) | FixedShapeImage(..) => self.as_physical()?.arr_lengths(),
+            Embedding(..) | FixedShapeImage(..) => self.as_physical()?.list_lengths(),
             Image(..) => {
                 let struct_array = self.as_physical()?;
                 let data_array = struct_array.struct_()?.as_arrow().values()[0]

--- a/src/daft-dsl/src/functions/list/lengths.rs
+++ b/src/daft-dsl/src/functions/list/lengths.rs
@@ -1,0 +1,50 @@
+use crate::Expr;
+use daft_core::{
+    datatypes::{DataType, Field},
+    schema::Schema,
+    series::{IntoSeries, Series},
+};
+
+use common_error::{DaftError, DaftResult};
+
+use super::super::FunctionEvaluator;
+
+pub(super) struct LengthsEvaluator {}
+
+impl FunctionEvaluator for LengthsEvaluator {
+    fn fn_name(&self) -> &'static str {
+        "lengths"
+    }
+
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+        match inputs {
+            [input] => {
+                let input_field = input.to_field(schema)?;
+
+                match input_field.dtype {
+                    DataType::List(_) | DataType::FixedSizeList(_, _) => {
+                        Ok(Field::new(input.name()?, DataType::UInt64))
+                    }
+                    _ => Err(DaftError::TypeError(format!(
+                        "Expected input to be a list type, received: {}",
+                        input_field.dtype
+                    ))),
+                }
+            }
+            _ => Err(DaftError::SchemaMismatch(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+
+    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+        match inputs {
+            [input] => Ok(input.list_lengths()?.into_series()),
+            _ => Err(DaftError::ValueError(format!(
+                "Expected 1 input arg, got {}",
+                inputs.len()
+            ))),
+        }
+    }
+}

--- a/src/daft-dsl/src/functions/list/mod.rs
+++ b/src/daft-dsl/src/functions/list/mod.rs
@@ -1,8 +1,10 @@
 mod explode;
 mod join;
+mod lengths;
 
 use explode::ExplodeEvaluator;
 use join::JoinEvaluator;
+use lengths::LengthsEvaluator;
 use serde::{Deserialize, Serialize};
 
 use crate::Expr;
@@ -13,6 +15,7 @@ use super::FunctionEvaluator;
 pub enum ListExpr {
     Explode,
     Join,
+    Lengths,
 }
 
 impl ListExpr {
@@ -22,6 +25,7 @@ impl ListExpr {
         match self {
             Explode => &ExplodeEvaluator {},
             Join => &JoinEvaluator {},
+            Lengths => &LengthsEvaluator {},
         }
     }
 }
@@ -37,5 +41,12 @@ pub fn join(input: &Expr, delimiter: &Expr) -> Expr {
     Expr::Function {
         func: super::FunctionExpr::List(ListExpr::Join),
         inputs: vec![input.clone(), delimiter.clone()],
+    }
+}
+
+pub fn lengths(input: &Expr) -> Expr {
+    Expr::Function {
+        func: super::FunctionExpr::List(ListExpr::Lengths),
+        inputs: vec![input.clone()],
     }
 }

--- a/src/daft-dsl/src/python.rs
+++ b/src/daft-dsl/src/python.rs
@@ -348,6 +348,11 @@ impl PyExpr {
         Ok(join(&self.expr, &delimiter.expr).into())
     }
 
+    pub fn list_lengths(&self) -> PyResult<Self> {
+        use crate::functions::list::lengths;
+        Ok(lengths(&self.expr).into())
+    }
+
     pub fn url_download(
         &self,
         max_connections: i64,

--- a/src/daft-table/src/ops/explode.rs
+++ b/src/daft-table/src/ops/explode.rs
@@ -60,11 +60,11 @@ impl Table {
                 }
             }
         }
-        let first_len = evaluated_columns.first().unwrap().arr_lengths()?;
+        let first_len = evaluated_columns.first().unwrap().list_lengths()?;
         if evaluated_columns
             .iter()
             .skip(1)
-            .any(|c| c.arr_lengths().unwrap().ne(&first_len))
+            .any(|c| c.list_lengths().unwrap().ne(&first_len))
         {
             return Err(DaftError::ValueError(
                 "In multicolumn explode, list length did not match".to_string(),

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -139,7 +139,7 @@ def test_series_cast_python_to_list(dtype) -> None:
     assert t.datatype() == target_dtype
     assert len(t) == len(data)
 
-    assert t.arr.lengths().to_pylist() == [3, 3, 3, 3, 2, 2, None]
+    assert t.list.lengths().to_pylist() == [3, 3, 3, 3, 2, 2, None]
 
     pydata = t.to_pylist()
     assert pydata[-1] is None
@@ -160,7 +160,7 @@ def test_series_cast_python_to_fixed_size_list(dtype) -> None:
     assert t.datatype() == target_dtype
     assert len(t) == len(data)
 
-    assert t.arr.lengths().to_pylist() == [3, 3, 3, 3, 3, 3, None]
+    assert t.list.lengths().to_pylist() == [3, 3, 3, 3, 3, 3, None]
 
     pydata = t.to_pylist()
     assert pydata[-1] is None
@@ -181,7 +181,7 @@ def test_series_cast_python_to_embedding(dtype) -> None:
     assert t.datatype() == target_dtype
     assert len(t) == len(data)
 
-    assert t.arr.lengths().to_pylist() == [3, 3, 3, 3, 3, 3, None]
+    assert t.list.lengths().to_pylist() == [3, 3, 3, 3, 3, 3, None]
 
     pydata = t.to_pylist()
     assert pydata[-1] is None
@@ -203,7 +203,7 @@ def test_series_cast_numpy_to_image() -> None:
     assert t.datatype() == target_dtype
     assert len(t) == len(data)
 
-    assert t.arr.lengths().to_pylist() == [12, 27, None]
+    assert t.list.lengths().to_pylist() == [12, 27, None]
 
     pydata = t.to_pylist()
     assert pydata[-1] is None
@@ -221,7 +221,7 @@ def test_series_cast_numpy_to_image_infer_mode() -> None:
     assert t.datatype() == target_dtype
     assert len(t) == len(data)
 
-    assert t.arr.lengths().to_pylist() == [4, 27, None]
+    assert t.list.lengths().to_pylist() == [4, 27, None]
 
     pydata = t.to_arrow().to_pylist()
     assert pydata[0] == {"data": data[0].ravel().tolist(), "mode": ImageMode.L, "channel": 1, "height": 2, "width": 2}
@@ -246,7 +246,7 @@ def test_series_cast_python_to_fixed_shape_image() -> None:
     assert t.datatype() == target_dtype
     assert len(t) == len(data)
 
-    assert t.arr.lengths().to_pylist() == [12, 12, None]
+    assert t.list.lengths().to_pylist() == [12, 12, None]
 
     pydata = t.to_pylist()
     assert pydata[-1] is None

--- a/tests/table/list/test_list_lengths.py
+++ b/tests/table/list/test_list_lengths.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from daft.expressions import col
+from daft.table import Table
+
+
+def test_list_lengths():
+    table = Table.from_pydict({"col": [None, [], ["a"], [None], ["a", "a"], ["a", None], ["a", None, "a"]]})
+    result = table.eval_expression_list([col("col").list.lengths()])
+    assert result.to_pydict() == {"col": [None, 0, 1, 1, 2, 2, 3]}


### PR DESCRIPTION
Closes: #1056 

* Consolidates on using `.list` as the namespace on both Series and Expression list operations
* As a driveby, exposes the `.list.lengths()` expression (the functionality on a Series was already implemented)