### PR TITLE
[CHORE] [New Query Planner] Add simple `df.explain()` option; change to fixed-point policy for rule batch

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -105,24 +105,26 @@ class DataFrame:
             return self._result_cache.value
 
     @DataframePublicAPI
-    def explain(self, show_optimized: bool = False) -> None:
-        """Prints the LogicalPlan that will be executed to produce this DataFrame.
+    def explain(self, show_optimized: bool = False, simple=False) -> None:
+        """Prints the logical plan that will be executed to produce this DataFrame.
         Defaults to showing the unoptimized plan. Use `show_optimized` to show the optimized one.
 
         Args:
             show_optimized (bool): shows the optimized QueryPlan instead of the unoptimized one.
+            simple (bool): Whether to only show the type of logical op for each node in the logical plan,
+                rather than showing details of how each logical op is configured.
         """
 
         if self._result_cache is not None:
             print("Result is cached and will skip computation\n")
-            print(self._builder.pretty_print())
+            print(self._builder.pretty_print(simple))
 
             print("However here is the logical plan used to produce this result:\n")
 
         builder = self.__builder
         if show_optimized:
             builder = builder.optimize()
-        print(builder.pretty_print())
+        print(builder.pretty_print(simple))
 
     def num_partitions(self) -> int:
         return self.__builder.num_partitions()

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -56,7 +56,7 @@ class LogicalPlanBuilder(ABC):
         return self.partition_spec().num_partitions
 
     @abstractmethod
-    def pretty_print(self) -> str:
+    def pretty_print(self, simple: bool = False) -> str:
         """
         Pretty prints the current underlying logical plan.
         """

--- a/daft/logical/logical_plan.py
+++ b/daft/logical/logical_plan.py
@@ -60,8 +60,8 @@ class PyLogicalPlanBuilder(LogicalPlanBuilder):
     def partition_spec(self) -> PartitionSpec:
         return self._plan.partition_spec()
 
-    def pretty_print(self) -> str:
-        return self._plan.pretty_print()
+    def pretty_print(self, simple: bool = False) -> str:
+        return self._plan.pretty_print(simple)
 
     def optimize(self) -> PyLogicalPlanBuilder:
         from daft.internal.rule_runner import (
@@ -338,14 +338,15 @@ class LogicalPlan(TreeNode["LogicalPlan"]):
     def copy_with_new_children(self, new_children: list[LogicalPlan]) -> LogicalPlan:
         raise NotImplementedError()
 
-    def pretty_print(
-        self,
-    ) -> str:
+    def pretty_print(self, simple: bool = False) -> str:
         builder: list[str] = []
 
         def helper(node: LogicalPlan, depth: int = 0, index: int = 0, prefix: str = "", header: str = ""):
             children: list[LogicalPlan] = node._children()
-            obj_repr_lines = repr(node).splitlines()
+            if simple:
+                obj_repr_lines = [node.__class__.__name__]
+            else:
+                obj_repr_lines = repr(node).splitlines()
             builder.append(f"{header}{obj_repr_lines[0]}\n")
 
             if len(children) > 0:

--- a/daft/logical/rust_logical_plan.py
+++ b/daft/logical/rust_logical_plan.py
@@ -37,11 +37,14 @@ class RustLogicalPlanBuilder(LogicalPlanBuilder):
         # TODO(Clark): Push PartitionSpec into planner.
         return self._builder.partition_spec()
 
-    def pretty_print(self) -> str:
-        return repr(self)
+    def pretty_print(self, simple: bool = False) -> str:
+        if simple:
+            return self._builder.repr_ascii(simple=True)
+        else:
+            return repr(self)
 
     def __repr__(self) -> str:
-        return self._builder.repr_ascii()
+        return self._builder.repr_ascii(simple=False)
 
     def optimize(self) -> RustLogicalPlanBuilder:
         builder = self._builder.optimize()

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -221,8 +221,8 @@ impl LogicalPlanBuilder {
         self.plan.partition_spec().as_ref().clone()
     }
 
-    pub fn repr_ascii(&self) -> String {
-        self.plan.repr_ascii()
+    pub fn repr_ascii(&self, simple: bool) -> String {
+        self.plan.repr_ascii(simple)
     }
 }
 
@@ -410,8 +410,8 @@ impl PyLogicalPlanBuilder {
         Ok(Arc::new(physical_plan).into())
     }
 
-    pub fn repr_ascii(&self) -> PyResult<String> {
-        Ok(self.builder.repr_ascii())
+    pub fn repr_ascii(&self, simple: bool) -> PyResult<String> {
+        Ok(self.builder.repr_ascii(simple))
     }
 }
 

--- a/src/daft-plan/src/logical_plan.rs
+++ b/src/daft-plan/src/logical_plan.rs
@@ -261,6 +261,24 @@ impl LogicalPlan {
             ),
         }
     }
+    pub fn name(&self) -> String {
+        let name = match self {
+            Self::Source(..) => "Source",
+            Self::Project(..) => "Project",
+            Self::Filter(..) => "Filter",
+            Self::Limit(..) => "Limit",
+            Self::Explode(..) => "Explode",
+            Self::Sort(..) => "Sort",
+            Self::Repartition(..) => "Repartition",
+            Self::Coalesce(..) => "Coalesce",
+            Self::Distinct(..) => "Distinct",
+            Self::Aggregate(..) => "Aggregate",
+            Self::Concat(..) => "Concat",
+            Self::Join(..) => "Join",
+            Self::Sink(..) => "Sink",
+        };
+        name.to_string()
+    }
 
     pub fn multiline_display(&self) -> Vec<String> {
         match self {
@@ -291,9 +309,9 @@ impl LogicalPlan {
         }
     }
 
-    pub fn repr_ascii(&self) -> String {
+    pub fn repr_ascii(&self, simple: bool) -> String {
         let mut s = String::new();
-        self.fmt_tree(&mut s).unwrap();
+        self.fmt_tree(&mut s, simple).unwrap();
         s
     }
 

--- a/src/daft-plan/src/optimization/optimizer.rs
+++ b/src/daft-plan/src/optimization/optimizer.rs
@@ -71,6 +71,22 @@ impl RuleBatch {
         }
     }
 
+    #[allow(dead_code)]
+    pub fn with_order(
+        rules: Vec<Box<dyn OptimizerRule>>,
+        strategy: RuleExecutionStrategy,
+        order: Option<ApplyOrder>,
+    ) -> Self {
+        debug_assert!(order.clone().map_or(true, |order| rules
+            .iter()
+            .all(|rule| rule.apply_order() == order)));
+        Self {
+            rules,
+            strategy,
+            order,
+        }
+    }
+
     /// Get the maximum number of passes the optimizer should make over this rule batch.
     fn max_passes(&self, config: &OptimizerConfig) -> usize {
         use RuleExecutionStrategy::*;
@@ -85,13 +101,13 @@ impl RuleBatch {
 /// The execution strategy for a batch of rules.
 pub enum RuleExecutionStrategy {
     // Apply the batch of rules only once.
+    #[allow(dead_code)]
     Once,
     // Apply the batch of rules multiple times, to a fixed-point or until the max
     // passes is hit.
     // If parametrized by Some(n), the batch of rules will be run a maximum
     // of n passes; if None, the number of passes is capped by the default max
     // passes given in the OptimizerConfig.
-    #[allow(dead_code)]
     FixedPoint(Option<usize>),
 }
 
@@ -113,7 +129,11 @@ impl Optimizer {
                 Box::new(PushDownProjection::new()),
                 Box::new(PushDownLimit::new()),
             ],
-            RuleExecutionStrategy::Once,
+            // Use a fixed-point policy for the pushdown rules: PushDownProjection can produce a Filter node
+            // at the current node, which would require another batch application in order to have a chance to push
+            // that Filter node through upstream nodes.
+            // TODO(Clark): Refine this fixed-point policy.
+            RuleExecutionStrategy::FixedPoint(Some(3)),
         )];
         Self::with_rule_batches(rule_batches, config)
     }


### PR DESCRIPTION
This PR:
- adds a `simple: bool` option to `df.explain()`, which prints out a node-name-only logical plan tree for quick visualizations;
- changes the optimizer to use a fixed-point policy for its single rule batch, which adds back some dropped optimizations in certain cases (e.g. `PushDownProjection` producing a `Filter` node which never has a chance to push through other upstream nodes).