### PR TITLE
[CHORE] Add pytest marker for integration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,12 @@ import pyarrow as pa
 import pytest
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "integration: mark test as an integration test that runs with external dependencies"
+    )
+
+
 class UuidType(pa.ExtensionType):
     NAME = "daft.uuid"
 


### PR DESCRIPTION
This removes warnings when running tests like:

```
tests/integration/io/test_url_download_http.py:18
  /Users/charles/daft/tests/integration/io/test_url_download_http.py:18: PytestUnknownMarkWarning: Unknown pytest.mark.integration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.integration()
```