### PR TITLE
[PERF] Native globbing early stopping

### DIFF
--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -432,6 +432,7 @@ impl ObjectSource for AzureBlobSource {
         uri: &str,
         delimiter: &str,
         posix: bool,
+        _page_size: Option<i32>,
         _limit: Option<usize>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         let uri = url::Url::parse(uri).with_context(|_| InvalidUrlSnafu { path: uri })?;
@@ -480,6 +481,7 @@ impl ObjectSource for AzureBlobSource {
         delimiter: &str,
         posix: bool,
         continuation_token: Option<&str>,
+        page_size: Option<i32>,
     ) -> super::Result<LSResult> {
         // It looks like the azure rust library API
         // does not currently allow using the continuation token:
@@ -494,7 +496,7 @@ impl ObjectSource for AzureBlobSource {
         }?;
 
         let files = self
-            .iter_dir(path, delimiter, posix, None)
+            .iter_dir(path, delimiter, posix, page_size, None)
             .await?
             .try_collect::<Vec<_>>()
             .await?;

--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -430,11 +430,11 @@ impl ObjectSource for AzureBlobSource {
     async fn iter_dir(
         &self,
         uri: &str,
-        delimiter: Option<&str>,
+        delimiter: &str,
+        _posix: bool,
         _limit: Option<usize>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         let uri = url::Url::parse(uri).with_context(|_| InvalidUrlSnafu { path: uri })?;
-        let delimiter = delimiter.unwrap_or("/");
 
         // path can be root (buckets) or path prefix within a bucket.
         let container = {
@@ -473,7 +473,8 @@ impl ObjectSource for AzureBlobSource {
     async fn ls(
         &self,
         path: &str,
-        delimiter: Option<&str>,
+        delimiter: &str,
+        posix: bool,
         continuation_token: Option<&str>,
     ) -> super::Result<LSResult> {
         // It looks like the azure rust library API
@@ -489,7 +490,7 @@ impl ObjectSource for AzureBlobSource {
         }?;
 
         let files = self
-            .iter_dir(path, delimiter, None)
+            .iter_dir(path, delimiter, posix, None)
             .await?
             .try_collect::<Vec<_>>()
             .await?;

--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -431,10 +431,14 @@ impl ObjectSource for AzureBlobSource {
         &self,
         uri: &str,
         delimiter: &str,
-        _posix: bool,
+        posix: bool,
         _limit: Option<usize>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         let uri = url::Url::parse(uri).with_context(|_| InvalidUrlSnafu { path: uri })?;
+
+        if !posix {
+            todo!("Prefix-listing is not yet implemented for Azure");
+        }
 
         // path can be root (buckets) or path prefix within a bucket.
         let container = {

--- a/src/daft-io/src/glob.rs
+++ b/src/daft-io/src/glob.rs
@@ -29,6 +29,7 @@ pub(crate) struct GlobState {
     pub glob_fragments: Arc<Vec<GlobFragment>>,
     pub full_glob_matcher: Arc<GlobMatcher>,
     pub fanout_limit: usize,
+    pub page_size: Option<i32>,
 }
 
 impl GlobState {

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -228,6 +228,7 @@ impl ObjectSource for HttpSource {
         _delimiter: &str,
         posix: bool,
         _continuation_token: Option<&str>,
+        _page_size: Option<i32>,
     ) -> super::Result<LSResult> {
         if !posix {
             todo!("Prefix-listing is not implemented for HTTP listing");

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -226,9 +226,13 @@ impl ObjectSource for HttpSource {
         &self,
         path: &str,
         _delimiter: &str,
-        _posix: bool,
+        posix: bool,
         _continuation_token: Option<&str>,
     ) -> super::Result<LSResult> {
+        if !posix {
+            todo!("Prefix-listing is not implemented for HTTP listing");
+        }
+
         let request = self.client.get(path);
         let response = request
             .send()

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -225,7 +225,8 @@ impl ObjectSource for HttpSource {
     async fn ls(
         &self,
         path: &str,
-        _delimiter: Option<&str>,
+        _delimiter: &str,
+        _posix: bool,
         _continuation_token: Option<&str>,
     ) -> super::Result<LSResult> {
         let request = self.client.get(path);

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -132,10 +132,11 @@ impl ObjectSource for LocalSource {
     async fn ls(
         &self,
         path: &str,
-        _delimiter: Option<&str>,
+        delimiter: &str,
+        posix: bool,
         _continuation_token: Option<&str>,
     ) -> super::Result<LSResult> {
-        let s = self.iter_dir(path, None, None).await?;
+        let s = self.iter_dir(path, delimiter, posix, None).await?;
         let files = s.try_collect::<Vec<_>>().await?;
         Ok(LSResult {
             files,
@@ -146,7 +147,8 @@ impl ObjectSource for LocalSource {
     async fn iter_dir(
         &self,
         uri: &str,
-        _delimiter: Option<&str>,
+        _delimiter: &str,
+        _posix: bool,
         _limit: Option<usize>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         const LOCAL_PROTOCOL: &str = "file://";
@@ -324,7 +326,7 @@ mod tests {
         let dir_path = format!("file://{}", dir.path().to_string_lossy());
         let client = LocalSource::get_client().await?;
 
-        let ls_result = client.ls(dir_path.as_ref(), None, None).await?;
+        let ls_result = client.ls(dir_path.as_ref(), "/", true, None).await?;
         let mut files = ls_result.files.clone();
         // Ensure stable sort ordering of file paths before comparing with expected payload.
         files.sort_by(|a, b| a.filepath.cmp(&b.filepath));

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -135,8 +135,11 @@ impl ObjectSource for LocalSource {
         delimiter: &str,
         posix: bool,
         _continuation_token: Option<&str>,
+        page_size: Option<i32>,
     ) -> super::Result<LSResult> {
-        let s = self.iter_dir(path, delimiter, posix, None).await?;
+        let s = self
+            .iter_dir(path, delimiter, posix, page_size, None)
+            .await?;
         let files = s.try_collect::<Vec<_>>().await?;
         Ok(LSResult {
             files,
@@ -149,6 +152,7 @@ impl ObjectSource for LocalSource {
         uri: &str,
         _delimiter: &str,
         posix: bool,
+        _page_size: Option<i32>,
         _limit: Option<usize>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         if !posix {
@@ -330,7 +334,7 @@ mod tests {
         let dir_path = format!("file://{}", dir.path().to_string_lossy());
         let client = LocalSource::get_client().await?;
 
-        let ls_result = client.ls(dir_path.as_ref(), "/", true, None).await?;
+        let ls_result = client.ls(dir_path.as_ref(), "/", true, None, None).await?;
         let mut files = ls_result.files.clone();
         // Ensure stable sort ordering of file paths before comparing with expected payload.
         files.sort_by(|a, b| a.filepath.cmp(&b.filepath));

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -148,9 +148,13 @@ impl ObjectSource for LocalSource {
         &self,
         uri: &str,
         _delimiter: &str,
-        _posix: bool,
+        posix: bool,
         _limit: Option<usize>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
+        if !posix {
+            todo!("Prefix-listing is not implemented for local");
+        }
+
         const LOCAL_PROTOCOL: &str = "file://";
         let Some(uri) = uri.strip_prefix(LOCAL_PROTOCOL) else {
             return Err(Error::InvalidFilePath { path: uri.into() }.into());

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -428,29 +428,29 @@ pub(crate) async fn glob(
                 while let Some(val) = results.next().await {
                     match val {
                         Ok(fm) => match fm.filetype {
-                            FileType::Directory => {
+                            FileType::Directory
                                 if partial_glob_matcher
-                                    .is_match(fm.filepath.as_str().trim_end_matches('/'))
-                                {
-                                    visit(
-                                        result_tx.clone(),
-                                        source.clone(),
-                                        state
-                                            .clone()
-                                            .advance(
-                                                fm.filepath,
-                                                state.current_fragment_idx + 1,
-                                                stream_dir_count,
-                                            )
-                                            .with_wildcard_mode(),
-                                    );
-                                }
+                                    .is_match(fm.filepath.as_str().trim_end_matches('/')) =>
+                            {
+                                visit(
+                                    result_tx.clone(),
+                                    source.clone(),
+                                    state
+                                        .clone()
+                                        .advance(
+                                            fm.filepath,
+                                            state.current_fragment_idx + 1,
+                                            stream_dir_count,
+                                        )
+                                        .with_wildcard_mode(),
+                                );
                             }
-                            FileType::File => {
-                                if state.full_glob_matcher.is_match(fm.filepath.as_str()) {
-                                    result_tx.send(Ok(fm)).await.expect("Internal multithreading channel is broken: results may be incorrect");
-                                }
+                            FileType::File
+                                if state.full_glob_matcher.is_match(fm.filepath.as_str()) =>
+                            {
+                                result_tx.send(Ok(fm)).await.expect("Internal multithreading channel is broken: results may be incorrect");
                             }
+                            _ => (),
                         },
                         // Always silence NotFound since we are in wildcard "search" mode here by definition
                         Err(super::Error::NotFound { .. }) => (),

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -457,7 +457,9 @@ pub(crate) async fn glob(
                 visit(
                     result_tx.clone(),
                     source.clone(),
-                    state.clone().advance(full_dir_path, state.current_fragment_idx + 1, 1),
+                    state
+                        .clone()
+                        .advance(full_dir_path, state.current_fragment_idx + 1, 1),
                 );
             }
         });

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -129,6 +129,10 @@ pub(crate) trait ObjectSource: Sync + Send {
         let delimiter = delimiter.to_string();
         let s = stream! {
             let lsr = self.ls(&uri, delimiter.as_str(), posix, None, page_size).await?;
+            for fm in lsr.files {
+                yield Ok(fm);
+            }
+
             let mut continuation_token = lsr.continuation_token.clone();
             while continuation_token.is_some() {
                 let lsr = self.ls(&uri, delimiter.as_str(), posix, continuation_token.as_deref(), page_size).await?;

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// Default limit before we fallback onto parallel prefix list streams
-static DEFAULT_FANOUT_LIMIT: usize = 128;
+static DEFAULT_FANOUT_LIMIT: usize = 1024;
 
 pub enum GetResult {
     File(LocalFile),

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -20,6 +20,7 @@ mod py {
         path: String,
         multithreaded_io: Option<bool>,
         io_config: Option<common_io_config::python::IOConfig>,
+        fanout_limit: Option<usize>,
     ) -> PyResult<&PyList> {
         let multithreaded_io = multithreaded_io.unwrap_or(true);
         let lsr: DaftResult<Vec<_>> = py.allow_threads(|| {
@@ -33,7 +34,10 @@ mod py {
 
             runtime_handle.block_on(async move {
                 let source = io_client.get_source(&scheme).await?;
-                let files = glob(source, path.as_ref()).await?.try_collect().await?;
+                let files = glob(source, path.as_ref(), fanout_limit)
+                    .await?
+                    .try_collect()
+                    .await?;
                 Ok(files)
             })
         });

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -21,6 +21,7 @@ mod py {
         multithreaded_io: Option<bool>,
         io_config: Option<common_io_config::python::IOConfig>,
         fanout_limit: Option<usize>,
+        page_size: Option<i32>,
     ) -> PyResult<&PyList> {
         let multithreaded_io = multithreaded_io.unwrap_or(true);
         let lsr: DaftResult<Vec<_>> = py.allow_threads(|| {
@@ -34,7 +35,7 @@ mod py {
 
             runtime_handle.block_on(async move {
                 let source = io_client.get_source(&scheme).await?;
-                let files = glob(source, path.as_ref(), fanout_limit)
+                let files = glob(source, path.as_ref(), fanout_limit, page_size)
                     .await?
                     .try_collect()
                     .await?;
@@ -79,7 +80,7 @@ mod py {
                         .await?
                 } else {
                     source
-                        .iter_dir(&path, "/", true, None)
+                        .iter_dir(&path, "/", true, None, None)
                         .await?
                         .try_collect::<Vec<_>>()
                         .await?

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -79,7 +79,7 @@ mod py {
                         .await?
                 } else {
                     source
-                        .iter_dir(&path, None, None)
+                        .iter_dir(&path, "/", true, None)
                         .await?
                         .try_collect::<Vec<_>>()
                         .await?

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -718,10 +718,7 @@ impl ObjectSource for S3LikeSource {
                 source: ParseError::EmptyHost,
             }),
         }?;
-        let key = parsed.path();
-        let key = key
-            .trim_start_matches(delimiter)
-            .trim_end_matches(delimiter);
+        let key = parsed.path().trim_start_matches(delimiter);
 
         if posix {
             // Perform a directory-based list of entries in the next level
@@ -729,7 +726,7 @@ impl ObjectSource for S3LikeSource {
             let key = if key.is_empty() {
                 "".to_string()
             } else {
-                format!("{key}{delimiter}")
+                format!("{}{delimiter}", key.trim_end_matches(delimiter))
             };
             let lsr = {
                 let permit = self

--- a/tests/integration/io/benchmarks/test_benchmark_glob.py
+++ b/tests/integration/io/benchmarks/test_benchmark_glob.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+import s3fs
+
+from daft.daft import io_glob
+
+from ..conftest import minio_create_bucket
+
+NUM_FILES = 10000
+NUM_LEVELS = 8
+FANOUT_PER_LEVEL = 24
+BUCKET = "bucket"
+
+
+def _generate_file_name(num_levels, fanout_per_level):
+    level = random.randint(0, num_levels)
+    return (
+        "/".join([f"part_col_{l}={random.randint(0, fanout_per_level)}" for l in range(1, level + 1)]) + "/file.parquet"
+    )
+
+
+@pytest.fixture(scope="module")
+def setup_bucket(minio_io_config):
+    with minio_create_bucket(minio_io_config, bucket_name=BUCKET) as fs:
+        files = [_generate_file_name(NUM_LEVELS, FANOUT_PER_LEVEL) for i in range(NUM_FILES)]
+        for name in files:
+            fs.touch(f"{BUCKET}/{name}")
+        yield len(set(files))
+
+
+@pytest.mark.benchmark(group="glob")
+@pytest.mark.integration()
+def test_benchmark_glob_s3fs(benchmark, setup_bucket, minio_io_config):
+    fs = s3fs.S3FileSystem(
+        key=minio_io_config.s3.key_id,
+        password=minio_io_config.s3.access_key,
+        client_kwargs={"endpoint_url": minio_io_config.s3.endpoint_url},
+    )
+    results = benchmark(lambda: fs.glob(f"s3://{BUCKET}/**/*.parquet"))
+    assert len(results) == setup_bucket
+
+
+@pytest.mark.benchmark(group="glob")
+@pytest.mark.integration()
+@pytest.mark.parametrize("fanout_limit", [8, 64, 512, 4096])
+def test_benchmark_glob_daft(benchmark, setup_bucket, minio_io_config, fanout_limit):
+    fs = s3fs.S3FileSystem(
+        key=minio_io_config.s3.key_id,
+        password=minio_io_config.s3.access_key,
+        client_kwargs={"endpoint_url": minio_io_config.s3.endpoint_url},
+    )
+    results = benchmark(
+        lambda: io_glob(f"s3://{BUCKET}/**/*.parquet", io_config=minio_io_config, fanout_limit=fanout_limit)
+    )
+    assert len(results) == setup_bucket

--- a/tests/integration/io/benchmarks/test_benchmark_glob.py
+++ b/tests/integration/io/benchmarks/test_benchmark_glob.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import random
+import itertools
 
+import boto3
 import pytest
 import s3fs
 
@@ -15,17 +16,125 @@ FANOUT_PER_LEVEL = 12
 BUCKET = "bucket"
 
 
-def _generate_file_name(num_levels, fanout_per_level):
-    level = random.randint(0, num_levels)
-    return (
-        "/".join([f"part_col_{l}={random.randint(0, fanout_per_level)}" for l in range(1, level + 1)]) + "/file.parquet"
-    )
+def generate_one_file_per_dir():
+    # Total of 10k files (10^4 * 1)
+    NUM_LEVELS = 4
+    FANOUT_PER_LEVEL = 10
+    return [
+        "/".join(f"part_col_{i}={val}" for i, val in enumerate(part_vals)) + f"/0.parquet"
+        for part_vals in itertools.product([str(i) for i in range(FANOUT_PER_LEVEL)], repeat=NUM_LEVELS)
+    ]
 
 
-@pytest.fixture(scope="module")
-def setup_bucket(minio_io_config):
+def generate_balanced_partitioned_data():
+    # Total of 10k files (10^3 * 10)
+    NUM_LEVELS = 3
+    FANOUT_PER_LEVEL = 10
+    FILES_PER_PARTITION = 10
+    return [
+        "/".join(f"part_col_{i}={val}" for i, val in enumerate(part_vals)) + f"/{i}.parquet"
+        for i in range(FILES_PER_PARTITION)
+        for part_vals in itertools.product([str(i) for i in range(FANOUT_PER_LEVEL)], repeat=NUM_LEVELS)
+    ]
+
+
+def generate_left_skew_partitioned_data():
+    # Total of 10k files (10^3 * 10)
+    NUM_LEVELS = 3
+    FANOUT_PER_LEVEL = 10
+
+    # First partition contains 1009 files, and the other partitions have 9 files each
+    num_files_per_partition = [1009] + [9 for i in range(999)]
+
+    return [
+        "/".join(f"part_col_{i}={val}" for i, val in enumerate(part_vals)) + f"/{i}.parquet"
+        for part_vals, num_files_for_this_partition in zip(
+            itertools.product([str(i) for i in range(FANOUT_PER_LEVEL)], repeat=NUM_LEVELS), num_files_per_partition
+        )
+        for i in range(num_files_for_this_partition)
+    ]
+
+
+def generate_right_skew_partitioned_data():
+    # Total of 10k files (10^3 * 10)
+    NUM_LEVELS = 3
+    FANOUT_PER_LEVEL = 10
+
+    # Last partition contains 1009 files, and the other partitions have 9 files each
+    num_files_per_partition = [9 for i in range(999)] + [1009]
+
+    return [
+        "/".join(f"part_col_{i}={val}" for i, val in enumerate(part_vals)) + f"/{i}.parquet"
+        for part_vals, num_files_for_this_partition in zip(
+            itertools.product([str(i) for i in range(FANOUT_PER_LEVEL)], repeat=NUM_LEVELS), num_files_per_partition
+        )
+        for i in range(num_files_for_this_partition)
+    ]
+
+
+def generate_left_skew_dirs_partitioned_data():
+    # First partition in level 0 fans out (1 * 20 * 20 * 10 files = 4000 files)
+    # The rest of the partitions in level 0 fan out much smaller (1 * 8 * 8 * 10 = 10 files) * 9 = 5940 files
+    first_partition_paths = [
+        "/".join(f"part_col_{i}={val}" for i, val in enumerate([0, *part_vals])) + f"/{i}.parquet"
+        for i in range(10)
+        for part_vals in itertools.product([str(i) for i in range(20)], repeat=2)
+    ]
+    other_partition_paths = [
+        "/".join(f"part_col_{i}={val}" for i, val in enumerate([first_level_val, *part_vals])) + f"/{i}.parquet"
+        for first_level_val in range(1, 10)
+        for part_vals in itertools.product([str(i) for i in range(8)], repeat=2)
+        for i in range(10)
+    ]
+
+    return first_partition_paths + other_partition_paths
+
+
+def generate_right_skew_dirs_partitioned_data():
+    # Last partition in level 0 fans out (1 * 20 * 20 * 10 files = 4000 files)
+    # The rest of the partitions in level 0 fan out much smaller (1 * 8 * 8 * 10 = 10 files) * 9 = 5940 files
+    last_partition_paths = [
+        "/".join(f"part_col_{i}={val}" for i, val in enumerate([9, *part_vals])) + f"/{i}.parquet"
+        for i in range(10)
+        for part_vals in itertools.product([str(i) for i in range(20)], repeat=2)
+    ]
+    other_partition_paths = [
+        "/".join(f"part_col_{i}={val}" for i, val in enumerate([first_level_val, *part_vals])) + f"/{i}.parquet"
+        for first_level_val in range(0, 9)
+        for part_vals in itertools.product([str(i) for i in range(8)], repeat=2)
+        for i in range(10)
+    ]
+
+    return other_partition_paths + last_partition_paths
+
+
+FILE_NAME_GENERATORS = {
+    "one-file-per-dir": generate_one_file_per_dir,
+    "partitioned-data-balanced": generate_balanced_partitioned_data,
+    "partitioned-data-left-skew-files": generate_left_skew_partitioned_data,
+    "partitioned-data-right-skew-files": generate_right_skew_partitioned_data,
+    "partitioned-data-left-skew-dirs": generate_left_skew_dirs_partitioned_data,
+    "partitioned-data-right-skew-dirs": generate_right_skew_dirs_partitioned_data,
+}
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        "one-file-per-dir",
+        "partitioned-data-balanced",
+        "partitioned-data-left-skew-files",
+        "partitioned-data-right-skew-files",
+        "partitioned-data-right-skew-dirs",
+        "partitioned-data-left-skew-dirs",
+    ],
+)
+def setup_bucket(request, minio_io_config):
+    test_name = request.param
+    file_name_generator = FILE_NAME_GENERATORS[test_name]
     with minio_create_bucket(minio_io_config, bucket_name=BUCKET) as fs:
-        files = [_generate_file_name(NUM_LEVELS, FANOUT_PER_LEVEL) for i in range(NUM_FILES)]
+        files = file_name_generator()
+        print(f"Num files: {len(files)}")
         for name in files:
             fs.touch(f"{BUCKET}/{name}")
         yield len(set(files))
@@ -39,18 +148,60 @@ def test_benchmark_glob_s3fs(benchmark, setup_bucket, minio_io_config):
         password=minio_io_config.s3.access_key,
         client_kwargs={"endpoint_url": minio_io_config.s3.endpoint_url},
     )
-    results = benchmark(lambda: fs.glob(f"s3://{BUCKET}/**/*.parquet"))
+    results = benchmark(
+        lambda: fs.glob(
+            f"s3://{BUCKET}/**/*.parquet",
+            # Can't set page size for s3fs
+            # max_items=PAGE_SIZE,
+        )
+    )
     assert len(results) == setup_bucket
 
 
 @pytest.mark.benchmark(group="glob")
 @pytest.mark.integration()
-@pytest.mark.parametrize("fanout_limit", [8, 64, 512, 4096])
-def test_benchmark_glob_daft(benchmark, setup_bucket, minio_io_config, fanout_limit):
-    results = benchmark.pedantic(
-        lambda: io_glob(f"s3://{BUCKET}/**/*.parquet", io_config=minio_io_config, fanout_limit=fanout_limit),
-        rounds=1,
-        iterations=1,
+@pytest.mark.parametrize("page_size", [100, 1000])
+def test_benchmark_glob_boto3_list(benchmark, setup_bucket, minio_io_config, page_size):
+    s3 = boto3.client(
+        "s3",
+        aws_access_key_id=minio_io_config.s3.key_id,
+        aws_secret_access_key=minio_io_config.s3.access_key,
+        endpoint_url=minio_io_config.s3.endpoint_url,
+    )
+
+    def f():
+        continuation_token = None
+        has_next = True
+        opts = {"MaxKeys": page_size}
+        data = []
+        while has_next:
+            if continuation_token is not None:
+                opts["ContinuationToken"] = continuation_token
+
+            response = s3.list_objects_v2(
+                Bucket=BUCKET,
+                Prefix="",
+                **opts,
+            )
+            data.extend([{"path": f"s3://{BUCKET}/{d['Key']}", "type": "File"} for d in response.get("Contents", [])])
+            continuation_token = response.get("NextContinuationToken")
+            has_next = continuation_token is not None
+
+        return data
+
+    data = benchmark(f)
+    assert len(data) == setup_bucket
+
+
+@pytest.mark.benchmark(group="glob")
+@pytest.mark.integration()
+@pytest.mark.parametrize("fanout_limit", [8, 64, 128, 256, 512])
+@pytest.mark.parametrize("page_size", [100, 1000])
+def test_benchmark_glob_daft(benchmark, setup_bucket, minio_io_config, fanout_limit, page_size):
+    results = benchmark(
+        lambda: io_glob(
+            f"s3://{BUCKET}/**/*.parquet", io_config=minio_io_config, fanout_limit=fanout_limit, page_size=page_size
+        )
     )
     assert len(results) == setup_bucket
 

--- a/tests/integration/io/benchmarks/test_benchmark_glob.py
+++ b/tests/integration/io/benchmarks/test_benchmark_glob.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import itertools
 
-import boto3
 import pytest
 import s3fs
 
@@ -176,6 +175,8 @@ def test_benchmark_glob_s3fs(benchmark, setup_bucket, minio_io_config):
 @pytest.mark.integration()
 @pytest.mark.parametrize("page_size", [100, 1000])
 def test_benchmark_glob_boto3_list(benchmark, setup_bucket, minio_io_config, page_size):
+    import boto3
+
     s3 = boto3.client(
         "s3",
         aws_access_key_id=minio_io_config.s3.key_id,

--- a/tests/integration/io/benchmarks/test_benchmark_glob.py
+++ b/tests/integration/io/benchmarks/test_benchmark_glob.py
@@ -108,6 +108,16 @@ def generate_right_skew_dirs_partitioned_data():
     return other_partition_paths + last_partition_paths
 
 
+def generate_bushy_late_partitioned_data():
+    # Total of 10k files (10^3 * 10)
+    return [f"single/single/part_col={val}" + f"/{i}.parquet" for i in range(10) for val in range(1000)]
+
+
+def generate_bushy_early_partitioned_data():
+    # Total of 10k files (10^3 * 10)
+    return [f"part_col={val}/single/single" + f"/{i}.parquet" for i in range(10) for val in range(1000)]
+
+
 FILE_NAME_GENERATORS = {
     "one-file-per-dir": generate_one_file_per_dir,
     "partitioned-data-balanced": generate_balanced_partitioned_data,
@@ -115,6 +125,8 @@ FILE_NAME_GENERATORS = {
     "partitioned-data-right-skew-files": generate_right_skew_partitioned_data,
     "partitioned-data-left-skew-dirs": generate_left_skew_dirs_partitioned_data,
     "partitioned-data-right-skew-dirs": generate_right_skew_dirs_partitioned_data,
+    "partitioned-data-bushy-early": generate_bushy_early_partitioned_data,
+    "partitioned-data-bushy-late": generate_bushy_late_partitioned_data,
 }
 
 
@@ -127,6 +139,8 @@ FILE_NAME_GENERATORS = {
         "partitioned-data-right-skew-files",
         "partitioned-data-right-skew-dirs",
         "partitioned-data-left-skew-dirs",
+        "partitioned-data-bushy-early",
+        "partitioned-data-bushy-late",
     ],
 )
 def setup_bucket(request, minio_io_config):
@@ -195,7 +209,7 @@ def test_benchmark_glob_boto3_list(benchmark, setup_bucket, minio_io_config, pag
 
 @pytest.mark.benchmark(group="glob")
 @pytest.mark.integration()
-@pytest.mark.parametrize("fanout_limit", [8, 64, 128, 256, 512])
+@pytest.mark.parametrize("fanout_limit", [128, 256])
 @pytest.mark.parametrize("page_size", [100, 1000])
 def test_benchmark_glob_daft(benchmark, setup_bucket, minio_io_config, fanout_limit, page_size):
     results = benchmark(

--- a/tests/integration/io/test_list_files_s3_minio.py
+++ b/tests/integration/io/test_list_files_s3_minio.py
@@ -174,7 +174,8 @@ def s3fs_recursive_list(fs, path) -> list:
         ),
     ],
 )
-def test_directory_globbing_fragment_wildcard(minio_io_config, path_expect_pair):
+@pytest.mark.parametrize("fanout_limit", [None, 1])
+def test_directory_globbing_fragment_wildcard(minio_io_config, path_expect_pair, fanout_limit):
     globpath, expect = path_expect_pair
     with minio_create_bucket(minio_io_config, bucket_name="bucket") as fs:
         files = [
@@ -193,7 +194,7 @@ def test_directory_globbing_fragment_wildcard(minio_io_config, path_expect_pair)
 
         if type(expect) == type and issubclass(expect, BaseException):
             with pytest.raises(expect):
-                io_glob(globpath, io_config=minio_io_config)
+                io_glob(globpath, io_config=minio_io_config, fanout_limit=fanout_limit)
         else:
             daft_ls_result = io_glob(globpath, io_config=minio_io_config)
             assert sorted(daft_ls_result, key=lambda d: d["path"]) == sorted(expect, key=lambda d: d["path"])

--- a/tests/integration/io/test_list_files_s3_minio.py
+++ b/tests/integration/io/test_list_files_s3_minio.py
@@ -196,7 +196,7 @@ def test_directory_globbing_fragment_wildcard(minio_io_config, path_expect_pair,
             with pytest.raises(expect):
                 io_glob(globpath, io_config=minio_io_config, fanout_limit=fanout_limit)
         else:
-            daft_ls_result = io_glob(globpath, io_config=minio_io_config)
+            daft_ls_result = io_glob(globpath, io_config=minio_io_config, fanout_limit=fanout_limit)
             assert sorted(daft_ls_result, key=lambda d: d["path"]) == sorted(expect, key=lambda d: d["path"])
 
 
@@ -263,6 +263,32 @@ def test_directory_globbing_special_characters(minio_io_config, path_expect_pair
             fs.touch(f"bucket/{name}")
         daft_ls_result = io_glob(globpath, io_config=minio_io_config)
         assert sorted(daft_ls_result, key=lambda d: d["path"]) == sorted(expect, key=lambda d: d["path"])
+
+
+@pytest.mark.integration()
+def test_directory_globbing_common_prefix_cornercase(minio_io_config):
+    with minio_create_bucket(minio_io_config, bucket_name="bucket") as fs:
+        files = [
+            "1/a/file.txt",
+            "1/b/file.txt",
+            # share a prefix with `1` which may cause issues if we drop the trailing / in a prefix list
+            "11/a/file.txt",
+            "11/b/file.txt",
+        ]
+        for name in files:
+            fs.touch(f"bucket/{name}")
+
+        # Force a prefix listing on the second level when the fanout becomes more than 2
+        daft_ls_result = io_glob("s3://bucket/**", io_config=minio_io_config, fanout_limit=2)
+        assert sorted(daft_ls_result, key=lambda d: d["path"]) == sorted(
+            [
+                {"type": "File", "path": "s3://bucket/1/a/file.txt", "size": 0},
+                {"type": "File", "path": "s3://bucket/1/b/file.txt", "size": 0},
+                {"type": "File", "path": "s3://bucket/11/a/file.txt", "size": 0},
+                {"type": "File", "path": "s3://bucket/11/b/file.txt", "size": 0},
+            ],
+            key=lambda d: d["path"],
+        )
 
 
 @pytest.mark.integration()


### PR DESCRIPTION
Adds early stopping capabilities for our native globbing to prevent runaway parallelism when listing adverserial cases (one file per folder)

Other changes in this PR:

1. Adds benchmarks on 10k local files
2. Adds a new `posix` argument to `ls` and `iter_dir`: this controls whether the operation will perform a posix-like list (of just the next level), or an object-store-like prefix list (of all files starting with the provided prefix)
3. `delimiter` is no longer an `Option` argument and is required by all the ObjectSources: it could actually be argued that this should be automatically determined by the ObjectSource itself?

Not in scope in this PR:

1. Prefix listing for GCS/Azure/Local/HTTP are not implemented in this PR, thus the globbing algorithm will actually not work for those cases
2. We may need a different globbing implementation for Local and HTTP given that they do not support prefix listing

## How it works

1. We can think of globbing a path as a tree search.
4. At tree depth `d`, we define the number of nodes at the depth as `fanout`.
5. This PR adds a `fanout_limit` to limit the fanout of our globbing. When we perform a recursive list and see that entering depth `d+1` will increase `fanout` by more than `fanout_limit`, we will instead fall back on "flat listing" which is a listing of all files starting with the current path as their prefix.

## Benchmarks

These were run locally on a minio Docker container

<img width="1466" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/17691182/b14e580b-89d1-4941-994e-ae3356a3efce">

We see that limiting the parallelism helps a lot in this adversarial example, where instead of traversing the entire directory structure recursively we will stop after a certain depth and fall back onto prefix listing.