### PR TITLE
[FEAT] Add flag to limit number of connections to S3

### DIFF
--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -14,7 +14,6 @@ use crate::config;
 ///     max_connections: Maximum number of connections to S3 at any time, defaults to 25
 ///     session_token: AWS Session Token, required only if `key_id` and `access_key` are temporary credentials
 ///     retry_initial_backoff_ms: Initial backoff duration in milliseconds for an S3 retry, defaults to 1000ms
-///     retry_initial_backoff_ms: Initial backoff duration in milliseconds for an S3 retry, defaults to 1000ms
 ///     connect_timeout_ms: Timeout duration to wait to make a connection to S3 in milliseconds, defaults to 60 seconds
 ///     read_timeout_ms: Timeout duration to wait to read the first byte from S3 in milliseconds, defaults to 60 seconds
 ///     num_tries: Number of attempts to make a connection, defaults to 5

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -11,7 +11,9 @@ use crate::config;
 ///     endpoint_url: URL to the S3 endpoint, defaults to endpoints to AWS
 ///     key_id: AWS Access Key ID, defaults to auto-detection from the current environment
 ///     access_key: AWS Secret Access Key, defaults to auto-detection from the current environment
+///     max_connections: Maximum number of connections to S3 at any time, defaults to 25
 ///     session_token: AWS Session Token, required only if `key_id` and `access_key` are temporary credentials
+///     retry_initial_backoff_ms: Initial backoff duration in milliseconds for an S3 retry, defaults to 1000ms
 ///     retry_initial_backoff_ms: Initial backoff duration in milliseconds for an S3 retry, defaults to 1000ms
 ///     connect_timeout_ms: Timeout duration to wait to make a connection to S3 in milliseconds, defaults to 60 seconds
 ///     read_timeout_ms: Timeout duration to wait to read the first byte from S3 in milliseconds, defaults to 60 seconds
