### PR TITLE
[PERF] Optimize filter on nested growables

### DIFF
--- a/src/daft-core/src/array/ops/full.rs
+++ b/src/daft-core/src/array/ops/full.rs
@@ -94,7 +94,8 @@ impl FullNull for FixedSizeListArray {
 
         match dtype {
             DataType::FixedSizeList(child, size) => {
-                let flat_child = Series::full_null(child.name.as_str(), &child.dtype, length * size);
+                let flat_child =
+                    Series::full_null(child.name.as_str(), &child.dtype, length * size);
                 Self::new(Field::new(name, dtype.clone()), flat_child, Some(validity))
             }
             _ => panic!(

--- a/src/daft-core/src/array/ops/full.rs
+++ b/src/daft-core/src/array/ops/full.rs
@@ -94,7 +94,7 @@ impl FullNull for FixedSizeListArray {
 
         match dtype {
             DataType::FixedSizeList(child, size) => {
-                let flat_child = Series::full_null(name, &child.dtype, length * size);
+                let flat_child = Series::full_null(child.name.as_str(), &child.dtype, length * size);
                 Self::new(Field::new(name, dtype.clone()), flat_child, Some(validity))
             }
             _ => panic!(
@@ -108,7 +108,7 @@ impl FullNull for FixedSizeListArray {
         match dtype {
             DataType::FixedSizeList(child, _) => {
                 let field = Field::new(name, dtype.clone());
-                let empty_child = Series::empty(name, &child.dtype);
+                let empty_child = Series::empty(child.name.as_str(), &child.dtype);
                 Self::new(field, empty_child, None)
             }
             _ => panic!(
@@ -125,7 +125,7 @@ impl FullNull for ListArray {
 
         match dtype {
             DataType::List(child) => {
-                let empty_flat_child = Series::empty(name, &child.dtype);
+                let empty_flat_child = Series::empty(child.name.as_str(), &child.dtype);
                 Self::new(
                     Field::new(name, dtype.clone()),
                     empty_flat_child,
@@ -144,7 +144,7 @@ impl FullNull for ListArray {
         match dtype {
             DataType::List(child) => {
                 let field = Field::new(name, dtype.clone());
-                let empty_child = Series::empty(name, &child.dtype);
+                let empty_child = Series::empty(child.name.as_str(), &child.dtype);
                 Self::new(field, empty_child, OffsetsBuffer::default(), None)
             }
             _ => panic!("Cannot create empty ListArray with dtype: {}", dtype),
@@ -160,7 +160,7 @@ impl FullNull for StructArray {
                 let field = Field::new(name, dtype.clone());
                 let empty_children = children
                     .iter()
-                    .map(|f| Series::full_null(name, &f.dtype, length))
+                    .map(|f| Series::full_null(f.name.as_str(), &f.dtype, length))
                     .collect::<Vec<_>>();
                 Self::new(field, empty_children, Some(validity))
             }
@@ -174,7 +174,7 @@ impl FullNull for StructArray {
                 let field = Field::new(name, dtype.clone());
                 let empty_children = children
                     .iter()
-                    .map(|f| Series::empty(name, &f.dtype))
+                    .map(|f| Series::empty(f.name.as_str(), &f.dtype))
                     .collect::<Vec<_>>();
                 Self::new(field, empty_children, None)
             }
@@ -197,7 +197,7 @@ mod tests {
     fn create_fixed_size_list_full_null() -> DaftResult<()> {
         let arr = FixedSizeListArray::full_null(
             "foo",
-            &DataType::FixedSizeList(Box::new(Field::new("foo", DataType::Int64)), 3),
+            &DataType::FixedSizeList(Box::new(Field::new("bar", DataType::Int64)), 3),
             3,
         );
         assert_eq!(arr.len(), 3);
@@ -207,10 +207,11 @@ mod tests {
         Ok(())
     }
 
+    #[test]
     fn create_struct_full_null() -> DaftResult<()> {
         let arr = StructArray::full_null(
             "foo",
-            &DataType::Struct(vec![Field::new("foo", DataType::Int64)]),
+            &DataType::Struct(vec![Field::new("bar", DataType::Int64)]),
             3,
         );
         assert_eq!(arr.len(), 3);
@@ -224,17 +225,18 @@ mod tests {
     fn create_fixed_size_list_full_null_empty() -> DaftResult<()> {
         let arr = FixedSizeListArray::full_null(
             "foo",
-            &DataType::FixedSizeList(Box::new(Field::new("foo", DataType::Int64)), 3),
+            &DataType::FixedSizeList(Box::new(Field::new("bar", DataType::Int64)), 3),
             0,
         );
         assert_eq!(arr.len(), 0);
         Ok(())
     }
 
+    #[test]
     fn create_struct_full_null_empty() -> DaftResult<()> {
         let arr = StructArray::full_null(
             "foo",
-            &DataType::Struct(vec![Field::new("foo", DataType::Int64)]),
+            &DataType::Struct(vec![Field::new("bar", DataType::Int64)]),
             0,
         );
         assert_eq!(arr.len(), 0);
@@ -245,16 +247,17 @@ mod tests {
     fn create_fixed_size_list_empty() -> DaftResult<()> {
         let arr = FixedSizeListArray::empty(
             "foo",
-            &DataType::FixedSizeList(Box::new(Field::new("foo", DataType::Int64)), 3),
+            &DataType::FixedSizeList(Box::new(Field::new("bar", DataType::Int64)), 3),
         );
         assert_eq!(arr.len(), 0);
         Ok(())
     }
 
+    #[test]
     fn create_struct_empty() -> DaftResult<()> {
         let arr = StructArray::empty(
             "foo",
-            &DataType::Struct(vec![Field::new("foo", DataType::Int64)]),
+            &DataType::Struct(vec![Field::new("bar", DataType::Int64)]),
         );
         assert_eq!(arr.len(), 0);
         Ok(())

--- a/tests/benchmarks/test_filter.py
+++ b/tests/benchmarks/test_filter.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+from daft import DataFrame
+
+NUM_ROWS = 1_000_000
+
+# Perform filter against a int64 column: selecting every other element
+def generate_int64_keep_every_other() -> tuple[dict, daft.Expression, list]:
+    return (
+        {"data": list(range(NUM_ROWS)), "mask": [True if i % 2 == 0 else False for i in range(NUM_ROWS)]},
+        [i for i in range(NUM_ROWS) if i % 2 == 0],
+    )
+
+
+# Perform filter against a int64 column: selecting every third element, where every two elements in between are False and Null
+def generate_int64_keep_every_other_nulls() -> tuple[dict, daft.Expression, list]:
+    return (
+        {
+            "data": list(range(NUM_ROWS)),
+            "mask": [True if i % 3 == 0 else (False if i % 3 == 1 else None) for i in range(NUM_ROWS)],
+        },
+        [i for i in range(NUM_ROWS) if i % 3 == 0],
+    )
+
+
+# Perform filter against a int64 column: contiguous segments of True/False
+def generate_int64_keep_contiguous_chunk() -> tuple[dict, daft.Expression, list]:
+    return (
+        {
+            "data": list(range(NUM_ROWS)),
+            "mask": [True for _ in range(NUM_ROWS // 2)] + [False for _ in range(NUM_ROWS // 2)],
+        },
+        list(range(NUM_ROWS // 2)),
+    )
+
+
+# Perform filter against a list[int64] column: selecting every other element
+def generate_list_int64_keep_every_other() -> tuple[dict, daft.Expression, list]:
+    data = [list(range(i, i + 4)) for i in range(NUM_ROWS)]
+    return (
+        {"data": data, "mask": [True if i % 2 == 0 else False for i in range(NUM_ROWS)]},
+        [d for i, d in enumerate(data) if i % 2 == 0],
+    )
+
+
+# Perform filter against a list[int64] column: selecting every third element, where every two elements in between are False and Null
+def generate_list_int64_keep_every_other_nulls() -> tuple[dict, daft.Expression, list]:
+    data = [list(range(i, i + 4)) for i in range(NUM_ROWS)]
+    return (
+        {"data": data, "mask": [True if i % 3 == 0 else (False if i % 3 == 1 else None) for i in range(NUM_ROWS)]},
+        [d for i, d in enumerate(data) if i % 3 == 0],
+    )
+
+
+# Perform filter against a list[int64] column: contiguous segments of True/False
+def generate_list_int64_keep_contiguous_chunks() -> tuple[dict, daft.Expression, list]:
+    data = [list(range(i, i + 4)) for i in range(NUM_ROWS)]
+    return (
+        {"data": data, "mask": [int(i // 100) % 2 == 0 for i in range(NUM_ROWS)]},
+        [d for i, d in enumerate(data) if int(i // 100) % 2 == 0],
+    )
+
+
+# Perform filter against a list[int64] column: keep all values
+def generate_list_int64_keep_all() -> tuple[dict, daft.Expression, list]:
+    data = [list(range(i, i + 4)) for i in range(NUM_ROWS)]
+    return (
+        {"data": data, "mask": [True for _ in range(NUM_ROWS)]},
+        data,
+    )
+
+
+# Perform filter against a list[int64] column: keep none of the values
+def generate_list_int64_keep_none() -> tuple[dict, daft.Expression, list]:
+    data = [list(range(i, i + 4)) for i in range(NUM_ROWS)]
+    return (
+        {"data": data, "mask": [False for _ in range(NUM_ROWS)]},
+        [],
+    )
+
+
+@pytest.mark.benchmark(group="if_else")
+@pytest.mark.parametrize(
+    "test_data_generator",
+    [
+        pytest.param(
+            generate_int64_keep_every_other,
+            id="int64-every-other",
+        ),
+        pytest.param(
+            generate_int64_keep_every_other_nulls,
+            id="int64-every-other-with-nulls",
+        ),
+        pytest.param(
+            generate_int64_keep_contiguous_chunk,
+            id="int64-contiguous",
+        ),
+        pytest.param(
+            generate_list_int64_keep_every_other,
+            id="int64-list-every-other",
+        ),
+        pytest.param(
+            generate_list_int64_keep_every_other_nulls,
+            id="int64-list-every-other-with-nulls",
+        ),
+        pytest.param(
+            generate_list_int64_keep_contiguous_chunks,
+            id="int64-list-contiguous",
+        ),
+        pytest.param(
+            generate_list_int64_keep_all,
+            id="int64-list-all",
+        ),
+        pytest.param(
+            generate_list_int64_keep_none,
+            id="int64-list-none",
+        ),
+    ],
+)
+def test_filter(test_data_generator, benchmark) -> None:
+    """If_else between NUM_ROWS values"""
+    data, expected = test_data_generator()
+    table = daft.table.Table.from_pydict(data)
+
+    def bench_filter() -> DataFrame:
+        return table.filter([daft.col("mask")])
+
+    result = benchmark(bench_filter)
+    assert result.to_pydict()["data"] == expected


### PR DESCRIPTION
This PR optimizes the new filter on nested arrays that uses growables

1. Adds some fixes for FullNull impls of the arrays, which was broken due to some naming problems
2. Adds microbenchmarks for filter
3. Adds optimizations for our filter and growable impls:
    a. Make `self.growable_validity` optional, which speeds up the case where `use_validity=False`
    b. Adds an early return for when the mask is all true/all false
4. Share a generic filter implementation across ListArray, StructArray and FixedSizeListArray