### PR TITLE
[FEAT] [New Query Planner] Add optimization framework and `PushDownFilter` rule.

### DIFF
--- a/daft/logical/rust_logical_plan.py
+++ b/daft/logical/rust_logical_plan.py
@@ -46,8 +46,8 @@ class RustLogicalPlanBuilder(LogicalPlanBuilder):
         return self._builder.repr_ascii()
 
     def optimize(self) -> RustLogicalPlanBuilder:
-        # TODO(Clark): Add optimization framework.
-        return self
+        builder = self._builder.optimize()
+        return RustLogicalPlanBuilder(builder)
 
     @classmethod
     def from_in_memory_scan(
@@ -222,7 +222,6 @@ class RustLogicalPlanBuilder(LogicalPlanBuilder):
             left_columns = ExpressionsProjection.from_schema(self.schema())
             right_columns = ExpressionsProjection([col(f.name) for f in right.schema() if f.name not in right_drop_set])
             output_projection = left_columns.union(right_columns, rename_dup="right.")
-            left_columns = left_columns
             right_columns = ExpressionsProjection(list(output_projection)[len(left_columns) :])
             output_schema = left_columns.resolve_schema(self.schema()).union(
                 right_columns.resolve_schema(right.schema())

--- a/src/daft-dsl/src/functions/float/mod.rs
+++ b/src/daft-dsl/src/functions/float/mod.rs
@@ -7,7 +7,7 @@ use crate::Expr;
 
 use super::FunctionEvaluator;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum FloatExpr {
     IsNan,
 }

--- a/src/daft-dsl/src/functions/image/mod.rs
+++ b/src/daft-dsl/src/functions/image/mod.rs
@@ -15,7 +15,7 @@ use crate::Expr;
 
 use super::FunctionEvaluator;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum ImageExpr {
     Decode(),
     Encode { image_format: ImageFormat },

--- a/src/daft-dsl/src/functions/list/mod.rs
+++ b/src/daft-dsl/src/functions/list/mod.rs
@@ -11,7 +11,7 @@ use crate::Expr;
 
 use super::FunctionEvaluator;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum ListExpr {
     Explode,
     Join,

--- a/src/daft-dsl/src/functions/mod.rs
+++ b/src/daft-dsl/src/functions/mod.rs
@@ -23,7 +23,7 @@ use python::PythonUDF;
 
 use super::Expr;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum FunctionExpr {
     Numeric(NumericExpr),
     Float(FloatExpr),

--- a/src/daft-dsl/src/functions/numeric/mod.rs
+++ b/src/daft-dsl/src/functions/numeric/mod.rs
@@ -7,7 +7,7 @@ use crate::Expr;
 
 use super::FunctionEvaluator;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum NumericExpr {
     Abs,
 }

--- a/src/daft-dsl/src/functions/python/mod.rs
+++ b/src/daft-dsl/src/functions/python/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Expr;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PythonUDF {
     func: partial_udf::PartialUDF,
     num_expressions: usize,

--- a/src/daft-dsl/src/functions/python/partial_udf.rs
+++ b/src/daft-dsl/src/functions/python/partial_udf.rs
@@ -1,3 +1,5 @@
+use std::hash::{Hash, Hasher};
+
 use pyo3::{
     types::{PyBytes, PyModule},
     PyObject, Python, ToPyObject,
@@ -60,5 +62,14 @@ impl<'de> Deserialize<'de> for PartialUDF {
 impl PartialEq for PartialUDF {
     fn eq(&self, other: &Self) -> bool {
         Python::with_gil(|py| self.0.as_ref(py).eq(other.0.as_ref(py)).unwrap())
+    }
+}
+
+impl Eq for PartialUDF {}
+
+impl Hash for PartialUDF {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let py_obj_hash = Python::with_gil(|py| self.0.as_ref(py).hash().unwrap());
+        py_obj_hash.hash(state)
     }
 }

--- a/src/daft-dsl/src/functions/temporal/mod.rs
+++ b/src/daft-dsl/src/functions/temporal/mod.rs
@@ -12,7 +12,7 @@ use crate::Expr;
 
 use super::FunctionEvaluator;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum TemporalExpr {
     Day,
     Month,

--- a/src/daft-dsl/src/functions/uri/mod.rs
+++ b/src/daft-dsl/src/functions/uri/mod.rs
@@ -11,7 +11,7 @@ use super::FunctionEvaluator;
 
 use daft_io::config::IOConfig;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum UriExpr {
     Download {
         max_connections: usize,

--- a/src/daft-dsl/src/functions/utf8/mod.rs
+++ b/src/daft-dsl/src/functions/utf8/mod.rs
@@ -13,7 +13,7 @@ use crate::Expr;
 
 use super::FunctionEvaluator;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Utf8Expr {
     EndsWith,
     StartsWith,

--- a/src/daft-dsl/src/optimization.rs
+++ b/src/daft-dsl/src/optimization.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use super::expr::{AggExpr, Expr};
 
 pub fn get_required_columns(e: &Expr) -> Vec<String> {
@@ -53,6 +55,78 @@ pub fn requires_computation(e: &Expr) -> bool {
         | Expr::Not(..)
         | Expr::IsNull(..)
         | Expr::IfElse { .. } => true,
+    }
+}
+
+pub fn replace_columns_with_expressions(expr: &Expr, replace_map: &HashMap<String, Expr>) -> Expr {
+    // Constructs a new deep-copied Expr which is `expr` but with all occurrences of Column(column_name) recursively
+    // replaced with `new_expr` for all column_name -> new_expr mappings in replace_map.
+    match expr {
+        // BASE CASE: found a matching column
+        Expr::Column(name) => match replace_map.get(&name.to_string()) {
+            Some(replacement) => replacement.clone(),
+            None => expr.clone(),
+        },
+
+        // BASE CASE: reached non-matching leaf node
+        Expr::Literal(_) => expr.clone(),
+
+        // RECURSIVE CASE: recursively replace for matching column
+        Expr::Alias(child, name) => Expr::Alias(
+            replace_columns_with_expressions(child, replace_map).into(),
+            (*name).clone(),
+        ),
+        Expr::Agg(agg) => match agg {
+            AggExpr::Count(child, mode) => Expr::Agg(AggExpr::Count(
+                replace_columns_with_expressions(child, replace_map).into(),
+                *mode,
+            )),
+            AggExpr::Sum(child) => Expr::Agg(AggExpr::Sum(
+                replace_columns_with_expressions(child, replace_map).into(),
+            )),
+            AggExpr::Mean(child) => Expr::Agg(AggExpr::Mean(
+                replace_columns_with_expressions(child, replace_map).into(),
+            )),
+            AggExpr::Min(child) => Expr::Agg(AggExpr::Min(
+                replace_columns_with_expressions(child, replace_map).into(),
+            )),
+            AggExpr::Max(child) => Expr::Agg(AggExpr::Max(
+                replace_columns_with_expressions(child, replace_map).into(),
+            )),
+            AggExpr::List(child) => Expr::Agg(AggExpr::List(
+                replace_columns_with_expressions(child, replace_map).into(),
+            )),
+            AggExpr::Concat(child) => Expr::Agg(AggExpr::List(
+                replace_columns_with_expressions(child, replace_map).into(),
+            )),
+        },
+        Expr::BinaryOp { left, right, op } => Expr::BinaryOp {
+            op: *op,
+            left: replace_columns_with_expressions(left, replace_map).into(),
+            right: replace_columns_with_expressions(right, replace_map).into(),
+        },
+        Expr::Cast(child, name) => Expr::Cast(
+            replace_columns_with_expressions(child, replace_map).into(),
+            (*name).clone(),
+        ),
+        Expr::Function { inputs, func } => Expr::Function {
+            func: func.clone(),
+            inputs: inputs
+                .iter()
+                .map(|e| replace_columns_with_expressions(e, replace_map))
+                .collect(),
+        },
+        Expr::Not(child) => replace_columns_with_expressions(child, replace_map),
+        Expr::IsNull(child) => replace_columns_with_expressions(child, replace_map),
+        Expr::IfElse {
+            if_true,
+            if_false,
+            predicate,
+        } => Expr::IfElse {
+            if_true: replace_columns_with_expressions(if_true, replace_map).into(),
+            if_false: replace_columns_with_expressions(if_false, replace_map).into(),
+            predicate: replace_columns_with_expressions(predicate, replace_map).into(),
+        },
     }
 }
 

--- a/src/daft-dsl/src/pyobject.rs
+++ b/src/daft-dsl/src/pyobject.rs
@@ -1,3 +1,5 @@
+use std::hash::{Hash, Hasher};
+
 use pyo3::prelude::*;
 
 use serde::{
@@ -18,6 +20,15 @@ impl PartialEq for DaftPyObject {
                 .eq(other.pyobject.as_ref(py))
                 .unwrap()
         })
+    }
+}
+
+impl Eq for DaftPyObject {}
+
+impl Hash for DaftPyObject {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let py_obj_hash = Python::with_gil(|py| self.pyobject.as_ref(py).hash().unwrap());
+        py_obj_hash.hash(state)
     }
 }
 

--- a/src/daft-dsl/src/python.rs
+++ b/src/daft-dsl/src/python.rs
@@ -107,16 +107,7 @@ impl PyExpr {
     }
 
     pub fn _input_mapping(&self) -> PyResult<Option<String>> {
-        let required_columns = optimization::get_required_columns(&self.expr);
-        let requires_computation = optimization::requires_computation(&self.expr);
-
-        // Return the required column only if:
-        //   1. There is only one required column
-        //   2. No computation is run on this required column
-        match (&required_columns[..], requires_computation) {
-            ([required_col], false) => Ok(Some(required_col.clone())),
-            _ => Ok(None),
-        }
+        Ok(self.expr.input_mapping())
     }
 
     pub fn _required_columns(&self) -> PyResult<HashSet<String>> {

--- a/src/daft-plan/Cargo.toml
+++ b/src/daft-plan/Cargo.toml
@@ -12,7 +12,7 @@ serde = {workspace = true, features = ["rc"]}
 
 [features]
 default = ["python"]
-python = ["dep:pyo3"]
+python = ["dep:pyo3", "common-error/python", "daft-core/python", "daft-dsl/python", "daft-io/python", "daft-table/python"]
 
 [package]
 edition = {workspace = true}

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 
-use crate::{logical_plan::LogicalPlan, ResourceRequest};
+use crate::{logical_plan::LogicalPlan, optimization::Optimizer, ResourceRequest};
 
 #[cfg(feature = "python")]
 use {
@@ -24,6 +24,7 @@ use {
 #[cfg_attr(feature = "python", pyclass)]
 #[derive(Debug)]
 pub struct LogicalPlanBuilder {
+    // The current root of the logical plan in this builder.
     plan: Arc<LogicalPlan>,
 }
 
@@ -53,8 +54,7 @@ impl LogicalPlanBuilder {
             partition_spec.clone().into(),
         )
         .into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     #[staticmethod]
@@ -76,8 +76,7 @@ impl LogicalPlanBuilder {
             partition_spec.into(),
         )
         .into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn project(
@@ -97,21 +96,18 @@ impl LogicalPlanBuilder {
             self.plan.clone(),
         )
         .into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn filter(&self, predicate: &PyExpr) -> PyResult<LogicalPlanBuilder> {
         let logical_plan: LogicalPlan =
             ops::Filter::new(predicate.expr.clone(), self.plan.clone()).into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn limit(&self, limit: i64) -> PyResult<LogicalPlanBuilder> {
         let logical_plan: LogicalPlan = ops::Limit::new(limit, self.plan.clone()).into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn explode(
@@ -129,8 +125,7 @@ impl LogicalPlanBuilder {
             self.plan.clone(),
         )
         .into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn sort(
@@ -138,11 +133,15 @@ impl LogicalPlanBuilder {
         sort_by: Vec<PyExpr>,
         descending: Vec<bool>,
     ) -> PyResult<LogicalPlanBuilder> {
+        if sort_by.is_empty() {
+            return Err(PyValueError::new_err(
+                "df.sort() must be given at least one column/expression to sort by",
+            ));
+        }
         let sort_by_exprs: Vec<Expr> = sort_by.iter().map(|expr| expr.clone().into()).collect();
         let logical_plan: LogicalPlan =
             ops::Sort::new(sort_by_exprs, descending, self.plan.clone()).into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn repartition(
@@ -162,21 +161,18 @@ impl LogicalPlanBuilder {
             self.plan.clone(),
         )
         .into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn coalesce(&self, num_partitions: usize) -> PyResult<LogicalPlanBuilder> {
         let logical_plan: LogicalPlan =
             ops::Coalesce::new(num_partitions, self.plan.clone()).into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn distinct(&self) -> PyResult<LogicalPlanBuilder> {
         let logical_plan: LogicalPlan = ops::Distinct::new(self.plan.clone()).into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn aggregate(
@@ -185,6 +181,7 @@ impl LogicalPlanBuilder {
         groupby_exprs: Vec<PyExpr>,
     ) -> PyResult<LogicalPlanBuilder> {
         use crate::ops::Aggregate;
+        // TODO(Clark): Move validation into Aggregate::new() (changing it to a ::try_new()).
         let agg_exprs = agg_exprs
             .iter()
             .map(|expr| match &expr.expr {
@@ -218,8 +215,7 @@ impl LogicalPlanBuilder {
             self.plan.clone(),
         )
         .into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn join(
@@ -253,13 +249,13 @@ impl LogicalPlanBuilder {
             self.plan.clone(),
         )
         .into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn concat(&self, other: &Self) -> PyResult<LogicalPlanBuilder> {
         let self_schema = self.plan.schema();
         let other_schema = other.plan.schema();
+        // TODO(Clark): Move validation into Concat::new() (changing it to a ::try_new()).
         if self_schema != other_schema {
             return Err(PyValueError::new_err(format!(
                 "Both DataFrames must have the same schema to concatenate them, but got: {}, {}",
@@ -268,8 +264,7 @@ impl LogicalPlanBuilder {
         }
         let logical_plan: LogicalPlan =
             ops::Concat::new(other.plan.clone(), self.plan.clone()).into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
     }
 
     pub fn table_write(
@@ -294,8 +289,13 @@ impl LogicalPlanBuilder {
             self.plan.clone(),
         )
         .into();
-        let logical_plan_builder = LogicalPlanBuilder::new(logical_plan.into());
-        Ok(logical_plan_builder)
+        Ok(logical_plan.into())
+    }
+
+    pub fn optimize(&self) -> PyResult<LogicalPlanBuilder> {
+        let optimizer = Optimizer::new();
+        let new_plan = optimizer.optimize(self.plan.clone(), &Default::default())?;
+        Ok(Self::new(new_plan))
     }
 
     pub fn schema(&self) -> PyResult<PySchema> {
@@ -313,5 +313,11 @@ impl LogicalPlanBuilder {
 
     pub fn repr_ascii(&self) -> PyResult<String> {
         Ok(self.plan.repr_ascii())
+    }
+}
+
+impl From<LogicalPlan> for LogicalPlanBuilder {
+    fn from(plan: LogicalPlan) -> Self {
+        Self::new(plan.into())
     }
 }

--- a/src/daft-plan/src/lib.rs
+++ b/src/daft-plan/src/lib.rs
@@ -3,6 +3,7 @@ mod display;
 mod join;
 mod logical_plan;
 mod ops;
+mod optimization;
 mod partitioning;
 mod physical_ops;
 mod physical_plan;

--- a/src/daft-plan/src/ops/agg.rs
+++ b/src/daft-plan/src/ops/agg.rs
@@ -54,9 +54,9 @@ impl Aggregate {
         let mut res = vec![];
         res.push(format!("Aggregation: {:?}", self.aggregations));
         if !self.groupby.is_empty() {
-            res.push(format!("  Group by: {:?}", self.groupby));
+            res.push(format!("Group by = {:?}", self.groupby));
         }
-        res.push(format!("  Output schema: {}", self.schema().short_string()));
+        res.push(format!("Output schema = {}", self.schema().short_string()));
         res
     }
 }

--- a/src/daft-plan/src/ops/join.rs
+++ b/src/daft-plan/src/ops/join.rs
@@ -40,15 +40,40 @@ impl Join {
 
     pub fn multiline_display(&self) -> Vec<String> {
         let mut res = vec![];
-        res.push(format!("Join ({}):", self.join_type));
-        if !self.left_on.is_empty() {
-            res.push(format!("  Left on: {:?}", self.left_on));
-        }
-        if !self.right_on.is_empty() {
-            res.push(format!("  Right on: {:?}", self.left_on));
+        res.push(format!("Join: Type = {}", self.join_type));
+        if !self.left_on.is_empty() && !self.right_on.is_empty() && self.left_on == self.right_on {
+            res.push(format!(
+                "On = {}",
+                self.left_on
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        } else {
+            if !self.left_on.is_empty() {
+                res.push(format!(
+                    "Left on = {}",
+                    self.left_on
+                        .iter()
+                        .map(|e| e.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            if !self.right_on.is_empty() {
+                res.push(format!(
+                    "Right on = {}",
+                    self.right_on
+                        .iter()
+                        .map(|e| e.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
         }
         res.push(format!(
-            "  Output schema: {}",
+            "Output schema = {}",
             self.output_schema.short_string()
         ));
         res

--- a/src/daft-plan/src/ops/repartition.rs
+++ b/src/daft-plan/src/ops/repartition.rs
@@ -30,12 +30,17 @@ impl Repartition {
 
     pub fn multiline_display(&self) -> Vec<String> {
         let mut res = vec![];
-        res.push(format!(
-            "Repartition ({:?}): n={}",
-            self.scheme, self.num_partitions
-        ));
+        res.push(format!("Repartition: Scheme = {:?}", self.scheme));
+        res.push(format!("Number of partitions = {}", self.num_partitions));
         if !self.partition_by.is_empty() {
-            res.push(format!("  Partition by: {:?}", self.partition_by));
+            res.push(format!(
+                "Partition by = {}",
+                self.partition_by
+                    .iter()
+                    .map(|e| e.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
         }
         res
     }

--- a/src/daft-plan/src/ops/sink.rs
+++ b/src/daft-plan/src/ops/sink.rs
@@ -42,15 +42,15 @@ impl Sink {
             }) => {
                 res.push(format!("Sink: {:?}", file_format));
                 if let Some(partition_cols) = partition_cols {
-                    res.push(format!("  Partition cols: {:?}", partition_cols));
+                    res.push(format!("Partition cols = {:?}", partition_cols));
                 }
                 if let Some(compression) = compression {
-                    res.push(format!("  Compression: {:?}", compression));
+                    res.push(format!("Compression = {:?}", compression));
                 }
-                res.push(format!("  Root dir: {:?}", root_dir));
+                res.push(format!("Root dir = {:?}", root_dir));
             }
         }
-        res.push(format!("  Output schema: {}", self.schema.short_string()));
+        res.push(format!("Output schema = {}", self.schema.short_string()));
         res
     }
 }

--- a/src/daft-plan/src/ops/sort.rs
+++ b/src/daft-plan/src/ops/sort.rs
@@ -23,22 +23,16 @@ impl Sort {
 
     pub fn multiline_display(&self) -> Vec<String> {
         let mut res = vec![];
-        res.push("Sort:".to_string());
-        if !self.sort_by.is_empty() {
-            let pairs: Vec<String> = self
-                .sort_by
-                .iter()
-                .zip(self.descending.iter())
-                .map(|(sb, d)| {
-                    format!(
-                        "({:?}, {})",
-                        sb,
-                        if *d { "descending" } else { "ascending" },
-                    )
-                })
-                .collect();
-            res.push(format!("  Sort by: {:?}", pairs));
-        }
+        // Must have at least one expression to sort by.
+        assert!(!self.sort_by.is_empty());
+        let pairs = self
+            .sort_by
+            .iter()
+            .zip(self.descending.iter())
+            .map(|(sb, d)| format!("({}, {})", sb, if *d { "descending" } else { "ascending" },))
+            .collect::<Vec<_>>()
+            .join(", ");
+        res.push(format!("Sort: Sort by = {}", pairs));
         res
     }
 }

--- a/src/daft-plan/src/ops/source.rs
+++ b/src/daft-plan/src/ops/source.rs
@@ -51,23 +51,20 @@ impl Source {
             }) => {
                 res.push(format!("Source: {:?}", file_format_config.var_name()));
                 for fp in file_info.file_paths.iter() {
-                    res.push(format!("  {}", fp));
+                    res.push(format!("File paths = {}", fp));
                 }
-                res.push(format!("  File schema: {}", schema.short_string()));
-                res.push(format!(
-                    "  Format-specific config: {:?}",
-                    file_format_config
-                ));
+                res.push(format!("File schema = {}", schema.short_string()));
+                res.push(format!("Format-specific config = {:?}", file_format_config));
             }
             #[cfg(feature = "python")]
             SourceInfo::InMemoryInfo(_) => {}
         }
-        res.push(format!("  Output schema: {}", self.schema.short_string()));
+        res.push(format!("Output schema = {}", self.schema.short_string()));
         if !self.filters.is_empty() {
-            res.push(format!("  Filters: {:?}", self.filters));
+            res.push(format!("Filters = {:?}", self.filters));
         }
         if let Some(limit) = self.limit {
-            res.push(format!("  Limit: {}", limit));
+            res.push(format!("Limit = {}", limit));
         }
         res
     }

--- a/src/daft-plan/src/optimization/mod.rs
+++ b/src/daft-plan/src/optimization/mod.rs
@@ -1,0 +1,4 @@
+mod optimizer;
+mod rules;
+
+pub use optimizer::Optimizer;

--- a/src/daft-plan/src/optimization/optimizer.rs
+++ b/src/daft-plan/src/optimization/optimizer.rs
@@ -1,0 +1,128 @@
+use std::sync::Arc;
+
+use common_error::DaftResult;
+
+use crate::LogicalPlan;
+
+use super::rules::{ApplyOrder, OptimizerRule, PushDownFilter};
+
+pub struct OptimizerConfig {
+    // Maximum number of optimization passes the optimizer will make over the logical plan.
+    pub max_optimizer_passes: usize,
+}
+
+impl OptimizerConfig {
+    fn new(max_optimizer_passes: usize) -> Self {
+        OptimizerConfig {
+            max_optimizer_passes,
+        }
+    }
+}
+
+impl Default for OptimizerConfig {
+    fn default() -> Self {
+        OptimizerConfig::new(3usize)
+    }
+}
+
+/// Logical rule-based optimizer.
+pub struct Optimizer {
+    pub rules: Vec<Arc<dyn OptimizerRule>>,
+}
+
+impl Optimizer {
+    pub fn new() -> Self {
+        let rules: Vec<Arc<dyn OptimizerRule>> = vec![Arc::new(PushDownFilter::new())];
+        Self::with_rules(rules)
+    }
+    pub fn with_rules(rules: Vec<Arc<dyn OptimizerRule>>) -> Self {
+        Self { rules }
+    }
+
+    pub fn optimize(
+        &self,
+        plan: Arc<LogicalPlan>,
+        config: &OptimizerConfig,
+    ) -> DaftResult<Arc<LogicalPlan>> {
+        let mut new_plan = plan.clone();
+        let mut i = 0;
+        while i < config.max_optimizer_passes {
+            for rule in &self.rules {
+                let result = self.optimize_with_rule(rule, &new_plan);
+                match result {
+                    Ok(Some(plan)) => {
+                        new_plan = plan;
+                    }
+                    Ok(None) => {}
+                    // TODO(Clark): Return nice optimization error to user.
+                    Err(e) => panic!("Optimization failed: {:?}", e),
+                }
+            }
+            // TODO(Clark): Terminate optimization loop if logical plan has not changed on this optimization pass.
+            i += 1;
+        }
+        Ok(new_plan)
+    }
+
+    pub fn optimize_with_rule(
+        &self,
+        rule: &Arc<dyn OptimizerRule>,
+        plan: &Arc<LogicalPlan>,
+    ) -> DaftResult<Option<Arc<LogicalPlan>>> {
+        match rule.apply_order() {
+            Some(ApplyOrder::TopDown) => {
+                // First optimize the current node, and then it's children.
+                let curr_opt = self.optimize_node(rule, plan)?;
+                let children_opt = match &curr_opt {
+                    Some(opt_plan) => self.optimize_children(rule, opt_plan)?,
+                    None => self.optimize_children(rule, plan)?,
+                };
+                Ok(children_opt.or(curr_opt))
+            }
+            Some(ApplyOrder::BottomUp) => {
+                // First optimize the current node's children, and then the current node.
+                let children_opt = self.optimize_children(rule, plan)?;
+                let curr_opt = match &children_opt {
+                    Some(opt_plan) => self.optimize_node(rule, opt_plan)?,
+                    None => self.optimize_node(rule, plan)?,
+                };
+                Ok(curr_opt.or(children_opt))
+            }
+            None => rule.try_optimize(plan.as_ref()),
+        }
+    }
+
+    fn optimize_node(
+        &self,
+        rule: &Arc<dyn OptimizerRule>,
+        plan: &Arc<LogicalPlan>,
+    ) -> DaftResult<Option<Arc<LogicalPlan>>> {
+        // TODO(Clark): Add optimization rule batching.
+        rule.try_optimize(plan.as_ref())
+    }
+
+    fn optimize_children(
+        &self,
+        rule: &Arc<dyn OptimizerRule>,
+        plan: &LogicalPlan,
+    ) -> DaftResult<Option<Arc<LogicalPlan>>> {
+        // Run optimization rule on children.
+        let children = plan.children();
+        let result = children
+            .iter()
+            .map(|child_plan| self.optimize_with_rule(rule, child_plan))
+            .collect::<DaftResult<Vec<_>>>()?;
+        // If the optimization rule didn't change any of the children, return without modifying the plan.
+        if result.is_empty() || result.iter().all(|o| o.is_none()) {
+            return Ok(None);
+        }
+        // Otherwise, update that parent to point to its optimized children.
+        let new_children = result
+            .into_iter()
+            .zip(children.iter())
+            .map(|(opt_child, old_child)| opt_child.unwrap_or_else(|| (*old_child).clone()))
+            .collect::<Vec<_>>();
+
+        Ok(Some(plan.with_new_children(&new_children)))
+    }
+}

--- a/src/daft-plan/src/optimization/rules/mod.rs
+++ b/src/daft-plan/src/optimization/rules/mod.rs
@@ -1,0 +1,6 @@
+mod push_down_filter;
+mod rule;
+mod utils;
+
+pub use push_down_filter::PushDownFilter;
+pub use rule::{ApplyOrder, OptimizerRule};

--- a/src/daft-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_filter.rs
@@ -1,0 +1,542 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use common_error::DaftResult;
+use daft_dsl::{
+    col,
+    optimization::{get_required_columns, replace_columns_with_expressions},
+    Expr,
+};
+
+use crate::{
+    ops::{Concat, Filter, Project},
+    LogicalPlan,
+};
+
+use super::{
+    utils::{conjuct, split_conjuction},
+    ApplyOrder, OptimizerRule,
+};
+
+/// Optimization rules for pushing Filters further into the logical plan.
+
+#[derive(Default)]
+pub struct PushDownFilter {}
+
+impl PushDownFilter {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for PushDownFilter {
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::TopDown)
+    }
+
+    fn try_optimize(&self, plan: &LogicalPlan) -> DaftResult<Option<Arc<LogicalPlan>>> {
+        let filter = match plan {
+            LogicalPlan::Filter(filter) => filter,
+            _ => return Ok(None),
+        };
+        let child_plan = filter.input.as_ref();
+        let new_plan = match child_plan {
+            LogicalPlan::Filter(child_filter) => {
+                // Combine filters.
+                //
+                // Filter-Filter --> Filter
+
+                // Split predicate expression on conjunctions (ANDs).
+                let parent_predicates = split_conjuction(&filter.predicate);
+                let predicate_set: HashSet<&&Expr> = parent_predicates.iter().collect();
+                // Add child predicate expressions to parent predicate expressions, eliminating duplicates.
+                let new_predicates = parent_predicates
+                    .iter()
+                    .chain(
+                        split_conjuction(&child_filter.predicate)
+                            .iter()
+                            .filter(|e| !predicate_set.contains(e)),
+                    )
+                    .map(|e| (*e).clone())
+                    .collect::<Vec<_>>();
+                // Reconjunct predicate expressions.
+                let new_predicate = conjuct(new_predicates).unwrap();
+                let new_filter: LogicalPlan =
+                    Filter::new(new_predicate, child_filter.input.clone()).into();
+                self.try_optimize(&new_filter)?.unwrap_or(new_filter.into())
+            }
+            LogicalPlan::Project(child_project) => {
+                // Commute filter with projection if predicate only depends on projection columns that
+                // don't involve compute.
+                //
+                // Filter-Projection --> {Filter-}Projection-Filter
+                let predicates = split_conjuction(&filter.predicate);
+                let projection_input_mapping = child_project
+                    .projection
+                    .iter()
+                    .filter_map(|e| {
+                        e.input_mapping()
+                            .map(|s| (e.name().unwrap().to_string(), col(s)))
+                    })
+                    .collect::<HashMap<String, Expr>>();
+                // Split predicate expressions into those that don't depend on projection compute (can_push) and those
+                // that do (can_not_push).
+                // TODO(Clark): Push Filters depending on Projection columns involving compute if those expressions are
+                // (1) determinstic && (pure || idempotent),
+                // (2) inexpensive to recompute.
+                // This can be done by rewriting the Filter predicate expression to contain the relevant Projection expression.
+                let mut can_push = vec![];
+                let mut can_not_push = vec![];
+                for predicate in predicates {
+                    let predicate_cols = get_required_columns(predicate);
+                    if predicate_cols
+                        .iter()
+                        .all(|col| projection_input_mapping.contains_key(col))
+                    {
+                        // Can push predicate through expression.
+                        let new_predicate =
+                            replace_columns_with_expressions(predicate, &projection_input_mapping);
+                        can_push.push(new_predicate);
+                    } else {
+                        // Can't push predicate expression through projection.
+                        can_not_push.push(predicate.clone());
+                    }
+                }
+                if can_push.is_empty() {
+                    // No predicate expressions can be pushed through projection.
+                    return Ok(None);
+                }
+                // Create new Filter with predicates that can be pushed past Projection.
+                let push_down_predicate = conjuct(can_push).unwrap();
+                let push_down_filter: LogicalPlan =
+                    Filter::new(push_down_predicate, child_project.input.clone()).into();
+                // Create new Projection.
+                let new_projection: LogicalPlan = Project::new(
+                    child_project.projection.clone(),
+                    child_project.projected_schema.clone(),
+                    child_project.resource_request.clone(),
+                    push_down_filter.into(),
+                )
+                .into();
+                if can_not_push.is_empty() {
+                    // If all Filter predicate expressions were pushable past Projection, return new
+                    // Projection-Filter subplan.
+                    new_projection.into()
+                } else {
+                    // Otherwise, add a Filter after Projection that filters with predicate expressions
+                    // that couldn't be pushed past the Projection, returning a Filter-Projection-Filter subplan.
+                    let post_projection_predicate = conjuct(can_not_push).unwrap();
+                    let post_projection_filter: LogicalPlan =
+                        Filter::new(post_projection_predicate, new_projection.into()).into();
+                    post_projection_filter.into()
+                }
+            }
+            LogicalPlan::Sort(_) | LogicalPlan::Repartition(_) | LogicalPlan::Coalesce(_) => {
+                // Naive commuting with unary ops.
+                let new_filter = plan.with_new_children(&[child_plan.children()[0].clone()]);
+                child_plan.with_new_children(&[new_filter])
+            }
+            LogicalPlan::Concat(Concat { input, other }) => {
+                // Push filter into each side of the concat.
+                let new_input: LogicalPlan =
+                    Filter::new(filter.predicate.clone(), input.clone()).into();
+                let new_other: LogicalPlan =
+                    Filter::new(filter.predicate.clone(), other.clone()).into();
+                let new_concat: LogicalPlan =
+                    Concat::new(new_other.into(), new_input.into()).into();
+                new_concat.into()
+            }
+            LogicalPlan::Join(child_join) => {
+                // Push filter into each side of the join.
+                // TODO(Clark): Merge filter predicate with on predicate, if present.
+                // TODO(Clark): Duplicate filters for joined columns so filters can be pushed down to both sides.
+
+                // Get all input columns for predicate.
+                let predicate_cols: HashSet<_> = get_required_columns(&filter.predicate)
+                    .iter()
+                    .cloned()
+                    .collect();
+                // Only push the filter into the left side of the join if the left side of the join has all columns
+                // required by the predicate.
+                let left_cols: HashSet<_> =
+                    child_join.input.schema().names().iter().cloned().collect();
+                let can_push_left = left_cols
+                    .intersection(&predicate_cols)
+                    .collect::<HashSet<_>>()
+                    .len()
+                    == predicate_cols.len();
+                // Only push the filter into the right side of the join if the right side of the join has all columns
+                // required by the predicate.
+                let right_cols: HashSet<_> =
+                    child_join.right.schema().names().iter().cloned().collect();
+                let can_push_right = right_cols
+                    .intersection(&predicate_cols)
+                    .collect::<HashSet<_>>()
+                    .len()
+                    == predicate_cols.len();
+                if !can_push_left && !can_push_right {
+                    return Ok(None);
+                }
+                let new_left: Arc<LogicalPlan> = if can_push_left {
+                    LogicalPlan::from(Filter::new(
+                        filter.predicate.clone(),
+                        child_join.input.clone(),
+                    ))
+                    .into()
+                } else {
+                    child_join.input.clone()
+                };
+                let new_right: Arc<LogicalPlan> = if can_push_right {
+                    LogicalPlan::from(Filter::new(
+                        filter.predicate.clone(),
+                        child_join.right.clone(),
+                    ))
+                    .into()
+                } else {
+                    child_join.right.clone()
+                };
+                child_plan.with_new_children(&[new_left, new_right])
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(new_plan))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_error::DaftResult;
+    use daft_core::{datatypes::Field, schema::Schema, DataType};
+    use daft_dsl::{col, lit};
+
+    use crate::{
+        display::TreeDisplay,
+        ops::{Coalesce, Concat, Filter, Join, Project, Repartition, Sort, Source},
+        optimization::{rules::PushDownFilter, Optimizer},
+        source_info::{ExternalInfo, FileFormatConfig, FileInfo, SourceInfo},
+        JoinType, JsonSourceConfig, LogicalPlan, PartitionScheme, PartitionSpec,
+    };
+
+    fn assert_optimized_plan_eq(plan: Arc<LogicalPlan>, expected: &str) -> DaftResult<()> {
+        let optimizer = Optimizer::with_rules(vec![Arc::new(PushDownFilter::new())]);
+        let optimized_plan = optimizer
+            .optimize_with_rule(optimizer.rules.get(0).unwrap(), &plan)?
+            .unwrap_or_else(|| plan.clone());
+        let mut formatted_plan = String::new();
+        optimized_plan.fmt_tree_indent_style(0, &mut formatted_plan)?;
+        println!("{}", formatted_plan);
+        assert_eq!(formatted_plan, expected);
+
+        Ok(())
+    }
+
+    fn dummy_scan_node(fields: Vec<Field>) -> Source {
+        let schema = Arc::new(Schema::new(fields).unwrap());
+        Source::new(
+            schema.clone(),
+            SourceInfo::ExternalInfo(ExternalInfo::new(
+                schema.clone(),
+                FileInfo::new(vec!["/foo".to_string()], None, None, None).into(),
+                FileFormatConfig::Json(JsonSourceConfig {}).into(),
+            ))
+            .into(),
+            PartitionSpec::default().into(),
+        )
+    }
+
+    #[test]
+    fn filter_combine_with_filter() -> DaftResult<()> {
+        let source: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let first_filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), source.into()).into();
+        let second_filter: LogicalPlan =
+            Filter::new(col("b").eq(&lit("foo")), first_filter.into()).into();
+        let expected = "\
+        Filter: [col(b) == lit(\"foo\")] & [col(a) < lit(2)]\
+        \n  Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)";
+        assert_optimized_plan_eq(second_filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_commutes_with_projection() -> DaftResult<()> {
+        let source: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let projection: LogicalPlan = Project::new(
+            vec![col("a")],
+            Schema::new(vec![source.schema().get_field("a")?.clone()])?.into(),
+            Default::default(),
+            source.into(),
+        )
+        .into();
+        let filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), projection.into()).into();
+        let expected = "\
+        Project: col(a)\
+        \n  Filter: col(a) < lit(2)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_commutes_with_projection_multi() -> DaftResult<()> {
+        let source: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let projection: LogicalPlan = Project::new(
+            vec![col("a"), col("b")],
+            source.schema().clone(),
+            Default::default(),
+            source.into(),
+        )
+        .into();
+        let filter: LogicalPlan = Filter::new(
+            col("a").lt(&lit(2)).and(&col("b").eq(&lit("foo"))),
+            projection.into(),
+        )
+        .into();
+        let expected = "\
+        Project: col(a), col(b)\
+        \n  Filter: [col(a) < lit(2)] & [col(b) == lit(\"foo\")]\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_does_not_commute_with_projection_if_compute() -> DaftResult<()> {
+        let source: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        // Projection involves compute on filtered column "a".
+        let projection: LogicalPlan = Project::new(
+            vec![col("a") + lit(1)],
+            Schema::new(vec![source.schema().get_field("a")?.clone()])?.into(),
+            Default::default(),
+            source.into(),
+        )
+        .into();
+        let filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), projection.into()).into();
+        // Filter should NOT commute with Project, since this would involve redundant computation.
+        let expected = "\
+        Filter: col(a) < lit(2)\
+        \n  Project: col(a) + lit(1)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    // REASON - No expression attribute indicating whether deterministic && (pure || idempotent).
+    #[ignore]
+    #[test]
+    fn filter_commutes_with_projection_deterministic_compute() -> DaftResult<()> {
+        let source: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let projection: LogicalPlan = Project::new(
+            vec![col("a") + lit(1)],
+            Schema::new(vec![source.schema().get_field("a")?.clone()])?.into(),
+            Default::default(),
+            source.into(),
+        )
+        .into();
+        let filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), projection.into()).into();
+        let expected = "\
+        Project: col(a) + lit(1)\
+        \n  Filter: [col(a) + lit(1)] < lit(2)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_commutes_with_sort() -> DaftResult<()> {
+        let source: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let sort: LogicalPlan = Sort::new(vec![col("a")], vec![true], source.into()).into();
+        let filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), sort.into()).into();
+        let expected = "\
+        Sort: Sort by = (col(a), descending)\
+        \n  Filter: col(a) < lit(2)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)";
+        // TODO(Clark): For tests in which we only care about reordering of operators, maybe switch to a form that leverages the single-node display?
+        // let expected = format!("{sort}\n  {filter}\n    {source}");
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_commutes_with_repartition() -> DaftResult<()> {
+        let source: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let repartition: LogicalPlan =
+            Repartition::new(1, vec![col("a")], PartitionScheme::Hash, source.into()).into();
+        let filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), repartition.into()).into();
+        let expected = "\
+        Repartition: Scheme = Hash, Number of partitions = 1, Partition by = col(a)\
+        \n  Filter: col(a) < lit(2)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_commutes_with_coalesce() -> DaftResult<()> {
+        let source: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let coalesce: LogicalPlan = Coalesce::new(1, source.into()).into();
+        let filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), coalesce.into()).into();
+        let expected = "\
+        Coalesce: To = 1\
+        \n  Filter: col(a) < lit(2)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_commutes_with_concat() -> DaftResult<()> {
+        let fields = vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ];
+        let source1: LogicalPlan = dummy_scan_node(fields.clone()).into();
+        let source2: LogicalPlan = dummy_scan_node(fields).into();
+        let concat: LogicalPlan = Concat::new(source2.into(), source1.into()).into();
+        let filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), concat.into()).into();
+        let expected = "\
+        Concat\
+        \n  Filter: col(a) < lit(2)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)\
+        \n  Filter: col(a) < lit(2)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_commutes_with_join_left_side() -> DaftResult<()> {
+        let source1: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let source2: LogicalPlan = dummy_scan_node(vec![
+            Field::new("b", DataType::Utf8),
+            Field::new("c", DataType::Float64),
+        ])
+        .into();
+        let output_schema = source1.schema().union(source2.schema().as_ref())?;
+        let join: LogicalPlan = Join::new(
+            source2.into(),
+            vec![col("b")],
+            vec![col("b")],
+            vec![],
+            output_schema.into(),
+            JoinType::Inner,
+            source1.into(),
+        )
+        .into();
+        let filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), join.into()).into();
+        let expected = "\
+        Join: Type = Inner, On = col(b), Output schema = a (Int64), b (Utf8), c (Float64)\
+        \n  Filter: col(a) < lit(2)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)\
+        \n  Source: \"Json\", File paths = /foo, File schema = b (Utf8), c (Float64), Format-specific config = Json(JsonSourceConfig), Output schema = b (Utf8), c (Float64)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_commutes_with_join_right_side() -> DaftResult<()> {
+        let source1: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let source2: LogicalPlan = dummy_scan_node(vec![
+            Field::new("b", DataType::Utf8),
+            Field::new("c", DataType::Float64),
+        ])
+        .into();
+        let output_schema = source1.schema().union(source2.schema().as_ref())?;
+        let join: LogicalPlan = Join::new(
+            source2.into(),
+            vec![col("b")],
+            vec![col("b")],
+            vec![],
+            output_schema.into(),
+            JoinType::Inner,
+            source1.into(),
+        )
+        .into();
+        let filter: LogicalPlan = Filter::new(col("c").lt(&lit(2.0)), join.into()).into();
+        let expected = "\
+        Join: Type = Inner, On = col(b), Output schema = a (Int64), b (Utf8), c (Float64)\
+        \n  Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8)\
+        \n  Filter: col(c) < lit(2.0)\
+        \n    Source: \"Json\", File paths = /foo, File schema = b (Utf8), c (Float64), Format-specific config = Json(JsonSourceConfig), Output schema = b (Utf8), c (Float64)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn filter_commutes_with_join_both_sides() -> DaftResult<()> {
+        let source1: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+            Field::new("c", DataType::Float64),
+        ])
+        .into();
+        let source2: LogicalPlan = dummy_scan_node(vec![
+            Field::new("b", DataType::Utf8),
+            Field::new("c", DataType::Float64),
+        ])
+        .into();
+        let output_schema = source1.schema().union(source2.schema().as_ref())?;
+        let join: LogicalPlan = Join::new(
+            source2.into(),
+            vec![col("b")],
+            vec![col("b")],
+            vec![],
+            output_schema.into(),
+            JoinType::Inner,
+            source1.into(),
+        )
+        .into();
+        let filter: LogicalPlan = Filter::new(col("c").lt(&lit(2.0)), join.into()).into();
+        let expected = "\
+        Join: Type = Inner, On = col(b), Output schema = a (Int64), b (Utf8), c (Float64)\
+        \n  Filter: col(c) < lit(2.0)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), b (Utf8), c (Float64), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64), b (Utf8), c (Float64)\
+        \n  Filter: col(c) < lit(2.0)\
+        \n    Source: \"Json\", File paths = /foo, File schema = b (Utf8), c (Float64), Format-specific config = Json(JsonSourceConfig), Output schema = b (Utf8), c (Float64)";
+        assert_optimized_plan_eq(filter.into(), expected)?;
+        Ok(())
+    }
+}

--- a/src/daft-plan/src/optimization/rules/rule.rs
+++ b/src/daft-plan/src/optimization/rules/rule.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+
+use common_error::DaftResult;
+
+use crate::LogicalPlan;
+
+pub enum ApplyOrder {
+    TopDown,
+    #[allow(dead_code)]
+    BottomUp,
+}
+
+// TODO(Clark): Add fixed-point policy if needed.
+pub trait OptimizerRule {
+    /// Try to optimize the logical plan with this rule.
+    ///
+    /// This returns Some(new_plan) if the rule modified the plan, None otherwise.
+    fn try_optimize(&self, plan: &LogicalPlan) -> DaftResult<Option<Arc<LogicalPlan>>>;
+
+    /// The plan tree order in which this rule should be applied (top-down or bottom-up).
+    fn apply_order(&self) -> Option<ApplyOrder>;
+}

--- a/src/daft-plan/src/optimization/rules/utils.rs
+++ b/src/daft-plan/src/optimization/rules/utils.rs
@@ -1,0 +1,28 @@
+use daft_dsl::{Expr, Operator};
+
+pub fn split_conjuction(expr: &Expr) -> Vec<&Expr> {
+    let mut splits = vec![];
+    _split_conjuction(expr, &mut splits);
+    splits
+}
+
+fn _split_conjuction<'a>(expr: &'a Expr, out_exprs: &mut Vec<&'a Expr>) {
+    match expr {
+        Expr::BinaryOp {
+            op: Operator::And,
+            left,
+            right,
+        } => {
+            _split_conjuction(left, out_exprs);
+            _split_conjuction(right, out_exprs);
+        }
+        Expr::Alias(inner_expr, ..) => _split_conjuction(inner_expr, out_exprs),
+        _ => {
+            out_exprs.push(expr);
+        }
+    }
+}
+
+pub fn conjuct(exprs: Vec<Expr>) -> Option<Expr> {
+    exprs.into_iter().reduce(|acc, expr| acc.and(&expr))
+}


### PR DESCRIPTION
This PR adds an optimization framework for the new query planner, along with a proof-of-concept port of our existing [`PushDownPredicates` rule](https://github.com/Eventual-Inc/Daft/blob/857162ce8df7b83b4fd583d432b3abf3145eac32/daft/logical/optimizer.py#L25-L141) as a new `PushDownFilter` rule.

For this first optimization parity pass, we will be opting for a more direct port rather than changing the semantics of the optimization rules, although I've left TODOs for how we can potentially improve the rules.

# Major Change Summary

## Logical Plan Changes
- Added an indentation-style plan visualization, which makes writing tests easier. The biggest change to the existing git-style visualization is that only the first line for an op will use the `Foo: Bar` syntax, with the rest using an equals separator `Baz = Quux`.

## Expression Changes
- `Expr`s now derive `Eq` and `Hash`, where the hashing/equality semantics are in terms of a single table/relation; the hash implementation can serve as alternative intra-table semantic ID compared to `Expr::semantic_id()`. We could extend this to be e.g. invariant under operand commuting for commutative operators by changing how we hash operands (hash the operands, sort the hashes, hash the sorted hash list).
- For expression rewriting, I've added `replace_columns_with_expressions`, which takes a column name --> new expression map; this allows us to rewrite expressions in batches so we're not duplicating the tree traversal + cloning.

# TODOs (future PRs)

- [ ] Add remaining rules to reach parity with status quo
- [ ] Add rule batching
- [ ] Add fixed-point policy
- [ ] Add optimization loop termination of logical plan hasn't changed (requires logical plan equality and/or hashing, although we can stopgap with a small refactor that tracks whether any rules have changed the plan on a given optimization pass)
- [ ] Update `PushDownFilter` rules with misc. improvements noted as TODOs in the code
- [ ] Add Python-agnostic `LogicalPlanBuilder` on the Rust side that tests can use for easily building up logical plans; the current pyo3-laden `LogicalPlanBuilder` could be turned into a thin `PyAny` --> Rust type adapter layer on top of the former.