### PR TITLE
[PERF] Use pyarrow table for pickling rather than ChunkedArray

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -498,6 +498,9 @@ class Series:
 
     def _to_arrow_table_for_serdes(self) -> tuple[pa.Table, pa.ExtensionType | None]:
         array = self.to_arrow()
+        if len(array) == 0:
+            array = pa.array([], type=array.type)
+
         if isinstance(array.type, pa.BaseExtensionType):
             stype = array.type.storage_type
             ltype = array.type

--- a/daft/series.py
+++ b/daft/series.py
@@ -499,6 +499,9 @@ class Series:
     def _to_arrow_table_for_serdes(self) -> tuple[pa.Table, pa.ExtensionType | None]:
         array = self.to_arrow()
         if len(array) == 0:
+            # This is a workaround for:
+            # pyarrow.lib.ArrowIndexError: buffer slice would exceed buffer length
+            # when we have 0 length arrays
             array = pa.array([], type=array.type)
 
         if isinstance(array.type, pa.BaseExtensionType):

--- a/daft/series.py
+++ b/daft/series.py
@@ -33,6 +33,8 @@ except ImportError:
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
 
+_ARROW_TABLE_NAME_SERIAL_NAME = "ITEM"
+
 
 class Series:
     """
@@ -491,7 +493,15 @@ class Series:
         if self.datatype()._is_python_type():
             return (Series.from_pylist, (self.to_pylist(), self.name(), "force"))
         else:
-            return (Series.from_arrow, (self.to_arrow(), self.name()))
+            return (
+                Series._from_arrow_table_to_series,
+                (pa.table({_ARROW_TABLE_NAME_SERIAL_NAME: self.to_arrow()}), self.name()),
+            )
+
+    @classmethod
+    def _from_arrow_table_to_series(cls, table: pa.Table, name: str) -> Series:
+        array = table[_ARROW_TABLE_NAME_SERIAL_NAME]
+        return cls.from_arrow(array, name)
 
 
 SomeSeriesNamespace = TypeVar("SomeSeriesNamespace", bound="SeriesNamespace")

--- a/daft/series.py
+++ b/daft/series.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TypeVar
 
 import pyarrow as pa
@@ -490,7 +491,11 @@ class Series:
     def __reduce__(self) -> tuple:
         if self.datatype()._is_python_type():
             return (Series.from_pylist, (self.to_pylist(), self.name(), "force"))
+        elif sys.platform == "win32":
+            return (Series.from_arrow, (self.to_arrow(), self.name()))
         else:
+            # Ray Special CloudPickling fast path.
+            # Only run for Linux and Mac, since windows runs slower for some reason
             return (
                 Series._from_arrow_table_to_series,
                 self._to_arrow_table_for_serdes(),


### PR DESCRIPTION
* Use pyarrow table for pickling rather than ChunkedArray so we can exploit ray's special pickling for arrow tables which doesn't work on ChunkedArray