### PR TITLE
[FEAT] [New Query Plan] Add support for Projection and Coalesce, enable many tests

### DIFF
--- a/daft/execution/rust_physical_plan_shim.py
+++ b/daft/execution/rust_physical_plan_shim.py
@@ -41,6 +41,17 @@ def tabular_scan(
     )
 
 
+def project(
+    input: physical_plan.InProgressPhysicalPlan[PartitionT], projection: list[PyExpr]
+) -> physical_plan.InProgressPhysicalPlan[PartitionT]:
+    expr_projection = ExpressionsProjection([Expression._from_pyexpr(expr) for expr in projection])
+    return physical_plan.pipeline_instruction(
+        child_plan=input,
+        pipeable_instruction=execution_step.Project(expr_projection),
+        resource_request=ResourceRequest(),  # TODO(Clark): Use real ResourceRequest.
+    )
+
+
 def sort(
     input: physical_plan.InProgressPhysicalPlan[PartitionT],
     sort_by: list[PyExpr],

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -79,6 +79,25 @@ impl LogicalPlanBuilder {
         Ok(logical_plan_builder)
     }
 
+    pub fn project(
+        &self,
+        projection: Vec<PyExpr>,
+        projected_schema: &PySchema,
+    ) -> PyResult<LogicalPlanBuilder> {
+        let projection_exprs = projection
+            .iter()
+            .map(|e| e.clone().into())
+            .collect::<Vec<Expr>>();
+        let logical_plan: LogicalPlan = ops::Project::new(
+            projection_exprs,
+            projected_schema.clone().into(),
+            self.plan.clone(),
+        )
+        .into();
+        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
+        Ok(logical_plan_builder)
+    }
+
     pub fn filter(&self, predicate: &PyExpr) -> PyResult<LogicalPlanBuilder> {
         let logical_plan: LogicalPlan =
             ops::Filter::new(predicate.expr.clone(), self.plan.clone()).into();
@@ -121,6 +140,13 @@ impl LogicalPlanBuilder {
             self.plan.clone(),
         )
         .into();
+        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
+        Ok(logical_plan_builder)
+    }
+
+    pub fn coalesce(&self, num_partitions: usize) -> PyResult<LogicalPlanBuilder> {
+        let logical_plan: LogicalPlan =
+            ops::Coalesce::new(num_partitions, self.plan.clone()).into();
         let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
         Ok(logical_plan_builder)
     }

--- a/src/daft-plan/src/ops/coalesce.rs
+++ b/src/daft-plan/src/ops/coalesce.rs
@@ -1,0 +1,17 @@
+use std::sync::Arc;
+
+use crate::LogicalPlan;
+
+#[derive(Clone, Debug)]
+pub struct Coalesce {
+    // Number of partitions to coalesce to.
+    pub num_to: usize,
+    // Upstream node.
+    pub input: Arc<LogicalPlan>,
+}
+
+impl Coalesce {
+    pub(crate) fn new(num_to: usize, input: Arc<LogicalPlan>) -> Self {
+        Self { num_to, input }
+    }
+}

--- a/src/daft-plan/src/ops/mod.rs
+++ b/src/daft-plan/src/ops/mod.rs
@@ -1,18 +1,22 @@
 mod agg;
+mod coalesce;
 mod concat;
 mod distinct;
 mod filter;
 mod limit;
+mod project;
 mod repartition;
 mod sink;
 mod sort;
 mod source;
 
 pub use agg::Aggregate;
+pub use coalesce::Coalesce;
 pub use concat::Concat;
 pub use distinct::Distinct;
 pub use filter::Filter;
 pub use limit::Limit;
+pub use project::Project;
 pub use repartition::Repartition;
 pub use sink::Sink;
 pub use sort::Sort;

--- a/src/daft-plan/src/ops/project.rs
+++ b/src/daft-plan/src/ops/project.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use daft_core::schema::SchemaRef;
+use daft_dsl::Expr;
+
+use crate::LogicalPlan;
+
+#[derive(Clone, Debug)]
+pub struct Project {
+    pub projection: Vec<Expr>,
+    pub projected_schema: SchemaRef,
+    // Upstream node.
+    pub input: Arc<LogicalPlan>,
+}
+
+impl Project {
+    pub(crate) fn new(
+        projection: Vec<Expr>,
+        projected_schema: SchemaRef,
+        input: Arc<LogicalPlan>,
+    ) -> Self {
+        Self {
+            projection,
+            projected_schema,
+            input,
+        }
+    }
+}

--- a/src/daft-plan/src/physical_ops/flatten.rs
+++ b/src/daft-plan/src/physical_ops/flatten.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+use crate::physical_plan::PhysicalPlan;
+
+#[derive(Clone, Debug)]
+pub struct Flatten {
+    // Upstream node.
+    pub input: Arc<PhysicalPlan>,
+}
+
+impl Flatten {
+    pub(crate) fn new(input: Arc<PhysicalPlan>) -> Self {
+        Self { input }
+    }
+}

--- a/src/daft-plan/src/physical_ops/mod.rs
+++ b/src/daft-plan/src/physical_ops/mod.rs
@@ -4,11 +4,13 @@ mod concat;
 mod csv;
 mod fanout;
 mod filter;
+mod flatten;
 #[cfg(feature = "python")]
 mod in_memory;
 mod json;
 mod limit;
 mod parquet;
+mod project;
 mod reduce;
 mod sort;
 mod split;
@@ -19,11 +21,13 @@ pub use concat::Concat;
 pub use csv::{TabularScanCsv, TabularWriteCsv};
 pub use fanout::{FanoutByHash, FanoutByRange, FanoutRandom};
 pub use filter::Filter;
+pub use flatten::Flatten;
 #[cfg(feature = "python")]
 pub use in_memory::InMemoryScan;
 pub use json::{TabularScanJson, TabularWriteJson};
 pub use limit::Limit;
 pub use parquet::{TabularScanParquet, TabularWriteParquet};
+pub use project::Project;
 pub use reduce::ReduceMerge;
 pub use sort::Sort;
 pub use split::Split;

--- a/src/daft-plan/src/physical_ops/project.rs
+++ b/src/daft-plan/src/physical_ops/project.rs
@@ -1,0 +1,18 @@
+use std::sync::Arc;
+
+use daft_dsl::Expr;
+
+use crate::physical_plan::PhysicalPlan;
+
+#[derive(Clone, Debug)]
+pub struct Project {
+    pub projection: Vec<Expr>,
+    // Upstream node.
+    pub input: Arc<PhysicalPlan>,
+}
+
+impl Project {
+    pub(crate) fn new(projection: Vec<Expr>, input: Arc<PhysicalPlan>) -> Self {
+        Self { projection, input }
+    }
+}

--- a/tests/cookbook/test_distinct.py
+++ b/tests/cookbook/test_distinct.py
@@ -13,7 +13,7 @@ from tests.conftest import assert_df_equals
         pytest.param(["Borough", "Complaint Type"], id="NumGroupByKeys:2"),
     ],
 )
