### PR TITLE
[CHORE] Refactor Series downcast and LogicalArrayImpl

### DIFF
--- a/src/daft-core/src/array/mod.rs
+++ b/src/daft-core/src/array/mod.rs
@@ -5,7 +5,7 @@ pub mod pseudo_arrow;
 
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::datatypes::{DaftPhysicalType, DataType, Field};
+use crate::datatypes::{DaftArrayType, DaftPhysicalType, DataType, Field};
 
 use common_error::{DaftError, DaftResult};
 
@@ -21,6 +21,8 @@ impl<T: DaftPhysicalType> Clone for DataArray<T> {
         DataArray::new(self.field.clone(), self.data.clone()).unwrap()
     }
 }
+
+impl<T: DaftPhysicalType> DaftArrayType for DataArray<T> {}
 
 impl<T> DataArray<T>
 where

--- a/src/daft-core/src/array/ops/arange.rs
+++ b/src/daft-core/src/array/ops/arange.rs
@@ -19,7 +19,7 @@ where
         let arrow_array = Box::new(arrow2::array::PrimitiveArray::<i64>::from_vec(data));
         let data_array = Int64Array::from((name.as_ref(), arrow_array));
         let casted_array = data_array.cast(&T::get_dtype())?;
-        let downcasted = casted_array.downcast::<T>()?;
+        let downcasted = casted_array.downcast::<DataArray<T>>()?;
         Ok(downcasted.clone())
     }
 }

--- a/src/daft-core/src/array/ops/arithmetic.rs
+++ b/src/daft-core/src/array/ops/arithmetic.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use common_error::{DaftError, DaftResult};
 
-use super::as_arrow::AsArrow;
+use super::{as_arrow::AsArrow, full::FullNull};
 /// Helper function to perform arithmetic operations on a DataArray
 /// Takes both Kernel (array x array operation) and operation (scalar x scalar) functions
 /// The Kernel is used for when both arrays are non-unit length and the operation is used when broadcasting

--- a/src/daft-core/src/array/ops/broadcast.rs
+++ b/src/daft-core/src/array/ops/broadcast.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use common_error::{DaftError, DaftResult};
 
-use super::as_arrow::AsArrow;
+use super::{as_arrow::AsArrow, full::FullNull};
 
 #[cfg(feature = "python")]
 use crate::array::pseudo_arrow::PseudoArrowArray;

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -6,8 +6,8 @@ use crate::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
             FixedShapeTensorArray, ImageArray, LogicalDataArray, TensorArray, TimestampArray,
         },
-        DaftArrowBackedType, DaftLogicalType, DataType, Field, FixedShapeTensorType,
-        FixedSizeListArray, ImageMode, StructArray, TensorType, TimeUnit, Utf8Array,
+        DaftArrowBackedType, DaftLogicalType, DataType, Field, FixedSizeListArray, ImageMode,
+        StructArray, TimeUnit, Utf8Array,
     },
     series::{IntoSeries, Series},
     with_match_arrow_daft_types, with_match_daft_logical_primitive_types,
@@ -1111,8 +1111,8 @@ impl EmbeddingArray {
                 let fixed_shape_tensor_dtype =
                     DataType::FixedShapeTensor(Box::new(inner_dtype.clone().dtype), image_shape);
                 let fixed_shape_tensor_array = self.cast(&fixed_shape_tensor_dtype)?;
-                let fixed_shape_tensor_array = fixed_shape_tensor_array
-                    .downcast_logical_data_array::<FixedShapeTensorType>()?;
+                let fixed_shape_tensor_array =
+                    fixed_shape_tensor_array.downcast::<FixedShapeTensorArray>()?;
                 fixed_shape_tensor_array.cast(dtype)
             }
             // NOTE(Clark): Casting to FixedShapeTensor is supported by the physical array cast.
@@ -1174,8 +1174,8 @@ impl ImageArray {
                             Err(e)
                         }
                     })?;
-                let fixed_shape_tensor_array = fixed_shape_tensor_array
-                    .downcast_logical_data_array::<FixedShapeTensorType>()?;
+                let fixed_shape_tensor_array =
+                    fixed_shape_tensor_array.downcast::<FixedShapeTensorArray>()?;
                 fixed_shape_tensor_array.cast(dtype)
             }
             DataType::Tensor(_) => {
@@ -1231,7 +1231,7 @@ impl ImageArray {
             DataType::FixedShapeTensor(inner_dtype, _) => {
                 let tensor_dtype = DataType::Tensor(inner_dtype.clone());
                 let tensor_array = self.cast(&tensor_dtype)?;
-                let tensor_array = tensor_array.downcast_logical_data_array::<TensorType>()?;
+                let tensor_array = tensor_array.downcast::<TensorArray>()?;
                 tensor_array.cast(dtype)
             }
             _ => self.physical.cast(dtype),
@@ -1299,14 +1299,14 @@ impl FixedShapeImageArray {
                             Err(e)
                         }
                     })?;
-                let fixed_shape_tensor_array = fixed_shape_tensor_array
-                    .downcast_logical_data_array::<FixedShapeTensorType>()?;
+                let fixed_shape_tensor_array =
+                    fixed_shape_tensor_array.downcast::<FixedShapeTensorArray>()?;
                 fixed_shape_tensor_array.cast(dtype)
             }
             (DataType::Image(_), DataType::FixedShapeImage(mode, _, _)) => {
                 let tensor_dtype = DataType::Tensor(Box::new(mode.get_dtype()));
                 let tensor_array = self.cast(&tensor_dtype)?;
-                let tensor_array = tensor_array.downcast_logical_data_array::<TensorType>()?;
+                let tensor_array = tensor_array.downcast::<TensorArray>()?;
                 tensor_array.cast(dtype)
             }
             // NOTE(Clark): Casting to FixedShapeTensor is supported by the physical array cast.
@@ -1505,8 +1505,8 @@ impl TensorArray {
                             Err(e)
                         }
                     })?;
-                let fixed_shape_tensor_array = fixed_shape_tensor_array
-                    .downcast_logical_data_array::<FixedShapeTensorType>()?;
+                let fixed_shape_tensor_array =
+                    fixed_shape_tensor_array.downcast::<FixedShapeTensorArray>()?;
                 fixed_shape_tensor_array.cast(dtype)
             }
             _ => self.physical.cast(dtype),

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -4,7 +4,7 @@ use crate::{
     datatypes::{
         logical::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
-            FixedShapeTensorArray, ImageArray, LogicalArray, TensorArray, TimestampArray,
+            FixedShapeTensorArray, ImageArray, LogicalDataArray, TensorArray, TimestampArray,
         },
         DaftArrowBackedType, DaftLogicalType, DataType, Field, FixedShapeTensorType,
         FixedSizeListArray, ImageMode, StructArray, TensorType, TimeUnit, Utf8Array,
@@ -39,11 +39,12 @@ use {
     std::ops::Deref,
 };
 
-fn arrow_logical_cast<T>(to_cast: &LogicalArray<T>, dtype: &DataType) -> DaftResult<Series>
+fn arrow_logical_cast<T>(to_cast: &LogicalDataArray<T>, dtype: &DataType) -> DaftResult<Series>
 where
     T: DaftLogicalType,
+    T::PhysicalType: DaftArrowBackedType,
 {
-    // Cast from LogicalArray to the target DataType
+    // Cast from LogicalDataArray to the target DataType
     // using Arrow's casting mechanisms.
 
     // Note that Arrow Logical->Logical direct casts (what this method exposes)
@@ -55,7 +56,7 @@ where
 
     // Get the result of the Arrow Logical->Target cast.
     let result_arrow_array = {
-        // First, get corresponding Arrow LogicalArray of source DataArray
+        // First, get corresponding Arrow LogicalDataArray of source DataArray
         use DataType::*;
         let source_arrow_array = match source_dtype {
             // Wrapped primitives
@@ -83,7 +84,7 @@ where
             )?,
         };
 
-        // Then, cast source Arrow LogicalArray to target Arrow LogicalArray.
+        // Then, cast source Arrow LogicalDataArray to target Arrow LogicalDataArray.
 
         cast(
             source_arrow_array.as_ref(),
@@ -132,7 +133,7 @@ where
 
     if dtype.is_logical() {
         with_match_daft_logical_types!(dtype, |$T| {
-            return Ok(LogicalArray::<$T>::from_arrow(new_field.as_ref(), result_arrow_physical_array)?.into_series())
+            return Ok(LogicalDataArray::<$T>::from_arrow(new_field.as_ref(), result_arrow_physical_array)?.into_series())
         })
     }
     with_match_arrow_daft_types!(dtype, |$T| {
@@ -223,7 +224,7 @@ where
 
     if dtype.is_logical() {
         with_match_daft_logical_types!(dtype, |$T| {
-            return Ok(LogicalArray::<$T>::from_arrow(new_field.as_ref(), result_array)?.into_series());
+            return Ok(LogicalDataArray::<$T>::from_arrow(new_field.as_ref(), result_array)?.into_series());
         })
     }
     with_match_arrow_daft_types!(dtype, |$T| {
@@ -1110,8 +1111,8 @@ impl EmbeddingArray {
                 let fixed_shape_tensor_dtype =
                     DataType::FixedShapeTensor(Box::new(inner_dtype.clone().dtype), image_shape);
                 let fixed_shape_tensor_array = self.cast(&fixed_shape_tensor_dtype)?;
-                let fixed_shape_tensor_array =
-                    fixed_shape_tensor_array.downcast_logical::<FixedShapeTensorType>()?;
+                let fixed_shape_tensor_array = fixed_shape_tensor_array
+                    .downcast_logical_data_array::<FixedShapeTensorType>()?;
                 fixed_shape_tensor_array.cast(dtype)
             }
             // NOTE(Clark): Casting to FixedShapeTensor is supported by the physical array cast.
@@ -1173,8 +1174,8 @@ impl ImageArray {
                             Err(e)
                         }
                     })?;
-                let fixed_shape_tensor_array =
-                    fixed_shape_tensor_array.downcast_logical::<FixedShapeTensorType>()?;
+                let fixed_shape_tensor_array = fixed_shape_tensor_array
+                    .downcast_logical_data_array::<FixedShapeTensorType>()?;
                 fixed_shape_tensor_array.cast(dtype)
             }
             DataType::Tensor(_) => {
@@ -1230,7 +1231,7 @@ impl ImageArray {
             DataType::FixedShapeTensor(inner_dtype, _) => {
                 let tensor_dtype = DataType::Tensor(inner_dtype.clone());
                 let tensor_array = self.cast(&tensor_dtype)?;
-                let tensor_array = tensor_array.downcast_logical::<TensorType>()?;
+                let tensor_array = tensor_array.downcast_logical_data_array::<TensorType>()?;
                 tensor_array.cast(dtype)
             }
             _ => self.physical.cast(dtype),
@@ -1298,14 +1299,14 @@ impl FixedShapeImageArray {
                             Err(e)
                         }
                     })?;
-                let fixed_shape_tensor_array =
-                    fixed_shape_tensor_array.downcast_logical::<FixedShapeTensorType>()?;
+                let fixed_shape_tensor_array = fixed_shape_tensor_array
+                    .downcast_logical_data_array::<FixedShapeTensorType>()?;
                 fixed_shape_tensor_array.cast(dtype)
             }
             (DataType::Image(_), DataType::FixedShapeImage(mode, _, _)) => {
                 let tensor_dtype = DataType::Tensor(Box::new(mode.get_dtype()));
                 let tensor_array = self.cast(&tensor_dtype)?;
-                let tensor_array = tensor_array.downcast_logical::<TensorType>()?;
+                let tensor_array = tensor_array.downcast_logical_data_array::<TensorType>()?;
                 tensor_array.cast(dtype)
             }
             // NOTE(Clark): Casting to FixedShapeTensor is supported by the physical array cast.
@@ -1504,8 +1505,8 @@ impl TensorArray {
                             Err(e)
                         }
                     })?;
-                let fixed_shape_tensor_array =
-                    fixed_shape_tensor_array.downcast_logical::<FixedShapeTensorType>()?;
+                let fixed_shape_tensor_array = fixed_shape_tensor_array
+                    .downcast_logical_data_array::<FixedShapeTensorType>()?;
                 fixed_shape_tensor_array.cast(dtype)
             }
             _ => self.physical.cast(dtype),
