### PR TITLE
[FEAT] Add Azure Support for Native Downloader

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -213,7 +213,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7']
+        python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     # This is used in the step "Assume GitHub Actions AWS Credentials"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "RustyXML"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5ace29ee3216de37c0546865ad08edef58b0f9e76838ed8959a84a990e58c5"
+
+[[package]]
 name = "addr2line"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,7 +30,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -69,6 +75,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+
+[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,7 +109,7 @@ source = "git+https://github.com/Eventual-Inc/arrow2?branch=clark/expand-casting
 dependencies = [
  "ahash",
  "arrow-format",
- "base64",
+ "base64 0.21.2",
  "bytemuck",
  "chrono",
  "chrono-tz",
@@ -107,7 +119,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "foreign_vec",
  "futures",
- "getrandom",
+ "getrandom 0.2.10",
  "hash_hasher",
  "hashbrown 0.13.2",
  "lexical-core",
@@ -118,6 +130,17 @@ dependencies = [
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
 ]
 
 [[package]]
@@ -545,6 +568,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b0f0eea648347e40f5f7f7e6bfea4553bcefad0fbf52044ea339e5ce3aba61"
+dependencies = [
+ "async-trait",
+ "base64 0.21.2",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.2.10",
+ "http-types",
+ "log",
+ "paste",
+ "pin-project",
+ "quick-xml",
+ "rand 0.8.5",
+ "reqwest",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "time 0.3.23",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_storage"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d9cfa13ed9acb51cd663e04f343bd550a92b455add96c90de387a9a6bc4dbc"
+dependencies = [
+ "RustyXML",
+ "async-trait",
+ "azure_core",
+ "bytes",
+ "futures",
+ "hmac",
+ "log",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2",
+ "time 0.3.23",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "azure_storage_blobs"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cb0fe58af32a3fb49e560613cb1e4937f9f13161a2c1caf1bba0224435f2af"
+dependencies = [
+ "RustyXML",
+ "azure_core",
+ "azure_storage",
+ "bytes",
+ "futures",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time 0.3.23",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +651,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -742,6 +841,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,7 +985,7 @@ name = "daft-core"
 version = "0.1.10"
 dependencies = [
  "arrow2",
- "base64",
+ "base64 0.21.2",
  "bincode",
  "chrono",
  "chrono-tz",
@@ -896,7 +1004,7 @@ dependencies = [
  "prettytable-rs",
  "pyo3",
  "pyo3-log",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "xxhash-rust",
@@ -927,6 +1035,8 @@ dependencies = [
  "aws-sig-auth",
  "aws-sigv4",
  "aws-smithy-async",
+ "azure_storage",
+ "azure_storage_blobs",
  "bytes",
  "common-error",
  "daft-core",
@@ -998,7 +1108,7 @@ dependencies = [
  "prettytable-rs",
  "pyo3",
  "pyo3-log",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1100,6 +1210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04"
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
 name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1260,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign_vec"
@@ -1209,6 +1340,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1403,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1390,6 +1547,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1629,19 @@ dependencies = [
  "rustls 0.21.5",
  "tokio",
  "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1530,6 +1720,12 @@ name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+
+[[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "instant"
@@ -1801,6 +1997,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +2088,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "numpy"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,16 +2127,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "openssl"
+version = "0.10.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.25",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-sys"
+version = "0.9.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "parking"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
 name = "parking_lot"
@@ -1977,6 +2244,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,7 +2281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2182,6 +2455,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,13 +2475,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2208,7 +2514,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -2217,7 +2532,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2272,7 +2596,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror",
 ]
@@ -2312,7 +2636,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2322,10 +2646,12 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls 0.24.1",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2335,6 +2661,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
@@ -2438,7 +2765,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -2552,6 +2879,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -2813,6 +3151,9 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -2876,6 +3217,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.25",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3045,6 +3396,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -3060,6 +3412,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom 0.2.10",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,6 +3439,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3452,12 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import sys
 
+from daft.daft import AzureConfig, IOConfig, S3Config
 from daft.io._csv import read_csv
 from daft.io._json import read_json
 from daft.io._parquet import read_parquet
-from daft.io.config import IOConfig, S3Config
 from daft.io.file_path import from_glob_path
 
 
@@ -23,4 +23,4 @@ def _set_linux_cert_paths():
 if sys.platform == "linux":
     _set_linux_cert_paths()
 
-__all__ = ["read_csv", "read_json", "from_glob_path", "read_parquet", "IOConfig", "S3Config"]
+__all__ = ["read_csv", "read_json", "from_glob_path", "read_parquet", "IOConfig", "S3Config", "AzureConfig"]

--- a/daft/io/config.py
+++ b/daft/io/config.py
@@ -1,12 +1,8 @@
 from __future__ import annotations
 
-import json
-
-from daft.daft import IOConfig, S3Config
+from daft.daft import IOConfig
 
 
 def _io_config_from_json(io_config_json: str) -> IOConfig:
     """Used when deserializing a serialized IOConfig object"""
-    data = json.loads(io_config_json)
-    s3_config = S3Config(**data["s3"]) if "s3" in data else None
-    return IOConfig(s3=s3_config)
+    return IOConfig.from_json(io_config_json)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,9 @@ readme = "README.rst"
 requires-python = ">=3.7"
 
 [project.optional-dependencies]
-all = ["getdaft[aws, ray, pandas, numpy, viz]"]
+all = ["getdaft[aws, azure, ray, pandas, numpy, viz]"]
 aws = ["s3fs"]
+azure = ["adlfs"]
 numpy = ["numpy"]
 pandas = ["pandas"]
 ray = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,6 +40,7 @@ s3fs==2023.6.0; python_version >= '3.8'
 urllib3<2; python_version < '3.8'
 
 # Azure
+adlfs==2022.2.0; python_version < '3.8'
 adlfs==2023.8.0
 
 # Documentation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,6 +39,9 @@ s3fs==2023.6.0; python_version >= '3.8'
 # "ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_'"
 urllib3<2; python_version < '3.8'
 
+# Azure
+adlfs==2023.8.0
+
 # Documentation
 myst-nb>=0.16.0
 Sphinx <= 5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,7 +41,7 @@ urllib3<2; python_version < '3.8'
 
 # Azure
 adlfs==2022.2.0; python_version < '3.8'
-adlfs==2023.8.0
+adlfs==2023.8.0; python_version >= '3.8'
 
 # Documentation
 myst-nb>=0.16.0

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -82,7 +82,7 @@ impl Display for DaftError {
             #[cfg(feature = "python")]
             Self::PyO3Error(e) => write!(f, "DaftError::PyO3Error {e}"),
             Self::IoError(e) => write!(f, "DaftError::IoError {e}"),
-            Self::External(e) => write!(f, "DaftError::External {:?}", e),
+            Self::External(e) => write!(f, "DaftError::External {}", e),
             Self::FileNotFound { path, source } => {
                 write!(f, "DaftError::FileNotFound {path}: {source}")
             }

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -7,6 +7,8 @@ aws-sdk-s3 = "0.28.0"
 aws-sig-auth = "0.55.3"
 aws-sigv4 = "0.55.3"
 aws-smithy-async = "0.55.3"
+azure_storage = {version = "0.13.0"}
+azure_storage_blobs = {version = "0.13.1", features = ["enable_reqwest_rustls"]}
 bytes = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}

--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -1,0 +1,174 @@
+use async_trait::async_trait;
+use azure_storage::prelude::*;
+use azure_storage_blobs::prelude::*;
+use futures::{StreamExt, TryStreamExt};
+use snafu::{IntoError, ResultExt, Snafu};
+use std::{num::ParseIntError, ops::Range, string::FromUtf8Error, sync::Arc};
+
+use crate::{config::AzureConfig, object_io::ObjectSource, GetResult};
+
+#[derive(Debug, Snafu)]
+enum Error {
+    #[snafu(display("Unable to connect to {}: {}", path, source))]
+    UnableToConnect {
+        path: String,
+        source: reqwest::Error,
+    },
+
+    #[snafu(display("Unable to open {}: {}", path, source))]
+    UnableToOpenFile {
+        path: String,
+        source: azure_storage::Error,
+    },
+
+    #[snafu(display("Unable to determine size of {}", path))]
+    UnableToDetermineSize { path: String },
+
+    #[snafu(display("Unable to read data from {}: {}", path, source))]
+    UnableToReadBytes {
+        path: String,
+        source: azure_storage::Error,
+    },
+
+    #[snafu(display("Unable to create Http Client {}", source))]
+    UnableToCreateClient { source: reqwest::Error },
+
+    #[snafu(display("Unable to parse URL: \"{}\"", path))]
+    InvalidUrl {
+        path: String,
+        source: url::ParseError,
+    },
+
+    #[snafu(display("Azure Storage Account not set and is required.\n Set either `AzureConfig.storage_account` or the `AZURE_STORAGE_ACCOUNT` environment variable."))]
+    StorageAccountNotSet,
+
+    #[snafu(display(
+        "Unable to parse data as Utf8 while reading header for file: {path}. {source}"
+    ))]
+    UnableToParseUtf8 { path: String, source: FromUtf8Error },
+
+    #[snafu(display(
+        "Unable to parse data as Integer while reading header for file: {path}. {source}"
+    ))]
+    UnableToParseInteger { path: String, source: ParseIntError },
+}
+
+impl From<Error> for super::Error {
+    fn from(error: Error) -> Self {
+        use Error::*;
+        match error {
+            UnableToReadBytes { path, source } | UnableToOpenFile { path, source } => {
+                match source.as_http_error().map(|v| v.status().into()) {
+                    Some(404) | Some(410) => super::Error::NotFound {
+                        path,
+                        source: source.into(),
+                    },
+                    Some(401) => super::Error::Unauthorized {
+                        store: super::SourceType::AzureBlob,
+                        path,
+                        source: source.into(),
+                    },
+                    None | Some(_) => super::Error::UnableToOpenFile {
+                        path,
+                        source: source.into(),
+                    },
+                }
+            }
+            _ => super::Error::Generic {
+                store: super::SourceType::AzureBlob,
+                source: error.into(),
+            },
+        }
+    }
+}
+
+pub(crate) struct AzureBlobSource {
+    blob_client: Arc<BlobServiceClient>,
+}
+
+impl AzureBlobSource {
+    pub async fn get_client(config: &AzureConfig) -> super::Result<Arc<Self>> {
+        let storage_account = if let Some(storage_account) = &config.storage_account {
+            storage_account.clone()
+        } else if let Ok(storage_account) = std::env::var("AZURE_STORAGE_ACCOUNT") {
+            storage_account
+        } else {
+            return Err(Error::StorageAccountNotSet.into());
+        };
+
+        let storage_credentials = if config.anonymous {
+            StorageCredentials::anonymous()
+        } else if let Some(access_key) = &config.access_key {
+            StorageCredentials::access_key(&storage_account, access_key)
+        } else if let Ok(access_key) = std::env::var("AZURE_STORAGE_KEY") {
+            StorageCredentials::access_key(&storage_account, access_key)
+        } else {
+            log::warn!("Azure access key not found, Set either `AzureConfig.access_key` or the `AZURE_STORAGE_KEY` environment variable. Defaulting to anonymous mode.");
+            StorageCredentials::anonymous()
+        };
+
+        let blob_client = BlobServiceClient::new(storage_account, storage_credentials);
+
+        Ok(AzureBlobSource {
+            blob_client: blob_client.into(),
+        }
+        .into())
+    }
+}
+
+#[async_trait]
+impl ObjectSource for AzureBlobSource {
+    async fn get(&self, uri: &str, range: Option<Range<usize>>) -> super::Result<GetResult> {
+        let parsed = url::Url::parse(uri).with_context(|_| InvalidUrlSnafu { path: uri })?;
+        let container = match parsed.host_str() {
+            Some(s) => Ok(s),
+            None => Err(Error::InvalidUrl {
+                path: uri.into(),
+                source: url::ParseError::EmptyHost,
+            }),
+        }?;
+        let key = parsed.path();
+
+        let container_client = self.blob_client.container_client(container);
+        let blob_client = container_client.blob_client(key);
+        let request_builder = blob_client.get();
+        let request_builder = if let Some(range) = range {
+            request_builder.range(range)
+        } else {
+            request_builder
+        };
+        let blob_stream = request_builder.into_stream();
+
+        let owned_string = uri.to_string();
+        let stream = blob_stream
+            .and_then(async move |v| v.data.collect().await)
+            .map_err(move |e| {
+                UnableToReadBytesSnafu::<String> {
+                    path: owned_string.clone(),
+                }
+                .into_error(e)
+                .into()
+            });
+        Ok(GetResult::Stream(stream.boxed(), None))
+    }
+
+    async fn get_size(&self, uri: &str) -> super::Result<usize> {
+        let parsed = url::Url::parse(uri).with_context(|_| InvalidUrlSnafu { path: uri })?;
+        let container = match parsed.host_str() {
+            Some(s) => Ok(s),
+            None => Err(Error::InvalidUrl {
+                path: uri.into(),
+                source: url::ParseError::EmptyHost,
+            }),
+        }?;
+        let key = parsed.path();
+
+        let container_client = self.blob_client.container_client(container);
+        let blob_client = container_client.blob_client(key);
+        let metadata = blob_client
+            .get_properties()
+            .await
+            .context(UnableToOpenFileSnafu::<String> { path: uri.into() })?;
+        Ok(metadata.blob.properties.content_length as usize)
+    }
+}

--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -106,7 +106,7 @@ impl AzureBlobSource {
             log::warn!("Azure access key not found, Set either `AzureConfig.access_key` or the `AZURE_STORAGE_KEY` environment variable. Defaulting to anonymous mode.");
             StorageCredentials::anonymous()
         };
-
+        log::warn!("{:?}", storage_credentials);
         let blob_client = BlobServiceClient::new(storage_account, storage_credentials);
 
         Ok(AzureBlobSource {

--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -106,7 +106,6 @@ impl AzureBlobSource {
             log::warn!("Azure access key not found, Set either `AzureConfig.access_key` or the `AZURE_STORAGE_KEY` environment variable. Defaulting to anonymous mode.");
             StorageCredentials::anonymous()
         };
-        log::warn!("{:?}", storage_credentials);
         let blob_client = BlobServiceClient::new(storage_account, storage_credentials);
 
         Ok(AzureBlobSource {

--- a/src/daft-io/src/config.rs
+++ b/src/daft-io/src/config.rs
@@ -30,11 +30,6 @@ impl Default for S3Config {
     }
 }
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
-pub struct IOConfig {
-    pub s3: S3Config,
-}
-
 impl Display for S3Config {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         write!(
@@ -60,13 +55,40 @@ impl Display for S3Config {
     }
 }
 
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct AzureConfig {
+    pub storage_account: Option<String>,
+    pub access_key: Option<String>,
+    pub anonymous: bool,
+}
+
+impl Display for AzureConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "AzureConfig
+    storage_account: {:?}
+    access_key: {:?}
+    anonymous: {:?}",
+            self.storage_account, self.access_key, self.anonymous
+        )
+    }
+}
+
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct IOConfig {
+    pub s3: S3Config,
+    pub azure: AzureConfig,
+}
+
 impl Display for IOConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
         write!(
             f,
             "IOConfig:
+{}
 {}",
-            self.s3
+            self.s3, self.azure
         )
     }
 }

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -23,23 +23,16 @@ use pyo3::prelude::*;
 pub struct S3Config {
     pub config: config::S3Config,
 }
-
 /// Create configurations to be used when accessing Azure Blob Storage
 ///
 /// Args:
-///     region_name: Name of the region to be used (used when accessing AWS S3), defaults to "us-east-1".
-///         If wrongly provided, Daft will attempt to auto-detect the buckets' region at the cost of extra S3 requests.
-///     endpoint_url: URL to the S3 endpoint, defaults to endpoints to AWS
-///     key_id: AWS Access Key ID, defaults to auto-detection from the current environment
-///     access_key: AWS Secret Access Key, defaults to auto-detection from the current environment
-///     session_token: AWS Session Token, required only if `key_id` and `access_key` are temporary credentials
-///     retry_initial_backoff_ms: Initial backoff duration in milliseconds for an S3 retry, defaults to 1000ms
-///     num_tries: Number of attempts to make a connection, defaults to 5
-///     anonymous: Whether or not to use "anonymous mode", which will access S3 without any credentials
+///     storage_account: Azure Storage Account, defaults to reading from `AZURE_STORAGE_ACCOUNT` environment variable.
+///     access_key: Azure Secret Access Key, defaults to reading from `AZURE_STORAGE_KEY` environment variable
+///     anonymous: Whether or not to use "anonymous mode", which will access Azure without any credentials
 ///
 /// Example:
-///     >>> io_config = IOConfig(s3=S3Config(key_id="xxx", access_key="xxx"))
-///     >>> daft.read_parquet("s3://some-path", io_config=io_config)
+///     >>> io_config = IOConfig(azure=AzureConfig(storage_account="dafttestdata", access_key="xxx"))
+///     >>> daft.read_parquet("az://some-path", io_config=io_config)
 #[derive(Clone, Default)]
 #[pyclass]
 pub struct AzureConfig {

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -43,10 +43,10 @@ pub struct AzureConfig {
 ///
 /// Args:
 ///     s3: Configurations to use when accessing URLs with the `s3://` scheme
-///
+///     azure: Configurations to use when accessing URLs with the `az://` or `abfs://` scheme
 /// Example:
-///     >>> io_config = IOConfig(s3=S3Config(key_id="xxx", access_key="xxx", num_tries=10))
-///     >>> daft.read_parquet("s3://some-path", io_config=io_config)
+///     >>> io_config = IOConfig(s3=S3Config(key_id="xxx", access_key="xxx", num_tries=10), azure=AzureConfig(anonymous=True))
+///     >>> daft.read_parquet(["s3://some-path", "az://some-other-path"], io_config=io_config)
 #[derive(Clone, Default)]
 #[pyclass]
 pub struct IOConfig {

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -16,7 +16,7 @@ use snafu::ResultExt;
 use crate::{
     metadata::read_parquet_metadata,
     read_planner::{CoalescePass, RangesContainer, ReadPlanner, SplitLargeRequestPass},
-    JoinSnafu, OneShotRecvSnafu, UnableToCreateParquetPageStreamSnafu, UnableToOpenFileSnafu,
+    JoinSnafu, OneShotRecvSnafu, UnableToCreateParquetPageStreamSnafu,
     UnableToParseSchemaFromMetadataSnafu,
 };
 use arrow2::io::parquet::read::column_iter_to_arrays;
@@ -87,11 +87,7 @@ impl FallibleStreamingIterator for VecIterator {
 impl ParquetReaderBuilder {
     pub async fn from_uri(uri: &str, io_client: Arc<daft_io::IOClient>) -> super::Result<Self> {
         // TODO(sammy): We actually don't need this since we can do negative offsets when reading the metadata
-        let size = io_client
-            .single_url_get_size(uri.into())
-            .await
-            .context(UnableToOpenFileSnafu::<String> { path: uri.into() })?;
-
+        let size = io_client.single_url_get_size(uri.into()).await?;
         let metadata = read_parquet_metadata(uri, size, io_client).await?;
         let num_rows = metadata.num_rows;
         let schema =

--- a/tests/integration/io/conftest.py
+++ b/tests/integration/io/conftest.py
@@ -46,6 +46,17 @@ def aws_public_s3_config() -> daft.io.IOConfig:
 
 
 @pytest.fixture(scope="session")
+def azure_storage_public_config() -> daft.io.IOConfig:
+    return daft.io.IOConfig(
+        azure=daft.io.AzureConfig(
+            # NOTE: no keys or endpoints specified for an AWS public s3 bucket
+            storage_account="dafttestdata",
+            anonymous=True,
+        )
+    )
+
+
+@pytest.fixture(scope="session")
 def nginx_config() -> tuple[str, pathlib.Path]:
     """Returns the (nginx_server_url, static_files_tmpdir) as a tuple"""
     return (

--- a/tests/integration/io/conftest.py
+++ b/tests/integration/io/conftest.py
@@ -49,7 +49,6 @@ def aws_public_s3_config() -> daft.io.IOConfig:
 def azure_storage_public_config() -> daft.io.IOConfig:
     return daft.io.IOConfig(
         azure=daft.io.AzureConfig(
-            # NOTE: no keys or endpoints specified for an AWS public s3 bucket
             storage_account="dafttestdata",
             anonymous=True,
         )

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -186,7 +186,6 @@ def read_parquet_with_pyarrow(path) -> pa.Table:
     if get_protocol_from_path(path) == "az":
         kwargs["account_name"] = "dafttestdata"
         kwargs["anon"] = True
-        kwargs["credential"] = "anon"
 
     fs = get_filesystem_from_path(path, **kwargs)
     table = pq.read_table(path, filesystem=fs)
@@ -221,7 +220,7 @@ def test_parquet_read_df(parquet_file, public_storage_io_config):
     if url.startswith("az"):
         import adlfs
 
-        fs = adlfs.AzureBlobFileSystem(account_name="dafttestdata", credential="anon")
+        fs = adlfs.AzureBlobFileSystem(account_name="dafttestdata", anon=True)
     else:
         fs = None
     daft_native_read = daft.read_parquet(url, io_config=public_storage_io_config, use_native_downloader=True, fs=fs)

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -186,7 +186,7 @@ def read_parquet_with_pyarrow(path) -> pa.Table:
     if get_protocol_from_path(path) == "az":
         kwargs["account_name"] = "dafttestdata"
         kwargs["anon"] = True
-        kwargs["account_key"] = ""
+        kwargs["credential"] = "anon"
 
     fs = get_filesystem_from_path(path, **kwargs)
     table = pq.read_table(path, filesystem=fs)
@@ -221,7 +221,7 @@ def test_parquet_read_df(parquet_file, public_storage_io_config):
     if url.startswith("az"):
         import adlfs
 
-        fs = adlfs.AzureBlobFileSystem(account_name="dafttestdata", account_key="", anon=True)
+        fs = adlfs.AzureBlobFileSystem(account_name="dafttestdata", credential="anon")
     else:
         fs = None
     daft_native_read = daft.read_parquet(url, io_config=public_storage_io_config, use_native_downloader=True, fs=fs)

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -220,7 +220,7 @@ def test_parquet_read_df(parquet_file, public_storage_io_config):
     if url.startswith("az"):
         import adlfs
 
-        fs = adlfs.AzureBlobFileSystem(account_name="dafttestdata", anonymous=True)
+        fs = adlfs.AzureBlobFileSystem(account_name="dafttestdata", anon=True)
     else:
         fs = None
     daft_native_read = daft.read_parquet(url, io_config=public_storage_io_config, use_native_downloader=True, fs=fs)

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -186,6 +186,7 @@ def read_parquet_with_pyarrow(path) -> pa.Table:
     if get_protocol_from_path(path) == "az":
         kwargs["account_name"] = "dafttestdata"
         kwargs["anon"] = True
+        kwargs["account_key"] = ""
 
     fs = get_filesystem_from_path(path, **kwargs)
     table = pq.read_table(path, filesystem=fs)
@@ -220,7 +221,7 @@ def test_parquet_read_df(parquet_file, public_storage_io_config):
     if url.startswith("az"):
         import adlfs
 
-        fs = adlfs.AzureBlobFileSystem(account_name="dafttestdata", anon=True)
+        fs = adlfs.AzureBlobFileSystem(account_name="dafttestdata", account_key="", anon=True)
     else:
         fs = None
     daft_native_read = daft.read_parquet(url, io_config=public_storage_io_config, use_native_downloader=True, fs=fs)

--- a/tests/integration/io/test_url_download_http.py
+++ b/tests/integration/io/test_url_download_http.py
@@ -41,8 +41,7 @@ def test_url_download_http_error_codes(nginx_config, use_native_downloader, stat
         assert e.value.code == status_code
     # When using native downloader, we throw a ValueError
     else:
-        with pytest.raises(ValueError) as e:
-            df.collect()
         # NOTE: We may want to add better errors in the future to provide a better
         # user-facing I/O error with the error code
-        assert f"Status({status_code})" in str(e.value)
+        with pytest.raises(ValueError, match=f"{status_code}") as e:
+            df.collect()

--- a/tests/integration/io/test_url_download_public_aws_s3.py
+++ b/tests/integration/io/test_url_download_public_aws_s3.py
@@ -33,9 +33,6 @@ def test_url_download_aws_s3_public_bucket_custom_s3fs_wrong_region(small_images
 
 
 @pytest.mark.integration()
-@pytest.mark.skip(
-    reason='[ISSUE #1091] We do not yet support "anonymous-mode" (no credentials) for accessing public buckets with the native downloader'
-)
 def test_url_download_aws_s3_public_bucket_native_downloader(aws_public_s3_config, small_images_s3_paths):
     data = {"urls": small_images_s3_paths}
     df = daft.from_pydict(data)

--- a/tests/integration/io/test_url_download_public_azure.py
+++ b/tests/integration/io/test_url_download_public_azure.py
@@ -7,7 +7,7 @@ import daft
 
 @pytest.mark.integration()
 def test_url_download_public_azure(azure_storage_public_config) -> None:
-    data = {"urls": ["public-anonymous/mvp.parquet"]}
+    data = {"urls": ["az://public-anonymous/mvp.parquet"]}
     df = daft.from_pydict(data)
     df = df.with_column(
         "data", df["urls"].url.download(io_config=azure_storage_public_config, use_native_downloader=True)

--- a/tests/integration/io/test_url_download_public_azure.py
+++ b/tests/integration/io/test_url_download_public_azure.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+
+
+@pytest.mark.integration()
+def test_url_download_public_azure(azure_storage_public_config) -> None:
+    data = {"urls": ["public-anonymous/mvp.parquet"]}
+    df = daft.from_pydict(data)
+    df = df.with_column(
+        "data", df["urls"].url.download(io_config=azure_storage_public_config, use_native_downloader=True)
+    )
+
+    data = df.to_pydict()
+    assert len(data["data"]) == 1
+    for databytes in data["data"]:
+        assert databytes is not None


### PR DESCRIPTION
* Add Azure Blob Storage Support to Daft native reader (`az://` or `adfs://`) protocols
* requires`storage_account` to be set in IOConfig or env variable.
```
    daft.io.IOConfig(
        azure=daft.io.AzureConfig(
            storage_account="dafttestdata",
            access_key="...",
            #anonymous = True
        )
    )
```
* Bumps up `integration-tests-io` python version to 3.8 since adls doesn't support anon mode