### PR TITLE
[BUG] Fix Table.read_parquet behavior when it encounters arrow_schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.1"
-source = "git+https://github.com/Eventual-Inc/arrow2?rev=bd7ea9f274dd8739b40917fdb176df0352a3b0bb#bd7ea9f274dd8739b40917fdb176df0352a3b0bb"
+source = "git+https://github.com/Eventual-Inc/arrow2?rev=766eb727a9a06e99fc94de1880f6e5c2b1e211ee#766eb727a9a06e99fc94de1880f6e5c2b1e211ee"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.1"
-source = "git+https://github.com/Eventual-Inc/arrow2?rev=766eb727a9a06e99fc94de1880f6e5c2b1e211ee#766eb727a9a06e99fc94de1880f6e5c2b1e211ee"
+source = "git+https://github.com/Eventual-Inc/arrow2?rev=3ffe9226#3ffe92263335b645c04cd77405f3a09f43b6f44b"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.1"
-source = "git+https://github.com/Eventual-Inc/arrow2?rev=2834446a10545156bdf9c2898577e87e07d4d42d#2834446a10545156bdf9c2898577e87e07d4d42d"
+source = "git+https://github.com/Eventual-Inc/arrow2?rev=bd7ea9f274dd8739b40917fdb176df0352a3b0bb#bd7ea9f274dd8739b40917fdb176df0352a3b0bb"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -2099,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "multiversion"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cda45dade5144c2c929bf2ed6c24bebbba784e9198df049ec87d722b9462bd1"
+checksum = "b2c7b9d7fe61760ce5ea19532ead98541f6b4c495d87247aff9826445cf6872a"
 dependencies = [
  "multiversion-macros",
  "target-features",
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "multiversion-macros"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bffdccbd4798b61dce08c97ce8c66a68976f95541aaf284a6e90c1d1c306e1"
+checksum = "26a83d8500ed06d68877e9de1dde76c1dbb83885dcdbda4ef44ccbc3fbda2ac8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ tokio = {version = "1.29.1", features = ["net", "time", "bytes", "process", "sig
 [workspace.dependencies.arrow2]
 git = "https://github.com/Eventual-Inc/arrow2"
 package = "arrow2"
-# branch = "jay/decimal-binary-types"
-rev = "2834446a10545156bdf9c2898577e87e07d4d42d"
+# branch = "jay/parquet-parsing-options-arrow-schema"
+rev = "bd7ea9f274dd8739b40917fdb176df0352a3b0bb"
 version = "0.17.1"
 
 [workspace.dependencies.bincode]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ tokio = {version = "1.29.1", features = ["net", "time", "bytes", "process", "sig
 git = "https://github.com/Eventual-Inc/arrow2"
 package = "arrow2"
 # branch = "jay/parquet-parsing-options-arrow-schema"
-rev = "bd7ea9f274dd8739b40917fdb176df0352a3b0bb"
+rev = "766eb727a9a06e99fc94de1880f6e5c2b1e211ee"
 version = "0.17.1"
 
 [workspace.dependencies.bincode]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ tokio = {version = "1.29.1", features = ["net", "time", "bytes", "process", "sig
 [workspace.dependencies.arrow2]
 git = "https://github.com/Eventual-Inc/arrow2"
 package = "arrow2"
-# branch = "jay/parquet-parsing-options-arrow-schema"
-rev = "766eb727a9a06e99fc94de1880f6e5c2b1e211ee"
+# branch = "jay/logical-type-null"
+rev = "3ffe9226"
 version = "0.17.1"
 
 [workspace.dependencies.bincode]

--- a/tests/table/table_io/test_parquet.py
+++ b/tests/table/table_io/test_parquet.py
@@ -53,7 +53,7 @@ def _parquet_write_helper(data: pa.Table, row_group_size: int = None, papq_write
         (1, DataType.int64()),
         (1.5, DataType.float64()),
         (True, DataType.bool()),
-        (None, DataType.int32()),  # NOTE: When data is all-none, Arrow still stores it as int32
+        (None, DataType.null()),
         ({"foo": 1}, DataType.struct({"foo": DataType.int64()})),
         ([1, None, 2], DataType.list("item", DataType.int64())),
     ],

--- a/tests/table/table_io/test_parquet.py
+++ b/tests/table/table_io/test_parquet.py
@@ -264,9 +264,9 @@ def test_parquet_read_int96_timestamps_schema_inference(coerce_to, store_schema)
     }
     schema = [
         ("timestamp", DataType.timestamp(coerce_to)),
-        ("nested_timestamp", DataType.list("element", DataType.timestamp(coerce_to))),
+        ("nested_timestamp", DataType.list("item", DataType.timestamp(coerce_to))),
         ("struct_timestamp", DataType.struct({"foo": DataType.timestamp(coerce_to)})),
-        ("struct_nested_timestamp", DataType.struct({"foo": DataType.list("element", DataType.timestamp(coerce_to))})),
+        ("struct_nested_timestamp", DataType.struct({"foo": DataType.list("item", DataType.timestamp(coerce_to))})),
     ]
     expected = Schema._from_field_name_and_types(schema)
 

--- a/tests/table/table_io/test_parquet.py
+++ b/tests/table/table_io/test_parquet.py
@@ -53,7 +53,7 @@ def _parquet_write_helper(data: pa.Table, row_group_size: int = None, papq_write
         (1, DataType.int64()),
         (1.5, DataType.float64()),
         (True, DataType.bool()),
-        (None, DataType.null()),
+        (None, DataType.int32()),  # NOTE: When data is all-none, Arrow still stores it as int32
         ({"foo": 1}, DataType.struct({"foo": DataType.int64()})),
         ([1, None, 2], DataType.list("item", DataType.int64())),
     ],

--- a/tests/table/table_io/test_parquet.py
+++ b/tests/table/table_io/test_parquet.py
@@ -247,15 +247,26 @@ def test_parquet_read_int96_timestamps_overflow(coerce_to, use_native_downloader
 
 
 @pytest.mark.parametrize("coerce_to", [TimeUnit.ms(), TimeUnit.us()])
-def test_parquet_read_int96_timestamps_schema_inference(coerce_to):
+@pytest.mark.parametrize("store_schema", [True, False])
+def test_parquet_read_int96_timestamps_schema_inference(coerce_to, store_schema):
+    dt = datetime.datetime(2000, 1, 1)
+    ns_ts_array = pa.array(
+        [dt, dt, dt],
+        pa.timestamp("ns"),
+    )
     data = {
-        "timestamp": pa.array(
-            [datetime.datetime(1000, 1, 1), datetime.datetime(2000, 1, 1), datetime.datetime(3000, 1, 1)],
-            pa.timestamp(str(coerce_to)),
+        "timestamp": ns_ts_array,
+        "nested_timestamp": pa.array([[dt], [dt], [dt]], type=pa.list_(pa.timestamp("ns"))),
+        "struct_timestamp": pa.array([{"foo": dt} for _ in range(3)], type=pa.struct({"foo": pa.timestamp("ns")})),
+        "struct_nested_timestamp": pa.array(
+            [{"foo": [dt]} for _ in range(3)], type=pa.struct({"foo": pa.list_(pa.timestamp("ns"))})
         ),
     }
     schema = [
         ("timestamp", DataType.timestamp(coerce_to)),
+        ("nested_timestamp", DataType.list("element", DataType.timestamp(coerce_to))),
+        ("struct_timestamp", DataType.struct({"foo": DataType.timestamp(coerce_to)})),
+        ("struct_nested_timestamp", DataType.struct({"foo": DataType.list("element", DataType.timestamp(coerce_to))})),
     ]
     expected = Schema._from_field_name_and_types(schema)
 
@@ -263,7 +274,7 @@ def test_parquet_read_int96_timestamps_schema_inference(coerce_to):
         "use_deprecated_int96_timestamps": True,
     }
     if PYARROW_GE_11_0_0:
-        papq_write_table_kwargs["store_schema"] = False
+        papq_write_table_kwargs["store_schema"] = store_schema
 
     with _parquet_write_helper(
         pa.Table.from_pydict(data),


### PR DESCRIPTION
This PR incorporates changes in our [Arrow2 fork](https://github.com/Eventual-Inc/arrow2/commit/766eb727a9a06e99fc94de1880f6e5c2b1e211ee)

Previously, if Daft/arrow2 encountered an Arrow schema embedded in Parquet metadata, that Arrow schema was used as the source-of-truth for an inferred schema from the parquet file

After this change, this arrow schema is instead used as "hints" to rectify the inferred schema from Parquet.

This allows us to still leverage user-provided configurations (such as timeunit for int96 timestamps), but also still leverage information provided by the arrow schema for inferring correct arrow types.

NOTE: This PR also adds a fix for inferring Arrow `Null` types from Parquet `LogicalType::Unknown`