### PR TITLE
[FEAT] [New Query Planner] Add support for tabular writes.

### DIFF
--- a/daft/logical/rust_logical_plan.py
+++ b/daft/logical/rust_logical_plan.py
@@ -173,4 +173,8 @@ class RustLogicalPlanBuilder(LogicalPlanBuilder):
         partition_cols: ExpressionsProjection | None = None,
         compression: str | None = None,
     ) -> RustLogicalPlanBuilder:
-        raise NotImplementedError("not implemented")
+        if file_format != FileFormat.Csv and file_format != FileFormat.Parquet:
+            raise ValueError(f"Writing is only supported for Parquet and CSV file formats, but got: {file_format}")
+        part_cols_pyexprs = [expr._expr for expr in partition_cols] if partition_cols is not None else None
+        builder = self._builder.table_write(str(root_dir), file_format, part_cols_pyexprs, compression)
+        return RustLogicalPlanBuilder(builder)

--- a/src/daft-plan/src/lib.rs
+++ b/src/daft-plan/src/lib.rs
@@ -6,6 +6,7 @@ mod partitioning;
 mod physical_ops;
 mod physical_plan;
 mod planner;
+mod sink_info;
 mod source_info;
 
 pub use builder::LogicalPlanBuilder;

--- a/src/daft-plan/src/logical_plan.rs
+++ b/src/daft-plan/src/logical_plan.rs
@@ -13,6 +13,7 @@ pub enum LogicalPlan {
     Repartition(Repartition),
     Distinct(Distinct),
     Aggregate(Aggregate),
+    Sink(Sink),
 }
 
 impl LogicalPlan {
@@ -25,6 +26,7 @@ impl LogicalPlan {
             Self::Repartition(Repartition { input, .. }) => input.schema(),
             Self::Distinct(Distinct { input, .. }) => input.schema(),
             Self::Aggregate(aggregate) => aggregate.schema(),
+            Self::Sink(Sink { schema, .. }) => schema.clone(),
         }
     }
 
@@ -52,6 +54,7 @@ impl LogicalPlan {
             .into(),
             Self::Distinct(Distinct { input, .. }) => input.partition_spec(),
             Self::Aggregate(Aggregate { input, .. }) => input.partition_spec(), // TODO
+            Self::Sink(Sink { input, .. }) => input.partition_spec(),
         }
     }
 
@@ -64,6 +67,7 @@ impl LogicalPlan {
             Self::Repartition(Repartition { input, .. }) => vec![input],
             Self::Distinct(Distinct { input, .. }) => vec![input],
             Self::Aggregate(Aggregate { input, .. }) => vec![input],
+            Self::Sink(Sink { input, .. }) => vec![input],
         }
     }
 
@@ -76,6 +80,7 @@ impl LogicalPlan {
             Self::Repartition(repartition) => repartition.multiline_display(),
             Self::Distinct(_) => vec!["Distinct".to_string()],
             Self::Aggregate(aggregate) => aggregate.multiline_display(),
+            Self::Sink(sink) => sink.multiline_display(),
         }
     }
 
@@ -103,3 +108,4 @@ impl_from_data_struct_for_logical_plan!(Sort);
 impl_from_data_struct_for_logical_plan!(Repartition);
 impl_from_data_struct_for_logical_plan!(Distinct);
 impl_from_data_struct_for_logical_plan!(Aggregate);
+impl_from_data_struct_for_logical_plan!(Sink);

--- a/src/daft-plan/src/ops/mod.rs
+++ b/src/daft-plan/src/ops/mod.rs
@@ -3,6 +3,7 @@ mod distinct;
 mod filter;
 mod limit;
 mod repartition;
+mod sink;
 mod sort;
 mod source;
 
@@ -11,5 +12,6 @@ pub use distinct::Distinct;
 pub use filter::Filter;
 pub use limit::Limit;
 pub use repartition::Repartition;
+pub use sink::Sink;
 pub use sort::Sort;
 pub use source::Source;

