### PR TITLE
[PERF] Native Parquet Bulk Reader

### DIFF
--- a/benchmarking/parquet/conftest.py
+++ b/benchmarking/parquet/conftest.py
@@ -70,7 +70,8 @@ def bulk_read_adapter(func):
 
 
 def daft_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[pa.Table]:
-    return [daft_native_read(f, columns=columns) for f in paths]
+    tables = daft.table.Table.read_parquet_bulk(paths, columns=columns)
+    return [t.to_arrow() for t in tables]
 
 
 def pyarrow_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[pa.Table]:

--- a/benchmarking/parquet/conftest.py
+++ b/benchmarking/parquet/conftest.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import io
-import multiprocessing
-from functools import partial
 
 import boto3
 import pyarrow as pa
@@ -11,6 +9,12 @@ import pyarrow.parquet as papq
 import pytest
 
 import daft
+
+# def daft_legacy_read(path: str, columns: list[str] | None = None) -> pa.Table:
+#     df = daft.read_parquet(path)
+#     if columns is not None:
+#         df = df.select(*columns)
+#     return df.to_arrow()
 
 
 def pyarrow_read(path: str, columns: list[str] | None = None) -> pa.Table:
@@ -71,19 +75,11 @@ def daft_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[p
 
 
 def pyarrow_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[pa.Table]:
-
-    pool = multiprocessing.Pool()
-
-    downloader = partial(pyarrow_read, columns=columns)
-
-    return [table for table in pool.map(downloader, paths)]
+    return [pyarrow_read(f, columns=columns) for f in paths]
 
 
 def boto_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[pa.Table]:
-    pool = multiprocessing.Pool()
-    downloader = partial(boto3_get_object_read, columns=columns)
-
-    return [table for table in pool.map(downloader, paths)]
+    return [boto3_get_object_read(f, columns=columns) for f in paths]
 
 
 @pytest.fixture(
@@ -94,8 +90,8 @@ def boto_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[p
     ],
     ids=[
         "daft_bulk_read",
-        "pyarrow_mp_bulk_read",
-        "boto3_mp_bulk_read",
+        "pyarrow_bulk_read",
+        "boto3_bulk_read",
     ],
 )
 def bulk_read_fn(request):

--- a/benchmarking/parquet/test_bulk_reads.py
+++ b/benchmarking/parquet/test_bulk_reads.py
@@ -10,7 +10,7 @@ PATH = (
 @pytest.mark.benchmark(group="num_files_single_column")
 @pytest.mark.parametrize(
     "num_files",
-    [1, 2, 4, 8],
+    [1, 2, 4, 8, 16, 32],
 )
 def test_read_parquet_num_files_single_column(num_files, bulk_read_fn, benchmark):
     data = benchmark(bulk_read_fn, [PATH] * num_files, columns=["L_ORDERKEY"])
@@ -24,7 +24,7 @@ def test_read_parquet_num_files_single_column(num_files, bulk_read_fn, benchmark
 @pytest.mark.benchmark(group="num_rowgroups_all_columns")
 @pytest.mark.parametrize(
     "num_files",
-    [1, 2, 4],
+    [1, 2, 4, 8],
 )
 def test_read_parquet_num_files_all_columns(num_files, bulk_read_fn, benchmark):
     data = benchmark(bulk_read_fn, [PATH] * num_files)

--- a/benchmarking/parquet/test_bulk_reads.py
+++ b/benchmarking/parquet/test_bulk_reads.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import pytest
 
-PATH = "s3://eventual-dev-benchmarking-fixtures/parquet-benchmarking/tpch/8RG/daft_tpch_100g_32part_8RG.parquet"
+PATH = (
+    "s3://eventual-dev-benchmarking-fixtures/parquet-benchmarking/tpch/200MB-2RG/daft_200MB_lineitem_chunk.RG-2.parquet"
+)
 
 
 @pytest.mark.benchmark(group="num_files_single_column")

--- a/benchmarking/parquet/test_bulk_reads.py
+++ b/benchmarking/parquet/test_bulk_reads.py
@@ -10,7 +10,7 @@ PATH = (
 @pytest.mark.benchmark(group="num_files_single_column")
 @pytest.mark.parametrize(
     "num_files",
-    [1, 2, 4, 8, 16, 32],
+    [1, 2, 4, 8, 16, 32, 64],
 )
 def test_read_parquet_num_files_single_column(num_files, bulk_read_fn, benchmark):
     data = benchmark(bulk_read_fn, [PATH] * num_files, columns=["L_ORDERKEY"])

--- a/benchmarking/parquet/test_bulk_reads.py
+++ b/benchmarking/parquet/test_bulk_reads.py
@@ -10,7 +10,7 @@ PATH = (
 @pytest.mark.benchmark(group="num_files_single_column")
 @pytest.mark.parametrize(
     "num_files",
-    [1, 2, 4, 8, 16, 32, 64],
+    [1, 2, 4, 8],
 )
 def test_read_parquet_num_files_single_column(num_files, bulk_read_fn, benchmark):
     data = benchmark(bulk_read_fn, [PATH] * num_files, columns=["L_ORDERKEY"])
@@ -24,7 +24,7 @@ def test_read_parquet_num_files_single_column(num_files, bulk_read_fn, benchmark
 @pytest.mark.benchmark(group="num_rowgroups_all_columns")
 @pytest.mark.parametrize(
     "num_files",
-    [1, 2, 4, 8],
+    [1, 2, 4],
 )
 def test_read_parquet_num_files_all_columns(num_files, bulk_read_fn, benchmark):
     data = benchmark(bulk_read_fn, [PATH] * num_files)

--- a/benchmarking/parquet/test_bulk_reads.py
+++ b/benchmarking/parquet/test_bulk_reads.py
@@ -18,7 +18,7 @@ def test_read_parquet_num_files_single_column(num_files, bulk_read_fn, benchmark
     # Make sure the data is correct
     for i in range(num_files):
         assert data[i].column_names == ["L_ORDERKEY"]
-        assert len(data[i]) == 18751674
+        assert len(data[i]) == 5515199
 
 
 @pytest.mark.benchmark(group="num_rowgroups_all_columns")
@@ -33,4 +33,4 @@ def test_read_parquet_num_files_all_columns(num_files, bulk_read_fn, benchmark):
     # Make sure the data is correct
     for i in range(num_files):
         assert len(data[i].column_names) == 16
-        assert len(data[i]) == 18751674
+        assert len(data[i]) == 5515199

--- a/benchmarking/parquet/test_bulk_reads.py
+++ b/benchmarking/parquet/test_bulk_reads.py
@@ -8,7 +8,7 @@ PATH = "s3://eventual-dev-benchmarking-fixtures/parquet-benchmarking/tpch/8RG/da
 @pytest.mark.benchmark(group="num_files_single_column")
 @pytest.mark.parametrize(
     "num_files",
-    [2, 4, 8],
+    [1, 2, 4, 8],
 )
 def test_read_parquet_num_files_single_column(num_files, bulk_read_fn, benchmark):
     data = benchmark(bulk_read_fn, [PATH] * num_files, columns=["L_ORDERKEY"])
@@ -22,7 +22,7 @@ def test_read_parquet_num_files_single_column(num_files, bulk_read_fn, benchmark
 @pytest.mark.benchmark(group="num_rowgroups_all_columns")
 @pytest.mark.parametrize(
     "num_files",
-    [2, 4, 8],
+    [1, 2, 4],
 )
 def test_read_parquet_num_files_all_columns(num_files, bulk_read_fn, benchmark):
     data = benchmark(bulk_read_fn, [PATH] * num_files)

--- a/benchmarking/parquet/test_bulk_reads.py
+++ b/benchmarking/parquet/test_bulk_reads.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+PATH = "s3://eventual-dev-benchmarking-fixtures/parquet-benchmarking/tpch/8RG/daft_tpch_100g_32part_8RG.parquet"
+
+
+@pytest.mark.benchmark(group="num_files_single_column")
+@pytest.mark.parametrize(
+    "num_files",
+    [2, 4, 8],
+)
+def test_read_parquet_num_files_single_column(num_files, bulk_read_fn, benchmark):
+    data = benchmark(bulk_read_fn, [PATH] * num_files, columns=["L_ORDERKEY"])
+    assert len(data) == num_files
+    # Make sure the data is correct
+    for i in range(num_files):
+        assert data[i].column_names == ["L_ORDERKEY"]
+        assert len(data[i]) == 18751674
+
+
+@pytest.mark.benchmark(group="num_rowgroups_all_columns")
+@pytest.mark.parametrize(
+    "num_files",
+    [2, 4, 8],
+)
+def test_read_parquet_num_files_all_columns(num_files, bulk_read_fn, benchmark):
+    data = benchmark(bulk_read_fn, [PATH] * num_files)
+    assert len(data) == num_files
+
+    # Make sure the data is correct
+    for i in range(num_files):
+        assert len(data[i].column_names) == 16
+        assert len(data[i]) == 18751674

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -7,7 +7,8 @@ from loguru import logger
 
 from daft.arrow_utils import ensure_table
 from daft.daft import PyTable as _PyTable
-from daft.daft import _read_parquet
+from daft.daft import read_parquet as _read_parquet
+from daft.daft import read_parquet_bulk as _read_parquet_bulk
 from daft.daft import read_parquet_statistics as _read_parquet_statistics
 from daft.datatype import DataType
 from daft.expressions import Expression, ExpressionsProjection
@@ -356,6 +357,20 @@ class Table:
         return Table._from_pytable(
             _read_parquet(uri=path, columns=columns, start_offset=start_offset, num_rows=num_rows, io_config=io_config)
         )
+
+    @classmethod
+    def read_parquet_bulk(
+        cls,
+        paths: list[str],
+        columns: list[str] | None = None,
+        start_offset: int | None = None,
+        num_rows: int | None = None,
+        io_config: IOConfig | None = None,
+    ) -> list[Table]:
+        pytables = _read_parquet_bulk(
+            uris=paths, columns=columns, start_offset=start_offset, num_rows=num_rows, io_config=io_config
+        )
+        return [Table._from_pytable(t) for t in pytables]
 
     @classmethod
     def read_parquet_statistics(

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -187,6 +187,17 @@ def test_parquet_read_table(parquet_file):
 
 
 @pytest.mark.integration()
+def test_parquet_read_table_bulk(parquet_file):
+    _, url = parquet_file
+    daft_native_reads = Table.read_parquet_bulk([url] * 2, io_config=IOConfig(s3=S3Config(anonymous=True)))
+    pa_read = Table.from_arrow(read_parquet_with_pyarrow(url))
+
+    for daft_native_read in daft_native_reads:
+        assert daft_native_read.schema() == pa_read.schema()
+        pd.testing.assert_frame_equal(daft_native_read.to_pandas(), pa_read.to_pandas())
+
+
+@pytest.mark.integration()
 def test_parquet_read_df(parquet_file):
     _, url = parquet_file
     daft_native_read = daft.read_parquet(


### PR DESCRIPTION
* Adds parquet bulk reader which can parallelize across files for IO and compute
* Yielding up to a 5.3x speed up compared to the daft non bulk reader.
![Daft Bulk Reader Relative Speedup (Single Column)](https://github.com/Eventual-Inc/Daft/assets/2550285/be310944-2348-4f85-9441-9695f5b676d9)
