### PR TITLE
[CHORE] Add new ListArray

### DIFF
--- a/src/daft-core/src/array/fixed_size_list_array.rs
+++ b/src/daft-core/src/array/fixed_size_list_array.rs
@@ -24,7 +24,7 @@ impl FixedSizeListArray {
     ) -> Self {
         let field: Arc<Field> = field.into();
         match &field.as_ref().dtype {
-            DataType::FixedSizeList(_, size) => {
+            DataType::FixedSizeList(child_field, size) => {
                 if let Some(validity) = validity.as_ref() && (validity.len() * size) != flat_child.len() {
                     panic!(
                         "FixedSizeListArray::new received values with len {} but expected it to match len of validity * size: {}",
@@ -32,11 +32,18 @@ impl FixedSizeListArray {
                         (validity.len() * size),
                     )
                 }
+                if child_field.as_ref() != flat_child.field() {
+                    panic!(
+                        "FixedSizeListArray::new expects the child series to have field {}, but received: {}",
+                        child_field,
+                        flat_child.field(),
+                    )
+                }
             }
             _ => panic!(
                 "FixedSizeListArray::new expected FixedSizeList datatype, but received field: {}",
                 field
-            )
+            ),
         }
         FixedSizeListArray {
             field,

--- a/src/daft-core/src/array/fixed_size_list_array.rs
+++ b/src/daft-core/src/array/fixed_size_list_array.rs
@@ -11,7 +11,7 @@ use crate::DataType;
 pub struct FixedSizeListArray {
     pub field: Arc<Field>,
     pub flat_child: Series,
-    pub validity: Option<arrow2::bitmap::Bitmap>,
+    validity: Option<arrow2::bitmap::Bitmap>,
 }
 
 impl DaftArrayType for FixedSizeListArray {}

--- a/src/daft-core/src/array/fixed_size_list_array.rs
+++ b/src/daft-core/src/array/fixed_size_list_array.rs
@@ -111,7 +111,7 @@ impl FixedSizeListArray {
     pub fn rename(&self, name: &str) -> Self {
         Self::new(
             Field::new(name, self.data_type().clone()),
-            self.flat_child.rename(name),
+            self.flat_child.clone(),
             self.validity.clone(),
         )
     }

--- a/src/daft-core/src/array/fixed_size_list_array.rs
+++ b/src/daft-core/src/array/fixed_size_list_array.rs
@@ -52,6 +52,10 @@ impl FixedSizeListArray {
         }
     }
 
+    pub fn validity(&self) -> Option<&arrow2::bitmap::Bitmap> {
+        self.validity.as_ref()
+    }
+
     pub fn concat(arrays: &[&Self]) -> DaftResult<Self> {
         if arrays.is_empty() {
             return Err(DaftError::ValueError(

--- a/src/daft-core/src/array/growable/arrow_growable.rs
+++ b/src/daft-core/src/array/growable/arrow_growable.rs
@@ -9,8 +9,8 @@ use crate::{
     },
     datatypes::{
         BinaryType, BooleanType, DaftArrowBackedType, DaftDataType, ExtensionArray, Field,
-        Float32Type, Float64Type, Int128Type, Int16Type, Int32Type, Int64Type, Int8Type, ListType,
-        NullType, UInt16Type, UInt32Type, UInt64Type, UInt8Type, Utf8Type,
+        Float32Type, Float64Type, Int128Type, Int16Type, Int32Type, Int64Type, Int8Type, NullType,
+        UInt16Type, UInt32Type, UInt64Type, UInt8Type, Utf8Type,
     },
     DataType, IntoSeries, Series,
 };
@@ -163,11 +163,6 @@ impl_arrow_backed_data_array_growable!(
     ArrowUtf8Growable,
     Utf8Type,
     arrow2::array::growable::GrowableUtf8<'a, i64>
-);
-impl_arrow_backed_data_array_growable!(
-    ArrowListGrowable,
-    ListType,
-    arrow2::array::growable::GrowableList<'a, i64>
 );
 
 /// ExtensionTypes are slightly different, because they have a dynamic inner type

--- a/src/daft-core/src/array/growable/mod.rs
+++ b/src/daft-core/src/array/growable/mod.rs
@@ -1,15 +1,15 @@
 use common_error::DaftResult;
 
 use crate::{
-    array::{FixedSizeListArray, StructArray},
+    array::{FixedSizeListArray, ListArray, StructArray},
     datatypes::{
         logical::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
             FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
         },
         BinaryArray, BooleanArray, ExtensionArray, Float32Array, Float64Array, Int128Array,
-        Int16Array, Int32Array, Int64Array, Int8Array, ListArray, NullArray, UInt16Array,
-        UInt32Array, UInt64Array, UInt8Array, Utf8Array,
+        Int16Array, Int32Array, Int64Array, Int8Array, NullArray, UInt16Array, UInt32Array,
+        UInt64Array, UInt8Array, Utf8Array,
     },
     DataType, Series,
 };
@@ -119,13 +119,13 @@ impl_growable_array!(Float32Array, arrow_growable::ArrowFloat32Growable<'a>);
 impl_growable_array!(Float64Array, arrow_growable::ArrowFloat64Growable<'a>);
 impl_growable_array!(BinaryArray, arrow_growable::ArrowBinaryGrowable<'a>);
 impl_growable_array!(Utf8Array, arrow_growable::ArrowUtf8Growable<'a>);
-impl_growable_array!(ListArray, arrow_growable::ArrowListGrowable<'a>);
 impl_growable_array!(ExtensionArray, arrow_growable::ArrowExtensionGrowable<'a>);
 impl_growable_array!(
     FixedSizeListArray,
     nested_growable::FixedSizeListGrowable<'a>
 );
 impl_growable_array!(StructArray, nested_growable::StructGrowable<'a>);
+impl_growable_array!(ListArray, nested_growable::ListGrowable<'a>);
 impl_growable_array!(
     TimestampArray,
     logical_growable::LogicalTimestampGrowable<'a>

--- a/src/daft-core/src/array/growable/mod.rs
+++ b/src/daft-core/src/array/growable/mod.rs
@@ -105,6 +105,28 @@ macro_rules! impl_growable_array {
     };
 }
 
+impl GrowableArray for ListArray {
+    type GrowableType<'a> = nested_growable::ListGrowable<'a>;
+
+    fn make_growable<'a>(
+        name: String,
+        dtype: &DataType,
+        arrays: Vec<&'a Self>,
+        use_validity: bool,
+        capacity: usize,
+    ) -> Self::GrowableType<'a> {
+        Self::GrowableType::new(
+            name,
+            dtype,
+            arrays,
+            use_validity,
+            capacity,
+            // NOTE: use ListGrowable::new directly if you wish to specify the child Series' capacity
+            0,
+        )
+    }
+}
+
 impl_growable_array!(BooleanArray, arrow_growable::ArrowBooleanGrowable<'a>);
 impl_growable_array!(Int8Array, arrow_growable::ArrowInt8Growable<'a>);
 impl_growable_array!(Int16Array, arrow_growable::ArrowInt16Growable<'a>);
@@ -125,7 +147,6 @@ impl_growable_array!(
     nested_growable::FixedSizeListGrowable<'a>
 );
 impl_growable_array!(StructArray, nested_growable::StructGrowable<'a>);
-impl_growable_array!(ListArray, nested_growable::ListGrowable<'a>);
 impl_growable_array!(
     TimestampArray,
     logical_growable::LogicalTimestampGrowable<'a>

--- a/src/daft-core/src/array/growable/nested_growable.rs
+++ b/src/daft-core/src/array/growable/nested_growable.rs
@@ -64,7 +64,7 @@ impl<'a> FixedSizeListGrowable<'a> {
             DataType::FixedSizeList(child_field, element_fixed_len) => {
                 with_match_daft_types!(&child_field.dtype, |$T| {
                     let child_growable = <<$T as DaftDataType>::ArrayType as GrowableArray>::make_growable(
-                        name.clone(),
+                        child_field.name.clone(),
                         &child_field.dtype,
                         arrays.iter().map(|a| a.flat_child.downcast::<<$T as DaftDataType>::ArrayType>().unwrap()).collect::<Vec<_>>(),
                         use_validity,
@@ -220,7 +220,7 @@ impl<'a> ListGrowable<'a> {
             DataType::List(child_field) => {
                 with_match_daft_types!(&child_field.dtype, |$T| {
                     let child_growable = <<$T as DaftDataType>::ArrayType as GrowableArray>::make_growable(
-                        name.clone(),
+                        child_field.name.clone(),
                         &child_field.dtype,
                         arrays.iter().map(|a| a.flat_child.downcast::<<$T as DaftDataType>::ArrayType>().unwrap()).collect::<Vec<_>>(),
                         use_validity,
@@ -250,7 +250,7 @@ impl<'a> ListGrowable<'a> {
 impl<'a> Growable for ListGrowable<'a> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
         let offsets = self.child_arrays_offsets.get(index).unwrap();
-        let offset_slice = &offsets.as_slice()[start..(start + len)];
+        let offset_slice = &offsets.as_slice()[start..(start + len + 1)];
         self.child_growable.extend(
             index,
             *offset_slice.first().unwrap() as usize,

--- a/src/daft-core/src/array/growable/nested_growable.rs
+++ b/src/daft-core/src/array/growable/nested_growable.rs
@@ -215,6 +215,7 @@ impl<'a> ListGrowable<'a> {
         arrays: Vec<&'a ListArray>,
         use_validity: bool,
         capacity: usize,
+        child_capacity: usize,
     ) -> Self {
         match dtype {
             DataType::List(child_field) => {
@@ -224,7 +225,7 @@ impl<'a> ListGrowable<'a> {
                         &child_field.dtype,
                         arrays.iter().map(|a| a.flat_child.downcast::<<$T as DaftDataType>::ArrayType>().unwrap()).collect::<Vec<_>>(),
                         use_validity,
-                        0,   // List is variable-length per element, so we cannot provide a good estimate for capacity
+                        child_capacity,
                     );
                     let growable_validity = ArrowBitmapGrowable::new(
                         arrays.iter().map(|a| a.validity()).collect(),

--- a/src/daft-core/src/array/growable/nested_growable.rs
+++ b/src/daft-core/src/array/growable/nested_growable.rs
@@ -71,7 +71,7 @@ impl<'a> FixedSizeListGrowable<'a> {
                         capacity * element_fixed_len,
                     );
                     let growable_validity = ArrowBitmapGrowable::new(
-                        arrays.iter().map(|a| a.validity.as_ref()).collect(),
+                        arrays.iter().map(|a| a.validity()).collect(),
                         capacity,
                     );
                     Self {
@@ -149,7 +149,7 @@ impl<'a> StructGrowable<'a> {
                     })
                 }).collect::<Vec<_>>();
                 let growable_validity = ArrowBitmapGrowable::new(
-                    arrays.iter().map(|a| a.validity.as_ref()).collect(),
+                    arrays.iter().map(|a| a.validity()).collect(),
                     capacity,
                 );
                 Self {
@@ -227,11 +227,11 @@ impl<'a> ListGrowable<'a> {
                         0,   // List is variable-length per element, so we cannot provide a good estimate for capacity
                     );
                     let growable_validity = ArrowBitmapGrowable::new(
-                        arrays.iter().map(|a| a.validity.as_ref()).collect(),
+                        arrays.iter().map(|a| a.validity()).collect(),
                         capacity,
                     );
                     let growable_offsets: Vec<i64> = vec![0];
-                    let child_arrays_offsets = arrays.iter().map(|arr| &arr.offsets).collect::<Vec<_>>();
+                    let child_arrays_offsets = arrays.iter().map(|arr| arr.offsets()).collect::<Vec<_>>();
                     Self {
                         name,
                         dtype: dtype.clone(),

--- a/src/daft-core/src/array/list_array.rs
+++ b/src/daft-core/src/array/list_array.rs
@@ -27,10 +27,7 @@ impl ListArray {
         let field: Arc<Field> = field.into();
         match &field.as_ref().dtype {
             DataType::List(child_field) => {
-                if validity
-                    .as_ref()
-                    .map_or(false, |validity| validity.len() != offsets.len_proxy())
-                {
+                if let Some(validity) = validity.as_ref() && validity.len() != offsets.len_proxy() {
                     panic!("ListArray::new validity length does not match computed length from offsets")
                 }
                 if child_field.as_ref() != flat_child.field() {
@@ -63,6 +60,13 @@ impl ListArray {
 
     pub fn validity(&self) -> Option<&arrow2::bitmap::Bitmap> {
         self.validity.as_ref()
+    }
+
+    pub fn null_count(&self) -> usize {
+        match self.validity() {
+            None => 0,
+            Some(validity) => validity.unset_bits(),
+        }
     }
 
     pub fn concat(arrays: &[&Self]) -> DaftResult<Self> {

--- a/src/daft-core/src/array/list_array.rs
+++ b/src/daft-core/src/array/list_array.rs
@@ -136,9 +136,9 @@ impl ListArray {
                 "Trying to slice array with negative length, start: {start} vs end: {end}"
             )));
         }
-        let new_offsets = arrow2::offset::OffsetsBuffer::try_from(
-            self.offsets.as_slice()[start..end + 1].to_vec(),
-        )?;
+        let mut new_offsets = self.offsets.clone();
+        new_offsets.slice(start, end - start + 1);
+
         let new_validity = self
             .validity
             .as_ref()

--- a/src/daft-core/src/array/list_array.rs
+++ b/src/daft-core/src/array/list_array.rs
@@ -11,8 +11,8 @@ use crate::DataType;
 pub struct ListArray {
     pub field: Arc<Field>,
     pub flat_child: Series,
-    pub offsets: arrow2::offset::OffsetsBuffer<i64>,
-    pub validity: Option<arrow2::bitmap::Bitmap>,
+    offsets: arrow2::offset::OffsetsBuffer<i64>,
+    validity: Option<arrow2::bitmap::Bitmap>,
 }
 
 impl DaftArrayType for ListArray {}

--- a/src/daft-core/src/array/list_array.rs
+++ b/src/daft-core/src/array/list_array.rs
@@ -133,7 +133,7 @@ impl ListArray {
             )));
         }
         let offsets = &self.offsets.as_slice()[start..end];
-        if offsets.len() == 0 {
+        if offsets.is_empty() {
             let sliced_child = self.flat_child.slice(0, 0)?;
             let new_offsets = arrow2::offset::OffsetsBuffer::default();
             Ok(Self::new(
@@ -170,7 +170,7 @@ impl ListArray {
         let arrow_dtype = self.data_type().to_arrow().unwrap();
         Box::new(arrow2::array::ListArray::new(
             arrow_dtype,
-            self.offsets.into(),
+            self.offsets().clone(),
             self.flat_child.to_arrow(),
             self.validity.clone(),
         ))

--- a/src/daft-core/src/array/mod.rs
+++ b/src/daft-core/src/array/mod.rs
@@ -5,8 +5,10 @@ pub mod ops;
 pub mod pseudo_arrow;
 
 mod fixed_size_list_array;
+mod list_array;
 mod struct_array;
 pub use fixed_size_list_array::FixedSizeListArray;
+pub use list_array::ListArray;
 pub use struct_array::StructArray;
 
 use std::{marker::PhantomData, sync::Arc};

--- a/src/daft-core/src/array/ops/as_arrow.rs
+++ b/src/daft-core/src/array/ops/as_arrow.rs
@@ -5,7 +5,7 @@ use crate::{
     array::DataArray,
     datatypes::{
         logical::{DateArray, Decimal128Array, DurationArray, TimestampArray},
-        BinaryArray, BooleanArray, DaftNumericType, ListArray, NullArray, Utf8Array,
+        BinaryArray, BooleanArray, DaftNumericType, NullArray, Utf8Array,
     },
 };
 
@@ -59,7 +59,6 @@ impl_asarrow_dataarray!(NullArray, array::NullArray);
 impl_asarrow_dataarray!(Utf8Array, array::Utf8Array<i64>);
 impl_asarrow_dataarray!(BooleanArray, array::BooleanArray);
 impl_asarrow_dataarray!(BinaryArray, array::BinaryArray<i64>);
-impl_asarrow_dataarray!(ListArray, array::ListArray<i64>);
 
 #[cfg(feature = "python")]
 impl_asarrow_dataarray!(PythonArray, PseudoArrowArray<pyo3::PyObject>);

--- a/src/daft-core/src/array/ops/broadcast.rs
+++ b/src/daft-core/src/array/ops/broadcast.rs
@@ -1,7 +1,7 @@
 use crate::{
     array::{
         growable::{Growable, GrowableArray},
-        DataArray, FixedSizeListArray, StructArray,
+        DataArray, FixedSizeListArray, StructArray, ListArray,
     },
     datatypes::{DaftArrayType, DaftPhysicalType, DataType},
 };
@@ -67,6 +67,27 @@ impl Broadcastable for FixedSizeListArray {
             generic_growable_broadcast(self, num, self.name(), self.data_type())
         } else {
             Ok(FixedSizeListArray::full_null(
+                self.name(),
+                self.data_type(),
+                num,
+            ))
+        }
+    }
+}
+
+impl Broadcastable for ListArray {
+    fn broadcast(&self, num: usize) -> DaftResult<Self> {
+        if self.len() != 1 {
+            return Err(DaftError::ValueError(format!(
+                "Attempting to broadcast non-unit length Array named: {}",
+                self.name()
+            )));
+        }
+
+        if self.is_valid(0) {
+            generic_growable_broadcast(self, num, self.name(), self.data_type())
+        } else {
+            Ok(ListArray::full_null(
                 self.name(),
                 self.data_type(),
                 num,

--- a/src/daft-core/src/array/ops/broadcast.rs
+++ b/src/daft-core/src/array/ops/broadcast.rs
@@ -1,7 +1,7 @@
 use crate::{
     array::{
         growable::{Growable, GrowableArray},
-        DataArray, FixedSizeListArray, StructArray, ListArray,
+        DataArray, FixedSizeListArray, ListArray, StructArray,
     },
     datatypes::{DaftArrayType, DaftPhysicalType, DataType},
 };
@@ -87,11 +87,7 @@ impl Broadcastable for ListArray {
         if self.is_valid(0) {
             generic_growable_broadcast(self, num, self.name(), self.data_type())
         } else {
-            Ok(ListArray::full_null(
-                self.name(),
-                self.data_type(),
-                num,
-            ))
+            Ok(ListArray::full_null(self.name(), self.data_type(), num))
         }
     }
 }

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1709,8 +1709,11 @@ impl ListArray {
                         let mut invalid_ptr = 0;
                         for (start, len) in SlicesIterator::new(validity) {
                             child_growable.add_nulls((start - invalid_ptr) * size);
+                            let child_start = self.offsets().start_end(start).0;
+                            child_growable.extend(0, child_start, len * size);
                             invalid_ptr = start + len;
                         }
+                        child_growable.add_nulls((self.len() - invalid_ptr) * size);
 
                         Ok(FixedSizeListArray::new(
                             Field::new(self.name(), dtype.clone()),

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1583,7 +1583,10 @@ impl FixedSizeListArray {
                         size
                     )));
                 }
-                let casted_child = self.flat_child.cast(&child.dtype)?;
+                let casted_child = self
+                    .flat_child
+                    .cast(&child.dtype)?
+                    .rename(child.name.as_str());
                 Ok(FixedSizeListArray::new(
                     Field::new(self.name().to_string(), dtype.clone()),
                     casted_child,

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1103,7 +1103,7 @@ impl EmbeddingArray {
                     .map(|a| a.unwrap().to_object(py))
                     .collect::<Vec<PyObject>>();
                 let values_array =
-                    PseudoArrowArray::new(ndarrays.into(), self.physical.validity.clone());
+                    PseudoArrowArray::new(ndarrays.into(), self.physical.validity().cloned());
                 Ok(PythonArray::new(
                     Field::new(self.name(), dtype.clone()).into(),
                     values_array.to_boxed(),
@@ -1154,7 +1154,7 @@ impl ImageArray {
                     ndarrays.push(py_array);
                 }
                 let values_array =
-                    PseudoArrowArray::new(ndarrays.into(), self.physical.validity.clone());
+                    PseudoArrowArray::new(ndarrays.into(), self.physical.validity().cloned());
                 Ok(PythonArray::new(
                     Field::new(self.name(), dtype.clone()).into(),
                     values_array.to_boxed(),
@@ -1190,7 +1190,7 @@ impl ImageArray {
                     .step_by(ndim)
                     .map(|v| v as i64)
                     .collect::<Vec<i64>>();
-                let validity = self.physical.validity.as_ref();
+                let validity = self.physical.validity();
                 let data_array = self.data_array();
                 let ca = self.channel_array();
                 let ha = self.height_array();
@@ -1264,7 +1264,7 @@ impl FixedShapeImageArray {
                         .map(|a| a.unwrap().to_object(py))
                         .collect::<Vec<PyObject>>();
                     let values_array =
-                        PseudoArrowArray::new(ndarrays.into(), self.physical.validity.clone());
+                        PseudoArrowArray::new(ndarrays.into(), self.physical.validity().cloned());
                     Ok(PythonArray::new(
                         Field::new(self.name(), dtype.clone()).into(),
                         values_array.to_boxed(),
@@ -1327,10 +1327,8 @@ impl TensorArray {
                         ndarrays.push(py.None())
                     }
                 }
-                let values_array = PseudoArrowArray::new(
-                    ndarrays.into(),
-                    self.physical.validity.as_ref().cloned(),
-                );
+                let values_array =
+                    PseudoArrowArray::new(ndarrays.into(), self.physical.validity().cloned());
                 Ok(PythonArray::new(
                     Field::new(self.name(), dtype.clone()).into(),
                     values_array.to_boxed(),
@@ -1509,10 +1507,8 @@ impl FixedShapeTensorArray {
                         .iter()?
                         .map(|a| a.unwrap().to_object(py))
                         .collect::<Vec<PyObject>>();
-                    let values_array = PseudoArrowArray::new(
-                        ndarrays.into(),
-                        self.physical.validity.as_ref().cloned(),
-                    );
+                    let values_array =
+                        PseudoArrowArray::new(ndarrays.into(), self.physical.validity().cloned());
                     Ok(PythonArray::new(
                         Field::new(self.name(), dtype.clone()).into(),
                         values_array.to_boxed(),
@@ -1534,7 +1530,7 @@ impl FixedShapeTensorArray {
                     .collect::<Vec<i64>>();
 
                 let physical_arr = &self.physical;
-                let validity = self.physical.validity.as_ref();
+                let validity = self.physical.validity();
 
                 // FixedSizeList -> List
                 let list_arr = physical_arr
@@ -1594,7 +1590,7 @@ impl FixedSizeListArray {
                 Ok(FixedSizeListArray::new(
                     Field::new(self.name().to_string(), dtype.clone()),
                     casted_child,
-                    self.validity.clone(),
+                    self.validity().cloned(),
                 )
                 .into_series())
             }
@@ -1604,7 +1600,7 @@ impl FixedSizeListArray {
                     .flat_child
                     .cast(&child.dtype)?
                     .rename(child.name.as_str());
-                let offsets: Offsets<i64> = match &self.validity {
+                let offsets: Offsets<i64> = match self.validity() {
                     None => Offsets::try_from_iter(repeat(element_size).take(self.len()))?,
                     Some(validity) => Offsets::try_from_iter(validity.iter().map(|v| {
                         if v {
@@ -1618,7 +1614,7 @@ impl FixedSizeListArray {
                     Field::new(self.name().to_string(), dtype.clone()),
                     casted_child,
                     offsets.into(),
-                    self.validity.clone(),
+                    self.validity().cloned(),
                 )
                 .into_series())
             }
@@ -1671,7 +1667,7 @@ impl ListArray {
                     .cast(&child_field.dtype)?
                     .rename(child_field.name.as_str()),
                 self.offsets().clone(),
-                self.validity.clone(),
+                self.validity().cloned(),
             )
             .into_series()),
             DataType::FixedSizeList(child_field, size) => {
@@ -1760,7 +1756,7 @@ impl StructArray {
                 Ok(StructArray::new(
                     Field::new(self.name(), dtype.clone()),
                     casted_series?,
-                    self.validity.clone(),
+                    self.validity().cloned(),
                 )
                 .into_series())
             }

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -5,7 +5,7 @@ use crate::{
     array::{
         ops::image::ImageArraySidecarData,
         ops::{from_arrow::FromArrow, full::FullNull},
-        DataArray, FixedSizeListArray, StructArray,
+        DataArray, FixedSizeListArray, ListArray, StructArray,
     },
     datatypes::{
         logical::{
@@ -13,8 +13,7 @@ use crate::{
             FixedShapeTensorArray, ImageArray, LogicalArray, LogicalArrayImpl, TensorArray,
             TimestampArray,
         },
-        DaftArrowBackedType, DaftLogicalType, DataType, Field, ImageMode, ListArray, TimeUnit,
-        Utf8Array,
+        DaftArrowBackedType, DaftLogicalType, DataType, Field, ImageMode, TimeUnit, Utf8Array,
     },
     series::{IntoSeries, Series},
     with_match_arrow_daft_types, with_match_daft_logical_primitive_types, with_match_daft_types,

--- a/src/daft-core/src/array/ops/compare_agg.rs
+++ b/src/daft-core/src/array/ops/compare_agg.rs
@@ -1,7 +1,7 @@
 use super::full::FullNull;
 use super::{DaftCompareAggable, GroupIndices};
 use crate::{
-    array::{DataArray, FixedSizeListArray, StructArray},
+    array::{DataArray, FixedSizeListArray, ListArray, StructArray},
     datatypes::*,
 };
 use arrow2::array::PrimitiveArray;

--- a/src/daft-core/src/array/ops/concat_agg.rs
+++ b/src/daft-core/src/array/ops/concat_agg.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     with_match_daft_types,
 };
-use arrow2::offset::OffsetsBuffer;
+use arrow2::{bitmap::utils::SlicesIterator, offset::OffsetsBuffer, types::Index};
 use common_error::DaftResult;
 
 use super::{as_arrow::AsArrow, DaftConcatAggable};
@@ -62,16 +62,54 @@ impl DaftConcatAggable for crate::datatypes::PythonArray {
 impl DaftConcatAggable for ListArray {
     type Output = DaftResult<Self>;
     fn concat(&self) -> Self::Output {
-        let new_offsets = OffsetsBuffer::<i64>::try_from(vec![0, self.flat_child.len() as i64])?;
+        if self.null_count() == 0 {
+            let new_offsets = OffsetsBuffer::<i64>::try_from(vec![0, *self.offsets().last()])?;
+            return Ok(ListArray::new(
+                self.field.clone(),
+                self.flat_child.clone(),
+                new_offsets,
+                None,
+            ));
+        }
+
+        // Only the all-null case leads to a null result. If any single element is non-null (e.g. an empty list []),
+        // The concat will successfully return a single non-null element.
+        let new_validity = match self.validity() {
+            Some(validity) if validity.unset_bits() == self.len() => {
+                Some(arrow2::bitmap::Bitmap::from(vec![false]))
+            }
+            _ => None,
+        };
+
+        // Re-grow the child, dropping elements where the parent is null
+        let mut child_growable: Box<dyn Growable> = with_match_daft_types!(self.flat_child.data_type(), |$T| {
+            Box::new(<<$T as DaftDataType>::ArrayType as GrowableArray>::make_growable(
+                self.flat_child.name().to_string(),
+                self.flat_child.data_type(),
+                vec![self.flat_child.downcast::<<$T as DaftDataType>::ArrayType>().unwrap()],
+                true,
+                self.flat_child.len(),  // Conservatively reserve a capacity == full size of the child
+            ))
+        });
+        for (start_valid, len_valid) in SlicesIterator::new(self.validity().unwrap()) {
+            let child_start = self.offsets().start_end(start_valid).0;
+            let child_end = self.offsets().start_end(start_valid + len_valid - 1).1;
+            child_growable.extend(0, child_start, child_end - child_start);
+        }
+        let new_child = child_growable.build()?;
+        let new_offsets = OffsetsBuffer::<i64>::try_from(vec![0, new_child.len() as i64])?;
+
         Ok(ListArray::new(
             self.field.clone(),
-            self.flat_child.clone(),
+            new_child,
             new_offsets,
-            None,
+            new_validity,
         ))
     }
 
     fn grouped_concat(&self, groups: &super::GroupIndices) -> Self::Output {
+        let all_valid = self.null_count() == 0;
+
         let mut child_array_growable: Box<dyn Growable> = with_match_daft_types!(self.child_data_type(), |$T| {
             Box::new(<<$T as DaftDataType>::ArrayType as GrowableArray>::make_growable(
                 self.flat_child.name().to_string(),
@@ -82,24 +120,190 @@ impl DaftConcatAggable for ListArray {
             ))
         });
 
-        let mut group_lens = vec![];
+        let mut group_lens: Vec<usize> = vec![];
+        let mut group_valids: Vec<bool> = vec![];
         for group in groups {
-            let mut group_len = 0;
+            let mut group_valid = false;
+            let mut group_len: usize = 0;
             for idx in group {
-                let (start, end) = self.offsets().start_end(*idx as usize);
-                let len = end - start;
-                child_array_growable.extend(0, start, len);
-                group_len += len;
+                if all_valid || self.is_valid(idx.to_usize()) {
+                    let (start, end) = self.offsets().start_end(*idx as usize);
+                    let len = end - start;
+                    child_array_growable.extend(0, start, len);
+                    group_len += len;
+                    group_valid = true;
+                }
             }
-            group_lens.push(group_len);
+            group_valids.push(group_valid);
+            group_lens.push(if group_valid { group_len } else { 0 });
         }
         let new_offsets = arrow2::offset::Offsets::try_from_lengths(group_lens.iter().copied())?;
+        let new_validities = if all_valid {
+            None
+        } else {
+            Some(arrow2::bitmap::Bitmap::from(group_valids))
+        };
 
         Ok(ListArray::new(
             self.field.clone(),
             child_array_growable.build()?,
             new_offsets.into(),
-            None,
+            new_validities,
         ))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::iter::repeat;
+
+    use common_error::DaftResult;
+
+    use crate::{
+        array::{ops::DaftConcatAggable, ListArray},
+        datatypes::{Field, Int64Array},
+        DataType, IntoSeries,
+    };
+
+    #[test]
+    fn test_list_concat_agg_all_null() -> DaftResult<()> {
+        // [None, None, None]
+        let list_array = ListArray::new(
+            Field::new(
+                "foo",
+                DataType::List(Box::new(Field::new("item", DataType::Int64))),
+            ),
+            Int64Array::from((
+                "item",
+                Box::new(arrow2::array::Int64Array::from_iter(vec![].iter())),
+            ))
+            .into_series(),
+            arrow2::offset::OffsetsBuffer::<i64>::try_from(vec![0, 0, 0, 0])?,
+            Some(arrow2::bitmap::Bitmap::from_iter(repeat(false).take(3))),
+        );
+
+        // Expected: [None]
+        let concatted = list_array.concat()?;
+        assert_eq!(concatted.len(), 1);
+        assert_eq!(
+            concatted.validity(),
+            Some(&arrow2::bitmap::Bitmap::from_iter(repeat(false).take(1)))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_list_concat_agg_with_nulls() -> DaftResult<()> {
+        // [[0], [1, 1], [2, None], [None], [], None, None]
+        let list_array = ListArray::new(
+            Field::new(
+                "foo",
+                DataType::List(Box::new(Field::new("item", DataType::Int64))),
+            ),
+            Int64Array::from((
+                "item",
+                Box::new(arrow2::array::Int64Array::from_iter(
+                    vec![Some(0), Some(1), Some(1), Some(2), None, None, Some(10000)].iter(),
+                )),
+            ))
+            .into_series(),
+            arrow2::offset::OffsetsBuffer::<i64>::try_from(vec![0, 1, 3, 5, 6, 6, 6, 7])?,
+            Some(arrow2::bitmap::Bitmap::from(vec![
+                true, true, true, true, true, false, false,
+            ])),
+        );
+
+        // Expected: [[0, 1, 1, 2, None, None]]
+        let concatted = list_array.concat()?;
+        assert_eq!(concatted.len(), 1);
+        assert_eq!(concatted.validity(), None);
+        let element = concatted.get(0).unwrap();
+        assert_eq!(
+            element
+                .downcast::<Int64Array>()
+                .unwrap()
+                .into_iter()
+                .collect::<Vec<Option<&i64>>>(),
+            vec![Some(&0), Some(&1), Some(&1), Some(&2), None, None]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_grouped_list_concat_agg() -> DaftResult<()> {
+        // [[0], [0, 0], [1, None], [None], [2, None], None, None, None]
+        //  |  group0 |  |     group1    |  | group 2     |  group 3   |
+        let list_array = ListArray::new(
+            Field::new(
+                "foo",
+                DataType::List(Box::new(Field::new("item", DataType::Int64))),
+            ),
+            Int64Array::from((
+                "item",
+                Box::new(arrow2::array::Int64Array::from_iter(
+                    vec![
+                        Some(0),
+                        Some(0),
+                        Some(0),
+                        Some(1),
+                        None,
+                        None,
+                        Some(2),
+                        None,
+                        Some(1000),
+                    ]
+                    .iter(),
+                )),
+            ))
+            .into_series(),
+            arrow2::offset::OffsetsBuffer::<i64>::try_from(vec![0, 1, 3, 5, 6, 8, 8, 8, 9])?,
+            Some(arrow2::bitmap::Bitmap::from(vec![
+                true, true, true, true, true, false, false, false,
+            ])),
+        );
+
+        let concatted =
+            list_array.grouped_concat(&vec![vec![0, 1], vec![2, 3], vec![4, 5], vec![6, 7]])?;
+
+        // Expected: [[0, 0, 0], [1, None, None], [2, None], None]
+        assert_eq!(concatted.len(), 4);
+        assert_eq!(
+            concatted.validity(),
+            Some(&arrow2::bitmap::Bitmap::from(vec![true, true, true, false]))
+        );
+
+        let element_0 = concatted.get(0).unwrap();
+        assert_eq!(
+            element_0
+                .downcast::<Int64Array>()
+                .unwrap()
+                .into_iter()
+                .collect::<Vec<Option<&i64>>>(),
+            vec![Some(&0), Some(&0), Some(&0)]
+        );
+
+        let element_1 = concatted.get(1).unwrap();
+        assert_eq!(
+            element_1
+                .downcast::<Int64Array>()
+                .unwrap()
+                .into_iter()
+                .collect::<Vec<Option<&i64>>>(),
+            vec![Some(&1), None, None]
+        );
+
+        let element_2 = concatted.get(2).unwrap();
+        assert_eq!(
+            element_2
+                .downcast::<Int64Array>()
+                .unwrap()
+                .into_iter()
+                .collect::<Vec<Option<&i64>>>(),
+            vec![Some(&2), None]
+        );
+
+        let element_3 = concatted.get(3);
+        assert!(element_3.is_none());
+        Ok(())
     }
 }

--- a/src/daft-core/src/array/ops/concat_agg.rs
+++ b/src/daft-core/src/array/ops/concat_agg.rs
@@ -86,7 +86,7 @@ impl DaftConcatAggable for ListArray {
         for group in groups {
             let mut group_len = 0;
             for idx in group {
-                let (start, end) = self.offsets.start_end(*idx as usize);
+                let (start, end) = self.offsets().start_end(*idx as usize);
                 let len = end - start;
                 child_array_growable.extend(0, start, len);
                 group_len += len;

--- a/src/daft-core/src/array/ops/concat_agg.rs
+++ b/src/daft-core/src/array/ops/concat_agg.rs
@@ -1,5 +1,3 @@
-use std::{iter::empty, vec};
-
 use crate::{
     array::{
         growable::{Growable, GrowableArray},
@@ -7,7 +5,7 @@ use crate::{
     },
     with_match_daft_types,
 };
-use arrow2::{array::Array, offset::OffsetsBuffer};
+use arrow2::offset::OffsetsBuffer;
 use common_error::DaftResult;
 
 use super::{as_arrow::AsArrow, DaftConcatAggable};
@@ -65,12 +63,12 @@ impl DaftConcatAggable for ListArray {
     type Output = DaftResult<Self>;
     fn concat(&self) -> Self::Output {
         let new_offsets = OffsetsBuffer::<i64>::try_from(vec![0, self.flat_child.len() as i64])?;
-        return Ok(ListArray::new(
+        Ok(ListArray::new(
             self.field.clone(),
-            self.flat_child,
+            self.flat_child.clone(),
             new_offsets,
             None,
-        ));
+        ))
     }
 
     fn grouped_concat(&self, groups: &super::GroupIndices) -> Self::Output {
@@ -88,12 +86,10 @@ impl DaftConcatAggable for ListArray {
         )?;
 
         for group in groups {
-            let mut group_len = 0;
             for idx in group {
                 let (start, end) = self.offsets.start_end(*idx as usize);
                 let len = end - start;
                 child_array_growable.extend(0, start, len);
-                group_len += len;
             }
         }
 

--- a/src/daft-core/src/array/ops/concat_agg.rs
+++ b/src/daft-core/src/array/ops/concat_agg.rs
@@ -1,8 +1,13 @@
-use std::vec;
+use std::{iter::empty, vec};
 
+use crate::{
+    array::{
+        growable::{Growable, GrowableArray},
+        ListArray,
+    },
+    with_match_daft_types,
+};
 use arrow2::{array::Array, offset::OffsetsBuffer};
-
-use crate::datatypes::ListArray;
 use common_error::DaftResult;
 
 use super::{as_arrow::AsArrow, DaftConcatAggable};
@@ -59,110 +64,44 @@ impl DaftConcatAggable for crate::datatypes::PythonArray {
 impl DaftConcatAggable for ListArray {
     type Output = DaftResult<Self>;
     fn concat(&self) -> Self::Output {
-        let array = self.as_arrow();
-        if array.null_count() == 0 {
-            let values = array.values();
-            let new_offsets = OffsetsBuffer::<i64>::try_from(vec![0, values.len() as i64])?;
-            let result = Box::new(
-                arrow2::array::ListArray::<i64>::try_new(
-                    self.data_type().to_physical().to_arrow()?,
-                    new_offsets,
-                    values.clone(),
-                    None,
-                )
-                .unwrap(),
-            );
-            return ListArray::new(self.field.clone(), result);
-        }
-
-        let old_offsets: &OffsetsBuffer<i64> = array.offsets();
-
-        let len = array.len();
-        let capacity: i64 = (0..len)
-            .map(|i| match array.is_valid(i) {
-                false => 0,
-                true => old_offsets.get(i + 1_usize).unwrap() - old_offsets.get(i).unwrap(),
-            })
-            .sum();
-        let mut growable = arrow2::array::growable::make_growable(
-            &[array.values().as_ref()],
-            true,
-            capacity as usize,
-        );
-
-        (0..len).for_each(|i| {
-            if array.is_valid(i) {
-                let start = *old_offsets.get(i).unwrap();
-                let len = old_offsets.get(i + 1).unwrap() - start;
-                growable.extend(0, start as usize, len as usize);
-            }
-        });
-
-        let nested_array = Box::new(
-            arrow2::array::ListArray::<i64>::try_new(
-                self.data_type().to_physical().to_arrow()?,
-                arrow2::offset::OffsetsBuffer::try_from(vec![0, capacity])?,
-                growable.as_box(),
-                None,
-            )
-            .unwrap(),
-        );
-        ListArray::new(self.field.clone(), nested_array)
+        let new_offsets = OffsetsBuffer::<i64>::try_from(vec![0, self.flat_child.len() as i64])?;
+        return Ok(ListArray::new(
+            self.field.clone(),
+            self.flat_child,
+            new_offsets,
+            None,
+        ));
     }
 
     fn grouped_concat(&self, groups: &super::GroupIndices) -> Self::Output {
-        let arrow_array = self.as_arrow();
+        let mut child_array_growable: Box<dyn Growable> = with_match_daft_types!(self.child_data_type(), |$T| {
+            Box::new(<<$T as DaftDataType>::ArrayType as GrowableArray>::make_growable(
+                self.flat_child.name().to_string(),
+                self.child_data_type(),
+                vec![self.flat_child.downcast::<<$T as DaftDataType>::ArrayType>().unwrap()],
+                false,
+                self.flat_child.len(),
+            ))
+        });
+        let new_offsets = arrow2::offset::Offsets::try_from_lengths(
+            std::iter::once(0).chain(groups.iter().map(|g| g.len())),
+        )?;
 
-        let old_offsets: &OffsetsBuffer<i64> = arrow_array.offsets();
-        let mut offsets = Vec::with_capacity(groups.len() + 1);
-        offsets.push(0);
-
-        for g in groups {
-            let total_elems: i64 = g
-                .iter()
-                .map(|g_idx| {
-                    let g_idx = *g_idx as usize;
-                    let is_valid = arrow_array.is_valid(g_idx);
-                    match is_valid {
-                        false => 0,
-                        true => {
-                            old_offsets.get(g_idx + 1_usize).unwrap()
-                                - old_offsets.get(g_idx).unwrap()
-                        }
-                    }
-                })
-                .sum();
-
-            offsets.push(offsets.last().unwrap() + total_elems);
-        }
-
-        let total_capacity = *offsets.last().unwrap();
-
-        let offsets: OffsetsBuffer<i64> = arrow2::offset::OffsetsBuffer::try_from(offsets)?;
-
-        let mut growable = arrow2::array::growable::make_growable(
-            &[arrow_array.values().as_ref()],
-            true,
-            total_capacity as usize,
-        );
-        for g in groups {
-            for idx in g {
-                let idx = *idx as usize;
-                if arrow_array.is_valid(idx) {
-                    let start = *old_offsets.get(idx).unwrap();
-                    let len = old_offsets.get(idx + 1).unwrap() - start;
-                    growable.extend(0, start as usize, len as usize);
-                }
+        for group in groups {
+            let mut group_len = 0;
+            for idx in group {
+                let (start, end) = self.offsets.start_end(*idx as usize);
+                let len = end - start;
+                child_array_growable.extend(0, start, len);
+                group_len += len;
             }
         }
 
-        let nested_array = Box::new(arrow2::array::ListArray::<i64>::try_new(
-            self.data_type().to_physical().to_arrow()?,
-            offsets,
-            growable.as_box(),
+        Ok(ListArray::new(
+            self.field.clone(),
+            child_array_growable.build()?,
+            new_offsets.into(),
             None,
-        )?);
-
-        ListArray::new(self.field.clone(), nested_array)
+        ))
     }
 }

--- a/src/daft-core/src/array/ops/count.rs
+++ b/src/daft-core/src/array/ops/count.rs
@@ -100,7 +100,7 @@ macro_rules! impl_daft_count_aggable_nested_array {
             type Output = DaftResult<DataArray<UInt64Type>>;
 
             fn count(&self, mode: CountMode) -> Self::Output {
-                let count = count_arrow_bitmap(&mode, self.validity.as_ref(), self.len());
+                let count = count_arrow_bitmap(&mode, self.validity(), self.len());
                 let result_arrow_array =
                     Box::new(arrow2::array::PrimitiveArray::from([Some(count)]));
                 DataArray::<UInt64Type>::new(
@@ -111,7 +111,7 @@ macro_rules! impl_daft_count_aggable_nested_array {
 
             fn grouped_count(&self, groups: &GroupIndices, mode: CountMode) -> Self::Output {
                 let counts_per_group: Vec<_> =
-                    grouped_count_arrow_bitmap(groups, &mode, self.validity.as_ref());
+                    grouped_count_arrow_bitmap(groups, &mode, self.validity());
                 Ok(DataArray::<UInt64Type>::from((
                     self.field.name.as_ref(),
                     counts_per_group,

--- a/src/daft-core/src/array/ops/count.rs
+++ b/src/daft-core/src/array/ops/count.rs
@@ -3,7 +3,7 @@ use std::{iter::repeat, sync::Arc};
 use arrow2;
 
 use crate::{
-    array::{DataArray, FixedSizeListArray, StructArray},
+    array::{DataArray, FixedSizeListArray, ListArray, StructArray},
     count_mode::CountMode,
     datatypes::*,
 };
@@ -94,46 +94,33 @@ where
     }
 }
 
-impl DaftCountAggable for &FixedSizeListArray {
-    type Output = DaftResult<DataArray<UInt64Type>>;
+macro_rules! impl_daft_count_aggable_nested_array {
+    ($arr:ident) => {
+        impl DaftCountAggable for &$arr {
+            type Output = DaftResult<DataArray<UInt64Type>>;
 
-    fn count(&self, mode: CountMode) -> Self::Output {
-        let count = count_arrow_bitmap(&mode, self.validity.as_ref(), self.len());
-        let result_arrow_array = Box::new(arrow2::array::PrimitiveArray::from([Some(count)]));
-        DataArray::<UInt64Type>::new(
-            Arc::new(Field::new(self.field.name.clone(), DataType::UInt64)),
-            result_arrow_array,
-        )
-    }
+            fn count(&self, mode: CountMode) -> Self::Output {
+                let count = count_arrow_bitmap(&mode, self.validity.as_ref(), self.len());
+                let result_arrow_array =
+                    Box::new(arrow2::array::PrimitiveArray::from([Some(count)]));
+                DataArray::<UInt64Type>::new(
+                    Arc::new(Field::new(self.field.name.clone(), DataType::UInt64)),
+                    result_arrow_array,
+                )
+            }
 
-    fn grouped_count(&self, groups: &GroupIndices, mode: CountMode) -> Self::Output {
-        let counts_per_group: Vec<_> =
-            grouped_count_arrow_bitmap(groups, &mode, self.validity.as_ref());
-        Ok(DataArray::<UInt64Type>::from((
-            self.field.name.as_ref(),
-            counts_per_group,
-        )))
-    }
+            fn grouped_count(&self, groups: &GroupIndices, mode: CountMode) -> Self::Output {
+                let counts_per_group: Vec<_> =
+                    grouped_count_arrow_bitmap(groups, &mode, self.validity.as_ref());
+                Ok(DataArray::<UInt64Type>::from((
+                    self.field.name.as_ref(),
+                    counts_per_group,
+                )))
+            }
+        }
+    };
 }
 
-impl DaftCountAggable for &StructArray {
-    type Output = DaftResult<DataArray<UInt64Type>>;
-
-    fn count(&self, mode: CountMode) -> Self::Output {
-        let count = count_arrow_bitmap(&mode, self.validity.as_ref(), self.len());
-        let result_arrow_array = Box::new(arrow2::array::PrimitiveArray::from([Some(count)]));
-        DataArray::<UInt64Type>::new(
-            Arc::new(Field::new(self.field.name.clone(), DataType::UInt64)),
-            result_arrow_array,
-        )
-    }
-
-    fn grouped_count(&self, groups: &GroupIndices, mode: CountMode) -> Self::Output {
-        let counts_per_group: Vec<_> =
-            grouped_count_arrow_bitmap(groups, &mode, self.validity.as_ref());
-        Ok(DataArray::<UInt64Type>::from((
-            self.field.name.as_ref(),
-            counts_per_group,
-        )))
-    }
-}
+impl_daft_count_aggable_nested_array!(FixedSizeListArray);
+impl_daft_count_aggable_nested_array!(ListArray);
+impl_daft_count_aggable_nested_array!(StructArray);

--- a/src/daft-core/src/array/ops/filter.rs
+++ b/src/daft-core/src/array/ops/filter.rs
@@ -1,4 +1,4 @@
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 
 use crate::{
     array::{
@@ -82,9 +82,8 @@ impl ListArray {
             None => Cow::Borrowed(mask.as_arrow().values()),
             Some(validity) => Cow::Owned(mask.as_arrow().values() & validity),
         };
-        let keep_bitmap: &arrow2::bitmap::Bitmap = keep_bitmap.borrow();
 
-        let child_capacity = SlicesIterator::new(keep_bitmap)
+        let child_capacity = SlicesIterator::new(keep_bitmap.as_ref())
             .map(|(start_valid, len_valid)| {
                 self.offsets().start_end(start_valid + len_valid - 1).1
                     - self.offsets().start_end(start_valid).0
@@ -100,7 +99,7 @@ impl ListArray {
             child_capacity,
         );
 
-        for (start_keep, len_keep) in SlicesIterator::new(keep_bitmap) {
+        for (start_keep, len_keep) in SlicesIterator::new(keep_bitmap.as_ref()) {
             growable.extend(0, start_keep, len_keep);
         }
 
@@ -114,7 +113,6 @@ impl FixedSizeListArray {
             None => Cow::Borrowed(mask.as_arrow().values()),
             Some(validity) => Cow::Owned(mask.as_arrow().values() & validity),
         };
-        let keep_bitmap: &arrow2::bitmap::Bitmap = keep_bitmap.borrow();
 
         let mut growable = FixedSizeListArray::make_growable(
             self.name().to_string(),
@@ -124,7 +122,7 @@ impl FixedSizeListArray {
             mask.len(),
         );
 
-        for (start_keep, len_keep) in SlicesIterator::new(keep_bitmap) {
+        for (start_keep, len_keep) in SlicesIterator::new(keep_bitmap.as_ref()) {
             growable.extend(0, start_keep, len_keep);
         }
 
@@ -138,7 +136,6 @@ impl StructArray {
             None => Cow::Borrowed(mask.as_arrow().values()),
             Some(validity) => Cow::Owned(mask.as_arrow().values() & validity),
         };
-        let keep_bitmap: &arrow2::bitmap::Bitmap = keep_bitmap.borrow();
 
         let mut growable = StructArray::make_growable(
             self.name().to_string(),
@@ -148,7 +145,7 @@ impl StructArray {
             mask.len(),
         );
 
-        for (start_keep, len_keep) in SlicesIterator::new(keep_bitmap) {
+        for (start_keep, len_keep) in SlicesIterator::new(keep_bitmap.as_ref()) {
             growable.extend(0, start_keep, len_keep);
         }
 

--- a/src/daft-core/src/array/ops/get.rs
+++ b/src/daft-core/src/array/ops/get.rs
@@ -148,7 +148,7 @@ impl ListArray {
         }
         let valid = self.is_valid(idx);
         if valid {
-            let (start, end) = self.offsets.start_end(idx);
+            let (start, end) = self.offsets().start_end(idx);
             Some(self.flat_child.slice(start, end).unwrap())
         } else {
             None

--- a/src/daft-core/src/array/ops/get.rs
+++ b/src/daft-core/src/array/ops/get.rs
@@ -1,9 +1,9 @@
 use crate::{
-    array::{DataArray, FixedSizeListArray},
+    array::{DataArray, FixedSizeListArray, ListArray},
     datatypes::{
         logical::{DateArray, Decimal128Array, DurationArray, LogicalArrayImpl, TimestampArray},
-        BinaryArray, BooleanArray, DaftLogicalType, DaftNumericType, ExtensionArray, ListArray,
-        NullArray, Utf8Array,
+        BinaryArray, BooleanArray, DaftLogicalType, DaftNumericType, ExtensionArray, NullArray,
+        Utf8Array,
     },
     Series,
 };
@@ -64,7 +64,6 @@ impl<L: DaftLogicalType> LogicalArrayImpl<L, FixedSizeListArray> {
 impl_array_arrow_get!(Utf8Array, &str);
 impl_array_arrow_get!(BooleanArray, bool);
 impl_array_arrow_get!(BinaryArray, &[u8]);
-impl_array_arrow_get!(ListArray, Box<dyn arrow2::array::Array>);
 impl_array_arrow_get!(Decimal128Array, i128);
 impl_array_arrow_get!(DateArray, i32);
 impl_array_arrow_get!(DurationArray, i64);
@@ -121,27 +120,6 @@ impl crate::datatypes::PythonArray {
     }
 }
 
-// impl ImageArray {
-//     #[inline]
-//     pub fn get(&self, idx: usize) -> Option<Box<dyn arrow2::array::Array>> {
-//         if idx >= self.len() {
-//             panic!("Out of bounds: {} vs len: {}", idx, self.len())
-//         }
-//         let arrow_array = self.as_arrow();
-//         let is_valid = arrow_array
-//             .validity()
-//             .map_or(true, |validity| validity.get_bit(idx));
-//         if is_valid {
-//             let data_array = arrow_array.values()[0]
-//                 .as_any()
-//                 .downcast_ref::<arrow2::array::ListArray<i64>>()?;
-//             Some(unsafe { data_array.value_unchecked(idx) })
-//         } else {
-//             None
-//         }
-//     }
-// }
-
 impl FixedSizeListArray {
     #[inline]
     pub fn get(&self, idx: usize) -> Option<Series> {
@@ -156,6 +134,22 @@ impl FixedSizeListArray {
                     .slice(idx * fixed_len, (idx + 1) * fixed_len)
                     .unwrap(),
             )
+        } else {
+            None
+        }
+    }
+}
+
+impl ListArray {
+    #[inline]
+    pub fn get(&self, idx: usize) -> Option<Series> {
+        if idx >= self.len() {
+            panic!("Out of bounds: {} vs len: {}", idx, self.len())
+        }
+        let valid = self.is_valid(idx);
+        if valid {
+            let (start, end) = self.offsets.start_end(idx);
+            Some(self.flat_child.slice(start, end).unwrap())
         } else {
             None
         }

--- a/src/daft-core/src/array/ops/if_else.rs
+++ b/src/daft-core/src/array/ops/if_else.rs
@@ -1,6 +1,6 @@
 use crate::array::growable::{Growable, GrowableArray};
 use crate::array::ops::full::FullNull;
-use crate::array::{DataArray, FixedSizeListArray, StructArray, ListArray};
+use crate::array::{DataArray, FixedSizeListArray, ListArray, StructArray};
 use crate::datatypes::{BooleanArray, DaftPhysicalType};
 use crate::{DataType, IntoSeries, Series};
 use arrow2::array::Array;

--- a/src/daft-core/src/array/ops/image.rs
+++ b/src/daft-core/src/array/ops/image.rs
@@ -421,7 +421,7 @@ impl ImageArray {
         }
         let data_array = ListArray::new(
             Field::new(
-                name,
+                "data",
                 DataType::List(Box::new(Field::new("data", (&arrow_dtype).into()))),
             ),
             Series::try_from((

--- a/src/daft-core/src/array/ops/image.rs
+++ b/src/daft-core/src/array/ops/image.rs
@@ -443,7 +443,7 @@ impl ImageArray {
         sidecar_data: ImageArraySidecarData,
     ) -> DaftResult<Self> {
         let values: Vec<Series> = vec![
-            data_array.into_series(),
+            data_array.into_series().rename("data"),
             UInt16Array::from((
                 "channel",
                 Box::new(

--- a/src/daft-core/src/array/ops/image.rs
+++ b/src/daft-core/src/array/ops/image.rs
@@ -5,12 +5,12 @@ use std::vec;
 use arrow2::array::Array;
 use image::{ColorType, DynamicImage, ImageBuffer};
 
-use crate::array::{FixedSizeListArray, StructArray};
+use crate::array::{FixedSizeListArray, ListArray, StructArray};
 use crate::datatypes::{
     logical::{DaftImageryType, FixedShapeImageArray, ImageArray, LogicalArray},
     BinaryArray, DataType, Field, ImageFormat, ImageMode,
 };
-use crate::datatypes::{ListArray, UInt16Array, UInt32Array, UInt8Array};
+use crate::datatypes::{UInt16Array, UInt32Array, UInt8Array};
 use crate::{IntoSeries, Series};
 use common_error::{DaftError, DaftResult};
 use image::{Luma, LumaA, Rgb, Rgba};
@@ -369,10 +369,10 @@ impl ImageArray {
         }
     }
 
-    pub fn data_array(&self) -> &arrow2::array::ListArray<i64> {
+    pub fn data_array(&self) -> &ListArray {
         const IMAGE_DATA_IDX: usize = 0;
         let array = self.physical.children.get(IMAGE_DATA_IDX).unwrap();
-        array.list().unwrap().as_arrow()
+        array.list().unwrap()
     }
 
     pub fn channel_array(&self) -> &arrow2::array::UInt16Array {
@@ -606,8 +606,10 @@ impl AsImageObj for ImageArray {
         let end = *offsets.get(idx + 1).unwrap() as usize;
 
         let values = da
-            .values()
-            .as_ref()
+            .flat_child
+            .u8()
+            .unwrap()
+            .data()
             .as_any()
             .downcast_ref::<arrow2::array::UInt8Array>()
             .unwrap();

--- a/src/daft-core/src/array/ops/len.rs
+++ b/src/daft-core/src/array/ops/len.rs
@@ -1,5 +1,5 @@
 use crate::{
-    array::{DataArray, FixedSizeListArray, StructArray, ListArray},
+    array::{DataArray, FixedSizeListArray, ListArray, StructArray},
     datatypes::DaftArrowBackedType,
 };
 use common_error::DaftResult;
@@ -56,7 +56,9 @@ impl FixedSizeListArray {
 
 impl ListArray {
     pub fn size_bytes(&self) -> DaftResult<usize> {
-        Ok(self.flat_child.size_bytes()? + validity_size(self.validity()) + offset_size(self.offsets()))
+        Ok(self.flat_child.size_bytes()?
+            + validity_size(self.validity())
+            + offset_size(self.offsets()))
     }
 }
 

--- a/src/daft-core/src/array/ops/len.rs
+++ b/src/daft-core/src/array/ops/len.rs
@@ -1,5 +1,5 @@
 use crate::{
-    array::{DataArray, FixedSizeListArray, StructArray},
+    array::{DataArray, FixedSizeListArray, StructArray, ListArray},
     datatypes::DaftArrowBackedType,
 };
 use common_error::DaftResult;
@@ -44,9 +44,19 @@ fn validity_size(validity: Option<&arrow2::bitmap::Bitmap>) -> usize {
     validity.as_ref().map(|b| b.as_slice().0.len()).unwrap_or(0)
 }
 
+fn offset_size(offsets: &arrow2::offset::OffsetsBuffer<i64>) -> usize {
+    offsets.len_proxy() * std::mem::size_of::<i64>()
+}
+
 impl FixedSizeListArray {
     pub fn size_bytes(&self) -> DaftResult<usize> {
         Ok(self.flat_child.size_bytes()? + validity_size(self.validity.as_ref()))
+    }
+}
+
+impl ListArray {
+    pub fn size_bytes(&self) -> DaftResult<usize> {
+        Ok(self.flat_child.size_bytes()? + validity_size(self.validity()) + offset_size(self.offsets()))
     }
 }
 

--- a/src/daft-core/src/array/ops/len.rs
+++ b/src/daft-core/src/array/ops/len.rs
@@ -50,7 +50,7 @@ fn offset_size(offsets: &arrow2::offset::OffsetsBuffer<i64>) -> usize {
 
 impl FixedSizeListArray {
     pub fn size_bytes(&self) -> DaftResult<usize> {
-        Ok(self.flat_child.size_bytes()? + validity_size(self.validity.as_ref()))
+        Ok(self.flat_child.size_bytes()? + validity_size(self.validity()))
     }
 }
 
@@ -71,6 +71,6 @@ impl StructArray {
             .collect::<DaftResult<Vec<usize>>>()?
             .iter()
             .sum();
-        Ok(children_size_bytes + validity_size(self.validity.as_ref()))
+        Ok(children_size_bytes + validity_size(self.validity()))
     }
 }

--- a/src/daft-core/src/array/ops/list.rs
+++ b/src/daft-core/src/array/ops/list.rs
@@ -4,14 +4,12 @@ use crate::array::{
     growable::{Growable, GrowableArray},
     FixedSizeListArray, ListArray,
 };
-use crate::datatypes::{DaftDataType, Utf8Type};
 use crate::datatypes::{UInt64Array, Utf8Array};
 use crate::{with_match_daft_types, DataType};
 
 use crate::series::Series;
 
 use arrow2;
-use arrow2::array::Array;
 
 use common_error::DaftResult;
 
@@ -54,8 +52,7 @@ impl ListArray {
     }
 
     pub fn explode(&self) -> DaftResult<Series> {
-        let child_array = self.flat_child;
-        let offsets = self.offsets;
+        let offsets = self.offsets();
 
         let total_capacity: usize = (0..self.len())
             .map(|i| {

--- a/src/daft-core/src/array/ops/list.rs
+++ b/src/daft-core/src/array/ops/list.rs
@@ -43,10 +43,10 @@ fn join_arrow_list_of_utf8s(
 
 impl ListArray {
     pub fn lengths(&self) -> DaftResult<UInt64Array> {
-        let lengths = self.offsets.lengths().map(|l| Some(l as u64));
+        let lengths = self.offsets().lengths().map(|l| Some(l as u64));
         let array = Box::new(
             arrow2::array::PrimitiveArray::from_iter(lengths)
-                .with_validity(self.validity.as_ref().cloned()),
+                .with_validity(self.validity().cloned()),
         );
         Ok(UInt64Array::from((self.name(), array)))
     }
@@ -119,7 +119,7 @@ impl ListArray {
 impl FixedSizeListArray {
     pub fn lengths(&self) -> DaftResult<UInt64Array> {
         let size = self.fixed_element_len();
-        match &self.validity {
+        match self.validity() {
             None => Ok(UInt64Array::from((
                 self.name(),
                 repeat(size as u64)
@@ -145,7 +145,7 @@ impl FixedSizeListArray {
         let total_capacity = if list_size == 0 {
             self.len()
         } else {
-            let null_count = self.validity.as_ref().map(|v| v.unset_bits()).unwrap_or(0);
+            let null_count = self.validity().map(|v| v.unset_bits()).unwrap_or(0);
             list_size * (self.len() - null_count)
         };
 

--- a/src/daft-core/src/array/ops/list.rs
+++ b/src/daft-core/src/array/ops/list.rs
@@ -2,10 +2,10 @@ use std::iter::repeat;
 
 use crate::array::{
     growable::{Growable, GrowableArray},
-    FixedSizeListArray,
+    FixedSizeListArray, ListArray,
 };
 use crate::datatypes::{DaftDataType, Utf8Type};
-use crate::datatypes::{ListArray, UInt64Array, Utf8Array};
+use crate::datatypes::{UInt64Array, Utf8Array};
 use crate::{with_match_daft_types, DataType};
 
 use crate::series::Series;
@@ -45,29 +45,22 @@ fn join_arrow_list_of_utf8s(
 
 impl ListArray {
     pub fn lengths(&self) -> DaftResult<UInt64Array> {
-        let list_array = self.as_arrow();
-        let offsets = list_array.offsets();
-
-        let mut lens = Vec::with_capacity(self.len());
-        for i in 0..self.len() {
-            lens.push((unsafe { offsets.get_unchecked(i + 1) - offsets.get_unchecked(i) }) as u64)
-        }
+        let lengths = self.offsets.lengths().map(|l| Some(l as u64));
         let array = Box::new(
-            arrow2::array::PrimitiveArray::from_vec(lens)
-                .with_validity(list_array.validity().cloned()),
+            arrow2::array::PrimitiveArray::from_iter(lengths)
+                .with_validity(self.validity.as_ref().cloned()),
         );
         Ok(UInt64Array::from((self.name(), array)))
     }
 
     pub fn explode(&self) -> DaftResult<Series> {
-        let list_array = self.as_arrow();
-        let child_array = list_array.values().as_ref();
-        let offsets = list_array.offsets();
+        let child_array = self.flat_child;
+        let offsets = self.offsets;
 
-        let total_capacity: i64 = (0..list_array.len())
+        let total_capacity: usize = (0..self.len())
             .map(|i| {
-                let is_valid = list_array.is_valid(i);
-                let len: i64 = offsets.get(i + 1).unwrap() - offsets.get(i).unwrap();
+                let is_valid = self.is_valid(i);
+                let len: usize = (offsets.get(i + 1).unwrap() - offsets.get(i).unwrap()) as usize;
                 match (is_valid, len) {
                     (false, _) => 1,
                     (true, 0) => 1,
@@ -75,55 +68,54 @@ impl ListArray {
                 }
             })
             .sum();
-        let mut growable =
-            arrow2::array::growable::make_growable(&[child_array], true, total_capacity as usize);
+        let mut growable: Box<dyn Growable> = with_match_daft_types!(self.child_data_type(), |$T| {
+            Box::new(<<$T as DaftDataType>::ArrayType as GrowableArray>::make_growable(
+                self.name().to_string(),
+                self.child_data_type(),
+                vec![self.flat_child.downcast::<<$T as DaftDataType>::ArrayType>()?],
+                true,
+                total_capacity,
+            ))
+        });
 
-        for i in 0..list_array.len() {
-            let is_valid = list_array.is_valid(i);
+        for i in 0..self.len() {
+            let is_valid = self.is_valid(i);
             let start = offsets.get(i).unwrap();
             let len = offsets.get(i + 1).unwrap() - start;
             match (is_valid, len) {
-                (false, _) => growable.extend_validity(1),
-                (true, 0) => growable.extend_validity(1),
+                (false, _) => growable.add_nulls(1),
+                (true, 0) => growable.add_nulls(1),
                 (true, l) => growable.extend(0, *start as usize, l as usize),
             }
         }
 
-        Series::try_from((self.field.name.as_ref(), growable.as_box()))
+        growable.build()
     }
 
     pub fn join(&self, delimiter: &Utf8Array) -> DaftResult<Utf8Array> {
-        let list_array = self.as_arrow();
-        assert_eq!(
-            list_array.values().data_type(),
-            &arrow2::datatypes::DataType::LargeUtf8
-        );
+        assert_eq!(self.child_data_type(), &DataType::Utf8,);
 
-        if delimiter.len() == 1 {
-            let delimiter_str = delimiter.get(0).unwrap();
-            let result = list_array.iter().map(|list_element| {
-                join_arrow_list_of_utf8s(list_element.as_ref().map(|b| b.as_ref()), delimiter_str)
-            });
-            Ok(Utf8Array::from((
-                self.name(),
-                Box::new(arrow2::array::Utf8Array::from_iter(result)),
-            )))
+        let delimiter_iter: Box<dyn Iterator<Item = Option<&str>>> = if delimiter.len() == 1 {
+            Box::new(repeat(delimiter.get(0)).take(self.len()))
         } else {
             assert_eq!(delimiter.len(), self.len());
-            let result = list_array.iter().zip(delimiter.as_arrow().iter()).map(
-                |(list_element, delimiter_element)| {
-                    let delimiter_str = delimiter_element.unwrap_or("");
-                    join_arrow_list_of_utf8s(
-                        list_element.as_ref().map(|b| b.as_ref()),
-                        delimiter_str,
-                    )
-                },
-            );
-            Ok(Utf8Array::from((
-                self.name(),
-                Box::new(arrow2::array::Utf8Array::from_iter(result)),
-            )))
-        }
+            Box::new(delimiter.as_arrow().iter())
+        };
+        let self_iter = (0..self.len()).map(|i| self.get(i));
+
+        let result = self_iter
+            .zip(delimiter_iter)
+            .map(|(list_element, delimiter)| {
+                join_arrow_list_of_utf8s(
+                    list_element.as_ref().map(|l| l.utf8().unwrap().data()),
+                    delimiter.unwrap_or(""),
+                )
+            });
+
+        Ok(Utf8Array::from((
+            self.name(),
+            Box::new(arrow2::array::Utf8Array::from_iter(result)),
+        )))
     }
 }
 
@@ -195,11 +187,7 @@ impl FixedSizeListArray {
             .zip(delimiter_iter)
             .map(|(list_element, delimiter)| {
                 join_arrow_list_of_utf8s(
-                    list_element.as_ref().map(|l| {
-                        l.downcast::<<Utf8Type as DaftDataType>::ArrayType>()
-                            .unwrap()
-                            .as_arrow() as &dyn arrow2::array::Array
-                    }),
+                    list_element.as_ref().map(|l| l.utf8().unwrap().data()),
                     delimiter.unwrap_or(""),
                 )
             });

--- a/src/daft-core/src/array/ops/list_agg.rs
+++ b/src/daft-core/src/array/ops/list_agg.rs
@@ -101,6 +101,20 @@ impl DaftListAggable for crate::datatypes::PythonArray {
     }
 }
 
+impl DaftListAggable for ListArray {
+    type Output = DaftResult<ListArray>;
+
+    fn list(&self) -> Self::Output {
+        // TODO(FixedSizeList)
+        todo!("Requires new ListArrays for implementation")
+    }
+
+    fn grouped_list(&self, _groups: &GroupIndices) -> Self::Output {
+        // TODO(FixedSizeList)
+        todo!("Requires new ListArrays for implementation")
+    }
+}
+
 impl DaftListAggable for FixedSizeListArray {
     type Output = DaftResult<ListArray>;
 

--- a/src/daft-core/src/array/ops/null.rs
+++ b/src/daft-core/src/array/ops/null.rs
@@ -44,7 +44,7 @@ macro_rules! impl_is_null_nested_array {
             type Output = DaftResult<DataArray<BooleanType>>;
 
             fn is_null(&self) -> Self::Output {
-                match &self.validity {
+                match self.validity() {
                     None => Ok(BooleanArray::from((
                         self.name(),
                         repeat(false)
@@ -79,7 +79,7 @@ where
 impl FixedSizeListArray {
     #[inline]
     pub fn is_valid(&self, idx: usize) -> bool {
-        match &self.validity {
+        match self.validity() {
             None => true,
             Some(validity) => validity.get(idx).unwrap(),
         }
@@ -89,7 +89,7 @@ impl FixedSizeListArray {
 impl ListArray {
     #[inline]
     pub fn is_valid(&self, idx: usize) -> bool {
-        match &self.validity {
+        match self.validity() {
             None => true,
             Some(validity) => validity.get(idx).unwrap(),
         }
@@ -99,7 +99,7 @@ impl ListArray {
 impl StructArray {
     #[inline]
     pub fn is_valid(&self, idx: usize) -> bool {
-        match &self.validity {
+        match self.validity() {
             None => true,
             Some(validity) => validity.get(idx).unwrap(),
         }

--- a/src/daft-core/src/array/ops/null.rs
+++ b/src/daft-core/src/array/ops/null.rs
@@ -42,7 +42,7 @@ macro_rules! impl_is_null_nested_array {
     ($arr:ident) => {
         impl DaftIsNull for $arr {
             type Output = DaftResult<DataArray<BooleanType>>;
-        
+
             fn is_null(&self) -> Self::Output {
                 match &self.validity {
                     None => Ok(BooleanArray::from((

--- a/src/daft-core/src/array/ops/null.rs
+++ b/src/daft-core/src/array/ops/null.rs
@@ -54,7 +54,11 @@ macro_rules! impl_is_null_nested_array {
                     ))),
                     Some(validity) => Ok(BooleanArray::from((
                         self.name(),
-                        validity.into_iter().collect::<Vec<_>>().as_slice(),
+                        arrow2::array::BooleanArray::new(
+                            arrow2::datatypes::DataType::Boolean,
+                            validity.clone(),
+                            None,
+                        ),
                     ))),
                 }
             }

--- a/src/daft-core/src/array/ops/null.rs
+++ b/src/daft-core/src/array/ops/null.rs
@@ -3,7 +3,7 @@ use std::{iter::repeat, sync::Arc};
 use arrow2;
 
 use crate::{
-    array::{DataArray, FixedSizeListArray, StructArray},
+    array::{DataArray, FixedSizeListArray, ListArray, StructArray},
     datatypes::*,
 };
 use common_error::DaftResult;
@@ -89,6 +89,16 @@ where
 }
 
 impl FixedSizeListArray {
+    #[inline]
+    pub fn is_valid(&self, idx: usize) -> bool {
+        match &self.validity {
+            None => true,
+            Some(validity) => validity.get(idx).unwrap(),
+        }
+    }
+}
+
+impl ListArray {
     #[inline]
     pub fn is_valid(&self, idx: usize) -> bool {
         match &self.validity {

--- a/src/daft-core/src/array/ops/null.rs
+++ b/src/daft-core/src/array/ops/null.rs
@@ -38,45 +38,33 @@ where
     }
 }
 
-impl DaftIsNull for FixedSizeListArray {
-    type Output = DaftResult<DataArray<BooleanType>>;
-
-    fn is_null(&self) -> Self::Output {
-        match &self.validity {
-            None => Ok(BooleanArray::from((
-                self.name(),
-                repeat(false)
-                    .take(self.len())
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            ))),
-            Some(validity) => Ok(BooleanArray::from((
-                self.name(),
-                validity.into_iter().collect::<Vec<_>>().as_slice(),
-            ))),
+macro_rules! impl_is_null_nested_array {
+    ($arr:ident) => {
+        impl DaftIsNull for $arr {
+            type Output = DaftResult<DataArray<BooleanType>>;
+        
+            fn is_null(&self) -> Self::Output {
+                match &self.validity {
+                    None => Ok(BooleanArray::from((
+                        self.name(),
+                        repeat(false)
+                            .take(self.len())
+                            .collect::<Vec<_>>()
+                            .as_slice(),
+                    ))),
+                    Some(validity) => Ok(BooleanArray::from((
+                        self.name(),
+                        validity.into_iter().collect::<Vec<_>>().as_slice(),
+                    ))),
+                }
+            }
         }
-    }
+    };
 }
 
-impl DaftIsNull for StructArray {
-    type Output = DaftResult<DataArray<BooleanType>>;
-
-    fn is_null(&self) -> Self::Output {
-        match &self.validity {
-            None => Ok(BooleanArray::from((
-                self.name(),
-                repeat(false)
-                    .take(self.len())
-                    .collect::<Vec<_>>()
-                    .as_slice(),
-            ))),
-            Some(validity) => Ok(BooleanArray::from((
-                self.name(),
-                validity.into_iter().collect::<Vec<_>>().as_slice(),
-            ))),
-        }
-    }
-}
+impl_is_null_nested_array!(ListArray);
+impl_is_null_nested_array!(FixedSizeListArray);
+impl_is_null_nested_array!(StructArray);
 
 impl<T> DataArray<T>
 where

--- a/src/daft-core/src/array/ops/repr.rs
+++ b/src/daft-core/src/array/ops/repr.rs
@@ -435,3 +435,12 @@ impl FixedShapeTensorArray {
             .replace('\n', "<br />")
     }
 }
+
+impl TensorArray {
+    pub fn html_value(&self, idx: usize) -> String {
+        let str_value = self.str_value(idx).unwrap();
+        html_escape::encode_text(&str_value)
+            .into_owned()
+            .replace('\n', "<br />")
+    }
+}

--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -1,12 +1,12 @@
 use crate::{
-    array::{DataArray, FixedSizeListArray, StructArray},
+    array::{DataArray, FixedSizeListArray, ListArray, StructArray},
     datatypes::{
         logical::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
             FixedShapeTensorArray, ImageArray, TensorArray, TimestampArray,
         },
         BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, ExtensionArray, Float32Array,
-        Float64Array, ListArray, NullArray, Utf8Array,
+        Float64Array, NullArray, Utf8Array,
     },
     kernels::search_sorted::{build_compare_with_nulls, cmp_float},
     series::Series,

--- a/src/daft-core/src/array/ops/take.rs
+++ b/src/daft-core/src/array/ops/take.rs
@@ -207,7 +207,7 @@ impl StructArray {
         <I as DaftNumericType>::Native: arrow2::types::Index,
     {
         let idx_as_u64 = idx.cast(&DataType::UInt64)?;
-        let taken_validity = self.validity.as_ref().map(|v| {
+        let taken_validity = self.validity().map(|v| {
             arrow2::bitmap::Bitmap::from_iter(idx.into_iter().map(|i| match i {
                 None => false,
                 Some(i) => v.get_bit(i.to_usize()),

--- a/src/daft-core/src/array/ops/take.rs
+++ b/src/daft-core/src/array/ops/take.rs
@@ -1,5 +1,8 @@
 use crate::{
-    array::{DataArray, FixedSizeListArray, ListArray, StructArray, growable::{GrowableArray, Growable}},
+    array::{
+        growable::{Growable, GrowableArray},
+        DataArray, FixedSizeListArray, ListArray, StructArray,
+    },
     datatypes::{
         logical::{
             DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,

--- a/src/daft-core/src/array/ops/tensor.rs
+++ b/src/daft-core/src/array/ops/tensor.rs
@@ -1,15 +1,15 @@
-use crate::{array::ops::as_arrow::AsArrow, datatypes::logical::TensorArray};
+use crate::{array::ListArray, datatypes::logical::TensorArray};
 
 impl TensorArray {
-    pub fn data_array(&self) -> &arrow2::array::ListArray<i64> {
+    pub fn data_array(&self) -> &ListArray {
         const DATA_IDX: usize = 0;
         let array = self.physical.children.get(DATA_IDX).unwrap();
-        array.list().unwrap().as_arrow()
+        array.list().unwrap()
     }
 
-    pub fn shape_array(&self) -> &arrow2::array::ListArray<i64> {
+    pub fn shape_array(&self) -> &ListArray {
         const SHAPE_IDX: usize = 1;
         let array = self.physical.children.get(SHAPE_IDX).unwrap();
-        array.list().unwrap().as_arrow()
+        array.list().unwrap()
     }
 }

--- a/src/daft-core/src/array/struct_array.rs
+++ b/src/daft-core/src/array/struct_array.rs
@@ -67,6 +67,10 @@ impl StructArray {
         }
     }
 
+    pub fn validity(&self) -> Option<&arrow2::bitmap::Bitmap> {
+        self.validity.as_ref()
+    }
+
     pub fn concat(arrays: &[&Self]) -> DaftResult<Self> {
         if arrays.is_empty() {
             return Err(DaftError::ValueError(

--- a/src/daft-core/src/array/struct_array.rs
+++ b/src/daft-core/src/array/struct_array.rs
@@ -11,7 +11,7 @@ use crate::DataType;
 pub struct StructArray {
     pub field: Arc<Field>,
     pub children: Vec<Series>,
-    pub validity: Option<arrow2::bitmap::Bitmap>,
+    validity: Option<arrow2::bitmap::Bitmap>,
     len: usize,
 }
 

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -8,8 +8,8 @@ mod time_unit;
 
 use std::ops::{Add, Div, Mul, Rem, Sub};
 
-use crate::array::StructArray;
 pub use crate::array::{DataArray, FixedSizeListArray};
+use crate::array::{ListArray, StructArray};
 use arrow2::{
     compute::comparison::Simd8,
     types::{simd::Simd, NativeType},
@@ -164,11 +164,11 @@ impl_daft_arrow_datatype!(Float32Type, Float32);
 impl_daft_arrow_datatype!(Float64Type, Float64);
 impl_daft_arrow_datatype!(BinaryType, Binary);
 impl_daft_arrow_datatype!(Utf8Type, Utf8);
-impl_daft_arrow_datatype!(ListType, Unknown);
 impl_daft_arrow_datatype!(ExtensionType, Unknown);
 
 impl_nested_datatype!(FixedSizeListType, FixedSizeListArray);
 impl_nested_datatype!(StructType, StructArray);
+impl_nested_datatype!(ListType, ListArray);
 
 impl_daft_logical_data_array_datatype!(Decimal128Type, Unknown, Int128Type);
 impl_daft_logical_data_array_datatype!(TimestampType, Unknown, Int64Type);
@@ -325,7 +325,6 @@ pub type Float32Array = DataArray<Float32Type>;
 pub type Float64Array = DataArray<Float64Type>;
 pub type BinaryArray = DataArray<BinaryType>;
 pub type Utf8Array = DataArray<Utf8Type>;
-pub type ListArray = DataArray<ListType>;
 pub type ExtensionArray = DataArray<ExtensionType>;
 
 #[cfg(feature = "python")]

--- a/src/daft-core/src/series/array_impl/binary_ops.rs
+++ b/src/daft-core/src/series/array_impl/binary_ops.rs
@@ -5,7 +5,7 @@ use common_error::DaftResult;
 use crate::{
     array::{
         ops::{DaftCompare, DaftLogical},
-        FixedSizeListArray, StructArray,
+        FixedSizeListArray, ListArray, StructArray,
     },
     datatypes::{logical::Decimal128Array, Int128Array},
     series::series_like::SeriesLike,
@@ -18,8 +18,7 @@ use crate::datatypes::logical::{
 };
 use crate::datatypes::{
     BinaryArray, BooleanArray, ExtensionArray, Float32Array, Float64Array, Int16Array, Int32Array,
-    Int64Array, Int8Array, ListArray, NullArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
-    Utf8Array,
+    Int64Array, Int8Array, NullArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array, Utf8Array,
 };
 
 use super::{ArrayWrapper, IntoSeries, Series};

--- a/src/daft-core/src/series/array_impl/data_array.rs
+++ b/src/daft-core/src/series/array_impl/data_array.rs
@@ -14,8 +14,8 @@ use crate::series::Field;
 use crate::{
     datatypes::{
         BinaryArray, BooleanArray, ExtensionArray, Float32Array, Float64Array, Int128Array,
-        Int16Array, Int32Array, Int64Array, Int8Array, NullArray, UInt16Array,
-        UInt32Array, UInt64Array, UInt8Array, Utf8Array,
+        Int16Array, Int32Array, Int64Array, Int8Array, NullArray, UInt16Array, UInt32Array,
+        UInt64Array, UInt8Array, Utf8Array,
     },
     series::series_like::SeriesLike,
     with_match_integer_daft_types,

--- a/src/daft-core/src/series/array_impl/data_array.rs
+++ b/src/daft-core/src/series/array_impl/data_array.rs
@@ -10,7 +10,6 @@ use crate::datatypes::DaftArrowBackedType;
 #[cfg(feature = "python")]
 use crate::datatypes::PythonArray;
 use crate::series::array_impl::binary_ops::SeriesBinaryOps;
-use crate::series::Field;
 use crate::{
     datatypes::{
         BinaryArray, BooleanArray, ExtensionArray, Float32Array, Float64Array, Int128Array,
@@ -23,7 +22,6 @@ use crate::{
 use common_error::DaftResult;
 
 use crate::datatypes::DataType;
-use std::borrow::Cow;
 
 impl<T: DaftArrowBackedType> IntoSeries for DataArray<T>
 where

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -141,7 +141,7 @@ macro_rules! impl_series_like_for_logical_array {
                 Ok($da::new(self.0.field.clone(), data_array).into_series())
             }
             fn agg_list(&self, groups: Option<&GroupIndices>) -> DaftResult<Series> {
-                use crate::array::{ListArray, ops::DaftListAggable};
+                use crate::array::{ops::DaftListAggable, ListArray};
                 let data_array = match groups {
                     Some(groups) => self.0.physical.grouped_list(groups)?,
                     None => self.0.physical.list()?,
@@ -152,7 +152,8 @@ macro_rules! impl_series_like_for_logical_array {
                     data_array.flat_child.cast(self.data_type())?,
                     data_array.offsets,
                     data_array.validity,
-                ).into_series())
+                )
+                .into_series())
             }
 
             fn add(&self, rhs: &Series) -> DaftResult<Series> {

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -150,8 +150,8 @@ macro_rules! impl_series_like_for_logical_array {
                 Ok(ListArray::new(
                     new_field,
                     data_array.flat_child.cast(self.data_type())?,
-                    data_array.offsets,
-                    data_array.validity,
+                    data_array.offsets().clone(),
+                    data_array.validity().cloned(),
                 )
                 .into_series())
             }

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -141,14 +141,18 @@ macro_rules! impl_series_like_for_logical_array {
                 Ok($da::new(self.0.field.clone(), data_array).into_series())
             }
             fn agg_list(&self, groups: Option<&GroupIndices>) -> DaftResult<Series> {
-                use crate::array::ops::DaftListAggable;
-                use crate::datatypes::ListArray;
+                use crate::array::{ListArray, ops::DaftListAggable};
                 let data_array = match groups {
                     Some(groups) => self.0.physical.grouped_list(groups)?,
                     None => self.0.physical.list()?,
                 };
                 let new_field = self.field().to_list_field()?;
-                Ok(ListArray::new(Arc::new(new_field), data_array.data)?.into_series())
+                Ok(ListArray::new(
+                    new_field,
+                    data_array.flat_child.cast(self.data_type())?,
+                    data_array.offsets,
+                    data_array.validity,
+                ).into_series())
             }
 
             fn add(&self, rhs: &Series) -> DaftResult<Series> {

--- a/src/daft-core/src/series/array_impl/nested_array.rs
+++ b/src/daft-core/src/series/array_impl/nested_array.rs
@@ -4,7 +4,7 @@ use common_error::{DaftError, DaftResult};
 
 use crate::array::ops::broadcast::Broadcastable;
 use crate::array::ops::{DaftIsNull, GroupIndices};
-use crate::array::{FixedSizeListArray, StructArray};
+use crate::array::{FixedSizeListArray, ListArray, StructArray};
 use crate::datatypes::BooleanArray;
 use crate::datatypes::Field;
 use crate::series::{array_impl::binary_ops::SeriesBinaryOps, IntoSeries, Series, SeriesLike};
@@ -187,3 +187,4 @@ macro_rules! impl_series_like_for_nested_arrays {
 
 impl_series_like_for_nested_arrays!(FixedSizeListArray);
 impl_series_like_for_nested_arrays!(StructArray);
+impl_series_like_for_nested_arrays!(ListArray);

--- a/src/daft-core/src/series/ops/agg.rs
+++ b/src/daft-core/src/series/ops/agg.rs
@@ -1,3 +1,4 @@
+use crate::array::ListArray;
 use crate::count_mode::CountMode;
 use crate::series::IntoSeries;
 use crate::{array::ops::GroupIndices, series::Series, with_match_physical_daft_types};

--- a/src/daft-core/src/series/ops/downcast.rs
+++ b/src/daft-core/src/series/ops/downcast.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::array::{FixedSizeListArray, StructArray};
+use crate::array::{FixedSizeListArray, ListArray, StructArray};
 use crate::datatypes::logical::FixedShapeImageArray;
 use crate::datatypes::*;
 use crate::series::array_impl::ArrayWrapper;

--- a/src/daft-core/src/series/ops/downcast.rs
+++ b/src/daft-core/src/series/ops/downcast.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use crate::array::{FixedSizeListArray, ListArray, StructArray};
 use crate::datatypes::logical::FixedShapeImageArray;
 use crate::datatypes::*;
@@ -12,11 +10,10 @@ impl Series {
         match self.inner.as_any().downcast_ref() {
             Some(ArrayWrapper(arr)) => Ok(arr),
             None => {
-                let phantom: PhantomData<Arr> = PhantomData {};
                 panic!(
                     "Attempting to downcast {:?} to {:?}",
                     self.data_type(),
-                    phantom
+                    std::any::type_name::<Arr>(),
                 )
             }
         }

--- a/src/daft-core/src/series/ops/list.rs
+++ b/src/daft-core/src/series/ops/list.rs
@@ -27,21 +27,13 @@ impl Series {
             Embedding(..) | FixedShapeImage(..) => self.as_physical()?.list_lengths(),
             Image(..) => {
                 let struct_array = self.as_physical()?;
-                let data_array = struct_array.struct_()?.children[0]
-                    .list()
-                    .unwrap()
-                    .as_arrow();
-                let offsets = data_array.offsets();
-
-                let mut lens = Vec::with_capacity(self.len());
-                for i in 0..self.len() {
-                    lens.push(
-                        (unsafe { offsets.get_unchecked(i + 1) - offsets.get_unchecked(i) }) as u64,
-                    )
-                }
+                let data_array = struct_array.struct_()?.children[0].list().unwrap();
+                let offsets = &data_array.offsets;
                 let array = Box::new(
-                    arrow2::array::PrimitiveArray::from_vec(lens)
-                        .with_validity(data_array.validity().cloned()),
+                    arrow2::array::PrimitiveArray::from_vec(
+                        offsets.lengths().map(|l| l as u64).collect(),
+                    )
+                    .with_validity(data_array.validity.as_ref().cloned()),
                 );
                 Ok(UInt64Array::from((self.name(), array)))
             }

--- a/src/daft-core/src/series/ops/list.rs
+++ b/src/daft-core/src/series/ops/list.rs
@@ -1,4 +1,3 @@
-use crate::array::ops::as_arrow::AsArrow;
 use crate::datatypes::{DataType, UInt64Array, Utf8Array};
 use crate::series::Series;
 use common_error::DaftError;

--- a/src/daft-core/src/series/ops/list.rs
+++ b/src/daft-core/src/series/ops/list.rs
@@ -27,12 +27,12 @@ impl Series {
             Image(..) => {
                 let struct_array = self.as_physical()?;
                 let data_array = struct_array.struct_()?.children[0].list().unwrap();
-                let offsets = &data_array.offsets;
+                let offsets = data_array.offsets();
                 let array = Box::new(
                     arrow2::array::PrimitiveArray::from_vec(
                         offsets.lengths().map(|l| l as u64).collect(),
                     )
-                    .with_validity(data_array.validity.as_ref().cloned()),
+                    .with_validity(data_array.validity().cloned()),
                 );
                 Ok(UInt64Array::from((self.name(), array)))
             }

--- a/tests/series/test_tensor.py
+++ b/tests/series/test_tensor.py
@@ -116,3 +116,26 @@ def test_tensor_numpy_inference(dtype, fixed_shape):
     assert s.datatype() == DataType.tensor(DataType.from_arrow_type(dtype))
     out = s.to_pylist()
     np.testing.assert_equal(out, arrs)
+
+
+def test_tensor_repr():
+    arr = np.arange(np.prod((2, 2)), dtype=np.int64).reshape((2, 2))
+    arrs = [arr, arr, None]
+    s = Series.from_pylist(arrs, pyobj="allow")
+    assert (
+        repr(s)
+        == """
++-----------------------+
+| list_series           |
+| Tensor(Int64)         |
++-----------------------+
+| <Tensor shape=(2, 2)> |
++-----------------------+
+| <Tensor shape=(2, 2)> |
++-----------------------+
+| None                  |
++-----------------------+
+"""[
+            1:
+        ]
+    )


### PR DESCRIPTION
Adds a new `ListArray` implementation

1. Adds all array ops (broadcast, filter, take etc)
2. Adds casting logic
3. Fixes for list kernels (grouped_concat, join etc)
4. Fixes for all kernels where `list_array.as_arrow()` is used, since `ListArray` is no longer arrow-backed

As drive-bys:

1. Refactor `filter.rs` to use growables
2. Refactor `take.rs` to use growables
5. Makes `.validity` and `.offsets` private fields on `ListArray`, `FixedSizeListArray` and `StructArray`