### PR TITLE
[FEAT] Native listing of http URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,7 @@ dependencies = [
  "openssl-sys",
  "pyo3",
  "pyo3-log",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
@@ -2066,9 +2067,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
@@ -2834,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2846,9 +2847,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2857,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -24,6 +24,7 @@ log = {workspace = true}
 openssl-sys = {version = "0.9.93", features = ["vendored"]}
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true, optional = true}
+regex = {version = "1.9.5"}
 serde = {workspace = true}
 serde_json = {workspace = true}
 snafu = {workspace = true}

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -225,7 +225,10 @@ impl ObjectSource for HttpSource {
         let response = request
             .send()
             .await
-            .context(UnableToConnectSnafu::<String> { path: path.into() })?;
+            .context(UnableToConnectSnafu::<String> { path: path.into() })?
+            .error_for_status()
+            .with_context(|_| UnableToOpenFileSnafu { path })?;
+
         match response.headers().get("content-type") {
             // If the content-type is text/html, we treat the data on this path as a traversable "directory"
             Some(header_value) if header_value.to_str().map_or(false, |v| v == "text/html") => {

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -14,6 +14,7 @@ use crate::object_io::{FileMetadata, FileType, LSResult};
 use super::object_io::{GetResult, ObjectSource};
 
 lazy_static! {
+    // Taken from: https://stackoverflow.com/a/15926317/3821154
     static ref HTML_A_TAG_HREF_RE: Regex =
         Regex::new(r#"<(a|A)\s+(?:[^>]*?\s+)?(href|HREF)=["'](?P<url>[^"']+)"#).unwrap();
 }

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -112,7 +112,9 @@ fn _get_file_metadata_from_html(path: &str, text: &str) -> super::Result<Vec<Fil
             };
             Ok(Some(FileMetadata {
                 filepath: absolute_path,
-                size: None, // TODO: fire HEAD requests to grab the content-length headers
+                // NOTE: This is consistent with fsspec behavior, but we may choose to HEAD the files to grab Content-Length
+                // for populating `size` if necessary
+                size: None,
                 filetype,
             }))
         })

--- a/tests/integration/docker-compose/nginx-serve-static-files.conf
+++ b/tests/integration/docker-compose/nginx-serve-static-files.conf
@@ -11,7 +11,7 @@ http {
         listen [::]:8080;
 
         resolver 127.0.0.11;
-        autoindex off;
+        autoindex on;
 
         server_name _;
         server_tokens off;

--- a/tests/integration/io/test_list_files_http.py
+++ b/tests/integration/io/test_list_files_http.py
@@ -10,8 +10,8 @@ from tests.integration.io.conftest import mount_data_nginx
 
 
 def compare_http_result(daft_ls_result: list, fsspec_result: list):
-    daft_files = [(f["path"], f["type"].lower()) for f in daft_ls_result]
-    httpfs_files = [(f["name"], f["type"]) for f in fsspec_result]
+    daft_files = [(f["path"], f["type"].lower(), f["size"]) for f in daft_ls_result]
+    httpfs_files = [(f["name"], f["type"], f["size"]) for f in fsspec_result]
     assert len(daft_files) == len(httpfs_files)
     assert sorted(daft_files) == sorted(httpfs_files)
 
@@ -61,7 +61,7 @@ def test_gs_single_file_listing(nginx_http_url):
     # fsspec_result = fs.ls(path, detail=True)
 
     assert len(daft_ls_result) == 1
-    assert daft_ls_result[0] == {"path": path, "size": None, "type": "File"}
+    assert daft_ls_result[0] == {"path": path, "size": 0, "type": "File"}
 
 
 @pytest.mark.integration()

--- a/tests/integration/io/test_list_files_http.py
+++ b/tests/integration/io/test_list_files_http.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fsspec.implementations.http import HTTPFileSystem
+
+from tests.integration.io.conftest import mount_data_nginx
+
+
+def compare_http_result(daft_ls_result: list, fsspec_result: list):
+    daft_files = [(f["path"], f["type"].lower()) for f in daft_ls_result]
+    gcsfs_files = [(f"http://{f['name']}", f["type"]) for f in fsspec_result]
+
+    # Perform necessary post-processing of fsspec results to match expected behavior from Daft:
+
+    # # NOTE: gcsfs sometimes does not return the trailing / for directories, so we have to ensure it
+    # gcsfs_files = [
+    #     (f"{path.rstrip('/')}/", type_) if type_ == "directory" else (path, type_) for path, type_ in gcsfs_files
+    # ]
+
+    # # NOTE: gcsfs will sometimes return 0-sized marker files for manually-created folders, which we ignore here
+    # # Be careful here because this will end up pruning any truly size-0 files that are actually files and not folders!
+    # size_0_files = {f"gs://{f['name']}" for f in fsspec_result if f["size"] == 0 and f["type"] == "file"}
+    # gcsfs_files = [(path, type_) for path, type_ in gcsfs_files if path not in size_0_files]
+
+    assert len(daft_files) == len(gcsfs_files)
+    assert sorted(daft_files) == sorted(gcsfs_files)
+
+
+@pytest.fixture(scope="module")
+def nginx_http_url(nginx_config, tmpdir_factory):
+    tmpdir = tmpdir_factory.mktemp("test-list-http")
+    data_path = Path(tmpdir)
+    (Path(data_path) / "file.txt").touch()
+    (Path(data_path) / "test_ls").mkdir()
+    (Path(data_path) / "test_ls" / "file.txt").touch()
+    (Path(data_path) / "test_ls" / "paginated-10-files").mkdir()
+    for i in range(10):
+        (Path(data_path) / "test_ls" / "paginated-10-files" / f"file.{i}.txt").touch()
+
+    with mount_data_nginx(nginx_config, data_path):
+        yield nginx_config[0]
+
+
+@pytest.mark.integration()
+@pytest.mark.parametrize(
+    "path",
+    [
+        f"",
+        f"/",
+        f"test_ls",
+        f"test_ls/",
+        f"test_ls/paginated-10-files/",
+    ],
+)
+def test_http_flat_directory_listing(path, nginx_http_url):
+    http_path = f"{nginx_http_url}/{path}"
+    fs = HTTPFileSystem()
+    fsspec_result = fs.ls(http_path, detail=True)
+    # compare_http_result(daft_ls_result, fsspec_result)
+
+
+# @pytest.mark.integration()
+# def test_gs_single_file_listing():
+#     path = f"gs://{BUCKET}/test_ls/file.txt"
+#     fs = gcsfs.GCSFileSystem()
+#     daft_ls_result = io_list(path)
+#     fsspec_result = fs.ls(path, detail=True)
+#     compare_http_result(daft_ls_result, fsspec_result)
+
+
+# @pytest.mark.integration()
+# def test_gs_notfound():
+#     path = f"gs://{BUCKET}/test_ls/MISSING"
+#     fs = gcsfs.GCSFileSystem()
+#     with pytest.raises(FileNotFoundError):
+#         fs.ls(path, detail=True)
+
+#     # NOTE: Google Cloud does not return a 404 to indicate anything missing, but just returns empty results
+#     # Thus Daft is unable to differentiate between "missing" folders and "empty" folders
+#     daft_ls_result = io_list(path)
+#     assert daft_ls_result == []
+
+
+# @pytest.mark.integration()
+# @pytest.mark.parametrize(
+#     "path",
+#     [
+#         f"gs://{BUCKET}/test_ls",
+#         f"gs://{BUCKET}/test_ls/",
+#     ],
+# )
+# def test_gs_flat_directory_listing_recursive(path):
+#     fs = gcsfs.GCSFileSystem()
+#     daft_ls_result = io_list(path, recursive=True)
+#     fsspec_result = list(fs.glob(path.rstrip("/") + "/**", detail=True).values())
+#     compare_gcs_result(daft_ls_result, fsspec_result)

--- a/tests/integration/io/test_list_files_http.py
+++ b/tests/integration/io/test_list_files_http.py
@@ -12,19 +12,6 @@ from tests.integration.io.conftest import mount_data_nginx
 def compare_http_result(daft_ls_result: list, fsspec_result: list):
     daft_files = [(f["path"], f["type"].lower()) for f in daft_ls_result]
     httpfs_files = [(f["name"], f["type"]) for f in fsspec_result]
-
-    # Perform necessary post-processing of fsspec results to match expected behavior from Daft:
-
-    # # NOTE: gcsfs sometimes does not return the trailing / for directories, so we have to ensure it
-    # gcsfs_files = [
-    #     (f"{path.rstrip('/')}/", type_) if type_ == "directory" else (path, type_) for path, type_ in gcsfs_files
-    # ]
-
-    # # NOTE: gcsfs will sometimes return 0-sized marker files for manually-created folders, which we ignore here
-    # # Be careful here because this will end up pruning any truly size-0 files that are actually files and not folders!
-    # size_0_files = {f"gs://{f['name']}" for f in fsspec_result if f["size"] == 0 and f["type"] == "file"}
-    # gcsfs_files = [(path, type_) for path, type_ in gcsfs_files if path not in size_0_files]
-
     assert len(daft_files) == len(httpfs_files)
     assert sorted(daft_files) == sorted(httpfs_files)
 
@@ -63,39 +50,42 @@ def test_http_flat_directory_listing(path, nginx_http_url):
     compare_http_result(daft_ls_result, fsspec_result)
 
 
-# @pytest.mark.integration()
-# def test_gs_single_file_listing():
-#     path = f"gs://{BUCKET}/test_ls/file.txt"
-#     fs = gcsfs.GCSFileSystem()
-#     daft_ls_result = io_list(path)
-#     fsspec_result = fs.ls(path, detail=True)
-#     compare_http_result(daft_ls_result, fsspec_result)
+@pytest.mark.integration()
+def test_gs_single_file_listing(nginx_http_url):
+    path = f"{nginx_http_url}/test_ls/file.txt"
+    daft_ls_result = io_list(path)
+
+    # NOTE: FSSpec will return size 0 list for this case, but we want to return 1 element to be
+    # consistent with behavior of our other file listing utilities
+    # fs = HTTPFileSystem()
+    # fsspec_result = fs.ls(path, detail=True)
+
+    assert len(daft_ls_result) == 1
+    assert daft_ls_result[0] == {"path": path, "size": 24, "type": "File"}
 
 
-# @pytest.mark.integration()
-# def test_gs_notfound():
-#     path = f"gs://{BUCKET}/test_ls/MISSING"
-#     fs = gcsfs.GCSFileSystem()
-#     with pytest.raises(FileNotFoundError):
-#         fs.ls(path, detail=True)
+@pytest.mark.integration()
+def test_http_notfound(nginx_http_url):
+    path = f"{nginx_http_url}/test_ls/MISSING"
+    fs = HTTPFileSystem()
+    with pytest.raises(FileNotFoundError, match=path):
+        fs.ls(path, detail=True)
 
-#     # NOTE: Google Cloud does not return a 404 to indicate anything missing, but just returns empty results
-#     # Thus Daft is unable to differentiate between "missing" folders and "empty" folders
-#     daft_ls_result = io_list(path)
-#     assert daft_ls_result == []
+    with pytest.raises(FileNotFoundError, match=path):
+        io_list(path)
 
 
-# @pytest.mark.integration()
-# @pytest.mark.parametrize(
-#     "path",
-#     [
-#         f"",
-#         f"/",
-#     ],
-# )
-# def test_http_flat_directory_listing_recursive(path, nginx_http_url):
-#     http_path = f"{nginx_http_url}/{path}"
-#     fs = HTTPFileSystem()
-#     fsspec_result = list(fs.glob(http_path.rstrip("/") + "/**", detail=True).values())
-#     # daft_ls_result = io_list(http_path, recursive=True)
-#     # compare_http_result(daft_ls_result, fsspec_result)
+@pytest.mark.integration()
+@pytest.mark.parametrize(
+    "path",
+    [
+        f"",
+        f"/",
+    ],
+)
+def test_http_flat_directory_listing_recursive(path, nginx_http_url):
+    http_path = f"{nginx_http_url}/{path}"
+    fs = HTTPFileSystem()
+    fsspec_result = list(fs.glob(http_path.rstrip("/") + "/**", detail=True).values())
+    daft_ls_result = io_list(http_path, recursive=True)
+    compare_http_result(daft_ls_result, fsspec_result)

--- a/tests/integration/io/test_list_files_http.py
+++ b/tests/integration/io/test_list_files_http.py
@@ -39,6 +39,7 @@ def nginx_http_url(nginx_config, tmpdir_factory):
         f"/",
         f"test_ls",
         f"test_ls/",
+        f"test_ls//",
         f"test_ls/paginated-10-files/",
     ],
 )

