### PR TITLE
[CHORE][WIP] Refactor LogicalArray to have a SeriesLike child

### DIFF
--- a/src/daft-core/src/array/ops/as_arrow.rs
+++ b/src/daft-core/src/array/ops/as_arrow.rs
@@ -53,7 +53,7 @@ macro_rules! impl_asarrow_logicalarray {
         impl AsArrow for $da {
             type Output = $output;
             fn as_arrow(&self) -> &Self::Output {
-                self.physical.data().as_any().downcast_ref().unwrap()
+                self.physical.0.data().as_any().downcast_ref().unwrap()
             }
         }
     };

--- a/src/daft-core/src/array/ops/concat.rs
+++ b/src/daft-core/src/array/ops/concat.rs
@@ -1,6 +1,10 @@
 use arrow2::array::Array;
 
-use crate::{array::DataArray, datatypes::DaftPhysicalType};
+use crate::{
+    array::DataArray,
+    datatypes::{logical::LogicalArray, DaftLogicalType, DaftPhysicalType},
+    series::{ArrayWrapper, SeriesLike},
+};
 use common_error::{DaftError, DaftResult};
 
 #[cfg(feature = "python")]
@@ -47,5 +51,22 @@ where
                 DataArray::try_from((field.clone(), cat_array))
             }
         }
+    }
+}
+
+impl<T> LogicalArray<T>
+where
+    T: DaftLogicalType,
+    ArrayWrapper<T::ChildArrayType>: SeriesLike,
+{
+    pub fn concat(arrays: &[&Self]) -> DaftResult<Self> {
+        if arrays.is_empty() {
+            return Err(common_error::DaftError::ValueError(
+                "Need at least 1 logical array to concat".to_string(),
+            ));
+        }
+
+        // WIP: SeriesLike to implement concat so we can forward it to `array.physical`
+        todo!()
     }
 }

