### PR TITLE
[FEAT] bulk parquet pyarrow reader

### DIFF
--- a/benchmarking/parquet/conftest.py
+++ b/benchmarking/parquet/conftest.py
@@ -80,6 +80,10 @@ def daft_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[p
     return [t.to_arrow() for t in tables]
 
 
+def daft_into_pyarrow_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[pa.Table]:
+    return daft.table.read_parquet_into_pyarrow_bulk(paths, columns=columns)
+
+
 def pyarrow_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[pa.Table]:
     return [pyarrow_read(f, columns=columns) for f in paths]
 
@@ -91,11 +95,13 @@ def boto_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[p
 @pytest.fixture(
     params=[
         daft_bulk_read,
+        daft_into_pyarrow_bulk_read,
         pyarrow_bulk_read,
         boto_bulk_read,
     ],
     ids=[
         "daft_bulk_read",
+        "daft_into_pyarrow_bulk_read",
         "pyarrow_bulk_read",
         "boto3_bulk_read",
     ],

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -391,6 +391,16 @@ def read_parquet_into_pyarrow(
     multithreaded_io: bool | None = None,
     coerce_int96_timestamp_unit: PyTimeUnit | None = None,
 ): ...
+def read_parquet_into_pyarrow_bulk(
+    uris: list[str],
+    columns: list[str] | None = None,
+    start_offset: int | None = None,
+    num_rows: int | None = None,
+    row_groups: list[list[int]] | None = None,
+    io_config: IOConfig | None = None,
+    multithreaded_io: bool | None = None,
+    coerce_int96_timestamp_unit: PyTimeUnit | None = None,
+): ...
 def read_parquet_schema(
     uri: str,
     io_config: IOConfig | None = None,

--- a/daft/table/__init__.py
+++ b/daft/table/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from .table import Table, read_parquet_into_pyarrow
+from .table import Table, read_parquet_into_pyarrow, read_parquet_into_pyarrow_bulk
 
-__all__ = ["Table", "read_parquet_into_pyarrow"]
+__all__ = ["Table", "read_parquet_into_pyarrow", "read_parquet_into_pyarrow_bulk"]

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -370,7 +370,6 @@ pub fn read_parquet_bulk(
     tables.into_iter().collect::<DaftResult<Vec<_>>>()
 }
 
-
 #[allow(clippy::too_many_arguments)]
 pub fn read_parquet_into_pyarrow_bulk(
     uris: &[&str],


### PR DESCRIPTION
* Adds a bulk reader `daft.table.read_parquet_into_pyarrow_bulk` for reading parquet into pyarrow tables
* TODO: Limit parallelism for parquet decoding.