### PR TITLE
[CHORE] Add Series::full_null/empty/from_arrow to reduce code duplication

### DIFF
--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -4,7 +4,6 @@ use std::collections::HashSet;
 use std::fmt::{Display, Formatter, Result};
 
 use daft_core::array::ops::full::FullNull;
-use daft_core::with_match_daft_types;
 use num_traits::ToPrimitive;
 
 use daft_core::array::ops::GroupIndices;
@@ -73,9 +72,7 @@ impl Table {
             Some(schema) => {
                 let mut columns: Vec<Series> = Vec::with_capacity(schema.names().len());
                 for (field_name, field) in schema.fields.iter() {
-                    let series = with_match_daft_types!(&field.dtype, |$T| {
-                        <$T as DaftDataType>::ArrayType::empty(field_name, &field.dtype).into_series()
-                    });
+                    let series = Series::empty(field_name, &field.dtype);
                     columns.push(series)
                 }
                 Ok(Table { schema, columns })


### PR DESCRIPTION
We use `with_match_daft_types!` in a bunch of places that really should just be delegated to the `Series` instead.

This PR centralizes that logic under dedicated methods on `Series::full_null/empty/from_arrow` which account for most of the usage of `with_match_daft_types!` outside of specific places that still require it (`make_growable` and `repr`)