-def test_distinct_all_columns(daft_df, service_requests_csv_pd_df, repartition_nparts, keys):
+def test_distinct_all_columns(daft_df, service_requests_csv_pd_df, repartition_nparts, keys, use_new_planner):
     """Sums across groups"""
     daft_df = daft_df.repartition(repartition_nparts).select(*[col(k) for k in keys]).distinct()
 

--- a/tests/cookbook/test_filter.py
+++ b/tests/cookbook/test_filter.py
@@ -30,7 +30,7 @@ COL_SUBSET = ["Unique Key", "Complaint Type", "Borough", "Descriptor"]
         ),
     ],
 )
-def test_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts):
+def test_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts, use_new_planner):
     """Filter the dataframe, retrieve the top N results and select a subset of columns"""
 
     daft_noise_complaints = daft_df_ops(daft_df.repartition(repartition_nparts))
@@ -83,7 +83,7 @@ def test_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_np
         ),
     ],
 )
-def test_complex_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts):
+def test_complex_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts, use_new_planner):
     """Filter the dataframe with a complex filter and select a subset of columns"""
     daft_noise_complaints_brooklyn = daft_df_ops(daft_df.repartition(repartition_nparts))
 
@@ -127,7 +127,7 @@ def test_complex_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repart
         ),
     ],
 )
