### PR TITLE
[CHORE] Exclude JSON pre-commit fixer for ipynb files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,11 @@ repos:
   - id: check-yaml
     exclude: kubernetes-ops
   - id: pretty-format-json
-    exclude: tutorials/.*\.ipynb
+    exclude: |
+      (?x)^(
+          tutorials/.*\.ipynb|
+          docs/.*\.ipynb
+      )$
     args:
     - --autofix
     - --no-sort-keys

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
   - id: check-yaml
     exclude: kubernetes-ops
   - id: pretty-format-json
+    exclude: tutorials/.*\.ipynb
     args:
     - --autofix
     - --no-sort-keys


### PR DESCRIPTION
For some reason this is only happening in CI but not locally, breaking our CI builds.

Let's disable this since ipynb files are not human-readable anyways.