### PR TITLE
[FEAT] [New Query Planner] Refactor file globbing logic by exposing `FileInfos` to Python

### DIFF
--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -319,7 +319,6 @@ class ReadFile(SingleOutputInstruction):
     fs: fsspec.AbstractFileSystem | None
     columns_to_read: list[str] | None
     file_format_config: FileFormatConfig
-    filepaths_column_name: str
 
     def run(self, inputs: list[Table]) -> list[Table]:
         return self._read_file(inputs)
@@ -352,10 +351,7 @@ class ReadFile(SingleOutputInstruction):
         filepaths_partition: Table,
     ) -> Table:
         data = filepaths_partition.to_pydict()
-        assert (
-            self.filepaths_column_name in data
-        ), f"TabularFilesScan should be ran on vPartitions with '{self.filepaths_column_name}' column"
-        filepaths = data[self.filepaths_column_name]
+        filepaths = data["file_paths"]
 
         if self.index is not None:
             filepaths = [filepaths[self.index]]

--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -70,7 +70,6 @@ def file_read(
     fs: fsspec.AbstractFileSystem | None,
     columns_to_read: list[str] | None,
     file_format_config: FileFormatConfig,
-    filepaths_column_name: str,
 ) -> InProgressPhysicalPlan[PartitionT]:
     """child_plan represents partitions with filenames.
 
@@ -85,8 +84,9 @@ def file_read(
             done_task = materializations.popleft()
 
             vpartition = done_task.vpartition()
-            file_sizes_bytes = vpartition.to_pydict()["size"]
-            file_rows = vpartition.to_pydict()["rows"]
+            file_infos = vpartition.to_pydict()
+            file_sizes_bytes = file_infos["file_sizes"]
+            file_rows = file_infos["num_rows"]
 
             # Emit one partition for each file (NOTE: hardcoded for now).
             for i in range(len(vpartition)):
@@ -102,7 +102,6 @@ def file_read(
                         fs=fs,
                         columns_to_read=columns_to_read,
                         file_format_config=file_format_config,
-                        filepaths_column_name=filepaths_column_name,
                     ),
                     # Set the filesize as the memory request.
                     # (Note: this is very conservative; file readers empirically use much more peak memory than 1x file size.)

--- a/daft/execution/physical_plan_factory.py
+++ b/daft/execution/physical_plan_factory.py
@@ -42,7 +42,6 @@ def _get_physical_plan(node: LogicalPlan, psets: dict[str, list[PartitionT]]) ->
                 fs=node._fs,
                 columns_to_read=node._column_names,
                 file_format_config=node._file_format_config,
-                filepaths_column_name=node._filepaths_column_name,
             )
 
         elif isinstance(node, logical_plan.Filter):

--- a/daft/execution/rust_physical_plan_shim.py
+++ b/daft/execution/rust_physical_plan_shim.py
@@ -39,16 +39,13 @@ def tabular_scan(
     parts_t = cast(Iterator[PartitionT], parts)
 
     file_info_iter = physical_plan.partition_read(iter(parts_t))
-    filepaths_column_name = get_context().runner().runner_io().FS_LISTING_PATH_COLUMN_NAME
-    pyschema = Schema._from_pyschema(schema)
     return physical_plan.file_read(
         child_plan=file_info_iter,
         limit_rows=limit,
-        schema=pyschema,
+        schema=Schema._from_pyschema(schema),
         fs=None,
         columns_to_read=columns_to_read,
         file_format_config=file_format_config,
-        filepaths_column_name=filepaths_column_name,
     )
 
 

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -9,6 +9,7 @@ import fsspec
 from daft.daft import (
     FileFormat,
     FileFormatConfig,
+    FileInfos,
     JoinType,
     PartitionScheme,
     PartitionSpec,
@@ -80,9 +81,9 @@ class LogicalPlanBuilder(ABC):
     def from_tabular_scan(
         cls,
         *,
-        paths: list[str],
+        file_infos: FileInfos,
+        schema: Schema,
         file_format_config: FileFormatConfig,
-        schema_hint: Schema | None,
         fs: fsspec.AbstractFileSystem | None,
     ) -> LogicalPlanBuilder:
         pass

--- a/daft/logical/optimizer.py
+++ b/daft/logical/optimizer.py
@@ -335,7 +335,6 @@ class PushDownClausesIntoScan(Rule[LogicalPlan]):
             file_format_config=child._file_format_config,
             fs=child._fs,
             filepaths_child=child._filepaths_child,
-            filepaths_column_name=child._filepaths_column_name,
             limit_rows=new_limit_rows,
         )
         return new_scan
@@ -359,7 +358,6 @@ class PushDownClausesIntoScan(Rule[LogicalPlan]):
             file_format_config=child._file_format_config,
             fs=child._fs,
             filepaths_child=child._filepaths_child,
-            filepaths_column_name=child._filepaths_column_name,
         )
         if any(not e._is_column() for e in parent._projection):
             return parent.copy_with_new_children([new_scan])

--- a/daft/runners/runner_io.py
+++ b/daft/runners/runner_io.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 import fsspec
 
@@ -9,39 +9,23 @@ from daft.daft import (
     CsvSourceConfig,
     FileFormat,
     FileFormatConfig,
+    FileInfos,
     JsonSourceConfig,
     ParquetSourceConfig,
 )
-from daft.datatype import DataType
 from daft.filesystem import get_filesystem_from_path
 from daft.logical.schema import Schema
-from daft.runners.partitioning import PartitionSet, TableParseCSVOptions
+from daft.runners.partitioning import TableParseCSVOptions
 from daft.table import schema_inference
 
 PartitionT = TypeVar("PartitionT")
 
 
-class RunnerIO(Generic[PartitionT]):
+class RunnerIO:
     """Reading and writing data from the Runner.
 
     This is an abstract class and each runner must write their own implementation.
