### PR TITLE
[FEAT] parquet reader refactor, add parquet_stats_reader and parquet_schema_reader (1/2)

### DIFF
--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 from daft.daft import PyField as _PyField
 from daft.daft import PySchema as _PySchema
+from daft.daft import read_parquet_schema as _read_parquet_schema
 from daft.datatype import DataType
+
+if TYPE_CHECKING:
+    from daft.io import IOConfig
 
 
 class Field:
@@ -113,3 +117,7 @@ class Schema:
     def __setstate__(self, state: bytes) -> None:
         self._schema = _PySchema.__new__(_PySchema)
         self._schema.__setstate__(state)
+
+    @classmethod
+    def from_parquet(cls, path: str, io_config: IOConfig | None = None) -> Schema:
+        return Schema._from_pyschema(_read_parquet_schema(uri=path, io_config=io_config))

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -348,10 +348,10 @@ class Table:
         cls,
         path: str,
         columns: list[str] | None = None,
-        row_groups: list[int] | None = None,
-        file_size: None | int = None,
+        start_offset: int | None = None,
+        num_rows: int | None = None,
         io_config: IOConfig | None = None,
     ) -> Table:
         return Table._from_pytable(
-            _read_parquet(uri=path, columns=columns, row_groups=row_groups, size=file_size, io_config=io_config)
+            _read_parquet(uri=path, columns=columns, start_offset=start_offset, num_rows=num_rows, io_config=io_config)
         )

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -8,6 +8,7 @@ from loguru import logger
 from daft.arrow_utils import ensure_table
 from daft.daft import PyTable as _PyTable
 from daft.daft import read_parquet as _read_parquet
+from daft.daft import read_parquet_statistics as _read_parquet_statistics
 from daft.datatype import DataType
 from daft.expressions import Expression, ExpressionsProjection
 from daft.logical.schema import Schema
@@ -355,3 +356,14 @@ class Table:
         return Table._from_pytable(
             _read_parquet(uri=path, columns=columns, start_offset=start_offset, num_rows=num_rows, io_config=io_config)
         )