--- a/src/daft-plan/src/ops/sink.rs
+++ b/src/daft-plan/src/ops/sink.rs
@@ -1,0 +1,56 @@
+use std::sync::Arc;
+
+use daft_core::schema::SchemaRef;
+
+use crate::{
+    sink_info::{OutputFileInfo, SinkInfo},
+    LogicalPlan,
+};
+
+#[derive(Clone, Debug)]
+pub struct Sink {
+    pub schema: SchemaRef,
+    /// Information about the sink data location.
+    pub sink_info: Arc<SinkInfo>,
+
+    // Upstream node.
+    pub input: Arc<LogicalPlan>,
+}
+
+impl Sink {
+    pub(crate) fn new(
+        schema: SchemaRef,
+        sink_info: Arc<SinkInfo>,
+        input: Arc<LogicalPlan>,
+    ) -> Self {
+        Self {
+            schema,
+            sink_info,
+            input,
+        }
+    }
+
+    pub fn multiline_display(&self) -> Vec<String> {
+        let mut res = vec![];
+
+        match self.sink_info.as_ref() {
+            SinkInfo::OutputFileInfo(OutputFileInfo {
+                root_dir,
+                file_format,
+                partition_cols,
+                compression,
+            }) => {
+                res.push(format!("Sink: {:?}", file_format));
+                if let Some(partition_cols) = partition_cols {
+                    res.push(format!("  Partition cols: {:?}", partition_cols));
+                }
+                if let Some(compression) = compression {
+                    res.push(format!("  Compression: {:?}", compression));
+                }
+                res.push(format!("  Root dir: {:?}", root_dir));
+            }
+        }
+        res.push(format!("  Output schema: {}", self.schema.short_string()));
+        res
+    }
+}

--- a/src/daft-plan/src/physical_ops/csv.rs
+++ b/src/daft-plan/src/physical_ops/csv.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use daft_core::schema::SchemaRef;
 use daft_dsl::ExprRef;
 