--- a/tests/integration/io/test_list_files_http.py
+++ b/tests/integration/io/test_list_files_http.py
@@ -61,7 +61,7 @@ def test_gs_single_file_listing(nginx_http_url):
     # fsspec_result = fs.ls(path, detail=True)
 
     assert len(daft_ls_result) == 1
-    assert daft_ls_result[0] == {"path": path, "size": 24, "type": "File"}
+    assert daft_ls_result[0] == {"path": path, "size": None, "type": "File"}
 
 
 @pytest.mark.integration()

--- a/tests/integration/io/test_list_files_http.py
+++ b/tests/integration/io/test_list_files_http.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from fsspec.implementations.http import HTTPFileSystem
 
+from daft.daft import io_list
 from tests.integration.io.conftest import mount_data_nginx
 
 
@@ -58,7 +59,8 @@ def test_http_flat_directory_listing(path, nginx_http_url):
     http_path = f"{nginx_http_url}/{path}"
     fs = HTTPFileSystem()
     fsspec_result = fs.ls(http_path, detail=True)
-    # compare_http_result(daft_ls_result, fsspec_result)
+    daft_ls_result = io_list(http_path)
+    compare_http_result(daft_ls_result, fsspec_result)
 
 
 # @pytest.mark.integration()

--- a/tests/integration/io/test_list_files_http.py
+++ b/tests/integration/io/test_list_files_http.py
@@ -11,7 +11,7 @@ from tests.integration.io.conftest import mount_data_nginx
 
 def compare_http_result(daft_ls_result: list, fsspec_result: list):
     daft_files = [(f["path"], f["type"].lower()) for f in daft_ls_result]