-
-    This is a generic class and each runner needs to parametrize their implementation with the appropriate
-    PartitionT that it uses for in-memory data representation.
     """
-
-    FS_LISTING_PATH_COLUMN_NAME = "path"
-    FS_LISTING_SIZE_COLUMN_NAME = "size"
-    FS_LISTING_TYPE_COLUMN_NAME = "type"
-    FS_LISTING_ROWS_COLUMN_NAME = "rows"
-    FS_LISTING_SCHEMA = Schema._from_field_name_and_types(
-        [
-            (FS_LISTING_SIZE_COLUMN_NAME, DataType.int64()),
-            (FS_LISTING_PATH_COLUMN_NAME, DataType.string()),
-            (FS_LISTING_TYPE_COLUMN_NAME, DataType.string()),
-            (FS_LISTING_ROWS_COLUMN_NAME, DataType.int64()),
-        ]
-    )
 
     @abstractmethod
     def glob_paths_details(
@@ -49,21 +33,21 @@ class RunnerIO(Generic[PartitionT]):
         source_path: list[str],
         file_format_config: FileFormatConfig | None = None,
         fs: fsspec.AbstractFileSystem | None = None,
-    ) -> PartitionSet[PartitionT]:
-        """Globs the specified filepath to construct Partitions containing file and dir metadata
+    ) -> FileInfos:
+        """Globs the specified filepath to construct a FileInfos object containing file and dir metadata.
 
         Args:
             source_path (str): path to glob
 
         Returns:
-            PartitionSet[PartitionT]: Partitions containing the listings' metadata
+            FileInfo: The file infos for the globbed paths.
         """
         raise NotImplementedError()
 
     @abstractmethod
     def get_schema_from_first_filepath(
         self,
-        listing_details_partitions: PartitionSet[PartitionT],
+        file_info: FileInfos,
         file_format_config: FileFormatConfig,
         fs: fsspec.AbstractFileSystem | None,
     ) -> Schema:

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -9,7 +9,7 @@ use {
         planner::plan,
         sink_info::{OutputFileInfo, SinkInfo},
         source_info::{
-            ExternalInfo as ExternalSourceInfo, FileInfo as InputFileInfo, InMemoryInfo,
+            ExternalInfo as ExternalSourceInfo, FileInfos as InputFileInfos, InMemoryInfo,
             PyFileFormatConfig, SourceInfo,
         },
         FileFormat, JoinType, PartitionScheme, PartitionSpec, PhysicalPlanScheduler,
@@ -58,16 +58,14 @@ impl LogicalPlanBuilder {
 
     #[staticmethod]
     pub fn table_scan(
-        file_paths: Vec<String>,
-        file_sizes: Vec<Option<i64>>,
-        file_rows: Vec<Option<i64>>,
+        file_infos: InputFileInfos,
         schema: &PySchema,
         file_format_config: PyFileFormatConfig,
     ) -> PyResult<LogicalPlanBuilder> {
-        let num_partitions = file_paths.len();
+        let num_partitions = file_infos.len();
         let source_info = SourceInfo::ExternalInfo(ExternalSourceInfo::new(
             schema.schema.clone(),
-            InputFileInfo::new(file_paths, file_sizes, file_rows).into(),
+            file_infos.into(),
             file_format_config.into(),
         ));
         let partition_spec = PartitionSpec::new(PartitionScheme::Unknown, num_partitions, None);

--- a/src/daft-plan/src/lib.rs
+++ b/src/daft-plan/src/lib.rs
@@ -23,7 +23,8 @@ pub use partitioning::{PartitionScheme, PartitionSpec};
 pub use physical_plan::PhysicalPlanScheduler;
 pub use resource_request::ResourceRequest;
 pub use source_info::{
-    CsvSourceConfig, FileFormat, JsonSourceConfig, ParquetSourceConfig, PyFileFormatConfig,
+    CsvSourceConfig, FileFormat, FileInfo, FileInfos, JsonSourceConfig, ParquetSourceConfig,
+    PyFileFormatConfig,
 };
 
 #[cfg(feature = "python")]
@@ -42,6 +43,8 @@ pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
     parent.add_class::<JoinType>()?;
     parent.add_class::<PhysicalPlanScheduler>()?;
     parent.add_class::<ResourceRequest>()?;
+    parent.add_class::<FileInfos>()?;
+    parent.add_class::<FileInfo>()?;
 
     Ok(())
 }

--- a/src/daft-plan/src/ops/source.rs
+++ b/src/daft-plan/src/ops/source.rs
@@ -66,11 +66,11 @@ impl Source {
         match self.source_info.as_ref() {
             SourceInfo::ExternalInfo(ExternalInfo {
                 source_schema,
-                file_info,
+                file_infos,
                 file_format_config,
             }) => {
                 res.push(format!("Source: {:?}", file_format_config.var_name()));
-                for fp in file_info.file_paths.iter() {
+                for fp in file_infos.file_paths.iter() {
                     res.push(format!("File paths = {}", fp));
                 }
                 res.push(format!("File schema = {}", source_schema.short_string()));

--- a/src/daft-plan/src/physical_plan.rs
+++ b/src/daft-plan/src/physical_plan.rs
@@ -3,14 +3,13 @@ use {
     crate::{
         sink_info::OutputFileInfo,
         source_info::{
-            ExternalInfo, FileFormat, FileFormatConfig, FileInfo, InMemoryInfo, PyFileFormatConfig,
+            ExternalInfo, FileFormat, FileFormatConfig, FileInfos, InMemoryInfo, PyFileFormatConfig,
         },
     },
     daft_core::python::schema::PySchema,
     daft_core::schema::SchemaRef,
     daft_dsl::python::PyExpr,
     daft_dsl::Expr,
-    daft_table::python::PyTable,
     pyo3::{
         exceptions::PyValueError,
         pyclass, pymethods,
@@ -123,11 +122,10 @@ fn tabular_scan(
     py: Python<'_>,
     source_schema: &SchemaRef,
     projection_schema: &SchemaRef,
-    file_info: &Arc<FileInfo>,
+    file_infos: &Arc<FileInfos>,
     file_format_config: &Arc<FileFormatConfig>,
     limit: &Option<usize>,
 ) -> PyResult<PyObject> {
-    let file_info_table: PyTable = file_info.to_table()?.into();
     let columns_to_read = projection_schema
         .fields
         .iter()
@@ -140,7 +138,7 @@ fn tabular_scan(
         .call1((
             PySchema::from(source_schema.clone()),
             columns_to_read,
-            file_info_table,
+            file_infos.to_table()?,
             PyFileFormatConfig::from(file_format_config.clone()),
             *limit,
         ))?;
@@ -203,7 +201,7 @@ impl PhysicalPlan {
                 external_info:
                     ExternalInfo {
                         source_schema,
-                        file_info,
+                        file_infos,
                         file_format_config,
                         ..
                     },
@@ -213,7 +211,7 @@ impl PhysicalPlan {
                 py,
                 source_schema,
                 projection_schema,
-                file_info,
+                file_infos,
                 file_format_config,
                 limit,
             ),
@@ -222,7 +220,7 @@ impl PhysicalPlan {
                 external_info:
                     ExternalInfo {
                         source_schema,
-                        file_info,
+                        file_infos,
                         file_format_config,
                         ..
                     },
@@ -232,7 +230,7 @@ impl PhysicalPlan {
                 py,
                 source_schema,
                 projection_schema,
-                file_info,
+                file_infos,
                 file_format_config,
                 limit,
             ),
@@ -241,7 +239,7 @@ impl PhysicalPlan {
                 external_info:
                     ExternalInfo {
                         source_schema,
-                        file_info,
+                        file_infos,
                         file_format_config,
                         ..
                     },
@@ -251,7 +249,7 @@ impl PhysicalPlan {
                 py,
                 source_schema,
                 projection_schema,
-                file_info,
+                file_infos,
                 file_format_config,
                 limit,
             ),

--- a/src/daft-plan/src/test/mod.rs
+++ b/src/daft-plan/src/test/mod.rs
@@ -4,7 +4,7 @@ use daft_core::{datatypes::Field, schema::Schema};
 
 use crate::{
     ops::Source,
-    source_info::{ExternalInfo, FileFormatConfig, FileInfo, SourceInfo},
+    source_info::{ExternalInfo, FileFormatConfig, FileInfos, SourceInfo},
     JsonSourceConfig, PartitionSpec,
 };
 
@@ -15,7 +15,7 @@ pub fn dummy_scan_node(fields: Vec<Field>) -> Source {
         schema.clone(),
         SourceInfo::ExternalInfo(ExternalInfo::new(
             schema.clone(),
-            FileInfo::new(vec!["/foo".to_string()], vec![None], vec![None]).into(),
+            FileInfos::new_internal(vec!["/foo".to_string()], vec![None], vec![None]).into(),
             FileFormatConfig::Json(JsonSourceConfig {}).into(),
         ))
         .into(),

--- a/tests/cookbook/test_dataloading.py
+++ b/tests/cookbook/test_dataloading.py
@@ -84,12 +84,12 @@ def test_glob_files(tmpdir):
     daft_df = daft.from_glob_path(f"{tmpdir}/*.foo")
     daft_pd_df = daft_df.to_pandas()
     pd_df = pd.DataFrame.from_records(
-        {"path": str(path), "size": size, "type": "file", "rows": None}
+        {"file_paths": str(path), "file_sizes": size, "num_rows": None}
         for path, size in zip(filepaths, list(range(10)))
     )
-    pd_df = pd_df[~pd_df["path"].str.endswith(".bar")]
-    pd_df = pd_df.astype({"rows": float})
-    assert_df_equals(daft_pd_df, pd_df, sort_key="path")
+    pd_df = pd_df[~pd_df["file_paths"].str.endswith(".bar")]
+    pd_df = pd_df.astype({"num_rows": float})
+    assert_df_equals(daft_pd_df, pd_df, sort_key="file_paths")
 
 
 def test_glob_files_single_file(tmpdir):
@@ -97,9 +97,9 @@ def test_glob_files_single_file(tmpdir):
     filepath.write_text("b" * 10)
     daft_df = daft.from_glob_path(f"{tmpdir}/file.foo")
     daft_pd_df = daft_df.to_pandas()
-    pd_df = pd.DataFrame.from_records([{"path": str(filepath), "size": 10, "type": "file", "rows": None}])
-    pd_df = pd_df.astype({"rows": float})
-    assert_df_equals(daft_pd_df, pd_df, sort_key="path")
+    pd_df = pd.DataFrame.from_records([{"file_paths": str(filepath), "file_sizes": 10, "num_rows": None}])
+    pd_df = pd_df.astype({"num_rows": float})
+    assert_df_equals(daft_pd_df, pd_df, sort_key="file_paths")
 
 
 def test_glob_files_directory(tmpdir):
@@ -116,16 +116,16 @@ def test_glob_files_directory(tmpdir):
     daft_pd_df = daft_df.to_pandas()
 
     listing_records = [
-        {"path": str(path), "size": size, "type": "file", "rows": None}
+        {"file_paths": str(path), "file_sizes": size, "num_rows": None}
         for path, size in zip(filepaths, [i for i in range(10) for _ in range(2)])
     ]
     listing_records = listing_records + [
-        {"path": str(extra_empty_dir), "size": extra_empty_dir.stat().st_size, "type": "directory", "rows": None}
+        {"file_paths": str(extra_empty_dir), "file_sizes": extra_empty_dir.stat().st_size, "num_rows": None}
     ]
     pd_df = pd.DataFrame.from_records(listing_records)
-    pd_df = pd_df.astype({"rows": float})
+    pd_df = pd_df.astype({"num_rows": float})
 
-    assert_df_equals(daft_pd_df, pd_df, sort_key="path")
+    assert_df_equals(daft_pd_df, pd_df, sort_key="file_paths")
 
 
 def test_glob_files_recursive(tmpdir):
@@ -142,16 +142,16 @@ def test_glob_files_recursive(tmpdir):
     daft_pd_df = daft_df.to_pandas()
 
     listing_records = [
-        {"path": str(path), "size": size, "type": "file", "rows": None}
+        {"file_paths": str(path), "file_sizes": size, "num_rows": None}
         for path, size in zip(paths, [i for i in range(10) for _ in range(2)])
     ]
     listing_records = listing_records + [
-        {"path": str(nested_dir_path), "size": nested_dir_path.stat().st_size, "type": "directory", "rows": None}
+        {"file_paths": str(nested_dir_path), "file_sizes": nested_dir_path.stat().st_size, "num_rows": None}
     ]
     pd_df = pd.DataFrame.from_records(listing_records)
-    pd_df = pd_df.astype({"rows": float})
+    pd_df = pd_df.astype({"num_rows": float})
 
-    assert_df_equals(daft_pd_df, pd_df, sort_key="path")
+    assert_df_equals(daft_pd_df, pd_df, sort_key="file_paths")
 
 
 @pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
@@ -176,9 +176,9 @@ def test_glob_files_custom_fs(tmpdir):
 
     daft_pd_df = daft_df.to_pandas()
     pd_df = pd.DataFrame.from_records(
-        {"path": str(path), "size": size, "type": "file", "rows": None}
+        {"file_paths": str(path), "file_sizes": size, "num_rows": None}
         for path, size in zip(filepaths, list(range(10)))
     )
-    pd_df = pd_df[~pd_df["path"].str.endswith(".bar")]
-    pd_df = pd_df.astype({"rows": float})
-    assert_df_equals(daft_pd_df, pd_df, sort_key="path")
+    pd_df = pd_df[~pd_df["file_paths"].str.endswith(".bar")]
+    pd_df = pd_df.astype({"num_rows": float})
+    assert_df_equals(daft_pd_df, pd_df, sort_key="file_paths")

--- a/tests/cookbook/test_image.py
+++ b/tests/cookbook/test_image.py
@@ -68,7 +68,7 @@ def test_image_decode() -> None:
     df = (
         daft.from_glob_path(f"{ASSET_FOLDER}/images/**")
         .into_partitions(2)
-        .with_column("image", col("path").url.download().image.decode().image.resize(10, 10))
+        .with_column("image", col("file_paths").url.download().image.decode().image.resize(10, 10))
     )
     target_dtype = DataType.image()
     assert df.schema()["image"].dtype == target_dtype

--- a/tests/optimizer/test_pushdown_clauses_into_scan.py
+++ b/tests/optimizer/test_pushdown_clauses_into_scan.py
@@ -29,7 +29,6 @@ def test_push_projection_scan_all_cols(valid_data_json_path: str, optimizer):
             file_format_config=df_unoptimized_scan._get_current_builder()._plan._file_format_config,
             fs=df_unoptimized_scan._get_current_builder()._plan._fs,
             filepaths_child=df_unoptimized_scan._get_current_builder()._plan._filepaths_child,
-            filepaths_column_name=df_unoptimized_scan._get_current_builder()._plan._filepaths_column_name,
         ).to_builder()
     )
 
@@ -50,7 +49,6 @@ def test_push_projection_scan_all_cols_alias(valid_data_json_path: str, optimize
             file_format_config=df_unoptimized_scan._get_current_builder()._plan._file_format_config,
             fs=df_unoptimized_scan._get_current_builder()._plan._fs,
             filepaths_child=df_unoptimized_scan._get_current_builder()._plan._filepaths_child,
-            filepaths_column_name=df_unoptimized_scan._get_current_builder()._plan._filepaths_column_name,
         ).to_builder()
     )
     df_optimized = df_optimized.select(col("sepal_length").alias("foo"))
@@ -72,7 +70,6 @@ def test_push_projection_scan_some_cols_aliases(valid_data_json_path: str, optim
             file_format_config=df_unoptimized_scan._get_current_builder()._plan._file_format_config,
             fs=df_unoptimized_scan._get_current_builder()._plan._fs,
             filepaths_child=df_unoptimized_scan._get_current_builder()._plan._filepaths_child,
-            filepaths_column_name=df_unoptimized_scan._get_current_builder()._plan._filepaths_column_name,
         ).to_builder()
     )
     df_optimized = df_optimized.select(col("sepal_length").alias("foo"), col("sepal_width") + 1)


### PR DESCRIPTION
This PR refactors the file globbing logic by exposing `FileInfos` from the new query planner to Python and using it for both the old query planner and the new query planner. Hopefully the upcoming Rust-native file globber will be able to leverage the `FileInfos` struct or something akin to it, allowing it to be a ~drop-in replacement for the existing Python file globber.