### PR TITLE
[BUG] Use manylinux_2_24 for aarch64 linux to be able to publish manylinux2014

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,8 +13,6 @@ on:
   push:
     tags:
     - v*
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 env:
@@ -34,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu] #[ubuntu, macos]
+        os: [ubuntu, macos]
         compile_arch: [x86_64, aarch64]
     steps:
     - uses: actions/checkout@v3
@@ -112,75 +110,75 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
 
-  # publish:
-  #   name: Publish wheels to PYPI and Anaconda
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #   - build-and-test
-  #   steps:
-  #   - uses: actions/setup-python@v4
-  #     with:
-  #       python-version: ${{ env.PYTHON_VERSION }}
-  #       architecture: x64
-  #   - run: pip install -U twine
-  #   - uses: actions/checkout@v3
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: wheels
-  #       path: dist
-  #   - run: ls -R ./dist
-  #   - name: Publish bdist package to PYPI
-  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
-  #     run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
-  #     env:
-  #       TWINE_USERNAME: __token__
-  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  publish:
+    name: Publish wheels to PYPI and Anaconda
+    runs-on: ubuntu-latest
+    needs:
+    - build-and-test
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+        architecture: x64
+    - run: pip install -U twine
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
+      with:
+        name: wheels
+        path: dist
+    - run: ls -R ./dist
+    - name: Publish bdist package to PYPI
+      if: ${{ success() && (env.IS_PUSH == 'true') }}
+      run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
-  #   - uses: conda-incubator/setup-miniconda@v2
-  #     with:
-  #       # Really doesn't matter what version we upload with
-  #       # just the version we test with
-  #       python-version: '3.8'
-  #       channels: conda-forge
-  #       channel-priority: true
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        # Really doesn't matter what version we upload with
+        # just the version we test with
+        python-version: '3.8'
+        channels: conda-forge
+        channel-priority: true
 
-  #   - name: Install anaconda client
-  #     shell: bash -el {0}
-  #     run: conda install -q -y anaconda-client "urllib3<2.0"
+    - name: Install anaconda client
+      shell: bash -el {0}
+      run: conda install -q -y anaconda-client "urllib3<2.0"
 
-  #   - name: Upload wheels to anaconda nightly
-  #     if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
-  #     shell: bash -el {0}
-  #     env:
-  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-  #     run: |
-  #       source ci/upload_wheels.sh
-  #       set_upload_vars
-  #       # trigger an upload to
-  #       # https://anaconda.org/daft-nightly/getdaft
-  #       # for cron jobs or "Run workflow" (restricted to main branch).
-  #       # Tags will upload to
-  #       # https://anaconda.org/daft/getdaft
-  #       # The tokens were originally generated at anaconda.org
-  #       upload_wheels
+    - name: Upload wheels to anaconda nightly
+      if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
+      shell: bash -el {0}
+      env:
+        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+      run: |
+        source ci/upload_wheels.sh
+        set_upload_vars
+        # trigger an upload to
+        # https://anaconda.org/daft-nightly/getdaft
+        # for cron jobs or "Run workflow" (restricted to main branch).
+        # Tags will upload to
+        # https://anaconda.org/daft/getdaft
+        # The tokens were originally generated at anaconda.org
+        upload_wheels
 
-  #   - name: Send Slack notification on failure
-  #     uses: slackapi/slack-github-action@v1.24.0
-  #     if: failure()
-  #     with:
-  #       payload: |
-  #         {
-  #           "blocks": [
-  #             {
-  #               "type": "section",
-  #               "text": {
-  #                 "type": "mrkdwn",
-  #                 "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-  #               }
-  #             }
-  #           ]
-  #         }
-  #     env:
-  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    - name: Send Slack notification on failure
+      uses: slackapi/slack-github-action@v1.24.0
+      if: failure()
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -56,7 +56,7 @@ jobs:
         manylinux: auto
         args: --profile release-lto --out dist --sdist
       env:
-        RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
+        RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma,+aes
 
     - name: Build wheels - Linux aarch64
       if: ${{ (matrix.os == 'ubuntu') && (matrix.compile_arch == 'aarch64') }}
@@ -67,6 +67,7 @@ jobs:
         # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic. This caused issues with the `ring` crate that causes TLS to fail
         container: messense/manylinux_2_24-cross:aarch64
         args: --profile release --out dist --sdist
