### PR TITLE
[CHORE] Refactor LogicalArray

### DIFF
--- a/src/daft-core/src/array/ops/from_arrow.rs
+++ b/src/daft-core/src/array/ops/from_arrow.rs
@@ -2,7 +2,7 @@ use common_error::DaftResult;
 
 use crate::{
     array::DataArray,
-    datatypes::{logical::LogicalArray, DaftLogicalType, DaftPhysicalType, Field},
+    datatypes::{logical::LogicalDataArray, DaftLogicalType, DaftPhysicalType, Field, DaftArrowBackedType},
 };
 
 /// Arrays that implement [`FromArrow`] can be instantiated from a Box<dyn arrow2::array::Array>
@@ -19,10 +19,13 @@ impl<T: DaftPhysicalType> FromArrow for DataArray<T> {
     }
 }
 
-impl<L: DaftLogicalType> FromArrow for LogicalArray<L> {
+impl<L: DaftLogicalType> FromArrow for LogicalDataArray<L>
+where
+    L::WrappedType: DaftArrowBackedType
+{
     fn from_arrow(field: &Field, arrow_arr: Box<dyn arrow2::array::Array>) -> DaftResult<Self> {
         let data_array_field = Field::new(field.name.clone(), field.dtype.to_physical());
         let physical = DataArray::try_from((data_array_field, arrow_arr))?;
-        Ok(LogicalArray::<L>::new(field.clone(), physical))
+        Ok(LogicalDataArray::<L>::new(field.clone(), physical))
     }
 }

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -36,7 +36,7 @@ pub trait DaftPhysicalType: Send + Sync + DaftDataType {}
 pub trait DaftArrowBackedType: Send + Sync + DaftPhysicalType + 'static {}
 
 pub trait DaftLogicalType: Send + Sync + DaftDataType + 'static {
-    type PhysicalType: DaftArrowBackedType;
+    type WrappedType: DaftDataType;
 }
 
 macro_rules! impl_daft_arrow_datatype {
@@ -70,7 +70,7 @@ macro_rules! impl_daft_non_arrow_datatype {
 }
 
 macro_rules! impl_daft_logical_datatype {
-    ($ca:ident, $variant:ident, $physical_type:ident) => {
+    ($ca:ident, $variant:ident, $wrapped_type:ident) => {
         pub struct $ca {}
 
         impl DaftDataType for $ca {
@@ -81,7 +81,7 @@ macro_rules! impl_daft_logical_datatype {
         }
 
         impl DaftLogicalType for $ca {
-            type PhysicalType = $physical_type;
+            type WrappedType = $wrapped_type;
         }
     };
 }

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -92,7 +92,7 @@ macro_rules! impl_series_like_for_logical_array {
             fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series> {
                 Ok(self
                     .0
-                    .if_else(other.downcast_logical()?, predicate.downcast()?)?
+                    .if_else(other.downcast_logical_data_array()?, predicate.downcast()?)?
                     .into_series())
             }
 

--- a/src/daft-core/src/series/from.rs
+++ b/src/daft-core/src/series/from.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    datatypes::{logical::LogicalArray, DataType, Field},
+    datatypes::{logical::LogicalDataArray, DataType, Field},
     with_match_daft_logical_primitive_types, with_match_daft_logical_types,
     with_match_physical_daft_types,
 };
@@ -53,7 +53,7 @@ impl TryFrom<(&str, Box<dyn arrow2::array::Array>)> for Series {
             };
 
             let res = with_match_daft_logical_types!(dtype, |$T| {
-                LogicalArray::<$T>::from_arrow(field.as_ref(), physical_arrow_array)?.into_series()
+                LogicalDataArray::<$T>::from_arrow(field.as_ref(), physical_arrow_array)?.into_series()
             });
             return Ok(res);
         }

--- a/src/daft-core/src/series/mod.rs
+++ b/src/daft-core/src/series/mod.rs
@@ -13,7 +13,7 @@ use common_error::DaftResult;
 
 pub use array_impl::IntoSeries;
 
-use self::series_like::SeriesLike;
+pub(crate) use self::series_like::SeriesLike;
 
 #[derive(Clone)]
 pub struct Series {

--- a/src/daft-core/src/series/ops/concat.rs
+++ b/src/daft-core/src/series/ops/concat.rs
@@ -1,4 +1,4 @@
-use crate::datatypes::logical::LogicalArray;
+use crate::datatypes::logical::LogicalDataArray;
 use crate::{
     series::{IntoSeries, Series},
     with_match_daft_logical_types, with_match_physical_daft_types,
@@ -29,8 +29,8 @@ impl Series {
         }
         if first_dtype.is_logical() {
             return Ok(with_match_daft_logical_types!(first_dtype, |$T| {
-                let downcasted = series.into_iter().map(|s| s.downcast_logical::<$T>()).collect::<DaftResult<Vec<_>>>()?;
-                LogicalArray::<$T>::concat(downcasted.as_slice())?.into_series()
+                let downcasted = series.into_iter().map(|s| s.downcast_logical_data_array::<$T>()).collect::<DaftResult<Vec<_>>>()?;
+                LogicalDataArray::<$T>::concat(downcasted.as_slice())?.into_series()
             }));
         }
 

--- a/src/daft-core/src/series/ops/date.rs
+++ b/src/daft-core/src/series/ops/date.rs
@@ -14,7 +14,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical::<DateType>()?;
+        let downcasted = self.downcast_logical_data_array::<DateType>()?;
         Ok(downcasted.day()?.into_series())
     }
 
@@ -26,7 +26,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical::<DateType>()?;
+        let downcasted = self.downcast_logical_data_array::<DateType>()?;
         Ok(downcasted.month()?.into_series())
     }
 
@@ -38,7 +38,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical::<DateType>()?;
+        let downcasted = self.downcast_logical_data_array::<DateType>()?;
         Ok(downcasted.year()?.into_series())
     }
 
@@ -50,7 +50,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical::<DateType>()?;
+        let downcasted = self.downcast_logical_data_array::<DateType>()?;
         Ok(downcasted.day_of_week()?.into_series())
     }
 }

