### PR TITLE
[CHORE] [New Query Planner] Remove `ExpressionsProjection` from builder, move validation into `Op::try_new()`

### DIFF
--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -15,7 +15,7 @@ from daft.daft import (
     PartitionSpec,
     ResourceRequest,
 )
-from daft.expressions.expressions import Expression, ExpressionsProjection
+from daft.expressions.expressions import Expression
 from daft.logical.schema import Schema
 from daft.runners.partitioning import PartitionCacheEntry
 
@@ -91,7 +91,7 @@ class LogicalPlanBuilder(ABC):
     @abstractmethod
     def project(
         self,
-        projection: ExpressionsProjection,
+        projection: list[Expression],
         custom_resource_request: ResourceRequest = ResourceRequest(),
     ) -> LogicalPlanBuilder:
         pass
@@ -105,7 +105,7 @@ class LogicalPlanBuilder(ABC):
         pass
 
     @abstractmethod
-    def explode(self, explode_expressions: ExpressionsProjection) -> LogicalPlanBuilder:
+    def explode(self, explode_expressions: list[Expression]) -> LogicalPlanBuilder:
         pass
 
     @abstractmethod
@@ -117,12 +117,12 @@ class LogicalPlanBuilder(ABC):
         pass
 
     @abstractmethod
-    def sort(self, sort_by: ExpressionsProjection, descending: list[bool] | bool = False) -> LogicalPlanBuilder:
+    def sort(self, sort_by: list[Expression], descending: list[bool] | bool = False) -> LogicalPlanBuilder:
         pass
 
     @abstractmethod
     def repartition(
-        self, num_partitions: int, partition_by: ExpressionsProjection, scheme: PartitionScheme
+        self, num_partitions: int, partition_by: list[Expression], scheme: PartitionScheme
     ) -> LogicalPlanBuilder:
         pass
 
@@ -131,7 +131,7 @@ class LogicalPlanBuilder(ABC):
         pass
 
     @abstractmethod
