### PR TITLE
[PERF] Update number of cores on every iteration

### DIFF
--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -447,13 +447,12 @@ class Scheduler:
                 next_step = next(tasks)
 
                 while True:  # Loop: Dispatch -> await.
-                    # This call takes about 0.3ms and hits a locally in-memory cached record of cluster resources
-                    cores: int = int(ray.cluster_resources()["CPU"]) - self.reserved_cores
-                    max_inflight_tasks = cores + self.max_task_backlog
-
                     while True:  # Loop: Dispatch (get tasks -> batch dispatch).
                         tasks_to_dispatch: list[PartitionTask] = []
 
+                        # This call takes about 0.3ms and hits a locally in-memory cached record of cluster resources
+                        cores: int = int(ray.cluster_resources()["CPU"]) - self.reserved_cores
+                        max_inflight_tasks = cores + self.max_task_backlog
                         dispatches_allowed = max_inflight_tasks - len(inflight_tasks)
                         dispatches_allowed = min(cores, dispatches_allowed)
 

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -434,8 +434,6 @@ class Scheduler:
         # Get executable tasks from plan scheduler.
         tasks = plan_scheduler.to_partition_tasks(psets, is_ray_runner=True)
 
-        max_inflight_tasks = cores + self.max_task_backlog
-
         inflight_tasks: dict[str, PartitionTask[ray.ObjectRef]] = dict()
         inflight_ref_to_task: dict[ray.ObjectRef, str] = dict()
 
@@ -451,6 +449,7 @@ class Scheduler:
                 while True:  # Loop: Dispatch -> await.
                     # This call takes about 0.3ms and hits a locally in-memory cached record of cluster resources
                     cores: int = int(ray.cluster_resources()["CPU"]) - self.reserved_cores
+                    max_inflight_tasks = cores + self.max_task_backlog
 
                     while True:  # Loop: Dispatch (get tasks -> batch dispatch).
                         tasks_to_dispatch: list[PartitionTask] = []


### PR DESCRIPTION
Updates the number of cores available before/after every batch dispatch

This should allow us to take advantage of autoscaling of the Ray cluster better as we will schedule larger batches of tasks + more total inflight tasks as the cluster autoscales.