### PR TITLE
[PERF] Use region from system and leverage cached credentials when making new clients

### DIFF
--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(async_closure)]
 #![feature(let_chains)]
-#![feature(if_let_guard)]
+
 mod azure_blob;
 mod google_cloud;
 mod http;

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(async_closure)]
 #![feature(let_chains)]
+#![feature(if_let_guard)]
 mod azure_blob;
 mod google_cloud;
 mod http;

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -364,11 +364,9 @@ impl S3LikeSource {
         let mut new_config = self.s3_config.clone();
         new_config.region_name = Some(region.to_string());
 
-        let creds_cache = if let Some(current_client) = w_handle.get(&self.default_region) {
-            Some(current_client.conf().credentials_cache())
-        } else {
-            None
-        };
+        let creds_cache = w_handle
+            .get(&self.default_region)
+            .map(|current_client| current_client.conf().credentials_cache());
 
         let (_, new_client) = build_s3_client(&new_config, creds_cache).await?;
 

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -363,10 +363,14 @@ impl S3LikeSource {
 
         let mut new_config = self.s3_config.clone();
         new_config.region_name = Some(region.to_string());
-        let current_client = w_handle.get(&self.default_region).unwrap();
-        let creds_cache = current_client.conf().credentials_cache();
 
-        let (_, new_client) = build_s3_client(&new_config, Some(creds_cache)).await?;
+        let creds_cache = if let Some(current_client) = w_handle.get(&self.default_region) {
+            Some(current_client.conf().credentials_cache())
+        } else {
+            None
+        };
+
+        let (_, new_client) = build_s3_client(&new_config, creds_cache).await?;
 
         if w_handle.get(region).is_none() {
             w_handle.insert(region.clone(), new_client.into());


### PR DESCRIPTION
* Fixes 2 issues: 
* We always set to default region even when the system can provide us creds
* We reran the credential chain even though we can leverage a cache