-use crate::{source_info::ExternalInfo, PartitionSpec};
+use crate::{
+    physical_plan::PhysicalPlan, sink_info::OutputFileInfo, source_info::ExternalInfo,
+    PartitionSpec,
+};
 
 #[derive(Debug)]
 pub struct TabularScanCsv {
@@ -28,6 +31,28 @@ impl TabularScanCsv {
             partition_spec,
             limit,
             filters,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TabularWriteCsv {
+    pub schema: SchemaRef,
+    pub file_info: OutputFileInfo,
+    // Upstream node.
+    pub input: Arc<PhysicalPlan>,
+}
+
+impl TabularWriteCsv {
+    pub(crate) fn new(
+        schema: SchemaRef,
+        file_info: OutputFileInfo,
+        input: Arc<PhysicalPlan>,
+    ) -> Self {
+        Self {
+            schema,
+            file_info,
+            input,
         }
     }
 }

--- a/src/daft-plan/src/physical_ops/json.rs
+++ b/src/daft-plan/src/physical_ops/json.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use daft_core::schema::SchemaRef;
 use daft_dsl::ExprRef;
 
-use crate::{source_info::ExternalInfo, PartitionSpec};
+use crate::{
+    physical_plan::PhysicalPlan, sink_info::OutputFileInfo, source_info::ExternalInfo,
+    PartitionSpec,
+};
 
 #[derive(Debug)]
 pub struct TabularScanJson {
@@ -28,6 +31,28 @@ impl TabularScanJson {
             partition_spec,
             limit,
             filters,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TabularWriteJson {
+    pub schema: SchemaRef,
+    pub file_info: OutputFileInfo,
+    // Upstream node.
+    pub input: Arc<PhysicalPlan>,
+}
+
+impl TabularWriteJson {
+    pub(crate) fn new(
+        schema: SchemaRef,
+        file_info: OutputFileInfo,
+        input: Arc<PhysicalPlan>,
+    ) -> Self {
+        Self {
+            schema,
+            file_info,
+            input,
         }
     }
 }

--- a/src/daft-plan/src/physical_ops/mod.rs
+++ b/src/daft-plan/src/physical_ops/mod.rs
@@ -14,14 +14,14 @@ mod split;
 
 pub use agg::Aggregate;
 pub use coalesce::Coalesce;
-pub use csv::TabularScanCsv;
+pub use csv::{TabularScanCsv, TabularWriteCsv};
 pub use fanout::{FanoutByHash, FanoutByRange, FanoutRandom};
 pub use filter::Filter;
 #[cfg(feature = "python")]
 pub use in_memory::InMemoryScan;
-pub use json::TabularScanJson;
+pub use json::{TabularScanJson, TabularWriteJson};
 pub use limit::Limit;
-pub use parquet::TabularScanParquet;
+pub use parquet::{TabularScanParquet, TabularWriteParquet};
 pub use reduce::ReduceMerge;
 pub use sort::Sort;
 pub use split::Split;

--- a/src/daft-plan/src/physical_ops/parquet.rs
+++ b/src/daft-plan/src/physical_ops/parquet.rs
@@ -3,12 +3,15 @@ use std::sync::Arc;
 use daft_core::schema::SchemaRef;
 use daft_dsl::ExprRef;
 
-use crate::{source_info::ExternalInfo, PartitionSpec};
+use crate::{
+    physical_plan::PhysicalPlan, sink_info::OutputFileInfo,
+    source_info::ExternalInfo as ExternalSourceInfo, PartitionSpec,
+};
 
 #[derive(Debug)]
 pub struct TabularScanParquet {
     pub schema: SchemaRef,
-    pub external_info: ExternalInfo,
+    pub external_info: ExternalSourceInfo,
     pub partition_spec: Arc<PartitionSpec>,
     pub limit: Option<usize>,
     pub filters: Vec<ExprRef>,
@@ -17,7 +20,7 @@ pub struct TabularScanParquet {
 impl TabularScanParquet {
     pub(crate) fn new(
         schema: SchemaRef,
-        external_info: ExternalInfo,
+        external_info: ExternalSourceInfo,
         partition_spec: Arc<PartitionSpec>,
         limit: Option<usize>,
         filters: Vec<ExprRef>,
@@ -28,6 +31,28 @@ impl TabularScanParquet {
             partition_spec,
             limit,
             filters,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TabularWriteParquet {
+    pub schema: SchemaRef,
+    pub file_info: OutputFileInfo,
+    // Upstream node.
+    pub input: Arc<PhysicalPlan>,
+}
+
+impl TabularWriteParquet {
+    pub(crate) fn new(
+        schema: SchemaRef,
+        file_info: OutputFileInfo,
+        input: Arc<PhysicalPlan>,
+    ) -> Self {
+        Self {
+            schema,
+            file_info,
+            input,
         }
     }
 }

--- a/src/daft-plan/src/sink_info.rs
+++ b/src/daft-plan/src/sink_info.rs
@@ -1,0 +1,32 @@
+use daft_dsl::Expr;
+
+use crate::FileFormat;
+
+#[derive(Debug)]
+pub enum SinkInfo {
+    OutputFileInfo(OutputFileInfo),
+}
+
+#[derive(Debug, Clone)]
+pub struct OutputFileInfo {
+    pub root_dir: String,
+    pub file_format: FileFormat,
+    pub partition_cols: Option<Vec<Expr>>,
+    pub compression: Option<String>,
+}
+
+impl OutputFileInfo {
+    pub fn new(
+        root_dir: String,
+        file_format: FileFormat,
+        partition_cols: Option<Vec<Expr>>,
+        compression: Option<String>,
+    ) -> Self {
+        Self {
+            root_dir,
+            file_format,
+            partition_cols,
+            compression,
+        }
+    }
+}

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -7,7 +7,7 @@ from tests.conftest import assert_df_equals
 from tests.cookbook.assets import COOKBOOK_DATA_CSV
 
 
-def test_parquet_write(tmp_path):
+def test_parquet_write(tmp_path, use_new_planner):
     df = daft.read_csv(COOKBOOK_DATA_CSV)
 
     pd_df = df.write_parquet(tmp_path)
@@ -28,7 +28,7 @@ def test_parquet_write_with_partitioning(tmp_path):
     assert len(pd_df.to_pandas()) == 5
 
 
-def test_csv_write(tmp_path):
+def test_csv_write(tmp_path, use_new_planner):
     df = daft.read_csv(COOKBOOK_DATA_CSV)
 
     pd_df = df.write_csv(tmp_path)


### PR DESCRIPTION
This PR adds support for tabular writes (`df.write_parquet()` and `df.write_csv()`).