+        RUSTFLAGS: -C target-feature=+aes,+neon
 
     - name: Build wheels - Mac aarch64
       if: ${{ (matrix.os == 'macos') && (matrix.compile_arch == 'aarch64')  }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -56,7 +56,7 @@ jobs:
         manylinux: auto
         args: --profile release-lto --out dist --sdist
       env:
-        RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma,+aes
+        RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
 
     - name: Build wheels - Linux aarch64
       if: ${{ (matrix.os == 'ubuntu') && (matrix.compile_arch == 'aarch64') }}
@@ -67,7 +67,6 @@ jobs:
         # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic. This caused issues with the `ring` crate that causes TLS to fail
         container: messense/manylinux_2_24-cross:aarch64
         args: --profile release-lto --out dist --sdist
-        RUSTFLAGS: -C target-feature=+aes,+neon
 
     - name: Build wheels - Mac aarch64
       if: ${{ (matrix.os == 'macos') && (matrix.compile_arch == 'aarch64')  }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu] #[ubuntu, macos]
-        compile_arch: [aarch64] #[x86_64, aarch64]
+        compile_arch: [x86_64, aarch64]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -66,7 +66,7 @@ jobs:
         manylinux: auto
         # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic. This caused issues with the `ring` crate that causes TLS to fail
         container: messense/manylinux_2_24-cross:aarch64
-        args: --profile release --out dist --sdist
+        args: --profile release-lto --out dist --sdist
         RUSTFLAGS: -C target-feature=+aes,+neon
 
     - name: Build wheels - Mac aarch64

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,8 +34,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
-        compile_arch: [x86_64, aarch64]
+        os: [ubuntu] #[ubuntu, macos]
+        compile_arch: [aarch64] #[x86_64, aarch64]
     steps:
     - uses: actions/checkout@v3
       with:
@@ -66,7 +66,7 @@ jobs:
         manylinux: auto
         # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic. This caused issues with the `ring` crate that causes TLS to fail
         container: messense/manylinux_2_24-cross:aarch64
-        args: --profile release-lto --out dist --sdist
+        args: --profile release --out dist --sdist
 
     - name: Build wheels - Mac aarch64
       if: ${{ (matrix.os == 'macos') && (matrix.compile_arch == 'aarch64')  }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,6 +13,8 @@ on:
   push:
     tags:
     - v*
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 env:
@@ -61,7 +63,9 @@ jobs:
       uses: messense/maturin-action@v1
       with:
         target: aarch64-unknown-linux-gnu
-        manylinux: 2_28
+        manylinux: auto
+        # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic. This caused issues with the `ring` crate that causes TLS to fail
+        container: messense/manylinux_2_24-cross:aarch64
         args: --profile release-lto --out dist --sdist
 
     - name: Build wheels - Mac aarch64
@@ -108,75 +112,75 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
 
-  publish:
-    name: Publish wheels to PYPI and Anaconda
-    runs-on: ubuntu-latest
-    needs:
-    - build-and-test
-    steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-        architecture: x64
-    - run: pip install -U twine
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
-      with:
-        name: wheels
-        path: dist
-    - run: ls -R ./dist
-    - name: Publish bdist package to PYPI
-      if: ${{ success() && (env.IS_PUSH == 'true') }}
-      run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  # publish:
+  #   name: Publish wheels to PYPI and Anaconda
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #   - build-and-test
+  #   steps:
+  #   - uses: actions/setup-python@v4
+  #     with:
+  #       python-version: ${{ env.PYTHON_VERSION }}
+  #       architecture: x64
+  #   - run: pip install -U twine
+  #   - uses: actions/checkout@v3
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: wheels
+  #       path: dist
+  #   - run: ls -R ./dist
+  #   - name: Publish bdist package to PYPI
+  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
+  #     run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
+  #     env:
+  #       TWINE_USERNAME: __token__
+  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        # Really doesn't matter what version we upload with
-        # just the version we test with
-        python-version: '3.8'
-        channels: conda-forge
-        channel-priority: true
+  #   - uses: conda-incubator/setup-miniconda@v2
+  #     with:
+  #       # Really doesn't matter what version we upload with
+  #       # just the version we test with
+  #       python-version: '3.8'
+  #       channels: conda-forge
+  #       channel-priority: true
 
-    - name: Install anaconda client
-      shell: bash -el {0}
-      run: conda install -q -y anaconda-client "urllib3<2.0"
+  #   - name: Install anaconda client
+  #     shell: bash -el {0}
+  #     run: conda install -q -y anaconda-client "urllib3<2.0"
 
-    - name: Upload wheels to anaconda nightly
-      if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
-      shell: bash -el {0}
-      env:
-        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-      run: |
-        source ci/upload_wheels.sh
-        set_upload_vars
-        # trigger an upload to
-        # https://anaconda.org/daft-nightly/getdaft
-        # for cron jobs or "Run workflow" (restricted to main branch).
-        # Tags will upload to
-        # https://anaconda.org/daft/getdaft
-        # The tokens were originally generated at anaconda.org
-        upload_wheels
+  #   - name: Upload wheels to anaconda nightly
+  #     if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
+  #     shell: bash -el {0}
+  #     env:
+  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+  #     run: |
+  #       source ci/upload_wheels.sh
+  #       set_upload_vars
+  #       # trigger an upload to
+  #       # https://anaconda.org/daft-nightly/getdaft
+  #       # for cron jobs or "Run workflow" (restricted to main branch).
+  #       # Tags will upload to
+  #       # https://anaconda.org/daft/getdaft
+  #       # The tokens were originally generated at anaconda.org
+  #       upload_wheels
 
-    - name: Send Slack notification on failure
-      uses: slackapi/slack-github-action@v1.24.0
-      if: failure()
-      with:
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-                }
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  #   - name: Send Slack notification on failure
+  #     uses: slackapi/slack-github-action@v1.24.0
+  #     if: failure()
+  #     with:
+  #       payload: |
+  #         {
+  #           "blocks": [
+  #             {
+  #               "type": "section",
+  #               "text": {
+  #                 "type": "mrkdwn",
+  #                 "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+  #               }
+  #             }
+  #           ]
+  #         }
+  #     env:
+  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "maturin"
-requires = ["maturin>=0.14,<0.15"]
+requires = ["maturin>=1.2.0,<1.3.0"]
 
 [project]
 authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]


### PR DESCRIPTION
* Downgrade container version to use `manylinux_2_24` so we can publish manylinux2014 wheels so that older versions of pip will work with daft.