### PR TITLE
[CHORE] Implement growables for array types

### DIFF
--- a/src/daft-core/src/array/growable/arrow_growable.rs
+++ b/src/daft-core/src/array/growable/arrow_growable.rs
@@ -47,14 +47,17 @@ where
     T: DaftArrowBackedType,
     DataArray<T>: IntoSeries,
 {
+    #[inline]
     fn extend(&mut self, index: usize, start: usize, len: usize) {
         self.arrow2_growable.extend(index, start, len);
     }
 
+    #[inline]
     fn add_nulls(&mut self, additional: usize) {
         self.arrow2_growable.extend_validity(additional)
     }
 
+    #[inline]
     fn build(&mut self) -> DaftResult<DataArray<T>> {
         let arrow_array = self.arrow2_growable.as_box();
         let field = Field::new(self.name.clone(), self.dtype.clone());
@@ -84,14 +87,15 @@ impl<'a> ArrowExtensionGrowable<'a> {
 }
 
 impl<'a> Growable<DataArray<ExtensionType>> for ArrowExtensionGrowable<'a> {
+    #[inline]
     fn extend(&mut self, index: usize, start: usize, len: usize) {
         self.child_growable.extend(index, start, len)
     }
-
+    #[inline]
     fn add_nulls(&mut self, additional: usize) {
         self.child_growable.extend_validity(additional)
     }
-
+    #[inline]
     fn build(&mut self) -> DaftResult<DataArray<ExtensionType>> {
         let arr = self.child_growable.as_box();
         let field = Field::new(self.name.clone(), self.dtype.clone());

--- a/src/daft-core/src/array/growable/arrow_growable.rs
+++ b/src/daft-core/src/array/growable/arrow_growable.rs
@@ -1,0 +1,113 @@
+use std::{marker::PhantomData, sync::Arc};
+
+use common_error::DaftResult;
+
+use crate::{
+    array::{
+        ops::{as_arrow::AsArrow, from_arrow::FromArrow},
+        DataArray,
+    },
+    datatypes::{DaftArrowBackedType, DaftDataType, Field},
+    with_match_arrow_backed_physical_types, DataType, IntoSeries, Series,
+};
+
+use super::Growable;
+
+pub struct ArrowGrowable<'a, T: DaftDataType, G: arrow2::array::growable::Growable<'a>>
+where
+    T: DaftArrowBackedType,
+    DataArray<T>: IntoSeries,
+{
+    name: String,
+    dtype: DataType,
+    arrow2_growable: G,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T: DaftDataType, G: arrow2::array::growable::Growable<'a>> ArrowGrowable<'a, T, G>
+where
+    T: DaftArrowBackedType,
+    DataArray<T>: IntoSeries,
+{
+    pub fn new(name: String, dtype: &DataType, arrow2_growable: G) -> Self {
+        Self {
+            name,
+            dtype: dtype.clone(),
+            arrow2_growable,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, T: DaftDataType, G: arrow2::array::growable::Growable<'a>> Growable
+    for ArrowGrowable<'a, T, G>
+where
+    T: DaftArrowBackedType,
+    DataArray<T>: IntoSeries,
+{
+    fn extend(&mut self, index: usize, start: usize, len: usize) {
+        self.arrow2_growable.extend(index, start, len);
+    }
+
+    fn add_nulls(&mut self, additional: usize) {
+        self.arrow2_growable.extend_validity(additional)
+    }
+
+    fn build(&mut self) -> DaftResult<Series> {
+        let arrow_array = self.arrow2_growable.as_box();
+        let field = Field::new(self.name.clone(), self.dtype.clone());
+        Ok(DataArray::<T>::from_arrow(&field, arrow_array)?.into_series())
+    }
+}
+
+pub struct ArrowExtensionGrowable<'a> {
+    name: String,
+    dtype: DataType,
+    child_growable: Box<dyn Growable + 'a>,
+}
+
+impl<'a> ArrowExtensionGrowable<'a> {
+    pub fn new(name: String, dtype: &DataType, child_growable: Box<dyn Growable + 'a>) -> Self {
+        assert!(matches!(dtype, DataType::Extension(..)));
+        Self {
+            name,
+            dtype: dtype.clone(),
+            child_growable,
+        }
+    }
+}
+
+impl<'a> Growable for ArrowExtensionGrowable<'a> {
+    fn extend(&mut self, index: usize, start: usize, len: usize) {
+        self.child_growable.extend(index, start, len)
+    }
+
+    fn add_nulls(&mut self, additional: usize) {
+        self.child_growable.add_nulls(additional)
+    }
+
+    fn build(&mut self) -> DaftResult<Series> {
+        let child_series = self.child_growable.build()?;
+
+        // Wrap the child series with the appropriate extension type
+        match &self.dtype {
+            DataType::Extension(s1, child_dtype, s2) => {
+                let arrow_extension_type = arrow2::datatypes::DataType::Extension(
+                    s1.clone(),
+                    Box::new(child_series.data_type().to_arrow()?),
+                    s2.clone(),
+                );
+                with_match_arrow_backed_physical_types!(child_dtype.as_ref(), |$T| {
+                    // TODO: Can we downcast and move here?
+                    let child_arrow_array = child_series.downcast::<<$T as DaftDataType>::ArrayType>()?.as_arrow().clone();
+                    let child_arrow_array = child_arrow_array.to(arrow_extension_type);
+                    Ok(DataArray::<ExtensionType>::new(
+                        Arc::new(Field::new(self.name.clone(), self.dtype.clone())),
+                        Box::new(child_arrow_array),
+                    )?.into_series())
+                })
+            }
+            _ => unreachable!("ArrowExtensionGrowable must have Extension dtype"),
+        }
+    }
+}

--- a/src/daft-core/src/array/growable/arrow_growable.rs
+++ b/src/daft-core/src/array/growable/arrow_growable.rs
@@ -98,7 +98,6 @@ impl<'a> Growable for ArrowExtensionGrowable<'a> {
                     s2.clone(),
                 );
                 with_match_arrow_backed_physical_types!(child_dtype.as_ref(), |$T| {
-                    // TODO: Can we downcast and move here?
                     let child_arrow_array = child_series.downcast::<<$T as DaftDataType>::ArrayType>()?.as_arrow().clone();
                     let child_arrow_array = child_arrow_array.to(arrow_extension_type);
                     Ok(DataArray::<ExtensionType>::new(

--- a/src/daft-core/src/array/growable/logical_growable.rs
+++ b/src/daft-core/src/array/growable/logical_growable.rs
@@ -41,14 +41,15 @@ impl<'a, L: DaftLogicalType> Growable<LogicalArray<L>> for LogicalGrowable<'a, L
 where
     LogicalArray<L>: IntoSeries,
 {
+    #[inline]
     fn extend(&mut self, index: usize, start: usize, len: usize) {
         self.physical_growable.extend(index, start, len);
     }
-
+    #[inline]
     fn add_nulls(&mut self, additional: usize) {
         self.physical_growable.add_nulls(additional)
     }
-
+    #[inline]
     fn build(&mut self) -> DaftResult<LogicalArray<L>> {
         let physical_arr = self.physical_growable.build()?;
         let arr = LogicalArray::<L>::new(

--- a/src/daft-core/src/array/growable/logical_growable.rs
+++ b/src/daft-core/src/array/growable/logical_growable.rs
@@ -1,0 +1,59 @@
+use std::marker::PhantomData;
+
+use common_error::DaftResult;
+
+use crate::{
+    datatypes::{logical::LogicalArray, DaftLogicalType, Field, DaftDataType},
+    DataType, IntoSeries, Series,
+};
+
+use super::Growable;
+
+pub struct LogicalGrowable<'a, L: DaftLogicalType>
+where
+    LogicalArray<L>: IntoSeries,
+{
+    name: String,
+    dtype: DataType,
+    physical_growable: Box<dyn Growable + 'a>,
+    _phantom: PhantomData<L>,
+}
+
+impl<'a, L: DaftLogicalType> LogicalGrowable<'a, L>
+where
+    LogicalArray<L>: IntoSeries,
+{
+    pub fn new(name: String, dtype: &DataType, physical_growable: Box<dyn Growable + 'a>) -> Self {
+        Self {
+            name,
+            dtype: dtype.clone(),
+            physical_growable,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, L: DaftLogicalType> Growable for LogicalGrowable<'a, L>
+where
+    LogicalArray<L>: IntoSeries,
+{
+    fn extend(&mut self, index: usize, start: usize, len: usize) {
+        self.physical_growable.extend(index, start, len);
+    }
+
+    fn add_nulls(&mut self, additional: usize) {
+        self.physical_growable.add_nulls(additional)
+    }
+
+    fn build(&mut self) -> DaftResult<Series> {
+        let physical_series = self.physical_growable.build()?;
+        let arr = LogicalArray::<L>::new(
+            Field::new(self.name.clone(), self.dtype.clone()),
+            // TODO: is it possible to avoid the clone here with a .downcast_move() -> DataArray?
+            // I don't think so because going from Series (multiple owners) to DataArray (single owner)
+            // isn't safe to move.
+            physical_series.downcast::<<L::PhysicalType as DaftDataType>::ArrayType>()?.clone(),
+        );
+        Ok(arr.into_series())
+    }
+}

--- a/src/daft-core/src/array/growable/logical_growable.rs
+++ b/src/daft-core/src/array/growable/logical_growable.rs
@@ -49,9 +49,6 @@ where
         let physical_series = self.physical_growable.build()?;
         let arr = LogicalArray::<L>::new(
             Field::new(self.name.clone(), self.dtype.clone()),
-            // TODO: is it possible to avoid the clone here with a .downcast_move() -> DataArray?
-            // I don't think so because going from Series (multiple owners) to DataArray (single owner)
-            // isn't safe to move.
             physical_series.downcast::<<L::PhysicalType as DaftDataType>::ArrayType>()?.clone(),
         );
         Ok(arr.into_series())

--- a/src/daft-core/src/array/growable/mod.rs
+++ b/src/daft-core/src/array/growable/mod.rs
@@ -1,0 +1,412 @@
+use common_error::DaftResult;
+
+use crate::{
+    datatypes::{self, DaftDataType, DaftLogicalType},
+    DataType, Series,
+};
+
+use super::ops::as_arrow::AsArrow;
+
+mod arrow_growable;
+mod logical_growable;
+
+#[cfg(feature = "python")]
+mod python_growable;
+
+/// Describes a struct that can be extended from slices of other pre-existing Series.
+/// This is very useful for abstracting many "physical" operations such as takes, broadcasts,
+/// filters and more.
+pub trait Growable {
+    /// Extends this [`Growable`] with elements from the bounded [`Array`] at index `index` from
+    /// a slice starting at `start` and length `len`.
+    /// # Panic
+    /// This function panics if the range is out of bounds, i.e. if `start + len >= array.len()`.
+    fn extend(&mut self, index: usize, start: usize, len: usize);
+
+    /// Extends this [`Growable`] with null elements
+    fn add_nulls(&mut self, additional: usize);
+
+    /// Builds an array from the [`Growable`]
+    fn build(&mut self) -> DaftResult<Series>;
+}
+
+type ArrowNullGrowable<'a> =
+    arrow_growable::ArrowGrowable<'a, datatypes::NullType, arrow2::array::growable::GrowableNull>;
+type ArrowBooleanGrowable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::BooleanType,
+    arrow2::array::growable::GrowableBoolean<'a>,
+>;
+type ArrowInt8Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::Int8Type,
+    arrow2::array::growable::GrowablePrimitive<'a, i8>,
+>;
+type ArrowInt16Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::Int16Type,
+    arrow2::array::growable::GrowablePrimitive<'a, i16>,
+>;
+type ArrowInt32Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::Int32Type,
+    arrow2::array::growable::GrowablePrimitive<'a, i32>,
+>;
+type ArrowInt64Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::Int64Type,
+    arrow2::array::growable::GrowablePrimitive<'a, i64>,
+>;
+type ArrowInt128Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::Int128Type,
+    arrow2::array::growable::GrowablePrimitive<'a, i128>,
+>;
+type ArrowUInt8Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::UInt8Type,
+    arrow2::array::growable::GrowablePrimitive<'a, u8>,
+>;
+type ArrowUInt16Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::UInt16Type,
+    arrow2::array::growable::GrowablePrimitive<'a, u16>,
+>;
+type ArrowUInt32Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::UInt32Type,
+    arrow2::array::growable::GrowablePrimitive<'a, u32>,
+>;
+type ArrowUInt64Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::UInt64Type,
+    arrow2::array::growable::GrowablePrimitive<'a, u64>,
+>;
+// type ArrowFloat16Growable<'a> = ArrowGrowable<'a, datatypes::Float16Type, arrow2::array::growable::GrowablePrimitive::<'a, f16>>;
+type ArrowFloat32Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::Float32Type,
+    arrow2::array::growable::GrowablePrimitive<'a, f32>,
+>;
+type ArrowFloat64Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::Float64Type,
+    arrow2::array::growable::GrowablePrimitive<'a, f64>,
+>;
+type ArrowBinaryGrowable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::BinaryType,
+    arrow2::array::growable::GrowableBinary<'a, i64>,
+>;
+type ArrowUtf8Growable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::Utf8Type,
+    arrow2::array::growable::GrowableUtf8<'a, i64>,
+>;
+type ArrowListGrowable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::ListType,
+    arrow2::array::growable::GrowableList<'a, i64>,
+>;
+type ArrowStructGrowable<'a> = arrow_growable::ArrowGrowable<
+    'a,
+    datatypes::StructType,
+    arrow2::array::growable::GrowableStruct<'a>,
+>;
+
+/// Helper macro to downcast a series to its underlying concrete arrow array type
+macro_rules! series_to_arrow_array {
+    ($series:ident, $daft_type:path) => {
+        $series
+            .iter()
+            .map(|s| s.downcast::<<$daft_type as DaftDataType>::ArrayType>().unwrap().as_arrow())
+            .collect::<Vec<_>>()
+    };
+}
+
+pub fn make_growable<'a>(
+    name: String,
+    dtype: &DataType,
+    series: &'a [&'a Series],
+    capacity: usize,
+) -> Box<dyn Growable + 'a> {
+    match dtype {
+        // Arrow-backed types
+        DataType::Null => Box::new(ArrowNullGrowable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowableNull::new(dtype.to_arrow().unwrap()),
+        )),
+        DataType::Boolean => Box::new(ArrowBooleanGrowable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowableBoolean::new(
+                series_to_arrow_array!(series, datatypes::BooleanType),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Int8 => Box::new(ArrowInt8Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<i8>::new(
+                series_to_arrow_array!(series, datatypes::Int8Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Int16 => Box::new(ArrowInt16Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<i16>::new(
+                series_to_arrow_array!(series, datatypes::Int16Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Int32 => Box::new(ArrowInt32Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<i32>::new(
+                series_to_arrow_array!(series, datatypes::Int32Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Int64 => Box::new(ArrowInt64Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<i64>::new(
+                series_to_arrow_array!(series, datatypes::Int64Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Int128 => Box::new(ArrowInt128Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<i128>::new(
+                series_to_arrow_array!(series, datatypes::Int128Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::UInt8 => Box::new(ArrowUInt8Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<u8>::new(
+                series_to_arrow_array!(series, datatypes::UInt8Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::UInt16 => Box::new(ArrowUInt16Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<u16>::new(
+                series_to_arrow_array!(series, datatypes::UInt16Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::UInt32 => Box::new(ArrowUInt32Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<u32>::new(
+                series_to_arrow_array!(series, datatypes::UInt32Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::UInt64 => Box::new(ArrowUInt64Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<u64>::new(
+                series_to_arrow_array!(series, datatypes::UInt64Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Float32 => Box::new(ArrowFloat32Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<f32>::new(
+                series_to_arrow_array!(series, datatypes::Float32Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Float64 => Box::new(ArrowFloat64Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowablePrimitive::<f64>::new(
+                series_to_arrow_array!(series, datatypes::Float64Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Binary => Box::new(ArrowBinaryGrowable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowableBinary::<i64>::new(
+                series_to_arrow_array!(series, datatypes::BinaryType),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Utf8 => Box::new(ArrowUtf8Growable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowableUtf8::<i64>::new(
+                series_to_arrow_array!(series, datatypes::Utf8Type),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::List(..) => Box::new(ArrowListGrowable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowableList::<i64>::new(
+                series_to_arrow_array!(series, datatypes::ListType),
+                false,
+                capacity,
+            ),
+        )),
+        DataType::Struct(..) => Box::new(ArrowStructGrowable::new(
+            name,
+            dtype,
+            arrow2::array::growable::GrowableStruct::new(
+                series_to_arrow_array!(series, datatypes::StructType),
+                false,
+                capacity,
+            ),
+        )),
+
+        // Logical types
+        DataType::Extension(_, child_dtype, _) => {
+            Box::new(arrow_growable::ArrowExtensionGrowable::new(
+                name.clone(),
+                dtype,
+                make_growable(name, child_dtype.as_ref(), series, capacity),
+            ))
+        }
+        DataType::Timestamp(..) => Box::new(logical_growable::LogicalGrowable::<
+            datatypes::TimestampType,
+        >::new(
+            name.clone(),
+            dtype,
+            make_growable(
+                name,
+                &<datatypes::TimestampType as DaftLogicalType>::PhysicalType::get_dtype(),
+                series,
+                capacity,
+            ),
+        )),
+        DataType::Duration(..) => Box::new(logical_growable::LogicalGrowable::<
+            datatypes::DurationType,
+        >::new(
+            name.clone(),
+            dtype,
+            make_growable(
+                name,
+                &<datatypes::DurationType as DaftLogicalType>::PhysicalType::get_dtype(),
+                series,
+                capacity,
+            ),
+        )),
+        DataType::Date => Box::new(
+            logical_growable::LogicalGrowable::<datatypes::DateType>::new(
+                name.clone(),
+                dtype,
+                make_growable(
+                    name,
+                    &<datatypes::DateType as DaftLogicalType>::PhysicalType::get_dtype(),
+                    series,
+                    capacity,
+                ),
+            ),
+        ),
+        DataType::Embedding(..) => Box::new(logical_growable::LogicalGrowable::<
+            datatypes::EmbeddingType,
+        >::new(
+            name.clone(),
+            dtype,
+            make_growable(
+                name,
+                &<datatypes::DurationType as DaftLogicalType>::PhysicalType::get_dtype(),
+                series,
+                capacity,
+            ),
+        )),
+        DataType::FixedShapeImage(..) => Box::new(logical_growable::LogicalGrowable::<
+            datatypes::FixedShapeImageType,
+        >::new(
+            name.clone(),
+            dtype,
+            make_growable(
+                name,
+                &<datatypes::FixedShapeImageType as DaftLogicalType>::PhysicalType::get_dtype(),
+                series,
+                capacity,
+            ),
+        )),
+        DataType::FixedShapeTensor(..) => Box::new(logical_growable::LogicalGrowable::<
+            datatypes::FixedShapeTensorType,
+        >::new(
+            name.clone(),
+            dtype,
+            make_growable(
+                name,
+                &<datatypes::FixedShapeTensorType as DaftLogicalType>::PhysicalType::get_dtype(),
+                series,
+                capacity,
+            ),
+        )),
+        DataType::Image(..) => Box::new(
+            logical_growable::LogicalGrowable::<datatypes::ImageType>::new(
+                name.clone(),
+                dtype,
+                make_growable(
+                    name,
+                    &<datatypes::ImageType as DaftLogicalType>::PhysicalType::get_dtype(),
+                    series,
+                    capacity,
+                ),
+            ),
+        ),
+        DataType::Tensor(..) => Box::new(
+            logical_growable::LogicalGrowable::<datatypes::TensorType>::new(
+                name.clone(),
+                dtype,
+                make_growable(
+                    name,
+                    &<datatypes::TensorType as DaftLogicalType>::PhysicalType::get_dtype(),
+                    series,
+                    capacity,
+                ),
+            ),
+        ),
+        DataType::Decimal128(..) => Box::new(logical_growable::LogicalGrowable::<
+            datatypes::Decimal128Type,
+        >::new(
+            name.clone(),
+            dtype,
+            make_growable(
+                name,
+                &<datatypes::Decimal128Type as DaftLogicalType>::PhysicalType::get_dtype(),
+                series,
+                capacity,
+            ),
+        )),
+
+        #[cfg(feature = "python")]
+        DataType::Python => Box::new(python_growable::PythonGrowable::new(
+            name, dtype, series, capacity,
+        )),
+
+        // Custom arrays
+        DataType::FixedSizeList(..) => todo!("Implement growable for FixedSizeList"),
+        DataType::Time(..) => unimplemented!("Cannot create growable for Time type"),
+        DataType::Unknown => panic!("Cannot create growable for unknown type"),
+    }
+}

--- a/src/daft-core/src/array/growable/mod.rs
+++ b/src/daft-core/src/array/growable/mod.rs
@@ -1,17 +1,28 @@
 use common_error::DaftResult;
 
 use crate::{
-    datatypes::{self, DaftDataType, DaftLogicalType},
+    datatypes::{
+        logical::LogicalArray, BinaryArray, BinaryType, BooleanArray, BooleanType, DaftLogicalType,
+        DateType, Decimal128Type, DurationType, EmbeddingType, ExtensionArray, FixedShapeImageType,
+        FixedShapeTensorType, FixedSizeListArray, FixedSizeListType, Float32Array, Float32Type,
+        Float64Array, Float64Type, ImageType, Int128Array, Int128Type, Int16Array, Int16Type,
+        Int32Array, Int32Type, Int64Array, Int64Type, Int8Array, Int8Type, ListArray, ListType,
+        NullArray, NullType, StructArray, StructType, TensorType, TimestampType, UInt16Array,
+        UInt16Type, UInt32Array, UInt32Type, UInt64Array, UInt64Type, UInt8Array, UInt8Type,
+        Utf8Array, Utf8Type,
+    },
     DataType, Series,
 };
 
-use super::ops::as_arrow::AsArrow;
+use super::{ops::as_arrow::AsArrow, DataArray};
 
 mod arrow_growable;
 mod logical_growable;
 
 #[cfg(feature = "python")]
 mod python_growable;
+#[cfg(feature = "python")]
+use crate::datatypes::PythonArray;
 
 /// Describes a struct that can be extended from slices of other pre-existing Series.
 /// This is very useful for abstracting many "physical" operations such as takes, broadcasts,
@@ -31,382 +42,270 @@ pub trait Growable {
 }
 
 type ArrowNullGrowable<'a> =
-    arrow_growable::ArrowGrowable<'a, datatypes::NullType, arrow2::array::growable::GrowableNull>;
-type ArrowBooleanGrowable<'a> = arrow_growable::ArrowGrowable<
-    'a,
-    datatypes::BooleanType,
-    arrow2::array::growable::GrowableBoolean<'a>,
->;
-type ArrowInt8Growable<'a> = arrow_growable::ArrowGrowable<
-    'a,
-    datatypes::Int8Type,
-    arrow2::array::growable::GrowablePrimitive<'a, i8>,
->;
+    arrow_growable::ArrowGrowable<'a, NullType, arrow2::array::growable::GrowableNull>;
+type ArrowBooleanGrowable<'a> =
+    arrow_growable::ArrowGrowable<'a, BooleanType, arrow2::array::growable::GrowableBoolean<'a>>;
+type ArrowInt8Growable<'a> =
+    arrow_growable::ArrowGrowable<'a, Int8Type, arrow2::array::growable::GrowablePrimitive<'a, i8>>;
 type ArrowInt16Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::Int16Type,
+    Int16Type,
     arrow2::array::growable::GrowablePrimitive<'a, i16>,
 >;
 type ArrowInt32Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::Int32Type,
+    Int32Type,
     arrow2::array::growable::GrowablePrimitive<'a, i32>,
 >;
 type ArrowInt64Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::Int64Type,
+    Int64Type,
     arrow2::array::growable::GrowablePrimitive<'a, i64>,
 >;
 type ArrowInt128Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::Int128Type,
+    Int128Type,
     arrow2::array::growable::GrowablePrimitive<'a, i128>,
 >;
 type ArrowUInt8Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::UInt8Type,
+    UInt8Type,
     arrow2::array::growable::GrowablePrimitive<'a, u8>,
 >;
 type ArrowUInt16Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::UInt16Type,
+    UInt16Type,
     arrow2::array::growable::GrowablePrimitive<'a, u16>,
 >;
 type ArrowUInt32Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::UInt32Type,
+    UInt32Type,
     arrow2::array::growable::GrowablePrimitive<'a, u32>,
 >;
 type ArrowUInt64Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::UInt64Type,
+    UInt64Type,
     arrow2::array::growable::GrowablePrimitive<'a, u64>,
 >;
-// type ArrowFloat16Growable<'a> = ArrowGrowable<'a, datatypes::Float16Type, arrow2::array::growable::GrowablePrimitive::<'a, f16>>;
 type ArrowFloat32Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::Float32Type,
+    Float32Type,
     arrow2::array::growable::GrowablePrimitive<'a, f32>,
 >;
 type ArrowFloat64Growable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::Float64Type,
+    Float64Type,
     arrow2::array::growable::GrowablePrimitive<'a, f64>,
 >;
-type ArrowBinaryGrowable<'a> = arrow_growable::ArrowGrowable<
+type ArrowBinaryGrowable<'a> =
+    arrow_growable::ArrowGrowable<'a, BinaryType, arrow2::array::growable::GrowableBinary<'a, i64>>;
+type ArrowUtf8Growable<'a> =
+    arrow_growable::ArrowGrowable<'a, Utf8Type, arrow2::array::growable::GrowableUtf8<'a, i64>>;
+type ArrowListGrowable<'a> =
+    arrow_growable::ArrowGrowable<'a, ListType, arrow2::array::growable::GrowableList<'a, i64>>;
+type ArrowFixedSizeListGrowable<'a> = arrow_growable::ArrowGrowable<
     'a,
-    datatypes::BinaryType,
-    arrow2::array::growable::GrowableBinary<'a, i64>,
+    FixedSizeListType,
+    arrow2::array::growable::GrowableFixedSizeList<'a>,
 >;
-type ArrowUtf8Growable<'a> = arrow_growable::ArrowGrowable<
-    'a,
-    datatypes::Utf8Type,
-    arrow2::array::growable::GrowableUtf8<'a, i64>,
->;
-type ArrowListGrowable<'a> = arrow_growable::ArrowGrowable<
-    'a,
-    datatypes::ListType,
-    arrow2::array::growable::GrowableList<'a, i64>,
->;
-type ArrowStructGrowable<'a> = arrow_growable::ArrowGrowable<
-    'a,
-    datatypes::StructType,
-    arrow2::array::growable::GrowableStruct<'a>,
->;
+type ArrowStructGrowable<'a> =
+    arrow_growable::ArrowGrowable<'a, StructType, arrow2::array::growable::GrowableStruct<'a>>;
 
-/// Helper macro to downcast a series to its underlying concrete arrow array type
-macro_rules! series_to_arrow_array {
-    ($series:ident, $daft_type:path) => {
-        $series
-            .iter()
-            .map(|s| s.downcast::<<$daft_type as DaftDataType>::ArrayType>().unwrap().as_arrow())
-            .collect::<Vec<_>>()
-    };
+/// Trait that an Array type can implement to provide a Growable factory method
+pub trait GrowableArray<'a, G: Growable> {
+    fn make_growable(name: String, dtype: &DataType, arrays: Vec<&'a Self>, capacity: usize) -> G;
 }
 
-pub fn make_growable<'a>(
-    name: String,
-    dtype: &DataType,
-    series: &'a [&'a Series],
-    capacity: usize,
-) -> Box<dyn Growable + 'a> {
-    match dtype {
-        // Arrow-backed types
-        DataType::Null => Box::new(ArrowNullGrowable::new(
+impl<'a> GrowableArray<'a, ArrowNullGrowable<'a>> for NullArray {
+    fn make_growable(
+        name: String,
+        dtype: &DataType,
+        _arrays: Vec<&Self>,
+        _capacity: usize,
+    ) -> ArrowNullGrowable<'a> {
+        ArrowNullGrowable::new(
             name,
             dtype,
             arrow2::array::growable::GrowableNull::new(dtype.to_arrow().unwrap()),
-        )),
-        DataType::Boolean => Box::new(ArrowBooleanGrowable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowableBoolean::new(
-                series_to_arrow_array!(series, datatypes::BooleanType),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Int8 => Box::new(ArrowInt8Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<i8>::new(
-                series_to_arrow_array!(series, datatypes::Int8Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Int16 => Box::new(ArrowInt16Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<i16>::new(
-                series_to_arrow_array!(series, datatypes::Int16Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Int32 => Box::new(ArrowInt32Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<i32>::new(
-                series_to_arrow_array!(series, datatypes::Int32Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Int64 => Box::new(ArrowInt64Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<i64>::new(
-                series_to_arrow_array!(series, datatypes::Int64Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Int128 => Box::new(ArrowInt128Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<i128>::new(
-                series_to_arrow_array!(series, datatypes::Int128Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::UInt8 => Box::new(ArrowUInt8Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<u8>::new(
-                series_to_arrow_array!(series, datatypes::UInt8Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::UInt16 => Box::new(ArrowUInt16Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<u16>::new(
-                series_to_arrow_array!(series, datatypes::UInt16Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::UInt32 => Box::new(ArrowUInt32Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<u32>::new(
-                series_to_arrow_array!(series, datatypes::UInt32Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::UInt64 => Box::new(ArrowUInt64Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<u64>::new(
-                series_to_arrow_array!(series, datatypes::UInt64Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Float32 => Box::new(ArrowFloat32Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<f32>::new(
-                series_to_arrow_array!(series, datatypes::Float32Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Float64 => Box::new(ArrowFloat64Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowablePrimitive::<f64>::new(
-                series_to_arrow_array!(series, datatypes::Float64Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Binary => Box::new(ArrowBinaryGrowable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowableBinary::<i64>::new(
-                series_to_arrow_array!(series, datatypes::BinaryType),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Utf8 => Box::new(ArrowUtf8Growable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowableUtf8::<i64>::new(
-                series_to_arrow_array!(series, datatypes::Utf8Type),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::List(..) => Box::new(ArrowListGrowable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowableList::<i64>::new(
-                series_to_arrow_array!(series, datatypes::ListType),
-                false,
-                capacity,
-            ),
-        )),
-        DataType::Struct(..) => Box::new(ArrowStructGrowable::new(
-            name,
-            dtype,
-            arrow2::array::growable::GrowableStruct::new(
-                series_to_arrow_array!(series, datatypes::StructType),
-                false,
-                capacity,
-            ),
-        )),
-
-        // Logical types
-        DataType::Extension(_, child_dtype, _) => {
-            Box::new(arrow_growable::ArrowExtensionGrowable::new(
-                name.clone(),
-                dtype,
-                make_growable(name, child_dtype.as_ref(), series, capacity),
-            ))
-        }
-        DataType::Timestamp(..) => Box::new(logical_growable::LogicalGrowable::<
-            datatypes::TimestampType,
-        >::new(
-            name.clone(),
-            dtype,
-            make_growable(
-                name,
-                &<datatypes::TimestampType as DaftLogicalType>::PhysicalType::get_dtype(),
-                series,
-                capacity,
-            ),
-        )),
-        DataType::Duration(..) => Box::new(logical_growable::LogicalGrowable::<
-            datatypes::DurationType,
-        >::new(
-            name.clone(),
-            dtype,
-            make_growable(
-                name,
-                &<datatypes::DurationType as DaftLogicalType>::PhysicalType::get_dtype(),
-                series,
-                capacity,
-            ),
-        )),
-        DataType::Date => Box::new(
-            logical_growable::LogicalGrowable::<datatypes::DateType>::new(
-                name.clone(),
-                dtype,
-                make_growable(
-                    name,
-                    &<datatypes::DateType as DaftLogicalType>::PhysicalType::get_dtype(),
-                    series,
-                    capacity,
-                ),
-            ),
-        ),
-        DataType::Embedding(..) => Box::new(logical_growable::LogicalGrowable::<
-            datatypes::EmbeddingType,
-        >::new(
-            name.clone(),
-            dtype,
-            make_growable(
-                name,
-                &<datatypes::DurationType as DaftLogicalType>::PhysicalType::get_dtype(),
-                series,
-                capacity,
-            ),
-        )),
-        DataType::FixedShapeImage(..) => Box::new(logical_growable::LogicalGrowable::<
-            datatypes::FixedShapeImageType,
-        >::new(
-            name.clone(),
-            dtype,
-            make_growable(
-                name,
-                &<datatypes::FixedShapeImageType as DaftLogicalType>::PhysicalType::get_dtype(),
-                series,
-                capacity,
-            ),
-        )),
-        DataType::FixedShapeTensor(..) => Box::new(logical_growable::LogicalGrowable::<
-            datatypes::FixedShapeTensorType,
-        >::new(
-            name.clone(),
-            dtype,
-            make_growable(
-                name,
-                &<datatypes::FixedShapeTensorType as DaftLogicalType>::PhysicalType::get_dtype(),
-                series,
-                capacity,
-            ),
-        )),
-        DataType::Image(..) => Box::new(
-            logical_growable::LogicalGrowable::<datatypes::ImageType>::new(
-                name.clone(),
-                dtype,
-                make_growable(
-                    name,
-                    &<datatypes::ImageType as DaftLogicalType>::PhysicalType::get_dtype(),
-                    series,
-                    capacity,
-                ),
-            ),
-        ),
-        DataType::Tensor(..) => Box::new(
-            logical_growable::LogicalGrowable::<datatypes::TensorType>::new(
-                name.clone(),
-                dtype,
-                make_growable(
-                    name,
-                    &<datatypes::TensorType as DaftLogicalType>::PhysicalType::get_dtype(),
-                    series,
-                    capacity,
-                ),
-            ),
-        ),
-        DataType::Decimal128(..) => Box::new(logical_growable::LogicalGrowable::<
-            datatypes::Decimal128Type,
-        >::new(
-            name.clone(),
-            dtype,
-            make_growable(
-                name,
-                &<datatypes::Decimal128Type as DaftLogicalType>::PhysicalType::get_dtype(),
-                series,
-                capacity,
-            ),
-        )),
-
-        #[cfg(feature = "python")]
-        DataType::Python => Box::new(python_growable::PythonGrowable::new(
-            name, dtype, series, capacity,
-        )),
-
-        // Custom arrays
-        DataType::FixedSizeList(..) => todo!("Implement growable for FixedSizeList"),
-        DataType::Time(..) => unimplemented!("Cannot create growable for Time type"),
-        DataType::Unknown => panic!("Cannot create growable for unknown type"),
+        )
     }
 }
+
+#[cfg(feature = "python")]
+impl<'a> GrowableArray<'a, python_growable::PythonGrowable<'a>> for PythonArray {
+    fn make_growable(
+        name: String,
+        dtype: &DataType,
+        arrays: Vec<&'a Self>,
+        capacity: usize,
+    ) -> python_growable::PythonGrowable<'a> {
+        python_growable::PythonGrowable::new(name, dtype, arrays, capacity)
+    }
+}
+
+impl<'a> GrowableArray<'a, arrow_growable::ArrowExtensionGrowable<'a>> for ExtensionArray {
+    fn make_growable(
+        name: String,
+        dtype: &DataType,
+        arrays: Vec<&'a Self>,
+        capacity: usize,
+    ) -> arrow_growable::ArrowExtensionGrowable<'a> {
+        let downcasted_arrays = arrays.iter().map(|arr| arr.data()).collect::<Vec<_>>();
+        let arrow2_growable =
+            arrow2::array::growable::make_growable(downcasted_arrays.as_slice(), false, capacity);
+        arrow_growable::ArrowExtensionGrowable::new(name, dtype, arrow2_growable)
+    }
+}
+
+macro_rules! impl_primitive_growable_array {
+    (
+        $daft_array:ident,
+        $growable:ident,
+        $arrow_growable:ty
+    ) => {
+        impl<'a> GrowableArray<'a, $growable<'a>> for $daft_array {
+            fn make_growable(
+                name: String,
+                dtype: &DataType,
+                arrays: Vec<&'a Self>,
+                capacity: usize,
+            ) -> $growable<'a> {
+                $growable::new(
+                    name,
+                    dtype,
+                    <$arrow_growable>::new(
+                        arrays.iter().map(|a| a.as_arrow()).collect::<Vec<_>>(),
+                        false,
+                        capacity,
+                    ),
+                )
+            }
+        }
+    };
+}
+
+macro_rules! impl_logical_growable_array {
+    (
+        $daft_logical_type:ident
+    ) => {
+        impl<'a> GrowableArray<'a, logical_growable::LogicalGrowable<'a, $daft_logical_type>>
+            for LogicalArray<$daft_logical_type>
+        {
+            fn make_growable(
+                name: String,
+                dtype: &DataType,
+                arrays: Vec<&'a Self>,
+                capacity: usize,
+            ) -> logical_growable::LogicalGrowable<'a, $daft_logical_type> {
+                logical_growable::LogicalGrowable::<$daft_logical_type>::new(
+                    name.clone(),
+                    dtype,
+                    Box::new(DataArray::<
+                        <$daft_logical_type as DaftLogicalType>::PhysicalType,
+                    >::make_growable(
+                        name,
+                        &dtype.to_physical(),
+                        arrays.iter().map(|a| &a.physical).collect::<Vec<_>>(),
+                        capacity,
+                    )),
+                )
+            }
+        }
+    };
+}
+
+impl_primitive_growable_array!(
+    BooleanArray,
+    ArrowBooleanGrowable,
+    arrow2::array::growable::GrowableBoolean
+);
+impl_primitive_growable_array!(
+    Int8Array,
+    ArrowInt8Growable,
+    arrow2::array::growable::GrowablePrimitive<i8>
+);
+impl_primitive_growable_array!(
+    Int16Array,
+    ArrowInt16Growable,
+    arrow2::array::growable::GrowablePrimitive<i16>
+);
+impl_primitive_growable_array!(
+    Int32Array,
+    ArrowInt32Growable,
+    arrow2::array::growable::GrowablePrimitive<i32>
+);
+impl_primitive_growable_array!(
+    Int64Array,
+    ArrowInt64Growable,
+    arrow2::array::growable::GrowablePrimitive<i64>
+);
+impl_primitive_growable_array!(
+    Int128Array,
+    ArrowInt128Growable,
+    arrow2::array::growable::GrowablePrimitive<i128>
+);
+impl_primitive_growable_array!(
+    UInt8Array,
+    ArrowUInt8Growable,
+    arrow2::array::growable::GrowablePrimitive<u8>
+);
+impl_primitive_growable_array!(
+    UInt16Array,
+    ArrowUInt16Growable,
+    arrow2::array::growable::GrowablePrimitive<u16>
+);
+impl_primitive_growable_array!(
+    UInt32Array,
+    ArrowUInt32Growable,
+    arrow2::array::growable::GrowablePrimitive<u32>
+);
+impl_primitive_growable_array!(
+    UInt64Array,
+    ArrowUInt64Growable,
+    arrow2::array::growable::GrowablePrimitive<u64>
+);
+impl_primitive_growable_array!(
+    Float32Array,
+    ArrowFloat32Growable,
+    arrow2::array::growable::GrowablePrimitive<f32>
+);
+impl_primitive_growable_array!(
+    Float64Array,
+    ArrowFloat64Growable,
+    arrow2::array::growable::GrowablePrimitive<f64>
+);
+impl_primitive_growable_array!(
+    BinaryArray,
+    ArrowBinaryGrowable,
+    arrow2::array::growable::GrowableBinary<i64>
+);
+impl_primitive_growable_array!(
+    Utf8Array,
+    ArrowUtf8Growable,
+    arrow2::array::growable::GrowableUtf8<i64>
+);
+impl_primitive_growable_array!(
+    ListArray,
+    ArrowListGrowable,
+    arrow2::array::growable::GrowableList<i64>
+);
+impl_primitive_growable_array!(
+    FixedSizeListArray,
+    ArrowFixedSizeListGrowable,
+    arrow2::array::growable::GrowableFixedSizeList
+);
+impl_primitive_growable_array!(
+    StructArray,
+    ArrowStructGrowable,
+    arrow2::array::growable::GrowableStruct
+);
+
+impl_logical_growable_array!(TimestampType);
+impl_logical_growable_array!(DurationType);
+impl_logical_growable_array!(DateType);
+impl_logical_growable_array!(EmbeddingType);
+impl_logical_growable_array!(FixedShapeImageType);
+impl_logical_growable_array!(FixedShapeTensorType);
+impl_logical_growable_array!(ImageType);
+impl_logical_growable_array!(TensorType);
+impl_logical_growable_array!(Decimal128Type);

--- a/src/daft-core/src/array/growable/python_growable.rs
+++ b/src/daft-core/src/array/growable/python_growable.rs
@@ -4,7 +4,7 @@ use pyo3;
 
 use crate::{
     array::{pseudo_arrow::PseudoArrowArray, DataArray},
-    datatypes::{Field, PythonType, PythonArray},
+    datatypes::{Field, PythonArray, PythonType},
     DataType, IntoSeries, Series,
 };
 
@@ -21,18 +21,9 @@ impl<'a> PythonGrowable<'a> {
     pub fn new(
         name: String,
         dtype: &DataType,
-        series_refs: &'a [&'a Series],
+        arr_refs: Vec<&'a PythonArray>,
         capacity: usize,
     ) -> Self {
-        for s in series_refs.iter() {
-            if s.data_type() != &DataType::Python {
-                panic!("PythonGrowable expected all Series to be of DataType::Python, but received: {}", s.data_type());
-            }
-        }
-        let arr_refs = series_refs
-            .iter()
-            .map(|s| s.downcast::<PythonArray>().unwrap())
-            .collect::<Vec<_>>();
         Self {
             name,
             dtype: dtype.clone(),

--- a/src/daft-core/src/array/growable/python_growable.rs
+++ b/src/daft-core/src/array/growable/python_growable.rs
@@ -1,0 +1,42 @@
+use pyo3;
+
+use crate::{DataType, Series};
+
+use super::Growable;
+
+pub struct PythonGrowable<'a> {
+    _name: String,
+    _dtype: DataType,
+    _series_refs: &'a [&'a Series],
+    _buffer: Vec<pyo3::PyObject>,
+}
+
+impl<'a> PythonGrowable<'a> {
+    pub fn new(
+        name: String,
+        dtype: &DataType,
+        series_refs: &'a [&'a Series],
+        capacity: usize,
+    ) -> Self {
+        Self {
+            _name: name,
+            _dtype: dtype.clone(),
+            _series_refs: series_refs,
+            _buffer: Vec::with_capacity(capacity),
+        }
+    }
+}
+
+impl<'a> Growable for PythonGrowable<'a> {
+    fn extend(&mut self, _index: usize, _start: usize, _len: usize) {
+        todo!()
+    }
+
+    fn add_nulls(&mut self, _additional: usize) {
+        todo!()
+    }
+
+    fn build(&mut self) -> common_error::DaftResult<Series> {
+        todo!()
+    }
+}

--- a/src/daft-core/src/array/growable/python_growable.rs
+++ b/src/daft-core/src/array/growable/python_growable.rs
@@ -34,6 +34,7 @@ impl<'a> PythonGrowable<'a> {
 }
 
 impl<'a> Growable<DataArray<PythonType>> for PythonGrowable<'a> {
+    #[inline]
     fn extend(&mut self, index: usize, start: usize, len: usize) {
         let arr = self.arr_refs.get(index).unwrap();
         let arr = arr.slice(start, start + len).unwrap();
@@ -50,14 +51,14 @@ impl<'a> Growable<DataArray<PythonType>> for PythonGrowable<'a> {
             }
         }
     }
-
+    #[inline]
     fn add_nulls(&mut self, additional: usize) {
         let pynone = pyo3::Python::with_gil(|py| py.None());
         for _ in 0..additional {
             self.buffer.push(pynone.clone());
         }
     }
-
+    #[inline]
     fn build(&mut self) -> common_error::DaftResult<DataArray<PythonType>> {
         let mut buf: Vec<pyo3::PyObject> = vec![];
         swap(&mut self.buffer, &mut buf);

--- a/src/daft-core/src/array/growable/python_growable.rs
+++ b/src/daft-core/src/array/growable/python_growable.rs
@@ -1,14 +1,20 @@
+use std::{mem::swap, sync::Arc};
+
 use pyo3;
 
-use crate::{DataType, Series};
+use crate::{
+    array::{pseudo_arrow::PseudoArrowArray, DataArray},
+    datatypes::{Field, PythonType, PythonArray},
+    DataType, IntoSeries, Series,
+};
 
 use super::Growable;
 
 pub struct PythonGrowable<'a> {
-    _name: String,
-    _dtype: DataType,
-    _series_refs: &'a [&'a Series],
-    _buffer: Vec<pyo3::PyObject>,
+    name: String,
+    dtype: DataType,
+    arr_refs: Vec<&'a DataArray<PythonType>>,
+    buffer: Vec<pyo3::PyObject>,
 }
 
 impl<'a> PythonGrowable<'a> {
@@ -18,25 +24,56 @@ impl<'a> PythonGrowable<'a> {
         series_refs: &'a [&'a Series],
         capacity: usize,
     ) -> Self {
+        for s in series_refs.iter() {
+            if s.data_type() != &DataType::Python {
+                panic!("PythonGrowable expected all Series to be of DataType::Python, but received: {}", s.data_type());
+            }
+        }
+        let arr_refs = series_refs
+            .iter()
+            .map(|s| s.downcast::<PythonArray>().unwrap())
+            .collect::<Vec<_>>();
         Self {
-            _name: name,
-            _dtype: dtype.clone(),
-            _series_refs: series_refs,
-            _buffer: Vec::with_capacity(capacity),
+            name,
+            dtype: dtype.clone(),
+            arr_refs,
+            buffer: Vec::with_capacity(capacity),
         }
     }
 }
 
 impl<'a> Growable for PythonGrowable<'a> {
-    fn extend(&mut self, _index: usize, _start: usize, _len: usize) {
-        todo!()
+    fn extend(&mut self, index: usize, start: usize, len: usize) {
+        let arr = self.arr_refs.get(index).unwrap();
+        let arr = arr.slice(start, start + len).unwrap();
+        let slice_to_copy = arr
+            .data()
+            .as_any()
+            .downcast_ref::<PseudoArrowArray<pyo3::PyObject>>()
+            .unwrap();
+        let pynone = pyo3::Python::with_gil(|py| py.None());
+        for obj in slice_to_copy.iter() {
+            match obj {
+                None => self.buffer.push(pynone.clone()),
+                Some(obj) => self.buffer.push(obj.clone()),
+            }
+        }
     }
 
-    fn add_nulls(&mut self, _additional: usize) {
-        todo!()
+    fn add_nulls(&mut self, additional: usize) {
+        let pynone = pyo3::Python::with_gil(|py| py.None());
+        for _ in 0..additional {
+            self.buffer.push(pynone.clone());
+        }
     }
 
     fn build(&mut self) -> common_error::DaftResult<Series> {
-        todo!()
+        let mut buf: Vec<pyo3::PyObject> = vec![];
+        swap(&mut self.buffer, &mut buf);
+
+        let field = Arc::new(Field::new(self.name.clone(), self.dtype.clone()));
+        let arr = PseudoArrowArray::<pyo3::PyObject>::from_pyobj_vec(buf);
+        let arr = DataArray::<PythonType>::new(field, Box::new(arr))?;
+        Ok(arr.into_series())
     }
 }

--- a/src/daft-core/src/array/growable/python_growable.rs
+++ b/src/daft-core/src/array/growable/python_growable.rs
@@ -5,7 +5,7 @@ use pyo3;
 use crate::{
     array::{pseudo_arrow::PseudoArrowArray, DataArray},
     datatypes::{Field, PythonArray, PythonType},
-    DataType, IntoSeries, Series,
+    DataType,
 };
 
 use super::Growable;
@@ -33,7 +33,7 @@ impl<'a> PythonGrowable<'a> {
     }
 }
 
-impl<'a> Growable for PythonGrowable<'a> {
+impl<'a> Growable<DataArray<PythonType>> for PythonGrowable<'a> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
         let arr = self.arr_refs.get(index).unwrap();
         let arr = arr.slice(start, start + len).unwrap();
@@ -58,13 +58,12 @@ impl<'a> Growable for PythonGrowable<'a> {
         }
     }
 
-    fn build(&mut self) -> common_error::DaftResult<Series> {
+    fn build(&mut self) -> common_error::DaftResult<DataArray<PythonType>> {
         let mut buf: Vec<pyo3::PyObject> = vec![];
         swap(&mut self.buffer, &mut buf);
 
         let field = Arc::new(Field::new(self.name.clone(), self.dtype.clone()));
         let arr = PseudoArrowArray::<pyo3::PyObject>::from_pyobj_vec(buf);
-        let arr = DataArray::<PythonType>::new(field, Box::new(arr))?;
-        Ok(arr.into_series())
+        DataArray::<PythonType>::new(field, Box::new(arr))
     }
 }

--- a/src/daft-core/src/array/mod.rs
+++ b/src/daft-core/src/array/mod.rs
@@ -1,4 +1,5 @@
 pub mod from;
+pub mod growable;
 pub mod iterator;
 pub mod ops;
 pub mod pseudo_arrow;

--- a/src/daft-core/src/array/ops/as_arrow.rs
+++ b/src/daft-core/src/array/ops/as_arrow.rs
@@ -8,8 +8,8 @@ use crate::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
             FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
         },
-        BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray, ListArray, StructArray,
-        Utf8Array,
+        BinaryArray, BooleanArray, DaftNumericType, FixedSizeListArray, ListArray, NullArray,
+        StructArray, Utf8Array,
     },
 };
 
@@ -59,6 +59,7 @@ macro_rules! impl_asarrow_logicalarray {
     };
 }
 
+impl_asarrow_dataarray!(NullArray, array::NullArray);
 impl_asarrow_dataarray!(Utf8Array, array::Utf8Array<i64>);
 impl_asarrow_dataarray!(BooleanArray, array::BooleanArray);
 impl_asarrow_dataarray!(BinaryArray, array::BinaryArray<i64>);

--- a/src/daft-core/src/array/ops/if_else.rs
+++ b/src/daft-core/src/array/ops/if_else.rs
@@ -3,8 +3,64 @@ use crate::array::ops::full::FullNull;
 use crate::array::DataArray;
 use crate::datatypes::logical::LogicalArrayImpl;
 use crate::datatypes::{BooleanArray, DaftLogicalType, DaftPhysicalType};
+use crate::DataType;
 use common_error::DaftResult;
 use std::convert::identity;
+
+fn generic_if_else<'a, T: GrowableArray<'a> + FullNull + Clone>(
+    predicate: &BooleanArray,
+    name: &str,
+    lhs: &'a T,
+    rhs: &'a T,
+    dtype: &DataType,
+    lhs_len: usize,
+    rhs_len: usize,
+) -> DaftResult<T> {
+    // Broadcast predicate
+    if predicate.len() == 1 {
+        return match predicate.get(0) {
+            None => Ok(T::full_null(name, dtype, lhs_len)),
+            Some(predicate_scalar_value) => {
+                if predicate_scalar_value {
+                    Ok(lhs.clone())
+                } else {
+                    Ok(rhs.clone())
+                }
+            }
+        };
+    }
+
+    // If either lhs or rhs has len == 1, we perform broadcasting by always selecting the 0th element
+    let broadcasted_getter = |_i: usize| 0usize;
+    let get_lhs = if lhs_len == 1 {
+        broadcasted_getter
+    } else {
+        identity
+    };
+    let get_rhs = if rhs_len == 1 {
+        broadcasted_getter
+    } else {
+        identity
+    };
+
+    // Build the result using a Growable
+    let mut growable = T::make_growable(name.to_string(), dtype, vec![lhs, rhs], predicate.len());
+    for (i, pred) in predicate.into_iter().enumerate() {
+        match pred {
+            None => {
+                growable.add_nulls(1);
+            }
+            Some(pred) if pred => {
+                growable.extend(0, get_lhs(i), 1);
+            }
+            Some(_) => {
+                growable.extend(1, get_rhs(i), 1);
+            }
+        }
+    }
+
+    growable.build()
+}
 
 impl<'a, T> DataArray<T>
 where
@@ -16,59 +72,15 @@ where
         other: &'a DataArray<T>,
         predicate: &BooleanArray,
     ) -> DaftResult<DataArray<T>> {
-        // Broadcast predicate case
-        if predicate.len() == 1 {
-            return match predicate.get(0) {
-                None => Ok(DataArray::full_null(
-                    self.name(),
-                    self.data_type(),
-                    self.len(),
-                )),
-                Some(predicate_scalar_value) => {
-                    if predicate_scalar_value {
-                        Ok(self.clone())
-                    } else {
-                        Ok(other.clone())
-                    }
-                }
-            };
-        }
-
-        // If either lhs or rhs has len == 1, we perform broadcasting by always selecting the 0th element
-        let broadcasted_getter = |_i: usize| 0usize;
-        let get_lhs = if self.len() == 1 {
-            broadcasted_getter
-        } else {
-            identity
-        };
-        let get_rhs = if other.len() == 1 {
-            broadcasted_getter
-        } else {
-            identity
-        };
-
-        // Build the result using a Growable
-        let mut growable = DataArray::<T>::make_growable(
-            self.name().to_string(),
+        generic_if_else(
+            predicate,
+            self.name(),
+            self,
+            other,
             self.data_type(),
-            vec![self, other],
-            predicate.len(),
-        );
-        for (i, pred) in predicate.into_iter().enumerate() {
-            match pred {
-                None => {
-                    growable.add_nulls(1);
-                }
-                Some(pred) if pred => {
-                    growable.extend(0, get_lhs(i), 1);
-                }
-                Some(_) => {
-                    growable.extend(1, get_rhs(i), 1);
-                }
-            }
-        }
-
-        growable.build()
+            self.len(),
+            other.len(),
+        )
     }
 }
 
@@ -76,67 +88,21 @@ impl<'a, L> LogicalArrayImpl<L, DataArray<L::PhysicalType>>
 where
     L: DaftLogicalType,
     LogicalArrayImpl<L, DataArray<L::PhysicalType>>: GrowableArray<'a>,
+    LogicalArrayImpl<L, DataArray<L::PhysicalType>>: FullNull,
 {
     pub fn if_else(
         &'a self,
         other: &'a LogicalArrayImpl<L, DataArray<L::PhysicalType>>,
         predicate: &BooleanArray,
     ) -> DaftResult<LogicalArrayImpl<L, DataArray<L::PhysicalType>>> {
-        // Broadcast predicate case
-        if predicate.len() == 1 {
-            return match predicate.get(0) {
-                None => Ok(LogicalArrayImpl::<L, DataArray<L::PhysicalType>>::new(
-                    self.field.clone(),
-                    DataArray::<L::PhysicalType>::full_null(
-                        self.name(),
-                        self.physical.data_type(),
-                        self.len(),
-                    ),
-                )),
-                Some(predicate_scalar_value) => {
-                    if predicate_scalar_value {
-                        Ok(self.clone())
-                    } else {
-                        Ok(other.clone())
-                    }
-                }
-            };
-        }
-
-        // If either lhs or rhs has len == 1, we perform broadcasting by always selecting the 0th element
-        let broadcasted_getter = |_i: usize| 0usize;
-        let get_lhs = if self.len() == 1 {
-            broadcasted_getter
-        } else {
-            identity
-        };
-        let get_rhs = if other.len() == 1 {
-            broadcasted_getter
-        } else {
-            identity
-        };
-
-        // Build the result using a Growable
-        let mut growable = LogicalArrayImpl::<L, DataArray<L::PhysicalType>>::make_growable(
-            self.name().to_string(),
+        generic_if_else(
+            predicate,
+            self.name(),
+            self,
+            other,
             self.data_type(),
-            vec![self, other],
-            predicate.len(),
-        );
-        for (i, pred) in predicate.into_iter().enumerate() {
-            match pred {
-                None => {
-                    growable.add_nulls(1);
-                }
-                Some(pred) if pred => {
-                    growable.extend(0, get_lhs(i), 1);
-                }
-                Some(_) => {
-                    growable.extend(1, get_rhs(i), 1);
-                }
-            }
-        }
-
-        growable.build()
+            self.len(),
+            other.len(),
+        )
     }
 }

--- a/src/daft-core/src/array/ops/if_else.rs
+++ b/src/daft-core/src/array/ops/if_else.rs
@@ -1,347 +1,143 @@
 use crate::array::ops::full::FullNull;
+use crate::array::growable::{Growable, GrowableArray};
 use crate::array::DataArray;
-use crate::datatypes::logical::{
-    DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
-    FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
-};
-use crate::datatypes::{
-    BinaryArray, BooleanArray, DaftArrowBackedType, DaftNumericType, ExtensionArray, Field,
-    FixedSizeListArray, ListArray, NullArray, StructArray, Utf8Array,
-};
-use crate::utils::arrow::arrow_bitmap_and_helper;
-use common_error::{DaftError, DaftResult};
+use crate::datatypes::logical::LogicalArrayImpl;
+use crate::datatypes::{BooleanArray, DaftLogicalType, DaftPhysicalType};
+use common_error::DaftResult;
 use std::convert::identity;
-use std::sync::Arc;
 
-use super::as_arrow::AsArrow;
-use super::broadcast::Broadcastable;
 
-#[cfg(feature = "python")]
-use crate::datatypes::PythonArray;
-
-// Helper macro for broadcasting if/else across the if_true/if_false/predicate DataArrays
-//
-// `array_type`: the Arrow2 array type that if_true/if_false should be downcasted to
-// `if_true/if_false`: the DataArrays to select data from, conditional on the predicate
-// `predicate`: the predicate boolean DataArray
-// `scalar_copy`: a simple inlined function to run on each borrowed scalar value when iterating through if_true/if_else.
-//   Note that this is potentially the identity function if Arrow2 allows for creation of this Array from borrowed data (e.g. &str)
-macro_rules! broadcast_if_else{(
-    $array_type:ty, $if_true:expr, $if_false:expr, $predicate:expr, $scalar_copy:expr, $if_then_else:expr,
-) => ({
-    match ($if_true.len(), $if_false.len(), $predicate.len()) {
-        // CASE: Equal lengths across all 3 arguments
-        (self_len, other_len, predicate_len) if self_len == other_len && other_len == predicate_len => {
-            let result = $if_then_else($predicate.as_arrow(), $if_true.data(), $if_false.data())?;
-            DataArray::try_from(($if_true.field.clone(), result))
-        },
-        // CASE: Broadcast predicate
-        (self_len, _, 1) => {
-            let predicate_scalar = $predicate.get(0);
-            match predicate_scalar {
-                None => Ok(DataArray::full_null($if_true.name(), $if_true.data_type(), self_len)),
-                Some(predicate_scalar_value) => {
-                    if predicate_scalar_value {
-                        Ok($if_true.clone())
-                    } else {
-                        Ok($if_false.clone())
-                    }
-                }
-            }
-        }
-        // CASE: Broadcast both arrays
-        (1, 1, _) => {
-            let self_scalar = $if_true.get(0);
-            let other_scalar = $if_false.get(0);
-            let predicate_arr = $predicate.as_arrow();
-            let predicate_values = predicate_arr.values();
-            let naive_if_else: $array_type = predicate_values.iter().map(
-                |pred_val| match pred_val {
-                    true => self_scalar,
-                    false => other_scalar,
-                }
-            ).collect();
-            let validity = arrow_bitmap_and_helper(predicate_arr.validity(), naive_if_else.validity());
-            DataArray::new($if_true.field.clone(), Box::new(naive_if_else.with_validity(validity)))
-        }
-        // CASE: Broadcast truthy array
-        (1, o, p)  if o == p => {
-            let self_scalar = $if_true.get(0);
-            let predicate_arr = $predicate.as_arrow();
-            let predicate_values = predicate_arr.values();
-            let naive_if_else: $array_type = $if_false.as_arrow().iter().zip(predicate_values.iter()).map(
-                |(other_val, pred_val)| match pred_val {
-                    true => self_scalar,
-                    false => $scalar_copy(other_val),
-                }
-            ).collect();
-            let validity = arrow_bitmap_and_helper(predicate_arr.validity(), naive_if_else.validity());
-            DataArray::new($if_true.field.clone(), Box::new(naive_if_else.with_validity(validity)))
-        }
-        // CASE: Broadcast falsey array
-        (s, 1, p)  if s == p => {
-            let other_scalar = $if_false.get(0);
-            let predicate_arr = $predicate.as_arrow();
-            let predicate_values = predicate_arr.values();
-            let naive_if_else: $array_type = $if_true.as_arrow().iter().zip(predicate_values.iter()).map(
-                |(self_val, pred_val)| match pred_val {
-                    true => $scalar_copy(self_val),
-                    false => other_scalar,
-                }
-            ).collect();
-            let validity = arrow_bitmap_and_helper(predicate_arr.validity(), naive_if_else.validity());
-            DataArray::new($if_true.field.clone(), Box::new(naive_if_else.with_validity(validity)))
-        }
-        (s, o, p) => Err(DaftError::ValueError(format!("Cannot run if_else against arrays with non-broadcastable lengths: self={s}, other={o}, predicate={p}")))
-    }
-})}
-
-#[inline(always)]
-fn copy_optional_native<T: DaftNumericType>(v: Option<&T::Native>) -> Option<T::Native> {
-    v.copied()
-}
-
-fn get_result_size(if_true_len: usize, if_false_len: usize, pred_len: usize) -> DaftResult<usize> {
-    let input_lengths = [if_true_len, if_false_len, pred_len];
-    let result_len = *input_lengths.iter().max().unwrap();
-    let length_error = Err(DaftError::ValueError(format!(
-        "Cannot run if_else against arrays with non-broadcastable lengths: if_true={}, if_false={}, predicate={}",
-        if_true_len, if_false_len, pred_len
-    )));
-    for len in input_lengths {
-        if len != 1 && len != result_len {
-            return length_error;
-        }
-    }
-    Ok(result_len)
-}
-
-impl<T> DataArray<T>
+impl<'a, T> DataArray<T>
 where
-    T: DaftNumericType,
+    T: DaftPhysicalType + 'static,
+    DataArray<T>: GrowableArray<'a>,
 {
     pub fn if_else(
-        &self,
-        other: &DataArray<T>,
+        &'a self,
+        other: &'a DataArray<T>,
         predicate: &BooleanArray,
     ) -> DaftResult<DataArray<T>> {
-        broadcast_if_else!(
-            arrow2::array::PrimitiveArray::<T::Native>,
-            self,
-            other,
-            predicate,
-            copy_optional_native::<T>,
-            arrow2::compute::if_then_else::if_then_else,
-        )
-    }
-}
+        // Broadcast predicate case
+        if predicate.len() == 1 {
+            return match predicate.get(0) {
+                None => Ok(DataArray::full_null(
+                    self.name(),
+                    self.data_type(),
+                    self.len(),
+                )),
+                Some(predicate_scalar_value) => {
+                    if predicate_scalar_value {
+                        Ok(self.clone())
+                    } else {
+                        Ok(other.clone())
+                    }
+                }
+            };
+        }
 
-impl Utf8Array {
-    pub fn if_else(&self, other: &Utf8Array, predicate: &BooleanArray) -> DaftResult<Utf8Array> {
-        broadcast_if_else!(
-            arrow2::array::Utf8Array<i64>,
-            self,
-            other,
-            predicate,
-            identity,
-            arrow2::compute::if_then_else::if_then_else,
-        )
-    }
-}
+        // If either lhs or rhs has len == 1, we perform broadcasting by always selecting the 0th element
+        let broadcasted_getter = |_i: usize| 0usize;
+        let get_lhs = if self.len() == 1 {
+            broadcasted_getter
+        } else {
+            identity
+        };
+        let get_rhs = if other.len() == 1 {
+            broadcasted_getter
+        } else {
+            identity
+        };
 
-impl BooleanArray {
-    pub fn if_else(
-        &self,
-        other: &BooleanArray,
-        predicate: &BooleanArray,
-    ) -> DaftResult<BooleanArray> {
-        broadcast_if_else!(
-            arrow2::array::BooleanArray,
-            self,
-            other,
-            predicate,
-            identity,
-            arrow2::compute::if_then_else::if_then_else,
-        )
-    }
-}
-
-impl BinaryArray {
-    pub fn if_else(
-        &self,
-        other: &BinaryArray,
-        predicate: &BooleanArray,
-    ) -> DaftResult<BinaryArray> {
-        broadcast_if_else!(
-            arrow2::array::BinaryArray<i64>,
-            self,
-            other,
-            predicate,
-            identity,
-            arrow2::compute::if_then_else::if_then_else,
-        )
-    }
-}
-
-impl NullArray {
-    pub fn if_else(&self, other: &NullArray, predicate: &BooleanArray) -> DaftResult<NullArray> {
-        let result_len = get_result_size(self.len(), other.len(), predicate.len())?;
-        Ok(DataArray::full_null(
-            self.name(),
+        // Build the result using a Growable
+        let mut growable = DataArray::<T>::make_growable(
+            self.name().to_string(),
             self.data_type(),
-            result_len,
-        ))
-    }
-}
-
-#[cfg(feature = "python")]
-impl PythonArray {
-    pub fn if_else(
-        &self,
-        other: &PythonArray,
-        predicate: &BooleanArray,
-    ) -> DaftResult<PythonArray> {
-        use crate::array::pseudo_arrow::PseudoArrowArray;
-        use crate::datatypes::PythonType;
-        use pyo3::prelude::*;
-
-        let result_len = get_result_size(self.len(), other.len(), predicate.len())?;
-
-        let predicate_arr = match predicate.len() {
-            1 => predicate.broadcast(result_len)?,
-            _ => predicate.clone(),
-        };
-
-        let if_true_arr = match self.len() {
-            1 => self.broadcast(result_len)?,
-            _ => self.clone(),
-        };
-
-        let if_false_arr = match other.len() {
-            1 => other.broadcast(result_len)?,
-            _ => other.clone(),
-        };
-
-        DataArray::<PythonType>::new(
-            self.field.clone(),
-            Box::new(PseudoArrowArray::<PyObject>::if_then_else(
-                predicate_arr.as_arrow(),
-                if_true_arr.as_arrow(),
-                if_false_arr.as_arrow(),
-            )),
-        )
-    }
-}
-
-fn nested_if_then_else<T: DaftArrowBackedType + 'static>(
-    predicate: &BooleanArray,
-    if_true: &DataArray<T>,
-    if_false: &DataArray<T>,
-) -> DaftResult<DataArray<T>>
-where
-    DataArray<T>: Broadcastable
-        + for<'a> TryFrom<(Arc<Field>, Box<dyn arrow2::array::Array>), Error = DaftError>,
-{
-    // TODO(Clark): Support streaming broadcasting, i.e. broadcasting without inflating scalars to full array length.
-    let result = match (predicate.len(), if_true.len(), if_false.len()) {
-        (predicate_len, if_true_len, if_false_len)
-            if predicate_len == if_true_len && if_true_len == if_false_len =>
-        {
-            arrow2::compute::if_then_else::if_then_else(
-                predicate.as_arrow(),
-                if_true.data(),
-                if_false.data(),
-            )?
-        }
-        (1, if_true_len, 1) => arrow2::compute::if_then_else::if_then_else(
-            predicate.broadcast(if_true_len)?.as_arrow(),
-            if_true.data(),
-            if_false.broadcast(if_true_len)?.data(),
-        )?,
-        (1, 1, if_false_len) => arrow2::compute::if_then_else::if_then_else(
-            predicate.broadcast(if_false_len)?.as_arrow(),
-            if_true.broadcast(if_false_len)?.data(),
-            if_false.data(),
-        )?,
-        (predicate_len, 1, 1) => arrow2::compute::if_then_else::if_then_else(
-            predicate.as_arrow(),
-            if_true.broadcast(predicate_len)?.data(),
-            if_false.broadcast(predicate_len)?.data(),
-        )?,
-        (predicate_len, if_true_len, 1) if predicate_len == if_true_len => {
-            arrow2::compute::if_then_else::if_then_else(
-                predicate.as_arrow(),
-                if_true.data(),
-                if_false.broadcast(predicate_len)?.data(),
-            )?
-        }
-        (predicate_len, 1, if_false_len) if predicate_len == if_false_len => {
-            arrow2::compute::if_then_else::if_then_else(
-                predicate.as_arrow(),
-                if_true.broadcast(predicate_len)?.data(),
-                if_false.data(),
-            )?
-        }
-        (p, s, o) => {
-            return Err(DaftError::ValueError(format!("Cannot run if_else against arrays with non-broadcastable lengths: if_true={s}, if_false={o}, predicate={p}")));
-        }
-    };
-    DataArray::try_from((if_true.field.clone(), result))
-}
-
-impl ListArray {
-    pub fn if_else(&self, other: &ListArray, predicate: &BooleanArray) -> DaftResult<ListArray> {
-        nested_if_then_else(predicate, self, other)
-    }
-}
-
-impl FixedSizeListArray {
-    pub fn if_else(
-        &self,
-        other: &FixedSizeListArray,
-        predicate: &BooleanArray,
-    ) -> DaftResult<FixedSizeListArray> {
-        nested_if_then_else(predicate, self, other)
-    }
-}
-
-impl StructArray {
-    pub fn if_else(
-        &self,
-        other: &StructArray,
-        predicate: &BooleanArray,
-    ) -> DaftResult<StructArray> {
-        nested_if_then_else(predicate, self, other)
-    }
-}
-
-impl ExtensionArray {
-    pub fn if_else(
-        &self,
-        other: &ExtensionArray,
-        predicate: &BooleanArray,
-    ) -> DaftResult<ExtensionArray> {
-        nested_if_then_else(predicate, self, other)
-    }
-}
-
-macro_rules! impl_logicalarray_if_else {
-    ($ArrayT:ty) => {
-        impl $ArrayT {
-            pub fn if_else(&self, other: &Self, predicate: &BooleanArray) -> DaftResult<Self> {
-                let new_array = self.physical.if_else(&other.physical, predicate)?;
-                Ok(Self::new(self.field.clone(), new_array))
+            vec![self, other],
+            predicate.len(),
+        );
+        for (i, pred) in predicate.into_iter().enumerate() {
+            match pred {
+                None => {
+                    growable.add_nulls(1);
+                }
+                Some(pred) if pred => {
+                    growable.extend(0, get_lhs(i), 1);
+                }
+                Some(_) => {
+                    growable.extend(1, get_rhs(i), 1);
+                }
             }
         }
-    };
+
+        growable.build()
+    }
 }
 
-impl_logicalarray_if_else!(Decimal128Array);
-impl_logicalarray_if_else!(DateArray);
-impl_logicalarray_if_else!(DurationArray);
-impl_logicalarray_if_else!(TimestampArray);
-impl_logicalarray_if_else!(EmbeddingArray);
-impl_logicalarray_if_else!(ImageArray);
-impl_logicalarray_if_else!(FixedShapeImageArray);
-impl_logicalarray_if_else!(TensorArray);
-impl_logicalarray_if_else!(FixedShapeTensorArray);
+impl<'a, L> LogicalArrayImpl<L, DataArray<L::PhysicalType>>
+where
+    L: DaftLogicalType,
+    LogicalArrayImpl<L, DataArray<L::PhysicalType>>: GrowableArray<'a>,
+{
+    pub fn if_else(
+        &'a self,
+        other: &'a LogicalArrayImpl<L, DataArray<L::PhysicalType>>,
+        predicate: &BooleanArray,
+    ) -> DaftResult<LogicalArrayImpl<L, DataArray<L::PhysicalType>>> {
+        // Broadcast predicate case
+        if predicate.len() == 1 {
+            return match predicate.get(0) {
+                None => Ok(LogicalArrayImpl::<L, DataArray<L::PhysicalType>>::new(
+                    self.field.clone(),
+                    DataArray::<L::PhysicalType>::full_null(
+                        self.name(),
+                        self.physical.data_type(),
+                        self.len(),
+                    ),
+                )),
+                Some(predicate_scalar_value) => {
+                    if predicate_scalar_value {
+                        Ok(self.clone())
+                    } else {
+                        Ok(other.clone())
+                    }
+                }
+            };
+        }
+
+        // If either lhs or rhs has len == 1, we perform broadcasting by always selecting the 0th element
+        let broadcasted_getter = |_i: usize| 0usize;
+        let get_lhs = if self.len() == 1 {
+            broadcasted_getter
+        } else {
+            identity
+        };
+        let get_rhs = if other.len() == 1 {
+            broadcasted_getter
+        } else {
+            identity
+        };
+
+        // Build the result using a Growable
+        let mut growable = LogicalArrayImpl::<L, DataArray<L::PhysicalType>>::make_growable(
+            self.name().to_string(),
+            self.data_type(),
+            vec![self, other],
+            predicate.len(),
+        );
+        for (i, pred) in predicate.into_iter().enumerate() {
+            match pred {
+                None => {
+                    growable.add_nulls(1);
+                }
+                Some(pred) if pred => {
+                    growable.extend(0, get_lhs(i), 1);
+                }
+                Some(_) => {
+                    growable.extend(1, get_rhs(i), 1);
+                }
+            }
+        }
+
+        growable.build()
+    }
+}

--- a/src/daft-core/src/array/ops/if_else.rs
+++ b/src/daft-core/src/array/ops/if_else.rs
@@ -1,11 +1,10 @@
-use crate::array::ops::full::FullNull;
 use crate::array::growable::{Growable, GrowableArray};
+use crate::array::ops::full::FullNull;
 use crate::array::DataArray;
 use crate::datatypes::logical::LogicalArrayImpl;
 use crate::datatypes::{BooleanArray, DaftLogicalType, DaftPhysicalType};
 use common_error::DaftResult;
 use std::convert::identity;
-
 
 impl<'a, T> DataArray<T>
 where

--- a/src/daft-core/src/array/ops/if_else.rs
+++ b/src/daft-core/src/array/ops/if_else.rs
@@ -50,10 +50,10 @@ fn generic_if_else<'a, T: GrowableArray<'a> + FullNull + Clone>(
             None => {
                 growable.add_nulls(1);
             }
-            Some(pred) if pred => {
+            Some(true) => {
                 growable.extend(0, get_lhs(i), 1);
             }
-            Some(_) => {
+            Some(false) => {
                 growable.extend(1, get_rhs(i), 1);
             }
         }

--- a/src/daft-core/src/datatypes/dtype.rs
+++ b/src/daft-core/src/datatypes/dtype.rs
@@ -36,7 +36,7 @@ pub enum DataType {
     /// An [`u64`]
     UInt64,
     /// An 16-bit float
-    Float16,
+    // Float16,
     /// A [`f32`]
     Float32,
     /// A [`f64`]
@@ -89,6 +89,7 @@ pub enum DataType {
     Tensor(Box<DataType>),
     /// A logical type for tensors with the same shape.
     FixedShapeTensor(Box<DataType>, Vec<u64>),
+    #[cfg(feature = "python")]
     Python,
     Unknown,
 }
@@ -129,7 +130,7 @@ impl DataType {
             DataType::UInt16 => Ok(ArrowType::UInt16),
             DataType::UInt32 => Ok(ArrowType::UInt32),
             DataType::UInt64 => Ok(ArrowType::UInt64),
-            DataType::Float16 => Ok(ArrowType::Float16),
+            // DataType::Float16 => Ok(ArrowType::Float16),
             DataType::Float32 => Ok(ArrowType::Float32),
             DataType::Float64 => Ok(ArrowType::Float64),
             DataType::Decimal128(precision, scale) => Ok(ArrowType::Decimal(*precision, *scale)),
@@ -277,7 +278,8 @@ impl DataType {
     pub fn is_floating(&self) -> bool {
         matches!(
             self,
-            DataType::Float16 | DataType::Float32 | DataType::Float64
+            // DataType::Float16 |
+            DataType::Float32 | DataType::Float64
         )
     }
 
@@ -327,6 +329,7 @@ impl DataType {
     #[inline]
     pub fn is_python(&self) -> bool {
         match self {
+            #[cfg(feature = "python")]
             DataType::Python => true,
             DataType::Extension(_, inner, _) => inner.is_python(),
             _ => false,
@@ -399,7 +402,7 @@ impl From<&ArrowType> for DataType {
             ArrowType::UInt16 => DataType::UInt16,
             ArrowType::UInt32 => DataType::UInt32,
             ArrowType::UInt64 => DataType::UInt64,
-            ArrowType::Float16 => DataType::Float16,
+            // ArrowType::Float16 => DataType::Float16,
             ArrowType::Float32 => DataType::Float32,
             ArrowType::Float64 => DataType::Float64,
             ArrowType::Timestamp(unit, timezone) => {

--- a/src/daft-core/src/datatypes/matching.rs
+++ b/src/daft-core/src/datatypes/matching.rs
@@ -48,38 +48,6 @@ macro_rules! with_match_daft_types {(
 })}
 
 #[macro_export]
-macro_rules! with_match_arrow_backed_physical_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    use $crate::datatypes::*;
-
-    match $key_type {
-        Null => __with_ty__! { NullType },
-        Boolean => __with_ty__! { BooleanType },
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        Int128 => __with_ty__! { Int128Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        Binary => __with_ty__! { BinaryType },
-        Utf8 => __with_ty__! { Utf8Type },
-        List(_) => __with_ty__! { ListType },
-        Struct(_) => __with_ty__! { StructType },
-        // Extension types are more like logical types, as they wrap a dynamic inner type
-        // Extension(_, _, _) => __with_ty__! { ExtensionType },
-        _ => panic!("{:?} not implemented for with_match_arrow_backed_physical_types", $key_type)
-    }
-})}
-
-#[macro_export]
 macro_rules! with_match_physical_daft_types {(
     $key_type:expr, | $_:tt $T:ident | $($body:tt)*
 ) => ({

--- a/src/daft-core/src/datatypes/matching.rs
+++ b/src/daft-core/src/datatypes/matching.rs
@@ -32,7 +32,50 @@ macro_rules! with_match_daft_types {(
         Extension(_, _, _) => __with_ty__! { ExtensionType },
         #[cfg(feature = "python")]
         Python => __with_ty__! { PythonType },
-        _ => panic!("{:?} not implemented for with_match_daft_types", $key_type)
+        Embedding(..) => __with_ty__! { EmbeddingType },
+        Image(..) => __with_ty__! { ImageType },
+        FixedShapeImage(..) => __with_ty__! { FixedShapeImageType },
+        Tensor(..) => __with_ty__! { TensorType },
+        FixedShapeTensor(..) => __with_ty__! { FixedShapeTensorType },
+        Time(_) => unimplemented!("Array for Time not implemented"),
+        Float16 => unimplemented!("Array for Float16 not implemented"),
+        Unknown => unimplemented!("Array for Unknown DataType not implemented"),
+
+        // NOTE: We should not implement a default for match here, because this is meant to be
+        // an exhaustive match across **all** Daft types.
+        // _ => panic!("{:?} not implemented for with_match_daft_types", $key_type)
+    }
+})}
+
+#[macro_export]
+macro_rules! with_match_arrow_backed_physical_types {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    use $crate::datatypes::*;
+
+    match $key_type {
+        Null => __with_ty__! { NullType },
+        Boolean => __with_ty__! { BooleanType },
+        Int8 => __with_ty__! { Int8Type },
+        Int16 => __with_ty__! { Int16Type },
+        Int32 => __with_ty__! { Int32Type },
+        Int64 => __with_ty__! { Int64Type },
+        Int128 => __with_ty__! { Int128Type },
+        UInt8 => __with_ty__! { UInt8Type },
+        UInt16 => __with_ty__! { UInt16Type },
+        UInt32 => __with_ty__! { UInt32Type },
+        UInt64 => __with_ty__! { UInt64Type },
+        Float32 => __with_ty__! { Float32Type },
+        Float64 => __with_ty__! { Float64Type },
+        Binary => __with_ty__! { BinaryType },
+        Utf8 => __with_ty__! { Utf8Type },
+        List(_) => __with_ty__! { ListType },
+        Struct(_) => __with_ty__! { StructType },
+        // Extension types are more like logical types, as they wrap a dynamic inner type
+        // Extension(_, _, _) => __with_ty__! { ExtensionType },
+        _ => panic!("{:?} not implemented for with_match_arrow_backed_physical_types", $key_type)
     }
 })}
 

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -24,7 +24,7 @@ pub use time_unit::TimeUnit;
 pub mod logical;
 
 /// Trait that is implemented by all Array types
-pub trait DaftArrayType {}
+pub trait DaftArrayType: Clone {}
 
 /// Trait to wrap DataType Enum
 pub trait DaftDataType: Sync + Send + Clone {
@@ -112,7 +112,7 @@ impl_daft_arrow_datatype!(UInt8Type, UInt8);
 impl_daft_arrow_datatype!(UInt16Type, UInt16);
 impl_daft_arrow_datatype!(UInt32Type, UInt32);
 impl_daft_arrow_datatype!(UInt64Type, UInt64);
-impl_daft_arrow_datatype!(Float16Type, Float16);
+// impl_daft_arrow_datatype!(Float16Type, Float16);
 impl_daft_arrow_datatype!(Float32Type, Float32);
 impl_daft_arrow_datatype!(Float64Type, Float64);
 impl_daft_arrow_datatype!(BinaryType, Binary);
@@ -272,7 +272,7 @@ pub type UInt8Array = DataArray<UInt8Type>;
 pub type UInt16Array = DataArray<UInt16Type>;
 pub type UInt32Array = DataArray<UInt32Type>;
 pub type UInt64Array = DataArray<UInt64Type>;
-pub type Float16Array = DataArray<Float16Type>;
+// pub type Float16Array = DataArray<Float16Type>;
 pub type Float32Array = DataArray<Float32Type>;
 pub type Float64Array = DataArray<Float64Type>;
 pub type BinaryArray = DataArray<BinaryType>;

--- a/src/daft-core/src/series/ops/downcast.rs
+++ b/src/daft-core/src/series/ops/downcast.rs
@@ -62,9 +62,9 @@ impl Series {
         self.downcast()
     }
 
-    pub fn f16(&self) -> DaftResult<&Float16Array> {
-        self.downcast()
-    }
+    // pub fn f16(&self) -> DaftResult<&Float16Array> {
+    //     self.downcast()
+    // }
 
     pub fn f32(&self) -> DaftResult<&Float32Array> {
         self.downcast()

--- a/src/daft-dsl/src/functions/float/is_nan.rs
+++ b/src/daft-dsl/src/functions/float/is_nan.rs
@@ -21,7 +21,8 @@ impl FunctionEvaluator for IsNanEvaluator {
         match inputs {
             [data] => match data.to_field(schema) {
                 Ok(data_field) => match &data_field.dtype {
-                    DataType::Float16 | DataType::Float32 | DataType::Float64 => {
+                    // DataType::Float16 |
+                    DataType::Float32 | DataType::Float64 => {
                         Ok(Field::new(data_field.name, DataType::Boolean))
                     }
                     _ => Err(DaftError::TypeError(format!(

--- a/tests/benchmarks/test_if_else.py
+++ b/tests/benchmarks/test_if_else.py
@@ -61,10 +61,10 @@ def generate_list_params() -> tuple[dict, daft.Expression, list]:
 def test_if_else(test_data_generator, benchmark) -> None:
     """If_else between NUM_ROWS values"""
     data, expr, expected = test_data_generator()
-    df = daft.from_pydict(data)
+    table = daft.table.Table.from_pydict(data)
 
     def bench_if_else() -> DataFrame:
-        return df.select(expr.alias("result")).collect()
+        return table.eval_expression_list([expr.alias("result")])
 
     result = benchmark(bench_if_else)
     assert result.to_pydict()["result"] == expected

--- a/tests/benchmarks/test_if_else.py
+++ b/tests/benchmarks/test_if_else.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+import daft
+from daft import DataFrame
+
+NUM_ROWS = 1_000_000
+
+# Perform if/else against two int64 columns, selecting exactly half of the first and half of the second
+def generate_int64_params() -> tuple[dict, daft.Expression, list]:
+    return (
+        {"lhs": [0 for _ in range(NUM_ROWS)], "rhs": [1 for _ in range(NUM_ROWS)], "pred": list(range(NUM_ROWS))},
+        (daft.col("pred") < NUM_ROWS // 2).if_else(daft.col("lhs"), daft.col("rhs")),
+        [0 for _ in range(NUM_ROWS // 2)] + [1 for _ in range(NUM_ROWS // 2)],
+    )
+
+
+# Perform if/else against two string columns, selecting exactly half of the first and half of the second
+def generate_string_params() -> tuple[dict, daft.Expression, list]:
+    STRING_TEST_LHS = [str(uuid.uuid4()) for _ in range(NUM_ROWS)]
+    STRING_TEST_RHS = [str(uuid.uuid4()) for _ in range(NUM_ROWS)]
+    return (
+        {"lhs": STRING_TEST_LHS, "rhs": STRING_TEST_RHS, "pred": list(range(NUM_ROWS))},
+        (daft.col("pred") < NUM_ROWS // 2).if_else(daft.col("lhs"), daft.col("rhs")),
+        STRING_TEST_LHS[: NUM_ROWS // 2] + STRING_TEST_RHS[NUM_ROWS // 2 :],
+    )
+
+
+# Perform if/else against two list columns, selecting exactly half of the first and half of the second
+def generate_list_params() -> tuple[dict, daft.Expression, list]:
+    LIST_TEST_LHS = [[0 for _ in range(5)] for _ in range(NUM_ROWS)]
+    LIST_TEST_RHS = [[1 for _ in range(5)] for _ in range(NUM_ROWS)]
+    return (
+        {"lhs": LIST_TEST_LHS, "rhs": LIST_TEST_RHS, "pred": list(range(NUM_ROWS))},
+        (daft.col("pred") < NUM_ROWS // 2).if_else(daft.col("lhs"), daft.col("rhs")),
+        LIST_TEST_LHS[: NUM_ROWS // 2] + LIST_TEST_RHS[NUM_ROWS // 2 :],
+    )
+
+
+@pytest.mark.benchmark(group="if_else")
+@pytest.mark.parametrize(
+    "test_data_generator",
+    [
+        pytest.param(
+            generate_int64_params,
+            id="int64",
+        ),
+        pytest.param(
+            generate_string_params,
+            id="string",
+        ),
+        pytest.param(
+            generate_list_params,
+            id="list",
+        ),
+    ],
+)
+def test_if_else(test_data_generator, benchmark) -> None:
+    """If_else between NUM_ROWS values"""
+    data, expr, expected = test_data_generator()
+    df = daft.from_pydict(data)
+
+    def bench_if_else() -> DataFrame:
+        return df.select(expr.alias("result")).collect()
+
+    result = benchmark(bench_if_else)
+    assert result.to_pydict()["result"] == expected


### PR DESCRIPTION
Growables are generally useful for abstracting "physical" operations such as:

1. Take
2. Broadcast
3. Filter

This will become much more important as we add new Array types (FixedSizeListArray, StructArray etc). These arrays can just implement their own Growable classes, and implementations for the physical kernels will be easy to implement.

## Changes

1. Adds a new `Growable<Arr>` trait that is a growable to build the specified `Arr`
2. Adds a new `GrowableArray` trait which is implemented by `DataArray` and `LogicalArray`: these types can now create a growable using their associated `::make_growable` functions
3. Refactors `if_else` to use the new growables, reducing quite a bit of code and nasty macro usage