### PR TITLE
[FEAT] [New Query Planner] Add logical plan hashing, rule batches, fixed-point policies, early optimizer termination, and optimization cycle detection.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,6 +1117,7 @@ dependencies = [
  "indexmap 2.0.0",
  "pyo3",
  "serde",
+ "serde_json",
  "snafu",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "pyo3",
  "pyo3-log",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -379,6 +379,9 @@ class Expression:
     def _to_field(self, schema: Schema) -> Field:
         return Field._from_pyfield(self._expr.to_field(schema._schema))
 
+    def __hash__(self) -> int:
+        return self._expr.__hash__()
+
     def __getstate__(self) -> bytes:
         return self._expr.__getstate__()
 

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -153,6 +153,9 @@ class PartitionCacheEntry:
     def __eq__(self, other: object) -> bool:
         return isinstance(other, PartitionCacheEntry) and self.key == other.key
 
+    def __hash__(self) -> int:
+        return hash(self.key)
+
     def __repr__(self) -> str:
         return f"PartitionCacheEntry: {self.key}"
 

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -83,6 +83,10 @@ class PartialUDF:
         else:
             raise NotImplementedError(f"Return type not supported for UDF: {type(result)}")
 
+    def __hash__(self) -> int:
+        args = frozenset(self.bound_args.arguments.items())
+        return hash((self.udf, args))
+
 
 @dataclasses.dataclass
 class UDF:
@@ -131,6 +135,9 @@ class UDF:
             # NOTE: This potentially runs expensive initializations on the class
             return self.func()
         raise NotImplementedError(f"UDF type not supported: {type(self.func)}")
+
+    def __hash__(self) -> int:
+        return hash((self.func, self.return_dtype))
 
 
 def udf(

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -84,6 +84,10 @@ class PartialUDF:
             raise NotImplementedError(f"Return type not supported for UDF: {type(result)}")
 
     def __hash__(self) -> int:
+        # Make the bound arguments hashable in the basic case when every argument is itself hashable.
+        # NOTE: This will fail if any of the arguments are not hashable (e.g. dicts, Python classes that
+        # don't implement __hash__). In that case, Daft's Rust-side hasher will fall back to hashing the
+        # pickled UDF. See daft-dsl/src/python/partial_udf.rs
         args = frozenset(self.bound_args.arguments.items())
         return hash((self.udf, args))
 

--- a/src/daft-core/Cargo.toml
+++ b/src/daft-core/Cargo.toml
@@ -8,7 +8,7 @@ common-error = {path = "../common/error", default-features = false}
 dyn-clone = "1.0.12"
 fnv = "1.0.7"
 html-escape = {workspace = true}
-indexmap = {workspace = true, features = ["serde"]}
+indexmap = {workspace = true, features = ["serde"], version = "2.0.0"}
 lazy_static = {workspace = true}
 log = {workspace = true}
 ndarray = "0.15.6"

--- a/src/daft-core/src/schema.rs
+++ b/src/daft-core/src/schema.rs
@@ -141,7 +141,8 @@ impl Hash for Schema {
         // Moreover, the hashing of each individual element must be independent of the hashing of other elements, so we hash
         // each element with a fresh state (hasher).
         //
-        // NOTE: This is a relatively weak hash function, but should be fine for our purposes.
+        // NOTE: This is a relatively weak hash function, but should be fine for our current hashing use case, which is detecting
+        // logical optimization cycles in the optimizer.
         state.write_u64(
             self.fields
                 .iter()

--- a/src/daft-core/src/utils/hashable_float_wrapper.rs
+++ b/src/daft-core/src/utils/hashable_float_wrapper.rs
@@ -1,9 +1,13 @@
 use std::hash::{Hash, Hasher};
 
+// An f64 newtype wrapper that implements basic hashability.
 pub struct FloatWrapper(pub f64);
 
 impl Hash for FloatWrapper {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        // This is a super basic hash function that could lead to e.g. different hashes for different
+        // NaN representations. Look to crates like https://docs.rs/ordered-float/latest/ordered_float/index.html
+        // for a more advanced Hash implementation, if we end up needing it.
         state.write(&u64::from_ne_bytes(self.0.to_ne_bytes()).to_ne_bytes())
     }
 }

--- a/src/daft-core/src/utils/hashable_float_wrapper.rs
+++ b/src/daft-core/src/utils/hashable_float_wrapper.rs
@@ -1,0 +1,9 @@
+use std::hash::{Hash, Hasher};
+
+pub struct FloatWrapper(pub f64);
+
+impl Hash for FloatWrapper {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(&u64::from_ne_bytes(self.0.to_ne_bytes()).to_ne_bytes())
+    }
+}

--- a/src/daft-core/src/utils/mod.rs
+++ b/src/daft-core/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod arrow;
+pub mod hashable_float_wrapper;
 pub mod supertype;
 
 #[macro_export]

--- a/src/daft-dsl/Cargo.toml
+++ b/src/daft-dsl/Cargo.toml
@@ -6,6 +6,7 @@ daft-io = {path = "../daft-io", default-features = false}
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true, optional = true}
 serde = {workspace = true}
+serde_json = {workspace = true}
 
 [features]
 default = ["python"]

--- a/src/daft-dsl/src/functions/python/partial_udf.rs
+++ b/src/daft-dsl/src/functions/python/partial_udf.rs
@@ -69,7 +69,12 @@ impl Eq for PartialUDF {}
 
 impl Hash for PartialUDF {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let py_obj_hash = Python::with_gil(|py| self.0.as_ref(py).hash().unwrap());
-        py_obj_hash.hash(state)
+        let py_obj_hash = Python::with_gil(|py| self.0.as_ref(py).hash());
+        match py_obj_hash {
+            // If Python object is hashable, hash the Python-side hash.
+            Ok(py_obj_hash) => py_obj_hash.hash(state),
+            // Fall back to hashing the pickled Python object.
+            Err(_) => serde_json::to_vec(self).unwrap().hash(state),
+        }
     }
 }

