### PR TITLE
[FEAT] [New Query Planner] Add support for Concat.

### DIFF
--- a/daft/logical/rust_logical_plan.py
+++ b/daft/logical/rust_logical_plan.py
@@ -139,15 +139,6 @@ class RustLogicalPlanBuilder(LogicalPlanBuilder):
     def coalesce(self, num_partitions: int) -> RustLogicalPlanBuilder:
         raise NotImplementedError("not implemented")
 
-    def join(
-        self,
-        right: LogicalPlanBuilder,
-        left_on: ExpressionsProjection,
-        right_on: ExpressionsProjection,
-        how: JoinType = JoinType.INNER,
-    ) -> RustLogicalPlanBuilder:
-        raise NotImplementedError("not implemented")
-
     def agg(
         self,
         to_agg: list[tuple[Expression, str]],
@@ -163,8 +154,18 @@ class RustLogicalPlanBuilder(LogicalPlanBuilder):
         builder = self._builder.aggregate([expr._expr for expr in exprs])
         return RustLogicalPlanBuilder(builder)
 
-    def concat(self, other: LogicalPlanBuilder) -> RustLogicalPlanBuilder:
+    def join(  # type: ignore[override]
+        self,
+        right: RustLogicalPlanBuilder,
+        left_on: ExpressionsProjection,
+        right_on: ExpressionsProjection,
+        how: JoinType = JoinType.INNER,
+    ) -> RustLogicalPlanBuilder:
         raise NotImplementedError("not implemented")
+
+    def concat(self, other: RustLogicalPlanBuilder) -> RustLogicalPlanBuilder:  # type: ignore[override]
+        builder = self._builder.concat(other._builder)
+        return RustLogicalPlanBuilder(builder)
 
     def write_tabular(
         self,

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -148,6 +148,21 @@ impl LogicalPlanBuilder {
         Ok(logical_plan_builder)
     }
 
+    pub fn concat(&self, other: &Self) -> PyResult<LogicalPlanBuilder> {
+        let self_schema = self.plan.schema();
+        let other_schema = other.plan.schema();
+        if self_schema != other_schema {
+            return Err(PyValueError::new_err(format!(
+                "Both DataFrames must have the same schema to concatenate them, but got: {}, {}",
+                self_schema, other_schema
+            )));
+        }
+        let logical_plan: LogicalPlan =
+            ops::Concat::new(other.plan.clone(), self.plan.clone()).into();
+        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
+        Ok(logical_plan_builder)
+    }
+
     pub fn table_write(
         &self,
         root_dir: &str,

--- a/src/daft-plan/src/ops/concat.rs
+++ b/src/daft-plan/src/ops/concat.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+
+use crate::LogicalPlan;
+
+#[derive(Clone, Debug)]
+pub struct Concat {
+    pub other: Arc<LogicalPlan>,
+    // Upstream node.
+    pub input: Arc<LogicalPlan>,
+}
+
+impl Concat {
+    pub(crate) fn new(other: Arc<LogicalPlan>, input: Arc<LogicalPlan>) -> Self {
+        Self { other, input }
+    }
+}

--- a/src/daft-plan/src/ops/mod.rs
+++ b/src/daft-plan/src/ops/mod.rs
@@ -1,4 +1,5 @@
 mod agg;
+mod concat;
 mod distinct;
 mod filter;
 mod limit;
@@ -8,6 +9,7 @@ mod sort;
 mod source;
 
 pub use agg::Aggregate;
+pub use concat::Concat;
 pub use distinct::Distinct;
 pub use filter::Filter;
 pub use limit::Limit;

--- a/src/daft-plan/src/physical_ops/concat.rs
+++ b/src/daft-plan/src/physical_ops/concat.rs
@@ -1,0 +1,16 @@
+use std::sync::Arc;
+
+use crate::physical_plan::PhysicalPlan;
+
+#[derive(Clone, Debug)]
+pub struct Concat {
+    pub other: Arc<PhysicalPlan>,
+    // Upstream node.
+    pub input: Arc<PhysicalPlan>,
+}
+
+impl Concat {
+    pub(crate) fn new(other: Arc<PhysicalPlan>, input: Arc<PhysicalPlan>) -> Self {
+        Self { other, input }
+    }
+}

--- a/src/daft-plan/src/physical_ops/mod.rs
+++ b/src/daft-plan/src/physical_ops/mod.rs
@@ -1,5 +1,6 @@
 mod agg;
 mod coalesce;
+mod concat;
 mod csv;
 mod fanout;
 mod filter;
@@ -14,6 +15,7 @@ mod split;
 
 pub use agg::Aggregate;
 pub use coalesce::Coalesce;
+pub use concat::Concat;
 pub use csv::{TabularScanCsv, TabularWriteCsv};
 pub use fanout::{FanoutByHash, FanoutByRange, FanoutRandom};
 pub use filter::Filter;

--- a/src/daft-plan/src/planner.rs
+++ b/src/daft-plan/src/planner.rs
@@ -5,9 +5,9 @@ use daft_dsl::Expr;
 
 use crate::logical_plan::LogicalPlan;
 use crate::ops::{
-    Aggregate as LogicalAggregate, Distinct as LogicalDistinct, Filter as LogicalFilter,
-    Limit as LogicalLimit, Repartition as LogicalRepartition, Sink as LogicalSink,
-    Sort as LogicalSort, Source,
+    Aggregate as LogicalAggregate, Concat as LogicalConcat, Distinct as LogicalDistinct,
+    Filter as LogicalFilter, Limit as LogicalLimit, Repartition as LogicalRepartition,
+    Sink as LogicalSink, Sort as LogicalSort, Source,
 };
 use crate::physical_ops::*;
 use crate::physical_plan::PhysicalPlan;
@@ -251,6 +251,14 @@ pub fn plan(logical_plan: &LogicalPlan) -> DaftResult<PhysicalPlan> {
             };
 
             Ok(result_plan)
+        }
+        LogicalPlan::Concat(LogicalConcat { other, input }) => {
+            let input_physical = plan(input)?;
+            let other_physical = plan(other)?;
+            Ok(PhysicalPlan::Concat(Concat::new(
+                other_physical.into(),
+                input_physical.into(),
+            )))
         }
         LogicalPlan::Sink(LogicalSink {
             schema,

--- a/tests/dataframe/test_concat.py
+++ b/tests/dataframe/test_concat.py
@@ -5,14 +5,14 @@ import pytest
 import daft
 
 
-def test_simple_concat():
+def test_simple_concat(use_new_planner):
     df1 = daft.from_pydict({"foo": [1, 2, 3]})
     df2 = daft.from_pydict({"foo": [4, 5, 6]})
     result = df1.concat(df2)
     assert result.to_pydict() == {"foo": [1, 2, 3, 4, 5, 6]}
 
 
-def test_concat_schema_mismatch():
+def test_concat_schema_mismatch(use_new_planner):
     df1 = daft.from_pydict({"foo": [1, 2, 3]})
     df2 = daft.from_pydict({"foo": ["4", "5", "6"]})
     with pytest.raises(ValueError):


### PR DESCRIPTION
This PR adds support for `df.concat()`, our first plan-binary logical operator. This PR is stacked on top of https://github.com/Eventual-Inc/Daft/pull/1252, so the actual diff is contained in commit https://github.com/Eventual-Inc/Daft/pull/1254/commits/98a7c6ad73443d5edad8bbb24541a7d1e3ea93f9.