--- a/src/daft-core/src/series/ops/downcast.rs
+++ b/src/daft-core/src/series/ops/downcast.rs
@@ -1,6 +1,6 @@
 use crate::datatypes::*;
 
-use crate::datatypes::logical::{FixedShapeImageArray, ImageArray, LogicalArray};
+use crate::datatypes::logical::{FixedShapeImageArray, ImageArray, LogicalDataArray};
 use crate::series::array_impl::ArrayWrapper;
 use crate::series::Series;
 use common_error::DaftResult;
@@ -20,7 +20,12 @@ impl Series {
         }
     }
 
-    pub fn downcast_logical<L: DaftLogicalType>(&self) -> DaftResult<&LogicalArray<L>> {
+    pub fn downcast_logical_data_array<L: DaftLogicalType>(
+        &self,
+    ) -> DaftResult<&LogicalDataArray<L>>
+    where
+        L::WrappedType: DaftPhysicalType,
+    {
         match self.inner.as_any().downcast_ref() {
             Some(ArrayWrapper(arr)) => Ok(arr),
             None => panic!(
@@ -128,11 +133,11 @@ impl Series {
     }
 
     pub fn image(&self) -> DaftResult<&ImageArray> {
-        self.downcast_logical()
+        self.downcast_logical_data_array()
     }
 
     pub fn fixed_size_image(&self) -> DaftResult<&FixedShapeImageArray> {
-        self.downcast_logical()
+        self.downcast_logical_data_array()
     }
 
     #[cfg(feature = "python")]

--- a/src/daft-core/src/series/ops/image.rs
+++ b/src/daft-core/src/series/ops/image.rs
@@ -16,11 +16,11 @@ impl Series {
     pub fn image_encode(&self, image_format: ImageFormat) -> DaftResult<Series> {
         match self.data_type() {
             DataType::Image(..) => Ok(self
-                .downcast_logical::<ImageType>()?
+                .downcast_logical_data_array::<ImageType>()?
                 .encode(image_format)?
                 .into_series()),
             DataType::FixedShapeImage(..) => Ok(self
-                .downcast_logical::<FixedShapeImageType>()?
+                .downcast_logical_data_array::<FixedShapeImageType>()?
                 .encode(image_format)?
                 .into_series()),
             dtype => Err(DaftError::ValueError(format!(
@@ -33,7 +33,7 @@ impl Series {
     pub fn image_resize(&self, w: u32, h: u32) -> DaftResult<Series> {
         match self.data_type() {
             DataType::Image(mode) => {
-                let array = self.downcast_logical::<ImageType>()?;
+                let array = self.downcast_logical_data_array::<ImageType>()?;
                 match mode {
                     // If the image mode is specified at the type-level (and is therefore guaranteed to be consistent
                     // across all images across all partitions), store the resized image in a fixed shape image array,
@@ -45,7 +45,7 @@ impl Series {
                 }
             }
             DataType::FixedShapeImage(..) => Ok(self
-                .downcast_logical::<FixedShapeImageType>()?
+                .downcast_logical_data_array::<FixedShapeImageType>()?
                 .resize(w, h)?
                 .into_series()),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -8,7 +8,7 @@ use num_traits::ToPrimitive;
 use daft_core::array::ops::GroupIndices;
 
 use common_error::{DaftError, DaftResult};
-use daft_core::datatypes::logical::LogicalArray;
+use daft_core::datatypes::logical::LogicalDataArray;
 use daft_core::datatypes::{BooleanType, DataType, Field, UInt64Array};
 use daft_core::schema::{Schema, SchemaRef};
 use daft_core::series::{IntoSeries, Series};
@@ -74,7 +74,7 @@ impl Table {
                 for (field_name, field) in schema.fields.iter() {
                     if field.dtype.is_logical() {
                         with_match_daft_logical_types!(field.dtype, |$T| {
-                            columns.push(LogicalArray::<$T>::empty(field_name, &field.dtype).into_series())
+                            columns.push(LogicalDataArray::<$T>::empty(field_name, &field.dtype).into_series())
                         })
                     } else {
                         with_match_physical_daft_types!(field.dtype, |$T| {


### PR DESCRIPTION
Refactors LogicalArray to be generic over a `<L: DaftLogicalType, WrappedArray>` instead of just `<L: DaftLogicalType>`

1. Instead of being constrained to a child `DataArray<T>`, LogicalArray can now have different children (e.g. another LogicalArray, or a NestedArray in an upcoming PR)
2. Renames a LogicalArray's child array from `self.physical` to `self.wrapped` to more accurately reflect the new semantics