--- a/src/daft-dsl/src/lit.rs
+++ b/src/daft-dsl/src/lit.rs
@@ -5,6 +5,7 @@ use std::{
 
 use crate::expr::Expr;
 use daft_core::series::Series;
+use daft_core::utils::hashable_float_wrapper::FloatWrapper;
 use daft_core::{array::ops::full::FullNull, datatypes::DataType};
 use serde::{Deserialize, Serialize};
 
@@ -37,15 +38,7 @@ pub enum LiteralValue {
     Python(DaftPyObject),
 }
 
-struct FloatWrapper(f64);
-
 impl Eq for LiteralValue {}
-
-impl Hash for FloatWrapper {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write(&u64::from_ne_bytes(self.0.to_ne_bytes()).to_ne_bytes())
-    }
-}
 
 impl Hash for LiteralValue {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/src/daft-plan/Cargo.toml
+++ b/src/daft-plan/Cargo.toml
@@ -9,6 +9,7 @@ daft-table = {path = "../daft-table", default-features = false}
 indexmap = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 serde = {workspace = true, features = ["rc"]}
+serde_json = {workspace = true}
 snafu = {workspace = true}
 
 [features]

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -255,8 +255,8 @@ impl LogicalPlanBuilder {
     }
 
     pub fn optimize(&self) -> PyResult<LogicalPlanBuilder> {
-        let optimizer = Optimizer::new();
-        let new_plan = optimizer.optimize(self.plan.clone(), &Default::default())?;
+        let optimizer = Optimizer::new(Default::default());
+        let new_plan = optimizer.optimize(self.plan.clone(), |_, _, _, _, _| {})?;
         Ok(Self::new(new_plan))
     }
 

--- a/src/daft-plan/src/lib.rs
+++ b/src/daft-plan/src/lib.rs
@@ -11,6 +11,8 @@ mod planner;
 mod resource_request;
 mod sink_info;
 mod source_info;
+#[cfg(test)]
+mod test;
 
 pub use builder::LogicalPlanBuilder;
 pub use join::JoinType;

--- a/src/daft-plan/src/logical_plan.rs
+++ b/src/daft-plan/src/logical_plan.rs
@@ -128,15 +128,6 @@ impl LogicalPlan {
     }
 
     pub fn with_new_children(&self, children: &[Arc<LogicalPlan>]) -> Arc<LogicalPlan> {
-        println!(
-            "Updating with new children: {}, {}",
-            self,
-            children
-                .iter()
-                .map(|child| child.to_string())
-                .collect::<Vec<String>>()
-                .join(", ")
-        );
         let new_plan = match children {
             [input] => match self {
                 Self::Source(_) => panic!("Source nodes don't have children, with_new_children() should never be called for Source ops"),
@@ -165,6 +156,7 @@ impl LogicalPlan {
         new_plan.into()
     }
 
+    /// Get the number of nodes in the logical plan tree.
     pub fn node_count(&self) -> NonZeroUsize {
         match self.children().as_slice() {
             [] => 1usize.try_into().unwrap(),

--- a/src/daft-plan/src/ops/agg.rs
+++ b/src/daft-plan/src/ops/agg.rs
@@ -8,7 +8,7 @@ use daft_dsl::{AggExpr, Expr};
 use crate::logical_plan::{self, CreationSnafu};
 use crate::LogicalPlan;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Aggregate {
     // Upstream node.
     pub input: Arc<LogicalPlan>,

--- a/src/daft-plan/src/ops/coalesce.rs
+++ b/src/daft-plan/src/ops/coalesce.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::LogicalPlan;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Coalesce {
     // Number of partitions to coalesce to.
     pub num_to: usize,

--- a/src/daft-plan/src/ops/concat.rs
+++ b/src/daft-plan/src/ops/concat.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::LogicalPlan;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Concat {
     pub other: Arc<LogicalPlan>,
     // Upstream node.

--- a/src/daft-plan/src/ops/distinct.rs
+++ b/src/daft-plan/src/ops/distinct.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::LogicalPlan;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Distinct {
     // Upstream node.
     pub input: Arc<LogicalPlan>,

--- a/src/daft-plan/src/ops/explode.rs
+++ b/src/daft-plan/src/ops/explode.rs
@@ -9,7 +9,7 @@ use crate::{
     LogicalPlan,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Explode {
     // Upstream node.
     pub input: Arc<LogicalPlan>,

--- a/src/daft-plan/src/ops/filter.rs
+++ b/src/daft-plan/src/ops/filter.rs
@@ -4,7 +4,7 @@ use daft_dsl::Expr;
 
 use crate::LogicalPlan;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Filter {
     // The Boolean expression to filter on.
     pub predicate: Expr,

--- a/src/daft-plan/src/ops/join.rs
+++ b/src/daft-plan/src/ops/join.rs
@@ -9,7 +9,7 @@ use crate::{
     JoinType, LogicalPlan,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Join {
     // Upstream nodes.
     pub input: Arc<LogicalPlan>,

--- a/src/daft-plan/src/ops/limit.rs
+++ b/src/daft-plan/src/ops/limit.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::LogicalPlan;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Limit {
     pub limit: i64,
     // Upstream node.

--- a/src/daft-plan/src/ops/project.rs
+++ b/src/daft-plan/src/ops/project.rs
@@ -7,7 +7,7 @@ use snafu::ResultExt;
 use crate::logical_plan::{CreationSnafu, Result};
 use crate::{LogicalPlan, ResourceRequest};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Project {
     // Upstream node.
     pub input: Arc<LogicalPlan>,

--- a/src/daft-plan/src/ops/repartition.rs
+++ b/src/daft-plan/src/ops/repartition.rs
@@ -4,7 +4,7 @@ use daft_dsl::Expr;
 
 use crate::{LogicalPlan, PartitionScheme};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Repartition {
     pub num_partitions: usize,
     pub partition_by: Vec<Expr>,

--- a/src/daft-plan/src/ops/sink.rs
+++ b/src/daft-plan/src/ops/sink.rs
@@ -7,7 +7,7 @@ use crate::{
     LogicalPlan,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Sink {
     pub schema: SchemaRef,
     /// Information about the sink data location.

--- a/src/daft-plan/src/ops/sort.rs
+++ b/src/daft-plan/src/ops/sort.rs
@@ -4,7 +4,7 @@ use daft_dsl::Expr;
 
 use crate::LogicalPlan;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Sort {
     pub sort_by: Vec<Expr>,
     pub descending: Vec<bool>,

--- a/src/daft-plan/src/ops/source.rs
+++ b/src/daft-plan/src/ops/source.rs
@@ -8,7 +8,7 @@ use crate::{
     PartitionSpec,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Source {
     /// The schema of the output of this node (the source data schema).
     /// May be a subset of the source data schema; executors should push down this projection if possible.

--- a/src/daft-plan/src/optimization/logical_plan_tracker.rs
+++ b/src/daft-plan/src/optimization/logical_plan_tracker.rs
@@ -10,8 +10,8 @@ use crate::LogicalPlan;
 ///
 /// The digests are cheaply hashable + comparable, and have the following guarantees:
 ///
-///   p1 == p2 -> digest(p1) == digest(p2)
-///   hash(digest(p1)) == hash(digest(p2)) -> hash(p1) == hash(p2)
+///   hash(digest(p1)) != hash(digest(p2)) -> digest(p1) != digest(p2) -> p1 != p2
+///   hash(p1) != hash(p2) -> hash(digest(p1)) != hash(digest(p2))
 ///
 /// These guarantees allow us to use a HashSet of such digests as a cheap cycle detector in
 /// our optimizer, with the negligible possibility of plan hash + node count collisions leading
@@ -45,8 +45,11 @@ impl LogicalPlanTracker {
 /// A simple logical plan summary that's cheaply hashable + comparable, and that has the
 /// following guarantees:
 ///
-///   p1 == p2 -> digest(p1) == digest(p2)
-///   hash(digest(p1)) == hash(digest(p2)) -> hash(p1) == hash(p2)
+///   hash(digest(p1)) != hash(digest(p2)) -> digest(p1) != digest(p2) -> p1 != p2
+///   hash(p1) != hash(p2) -> hash(digest(p1)) != hash(digest(p2))
+///
+/// The incorporation of the node count with the plan hash makes hash collisions less likely across
+/// distinctly different plans.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct LogicalPlanDigest {
     plan_hash: u64,

--- a/src/daft-plan/src/optimization/logical_plan_tracker.rs
+++ b/src/daft-plan/src/optimization/logical_plan_tracker.rs
@@ -1,0 +1,208 @@
+use std::{
+    collections::{hash_map::DefaultHasher, HashSet},
+    hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
+    num::NonZeroUsize,
+};
+
+use crate::LogicalPlan;
+
+pub struct LogicalPlanTracker {
+    past_plans: HashSet<LogicalPlanDigest>,
+    hasher_builder: BuildHasherDefault<DefaultHasher>,
+}
+
+impl LogicalPlanTracker {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            past_plans: HashSet::with_capacity(capacity),
+            hasher_builder: Default::default(),
+        }
+    }
+
+    pub fn add_plan(&mut self, plan: &LogicalPlan) -> bool {
+        self.past_plans.insert(LogicalPlanDigest::new(
+            plan,
+            &mut self.hasher_builder.build_hasher(),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct LogicalPlanDigest {
+    plan_hash: u64,
+    node_count: NonZeroUsize,
+}
+
+impl LogicalPlanDigest {
+    fn new(plan: &LogicalPlan, hasher: &mut DefaultHasher) -> Self {
+        plan.hash(hasher);
+        Self {
+            plan_hash: hasher.finish(),
+            node_count: plan.node_count(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
+    use common_error::DaftResult;
+    use daft_core::{datatypes::Field, schema::Schema, DataType};
+    use daft_dsl::{col, lit};
+
+    use crate::{
+        ops::{Concat, Filter, Project},
+        optimization::logical_plan_tracker::LogicalPlanDigest,
+        test::dummy_scan_node,
+        LogicalPlan,
+    };
+
+    #[test]
+    fn node_count() -> DaftResult<()> {
+        // plan is Filter -> Concat -> {Projection -> Source, Projection -> Source},
+        // and should have a node count of 6.
+        let plan1: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        assert_eq!(
+            LogicalPlanDigest::new(&plan1, &mut Default::default()).node_count,
+            1usize.try_into().unwrap()
+        );
+        let plan1: LogicalPlan = Project::new(
+            vec![col("a")],
+            Schema::new(vec![plan1.schema().get_field("a")?.clone()])?.into(),
+            Default::default(),
+            plan1.into(),
+        )
+        .into();
+        assert_eq!(
+            LogicalPlanDigest::new(&plan1, &mut Default::default()).node_count,
+            2usize.try_into().unwrap()
+        );
+        let plan2: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        assert_eq!(
+            LogicalPlanDigest::new(&plan2, &mut Default::default()).node_count,
+            1usize.try_into().unwrap()
+        );
+        let plan2: LogicalPlan = Project::new(
+            vec![col("a")],
+            Schema::new(vec![plan2.schema().get_field("a")?.clone()])?.into(),
+            Default::default(),
+            plan2.into(),
+        )
+        .into();
+        assert_eq!(
+            LogicalPlanDigest::new(&plan2, &mut Default::default()).node_count,
+            2usize.try_into().unwrap()
+        );
+        let plan: LogicalPlan = Concat::new(plan1.into(), plan2.into()).into();
+        assert_eq!(
+            LogicalPlanDigest::new(&plan, &mut Default::default()).node_count,
+            5usize.try_into().unwrap()
+        );
+        let plan: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan.into()).into();
+        assert_eq!(
+            LogicalPlanDigest::new(&plan, &mut Default::default()).node_count,
+            6usize.try_into().unwrap()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn same_plans_eq() -> DaftResult<()> {
+        // Both plan1 and plan2 are Filter -> Project -> Source
+        let plan1: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let plan1: LogicalPlan = Project::new(
+            vec![col("a")],
+            Schema::new(vec![plan1.schema().get_field("a")?.clone()])?.into(),
+            Default::default(),
+            plan1.into(),
+        )
+        .into();
+        let plan1: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan1.into()).into();
+        let plan2: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let plan2: LogicalPlan = Project::new(
+            vec![col("a")],
+            Schema::new(vec![plan2.schema().get_field("a")?.clone()])?.into(),
+            Default::default(),
+            plan2.into(),
+        )
+        .into();
+        let plan2: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan2.into()).into();
+        // Double-check that logical plans are equal.
+        assert_eq!(plan1, plan2);
+
+        // Plans should have the same digest.
+        let digest1 = LogicalPlanDigest::new(&plan1, &mut Default::default());
+        let digest2 = LogicalPlanDigest::new(&plan2, &mut Default::default());
+        assert_eq!(digest1, digest2);
+        let mut hasher1 = DefaultHasher::new();
+        digest1.hash(&mut hasher1);
+        let mut hasher2 = DefaultHasher::new();
+        digest2.hash(&mut hasher2);
+        assert_eq!(hasher1.finish(), hasher2.finish());
+        Ok(())
+    }
+
+    #[test]
+    fn different_plans_not_eq() -> DaftResult<()> {
+        // plan1 is Project -> Filter -> Source, while plan2 is Filter -> Project -> Source.
+        let plan1: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let plan1: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan1.into()).into();
+        let plan1: LogicalPlan = Project::new(
+            vec![col("a")],
+            Schema::new(vec![plan1.schema().get_field("a")?.clone()])?.into(),
+            Default::default(),
+            plan1.into(),
+        )
+        .into();
+        let plan2: LogicalPlan = dummy_scan_node(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ])
+        .into();
+        let plan2: LogicalPlan = Project::new(
+            vec![col("a")],
+            Schema::new(vec![plan2.schema().get_field("a")?.clone()])?.into(),
+            Default::default(),
+            plan2.into(),
+        )
+        .into();
+        let plan2: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan2.into()).into();
+        // Double-check that logical plans are NOT equal.
+        assert_ne!(plan1, plan2);
+
+        // Plans should NOT have the same digest.
+        let digest1 = LogicalPlanDigest::new(&plan1, &mut Default::default());
+        let digest2 = LogicalPlanDigest::new(&plan2, &mut Default::default());
+        assert_ne!(digest1, digest2);
+        let mut hasher1 = DefaultHasher::new();
+        digest1.hash(&mut hasher1);
+        let mut hasher2 = DefaultHasher::new();
+        digest2.hash(&mut hasher2);
+        assert_ne!(hasher1.finish(), hasher2.finish());
+        Ok(())
+    }
+}

--- a/src/daft-plan/src/optimization/mod.rs
+++ b/src/daft-plan/src/optimization/mod.rs
@@ -1,3 +1,4 @@
+mod logical_plan_tracker;
 mod optimizer;
 mod rules;
 

--- a/src/daft-plan/src/optimization/optimizer.rs
+++ b/src/daft-plan/src/optimization/optimizer.rs
@@ -134,7 +134,7 @@ impl Optimizer {
         })
     }
 
-    // Optimize the provied plan with the provied rule batch.
+    // Optimize the provided plan with the provided rule batch.
     pub fn optimize_with_rule_batch<F>(
         &self,
         batch: &RuleBatch,

--- a/src/daft-plan/src/optimization/optimizer.rs
+++ b/src/daft-plan/src/optimization/optimizer.rs
@@ -189,6 +189,10 @@ impl Optimizer {
         plan: Arc<LogicalPlan>,
         order: &Option<ApplyOrder>,
     ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+        // Double-check that all rules have the same application order as `order`, if `order` is not None.
+        debug_assert!(order.clone().map_or(true, |order| rules
+            .iter()
+            .all(|rule| rule.apply_order() == order)));
         match order {
             // Perform a single top-down traversal and apply all rules on each node.
             Some(ApplyOrder::TopDown) => {

--- a/src/daft-plan/src/optimization/optimizer.rs
+++ b/src/daft-plan/src/optimization/optimizer.rs
@@ -1,128 +1,546 @@
-use std::sync::Arc;
+use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 
 use common_error::DaftResult;
 
 use crate::LogicalPlan;
 
-use super::rules::{ApplyOrder, OptimizerRule, PushDownFilter};
+use super::{
+    logical_plan_tracker::LogicalPlanTracker,
+    rules::{ApplyOrder, OptimizerRule, PushDownFilter, Transformed},
+};
 
+// Config for optimizer.
 pub struct OptimizerConfig {
-    // Maximum number of optimization passes the optimizer will make over the logical plan.
-    pub max_optimizer_passes: usize,
+    // Default maximum number of optimization passes the optimizer will make over a fixed-point RuleBatch.
+    pub default_max_optimizer_passes: usize,
 }
 
 impl OptimizerConfig {
     fn new(max_optimizer_passes: usize) -> Self {
         OptimizerConfig {
-            max_optimizer_passes,
+            default_max_optimizer_passes: max_optimizer_passes,
         }
     }
 }
 
 impl Default for OptimizerConfig {
     fn default() -> Self {
-        OptimizerConfig::new(3usize)
+        // Default to a max of 5 optimizer passes for a given batch.
+        OptimizerConfig::new(5)
     }
+}
+
+pub struct RuleBatch {
+    pub rules: Vec<Box<dyn OptimizerRule>>,
+    pub strategy: RuleExecutionStrategy,
+    pub order: Option<ApplyOrder>,
+}
+
+impl RuleBatch {
+    pub fn new(rules: Vec<Box<dyn OptimizerRule>>, strategy: RuleExecutionStrategy) -> Self {
+        let unique_application_orders: Vec<ApplyOrder> = rules
+            .iter()
+            .map(|rule| rule.apply_order())
+            .collect::<HashSet<ApplyOrder>>()
+            .into_iter()
+            .collect();
+        let order = match unique_application_orders.as_slice() {
+            [order] => Some(order.clone()),
+            // If rules have different application orders, run each rule as a separate tree pass with its own application order.
+            _ => None,
+        };
+        Self {
+            rules,
+            strategy,
+            order,
+        }
+    }
+
+    fn max_passes(&self, config: &OptimizerConfig) -> usize {
+        use RuleExecutionStrategy::*;
+
+        match self.strategy {
+            Once => 1usize,
+            FixedPoint(max_passes) => max_passes.unwrap_or(config.default_max_optimizer_passes),
+        }
+    }
+}
+
+pub enum RuleExecutionStrategy {
+    Once,
+    #[allow(dead_code)]
+    FixedPoint(Option<usize>),
 }
 
 /// Logical rule-based optimizer.
 pub struct Optimizer {
-    pub rules: Vec<Arc<dyn OptimizerRule>>,
+    pub rule_batches: Vec<RuleBatch>,
+    config: OptimizerConfig,
 }
 
 impl Optimizer {
-    pub fn new() -> Self {
-        let rules: Vec<Arc<dyn OptimizerRule>> = vec![Arc::new(PushDownFilter::new())];
-        Self::with_rules(rules)
+    pub fn new(config: OptimizerConfig) -> Self {
+        // Default rule batches.
+        let rule_batches: Vec<RuleBatch> = vec![RuleBatch::new(
+            vec![Box::new(PushDownFilter::new())],
+            RuleExecutionStrategy::Once,
+        )];
+        Self::with_rule_batches(rule_batches, config)
     }
-    pub fn with_rules(rules: Vec<Arc<dyn OptimizerRule>>) -> Self {
-        Self { rules }
+    pub fn with_rule_batches(rule_batches: Vec<RuleBatch>, config: OptimizerConfig) -> Self {
+        Self {
+            rule_batches,
+            config,
+        }
     }
 
-    pub fn optimize(
+    pub fn optimize<F>(
         &self,
         plan: Arc<LogicalPlan>,
-        config: &OptimizerConfig,
-    ) -> DaftResult<Arc<LogicalPlan>> {
-        let mut new_plan = plan.clone();
-        let mut i = 0;
-        while i < config.max_optimizer_passes {
-            for rule in &self.rules {
-                let result = self.optimize_with_rule(rule, &new_plan);
-                match result {
-                    Ok(Some(plan)) => {
-                        new_plan = plan;
-                    }
-                    Ok(None) => {}
-                    // TODO(Clark): Return nice optimization error to user.
-                    Err(e) => panic!("Optimization failed: {:?}", e),
-                }
-            }
-            // TODO(Clark): Terminate optimization loop if logical plan has not changed on this optimization pass.
-            i += 1;
-        }
-        Ok(new_plan)
+        mut observer: F,
+    ) -> DaftResult<Arc<LogicalPlan>>
+    where
+        F: FnMut(&LogicalPlan, &RuleBatch, usize, bool, bool),
+    {
+        let mut plan_tracker = LogicalPlanTracker::new(self.config.default_max_optimizer_passes);
+        plan_tracker.add_plan(plan.as_ref());
+        self.rule_batches.iter().try_fold(plan, |plan, batch| {
+            self.optimize_with_rule_batch(batch, plan, &mut observer, &mut plan_tracker)
+        })
     }
 
-    pub fn optimize_with_rule(
+    pub fn optimize_with_rule_batch<F>(
         &self,
-        rule: &Arc<dyn OptimizerRule>,
-        plan: &Arc<LogicalPlan>,
-    ) -> DaftResult<Option<Arc<LogicalPlan>>> {
-        match rule.apply_order() {
+        batch: &RuleBatch,
+        plan: Arc<LogicalPlan>,
+        observer: &mut F,
+        plan_tracker: &mut LogicalPlanTracker,
+    ) -> DaftResult<Arc<LogicalPlan>>
+    where
+        F: FnMut(&LogicalPlan, &RuleBatch, usize, bool, bool),
+    {
+        let result = (0..batch.max_passes(&self.config)).try_fold(
+            plan,
+            |plan, pass| -> ControlFlow<DaftResult<Arc<LogicalPlan>>, Arc<LogicalPlan>> {
+                match self.optimize_with_rules(batch.rules.as_slice(), plan, &batch.order) {
+                    Ok(Transformed::Yes(new_plan)) => {
+                        if plan_tracker.add_plan(new_plan.as_ref()) {
+                            observer(new_plan.as_ref(), batch, pass, true, true);
+                            ControlFlow::Continue(new_plan)
+                        } else {
+                            observer(new_plan.as_ref(), batch, pass, true, false);
+                            ControlFlow::Break(Ok(new_plan))
+                        }
+                    }
+                    Ok(Transformed::No(plan)) => {
+                        observer(plan.as_ref(), batch, pass, false, false);
+                        ControlFlow::Break(Ok(plan))
+                    }
+                    Err(e) => ControlFlow::Break(Err(e)),
+                }
+            },
+        );
+        match result {
+            ControlFlow::Continue(result) => Ok(result),
+            ControlFlow::Break(result) => result,
+        }
+    }
+
+    pub fn optimize_with_rules(
+        &self,
+        rules: &[Box<dyn OptimizerRule>],
+        plan: Arc<LogicalPlan>,
+        order: &Option<ApplyOrder>,
+    ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+        match order {
             Some(ApplyOrder::TopDown) => {
                 // First optimize the current node, and then it's children.
-                let curr_opt = self.optimize_node(rule, plan)?;
-                let children_opt = match &curr_opt {
-                    Some(opt_plan) => self.optimize_children(rule, opt_plan)?,
-                    None => self.optimize_children(rule, plan)?,
-                };
+                let curr_opt = self.optimize_node(rules, plan)?;
+                let children_opt =
+                    self.optimize_children(rules, curr_opt.unwrap().clone(), ApplyOrder::TopDown)?;
                 Ok(children_opt.or(curr_opt))
             }
             Some(ApplyOrder::BottomUp) => {
                 // First optimize the current node's children, and then the current node.
-                let children_opt = self.optimize_children(rule, plan)?;
-                let curr_opt = match &children_opt {
-                    Some(opt_plan) => self.optimize_node(rule, opt_plan)?,
-                    None => self.optimize_node(rule, plan)?,
-                };
+                let children_opt = self.optimize_children(rules, plan, ApplyOrder::BottomUp)?;
+                let curr_opt = self.optimize_node(rules, children_opt.unwrap().clone())?;
                 Ok(curr_opt.or(children_opt))
             }
-            None => rule.try_optimize(plan.as_ref()),
+            // All rules do their own internal tree traversals.
+            Some(ApplyOrder::Delegated) => self.optimize_node(rules, plan),
+            // Rule batch doesn't share a single application order, so we apply each rule with its own dedicated tree pass.
+            None => rules
+                .windows(1)
+                .try_fold(Transformed::No(plan), |plan, rule| {
+                    self.optimize_with_rules(
+                        rule,
+                        plan.unwrap().clone(),
+                        &Some(rule[0].apply_order()),
+                    )
+                }),
         }
     }
 
     fn optimize_node(
         &self,
-        rule: &Arc<dyn OptimizerRule>,
-        plan: &Arc<LogicalPlan>,
-    ) -> DaftResult<Option<Arc<LogicalPlan>>> {
-        // TODO(Clark): Add optimization rule batching.
-        rule.try_optimize(plan.as_ref())
+        rules: &[Box<dyn OptimizerRule>],
+        plan: Arc<LogicalPlan>,
+    ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+        rules.iter().try_fold(Transformed::No(plan), |plan, rule| {
+            rule.try_optimize(plan.unwrap().clone())
+        })
     }
 
     fn optimize_children(
         &self,
-        rule: &Arc<dyn OptimizerRule>,
-        plan: &LogicalPlan,
-    ) -> DaftResult<Option<Arc<LogicalPlan>>> {
-        // Run optimization rule on children.
+        rules: &[Box<dyn OptimizerRule>],
+        plan: Arc<LogicalPlan>,
+        order: ApplyOrder,
+    ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+        // Run optimization rules on children.
         let children = plan.children();
         let result = children
-            .iter()
-            .map(|child_plan| self.optimize_with_rule(rule, child_plan))
+            .into_iter()
+            .map(|child_plan| {
+                self.optimize_with_rules(rules, child_plan.clone(), &Some(order.clone()))
+            })
             .collect::<DaftResult<Vec<_>>>()?;
         // If the optimization rule didn't change any of the children, return without modifying the plan.
-        if result.is_empty() || result.iter().all(|o| o.is_none()) {
-            return Ok(None);
+        if result.is_empty() || result.iter().all(|o| o.is_no()) {
+            return Ok(Transformed::No(plan));
         }
-        // Otherwise, update that parent to point to its optimized children.
+        // Otherwise, update the parent to point to its optimized children.
         let new_children = result
             .into_iter()
-            .zip(children.iter())
-            .map(|(opt_child, old_child)| opt_child.unwrap_or_else(|| (*old_child).clone()))
+            .map(|maybe_opt_child| maybe_opt_child.unwrap().clone())
             .collect::<Vec<_>>();
 
-        Ok(Some(plan.with_new_children(&new_children)))
+        Ok(Transformed::Yes(plan.with_new_children(&new_children)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use common_error::DaftResult;
+    use daft_core::{datatypes::Field, schema::Schema, DataType};
+    use daft_dsl::{col, lit};
+
+    use crate::{
+        ops::{Filter, Project},
+        optimization::rules::{ApplyOrder, OptimizerRule, Transformed},
+        test::dummy_scan_node,
+        LogicalPlan,
+    };
+
+    use super::{Optimizer, OptimizerConfig, RuleBatch, RuleExecutionStrategy};
+
+    #[test]
+    fn early_termination_no_transform() -> DaftResult<()> {
+        let optimizer = Optimizer::with_rule_batches(
+            vec![RuleBatch::new(
+                vec![Box::new(NoOp::new())],
+                RuleExecutionStrategy::Once,
+            )],
+            OptimizerConfig::new(5),
+        );
+        let plan: Arc<LogicalPlan> =
+            LogicalPlan::from(dummy_scan_node(vec![Field::new("a", DataType::Int64)])).into();
+        let mut pass_count = 0;
+        let mut did_transform = false;
+        optimizer.optimize(plan.clone(), |new_plan, _, _, transformed, _| {
+            assert_eq!(new_plan, plan.as_ref());
+            pass_count += 1;
+            did_transform |= transformed;
+        })?;
+        assert!(!did_transform);
+        assert_eq!(pass_count, 1);
+        Ok(())
+    }
+
+    struct NoOp {}
+
+    impl NoOp {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl OptimizerRule for NoOp {
+        fn apply_order(&self) -> ApplyOrder {
+            ApplyOrder::TopDown
+        }
+
+        fn try_optimize(
+            &self,
+            plan: Arc<LogicalPlan>,
+        ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+            Ok(Transformed::No(plan))
+        }
+    }
+
+    #[test]
+    fn early_termination_equal_plan_cycle() -> DaftResult<()> {
+        // Tests that the optimizer terminates early when a cycle is detected.
+        // This test creates a Projection -> Source plan where the projection has [1, 2, 3] projections;
+        // the optimizer will rotate the projection expressions to the left on each pass.
+        //   [1, 2, 3] -> [2, 3, 1] -> [3, 1, 2] -> [1, 2, 3]
+        // The optimization loop should therefore terminate on the 4th pass.
+        let optimizer = Optimizer::with_rule_batches(
+            vec![RuleBatch::new(
+                vec![Box::new(RotateProjection::new(false))],
+                RuleExecutionStrategy::FixedPoint(Some(20)),
+            )],
+            OptimizerConfig::new(20),
+        );
+        let plan: LogicalPlan = dummy_scan_node(vec![Field::new("a", DataType::Int64)]).into();
+        let proj_exprs = vec![col("a") + lit(1), col("a") + lit(2), col("a") + lit(3)];
+        let plan: LogicalPlan = Project::new(
+            proj_exprs.clone(),
+            Schema::new(
+                proj_exprs
+                    .iter()
+                    .map(|e| {
+                        Field::new(
+                            e.semantic_id(plan.schema().as_ref()).to_string(),
+                            DataType::Int64,
+                        )
+                    })
+                    .collect(),
+            )?
+            .into(),
+            Default::default(),
+            plan.into(),
+        )
+        .into();
+        let initial_plan: Arc<LogicalPlan> = plan.into();
+        let mut pass_count = 0;
+        let mut did_transform = false;
+        optimizer.optimize(initial_plan.clone(), |_, _, _, transformed, _| {
+            pass_count += 1;
+            did_transform |= transformed;
+        })?;
+        assert!(did_transform);
+        assert_eq!(pass_count, 3);
+        Ok(())
+    }
+
+    #[test]
+    fn early_termination_equal_plan_cycle_after_first() -> DaftResult<()> {
+        // Tests that the optimizer terminates early when a cycle is detected.
+        // This test creates a Projection -> Source plan where the projection has [1, 2, 3] projections;
+        // the optimizer will reverse the projection expressions on the first pass and rotate them to the
+        // left on each pass thereafter.
+        //   [1, 2, 3] -> [3, 2, 1] -> [2, 1, 3] -> [1, 3, 2] -> [3, 2, 1]
+        // The optimization loop should therefore terminate on the 5th pass.
+        let optimizer = Optimizer::with_rule_batches(
+            vec![RuleBatch::new(
+                vec![Box::new(RotateProjection::new(true))],
+                RuleExecutionStrategy::FixedPoint(Some(20)),
+            )],
+            OptimizerConfig::new(20),
+        );
+        let plan: LogicalPlan = dummy_scan_node(vec![Field::new("a", DataType::Int64)]).into();
+        let proj_exprs = vec![col("a") + lit(1), col("a") + lit(2), col("a") + lit(3)];
+        let plan: LogicalPlan = Project::new(
+            proj_exprs.clone(),
+            Schema::new(
+                proj_exprs
+                    .iter()
+                    .map(|e| {
+                        Field::new(
+                            e.semantic_id(plan.schema().as_ref()).to_string(),
+                            DataType::Int64,
+                        )
+                    })
+                    .collect(),
+            )?
+            .into(),
+            Default::default(),
+            plan.into(),
+        )
+        .into();
+        let initial_plan: Arc<LogicalPlan> = plan.into();
+        let mut pass_count = 0;
+        let mut did_transform = false;
+        optimizer.optimize(initial_plan.clone(), |_, _, _, transformed, _| {
+            pass_count += 1;
+            did_transform |= transformed;
+        })?;
+        assert!(did_transform);
+        assert_eq!(pass_count, 4);
+        Ok(())
+    }
+
+    struct RotateProjection {
+        reverse_first: Mutex<bool>,
+    }
+
+    impl RotateProjection {
+        pub fn new(reverse_first: bool) -> Self {
+            Self {
+                reverse_first: Mutex::new(reverse_first),
+            }
+        }
+    }
+
+    impl OptimizerRule for RotateProjection {
+        fn apply_order(&self) -> ApplyOrder {
+            ApplyOrder::TopDown
+        }
+
+        fn try_optimize(
+            &self,
+            plan: Arc<LogicalPlan>,
+        ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+            let project = match plan.as_ref() {
+                LogicalPlan::Project(project) => project.clone(),
+                _ => return Ok(Transformed::No(plan)),
+            };
+            let mut exprs = project.projection.clone();
+            let mut reverse = self.reverse_first.lock().unwrap();
+            if *reverse {
+                exprs.reverse();
+                *reverse = false;
+            } else {
+                exprs.rotate_left(1);
+            }
+            Ok(Transformed::Yes(
+                LogicalPlan::from(Project::new(
+                    exprs,
+                    project.projected_schema.clone(),
+                    project.resource_request.clone(),
+                    project.input.clone(),
+                ))
+                .into(),
+            ))
+        }
+    }
+
+    #[test]
+    fn multiple_rule_batches() -> DaftResult<()> {
+        // Tests that the optimizer applies multiple rule batches.
+        // This test creates a Filter -> Projection -> Source plan and has 3 rule batches:
+        // (1) ([NoOp, RotateProjection], FixedPoint(20)), which should terminate due to a plan cycle.
+        // (2) ([FilterOrFalse, RotateProjection], FixedPoint(2)), which should run twice.
+        // (3) ([FilterAndTrue], Once), which should run once.
+        // The Projection has exprs [1, 2, 3], meaning that (1) should run 4 times before the cycle is hit.
+        let optimizer = Optimizer::with_rule_batches(
+            vec![
+                RuleBatch::new(
+                    vec![
+                        Box::new(NoOp::new()),
+                        Box::new(RotateProjection::new(false)),
+                    ],
+                    RuleExecutionStrategy::FixedPoint(Some(20)),
+                ),
+                RuleBatch::new(
+                    vec![
+                        Box::new(FilterOrFalse::new()),
+                        Box::new(RotateProjection::new(false)),
+                    ],
+                    RuleExecutionStrategy::FixedPoint(Some(2)),
+                ),
+                RuleBatch::new(
+                    vec![Box::new(FilterAndTrue::new())],
+                    RuleExecutionStrategy::Once,
+                ),
+            ],
+            OptimizerConfig::new(20),
+        );
+        let plan: LogicalPlan = dummy_scan_node(vec![Field::new("a", DataType::Int64)]).into();
+        let proj_exprs = vec![col("a") + lit(1), col("a") + lit(2), col("a") + lit(3)];
+        let plan: LogicalPlan = Project::new(
+            proj_exprs.clone(),
+            Schema::new(
+                proj_exprs
+                    .iter()
+                    .map(|e| {
+                        Field::new(
+                            e.semantic_id(plan.schema().as_ref()).to_string(),
+                            DataType::Int64,
+                        )
+                    })
+                    .collect(),
+            )?
+            .into(),
+            Default::default(),
+            plan.into(),
+        )
+        .into();
+        let plan: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan.into()).into();
+        let initial_plan: Arc<LogicalPlan> = plan.into();
+        let mut pass_count = 0;
+        let mut did_transform = false;
+        let opt_plan = optimizer.optimize(initial_plan.clone(), |_, _, _, transformed, _| {
+            pass_count += 1;
+            did_transform |= transformed;
+        })?;
+        assert!(did_transform);
+        // 4 + 2 + 1
+        assert_eq!(pass_count, 6);
+        let expected = "\
+        Filter: [[[col(a) < lit(2)] | lit(false)] | lit(false)] & lit(true)\
+        \n  Project: col(a) + lit(3), col(a) + lit(1), col(a) + lit(2)\
+        \n    Source: \"Json\", File paths = /foo, File schema = a (Int64), Format-specific config = Json(JsonSourceConfig), Output schema = a (Int64)";
+        assert_eq!(opt_plan.repr_indent(), expected);
+        Ok(())
+    }
+
+    struct FilterOrFalse {}
+
+    impl FilterOrFalse {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl OptimizerRule for FilterOrFalse {
+        fn apply_order(&self) -> ApplyOrder {
+            ApplyOrder::TopDown
+        }
+
+        fn try_optimize(
+            &self,
+            plan: Arc<LogicalPlan>,
+        ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+            let filter = match plan.as_ref() {
+                LogicalPlan::Filter(filter) => filter.clone(),
+                _ => return Ok(Transformed::No(plan)),
+            };
+            let new_predicate = filter.predicate.or(&lit(false));
+            Ok(Transformed::Yes(
+                LogicalPlan::from(Filter::new(new_predicate, filter.input.clone())).into(),
+            ))
+        }
+    }
+
+    struct FilterAndTrue {}
+
+    impl FilterAndTrue {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl OptimizerRule for FilterAndTrue {
+        fn apply_order(&self) -> ApplyOrder {
+            ApplyOrder::TopDown
+        }
+
+        fn try_optimize(
+            &self,
+            plan: Arc<LogicalPlan>,
+        ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+            let filter = match plan.as_ref() {
+                LogicalPlan::Filter(filter) => filter.clone(),
+                _ => return Ok(Transformed::No(plan)),
+            };
+            let new_predicate = filter.predicate.and(&lit(true));
+            Ok(Transformed::Yes(
+                LogicalPlan::from(Filter::new(new_predicate, filter.input.clone())).into(),
+            ))
+        }
     }
 }

--- a/src/daft-plan/src/optimization/rules/mod.rs
+++ b/src/daft-plan/src/optimization/rules/mod.rs
@@ -3,4 +3,4 @@ mod rule;
 mod utils;
 
 pub use push_down_filter::PushDownFilter;
-pub use rule::{ApplyOrder, OptimizerRule};
+pub use rule::{ApplyOrder, OptimizerRule, Transformed};

--- a/src/daft-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_filter.rs
@@ -21,7 +21,6 @@ use super::{
 };
 
 /// Optimization rules for pushing Filters further into the logical plan.
-
 #[derive(Default)]
 pub struct PushDownFilter {}
 
@@ -213,7 +212,7 @@ mod tests {
     use std::sync::Arc;
 
     use common_error::DaftResult;
-    use daft_core::{datatypes::Field, schema::Schema, DataType};
+    use daft_core::{datatypes::Field, DataType};
     use daft_dsl::{col, lit};
 
     use crate::{
@@ -227,6 +226,9 @@ mod tests {
         JoinType, LogicalPlan, PartitionScheme,
     };
 
+    /// Helper that creates an optimizer with the PushDownFilter rule registered, optimizes
+    /// the provided plan with said optimizer, and compares the optimized plan's repr with
+    /// the provided expected repr.
     fn assert_optimized_plan_eq(plan: Arc<LogicalPlan>, expected: &str) -> DaftResult<()> {
         let optimizer = Optimizer::with_rule_batches(
             vec![RuleBatch::new(
@@ -248,6 +250,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests combining of two Filters by merging their predicates.
     #[test]
     fn filter_combine_with_filter() -> DaftResult<()> {
         let source: LogicalPlan = dummy_scan_node(vec![
@@ -265,6 +268,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter commutes with Projections.
     #[test]
     fn filter_commutes_with_projection() -> DaftResult<()> {
         let source: LogicalPlan = dummy_scan_node(vec![
@@ -283,6 +287,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that a Filter with multiple columns in its predicate commutes with a Projection on both of those columns.
     #[test]
     fn filter_commutes_with_projection_multi() -> DaftResult<()> {
         let source: LogicalPlan = dummy_scan_node(vec![
@@ -305,6 +310,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter does not commute with a Projection if the projection expression involves compute.
     #[test]
     fn filter_does_not_commute_with_projection_if_compute() -> DaftResult<()> {
         let source: LogicalPlan = dummy_scan_node(vec![
@@ -325,6 +331,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter commutes with Projection if projection expression involves deterministic compute.
     // REASON - No expression attribute indicating whether deterministic && (pure || idempotent).
     #[ignore]
     #[test]
@@ -345,6 +352,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter commutes with Sort.
     #[test]
     fn filter_commutes_with_sort() -> DaftResult<()> {
         let source: LogicalPlan = dummy_scan_node(vec![
@@ -364,6 +372,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter commutes with Repartition.
     #[test]
     fn filter_commutes_with_repartition() -> DaftResult<()> {
         let source: LogicalPlan = dummy_scan_node(vec![
@@ -382,6 +391,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter commutes with Coalesce.
     #[test]
     fn filter_commutes_with_coalesce() -> DaftResult<()> {
         let source: LogicalPlan = dummy_scan_node(vec![
@@ -399,6 +409,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter commutes with Concat.
     #[test]
     fn filter_commutes_with_concat() -> DaftResult<()> {
         let fields = vec![
@@ -419,6 +430,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter can be pushed into the left side of a Join.
     #[test]
     fn filter_commutes_with_join_left_side() -> DaftResult<()> {
         let source1: LogicalPlan = dummy_scan_node(vec![
@@ -449,6 +461,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter can be pushed into the right side of a Join.
     #[test]
     fn filter_commutes_with_join_right_side() -> DaftResult<()> {
         let source1: LogicalPlan = dummy_scan_node(vec![
@@ -479,6 +492,7 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that Filter can be pushed into both sides of a Join.
     #[test]
     fn filter_commutes_with_join_both_sides() -> DaftResult<()> {
         let source1: LogicalPlan = dummy_scan_node(vec![

--- a/src/daft-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_filter.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{
     utils::{conjuct, split_conjuction},
-    ApplyOrder, OptimizerRule,
+    ApplyOrder, OptimizerRule, Transformed,
 };
 
 /// Optimization rules for pushing Filters further into the logical plan.
@@ -32,14 +32,14 @@ impl PushDownFilter {
 }
 
 impl OptimizerRule for PushDownFilter {
-    fn apply_order(&self) -> Option<ApplyOrder> {
-        Some(ApplyOrder::TopDown)
+    fn apply_order(&self) -> ApplyOrder {
+        ApplyOrder::TopDown
     }
 
-    fn try_optimize(&self, plan: &LogicalPlan) -> DaftResult<Option<Arc<LogicalPlan>>> {
-        let filter = match plan {
+    fn try_optimize(&self, plan: Arc<LogicalPlan>) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+        let filter = match plan.as_ref() {
             LogicalPlan::Filter(filter) => filter,
-            _ => return Ok(None),
+            _ => return Ok(Transformed::No(plan)),
         };
         let child_plan = filter.input.as_ref();
         let new_plan = match child_plan {
@@ -63,9 +63,13 @@ impl OptimizerRule for PushDownFilter {
                     .collect::<Vec<_>>();
                 // Reconjunct predicate expressions.
                 let new_predicate = conjuct(new_predicates).unwrap();
-                let new_filter: LogicalPlan =
-                    Filter::new(new_predicate, child_filter.input.clone()).into();
-                self.try_optimize(&new_filter)?.unwrap_or(new_filter.into())
+                let new_filter: Arc<LogicalPlan> =
+                    LogicalPlan::from(Filter::new(new_predicate, child_filter.input.clone()))
+                        .into();
+                self.try_optimize(new_filter.clone())?
+                    .or(Transformed::Yes(new_filter))
+                    .unwrap()
+                    .clone()
             }
             LogicalPlan::Project(child_project) => {
                 // Commute filter with projection if predicate only depends on projection columns that
@@ -106,7 +110,7 @@ impl OptimizerRule for PushDownFilter {
                 }
                 if can_push.is_empty() {
                     // No predicate expressions can be pushed through projection.
-                    return Ok(None);
+                    return Ok(Transformed::No(plan));
                 }
                 // Create new Filter with predicates that can be pushed past Projection.
                 let predicates_to_push = conjuct(can_push).unwrap();
@@ -176,7 +180,7 @@ impl OptimizerRule for PushDownFilter {
                     .len()
                     == predicate_cols.len();
                 if !can_push_left && !can_push_right {
-                    return Ok(None);
+                    return Ok(Transformed::No(plan));
                 }
                 let new_left: Arc<LogicalPlan> = if can_push_left {
                     LogicalPlan::from(Filter::new(
@@ -198,9 +202,9 @@ impl OptimizerRule for PushDownFilter {
                 };
                 child_plan.with_new_children(&[new_left, new_right])
             }
-            _ => return Ok(None),
+            _ => return Ok(Transformed::No(plan)),
         };
-        Ok(Some(new_plan))
+        Ok(Transformed::Yes(new_plan))
     }
 }
 
@@ -213,38 +217,35 @@ mod tests {
     use daft_dsl::{col, lit};
 
     use crate::{
-        display::TreeDisplay,
-        ops::{Coalesce, Concat, Filter, Join, Project, Repartition, Sort, Source},
-        optimization::{rules::PushDownFilter, Optimizer},
-        source_info::{ExternalInfo, FileFormatConfig, FileInfo, SourceInfo},
-        JoinType, JsonSourceConfig, LogicalPlan, PartitionScheme, PartitionSpec,
+        ops::{Coalesce, Concat, Filter, Join, Project, Repartition, Sort},
+        optimization::{
+            optimizer::{RuleBatch, RuleExecutionStrategy},
+            rules::PushDownFilter,
+            Optimizer,
+        },
+        test::dummy_scan_node,
+        JoinType, LogicalPlan, PartitionScheme,
     };
 
     fn assert_optimized_plan_eq(plan: Arc<LogicalPlan>, expected: &str) -> DaftResult<()> {
-        let optimizer = Optimizer::with_rules(vec![Arc::new(PushDownFilter::new())]);
+        let optimizer = Optimizer::with_rule_batches(
+            vec![RuleBatch::new(
+                vec![Box::new(PushDownFilter::new())],
+                RuleExecutionStrategy::Once,
+            )],
+            Default::default(),
+        );
         let optimized_plan = optimizer
-            .optimize_with_rule(optimizer.rules.get(0).unwrap(), &plan)?
-            .unwrap_or_else(|| plan.clone());
-        let mut formatted_plan = String::new();
-        optimized_plan.fmt_tree_indent_style(0, &mut formatted_plan)?;
-        println!("{}", formatted_plan);
-        assert_eq!(formatted_plan, expected);
+            .optimize_with_rules(
+                optimizer.rule_batches[0].rules.as_slice(),
+                plan.clone(),
+                &optimizer.rule_batches[0].order,
+            )?
+            .unwrap()
+            .clone();
+        assert_eq!(optimized_plan.repr_indent(), expected);
 
         Ok(())
-    }
-
-    fn dummy_scan_node(fields: Vec<Field>) -> Source {
-        let schema = Arc::new(Schema::new(fields).unwrap());
-        Source::new(
-            schema.clone(),
-            SourceInfo::ExternalInfo(ExternalInfo::new(
-                schema.clone(),
-                FileInfo::new(vec!["/foo".to_string()], vec![None], vec![None]).into(),
-                FileFormatConfig::Json(JsonSourceConfig {}).into(),
-            ))
-            .into(),
-            PartitionSpec::default().into(),
-        )
     }
 
     #[test]

--- a/src/daft-plan/src/optimization/rules/rule.rs
+++ b/src/daft-plan/src/optimization/rules/rule.rs
@@ -18,7 +18,6 @@ pub enum ApplyOrder {
 }
 
 /// A logical plan optimization rule.
-// TODO(Clark): Add fixed-point policy if needed.
 pub trait OptimizerRule {
     /// Try to optimize the logical plan with this rule.
     ///
@@ -52,7 +51,7 @@ impl<T> Transformed<T> {
     }
 
     /// Unwraps the enum and returns a reference to the inner value.
-    // TODO(Clark): Take ownership of self and return a plain T?
+    // TODO(Clark): Take ownership of self and return an owned T?
     pub fn unwrap(&self) -> &T {
         match self {
             Self::Yes(inner) => inner,

--- a/src/daft-plan/src/optimization/rules/rule.rs
+++ b/src/daft-plan/src/optimization/rules/rule.rs
@@ -4,32 +4,41 @@ use common_error::DaftResult;
 
 use crate::LogicalPlan;
 
+/// Application order of a rule or rule batch.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ApplyOrder {
+    // Apply a rule to a node and then it's children.
     TopDown,
     #[allow(dead_code)]
+    // Apply a rule to a node's children and then the node itself.
     BottomUp,
     #[allow(dead_code)]
+    // Delegate tree traversal to the rule.
     Delegated,
 }
 
+/// A logical plan optimization rule.
 // TODO(Clark): Add fixed-point policy if needed.
 pub trait OptimizerRule {
     /// Try to optimize the logical plan with this rule.
     ///
-    /// This returns Some(new_plan) if the rule modified the plan, None otherwise.
+    /// This returns Transformed::Yes(new_plan) if the rule modified the plan, Transformed::No(old_plan) otherwise.
     fn try_optimize(&self, plan: Arc<LogicalPlan>) -> DaftResult<Transformed<Arc<LogicalPlan>>>;
 
-    /// The plan tree order in which this rule should be applied (top-down or bottom-up).
+    /// The plan tree order in which this rule should be applied (top-down, bottom-up, or delegated to rule).
     fn apply_order(&self) -> ApplyOrder;
 }
 
+/// An enum indicating whether or not the wrapped data has been transformed.
 pub enum Transformed<T> {
+    // Yes, the data has been transformed.
     Yes(T),
+    // No, the data has not been transformed.
     No(T),
 }
 
 impl<T> Transformed<T> {
+    /// Returns self if self is Yes, otherwise returns other.
     pub fn or(self, other: Self) -> Self {
         match self {
             Self::Yes(_) => self,
@@ -37,10 +46,13 @@ impl<T> Transformed<T> {
         }
     }
 
+    /// Returns whether self is No.
     pub fn is_no(&self) -> bool {
         matches!(self, Self::No(_))
     }
 
+    /// Unwraps the enum and returns a reference to the inner value.
+    // TODO(Clark): Take ownership of self and return a plain T?
     pub fn unwrap(&self) -> &T {
         match self {
             Self::Yes(inner) => inner,

--- a/src/daft-plan/src/optimization/rules/rule.rs
+++ b/src/daft-plan/src/optimization/rules/rule.rs
@@ -4,10 +4,13 @@ use common_error::DaftResult;
 
 use crate::LogicalPlan;
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ApplyOrder {
     TopDown,
     #[allow(dead_code)]
     BottomUp,
+    #[allow(dead_code)]
+    Delegated,
 }
 
 // TODO(Clark): Add fixed-point policy if needed.
@@ -15,8 +18,33 @@ pub trait OptimizerRule {
     /// Try to optimize the logical plan with this rule.
     ///
     /// This returns Some(new_plan) if the rule modified the plan, None otherwise.
-    fn try_optimize(&self, plan: &LogicalPlan) -> DaftResult<Option<Arc<LogicalPlan>>>;
+    fn try_optimize(&self, plan: Arc<LogicalPlan>) -> DaftResult<Transformed<Arc<LogicalPlan>>>;
 
     /// The plan tree order in which this rule should be applied (top-down or bottom-up).
-    fn apply_order(&self) -> Option<ApplyOrder>;
+    fn apply_order(&self) -> ApplyOrder;
+}
+
+pub enum Transformed<T> {
+    Yes(T),
+    No(T),
+}
+
+impl<T> Transformed<T> {
+    pub fn or(self, other: Self) -> Self {
+        match self {
+            Self::Yes(_) => self,
+            Self::No(_) => other,
+        }
+    }
+
+    pub fn is_no(&self) -> bool {
+        matches!(self, Self::No(_))
+    }
+
+    pub fn unwrap(&self) -> &T {
+        match self {
+            Self::Yes(inner) => inner,
+            Self::No(inner) => inner,
+        }
+    }
 }

--- a/src/daft-plan/src/partitioning.rs
+++ b/src/daft-plan/src/partitioning.rs
@@ -12,7 +12,7 @@ use {
     },
 };
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "python", pyclass(module = "daft.daft"))]
 pub enum PartitionScheme {
     Range,
@@ -40,7 +40,7 @@ impl PartitionScheme {
 
 impl_bincode_py_state_serialization!(PartitionScheme);
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "python", pyclass(module = "daft.daft"))]
 pub struct PartitionSpec {
     pub scheme: PartitionScheme,

--- a/src/daft-plan/src/resource_request.rs
+++ b/src/daft-plan/src/resource_request.rs
@@ -1,4 +1,5 @@
-use daft_core::impl_bincode_py_state_serialization;
+use daft_core::{impl_bincode_py_state_serialization, utils::hashable_float_wrapper::FloatWrapper};
+use std::hash::{Hash, Hasher};
 #[cfg(feature = "python")]
 use {
     pyo3::{pyclass, pyclass::CompareOp, pymethods, types::PyBytes, PyResult, Python},
@@ -26,6 +27,16 @@ impl ResourceRequest {
             num_gpus,
             memory_bytes,
         }
+    }
+}
+
+impl Eq for ResourceRequest {}
+
+impl Hash for ResourceRequest {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.num_cpus.map(FloatWrapper).hash(state);
+        self.num_gpus.map(FloatWrapper).hash(state);
+        self.memory_bytes.hash(state)
     }
 }
 

--- a/src/daft-plan/src/sink_info.rs
+++ b/src/daft-plan/src/sink_info.rs
@@ -3,12 +3,12 @@ use daft_dsl::Expr;
 use crate::FileFormat;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum SinkInfo {
     OutputFileInfo(OutputFileInfo),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct OutputFileInfo {
     pub root_dir: String,
     pub file_format: FileFormat,

--- a/src/daft-plan/src/source_info.rs
+++ b/src/daft-plan/src/source_info.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 use arrow2::array::Array;
 use common_error::DaftResult;
@@ -27,7 +30,7 @@ use serde::de::{Error as DeError, Visitor};
 use serde::{ser::Error as SerError, Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum SourceInfo {
     #[cfg(feature = "python")]
     InMemoryInfo(InMemoryInfo),
@@ -116,7 +119,32 @@ impl InMemoryInfo {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg(feature = "python")]
+impl PartialEq for InMemoryInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.cache_key == other.cache_key
+            && Python::with_gil(|py| {
+                self.cache_entry
+                    .as_ref(py)
+                    .eq(other.cache_entry.as_ref(py))
+                    .unwrap()
+            })
+    }
+}
+
+#[cfg(feature = "python")]
+impl Eq for InMemoryInfo {}
+
+#[cfg(feature = "python")]
+impl Hash for InMemoryInfo {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.cache_key.hash(state);
+        let py_obj_hash = Python::with_gil(|py| self.cache_entry.as_ref(py).hash().unwrap());
+        py_obj_hash.hash(state)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ExternalInfo {
     pub schema: SchemaRef,
     pub file_info: Arc<FileInfo>,
@@ -137,7 +165,7 @@ impl ExternalInfo {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct FileInfo {
     pub file_paths: Vec<String>,
     pub file_sizes: Vec<Option<i64>>,
@@ -189,7 +217,7 @@ impl FileInfo {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "python", pyclass(module = "daft.daft"))]
 pub enum FileFormat {
     Parquet,
@@ -226,7 +254,7 @@ impl From<&FileFormatConfig> for FileFormat {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum FileFormatConfig {
     Parquet(ParquetSourceConfig),
     Csv(CsvSourceConfig),
@@ -245,7 +273,7 @@ impl FileFormatConfig {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "python", pyclass(module = "daft.daft"))]
 pub struct ParquetSourceConfig {
     pub use_native_downloader: bool,
@@ -276,7 +304,7 @@ impl ParquetSourceConfig {
 
 impl_bincode_py_state_serialization!(ParquetSourceConfig);
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "python", pyclass(module = "daft.daft", get_all))]
 pub struct CsvSourceConfig {
     pub delimiter: String,
@@ -297,7 +325,7 @@ impl CsvSourceConfig {
 
 impl_bincode_py_state_serialization!(CsvSourceConfig);
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[cfg_attr(feature = "python", pyclass(module = "daft.daft", get_all))]
 pub struct JsonSourceConfig {}
 

--- a/src/daft-plan/src/test/mod.rs
+++ b/src/daft-plan/src/test/mod.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+
+use daft_core::{datatypes::Field, schema::Schema};
+
+use crate::{
+    ops::Source,
+    source_info::{ExternalInfo, FileFormatConfig, FileInfo, SourceInfo},
+    JsonSourceConfig, PartitionSpec,
+};
+
+pub fn dummy_scan_node(fields: Vec<Field>) -> Source {
+    let schema = Arc::new(Schema::new(fields).unwrap());
+    Source::new(
+        schema.clone(),
+        SourceInfo::ExternalInfo(ExternalInfo::new(
+            schema.clone(),
+            FileInfo::new(vec!["/foo".to_string()], vec![None], vec![None]).into(),
+            FileFormatConfig::Json(JsonSourceConfig {}).into(),
+        ))
+        .into(),
+        PartitionSpec::default().into(),
+    )
+}

--- a/src/daft-plan/src/test/mod.rs
+++ b/src/daft-plan/src/test/mod.rs
@@ -8,6 +8,7 @@ use crate::{
     JsonSourceConfig, PartitionSpec,
 };
 
+/// Create a dummy scan node containing the provided fields in its schema.
 pub fn dummy_scan_node(fields: Vec<Field>) -> Source {
     let schema = Arc::new(Schema::new(fields).unwrap());
     Source::new(


### PR DESCRIPTION
This PR adds support for logical plan `Hash`/`Eq`, optimization rule batches + fixed-point policies per batch, early optimizer termination, and catches optimization cycles.

When refactoring the optimizer to support rule batches, I also changed the optimization methods to represent an optimization attempt with `Transformed<Arc<LogicalPlan>>` instead of the previous `Option<Arc<LogicalPlan>>`, which made things a bit cleaner.