### PR TITLE
[BUG] Fix num input partitions in coalesce.

### DIFF
--- a/src/daft-plan/src/planner.rs
+++ b/src/daft-plan/src/planner.rs
@@ -171,7 +171,7 @@ pub fn plan(logical_plan: &LogicalPlan) -> DaftResult<PhysicalPlan> {
             let input_physical = plan(input)?;
             Ok(PhysicalPlan::Coalesce(Coalesce::new(
                 input_physical.into(),
-                logical_plan.partition_spec().num_partitions,
+                input.partition_spec().num_partitions,
                 *num_to,
             )))
         }

--- a/tests/dataframe/test_repartition.py
+++ b/tests/dataframe/test_repartition.py
@@ -7,3 +7,9 @@ def test_into_partitions_some_empty() -> None:
     data = {"foo": [1, 2, 3]}
     df = daft.from_pydict(data).into_partitions(32).collect()
     assert df.to_pydict() == data
+
+
+def test_into_partitions_coalesce() -> None:
+    data = {"foo": list(range(100))}
+    df = daft.from_pydict(data).into_partitions(20).into_partitions(1).collect()
+    assert df.to_pydict() == data


### PR DESCRIPTION
This PR fixes the number of input partitions in our `Coalesce` implementation. The new query planner was incorrectly using the current logical node's `num_partitions` for the number of _input_ partitions, which for a `Coalesce` op, is equal to the _output_ number of partitions; we should instead be using the input (child) logical node's `num_partitions`.

The microbenchmarking failure also illustrated that we didn't have any unit testing coverage of `Coalesce` (i.e. `df.into_partitions(n)` where `n` is smaller than the current number of partitions), so we also add a sanity unit test.

Closes #1434 