### PR TITLE
[FEAT] native parquet correctness checks

### DIFF
--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -98,6 +98,30 @@ pub enum Error {
         total_row_groups: i64,
     },
 
+    #[snafu(display(
+        "Parquet file: {} metadata listed {} rows but only read: {} ",
+        path,
+        metadata_num_rows,
+        read_rows
+    ))]
+    ParquetNumRowMismatch {
+        path: String,
+        metadata_num_rows: usize,
+        read_rows: usize,
+    },
+
+    #[snafu(display(
+        "Parquet file: {} metadata listed {} columns but only read: {} ",
+        path,
+        metadata_num_columns,
+        read_columns
+    ))]
+    ParquetNumColumnMismatch {
+        path: String,
+        metadata_num_columns: usize,
+        read_columns: usize,
+    },
+
     #[snafu(display("Error joining spawned task: {} for path: {}", source, path))]
     JoinError {
         path: String,

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -44,7 +44,7 @@ pub fn read_parquet(
         (None, None) if metadata_num_rows != table.len() => {
             Err(super::Error::ParquetNumRowMismatch {
                 path: uri.into(),
-                metadata_num_rows: metadata_num_rows,
+                metadata_num_rows,
                 read_rows: table.len(),
             })
         }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -32,10 +32,53 @@ pub fn read_parquet(
         builder
     };
     let builder = builder.limit(start_offset, num_rows)?;
+
+    let metadata_num_rows = builder.metadata().num_rows;
+    let metadata_num_columns = builder.arrow_schema().fields.len();
+
     let parquet_reader = builder.build()?;
     let ranges = parquet_reader.prebuffer_ranges(io_client)?;
+    let table = runtime_handle.block_on(async { parquet_reader.read_from_ranges(ranges).await })?;
 
-    runtime_handle.block_on(async { parquet_reader.read_from_ranges(ranges).await })
+    match (start_offset, num_rows) {
+        (None, None) if metadata_num_rows != table.len() => {
+            Err(super::Error::ParquetNumRowMismatch {
+                path: uri.into(),
+                metadata_num_rows: metadata_num_rows,
+                read_rows: table.len(),
+            })
+        }
+        (Some(s), None) if metadata_num_rows.saturating_sub(s) != table.len() => {
+            Err(super::Error::ParquetNumRowMismatch {
+                path: uri.into(),
+                metadata_num_rows: metadata_num_rows.saturating_sub(s),
+                read_rows: table.len(),
+            })
+        }
+        (_, Some(n)) if n < table.len() => Err(super::Error::ParquetNumRowMismatch {
+            path: uri.into(),
+            metadata_num_rows: n.max(metadata_num_rows),
+            read_rows: table.len(),
+        }),
+        _ => Ok(()),
+    }?;
+
+    let expected_num_columns = if let Some(columns) = columns {
+        columns.len()
+    } else {
+        metadata_num_columns
+    };
+
+    if table.num_columns() != expected_num_columns {
+        return Err(super::Error::ParquetNumColumnMismatch {
+            path: uri.into(),
+            metadata_num_columns: expected_num_columns,
+            read_columns: table.num_columns(),
+        }
+        .into());
+    }
+
+    Ok(table)
 }
 
 pub fn read_parquet_schema(uri: &str, io_client: Arc<IOClient>) -> DaftResult<Schema> {


### PR DESCRIPTION
* Validates the number of rows and columns are correct (from parquet metadata) before returning a Table from the native reader.