--- a/src/daft-core/src/array/ops/date.rs
+++ b/src/daft-core/src/array/ops/date.rs
@@ -8,6 +8,7 @@ impl DateArray {
     pub fn day(&self) -> DaftResult<UInt32Array> {
         let input_array = self
             .physical
+            .0
             .as_arrow()
             .clone()
             .to(arrow2::datatypes::DataType::Date32);
@@ -18,6 +19,7 @@ impl DateArray {
     pub fn month(&self) -> DaftResult<UInt32Array> {
         let input_array = self
             .physical
+            .0
             .as_arrow()
             .clone()
             .to(arrow2::datatypes::DataType::Date32);
@@ -28,6 +30,7 @@ impl DateArray {
     pub fn year(&self) -> DaftResult<Int32Array> {
         let input_array = self
             .physical
+            .0
             .as_arrow()
             .clone()
             .to(arrow2::datatypes::DataType::Date32);
@@ -38,6 +41,7 @@ impl DateArray {
     pub fn day_of_week(&self) -> DaftResult<UInt32Array> {
         let input_array = self
             .physical
+            .0
             .as_arrow()
             .clone()
             .to(arrow2::datatypes::DataType::Date32);

--- a/src/daft-core/src/array/ops/if_else.rs
+++ b/src/daft-core/src/array/ops/if_else.rs
@@ -328,7 +328,7 @@ macro_rules! impl_logicalarray_if_else {
     ($ArrayT:ty) => {
         impl $ArrayT {
             pub fn if_else(&self, other: &Self, predicate: &BooleanArray) -> DaftResult<Self> {
-                let new_array = self.physical.if_else(&other.physical, predicate)?;
+                let new_array = self.physical.0.if_else(&other.physical.0, predicate)?;
                 Ok(Self::new(self.field.clone(), new_array))
             }
         }

--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -596,28 +596,28 @@ impl PythonArray {
 
 impl Decimal128Array {
     pub fn sort(&self, descending: bool) -> DaftResult<Self> {
-        let new_array = self.physical.sort(descending)?;
+        let new_array = self.physical.0.sort(descending)?;
         Ok(Self::new(self.field.clone(), new_array))
     }
 }
 
 impl DateArray {
     pub fn sort(&self, descending: bool) -> DaftResult<Self> {
-        let new_array = self.physical.sort(descending)?;
+        let new_array = self.physical.0.sort(descending)?;
         Ok(Self::new(self.field.clone(), new_array))
     }
 }
 
 impl DurationArray {
     pub fn sort(&self, descending: bool) -> DaftResult<Self> {
-        let new_array = self.physical.sort(descending)?;
+        let new_array = self.physical.0.sort(descending)?;
         Ok(Self::new(self.field.clone(), new_array))
     }
 }
 
 impl TimestampArray {
     pub fn sort(&self, descending: bool) -> DaftResult<Self> {
-        let new_array = self.physical.sort(descending)?;
+        let new_array = self.physical.0.sort(descending)?;
         Ok(Self::new(self.field.clone(), new_array))
     }
 }

--- a/src/daft-core/src/array/ops/take.rs
+++ b/src/daft-core/src/array/ops/take.rs
@@ -51,7 +51,7 @@ macro_rules! impl_logicalarray_take {
                 I: DaftIntegerType,
                 <I as DaftNumericType>::Native: arrow2::types::Index,
             {
-                let new_array = self.physical.take(idx)?;
+                let new_array = self.physical.0.take(idx)?;
                 Ok(Self::new(self.field.clone(), new_array))
             }
         }
@@ -164,7 +164,7 @@ impl TensorArray {
         I: DaftIntegerType,
         <I as DaftNumericType>::Native: arrow2::types::Index,
     {
-        let new_array = self.physical.take(idx)?;
+        let new_array = self.physical.0.take(idx)?;
         Ok(Self::new(self.field.clone(), new_array))
     }
 
@@ -206,7 +206,7 @@ impl FixedShapeTensorArray {
         I: DaftIntegerType,
         <I as DaftNumericType>::Native: arrow2::types::Index,
     {
-        let new_array = self.physical.take(idx)?;
+        let new_array = self.physical.0.take(idx)?;
         Ok(Self::new(self.field.clone(), new_array))
     }
 

--- a/src/daft-core/src/array/ops/tensor.rs
+++ b/src/daft-core/src/array/ops/tensor.rs
@@ -2,14 +2,14 @@ use crate::{array::ops::as_arrow::AsArrow, datatypes::logical::TensorArray};
 
 impl TensorArray {
     pub fn data_array(&self) -> &arrow2::array::ListArray<i64> {
-        let p = self.physical.as_arrow();
+        let p = self.physical.0.as_arrow();
         const DATA_IDX: usize = 0;
         let array = p.values().get(DATA_IDX).unwrap();
         array.as_ref().as_any().downcast_ref().unwrap()
     }
 
     pub fn shape_array(&self) -> &arrow2::array::ListArray<i64> {
-        let p = self.physical.as_arrow();
+        let p = self.physical.0.as_arrow();
         const SHAPE_IDX: usize = 1;
         let array = p.values().get(SHAPE_IDX).unwrap();
         array.as_ref().as_any().downcast_ref().unwrap()

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -35,8 +35,9 @@ pub trait DaftPhysicalType: Send + Sync + DaftDataType {}
 
 pub trait DaftArrowBackedType: Send + Sync + DaftPhysicalType + 'static {}
 
+/// A DaftLogicalType applies a logical "interpretation" on its ChildArray
 pub trait DaftLogicalType: Send + Sync + DaftDataType + 'static {
-    type PhysicalType: DaftArrowBackedType;
+    type ChildArrayType;
 }
 
 macro_rules! impl_daft_arrow_datatype {
@@ -70,7 +71,7 @@ macro_rules! impl_daft_non_arrow_datatype {
 }
 
 macro_rules! impl_daft_logical_datatype {
-    ($ca:ident, $variant:ident, $physical_type:ident) => {
+    ($ca:ident, $variant:ident, $child_array_type:ident) => {
         pub struct $ca {}
 
         impl DaftDataType for $ca {
@@ -81,7 +82,7 @@ macro_rules! impl_daft_logical_datatype {
         }
 
         impl DaftLogicalType for $ca {
-            type PhysicalType = $physical_type;
+            type ChildArrayType = $child_array_type;
         }
     };
 }
@@ -110,16 +111,16 @@ impl_daft_arrow_datatype!(ExtensionType, Unknown);
 #[cfg(feature = "python")]
 impl_daft_non_arrow_datatype!(PythonType, Python);
 
-impl_daft_logical_datatype!(Decimal128Type, Unknown, Int128Type);
-impl_daft_logical_datatype!(TimestampType, Unknown, Int64Type);
-impl_daft_logical_datatype!(DateType, Date, Int32Type);
-impl_daft_logical_datatype!(TimeType, Unknown, Int64Type);
-impl_daft_logical_datatype!(DurationType, Unknown, Int64Type);
-impl_daft_logical_datatype!(EmbeddingType, Unknown, FixedSizeListType);
-impl_daft_logical_datatype!(ImageType, Unknown, StructType);
-impl_daft_logical_datatype!(FixedShapeImageType, Unknown, FixedSizeListType);
-impl_daft_logical_datatype!(TensorType, Unknown, StructType);
-impl_daft_logical_datatype!(FixedShapeTensorType, Unknown, FixedSizeListType);
+impl_daft_logical_datatype!(Decimal128Type, Unknown, Int128Array);
+impl_daft_logical_datatype!(TimestampType, Unknown, Int64Array);
+impl_daft_logical_datatype!(DateType, Date, Int32Array);
+impl_daft_logical_datatype!(TimeType, Unknown, Int64Array);
+impl_daft_logical_datatype!(DurationType, Unknown, Int64Array);
+impl_daft_logical_datatype!(EmbeddingType, Unknown, FixedSizeListArray);
+impl_daft_logical_datatype!(ImageType, Unknown, StructArray);
+impl_daft_logical_datatype!(FixedShapeImageType, Unknown, FixedSizeListArray);
+impl_daft_logical_datatype!(TensorType, Unknown, StructArray);
+impl_daft_logical_datatype!(FixedShapeTensorType, Unknown, FixedSizeListArray);
 
 pub trait NumericNative:
     PartialOrd

--- a/src/daft-core/src/series/array_impl/data_array.rs
+++ b/src/daft-core/src/series/array_impl/data_array.rs
@@ -179,6 +179,11 @@ macro_rules! impl_series_like_for_data_array {
                 logical_to_arrow(Cow::Borrowed(&self.0.data), self.field()).into_owned()
             }
 
+            fn as_arrow(&self) -> Box<dyn arrow2::array::Array> {
+                // TODO(jay): Figure out if this is the correct behavior? Apparently to_arrow is FFI.
+                self.to_arrow()
+            }
+
             fn as_any(&self) -> &dyn std::any::Any {
                 self
             }

--- a/src/daft-core/src/series/array_impl/mod.rs
+++ b/src/daft-core/src/series/array_impl/mod.rs
@@ -4,6 +4,7 @@ pub mod logical_array;
 
 use super::Series;
 
+#[derive(Clone)]
 pub struct ArrayWrapper<T>(pub T);
 
 pub trait IntoSeries {

--- a/src/daft-core/src/series/mod.rs
+++ b/src/daft-core/src/series/mod.rs
@@ -13,7 +13,8 @@ use common_error::DaftResult;
 
 pub use array_impl::IntoSeries;
 
-use self::series_like::SeriesLike;
+pub(crate) use self::array_impl::ArrayWrapper;
+pub(crate) use self::series_like::SeriesLike;
 
 #[derive(Clone)]
 pub struct Series {

--- a/src/daft-core/src/series/series_like.rs
+++ b/src/daft-core/src/series/series_like.rs
@@ -5,33 +5,45 @@ use crate::{
     datatypes::{BooleanArray, DataType, Field},
 };
 use common_error::DaftResult;
+use dyn_clone::DynClone;
 
 use super::Series;
-pub trait SeriesLike: Send + Sync + Any {
-    #[allow(clippy::wrong_self_convention)]
-    fn into_series(&self) -> Series;
-    fn to_arrow(&self) -> Box<dyn arrow2::array::Array>;
-    fn as_any(&self) -> &dyn std::any::Any;
-    fn min(&self, groups: Option<&GroupIndices>) -> DaftResult<Series>;
-    fn max(&self, groups: Option<&GroupIndices>) -> DaftResult<Series>;
-    fn agg_list(&self, groups: Option<&GroupIndices>) -> DaftResult<Series>;
-    fn broadcast(&self, num: usize) -> DaftResult<Series>;
-    fn cast(&self, datatype: &DataType) -> DaftResult<Series>;
-    fn filter(&self, mask: &BooleanArray) -> DaftResult<Series>;
-    fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series>;
+
+/// Trait for a concrete Array to be used as the backing implementation of a Series
+///
+/// Functions on this trait should be generally applicable to *ALL* Arrays. These are
+/// generally either "black-box" functions (functionality that is independent of the
+/// values contained in the array) such as [`SeriesLike::name`] and [`SeriesLike::len`],
+/// or common functionality such as [`SeriesLike::add`] and [`SeriesLike::equal`].
+pub trait SeriesLike: Send + Sync + Any + DynClone {
+    // Metadata
     fn data_type(&self) -> &DataType;
     fn field(&self) -> &Field;
     fn len(&self) -> usize;
     fn name(&self) -> &str;
     fn rename(&self, name: &str) -> Series;
     fn size_bytes(&self) -> DaftResult<usize>;
-    fn is_null(&self) -> DaftResult<Series>;
-    fn sort(&self, descending: bool) -> DaftResult<Series>;
+
+    // Conversion
+    #[allow(clippy::wrong_self_convention)]
+    fn into_series(&self) -> Series;
+    fn to_arrow(&self) -> Box<dyn arrow2::array::Array>;
+    fn as_arrow(&self) -> Box<dyn arrow2::array::Array>;
+    fn as_any(&self) -> &dyn std::any::Any;
+
+    // Element selection
     fn head(&self, num: usize) -> DaftResult<Series>;
     fn slice(&self, start: usize, end: usize) -> DaftResult<Series>;
     fn take(&self, idx: &Series) -> DaftResult<Series>;
+    fn broadcast(&self, num: usize) -> DaftResult<Series>;
+    fn filter(&self, mask: &BooleanArray) -> DaftResult<Series>;
+    fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series>;
+
+    // Visualization
     fn str_value(&self, idx: usize) -> DaftResult<String>;
     fn html_value(&self, idx: usize) -> String;
+
+    // Common binary operations
     fn add(&self, rhs: &Series) -> DaftResult<Series>;
     fn sub(&self, rhs: &Series) -> DaftResult<Series>;
     fn mul(&self, rhs: &Series) -> DaftResult<Series>;
@@ -46,4 +58,12 @@ pub trait SeriesLike: Send + Sync + Any {
     fn lte(&self, rhs: &Series) -> DaftResult<BooleanArray>;
     fn gt(&self, rhs: &Series) -> DaftResult<BooleanArray>;
     fn gte(&self, rhs: &Series) -> DaftResult<BooleanArray>;
+
+    // Other common operations
+    fn min(&self, groups: Option<&GroupIndices>) -> DaftResult<Series>;
+    fn max(&self, groups: Option<&GroupIndices>) -> DaftResult<Series>;
+    fn agg_list(&self, groups: Option<&GroupIndices>) -> DaftResult<Series>;
+    fn cast(&self, datatype: &DataType) -> DaftResult<Series>;
+    fn is_null(&self) -> DaftResult<Series>;
+    fn sort(&self, descending: bool) -> DaftResult<Series>;
 }


### PR DESCRIPTION
Refactors LogicalArray to have a SeriesLike child, instead of always being hardcoded to a DataArray

This is still a WIP, with a couple of issues:

1. `LogicalArray<T>::concat` is currently hardcoded to use its child DataArray's concat. We may need to implement `concat` on the SeriesLike instead.
2. A lot of the "black-box" kernels like `LogicalArray::head` and `LogicalArray::slice` are currently broken -- they return a new Series with the **physical** type instead of maintaining the logical type