### PR TITLE
[FEAT] [New Query Planner] Add support for `df.count_rows().

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -9,7 +9,7 @@ import fsspec
 import pyarrow as pa
 
 from daft import context
-from daft.daft import ImageFormat
+from daft.daft import CountMode, ImageFormat
 from daft.daft import PyExpr as _PyExpr
 from daft.daft import col as _col
 from daft.daft import lit as _lit
@@ -275,8 +275,8 @@ class Expression:
         expr = self._expr.cast(dtype._dtype)
         return Expression._from_pyexpr(expr)
 
-    def _count(self) -> Expression:
-        expr = self._expr.count()
+    def _count(self, mode: CountMode = CountMode.Valid) -> Expression:
+        expr = self._expr.count(mode)
         return Expression._from_pyexpr(expr)
 
     def _sum(self) -> Expression:

--- a/daft/logical/rust_logical_plan.py
+++ b/daft/logical/rust_logical_plan.py
@@ -7,7 +7,7 @@ import fsspec
 
 from daft import DataType, col
 from daft.context import get_context
-from daft.daft import FileFormat, FileFormatConfig, JoinType
+from daft.daft import CountMode, FileFormat, FileFormatConfig, JoinType
 from daft.daft import LogicalPlanBuilder as _LogicalPlanBuilder
 from daft.daft import PartitionScheme, PartitionSpec, ResourceRequest
 from daft.errors import ExpressionTypeError
@@ -130,7 +130,10 @@ class RustLogicalPlanBuilder(LogicalPlanBuilder):
         return RustLogicalPlanBuilder(builder)
 
     def count(self) -> RustLogicalPlanBuilder:
-        raise NotImplementedError("not implemented")
+        # TODO(Clark): Add dedicated logical/physical ops when introducing metadata-based count optimizations.
+        first_col = col(self.schema().column_names()[0])
+        builder = self._builder.aggregate([first_col._count(CountMode.All)], [])
+        return RustLogicalPlanBuilder(builder)
 
     def distinct(self) -> RustLogicalPlanBuilder:
         builder = self._builder.distinct()

--- a/daft/series.py
+++ b/daft/series.py
@@ -5,7 +5,7 @@ from typing import TypeVar
 import pyarrow as pa
 
 from daft.arrow_utils import ensure_array, ensure_chunked_array
-from daft.daft import ImageFormat, PySeries
+from daft.daft import CountMode, ImageFormat, PySeries
 from daft.datatype import DataType
 from daft.utils import pyarrow_supports_fixed_shape_tensor
 
@@ -434,9 +434,9 @@ class Series:
         assert self._series is not None and other._series is not None
         return Series._from_pyseries(self._series ^ other._series)
 
-    def _count(self) -> Series:
+    def _count(self, mode: CountMode = CountMode.Valid) -> Series:
         assert self._series is not None
-        return Series._from_pyseries(self._series._count())
+        return Series._from_pyseries(self._series._count(mode))
 
     def _min(self) -> Series:
         assert self._series is not None

--- a/src/daft-core/src/array/ops/count.rs
+++ b/src/daft-core/src/array/ops/count.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use arrow2;
 
-use crate::{array::DataArray, datatypes::*};
+use crate::{array::DataArray, count_mode::CountMode, datatypes::*};
 use common_error::DaftResult;
 
 use super::{DaftCountAggable, GroupIndices};
@@ -13,9 +13,13 @@ where
 {
     type Output = DaftResult<DataArray<UInt64Type>>;
 
-    fn count(&self) -> Self::Output {
+    fn count(&self, mode: CountMode) -> Self::Output {
         let arrow_array = &self.data;
-        let count = arrow_array.len() - arrow_array.null_count();
+        let count = match mode {
+            CountMode::All => arrow_array.len(),
+            CountMode::Valid => arrow_array.len() - arrow_array.null_count(),
+            CountMode::Null => arrow_array.null_count(),
+        };
         let result_arrow_array =
             Box::new(arrow2::array::PrimitiveArray::from([Some(count as u64)]));
         DataArray::<UInt64Type>::new(
@@ -23,21 +27,33 @@ where
             result_arrow_array,
         )
     }
-    fn grouped_count(&self, groups: &GroupIndices) -> Self::Output {
+    fn grouped_count(&self, groups: &GroupIndices, mode: CountMode) -> Self::Output {
         let arrow_array = self.data.as_ref();
 
-        let counts_per_group: Vec<_> = if arrow_array.null_count() > 0 {
-            groups
+        let counts_per_group: Vec<_> = match mode {
+            CountMode::All => groups.iter().map(|g| g.len() as u64).collect(),
+            CountMode::Valid => {
+                if arrow_array.null_count() > 0 {
+                    groups
+                        .iter()
+                        .map(|g| {
+                            let null_count = g
+                                .iter()
+                                .fold(0u64, |acc, v| acc + arrow_array.is_null(*v as usize) as u64);
+                            (g.len() as u64) - null_count
+                        })
+                        .collect()
+                } else {
+                    groups.iter().map(|g| g.len() as u64).collect()
+                }
+            }
+            CountMode::Null => groups
                 .iter()
                 .map(|g| {
-                    let null_count = g
-                        .iter()
-                        .fold(0u64, |acc, v| acc + arrow_array.is_null(*v as usize) as u64);
-                    (g.len() as u64) - null_count
+                    g.iter()
+                        .fold(0u64, |acc, v| acc + arrow_array.is_null(*v as usize) as u64)
                 })
-                .collect()
-        } else {
-            groups.iter().map(|g| g.len() as u64).collect()
+                .collect(),
         };
 
         Ok(DataArray::<UInt64Type>::from((

--- a/src/daft-core/src/array/ops/mean.rs
+++ b/src/daft-core/src/array/ops/mean.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use arrow2;
 
+use crate::count_mode::CountMode;
 use crate::{array::DataArray, datatypes::*};
 
 use common_error::DaftResult;
@@ -16,7 +17,9 @@ impl DaftMeanAggable for &DataArray<Float64Type> {
 
     fn mean(&self) -> Self::Output {
         let sum_value = DaftSumAggable::sum(self)?.as_arrow().value(0);
-        let count_value = DaftCountAggable::count(self)?.as_arrow().value(0);
+        let count_value = DaftCountAggable::count(self, CountMode::Valid)?
+            .as_arrow()
+            .value(0);
 
         let result = match count_value {
             0 => None,
@@ -33,7 +36,7 @@ impl DaftMeanAggable for &DataArray<Float64Type> {
     fn grouped_mean(&self, groups: &GroupIndices) -> Self::Output {
         use arrow2::array::PrimitiveArray;
         let sum_values = self.grouped_sum(groups)?;
-        let count_values = self.grouped_count(groups)?;
+        let count_values = self.grouped_count(groups, CountMode::Valid)?;
         assert_eq!(sum_values.len(), count_values.len());
         let mean_per_group = sum_values
             .as_arrow()

--- a/src/daft-core/src/array/ops/mod.rs
+++ b/src/daft-core/src/array/ops/mod.rs
@@ -38,6 +38,8 @@ pub use sort::{build_multi_array_bicompare, build_multi_array_compare};
 
 use common_error::DaftResult;
 
+use crate::count_mode::CountMode;
+
 pub trait DaftCompare<Rhs> {
     type Output;
 
@@ -93,8 +95,8 @@ pub trait IntoGroups {
 
 pub trait DaftCountAggable {
     type Output;
-    fn count(&self) -> Self::Output;
-    fn grouped_count(&self, groups: &GroupIndices) -> Self::Output;
+    fn count(&self, mode: CountMode) -> Self::Output;
+    fn grouped_count(&self, groups: &GroupIndices, mode: CountMode) -> Self::Output;
 }
 
 pub trait DaftSumAggable {

--- a/src/daft-core/src/lib.rs
+++ b/src/daft-core/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(let_chains)]
 
 pub mod array;
+pub mod count_mode;
 pub mod datatypes;
 #[cfg(feature = "python")]
 pub mod ffi;
@@ -10,7 +11,10 @@ pub mod python;
 pub mod schema;
 pub mod series;
 pub mod utils;
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
 
+pub use count_mode::CountMode;
 pub use datatypes::DataType;
 pub use series::{IntoSeries, Series};
 
@@ -23,3 +27,10 @@ pub const DAFT_BUILD_TYPE: &str = {
         None => BUILD_TYPE_DEV,
     }
 };
+
+#[cfg(feature = "python")]
+pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
+    parent.add_class::<CountMode>()?;
+
+    Ok(())
+}

--- a/src/daft-core/src/python/series.rs
+++ b/src/daft-core/src/python/series.rs
@@ -4,6 +4,7 @@ use pyo3::{exceptions::PyValueError, prelude::*, pyclass::CompareOp, types::PyLi
 
 use crate::{
     array::{ops::DaftLogical, pseudo_arrow::PseudoArrowArray, DataArray},
+    count_mode::CountMode,
     datatypes::{DataType, Field, ImageFormat, ImageMode, PythonType, UInt64Type},
     ffi,
     series::{self, IntoSeries, Series},
@@ -176,8 +177,8 @@ impl PySeries {
         Ok((&self.series).not()?.into())
     }
 
-    pub fn _count(&self) -> PyResult<Self> {
-        Ok((self.series).count(None)?.into())
+    pub fn _count(&self, mode: CountMode) -> PyResult<Self> {
+        Ok((self.series).count(None, mode)?.into())
     }
 
     pub fn _sum(&self) -> PyResult<Self> {

--- a/src/daft-core/src/series/ops/agg.rs
+++ b/src/daft-core/src/series/ops/agg.rs
@@ -1,3 +1,4 @@
+use crate::count_mode::CountMode;
 use crate::series::IntoSeries;
 use crate::{array::ops::GroupIndices, series::Series, with_match_physical_daft_types};
 use common_error::{DaftError, DaftResult};
@@ -5,13 +6,13 @@ use common_error::{DaftError, DaftResult};
 use crate::datatypes::*;
 
 impl Series {
-    pub fn count(&self, groups: Option<&GroupIndices>) -> DaftResult<Series> {
+    pub fn count(&self, groups: Option<&GroupIndices>, mode: CountMode) -> DaftResult<Series> {
         use crate::array::ops::DaftCountAggable;
         let s = self.as_physical()?;
         with_match_physical_daft_types!(s.data_type(), |$T| {
             match groups {
-                Some(groups) => Ok(DaftCountAggable::grouped_count(&s.downcast::<$T>()?, groups)?.into_series()),
-                None => Ok(DaftCountAggable::count(&s.downcast::<$T>()?)?.into_series())
+                Some(groups) => Ok(DaftCountAggable::grouped_count(&s.downcast::<$T>()?, groups, mode)?.into_series()),
+                None => Ok(DaftCountAggable::count(&s.downcast::<$T>()?, mode)?.into_series())
             }
         })
     }

--- a/src/daft-dsl/src/optimization.rs
+++ b/src/daft-dsl/src/optimization.rs
@@ -5,7 +5,7 @@ pub fn get_required_columns(e: &Expr) -> Vec<String> {
     match e {
         Expr::Alias(child, _) => get_required_columns(child),
         Expr::Agg(agg) => match agg {
-            AggExpr::Count(child)
+            AggExpr::Count(child, ..)
             | AggExpr::Sum(child)
             | AggExpr::Mean(child)
             | AggExpr::Min(child)
@@ -73,8 +73,9 @@ pub fn replace_column_with_expression(expr: &Expr, column_name: &str, new_expr: 
             (*name).clone(),
         ),
         Expr::Agg(agg) => match agg {
-            AggExpr::Count(child) => Expr::Agg(AggExpr::Count(
+            AggExpr::Count(child, mode) => Expr::Agg(AggExpr::Count(
                 replace_column_with_expression(child, column_name, new_expr).into(),
+                *mode,
             )),
             AggExpr::Sum(child) => Expr::Agg(AggExpr::Sum(
                 replace_column_with_expression(child, column_name, new_expr).into(),

--- a/src/daft-dsl/src/python.rs
+++ b/src/daft-dsl/src/python.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use crate::{functions, optimization, Expr};
 use daft_core::{
+    count_mode::CountMode,
     datatypes::ImageFormat,
     python::{datatype::PyDataType, field::PyField, schema::PySchema},
 };
@@ -148,8 +149,8 @@ impl PyExpr {
         Ok(self.expr.if_else(&if_true.expr, &if_false.expr).into())
     }
 
-    pub fn count(&self) -> PyResult<Self> {
-        Ok(self.expr.count().into())
+    pub fn count(&self, mode: CountMode) -> PyResult<Self> {
+        Ok(self.expr.count(mode).into())
     }
 
     pub fn sum(&self) -> PyResult<Self> {

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -274,7 +274,7 @@ impl Table {
     ) -> DaftResult<Series> {
         use daft_dsl::AggExpr::*;
         match agg_expr {
-            Count(expr) => Series::count(&self.eval_expression(expr)?, groups),
+            Count(expr, mode) => Series::count(&self.eval_expression(expr)?, groups, *mode),
             Sum(expr) => Series::sum(&self.eval_expression(expr)?, groups),
             Mean(expr) => Series::mean(&self.eval_expression(expr)?, groups),
             Min(expr) => Series::min(&self.eval_expression(expr)?, groups),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pylib {
     fn daft(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
         pyo3_log::init();
 
+        daft_core::register_modules(_py, m)?;
         daft_core::python::register_modules(_py, m)?;
         daft_dsl::register_modules(_py, m)?;
         daft_table::register_modules(_py, m)?;

--- a/tests/cookbook/test_count_rows.py
+++ b/tests/cookbook/test_count_rows.py
@@ -5,13 +5,13 @@ import pytest
 from daft.expressions import col
 
 
-def test_count_rows(daft_df, service_requests_csv_pd_df, repartition_nparts):
+def test_count_rows(daft_df, service_requests_csv_pd_df, repartition_nparts, use_new_planner):
     """Count rows for the entire table"""
     daft_df_row_count = daft_df.repartition(repartition_nparts).count_rows()
     assert daft_df_row_count == service_requests_csv_pd_df.shape[0]
 
 
-def test_filtered_count_rows(daft_df, service_requests_csv_pd_df, repartition_nparts):
+def test_filtered_count_rows(daft_df, service_requests_csv_pd_df, repartition_nparts, use_new_planner):
     """Count rows on a table filtered by a certain condition"""
     daft_df_row_count = daft_df.repartition(repartition_nparts).where(col("Borough") == "BROOKLYN").count_rows()
 
@@ -26,20 +26,20 @@ def test_filtered_count_rows(daft_df, service_requests_csv_pd_df, repartition_np
         pytest.param(["Borough", "Complaint Type"], id="NumGroupByKeys:2"),
     ],
 )
-def test_groupby_count_rows(daft_df, service_requests_csv_pd_df, repartition_nparts, keys):
+def test_groupby_count_rows(daft_df, service_requests_csv_pd_df, repartition_nparts, keys, use_new_planner):
     """Count rows after group by"""
     daft_df = daft_df.repartition(repartition_nparts).groupby(*[col(k) for k in keys]).sum(col("Unique Key"))
     service_requests_csv_pd_df = service_requests_csv_pd_df.groupby(keys).sum("Unique Key").reset_index()
     assert daft_df.count_rows() == len(service_requests_csv_pd_df)
 
 
-def test_dataframe_length_after_collect(daft_df, service_requests_csv_pd_df, repartition_nparts):
+def test_dataframe_length_after_collect(daft_df, service_requests_csv_pd_df, repartition_nparts, use_new_planner):
     """Count rows after group by"""
     daft_df = daft_df.repartition(repartition_nparts).collect()
     assert len(daft_df) == len(service_requests_csv_pd_df)
 
 
-def test_dataframe_length_before_collect(daft_df):
+def test_dataframe_length_before_collect(daft_df, use_new_planner):
     """Count rows for the entire table"""
     with pytest.raises(RuntimeError) as err_info:
         len(daft_df)


### PR DESCRIPTION
This PR adds support for `df.count_rows()`, the final missing implementation from the `LogicalPlanBuilder` interface for the new query planner.