### PR TITLE
[BUG] Fix decimal byte arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.1"
-source = "git+https://github.com/Eventual-Inc/arrow2?branch=clark/expand-casting-support#46bc134e386f597eed00a0396ea2de224d12943c"
+source = "git+https://github.com/Eventual-Inc/arrow2?rev=2834446a10545156bdf9c2898577e87e07d4d42d#2834446a10545156bdf9c2898577e87e07d4d42d"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,10 @@ snafu = "0.7.4"
 tokio = {version = "1.29.1", features = ["net", "time", "bytes", "process", "signal", "macros", "rt", "rt-multi-thread"]}
 
 [workspace.dependencies.arrow2]
-branch = "clark/expand-casting-support"
 git = "https://github.com/Eventual-Inc/arrow2"
 package = "arrow2"
+# branch = "jay/decimal-binary-types"
+rev = "2834446a10545156bdf9c2898577e87e07d4d42d"
 version = "0.17.1"
 
 [workspace.dependencies.bincode]

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -37,10 +37,10 @@ DAFT_CAN_READ_FILES = [
         "https://raw.githubusercontent.com/apache/parquet-testing/master/data/binary.parquet",
     ),
     # Needs Decimals decoding from byte arrays
-    # (
-    #     "parquet-testing/data/byte_array_decimal.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/byte_array_decimal.parquet",
-    # ),
+    (
+        "parquet-testing/data/byte_array_decimal.parquet",
+        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/byte_array_decimal.parquet",
+    ),
     (
         "parquet-testing/data/data_index_bloom_encoding_stats.parquet",
         "https://raw.githubusercontent.com/apache/parquet-testing/master/data/data_index_bloom_encoding_stats.parquet",


### PR DESCRIPTION
Update Daft to use decimal byte array fixes in our fork of arrow2