-def test_chain_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts):
+def test_chain_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartition_nparts, use_new_planner):
     """Filter the dataframe with a chain of filters and select a subset of columns"""
     daft_noise_complaints_brooklyn = daft_df_ops(daft_df.repartition(repartition_nparts))
 
@@ -142,7 +142,7 @@ def test_chain_filter(daft_df_ops, daft_df, service_requests_csv_pd_df, repartit
     assert_df_equals(daft_pd_df, pd_noise_complaints_brooklyn)
 
 
-def test_filter_on_projection():
+def test_filter_on_projection(use_new_planner):
     """Filter the dataframe with on top of a projection"""
     df = daft.from_pydict({"x": [1, 1, 1, 1, 1]})
     df = df.select(col("x") * 2)

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -17,7 +17,7 @@ def test_parquet_write(tmp_path, use_new_planner):
     assert len(pd_df.to_pandas()) == 1
 
 
-def test_parquet_write_with_partitioning(tmp_path):
+def test_parquet_write_with_partitioning(tmp_path, use_new_planner):
     df = daft.read_csv(COOKBOOK_DATA_CSV)
 
     pd_df = df.write_parquet(tmp_path, partition_cols=["Borough"])
@@ -40,7 +40,7 @@ def test_csv_write(tmp_path, use_new_planner):
 
 
 @pytest.mark.skip()
-def test_csv_write_with_partitioning(tmp_path):
+def test_csv_write_with_partitioning(tmp_path, use_new_planner):
     df = daft.read_csv(COOKBOOK_DATA_CSV)
 
     pd_df = df.write_csv(tmp_path, partition_cols=["Borough"]).to_pandas()

--- a/tests/dataframe/test_accessors.py
+++ b/tests/dataframe/test_accessors.py
@@ -11,14 +11,14 @@ def df():
     return daft.from_pydict({"foo": [1, 2, 3]})
 
 
-def test_num_partitions(df):
+def test_num_partitions(df, use_new_planner):
     assert df.num_partitions() == 1
 
     df2 = df.repartition(2)
     assert df2.num_partitions() == 2
 
 
-def test_schema(df):
+def test_schema(df, use_new_planner):
     fields = [f for f in df.schema()]
     assert len(fields) == 1
     [field] = fields
@@ -26,11 +26,11 @@ def test_schema(df):
     assert field.dtype == DataType.int64()
 
 
-def test_column_names(df):
+def test_column_names(df, use_new_planner):
     assert df.column_names == ["foo"]
 
 
-def test_columns(df):
+def test_columns(df, use_new_planner):
     assert len(df.columns) == 1
     [ex] = df.columns
     assert ex.name() == "foo"

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -433,8 +433,6 @@ def test_create_dataframe_csv_generate_headers(valid_data: list[dict[str, float]
 
 
 def test_create_dataframe_csv_column_projection(valid_data: list[dict[str, float]], use_new_planner) -> None:
-    if use_new_planner:
-        pytest.skip("TODO: Column projection not yet supported")
     with tempfile.NamedTemporaryFile("w") as f:
         header = list(valid_data[0].keys())
         writer = csv.writer(f)
@@ -589,8 +587,6 @@ def test_create_dataframe_json_custom_fs(valid_data: list[dict[str, float]]) -> 
 
 
 def test_create_dataframe_json_column_projection(valid_data: list[dict[str, float]], use_new_planner) -> None:
-    if use_new_planner:
-        pytest.skip("TODO: Column projection not yet supported")
     with tempfile.NamedTemporaryFile("w") as f:
         for data in valid_data:
             f.write(json.dumps(data))
@@ -730,8 +726,6 @@ def test_create_dataframe_parquet_custom_fs(valid_data: list[dict[str, float]]) 
 def test_create_dataframe_parquet_column_projection(
     valid_data: list[dict[str, float]], use_native_downloader, use_new_planner
 ) -> None:
-    if use_new_planner:
-        pytest.skip("TODO: Column projection not yet supported")
     with tempfile.NamedTemporaryFile("w") as f:
         table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
         papq.write_table(table, f.name)

--- a/tests/dataframe/test_decimals.py
+++ b/tests/dataframe/test_decimals.py
@@ -10,7 +10,7 @@ import daft
 PYARROW_GE_7_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (7, 0, 0)
 
 
-def test_decimal_parquet_roundtrip() -> None:
+def test_decimal_parquet_roundtrip(use_new_planner) -> None:
     python_decimals = [decimal.Decimal("-2.010"), decimal.Decimal("0.000"), decimal.Decimal("2.010")]
     data = {
         "decimal128": pa.array(python_decimals),
@@ -27,7 +27,7 @@ def test_decimal_parquet_roundtrip() -> None:
     assert str(df.to_pydict()["decimal128"]) == str(df_readback.to_pydict()["decimal128"])
 
 
-def test_arrow_decimal() -> None:
+def test_arrow_decimal(use_new_planner) -> None:
     # Test roundtrip of Arrow decimals.
     pa_table = pa.Table.from_pydict(
         {"decimal128": pa.array([decimal.Decimal("-1.010"), decimal.Decimal("0.000"), decimal.Decimal("1.010")])}
@@ -38,7 +38,7 @@ def test_arrow_decimal() -> None:
     assert df.to_arrow() == pa_table
 
 
-def test_python_decimal() -> None:
+def test_python_decimal(use_new_planner) -> None:
     # Test roundtrip of Python decimals.
     python_decimals = [decimal.Decimal("-1.010"), decimal.Decimal("0.000"), decimal.Decimal("1.010")]
     df = daft.from_pydict({"decimal128": python_decimals})

--- a/tests/dataframe/test_distinct.py
+++ b/tests/dataframe/test_distinct.py
@@ -28,7 +28,7 @@ def test_distinct_with_nulls(repartition_nparts, use_new_planner):
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 5])
-def test_distinct_with_all_nulls(repartition_nparts):
+def test_distinct_with_all_nulls(repartition_nparts, use_new_planner):
     daft_df = daft.from_pydict(
         {
             "id": [None, None, None, None],

--- a/tests/dataframe/test_filter.py
+++ b/tests/dataframe/test_filter.py
@@ -8,14 +8,14 @@ import daft
 from daft import DataFrame
 
 
-def test_filter_missing_column(valid_data: list[dict[str, Any]]) -> None:
+def test_filter_missing_column(valid_data: list[dict[str, Any]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
     with pytest.raises(ValueError):
         df.select("sepal_width").where(df["petal_length"] > 4.8)
 
 
 @pytest.mark.skip(reason="Requires Expression.float.is_nan()")
-def test_drop_na(missing_value_data: list[dict[str, Any]]) -> None:
+def test_drop_na(missing_value_data: list[dict[str, Any]], use_new_planner) -> None:
     df: DataFrame = daft.from_pylist(missing_value_data)
     df_len_no_col = len(df.drop_nan().collect())
     assert df_len_no_col == 2
@@ -25,7 +25,7 @@ def test_drop_na(missing_value_data: list[dict[str, Any]]) -> None:
     assert df_len_col == 2
 
 
-def test_drop_null(missing_value_data: list[dict[str, Any]]) -> None:
+def test_drop_null(missing_value_data: list[dict[str, Any]], use_new_planner) -> None:
     df: DataFrame = daft.from_pylist(missing_value_data)
     df_len_no_col = len(df.drop_null().collect())
     assert df_len_no_col == 2

--- a/tests/dataframe/test_getitem.py
+++ b/tests/dataframe/test_getitem.py
@@ -6,7 +6,7 @@ import daft
 from daft import DataFrame
 
 
-def test_dataframe_getitem_single(valid_data: list[dict[str, float]]) -> None:
+def test_dataframe_getitem_single(valid_data: list[dict[str, float]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
     expanded_df = df.with_column("foo", df["sepal_length"] + df["sepal_width"])
     # TODO(jay): Test that the expression with name "foo" is equal to the expected expression, except for the IDs of the columns
@@ -16,7 +16,7 @@ def test_dataframe_getitem_single(valid_data: list[dict[str, float]]) -> None:
     assert df.select(df["sepal_length"]).column_names == ["sepal_length"]
 
 
-def test_dataframe_getitem_single_bad(valid_data: list[dict[str, float]]) -> None:
+def test_dataframe_getitem_single_bad(valid_data: list[dict[str, float]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
     with pytest.raises(ValueError, match="not found"):
         df["foo"]
@@ -28,7 +28,7 @@ def test_dataframe_getitem_single_bad(valid_data: list[dict[str, float]]) -> Non
         df[100]
 
 
-def test_dataframe_getitem_multiple_bad(valid_data: list[dict[str, float]]) -> None:
+def test_dataframe_getitem_multiple_bad(valid_data: list[dict[str, float]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
     with pytest.raises(ValueError, match="not found"):
         df["foo", "bar"]
@@ -49,7 +49,7 @@ def test_dataframe_getitem_multiple_bad(valid_data: list[dict[str, float]]) -> N
         df[A()]
 
 
-def test_dataframe_getitem_multiple(valid_data: list[dict[str, float]]) -> None:
+def test_dataframe_getitem_multiple(valid_data: list[dict[str, float]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
     expanded_df = df.with_column("foo", sum(df["sepal_length", "sepal_width"].columns))
     # TODO(jay): Test that the expression with name "foo" is equal to the expected expression, except for the IDs of the columns
@@ -58,13 +58,13 @@ def test_dataframe_getitem_multiple(valid_data: list[dict[str, float]]) -> None:
     assert df["sepal_length", "sepal_width"].column_names == ["sepal_length", "sepal_width"]
 
 
-def test_dataframe_getitem_slice(valid_data: list[dict[str, float]]) -> None:
+def test_dataframe_getitem_slice(valid_data: list[dict[str, float]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
     slice_df = df[:]
     assert df.column_names == slice_df.column_names
 
 
-def test_dataframe_getitem_slice_rev(valid_data: list[dict[str, float]]) -> None:
+def test_dataframe_getitem_slice_rev(valid_data: list[dict[str, float]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
     slice_df = df[::-1]
     assert df.column_names == slice_df.column_names[::-1]

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -10,7 +10,7 @@ class MockException(Exception):
 
 
 @pytest.mark.parametrize("materialized", [False, True])
-def test_iter_rows(materialized):
+def test_iter_rows(materialized, use_new_planner):
     # Test that df.__iter__ produces the correct rows in the correct order.
     # It should work regardless of whether the dataframe has already been materialized or not.
 
@@ -23,7 +23,7 @@ def test_iter_rows(materialized):
 
 
 @pytest.mark.parametrize("materialized", [False, True])
-def test_iter_partitions(materialized):
+def test_iter_partitions(materialized, use_new_planner):
     # Test that df.iter_partitions() produces partitions in the correct order.
     # It should work regardless of whether the dataframe has already been materialized or not.
 
@@ -48,7 +48,7 @@ def test_iter_partitions(materialized):
     ]
 
 
-def test_iter_exception():
+def test_iter_exception(use_new_planner):
     # Test that df.__iter__ actually returns results before completing execution.
     # We test this by raising an exception in a UDF if too many partitions are executed.
 
@@ -70,7 +70,7 @@ def test_iter_exception():
         list(it)
 
 
-def test_iter_partitions_exception():
+def test_iter_partitions_exception(use_new_planner):
     # Test that df.iter_partitions actually returns results before completing execution.
     # We test this by raising an exception in a UDF if too many partitions are executed.
 

--- a/tests/dataframe/test_logical_type.py
+++ b/tests/dataframe/test_logical_type.py
@@ -14,7 +14,7 @@ from daft.utils import pyarrow_supports_fixed_shape_tensor
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
 
 
-def test_embedding_type_df() -> None:
+def test_embedding_type_df(use_new_planner) -> None:
     data = [[1, 2, 3], np.arange(3), ["1", "2", "3"], [1, "2", 3.0], pd.Series([1.1, 2, 3]), (1, 2, 3), None]
     df = daft.from_pydict({"index": np.arange(len(data)), "embeddings": Series.from_pylist(data, pyobj="force")})
 
@@ -28,7 +28,7 @@ def test_embedding_type_df() -> None:
 
 
 @pytest.mark.parametrize("from_pil_imgs", [True, False])
-def test_image_type_df(from_pil_imgs) -> None:
+def test_image_type_df(from_pil_imgs, use_new_planner) -> None:
     data = [
         np.arange(12, dtype=np.uint8).reshape((2, 2, 3)),
         np.arange(12, 39, dtype=np.uint8).reshape((3, 3, 3)),
@@ -50,7 +50,7 @@ def test_image_type_df(from_pil_imgs) -> None:
     assert isinstance(arrow_table["image"].type, DaftExtension)
 
 
-def test_fixed_shape_image_type_df() -> None:
+def test_fixed_shape_image_type_df(use_new_planner) -> None:
     height = 2
     width = 2
     shape = (height, width, 3)
@@ -66,7 +66,7 @@ def test_fixed_shape_image_type_df() -> None:
     assert isinstance(arrow_table["image"].type, DaftExtension)
 
 
-def test_tensor_type_df() -> None:
+def test_tensor_type_df(use_new_planner) -> None:
     data = [
         np.arange(12).reshape((3, 2, 2)),
         np.arange(12, 39).reshape((3, 3, 3)),
@@ -82,7 +82,7 @@ def test_tensor_type_df() -> None:
     assert isinstance(arrow_table["tensor"].type, DaftExtension)
 
 
-def test_fixed_shape_tensor_type_df() -> None:
+def test_fixed_shape_tensor_type_df(use_new_planner) -> None:
     shape = (3, 2, 2)
     data = [
         np.arange(12).reshape(shape),

--- a/tests/dataframe/test_repartition.py
+++ b/tests/dataframe/test_repartition.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import daft
 
 
-def test_into_partitions_some_empty() -> None:
+def test_into_partitions_some_empty(use_new_planner) -> None:
     data = {"foo": [1, 2, 3]}
     df = daft.from_pydict(data).into_partitions(32).collect()
     assert df.to_pydict() == data

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -71,7 +71,7 @@ def parse_html_table(
     return result
 
 
-def test_empty_repr():
+def test_empty_repr(use_new_planner):
     df = daft.from_pydict({})
     assert df.__repr__() == "(No data to display: Dataframe has no columns)"
     assert df._repr_html_() == "<small>(No data to display: Dataframe has no columns)</small>"
@@ -81,7 +81,7 @@ def test_empty_repr():
     assert df._repr_html_() == "<small>(No data to display: Dataframe has no columns)</small>"
 
 
-def test_empty_df_repr():
+def test_empty_df_repr(use_new_planner):
     df = daft.from_pydict({"A": [1, 2, 3], "B": ["a", "b", "c"]})
     df = df.where(df["A"] > 10)
     expected_data = {"A": ("Int64", []), "B": ("Utf8", [])}
@@ -122,7 +122,7 @@ def test_empty_df_repr():
     )
 
 
-def test_alias_repr():
+def test_alias_repr(use_new_planner):
     df = daft.from_pydict({"A": [1, 2, 3], "B": ["a", "b", "c"]})
     df = df.select(df["A"].alias("A2"), df["B"])
 
@@ -170,7 +170,7 @@ def test_alias_repr():
     )
 
 
-def test_repr_with_html_string():
+def test_repr_with_html_string(use_new_planner):
     df = daft.from_pydict({"A": [f"<div>body{i}</div>" for i in range(3)]})
     df.collect()
 
@@ -186,7 +186,7 @@ class MyObj:
         return "myobj-custom-repr"
 
 
-def test_repr_html_custom_hooks():
+def test_repr_html_custom_hooks(use_new_planner):
     img = Image.fromarray(np.ones((3, 3)).astype(np.uint8))
     arr = np.ones((3, 3))
 

--- a/tests/dataframe/test_select.py
+++ b/tests/dataframe/test_select.py
@@ -5,20 +5,20 @@ import pytest
 import daft
 
 
-def test_select_dataframe_missing_col(valid_data: list[dict[str, float]]) -> None:
+def test_select_dataframe_missing_col(valid_data: list[dict[str, float]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
 
     with pytest.raises(ValueError):
         df = df.select("foo", "sepal_length")
 
 
-def test_select_dataframe(valid_data: list[dict[str, float]]) -> None:
+def test_select_dataframe(valid_data: list[dict[str, float]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
     df = df.select("sepal_length", "sepal_width")
     assert df.column_names == ["sepal_length", "sepal_width"]
 
 
-def test_multiple_select_same_col(valid_data: list[dict[str, float]]):
+def test_multiple_select_same_col(valid_data: list[dict[str, float]], use_new_planner):
     df = daft.from_pylist(valid_data)
     df = df.select(df["sepal_length"], df["sepal_length"].alias("sepal_length_2"))
     pdf = df.to_pandas()

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import daft
 
 
-def test_show_default(valid_data):
+def test_show_default(valid_data, use_new_planner):
     df = daft.from_pylist(valid_data)
     df_display = df.show()
 
@@ -13,7 +13,7 @@ def test_show_default(valid_data):
     assert df_display.num_rows == 8
 
 
-def test_show_some(valid_data):
+def test_show_some(valid_data, use_new_planner):
     df = daft.from_pylist(valid_data)
     df_display = df.show(1)
 

--- a/tests/dataframe/test_sort.py
+++ b/tests/dataframe/test_sort.py
@@ -14,21 +14,21 @@ from daft.errors import ExpressionTypeError
 ###
 
 
-def test_disallowed_sort_bool():
+def test_disallowed_sort_bool(use_new_planner):
     df = daft.from_pydict({"A": [True, False]})
 
     with pytest.raises(ExpressionTypeError):
         df.sort("A")
 
 
-def test_disallowed_sort_null():
+def test_disallowed_sort_null(use_new_planner):
     df = daft.from_pydict({"A": [None, None]})
 
     with pytest.raises(ExpressionTypeError):
         df.sort("A")
 
 
-def test_disallowed_sort_bytes():
+def test_disallowed_sort_bytes(use_new_planner):
     df = daft.from_pydict({"A": [b"a", b"b"]})
 
     with pytest.raises(ExpressionTypeError):
@@ -189,7 +189,7 @@ def test_sort_with_nulls_multikey(repartition_nparts, use_new_planner):
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
-def test_sort_with_all_nulls(repartition_nparts):
+def test_sort_with_all_nulls(repartition_nparts, use_new_planner):
     daft_df = daft.from_pydict(
         {
             "id": [None, None, None],

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -11,7 +11,7 @@ import daft
 PYARROW_GE_7_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (7, 0, 0)
 
 
-def test_temporal_arithmetic() -> None:
+def test_temporal_arithmetic(use_new_planner) -> None:
     now = datetime.now()
     now_tz = datetime.now(timezone.utc)
     df = daft.from_pydict(
@@ -42,7 +42,7 @@ def test_temporal_arithmetic() -> None:
 
 
 @pytest.mark.parametrize("format", ["csv", "parquet"])
-def test_temporal_file_roundtrip(format) -> None:
+def test_temporal_file_roundtrip(format, use_new_planner) -> None:
     data = {
         "date32": pa.array([1], pa.date32()),
         "date64": pa.array([1], pa.date64()),
@@ -97,7 +97,7 @@ def test_temporal_file_roundtrip(format) -> None:
     "timezone",
     [None, "UTC", "America/Los_Angeles", "+04:00"],
 )
-def test_arrow_timestamp(timeunit, timezone) -> None:
+def test_arrow_timestamp(timeunit, timezone, use_new_planner) -> None:
     # Test roundtrip of Arrow timestamps.
     pa_table = pa.Table.from_pydict({"timestamp": pa.array([1, 0, -1], pa.timestamp(timeunit, tz=timezone))})
 
@@ -108,7 +108,7 @@ def test_arrow_timestamp(timeunit, timezone) -> None:
 
 @pytest.mark.skipif(not PYARROW_GE_7_0_0, reason="PyArrow conversion of timezoned datetime is broken in 6.0.1")
 @pytest.mark.parametrize("timezone", [None, timezone.utc, timezone(timedelta(hours=-7))])
-def test_python_timestamp(timezone) -> None:
+def test_python_timestamp(timezone, use_new_planner) -> None:
     # Test roundtrip of Python timestamps.
     timestamp = datetime.now(timezone)
     df = daft.from_pydict({"timestamp": [timestamp]})
@@ -121,7 +121,7 @@ def test_python_timestamp(timezone) -> None:
     "timeunit",
     ["s", "ms", "us", "ns"],
 )
-def test_arrow_duration(timeunit) -> None:
+def test_arrow_duration(timeunit, use_new_planner) -> None:
     # Test roundtrip of Arrow timestamps.
     pa_table = pa.Table.from_pydict({"duration": pa.array([1, 0, -1], pa.duration(timeunit))})
 
@@ -130,7 +130,7 @@ def test_arrow_duration(timeunit) -> None:
     assert df.to_arrow() == pa_table
 
 
-def test_python_duration() -> None:
+def test_python_duration(use_new_planner) -> None:
     # Test roundtrip of Python durations.
     duration = timedelta(weeks=1, days=1, hours=1, minutes=1, seconds=1, milliseconds=1, microseconds=1)
     df = daft.from_pydict({"duration": [duration]})
@@ -147,7 +147,7 @@ def test_python_duration() -> None:
     "timezone",
     [None, "UTC"],
 )
-def test_temporal_arithmetic(timeunit, timezone) -> None:
+def test_temporal_arithmetic(timeunit, timezone, use_new_planner) -> None:
     pa_table = pa.Table.from_pydict(
         {
             "timestamp": pa.array([1, 0, -1], pa.timestamp(timeunit, timezone)),
@@ -194,7 +194,7 @@ def test_temporal_arithmetic(timeunit, timezone) -> None:
     "timezone",
     [None, "UTC"],
 )
-def test_temporal_arithmetic_mismatch_granularity(t_timeunit, d_timeunit, timezone) -> None:
+def test_temporal_arithmetic_mismatch_granularity(t_timeunit, d_timeunit, timezone, use_new_planner) -> None:
     if t_timeunit == d_timeunit:
         return
 

--- a/tests/dataframe/test_to_integrations.py
+++ b/tests/dataframe/test_to_integrations.py
@@ -41,7 +41,7 @@ TEST_DATA_SCHEMA = pa.schema(
 
 
 @pytest.mark.parametrize("n_partitions", [1, 2])
-def test_to_arrow(n_partitions: int) -> None:
+def test_to_arrow(n_partitions: int, use_new_planner) -> None:
     df = daft.from_pydict(TEST_DATA).repartition(n_partitions)
     table = df.to_arrow()
     # String column is converted to large_string column in Daft.
@@ -51,7 +51,7 @@ def test_to_arrow(n_partitions: int) -> None:
 
 
 @pytest.mark.parametrize("n_partitions", [1, 2])
-def test_to_pandas(n_partitions: int) -> None:
+def test_to_pandas(n_partitions: int, use_new_planner) -> None:
     df = daft.from_pydict(TEST_DATA).repartition(n_partitions)
     pd_df = df.to_pandas().sort_values("integers").reset_index(drop=True)
     expected_df = pd.DataFrame(TEST_DATA).sort_values("integers").reset_index(drop=True)

--- a/tests/dataframe/test_with_column.py
+++ b/tests/dataframe/test_with_column.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import daft
 
 
-def test_with_column(valid_data: list[dict[str, float]]) -> None:
+def test_with_column(valid_data: list[dict[str, float]], use_new_planner) -> None:
     df = daft.from_pylist(valid_data)
     expanded_df = df.with_column("bar", df["sepal_width"] + df["petal_length"])
     data = expanded_df.to_pydict()
@@ -11,7 +11,7 @@ def test_with_column(valid_data: list[dict[str, float]]) -> None:
     assert data["bar"] == [sw + pl for sw, pl in zip(data["sepal_width"], data["petal_length"])]
 
 
-def test_stacked_with_columns(valid_data: list[dict[str, float]]):
+def test_stacked_with_columns(valid_data: list[dict[str, float]], use_new_planner):
     df = daft.from_pylist(valid_data)
     df = df.select(df["sepal_length"])
     df = df.with_column("sepal_length_2", df["sepal_length"])


### PR DESCRIPTION
This PR adds support for projection (`df.select()`, `df.exclude()`, `df.with_column()`) and coalescing (`df.into_partitions()`), and enables a bunch of tests that depended on these features. The main fixes that popped up once enabling the tests were:
- Misc. input validation
- Missing plan flattening for `df.repartition()` with unknown partition scheme (i.e. simple split).

This PR is stacked on https://github.com/Eventual-Inc/Daft/pull/1254 and https://github.com/Eventual-Inc/Daft/pull/1252, so the final commit contains the actual diff: https://github.com/Eventual-Inc/Daft/commit/6754d67ac520eb812a00dd57aeff63ef8d181165