-    gcsfs_files = [(f"http://{f['name']}", f["type"]) for f in fsspec_result]
+    httpfs_files = [(f["name"], f["type"]) for f in fsspec_result]
 
     # Perform necessary post-processing of fsspec results to match expected behavior from Daft:
 
@@ -25,8 +25,8 @@ def compare_http_result(daft_ls_result: list, fsspec_result: list):
     # size_0_files = {f"gs://{f['name']}" for f in fsspec_result if f["size"] == 0 and f["type"] == "file"}
     # gcsfs_files = [(path, type_) for path, type_ in gcsfs_files if path not in size_0_files]
 
-    assert len(daft_files) == len(gcsfs_files)
-    assert sorted(daft_files) == sorted(gcsfs_files)
+    assert len(daft_files) == len(httpfs_files)
+    assert sorted(daft_files) == sorted(httpfs_files)
 
 
 @pytest.fixture(scope="module")
@@ -89,12 +89,13 @@ def test_http_flat_directory_listing(path, nginx_http_url):
 # @pytest.mark.parametrize(
 #     "path",
 #     [
-#         f"gs://{BUCKET}/test_ls",
-#         f"gs://{BUCKET}/test_ls/",
+#         f"",
+#         f"/",
 #     ],
 # )
-# def test_gs_flat_directory_listing_recursive(path):
-#     fs = gcsfs.GCSFileSystem()
-#     daft_ls_result = io_list(path, recursive=True)
-#     fsspec_result = list(fs.glob(path.rstrip("/") + "/**", detail=True).values())
-#     compare_gcs_result(daft_ls_result, fsspec_result)
+# def test_http_flat_directory_listing_recursive(path, nginx_http_url):
+#     http_path = f"{nginx_http_url}/{path}"
+#     fs = HTTPFileSystem()
+#     fsspec_result = list(fs.glob(http_path.rstrip("/") + "/**", detail=True).values())
+#     # daft_ls_result = io_list(http_path, recursive=True)
+#     # compare_http_result(daft_ls_result, fsspec_result)


### PR DESCRIPTION
Adds capabilities for our HTTP source to perform file listing

Logic is roughly adapted from fsspec's [HTTPFileSystem](https://filesystem-spec.readthedocs.io/en/latest/_modules/fsspec/implementations/http.html) in order to maintain some parity with how it behaves.

Current differences in behavior:

1. We don't support fsspec's `simple_links=True` option, which would search for any text starting with `http(s)://` and that aren't encased in a HTML `<a href=...>` tag.
2. When pointed at a single file, fsspec returns an empty list but we detect whether the file is HTML and return a list with just the file itself if we see that it is not HTML.