@@ -1613,11 +1614,15 @@ impl FixedShapeTensorArray {
 }
 
 #[cfg(feature = "python")]
-fn cast_logical_to_python_array<T>(array: &LogicalArray<T>, dtype: &DataType) -> DaftResult<Series>
+fn cast_logical_to_python_array<T>(
+    array: &LogicalDataArray<T>,
+    dtype: &DataType,
+) -> DaftResult<Series>
 where
     T: DaftLogicalType,
-    LogicalArray<T>: AsArrow,
-    <LogicalArray<T> as AsArrow>::Output: arrow2::array::Array,
+    T::PhysicalType: DaftArrowBackedType,
+    LogicalDataArray<T>: AsArrow,
+    <LogicalDataArray<T> as AsArrow>::Output: arrow2::array::Array,
 {
     Python::with_gil(|py| {
         let arrow_dtype = array.logical_type().to_arrow()?;

--- a/src/daft-core/src/array/ops/compare_agg.rs
+++ b/src/daft-core/src/array/ops/compare_agg.rs
@@ -1,5 +1,5 @@
 use super::{DaftCompareAggable, GroupIndices};
-use crate::{array::DataArray, datatypes::*};
+use crate::{array::ops::full::FullNull, array::DataArray, datatypes::*};
 use arrow2::array::PrimitiveArray;
 use arrow2::{self, array::Array};
 

--- a/src/daft-core/src/array/ops/comparison.rs
+++ b/src/daft-core/src/array/ops/comparison.rs
@@ -12,7 +12,7 @@ use common_error::{DaftError, DaftResult};
 
 use std::ops::Not;
 
-use super::{DaftCompare, DaftLogical};
+use super::{full::FullNull, DaftCompare, DaftLogical};
 
 use super::as_arrow::AsArrow;
 use arrow2::{compute::comparison, scalar::PrimitiveScalar};

--- a/src/daft-core/src/array/ops/from_arrow.rs
+++ b/src/daft-core/src/array/ops/from_arrow.rs
@@ -2,7 +2,9 @@ use common_error::DaftResult;
 
 use crate::{
     array::DataArray,
-    datatypes::{logical::LogicalArray, DaftLogicalType, DaftPhysicalType, Field},
+    datatypes::{
+        logical::LogicalDataArray, DaftArrowBackedType, DaftLogicalType, DaftPhysicalType, Field,
+    },
 };
 
 /// Arrays that implement [`FromArrow`] can be instantiated from a Box<dyn arrow2::array::Array>
@@ -19,10 +21,13 @@ impl<T: DaftPhysicalType> FromArrow for DataArray<T> {
     }
 }
 
-impl<L: DaftLogicalType> FromArrow for LogicalArray<L> {
+impl<L: DaftLogicalType> FromArrow for LogicalDataArray<L>
+where
+    L::PhysicalType: DaftArrowBackedType,
+{
     fn from_arrow(field: &Field, arrow_arr: Box<dyn arrow2::array::Array>) -> DaftResult<Self> {
         let data_array_field = Field::new(field.name.clone(), field.dtype.to_physical());
         let physical = DataArray::try_from((data_array_field, arrow_arr))?;
-        Ok(LogicalArray::<L>::new(field.clone(), physical))
+        Ok(LogicalDataArray::<L>::new(field.clone(), physical))
     }
 }

--- a/src/daft-core/src/array/ops/from_arrow.rs
+++ b/src/daft-core/src/array/ops/from_arrow.rs
@@ -2,9 +2,7 @@ use common_error::DaftResult;
 
 use crate::{
     array::DataArray,
-    datatypes::{
-        logical::LogicalDataArray, DaftArrowBackedType, DaftLogicalType, DaftPhysicalType, Field,
-    },
+    datatypes::{logical::LogicalArray, DaftDataType, DaftLogicalType, DaftPhysicalType, Field},
 };
 
 /// Arrays that implement [`FromArrow`] can be instantiated from a Box<dyn arrow2::array::Array>
@@ -21,13 +19,17 @@ impl<T: DaftPhysicalType> FromArrow for DataArray<T> {
     }
 }
 
-impl<L: DaftLogicalType> FromArrow for LogicalDataArray<L>
+impl<L: DaftLogicalType> FromArrow for LogicalArray<L>
 where
-    L::PhysicalType: DaftArrowBackedType,
+    <L::PhysicalType as DaftDataType>::ArrayType: FromArrow,
 {
     fn from_arrow(field: &Field, arrow_arr: Box<dyn arrow2::array::Array>) -> DaftResult<Self> {
         let data_array_field = Field::new(field.name.clone(), field.dtype.to_physical());
-        let physical = DataArray::try_from((data_array_field, arrow_arr))?;
-        Ok(LogicalDataArray::<L>::new(field.clone(), physical))
+        let physical_arrow_arr = arrow_arr.to_type(data_array_field.dtype.to_arrow()?);
+        let physical = <L::PhysicalType as DaftDataType>::ArrayType::from_arrow(
+            &data_array_field,
+            physical_arrow_arr,
+        )?;
+        Ok(LogicalArray::<L>::new(field.clone(), physical))
     }
 }

--- a/src/daft-core/src/array/ops/if_else.rs
+++ b/src/daft-core/src/array/ops/if_else.rs
@@ -1,3 +1,4 @@
+use crate::array::ops::full::FullNull;
 use crate::array::DataArray;
 use crate::datatypes::logical::{
     DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,

--- a/src/daft-core/src/array/ops/image.rs
+++ b/src/daft-core/src/array/ops/image.rs
@@ -4,8 +4,9 @@ use std::vec;
 
 use image::{ColorType, DynamicImage, ImageBuffer};
 
+use crate::datatypes::DaftArrowBackedType;
 use crate::datatypes::{
-    logical::{DaftImageryType, FixedShapeImageArray, ImageArray, LogicalArray},
+    logical::{DaftImageryType, FixedShapeImageArray, ImageArray, LogicalDataArray},
     BinaryArray, DaftLogicalType, DataType, Field, FixedSizeListArray, ImageFormat, ImageMode,
     StructArray,
 };
@@ -321,16 +322,18 @@ pub trait AsImageObj {
 pub struct ImageBufferIter<'a, T>
 where
     T: DaftLogicalType + DaftImageryType,
+    T::PhysicalType: DaftArrowBackedType,
 {
     cursor: usize,
-    image_array: &'a LogicalArray<T>,
+    image_array: &'a LogicalDataArray<T>,
 }
 
 impl<'a, T> ImageBufferIter<'a, T>
 where
     T: DaftLogicalType + DaftImageryType,
+    T::PhysicalType: DaftArrowBackedType,
 {
-    pub fn new(image_array: &'a LogicalArray<T>) -> Self {
+    pub fn new(image_array: &'a LogicalDataArray<T>) -> Self {
         Self {
             cursor: 0usize,
             image_array,
@@ -341,7 +344,8 @@ where
 impl<'a, T> Iterator for ImageBufferIter<'a, T>
 where
     T: DaftLogicalType + DaftImageryType,
-    LogicalArray<T>: AsImageObj,
+    T::PhysicalType: DaftArrowBackedType,
+    LogicalDataArray<T>: AsImageObj,
 {
     type Item = Option<DaftImageBuffer<'a>>;
 
@@ -766,10 +770,11 @@ impl AsImageObj for FixedShapeImageArray {
     }
 }
 
-impl<'a, T> IntoIterator for &'a LogicalArray<T>
+impl<'a, T> IntoIterator for &'a LogicalDataArray<T>
 where
     T: DaftImageryType,
-    LogicalArray<T>: AsImageObj,
+    T::PhysicalType: DaftArrowBackedType,
+    LogicalDataArray<T>: AsImageObj,
 {
     type Item = Option<DaftImageBuffer<'a>>;
     type IntoIter = ImageBufferIter<'a, T>;
@@ -816,13 +821,14 @@ impl BinaryArray {
 }
 
 fn encode_images<'a, T>(
-    images: &'a LogicalArray<T>,
+    images: &'a LogicalDataArray<T>,
     image_format: ImageFormat,
 ) -> DaftResult<BinaryArray>
 where
     T: DaftImageryType,
-    LogicalArray<T>: AsImageObj,
-    &'a LogicalArray<T>:
+    T::PhysicalType: DaftArrowBackedType,
+    LogicalDataArray<T>: AsImageObj,
+    &'a LogicalDataArray<T>:
         IntoIterator<Item = Option<DaftImageBuffer<'a>>, IntoIter = ImageBufferIter<'a, T>>,
 {
     let arrow_array = match image_format {
@@ -911,11 +917,16 @@ where
     )
 }
 
-fn resize_images<'a, T>(images: &'a LogicalArray<T>, w: u32, h: u32) -> Vec<Option<DaftImageBuffer>>
+fn resize_images<'a, T>(
+    images: &'a LogicalDataArray<T>,
+    w: u32,
+    h: u32,
+) -> Vec<Option<DaftImageBuffer>>
 where
     T: DaftImageryType,
-    LogicalArray<T>: AsImageObj,
-    &'a LogicalArray<T>:
+    T::PhysicalType: DaftArrowBackedType,
+    LogicalDataArray<T>: AsImageObj,
+    &'a LogicalDataArray<T>:
         IntoIterator<Item = Option<DaftImageBuffer<'a>>, IntoIter = ImageBufferIter<'a, T>>,
 {
     images
@@ -925,13 +936,14 @@ where
 }
 
 fn crop_images<'a, T>(
-    images: &'a LogicalArray<T>,
+    images: &'a LogicalDataArray<T>,
     bboxes: &mut dyn Iterator<Item = Option<BBox>>,
 ) -> Vec<Option<DaftImageBuffer<'a>>>
 where
     T: DaftImageryType,
-    LogicalArray<T>: AsImageObj,
-    &'a LogicalArray<T>:
+    T::PhysicalType: DaftArrowBackedType,
+    LogicalDataArray<T>: AsImageObj,
+    &'a LogicalDataArray<T>:
         IntoIterator<Item = Option<DaftImageBuffer<'a>>, IntoIter = ImageBufferIter<'a, T>>,
 {
     images

--- a/src/daft-core/src/array/ops/image.rs
+++ b/src/daft-core/src/array/ops/image.rs
@@ -4,16 +4,15 @@ use std::vec;
 
 use image::{ColorType, DynamicImage, ImageBuffer};
 
-use crate::datatypes::DaftArrowBackedType;
+use crate::datatypes::FixedSizeListArray;
 use crate::datatypes::{
-    logical::{DaftImageryType, FixedShapeImageArray, ImageArray, LogicalDataArray},
-    BinaryArray, DaftLogicalType, DataType, Field, FixedSizeListArray, ImageFormat, ImageMode,
-    StructArray,
+    logical::{DaftImageryType, FixedShapeImageArray, ImageArray, LogicalArray},
+    BinaryArray, DataType, Field, ImageFormat, ImageMode, StructArray,
 };
 use common_error::{DaftError, DaftResult};
 use image::{Luma, LumaA, Rgb, Rgba};
 
-use super::as_arrow::AsArrow;
+use super::{as_arrow::AsArrow, from_arrow::FromArrow};
 use num_traits::FromPrimitive;
 
 use std::ops::Deref;
@@ -316,24 +315,24 @@ pub struct ImageArraySidecarData {
 }
 
 pub trait AsImageObj {
+    fn name(&self) -> &str;
+    fn len(&self) -> usize;
     fn as_image_obj(&self, idx: usize) -> Option<DaftImageBuffer<'_>>;
 }
 
-pub struct ImageBufferIter<'a, T>
+pub struct ImageBufferIter<'a, Arr>
 where
-    T: DaftLogicalType + DaftImageryType,
-    T::PhysicalType: DaftArrowBackedType,
+    Arr: AsImageObj,
 {
     cursor: usize,
-    image_array: &'a LogicalDataArray<T>,
+    image_array: &'a Arr,
 }
 
-impl<'a, T> ImageBufferIter<'a, T>
+impl<'a, Arr> ImageBufferIter<'a, Arr>
 where
-    T: DaftLogicalType + DaftImageryType,
-    T::PhysicalType: DaftArrowBackedType,
+    Arr: AsImageObj,
 {
-    pub fn new(image_array: &'a LogicalDataArray<T>) -> Self {
+    pub fn new(image_array: &'a Arr) -> Self {
         Self {
             cursor: 0usize,
             image_array,
@@ -341,11 +340,9 @@ where
     }
 }
 
-impl<'a, T> Iterator for ImageBufferIter<'a, T>
+impl<'a, Arr> Iterator for ImageBufferIter<'a, Arr>
 where
-    T: DaftLogicalType + DaftImageryType,
-    T::PhysicalType: DaftArrowBackedType,
-    LogicalDataArray<T>: AsImageObj,
+    Arr: AsImageObj,
 {
     type Item = Option<DaftImageBuffer<'a>>;
 
@@ -362,7 +359,7 @@ where
 
 impl ImageArray {
     pub fn image_mode(&self) -> &Option<ImageMode> {
-        match self.logical_type() {
+        match self.data_type() {
             DataType::Image(mode) => mode,
             _ => panic!("Expected dtype to be Image"),
         }
@@ -583,6 +580,14 @@ impl ImageArray {
 }
 
 impl AsImageObj for ImageArray {
+    fn len(&self) -> usize {
+        ImageArray::len(self)
+    }
+
+    fn name(&self) -> &str {
+        ImageArray::name(self)
+    }
+
     fn as_image_obj<'a>(&'a self, idx: usize) -> Option<DaftImageBuffer<'a>> {
         assert!(idx < self.len());
         if !self.physical.is_valid(idx) {
@@ -689,10 +694,8 @@ impl FixedShapeImageArray {
             Box::new(arrow2::array::PrimitiveArray::from_vec(data)),
             validity,
         ));
-        let physical_array = FixedSizeListArray::new(
-            Field::new(name, (&arrow_dtype).into()).into(),
-            arrow_array.boxed(),
-        )?;
+        let physical_array =
+            FixedSizeListArray::from_arrow(&Field::new(name, (&arrow_dtype).into()), arrow_array)?;
         let logical_dtype = DataType::FixedShapeImage(*image_mode, height, width);
         Ok(Self::new(Field::new(name, logical_dtype), physical_array))
     }
@@ -703,7 +706,7 @@ impl FixedShapeImageArray {
 
     pub fn resize(&self, w: u32, h: u32) -> DaftResult<Self> {
         let result = resize_images(self, w, h);
-        match self.logical_type() {
+        match self.data_type() {
             DataType::FixedShapeImage(mode, _, _) => Self::from_daft_image_buffers(self.name(), result.as_slice(), mode, h, w),
             dt => panic!("FixedShapeImageArray should always have DataType::FixedShapeImage() as it's dtype, but got {}", dt),
         }
@@ -731,13 +734,21 @@ impl FixedShapeImageArray {
 }
 
 impl AsImageObj for FixedShapeImageArray {
+    fn len(&self) -> usize {
+        FixedShapeImageArray::len(self)
+    }
+
+    fn name(&self) -> &str {
+        FixedShapeImageArray::name(self)
+    }
+
     fn as_image_obj<'a>(&'a self, idx: usize) -> Option<DaftImageBuffer<'a>> {
         assert!(idx < self.len());
         if !self.physical.is_valid(idx) {
             return None;
         }
 
-        match self.logical_type() {
+        match self.data_type() {
             DataType::FixedShapeImage(mode, height, width) => {
                 let arrow_array = self.as_arrow().values().as_any().downcast_ref::<arrow2::array::UInt8Array>().unwrap();
                 let num_channels = mode.num_channels();
@@ -770,14 +781,13 @@ impl AsImageObj for FixedShapeImageArray {
     }
 }
 
-impl<'a, T> IntoIterator for &'a LogicalDataArray<T>
+impl<'a, T> IntoIterator for &'a LogicalArray<T>
 where
     T: DaftImageryType,
-    T::PhysicalType: DaftArrowBackedType,
-    LogicalDataArray<T>: AsImageObj,
+    LogicalArray<T>: AsImageObj,
 {
     type Item = Option<DaftImageBuffer<'a>>;
-    type IntoIter = ImageBufferIter<'a, T>;
+    type IntoIter = ImageBufferIter<'a, LogicalArray<T>>;
 
     fn into_iter(self) -> Self::IntoIter {
         ImageBufferIter::new(self)
@@ -820,16 +830,10 @@ impl BinaryArray {
     }
 }
 
-fn encode_images<'a, T>(
-    images: &'a LogicalDataArray<T>,
-    image_format: ImageFormat,
-) -> DaftResult<BinaryArray>
+fn encode_images<'a, Arr>(images: &'a Arr, image_format: ImageFormat) -> DaftResult<BinaryArray>
 where
-    T: DaftImageryType,
-    T::PhysicalType: DaftArrowBackedType,
-    LogicalDataArray<T>: AsImageObj,
-    &'a LogicalDataArray<T>:
-        IntoIterator<Item = Option<DaftImageBuffer<'a>>, IntoIter = ImageBufferIter<'a, T>>,
+    Arr: AsImageObj,
+    &'a Arr: IntoIterator<Item = Option<DaftImageBuffer<'a>>, IntoIter = ImageBufferIter<'a, Arr>>,
 {
     let arrow_array = match image_format {
         ImageFormat::TIFF => {
@@ -917,17 +921,10 @@ where
     )
 }
 
-fn resize_images<'a, T>(
-    images: &'a LogicalDataArray<T>,
-    w: u32,
-    h: u32,
-) -> Vec<Option<DaftImageBuffer>>
+fn resize_images<'a, Arr>(images: &'a Arr, w: u32, h: u32) -> Vec<Option<DaftImageBuffer>>
 where
-    T: DaftImageryType,
-    T::PhysicalType: DaftArrowBackedType,
-    LogicalDataArray<T>: AsImageObj,
-    &'a LogicalDataArray<T>:
-        IntoIterator<Item = Option<DaftImageBuffer<'a>>, IntoIter = ImageBufferIter<'a, T>>,
+    Arr: AsImageObj,
+    &'a Arr: IntoIterator<Item = Option<DaftImageBuffer<'a>>, IntoIter = ImageBufferIter<'a, Arr>>,
 {
     images
         .into_iter()
@@ -935,16 +932,13 @@ where
         .collect::<Vec<_>>()
 }
 
-fn crop_images<'a, T>(
-    images: &'a LogicalDataArray<T>,
+fn crop_images<'a, Arr>(
+    images: &'a Arr,
     bboxes: &mut dyn Iterator<Item = Option<BBox>>,
 ) -> Vec<Option<DaftImageBuffer<'a>>>
 where
-    T: DaftImageryType,
-    T::PhysicalType: DaftArrowBackedType,
-    LogicalDataArray<T>: AsImageObj,
-    &'a LogicalDataArray<T>:
-        IntoIterator<Item = Option<DaftImageBuffer<'a>>, IntoIter = ImageBufferIter<'a, T>>,
+    Arr: AsImageObj,
+    &'a Arr: IntoIterator<Item = Option<DaftImageBuffer<'a>>, IntoIter = ImageBufferIter<'a, Arr>>,
 {
     images
         .into_iter()

--- a/src/daft-core/src/array/ops/mod.rs
+++ b/src/daft-core/src/array/ops/mod.rs
@@ -15,7 +15,7 @@ mod date;
 mod filter;
 mod float;
 pub mod from_arrow;
-mod full;
+pub mod full;
 mod get;
 pub(crate) mod groups;
 mod hash;

--- a/src/daft-core/src/array/ops/utf8.rs
+++ b/src/daft-core/src/array/ops/utf8.rs
@@ -3,7 +3,7 @@ use arrow2;
 
 use common_error::{DaftError, DaftResult};
 
-use super::as_arrow::AsArrow;
+use super::{as_arrow::AsArrow, full::FullNull};
 
 impl Utf8Array {
     pub fn endswith(&self, pattern: &Utf8Array) -> DaftResult<BooleanArray> {

--- a/src/daft-core/src/datatypes/logical.rs
+++ b/src/daft-core/src/datatypes/logical.rs
@@ -1,141 +1,134 @@
 use std::{marker::PhantomData, sync::Arc};
 
-use crate::datatypes::{BooleanArray, DaftLogicalType, DateType, Field};
+use crate::{
+    datatypes::{DaftLogicalType, DateType, Field},
+    with_match_daft_logical_primitive_types,
+};
 use common_error::DaftResult;
 
 use super::{
-    DaftArrayType, DaftArrowBackedType, DataArray, DataType, Decimal128Type, DurationType,
-    EmbeddingType, FixedShapeImageType, FixedShapeTensorType, ImageType, TensorType, TimestampType,
+    DaftArrayType, DaftDataType, DataArray, DataType, Decimal128Type, DurationType, EmbeddingType,
+    FixedShapeImageType, FixedShapeTensorType, ImageType, TensorType, TimestampType,
 };
 
 /// A LogicalArray is a wrapper on top of some underlying array, applying the semantic meaning of its
 /// field.datatype() to the underlying array.
-pub struct LogicalArray<L: DaftLogicalType, PhysicalArray> {
+#[derive(Clone)]
+pub struct LogicalArrayImpl<L: DaftLogicalType, PhysicalArray: DaftArrayType> {
     pub field: Arc<Field>,
     pub physical: PhysicalArray,
     marker_: PhantomData<L>,
 }
 
-/// LogicalArrays implementations that wrap different underlying types
-#[allow(warnings)] // the "where" bounds in a type alias are not enforced on the lhs, but are enforced on the rhs
-pub type LogicalDataArray<L: DaftLogicalType>
-where
-    L::PhysicalType: DaftArrowBackedType,
-= LogicalArray<L, DataArray<<L as DaftLogicalType>::PhysicalType>>;
+impl<L: DaftLogicalType, W: DaftArrayType> DaftArrayType for LogicalArrayImpl<L, W> {}
 
-impl<L: DaftLogicalType, W> DaftArrayType for LogicalArray<L, W> {}
-
-impl<L: DaftLogicalType> Clone for LogicalDataArray<L>
-where
-    L::PhysicalType: DaftArrowBackedType,
-{
-    fn clone(&self) -> Self {
-        LogicalArray::new(self.field.clone(), self.physical.clone())
-    }
-}
-
-impl<L: DaftLogicalType> LogicalDataArray<L>
-where
-    L::PhysicalType: DaftArrowBackedType,
-{
-    pub fn new<F: Into<Arc<Field>>>(field: F, physical: DataArray<L::PhysicalType>) -> Self {
+impl<L: DaftLogicalType, P: DaftArrayType> LogicalArrayImpl<L, P> {
+    pub fn new<F: Into<Arc<Field>>>(field: F, physical: P) -> Self {
         let field = field.into();
         assert!(
             field.dtype.is_logical(),
             "Can only construct Logical Arrays on Logical Types, got {}",
             field.dtype
         );
-        assert_eq!(
-            physical.data_type(),
-            &field.dtype.to_physical(),
-            "Expected {} for Physical Array, got {}",
-            &field.dtype.to_physical(),
-            physical.data_type()
-        );
-
-        LogicalArray {
+        // TODO(FixedSizeList): How to do this assert on the physical datatype?
+        // assert_eq!(
+        //     physical.data_type(),
+        //     &field.dtype.to_physical(),
+        //     "Expected {} for Physical Array, got {}",
+        //     &field.dtype.to_physical(),
+        //     physical.data_type()
+        // );
+        LogicalArrayImpl {
             physical,
             field,
             marker_: PhantomData,
         }
     }
 
-    pub fn empty(name: &str, dtype: &DataType) -> Self {
-        let field = Field::new(name, dtype.clone());
-        Self::new(field, DataArray::empty(name, &dtype.to_physical()))
-    }
-
     pub fn name(&self) -> &str {
         self.field.name.as_ref()
-    }
-
-    pub fn rename(&self, name: &str) -> Self {
-        let new_field = self.field.rename(name);
-        let new_array = self.physical.rename(name);
-        Self::new(new_field, new_array)
     }
 
     pub fn field(&self) -> &Field {
         &self.field
     }
 
-    pub fn logical_type(&self) -> &DataType {
+    pub fn data_type(&self) -> &DataType {
         &self.field.dtype
-    }
-
-    pub fn physical_type(&self) -> &DataType {
-        self.physical.data_type()
-    }
-
-    // Linter bug: doesn't pick up `is_empty` which is defined below
-    #[allow(clippy::len_without_is_empty)]
-    pub fn len(&self) -> usize {
-        self.physical.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    pub fn size_bytes(&self) -> DaftResult<usize> {
-        self.physical.size_bytes()
-    }
-
-    pub fn slice(&self, start: usize, end: usize) -> DaftResult<Self> {
-        let new_array = self.physical.slice(start, end)?;
-        Ok(Self::new(self.field.clone(), new_array))
-    }
-
-    pub fn head(&self, num: usize) -> DaftResult<Self> {
-        self.slice(0, num)
-    }
-
-    pub fn concat(arrays: &[&Self]) -> DaftResult<Self> {
-        if arrays.is_empty() {
-            return Err(common_error::DaftError::ValueError(
-                "Need at least 1 logical array to concat".to_string(),
-            ));
-        }
-        let physicals: Vec<_> = arrays.iter().map(|a| &a.physical).collect();
-        let concatd = DataArray::<L::PhysicalType>::concat(physicals.as_slice())?;
-        Ok(Self::new(arrays.first().unwrap().field.clone(), concatd))
-    }
-
-    pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
-        let new_array = self.physical.filter(mask)?;
-        Ok(Self::new(self.field.clone(), new_array))
     }
 }
 
-pub type Decimal128Array = LogicalDataArray<Decimal128Type>;
-pub type DateArray = LogicalDataArray<DateType>;
-pub type DurationArray = LogicalDataArray<DurationType>;
-pub type EmbeddingArray = LogicalDataArray<EmbeddingType>;
-pub type ImageArray = LogicalDataArray<ImageType>;
-pub type FixedShapeImageArray = LogicalDataArray<FixedShapeImageType>;
-pub type TimestampArray = LogicalDataArray<TimestampType>;
-pub type TensorArray = LogicalDataArray<TensorType>;
-pub type FixedShapeTensorArray = LogicalDataArray<FixedShapeTensorType>;
+macro_rules! impl_logical_type {
+    ($physical_array_type:ident) => {
+        pub fn len(&self) -> usize {
+            self.physical.len()
+        }
+
+        pub fn is_empty(&self) -> bool {
+            self.len() == 0
+        }
+
+        pub fn concat(arrays: &[&Self]) -> DaftResult<Self> {
+            if arrays.is_empty() {
+                return Err(common_error::DaftError::ValueError(
+                    "Need at least 1 logical array to concat".to_string(),
+                ));
+            }
+            let physicals: Vec<_> = arrays.iter().map(|a| &a.physical).collect();
+            let concatd = $physical_array_type::concat(physicals.as_slice())?;
+            Ok(Self::new(arrays.first().unwrap().field.clone(), concatd))
+        }
+    };
+}
+
+/// Implementation for a LogicalArray that wraps a DataArray
+impl<L: DaftLogicalType> LogicalArrayImpl<L, DataArray<L::PhysicalType>> {
+    impl_logical_type!(DataArray);
+
+    pub fn to_arrow(&self) -> Box<dyn arrow2::array::Array> {
+        let daft_type = self.data_type();
+        let arrow_logical_type = daft_type.to_arrow().unwrap();
+        let physical_arrow_array = self.physical.data();
+        use crate::datatypes::DataType::*;
+        match daft_type {
+            // For wrapped primitive types, switch the datatype label on the arrow2 Array.
+            Decimal128(..) | Date | Timestamp(..) | Duration(..) => {
+                with_match_daft_logical_primitive_types!(daft_type, |$P| {
+                    use arrow2::array::Array;
+                    physical_arrow_array
+                        .as_any()
+                        .downcast_ref::<arrow2::array::PrimitiveArray<$P>>()
+                        .unwrap()
+                        .clone()
+                        .to(arrow_logical_type)
+                        .to_boxed()
+                })
+            }
+            // Otherwise, use arrow cast to make sure the result arrow2 array is of the correct type.
+            _ => arrow2::compute::cast::cast(
+                physical_arrow_array,
+                &arrow_logical_type,
+                arrow2::compute::cast::CastOptions {
+                    wrapped: true,
+                    partial: false,
+                },
+            )
+            .unwrap(),
+        }
+    }
+}
+
+pub type LogicalArray<L> =
+    LogicalArrayImpl<L, <<L as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType>;
+pub type Decimal128Array = LogicalArray<Decimal128Type>;
+pub type DateArray = LogicalArray<DateType>;
+pub type DurationArray = LogicalArray<DurationType>;
+pub type ImageArray = LogicalArray<ImageType>;
+pub type TimestampArray = LogicalArray<TimestampType>;
+pub type TensorArray = LogicalArray<TensorType>;
+pub type EmbeddingArray = LogicalArray<EmbeddingType>;
+pub type FixedShapeTensorArray = LogicalArray<FixedShapeTensorType>;
+pub type FixedShapeImageArray = LogicalArray<FixedShapeImageType>;
 
 pub trait DaftImageryType: DaftLogicalType {}
 

--- a/src/daft-core/src/datatypes/logical.rs
+++ b/src/daft-core/src/datatypes/logical.rs
@@ -4,8 +4,8 @@ use crate::datatypes::{BooleanArray, DaftLogicalType, DateType, Field};
 use common_error::DaftResult;
 
 use super::{
-    DaftArrowBackedType, DataArray, DataType, Decimal128Type, DurationType, EmbeddingType,
-    FixedShapeImageType, FixedShapeTensorType, ImageType, TensorType, TimestampType,
+    DaftArrayType, DaftArrowBackedType, DataArray, DataType, Decimal128Type, DurationType,
+    EmbeddingType, FixedShapeImageType, FixedShapeTensorType, ImageType, TensorType, TimestampType,
 };
 
 /// A LogicalArray is a wrapper on top of some underlying array, applying the semantic meaning of its
@@ -22,6 +22,8 @@ pub type LogicalDataArray<L: DaftLogicalType>
 where
     L::PhysicalType: DaftArrowBackedType,
 = LogicalArray<L, DataArray<<L as DaftLogicalType>::PhysicalType>>;
+
+impl<L: DaftLogicalType, W> DaftArrayType for LogicalArray<L, W> {}
 
 impl<L: DaftLogicalType> Clone for LogicalDataArray<L>
 where

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -36,7 +36,7 @@ pub trait DaftPhysicalType: Send + Sync + DaftDataType {}
 pub trait DaftArrowBackedType: Send + Sync + DaftPhysicalType + 'static {}
 
 pub trait DaftLogicalType: Send + Sync + DaftDataType + 'static {
-    type PhysicalType: DaftArrowBackedType;
+    type PhysicalType: DaftPhysicalType;
 }
 
 macro_rules! impl_daft_arrow_datatype {

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -27,7 +27,7 @@ pub mod logical;
 pub trait DaftArrayType {}
 
 /// Trait to wrap DataType Enum
-pub trait DaftDataType: Sync + Send {
+pub trait DaftDataType: Sync + Send + Clone {
     // Concrete ArrayType that backs data of this DataType
     type ArrayType: DaftArrayType;
 
@@ -47,6 +47,7 @@ pub trait DaftLogicalType: Send + Sync + DaftDataType + 'static {
 
 macro_rules! impl_daft_arrow_datatype {
     ($ca:ident, $variant:ident) => {
+        #[derive(Clone)]
         pub struct $ca {}
 
         impl DaftDataType for $ca {
@@ -65,6 +66,7 @@ macro_rules! impl_daft_arrow_datatype {
 
 macro_rules! impl_daft_non_arrow_datatype {
     ($ca:ident, $variant:ident) => {
+        #[derive(Clone)]
         pub struct $ca {}
 
         impl DaftDataType for $ca {
@@ -81,6 +83,7 @@ macro_rules! impl_daft_non_arrow_datatype {
 
 macro_rules! impl_daft_logical_datatype {
     ($ca:ident, $variant:ident, $physical_type:ident) => {
+        #[derive(Clone)]
         pub struct $ca {}
 
         impl DaftDataType for $ca {
@@ -89,10 +92,7 @@ macro_rules! impl_daft_logical_datatype {
                 DataType::$variant
             }
 
-            type ArrayType = logical::LogicalArray<
-                $ca,
-                <<$ca as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType,
-            >;
+            type ArrayType = logical::LogicalArray<$ca>;
         }
 
         impl DaftLogicalType for $ca {

--- a/src/daft-core/src/python/series.rs
+++ b/src/daft-core/src/python/series.rs
@@ -5,7 +5,7 @@ use pyo3::{exceptions::PyValueError, prelude::*, pyclass::CompareOp, types::PyLi
 use crate::{
     array::{ops::DaftLogical, pseudo_arrow::PseudoArrowArray, DataArray},
     count_mode::CountMode,
-    datatypes::{DataType, Field, ImageFormat, ImageMode, PythonType, UInt64Type},
+    datatypes::{DataType, Field, ImageFormat, ImageMode, PythonType},
     ffi,
     series::{self, IntoSeries, Series},
     utils::arrow::{cast_array_for_daft_if_needed, cast_array_from_daft_if_needed},
@@ -155,7 +155,7 @@ impl PySeries {
                 )));
             }
             seed_series = s.series;
-            seed_array = Some(seed_series.downcast::<UInt64Type>()?);
+            seed_array = Some(seed_series.u64()?);
         }
         Ok(self.series.hash(seed_array)?.into_series().into())
     }

--- a/src/daft-core/src/series/array_impl/data_array.rs
+++ b/src/daft-core/src/series/array_impl/data_array.rs
@@ -244,7 +244,10 @@ macro_rules! impl_series_like_for_data_array {
             }
             fn take(&self, idx: &Series) -> DaftResult<Series> {
                 with_match_integer_daft_types!(idx.data_type(), |$S| {
-                    Ok(self.0.take(idx.downcast::<$S>()?)?.into_series())
+                    Ok(self
+                        .0
+                        .take(idx.downcast::<<$S as DaftDataType>::ArrayType>()?)?
+                        .into_series())
                 })
             }
 

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -92,7 +92,7 @@ macro_rules! impl_series_like_for_logical_array {
             fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series> {
                 Ok(self
                     .0
-                    .if_else(other.downcast_logical()?, predicate.downcast()?)?
+                    .if_else(other.downcast_logical_data_array()?, predicate.downcast()?)?
                     .into_series())
             }
 

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -92,7 +92,7 @@ macro_rules! impl_series_like_for_logical_array {
             fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series> {
                 Ok(self
                     .0
-                    .if_else(other.downcast_logical_data_array()?, predicate.downcast()?)?
+                    .if_else(other.downcast()?, predicate.downcast()?)?
                     .into_series())
             }
 
@@ -136,7 +136,10 @@ macro_rules! impl_series_like_for_logical_array {
 
             fn take(&self, idx: &Series) -> DaftResult<Series> {
                 with_match_integer_daft_types!(idx.data_type(), |$S| {
-                    Ok(self.0.take(idx.downcast::<$S>()?)?.into_series())
+                    Ok(self
+                        .0
+                        .take(idx.downcast::<<$S as DaftDataType>::ArrayType>()?)?
+                        .into_series())
                 })
             }
 

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -1,62 +1,38 @@
 use crate::datatypes::logical::{
     DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
-    FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
+    FixedShapeTensorArray, ImageArray, LogicalArray, TensorArray, TimestampArray,
 };
-use crate::datatypes::BooleanArray;
+use crate::datatypes::{BooleanArray, DaftLogicalType, Field};
 
 use super::{ArrayWrapper, IntoSeries, Series};
 use crate::array::ops::GroupIndices;
 use crate::series::array_impl::binary_ops::SeriesBinaryOps;
 use crate::series::DaftResult;
 use crate::series::SeriesLike;
-use crate::with_match_daft_logical_primitive_types;
 use crate::with_match_integer_daft_types;
+use crate::DataType;
 use std::sync::Arc;
+
+impl<L> IntoSeries for LogicalArray<L>
+where
+    L: DaftLogicalType,
+    ArrayWrapper<LogicalArray<L>>: SeriesLike,
+{
+    fn into_series(self) -> Series {
+        Series {
+            inner: Arc::new(ArrayWrapper(self)),
+        }
+    }
+}
 
 macro_rules! impl_series_like_for_logical_array {
     ($da:ident) => {
-        impl IntoSeries for $da {
-            fn into_series(self) -> Series {
-                Series {
-                    inner: Arc::new(ArrayWrapper(self)),
-                }
-            }
-        }
-
         impl SeriesLike for ArrayWrapper<$da> {
             fn into_series(&self) -> Series {
                 self.0.clone().into_series()
             }
             fn to_arrow(&self) -> Box<dyn arrow2::array::Array> {
-                let daft_type = self.0.logical_type();
-                let arrow_logical_type = daft_type.to_arrow().unwrap();
-                let physical_arrow_array = self.0.physical.data();
-                use crate::datatypes::DataType::*;
-                match daft_type {
-                    // For wrapped primitive types, switch the datatype label on the arrow2 Array.
-                    Decimal128(..) | Date | Timestamp(..) | Duration(..) => {
-                        with_match_daft_logical_primitive_types!(daft_type, |$P| {
-                            use arrow2::array::Array;
-                            physical_arrow_array
-                                .as_any()
-                                .downcast_ref::<arrow2::array::PrimitiveArray<$P>>()
-                                .unwrap()
-                                .clone()
-                                .to(arrow_logical_type)
-                                .to_boxed()
-                        })
-                    }
-                    // Otherwise, use arrow cast to make sure the result arrow2 array is of the correct type.
-                    _ => arrow2::compute::cast::cast(
-                        physical_arrow_array,
-                        &arrow_logical_type,
-                        arrow2::compute::cast::CastOptions {
-                            wrapped: true,
-                            partial: false,
-                        },
-                    )
-                    .unwrap(),
-                }
+                self.0.to_arrow()
             }
 
             fn as_any(&self) -> &dyn std::any::Any {
@@ -69,24 +45,25 @@ macro_rules! impl_series_like_for_logical_array {
                 Ok($da::new(self.0.field.clone(), data_array).into_series())
             }
 
-            fn cast(&self, datatype: &crate::datatypes::DataType) -> DaftResult<Series> {
+            fn cast(&self, datatype: &DataType) -> DaftResult<Series> {
                 self.0.cast(datatype)
             }
 
-            fn data_type(&self) -> &crate::datatypes::DataType {
-                self.0.logical_type()
+            fn data_type(&self) -> &DataType {
+                self.0.data_type()
             }
 
-            fn field(&self) -> &crate::datatypes::Field {
+            fn field(&self) -> &Field {
                 self.0.field()
             }
 
             fn filter(&self, mask: &crate::datatypes::BooleanArray) -> DaftResult<Series> {
-                Ok(self.0.filter(mask)?.into_series())
+                let new_array = self.0.physical.filter(mask)?;
+                Ok($da::new(self.0.field.clone(), new_array).into_series())
             }
 
             fn head(&self, num: usize) -> DaftResult<Series> {
-                Ok(self.0.head(num)?.into_series())
+                self.slice(0, num)
             }
 
             fn if_else(&self, other: &Series, predicate: &Series) -> DaftResult<Series> {
@@ -103,23 +80,26 @@ macro_rules! impl_series_like_for_logical_array {
             }
 
             fn len(&self) -> usize {
-                self.0.len()
+                self.0.physical.len()
             }
 
             fn size_bytes(&self) -> DaftResult<usize> {
-                self.0.size_bytes()
+                self.0.physical.size_bytes()
             }
 
             fn name(&self) -> &str {
-                self.0.name()
+                self.0.field.name.as_str()
             }
 
             fn rename(&self, name: &str) -> Series {
-                self.0.rename(name).into_series()
+                let new_array = self.0.physical.rename(name);
+                let new_field = self.0.field.rename(name);
+                $da::new(new_field, new_array).into_series()
             }
 
             fn slice(&self, start: usize, end: usize) -> DaftResult<Series> {
-                Ok(self.0.slice(start, end)?.into_series())
+                let new_array = self.0.physical.slice(start, end)?;
+                Ok($da::new(self.0.field.clone(), new_array).into_series())
             }
 
             fn sort(&self, descending: bool) -> DaftResult<Series> {
@@ -223,9 +203,9 @@ macro_rules! impl_series_like_for_logical_array {
 impl_series_like_for_logical_array!(Decimal128Array);
 impl_series_like_for_logical_array!(DateArray);
 impl_series_like_for_logical_array!(DurationArray);
-impl_series_like_for_logical_array!(EmbeddingArray);
 impl_series_like_for_logical_array!(ImageArray);
-impl_series_like_for_logical_array!(FixedShapeImageArray);
 impl_series_like_for_logical_array!(TimestampArray);
 impl_series_like_for_logical_array!(TensorArray);
+impl_series_like_for_logical_array!(EmbeddingArray);
+impl_series_like_for_logical_array!(FixedShapeImageArray);
 impl_series_like_for_logical_array!(FixedShapeTensorArray);

--- a/src/daft-core/src/series/from.rs
+++ b/src/daft-core/src/series/from.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    datatypes::{logical::LogicalDataArray, DataType, Field},
+    datatypes::{logical::LogicalArray, DataType, Field},
     with_match_daft_logical_primitive_types, with_match_daft_logical_types,
     with_match_physical_daft_types,
 };
@@ -53,7 +53,7 @@ impl TryFrom<(&str, Box<dyn arrow2::array::Array>)> for Series {
             };
 
             let res = with_match_daft_logical_types!(dtype, |$T| {
-                LogicalDataArray::<$T>::from_arrow(field.as_ref(), physical_arrow_array)?.into_series()
+                LogicalArray::<$T>::from_arrow(field.as_ref(), physical_arrow_array)?.into_series()
             });
             return Ok(res);
         }

--- a/src/daft-core/src/series/from.rs
+++ b/src/daft-core/src/series/from.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
-    datatypes::{logical::LogicalArray, DataType, Field},
+    datatypes::{logical::LogicalDataArray, DataType, Field},
     with_match_daft_logical_primitive_types, with_match_daft_logical_types,
     with_match_physical_daft_types,
 };
@@ -53,7 +53,7 @@ impl TryFrom<(&str, Box<dyn arrow2::array::Array>)> for Series {
             };
 
             let res = with_match_daft_logical_types!(dtype, |$T| {
-                LogicalArray::<$T>::from_arrow(field.as_ref(), physical_arrow_array)?.into_series()
+                LogicalDataArray::<$T>::from_arrow(field.as_ref(), physical_arrow_array)?.into_series()
             });
             return Ok(res);
         }

--- a/src/daft-core/src/series/mod.rs
+++ b/src/daft-core/src/series/mod.rs
@@ -13,7 +13,7 @@ use common_error::DaftResult;
 
 pub use array_impl::IntoSeries;
 
-use self::series_like::SeriesLike;
+pub(crate) use self::series_like::SeriesLike;
 
 #[derive(Clone)]
 pub struct Series {

--- a/src/daft-core/src/series/ops/agg.rs
+++ b/src/daft-core/src/series/ops/agg.rs
@@ -11,8 +11,8 @@ impl Series {
         let s = self.as_physical()?;
         with_match_physical_daft_types!(s.data_type(), |$T| {
             match groups {
-                Some(groups) => Ok(DaftCountAggable::grouped_count(&s.downcast::<$T>()?, groups, mode)?.into_series()),
-                None => Ok(DaftCountAggable::count(&s.downcast::<$T>()?, mode)?.into_series())
+                Some(groups) => Ok(DaftCountAggable::grouped_count(&s.downcast::<<$T as DaftDataType>::ArrayType>()?, groups, mode)?.into_series()),
+                None => Ok(DaftCountAggable::count(&s.downcast::<<$T as DaftDataType>::ArrayType>()?, mode)?.into_series())
             }
         })
     }
@@ -45,19 +45,19 @@ impl Series {
             // floatX -> floatX (in line with numpy)
             Float32 => match groups {
                 Some(groups) => Ok(DaftSumAggable::grouped_sum(
-                    &self.downcast::<Float32Type>()?,
+                    &self.downcast::<Float32Array>()?,
                     groups,
                 )?
                 .into_series()),
-                None => Ok(DaftSumAggable::sum(&self.downcast::<Float32Type>()?)?.into_series()),
+                None => Ok(DaftSumAggable::sum(&self.downcast::<Float32Array>()?)?.into_series()),
             },
             Float64 => match groups {
                 Some(groups) => Ok(DaftSumAggable::grouped_sum(
-                    &self.downcast::<Float64Type>()?,
+                    &self.downcast::<Float64Array>()?,
                     groups,
                 )?
                 .into_series()),
-                None => Ok(DaftSumAggable::sum(&self.downcast::<Float64Type>()?)?.into_series()),
+                None => Ok(DaftSumAggable::sum(&self.downcast::<Float64Array>()?)?.into_series()),
             },
             other => Err(DaftError::TypeError(format!(
                 "Numeric sum is not implemented for type {}",
@@ -104,7 +104,7 @@ impl Series {
         use crate::array::ops::DaftConcatAggable;
         match self.data_type() {
             DataType::List(..) => {
-                let downcasted = self.downcast::<ListType>()?;
+                let downcasted = self.downcast::<ListArray>()?;
                 match groups {
                     Some(groups) => {
                         Ok(DaftConcatAggable::grouped_concat(downcasted, groups)?.into_series())
@@ -114,7 +114,7 @@ impl Series {
             }
             #[cfg(feature = "python")]
             DataType::Python => {
-                let downcasted = self.downcast::<PythonType>()?;
+                let downcasted = self.downcast::<PythonArray>()?;
                 match groups {
                     Some(groups) => {
                         Ok(DaftConcatAggable::grouped_concat(downcasted, groups)?.into_series())

--- a/src/daft-core/src/series/ops/arithmetic.rs
+++ b/src/daft-core/src/series/ops/arithmetic.rs
@@ -30,6 +30,7 @@ impl_arithmetic_for_series!(Rem, rem);
 
 #[cfg(test)]
 mod tests {
+    use crate::array::ops::full::FullNull;
     use crate::datatypes::{DataType, Float64Array, Int64Array, Utf8Array};
     use crate::series::IntoSeries;
     use common_error::DaftResult;

--- a/src/daft-core/src/series/ops/broadcast.rs
+++ b/src/daft-core/src/series/ops/broadcast.rs
@@ -9,6 +9,7 @@ impl Series {
 
 #[cfg(test)]
 mod tests {
+    use crate::array::ops::full::FullNull;
     use crate::datatypes::{DataType, Int64Array, Utf8Array};
     use crate::series::array_impl::IntoSeries;
     use common_error::DaftResult;

--- a/src/daft-core/src/series/ops/concat.rs
+++ b/src/daft-core/src/series/ops/concat.rs
@@ -29,13 +29,13 @@ impl Series {
         }
         if first_dtype.is_logical() {
             return Ok(with_match_daft_logical_types!(first_dtype, |$T| {
-                let downcasted = series.into_iter().map(|s| s.downcast_logical_data_array::<$T>()).collect::<DaftResult<Vec<_>>>()?;
+                let downcasted = series.into_iter().map(|s| s.downcast::<<$T as DaftDataType>::ArrayType>()).collect::<DaftResult<Vec<_>>>()?;
                 LogicalDataArray::<$T>::concat(downcasted.as_slice())?.into_series()
             }));
         }
 
         with_match_physical_daft_types!(first_dtype, |$T| {
-            let downcasted = series.into_iter().map(|s| s.downcast::<$T>()).collect::<DaftResult<Vec<_>>>()?;
+            let downcasted = series.into_iter().map(|s| s.downcast::<<$T as DaftDataType>::ArrayType>()).collect::<DaftResult<Vec<_>>>()?;
             Ok(DataArray::<$T>::concat(downcasted.as_slice())?.into_series())
         })
     }

--- a/src/daft-core/src/series/ops/concat.rs
+++ b/src/daft-core/src/series/ops/concat.rs
@@ -1,4 +1,4 @@
-use crate::datatypes::logical::LogicalArray;
+use crate::datatypes::logical::LogicalDataArray;
 use crate::{
     series::{IntoSeries, Series},
     with_match_daft_logical_types, with_match_physical_daft_types,
@@ -29,8 +29,8 @@ impl Series {
         }
         if first_dtype.is_logical() {
             return Ok(with_match_daft_logical_types!(first_dtype, |$T| {
-                let downcasted = series.into_iter().map(|s| s.downcast_logical::<$T>()).collect::<DaftResult<Vec<_>>>()?;
-                LogicalArray::<$T>::concat(downcasted.as_slice())?.into_series()
+                let downcasted = series.into_iter().map(|s| s.downcast_logical_data_array::<$T>()).collect::<DaftResult<Vec<_>>>()?;
+                LogicalDataArray::<$T>::concat(downcasted.as_slice())?.into_series()
             }));
         }
 

--- a/src/daft-core/src/series/ops/concat.rs
+++ b/src/daft-core/src/series/ops/concat.rs
@@ -1,4 +1,4 @@
-use crate::datatypes::logical::LogicalDataArray;
+use crate::datatypes::logical::LogicalArray;
 use crate::{
     series::{IntoSeries, Series},
     with_match_daft_logical_types, with_match_physical_daft_types,
@@ -30,7 +30,7 @@ impl Series {
         if first_dtype.is_logical() {
             return Ok(with_match_daft_logical_types!(first_dtype, |$T| {
                 let downcasted = series.into_iter().map(|s| s.downcast::<<$T as DaftDataType>::ArrayType>()).collect::<DaftResult<Vec<_>>>()?;
-                LogicalDataArray::<$T>::concat(downcasted.as_slice())?.into_series()
+                LogicalArray::<$T>::concat(downcasted.as_slice())?.into_series()
             }));
         }
 

--- a/src/daft-core/src/series/ops/date.rs
+++ b/src/daft-core/src/series/ops/date.rs
@@ -14,7 +14,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical::<DateType>()?;
+        let downcasted = self.downcast_logical_data_array::<DateType>()?;
         Ok(downcasted.day()?.into_series())
     }
 
@@ -26,7 +26,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical::<DateType>()?;
+        let downcasted = self.downcast_logical_data_array::<DateType>()?;
         Ok(downcasted.month()?.into_series())
     }
 
@@ -38,7 +38,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical::<DateType>()?;
+        let downcasted = self.downcast_logical_data_array::<DateType>()?;
         Ok(downcasted.year()?.into_series())
     }
 
@@ -50,7 +50,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical::<DateType>()?;
+        let downcasted = self.downcast_logical_data_array::<DateType>()?;
         Ok(downcasted.day_of_week()?.into_series())
     }
 }

--- a/src/daft-core/src/series/ops/date.rs
+++ b/src/daft-core/src/series/ops/date.rs
@@ -1,6 +1,6 @@
 use crate::series::array_impl::IntoSeries;
 use crate::{
-    datatypes::{DataType, DateType},
+    datatypes::{logical::DateArray, DataType},
     series::Series,
 };
 use common_error::{DaftError, DaftResult};
@@ -14,7 +14,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical_data_array::<DateType>()?;
+        let downcasted = self.downcast::<DateArray>()?;
         Ok(downcasted.day()?.into_series())
     }
 
@@ -26,7 +26,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical_data_array::<DateType>()?;
+        let downcasted = self.downcast::<DateArray>()?;
         Ok(downcasted.month()?.into_series())
     }
 
@@ -38,7 +38,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical_data_array::<DateType>()?;
+        let downcasted = self.downcast::<DateArray>()?;
         Ok(downcasted.year()?.into_series())
     }
 
@@ -50,7 +50,7 @@ impl Series {
             )));
         }
 
-        let downcasted = self.downcast_logical_data_array::<DateType>()?;
+        let downcasted = self.downcast::<DateArray>()?;
         Ok(downcasted.day_of_week()?.into_series())
     }
 }

--- a/src/daft-core/src/series/ops/downcast.rs
+++ b/src/daft-core/src/series/ops/downcast.rs
@@ -1,6 +1,6 @@
 use crate::datatypes::*;
 
-use crate::datatypes::logical::{FixedShapeImageArray, ImageArray, LogicalArray};
+use crate::datatypes::logical::{FixedShapeImageArray, ImageArray, LogicalDataArray};
 use crate::series::array_impl::ArrayWrapper;
 use crate::series::Series;
 use common_error::DaftResult;
@@ -20,7 +20,12 @@ impl Series {
         }
     }
 
-    pub fn downcast_logical<L: DaftLogicalType>(&self) -> DaftResult<&LogicalArray<L>> {
+    pub fn downcast_logical_data_array<L: DaftLogicalType>(
+        &self,
+    ) -> DaftResult<&LogicalDataArray<L>>
+    where
+        L::PhysicalType: DaftPhysicalType,
+    {
         match self.inner.as_any().downcast_ref() {
             Some(ArrayWrapper(arr)) => Ok(arr),
             None => panic!(
@@ -128,11 +133,11 @@ impl Series {
     }
 
     pub fn image(&self) -> DaftResult<&ImageArray> {
-        self.downcast_logical()
+        self.downcast_logical_data_array()
     }
 
     pub fn fixed_size_image(&self) -> DaftResult<&FixedShapeImageArray> {
-        self.downcast_logical()
+        self.downcast_logical_data_array()
     }
 
     #[cfg(feature = "python")]

--- a/src/daft-core/src/series/ops/float.rs
+++ b/src/daft-core/src/series/ops/float.rs
@@ -8,7 +8,7 @@ impl Series {
     pub fn is_nan(&self) -> DaftResult<Series> {
         use crate::array::ops::DaftIsNan;
         with_match_float_and_null_daft_types!(self.data_type(), |$T| {
-            Ok(DaftIsNan::is_nan(self.downcast::<$T>()?)?.into_series())
+            Ok(DaftIsNan::is_nan(self.downcast::<<$T as DaftDataType>::ArrayType>()?)?.into_series())
         })
     }
 }

--- a/src/daft-core/src/series/ops/groups.rs
+++ b/src/daft-core/src/series/ops/groups.rs
@@ -9,7 +9,7 @@ impl IntoGroups for Series {
     fn make_groups(&self) -> DaftResult<GroupIndicesPair> {
         let s = self.as_physical()?;
         with_match_comparable_daft_types!(s.data_type(), |$T| {
-            let array = s.downcast::<$T>()?;
+            let array = s.downcast::<<$T as DaftDataType>::ArrayType>()?;
             array.make_groups()
         })
     }

--- a/src/daft-core/src/series/ops/hash.rs
+++ b/src/daft-core/src/series/ops/hash.rs
@@ -5,7 +5,7 @@ impl Series {
     pub fn hash(&self, seed: Option<&UInt64Array>) -> DaftResult<UInt64Array> {
         let s = self.as_physical()?;
         with_match_comparable_daft_types!(s.data_type(), |$T| {
-            let downcasted = s.downcast::<$T>()?;
+            let downcasted = s.downcast::<<$T as DaftDataType>::ArrayType>()?;
             downcasted.hash(seed)
         })
     }

--- a/src/daft-core/src/series/ops/image.rs
+++ b/src/daft-core/src/series/ops/image.rs
@@ -16,11 +16,11 @@ impl Series {
     pub fn image_encode(&self, image_format: ImageFormat) -> DaftResult<Series> {
         match self.data_type() {
             DataType::Image(..) => Ok(self
-                .downcast_logical::<ImageType>()?
+                .downcast_logical_data_array::<ImageType>()?
                 .encode(image_format)?
                 .into_series()),
             DataType::FixedShapeImage(..) => Ok(self
-                .downcast_logical::<FixedShapeImageType>()?
+                .downcast_logical_data_array::<FixedShapeImageType>()?
                 .encode(image_format)?
                 .into_series()),
             dtype => Err(DaftError::ValueError(format!(
@@ -33,7 +33,7 @@ impl Series {
     pub fn image_resize(&self, w: u32, h: u32) -> DaftResult<Series> {
         match self.data_type() {
             DataType::Image(mode) => {
-                let array = self.downcast_logical::<ImageType>()?;
+                let array = self.downcast_logical_data_array::<ImageType>()?;
                 match mode {
                     // If the image mode is specified at the type-level (and is therefore guaranteed to be consistent
                     // across all images across all partitions), store the resized image in a fixed shape image array,
@@ -45,7 +45,7 @@ impl Series {
                 }
             }
             DataType::FixedShapeImage(..) => Ok(self
-                .downcast_logical::<FixedShapeImageType>()?
+                .downcast_logical_data_array::<FixedShapeImageType>()?
                 .resize(w, h)?
                 .into_series()),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-core/src/series/ops/image.rs
+++ b/src/daft-core/src/series/ops/image.rs
@@ -1,4 +1,5 @@
-use crate::datatypes::{DataType, Field, FixedShapeImageType, ImageFormat, ImageType};
+use crate::datatypes::logical::{FixedShapeImageArray, ImageArray};
+use crate::datatypes::{DataType, Field, ImageFormat};
 
 use crate::series::{IntoSeries, Series};
 use common_error::{DaftError, DaftResult};
@@ -16,11 +17,11 @@ impl Series {
     pub fn image_encode(&self, image_format: ImageFormat) -> DaftResult<Series> {
         match self.data_type() {
             DataType::Image(..) => Ok(self
-                .downcast_logical_data_array::<ImageType>()?
+                .downcast::<ImageArray>()?
                 .encode(image_format)?
                 .into_series()),
             DataType::FixedShapeImage(..) => Ok(self
-                .downcast_logical_data_array::<FixedShapeImageType>()?
+                .downcast::<FixedShapeImageArray>()?
                 .encode(image_format)?
                 .into_series()),
             dtype => Err(DaftError::ValueError(format!(
@@ -33,7 +34,7 @@ impl Series {
     pub fn image_resize(&self, w: u32, h: u32) -> DaftResult<Series> {
         match self.data_type() {
             DataType::Image(mode) => {
-                let array = self.downcast_logical_data_array::<ImageType>()?;
+                let array = self.downcast::<ImageArray>()?;
                 match mode {
                     // If the image mode is specified at the type-level (and is therefore guaranteed to be consistent
                     // across all images across all partitions), store the resized image in a fixed shape image array,
@@ -45,7 +46,7 @@ impl Series {
                 }
             }
             DataType::FixedShapeImage(..) => Ok(self
-                .downcast_logical_data_array::<FixedShapeImageType>()?
+                .downcast::<FixedShapeImageArray>()?
                 .resize(w, h)?
                 .into_series()),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-core/src/series/ops/not.rs
+++ b/src/daft-core/src/series/ops/not.rs
@@ -1,6 +1,6 @@
 use std::ops::Not;
 
-use crate::datatypes::BooleanType;
+use crate::datatypes::BooleanArray;
 use crate::series::array_impl::IntoSeries;
 use crate::series::Series;
 use common_error::DaftResult;
@@ -8,7 +8,7 @@ use common_error::DaftResult;
 impl Not for &Series {
     type Output = DaftResult<Series>;
     fn not(self) -> Self::Output {
-        let array = self.downcast::<BooleanType>()?;
+        let array = self.downcast::<BooleanArray>()?;
         Ok((!array)?.into_series())
     }
 }

--- a/src/daft-core/src/series/ops/search_sorted.rs
+++ b/src/daft-core/src/series/ops/search_sorted.rs
@@ -12,8 +12,8 @@ impl Series {
         let rhs = rhs.as_physical()?;
 
         with_match_comparable_daft_types!(lhs.data_type(), |$T| {
-            let lhs = lhs.downcast::<$T>().unwrap();
-            let rhs = rhs.downcast::<$T>().unwrap();
+            let lhs = lhs.downcast::<<$T as DaftDataType>::ArrayType>().unwrap();
+            let rhs = rhs.downcast::<<$T as DaftDataType>::ArrayType>().unwrap();
             lhs.search_sorted(rhs, descending)
         })
     }

--- a/src/daft-core/src/series/ops/sort.rs
+++ b/src/daft-core/src/series/ops/sort.rs
@@ -9,7 +9,7 @@ impl Series {
     pub fn argsort(&self, descending: bool) -> DaftResult<Series> {
         let series = self.as_physical()?;
         with_match_comparable_daft_types!(series.data_type(), |$T| {
-            let downcasted = series.downcast::<$T>()?;
+            let downcasted = series.downcast::<<$T as DaftDataType>::ArrayType>()?;
             Ok(downcasted.argsort::<UInt64Type>(descending)?.into_series())
         })
     }
@@ -32,7 +32,7 @@ impl Series {
 
         let first = sort_keys.first().unwrap().as_physical()?;
         with_match_comparable_daft_types!(first.data_type(), |$T| {
-            let downcasted = first.downcast::<$T>()?;
+            let downcasted = first.downcast::<<$T as DaftDataType>::ArrayType>()?;
             let result = downcasted.argsort_multikey::<UInt64Type>(&sort_keys[1..], descending)?;
             Ok(result.into_series())
         })

--- a/src/daft-dsl/src/lit.rs
+++ b/src/daft-dsl/src/lit.rs
@@ -4,8 +4,8 @@ use std::{
 };
 
 use crate::expr::Expr;
-use daft_core::datatypes::DataType;
 use daft_core::series::Series;
+use daft_core::{array::ops::full::FullNull, datatypes::DataType};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "python")]

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -8,7 +8,7 @@ use num_traits::ToPrimitive;
 use daft_core::array::ops::GroupIndices;
 
 use common_error::{DaftError, DaftResult};
-use daft_core::datatypes::logical::LogicalArray;
+use daft_core::datatypes::logical::LogicalDataArray;
 use daft_core::datatypes::{BooleanType, DataType, Field, UInt64Array};
 use daft_core::schema::{Schema, SchemaRef};
 use daft_core::series::{IntoSeries, Series};
@@ -74,7 +74,7 @@ impl Table {
                 for (field_name, field) in schema.fields.iter() {
                     if field.dtype.is_logical() {
                         with_match_daft_logical_types!(field.dtype, |$T| {
-                            columns.push(LogicalArray::<$T>::empty(field_name, &field.dtype).into_series())
+                            columns.push(LogicalDataArray::<$T>::empty(field_name, &field.dtype).into_series())
                         })
                     } else {
                         with_match_physical_daft_types!(field.dtype, |$T| {

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -9,7 +9,7 @@ use daft_core::array::ops::GroupIndices;
 
 use common_error::{DaftError, DaftResult};
 use daft_core::datatypes::logical::LogicalDataArray;
-use daft_core::datatypes::{BooleanType, DataType, Field, UInt64Array};
+use daft_core::datatypes::{BooleanArray, DataType, Field, UInt64Array};
 use daft_core::schema::{Schema, SchemaRef};
 use daft_core::series::{IntoSeries, Series};
 use daft_core::{with_match_daft_logical_types, with_match_physical_daft_types};
@@ -202,7 +202,7 @@ impl Table {
             )));
         }
 
-        let mask = mask.downcast::<BooleanType>().unwrap();
+        let mask = mask.downcast::<BooleanArray>().unwrap();
         let new_series: DaftResult<Vec<_>> = self.columns.iter().map(|s| s.filter(mask)).collect();
         Ok(Table {
             schema: self.schema.clone(),

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -3,12 +3,13 @@
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter, Result};
 
+use daft_core::array::ops::full::FullNull;
 use num_traits::ToPrimitive;
 
 use daft_core::array::ops::GroupIndices;
 
 use common_error::{DaftError, DaftResult};
-use daft_core::datatypes::logical::LogicalDataArray;
+use daft_core::datatypes::logical::LogicalArray;
 use daft_core::datatypes::{BooleanArray, DataType, Field, UInt64Array};
 use daft_core::schema::{Schema, SchemaRef};
 use daft_core::series::{IntoSeries, Series};
@@ -74,7 +75,7 @@ impl Table {
                 for (field_name, field) in schema.fields.iter() {
                     if field.dtype.is_logical() {
                         with_match_daft_logical_types!(field.dtype, |$T| {
-                            columns.push(LogicalDataArray::<$T>::empty(field_name, &field.dtype).into_series())
+                            columns.push(LogicalArray::<$T>::empty(field_name, &field.dtype).into_series())
                         })
                     } else {
                         with_match_physical_daft_types!(field.dtype, |$T| {

--- a/src/daft-table/src/ops/groups.rs
+++ b/src/daft-table/src/ops/groups.rs
@@ -4,7 +4,7 @@ use daft_core::{
         arrow2::comparison::build_multi_array_is_equal, as_arrow::AsArrow, GroupIndicesPair,
         IntoGroups,
     },
-    datatypes::{UInt64Array, UInt64Type},
+    datatypes::UInt64Array,
     series::Series,
 };
 
@@ -56,7 +56,7 @@ impl Table {
         // Begin by doing the argsort.
         let argsort_series =
             Series::argsort_multikey(self.columns.as_slice(), &vec![false; self.columns.len()])?;
-        let argsort_array = argsort_series.downcast::<UInt64Type>()?;
+        let argsort_array = argsort_series.downcast::<UInt64Array>()?;
 
         // The result indices.
         let mut key_indices: Vec<u64> = vec![];

--- a/src/daft-table/src/ops/joins/hash_join.rs
+++ b/src/daft-table/src/ops/joins/hash_join.rs
@@ -1,5 +1,5 @@
 use daft_core::{
-    array::ops::arrow2::comparison::build_multi_array_is_equal,
+    array::ops::{arrow2::comparison::build_multi_array_is_equal, full::FullNull},
     datatypes::{DataType, UInt64Array},
     series::{IntoSeries, Series},
 };


### PR DESCRIPTION
# Summary

1. Refactors `Series::downcast` to use the concrete array type instead of a DaftDataType
2. Refactors `LogicalArray<L> = LogicalArrayImpl<L, L::PhysicalType::ArrayType>`. The underlying `LogicalArrayImpl` is now generic over both its LogicalType, as well as its underlying container type.

Necessary drive-bys:

1. Refactors to `image.rs` which used to make a lot of assumptions about LogicalArrays holding DataArrays
2. Refactor to `::full_null()` and `::empty()`: we now need a generic implementation over all LogicalArray container types and this requires a `FullNull` trait to be used.

This paves the way for adding more LogicalArray container types that aren't `DataArray` (Coming soon: FixedSizeListArray, StructArray and more)
