### PR TITLE
[FEAT] [Native I/O] Add a native CSV reader.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.1"
-source = "git+https://github.com/Eventual-Inc/arrow2?rev=3ffe9226#3ffe92263335b645c04cd77405f3a09f43b6f44b"
+source = "git+https://github.com/Eventual-Inc/arrow2?rev=065a31da8fd8a75cbece5f99295a4068713a71ed#065a31da8fd8a75cbece5f99295a4068713a71ed"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -113,6 +113,9 @@ dependencies = [
  "bytemuck",
  "chrono",
  "chrono-tz",
+ "csv",
+ "csv-async",
+ "csv-core",
  "dyn-clone",
  "either",
  "ethnum",
@@ -736,6 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -998,6 +1002,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv-async"
+version = "1.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71933d3f2d0481d5111cb2817b15b6961961458ec58adf8008194e6c850046f4"
+dependencies = [
+ "bstr",
+ "cfg-if",
+ "csv-core",
+ "futures",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "csv-core"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1030,7 @@ name = "daft"
 version = "0.1.10"
 dependencies = [
  "daft-core",
+ "daft-csv",
  "daft-dsl",
  "daft-io",
  "daft-parquet",
@@ -1050,6 +1070,30 @@ dependencies = [
  "serde",
  "serde_json",
  "xxhash-rust",
+]
+
+[[package]]
+name = "daft-csv"
+version = "0.1.10"
+dependencies = [
+ "arrow2",
+ "async-compat",
+ "async-stream",
+ "bytes",
+ "common-error",
+ "csv-async",
+ "daft-core",
+ "daft-io",
+ "daft-table",
+ "futures",
+ "log",
+ "pyo3",
+ "pyo3-log",
+ "rayon",
+ "snafu",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,8 @@ members = [
 ]
 
 [workspace.dependencies]
+async-compat = "0.2.1"
+async-stream = "0.3.5"
 bytes = "1.4.0"
 futures = "0.3.28"
 html-escape = "0.2.13"
@@ -81,10 +83,12 @@ num-derive = "0.3.3"
 num-traits = "0.2"
 prettytable-rs = "0.10"
 rand = "^0.8"
+rayon = "1.7.0"
 serde_json = "1.0.104"
 snafu = "0.7.4"
 tokio = {version = "1.32.0", features = ["net", "time", "bytes", "process", "signal", "macros", "rt", "rt-multi-thread"]}
 tokio-stream = {version = "0.1.14", features = ["fs"]}
+tokio-util = "0.7.8"
 
 [workspace.dependencies.arrow2]
 git = "https://github.com/Eventual-Inc/arrow2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [dependencies]
 daft-core = {path = "src/daft-core", default-features = false}
+daft-csv = {path = "src/daft-csv", default-features = false}
 daft-dsl = {path = "src/daft-dsl", default-features = false}
 daft-io = {path = "src/daft-io", default-features = false}
 daft-parquet = {path = "src/daft-parquet", default-features = false}
@@ -18,7 +19,8 @@ python = [
   "daft-dsl/python",
   "daft-io/python",
   "daft-plan/python",
-  "daft-parquet/python"
+  "daft-parquet/python",
+  "daft-csv/python"
 ]
 
 [lib]
@@ -63,6 +65,7 @@ members = [
   "src/daft-core",
   "src/daft-io",
   "src/daft-parquet",
+  "src/daft-csv",
   "src/daft-dsl",
   "src/daft-table",
   "src/daft-plan"
@@ -86,9 +89,7 @@ tokio-stream = {version = "0.1.14", features = ["fs"]}
 [workspace.dependencies.arrow2]
 git = "https://github.com/Eventual-Inc/arrow2"
 package = "arrow2"
-# branch = "jay/logical-type-null"
-rev = "3ffe9226"
-version = "0.17.1"
+rev = "065a31da8fd8a75cbece5f99295a4068713a71ed"
 
 [workspace.dependencies.bincode]
 version = "1.3.3"

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -411,6 +411,23 @@ def read_parquet_schema(
     multithreaded_io: bool | None = None,
     coerce_int96_timestamp_unit: PyTimeUnit | None = None,
 ): ...
+def read_csv(
+    uri: str,
+    column_names: list[str] | None = None,
+    include_columns: list[str] | None = None,
+    num_rows: int | None = None,
+    has_header: bool | None = None,
+    delimiter: str | None = None,
+    io_config: IOConfig | None = None,
+    multithreaded_io: bool | None = None,
+): ...
+def read_csv_schema(
+    uri: str,
+    has_header: bool | None = None,
+    delimiter: str | None = None,
+    io_config: IOConfig | None = None,
+    multithreaded_io: bool | None = None,
+): ...
 
 class PyTimeUnit:
     @staticmethod

--- a/daft/execution/rust_physical_plan_shim.py
+++ b/daft/execution/rust_physical_plan_shim.py
@@ -23,7 +23,7 @@ PartitionT = TypeVar("PartitionT")
 
 def tabular_scan(
     schema: PySchema,
-    columns_to_read: list[str],
+    columns_to_read: list[str] | None,
     file_info_table: PyTable,
     file_format_config: FileFormatConfig,
     storage_config: StorageConfig,

--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Iterator
 
 from daft.daft import PyField as _PyField
 from daft.daft import PySchema as _PySchema
+from daft.daft import read_csv_schema as _read_csv_schema
 from daft.daft import read_parquet_schema as _read_parquet_schema
 from daft.datatype import DataType, TimeUnit
 
@@ -151,5 +152,24 @@ class Schema:
                 io_config=io_config,
                 multithreaded_io=multithreaded_io,
                 coerce_int96_timestamp_unit=coerce_int96_timestamp_unit._timeunit,
+            )
+        )
+
+    @classmethod
+    def from_csv(
+        cls,
+        path: str,
+        has_header: bool | None = None,
+        delimiter: str | None = None,
+        io_config: IOConfig | None = None,
+        multithreaded_io: bool | None = None,
+    ) -> Schema:
+        return Schema._from_pyschema(
+            _read_csv_schema(
+                uri=path,
+                has_header=has_header,
+                delimiter=delimiter,
+                io_config=io_config,
+                multithreaded_io=multithreaded_io,
             )
         )

--- a/daft/table/schema_inference.py
+++ b/daft/table/schema_inference.py
@@ -35,6 +35,16 @@ def from_csv(
 
     if storage_config is not None:
         config = storage_config.config
+        if isinstance(config, NativeStorageConfig):
+            assert isinstance(file, (str, pathlib.Path)), "Native downloader only works on string inputs to read_csv"
+            io_config = config.io_config
+            return Schema.from_csv(
+                str(file),
+                has_header=csv_options.header_index is not None,
+                delimiter=csv_options.delimiter,
+                io_config=io_config,
+            )
+
         assert isinstance(config, PythonStorageConfig)
         fs = config.fs
     else:

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -9,6 +9,7 @@ from loguru import logger
 from daft.arrow_utils import ensure_table
 from daft.daft import JoinType
 from daft.daft import PyTable as _PyTable
+from daft.daft import read_csv as _read_csv
 from daft.daft import read_parquet as _read_parquet
 from daft.daft import read_parquet_bulk as _read_parquet_bulk
 from daft.daft import read_parquet_into_pyarrow as _read_parquet_into_pyarrow
@@ -426,6 +427,31 @@ class Table:
         return Table._from_pytable(
             _read_parquet_statistics(
                 uris=paths._series,
+                io_config=io_config,
+                multithreaded_io=multithreaded_io,
+            )
+        )
+
+    @classmethod
+    def read_csv(
+        cls,
+        path: str,
+        column_names: list[str] | None = None,
+        include_columns: list[str] | None = None,
+        num_rows: int | None = None,
+        has_header: bool | None = None,
+        delimiter: str | None = None,
+        io_config: IOConfig | None = None,
+        multithreaded_io: bool | None = None,
+    ) -> Table:
+        return Table._from_pytable(
+            _read_csv(
+                uri=path,
+                column_names=column_names,
+                include_columns=include_columns,
+                num_rows=num_rows,
+                has_header=has_header,
+                delimiter=delimiter,
                 io_config=io_config,
                 multithreaded_io=multithreaded_io,
             )

--- a/daft/table/table_io.py
+++ b/daft/table/table_io.py
@@ -197,6 +197,22 @@ def read_csv(
     """
     if storage_config is not None:
         config = storage_config.config
+        if isinstance(config, NativeStorageConfig):
+            assert isinstance(
+                file, (str, pathlib.Path)
+            ), "Native downloader only works on string inputs to read_parquet"
+            has_header = csv_options.header_index is not None
+            tbl = Table.read_csv(
+                str(file),
+                column_names=schema.column_names() if not has_header else None,
+                include_columns=read_options.column_names,
+                num_rows=read_options.num_rows,
+                has_header=has_header,
+                delimiter=csv_options.delimiter,
+                io_config=config.io_config,
+            )
+            return _cast_table_to_schema(tbl, read_options=read_options, schema=schema)
+
         assert isinstance(config, PythonStorageConfig)
         fs = config.fs
     else:

--- a/src/daft-csv/Cargo.toml
+++ b/src/daft-csv/Cargo.toml
@@ -1,7 +1,7 @@
 [dependencies]
 arrow2 = {workspace = true, features = ["io_csv", "io_csv_async"]}
-async-compat = "0.2.1"
-async-stream = "0.3.5"
+async-compat = {workspace = true}
+async-stream = {workspace = true}
 bytes = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
 csv-async = "1.2.6"
@@ -12,11 +12,11 @@ futures = {workspace = true}
 log = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true, optional = true}
-rayon = "1.7.0"
+rayon = {workspace = true}
 snafu = {workspace = true}
 tokio = {workspace = true}
-tokio-stream = "0.1.14"
-tokio-util = "0.7.8"
+tokio-stream = {workspace = true}
+tokio-util = {workspace = true}
 
 [features]
 default = ["python"]

--- a/src/daft-csv/Cargo.toml
+++ b/src/daft-csv/Cargo.toml
@@ -1,0 +1,28 @@
+[dependencies]
+arrow2 = {workspace = true, features = ["io_csv", "io_csv_async"]}
+async-compat = "0.2.1"
+async-stream = "0.3.5"
+bytes = {workspace = true}
+common-error = {path = "../common/error", default-features = false}
+csv-async = "1.2.6"
+daft-core = {path = "../daft-core", default-features = false}
+daft-io = {path = "../daft-io", default-features = false}
+daft-table = {path = "../daft-table", default-features = false}
+futures = {workspace = true}
+log = {workspace = true}
+pyo3 = {workspace = true, optional = true}
+pyo3-log = {workspace = true, optional = true}
+rayon = "1.7.0"
+snafu = {workspace = true}
+tokio = {workspace = true}
+tokio-stream = "0.1.14"
+tokio-util = "0.7.8"
+
+[features]
+default = ["python"]
+python = ["dep:pyo3", "dep:pyo3-log", "common-error/python", "daft-core/python", "daft-io/python", "daft-table/python"]
+
+[package]
+edition = {workspace = true}
+name = "daft-csv"
+version = {workspace = true}

--- a/src/daft-csv/src/lib.rs
+++ b/src/daft-csv/src/lib.rs
@@ -1,0 +1,34 @@
+#![feature(async_closure)]
+#![feature(let_chains)]
+use common_error::DaftError;
+use snafu::Snafu;
+
+pub mod metadata;
+#[cfg(feature = "python")]
+pub mod python;
+pub mod read;
+#[cfg(feature = "python")]
+pub use python::register_modules;
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("{source}"))]
+    IOError { source: daft_io::Error },
+    #[snafu(display("{source}"))]
+    CSVError { source: csv_async::Error },
+}
+
+impl From<Error> for DaftError {
+    fn from(err: Error) -> DaftError {
+        match err {
+            Error::IOError { source } => source.into(),
+            _ => DaftError::External(err.into()),
+        }
+    }
+}
+
+impl From<daft_io::Error> for Error {
+    fn from(err: daft_io::Error) -> Self {
+        Error::IOError { source: err }
+    }
+}

--- a/src/daft-csv/src/metadata.rs
+++ b/src/daft-csv/src/metadata.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+
+use arrow2::io::csv::read_async::{infer, infer_schema, AsyncReaderBuilder};
+use async_compat::CompatExt;
+use common_error::DaftResult;
+use daft_core::schema::Schema;
+use daft_io::{get_runtime, GetResult, IOClient};
+use futures::{io::Cursor, AsyncRead, AsyncSeek};
+use tokio::fs::File;
+
+pub fn read_csv_schema(
+    uri: &str,
+    has_header: bool,
+    delimiter: Option<u8>,
+    io_client: Arc<IOClient>,
+) -> DaftResult<Schema> {
+    let runtime_handle = get_runtime(true)?;
+    let _rt_guard = runtime_handle.enter();
+    runtime_handle
+        .block_on(async { read_csv_schema_single(uri, has_header, delimiter, io_client).await })
+}
+
+async fn read_csv_schema_single(
+    uri: &str,
+    has_header: bool,
+    delimiter: Option<u8>,
+    io_client: Arc<IOClient>,
+) -> DaftResult<Schema> {
+    match io_client.single_url_get(uri.to_string(), None).await? {
+        GetResult::File(file) => {
+            read_csv_schema_from_reader(
+                File::open(file.path).await?.compat(),
+                has_header,
+                delimiter,
+            )
+            .await
+        }
+        result @ GetResult::Stream(..) => {
+            read_csv_schema_from_reader(Cursor::new(result.bytes().await?), has_header, delimiter)
+                .await
+        }
+    }
+}
+
+async fn read_csv_schema_from_reader<R>(
+    reader: R,
+    has_header: bool,
+    delimiter: Option<u8>,
+) -> DaftResult<Schema>
+where
+    R: AsyncRead + AsyncSeek + Unpin + Sync + Send,
+{
+    let mut reader = AsyncReaderBuilder::new()
+        .has_headers(has_header)
+        .delimiter(delimiter.unwrap_or(b','))
+        .create_reader(reader);
+    let (fields, _) = infer_schema(&mut reader, None, has_header, &infer).await?;
+    let schema: arrow2::datatypes::Schema = fields.into();
+    Schema::try_from(&schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_error::DaftResult;
+    use daft_core::{datatypes::Field, schema::Schema, DataType};
+    use daft_io::{IOClient, IOConfig};
+
+    use super::read_csv_schema;
+
+    #[test]
+    fn test_csv_schema_from_s3() -> DaftResult<()> {
+        let file = "s3://daft-public-data/test_fixtures/csv-dev/mvp.csv";
+
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
+        let io_client = Arc::new(IOClient::new(io_config.into())?);
+
+        let schema = read_csv_schema(file, true, None, io_client.clone())?;
+        assert_eq!(
+            schema,
+            Schema::new(vec![
+                Field::new("a", DataType::Int64),
+                Field::new("b", DataType::Utf8)
+            ])?
+        );
+
+        Ok(())
+    }
+}

--- a/src/daft-csv/src/python.rs
+++ b/src/daft-csv/src/python.rs
@@ -1,0 +1,84 @@
+use pyo3::prelude::*;
+
+pub mod pylib {
+    use std::sync::Arc;
+
+    use daft_core::python::schema::PySchema;
+    use daft_io::{get_io_client, python::IOConfig};
+    use daft_table::python::PyTable;
+    use pyo3::{exceptions::PyValueError, pyfunction, PyResult, Python};
+
+    fn str_delimiter_to_byte(delimiter: Option<&str>) -> PyResult<Option<u8>> {
+        delimiter
+            .map(|s| match s.as_bytes() {
+                &[c] => Ok(c),
+                _ => Err(PyValueError::new_err(format!(
+                    "Delimiter must be a single-character string, but got {}",
+                    s
+                ))),
+            })
+            .transpose()
+    }
+
+    #[pyfunction]
+    #[allow(clippy::too_many_arguments)]
+    pub fn read_csv(
+        py: Python,
+        uri: &str,
+        column_names: Option<Vec<&str>>,
+        include_columns: Option<Vec<&str>>,
+        num_rows: Option<usize>,
+        has_header: Option<bool>,
+        delimiter: Option<&str>,
+        io_config: Option<IOConfig>,
+        multithreaded_io: Option<bool>,
+    ) -> PyResult<PyTable> {
+        py.allow_threads(|| {
+            let io_client = get_io_client(
+                multithreaded_io.unwrap_or(true),
+                io_config.unwrap_or_default().config.into(),
+            )?;
+            Ok(crate::read::read_csv(
+                uri,
+                column_names,
+                include_columns,
+                num_rows,
+                has_header.unwrap_or(true),
+                str_delimiter_to_byte(delimiter)?,
+                io_client,
+                multithreaded_io.unwrap_or(true),
+            )?
+            .into())
+        })
+    }
+
+    #[pyfunction]
+    pub fn read_csv_schema(
+        py: Python,
+        uri: &str,
+        has_header: Option<bool>,
+        delimiter: Option<&str>,
+        io_config: Option<IOConfig>,
+        multithreaded_io: Option<bool>,
+    ) -> PyResult<PySchema> {
+        py.allow_threads(|| {
+            let io_client = get_io_client(
+                multithreaded_io.unwrap_or(true),
+                io_config.unwrap_or_default().config.into(),
+            )?;
+            Ok(Arc::new(crate::metadata::read_csv_schema(
+                uri,
+                has_header.unwrap_or(true),
+                str_delimiter_to_byte(delimiter)?,
+                io_client,
+            )?)
+            .into())
+        })
+    }
+}
+
+pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
+    parent.add_wrapped(wrap_pyfunction!(pylib::read_csv))?;
+    parent.add_wrapped(wrap_pyfunction!(pylib::read_csv_schema))?;
+    Ok(())
+}

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -1,0 +1,290 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use arrow2::{
+    datatypes::Field,
+    io::csv::read_async::{
+        deserialize_batch, deserialize_column, infer, infer_schema, read_rows, AsyncReaderBuilder,
+        ByteRecord,
+    },
+};
+use async_compat::CompatExt;
+use common_error::DaftResult;
+use daft_core::{schema::Schema, utils::arrow::cast_array_for_daft_if_needed, Series};
+use daft_io::{get_runtime, GetResult, IOClient};
+use daft_table::Table;
+use futures::{io::Cursor, AsyncRead, AsyncSeek};
+use tokio::fs::File;
+
+#[allow(clippy::too_many_arguments)]
+pub fn read_csv(
+    uri: &str,
+    column_names: Option<Vec<&str>>,
+    include_columns: Option<Vec<&str>>,
+    num_rows: Option<usize>,
+    has_header: bool,
+    delimiter: Option<u8>,
+    io_client: Arc<IOClient>,
+    multithreaded_io: bool,
+) -> DaftResult<Table> {
+    let runtime_handle = get_runtime(multithreaded_io)?;
+    let _rt_guard = runtime_handle.enter();
+    runtime_handle.block_on(async {
+        read_csv_single(
+            uri,
+            column_names,
+            include_columns,
+            num_rows,
+            has_header,
+            delimiter,
+            io_client,
+        )
+        .await
+    })
+}
+
+async fn read_csv_single(
+    uri: &str,
+    column_names: Option<Vec<&str>>,
+    include_columns: Option<Vec<&str>>,
+    num_rows: Option<usize>,
+    has_header: bool,
+    delimiter: Option<u8>,
+    io_client: Arc<IOClient>,
+) -> DaftResult<Table> {
+    match io_client.single_url_get(uri.to_string(), None).await? {
+        GetResult::File(file) => {
+            read_csv_single_from_reader(
+                File::open(file.path).await?.compat(),
+                column_names,
+                include_columns,
+                num_rows,
+                has_header,
+                delimiter,
+            )
+            .await
+        }
+        result @ GetResult::Stream(..) => {
+            // TODO(Clark): Enable streaming remote reads by wrapping the BoxStream in a buffered stream that's
+            // (1) sync and (2) seekable.
+            read_csv_single_from_reader(
+                Cursor::new(result.bytes().await?),
+                column_names,
+                include_columns,
+                num_rows,
+                has_header,
+                delimiter,
+            )
+            .await
+        }
+    }
+}
+
+async fn read_csv_single_from_reader<R>(
+    reader: R,
+    column_names: Option<Vec<&str>>,
+    include_columns: Option<Vec<&str>>,
+    num_rows: Option<usize>,
+    has_header: bool,
+    delimiter: Option<u8>,
+) -> DaftResult<Table>
+where
+    R: AsyncRead + AsyncSeek + Unpin + Sync + Send,
+{
+    let mut reader = AsyncReaderBuilder::new()
+        .has_headers(has_header)
+        .delimiter(delimiter.unwrap_or(b','))
+        .create_reader(reader);
+    let (mut fields, _) = infer_schema(&mut reader, None, has_header, &infer).await?;
+    if let Some(column_names) = column_names {
+        fields = fields
+            .into_iter()
+            .zip(column_names.iter())
+            .map(|(field, name)| {
+                Field::new(*name, field.data_type, field.is_nullable).with_metadata(field.metadata)
+            })
+            .collect();
+    }
+    let field_name_to_idx = fields
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| (f.name.as_ref(), idx))
+        .collect::<HashMap<&str, usize>>();
+    let projection_indices = include_columns.as_ref().map(|cols| {
+        cols.iter()
+            .map(|c| field_name_to_idx[c])
+            .collect::<Vec<_>>()
+    });
+    let num_rows = num_rows.unwrap_or(usize::MAX);
+    // TODO(Clark): Make batch size configurable.
+    // TODO(Clark): Get estimated average row size in bytes during schema inference and use it to:
+    //   1. Set a reasonable batch size.
+    //   2. Preallocate per-column batch vecs.
+    //   3. Preallocate column Arrow array buffers.
+    let batch_size = 1024.min(num_rows);
+    // TODO(Clark): Instead of allocating an array-per-column-batch and concatenating at the end,
+    // progressively grow a single array per column (with the above preallocation based on estimated
+    // number of rows).
+    let mut column_arrays = vec![
+        vec![];
+        projection_indices
+            .as_ref()
+            .map(|p| p.len())
+            .unwrap_or(fields.len())
+    ];
+    let mut buffer = vec![ByteRecord::with_capacity(0, fields.len()); batch_size];
+    let mut rows = buffer.as_mut_slice();
+    // Number of rows read in last read.
+    let mut rows_read = 1;
+    // Total number of rows read across all reads.
+    let mut total_rows_read = 0;
+    while rows_read > 0 && total_rows_read < num_rows {
+        if rows.len() > num_rows - total_rows_read {
+            // If we need to read less than the entire row buffer, truncate the buffer to the number
+            // of rows that we actually want to read.
+            rows = &mut rows[..num_rows - total_rows_read + 1]
+        }
+        rows_read = read_rows(&mut reader, 0, rows).await?;
+        total_rows_read += rows_read;
+        // TODO(Clark): Parallelize column deserialization over a rayon threadpool.
+        for (idx, array) in deserialize_batch(
+            &rows[..rows_read],
+            &fields,
+            projection_indices.as_deref(),
+            0,
+            deserialize_column,
+        )?
+        .into_arrays()
+        .into_iter()
+        .enumerate()
+        {
+            column_arrays[idx].push(array);
+        }
+    }
+    if let Some(include_columns) = include_columns {
+        // Truncate fields to only contain projected columns.
+        let include_columns: HashSet<&str> = include_columns.into_iter().collect();
+        fields.retain(|f| include_columns.contains(f.name.as_str()))
+    }
+    let columns_series = column_arrays
+        .into_iter()
+        .zip(fields.iter())
+        .map(|(mut arrays, field)| {
+            let array = if arrays.len() > 1 {
+                // Concatenate all array chunks.
+                let unboxed_arrays = arrays.iter().map(Box::as_ref).collect::<Vec<_>>();
+                arrow2::compute::concatenate::concatenate(unboxed_arrays.as_slice())?
+            } else {
+                // Return single array chunk directly.
+                arrays.pop().unwrap()
+            };
+            Series::try_from((field.name.as_ref(), cast_array_for_daft_if_needed(array)))
+        })
+        .collect::<DaftResult<Vec<Series>>>()?;
+    let schema: arrow2::datatypes::Schema = fields.into();
+    let daft_schema = Schema::try_from(&schema)?;
+    Table::new(daft_schema, columns_series)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_error::DaftResult;
+
+    use daft_core::{datatypes::Field, schema::Schema, DataType};
+    use daft_io::{IOClient, IOConfig};
+
+    use super::read_csv;
+
+    #[test]
+    fn test_csv_read_from_s3() -> DaftResult<()> {
+        let file = "s3://daft-public-data/test_fixtures/csv-dev/mvp.csv";
+
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
+
+        let io_client = Arc::new(IOClient::new(io_config.into())?);
+
+        let table = read_csv(file, None, None, None, true, None, io_client, true)?;
+        assert_eq!(table.len(), 100);
+        assert_eq!(
+            table.schema,
+            Schema::new(vec![
+                Field::new("a", DataType::Int64),
+                Field::new("b", DataType::Utf8)
+            ])?
+            .into(),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_csv_read_from_s3_larger_than_batch_size() -> DaftResult<()> {
+        let file = "s3://daft-public-data/test_fixtures/csv-dev/medium.csv";
+
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
+
+        let io_client = Arc::new(IOClient::new(io_config.into())?);
+
+        let table = read_csv(file, None, None, None, true, None, io_client, true)?;
+        assert_eq!(table.len(), 5000);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_csv_read_from_s3_limit() -> DaftResult<()> {
+        let file = "s3://daft-public-data/test_fixtures/csv-dev/mvp.csv";
+
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
+
+        let io_client = Arc::new(IOClient::new(io_config.into())?);
+
+        let table = read_csv(file, None, None, Some(10), true, None, io_client, true)?;
+        assert_eq!(table.len(), 10);
+        assert_eq!(
+            table.schema,
+            Schema::new(vec![
+                Field::new("a", DataType::Int64),
+                Field::new("b", DataType::Utf8)
+            ])?
+            .into(),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_csv_read_from_s3_projection() -> DaftResult<()> {
+        let file = "s3://daft-public-data/test_fixtures/csv-dev/mvp.csv";
+
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
+
+        let io_client = Arc::new(IOClient::new(io_config.into())?);
+
+        let table = read_csv(
+            file,
+            None,
+            Some(vec!["b"]),
+            None,
+            true,
+            None,
+            io_client,
+            true,
+        )?;
+        assert_eq!(table.len(), 100);
+        assert_eq!(
+            table.schema,
+            Schema::new(vec![Field::new("b", DataType::Utf8)])?.into(),
+        );
+
+        Ok(())
+    }
+}

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -101,8 +101,8 @@ impl LocalSource {
 }
 
 pub struct LocalFile {
-    path: PathBuf,
-    range: Option<Range<usize>>,
+    pub path: PathBuf,
+    pub range: Option<Range<usize>>,
 }
 
 #[async_trait]

--- a/src/daft-parquet/Cargo.toml
+++ b/src/daft-parquet/Cargo.toml
@@ -1,7 +1,7 @@
 [dependencies]
 arrow2 = {workspace = true, features = ["io_parquet", "io_parquet_compression"]}
-async-compat = "0.2.1"
-async-stream = "0.3.5"
+async-compat = {workspace = true}
+async-stream = {workspace = true}
 bytes = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
@@ -13,11 +13,11 @@ log = {workspace = true}
 parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true, optional = true}
-rayon = "1.7.0"
+rayon = {workspace = true}
 snafu = {workspace = true}
 tokio = {workspace = true}
-tokio-stream = "0.1.14"
-tokio-util = "0.7.8"
+tokio-stream = {workspace = true}
+tokio-util = {workspace = true}
 
 [features]
 default = ["python"]

--- a/src/daft-plan/src/physical_plan.rs
+++ b/src/daft-plan/src/physical_plan.rs
@@ -113,12 +113,18 @@ fn tabular_scan(
     limit: &Option<usize>,
     is_ray_runner: bool,
 ) -> PyResult<PyObject> {
-    let columns_to_read = projection_schema
-        .fields
-        .iter()
-        .map(|(name, _)| name)
-        .cloned()
-        .collect::<Vec<_>>();
+    let columns_to_read = if projection_schema.names() != source_schema.names() {
+        Some(
+            projection_schema
+                .fields
+                .iter()
+                .map(|(name, _)| name)
+                .cloned()
+                .collect::<Vec<_>>(),
+        )
+    } else {
+        None
+    };
     let py_iter = py
         .import(pyo3::intern!(py, "daft.execution.rust_physical_plan_shim"))?
         .getattr(pyo3::intern!(py, "tabular_scan"))?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod pylib {
         daft_table::register_modules(_py, m)?;
         daft_io::register_modules(_py, m)?;
         daft_parquet::register_modules(_py, m)?;
+        daft_csv::register_modules(_py, m)?;
         daft_plan::register_modules(_py, m)?;
 
         m.add_wrapped(wrap_pyfunction!(version))?;


### PR DESCRIPTION
This PR adds a simple native CSV reader. Local reads are fully async, while remote object store reads currently bulk-download each file into a byte buffer; streaming remote read support will be added in a follow-up PR.

**NOTE:** This PR required some changes to Arrow2's async CSV reading machinery, namely:
1. Schema inference was broken for headerless CSV files ([commit](https://github.com/Eventual-Inc/arrow2/commit/a14e8c7ec9eac77cc1aa5ee08b62c9d18f2408cf)).
2. Type inference was broken for CSV columns that contain nulls ([commit](https://github.com/Eventual-Inc/arrow2/commit/065a31da8fd8a75cbece5f99295a4068713a71ed)).

The requisite changes are contained on this branch: https://github.com/jorgecarleitao/arrow2/compare/main...Eventual-Inc:arrow2:clark/async-csv-fixes?expand=1

## TODOs (follow-up PRs)

- [ ] Add streaming remote reads
- [ ] Parallelize column/chunk deserialization

Closes #1462 