### PR TITLE
[CHORE] [New Query Planner] pyo3-agnostic `LogicalPlanBuilder`, op constructor arg orderings

### DIFF
--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -103,12 +103,12 @@ impl LogicalPlanBuilder {
     }
 
     pub fn filter(&self, predicate: Expr) -> DaftResult<Self> {
-        let logical_plan: LogicalPlan = ops::Filter::try_new(predicate, self.plan.clone())?.into();
+        let logical_plan: LogicalPlan = ops::Filter::try_new(self.plan.clone(), predicate)?.into();
         Ok(logical_plan.into())
     }
 
     pub fn limit(&self, limit: i64) -> DaftResult<Self> {
-        let logical_plan: LogicalPlan = ops::Limit::new(limit, self.plan.clone()).into();
+        let logical_plan: LogicalPlan = ops::Limit::new(self.plan.clone(), limit).into();
         Ok(logical_plan.into())
     }
 
@@ -120,7 +120,7 @@ impl LogicalPlanBuilder {
 
     pub fn sort(&self, sort_by: Vec<Expr>, descending: Vec<bool>) -> DaftResult<Self> {
         let logical_plan: LogicalPlan =
-            ops::Sort::try_new(sort_by, descending, self.plan.clone())?.into();
+            ops::Sort::try_new(self.plan.clone(), sort_by, descending)?.into();
         Ok(logical_plan.into())
     }
 
@@ -131,13 +131,13 @@ impl LogicalPlanBuilder {
         scheme: PartitionScheme,
     ) -> DaftResult<Self> {
         let logical_plan: LogicalPlan =
-            ops::Repartition::new(num_partitions, partition_by, scheme, self.plan.clone()).into();
+            ops::Repartition::new(self.plan.clone(), num_partitions, partition_by, scheme).into();
         Ok(logical_plan.into())
     }
 
     pub fn coalesce(&self, num_partitions: usize) -> DaftResult<Self> {
         let logical_plan: LogicalPlan =
-            ops::Coalesce::new(num_partitions, self.plan.clone()).into();
+            ops::Coalesce::new(self.plan.clone(), num_partitions).into();
         Ok(logical_plan.into())
     }
 
@@ -201,9 +201,9 @@ impl LogicalPlanBuilder {
         ));
         let fields = vec![Field::new("file_paths", DataType::Utf8)];
         let logical_plan: LogicalPlan = ops::Sink::new(
+            self.plan.clone(),
             Schema::new(fields)?.into(),
             sink_info.into(),
-            self.plan.clone(),
         )
         .into();
         Ok(logical_plan.into())

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -1,25 +1,30 @@
 use std::sync::Arc;
 
-use crate::{logical_plan::LogicalPlan, optimization::Optimizer, ResourceRequest};
+use crate::{
+    logical_plan::LogicalPlan,
+    ops,
+    optimization::Optimizer,
+    planner::plan,
+    sink_info::{OutputFileInfo, SinkInfo},
+    source_info::{
+        ExternalInfo as ExternalSourceInfo, FileFormatConfig, FileInfos as InputFileInfos,
+        SourceInfo,
+    },
+    FileFormat, JoinType, PartitionScheme, PartitionSpec, PhysicalPlanScheduler, ResourceRequest,
+};
+use common_error::{DaftError, DaftResult};
+use daft_core::schema::SchemaRef;
+use daft_core::{datatypes::Field, schema::Schema, DataType};
+use daft_dsl::Expr;
 
 #[cfg(feature = "python")]
 use {
-    crate::{
-        ops,
-        planner::plan,
-        sink_info::{OutputFileInfo, SinkInfo},
-        source_info::{
-            ExternalInfo as ExternalSourceInfo, FileInfos as InputFileInfos, InMemoryInfo,
-            PyFileFormatConfig, SourceInfo,
-        },
-        FileFormat, JoinType, PartitionScheme, PartitionSpec, PhysicalPlanScheduler,
-    },
-    daft_core::{datatypes::Field, python::schema::PySchema, schema::Schema, DataType},
-    daft_dsl::{python::PyExpr, Expr},
-    pyo3::{exceptions::PyValueError, prelude::*},
+    crate::source_info::{InMemoryInfo, PyFileFormatConfig},
+    daft_core::python::schema::PySchema,
+    daft_dsl::python::PyExpr,
+    pyo3::prelude::*,
 };
 
-#[cfg_attr(feature = "python", pyclass)]
 #[derive(Debug)]
 pub struct LogicalPlanBuilder {
     // The current root of the logical plan in this builder.
@@ -32,23 +37,21 @@ impl LogicalPlanBuilder {
     }
 }
 