+
+    @classmethod
+    def read_parquet_statistics(
+        cls,
+        paths: Series | list[str],
+        io_config: IOConfig | None = None,
+    ) -> Table:
+        if not isinstance(paths, Series):
+            paths = Series.from_pylist(paths)
+
+        return Table._from_pytable(_read_parquet_statistics(uris=paths._series, io_config=io_config))

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -18,7 +18,6 @@ use arrow2::io::parquet::read::column_iter_to_arrays;
 
 pub(crate) struct ParquetReaderBuilder {
     uri: String,
-    file_size: usize,
     metadata: parquet2::metadata::FileMetaData,
     arrow_schema: arrow2::datatypes::Schema,
     selected_columns: Option<HashSet<String>>,
@@ -41,7 +40,6 @@ impl ParquetReaderBuilder {
                 .context(UnableToParseSchemaFromMetadataSnafu::<String> { path: uri.into() })?;
         Ok(ParquetReaderBuilder {
             uri: uri.into(),
-            file_size: size,
             metadata: metadata,
             arrow_schema: schema,
             selected_columns: None,

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -89,12 +89,10 @@ impl ParquetReaderBuilder {
     pub fn build(mut self) -> super::Result<ParquetFileReader> {
         let mut row_ranges = vec![];
 
-        let mut rg_iter = self.metadata.row_groups.iter().enumerate();
-
         let mut curr_row_index = 0;
         let mut rows_to_add = self.num_rows;
 
-        while let Some((i, rg)) = rg_iter.next() {
+        for (i, rg) in self.metadata.row_groups.iter().enumerate() {
             if (curr_row_index + rg.num_rows()) < self.row_start_offset {
                 curr_row_index += rg.num_rows();
                 continue;

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -1,0 +1,90 @@
+use std::{sync::Arc, collections::HashSet};
+
+use arrow2::io::parquet::read::infer_schema;
+use snafu::ResultExt;
+
+use crate::{metadata::read_parquet_metadata, UnableToParseSchemaFromMetadataSnafu};
+
+
+
+struct ParquetReaderBuilder {
+    uri: String,
+    metadata: parquet2::metadata::FileMetaData,
+    arrow_schema: arrow2::datatypes::Schema,
+    selected_columns: Option<HashSet<String>>,
+    row_start_offset: usize,
+    num_rows: usize
+}
+
+
+impl ParquetReaderBuilder {
+    pub async fn from_uri(uri: &str, io_client: Arc<daft_io::IOClient>) -> super::Result<Self> {
+        let size = 10;
+        let metadata = read_parquet_metadata(uri, size, io_client).await?;
+        let num_rows = metadata.num_rows;
+        let schema = infer_schema(&metadata).context(UnableToParseSchemaFromMetadataSnafu::<String> {path: uri.into()})?;
+        Ok(ParquetReaderBuilder { uri: uri.into(), metadata: metadata, arrow_schema: schema, selected_columns: None, row_start_offset: 0, num_rows: num_rows})
+    }
+
+    pub fn prune_columns(mut self, columns: &[&str]) -> super::Result<Self> {
+        let avail_names = self.arrow_schema.fields
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect::<HashSet<_>>();
+        let mut names_to_keep = HashSet::new();
+        for col_name in columns {
+            if avail_names.contains(col_name) {
+                names_to_keep.insert(col_name.to_string());
+            } else {
+                return Err(super::Error::FieldNotFound{
+                    field: col_name.to_string(),
+                    available_fields: avail_names.iter().map(|v| v.to_string()).collect(),
+                    path: self.uri
+                });
+            }
+        }
+        self.selected_columns = Some(names_to_keep);
+        Ok(self)
+    }
+    pub fn limit(mut self, start_offset: Option<usize>, num_rows: Option<usize>) -> super::Result<Self> {
+        let start_offset = start_offset.unwrap_or(0);
+        let num_rows = num_rows.unwrap_or(self.metadata.num_rows.saturating_sub(start_offset));
+        self.row_start_offset = start_offset;
+        self.num_rows = num_rows;
+        Ok(self)
+    }
+
+    pub fn build(self) -> super::Result<ParquetReader> {
+        let mut row_ranges = vec![];
+
+        let rg_iter = self.metadata.row_groups.iter();
+
+        let mut curr_row_index = 0;
+
+        while let Some(rg) = rg_iter.next() {
+            if (curr_row_index + rg.num_rows()) < self.row_start_offset {
+                curr_row_index += rg.num_rows();
+                continue;
+            } else {
+                
+            }
+        }
+        
+
+    }
+
+}
+
+
+struct RowGroupRange {
+    row_group_index: usize,
+    start: usize,
+    end: usize,
+}
+
+struct ParquetReader {
+    uri: String,
+    metadata: parquet2::metadata::FileMetaData,
+    arrow_schema: arrow2::datatypes::Schema,
+    row_ranges: Vec<RowGroupRange>
+}

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -52,6 +52,10 @@ impl ParquetReaderBuilder {
         &self.metadata
     }
 
+    pub fn arrow_schema(&self) -> &arrow2::datatypes::Schema {
+        &self.arrow_schema
+    }
+
     pub fn prune_columns(mut self, columns: &[&str]) -> super::Result<Self> {
         let avail_names = self
             .arrow_schema

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -185,10 +185,7 @@ impl ParquetFileReader {
         Ok(read_planner)
     }
 
-    pub async fn prebuffer_ranges(
-        &self,
-        io_client: Arc<IOClient>,
-    ) -> super::Result<RangesContainer> {
+    pub async fn prebuffer_ranges(&self, io_client: Arc<IOClient>) -> DaftResult<RangesContainer> {
         let mut read_planner = self.naive_read_plan()?;
         // TODO(sammy) these values should be populated by io_client
         read_planner.add_pass(Box::new(SplitLargeRequestPass {
@@ -202,7 +199,7 @@ impl ParquetFileReader {
         }));
 
         read_planner.run_passes()?;
-        Ok(read_planner.collect(io_client).await.unwrap())
+        read_planner.collect(io_client).await
     }
 
     pub fn read_from_ranges(self, ranges: RangesContainer) -> DaftResult<Table> {

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -1,33 +1,49 @@
-use std::{sync::Arc, collections::HashSet};
+use std::{collections::HashSet, sync::Arc};
 
 use arrow2::io::parquet::read::infer_schema;
+use daft_io::IOClient;
+use daft_table::Table;
 use snafu::ResultExt;
 
-use crate::{metadata::read_parquet_metadata, UnableToParseSchemaFromMetadataSnafu};
-
-
+use crate::{
+    metadata::read_parquet_metadata,
+    read_planner::{self, CoalescePass, RangesContainer, ReadPlanner, SplitLargeRequestPass},
+    UnableToParseSchemaFromMetadataSnafu,
+};
 
 struct ParquetReaderBuilder {
     uri: String,
+    file_size: usize,
     metadata: parquet2::metadata::FileMetaData,
     arrow_schema: arrow2::datatypes::Schema,
     selected_columns: Option<HashSet<String>>,
     row_start_offset: usize,
-    num_rows: usize
+    num_rows: usize,
 }
-
 
 impl ParquetReaderBuilder {
     pub async fn from_uri(uri: &str, io_client: Arc<daft_io::IOClient>) -> super::Result<Self> {
         let size = 10;
         let metadata = read_parquet_metadata(uri, size, io_client).await?;
         let num_rows = metadata.num_rows;
-        let schema = infer_schema(&metadata).context(UnableToParseSchemaFromMetadataSnafu::<String> {path: uri.into()})?;
-        Ok(ParquetReaderBuilder { uri: uri.into(), metadata: metadata, arrow_schema: schema, selected_columns: None, row_start_offset: 0, num_rows: num_rows})
+        let schema =
+            infer_schema(&metadata)
+                .context(UnableToParseSchemaFromMetadataSnafu::<String> { path: uri.into() })?;
+        Ok(ParquetReaderBuilder {
+            uri: uri.into(),
+            file_size: size,
+            metadata: metadata,
+            arrow_schema: schema,
+            selected_columns: None,
+            row_start_offset: 0,
+            num_rows: num_rows,
+        })
     }
 
     pub fn prune_columns(mut self, columns: &[&str]) -> super::Result<Self> {
-        let avail_names = self.arrow_schema.fields
+        let avail_names = self
+            .arrow_schema
+            .fields
             .iter()
             .map(|f| f.name.as_str())
             .collect::<HashSet<_>>();
@@ -36,17 +52,23 @@ impl ParquetReaderBuilder {
             if avail_names.contains(col_name) {
                 names_to_keep.insert(col_name.to_string());
             } else {
-                return Err(super::Error::FieldNotFound{
+                return Err(super::Error::FieldNotFound {
                     field: col_name.to_string(),
                     available_fields: avail_names.iter().map(|v| v.to_string()).collect(),
-                    path: self.uri
+                    path: self.uri,
                 });
             }
         }
         self.selected_columns = Some(names_to_keep);
         Ok(self)
     }
-    pub fn limit(mut self, start_offset: Option<usize>, num_rows: Option<usize>) -> super::Result<Self> {
+
+    pub fn limit(
+        mut self,
+        start_offset: Option<usize>,
+        num_rows: Option<usize>,
+    ) -> super::Result<Self> {
+        todo!("TODO Need to test this before merging");
         let start_offset = start_offset.unwrap_or(0);
         let num_rows = num_rows.unwrap_or(self.metadata.num_rows.saturating_sub(start_offset));
         self.row_start_offset = start_offset;
@@ -54,37 +76,128 @@ impl ParquetReaderBuilder {
         Ok(self)
     }
 
-    pub fn build(self) -> super::Result<ParquetReader> {
+    pub fn build(mut self) -> super::Result<ParquetFileReader> {
         let mut row_ranges = vec![];
 
-        let rg_iter = self.metadata.row_groups.iter();
+        let mut rg_iter = self.metadata.row_groups.iter().enumerate();
 
         let mut curr_row_index = 0;
+        let mut rows_to_add = self.num_rows;
 
-        while let Some(rg) = rg_iter.next() {
+        while let Some((i, rg)) = rg_iter.next() {
             if (curr_row_index + rg.num_rows()) < self.row_start_offset {
                 curr_row_index += rg.num_rows();
                 continue;
+            } else if rows_to_add > 0 {
+                let range_to_add = RowGroupRange {
+                    row_group_index: i,
+                    start: self.row_start_offset.saturating_sub(curr_row_index),
+                    num_rows: rg.num_rows().min(rows_to_add),
+                };
+                rows_to_add = rows_to_add.saturating_sub(rg.num_rows().min(rows_to_add));
+                row_ranges.push(range_to_add);
             } else {
-                
+                break;
             }
+            curr_row_index += rg.num_rows();
         }
-        
 
+        if let Some(names_to_keep) = self.selected_columns {
+            self.arrow_schema
+                .fields
+                .retain(|f| names_to_keep.contains(f.name.as_str()));
+        }
+
+        ParquetFileReader::new(
+            self.uri,
+            self.file_size,
+            self.metadata,
+            self.arrow_schema,
+            row_ranges,
+        )
     }
-
 }
-
 
 struct RowGroupRange {
     row_group_index: usize,
     start: usize,
-    end: usize,
+    num_rows: usize,
 }
 
-struct ParquetReader {
+struct ParquetFileReader {
     uri: String,
+    file_size: usize,
     metadata: parquet2::metadata::FileMetaData,
     arrow_schema: arrow2::datatypes::Schema,
-    row_ranges: Vec<RowGroupRange>
+    row_ranges: Vec<RowGroupRange>,
+}
+
+impl ParquetFileReader {
+    fn new(
+        uri: String,
+        file_size: usize,
+        metadata: parquet2::metadata::FileMetaData,
+        arrow_schema: arrow2::datatypes::Schema,
+        row_ranges: Vec<RowGroupRange>,
+    ) -> super::Result<Self> {
+        Ok(ParquetFileReader {
+            uri,
+            file_size,
+            metadata,
+            arrow_schema,
+            row_ranges,
+        })
+    }
+
+    fn naive_read_plan(&self) -> super::Result<ReadPlanner> {
+        let arrow_fields = &self.arrow_schema.fields;
+
+        let mut read_planner = ReadPlanner::new(&self.uri);
+
+        for row_group_range in self.row_ranges.iter() {
+            let rg = self
+                .metadata
+                .row_groups
+                .get(row_group_range.row_group_index)
+                .unwrap();
+
+            let columns = rg.columns();
+            for field in arrow_fields.iter() {
+                let field_name = field.name.clone();
+                let filtered_cols = columns
+                    .iter()
+                    .filter(|x| x.descriptor().path_in_schema[0] == field_name)
+                    .collect::<Vec<_>>();
+
+                for col in filtered_cols {
+                    let (start, len) = col.byte_range();
+                    let end = start + len;
+
+                    read_planner.add_range(start as usize, end as usize);
+                }
+            }
+        }
+
+        Ok(read_planner)
+    }
+
+    pub async fn prebuffer_ranges(
+        &self,
+        io_client: Arc<IOClient>,
+    ) -> super::Result<RangesContainer> {
+        let mut read_planner = self.naive_read_plan()?;
+        // TODO(sammy) these values should be populated by io_client
+        read_planner.add_pass(Box::new(SplitLargeRequestPass {
+            max_request_size: 16 * 1024 * 1024,
+            split_threshold: 24 * 1024 * 1024,
+        }));
+
+        read_planner.add_pass(Box::new(CoalescePass {
+            max_hole_size: 1024 * 1024,
+            max_request_size: 16 * 1024 * 1024,
+        }));
+
+        read_planner.run_passes()?;
+        Ok(read_planner.collect(io_client).await.unwrap())
+    }
 }

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -40,11 +40,11 @@ impl ParquetReaderBuilder {
                 .context(UnableToParseSchemaFromMetadataSnafu::<String> { path: uri.into() })?;
         Ok(ParquetReaderBuilder {
             uri: uri.into(),
-            metadata: metadata,
+            metadata,
             arrow_schema: schema,
             selected_columns: None,
             row_start_offset: 0,
-            num_rows: num_rows,
+            num_rows,
         })
     }
 

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -48,6 +48,10 @@ impl ParquetReaderBuilder {
         })
     }
 
+    pub fn metadata(&self) -> &parquet2::metadata::FileMetaData {
+        &self.metadata
+    }
+
     pub fn prune_columns(mut self, columns: &[&str]) -> super::Result<Self> {
         let avail_names = self
             .arrow_schema

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -118,7 +118,6 @@ impl ParquetReaderBuilder {
 
         ParquetFileReader::new(
             self.uri,
-            self.file_size,
             self.metadata,
             self.arrow_schema,
             row_ranges,
@@ -134,7 +133,6 @@ struct RowGroupRange {
 
 pub(crate) struct ParquetFileReader {
     uri: String,
-    file_size: usize,
     metadata: parquet2::metadata::FileMetaData,
     arrow_schema: arrow2::datatypes::Schema,
     row_ranges: Vec<RowGroupRange>,
@@ -143,14 +141,12 @@ pub(crate) struct ParquetFileReader {
 impl ParquetFileReader {
     fn new(
         uri: String,
-        file_size: usize,
         metadata: parquet2::metadata::FileMetaData,
         arrow_schema: arrow2::datatypes::Schema,
         row_ranges: Vec<RowGroupRange>,
     ) -> super::Result<Self> {
         Ok(ParquetFileReader {
             uri,
-            file_size,
             metadata,
             arrow_schema,
             row_ranges,

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -6,7 +6,7 @@ use snafu::Snafu;
 pub mod metadata;
 pub mod read;
 mod read_planner;
-
+mod file;
 #[cfg(feature = "python")]
 pub mod python;
 #[cfg(feature = "python")]
@@ -30,6 +30,18 @@ pub enum Error {
     UnableToParseMetadata {
         path: String,
         source: parquet2::error::Error,
+    },
+
+    #[snafu(display("Unable to parse parquet metadata to arrow schema for file {}: {}", path, source))]
+    UnableToParseSchemaFromMetadata {
+        path: String,
+        source: arrow2::error::Error,
+    },
+    #[snafu(display("Field: {} not found in Parquet File: {} Available Fields: {:?}", field, path, available_fields))]
+    FieldNotFound {
+        field: String,
+        available_fields: Vec<String>,
+        path: String
     },
     #[snafu(display(
         "File: {} is not a valid parquet file. Has incorrect footer: {:?}",

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -33,6 +33,15 @@ pub enum Error {
     },
 
     #[snafu(display(
+        "Unable to create arrow arrays from parquet pages {}: {}",
+        path,
+        source
+    ))]
+    UnableToConvertParquetPagesToArrow {
+        path: String,
+        source: arrow2::error::Error,
+    },
+    #[snafu(display(
         "Unable to parse parquet metadata to arrow schema for file {}: {}",
         path,
         source

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -3,12 +3,12 @@
 use common_error::DaftError;
 use snafu::Snafu;
 
-pub mod metadata;
-pub mod read;
-mod read_planner;
 mod file;
+pub mod metadata;
 #[cfg(feature = "python")]
 pub mod python;
+pub mod read;
+mod read_planner;
 #[cfg(feature = "python")]
 pub use python::register_modules;
 
@@ -32,16 +32,25 @@ pub enum Error {
         source: parquet2::error::Error,
     },
 
-    #[snafu(display("Unable to parse parquet metadata to arrow schema for file {}: {}", path, source))]
+    #[snafu(display(
+        "Unable to parse parquet metadata to arrow schema for file {}: {}",
+        path,
+        source
+    ))]
     UnableToParseSchemaFromMetadata {
         path: String,
         source: arrow2::error::Error,
     },
-    #[snafu(display("Field: {} not found in Parquet File: {} Available Fields: {:?}", field, path, available_fields))]
+    #[snafu(display(
+        "Field: {} not found in Parquet File: {} Available Fields: {:?}",
+        field,
+        path,
+        available_fields
+    ))]
     FieldNotFound {
         field: String,
         available_fields: Vec<String>,
-        path: String
+        path: String,
     },
     #[snafu(display(
         "File: {} is not a valid parquet file. Has incorrect footer: {:?}",

--- a/src/daft-parquet/src/metadata.rs
+++ b/src/daft-parquet/src/metadata.rs
@@ -78,7 +78,7 @@ pub async fn read_parquet_metadata(
             footer: buffer[buffer.len() - 4..].into(),
         });
     }
-
+    // use rayon here
     tokio::task::spawn_blocking(move || {
         let reader = &data.as_ref()[remaining..];
         let max_size = reader.len() * 2 + 1024;

--- a/src/daft-parquet/src/metadata.rs
+++ b/src/daft-parquet/src/metadata.rs
@@ -22,7 +22,7 @@ pub async fn read_parquet_metadata(
     const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
 
     /// The number of bytes read at the end of the parquet file on first read
-    const DEFAULT_FOOTER_READ_SIZE: usize = 1024 * 1024;
+    const DEFAULT_FOOTER_READ_SIZE: usize = 128 * 1024;
     let default_end_len = std::cmp::min(DEFAULT_FOOTER_READ_SIZE, size);
 
     let start = size.saturating_sub(default_end_len);

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -10,8 +10,8 @@ pub mod pylib {
         py: Python,
         uri: &str,
         columns: Option<Vec<&str>>,
-        row_groups: Option<Vec<i64>>,
-        size: Option<usize>,
+        start_offset: Option<usize>,
+        num_rows: Option<usize>,
         io_config: Option<PyIOConfig>,
     ) -> PyResult<PyTable> {
         py.allow_threads(|| {
@@ -19,8 +19,8 @@ pub mod pylib {
             Ok(crate::read::read_parquet(
                 uri,
                 columns.as_deref(),
-                row_groups.as_deref(),
-                size,
+                start_offset,
+                num_rows,
                 io_client,
             )?
             .into())

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -16,7 +16,6 @@ pub mod pylib {
     ) -> PyResult<PyTable> {
         py.allow_threads(|| {
             let io_client = get_io_client(io_config.unwrap_or_default().config.into())?;
-
             Ok(crate::read::read_parquet(
                 uri,
                 columns.as_deref(),

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -1,6 +1,7 @@
 use pyo3::prelude::*;
 
 pub mod pylib {
+    use daft_core::python::PySeries;
     use daft_io::{get_io_client, python::PyIOConfig};
     use daft_table::python::PyTable;
     use pyo3::{pyfunction, PyResult, Python};
@@ -26,8 +27,21 @@ pub mod pylib {
             .into())
         })
     }
+
+    #[pyfunction]
+    pub fn read_parquet_statistics(
+        py: Python,
+        uris: PySeries,
+        io_config: Option<PyIOConfig>,
+    ) -> PyResult<PyTable> {
+        py.allow_threads(|| {
+            let io_client = get_io_client(io_config.unwrap_or_default().config.into())?;
+            Ok(crate::read::read_parquet_statistics(&uris.series, io_client)?.into())
+        })
+    }
 }
 pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
     parent.add_wrapped(wrap_pyfunction!(pylib::read_parquet))?;
+    parent.add_wrapped(wrap_pyfunction!(pylib::read_parquet_statistics))?;
     Ok(())
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -15,7 +15,7 @@ use parquet2::{
 
 use crate::{
     metadata::read_parquet_metadata,
-    read_planner::{self, CoalescePass, RangesContainer, ReadPlanBuilder, SplitLargeRequestPass},
+    read_planner::{self, CoalescePass, RangesContainer, ReadPlanner, SplitLargeRequestPass},
 };
 
 fn plan_read_row_groups(
@@ -23,7 +23,7 @@ fn plan_read_row_groups(
     columns: Option<&[&str]>,
     row_groups: Option<&[i64]>,
     metadata: &FileMetaData,
-) -> DaftResult<ReadPlanBuilder> {
+) -> DaftResult<ReadPlanner> {
     let arrow_schema = infer_schema(metadata)?;
     let mut arrow_fields = arrow_schema.fields;
     if let Some(columns) = columns {
@@ -47,7 +47,7 @@ fn plan_read_row_groups(
     };
 
     let num_row_groups = metadata.row_groups.len();
-    let mut read_plan = read_planner::ReadPlanBuilder::new(uri);
+    let mut read_plan = read_planner::ReadPlanner::new(uri);
     let row_groups = match row_groups {
         Some(rg) => rg.to_vec(),
         None => (0i64..num_row_groups as i64).collect(),

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -3,16 +3,12 @@ use std::sync::Arc;
 use common_error::DaftResult;
 
 use daft_core::{
-    array::ops::as_arrow,
     datatypes::{Int32Array, UInt64Array, Utf8Array},
     DataType, IntoSeries, Series,
 };
 use daft_io::{get_runtime, IOClient};
 use daft_table::Table;
-use futures::{
-    future::{join_all, try_join_all},
-    StreamExt, TryFutureExt,
-};
+use futures::future::join_all;
 use snafu::ResultExt;
 
 use crate::{file::ParquetReaderBuilder, JoinSnafu};

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -2,10 +2,20 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 
+use daft_core::{
+    array::ops::as_arrow,
+    datatypes::{Int32Array, UInt64Array, Utf8Array},
+    DataType, IntoSeries, Series,
+};
 use daft_io::{get_runtime, IOClient};
 use daft_table::Table;
+use futures::{
+    future::{join_all, try_join_all},
+    StreamExt, TryFutureExt,
+};
+use snafu::ResultExt;
 
-use crate::file::ParquetReaderBuilder;
+use crate::{file::ParquetReaderBuilder, JoinSnafu};
 
 pub fn read_parquet(
     uri: &str,
@@ -31,6 +41,78 @@ pub fn read_parquet(
     })?;
 
     reader.read_from_ranges(ranges)
+}
+
+// fn read_parquet_schema
+pub fn read_parquet_statistics(uris: &Series, io_client: Arc<IOClient>) -> DaftResult<Table> {
+    let runtime_handle = get_runtime(true)?;
+    let _rt_guard = runtime_handle.enter();
+
+    if uris.data_type() != &DataType::Utf8 {
+        return Err(common_error::DaftError::ValueError(format!(
+            "Expected Utf8 Datatype, got {}",
+            uris.data_type()
+        )));
+    }
+
+    let path_array: &Utf8Array = uris.downcast()?;
+    use daft_core::array::ops::as_arrow::AsArrow;
+    let values = path_array.as_arrow();
+
+    let handles_iter = values.iter().map(|uri| {
+        let owned_string = uri.map(|v| v.to_string());
+        let owned_client = io_client.clone();
+        tokio::spawn(async move {
+            if let Some(owned_string) = owned_string {
+                let builder = ParquetReaderBuilder::from_uri(&owned_string, owned_client).await?;
+                let num_rows = builder.metadata().num_rows;
+                let num_row_groups = builder.metadata().row_groups.len();
+                let version_num = builder.metadata().version;
+
+                Ok((Some(num_rows), Some(num_row_groups), Some(version_num)))
+            } else {
+                Ok((None, None, None))
+            }
+        })
+    });
+
+    let metadata_tuples = runtime_handle.block_on(async move { join_all(handles_iter).await });
+    let all_tuples = metadata_tuples
+        .into_iter()
+        .zip(values.iter())
+        .map(|(t, u)| {
+            t.with_context(|_| JoinSnafu::<String> {
+                path: u.unwrap().to_string(),
+            })?
+        })
+        .collect::<DaftResult<Vec<_>>>()?;
+    assert_eq!(all_tuples.len(), uris.len());
+
+    let row_count_series = UInt64Array::from((
+        "row_count",
+        Box::new(arrow2::array::UInt64Array::from_iter(
+            all_tuples.iter().map(|v| v.0.map(|v| v as u64)),
+        )),
+    ));
+    let row_group_series = UInt64Array::from((
+        "row_group_count",
+        Box::new(arrow2::array::UInt64Array::from_iter(
+            all_tuples.iter().map(|v| v.1.map(|v| v as u64)),
+        )),
+    ));
+    let version_series = Int32Array::from((
+        "version",
+        Box::new(arrow2::array::Int32Array::from_iter(
+            all_tuples.iter().map(|v| v.2),
+        )),
+    ));
+
+    Table::from_columns(vec![
+        uris.clone(),
+        row_count_series.into_series(),
+        row_group_series.into_series(),
+        version_series.into_series(),
+    ])
 }
 
 #[cfg(test)]

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -14,180 +14,10 @@ use parquet2::{
 };
 
 use crate::{
+    file::ParquetReaderBuilder,
     metadata::read_parquet_metadata,
     read_planner::{self, CoalescePass, RangesContainer, ReadPlanner, SplitLargeRequestPass},
 };
-
-fn plan_read_row_groups(
-    uri: &str,
-    columns: Option<&[&str]>,
-    row_groups: Option<&[i64]>,
-    metadata: &FileMetaData,
-) -> DaftResult<ReadPlanner> {
-    let arrow_schema = infer_schema(metadata)?;
-    let mut arrow_fields = arrow_schema.fields;
-    if let Some(columns) = columns {
-        let avail_names = arrow_fields
-            .iter()
-            .map(|f| f.name.as_str())
-            .collect::<HashSet<_>>();
-        let mut names_to_keep = HashSet::new();
-        for col_name in columns {
-            if avail_names.contains(col_name) {
-                names_to_keep.insert(*col_name);
-            } else {
-                return Err(common_error::DaftError::FieldNotFound(format!(
-                    "Field: {} not found in {:?} when planning read for parquet file",
-                    col_name, avail_names
-                )));
-            }
-        }
-
-        arrow_fields.retain(|f| names_to_keep.contains(f.name.as_str()))
-    };
-
-    let num_row_groups = metadata.row_groups.len();
-    let mut read_plan = read_planner::ReadPlanner::new(uri);
-    let row_groups = match row_groups {
-        Some(rg) => rg.to_vec(),
-        None => (0i64..num_row_groups as i64).collect(),
-    };
-
-    for row_group in row_groups {
-        if !(0i64..num_row_groups as i64).contains(&row_group) {
-            return Err(super::Error::ParquetRowGroupOutOfIndex {
-                path: uri.into(),
-                row_group,
-                total_row_groups: num_row_groups as i64,
-            }
-            .into());
-        }
-
-        let rg = metadata.row_groups.get(row_group as usize).unwrap();
-
-        let columns = rg.columns();
-        for field in arrow_fields.iter() {
-            let field_name = field.name.clone();
-            let filtered_cols = columns
-                .iter()
-                .filter(|x| x.descriptor().path_in_schema[0] == field_name)
-                .collect::<Vec<_>>();
-
-            for col in filtered_cols {
-                let (start, len) = col.byte_range();
-                let end = start + len;
-
-                read_plan.add_range(start as usize, end as usize);
-            }
-        }
-    }
-    Ok(read_plan)
-}
-
-fn read_row_groups_from_ranges(
-    reader: &RangesContainer,
-    columns: Option<&[&str]>,
-    row_groups: Option<&[i64]>,
-    metadata: &FileMetaData,
-) -> DaftResult<Table> {
-    let arrow_schema = infer_schema(metadata)?;
-
-    let mut arrow_fields = arrow_schema.fields;
-
-    if let Some(columns) = columns {
-        let avail_names = arrow_fields
-            .iter()
-            .map(|f| f.name.as_str())
-            .collect::<HashSet<_>>();
-        let mut names_to_keep = HashSet::new();
-        for col_name in columns {
-            if avail_names.contains(col_name) {
-                names_to_keep.insert(*col_name);
-            } else {
-                return Err(common_error::DaftError::FieldNotFound(format!(
-                    "Field: {} not found in {:?} when planning read for parquet file",
-                    col_name, avail_names
-                )));
-            }
-        }
-
-        arrow_fields.retain(|f| names_to_keep.contains(f.name.as_str()))
-    };
-    let daft_schema = daft_core::schema::Schema::try_from(&arrow2::datatypes::Schema {
-        fields: arrow_fields.clone(),
-        metadata: BTreeMap::new(),
-    })?;
-
-    let mut daft_series = vec![vec![]; arrow_fields.len()];
-    let num_row_groups = metadata.row_groups.len();
-
-    let row_groups = match row_groups {
-        Some(rg) => rg.to_vec(),
-        None => (0i64..num_row_groups as i64).collect(),
-    };
-
-    for row_group in row_groups {
-        if !(0i64..num_row_groups as i64).contains(&row_group) {
-            panic!("out of row group index");
-        }
-
-        let rg = metadata.row_groups.get(row_group as usize).unwrap();
-
-        let columns = rg.columns();
-        for (ii, field) in arrow_fields.iter().enumerate() {
-            let field_name = field.name.clone();
-            let mut decompressed_iters = vec![];
-            let mut ptypes = vec![];
-            let filtered_cols = columns
-                .iter()
-                .filter(|x| x.descriptor().path_in_schema[0] == field_name)
-                .collect::<Vec<_>>();
-
-            for col in filtered_cols {
-                let (start, len) = col.byte_range();
-                let end = start + len;
-
-                // should stream this instead
-                let range_reader = reader.get_range_reader(start as usize..end as usize)?;
-                let pages = PageReader::new(
-                    range_reader,
-                    col,
-                    Arc::new(|_, _| true),
-                    vec![],
-                    4 * 1024 * 1024,
-                );
-
-                decompressed_iters.push(BasicDecompressor::new(pages, vec![]));
-
-                ptypes.push(&col.descriptor().descriptor.primitive_type);
-            }
-
-            // let field = &arrow_schema.fields[ii];
-            let arr_iter = column_iter_to_arrays(
-                decompressed_iters,
-                ptypes,
-                field.clone(),
-                Some(4096),
-                rg.num_rows(),
-            )?;
-
-            let all_arrays = arr_iter.collect::<arrow2::error::Result<Vec<_>>>()?;
-            let ser = all_arrays
-                .into_iter()
-                .map(|a| Series::try_from((field.name.as_str(), cast_array_for_daft_if_needed(a))))
-                .collect::<DaftResult<Vec<Series>>>()?;
-
-            daft_series[ii].extend(ser);
-        }
-    }
-
-    let compacted_series = daft_series
-        .into_iter()
-        .map(|s| Series::concat(s.iter().collect::<Vec<_>>().as_ref()))
-        .collect::<DaftResult<_>>()?;
-
-    Table::new(daft_schema, compacted_series)
-}
 
 pub fn read_parquet(
     uri: &str,
@@ -198,31 +28,21 @@ pub fn read_parquet(
 ) -> DaftResult<Table> {
     let runtime_handle = get_runtime(true)?;
     let _rt_guard = runtime_handle.enter();
+    assert!(row_groups.is_none());
+    let (reader, ranges) = runtime_handle.block_on(async {
+        let builder = ParquetReaderBuilder::from_uri(uri, io_client.clone()).await?;
 
-    let (metadata, dl_ranges) = runtime_handle.block_on(async {
-        let size = match size {
-            Some(size) => size,
-            None => io_client.single_url_get_size(uri.into()).await?,
+        let builder = if let Some(columns) = columns {
+            builder.prune_columns(columns)?
+        } else {
+            builder
         };
-
-        let metadata = read_parquet_metadata(uri, size, io_client.clone()).await?;
-
-        let mut plan = plan_read_row_groups(uri, columns, row_groups, &metadata)?;
-
-        plan.add_pass(Box::new(SplitLargeRequestPass {
-            max_request_size: 16 * 1024 * 1024,
-            split_threshold: 24 * 1024 * 1024,
-        }));
-
-        plan.add_pass(Box::new(CoalescePass {
-            max_hole_size: 1024 * 1024,
-            max_request_size: 16 * 1024 * 1024,
-        }));
-        plan.run_passes()?;
-        DaftResult::Ok((metadata, plan.collect(io_client).await?))
+        let parquet_reader = builder.build()?;
+        let ranges = parquet_reader.prebuffer_ranges(io_client.clone()).await?;
+        DaftResult::Ok((parquet_reader, ranges))
     })?;
 
-    read_row_groups_from_ranges(&dl_ranges, columns, row_groups, &metadata)
+    reader.read_from_ranges(ranges)
 }
 
 #[cfg(test)]
@@ -233,46 +53,46 @@ mod tests {
     use daft_io::{config::IOConfig, IOClient};
 
     use super::read_parquet;
-    #[test]
-    fn test_parquet_read_from_s3() -> DaftResult<()> {
-        let file = "s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet";
+    // #[test]
+    // fn test_parquet_read_from_s3() -> DaftResult<()> {
+    //     let file = "s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet";
 
-        let mut io_config = IOConfig::default();
-        io_config.s3.anonymous = true;
+    //     let mut io_config = IOConfig::default();
+    //     io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+    //     let io_client = Arc::new(IOClient::new(io_config.into())?);
 
-        let table = read_parquet(file, None, None, None, io_client)?;
-        assert_eq!(table.len(), 100);
+    //     let table = read_parquet(file, None, None, None, io_client)?;
+    //     assert_eq!(table.len(), 100);
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
-    use crate::{
-        read::plan_read_row_groups, read::read_row_groups_from_ranges, read_planner::CoalescePass,
-    };
+    // use crate::{
+    //     read::plan_read_row_groups, read::read_row_groups_from_ranges, read_planner::CoalescePass,
+    // };
 
-    #[tokio::test]
-    async fn test_parquet_read_planner() -> DaftResult<()> {
-        let file = "s3://daft-public-data/test_fixtures/parquet_small/0dad4c3f-da0d-49db-90d8-98684571391b-0.parquet";
+    // #[tokio::test]
+    // async fn test_parquet_read_planner() -> DaftResult<()> {
+    //     let file = "s3://daft-public-data/test_fixtures/parquet_small/0dad4c3f-da0d-49db-90d8-98684571391b-0.parquet";
 
-        let mut io_config = IOConfig::default();
-        io_config.s3.anonymous = true;
+    //     let mut io_config = IOConfig::default();
+    //     io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
-        let size = io_client.single_url_get_size(file.into()).await?;
-        let metadata =
-            crate::metadata::read_parquet_metadata(file, size, io_client.clone()).await?;
-        let mut plan = plan_read_row_groups(file, Some(&["P_PARTKEY"]), Some(&[1, 2]), &metadata)?;
+    //     let io_client = Arc::new(IOClient::new(io_config.into())?);
+    //     let size = io_client.single_url_get_size(file.into()).await?;
+    //     let metadata =
+    //         crate::metadata::read_parquet_metadata(file, size, io_client.clone()).await?;
+    //     let mut plan = plan_read_row_groups(file, Some(&["P_PARTKEY"]), Some(&[1, 2]), &metadata)?;
 
-        plan.add_pass(Box::new(CoalescePass {
-            max_hole_size: 1024 * 1024,
-            max_request_size: 16 * 1024 * 1024,
-        }));
-        plan.run_passes()?;
-        let memory = plan.collect(io_client.clone()).await?;
-        let _table =
-            read_row_groups_from_ranges(&memory, Some(&["P_PARTKEY"]), Some(&[1, 2]), &metadata)?;
-        Ok(())
-    }
+    //     plan.add_pass(Box::new(CoalescePass {
+    //         max_hole_size: 1024 * 1024,
+    //         max_request_size: 16 * 1024 * 1024,
+    //     }));
+    //     plan.run_passes()?;
+    //     let memory = plan.collect(io_client.clone()).await?;
+    //     let _table =
+    //         read_row_groups_from_ranges(&memory, Some(&["P_PARTKEY"]), Some(&[1, 2]), &metadata)?;
+    //     Ok(())
+    // }
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -1,9 +1,7 @@
 use std::{
-    collections::{BTreeMap, HashSet},
     sync::Arc,
 };
 
-use arrow2::io::parquet::read::{column_iter_to_arrays, infer_schema};
 use common_error::DaftResult;
 use daft_core::{utils::arrow::cast_array_for_daft_if_needed, Series};
 use daft_io::{get_runtime, IOClient};
@@ -53,46 +51,18 @@ mod tests {
     use daft_io::{config::IOConfig, IOClient};
 
     use super::read_parquet;
-    // #[test]
-    // fn test_parquet_read_from_s3() -> DaftResult<()> {
-    //     let file = "s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet";
+    #[test]
+    fn test_parquet_read_from_s3() -> DaftResult<()> {
+        let file = "s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet";
 
-    //     let mut io_config = IOConfig::default();
-    //     io_config.s3.anonymous = true;
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
-    //     let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
-    //     let table = read_parquet(file, None, None, None, io_client)?;
-    //     assert_eq!(table.len(), 100);
+        let table = read_parquet(file, None, None, None, io_client)?;
+        assert_eq!(table.len(), 100);
 
-    //     Ok(())
-    // }
-
-    // use crate::{
-    //     read::plan_read_row_groups, read::read_row_groups_from_ranges, read_planner::CoalescePass,
-    // };
-
-    // #[tokio::test]
-    // async fn test_parquet_read_planner() -> DaftResult<()> {
-    //     let file = "s3://daft-public-data/test_fixtures/parquet_small/0dad4c3f-da0d-49db-90d8-98684571391b-0.parquet";
-
-    //     let mut io_config = IOConfig::default();
-    //     io_config.s3.anonymous = true;
-
-    //     let io_client = Arc::new(IOClient::new(io_config.into())?);
-    //     let size = io_client.single_url_get_size(file.into()).await?;
-    //     let metadata =
-    //         crate::metadata::read_parquet_metadata(file, size, io_client.clone()).await?;
-    //     let mut plan = plan_read_row_groups(file, Some(&["P_PARTKEY"]), Some(&[1, 2]), &metadata)?;
-
-    //     plan.add_pass(Box::new(CoalescePass {
-    //         max_hole_size: 1024 * 1024,
-    //         max_request_size: 16 * 1024 * 1024,
-    //     }));
-    //     plan.run_passes()?;
-    //     let memory = plan.collect(io_client.clone()).await?;
-    //     let _table =
-    //         read_row_groups_from_ranges(&memory, Some(&["P_PARTKEY"]), Some(&[1, 2]), &metadata)?;
-    //     Ok(())
-    // }
+        Ok(())
+    }
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -1,21 +1,11 @@
-use std::{
-    sync::Arc,
-};
+use std::sync::Arc;
 
 use common_error::DaftResult;
-use daft_core::{utils::arrow::cast_array_for_daft_if_needed, Series};
+
 use daft_io::{get_runtime, IOClient};
 use daft_table::Table;
-use parquet2::{
-    metadata::FileMetaData,
-    read::{BasicDecompressor, PageReader},
-};
 
-use crate::{
-    file::ParquetReaderBuilder,
-    metadata::read_parquet_metadata,
-    read_planner::{self, CoalescePass, RangesContainer, ReadPlanner, SplitLargeRequestPass},
-};
+use crate::file::ParquetReaderBuilder;
 
 pub fn read_parquet(
     uri: &str,

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -4,6 +4,7 @@ use common_error::DaftResult;
 
 use daft_core::{
     datatypes::{Int32Array, UInt64Array, Utf8Array},
+    schema::Schema,
     DataType, IntoSeries, Series,
 };
 use daft_io::{get_runtime, IOClient};
@@ -39,7 +40,14 @@ pub fn read_parquet(
     reader.read_from_ranges(ranges)
 }
 
-// fn read_parquet_schema
+pub fn read_parquet_schema(uri: &str, io_client: Arc<IOClient>) -> DaftResult<Schema> {
+    let runtime_handle = get_runtime(true)?;
+    let _rt_guard = runtime_handle.enter();
+    let builder = runtime_handle
+        .block_on(async { ParquetReaderBuilder::from_uri(uri, io_client.clone()).await })?;
+    Schema::try_from(builder.arrow_schema())
+}
+
 pub fn read_parquet_statistics(uris: &Series, io_client: Arc<IOClient>) -> DaftResult<Table> {
     let runtime_handle = get_runtime(true)?;
     let _rt_guard = runtime_handle.enter();

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -151,7 +151,7 @@ pub(crate) struct RangesContainer {
 }
 
 impl RangesContainer {
-    pub fn get_range_reader<'a>(&'a self, range: Range<usize>) -> DaftResult<MultiRead<'a>> {
+    pub fn get_range_reader<'a>(&'a self, range: Range<usize>) -> super::Result<MultiRead<'a>> {
         let mut current_pos = range.start;
         let mut curr_index;
         let start_point = self.ranges.binary_search_by_key(&current_pos, |(v, _)| *v);

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -83,15 +83,15 @@ impl ReadPlanPass for SplitLargeRequestPass {
     }
 }
 
-pub(crate) struct ReadPlanBuilder {
+pub(crate) struct ReadPlanner {
     source: String,
     ranges: RangeList,
     passes: Vec<Box<dyn ReadPlanPass>>,
 }
 
-impl ReadPlanBuilder {
+impl ReadPlanner {
     pub fn new(source: &str) -> Self {
-        ReadPlanBuilder {
+        ReadPlanner {
             source: source.into(),
             ranges: vec![],
             passes: vec![],
@@ -264,7 +264,7 @@ impl Read for MultiRead<'_> {
     }
 }
 
-impl Display for ReadPlanBuilder {
+impl Display for ReadPlanner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "ReadPlanBuilder: {} ranges", self.ranges.len())?;
         for range in self.ranges.iter() {


### PR DESCRIPTION
* Refactors Native parquet reader (without perf improvements)
* adds ability to add offset and limit to number of rows
* adds python: `Table.read_parquet_statistics` to grab basic stats from a series of urls
* adds python: `Schema.from_parquet` to generate Schema from parquet file