### PR TITLE
[BUG] Schema Display should use dtype Display instead of Debug

### DIFF
--- a/src/daft-core/src/schema.rs
+++ b/src/daft-core/src/schema.rs
@@ -172,7 +172,7 @@ impl Display for Schema {
         let header = self
             .fields
             .iter()
-            .map(|(name, field)| format!("{}\n{:?}", name, field.dtype))
+            .map(|(name, field)| format!("{}\n{}", name, field.dtype))
             .collect();
         table.add_row(header);
         write!(f, "{table}")


### PR DESCRIPTION
Fixes Display for schema, which affects how our dataframe is displayed when not yet collected.