-#[cfg(feature = "python")]
-#[pymethods]
 impl LogicalPlanBuilder {
-    #[staticmethod]
+    #[cfg(feature = "python")]
     pub fn in_memory_scan(
         partition_key: &str,
         cache_entry: &PyAny,
-        schema: &PySchema,
-        partition_spec: &PartitionSpec,
-    ) -> PyResult<LogicalPlanBuilder> {
+        schema: Arc<Schema>,
+        partition_spec: PartitionSpec,
+    ) -> DaftResult<Self> {
         let source_info = SourceInfo::InMemoryInfo(InMemoryInfo::new(
-            schema.schema.clone(),
+            schema.clone(),
             partition_key.into(),
             cache_entry.to_object(cache_entry.py()),
         ));
         let logical_plan: LogicalPlan = ops::Source::new(
-            schema.schema.clone(),
+            schema.clone(),
             source_info.into(),
             partition_spec.clone().into(),
         )
@@ -56,158 +59,113 @@ impl LogicalPlanBuilder {
         Ok(logical_plan.into())
     }
 
-    #[staticmethod]
     pub fn table_scan(
         file_infos: InputFileInfos,
-        schema: &PySchema,
-        file_format_config: PyFileFormatConfig,
-    ) -> PyResult<LogicalPlanBuilder> {
+        schema: Arc<Schema>,
+        file_format_config: Arc<FileFormatConfig>,
+    ) -> DaftResult<Self> {
         let num_partitions = file_infos.len();
         let source_info = SourceInfo::ExternalInfo(ExternalSourceInfo::new(
-            schema.schema.clone(),
+            schema.clone(),
             file_infos.into(),
-            file_format_config.into(),
+            file_format_config,
         ));
-        let partition_spec = PartitionSpec::new(PartitionScheme::Unknown, num_partitions, None);
-        let logical_plan: LogicalPlan = ops::Source::new(
-            schema.schema.clone(),
-            source_info.into(),
-            partition_spec.into(),
-        )
-        .into();
+        let partition_spec =
+            PartitionSpec::new_internal(PartitionScheme::Unknown, num_partitions, None);
+        let logical_plan: LogicalPlan =
+            ops::Source::new(schema.clone(), source_info.into(), partition_spec.into()).into();
         Ok(logical_plan.into())
     }
 
     pub fn project(
         &self,
-        projection: Vec<PyExpr>,
+        projection: Vec<Expr>,
         resource_request: ResourceRequest,
-    ) -> PyResult<LogicalPlanBuilder> {
-        let projection_exprs = projection
-            .iter()
-            .map(|e| e.clone().into())
-            .collect::<Vec<Expr>>();
+    ) -> DaftResult<Self> {
         let logical_plan: LogicalPlan =
-            ops::Project::try_new(self.plan.clone(), projection_exprs, resource_request)?.into();
+            ops::Project::try_new(self.plan.clone(), projection, resource_request)?.into();
         Ok(logical_plan.into())
     }
 
-    pub fn filter(&self, predicate: &PyExpr) -> PyResult<LogicalPlanBuilder> {
-        let logical_plan: LogicalPlan =
-            ops::Filter::try_new(predicate.expr.clone(), self.plan.clone())?.into();
+    pub fn filter(&self, predicate: Expr) -> DaftResult<Self> {
+        let logical_plan: LogicalPlan = ops::Filter::try_new(predicate, self.plan.clone())?.into();
         Ok(logical_plan.into())
     }
 
-    pub fn limit(&self, limit: i64) -> PyResult<LogicalPlanBuilder> {
+    pub fn limit(&self, limit: i64) -> DaftResult<Self> {
         let logical_plan: LogicalPlan = ops::Limit::new(limit, self.plan.clone()).into();
         Ok(logical_plan.into())
     }
 
-    pub fn explode(&self, to_explode_pyexprs: Vec<PyExpr>) -> PyResult<LogicalPlanBuilder> {
-        let to_explode = to_explode_pyexprs
-            .iter()
-            .map(|e| e.clone().into())
-            .collect::<Vec<Expr>>();
+    pub fn explode(&self, to_explode: Vec<Expr>) -> DaftResult<Self> {
         let logical_plan: LogicalPlan =
             ops::Explode::try_new(self.plan.clone(), to_explode)?.into();
         Ok(logical_plan.into())
     }
 
-    pub fn sort(
-        &self,
-        sort_by: Vec<PyExpr>,
-        descending: Vec<bool>,
-    ) -> PyResult<LogicalPlanBuilder> {
-        let sort_by_exprs: Vec<Expr> = sort_by.iter().map(|expr| expr.clone().into()).collect();
+    pub fn sort(&self, sort_by: Vec<Expr>, descending: Vec<bool>) -> DaftResult<Self> {
         let logical_plan: LogicalPlan =
-            ops::Sort::try_new(sort_by_exprs, descending, self.plan.clone())?.into();
+            ops::Sort::try_new(sort_by, descending, self.plan.clone())?.into();
         Ok(logical_plan.into())
     }
 
     pub fn repartition(
         &self,
         num_partitions: usize,
-        partition_by: Vec<PyExpr>,
+        partition_by: Vec<Expr>,
         scheme: PartitionScheme,
-    ) -> PyResult<LogicalPlanBuilder> {
-        let partition_by_exprs: Vec<Expr> = partition_by
-            .iter()
-            .map(|expr| expr.clone().into())
-            .collect();
-        let logical_plan: LogicalPlan = ops::Repartition::new(
-            num_partitions,
-            partition_by_exprs,
-            scheme,
-            self.plan.clone(),
-        )
-        .into();
+    ) -> DaftResult<Self> {
+        let logical_plan: LogicalPlan =
+            ops::Repartition::new(num_partitions, partition_by, scheme, self.plan.clone()).into();
         Ok(logical_plan.into())
     }
 
-    pub fn coalesce(&self, num_partitions: usize) -> PyResult<LogicalPlanBuilder> {
+    pub fn coalesce(&self, num_partitions: usize) -> DaftResult<Self> {
         let logical_plan: LogicalPlan =
             ops::Coalesce::new(num_partitions, self.plan.clone()).into();
         Ok(logical_plan.into())
     }
 
-    pub fn distinct(&self) -> PyResult<LogicalPlanBuilder> {
+    pub fn distinct(&self) -> DaftResult<Self> {
         let logical_plan: LogicalPlan = ops::Distinct::new(self.plan.clone()).into();
         Ok(logical_plan.into())
     }
 
-    pub fn aggregate(
-        &self,
-        agg_exprs: Vec<PyExpr>,
-        groupby_exprs: Vec<PyExpr>,
-    ) -> PyResult<LogicalPlanBuilder> {
-        use crate::ops::Aggregate;
+    pub fn aggregate(&self, agg_exprs: Vec<Expr>, groupby_exprs: Vec<Expr>) -> DaftResult<Self> {
         let agg_exprs = agg_exprs
             .iter()
-            .map(|expr| match &expr.expr {
+            .map(|expr| match expr {
                 Expr::Agg(agg_expr) => Ok(agg_expr.clone()),
-                _ => Err(PyValueError::new_err(format!(
-                    "Expected aggregation expression, but got: {}",
-                    expr.expr
+                _ => Err(DaftError::ValueError(format!(
+                    "Expected aggregation expression, but got: {expr}"
                 ))),
             })
-            .collect::<PyResult<Vec<daft_dsl::AggExpr>>>()?;
-        let groupby_exprs = groupby_exprs
-            .iter()
-            .map(|expr| expr.clone().into())
-            .collect::<Vec<Expr>>();
+            .collect::<DaftResult<Vec<daft_dsl::AggExpr>>>()?;
 
         let logical_plan: LogicalPlan =
-            Aggregate::try_new(self.plan.clone(), agg_exprs, groupby_exprs)?.into();
+            ops::Aggregate::try_new(self.plan.clone(), agg_exprs, groupby_exprs)?.into();
         Ok(logical_plan.into())
     }
 
     pub fn join(
         &self,
         other: &Self,
-        left_on: Vec<PyExpr>,
-        right_on: Vec<PyExpr>,
+        left_on: Vec<Expr>,
+        right_on: Vec<Expr>,
         join_type: JoinType,
-    ) -> PyResult<LogicalPlanBuilder> {
-        let left_on_exprs = left_on
-            .iter()
-            .map(|e| e.clone().into())
-            .collect::<Vec<Expr>>();
-        let right_on_exprs = right_on
-            .iter()
-            .map(|e| e.clone().into())
-            .collect::<Vec<Expr>>();
+    ) -> DaftResult<Self> {
         let logical_plan: LogicalPlan = ops::Join::try_new(
             self.plan.clone(),
             other.plan.clone(),
-            left_on_exprs,
-            right_on_exprs,
+            left_on,
+            right_on,
             join_type,
         )?
         .into();
         Ok(logical_plan.into())
     }
 
-    pub fn concat(&self, other: &Self) -> PyResult<LogicalPlanBuilder> {
+    pub fn concat(&self, other: &Self) -> DaftResult<Self> {
         let logical_plan: LogicalPlan =
             ops::Concat::try_new(self.plan.clone(), other.plan.clone())?.into();
         Ok(logical_plan.into())
@@ -217,15 +175,13 @@ impl LogicalPlanBuilder {
         &self,
         root_dir: &str,
         file_format: FileFormat,
-        partition_cols: Option<Vec<PyExpr>>,
+        partition_cols: Option<Vec<Expr>>,
         compression: Option<String>,
-    ) -> PyResult<LogicalPlanBuilder> {
-        let part_cols =
-            partition_cols.map(|cols| cols.iter().map(|e| e.clone().into()).collect::<Vec<Expr>>());
+    ) -> DaftResult<Self> {
         let sink_info = SinkInfo::OutputFileInfo(OutputFileInfo::new(
             root_dir.into(),
             file_format,
-            part_cols,
+            partition_cols,
             compression,
         ));
         let fields = vec![Field::new("file_paths", DataType::Utf8)];
@@ -238,32 +194,215 @@ impl LogicalPlanBuilder {
         Ok(logical_plan.into())
     }
 
-    pub fn optimize(&self) -> PyResult<LogicalPlanBuilder> {
+    pub fn optimize(&self) -> DaftResult<Self> {
         let optimizer = Optimizer::new(Default::default());
         let new_plan = optimizer.optimize(self.plan.clone(), |_, _, _, _, _| {})?;
         Ok(Self::new(new_plan))
     }
 
-    pub fn schema(&self) -> PyResult<PySchema> {
-        Ok(self.plan.schema().into())
+    pub fn schema(&self) -> SchemaRef {
+        self.plan.schema()
     }
 
-    pub fn partition_spec(&self) -> PyResult<PartitionSpec> {
-        Ok(self.plan.partition_spec().as_ref().clone())
+    pub fn partition_spec(&self) -> PartitionSpec {
+        self.plan.partition_spec().as_ref().clone()
     }
 
-    pub fn to_physical_plan_scheduler(&self) -> PyResult<PhysicalPlanScheduler> {
+    pub fn to_physical_plan_scheduler(&self) -> DaftResult<PhysicalPlanScheduler> {
         let physical_plan = plan(self.plan.as_ref())?;
         Ok(Arc::new(physical_plan).into())
     }
 
-    pub fn repr_ascii(&self) -> PyResult<String> {
-        Ok(self.plan.repr_ascii())
+    pub fn repr_ascii(&self) -> String {
+        self.plan.repr_ascii()
     }
 }
 
 impl From<LogicalPlan> for LogicalPlanBuilder {
     fn from(plan: LogicalPlan) -> Self {
         Self::new(plan.into())
+    }
+}
+
+#[cfg_attr(feature = "python", pyclass(name = "LogicalPlanBuilder"))]
+#[derive(Debug)]
+pub struct PyLogicalPlanBuilder {
+    // Internal logical plan builder.
+    builder: LogicalPlanBuilder,
+}
+
+impl PyLogicalPlanBuilder {
+    pub fn new(builder: LogicalPlanBuilder) -> Self {
+        Self { builder }
+    }
+}
+
+#[cfg(feature = "python")]
+#[pymethods]
+impl PyLogicalPlanBuilder {
+    #[staticmethod]
+    pub fn in_memory_scan(
+        partition_key: &str,
+        cache_entry: &PyAny,
+        schema: PySchema,
+        partition_spec: PartitionSpec,
+    ) -> PyResult<Self> {
+        Ok(LogicalPlanBuilder::in_memory_scan(
+            partition_key,
+            cache_entry,
+            schema.into(),
+            partition_spec,
+        )?
+        .into())
+    }
+
+    #[staticmethod]
+    pub fn table_scan(
+        file_infos: InputFileInfos,
+        schema: PySchema,
+        file_format_config: PyFileFormatConfig,
+    ) -> PyResult<Self> {
+        Ok(
+            LogicalPlanBuilder::table_scan(file_infos, schema.into(), file_format_config.into())?
+                .into(),
+        )
+    }
+
+    pub fn project(
+        &self,
+        projection: Vec<PyExpr>,
+        resource_request: ResourceRequest,
+    ) -> PyResult<Self> {
+        let projection_exprs = projection
+            .iter()
+            .map(|e| e.clone().into())
+            .collect::<Vec<Expr>>();
+        Ok(self
+            .builder
+            .project(projection_exprs, resource_request)?
+            .into())
+    }
+
+    pub fn filter(&self, predicate: PyExpr) -> PyResult<Self> {
+        Ok(self.builder.filter(predicate.expr)?.into())
+    }
+
+    pub fn limit(&self, limit: i64) -> PyResult<Self> {
+        Ok(self.builder.limit(limit)?.into())
+    }
+
+    pub fn explode(&self, to_explode: Vec<PyExpr>) -> PyResult<Self> {
+        let to_explode_exprs = to_explode
+            .iter()
+            .map(|e| e.clone().into())
+            .collect::<Vec<Expr>>();
+        Ok(self.builder.explode(to_explode_exprs)?.into())
+    }
+
+    pub fn sort(&self, sort_by: Vec<PyExpr>, descending: Vec<bool>) -> PyResult<Self> {
+        let sort_by_exprs: Vec<Expr> = sort_by.iter().map(|expr| expr.clone().into()).collect();
+        Ok(self.builder.sort(sort_by_exprs, descending)?.into())
+    }
+
+    pub fn repartition(
+        &self,
+        num_partitions: usize,
+        partition_by: Vec<PyExpr>,
+        scheme: PartitionScheme,
+    ) -> PyResult<Self> {
+        let partition_by_exprs: Vec<Expr> = partition_by
+            .iter()
+            .map(|expr| expr.clone().into())
+            .collect();
+        Ok(self
+            .builder
+            .repartition(num_partitions, partition_by_exprs, scheme)?
+            .into())
+    }
+
+    pub fn coalesce(&self, num_partitions: usize) -> PyResult<Self> {
+        Ok(self.builder.coalesce(num_partitions)?.into())
+    }
+
+    pub fn distinct(&self) -> PyResult<Self> {
+        Ok(self.builder.distinct()?.into())
+    }
+
+    pub fn aggregate(&self, agg_exprs: Vec<PyExpr>, groupby_exprs: Vec<PyExpr>) -> PyResult<Self> {
+        let agg_exprs = agg_exprs
+            .iter()
+            .map(|expr| expr.clone().into())
+            .collect::<Vec<Expr>>();
+        let groupby_exprs = groupby_exprs
+            .iter()
+            .map(|expr| expr.clone().into())
+            .collect::<Vec<Expr>>();
+        Ok(self.builder.aggregate(agg_exprs, groupby_exprs)?.into())
+    }
+
+    pub fn join(
+        &self,
+        other: &Self,
+        left_on: Vec<PyExpr>,
+        right_on: Vec<PyExpr>,
+        join_type: JoinType,
+    ) -> PyResult<Self> {
+        let left_on = left_on
+            .iter()
+            .map(|e| e.clone().into())
+            .collect::<Vec<Expr>>();
+        let right_on = right_on
+            .iter()
+            .map(|e| e.clone().into())
+            .collect::<Vec<Expr>>();
+        Ok(self
+            .builder
+            .join(&other.builder, left_on, right_on, join_type)?
+            .into())
+    }
+
+    pub fn concat(&self, other: &Self) -> DaftResult<Self> {
+        Ok(self.builder.concat(&other.builder)?.into())
+    }
+
+    pub fn table_write(
+        &self,
+        root_dir: &str,
+        file_format: FileFormat,
+        partition_cols: Option<Vec<PyExpr>>,
+        compression: Option<String>,
+    ) -> PyResult<Self> {
+        let partition_cols =
+            partition_cols.map(|cols| cols.iter().map(|e| e.clone().into()).collect::<Vec<Expr>>());
+        Ok(self
+            .builder
+            .table_write(root_dir, file_format, partition_cols, compression)?
+            .into())
+    }
+
+    pub fn optimize(&self) -> PyResult<Self> {
+        Ok(self.builder.optimize()?.into())
+    }
+
+    pub fn schema(&self) -> PyResult<PySchema> {
+        Ok(self.builder.schema().into())
+    }
+
+    pub fn partition_spec(&self) -> PyResult<PartitionSpec> {
+        Ok(self.builder.partition_spec())
+    }
+
+    pub fn to_physical_plan_scheduler(&self) -> PyResult<PhysicalPlanScheduler> {
+        Ok(self.builder.to_physical_plan_scheduler()?)
+    }
+
+    pub fn repr_ascii(&self) -> PyResult<String> {
+        Ok(self.builder.repr_ascii())
+    }
+}
+
+impl From<LogicalPlanBuilder> for PyLogicalPlanBuilder {
+    fn from(plan: LogicalPlanBuilder) -> Self {
+        Self::new(plan)
     }
 }

--- a/src/daft-plan/src/lib.rs
+++ b/src/daft-plan/src/lib.rs
@@ -16,7 +16,7 @@ mod source_info;
 #[cfg(test)]
 mod test;
 
-pub use builder::LogicalPlanBuilder;
+pub use builder::{LogicalPlanBuilder, PyLogicalPlanBuilder};
 pub use join::JoinType;
 pub use logical_plan::LogicalPlan;
 pub use partitioning::{PartitionScheme, PartitionSpec};
@@ -32,7 +32,7 @@ use pyo3::prelude::*;
 
 #[cfg(feature = "python")]
 pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
-    parent.add_class::<LogicalPlanBuilder>()?;
+    parent.add_class::<PyLogicalPlanBuilder>()?;
     parent.add_class::<FileFormat>()?;
     parent.add_class::<PyFileFormatConfig>()?;
     parent.add_class::<ParquetSourceConfig>()?;

--- a/src/daft-plan/src/logical_plan.rs
+++ b/src/daft-plan/src/logical_plan.rs
@@ -172,12 +172,12 @@ impl LogicalPlan {
             )
             .into(),
             Self::Join(Join {
-                input,
+                left,
                 right,
                 left_on,
                 ..
             }) => {
-                let input_partition_spec = input.partition_spec();
+                let input_partition_spec = left.partition_spec();
                 match max(
                     input_partition_spec.num_partitions,
                     right.partition_spec().num_partitions,
@@ -212,7 +212,7 @@ impl LogicalPlan {
             Self::Distinct(Distinct { input, .. }) => vec![input],
             Self::Aggregate(Aggregate { input, .. }) => vec![input],
             Self::Concat(Concat { input, other }) => vec![input, other],
-            Self::Join(Join { input, right, .. }) => vec![input, right],
+            Self::Join(Join { left, right, .. }) => vec![left, right],
             Self::Sink(Sink { input, .. }) => vec![input],
         }
     }
@@ -224,15 +224,15 @@ impl LogicalPlan {
                 Self::Project(Project { projection, resource_request, .. }) => Self::Project(Project::try_new(
                     input.clone(), projection.clone(), resource_request.clone(),
                 ).unwrap()),
-                Self::Filter(Filter { predicate, .. }) => Self::Filter(Filter::try_new(predicate.clone(), input.clone()).unwrap()),
-                Self::Limit(Limit { limit, .. }) => Self::Limit(Limit::new(*limit, input.clone())),
+                Self::Filter(Filter { predicate, .. }) => Self::Filter(Filter::try_new(input.clone(), predicate.clone()).unwrap()),
+                Self::Limit(Limit { limit, .. }) => Self::Limit(Limit::new(input.clone(), *limit)),
                 Self::Explode(Explode { to_explode, .. }) => Self::Explode(Explode::try_new(input.clone(), to_explode.clone()).unwrap()),
-                Self::Sort(Sort { sort_by, descending, .. }) => Self::Sort(Sort::try_new(sort_by.clone(), descending.clone(), input.clone()).unwrap()),
-                Self::Repartition(Repartition { num_partitions, partition_by, scheme, .. }) => Self::Repartition(Repartition::new(*num_partitions, partition_by.clone(), scheme.clone(), input.clone())),
-                Self::Coalesce(Coalesce { num_to, .. }) => Self::Coalesce(Coalesce::new(*num_to, input.clone())),
+                Self::Sort(Sort { sort_by, descending, .. }) => Self::Sort(Sort::try_new(input.clone(), sort_by.clone(), descending.clone()).unwrap()),
+                Self::Repartition(Repartition { num_partitions, partition_by, scheme, .. }) => Self::Repartition(Repartition::new(input.clone(), *num_partitions, partition_by.clone(), scheme.clone())),
+                Self::Coalesce(Coalesce { num_to, .. }) => Self::Coalesce(Coalesce::new(input.clone(), *num_to)),
                 Self::Distinct(_) => Self::Distinct(Distinct::new(input.clone())),
                 Self::Aggregate(Aggregate { aggregations, groupby, ..}) => Self::Aggregate(Aggregate::try_new(input.clone(), aggregations.clone(), groupby.clone()).unwrap()),
-                Self::Sink(Sink { schema, sink_info, .. }) => Self::Sink(Sink::new(schema.clone(), sink_info.clone(), input.clone())),
+                Self::Sink(Sink { schema, sink_info, .. }) => Self::Sink(Sink::new(input.clone(), schema.clone(), sink_info.clone())),
                 _ => panic!("Logical op {} has two inputs, but got one", self),
             },
             [input1, input2] => match self {

--- a/src/daft-plan/src/ops/coalesce.rs
+++ b/src/daft-plan/src/ops/coalesce.rs
@@ -4,14 +4,14 @@ use crate::LogicalPlan;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Coalesce {
-    // Number of partitions to coalesce to.
-    pub num_to: usize,
     // Upstream node.
     pub input: Arc<LogicalPlan>,
+    // Number of partitions to coalesce to.
+    pub num_to: usize,
 }
 
 impl Coalesce {
-    pub(crate) fn new(num_to: usize, input: Arc<LogicalPlan>) -> Self {
-        Self { num_to, input }
+    pub(crate) fn new(input: Arc<LogicalPlan>, num_to: usize) -> Self {
+        Self { input, num_to }
     }
 }

--- a/src/daft-plan/src/ops/filter.rs
+++ b/src/daft-plan/src/ops/filter.rs
@@ -10,14 +10,14 @@ use common_error::DaftError;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Filter {
-    // The Boolean expression to filter on.
-    pub predicate: Expr,
     // Upstream node.
     pub input: Arc<LogicalPlan>,
+    // The Boolean expression to filter on.
+    pub predicate: Expr,
 }
 
 impl Filter {
-    pub(crate) fn try_new(predicate: Expr, input: Arc<LogicalPlan>) -> Result<Self> {
+    pub(crate) fn try_new(input: Arc<LogicalPlan>, predicate: Expr) -> Result<Self> {
         let field = predicate
             .to_field(input.schema().as_ref())
             .context(CreationSnafu)?;
@@ -28,6 +28,6 @@ impl Filter {
             )))
             .context(CreationSnafu);
         }
-        Ok(Self { predicate, input })
+        Ok(Self { input, predicate })
     }
 }

--- a/src/daft-plan/src/ops/limit.rs
+++ b/src/daft-plan/src/ops/limit.rs
@@ -4,13 +4,14 @@ use crate::LogicalPlan;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Limit {
-    pub limit: i64,
     // Upstream node.
     pub input: Arc<LogicalPlan>,
+    // Limit on number of rows.
+    pub limit: i64,
 }
 
 impl Limit {
-    pub(crate) fn new(limit: i64, input: Arc<LogicalPlan>) -> Self {
-        Self { limit, input }
+    pub(crate) fn new(input: Arc<LogicalPlan>, limit: i64) -> Self {
+        Self { input, limit }
     }
 }

--- a/src/daft-plan/src/ops/repartition.rs
+++ b/src/daft-plan/src/ops/repartition.rs
@@ -6,25 +6,25 @@ use crate::{LogicalPlan, PartitionScheme};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Repartition {
+    // Upstream node.
+    pub input: Arc<LogicalPlan>,
     pub num_partitions: usize,
     pub partition_by: Vec<Expr>,
     pub scheme: PartitionScheme,
-    // Upstream node.
-    pub input: Arc<LogicalPlan>,
 }
 
 impl Repartition {
     pub(crate) fn new(
+        input: Arc<LogicalPlan>,
         num_partitions: usize,
         partition_by: Vec<Expr>,
         scheme: PartitionScheme,
-        input: Arc<LogicalPlan>,
     ) -> Self {
         Self {
+            input,
             num_partitions,
             partition_by,
             scheme,
-            input,
         }
     }
 

--- a/src/daft-plan/src/ops/sink.rs
+++ b/src/daft-plan/src/ops/sink.rs
@@ -9,24 +9,23 @@ use crate::{
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Sink {
+    // Upstream node.
+    pub input: Arc<LogicalPlan>,
     pub schema: SchemaRef,
     /// Information about the sink data location.
     pub sink_info: Arc<SinkInfo>,
-
-    // Upstream node.
-    pub input: Arc<LogicalPlan>,
 }
 
 impl Sink {
     pub(crate) fn new(
+        input: Arc<LogicalPlan>,
         schema: SchemaRef,
         sink_info: Arc<SinkInfo>,
-        input: Arc<LogicalPlan>,
     ) -> Self {
         Self {
+            input,
             schema,
             sink_info,
-            input,
         }
     }
 

--- a/src/daft-plan/src/ops/sort.rs
+++ b/src/daft-plan/src/ops/sort.rs
@@ -12,17 +12,17 @@ use crate::LogicalPlan;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Sort {
-    pub sort_by: Vec<Expr>,
-    pub descending: Vec<bool>,
     // Upstream node.
     pub input: Arc<LogicalPlan>,
+    pub sort_by: Vec<Expr>,
+    pub descending: Vec<bool>,
 }
 
 impl Sort {
     pub(crate) fn try_new(
+        input: Arc<LogicalPlan>,
         sort_by: Vec<Expr>,
         descending: Vec<bool>,
-        input: Arc<LogicalPlan>,
     ) -> logical_plan::Result<Self> {
         if sort_by.is_empty() {
             return Err(DaftError::ValueError(
@@ -50,9 +50,9 @@ impl Sort {
             }
         }
         Ok(Self {
+            input,
             sort_by,
             descending,
-            input,
         })
     }
 

--- a/src/daft-plan/src/ops/source.rs
+++ b/src/daft-plan/src/ops/source.rs
@@ -30,13 +30,14 @@ impl Source {
         output_schema: SchemaRef,
         source_info: Arc<SourceInfo>,
         partition_spec: Arc<PartitionSpec>,
+        limit: Option<usize>,
     ) -> Self {
         Self {
             output_schema,
             source_info,
             partition_spec,
+            limit,
             filters: vec![], // Will be populated by plan optimizer.
-            limit: None,     // Will be populated by plan optimizer.
         }
     }
 

--- a/src/daft-plan/src/optimization/optimizer.rs
+++ b/src/daft-plan/src/optimization/optimizer.rs
@@ -535,7 +535,7 @@ mod tests {
             };
             let new_predicate = filter.predicate.or(&lit(false));
             Ok(Transformed::Yes(
-                LogicalPlan::from(Filter::try_new(new_predicate, filter.input.clone())?).into(),
+                LogicalPlan::from(Filter::try_new(filter.input.clone(), new_predicate)?).into(),
             ))
         }
     }
@@ -563,7 +563,7 @@ mod tests {
             };
             let new_predicate = filter.predicate.and(&lit(true));
             Ok(Transformed::Yes(
-                LogicalPlan::from(Filter::try_new(new_predicate, filter.input.clone())?).into(),
+                LogicalPlan::from(Filter::try_new(filter.input.clone(), new_predicate)?).into(),
             ))
         }
     }

--- a/src/daft-plan/src/optimization/optimizer.rs
+++ b/src/daft-plan/src/optimization/optimizer.rs
@@ -307,7 +307,7 @@ mod tests {
             OptimizerConfig::new(5),
         );
         let plan: Arc<LogicalPlan> =
-            LogicalPlan::from(dummy_scan_node(vec![Field::new("a", DataType::Int64)])).into();
+            dummy_scan_node(vec![Field::new("a", DataType::Int64)]).build();
         let mut pass_count = 0;
         let mut did_transform = false;
         optimizer.optimize(plan.clone(), |new_plan, _, _, transformed, _| {
@@ -356,18 +356,17 @@ mod tests {
             )],
             OptimizerConfig::new(20),
         );
-        let plan: LogicalPlan = dummy_scan_node(vec![Field::new("a", DataType::Int64)]).into();
         let proj_exprs = vec![
             col("a") + lit(1),
             (col("a") + lit(2)).alias("b"),
             (col("a") + lit(3)).alias("c"),
         ];
-        let plan: LogicalPlan =
-            Project::try_new(plan.into(), proj_exprs.clone(), Default::default())?.into();
-        let initial_plan: Arc<LogicalPlan> = plan.into();
+        let plan = dummy_scan_node(vec![Field::new("a", DataType::Int64)])
+            .project(proj_exprs, Default::default())?
+            .build();
         let mut pass_count = 0;
         let mut did_transform = false;
-        optimizer.optimize(initial_plan.clone(), |_, _, _, transformed, _| {
+        optimizer.optimize(plan, |_, _, _, transformed, _| {
             pass_count += 1;
             did_transform |= transformed;
         })?;
@@ -392,18 +391,17 @@ mod tests {
             )],
             OptimizerConfig::new(20),
         );
-        let plan: LogicalPlan = dummy_scan_node(vec![Field::new("a", DataType::Int64)]).into();
         let proj_exprs = vec![
             col("a") + lit(1),
             (col("a") + lit(2)).alias("b"),
             (col("a") + lit(3)).alias("c"),
         ];
-        let plan: LogicalPlan =
-            Project::try_new(plan.into(), proj_exprs.clone(), Default::default())?.into();
-        let initial_plan: Arc<LogicalPlan> = plan.into();
+        let plan = dummy_scan_node(vec![Field::new("a", DataType::Int64)])
+            .project(proj_exprs, Default::default())?
+            .build();
         let mut pass_count = 0;
         let mut did_transform = false;
-        optimizer.optimize(initial_plan.clone(), |_, _, _, transformed, _| {
+        optimizer.optimize(plan, |_, _, _, transformed, _| {
             pass_count += 1;
             did_transform |= transformed;
         })?;
@@ -488,19 +486,18 @@ mod tests {
             ],
             OptimizerConfig::new(20),
         );
-        let plan: LogicalPlan = dummy_scan_node(vec![Field::new("a", DataType::Int64)]).into();
         let proj_exprs = vec![
             col("a") + lit(1),
             (col("a") + lit(2)).alias("b"),
             (col("a") + lit(3)).alias("c"),
         ];
-        let plan: LogicalPlan =
-            Project::try_new(plan.into(), proj_exprs.clone(), Default::default())?.into();
-        let plan: LogicalPlan = Filter::try_new(col("a").lt(&lit(2)), plan.into())?.into();
-        let initial_plan: Arc<LogicalPlan> = plan.into();
+        let plan = dummy_scan_node(vec![Field::new("a", DataType::Int64)])
+            .project(proj_exprs, Default::default())?
+            .filter(col("a").lt(&lit(2)))?
+            .build();
         let mut pass_count = 0;
         let mut did_transform = false;
-        let opt_plan = optimizer.optimize(initial_plan.clone(), |_, _, _, transformed, _| {
+        let opt_plan = optimizer.optimize(plan, |_, _, _, transformed, _| {
             pass_count += 1;
             did_transform |= transformed;
         })?;

--- a/src/daft-plan/src/optimization/rules/push_down_projection.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_projection.rs
@@ -71,6 +71,7 @@ impl PushDownProjection {
                         schema.into(),
                         source.source_info.clone(),
                         source.partition_spec.clone(),
+                        source.limit,
                     )
                     .into();
 

--- a/src/daft-plan/src/optimization/rules/push_down_projection.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_projection.rs
@@ -251,7 +251,7 @@ impl PushDownProjection {
                 };
 
                 let left_upstream_names = join
-                    .input
+                    .left
                     .schema()
                     .names()
                     .iter()
@@ -295,7 +295,7 @@ impl PushDownProjection {
                             .map(|s| Expr::Column(s.into()))
                             .collect::<Vec<_>>();
                         let new_project: LogicalPlan = Project::try_new(
-                            join.input.clone(),
+                            join.left.clone(),
                             pushdown_column_exprs,
                             Default::default(),
                         )?
@@ -326,7 +326,7 @@ impl PushDownProjection {
 
                 // If either pushdown is possible, create a new Join node.
                 if maybe_new_left_upstream.is_some() || maybe_new_right_upstream.is_some() {
-                    let new_left_upstream = maybe_new_left_upstream.unwrap_or(join.input.clone());
+                    let new_left_upstream = maybe_new_left_upstream.unwrap_or(join.left.clone());
                     let new_right_upstream = maybe_new_right_upstream.unwrap_or(join.right.clone());
                     let new_join =
                         upstream_plan.with_new_children(&[new_left_upstream, new_right_upstream]);

--- a/src/daft-plan/src/physical_ops/agg.rs
+++ b/src/daft-plan/src/physical_ops/agg.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Aggregate {
+    // Upstream node.
+    pub input: Arc<PhysicalPlan>,
+
     /// Aggregations to apply.
     pub aggregations: Vec<AggExpr>,
 
     /// Grouping to apply.
     pub groupby: Vec<Expr>,
-
-    // Upstream node.
-    pub input: Arc<PhysicalPlan>,
 }
 
 impl Aggregate {
@@ -24,9 +24,9 @@ impl Aggregate {
         groupby: Vec<Expr>,
     ) -> Self {
         Self {
+            input,
             aggregations,
             groupby,
-            input,
         }
     }
 }

--- a/src/daft-plan/src/physical_ops/concat.rs
+++ b/src/daft-plan/src/physical_ops/concat.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Concat {
-    pub other: Arc<PhysicalPlan>,
     // Upstream node.
     pub input: Arc<PhysicalPlan>,
+    pub other: Arc<PhysicalPlan>,
 }
 
 impl Concat {
-    pub(crate) fn new(other: Arc<PhysicalPlan>, input: Arc<PhysicalPlan>) -> Self {
-        Self { other, input }
+    pub(crate) fn new(input: Arc<PhysicalPlan>, other: Arc<PhysicalPlan>) -> Self {
+        Self { input, other }
     }
 }

--- a/src/daft-plan/src/physical_ops/fanout.rs
+++ b/src/daft-plan/src/physical_ops/fanout.rs
@@ -7,57 +7,57 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FanoutRandom {
-    pub num_partitions: usize,
     // Upstream node.
     pub input: Arc<PhysicalPlan>,
+    pub num_partitions: usize,
 }
 
 impl FanoutRandom {
-    pub(crate) fn new(num_partitions: usize, input: Arc<PhysicalPlan>) -> Self {
+    pub(crate) fn new(input: Arc<PhysicalPlan>, num_partitions: usize) -> Self {
         Self {
-            num_partitions,
             input,
+            num_partitions,
         }
     }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FanoutByHash {
-    pub num_partitions: usize,
-    pub partition_by: Vec<Expr>,
     // Upstream node.
     pub input: Arc<PhysicalPlan>,
+    pub num_partitions: usize,
+    pub partition_by: Vec<Expr>,
 }
 
 impl FanoutByHash {
     pub(crate) fn new(
+        input: Arc<PhysicalPlan>,
         num_partitions: usize,
         partition_by: Vec<Expr>,
-        input: Arc<PhysicalPlan>,
     ) -> Self {
         Self {
+            input,
             num_partitions,
             partition_by,
-            input,
         }
     }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FanoutByRange {
-    pub num_partitions: usize,
-    pub sort_by: Vec<Expr>,
     // Upstream node.
     pub input: Arc<PhysicalPlan>,
+    pub num_partitions: usize,
+    pub sort_by: Vec<Expr>,
 }
 
 impl FanoutByRange {
     #[allow(dead_code)]
-    pub(crate) fn new(num_partitions: usize, sort_by: Vec<Expr>, input: Arc<PhysicalPlan>) -> Self {
+    pub(crate) fn new(input: Arc<PhysicalPlan>, num_partitions: usize, sort_by: Vec<Expr>) -> Self {
         Self {
+            input,
             num_partitions,
             sort_by,
-            input,
         }
     }
 }

--- a/src/daft-plan/src/physical_ops/filter.rs
+++ b/src/daft-plan/src/physical_ops/filter.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Filter {
-    // The Boolean expression to filter on.
-    pub predicate: Expr,
     // Upstream node.
     pub input: Arc<PhysicalPlan>,
+    // The Boolean expression to filter on.
+    pub predicate: Expr,
 }
 
 impl Filter {
-    pub(crate) fn new(predicate: Expr, input: Arc<PhysicalPlan>) -> Self {
-        Self { predicate, input }
+    pub(crate) fn new(input: Arc<PhysicalPlan>, predicate: Expr) -> Self {
+        Self { input, predicate }
     }
 }

--- a/src/daft-plan/src/physical_ops/join.rs
+++ b/src/daft-plan/src/physical_ops/join.rs
@@ -7,28 +7,28 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Join {
+    // Upstream node.
+    pub left: Arc<PhysicalPlan>,
     pub right: Arc<PhysicalPlan>,
     pub left_on: Vec<Expr>,
     pub right_on: Vec<Expr>,
     pub join_type: JoinType,
-    // Upstream node.
-    pub input: Arc<PhysicalPlan>,
 }
 
 impl Join {
     pub(crate) fn new(
+        left: Arc<PhysicalPlan>,
         right: Arc<PhysicalPlan>,
         left_on: Vec<Expr>,
         right_on: Vec<Expr>,
         join_type: JoinType,
-        input: Arc<PhysicalPlan>,
     ) -> Self {
         Self {
+            left,
             right,
             left_on,
             right_on,
             join_type,
-            input,
         }
     }
 }

--- a/src/daft-plan/src/physical_ops/limit.rs
+++ b/src/daft-plan/src/physical_ops/limit.rs
@@ -5,18 +5,18 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Limit {
-    pub limit: i64,
-    pub num_partitions: usize,
     // Upstream node.
     pub input: Arc<PhysicalPlan>,
+    pub limit: i64,
+    pub num_partitions: usize,
 }
 
 impl Limit {
-    pub(crate) fn new(limit: i64, num_partitions: usize, input: Arc<PhysicalPlan>) -> Self {
+    pub(crate) fn new(input: Arc<PhysicalPlan>, limit: i64, num_partitions: usize) -> Self {
         Self {
+            input,
             limit,
             num_partitions,
-            input,
         }
     }
 }

--- a/src/daft-plan/src/physical_ops/project.rs
+++ b/src/daft-plan/src/physical_ops/project.rs
@@ -7,22 +7,22 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Project {
-    pub projection: Vec<Expr>,
-    pub resource_request: ResourceRequest,
     // Upstream node.
     pub input: Arc<PhysicalPlan>,
+    pub projection: Vec<Expr>,
+    pub resource_request: ResourceRequest,
 }
 
 impl Project {
     pub(crate) fn new(
+        input: Arc<PhysicalPlan>,
         projection: Vec<Expr>,
         resource_request: ResourceRequest,
-        input: Arc<PhysicalPlan>,
     ) -> Self {
         Self {
+            input,
             projection,
             resource_request,
-            input,
         }
     }
 }

--- a/src/daft-plan/src/physical_ops/sort.rs
+++ b/src/daft-plan/src/physical_ops/sort.rs
@@ -7,25 +7,25 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Sort {
+    // Upstream node.
+    pub input: Arc<PhysicalPlan>,
     pub sort_by: Vec<Expr>,
     pub descending: Vec<bool>,
     pub num_partitions: usize,
-    // Upstream node.
-    pub input: Arc<PhysicalPlan>,
 }
 
 impl Sort {
     pub(crate) fn new(
+        input: Arc<PhysicalPlan>,
         sort_by: Vec<Expr>,
         descending: Vec<bool>,
         num_partitions: usize,
-        input: Arc<PhysicalPlan>,
     ) -> Self {
         Self {
+            input,
             sort_by,
             descending,
             num_partitions,
-            input,
         }
     }
 }

--- a/src/daft-plan/src/physical_ops/split.rs
+++ b/src/daft-plan/src/physical_ops/split.rs
@@ -5,22 +5,22 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Split {
-    pub input_num_partitions: usize,
-    pub output_num_partitions: usize,
     // Upstream node.
     pub input: Arc<PhysicalPlan>,
+    pub input_num_partitions: usize,
+    pub output_num_partitions: usize,
 }
 
 impl Split {
     pub(crate) fn new(
+        input: Arc<PhysicalPlan>,
         input_num_partitions: usize,
         output_num_partitions: usize,
-        input: Arc<PhysicalPlan>,
     ) -> Self {
         Self {
+            input,
             input_num_partitions,
             output_num_partitions,
-            input,
         }
     }
 }

--- a/src/daft-plan/src/physical_plan.rs
+++ b/src/daft-plan/src/physical_plan.rs
@@ -445,14 +445,14 @@ impl PhysicalPlan {
                 Ok(py_iter.into())
             }
             PhysicalPlan::Join(Join {
+                left,
                 right,
                 left_on,
                 right_on,
                 join_type,
-                input,
                 ..
             }) => {
-                let upstream_input_iter = input.to_partition_tasks(py, psets)?;
+                let upstream_left_iter = left.to_partition_tasks(py, psets)?;
                 let upstream_right_iter = right.to_partition_tasks(py, psets)?;
                 let left_on_pyexprs: Vec<PyExpr> = left_on
                     .iter()
@@ -466,7 +466,7 @@ impl PhysicalPlan {
                     .import(pyo3::intern!(py, "daft.execution.rust_physical_plan_shim"))?
                     .getattr(pyo3::intern!(py, "join"))?
                     .call1((
-                        upstream_input_iter,
+                        upstream_left_iter,
                         upstream_right_iter,
                         left_on_pyexprs,
                         right_on_pyexprs,

--- a/src/daft-plan/src/test/mod.rs
+++ b/src/daft-plan/src/test/mod.rs
@@ -3,22 +3,30 @@ use std::sync::Arc;
 use daft_core::{datatypes::Field, schema::Schema};
 
 use crate::{
-    ops::Source,
-    source_info::{ExternalInfo, FileFormatConfig, FileInfos, SourceInfo},
-    JsonSourceConfig, PartitionSpec,
+    builder::LogicalPlanBuilder,
+    source_info::{FileFormatConfig, FileInfos},
+    JsonSourceConfig,
 };
 
 /// Create a dummy scan node containing the provided fields in its schema.
-pub fn dummy_scan_node(fields: Vec<Field>) -> Source {
+pub fn dummy_scan_node(fields: Vec<Field>) -> LogicalPlanBuilder {
     let schema = Arc::new(Schema::new(fields).unwrap());
-    Source::new(
-        schema.clone(),
-        SourceInfo::ExternalInfo(ExternalInfo::new(
-            schema.clone(),
-            FileInfos::new_internal(vec!["/foo".to_string()], vec![None], vec![None]).into(),
-            FileFormatConfig::Json(JsonSourceConfig {}).into(),
-        ))
-        .into(),
-        PartitionSpec::default().into(),
+    LogicalPlanBuilder::table_scan(
+        FileInfos::new_internal(vec!["/foo".to_string()], vec![None], vec![None]).into(),
+        schema,
+        FileFormatConfig::Json(JsonSourceConfig {}).into(),
     )
+    .unwrap()
+}
+
+/// Create a dummy scan node containing the provided fields in its schema and the provided limit.
+pub fn dummy_scan_node_with_limit(fields: Vec<Field>, limit: Option<usize>) -> LogicalPlanBuilder {
+    let schema = Arc::new(Schema::new(fields).unwrap());
+    LogicalPlanBuilder::table_scan_with_limit(
+        FileInfos::new_internal(vec!["/foo".to_string()], vec![None], vec![None]).into(),
+        schema,
+        FileFormatConfig::Json(JsonSourceConfig {}).into(),
+        limit,
+    )
+    .unwrap()
 }


### PR DESCRIPTION
This PR introduces a pyo3-agnostic `LogicalPlanBuilder` that can be used by Rust-side tests without going through the Python layer, making `LogicalPlan` construction much easier (this builder could eventually be used by a pure Rust `DataFrame` abstraction).

This PR also standardizes on the parent node of a newly constructed operator node to always be the first constructor argument, for both logical and physical ops.