### PR TITLE
[BUG] Fix gs listing to include 0 sized marker files

### DIFF
--- a/src/daft-io/src/google_cloud.rs
+++ b/src/daft-io/src/google_cloud.rs
@@ -45,7 +45,7 @@ enum Error {
     },
 
     #[snafu(display("Not a File: \"{}\"", path))]
-    NotAFile { path: String },
+    NotFound { path: String },
 }
 
 impl From<Error> for super::Error {
@@ -90,7 +90,10 @@ impl From<Error> for super::Error {
                     source: err,
                 },
             },
-            NotAFile { path } => super::Error::NotAFile { path },
+            NotFound { ref path } => super::Error::NotFound {
+                path: path.into(),
+                source: error.into(),
+            },
             InvalidUrl { path, source } => super::Error::InvalidUrl { path, source },
             UnableToLoadCredentials { source } => super::Error::UnableToLoadCredentials {
                 store: super::SourceType::GCS,
@@ -215,17 +218,10 @@ impl GCSClientWrapper {
             })?;
         let response_items = ls_response.items.unwrap_or_default();
         let response_prefixes = ls_response.prefixes.unwrap_or_default();
-        let files = response_items.iter().filter_map(|obj| {
-            if obj.name.ends_with('/') {
-                // Sometimes the GCS API returns "folders" in .items[], so we manually filter here
-                None
-            } else {
-                Some(FileMetadata {
-                    filepath: format!("gs://{}/{}", bucket, obj.name),
-                    size: Some(obj.size as u64),
-                    filetype: FileType::File,
-                })
-            }
+        let files = response_items.iter().map(|obj| FileMetadata {
+            filepath: format!("gs://{}/{}", bucket, obj.name),
+            size: Some(obj.size as u64),
+            filetype: FileType::File,
         });
         let dirs = response_prefixes.iter().map(|pref| FileMetadata {
             filepath: format!("gs://{}/{}", bucket, pref),
@@ -249,8 +245,6 @@ impl GCSClientWrapper {
         match self {
             GCSClientWrapper::Native(client) => {
                 // Attempt to forcefully ls the key as a directory (by ensuring a "/" suffix)
-                // If no items were obtained, then this is actually a file and we perform a second ls to obtain just the file's
-                // details as the one-and-only-one entry
                 let forced_directory_key = format!("{}/", key.strip_suffix('/').unwrap_or(key));
                 let forced_directory_ls_result = self
                     ._ls_impl(
@@ -261,9 +255,23 @@ impl GCSClientWrapper {
                         continuation_token,
                     )
                     .await?;
+
+                // If no items were obtained, then this is actually a file and we perform a second ls to obtain just the file's
+                // details as the one-and-only-one entry
                 if forced_directory_ls_result.files.is_empty() {
-                    self._ls_impl(client, bucket, key, delimiter, continuation_token)
-                        .await
+                    let file_result = self
+                        ._ls_impl(client, bucket, key, delimiter, continuation_token)
+                        .await?;
+
+                    // Not dir and not file, so it is missing
+                    if file_result.files.is_empty() {
+                        return Err(Error::NotFound {
+                            path: path.to_string(),
+                        }
+                        .into());
+                    }
+
+                    Ok(file_result)
                 } else {
                     Ok(forced_directory_ls_result)
                 }

--- a/tests/integration/io/test_list_files_gcs.py
+++ b/tests/integration/io/test_list_files_gcs.py
@@ -48,19 +48,21 @@ def compare_gcs_result(daft_ls_result: list, fsspec_result: list):
         f"gs://{BUCKET}/test_ls/paginated-1100-files/",
     ],
 )
-def test_gs_flat_directory_listing(path):
+@pytest.mark.parametrize("recursive", [False, True])
+def test_gs_flat_directory_listing(path, recursive):
     fs = gcsfs.GCSFileSystem()
-    daft_ls_result = io_list(path)
-    fsspec_result = fs.ls(path, detail=True)
+    daft_ls_result = io_list(path, recursive=recursive)
+    fsspec_result = gcsfs_recursive_list(fs, path) if recursive else fs.ls(path, detail=True)
     compare_gcs_result(daft_ls_result, fsspec_result)
 
 
 @pytest.mark.integration()
-def test_gs_single_file_listing():
+@pytest.mark.parametrize("recursive", [False, True])
+def test_gs_single_file_listing(recursive):
     path = f"gs://{BUCKET}/test_ls/file.txt"
     fs = gcsfs.GCSFileSystem()
-    daft_ls_result = io_list(path)
-    fsspec_result = fs.ls(path, detail=True)
+    daft_ls_result = io_list(path, recursive=recursive)
+    fsspec_result = gcsfs_recursive_list(fs, path) if recursive else fs.ls(path, detail=True)
     compare_gcs_result(daft_ls_result, fsspec_result)
 
 
@@ -72,18 +74,3 @@ def test_gs_notfound():
         fs.ls(path, detail=True)
     with pytest.raises(FileNotFoundError, match=path):
         io_list(path)
-
-
-@pytest.mark.integration()
-@pytest.mark.parametrize(
-    "path",
-    [
-        f"gs://{BUCKET}/test_ls",
-        f"gs://{BUCKET}/test_ls/",
-    ],
-)
-def test_gs_flat_directory_listing_recursive(path):
-    fs = gcsfs.GCSFileSystem()
-    daft_ls_result = io_list(path, recursive=True)
-    fsspec_result = gcsfs_recursive_list(fs, path)
-    compare_gcs_result(daft_ls_result, fsspec_result)

--- a/tests/integration/io/test_list_files_gcs.py
+++ b/tests/integration/io/test_list_files_gcs.py
@@ -30,7 +30,7 @@ def compare_gcs_result(daft_ls_result: list, fsspec_result: list):
         f"gs://{BUCKET}/",
         f"gs://{BUCKET}/test_ls",
         f"gs://{BUCKET}/test_ls/",
-        # f"gs://{BUCKET}/test_ls//",
+        f"gs://{BUCKET}/test_ls//",
         f"gs://{BUCKET}/test_ls/paginated-1100-files/",
     ],
 )

--- a/tests/integration/io/test_list_files_gcs.py
+++ b/tests/integration/io/test_list_files_gcs.py
@@ -13,16 +13,10 @@ def compare_gcs_result(daft_ls_result: list, fsspec_result: list):
     gcsfs_files = [(f"gs://{f['name']}", f["type"]) for f in fsspec_result]
 
     # Perform necessary post-processing of fsspec results to match expected behavior from Daft:
-
     # NOTE: gcsfs sometimes does not return the trailing / for directories, so we have to ensure it
     gcsfs_files = [
         (f"{path.rstrip('/')}/", type_) if type_ == "directory" else (path, type_) for path, type_ in gcsfs_files
     ]
-
-    # NOTE: gcsfs will sometimes return 0-sized marker files for manually-created folders, which we ignore here
-    # Be careful here because this will end up pruning any truly size-0 files that are actually files and not folders!
-    size_0_files = {f"gs://{f['name']}" for f in fsspec_result if f["size"] == 0 and f["type"] == "file"}
-    gcsfs_files = [(path, type_) for path, type_ in gcsfs_files if path not in size_0_files]
 
     assert len(daft_files) == len(gcsfs_files)
     assert sorted(daft_files) == sorted(gcsfs_files)
@@ -36,6 +30,7 @@ def compare_gcs_result(daft_ls_result: list, fsspec_result: list):
         f"gs://{BUCKET}/",
         f"gs://{BUCKET}/test_ls",
         f"gs://{BUCKET}/test_ls/",
+        # f"gs://{BUCKET}/test_ls//",
         f"gs://{BUCKET}/test_ls/paginated-1100-files/",
     ],
 )
@@ -61,11 +56,8 @@ def test_gs_notfound():
     fs = gcsfs.GCSFileSystem()
     with pytest.raises(FileNotFoundError):
         fs.ls(path, detail=True)
-
-    # NOTE: Google Cloud does not return a 404 to indicate anything missing, but just returns empty results
-    # Thus Daft is unable to differentiate between "missing" folders and "empty" folders
-    daft_ls_result = io_list(path)
-    assert daft_ls_result == []
+    with pytest.raises(FileNotFoundError, match=path):
+        io_list(path)
 
 
 @pytest.mark.integration()


### PR DESCRIPTION
* Fix gs listing to include 0 sized marker files (these files are created when manually creating folders in the UI)
* Fixes also for multiple trailing delimiters
* More test coverage for recursive cases