### PR TITLE
[FEAT] Add support for windows in daft

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,15 +6,15 @@ name: daft
 on:
   push:
     branches: [main]
-  # pull_request:
-  #   branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   DAFT_ANALYTICS_ENABLED: '0'
 
 jobs:
   unit-tests-with-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -23,12 +23,15 @@ jobs:
         daft-runner: [py, ray]
         new-query-planner: [1, 0]
         pyarrow-version: [6.0.1, 12.0]
+        os: [ubuntu, windows]
         exclude:
         - daft-runner: ray
           pyarrow-version: 6.0.1
         - daft-runner: py
           python-version: '3.10'
           pyarrow-version: 6.0.1
+        - os: windows
+          pyarrow-version: 12.0
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -431,11 +431,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-
     - name: Unix Build
       if: ${{ (matrix.os != 'windows') }}
       run: |
-        python3 -m venv venv
+        python -m venv venv
         source venv/bin/activate
         python -m pip install maturin
         maturin build --out dist
@@ -443,7 +442,7 @@ jobs:
     - name: Windows Build
       if: ${{ (matrix.os == 'windows') }}
       run: |
-        python3 -m venv venv
+        python -m venv venv
         .\venv\Scripts\activate
         python -m pip install maturin
         maturin build --out dist

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -465,7 +465,8 @@ jobs:
         rd -r venv
         python -m venv venv
         .\venv\Scripts\activate
-        python -m pip install --find-links=.\dist getdaft
+        $FILES = Get-ChildItem -Path .\dist\*.whl -Force -Recurse
+        python -m pip install $FILES[0].FullName
         python -c 'import daft; from daft import *'
 
     - name: Send Slack notification on failure

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,6 @@ jobs:
       matrix:
         python-version: ['3.7', '3.10']
         daft-runner: [py, ray]
-        new-query-planner: [1, 0]
         pyarrow-version: [6.0.1, 12.0]
         os: [ubuntu, windows]
         exclude:
@@ -83,11 +82,10 @@ jobs:
         maturin develop
         mkdir -p report-output && pytest --cov=daft --ignore tests/integration --durations=50
         coverage combine -a --data-file='.coverage' || true
-        coverage xml -o ./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.xml
-        # cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.lcov
+        coverage xml -o ./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}.xml
+        # cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}.lcov
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
     - name: Build library and Test with pytest (windows)
       if: ${{ (matrix.os == 'windows') }}
       run: |
@@ -99,11 +97,10 @@ jobs:
         maturin develop
         mkdir -p report-output && pytest --cov=daft --ignore tests\integration --durations=50
         coverage combine -a --data-file='.coverage' || true
-        coverage xml -o .\report-output\coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.xml
-        # cargo llvm-cov --no-run --lcov --output-path report-output\rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.lcov
+        coverage xml -o .\report-output\coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}.xml
+        # cargo llvm-cov --no-run --lcov --output-path report-output\rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}.lcov
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v3
@@ -179,7 +176,6 @@ jobs:
       matrix:
         python-version: ['3.7']
         daft-runner: [py, ray]
-        new-query-planner: [1, 0]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -214,7 +210,6 @@ jobs:
         pytest tests/integration/test_tpch.py --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.24.0
       if: ${{ failure() && (github.ref == 'refs/heads/main') }}
@@ -247,7 +242,6 @@ jobs:
       matrix:
         python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
-        new-query-planner: [1, 0]
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     # This is used in the step "Assume GitHub Actions AWS Credentials"
     permissions:
@@ -304,7 +298,6 @@ jobs:
         pytest tests/integration/io -m 'integration' --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.24.0
       if: ${{ failure() && (github.ref == 'refs/heads/main') }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   unit-tests-with-coverage:
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -327,7 +327,7 @@ jobs:
 
   rust-tests:
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -410,7 +410,7 @@ jobs:
 
   test-imports:
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -431,25 +431,43 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Setup Virtual Env
+
+    - name: Unix Build
+      if: ${{ (matrix.os != 'windows') }}
       run: |
-        python -m venv venv
+        python3 -m venv venv
         source venv/bin/activate
-        pip install maturin
+        python -m pip install maturin
+        maturin build --out dist
 
-    - name: Build Rust Library
+    - name: Windows Build
+      if: ${{ (matrix.os == 'windows') }}
       run: |
-        venv/bin/maturin build --out dist
+        python3 -m venv venv
+        .\venv\Scripts\activate
+        python -m pip install maturin
+        maturin build --out dist
 
-    - name: Test Imports in Clean Env
+    - name: Test Imports in Clean Env (Unix)
+      if: ${{ (matrix.os != 'windows') }}
       run: |
         rm -rf daft
         rm -rf venv
         python -m venv venv
         source venv/bin/activate
         ls -R ./dist
-        venv/bin/pip install dist/*.whl
-        venv/bin/python -c 'import daft; from daft import *'
+        pip install dist/*.whl
+        python -c 'import daft; from daft import *'
+
+    - name: Test Imports in Clean Env (Windows)
+      if: ${{ (matrix.os == 'windows') }}
+      run: |
+        rd -r daft
+        rd -r venv
+        python -m venv venv
+        .\venv\Scripts\activate
+        python -m pip install dist\*.whl
+        python -c 'import daft; from daft import *'
 
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.24.0

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -318,7 +318,7 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   rust-tests:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest]
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -399,7 +399,7 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   test-imports:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest]
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -326,10 +326,12 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   rust-tests:
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
+      matrix:
+        os: [windows]
     steps:
     - uses: actions/checkout@v4
     - uses: moonrepo/setup-rust@v0
@@ -407,13 +409,13 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   test-imports:
-    runs-on: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
+        os: [windows]
         python-version: ['3.7']
-
     steps:
     - uses: actions/checkout@v4
     - uses: moonrepo/setup-rust@v0

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,8 +6,8 @@ name: daft
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  # pull_request:
+  #   branches: [main]
 
 env:
   DAFT_ANALYTICS_ENABLED: '0'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -324,7 +324,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows]
+        os: [ubuntu, windows]
     steps:
     - uses: actions/checkout@v4
     - uses: moonrepo/setup-rust@v0
@@ -407,7 +407,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows]
+        os: [ubuntu, windows]
         python-version: ['3.7']
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,6 +26,7 @@ jobs:
         exclude:
         - daft-runner: ray
           pyarrow-version: 6.0.1
+          os: ubuntu
         - daft-runner: py
           python-version: '3.10'
           pyarrow-version: 6.0.1
@@ -68,7 +69,7 @@ jobs:
         python -m pip install -r requirements-dev.txt
 
     - name: Override pyarrow
-      if: ${{ matrix.pyarrow-version }}
+      if: ${{ (matrix.pyarrow-version) && (matrix.os != 'windows') }}
       run: pip install pyarrow==${{ matrix.pyarrow-version }}
 
     - name: Build library and Test with pytest (unix)

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -56,7 +56,15 @@ jobs:
         echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
 
     - name: Install dependencies
+      if: ${{ (matrix.os != 'windows') }}
       run: |
+        pip install --upgrade pip
+        pip install -r requirements-dev.txt
+
+    - name: Install dependencies (Windows)
+      if: ${{ (matrix.os == 'windows') }}
+      run: |
+        .\venv\Scripts\activate
         pip install --upgrade pip
         pip install -r requirements-dev.txt
 
@@ -83,16 +91,16 @@ jobs:
     - name: Build library and Test with pytest (windows)
       if: ${{ (matrix.os == 'windows') }}
       run: |
-        venv/bin/activate
+        .\venv\Scripts\activate
         # source <(cargo llvm-cov show-env --export-prefix)
         # export CARGO_TARGET_DIR=$CARGO_LLVM_COV_TARGET_DIR
         # export CARGO_INCREMENTAL=1
         # cargo llvm-cov clean --workspace
         maturin develop
-        mkdir -p report-output && pytest --cov=daft --ignore tests/integration --durations=50
+        mkdir -p report-output && pytest --cov=daft --ignore tests\integration --durations=50
         coverage combine -a --data-file='.coverage' || true
-        coverage xml -o ./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.xml
-        # cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.lcov
+        coverage xml -o .\report-output\coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.xml
+        # cargo llvm-cov --no-run --lcov --output-path report-output\rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.lcov
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
         DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,8 +65,8 @@ jobs:
       if: ${{ (matrix.os == 'windows') }}
       run: |
         .\venv\Scripts\activate
-        pip install --upgrade pip
-        pip install -r requirements-dev.txt
+        pip3 install --upgrade --user pip
+        pip3 install --user -r requirements-dev.txt
 
     - name: Override pyarrow
       if: ${{ matrix.pyarrow-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,8 +65,8 @@ jobs:
       if: ${{ (matrix.os == 'windows') }}
       run: |
         .\venv\Scripts\activate
-        pip3 install --upgrade --user pip
-        pip3 install --user -r requirements-dev.txt
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements-dev.txt
 
     - name: Override pyarrow
       if: ${{ matrix.pyarrow-version }}
@@ -131,199 +131,199 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-  integration-test-build:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      package-name: getdaft
-    strategy:
-      matrix:
-        python-version: ['3.7']
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-        fetch-depth: 0
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
-    - run: pip install -U twine toml maturin
-    - run: python tools/patch_package_version.py
-    - uses: moonrepo/setup-rust@v0
-      with:
-        cache: false
-    - uses: Swatinem/rust-cache@v2
-      with:
-        key: ${{ runner.os }}-integration-build
-        cache-all-crates: 'true'
+  # integration-test-build:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   env:
+  #     package-name: getdaft
+  #   strategy:
+  #     matrix:
+  #       python-version: ['3.7']
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #     with:
+  #       submodules: true
+  #       fetch-depth: 0
+  #   - uses: actions/setup-python@v4
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
+  #       architecture: x64
+  #   - run: pip install -U twine toml maturin
+  #   - run: python tools/patch_package_version.py
+  #   - uses: moonrepo/setup-rust@v0
+  #     with:
+  #       cache: false
+  #   - uses: Swatinem/rust-cache@v2
+  #     with:
+  #       key: ${{ runner.os }}-integration-build
+  #       cache-all-crates: 'true'
 
-    # NOTE: we don't build with all the actual release optimizations to avoid hellish CI times
-    - name: Build wheels
-      run: maturin build --release --compatibility linux --out dist
-    - name: Upload wheels
-      uses: actions/upload-artifact@v3
-      with:
-        name: wheels
-        path: dist
+  #   # NOTE: we don't build with all the actual release optimizations to avoid hellish CI times
+  #   - name: Build wheels
+  #     run: maturin build --release --compatibility linux --out dist
+  #   - name: Upload wheels
+  #     uses: actions/upload-artifact@v3
+  #     with:
+  #       name: wheels
+  #       path: dist
 
-  integration-test-tpch:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs:
-    - integration-test-build
-    env:
-      package-name: getdaft
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.7']
-        daft-runner: [py, ray]
-        new-query-planner: [1, 0]
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-        fetch-depth: 0
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
-    - name: Download built wheels
-      uses: actions/download-artifact@v3
-      with:
-        name: wheels
-        path: dist
-    - name: Setup Virtual Env
-      run: |
-        python -m venv venv
-        echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
-    - name: Install Daft and dev dependencies
-      run: |
-        pip install --upgrade pip
-        pip install -r requirements-dev.txt dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
-        rm -rf daft
-    - uses: actions/cache@v3
-      env:
-        cache-name: cache-tpch-data
-      with:
-        path: data/tpch-dbgen
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('tests/integration/test_tpch.py', 'benchmarking/tpch/**') }}
-    - name: Run TPCH integration tests
-      run: |
-        pytest tests/integration/test_tpch.py --durations=50
-      env:
-        DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
-    - name: Send Slack notification on failure
-      uses: slackapi/slack-github-action@v1.24.0
-      if: ${{ failure() && (github.ref == 'refs/heads/main') }}
-      with:
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": ":rotating_light: [CI] TPCH Integration Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
-                }
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  # integration-test-tpch:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   needs:
+  #   - integration-test-build
+  #   env:
+  #     package-name: getdaft
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version: ['3.7']
+  #       daft-runner: [py, ray]
+  #       new-query-planner: [1, 0]
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #     with:
+  #       submodules: true
+  #       fetch-depth: 0
+  #   - uses: actions/setup-python@v4
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
+  #       architecture: x64
+  #   - name: Download built wheels
+  #     uses: actions/download-artifact@v3
+  #     with:
+  #       name: wheels
+  #       path: dist
+  #   - name: Setup Virtual Env
+  #     run: |
+  #       python -m venv venv
+  #       echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
+  #   - name: Install Daft and dev dependencies
+  #     run: |
+  #       pip install --upgrade pip
+  #       pip install -r requirements-dev.txt dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
+  #       rm -rf daft
+  #   - uses: actions/cache@v3
+  #     env:
+  #       cache-name: cache-tpch-data
+  #     with:
+  #       path: data/tpch-dbgen
+  #       key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('tests/integration/test_tpch.py', 'benchmarking/tpch/**') }}
+  #   - name: Run TPCH integration tests
+  #     run: |
+  #       pytest tests/integration/test_tpch.py --durations=50
+  #     env:
+  #       DAFT_RUNNER: ${{ matrix.daft-runner }}
+  #       DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
+  #   - name: Send Slack notification on failure
+  #     uses: slackapi/slack-github-action@v1.24.0
+  #     if: ${{ failure() && (github.ref == 'refs/heads/main') }}
+  #     with:
+  #       payload: |
+  #         {
+  #           "blocks": [
+  #             {
+  #               "type": "section",
+  #               "text": {
+  #                 "type": "mrkdwn",
+  #                 "text": ":rotating_light: [CI] TPCH Integration Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
+  #               }
+  #             }
+  #           ]
+  #         }
+  #     env:
+  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-  integration-test-io:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs:
-    - integration-test-build
-    env:
-      package-name: getdaft
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
-        daft-runner: [py, ray]
-        new-query-planner: [1, 0]
-    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-    # This is used in the step "Assume GitHub Actions AWS Credentials"
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-        fetch-depth: 0
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
-    - name: Download built wheels
-      uses: actions/download-artifact@v3
-      with:
-        name: wheels
-        path: dist
-    - name: Setup Virtual Env
-      run: |
-        python -m venv venv
-        echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
-    - name: Install Daft and dev dependencies
-      run: |
-        pip install --upgrade pip
-        pip install -r requirements-dev.txt dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
-        rm -rf daft
-    - name: Prepare tmpdirs for IO services
-      run: |
-        mkdir -p /tmp/daft-integration-testing/nginx
-        chmod +rw /tmp/daft-integration-testing/nginx
-    - name: Assume GitHub Actions AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v3
-      with:
-        aws-region: us-west-2
-        role-to-assume: ${{ secrets.ACTIONS_AWS_ROLE_ARN }}
-        role-session-name: DaftPythonPackageGitHubWorkflow
-    - name: Assume GitHub Actions GCloud Credentials
-      uses: google-github-actions/auth@v1
-      with:
-        credentials_json: ${{ secrets.ACTIONS_GCP_SERVICE_ACCOUNT_JSON }}
-        # NOTE: Workload Identity seems to be having problems with our Rust crate, so we use JSON instead
-        # See issue: https://github.com/yoshidan/google-cloud-rust/issues/171#issuecomment-1730511655
-        # workload_identity_provider: ${{ secrets.ACTIONS_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-        # service_account: ${{ secrets.ACTIONS_GCP_SERVICE_ACCOUNT }}
-    - name: Spin up IO services
-      uses: isbang/compose-action@v1.5.1
-      with:
-        compose-file: ./tests/integration/docker-compose/docker-compose.yml
-        down-flags: --volumes
-    - name: Run IO integration tests
-      run: |
-        pytest tests/integration/io -m 'integration' --durations=50
-      env:
-        DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
-    - name: Send Slack notification on failure
-      uses: slackapi/slack-github-action@v1.24.0
-      if: ${{ failure() && (github.ref == 'refs/heads/main') }}
-      with:
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": ":rotating_light: [CI] IO Integration Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
-                }
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  # integration-test-io:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 30
+  #   needs:
+  #   - integration-test-build
+  #   env:
+  #     package-name: getdaft
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
+  #       daft-runner: [py, ray]
+  #       new-query-planner: [1, 0]
+  #   # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+  #   # This is used in the step "Assume GitHub Actions AWS Credentials"
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #     with:
+  #       submodules: true
+  #       fetch-depth: 0
+  #   - uses: actions/setup-python@v4
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
+  #       architecture: x64
+  #   - name: Download built wheels
+  #     uses: actions/download-artifact@v3
+  #     with:
+  #       name: wheels
+  #       path: dist
+  #   - name: Setup Virtual Env
+  #     run: |
+  #       python -m venv venv
+  #       echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
+  #   - name: Install Daft and dev dependencies
+  #     run: |
+  #       pip install --upgrade pip
+  #       pip install -r requirements-dev.txt dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
+  #       rm -rf daft
+  #   - name: Prepare tmpdirs for IO services
+  #     run: |
+  #       mkdir -p /tmp/daft-integration-testing/nginx
+  #       chmod +rw /tmp/daft-integration-testing/nginx
+  #   - name: Assume GitHub Actions AWS Credentials
+  #     uses: aws-actions/configure-aws-credentials@v3
+  #     with:
+  #       aws-region: us-west-2
+  #       role-to-assume: ${{ secrets.ACTIONS_AWS_ROLE_ARN }}
+  #       role-session-name: DaftPythonPackageGitHubWorkflow
+  #   - name: Assume GitHub Actions GCloud Credentials
+  #     uses: google-github-actions/auth@v1
+  #     with:
+  #       credentials_json: ${{ secrets.ACTIONS_GCP_SERVICE_ACCOUNT_JSON }}
+  #       # NOTE: Workload Identity seems to be having problems with our Rust crate, so we use JSON instead
+  #       # See issue: https://github.com/yoshidan/google-cloud-rust/issues/171#issuecomment-1730511655
+  #       # workload_identity_provider: ${{ secrets.ACTIONS_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+  #       # service_account: ${{ secrets.ACTIONS_GCP_SERVICE_ACCOUNT }}
+  #   - name: Spin up IO services
+  #     uses: isbang/compose-action@v1.5.1
+  #     with:
+  #       compose-file: ./tests/integration/docker-compose/docker-compose.yml
+  #       down-flags: --volumes
+  #   - name: Run IO integration tests
+  #     run: |
+  #       pytest tests/integration/io -m 'integration' --durations=50
+  #     env:
+  #       DAFT_RUNNER: ${{ matrix.daft-runner }}
+  #       DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
+  #   - name: Send Slack notification on failure
+  #     uses: slackapi/slack-github-action@v1.24.0
+  #     if: ${{ failure() && (github.ref == 'refs/heads/main') }}
+  #     with:
+  #       payload: |
+  #         {
+  #           "blocks": [
+  #             {
+  #               "type": "section",
+  #               "text": {
+  #                 "type": "mrkdwn",
+  #                 "text": ":rotating_light: [CI] IO Integration Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
+  #               }
+  #             }
+  #           ]
+  #         }
+  #     env:
+  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   rust-tests:
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
         daft-runner: [py, ray]
         new-query-planner: [1, 0]
         pyarrow-version: [6.0.1, 12.0]
-        os: [windows]
+        os: [ubuntu, windows]
         exclude:
         - daft-runner: ray
           pyarrow-version: 6.0.1
@@ -131,199 +131,199 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-  # integration-test-build:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   env:
-  #     package-name: getdaft
-  #   strategy:
-  #     matrix:
-  #       python-version: ['3.7']
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #     with:
-  #       submodules: true
-  #       fetch-depth: 0
-  #   - uses: actions/setup-python@v4
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
-  #       architecture: x64
-  #   - run: pip install -U twine toml maturin
-  #   - run: python tools/patch_package_version.py
-  #   - uses: moonrepo/setup-rust@v0
-  #     with:
-  #       cache: false
-  #   - uses: Swatinem/rust-cache@v2
-  #     with:
-  #       key: ${{ runner.os }}-integration-build
-  #       cache-all-crates: 'true'
+  integration-test-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      package-name: getdaft
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+    - run: pip install -U twine toml maturin
+    - run: python tools/patch_package_version.py
+    - uses: moonrepo/setup-rust@v0
+      with:
+        cache: false
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ runner.os }}-integration-build
+        cache-all-crates: 'true'
 
-  #   # NOTE: we don't build with all the actual release optimizations to avoid hellish CI times
-  #   - name: Build wheels
-  #     run: maturin build --release --compatibility linux --out dist
-  #   - name: Upload wheels
-  #     uses: actions/upload-artifact@v3
-  #     with:
-  #       name: wheels
-  #       path: dist
+    # NOTE: we don't build with all the actual release optimizations to avoid hellish CI times
+    - name: Build wheels
+      run: maturin build --release --compatibility linux --out dist
+    - name: Upload wheels
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheels
+        path: dist
 
-  # integration-test-tpch:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   needs:
-  #   - integration-test-build
-  #   env:
-  #     package-name: getdaft
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version: ['3.7']
-  #       daft-runner: [py, ray]
-  #       new-query-planner: [1, 0]
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #     with:
-  #       submodules: true
-  #       fetch-depth: 0
-  #   - uses: actions/setup-python@v4
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
-  #       architecture: x64
-  #   - name: Download built wheels
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: wheels
-  #       path: dist
-  #   - name: Setup Virtual Env
-  #     run: |
-  #       python -m venv venv
-  #       echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
-  #   - name: Install Daft and dev dependencies
-  #     run: |
-  #       pip install --upgrade pip
-  #       pip install -r requirements-dev.txt dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
-  #       rm -rf daft
-  #   - uses: actions/cache@v3
-  #     env:
-  #       cache-name: cache-tpch-data
-  #     with:
-  #       path: data/tpch-dbgen
-  #       key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('tests/integration/test_tpch.py', 'benchmarking/tpch/**') }}
-  #   - name: Run TPCH integration tests
-  #     run: |
-  #       pytest tests/integration/test_tpch.py --durations=50
-  #     env:
-  #       DAFT_RUNNER: ${{ matrix.daft-runner }}
-  #       DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
-  #   - name: Send Slack notification on failure
-  #     uses: slackapi/slack-github-action@v1.24.0
-  #     if: ${{ failure() && (github.ref == 'refs/heads/main') }}
-  #     with:
-  #       payload: |
-  #         {
-  #           "blocks": [
-  #             {
-  #               "type": "section",
-  #               "text": {
-  #                 "type": "mrkdwn",
-  #                 "text": ":rotating_light: [CI] TPCH Integration Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
-  #               }
-  #             }
-  #           ]
-  #         }
-  #     env:
-  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  integration-test-tpch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+    - integration-test-build
+    env:
+      package-name: getdaft
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7']
+        daft-runner: [py, ray]
+        new-query-planner: [1, 0]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+    - name: Download built wheels
+      uses: actions/download-artifact@v3
+      with:
+        name: wheels
+        path: dist
+    - name: Setup Virtual Env
+      run: |
+        python -m venv venv
+        echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
+    - name: Install Daft and dev dependencies
+      run: |
+        pip install --upgrade pip
+        pip install -r requirements-dev.txt dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
+        rm -rf daft
+    - uses: actions/cache@v3
+      env:
+        cache-name: cache-tpch-data
+      with:
+        path: data/tpch-dbgen
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('tests/integration/test_tpch.py', 'benchmarking/tpch/**') }}
+    - name: Run TPCH integration tests
+      run: |
+        pytest tests/integration/test_tpch.py --durations=50
+      env:
+        DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
+    - name: Send Slack notification on failure
+      uses: slackapi/slack-github-action@v1.24.0
+      if: ${{ failure() && (github.ref == 'refs/heads/main') }}
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: [CI] TPCH Integration Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-  # integration-test-io:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 30
-  #   needs:
-  #   - integration-test-build
-  #   env:
-  #     package-name: getdaft
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
-  #       daft-runner: [py, ray]
-  #       new-query-planner: [1, 0]
-  #   # These permissions are needed to interact with GitHub's OIDC Token endpoint.
-  #   # This is used in the step "Assume GitHub Actions AWS Credentials"
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #     with:
-  #       submodules: true
-  #       fetch-depth: 0
-  #   - uses: actions/setup-python@v4
-  #     with:
-  #       python-version: ${{ matrix.python-version }}
-  #       architecture: x64
-  #   - name: Download built wheels
-  #     uses: actions/download-artifact@v3
-  #     with:
-  #       name: wheels
-  #       path: dist
-  #   - name: Setup Virtual Env
-  #     run: |
-  #       python -m venv venv
-  #       echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
-  #   - name: Install Daft and dev dependencies
-  #     run: |
-  #       pip install --upgrade pip
-  #       pip install -r requirements-dev.txt dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
-  #       rm -rf daft
-  #   - name: Prepare tmpdirs for IO services
-  #     run: |
-  #       mkdir -p /tmp/daft-integration-testing/nginx
-  #       chmod +rw /tmp/daft-integration-testing/nginx
-  #   - name: Assume GitHub Actions AWS Credentials
-  #     uses: aws-actions/configure-aws-credentials@v3
-  #     with:
-  #       aws-region: us-west-2
-  #       role-to-assume: ${{ secrets.ACTIONS_AWS_ROLE_ARN }}
-  #       role-session-name: DaftPythonPackageGitHubWorkflow
-  #   - name: Assume GitHub Actions GCloud Credentials
-  #     uses: google-github-actions/auth@v1
-  #     with:
-  #       credentials_json: ${{ secrets.ACTIONS_GCP_SERVICE_ACCOUNT_JSON }}
-  #       # NOTE: Workload Identity seems to be having problems with our Rust crate, so we use JSON instead
-  #       # See issue: https://github.com/yoshidan/google-cloud-rust/issues/171#issuecomment-1730511655
-  #       # workload_identity_provider: ${{ secrets.ACTIONS_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-  #       # service_account: ${{ secrets.ACTIONS_GCP_SERVICE_ACCOUNT }}
-  #   - name: Spin up IO services
-  #     uses: isbang/compose-action@v1.5.1
-  #     with:
-  #       compose-file: ./tests/integration/docker-compose/docker-compose.yml
-  #       down-flags: --volumes
-  #   - name: Run IO integration tests
-  #     run: |
-  #       pytest tests/integration/io -m 'integration' --durations=50
-  #     env:
-  #       DAFT_RUNNER: ${{ matrix.daft-runner }}
-  #       DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
-  #   - name: Send Slack notification on failure
-  #     uses: slackapi/slack-github-action@v1.24.0
-  #     if: ${{ failure() && (github.ref == 'refs/heads/main') }}
-  #     with:
-  #       payload: |
-  #         {
-  #           "blocks": [
-  #             {
-  #               "type": "section",
-  #               "text": {
-  #                 "type": "mrkdwn",
-  #                 "text": ":rotating_light: [CI] IO Integration Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
-  #               }
-  #             }
-  #           ]
-  #         }
-  #     env:
-  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  integration-test-io:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs:
+    - integration-test-build
+    env:
+      package-name: getdaft
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
+        daft-runner: [py, ray]
+        new-query-planner: [1, 0]
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    # This is used in the step "Assume GitHub Actions AWS Credentials"
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 0
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+    - name: Download built wheels
+      uses: actions/download-artifact@v3
+      with:
+        name: wheels
+        path: dist
+    - name: Setup Virtual Env
+      run: |
+        python -m venv venv
+        echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
+    - name: Install Daft and dev dependencies
+      run: |
+        pip install --upgrade pip
+        pip install -r requirements-dev.txt dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
+        rm -rf daft
+    - name: Prepare tmpdirs for IO services
+      run: |
+        mkdir -p /tmp/daft-integration-testing/nginx
+        chmod +rw /tmp/daft-integration-testing/nginx
+    - name: Assume GitHub Actions AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v3
+      with:
+        aws-region: us-west-2
+        role-to-assume: ${{ secrets.ACTIONS_AWS_ROLE_ARN }}
+        role-session-name: DaftPythonPackageGitHubWorkflow
+    - name: Assume GitHub Actions GCloud Credentials
+      uses: google-github-actions/auth@v1
+      with:
+        credentials_json: ${{ secrets.ACTIONS_GCP_SERVICE_ACCOUNT_JSON }}
+        # NOTE: Workload Identity seems to be having problems with our Rust crate, so we use JSON instead
+        # See issue: https://github.com/yoshidan/google-cloud-rust/issues/171#issuecomment-1730511655
+        # workload_identity_provider: ${{ secrets.ACTIONS_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        # service_account: ${{ secrets.ACTIONS_GCP_SERVICE_ACCOUNT }}
+    - name: Spin up IO services
+      uses: isbang/compose-action@v1.5.1
+      with:
+        compose-file: ./tests/integration/docker-compose/docker-compose.yml
+        down-flags: --volumes
+    - name: Run IO integration tests
+      run: |
+        pytest tests/integration/io -m 'integration' --durations=50
+      env:
+        DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
+    - name: Send Slack notification on failure
+      uses: slackapi/slack-github-action@v1.24.0
+      if: ${{ failure() && (github.ref == 'refs/heads/main') }}
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: [CI] IO Integration Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   rust-tests:
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -465,7 +465,7 @@ jobs:
         rd -r venv
         python -m venv venv
         .\venv\Scripts\activate
-        python -m pip install dist\*.whl
+        python -m pip install --find-links=.\dist getdaft
         python -c 'import daft; from daft import *'
 
     - name: Send Slack notification on failure

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,7 +23,7 @@ jobs:
         daft-runner: [py, ray]
         new-query-planner: [1, 0]
         pyarrow-version: [6.0.1, 12.0]
-        os: [ubuntu, windows]
+        os: [windows]
         exclude:
         - daft-runner: ray
           pyarrow-version: 6.0.1
@@ -64,9 +64,26 @@ jobs:
       if: ${{ matrix.pyarrow-version }}
       run: pip install pyarrow==${{ matrix.pyarrow-version }}
 
-    - name: Build library and Test with pytest
+    - name: Build library and Test with pytest (unix)
+      if: ${{ (matrix.os != 'windows') }}
       run: |
         source activate
+        # source <(cargo llvm-cov show-env --export-prefix)
+        # export CARGO_TARGET_DIR=$CARGO_LLVM_COV_TARGET_DIR
+        # export CARGO_INCREMENTAL=1
+        # cargo llvm-cov clean --workspace
+        maturin develop
+        mkdir -p report-output && pytest --cov=daft --ignore tests/integration --durations=50
+        coverage combine -a --data-file='.coverage' || true
+        coverage xml -o ./report-output/coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.xml
+        # cargo llvm-cov --no-run --lcov --output-path report-output/rust-coverage-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.daft-runner }}-${{ matrix.pyarrow-version }}-${{ matrix.new-query-planner }}.lcov
+      env:
+        DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_NEW_QUERY_PLANNER: ${{ matrix.new-query-planner }}
+    - name: Build library and Test with pytest (windows)
+      if: ${{ (matrix.os == 'windows') }}
+      run: |
+        venv/bin/activate
         # source <(cargo llvm-cov show-env --export-prefix)
         # export CARGO_TARGET_DIR=$CARGO_LLVM_COV_TARGET_DIR
         # export CARGO_INCREMENTAL=1

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,6 +30,7 @@ jobs:
         - daft-runner: py
           python-version: '3.10'
           pyarrow-version: 6.0.1
+          os: ubuntu
         - os: windows
           pyarrow-version: 12.0
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,21 +1,19 @@
 name: daft-publish
 
 on:
-  # schedule:
-  # #        ┌───────────── minute (0 - 59)
-  # #        │  ┌───────────── hour (0 - 23)
-  # #        │  │ ┌───────────── day of the month (1 - 31)
-  # #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-  # #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-  # #        │  │ │ │ │
-  # - cron: 0 5 * * *
+  schedule:
+  #        ┌───────────── minute (0 - 59)
+  #        │  ┌───────────── hour (0 - 23)
+  #        │  │ ┌───────────── day of the month (1 - 31)
+  #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+  #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+  #        │  │ │ │ │
+  - cron: 0 5 * * *
 
-  # push:
-  #   tags:
-  #   - v*
-  # workflow_dispatch:
-  pull_request:
-    branches: [main]
+  push:
+    tags:
+    - v*
+  workflow_dispatch:
 env:
   PACKAGE_NAME: getdaft
   PYTHON_VERSION: 3.8

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -55,7 +55,7 @@ jobs:
       uses: messense/maturin-action@v1
       with:
         target: x86_64
-        args: --profile release --out dist --sdist
+        args: --profile release --out dist --sdist # CHANGE THIS BACK TO LTO
       env:
         RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2
     - name: Build wheels - Linux x86

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,7 +36,7 @@ jobs:
         runs: [ubuntu-latest, macos-latest-xl, windows-latest]
         compile_arch: [x86_64, aarch64]
         exclude:
-        - runs: windows-latest;
+        - runs: windows-latest
           compile_arch: aarch64
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,10 +33,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs: [ubuntu-latest, macos-latest-xl, windows-latest-xl]
+        runs: [ubuntu-latest, macos-latest-xl, windows-latest]
         compile_arch: [x86_64, aarch64]
         exclude:
-        - runs: windows-latest-xl;
+        - runs: windows-latest;
           compile_arch: aarch64
     steps:
     - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
     - run: pip install -U twine toml
     - run: python tools/patch_package_version.py
     - name: Build wheels - Mac and Windows x86
-      if: ${{ ((matrix.runs == 'macos-latest-xl') || (matrix.runs == 'windows-latest-xl')) && (matrix.compile_arch == 'x86_64')  }}
+      if: ${{ ((matrix.runs == 'macos-latest-xl') || (matrix.runs == 'windows-latest')) && (matrix.compile_arch == 'x86_64')  }}
       uses: messense/maturin-action@v1
       with:
         target: x86_64
@@ -96,7 +96,7 @@ jobs:
         pytest -v
 
     - name: Install and test built wheel - Windows x86_64
-      if: ${{ (matrix.runs == 'windows-latest-xl') && (matrix.compile_arch == 'x86_64')  }}
+      if: ${{ (matrix.runs == 'windows-latest') && (matrix.compile_arch == 'x86_64')  }}
       run: |
         pip install -r requirements-dev.txt dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
         rd -r daft

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,7 +18,7 @@ on:
     branches: [main]
 env:
   PACKAGE_NAME: getdaft
-  PYTHON_VERSION: 3.7.16   # to build abi3 wheels
+  PYTHON_VERSION: 3.8
   DAFT_ANALYTICS_ENABLED: '0'
 
   IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0')) }}
@@ -110,25 +110,25 @@ jobs:
         name: wheels
         path: dist
 
-    - name: Send Slack notification on failure
-      uses: slackapi/slack-github-action@v1.24.0
-      if: failure()
-      with:
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": ":rotating_light: Release: Building Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-                }
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    # - name: Send Slack notification on failure
+    #   uses: slackapi/slack-github-action@v1.24.0
+    #   if: failure()
+    #   with:
+    #     payload: |
+    #       {
+    #         "blocks": [
+    #           {
+    #             "type": "section",
+    #             "text": {
+    #               "type": "mrkdwn",
+    #               "text": ":rotating_light: Release: Building Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+    #             }
+    #           }
+    #         ]
+    #       }
+    #   env:
+    #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
 
   # publish:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -50,13 +50,12 @@ jobs:
         architecture: x64
     - run: pip install -U twine toml
     - run: python tools/patch_package_version.py
-    - uses: moonrepo/setup-rust@v0
     - name: Build wheels - Mac and Windows x86
       if: ${{ ((matrix.runs == 'macos-latest-xl') || (matrix.runs == 'windows-latest')) && (matrix.compile_arch == 'x86_64')  }}
       uses: messense/maturin-action@v1
       with:
         target: x86_64
-        args: --profile release-lto --out dist --sdist
+        args: --profile release --out dist --sdist
       env:
         RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2
     - name: Build wheels - Linux x86

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,7 +37,7 @@ jobs:
         runs: [windows-latest]
         compile_arch: [x86_64, aarch64]
         exclude:
-        - os: windows-latest
+        - runs: windows-latest
           compile_arch: aarch64
     steps:
     - uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
         pip install -r requirements-dev.txt dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
         rd -r daft
         pytest -v
-  
+
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,10 +33,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs: [ubuntu-latest, macos-latest-xl, windows-latest]
+        runs: [ubuntu-latest, macos-latest-xl, windows-latest-l]
         compile_arch: [x86_64, aarch64]
         exclude:
-        - runs: windows-latest
+        - runs: windows-latest-l
           compile_arch: aarch64
     steps:
     - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
     - run: pip install -U twine toml
     - run: python tools/patch_package_version.py
     - name: Build wheels - Mac and Windows x86
-      if: ${{ ((matrix.runs == 'macos-latest-xl') || (matrix.runs == 'windows-latest')) && (matrix.compile_arch == 'x86_64')  }}
+      if: ${{ ((matrix.runs == 'macos-latest-xl') || (matrix.runs == 'windows-latest-l')) && (matrix.compile_arch == 'x86_64')  }}
       uses: messense/maturin-action@v1
       with:
         target: x86_64
@@ -96,9 +96,10 @@ jobs:
         pytest -v
 
     - name: Install and test built wheel - Windows x86_64
-      if: ${{ (matrix.runs == 'windows-latest') && (matrix.compile_arch == 'x86_64')  }}
+      if: ${{ (matrix.runs == 'windows-latest-l') && (matrix.compile_arch == 'x86_64')  }}
       run: |
-        pip install -r requirements-dev.txt dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
+        $FILES = Get-ChildItem -Path .\dist\${{ env.PACKAGE_NAME }}-*-win_amd64.whl -Force -Recurse
+        pip install -r requirements-dev.txt $FILES[0].FullName --force-reinstall
         rd -r daft
         pytest -v
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -33,11 +33,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # runs: [ubuntu-latest, macos-latest-xl, windows-latest]
-        runs: [windows-latest]
+        runs: [ubuntu-latest, macos-latest-xl, windows-latest-xl]
         compile_arch: [x86_64, aarch64]
         exclude:
-        - runs: windows-latest
+        - runs: windows-latest-xl;
           compile_arch: aarch64
     steps:
     - uses: actions/checkout@v4
@@ -51,11 +50,11 @@ jobs:
     - run: pip install -U twine toml
     - run: python tools/patch_package_version.py
     - name: Build wheels - Mac and Windows x86
-      if: ${{ ((matrix.runs == 'macos-latest-xl') || (matrix.runs == 'windows-latest')) && (matrix.compile_arch == 'x86_64')  }}
+      if: ${{ ((matrix.runs == 'macos-latest-xl') || (matrix.runs == 'windows-latest-xl')) && (matrix.compile_arch == 'x86_64')  }}
       uses: messense/maturin-action@v1
       with:
         target: x86_64
-        args: --profile release --out dist --sdist # CHANGE THIS BACK TO LTO
+        args: --profile release-lto --out dist --sdist
       env:
         RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2
     - name: Build wheels - Linux x86
@@ -97,7 +96,7 @@ jobs:
         pytest -v
 
     - name: Install and test built wheel - Windows x86_64
-      if: ${{ (matrix.runs == 'windows-latest') && (matrix.compile_arch == 'x86_64')  }}
+      if: ${{ (matrix.runs == 'windows-latest-xl') && (matrix.compile_arch == 'x86_64')  }}
       run: |
         pip install -r requirements-dev.txt dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
         rd -r daft
@@ -109,96 +108,97 @@ jobs:
         name: wheels
         path: dist
 
-    # - name: Send Slack notification on failure
-    #   uses: slackapi/slack-github-action@v1.24.0
-    #   if: failure()
-    #   with:
-    #     payload: |
-    #       {
-    #         "blocks": [
-    #           {
-    #             "type": "section",
-    #             "text": {
-    #               "type": "mrkdwn",
-    #               "text": ":rotating_light: Release: Building Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-    #             }
-    #           }
-    #         ]
-    #       }
-    #   env:
-    #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-    #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    - name: Send Slack notification on failure
+      uses: slackapi/slack-github-action@v1.24.0
+      if: ${{ failure() && (github.ref == 'refs/heads/main') }}
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: Release: Building Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
 
-  # publish:
-  #   name: Publish wheels to PYPI and Anaconda
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #   - build-and-test
-  #   steps:
-  #   - uses: actions/setup-python@v4
-  #     with:
-  #       python-version: ${{ env.PYTHON_VERSION }}
-  #       architecture: x64
-  #   - run: pip install -U twine
-  #   - uses: actions/checkout@v4
-  #   - uses: actions/download-artifact@v3
-  #     with:
-  #       name: wheels
-  #       path: dist
-  #   - run: ls -R ./dist
-  #   - name: Publish bdist package to PYPI
-  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
-  #     run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
-  #     env:
-  #       TWINE_USERNAME: __token__
-  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  publish:
+    name: Publish wheels to PYPI and Anaconda
+    if: ${{ (github.ref == 'refs/heads/main') }}
+    runs-on: ubuntu-latest
+    needs:
+    - build-and-test
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+        architecture: x64
+    - run: pip install -U twine
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v3
+      with:
+        name: wheels
+        path: dist
+    - run: ls -R ./dist
+    - name: Publish bdist package to PYPI
+      if: ${{ success() && (env.IS_PUSH == 'true') }}
+      run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
-  #   - uses: conda-incubator/setup-miniconda@v2
-  #     with:
-  #       # Really doesn't matter what version we upload with
-  #       # just the version we test with
-  #       python-version: '3.8'
-  #       channels: conda-forge
-  #       channel-priority: true
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        # Really doesn't matter what version we upload with
+        # just the version we test with
+        python-version: '3.8'
+        channels: conda-forge
+        channel-priority: true
 
-  #   - name: Install anaconda client
-  #     shell: bash -el {0}
-  #     run: conda install -q -y anaconda-client "urllib3<2.0"
+    - name: Install anaconda client
+      shell: bash -el {0}
+      run: conda install -q -y anaconda-client "urllib3<2.0"
 
-  #   - name: Upload wheels to anaconda nightly
-  #     if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
-  #     shell: bash -el {0}
-  #     env:
-  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-  #     run: |
-  #       source ci/upload_wheels.sh
-  #       set_upload_vars
-  #       # trigger an upload to
-  #       # https://anaconda.org/daft-nightly/getdaft
-  #       # for cron jobs or "Run workflow" (restricted to main branch).
-  #       # Tags will upload to
-  #       # https://anaconda.org/daft/getdaft
-  #       # The tokens were originally generated at anaconda.org
-  #       upload_wheels
+    - name: Upload wheels to anaconda nightly
+      if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
+      shell: bash -el {0}
+      env:
+        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+      run: |
+        source ci/upload_wheels.sh
+        set_upload_vars
+        # trigger an upload to
+        # https://anaconda.org/daft-nightly/getdaft
+        # for cron jobs or "Run workflow" (restricted to main branch).
+        # Tags will upload to
+        # https://anaconda.org/daft/getdaft
+        # The tokens were originally generated at anaconda.org
+        upload_wheels
 
-  #   - name: Send Slack notification on failure
-  #     uses: slackapi/slack-github-action@v1.24.0
-  #     if: failure()
-  #     with:
-  #       payload: |
-  #         {
-  #           "blocks": [
-  #             {
-  #               "type": "section",
-  #               "text": {
-  #                 "type": "mrkdwn",
-  #                 "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-  #               }
-  #             }
-  #           ]
-  #         }
-  #     env:
-  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    - name: Send Slack notification on failure
+      uses: slackapi/slack-github-action@v1.24.0
+      if: failure()
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,20 +1,21 @@
 name: daft-publish
 
 on:
-  schedule:
-  #        ┌───────────── minute (0 - 59)
-  #        │  ┌───────────── hour (0 - 23)
-  #        │  │ ┌───────────── day of the month (1 - 31)
-  #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-  #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-  #        │  │ │ │ │
-  - cron: 0 5 * * *
+  # schedule:
+  # #        ┌───────────── minute (0 - 59)
+  # #        │  ┌───────────── hour (0 - 23)
+  # #        │  │ ┌───────────── day of the month (1 - 31)
+  # #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+  # #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+  # #        │  │ │ │ │
+  # - cron: 0 5 * * *
 
-  push:
-    tags:
-    - v*
-  workflow_dispatch:
-
+  # push:
+  #   tags:
+  #   - v*
+  # workflow_dispatch:
+  pull_request:
+    branches: [main]
 env:
   PACKAGE_NAME: getdaft
   PYTHON_VERSION: 3.7.16   # to build abi3 wheels
@@ -32,8 +33,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs: [ubuntu-latest, macos-latest-xl]
+        # runs: [ubuntu-latest, macos-latest-xl, windows-latest]
+        runs: [windows-latest]
         compile_arch: [x86_64, aarch64]
+        exclude:
+        - os: windows-latest
+          compile_arch: aarch64
     steps:
     - uses: actions/checkout@v4
       with:
@@ -46,15 +51,14 @@ jobs:
     - run: pip install -U twine toml
     - run: python tools/patch_package_version.py
     - uses: moonrepo/setup-rust@v0
-    - name: Build wheels - Mac x86
-      if: ${{ (matrix.runs == 'macos-latest-xl') && (matrix.compile_arch == 'x86_64')  }}
+    - name: Build wheels - Mac and Windows x86
+      if: ${{ ((matrix.runs == 'macos-latest-xl') || (matrix.runs == 'windows-latest')) && (matrix.compile_arch == 'x86_64')  }}
       uses: messense/maturin-action@v1
       with:
         target: x86_64
-        manylinux: auto
         args: --profile release-lto --out dist --sdist
       env:
-        RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
+        RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2
     - name: Build wheels - Linux x86
       if: ${{ (matrix.runs == 'ubuntu-latest') && (matrix.compile_arch == 'x86_64') }}
       uses: messense/maturin-action@v1
@@ -86,13 +90,20 @@ jobs:
       env:
         RUSTFLAGS: -Ctarget-cpu=apple-m1
 
-    - name: Install and test built wheel - x86_64
-      if: ${{ matrix.compile_arch == 'x86_64' }}
+    - name: Install and test built wheel - Linux and Mac x86_64
+      if: ${{ ((matrix.runs == 'macos-latest-xl') || (matrix.runs == 'ubuntu-latest')) && (matrix.compile_arch == 'x86_64')  }}
       run: |
         pip install -r requirements-dev.txt dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
         rm -rf daft
         pytest -v
 
+    - name: Install and test built wheel - Windows x86_64
+      if: ${{ (matrix.runs == 'windows-latest') && (matrix.compile_arch == 'x86_64')  }}
+      run: |
+        pip install -r requirements-dev.txt dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
+        rd -r daft
+        pytest -v
+  
     - name: Upload wheels
       uses: actions/upload-artifact@v3
       with:
@@ -120,75 +131,75 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
 
-  publish:
-    name: Publish wheels to PYPI and Anaconda
-    runs-on: ubuntu-latest
-    needs:
-    - build-and-test
-    steps:
-    - uses: actions/setup-python@v4
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-        architecture: x64
-    - run: pip install -U twine
-    - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v3
-      with:
-        name: wheels
-        path: dist
-    - run: ls -R ./dist
-    - name: Publish bdist package to PYPI
-      if: ${{ success() && (env.IS_PUSH == 'true') }}
-      run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  # publish:
+  #   name: Publish wheels to PYPI and Anaconda
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #   - build-and-test
+  #   steps:
+  #   - uses: actions/setup-python@v4
+  #     with:
+  #       python-version: ${{ env.PYTHON_VERSION }}
+  #       architecture: x64
+  #   - run: pip install -U twine
+  #   - uses: actions/checkout@v4
+  #   - uses: actions/download-artifact@v3
+  #     with:
+  #       name: wheels
+  #       path: dist
+  #   - run: ls -R ./dist
+  #   - name: Publish bdist package to PYPI
+  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
+  #     run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
+  #     env:
+  #       TWINE_USERNAME: __token__
+  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        # Really doesn't matter what version we upload with
-        # just the version we test with
-        python-version: '3.8'
-        channels: conda-forge
-        channel-priority: true
+  #   - uses: conda-incubator/setup-miniconda@v2
+  #     with:
+  #       # Really doesn't matter what version we upload with
+  #       # just the version we test with
+  #       python-version: '3.8'
+  #       channels: conda-forge
+  #       channel-priority: true
 
-    - name: Install anaconda client
-      shell: bash -el {0}
-      run: conda install -q -y anaconda-client "urllib3<2.0"
+  #   - name: Install anaconda client
+  #     shell: bash -el {0}
+  #     run: conda install -q -y anaconda-client "urllib3<2.0"
 
-    - name: Upload wheels to anaconda nightly
-      if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
-      shell: bash -el {0}
-      env:
-        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-      run: |
-        source ci/upload_wheels.sh
-        set_upload_vars
-        # trigger an upload to
-        # https://anaconda.org/daft-nightly/getdaft
-        # for cron jobs or "Run workflow" (restricted to main branch).
-        # Tags will upload to
-        # https://anaconda.org/daft/getdaft
-        # The tokens were originally generated at anaconda.org
-        upload_wheels
+  #   - name: Upload wheels to anaconda nightly
+  #     if: ${{ success() && (env.IS_SCHEDULE_DISPATCH == 'true' || env.IS_PUSH == 'true') }}
+  #     shell: bash -el {0}
+  #     env:
+  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+  #     run: |
+  #       source ci/upload_wheels.sh
+  #       set_upload_vars
+  #       # trigger an upload to
+  #       # https://anaconda.org/daft-nightly/getdaft
+  #       # for cron jobs or "Run workflow" (restricted to main branch).
+  #       # Tags will upload to
+  #       # https://anaconda.org/daft/getdaft
+  #       # The tokens were originally generated at anaconda.org
+  #       upload_wheels
 
-    - name: Send Slack notification on failure
-      uses: slackapi/slack-github-action@v1.24.0
-      if: failure()
-      with:
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-                }
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  #   - name: Send Slack notification on failure
+  #     uses: slackapi/slack-github-action@v1.24.0
+  #     if: failure()
+  #     with:
+  #       payload: |
+  #         {
+  #           "blocks": [
+  #             {
+  #               "type": "section",
+  #               "text": {
+  #                 "type": "mrkdwn",
+  #                 "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+  #               }
+  #             }
+  #           ]
+  #         }
+  #     env:
+  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import pathlib
 import sys
+import string
 import urllib.parse
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
@@ -102,6 +103,8 @@ def get_filesystem(protocol: str, **kwargs) -> fsspec.AbstractFileSystem:
 def get_protocol_from_path(path: str) -> str:
     parsed_scheme = urllib.parse.urlparse(path, allow_fragments=False).scheme
     if parsed_scheme == "" or parsed_scheme is None:
+        return "file"
+    if sys.platform == 'win32' and len(parsed_scheme) == 1 and parsed_scheme in string.ascii_letters:
         return "file"
     return parsed_scheme
 

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import pathlib
-import string
 import sys
 import urllib.parse
 from collections import defaultdict
@@ -105,7 +104,7 @@ def get_protocol_from_path(path: str) -> str:
     parsed_scheme = parsed_scheme.lower()
     if parsed_scheme == "" or parsed_scheme is None:
         return "file"
-    if sys.platform == "win32" and len(parsed_scheme) == 1 and ('a' <= parsed_scheme) and (parsed_scheme <= 'z'):
+    if sys.platform == "win32" and len(parsed_scheme) == 1 and ("a" <= parsed_scheme) and (parsed_scheme <= "z"):
         return "file"
     return parsed_scheme
 

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -102,9 +102,10 @@ def get_filesystem(protocol: str, **kwargs) -> fsspec.AbstractFileSystem:
 
 def get_protocol_from_path(path: str) -> str:
     parsed_scheme = urllib.parse.urlparse(path, allow_fragments=False).scheme
+    parsed_scheme = parsed_scheme.lower()
     if parsed_scheme == "" or parsed_scheme is None:
         return "file"
-    if sys.platform == "win32" and len(parsed_scheme) == 1 and parsed_scheme in string.ascii_letters:
+    if sys.platform == "win32" and len(parsed_scheme) == 1 and ('a' <= parsed_scheme) and (parsed_scheme <= 'z'):
         return "file"
     return parsed_scheme
 

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 import pathlib
-import sys
 import string
+import sys
 import urllib.parse
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
@@ -104,7 +104,7 @@ def get_protocol_from_path(path: str) -> str:
     parsed_scheme = urllib.parse.urlparse(path, allow_fragments=False).scheme
     if parsed_scheme == "" or parsed_scheme is None:
         return "file"
-    if sys.platform == 'win32' and len(parsed_scheme) == 1 and parsed_scheme in string.ascii_letters:
+    if sys.platform == "win32" and len(parsed_scheme) == 1 and parsed_scheme in string.ascii_letters:
         return "file"
     return parsed_scheme
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,8 +29,8 @@ Pillow==9.5.0
 opencv-python==4.8.0.76
 
 # Pyarrow
-pyarrow==12
-
+pyarrow==12; platform_system != "Windows"
+pyarrow==6.0.1; platform_system === "Windows"
 # Ray
 ray[data, default]==2.6.3
 pydantic<2  # pin pydantic because Ray uses broken APIs

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -250,6 +250,8 @@ fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
         "s3" => Ok((SourceType::S3, fixed_input)),
         "az" | "abfs" => Ok((SourceType::AzureBlob, fixed_input)),
         "gcs" | "gs" => Ok((SourceType::GCS, fixed_input)),
+        #[cfg(target_env = "msvc")]
+        _ if scheme.len() == 1 => k((SourceType::File, Cow::Owned(format!("file://{input}")))),
         _ => Err(Error::NotImplementedSource { store: scheme }),
     }
 }

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -251,7 +251,9 @@ fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
         "az" | "abfs" => Ok((SourceType::AzureBlob, fixed_input)),
         "gcs" | "gs" => Ok((SourceType::GCS, fixed_input)),
         #[cfg(target_env = "msvc")]
-        _ if scheme.len() == 1 && ("a" <= scheme.as_str() && (scheme.as_str() <= "z")) => Ok((SourceType::File, Cow::Owned(format!("file://{input}")))),
+        _ if scheme.len() == 1 && ("a" <= scheme.as_str() && (scheme.as_str() <= "z")) => {
+            Ok((SourceType::File, Cow::Owned(format!("file://{input}"))))
+        }
         _ => Err(Error::NotImplementedSource { store: scheme }),
     }
 }

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -251,7 +251,7 @@ fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
         "az" | "abfs" => Ok((SourceType::AzureBlob, fixed_input)),
         "gcs" | "gs" => Ok((SourceType::GCS, fixed_input)),
         #[cfg(target_env = "msvc")]
-        _ if scheme.len() == 1 => k((SourceType::File, Cow::Owned(format!("file://{input}")))),
+        _ if scheme.len() == 1 && ("a" <= scheme.as_str() && (scheme.as_str() <= "z")) => Ok((SourceType::File, Cow::Owned(format!("file://{input}")))),
         _ => Err(Error::NotImplementedSource { store: scheme }),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
+#[cfg(not(target_env = "msvc"))]
 union U {
     x: &'static u8,
     y: &'static libc::c_char,

--- a/tests/cookbook/test_dataloading.py
+++ b/tests/cookbook/test_dataloading.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import pathlib
 from unittest.mock import patch
+import sys
 
 import pandas as pd
 import pytest
@@ -120,7 +121,12 @@ def test_glob_files_directory(tmpdir):
         {"path": str(path.as_posix()), "size": size, "num_rows": None}
         for path, size in zip(filepaths, [i for i in range(10) for _ in range(2)])
     ]
-    listing_records = listing_records + [{"path": str(extra_empty_dir.as_posix()), "size": 0, "num_rows": None}]
+
+    dir_size = extra_empty_dir.stat().st_size
+    if sys.platform == 'win32':
+        dir_size = 0
+
+    listing_records = listing_records + [{"path": str(extra_empty_dir.as_posix()), "size": dir_size, "num_rows": None}]
     pd_df = pd.DataFrame.from_records(listing_records)
     pd_df = pd_df.astype({"num_rows": float})
     assert_df_equals(daft_pd_df, pd_df, sort_key="path")
@@ -142,7 +148,12 @@ def test_glob_files_recursive(tmpdir):
         {"path": str(path.as_posix()), "size": size, "num_rows": None}
         for path, size in zip(paths, [i for i in range(10) for _ in range(2)])
     ]
-    listing_records = listing_records + [{"path": str(nested_dir_path.as_posix()), "size": 0, "num_rows": None}]
+    dir_size = nested_dir_path.stat().st_size
+    if sys.platform == 'win32':
+        dir_size = 0
+        
+
+    listing_records = listing_records + [{"path": str(nested_dir_path.as_posix()), "size": dir_size, "num_rows": None}]
     pd_df = pd.DataFrame.from_records(listing_records)
     pd_df = pd_df.astype({"num_rows": float})
 

--- a/tests/cookbook/test_dataloading.py
+++ b/tests/cookbook/test_dataloading.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import os
 import pathlib
 from unittest.mock import patch
-import os
+
 import pandas as pd
 import pytest
 from fsspec.implementations.local import LocalFileSystem
@@ -119,9 +120,7 @@ def test_glob_files_directory(tmpdir):
         {"path": str(path.as_posix()), "size": size, "num_rows": None}
         for path, size in zip(filepaths, [i for i in range(10) for _ in range(2)])
     ]
-    listing_records = listing_records + [
-        {"path": str(extra_empty_dir.as_posix()), "size": 0, "num_rows": None}
-    ]
+    listing_records = listing_records + [{"path": str(extra_empty_dir.as_posix()), "size": 0, "num_rows": None}]
     pd_df = pd.DataFrame.from_records(listing_records)
     pd_df = pd_df.astype({"num_rows": float})
     assert_df_equals(daft_pd_df, pd_df, sort_key="path")
@@ -136,16 +135,14 @@ def test_glob_files_recursive(tmpdir):
             filepath = prefix / f"file_{i}.foo"
             filepath.write_text("a" * i)
             paths.append(filepath)
-    
+
     daft_df = daft.from_glob_path(os.path.join(tmpdir, "**"))
     daft_pd_df = daft_df.to_pandas()
     listing_records = [
         {"path": str(path.as_posix()), "size": size, "num_rows": None}
         for path, size in zip(paths, [i for i in range(10) for _ in range(2)])
     ]
-    listing_records = listing_records + [
-        {"path": str(nested_dir_path.as_posix()), "size": 0, "num_rows": None}
-    ]
+    listing_records = listing_records + [{"path": str(nested_dir_path.as_posix()), "size": 0, "num_rows": None}]
     pd_df = pd.DataFrame.from_records(listing_records)
     pd_df = pd_df.astype({"num_rows": float})
 

--- a/tests/cookbook/test_dataloading.py
+++ b/tests/cookbook/test_dataloading.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import os
 import pathlib
-from unittest.mock import patch
 import sys
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -123,7 +123,7 @@ def test_glob_files_directory(tmpdir):
     ]
 
     dir_size = extra_empty_dir.stat().st_size
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         dir_size = 0
 
     listing_records = listing_records + [{"path": str(extra_empty_dir.as_posix()), "size": dir_size, "num_rows": None}]
@@ -149,9 +149,8 @@ def test_glob_files_recursive(tmpdir):
         for path, size in zip(paths, [i for i in range(10) for _ in range(2)])
     ]
     dir_size = nested_dir_path.stat().st_size
-    if sys.platform == 'win32':
+    if sys.platform == "win32":
         dir_size = 0
-        
 
     listing_records = listing_records + [{"path": str(nested_dir_path.as_posix()), "size": dir_size, "num_rows": None}]
     pd_df = pd.DataFrame.from_records(listing_records)

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 import csv
 import decimal
 import json
+import os
 import tempfile
 import uuid
 from unittest.mock import MagicMock, patch
@@ -348,17 +350,22 @@ def test_load_pydict_types(data, expected_dtype):
 ###
 # CSV tests
 ###
+@contextlib.contextmanager
+def create_temp_filename() -> str:
+    with tempfile.TemporaryDirectory() as dir:
+        yield os.path.join(dir, "tempfile")
 
 
 def test_create_dataframe_csv(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        header = list(valid_data[0].keys())
-        writer = csv.writer(f)
-        writer.writerow(header)
-        writer.writerows([[item[col] for col in header] for item in valid_data])
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            header = list(valid_data[0].keys())
+            writer = csv.writer(f)
+            writer.writerow(header)
+            writer.writerows([[item[col] for col in header] for item in valid_data])
+            f.flush()
 
-        df = daft.read_csv(f.name)
+        df = daft.read_csv(fname)
         assert df.column_names == COL_NAMES
 
         pd_df = df.to_pandas()
@@ -367,15 +374,16 @@ def test_create_dataframe_csv(valid_data: list[dict[str, float]]) -> None:
 
 
 def test_create_dataframe_multiple_csvs(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f1, tempfile.NamedTemporaryFile("w") as f2:
-        for f in (f1, f2):
-            header = list(valid_data[0].keys())
-            writer = csv.writer(f)
-            writer.writerow(header)
-            writer.writerows([[item[col] for col in header] for item in valid_data])
-            f.flush()
+    with create_temp_filename() as f1name, create_temp_filename() as f2name:
+        with open(f1name, "w") as f1, open(f2name, "w") as f2:
+            for f in (f1, f2):
+                header = list(valid_data[0].keys())
+                writer = csv.writer(f)
+                writer.writerow(header)
+                writer.writerows([[item[col] for col in header] for item in valid_data])
+                f.flush()
 
-        df = daft.read_csv([f1.name, f2.name])
+        df = daft.read_csv([f1name, f2name])
         assert df.column_names == COL_NAMES
 
         pd_df = df.to_pandas()
@@ -388,12 +396,13 @@ def test_create_dataframe_multiple_csvs(valid_data: list[dict[str, float]]) -> N
     reason="requires PyRunner to be in use",
 )
 def test_create_dataframe_csv_custom_fs(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        header = list(valid_data[0].keys())
-        writer = csv.writer(f)
-        writer.writerow(header)
-        writer.writerows([[item[col] for col in header] for item in valid_data])
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            header = list(valid_data[0].keys())
+            writer = csv.writer(f)
+            writer.writerow(header)
+            writer.writerows([[item[col] for col in header] for item in valid_data])
+            f.flush()
 
         # Mark that this filesystem instance shouldn't be automatically reused by fsspec; without this,
         # fsspec would cache this instance and reuse it for Daft's default construction of filesystems,
@@ -403,7 +412,7 @@ def test_create_dataframe_csv_custom_fs(valid_data: list[dict[str, float]]) -> N
         with patch.object(fs, "info", wraps=fs.info) as mock_info, patch.object(
             fs, "open", wraps=fs.open
         ) as mock_open, patch("daft.filesystem._get_fs_from_cache", mock_cache):
-            df = daft.read_csv(f.name, fs=fs)
+            df = daft.read_csv(fname, fs=fs)
             # Check that info() is called on the passed filesystem.
             mock_info.assert_called()
 
@@ -418,14 +427,15 @@ def test_create_dataframe_csv_custom_fs(valid_data: list[dict[str, float]]) -> N
 
 
 def test_create_dataframe_csv_generate_headers(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        header = list(valid_data[0].keys())
-        writer = csv.writer(f)
-        writer.writerows([[item[col] for col in header] for item in valid_data])
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            header = list(valid_data[0].keys())
+            writer = csv.writer(f)
+            writer.writerows([[item[col] for col in header] for item in valid_data])
+            f.flush()
 
         cnames = [f"f{i}" for i in range(5)]
-        df = daft.read_csv(f.name, has_headers=False)
+        df = daft.read_csv(fname, has_headers=False)
         assert df.column_names == cnames
 
         pd_df = df.to_pandas()
@@ -434,16 +444,17 @@ def test_create_dataframe_csv_generate_headers(valid_data: list[dict[str, float]
 
 
 def test_create_dataframe_csv_column_projection(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        header = list(valid_data[0].keys())
-        writer = csv.writer(f)
-        writer.writerow(header)
-        writer.writerows([[item[col] for col in header] for item in valid_data])
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            header = list(valid_data[0].keys())
+            writer = csv.writer(f)
+            writer.writerow(header)
+            writer.writerows([[item[col] for col in header] for item in valid_data])
+            f.flush()
 
         col_subset = COL_NAMES[:3]
 
-        df = daft.read_csv(f.name)
+        df = daft.read_csv(fname)
         df = df.select(*col_subset)
         assert df.column_names == col_subset
 
@@ -453,14 +464,15 @@ def test_create_dataframe_csv_column_projection(valid_data: list[dict[str, float
 
 
 def test_create_dataframe_csv_custom_delimiter(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        header = list(valid_data[0].keys())
-        writer = csv.writer(f, delimiter="\t")
-        writer.writerow(header)
-        writer.writerows([[item[col] for col in header] for item in valid_data])
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            header = list(valid_data[0].keys())
+            writer = csv.writer(f, delimiter="\t")
+            writer.writerow(header)
+            writer.writerows([[item[col] for col in header] for item in valid_data])
+            f.flush()
 
-        df = daft.read_csv(f.name, delimiter="\t")
+        df = daft.read_csv(fname, delimiter="\t")
         assert df.column_names == COL_NAMES
 
         pd_df = df.to_pandas()
@@ -469,15 +481,16 @@ def test_create_dataframe_csv_custom_delimiter(valid_data: list[dict[str, float]
 
 
 def test_create_dataframe_csv_specify_schema(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        header = list(valid_data[0].keys())
-        writer = csv.writer(f, delimiter="\t")
-        writer.writerow(header)
-        writer.writerows([[item[col] for col in header] for item in valid_data])
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            header = list(valid_data[0].keys())
+            writer = csv.writer(f, delimiter="\t")
+            writer.writerow(header)
+            writer.writerows([[item[col] for col in header] for item in valid_data])
+            f.flush()
 
         df = daft.read_csv(
-            f.name,
+            fname,
             delimiter="\t",
             schema_hints={
                 "sepal_length": DataType.float32(),
@@ -495,14 +508,15 @@ def test_create_dataframe_csv_specify_schema(valid_data: list[dict[str, float]])
 
 
 def test_create_dataframe_csv_specify_schema_no_headers(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        header = list(valid_data[0].keys())
-        writer = csv.writer(f, delimiter="\t")
-        writer.writerows([[item[col] for col in header] for item in valid_data])
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            header = list(valid_data[0].keys())
+            writer = csv.writer(f, delimiter="\t")
+            writer.writerows([[item[col] for col in header] for item in valid_data])
+            f.flush()
 
         df = daft.read_csv(
-            f.name,
+            fname,
             delimiter="\t",
             schema_hints={
                 "sepal_length": DataType.float64(),
@@ -526,13 +540,14 @@ def test_create_dataframe_csv_specify_schema_no_headers(valid_data: list[dict[st
 
 
 def test_create_dataframe_json(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        for data in valid_data:
-            f.write(json.dumps(data))
-            f.write("\n")
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            for data in valid_data:
+                f.write(json.dumps(data))
+                f.write("\n")
+            f.flush()
 
-        df = daft.read_json(f.name)
+        df = daft.read_json(fname)
         assert df.column_names == COL_NAMES
 
         pd_df = df.to_pandas()
@@ -541,14 +556,15 @@ def test_create_dataframe_json(valid_data: list[dict[str, float]]) -> None:
 
 
 def test_create_dataframe_multiple_jsons(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f1, tempfile.NamedTemporaryFile("w") as f2:
-        for f in (f1, f2):
-            for data in valid_data:
-                f.write(json.dumps(data))
-                f.write("\n")
-            f.flush()
+    with create_temp_filename() as f1name, create_temp_filename() as f2name:
+        with open(f1name, "w") as f1, open(f2name, "w") as f2:
+            for f in (f1, f2):
+                for data in valid_data:
+                    f.write(json.dumps(data))
+                    f.write("\n")
+                f.flush()
 
-        df = daft.read_json([f1.name, f2.name])
+        df = daft.read_json([f1name, f2name])
         assert df.column_names == COL_NAMES
 
         pd_df = df.to_pandas()
@@ -561,11 +577,12 @@ def test_create_dataframe_multiple_jsons(valid_data: list[dict[str, float]]) -> 
     reason="requires PyRunner to be in use",
 )
 def test_create_dataframe_json_custom_fs(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        for data in valid_data:
-            f.write(json.dumps(data))
-            f.write("\n")
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            for data in valid_data:
+                f.write(json.dumps(data))
+                f.write("\n")
+            f.flush()
 
         # Mark that this filesystem instance shouldn't be automatically reused by fsspec; without this,
         # fsspec would cache this instance and reuse it for Daft's default construction of filesystems,
@@ -575,7 +592,7 @@ def test_create_dataframe_json_custom_fs(valid_data: list[dict[str, float]]) -> 
         with patch.object(fs, "info", wraps=fs.info) as mock_info, patch.object(
             fs, "open", wraps=fs.open
         ) as mock_open, patch("daft.filesystem._get_fs_from_cache", mock_cache):
-            df = daft.read_json(f.name, fs=fs)
+            df = daft.read_json(fname, fs=fs)
 
             # Check that info() is called on the passed filesystem.
             mock_info.assert_called()
@@ -591,15 +608,16 @@ def test_create_dataframe_json_custom_fs(valid_data: list[dict[str, float]]) -> 
 
 
 def test_create_dataframe_json_column_projection(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        for data in valid_data:
-            f.write(json.dumps(data))
-            f.write("\n")
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            for data in valid_data:
+                f.write(json.dumps(data))
+                f.write("\n")
+            f.flush()
 
         col_subset = COL_NAMES[:3]
 
-        df = daft.read_json(f.name)
+        df = daft.read_json(fname)
         df = df.select(*col_subset)
         assert df.column_names == col_subset
 
@@ -616,14 +634,15 @@ def test_create_dataframe_json_https() -> None:
 
 
 def test_create_dataframe_json_specify_schema(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        for data in valid_data:
-            f.write(json.dumps(data))
-            f.write("\n")
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            for data in valid_data:
+                f.write(json.dumps(data))
+                f.write("\n")
+            f.flush()
 
         df = daft.read_json(
-            f.name,
+            fname,
             schema_hints={
                 "sepal_length": DataType.float32(),
                 "sepal_width": DataType.float32(),
@@ -646,12 +665,13 @@ def test_create_dataframe_json_specify_schema(valid_data: list[dict[str, float]]
 
 @pytest.mark.parametrize("use_native_downloader", [True, False])
 def test_create_dataframe_parquet(valid_data: list[dict[str, float]], use_native_downloader) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
-        papq.write_table(table, f.name)
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
+            papq.write_table(table, f.name)
+            f.flush()
 
-        df = daft.read_parquet(f.name, use_native_downloader=use_native_downloader)
+        df = daft.read_parquet(fname, use_native_downloader=use_native_downloader)
         assert df.column_names == COL_NAMES
 
         pd_df = df.to_pandas()
@@ -661,12 +681,13 @@ def test_create_dataframe_parquet(valid_data: list[dict[str, float]], use_native
 
 @pytest.mark.parametrize("use_native_downloader", [True, False])
 def test_create_dataframe_parquet_with_filter(valid_data: list[dict[str, float]], use_native_downloader) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
-        papq.write_table(table, f.name)
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
+            papq.write_table(table, f.name)
+            f.flush()
 
-        df = daft.read_parquet(f.name, use_native_downloader=use_native_downloader)
+        df = daft.read_parquet(fname, use_native_downloader=use_native_downloader)
         assert df.column_names == COL_NAMES
 
         df = df.where(daft.col("sepal_length") > 4.8)
@@ -678,13 +699,14 @@ def test_create_dataframe_parquet_with_filter(valid_data: list[dict[str, float]]
 
 @pytest.mark.parametrize("use_native_downloader", [True, False])
 def test_create_dataframe_multiple_parquets(valid_data: list[dict[str, float]], use_native_downloader) -> None:
-    with tempfile.NamedTemporaryFile("w") as f1, tempfile.NamedTemporaryFile("w") as f2:
-        for f in (f1, f2):
-            table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
-            papq.write_table(table, f.name)
-            f.flush()
+    with create_temp_filename() as f1name, create_temp_filename() as f2name:
+        with open(f1name, "w") as f1, open(f2name, "w") as f2:
+            for f in (f1, f2):
+                table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
+                papq.write_table(table, f.name)
+                f.flush()
 
-        df = daft.read_parquet([f1.name, f2.name], use_native_downloader=use_native_downloader)
+        df = daft.read_parquet([f1name, f2name], use_native_downloader=use_native_downloader)
         assert df.column_names == COL_NAMES
 
         pd_df = df.to_pandas()
@@ -697,10 +719,11 @@ def test_create_dataframe_multiple_parquets(valid_data: list[dict[str, float]], 
     reason="requires PyRunner to be in use",
 )
 def test_create_dataframe_parquet_custom_fs(valid_data: list[dict[str, float]]) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
-        papq.write_table(table, f.name)
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
+            papq.write_table(table, f.name)
+            f.flush()
 
         # Mark that this filesystem instance shouldn't be automatically reused by fsspec; without this,
         # fsspec would cache this instance and reuse it for Daft's default construction of filesystems,
@@ -710,7 +733,7 @@ def test_create_dataframe_parquet_custom_fs(valid_data: list[dict[str, float]]) 
         with patch.object(fs, "info", wraps=fs.info) as mock_info, patch.object(
             fs, "open", wraps=fs.open
         ) as mock_open, patch("daft.filesystem._get_fs_from_cache", mock_cache):
-            df = daft.read_parquet(f.name, fs=fs)
+            df = daft.read_parquet(fname, fs=fs)
 
             # Check that info() is called on the passed filesystem.
             mock_info.assert_called()
@@ -727,14 +750,15 @@ def test_create_dataframe_parquet_custom_fs(valid_data: list[dict[str, float]]) 
 
 @pytest.mark.parametrize("use_native_downloader", [True, False])
 def test_create_dataframe_parquet_column_projection(valid_data: list[dict[str, float]], use_native_downloader) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
-        papq.write_table(table, f.name)
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
+            papq.write_table(table, fname)
+            f.flush()
 
         col_subset = COL_NAMES[:3]
 
-        df = daft.read_parquet(f.name, use_native_downloader=use_native_downloader)
+        df = daft.read_parquet(fname, use_native_downloader=use_native_downloader)
         df = df.select(*col_subset)
         assert df.column_names == col_subset
 
@@ -745,13 +769,14 @@ def test_create_dataframe_parquet_column_projection(valid_data: list[dict[str, f
 
 @pytest.mark.parametrize("use_native_downloader", [True, False])
 def test_create_dataframe_parquet_specify_schema(valid_data: list[dict[str, float]], use_native_downloader) -> None:
-    with tempfile.NamedTemporaryFile("w") as f:
-        table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
-        papq.write_table(table, f.name)
-        f.flush()
+    with create_temp_filename() as fname:
+        with open(fname, "w") as f:
+            table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
+            papq.write_table(table, fname)
+            f.flush()
 
         df = daft.read_parquet(
-            f.name,
+            fname,
             schema_hints={
                 "sepal_length": DataType.float64(),
                 "sepal_width": DataType.float64(),

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -323,7 +323,7 @@ def test_create_dataframe_pandas_tensor(valid_data: list[dict[str, float]]) -> N
             id="arrow_struct",
         ),
         pytest.param(
-            [np.array([1]), np.array([2]), np.array([3])],
+            [np.array([1], dtype=np.int64), np.array([2], dtype=np.int64), np.array([3], dtype=np.int64)],
             DataType.list(DataType.int64()),
             id="numpy_1d_arrays",
         ),

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -200,7 +200,7 @@ def test_repr_html_custom_hooks():
     df.collect()
 
     assert (
-        df.__repr__().replace('\r', '')
+        df.__repr__().replace("\r", "")
         == """+-------------------+-------------+----------------------------------+
 | objects           | np          | pil                              |
 | Python            | Python      | Python                           |

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -200,7 +200,7 @@ def test_repr_html_custom_hooks():
     df.collect()
 
     assert (
-        df.__repr__()
+        df.__repr__().replace('\r', '')
         == """+-------------------+-------------+----------------------------------+
 | objects           | np          | pil                              |
 | Python            | Python      | Python                           |

--- a/tests/integration/test_tpch.py
+++ b/tests/integration/test_tpch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pathlib
 import sqlite3
-
+import sys
 import pandas as pd
 import pytest
 from fsspec.implementations.local import LocalFileSystem
@@ -14,6 +14,9 @@ from tests.conftest import assert_df_equals
 
 # Hardcode scale factor to 200M for local testing
 SCALE_FACTOR = 0.2
+
+if sys.platform == 'win32':
+    pytest.skip(allow_module_level=True)
 
 
 @pytest.fixture(scope="session", autouse=True, params=[1, 2])

--- a/tests/integration/test_tpch.py
+++ b/tests/integration/test_tpch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pathlib
 import sqlite3
 import sys
+
 import pandas as pd
 import pytest
 from fsspec.implementations.local import LocalFileSystem
@@ -15,7 +16,7 @@ from tests.conftest import assert_df_equals
 # Hardcode scale factor to 200M for local testing
 SCALE_FACTOR = 0.2
 
-if sys.platform == 'win32':
+if sys.platform == "win32":
     pytest.skip(allow_module_level=True)
 
 

--- a/tests/series/test_concat.py
+++ b/tests/series/test_concat.py
@@ -99,9 +99,9 @@ def test_series_concat_tensor_array_ray(chunks) -> None:
     chunk_size = 3
     chunk_shape = (chunk_size,) + element_shape
     chunks = [
-        np.arange(i * chunk_size * num_elements_per_tensor, (i + 1) * chunk_size * num_elements_per_tensor, dtype=np.int64).reshape(
-            chunk_shape
-        )
+        np.arange(
+            i * chunk_size * num_elements_per_tensor, (i + 1) * chunk_size * num_elements_per_tensor, dtype=np.int64
+        ).reshape(chunk_shape)
         for i in range(chunks)
     ]
     series = [Series.from_arrow(ArrowTensorArray.from_numpy(chunk)) for chunk in chunks]

--- a/tests/series/test_concat.py
+++ b/tests/series/test_concat.py
@@ -99,7 +99,7 @@ def test_series_concat_tensor_array_ray(chunks) -> None:
     chunk_size = 3
     chunk_shape = (chunk_size,) + element_shape
     chunks = [
-        np.arange(i * chunk_size * num_elements_per_tensor, (i + 1) * chunk_size * num_elements_per_tensor).reshape(
+        np.arange(i * chunk_size * num_elements_per_tensor, (i + 1) * chunk_size * num_elements_per_tensor, dtype=np.int64).reshape(
             chunk_shape
         )
         for i in range(chunks)

--- a/tests/series/test_tensor.py
+++ b/tests/series/test_tensor.py
@@ -123,7 +123,7 @@ def test_tensor_repr():
     arrs = [arr, arr, None]
     s = Series.from_pylist(arrs, pyobj="allow")
     assert (
-        repr(s)
+        repr(s).replace('\r', '')
         == """
 +-----------------------+
 | list_series           |

--- a/tests/series/test_tensor.py
+++ b/tests/series/test_tensor.py
@@ -123,7 +123,7 @@ def test_tensor_repr():
     arrs = [arr, arr, None]
     s = Series.from_pylist(arrs, pyobj="allow")
     assert (
-        repr(s).replace('\r', '')
+        repr(s).replace("\r", "")
         == """
 +-----------------------+
 | list_series           |

--- a/tests/table/table_io/test_parquet.py
+++ b/tests/table/table_io/test_parquet.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import contextlib
 import datetime
+import os
 import pathlib
 import tempfile
-import os
+
 import pyarrow as pa
 import pyarrow.parquet as papq
 import pytest

--- a/tests/table/table_io/test_parquet.py
+++ b/tests/table/table_io/test_parquet.py
@@ -4,7 +4,7 @@ import contextlib
 import datetime
 import pathlib
 import tempfile
-
+import os
 import pyarrow as pa
 import pyarrow.parquet as papq
 import pytest
@@ -45,9 +45,10 @@ def test_read_input(tmpdir):
 
 @contextlib.contextmanager
 def _parquet_write_helper(data: pa.Table, row_group_size: int = None, papq_write_table_kwargs: dict = {}):
-    with tempfile.NamedTemporaryFile() as tmpfile:
-        papq.write_table(data, tmpfile.name, row_group_size=row_group_size, **papq_write_table_kwargs)
-        yield tmpfile.name
+    with tempfile.TemporaryDirectory() as directory_name:
+        file = os.path.join(directory_name, "tempfile")
+        papq.write_table(data, file, row_group_size=row_group_size, **papq_write_table_kwargs)
+        yield file
 
 
 @pytest.mark.parametrize(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -64,7 +64,7 @@ def test_schema_to_name_set():
 def test_repr():
     schema = TABLE.schema()
     assert (
-        repr(schema).replace('\r','')
+        repr(schema).replace("\r", "")
         == """+-------+---------+--------+---------+
 | int   | float   | string | bool    |
 | Int64 | Float64 | Utf8   | Boolean |

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -64,7 +64,7 @@ def test_schema_to_name_set():
 def test_repr():
     schema = TABLE.schema()
     assert (
-        repr(schema)
+        repr(schema).replace('\r','')
         == """+-------+---------+--------+---------+
 | int   | float   | string | bool    |
 | Int64 | Float64 | Utf8   | Boolean |

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import pathlib
-import uuid
 import sys
+import uuid
+
 import pandas as pd
 import pytest
 from fsspec.implementations.local import LocalFileSystem
@@ -17,7 +18,7 @@ def _get_filename():
     name = str(uuid.uuid4())
 
     # Inject colons into the name if not windows
-    if sys.platform != 'win32':
+    if sys.platform != "win32":
         name += ":foo:bar"
 
     return name

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pathlib
 import uuid
-
+import sys
 import pandas as pd
 import pytest
 from fsspec.implementations.local import LocalFileSystem
@@ -16,8 +16,9 @@ from tests.conftest import assert_df_equals
 def _get_filename():
     name = str(uuid.uuid4())
 
-    # Inject colons into the name
-    name += ":foo:bar"
+    # Inject colons into the name if not windows
+    if sys.platform != 'win32':
+        name += ":foo:bar"
 
     return name
 
@@ -39,7 +40,6 @@ def test_download(files, use_native_downloader):
         pd_df = pd.DataFrame.from_dict({"filenames": [str(f) for f in files]})
         pd_df["bytes"] = pd.Series([pathlib.Path(fn).read_bytes() for fn in files])
         assert_df_equals(df.to_pandas(), pd_df, sort_key="filenames")
-        print(_)
 
 
 @pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")


### PR DESCRIPTION
* Implements fixes for daft to be able to build for windows
* implements protocol checking in filesystem.py for windows style paths
* implements protocol checking in native local objectio for windows style paths.
* fix unit tests to use os libraries to construct path
* rewrite file io unit tests to not use a open file descriptor which breaks on windows
* disable AVX for x86 builds for mac and windows
* implement unit test, rust tests and import tests CI for windows 
* implements windows wheel building for publish pipeline
* disables query plan toggle for CI
* fix REPR style unit tests for `\r`