@@ -142,6 +144,7 @@ impl S3Config {
         key_id: Option<String>,
         session_token: Option<String>,
         access_key: Option<String>,
+        max_connections: Option<u32>,
         retry_initial_backoff_ms: Option<u64>,
         connect_timeout_ms: Option<u64>,
         read_timeout_ms: Option<u64>,
@@ -157,6 +160,7 @@ impl S3Config {
                 key_id: key_id.or(def.key_id),
                 session_token: session_token.or(def.session_token),
                 access_key: access_key.or(def.access_key),
+                max_connections: max_connections.unwrap_or(def.max_connections),
                 retry_initial_backoff_ms: retry_initial_backoff_ms
                     .unwrap_or(def.retry_initial_backoff_ms),
                 connect_timeout_ms: connect_timeout_ms.unwrap_or(def.connect_timeout_ms),
@@ -200,6 +204,12 @@ impl S3Config {
     #[getter]
     pub fn access_key(&self) -> PyResult<Option<String>> {
         Ok(self.config.access_key.clone())
+    }
+
+    /// AWS max connections
+    #[getter]
+    pub fn max_connections(&self) -> PyResult<u32> {
+        Ok(self.config.max_connections)
     }
 
     /// AWS Retry Initial Backoff Time in Milliseconds

--- a/src/common/io-config/src/s3.rs
+++ b/src/common/io-config/src/s3.rs
@@ -11,6 +11,7 @@ pub struct S3Config {
     pub key_id: Option<String>,
     pub session_token: Option<String>,
     pub access_key: Option<String>,
+    pub max_connections: u32,
     pub retry_initial_backoff_ms: u64,
     pub connect_timeout_ms: u64,
     pub read_timeout_ms: u64,
@@ -27,6 +28,7 @@ impl Default for S3Config {
             key_id: None,
             session_token: None,
             access_key: None,
+            max_connections: 25,
             retry_initial_backoff_ms: 1000,
             connect_timeout_ms: 60_000,
             read_timeout_ms: 60_000,
@@ -47,6 +49,7 @@ impl Display for S3Config {
     key_id: {:?}
     session_token: {:?},
     access_key: {:?}
+    max_connections: {},
     retry_initial_backoff_ms: {},
     connect_timeout_ms: {},
     read_timeout_ms: {},
@@ -59,6 +62,7 @@ impl Display for S3Config {
             self.session_token,
             self.access_key,
             self.retry_initial_backoff_ms,
+            self.max_connections,
             self.connect_timeout_ms,
             self.read_timeout_ms,
             self.num_tries,

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = {workspace = true}
 snafu = {workspace = true}
 tokio = {workspace = true}
 url = "2.4.0"
+
 [dependencies.reqwest]
 default-features = false
 features = ["stream", "native-tls"]

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -25,7 +25,6 @@ serde_json = {workspace = true}
 snafu = {workspace = true}
 tokio = {workspace = true}
 url = "2.4.0"
-
 [dependencies.reqwest]
 default-features = false
 features = ["stream", "native-tls"]

--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -152,7 +152,7 @@ impl ObjectSource for AzureBlobSource {
                 .into_error(e)
                 .into()
             });
-        Ok(GetResult::Stream(stream.boxed(), None))
+        Ok(GetResult::Stream(stream.boxed(), None, None))
     }
 
     async fn get_size(&self, uri: &str) -> super::Result<usize> {

--- a/src/daft-io/src/google_cloud.rs
+++ b/src/daft-io/src/google_cloud.rs
@@ -146,7 +146,7 @@ impl GCSClientWrapper {
                     .into_error(e)
                     .into()
                 });
-                Ok(GetResult::Stream(response.boxed(), size))
+                Ok(GetResult::Stream(response.boxed(), size, None))
             }
             GCSClientWrapper::S3Compat(client) => {
                 let uri = format!("s3://{}/{}", bucket, key);

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -119,7 +119,7 @@ impl ObjectSource for HttpSource {
             .into_error(e)
             .into()
         });
-        Ok(GetResult::Stream(stream.boxed(), size_bytes))
+        Ok(GetResult::Stream(stream.boxed(), size_bytes, None))
     }
 
     async fn get_size(&self, uri: &str) -> super::Result<usize> {

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -10,7 +10,11 @@ use crate::local::{collect_file, LocalFile};
 
 pub enum GetResult {
     File(LocalFile),
-    Stream(BoxStream<'static, super::Result<Bytes>>, Option<usize>, Option<OwnedSemaphorePermit>),
+    Stream(
+        BoxStream<'static, super::Result<Bytes>>,
+        Option<usize>,
+        Option<OwnedSemaphorePermit>,
+    ),
 }
 
 async fn collect_bytes<S>(mut stream: S, size_hint: Option<usize>) -> super::Result<Bytes>

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -4,12 +4,13 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{BoxStream, Stream};
 use futures::StreamExt;
+use tokio::sync::OwnedSemaphorePermit;
 
 use crate::local::{collect_file, LocalFile};
 
 pub enum GetResult {
     File(LocalFile),
-    Stream(BoxStream<'static, super::Result<Bytes>>, Option<usize>),
+    Stream(BoxStream<'static, super::Result<Bytes>>, Option<usize>, Option<OwnedSemaphorePermit>),
 }
 
 async fn collect_bytes<S>(mut stream: S, size_hint: Option<usize>) -> super::Result<Bytes>
@@ -40,7 +41,7 @@ impl GetResult {
         use GetResult::*;
         match self {
             File(f) => collect_file(f).await,
-            Stream(stream, size) => collect_bytes(stream, size).await,
+            Stream(stream, size, _permit) => collect_bytes(stream, size).await,
         }
     }
 }

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -612,7 +612,6 @@ impl S3LikeSource {
 #[async_trait]
 impl ObjectSource for S3LikeSource {
     async fn get(&self, uri: &str, range: Option<Range<usize>>) -> super::Result<GetResult> {
-        log::warn!("permits {}", self.connection_pool_sema.available_permits());
         let permit = self
             .connection_pool_sema
             .clone()

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -405,7 +405,7 @@ impl S3LikeSource {
     #[async_recursion]
     async fn _head_impl(
         &self,
-        permit: SemaphorePermit<'async_recursion>,
+        _permit: SemaphorePermit<'async_recursion>,
         uri: &str,
         region: &Region,
     ) -> super::Result<usize> {
@@ -471,7 +471,7 @@ impl S3LikeSource {
 
                             let new_region = Region::new(region_name);
                             log::debug!("S3 Region of {uri} different than client {:?} vs {:?} Attempting HEAD in that region with new client", new_region, region);
-                            self._head_impl(permit, uri, &new_region).await
+                            self._head_impl(_permit, uri, &new_region).await
                         }
                         _ => Err(UnableToHeadFileSnafu { path: uri }
                             .into_error(SdkError::ServiceError(err))
@@ -488,7 +488,7 @@ impl S3LikeSource {
     #[async_recursion]
     async fn _list_impl(
         &self,
-        permit: SemaphorePermit<'async_recursion>,
+        _permit: SemaphorePermit<'async_recursion>,
         bucket: &str,
         key: &str,
         delimiter: String,
@@ -588,7 +588,7 @@ impl S3LikeSource {
                         let new_region = Region::new(region_name);
                         log::debug!("S3 Region of {uri} different than client {:?} vs {:?} Attempting List in that region with new client", new_region, region);
                         self._list_impl(
-                            permit,
+                            _permit,
                             bucket,
                             key,
                             delimiter,


### PR DESCRIPTION
* Adds flag to S3Config that limits the number of connections to S3, default to 25 (recommended in the [aws-cpp-sdk](https://github.com/aws/aws-sdk-cpp/blob/c859aa7a1d85c5137f0416e4aa75b86ceb32e216/docs/ClientConfiguration_Parameters.md?plain=1#L46))