### PR TITLE
[FEAT] [New Query Planner] Enable new query planner by default.

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -57,7 +57,7 @@ _RUNNER: Runner | None = None
 
 def _get_planner_from_env() -> bool:
     """Returns whether or not to use the new query planner."""
-    return bool(int(os.getenv("DAFT_NEW_QUERY_PLANNER", default="0")))
+    return bool(int(os.getenv("DAFT_NEW_QUERY_PLANNER", default="1")))
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Enable new query planner by default. We retain the feature flag + the old query planner for now, in case a nightly wheel user hits an issue that needs a quick workaround, so we also keep the query planner feature flag in the CI matrix.

We shouldn't merge this until:

- [x] Projection folding support is merged: https://github.com/Eventual-Inc/Daft/pull/1374