-    def agg(self, to_agg: list[tuple[Expression, str]], group_by: ExpressionsProjection | None) -> LogicalPlanBuilder:
+    def agg(self, to_agg: list[tuple[Expression, str]], group_by: list[Expression] | None) -> LogicalPlanBuilder:
         """
         to_agg: (<expression identifying column>, <string identifying agg operation>)
         TODO - clean this up after old logical plan is removed
@@ -141,8 +141,8 @@ class LogicalPlanBuilder(ABC):
     def join(
         self,
         right: LogicalPlanBuilder,
-        left_on: ExpressionsProjection,
-        right_on: ExpressionsProjection,
+        left_on: list[Expression],
+        right_on: list[Expression],
         how: JoinType = JoinType.Inner,
     ) -> LogicalPlanBuilder:
         pass
@@ -156,7 +156,7 @@ class LogicalPlanBuilder(ABC):
         self,
         root_dir: str | pathlib.Path,
         file_format: FileFormat,
-        partition_cols: ExpressionsProjection | None = None,
+        partition_cols: list[Expression] | None = None,
         compression: str | None = None,
     ) -> LogicalPlanBuilder:
         pass

--- a/src/daft-plan/src/logical_plan.rs
+++ b/src/daft-plan/src/logical_plan.rs
@@ -224,10 +224,10 @@ impl LogicalPlan {
                 Self::Project(Project { projection, resource_request, .. }) => Self::Project(Project::try_new(
                     input.clone(), projection.clone(), resource_request.clone(),
                 ).unwrap()),
-                Self::Filter(Filter { predicate, .. }) => Self::Filter(Filter::new(predicate.clone(), input.clone())),
+                Self::Filter(Filter { predicate, .. }) => Self::Filter(Filter::try_new(predicate.clone(), input.clone()).unwrap()),
                 Self::Limit(Limit { limit, .. }) => Self::Limit(Limit::new(*limit, input.clone())),
                 Self::Explode(Explode { to_explode, .. }) => Self::Explode(Explode::try_new(input.clone(), to_explode.clone()).unwrap()),
-                Self::Sort(Sort { sort_by, descending, .. }) => Self::Sort(Sort::new(sort_by.clone(), descending.clone(), input.clone())),
+                Self::Sort(Sort { sort_by, descending, .. }) => Self::Sort(Sort::try_new(sort_by.clone(), descending.clone(), input.clone()).unwrap()),
                 Self::Repartition(Repartition { num_partitions, partition_by, scheme, .. }) => Self::Repartition(Repartition::new(*num_partitions, partition_by.clone(), scheme.clone(), input.clone())),
                 Self::Coalesce(Coalesce { num_to, .. }) => Self::Coalesce(Coalesce::new(*num_to, input.clone())),
                 Self::Distinct(_) => Self::Distinct(Distinct::new(input.clone())),
@@ -237,7 +237,7 @@ impl LogicalPlan {
             },
             [input1, input2] => match self {
                 Self::Source(_) => panic!("Source nodes don't have children, with_new_children() should never be called for Source ops"),
-                Self::Concat(_) => Self::Concat(Concat::new(input1.clone(), input2.clone())),
+                Self::Concat(_) => Self::Concat(Concat::try_new(input1.clone(), input2.clone()).unwrap()),
                 Self::Join(Join { left_on, right_on, join_type, .. }) => Self::Join(Join::try_new(input1.clone(), input2.clone(), left_on.clone(), right_on.clone(), *join_type).unwrap()),
                 _ => panic!("Logical op {} has one input, but got two", self),
             },

--- a/src/daft-plan/src/ops/concat.rs
+++ b/src/daft-plan/src/ops/concat.rs
@@ -1,5 +1,10 @@
 use std::sync::Arc;
 
+use common_error::DaftError;
+use snafu::ResultExt;
+
+use crate::logical_plan;
+use crate::logical_plan::CreationSnafu;
 use crate::LogicalPlan;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -10,7 +15,19 @@ pub struct Concat {
 }
 
 impl Concat {
-    pub(crate) fn new(input: Arc<LogicalPlan>, other: Arc<LogicalPlan>) -> Self {
-        Self { input, other }
+    pub(crate) fn try_new(
+        input: Arc<LogicalPlan>,
+        other: Arc<LogicalPlan>,
+    ) -> logical_plan::Result<Self> {
+        let self_schema = input.schema();
+        let other_schema = other.schema();
+        if self_schema != other_schema {
+            return Err(DaftError::ValueError(format!(
+                "Both DataFrames must have the same schema to concatenate them, but got: {}, {}",
+                self_schema, other_schema
+            )))
+            .context(CreationSnafu);
+        }
+        Ok(Self { input, other })
     }
 }

--- a/src/daft-plan/src/ops/filter.rs
+++ b/src/daft-plan/src/ops/filter.rs
@@ -1,8 +1,12 @@
 use std::sync::Arc;
 
+use daft_core::DataType;
 use daft_dsl::Expr;
+use snafu::ResultExt;
 
+use crate::logical_plan::{CreationSnafu, Result};
 use crate::LogicalPlan;
+use common_error::DaftError;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Filter {
@@ -13,7 +17,17 @@ pub struct Filter {
 }
 
 impl Filter {
-    pub(crate) fn new(predicate: Expr, input: Arc<LogicalPlan>) -> Self {
-        Self { predicate, input }
+    pub(crate) fn try_new(predicate: Expr, input: Arc<LogicalPlan>) -> Result<Self> {
+        let field = predicate
+            .to_field(input.schema().as_ref())
+            .context(CreationSnafu)?;
+        if !matches!(field.dtype, DataType::Boolean) {
+            return Err(DaftError::ValueError(format!(
+                "Expected expression {predicate} to resolve to type Boolean, but received: {}",
+                field.dtype
+            )))
+            .context(CreationSnafu);
+        }
+        Ok(Self { predicate, input })
     }
 }

--- a/src/daft-plan/src/ops/sort.rs
+++ b/src/daft-plan/src/ops/sort.rs
@@ -40,6 +40,8 @@ impl Sort {
             Schema::new(sort_by_fields).context(CreationSnafu)?
         };
         for (field, expr) in sort_by_resolved_schema.fields.values().zip(sort_by.iter()) {
+            // Disallow sorting by null, binary, and boolean columns.
+            // TODO(Clark): This is a port of an existing constraint, we should look at relaxing this.
             if let dt @ (DataType::Null | DataType::Binary | DataType::Boolean) = &field.dtype {
                 return Err(DaftError::ValueError(format!(
                     "Cannot sort on expression {expr} with type: {dt}",

--- a/src/daft-plan/src/optimization/logical_plan_tracker.rs
+++ b/src/daft-plan/src/optimization/logical_plan_tracker.rs
@@ -118,12 +118,12 @@ mod tests {
             LogicalPlanDigest::new(&plan2, &mut Default::default()).node_count,
             2usize.try_into().unwrap()
         );
-        let plan: LogicalPlan = Concat::new(plan1.into(), plan2.into()).into();
+        let plan: LogicalPlan = Concat::try_new(plan1.into(), plan2.into())?.into();
         assert_eq!(
             LogicalPlanDigest::new(&plan, &mut Default::default()).node_count,
             5usize.try_into().unwrap()
         );
-        let plan: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan.into()).into();
+        let plan: LogicalPlan = Filter::try_new(col("a").lt(&lit(2)), plan.into())?.into();
         assert_eq!(
             LogicalPlanDigest::new(&plan, &mut Default::default()).node_count,
             6usize.try_into().unwrap()
@@ -141,7 +141,7 @@ mod tests {
         .into();
         let plan1: LogicalPlan =
             Project::try_new(plan1.into(), vec![col("a")], Default::default())?.into();
-        let plan1: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan1.into()).into();
+        let plan1: LogicalPlan = Filter::try_new(col("a").lt(&lit(2)), plan1.into())?.into();
         let plan2: LogicalPlan = dummy_scan_node(vec![
             Field::new("a", DataType::Int64),
             Field::new("b", DataType::Utf8),
@@ -149,7 +149,7 @@ mod tests {
         .into();
         let plan2: LogicalPlan =
             Project::try_new(plan2.into(), vec![col("a")], Default::default())?.into();
-        let plan2: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan2.into()).into();
+        let plan2: LogicalPlan = Filter::try_new(col("a").lt(&lit(2)), plan2.into())?.into();
         // Double-check that logical plans are equal.
         assert_eq!(plan1, plan2);
 
@@ -173,7 +173,7 @@ mod tests {
             Field::new("b", DataType::Utf8),
         ])
         .into();
-        let plan1: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan1.into()).into();
+        let plan1: LogicalPlan = Filter::try_new(col("a").lt(&lit(2)), plan1.into())?.into();
         let plan1: LogicalPlan =
             Project::try_new(plan1.into(), vec![col("a")], Default::default())?.into();
         let plan2: LogicalPlan = dummy_scan_node(vec![
@@ -183,7 +183,7 @@ mod tests {
         .into();
         let plan2: LogicalPlan =
             Project::try_new(plan2.into(), vec![col("a")], Default::default())?.into();
-        let plan2: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan2.into()).into();
+        let plan2: LogicalPlan = Filter::try_new(col("a").lt(&lit(2)), plan2.into())?.into();
         // Double-check that logical plans are NOT equal.
         assert_ne!(plan1, plan2);
 

--- a/src/daft-plan/src/optimization/optimizer.rs
+++ b/src/daft-plan/src/optimization/optimizer.rs
@@ -496,7 +496,7 @@ mod tests {
         ];
         let plan: LogicalPlan =
             Project::try_new(plan.into(), proj_exprs.clone(), Default::default())?.into();
-        let plan: LogicalPlan = Filter::new(col("a").lt(&lit(2)), plan.into()).into();
+        let plan: LogicalPlan = Filter::try_new(col("a").lt(&lit(2)), plan.into())?.into();
         let initial_plan: Arc<LogicalPlan> = plan.into();
         let mut pass_count = 0;
         let mut did_transform = false;
@@ -538,7 +538,7 @@ mod tests {
             };
             let new_predicate = filter.predicate.or(&lit(false));
             Ok(Transformed::Yes(
-                LogicalPlan::from(Filter::new(new_predicate, filter.input.clone())).into(),
+                LogicalPlan::from(Filter::try_new(new_predicate, filter.input.clone())?).into(),
             ))
         }
     }
@@ -566,7 +566,7 @@ mod tests {
             };
             let new_predicate = filter.predicate.and(&lit(true));
             Ok(Transformed::Yes(
-                LogicalPlan::from(Filter::new(new_predicate, filter.input.clone())).into(),
+                LogicalPlan::from(Filter::try_new(new_predicate, filter.input.clone())?).into(),
             ))
         }
     }

--- a/src/daft-plan/src/optimization/rules/drop_repartition.rs
+++ b/src/daft-plan/src/optimization/rules/drop_repartition.rs
@@ -155,7 +155,8 @@ mod tests {
         .into();
         let repartition1: LogicalPlan =
             Repartition::new(10, vec![col("a")], PartitionScheme::Hash, source.into()).into();
-        let filter: LogicalPlan = Filter::new(col("a").lt(&lit(2)), repartition1.into()).into();
+        let filter: LogicalPlan =
+            Filter::try_new(col("a").lt(&lit(2)), repartition1.into())?.into();
         let repartition2: LogicalPlan =
             Repartition::new(10, vec![col("a")], PartitionScheme::Hash, filter.into()).into();
         let expected = "\
@@ -204,7 +205,8 @@ mod tests {
         .into();
         let repartition1: LogicalPlan =
             Repartition::new(10, vec![col("a")], PartitionScheme::Hash, source.into()).into();
-        let sort: LogicalPlan = Sort::new(vec![col("a")], vec![true], repartition1.into()).into();
+        let sort: LogicalPlan =
+            Sort::try_new(vec![col("a")], vec![true], repartition1.into())?.into();
         let repartition2: LogicalPlan =
             Repartition::new(10, vec![col("a")], PartitionScheme::Range, sort.into()).into();
         let expected = "\

--- a/tests/dataframe/test_joins.py
+++ b/tests/dataframe/test_joins.py
@@ -144,5 +144,5 @@ def test_inner_join_null_type_column():
         }
     )
 
-    with pytest.raises(ExpressionTypeError):
+    with pytest.raises((ExpressionTypeError, ValueError)):
         daft_df.join(daft_df2, on="id", how="inner")

--- a/tests/dataframe/test_sort.py
+++ b/tests/dataframe/test_sort.py
@@ -17,21 +17,21 @@ from daft.errors import ExpressionTypeError
 def test_disallowed_sort_bool():
     df = daft.from_pydict({"A": [True, False]})
 
-    with pytest.raises(ExpressionTypeError):
+    with pytest.raises((ExpressionTypeError, ValueError)):
         df.sort("A")
 
 
 def test_disallowed_sort_null():
     df = daft.from_pydict({"A": [None, None]})
 
-    with pytest.raises(ExpressionTypeError):
+    with pytest.raises((ExpressionTypeError, ValueError)):
         df.sort("A")
 
 
 def test_disallowed_sort_bytes():
     df = daft.from_pydict({"A": [b"a", b"b"]})
 
-    with pytest.raises(ExpressionTypeError):
+    with pytest.raises((ExpressionTypeError, ValueError)):
         df.sort("A")
 
 
@@ -228,5 +228,5 @@ def test_sort_with_all_null_type_column():
         }
     )
 
-    with pytest.raises(ExpressionTypeError):
+    with pytest.raises((ExpressionTypeError, ValueError)):
         daft_df = daft_df.sort(daft_df["id"])


### PR DESCRIPTION
This PR removes `ExpressionsProjection` from the `LogicalPlanBuilder` interface and the `RustLogicalPlanBuilder` implementation, and moves construction-time validation into `LogicalOp::try_new()` for misc. logical ops.