### PR TITLE
[CHORE] [New Query Planner] Introduce `LogicalPlanBuilder` and `QueryPlanner` interfaces to hide query planner implementations.

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, ClassVar
 from loguru import logger
 
 if TYPE_CHECKING:
+    from daft.logical.builder import LogicalPlanBuilder
     from daft.runners.runner import Runner
 
 
@@ -103,6 +104,12 @@ class DaftContext:
     @property
     def is_ray_runner(self) -> bool:
         return isinstance(self.runner_config, _RayRunnerConfig)
+
+    def logical_plan_builder_class(self) -> type[LogicalPlanBuilder]:
+        from daft.logical.logical_plan import PyLogicalPlanBuilder
+        from daft.logical.rust_logical_plan import RustLogicalPlanBuilder
+
+        return RustLogicalPlanBuilder if self.use_rust_planner else PyLogicalPlanBuilder
 
 
 _DaftContext = DaftContext()

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -30,8 +30,9 @@ from daft.dataframe.preview import DataFramePreview
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
 from daft.expressions import Expression, ExpressionsProjection, col, lit
-from daft.logical import logical_plan, rust_logical_plan
 from daft.logical.aggregation_plan_builder import AggregationPlanBuilder
+from daft.logical.builder import JoinType, LogicalPlanBuilder
+from daft.logical.logical_plan import PyLogicalPlanBuilder
 from daft.resource_request import ResourceRequest
 from daft.runners.partitioning import PartitionCacheEntry, PartitionSet
 from daft.runners.pyrunner import LocalPartitionSet
@@ -59,35 +60,41 @@ class DataFrame:
     number of items (rows) as all other columns.
     """
 
-    def __init__(self, plan: logical_plan.LogicalPlan) -> None:
+    def __init__(self, builder: LogicalPlanBuilder) -> None:
         """Constructs a DataFrame according to a given LogicalPlan. Users are expected instead to call
         the classmethods on DataFrame to create a DataFrame.
 
         Args:
             plan: LogicalPlan describing the steps required to arrive at this DataFrame
         """
-        if not isinstance(plan, (logical_plan.LogicalPlan, rust_logical_plan.RustLogicalPlanBuilder)):
-            if isinstance(plan, dict):
+        if not isinstance(builder, LogicalPlanBuilder):
+            if isinstance(builder, dict):
                 raise ValueError(
                     f"DataFrames should be constructed with a dictionary of columns using `daft.from_pydict`"
                 )
-            if isinstance(plan, list):
+            if isinstance(builder, list):
                 raise ValueError(
                     f"DataFrames should be constructed with a list of dictionaries using `daft.from_pylist`"
                 )
-            raise ValueError(f"Expected DataFrame to be constructed with a LogicalPlan, received: {plan}")
+            raise ValueError(f"Expected DataFrame to be constructed with a LogicalPlanBuilder, received: {builder}")
 
-        self.__plan = plan
+        self.__builder = builder
         self._result_cache: Optional[PartitionCacheEntry] = None
         self._preview = DataFramePreview(preview_partition=None, dataframe_num_rows=None)
 
     @property
-    def _plan(self) -> logical_plan.LogicalPlan:
+    def _builder(self) -> LogicalPlanBuilder:
         # TODO(Clark): Add caching for Rust query planner.
         if self._result_cache is None or get_context().use_rust_planner:
-            return self.__plan
+            return self.__builder
         else:
-            return logical_plan.InMemoryScan(self._result_cache, self.__plan.schema(), self.__plan.partition_spec())
+            return self.__builder.from_in_memory_scan(
+                self._result_cache, self.__builder.schema(), self.__builder.partition_spec()
+            )
+
+    def _get_current_builder(self) -> LogicalPlanBuilder:
+        """Returns the current logical plan builder, without any caching optimizations."""
+        return self.__builder
 
     @property
     def _result(self) -> Optional[PartitionSet]:
@@ -95,14 +102,6 @@ class DataFrame:
             return None
         else:
             return self._result_cache.value
-
-    def plan(self) -> logical_plan.LogicalPlan:
-        """Returns `LogicalPlan` that will be executed to compute the result of this DataFrame.
-
-        Returns:
-            logical_plan.LogicalPlan: LogicalPlan to compute this DataFrame.
-        """
-        return self.__plan
 
     @DataframePublicAPI
     def explain(self, show_optimized: bool = False) -> None:
@@ -115,17 +114,17 @@ class DataFrame:
 
         if self._result_cache is not None:
             print("Result is cached and will skip computation\n")
-            print(self._plan.pretty_print())
+            print(self._builder.pretty_print())
 
             print("However here is the logical plan used to produce this result:\n")
 
-        plan = self.__plan
+        builder = self.__builder
         if show_optimized:
-            plan = get_context().runner().optimize(plan)
-        print(plan.pretty_print())
+            builder = builder.optimize()
+        print(builder.pretty_print())
 
     def num_partitions(self) -> int:
-        return self.__plan.num_partitions()
+        return self.__builder.num_partitions()
 
     @DataframePublicAPI
     def schema(self) -> Schema:
@@ -134,7 +133,7 @@ class DataFrame:
         Returns:
             Schema: schema of the DataFrame
         """
-        return self.__plan.schema()
+        return self.__builder.schema()
 
     @property
     def column_names(self) -> List[str]:
@@ -143,7 +142,7 @@ class DataFrame:
         Returns:
             List[str]: Column names of this DataFrame.
         """
-        return self.__plan.schema().column_names()
+        return self.__builder.schema().column_names()
 
     @property
     def columns(self) -> List[Expression]:
@@ -152,7 +151,7 @@ class DataFrame:
         Returns:
             List[Expression]: Columns of this DataFrame.
         """
-        return [col(field.name) for field in self.__plan.schema()]
+        return [col(field.name) for field in self.__builder.schema()]
 
     @DataframePublicAPI
     def show(self, n: int = 8) -> "DataFrameDisplay":
@@ -200,7 +199,7 @@ class DataFrame:
         else:
             # Execute the dataframe in a streaming fashion.
             context = get_context()
-            partitions_iter = context.runner().run_iter_tables(self._plan)
+            partitions_iter = context.runner().run_iter_tables(self._builder)
 
             # Iterate through partitions.
             for partition in partitions_iter:
@@ -226,7 +225,7 @@ class DataFrame:
         else:
             # Execute the dataframe in a streaming fashion.
             context = get_context()
-            partitions_iter = context.runner().run_iter(self._plan)
+            partitions_iter = context.runner().run_iter(self._builder)
             yield from partitions_iter
 
     @DataframePublicAPI
@@ -297,13 +296,10 @@ class DataFrame:
 
         result_pset = LocalPartitionSet({i: part for i, part in enumerate(parts)})
 
-        cache_entry = get_context().runner().put_partition_set_into_cache(result_pset)
-
-        plan = logical_plan.InMemoryScan(
-            cache_entry=cache_entry,
-            schema=parts[0].schema(),
-        )
-        return cls(plan)
+        context = get_context()
+        cache_entry = context.runner().put_partition_set_into_cache(result_pset)
+        builder = context.logical_plan_builder_class().from_in_memory_scan(cache_entry, parts[0].schema())
+        return cls(builder)
 
     ###
     # Write methods
@@ -341,22 +337,20 @@ class DataFrame:
             cols = self.__column_input_to_expression(tuple(partition_cols))
             for c in cols:
                 assert c._is_column(), "we cant support non Column Expressions for partition writing"
-            df = self.repartition(self.num_partitions(), *cols)
+            self.repartition(self.num_partitions(), *cols)
         else:
-            df = self
-        plan = logical_plan.FileWrite(
-            df._plan,
+            pass
+        builder = self._builder.write_tabular(
             root_dir=root_dir,
             partition_cols=cols,
             file_format=FileFormat.Parquet,
             compression=compression,
         )
-
         # Block and write, then retrieve data and return a new disconnected DataFrame
-        write_df = DataFrame(plan)
+        write_df = DataFrame(builder)
         write_df.collect()
         assert write_df._result is not None
-        return DataFrame(write_df._plan)
+        return DataFrame(write_df._builder)
 
     @DataframePublicAPI
     def write_csv(
@@ -384,21 +378,20 @@ class DataFrame:
             cols = self.__column_input_to_expression(tuple(partition_cols))
             for c in cols:
                 assert c._is_column(), "we cant support non Column Expressions for partition writing"
-            df = self.repartition(self.num_partitions(), *cols)
+            self.repartition(self.num_partitions(), *cols)
         else:
-            df = self
-        plan = logical_plan.FileWrite(
-            df._plan,
+            pass
+        builder = self._builder.write_tabular(
             root_dir=root_dir,
             partition_cols=cols,
             file_format=FileFormat.Csv,
         )
 
         # Block and write, then retrieve data and return a new disconnected DataFrame
-        write_df = DataFrame(plan)
+        write_df = DataFrame(builder)
         write_df.collect()
         assert write_df._result is not None
-        return DataFrame(write_df._plan)
+        return DataFrame(write_df._builder)
 
     ###
     # DataFrame operations
@@ -413,18 +406,18 @@ class DataFrame:
         result: Optional[Expression]
 
         if isinstance(item, int):
-            schema = self._plan.schema()
+            schema = self._builder.schema()
             if item < -len(schema) or item >= len(schema):
                 raise ValueError(f"{item} out of bounds for {schema}")
             result = ExpressionsProjection.from_schema(schema)[item]
             assert result is not None
             return result
         elif isinstance(item, str):
-            schema = self._plan.schema()
+            schema = self._builder.schema()
             field = schema[item]
             return col(field.name)
         elif isinstance(item, Iterable):
-            schema = self._plan.schema()
+            schema = self._builder.schema()
 
             columns = []
             for it in item:
@@ -434,13 +427,13 @@ class DataFrame:
                 elif isinstance(it, int):
                     if it < -len(schema) or it >= len(schema):
                         raise ValueError(f"{it} out of bounds for {schema}")
-                    field = list(self._plan.schema())[it]
+                    field = list(self._builder.schema())[it]
                     columns.append(col(field.name))
                 else:
                     raise ValueError(f"unknown indexing type: {type(it)}")
             return self.select(*columns)
         elif isinstance(item, slice):
-            schema = self._plan.schema()
+            schema = self._builder.schema()
             columns_exprs: ExpressionsProjection = ExpressionsProjection.from_schema(schema)
             selected_columns = columns_exprs[item]
             return self.select(*selected_columns)
@@ -472,11 +465,8 @@ class DataFrame:
             DataFrame: new DataFrame that will select the passed in columns
         """
         assert len(columns) > 0
-        projection = logical_plan.Projection(
-            self._plan,
-            self.__column_input_to_expression(columns),
-        )
-        return DataFrame(projection)
+        builder = self._builder.project(self.__column_input_to_expression(columns))
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def distinct(self) -> "DataFrame":
@@ -488,17 +478,9 @@ class DataFrame:
         Returns:
             DataFrame: DataFrame that has only  unique rows.
         """
-        all_exprs = ExpressionsProjection.from_schema(self._plan.schema())
-        plan: logical_plan.LogicalPlan = logical_plan.LocalDistinct(self._plan, all_exprs)
-        if self.num_partitions() > 1:
-            plan = logical_plan.Repartition(
-                plan,
-                partition_by=all_exprs,
-                num_partitions=self.num_partitions(),
-                scheme=PartitionScheme.Hash,
-            )
-            plan = logical_plan.LocalDistinct(plan, all_exprs)
-        return DataFrame(plan)
+        ExpressionsProjection.from_schema(self._builder.schema())
+        builder = self._builder.distinct()
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def exclude(self, *names: str) -> "DataFrame":
@@ -516,8 +498,9 @@ class DataFrame:
             DataFrame: DataFrame with some columns excluded.
         """
         names_to_skip = set(names)
-        el = ExpressionsProjection([col(e.name) for e in self._plan.schema() if e.name not in names_to_skip])
-        return DataFrame(logical_plan.Projection(self._plan, el))
+        el = ExpressionsProjection([col(e.name) for e in self._builder.schema() if e.name not in names_to_skip])
+        builder = self._builder.project(el)
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def where(self, predicate: Expression) -> "DataFrame":
@@ -532,21 +515,8 @@ class DataFrame:
         Returns:
             DataFrame: Filtered DataFrame.
         """
-        use_rust_planner = get_context().use_rust_planner
-
-        if use_rust_planner:
-            new_builder = cast(
-                rust_logical_plan.RustLogicalPlanBuilder,
-                self._plan,
-            ).builder.filter(predicate._expr)
-
-            plan = cast(
-                logical_plan.LogicalPlan,
-                rust_logical_plan.RustLogicalPlanBuilder(new_builder),
-            )
-        else:
-            plan = logical_plan.Filter(self._plan, ExpressionsProjection([predicate]))
-        return DataFrame(plan)
+        builder = self._builder.filter(predicate)
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def with_column(
@@ -570,15 +540,11 @@ class DataFrame:
             raise TypeError(f"resource_request should be a ResourceRequest, but got {type(resource_request)}")
 
         prev_schema_as_cols = ExpressionsProjection(
-            [col(field.name) for field in self._plan.schema() if field.name != column_name]
+            [col(field.name) for field in self._builder.schema() if field.name != column_name]
         )
         new_schema = prev_schema_as_cols.union(ExpressionsProjection([expr.alias(column_name)]))
-        projection = logical_plan.Projection(
-            self._plan,
-            new_schema,
-            custom_resource_request=resource_request,
-        )
-        return DataFrame(projection)
+        builder = self._builder.project(new_schema, resource_request)
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def sort(
@@ -605,8 +571,9 @@ class DataFrame:
             by = [
                 by,
             ]
-        sort = logical_plan.Sort(self._plan, self.__column_input_to_expression(by), descending=desc)
-        return DataFrame(sort)
+        sort_by = self.__column_input_to_expression(by)
+        builder = self._builder.sort(sort_by=sort_by, descending=desc)
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def limit(self, num: int) -> "DataFrame":
@@ -621,20 +588,8 @@ class DataFrame:
         Returns:
             DataFrame: Limited DataFrame
         """
-        if get_context().use_rust_planner:
-            new_builder = cast(
-                rust_logical_plan.RustLogicalPlanBuilder,
-                self._plan,
-            ).builder.limit(num)
-
-            plan = cast(
-                logical_plan.LogicalPlan,
-                rust_logical_plan.RustLogicalPlanBuilder(new_builder),
-            )
-        else:
-            local_limit = logical_plan.LocalLimit(self._plan, num=num)
-            plan = logical_plan.GlobalLimit(local_limit, num=num)
-        return DataFrame(plan)
+        builder = self._builder.limit(num)
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def count_rows(self) -> int:
@@ -643,11 +598,11 @@ class DataFrame:
         Returns:
             int: count of the number of rows in this DataFrame.
         """
-        local_count_op = logical_plan.LocalCount(self._plan)
-        coalease_op = logical_plan.Coalesce(local_count_op, 1)
-        local_sum_op = logical_plan.LocalAggregate(coalease_op, [col("count")._sum()])
-        num_rows = DataFrame(local_sum_op).to_pydict()["count"][0]
-        return num_rows
+        builder = self._builder.count()
+        count_df = DataFrame(builder)
+        # Expects builder to produce a single-partition, single-row DataFrame containing
+        # a "count" column, where the lone value represents the row count for the DataFrame.
+        return count_df.to_pydict()["count"][0]
 
     @DataframePublicAPI
     def repartition(self, num: int, *partition_by: ColumnInputType) -> "DataFrame":
@@ -674,8 +629,8 @@ class DataFrame:
             scheme = PartitionScheme.Hash
             exprs = self.__column_input_to_expression(partition_by)
 
-        repartition_op = logical_plan.Repartition(self._plan, num_partitions=num, partition_by=exprs, scheme=scheme)
-        return DataFrame(repartition_op)
+        builder = self._builder.repartition(num_partitions=num, partition_by=exprs, scheme=scheme)
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def into_partitions(self, num: int) -> "DataFrame":
@@ -693,22 +648,21 @@ class DataFrame:
         Returns:
             DataFrame: Dataframe with ``num`` partitions.
         """
-        current_partitions = self._plan.num_partitions()
+        current_partitions = self._builder.num_partitions()
 
         if num > current_partitions:
             # Do a split (increase the number of partitions).
-            split_op = logical_plan.Repartition(
-                self._plan,
+            builder = self._builder.repartition(
                 num_partitions=num,
-                scheme=PartitionScheme.Unknown,
                 partition_by=ExpressionsProjection([]),
+                scheme=PartitionScheme.Unknown,
             )
-            return DataFrame(split_op)
+            return DataFrame(builder)
 
         elif num < current_partitions:
             # Do a coalese (decrease the number of partitions).
-            coalesce_op = logical_plan.Coalesce(self._plan, num)
-            return DataFrame(coalesce_op)
+            builder = self._builder.coalesce(num)
+            return DataFrame(builder)
 
         else:
             return self
@@ -754,10 +708,8 @@ class DataFrame:
 
         left_exprs = self.__column_input_to_expression(tuple(left_on) if isinstance(left_on, list) else (left_on,))
         right_exprs = self.__column_input_to_expression(tuple(right_on) if isinstance(right_on, list) else (right_on,))
-        join_op = logical_plan.Join(
-            self._plan, other._plan, left_on=left_exprs, right_on=right_exprs, how=logical_plan.JoinType.INNER
-        )
-        return DataFrame(join_op)
+        builder = self._builder.join(other._builder, left_on=left_exprs, right_on=right_exprs, how=JoinType.INNER)
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def concat(self, other: "DataFrame") -> "DataFrame":
@@ -779,7 +731,8 @@ class DataFrame:
             raise ValueError(
                 f"DataFrames must have exactly the same schema for concatenation! Expected:\n{self.schema()}\n\nReceived:\n{other.schema()}"
             )
-        return DataFrame(logical_plan.Concat(self._plan, other._plan))
+        builder = self._builder.concat(other._builder)
+        return DataFrame(builder)
 
     @DataframePublicAPI
     def drop_nan(self, *cols: ColumnInputType):
@@ -879,7 +832,8 @@ class DataFrame:
             DataFrame: DataFrame with exploded column
         """
         parsed_exprs = self.__column_input_to_expression(columns)
-        return DataFrame(logical_plan.Explode(self._plan, parsed_exprs))
+        builder = self._builder.explode(parsed_exprs)
+        return DataFrame(builder)
 
     def _agg(
         self, to_agg: List[Tuple[ColumnInputType, str]], group_by: Optional[ExpressionsProjection] = None
@@ -887,7 +841,9 @@ class DataFrame:
         exprs_to_agg: List[Tuple[Expression, str]] = list(
             zip(self.__column_input_to_expression([c for c, _ in to_agg]), [op for _, op in to_agg])
         )
-        builder = AggregationPlanBuilder(self._plan, group_by=group_by)
+        # TODO(Clark): Port AggregationPlanBuilder to new LogicalPlanBuilder once Charles has merged in his PR.
+        logical_plan_builder = cast(PyLogicalPlanBuilder, self._builder)
+        builder = AggregationPlanBuilder(logical_plan_builder._plan, group_by=group_by)
         for expr, op in exprs_to_agg:
             if op == "sum":
                 builder.add_sum(expr.name(), expr)
@@ -905,7 +861,7 @@ class DataFrame:
                 builder.add_concat(expr.name(), expr)
             else:
                 raise NotImplementedError(f"LogicalPlan construction for operation not implemented: {op}")
-        return DataFrame(builder.build())
+        return DataFrame(builder.build().to_builder())
 
     @DataframePublicAPI
     def sum(self, *cols: ColumnInputType) -> "DataFrame":
@@ -1029,7 +985,7 @@ class DataFrame:
         """Materializes the results of for this DataFrame and hold a pointer to the results."""
         context = get_context()
         if self._result is None:
-            self._result_cache = context.runner().run(self._plan)
+            self._result_cache = context.runner().run(self._builder)
             result = self._result
             assert result is not None
             result.wait()
@@ -1108,7 +1064,7 @@ class DataFrame:
         assert result is not None
 
         pd_df = result.to_pandas(
-            schema=self._plan.schema(), cast_tensors_to_ray_tensor_dtype=cast_tensors_to_ray_tensor_dtype
+            schema=self._builder.schema(), cast_tensors_to_ray_tensor_dtype=cast_tensors_to_ray_tensor_dtype
         )
         return pd_df
 
@@ -1215,23 +1171,23 @@ class DataFrame:
     @classmethod
     def _from_ray_dataset(cls, ds: "RayDataset") -> "DataFrame":
         """Creates a DataFrame from a Ray Dataset."""
-        if get_context().runner_config.name != "ray":
+        context = get_context()
+        if context.runner_config.name != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO
 
-        ray_runner_io = get_context().runner().runner_io()
+        ray_runner_io = context.runner().runner_io()
         assert isinstance(ray_runner_io, RayRunnerIO)
 
         partition_set, schema = ray_runner_io.partition_set_from_ray_dataset(ds)
-        cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
-        return cls(
-            logical_plan.InMemoryScan(
-                cache_entry=cache_entry,
-                schema=schema,
-                partition_spec=PartitionSpec(PartitionScheme.Unknown, partition_set.num_partitions()),
-            )
+        cache_entry = context.runner().put_partition_set_into_cache(partition_set)
+        builder = context.logical_plan_builder_class().from_in_memory_scan(
+            cache_entry,
+            schema=schema,
+            partition_spec=PartitionSpec(PartitionScheme.Unknown, partition_set.num_partitions()),
         )
+        return cls(builder)
 
     @DataframePublicAPI
     def to_dask_dataframe(
@@ -1284,23 +1240,23 @@ class DataFrame:
         """Creates a Daft DataFrame from a Dask DataFrame."""
         # TODO(Clark): Support Dask DataFrame conversion for the local runner if
         # Dask is using a non-distributed scheduler.
-        if get_context().runner_config.name != "ray":
+        context = get_context()
+        if context.runner_config.name != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO
 
-        ray_runner_io = get_context().runner().runner_io()
+        ray_runner_io = context.runner().runner_io()
         assert isinstance(ray_runner_io, RayRunnerIO)
 
         partition_set, schema = ray_runner_io.partition_set_from_dask_dataframe(ddf)
-        cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
-        return cls(
-            logical_plan.InMemoryScan(
-                cache_entry=cache_entry,
-                schema=schema,
-                partition_spec=PartitionSpec(PartitionScheme.Unknown, partition_set.num_partitions()),
-            )
+        cache_entry = context.runner().put_partition_set_into_cache(partition_set)
+        builder = context.logical_plan_builder_class().from_in_memory_scan(
+            cache_entry,
+            schema=schema,
+            partition_spec=PartitionSpec(PartitionScheme.Unknown, partition_set.num_partitions()),
         )
+        return cls(builder)
 
 
 @dataclass
@@ -1309,7 +1265,7 @@ class GroupedDataFrame:
     group_by: ExpressionsProjection
 
     def __post_init__(self):
-        resolved_groupby_schema = self.group_by.resolve_schema(self.df._plan.schema())
+        resolved_groupby_schema = self.group_by.resolve_schema(self.df._builder.schema())
         for field, e in zip(resolved_groupby_schema, self.group_by):
             if field.dtype == DataType.null():
                 raise ExpressionTypeError(f"Cannot groupby on null type expression: {e}")

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -22,7 +22,7 @@ from daft.daft import (
     ParquetSourceConfig,
 )
 from daft.expressions import Expression, ExpressionsProjection, col
-from daft.logical.logical_plan import JoinType
+from daft.logical.builder import JoinType
 from daft.logical.map_partition_ops import MapPartitionOp
 from daft.logical.schema import Schema
 from daft.resource_request import ResourceRequest

--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -34,7 +34,7 @@ from daft.execution.execution_step import (
     SingleOutputPartitionTask,
 )
 from daft.expressions import ExpressionsProjection
-from daft.logical.logical_plan import JoinType
+from daft.logical.builder import JoinType
 from daft.logical.schema import Schema
 from daft.resource_request import ResourceRequest
 from daft.runners.partitioning import PartialPartitionMetadata

--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -52,10 +52,5 @@ def read_csv(
 
     csv_config = CsvSourceConfig(delimiter=delimiter, has_headers=has_headers)
     file_format_config = FileFormatConfig.from_csv_config(csv_config)
-    plan = _get_tabular_files_scan(
-        path,
-        schema_hints,
-        file_format_config,
-        fs,
-    )
-    return DataFrame(plan)
+    builder = _get_tabular_files_scan(path, schema_hints, file_format_config, fs)
+    return DataFrame(builder)

--- a/daft/io/_json.py
+++ b/daft/io/_json.py
@@ -40,10 +40,5 @@ def read_json(
 
     json_config = JsonSourceConfig()
     file_format_config = FileFormatConfig.from_json_config(json_config)
-    plan = _get_tabular_files_scan(
-        path,
-        schema_hints,
-        file_format_config,
-        fs,
-    )
-    return DataFrame(plan)
+    builder = _get_tabular_files_scan(path, schema_hints, file_format_config, fs)
+    return DataFrame(builder)

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -1,16 +1,14 @@
 # isort: dont-add-import: from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import fsspec
 
 from daft.api_annotations import PublicAPI
-from daft.context import get_context
 from daft.daft import FileFormatConfig, ParquetSourceConfig
 from daft.dataframe import DataFrame
 from daft.datatype import DataType
-from daft.io.common import _get_files_scan_rustplan, _get_tabular_files_scan
-from daft.logical.logical_plan import LogicalPlan
+from daft.io.common import _get_tabular_files_scan
 
 if TYPE_CHECKING:
     from daft.io import IOConfig
@@ -49,26 +47,8 @@ def read_parquet(
     if isinstance(path, list) and len(path) == 0:
         raise ValueError(f"Cannot read DataFrame from from empty list of Parquet filepaths")
 
-    context = get_context()
-
     parquet_config = ParquetSourceConfig(use_native_downloader=use_native_downloader, io_config=io_config)
     file_format_config = FileFormatConfig.from_parquet_config(parquet_config)
-    if context.use_rust_planner:
-        plan = cast(
-            LogicalPlan,
-            _get_files_scan_rustplan(
-                path,
-                schema_hints,
-                file_format_config,
-                fs,
-            ),
-        )  # Cast for temporary type checking.
-    else:
-        plan = _get_tabular_files_scan(
-            path,
-            schema_hints,
-            file_format_config,
-            fs,
-        )
 
-    return DataFrame(plan)
+    builder = _get_tabular_files_scan(path, schema_hints, file_format_config, fs)
+    return DataFrame(builder)

--- a/daft/io/common.py
+++ b/daft/io/common.py
@@ -3,14 +3,9 @@ from __future__ import annotations
 import fsspec
 
 from daft.context import get_context
-from daft.daft import (
-    FileFormatConfig,
-    LogicalPlanBuilder,
-    PartitionScheme,
-    PartitionSpec,
-)
+from daft.daft import FileFormatConfig, LogicalPlanBuilder
 from daft.datatype import DataType
-from daft.logical import logical_plan, rust_logical_plan
+from daft.logical.builder import LogicalPlanBuilder
 from daft.logical.schema import Schema
 
 
@@ -26,70 +21,16 @@ def _get_tabular_files_scan(
     schema_hints: dict[str, DataType] | None,
     file_format_config: FileFormatConfig,
     fs: fsspec.AbstractFileSystem | None,
-) -> logical_plan.TabularFilesScan:
+) -> LogicalPlanBuilder:
     """Returns a TabularFilesScan LogicalPlan for a given glob filepath."""
-    # Glob the path using the Runner
-    runner_io = get_context().runner().runner_io()
-
     paths = path if isinstance(path, list) else [str(path)]
-    listing_details_partition_set = runner_io.glob_paths_details(paths, file_format_config, fs)
-
-    # Infer schema if no hints provided
-    inferred_or_provided_schema = (
-        _get_schema_from_hints(schema_hints)
-        if schema_hints is not None
-        else runner_io.get_schema_from_first_filepath(listing_details_partition_set, file_format_config, fs)
-    )
-
+    schema_hint = _get_schema_from_hints(schema_hints) if schema_hints is not None else None
     # Construct plan
-    cache_entry = get_context().runner().put_partition_set_into_cache(listing_details_partition_set)
-    filepath_plan = logical_plan.InMemoryScan(
-        cache_entry=cache_entry,
-        schema=runner_io.FS_LISTING_SCHEMA,
-        partition_spec=PartitionSpec(PartitionScheme.Unknown, listing_details_partition_set.num_partitions()),
-    )
-    return logical_plan.TabularFilesScan(
-        schema=inferred_or_provided_schema,
-        predicate=None,
-        columns=None,
+    builder_cls = get_context().logical_plan_builder_class()
+    builder = builder_cls.from_tabular_scan(
+        paths=paths,
+        schema_hint=schema_hint,
         file_format_config=file_format_config,
         fs=fs,
-        filepaths_child=filepath_plan,
-        filepaths_column_name=runner_io.FS_LISTING_PATH_COLUMN_NAME,
-        # WARNING: This is currently hardcoded to be the same number of partitions as rows!! This is because we emit
-        # one partition per filepath. This will change in the future and our logic here should change accordingly.
-        num_partitions=len(listing_details_partition_set),
     )
-
-
-def _get_files_scan_rustplan(
-    path: str | list[str],
-    schema_hints: dict[str, DataType] | None,
-    file_format_config: FileFormatConfig,
-    fs: fsspec.AbstractFileSystem | None,
-) -> rust_logical_plan.RustLogicalPlanBuilder:
-    """Returns a LogicalPlanBuilder with the file scan."""
-    # Glob the path using the Runner
-    runner_io = get_context().runner().runner_io()
-
-    paths = path if isinstance(path, list) else [str(path)]
-    listing_details_partition_set = runner_io.glob_paths_details(paths, file_format_config, fs)
-
-    # Infer schema if no hints provided
-    inferred_or_provided_schema = (
-        _get_schema_from_hints(schema_hints)
-        if schema_hints is not None
-        else runner_io.get_schema_from_first_filepath(listing_details_partition_set, file_format_config, fs)
-    )
-
-    # Construct plan
-    paths_details = listing_details_partition_set.to_pydict()
-
-    # TODO(Clark): Pass through other listing details fields.
-    filepaths = paths_details[runner_io.FS_LISTING_PATH_COLUMN_NAME]
-    rs_schema = inferred_or_provided_schema._schema
-
-    builder = LogicalPlanBuilder.table_scan(filepaths, rs_schema, file_format_config)
-    pybuilder = rust_logical_plan.RustLogicalPlanBuilder(builder)
-
-    return pybuilder
+    return builder

--- a/daft/io/file_path.py
+++ b/daft/io/file_path.py
@@ -8,7 +8,6 @@ from daft.api_annotations import PublicAPI
 from daft.context import get_context
 from daft.daft import PartitionScheme, PartitionSpec
 from daft.dataframe import DataFrame
-from daft.logical import logical_plan
 
 
 @PublicAPI
@@ -42,12 +41,14 @@ def from_glob_path(path: str, fs: Optional[fsspec.AbstractFileSystem] = None) ->
         DataFrame: DataFrame containing the path to each file as a row, along with other metadata
             parsed from the provided filesystem.
     """
-    runner_io = get_context().runner().runner_io()
+    context = get_context()
+    runner_io = context.runner().runner_io()
     partition_set = runner_io.glob_paths_details([path], fs=fs)
-    cache_entry = get_context().runner().put_partition_set_into_cache(partition_set)
-    filepath_plan = logical_plan.InMemoryScan(
-        cache_entry=cache_entry,
+    cache_entry = context.runner().put_partition_set_into_cache(partition_set)
+    builder_cls = context.logical_plan_builder_class()
+    builder = builder_cls.from_in_memory_scan(
+        cache_entry,
         schema=runner_io.FS_LISTING_SCHEMA,
         partition_spec=PartitionSpec(PartitionScheme.Unknown, partition_set.num_partitions()),
     )
-    return DataFrame(filepath_plan)
+    return DataFrame(builder)

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import pathlib
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import TYPE_CHECKING
+
+import fsspec
+
+from daft.daft import FileFormat, FileFormatConfig, PartitionScheme, PartitionSpec
+from daft.expressions.expressions import Expression, ExpressionsProjection
+from daft.logical.schema import Schema
+from daft.resource_request import ResourceRequest
+from daft.runners.partitioning import PartitionCacheEntry
+
+if TYPE_CHECKING:
+    from daft.planner import QueryPlanner
+
+
+class JoinType(Enum):
+    INNER = "inner"
+    LEFT = "left"
+    RIGHT = "right"
+
+
+class LogicalPlanBuilder(ABC):
+    """
+    An interface for building a logical plan for the Daft DataFrame.
+    """
+
+    @abstractmethod
+    def to_planner(self) -> QueryPlanner:
+        """
+        Convert this logical plan builder to a query planner, which is used to translate
+        a logical plan to a physical plan and to generate executable tasks for the physical plan.
+
+        This should be called after trigger optimization with self.optimize().
+        """
+
+    @abstractmethod
+    def schema(self) -> Schema:
+        """
+        The schema of the current logical plan.
+        """
+
+    @abstractmethod
+    def partition_spec(self) -> PartitionSpec:
+        """
+        Partition spec for the current logical plan.
+        """
+
+    def num_partitions(self) -> int:
+        """
+        Number of partitions for the current logical plan.
+        """
+        return self.partition_spec().num_partitions
+
+    @abstractmethod
+    def resource_request(self) -> ResourceRequest:
+        """
+        Returns a custom ResourceRequest if one has been attached to this logical plan.
+        """
+
+    @abstractmethod
+    def pretty_print(self) -> str:
+        """
+        Pretty prints the currentj underlying logical plan.
+        """
+
+    @abstractmethod
+    def optimize(self) -> LogicalPlanBuilder:
+        """
+        Optimize the underlying logical plan.
+        """
+
+    ### Logical operator building methods.
+
+    @classmethod
+    @abstractmethod
+    def from_in_memory_scan(
+        cls, partition: PartitionCacheEntry, schema: Schema, partition_spec: PartitionSpec | None = None
+    ) -> LogicalPlanBuilder:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def from_tabular_scan(
+        cls,
+        *,
+        paths: list[str],
+        file_format_config: FileFormatConfig,
+        schema_hint: Schema | None,
+        fs: fsspec.AbstractFileSystem | None,
+    ) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def project(
+        self,
+        projection: ExpressionsProjection,
+        custom_resource_request: ResourceRequest = ResourceRequest(),
+    ) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def filter(self, predicate: Expression) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def limit(self, num_rows: int) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def explode(self, explode_expressions: ExpressionsProjection) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def count(self) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def distinct(self) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def sort(self, sort_by: ExpressionsProjection, descending: list[bool] | bool = False) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def repartition(
+        self, num_partitions: int, partition_by: ExpressionsProjection, scheme: PartitionScheme
+    ) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def coalesce(self, num_partitions: int) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def join(
+        self,
+        right: LogicalPlanBuilder,
+        left_on: ExpressionsProjection,
+        right_on: ExpressionsProjection,
+        how: JoinType = JoinType.INNER,
+    ) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def concat(self, other: LogicalPlanBuilder) -> LogicalPlanBuilder:
+        pass
+
+    @abstractmethod
+    def write_tabular(
+        self,
+        root_dir: str | pathlib.Path,
+        file_format: FileFormat,
+        partition_cols: ExpressionsProjection | None = None,
+        compression: str | None = None,
+    ) -> LogicalPlanBuilder:
+        pass

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -64,7 +64,7 @@ class LogicalPlanBuilder(ABC):
     @abstractmethod
     def pretty_print(self) -> str:
         """
-        Pretty prints the currentj underlying logical plan.
+        Pretty prints the current underlying logical plan.
         """
 
     @abstractmethod
@@ -73,7 +73,7 @@ class LogicalPlanBuilder(ABC):
         Optimize the underlying logical plan.
         """
 
-    ### Logical operator building methods.
+    ### Logical operator builder methods.
 
     @classmethod
     @abstractmethod

--- a/daft/logical/rust_logical_plan.py
+++ b/daft/logical/rust_logical_plan.py
@@ -1,21 +1,142 @@
 from __future__ import annotations
 
-from daft.daft import LogicalPlanBuilder, PartitionSpec
+import pathlib
+from typing import TYPE_CHECKING
+
+import fsspec
+
+from daft.context import get_context
+from daft.daft import FileFormat, FileFormatConfig
+from daft.daft import LogicalPlanBuilder as _LogicalPlanBuilder
+from daft.daft import PartitionScheme, PartitionSpec
+from daft.expressions.expressions import Expression, ExpressionsProjection
+from daft.logical.builder import JoinType, LogicalPlanBuilder
 from daft.logical.schema import Schema
+from daft.resource_request import ResourceRequest
+from daft.runners.partitioning import PartitionCacheEntry
+
+if TYPE_CHECKING:
+    from daft.planner.rust_planner import RustQueryPlanner
 
 
-class RustLogicalPlanBuilder:
+class RustLogicalPlanBuilder(LogicalPlanBuilder):
     """Wrapper class for the new LogicalPlanBuilder in Rust."""
 
-    def __init__(self, builder: LogicalPlanBuilder) -> None:
-        self.builder = builder
+    def __init__(self, builder: _LogicalPlanBuilder) -> None:
+        self._builder = builder
+
+    def to_planner(self) -> RustQueryPlanner:
+        from daft.planner.rust_planner import RustQueryPlanner
+
+        return RustQueryPlanner(self._builder)
 
     def schema(self) -> Schema:
-        pyschema = self.builder.schema()
+        pyschema = self._builder.schema()
         return Schema._from_pyschema(pyschema)
 
     def partition_spec(self) -> PartitionSpec:
-        return self.builder.partition_spec()
+        # TODO(Clark): Push PartitionSpec into planner.
+        return self._builder.partition_spec()
+
+    def resource_request(self) -> ResourceRequest:
+        # TODO(Clark): Expose resource request via builder, or push it into the planner.
+        return ResourceRequest()
+
+    def pretty_print(self) -> str:
+        return repr(self)
 
     def __repr__(self) -> str:
-        return self.builder.repr_ascii()
+        return self._builder.repr_ascii()
+
+    def optimize(self) -> RustLogicalPlanBuilder:
+        # TODO(Clark): Add optimization framework.
+        return self
+
+    @classmethod
+    def from_in_memory_scan(
+        cls, partition: PartitionCacheEntry, schema: Schema, partition_spec: PartitionSpec | None = None
+    ) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    @classmethod
+    def from_tabular_scan(
+        cls,
+        *,
+        paths: list[str],
+        file_format_config: FileFormatConfig,
+        schema_hint: Schema | None,
+        fs: fsspec.AbstractFileSystem | None,
+    ) -> RustLogicalPlanBuilder:
+        if fs is not None:
+            raise ValueError("fsspec filesystems not supported for Rust query planner.")
+        # Glob the path using the Runner
+        runner_io = get_context().runner().runner_io()
+        file_info_partition_set = runner_io.glob_paths_details(paths, file_format_config, fs)
+
+        # Infer schema if no hints provided
+        inferred_or_provided_schema = (
+            schema_hint
+            if schema_hint is not None
+            else runner_io.get_schema_from_first_filepath(file_info_partition_set, file_format_config, fs)
+        )
+        paths_details = file_info_partition_set.to_pydict()
+        filepaths = paths_details[runner_io.FS_LISTING_PATH_COLUMN_NAME]
+        rs_schema = inferred_or_provided_schema._schema
+        builder = _LogicalPlanBuilder.table_scan(filepaths, rs_schema, file_format_config)
+        return RustLogicalPlanBuilder(builder)
+
+    def project(
+        self,
+        projection: ExpressionsProjection,
+        custom_resource_request: ResourceRequest = ResourceRequest(),
+    ) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    def filter(self, predicate: Expression) -> LogicalPlanBuilder:
+        builder = self._builder.filter(predicate._expr)
+        return RustLogicalPlanBuilder(builder)
+
+    def limit(self, num_rows: int) -> LogicalPlanBuilder:
+        builder = self._builder.limit(num_rows)
+        return RustLogicalPlanBuilder(builder)
+
+    def explode(self, explode_expressions: ExpressionsProjection) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    def count(self) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    def distinct(self) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    def sort(self, sort_by: ExpressionsProjection, descending: list[bool] | bool = False) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    def repartition(
+        self, num_partitions: int, partition_by: ExpressionsProjection, scheme: PartitionScheme
+    ) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    def coalesce(self, num_partitions: int) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    def join(
+        self,
+        right: LogicalPlanBuilder,
+        left_on: ExpressionsProjection,
+        right_on: ExpressionsProjection,
+        how: JoinType = JoinType.INNER,
+    ) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    def concat(self, other: LogicalPlanBuilder) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")
+
+    def write_tabular(
+        self,
+        root_dir: str | pathlib.Path,
+        file_format: FileFormat,
+        partition_cols: ExpressionsProjection | None = None,
+        compression: str | None = None,
+    ) -> LogicalPlanBuilder:
+        raise NotImplementedError("not implemented")

--- a/daft/planner/__init__.py
+++ b/daft/planner/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from daft.planner.planner import QueryPlanner
+
+__all__ = ["QueryPlanner"]

--- a/daft/planner/planner.py
+++ b/daft/planner/planner.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from daft.execution import physical_plan
+from daft.runners.partitioning import PartitionT
+
+
+class QueryPlanner(ABC):
+    """
+    An interface for translating a logical plan to a physical plan, and generating
+    executable tasks for the latter.
+    """
+
+    @abstractmethod
+    def plan(self, psets: dict[str, list[PartitionT]]) -> physical_plan.MaterializedPhysicalPlan:
+        pass

--- a/daft/planner/py_planner.py
+++ b/daft/planner/py_planner.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from daft.execution import physical_plan, physical_plan_factory
+from daft.logical import logical_plan
+from daft.planner.planner import PartitionT, QueryPlanner
+
+
+class PyQueryPlanner(QueryPlanner):
+    def __init__(self, plan: logical_plan.LogicalPlan):
+        self._plan = plan
+
+    def plan(self, psets: dict[str, list[PartitionT]]) -> physical_plan.MaterializedPhysicalPlan:
+        return physical_plan.materialize(physical_plan_factory._get_physical_plan(self._plan, psets))

--- a/daft/planner/rust_planner.py
+++ b/daft/planner/rust_planner.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from daft.daft import LogicalPlanBuilder as _LogicalPlanBuilder
+from daft.execution import physical_plan
+from daft.planner.planner import PartitionT, QueryPlanner
+
+
+class RustQueryPlanner(QueryPlanner):
+    def __init__(self, builder: _LogicalPlanBuilder):
+        self._builder = builder
+
+    def plan(self, psets: dict[str, list[PartitionT]]) -> physical_plan.MaterializedPhysicalPlan:
+        # TODO(Clark): Integrate partition set cache.
+        return physical_plan.materialize(self._builder.to_partition_tasks())

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -12,6 +12,9 @@ import fsspec
 import pyarrow as pa
 from loguru import logger
 
+from daft.logical.builder import LogicalPlanBuilder
+from daft.planner.planner import QueryPlanner
+
 try:
     import ray
 except ImportError:
@@ -22,7 +25,6 @@ except ImportError:
 
 from daft.daft import FileFormatConfig
 from daft.datatype import DataType
-from daft.execution import physical_plan_factory
 from daft.execution.execution_step import (
     FanoutInstruction,
     Instruction,
@@ -33,17 +35,6 @@ from daft.execution.execution_step import (
     SingleOutputPartitionTask,
 )
 from daft.filesystem import get_filesystem_from_path, glob_path_with_stats
-from daft.internal.rule_runner import FixedPointPolicy, Once, RuleBatch, RuleRunner
-from daft.logical import logical_plan
-from daft.logical.optimizer import (
-    DropProjections,
-    DropRepartition,
-    FoldProjections,
-    PruneColumns,
-    PushDownClausesIntoScan,
-    PushDownLimit,
-    PushDownPredicates,
-)
 from daft.resource_request import ResourceRequest
 from daft.runners import runner_io
 from daft.runners.partitioning import (
@@ -426,7 +417,7 @@ class Scheduler:
 
     def run_plan(
         self,
-        plan: logical_plan.LogicalPlan,
+        planner: QueryPlanner,
         psets: dict[str, ray.ObjectRef],
         result_uuid: str,
     ) -> None:
@@ -434,7 +425,7 @@ class Scheduler:
             target=self._run_plan,
             name=result_uuid,
             kwargs={
-                "plan": plan,
+                "planner": planner,
                 "psets": psets,
                 "result_uuid": result_uuid,
             },
@@ -444,13 +435,14 @@ class Scheduler:
 
     def _run_plan(
         self,
-        plan: logical_plan.LogicalPlan,
+        planner: QueryPlanner,
         psets: dict[str, ray.ObjectRef],
         result_uuid: str,
     ) -> None:
         from loguru import logger
 
-        phys_plan = physical_plan_factory.get_materializing_physical_plan(plan, psets)
+        # Get executable tasks from planner.
+        tasks = planner.plan(psets)
 
         # Note: For autoscaling clusters, we will probably want to query cores dynamically.
         # Keep in mind this call takes about 0.3ms.
@@ -468,7 +460,7 @@ class Scheduler:
         )
         with profiler(profile_filename):
             try:
-                next_step = next(phys_plan)
+                next_step = next(tasks)
 
                 while True:  # Loop: Dispatch -> await.
                     while True:  # Loop: Dispatch (get tasks -> batch dispatch).
@@ -486,7 +478,7 @@ class Scheduler:
                             elif isinstance(next_step, ray.ObjectRef):
                                 # A final result.
                                 self.results_by_df[result_uuid].put(next_step)
-                                next_step = next(phys_plan)
+                                next_step = next(tasks)
 
                             # next_step is a task.
 
@@ -499,12 +491,12 @@ class Scheduler:
                                 next_step.set_result(
                                     [RayMaterializedResult(partition) for partition in next_step.inputs]
                                 )
-                                next_step = next(phys_plan)
+                                next_step = next(tasks)
 
                             else:
                                 # Add the task to the batch.
                                 tasks_to_dispatch.append(next_step)
-                                next_step = next(phys_plan)
+                                next_step = next(tasks)
 
                         # Dispatch the batch of tasks.
                         logger.debug(
@@ -562,7 +554,7 @@ class Scheduler:
                     )
 
                     if next_step is None:
-                        next_step = next(phys_plan)
+                        next_step = next(tasks)
 
             except StopIteration as e:
                 self.results_by_df[result_uuid].put(e)
@@ -612,26 +604,6 @@ class RayRunner(Runner[ray.ObjectRef]):
         if ray.is_initialized():
             logger.warning(f"Ray has already been initialized, Daft will reuse the existing Ray context.")
         self.ray_context = ray.init(address=address, ignore_reinit_error=True)
-        self._optimizer = RuleRunner(
-            [
-                RuleBatch(
-                    "SinglePassPushDowns",
-                    Once,
-                    [
-                        DropRepartition(),
-                        PushDownPredicates(),
-                        PruneColumns(),
-                        FoldProjections(),
-                        PushDownClausesIntoScan(),
-                    ],
-                ),
-                RuleBatch(
-                    "PushDownLimitsAndRepartitions",
-                    FixedPointPolicy(3),
-                    [PushDownLimit(), DropRepartition(), DropProjections()],
-                ),
-            ]
-        )
 
         if isinstance(self.ray_context, ray.client_builder.ClientContext):
             # Run scheduler remotely if the cluster is connected remotely.
@@ -643,8 +615,12 @@ class RayRunner(Runner[ray.ObjectRef]):
                 max_task_backlog=max_task_backlog,
             )
 
-    def run_iter(self, plan: logical_plan.LogicalPlan) -> Iterator[ray.ObjectRef]:
-        plan = self.optimize(plan)
+    def run_iter(self, builder: LogicalPlanBuilder) -> Iterator[ray.ObjectRef]:
+        # Optimize the logical plan.
+        builder = builder.optimize()
+        # Finalize the logical plan and get a query planner for translating the
+        # logical plan to executable tasks.
+        planner = builder.to_planner()
 
         psets = {
             key: entry.value.values()
@@ -655,7 +631,7 @@ class RayRunner(Runner[ray.ObjectRef]):
         if isinstance(self.ray_context, ray.client_builder.ClientContext):
             ray.get(
                 self.scheduler_actor.run_plan.remote(
-                    plan=plan,
+                    planner=planner,
                     psets=psets,
                     result_uuid=result_uuid,
                 )
@@ -663,7 +639,7 @@ class RayRunner(Runner[ray.ObjectRef]):
 
         else:
             self.scheduler.run_plan(
-                plan=plan,
+                planner=planner,
                 psets=psets,
                 result_uuid=result_uuid,
             )
@@ -678,14 +654,14 @@ class RayRunner(Runner[ray.ObjectRef]):
                 return
             yield result
 
-    def run_iter_tables(self, plan: logical_plan.LogicalPlan) -> Iterator[Table]:
-        for ref in self.run_iter(plan):
+    def run_iter_tables(self, builder: LogicalPlanBuilder) -> Iterator[Table]:
+        for ref in self.run_iter(builder):
             yield ray.get(ref)
 
-    def run(self, plan: logical_plan.LogicalPlan) -> PartitionCacheEntry:
+    def run(self, builder: LogicalPlanBuilder) -> PartitionCacheEntry:
         result_pset = RayPartitionSet({})
 
-        partitions_iter = self.run_iter(plan)
+        partitions_iter = self.run_iter(builder)
 
         for i, partition in enumerate(partitions_iter):
             result_pset.set_partition(i, partition)
@@ -699,9 +675,6 @@ class RayRunner(Runner[ray.ObjectRef]):
             pset = RayPartitionSet({pid: ray.put(val) for pid, val in pset._partitions.items()})
 
         return self._part_set_cache.put_partition_set(pset=pset)
-
-    def optimize(self, plan: logical_plan.LogicalPlan) -> logical_plan.LogicalPlan:
-        return self._optimizer.optimize(plan)
 
     def runner_io(self) -> RayRunnerIO:
         return RayRunnerIO()

--- a/daft/runners/runner.py
+++ b/daft/runners/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import Generic, Iterator, TypeVar
 
+from daft.logical.builder import LogicalPlanBuilder
 from daft.logical.logical_plan import LogicalPlan
 from daft.runners.partitioning import (
     PartitionCacheEntry,
@@ -30,16 +31,16 @@ class Runner(Generic[PartitionT]):
         ...
 
     @abstractmethod
-    def run(self, plan: LogicalPlan) -> PartitionCacheEntry:
+    def run(self, builder: LogicalPlanBuilder) -> PartitionCacheEntry:
         ...
 
     @abstractmethod
-    def run_iter(self, plan: LogicalPlan) -> Iterator[PartitionT]:
+    def run_iter(self, builder: LogicalPlanBuilder) -> Iterator[PartitionT]:
         """Similar to run(), but yield the individual partitions as they are completed."""
         ...
 
     @abstractmethod
-    def run_iter_tables(self, plan: LogicalPlan) -> Iterator[Table]:
+    def run_iter_tables(self, builder: LogicalPlanBuilder) -> Iterator[Table]:
         """Similar to run_iter(), but always dereference and yield Table objects."""
         ...
 

--- a/tests/dataframe/test_accessors.py
+++ b/tests/dataframe/test_accessors.py
@@ -4,16 +4,11 @@ import pytest
 
 import daft
 from daft.datatype import DataType
-from daft.logical.logical_plan import LogicalPlan
 
 
 @pytest.fixture(scope="function")
 def df():
     return daft.from_pydict({"foo": [1, 2, 3]})
-
-
-def test_get_plan(df):
-    assert isinstance(df.plan(), LogicalPlan)
 
 
 def test_num_partitions(df):

--- a/tests/optimizer/test_drop_projections.py
+++ b/tests/optimizer/test_drop_projections.py
@@ -26,7 +26,7 @@ def optimizer() -> RuleRunner[LogicalPlan]:
 def test_drop_projections(valid_data: list[dict[str, float]], optimizer) -> None:
     df = daft.from_pylist(valid_data)
     projection_df = df.select("petal_length", "petal_width", "sepal_length", "sepal_width", "variety")
-    assert_plan_eq(optimizer(projection_df.plan()), df.plan())
+    assert_plan_eq(optimizer(projection_df._get_current_builder()._plan), df._get_current_builder()._plan)
 
 
 @pytest.mark.parametrize(
@@ -45,4 +45,4 @@ def test_drop_projections(valid_data: list[dict[str, float]], optimizer) -> None
 def test_cannot_drop_projections(valid_data: list[dict[str, float]], selection, optimizer) -> None:
     df = daft.from_pylist(valid_data)
     projection_df = df.select(*selection)
-    assert_plan_eq(optimizer(projection_df.plan()), projection_df.plan())
+    assert_plan_eq(optimizer(projection_df._get_current_builder()._plan), projection_df._get_current_builder()._plan)

--- a/tests/optimizer/test_drop_repartition.py
+++ b/tests/optimizer/test_drop_repartition.py
@@ -28,24 +28,24 @@ def test_drop_unneeded_repartition(valid_data: list[dict[str, float]], tmpdir, o
     df = df.repartition(2)
     df = df.groupby("variety").agg([("sepal_length", "mean")])
     repartitioned_df = df.repartition(2, df["variety"])
-    assert_plan_eq(optimizer(repartitioned_df.plan()), df.plan())
+    assert_plan_eq(optimizer(repartitioned_df._get_current_builder()._plan), df._get_current_builder()._plan)
 
 
 def test_drop_single_repartitions(valid_data: list[dict[str, float]], optimizer) -> None:
     df = daft.from_pylist(valid_data)
     unoptimized_df = df.repartition(1, "variety")
-    assert_plan_eq(optimizer(unoptimized_df.plan()), df.plan())
+    assert_plan_eq(optimizer(unoptimized_df._get_current_builder()._plan), df._get_current_builder()._plan)
 
 
 def test_drop_double_repartition(valid_data: list[dict[str, float]], tmpdir, optimizer) -> None:
     df = daft.from_pylist(valid_data)
     unoptimized_df = df.repartition(2).repartition(3)
     optimized_df = df.repartition(3)
-    assert_plan_eq(optimizer(unoptimized_df.plan()), optimized_df.plan())
+    assert_plan_eq(optimizer(unoptimized_df._get_current_builder()._plan), optimized_df._get_current_builder()._plan)
 
 
 @pytest.mark.skip(reason="Broken on issue: https://github.com/Eventual-Inc/Daft/issues/596")
 def test_repartition_alias(valid_data: list[dict[str, float]], tmpdir, optimizer) -> None:
     df = daft.from_pylist(valid_data)
     df = df.repartition(2, "variety").select(col("sepal_length").alias("variety")).repartition(2, "variety")
-    assert_plan_eq(optimizer(df.plan()), df.plan())
+    assert_plan_eq(optimizer(df._get_current_builder()._plan), df._get_current_builder()._plan)

--- a/tests/optimizer/test_fold_projections.py
+++ b/tests/optimizer/test_fold_projections.py
@@ -29,7 +29,7 @@ def test_fold_projections(valid_data: list[dict[str, float]], optimizer) -> None
     df_unoptimized = df.select("sepal_length", "sepal_width").select("sepal_length")
     df_optimized = df.select("sepal_length")
     assert df_unoptimized.column_names == ["sepal_length"]
-    assert_plan_eq(optimizer(df_unoptimized.plan()), df_optimized.plan())
+    assert_plan_eq(optimizer(df_unoptimized._get_current_builder()._plan), df_optimized._get_current_builder()._plan)
 
 
 def test_fold_projections_aliases(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -38,13 +38,13 @@ def test_fold_projections_aliases(valid_data: list[dict[str, float]], optimizer)
     df_optimized = df.select(col("sepal_length").alias("foo").alias("sepal_width"))
 
     assert df_unoptimized.column_names == ["sepal_width"]
-    assert_plan_eq(optimizer(df_unoptimized.plan()), df_optimized.plan())
+    assert_plan_eq(optimizer(df_unoptimized._get_current_builder()._plan), df_optimized._get_current_builder()._plan)
 
 
 def test_cannot_fold_projections(valid_data: list[dict[str, float]], optimizer) -> None:
     df = daft.from_pylist(valid_data)
     df_unoptimized = df.select(col("sepal_length") + 1, "sepal_width").select("sepal_length")
-    assert_plan_eq(optimizer(df_unoptimized.plan()), df_unoptimized.plan())
+    assert_plan_eq(optimizer(df_unoptimized._get_current_builder()._plan), df_unoptimized._get_current_builder()._plan)
 
 
 def test_fold_projections_resource_requests(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -53,7 +53,7 @@ def test_fold_projections_resource_requests(valid_data: list[dict[str, float]], 
         "bar", col("sepal_length"), resource_request=ResourceRequest(num_cpus=1)
     ).with_column("foo", col("sepal_length"), resource_request=ResourceRequest(num_gpus=1))
     df_optimized = df.select(*df.column_names, col("sepal_length").alias("bar"), col("sepal_length").alias("foo"))
-    df_optimized._plan._resource_request = ResourceRequest(num_cpus=1, num_gpus=1)
+    df_optimized._get_current_builder()._plan._resource_request = ResourceRequest(num_cpus=1, num_gpus=1)
 
     assert df_unoptimized.column_names == [*df.column_names, "bar", "foo"]
-    assert_plan_eq(optimizer(df_unoptimized.plan()), df_optimized.plan())
+    assert_plan_eq(optimizer(df_unoptimized._get_current_builder()._plan), df_optimized._get_current_builder()._plan)

--- a/tests/optimizer/test_pushdown_clauses_into_scan.py
+++ b/tests/optimizer/test_pushdown_clauses_into_scan.py
@@ -23,17 +23,17 @@ def test_push_projection_scan_all_cols(valid_data_json_path: str, optimizer):
     # Manually construct a plan to be what we expect after optimization
     df_optimized = DataFrame(
         TabularFilesScan(
-            schema=df_unoptimized_scan.plan()._schema,
-            predicate=df_unoptimized_scan.plan()._predicate,
+            schema=df_unoptimized_scan._get_current_builder()._plan._schema,
+            predicate=df_unoptimized_scan._get_current_builder()._plan._predicate,
             columns=["sepal_length"],
-            file_format_config=df_unoptimized_scan.plan()._file_format_config,
-            fs=df_unoptimized_scan.plan()._fs,
-            filepaths_child=df_unoptimized_scan.plan()._filepaths_child,
-            filepaths_column_name=df_unoptimized_scan.plan()._filepaths_column_name,
-        )
+            file_format_config=df_unoptimized_scan._get_current_builder()._plan._file_format_config,
+            fs=df_unoptimized_scan._get_current_builder()._plan._fs,
+            filepaths_child=df_unoptimized_scan._get_current_builder()._plan._filepaths_child,
+            filepaths_column_name=df_unoptimized_scan._get_current_builder()._plan._filepaths_column_name,
+        ).to_builder()
     )
 
-    assert_plan_eq(optimizer(df_unoptimized.plan()), df_optimized.plan())
+    assert_plan_eq(optimizer(df_unoptimized._get_current_builder()._plan), df_optimized._get_current_builder()._plan)
 
 
 def test_push_projection_scan_all_cols_alias(valid_data_json_path: str, optimizer):
@@ -44,18 +44,18 @@ def test_push_projection_scan_all_cols_alias(valid_data_json_path: str, optimize
     # Manually construct a plan to be what we expect after optimization
     df_optimized = DataFrame(
         TabularFilesScan(
-            schema=df_unoptimized_scan.plan()._schema,
-            predicate=df_unoptimized_scan.plan()._predicate,
+            schema=df_unoptimized_scan._get_current_builder()._plan._schema,
+            predicate=df_unoptimized_scan._get_current_builder()._plan._predicate,
             columns=["sepal_length"],
-            file_format_config=df_unoptimized_scan.plan()._file_format_config,
-            fs=df_unoptimized_scan.plan()._fs,
-            filepaths_child=df_unoptimized_scan.plan()._filepaths_child,
-            filepaths_column_name=df_unoptimized_scan.plan()._filepaths_column_name,
-        )
+            file_format_config=df_unoptimized_scan._get_current_builder()._plan._file_format_config,
+            fs=df_unoptimized_scan._get_current_builder()._plan._fs,
+            filepaths_child=df_unoptimized_scan._get_current_builder()._plan._filepaths_child,
+            filepaths_column_name=df_unoptimized_scan._get_current_builder()._plan._filepaths_column_name,
+        ).to_builder()
     )
     df_optimized = df_optimized.select(col("sepal_length").alias("foo"))
 
-    assert_plan_eq(optimizer(df_unoptimized.plan()), df_optimized.plan())
+    assert_plan_eq(optimizer(df_unoptimized._get_current_builder()._plan), df_optimized._get_current_builder()._plan)
 
 
 def test_push_projection_scan_some_cols_aliases(valid_data_json_path: str, optimizer):
@@ -66,15 +66,15 @@ def test_push_projection_scan_some_cols_aliases(valid_data_json_path: str, optim
     # Manually construct a plan to be what we expect after optimization
     df_optimized = DataFrame(
         TabularFilesScan(
-            schema=df_unoptimized_scan.plan()._schema,
-            predicate=df_unoptimized_scan.plan()._predicate,
+            schema=df_unoptimized_scan._get_current_builder()._plan._schema,
+            predicate=df_unoptimized_scan._get_current_builder()._plan._predicate,
             columns=["sepal_length", "sepal_width"],
-            file_format_config=df_unoptimized_scan.plan()._file_format_config,
-            fs=df_unoptimized_scan.plan()._fs,
-            filepaths_child=df_unoptimized_scan.plan()._filepaths_child,
-            filepaths_column_name=df_unoptimized_scan.plan()._filepaths_column_name,
-        )
+            file_format_config=df_unoptimized_scan._get_current_builder()._plan._file_format_config,
+            fs=df_unoptimized_scan._get_current_builder()._plan._fs,
+            filepaths_child=df_unoptimized_scan._get_current_builder()._plan._filepaths_child,
+            filepaths_column_name=df_unoptimized_scan._get_current_builder()._plan._filepaths_column_name,
+        ).to_builder()
     )
     df_optimized = df_optimized.select(col("sepal_length").alias("foo"), col("sepal_width") + 1)
 
-    assert_plan_eq(optimizer(df_unoptimized.plan()), df_optimized.plan())
+    assert_plan_eq(optimizer(df_unoptimized._get_current_builder()._plan), df_optimized._get_current_builder()._plan)

--- a/tests/optimizer/test_pushdown_limit.py
+++ b/tests/optimizer/test_pushdown_limit.py
@@ -26,11 +26,11 @@ def test_limit_pushdown_repartition(valid_data: list[dict[str, float]], optimize
     df = daft.from_pylist(valid_data)
     unoptimized_df = df.repartition(3).limit(1)
     optimized_df = df.limit(1).repartition(3)
-    assert_plan_eq(optimizer(unoptimized_df.plan()), optimized_df.plan())
+    assert_plan_eq(optimizer(unoptimized_df._get_current_builder()._plan), optimized_df._get_current_builder()._plan)
 
 
 def test_limit_pushdown_projection(valid_data: list[dict[str, float]], optimizer) -> None:
     df = daft.from_pylist(valid_data)
     unoptimized_df = df.select("variety").limit(1)
     optimized_df = df.limit(1).select("variety")
-    assert_plan_eq(optimizer(unoptimized_df.plan()), optimized_df.plan())
+    assert_plan_eq(optimizer(unoptimized_df._get_current_builder()._plan), optimized_df._get_current_builder()._plan)

--- a/tests/optimizer/test_pushdown_predicates.py
+++ b/tests/optimizer/test_pushdown_predicates.py
@@ -33,7 +33,7 @@ def test_no_pushdown_on_modified_column(optimizer) -> None:
     ).where(col("ints") == col("modified").alias("ints_dup"))
 
     # Optimizer cannot push down the filter because it uses a column that was projected
-    assert_plan_eq(optimizer(df.plan()), df.plan())
+    assert_plan_eq(optimizer(df._get_current_builder()._plan), df._get_current_builder()._plan)
 
 
 def test_filter_pushdown_select(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -41,7 +41,7 @@ def test_filter_pushdown_select(valid_data: list[dict[str, float]], optimizer) -
     unoptimized = df.select("sepal_length", "sepal_width").where(col("sepal_length") > 4.8)
     optimized = df.where(col("sepal_length") > 4.8).select("sepal_length", "sepal_width")
     assert unoptimized.column_names == ["sepal_length", "sepal_width"]
-    assert_plan_eq(optimizer(unoptimized.plan()), optimized.plan())
+    assert_plan_eq(optimizer(unoptimized._get_current_builder()._plan), optimized._get_current_builder()._plan)
 
 
 def test_filter_pushdown_select_alias(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -49,7 +49,7 @@ def test_filter_pushdown_select_alias(valid_data: list[dict[str, float]], optimi
     unoptimized = df.select("sepal_length", "sepal_width").where(col("sepal_length").alias("foo") > 4.8)
     optimized = df.where(col("sepal_length").alias("foo") > 4.8).select("sepal_length", "sepal_width")
     assert unoptimized.column_names == ["sepal_length", "sepal_width"]
-    assert_plan_eq(optimizer(unoptimized.plan()), optimized.plan())
+    assert_plan_eq(optimizer(unoptimized._get_current_builder()._plan), optimized._get_current_builder()._plan)
 
 
 def test_filter_pushdown_with_column(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -57,7 +57,7 @@ def test_filter_pushdown_with_column(valid_data: list[dict[str, float]], optimiz
     unoptimized = df.with_column("foo", col("sepal_length") + 1).where(col("sepal_length") > 4.8)
     optimized = df.where(col("sepal_length") > 4.8).with_column("foo", col("sepal_length") + 1)
     assert unoptimized.column_names == [*df.column_names, "foo"]
-    assert_plan_eq(optimizer(unoptimized.plan()), optimized.plan())
+    assert_plan_eq(optimizer(unoptimized._get_current_builder()._plan), optimized._get_current_builder()._plan)
 
 
 def test_filter_pushdown_with_column_partial_predicate_pushdown(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -67,7 +67,7 @@ def test_filter_pushdown_with_column_partial_predicate_pushdown(valid_data: list
     )
     optimized = df.where(col("sepal_length") > 4.8).with_column("foo", col("sepal_length") + 1).where(col("foo") > 4.8)
     assert unoptimized.column_names == [*df.column_names, "foo"]
-    assert_plan_eq(optimizer(unoptimized.plan()), optimized.plan())
+    assert_plan_eq(optimizer(unoptimized._get_current_builder()._plan), optimized._get_current_builder()._plan)
 
 
 def test_filter_pushdown_with_column_alias(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -79,7 +79,7 @@ def test_filter_pushdown_with_column_alias(valid_data: list[dict[str, float]], o
         "foo", col("sepal_length").alias("foo") + 1
     )
     assert unoptimized.column_names == [*df.column_names, "foo"]
-    assert_plan_eq(optimizer(unoptimized.plan()), optimized.plan())
+    assert_plan_eq(optimizer(unoptimized._get_current_builder()._plan), optimized._get_current_builder()._plan)
 
 
 def test_filter_merge(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -92,9 +92,9 @@ def test_filter_merge(valid_data: list[dict[str, float]], optimizer) -> None:
         [(col("sepal_width") > 2.4).alias("foo"), (col("sepal_length") > 4.8).alias("foo").alias("copy.foo")]
     )
     optimized = df.where(DUMMY)
-    optimized._plan._predicate = EXPECTED
+    optimized._get_current_builder()._plan._predicate = EXPECTED
 
-    assert_plan_eq(optimizer(unoptimized.plan()), optimized.plan())
+    assert_plan_eq(optimizer(unoptimized._get_current_builder()._plan), optimized._get_current_builder()._plan)
 
 
 def test_filter_pushdown_sort(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -102,7 +102,7 @@ def test_filter_pushdown_sort(valid_data: list[dict[str, float]], optimizer) -> 
     unoptimized = df.sort("sepal_length").select("sepal_length", "sepal_width").where(col("sepal_length") > 4.8)
     optimized = df.where(col("sepal_length") > 4.8).sort("sepal_length").select("sepal_length", "sepal_width")
     assert unoptimized.column_names == ["sepal_length", "sepal_width"]
-    assert_plan_eq(optimizer(unoptimized.plan()), optimized.plan())
+    assert_plan_eq(optimizer(unoptimized._get_current_builder()._plan), optimized._get_current_builder()._plan)
 
 
 def test_filter_pushdown_repartition(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -110,7 +110,7 @@ def test_filter_pushdown_repartition(valid_data: list[dict[str, float]], optimiz
     unoptimized = df.repartition(2).select("sepal_length", "sepal_width").where(col("sepal_length") > 4.8)
     optimized = df.where(col("sepal_length") > 4.8).repartition(2).select("sepal_length", "sepal_width")
     assert unoptimized.column_names == ["sepal_length", "sepal_width"]
-    assert_plan_eq(optimizer(unoptimized.plan()), optimized.plan())
+    assert_plan_eq(optimizer(unoptimized._get_current_builder()._plan), optimized._get_current_builder()._plan)
 
 
 def test_filter_join_pushdown(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -122,12 +122,12 @@ def test_filter_join_pushdown(valid_data: list[dict[str, float]], optimizer) -> 
     filtered = joined.where(col("sepal_length") > 4.8)
     filtered = filtered.where(col("right.sepal_width") > 4.8)
 
-    optimized = optimizer(filtered.plan())
+    optimized = optimizer(filtered._get_current_builder()._plan)
 
     expected = df1.where(col("sepal_length") > 4.8).join(df2.where(col("sepal_width") > 4.8), on="variety")
     assert isinstance(optimized, Join)
-    assert isinstance(expected.plan(), Join)
-    assert_plan_eq(optimized, expected.plan())
+    assert isinstance(expected._get_current_builder()._plan, Join)
+    assert_plan_eq(optimized, expected._get_current_builder()._plan)
 
 
 def test_filter_join_pushdown_aliases(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -139,15 +139,15 @@ def test_filter_join_pushdown_aliases(valid_data: list[dict[str, float]], optimi
     filtered = joined.where(col("sepal_length").alias("foo") > 4.8)
     filtered = filtered.where(col("right.sepal_width").alias("foo") > 4.8)
 
-    optimized = optimizer(filtered.plan())
+    optimized = optimizer(filtered._get_current_builder()._plan)
 
     expected = df1.where(
         # Filter merging creates a `copy.*` column when merging predicates with the same name
         (col("sepal_length").alias("foo") > 4.8).alias("copy.foo")
     ).join(df2.where(col("sepal_width").alias("foo") > 4.8), on="variety")
     assert isinstance(optimized, Join)
-    assert isinstance(expected.plan(), Join)
-    assert_plan_eq(optimized, expected.plan())
+    assert isinstance(expected._get_current_builder()._plan, Join)
+    assert_plan_eq(optimized, expected._get_current_builder()._plan)
 
 
 def test_filter_join_pushdown_nonvalid(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -158,10 +158,10 @@ def test_filter_join_pushdown_nonvalid(valid_data: list[dict[str, float]], optim
 
     filtered = joined.where(col("right.sepal_width") > col("sepal_length"))
 
-    optimized = optimizer(filtered.plan())
+    optimized = optimizer(filtered._get_current_builder()._plan)
 
     assert isinstance(optimized, Filter)
-    assert_plan_eq(optimized, filtered.plan())
+    assert_plan_eq(optimized, filtered._get_current_builder()._plan)
 
 
 def test_filter_join_pushdown_nonvalid_aliases(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -172,10 +172,10 @@ def test_filter_join_pushdown_nonvalid_aliases(valid_data: list[dict[str, float]
 
     filtered = joined.where(col("right.sepal_width").alias("sepal_width") > col("sepal_length"))
 
-    optimized = optimizer(filtered.plan())
+    optimized = optimizer(filtered._get_current_builder()._plan)
 
     assert isinstance(optimized, Filter)
-    assert_plan_eq(optimized, filtered.plan())
+    assert_plan_eq(optimized, filtered._get_current_builder()._plan)
 
 
 def test_filter_join_partial_predicate_pushdown(valid_data: list[dict[str, float]], optimizer) -> None:
@@ -188,7 +188,7 @@ def test_filter_join_partial_predicate_pushdown(valid_data: list[dict[str, float
     filtered = filtered.where(col("right.sepal_width") > 4.8)
     filtered = filtered.where(((col("sepal_length") > 4.8) | (col("right.sepal_length") > 4.8)).alias("foo"))
 
-    optimized = optimizer(filtered.plan())
+    optimized = optimizer(filtered._get_current_builder()._plan)
 
     expected = (
         df1.where(col("sepal_length") > 4.8)
@@ -196,8 +196,8 @@ def test_filter_join_partial_predicate_pushdown(valid_data: list[dict[str, float
         .where(((col("sepal_length") > 4.8) | (col("right.sepal_length") > 4.8)).alias("foo"))
     )
     assert isinstance(optimized, Filter)
-    assert isinstance(expected.plan(), Filter)
-    assert_plan_eq(optimized, expected.plan())
+    assert isinstance(expected._get_current_builder()._plan, Filter)
+    assert_plan_eq(optimized, expected._get_current_builder()._plan)
 
 
 def test_filter_concat_predicate_pushdown(valid_data, optimizer) -> None:
@@ -205,9 +205,9 @@ def test_filter_concat_predicate_pushdown(valid_data, optimizer) -> None:
     df2 = daft.from_pylist(valid_data)
     concatted = df1.concat(df2)
     filtered = concatted.where(col("sepal_length") > 4.8)
-    optimized = optimizer(filtered.plan())
+    optimized = optimizer(filtered._get_current_builder()._plan)
 
     expected = df1.where(col("sepal_length") > 4.8).concat(df2.where(col("sepal_length") > 4.8))
     assert isinstance(optimized, Concat)
-    assert isinstance(expected.plan(), Concat)
-    assert_plan_eq(optimized, expected.plan())
+    assert isinstance(expected._get_current_builder()._plan, Concat)
+    assert_plan_eq(optimized, expected._get_current_builder()._plan)


### PR DESCRIPTION
This PR introduces `LogicalPlanBuilder` and `QueryPlanner` interfaces to the `DataFrame` API and execution layers in order to hide the query planner implementation. This should allow us to build out the new Rust query planner without having to switch on the `use_rust_planner` feature flag everywhere, as well as allowing the logical plan --> executable tasks translation to deviate more, if we wish.

## TODOs

- [ ] Push `PartitionSpec` into planner.
- [ ] Push `ResourceRequest` into planner.