### PR TITLE
[FEAT] IOStats for Native Reader

### DIFF
--- a/src/daft-csv/src/python.rs
+++ b/src/daft-csv/src/python.rs
@@ -4,7 +4,7 @@ pub mod pylib {
     use std::sync::Arc;
 
     use daft_core::python::schema::PySchema;
-    use daft_io::{get_io_client, python::IOConfig};
+    use daft_io::{get_io_client, python::IOConfig, IOStatsContext};
     use daft_table::python::PyTable;
     use pyo3::{exceptions::PyValueError, pyfunction, PyResult, Python};
 
@@ -34,6 +34,8 @@ pub mod pylib {
         multithreaded_io: Option<bool>,
     ) -> PyResult<PyTable> {
         py.allow_threads(|| {
+            let io_stats = IOStatsContext::new(format!("read_csv: for uri {uri}"));
+
             let io_client = get_io_client(
                 multithreaded_io.unwrap_or(true),
                 io_config.unwrap_or_default().config.into(),
@@ -46,6 +48,7 @@ pub mod pylib {
                 has_header.unwrap_or(true),
                 str_delimiter_to_byte(delimiter)?,
                 io_client,
+                Some(io_stats),
                 multithreaded_io.unwrap_or(true),
             )?
             .into())
@@ -71,6 +74,7 @@ pub mod pylib {
                 has_header.unwrap_or(true),
                 str_delimiter_to_byte(delimiter)?,
                 io_client,
+                None, // PRINT HERE TOO
             )?)
             .into())
         })

--- a/src/daft-csv/src/python.rs
+++ b/src/daft-csv/src/python.rs
@@ -65,6 +65,8 @@ pub mod pylib {
         multithreaded_io: Option<bool>,
     ) -> PyResult<PySchema> {
         py.allow_threads(|| {
+            let io_stats = IOStatsContext::new(format!("read_csv_schema: for uri {uri}"));
+
             let io_client = get_io_client(
                 multithreaded_io.unwrap_or(true),
                 io_config.unwrap_or_default().config.into(),
@@ -74,7 +76,7 @@ pub mod pylib {
                 has_header.unwrap_or(true),
                 str_delimiter_to_byte(delimiter)?,
                 io_client,
-                None, // PRINT HERE TOO
+                Some(io_stats),
             )?)
             .into())
         })

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -47,6 +47,7 @@ pub fn read_csv(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn read_csv_single(
     uri: &str,
     column_names: Option<Vec<&str>>,

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -13,7 +13,7 @@ use arrow2::{
 use async_compat::CompatExt;
 use common_error::DaftResult;
 use daft_core::{schema::Schema, utils::arrow::cast_array_for_daft_if_needed, Series};
-use daft_io::{get_runtime, GetResult, IOClient};
+use daft_io::{get_runtime, GetResult, IOClient, IOStatsRef};
 use daft_table::Table;
 use futures::{io::Cursor, AsyncRead, AsyncSeek};
 use tokio::fs::File;
@@ -27,6 +27,7 @@ pub fn read_csv(
     has_header: bool,
     delimiter: Option<u8>,
     io_client: Arc<IOClient>,
+    io_stats: Option<IOStatsRef>,
     multithreaded_io: bool,
 ) -> DaftResult<Table> {
     let runtime_handle = get_runtime(multithreaded_io)?;
@@ -40,6 +41,7 @@ pub fn read_csv(
             has_header,
             delimiter,
             io_client,
+            io_stats,
         )
         .await
     })
@@ -53,8 +55,12 @@ async fn read_csv_single(
     has_header: bool,
     delimiter: Option<u8>,
     io_client: Arc<IOClient>,
+    io_stats: Option<IOStatsRef>,
 ) -> DaftResult<Table> {
-    match io_client.single_url_get(uri.to_string(), None).await? {
+    match io_client
+        .single_url_get(uri.to_string(), None, io_stats)
+        .await?
+    {
         GetResult::File(file) => {
             read_csv_single_from_reader(
                 File::open(file.path).await?.compat(),
@@ -208,7 +214,7 @@ mod tests {
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
-        let table = read_csv(file, None, None, None, true, None, io_client, true)?;
+        let table = read_csv(file, None, None, None, true, None, io_client, None, true)?;
         assert_eq!(table.len(), 100);
         assert_eq!(
             table.schema,
@@ -231,7 +237,7 @@ mod tests {
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
-        let table = read_csv(file, None, None, None, true, None, io_client, true)?;
+        let table = read_csv(file, None, None, None, true, None, io_client, None, true)?;
         assert_eq!(table.len(), 5000);
 
         Ok(())
@@ -246,7 +252,17 @@ mod tests {
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
-        let table = read_csv(file, None, None, Some(10), true, None, io_client, true)?;
+        let table = read_csv(
+            file,
+            None,
+            None,
+            Some(10),
+            true,
+            None,
+            io_client,
+            None,
+            true,
+        )?;
         assert_eq!(table.len(), 10);
         assert_eq!(
             table.schema,
@@ -277,6 +293,7 @@ mod tests {
             true,
             None,
             io_client,
+            None,
             true,
         )?;
         assert_eq!(table.len(), 100);

--- a/src/daft-dsl/src/functions/uri/download.rs
+++ b/src/daft-dsl/src/functions/uri/download.rs
@@ -64,6 +64,7 @@ impl FunctionEvaluator for DownloadEvaluator {
                 *raise_error_on_failure,
                 *multi_thread,
                 config.clone(),
+                None,
             ),
             _ => Err(DaftError::ValueError(format!(
                 "Expected 1 input arg, got {}",

--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -156,7 +156,9 @@ impl AzureBlobSource {
         // Flatmap each page of results to a single stream of our standardized FileMetadata.
         responses_stream
             .map(move |response| {
-                io_stats.clone().map(|is| is.mark_list_requests(1));
+                if let Some(is) = io_stats.clone() {
+                    is.mark_list_requests(1)
+                }
                 (response, protocol.clone())
             })
             .flat_map(move |(response, protocol)| match response {
@@ -334,7 +336,9 @@ impl AzureBlobSource {
         // Map each page of results to a page of standardized FileMetadata.
         responses_stream
             .map(move |response| {
-                io_stats.clone().map(|is| is.mark_list_requests(1));
+                if let Some(is) = io_stats.clone() {
+                    is.mark_list_requests(1)
+                }
                 (response, protocol.clone(), container_name.clone())
             })
             .flat_map(move |(response, protocol, container_name)| match response {
@@ -430,7 +434,9 @@ impl ObjectSource for AzureBlobSource {
                 .into_error(e)
                 .into()
             });
-        io_stats.as_ref().map(|is| is.mark_get_requests(1));
+        if let Some(is) = io_stats.as_ref() {
+            is.mark_get_requests(1)
+        }
         Ok(GetResult::Stream(
             io_stats_on_bytestream(Box::pin(stream), io_stats),
             None,
@@ -455,7 +461,9 @@ impl ObjectSource for AzureBlobSource {
             .get_properties()
             .await
             .context(UnableToOpenFileSnafu::<String> { path: uri.into() })?;
-        io_stats.as_ref().map(|is| is.mark_head_requests(1));
+        if let Some(is) = io_stats.as_ref() {
+            is.mark_head_requests(1)
+        }
 
         Ok(metadata.blob.properties.content_length as usize)
     }

--- a/src/daft-io/src/google_cloud.rs
+++ b/src/daft-io/src/google_cloud.rs
@@ -1,6 +1,7 @@
 use std::ops::Range;
 use std::sync::Arc;
 
+use futures::io;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use futures::TryStreamExt;
@@ -21,6 +22,8 @@ use crate::object_io::FileType;
 use crate::object_io::LSResult;
 use crate::object_io::ObjectSource;
 use crate::s3_like;
+use crate::stats::IOStatsRef;
+use crate::stream_utils::io_stats_on_bytestream;
 use crate::GetResult;
 use common_io_config::GCSConfig;
 
@@ -127,7 +130,12 @@ fn parse_uri(uri: &url::Url) -> super::Result<(&str, &str)> {
 }
 
 impl GCSClientWrapper {
-    async fn get(&self, uri: &str, range: Option<Range<usize>>) -> super::Result<GetResult> {
+    async fn get(
+        &self,
+        uri: &str,
+        range: Option<Range<usize>>,
+        io_stats: Option<IOStatsRef>,
+    ) -> super::Result<GetResult> {
         let uri = url::Url::parse(uri).with_context(|_| InvalidUrlSnafu { path: uri })?;
         let (bucket, key) = parse_uri(&uri)?;
         match self {
@@ -160,16 +168,21 @@ impl GCSClientWrapper {
                     .into_error(e)
                     .into()
                 });
-                Ok(GetResult::Stream(response.boxed(), size, None))
+                io_stats.as_ref().map(|is| is.mark_get_requests(1));
+                Ok(GetResult::Stream(
+                    io_stats_on_bytestream(response, io_stats),
+                    size,
+                    None,
+                ))
             }
             GCSClientWrapper::S3Compat(client) => {
                 let uri = format!("s3://{}/{}", bucket, key);
-                client.get(&uri, range).await
+                client.get(&uri, range, io_stats).await
             }
         }
     }
 
-    async fn get_size(&self, uri: &str) -> super::Result<usize> {
+    async fn get_size(&self, uri: &str, io_stats: Option<IOStatsRef>) -> super::Result<usize> {
         let uri = url::Url::parse(uri).with_context(|_| InvalidUrlSnafu { path: uri })?;
         let (bucket, key) = parse_uri(&uri)?;
         match self {
@@ -186,11 +199,12 @@ impl GCSClientWrapper {
                     .context(UnableToOpenFileSnafu {
                         path: uri.to_string(),
                     })?;
+                io_stats.as_ref().map(|is| is.mark_head_requests(1));
                 Ok(response.size as usize)
             }
             GCSClientWrapper::S3Compat(client) => {
                 let uri = format!("s3://{}/{}", bucket, key);
-                client.get_size(&uri).await
+                client.get_size(&uri, io_stats).await
             }
         }
     }
@@ -203,6 +217,7 @@ impl GCSClientWrapper {
         delimiter: Option<&str>,
         continuation_token: Option<&str>,
         page_size: Option<i32>,
+        io_stats: Option<&IOStatsRef>,
     ) -> super::Result<LSResult> {
         let req = ListObjectsRequest {
             bucket: bucket.to_string(),
@@ -222,6 +237,8 @@ impl GCSClientWrapper {
             .context(UnableToListObjectsSnafu {
                 path: format!("{GCS_SCHEME}://{}/{}", bucket, key),
             })?;
+        io_stats.map(|is| is.mark_list_requests(1));
+
         let response_items = ls_response.items.unwrap_or_default();
         let response_prefixes = ls_response.prefixes.unwrap_or_default();
         let files = response_items.iter().map(|obj| FileMetadata {
@@ -246,6 +263,7 @@ impl GCSClientWrapper {
         posix: bool,
         continuation_token: Option<&str>,
         page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<LSResult> {
         let uri = url::Url::parse(path).with_context(|_| InvalidUrlSnafu { path })?;
         let (bucket, key) = parse_uri(&uri)?;
@@ -266,6 +284,7 @@ impl GCSClientWrapper {
                             Some(GCS_DELIMITER),
                             continuation_token,
                             page_size,
+                            io_stats.as_ref(),
                         )
                         .await?;
 
@@ -280,6 +299,7 @@ impl GCSClientWrapper {
                                 Some(GCS_DELIMITER),
                                 continuation_token,
                                 page_size,
+                                io_stats.as_ref(),
                             )
                             .await?;
 
@@ -307,12 +327,15 @@ impl GCSClientWrapper {
                         None, // Force a prefix-listing
                         continuation_token,
                         page_size,
+                        io_stats.as_ref(),
                     )
                     .await
                 }
             }
             GCSClientWrapper::S3Compat(client) => {
-                client.ls(path, posix, continuation_token, page_size).await
+                client
+                    .ls(path, posix, continuation_token, page_size, io_stats)
+                    .await
             }
         }
     }
@@ -362,12 +385,17 @@ impl GCSSource {
 
 #[async_trait]
 impl ObjectSource for GCSSource {
-    async fn get(&self, uri: &str, range: Option<Range<usize>>) -> super::Result<GetResult> {
-        self.client.get(uri, range).await
+    async fn get(
+        &self,
+        uri: &str,
+        range: Option<Range<usize>>,
+        io_stats: Option<IOStatsRef>,
+    ) -> super::Result<GetResult> {
+        self.client.get(uri, range, io_stats).await
     }
 
-    async fn get_size(&self, uri: &str) -> super::Result<usize> {
-        self.client.get_size(uri).await
+    async fn get_size(&self, uri: &str, io_stats: Option<IOStatsRef>) -> super::Result<usize> {
+        self.client.get_size(uri, io_stats).await
     }
 
     async fn glob(
@@ -375,13 +403,21 @@ impl ObjectSource for GCSSource {
         glob_path: &str,
         fanout_limit: Option<usize>,
         page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         use crate::object_store_glob::glob;
 
         // Ensure fanout_limit is not None to prevent runaway concurrency
         let fanout_limit = fanout_limit.or(Some(DEFAULT_GLOB_FANOUT_LIMIT));
 
-        glob(self, glob_path, fanout_limit, page_size.or(Some(1000))).await
+        glob(
+            self,
+            glob_path,
+            fanout_limit,
+            page_size.or(Some(1000)),
+            io_stats,
+        )
+        .await
     }
 
     async fn ls(
@@ -390,9 +426,10 @@ impl ObjectSource for GCSSource {
         posix: bool,
         continuation_token: Option<&str>,
         page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<LSResult> {
         self.client
-            .ls(path, posix, continuation_token, page_size)
+            .ls(path, posix, continuation_token, page_size, io_stats)
             .await
     }
 }

--- a/src/daft-io/src/google_cloud.rs
+++ b/src/daft-io/src/google_cloud.rs
@@ -237,7 +237,7 @@ impl GCSClientWrapper {
             .context(UnableToListObjectsSnafu {
                 path: format!("{GCS_SCHEME}://{}/{}", bucket, key),
             })?;
-        io_stats.map(|is| is.mark_list_requests(1));
+        io_stats.as_ref().map(|is| is.mark_list_requests(1));
 
         let response_items = ls_response.items.unwrap_or_default();
         let response_prefixes = ls_response.prefixes.unwrap_or_default();

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -195,7 +195,7 @@ impl ObjectSource for HttpSource {
         let response = response
             .error_for_status()
             .context(UnableToOpenFileSnafu::<String> { path: uri.into() })?;
-        io_stats.map(|is| is.mark_get_requests(1));
+        io_stats.as_ref().map(|is| is.mark_get_requests(1));
         let size_bytes = response.content_length().map(|s| s as usize);
         let stream = response.bytes_stream();
         let owned_string = uri.to_owned();
@@ -223,7 +223,7 @@ impl ObjectSource for HttpSource {
             .error_for_status()
             .context(UnableToOpenFileSnafu::<String> { path: uri.into() })?;
 
-        io_stats.map(|is| is.mark_head_requests(1));
+        io_stats.as_ref().map(|is| is.mark_head_requests(1));
 
         let headers = response.headers();
         match headers.get(CONTENT_LENGTH) {
@@ -275,7 +275,7 @@ impl ObjectSource for HttpSource {
             .context(UnableToConnectSnafu::<String> { path: path.into() })?
             .error_for_status()
             .with_context(|_| UnableToOpenFileSnafu { path })?;
-        io_stats.map(|is| is.mark_list_requests(1));
+        io_stats.as_ref().map(|is| is.mark_list_requests(1));
 
         // Reconstruct the actual path of the request, which may have been redirected via a 301
         // This is important because downstream URL joining logic relies on proper trailing-slashes/index.html

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -1,7 +1,7 @@
 use std::{num::ParseIntError, ops::Range, string::FromUtf8Error, sync::Arc};
 
 use async_trait::async_trait;
-use futures::{stream::BoxStream, StreamExt, TryStreamExt};
+use futures::{stream::BoxStream, TryStreamExt};
 
 use lazy_static::lazy_static;
 use regex::Regex;

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -195,7 +195,9 @@ impl ObjectSource for HttpSource {
         let response = response
             .error_for_status()
             .context(UnableToOpenFileSnafu::<String> { path: uri.into() })?;
-        io_stats.as_ref().map(|is| is.mark_get_requests(1));
+        if let Some(is) = io_stats.as_ref() {
+            is.mark_get_requests(1)
+        }
         let size_bytes = response.content_length().map(|s| s as usize);
         let stream = response.bytes_stream();
         let owned_string = uri.to_owned();
@@ -223,7 +225,9 @@ impl ObjectSource for HttpSource {
             .error_for_status()
             .context(UnableToOpenFileSnafu::<String> { path: uri.into() })?;
 
-        io_stats.as_ref().map(|is| is.mark_head_requests(1));
+        if let Some(is) = io_stats.as_ref() {
+            is.mark_head_requests(1)
+        }
 
         let headers = response.headers();
         match headers.get(CONTENT_LENGTH) {
@@ -275,7 +279,9 @@ impl ObjectSource for HttpSource {
             .context(UnableToConnectSnafu::<String> { path: path.into() })?
             .error_for_status()
             .with_context(|_| UnableToOpenFileSnafu { path })?;
-        io_stats.as_ref().map(|is| is.mark_list_requests(1));
+        if let Some(is) = io_stats.as_ref() {
+            is.mark_list_requests(1)
+        }
 
         // Reconstruct the actual path of the request, which may have been redirected via a 301
         // This is important because downstream URL joining logic relies on proper trailing-slashes/index.html

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -8,6 +8,8 @@ mod local;
 mod object_io;
 mod object_store_glob;
 mod s3_like;
+mod stats;
+mod stream_utils;
 use azure_blob::AzureBlobSource;
 use google_cloud::GCSSource;
 use lazy_static::lazy_static;

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -3,6 +3,7 @@ use std::ops::Range;
 use std::path::PathBuf;
 
 use crate::object_io::{self, FileMetadata, LSResult};
+use crate::stats::IOStatsRef;
 
 use super::object_io::{GetResult, ObjectSource};
 use super::Result;
@@ -111,7 +112,12 @@ pub struct LocalFile {
 
 #[async_trait]
 impl ObjectSource for LocalSource {
-    async fn get(&self, uri: &str, range: Option<Range<usize>>) -> super::Result<GetResult> {
+    async fn get(
+        &self,
+        uri: &str,
+        range: Option<Range<usize>>,
+        io_stats: Option<IOStatsRef>,
+    ) -> super::Result<GetResult> {
         const LOCAL_PROTOCOL: &str = "file://";
         if let Some(uri) = uri.strip_prefix(LOCAL_PROTOCOL) {
             Ok(GetResult::File(LocalFile {
@@ -123,7 +129,7 @@ impl ObjectSource for LocalSource {
         }
     }
 
-    async fn get_size(&self, uri: &str) -> super::Result<usize> {
+    async fn get_size(&self, uri: &str, io_stats: Option<IOStatsRef>) -> super::Result<usize> {
         const LOCAL_PROTOCOL: &str = "file://";
         let Some(uri) = uri.strip_prefix(LOCAL_PROTOCOL) else {
             return Err(Error::InvalidFilePath { path: uri.into() }.into());
@@ -141,6 +147,7 @@ impl ObjectSource for LocalSource {
         glob_path: &str,
         _fanout_limit: Option<usize>,
         _page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         use crate::object_store_glob::glob;
 
@@ -156,7 +163,7 @@ impl ObjectSource for LocalSource {
             return glob(self, glob_path.as_str(), fanout_limit, page_size).await;
         }
 
-        glob(self, glob_path, fanout_limit, page_size).await
+        glob(self, glob_path, fanout_limit, page_size, io_stats).await
     }
 
     async fn ls(
@@ -165,8 +172,9 @@ impl ObjectSource for LocalSource {
         posix: bool,
         _continuation_token: Option<&str>,
         _page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<LSResult> {
-        let s = self.iter_dir(path, posix, None).await?;
+        let s = self.iter_dir(path, posix, None, io_stats).await?;
         let files = s.try_collect::<Vec<_>>().await?;
         Ok(LSResult {
             files,
@@ -179,6 +187,7 @@ impl ObjectSource for LocalSource {
         uri: &str,
         posix: bool,
         _page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         if !posix {
             unimplemented!("Prefix-listing is not implemented for local.");
@@ -308,7 +317,7 @@ mod tests {
         let parquet_expected_md5 = "929674747af64a98aceaa6d895863bd3";
 
         let client = HttpSource::get_client().await?;
-        let parquet_file = client.get(parquet_file_path, None).await?;
+        let parquet_file = client.get(parquet_file_path, None, None).await?;
         let bytes = parquet_file.bytes().await?;
         let all_bytes = bytes.as_ref();
         let checksum = format!("{:x}", md5::compute(all_bytes));
@@ -326,12 +335,16 @@ mod tests {
         let parquet_file_path = format!("file://{}", file1.path().to_str().unwrap());
         let client = LocalSource::get_client().await?;
 
-        let try_all_bytes = client.get(&parquet_file_path, None).await?.bytes().await?;
+        let try_all_bytes = client
+            .get(&parquet_file_path, None, None)
+            .await?
+            .bytes()
+            .await?;
         assert_eq!(try_all_bytes.len(), bytes.len());
         assert_eq!(try_all_bytes, bytes);
 
         let first_bytes = client
-            .get_range(&parquet_file_path, 0..10)
+            .get_range(&parquet_file_path, 0..10, None)
             .await?
             .bytes()
             .await?;
@@ -339,7 +352,7 @@ mod tests {
         assert_eq!(first_bytes.as_ref(), &bytes[..10]);
 
         let first_bytes = client
-            .get_range(&parquet_file_path, 10..100)
+            .get_range(&parquet_file_path, 10..100, None)
             .await?
             .bytes()
             .await?;
@@ -347,14 +360,18 @@ mod tests {
         assert_eq!(first_bytes.as_ref(), &bytes[10..100]);
 
         let last_bytes = client
-            .get_range(&parquet_file_path, (bytes.len() - 10)..(bytes.len() + 10))
+            .get_range(
+                &parquet_file_path,
+                (bytes.len() - 10)..(bytes.len() + 10),
+                None,
+            )
             .await?
             .bytes()
             .await?;
         assert_eq!(last_bytes.len(), 10);
         assert_eq!(last_bytes.as_ref(), &bytes[(bytes.len() - 10)..]);
 
-        let size_from_get_size = client.get_size(parquet_file_path.as_str()).await?;
+        let size_from_get_size = client.get_size(parquet_file_path.as_str(), None).await?;
         assert_eq!(size_from_get_size, bytes.len());
 
         Ok(())
@@ -372,7 +389,7 @@ mod tests {
         let dir_path = format!("file://{}", dir.path().to_string_lossy().replace("\\", "/"));
         let client = LocalSource::get_client().await?;
 
-        let ls_result = client.ls(dir_path.as_ref(), true, None, None).await?;
+        let ls_result = client.ls(dir_path.as_ref(), true, None, None, None).await?;
         let mut files = ls_result.files.clone();
         // Ensure stable sort ordering of file paths before comparing with expected payload.
         files.sort_by(|a, b| a.filepath.cmp(&b.filepath));

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -160,7 +160,7 @@ impl ObjectSource for LocalSource {
         #[cfg(target_env = "msvc")]
         {
             let glob_path = glob_path.replace("\\", "/");
-            return glob(self, glob_path.as_str(), fanout_limit, page_size).await;
+            return glob(self, glob_path.as_str(), fanout_limit, page_size, io_stats).await;
         }
 
         glob(self, glob_path, fanout_limit, page_size, io_stats).await

--- a/src/daft-io/src/local.rs
+++ b/src/daft-io/src/local.rs
@@ -116,7 +116,7 @@ impl ObjectSource for LocalSource {
         &self,
         uri: &str,
         range: Option<Range<usize>>,
-        io_stats: Option<IOStatsRef>,
+        _io_stats: Option<IOStatsRef>,
     ) -> super::Result<GetResult> {
         const LOCAL_PROTOCOL: &str = "file://";
         if let Some(uri) = uri.strip_prefix(LOCAL_PROTOCOL) {
@@ -129,7 +129,7 @@ impl ObjectSource for LocalSource {
         }
     }
 
-    async fn get_size(&self, uri: &str, io_stats: Option<IOStatsRef>) -> super::Result<usize> {
+    async fn get_size(&self, uri: &str, _io_stats: Option<IOStatsRef>) -> super::Result<usize> {
         const LOCAL_PROTOCOL: &str = "file://";
         let Some(uri) = uri.strip_prefix(LOCAL_PROTOCOL) else {
             return Err(Error::InvalidFilePath { path: uri.into() }.into());
@@ -187,7 +187,7 @@ impl ObjectSource for LocalSource {
         uri: &str,
         posix: bool,
         _page_size: Option<i32>,
-        io_stats: Option<IOStatsRef>,
+        _io_stats: Option<IOStatsRef>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         if !posix {
             unimplemented!("Prefix-listing is not implemented for local.");
@@ -386,7 +386,7 @@ mod tests {
         write_remote_parquet_to_local_file(&mut file2).await?;
         let mut file3 = tempfile::NamedTempFile::new_in(dir.path()).unwrap();
         write_remote_parquet_to_local_file(&mut file3).await?;
-        let dir_path = format!("file://{}", dir.path().to_string_lossy().replace("\\", "/"));
+        let dir_path = format!("file://{}", dir.path().to_string_lossy().replace('\\', "/"));
         let client = LocalSource::get_client().await?;
 
         let ls_result = client.ls(dir_path.as_ref(), true, None, None, None).await?;
@@ -397,7 +397,7 @@ mod tests {
             FileMetadata {
                 filepath: format!(
                     "file://{}/{}",
-                    dir.path().to_string_lossy().replace("\\", "/"),
+                    dir.path().to_string_lossy().replace('\\', "/"),
                     file1.path().file_name().unwrap().to_string_lossy(),
                 ),
                 size: Some(file1.as_file().metadata().unwrap().len()),
@@ -406,7 +406,7 @@ mod tests {
             FileMetadata {
                 filepath: format!(
                     "file://{}/{}",
-                    dir.path().to_string_lossy().replace("\\", "/"),
+                    dir.path().to_string_lossy().replace('\\', "/"),
                     file2.path().file_name().unwrap().to_string_lossy(),
                 ),
                 size: Some(file2.as_file().metadata().unwrap().len()),
@@ -415,7 +415,7 @@ mod tests {
             FileMetadata {
                 filepath: format!(
                     "file://{}/{}",
-                    dir.path().to_string_lossy().replace("\\", "/"),
+                    dir.path().to_string_lossy().replace('\\', "/"),
                     file3.path().file_name().unwrap().to_string_lossy(),
                 ),
                 size: Some(file3.as_file().metadata().unwrap().len()),

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -10,6 +10,7 @@ use futures::StreamExt;
 use tokio::sync::OwnedSemaphorePermit;
 
 use crate::local::{collect_file, LocalFile};
+use crate::stats::IOStatsRef;
 
 pub enum GetResult {
     File(LocalFile),
@@ -94,17 +95,28 @@ use async_stream::stream;
 
 #[async_trait]
 pub(crate) trait ObjectSource: Sync + Send {
-    async fn get(&self, uri: &str, range: Option<Range<usize>>) -> super::Result<GetResult>;
-    async fn get_range(&self, uri: &str, range: Range<usize>) -> super::Result<GetResult> {
-        self.get(uri, Some(range)).await
+    async fn get(
+        &self,
+        uri: &str,
+        range: Option<Range<usize>>,
+        io_stats: Option<IOStatsRef>,
+    ) -> super::Result<GetResult>;
+    async fn get_range(
+        &self,
+        uri: &str,
+        range: Range<usize>,
+        io_stats: Option<IOStatsRef>,
+    ) -> super::Result<GetResult> {
+        self.get(uri, Some(range), io_stats).await
     }
-    async fn get_size(&self, uri: &str) -> super::Result<usize>;
+    async fn get_size(&self, uri: &str, io_stats: Option<IOStatsRef>) -> super::Result<usize>;
 
     async fn glob(
         self: Arc<Self>,
         glob_path: &str,
         fanout_limit: Option<usize>,
         page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>>;
 
     async fn ls(
@@ -113,6 +125,7 @@ pub(crate) trait ObjectSource: Sync + Send {
         posix: bool,
         continuation_token: Option<&str>,
         page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<LSResult>;
 
     async fn iter_dir(
@@ -120,17 +133,18 @@ pub(crate) trait ObjectSource: Sync + Send {
         uri: &str,
         posix: bool,
         page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         let uri = uri.to_string();
         let s = stream! {
-            let lsr = self.ls(&uri, posix, None, page_size).await?;
+            let lsr = self.ls(&uri, posix, None, page_size, io_stats).await?;
             for fm in lsr.files {
                 yield Ok(fm);
             }
 
             let mut continuation_token = lsr.continuation_token.clone();
             while continuation_token.is_some() {
-                let lsr = self.ls(&uri, posix, continuation_token.as_deref(), page_size).await?;
+                let lsr = self.ls(&uri, posix, continuation_token.as_deref(), page_size, io_stats).await?;
                 continuation_token = lsr.continuation_token.clone();
                 for fm in lsr.files {
                     yield Ok(fm);

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -137,14 +137,14 @@ pub(crate) trait ObjectSource: Sync + Send {
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         let uri = uri.to_string();
         let s = stream! {
-            let lsr = self.ls(&uri, posix, None, page_size, io_stats).await?;
+            let lsr = self.ls(&uri, posix, None, page_size, io_stats.clone()).await?;
             for fm in lsr.files {
                 yield Ok(fm);
             }
 
             let mut continuation_token = lsr.continuation_token.clone();
             while continuation_token.is_some() {
-                let lsr = self.ls(&uri, posix, continuation_token.as_deref(), page_size, io_stats).await?;
+                let lsr = self.ls(&uri, posix, continuation_token.as_deref(), page_size, io_stats.clone()).await?;
                 continuation_token = lsr.continuation_token.clone();
                 for fm in lsr.files {
                     yield Ok(fm);

--- a/src/daft-io/src/object_store_glob.rs
+++ b/src/daft-io/src/object_store_glob.rs
@@ -393,7 +393,7 @@ pub(crate) async fn glob(
                         .fanout_limit
                         .map(|fanout_limit| fanout_limit / state.current_fanout),
                     state.page_size,
-                    io_stats,
+                    io_stats.clone(),
                 )
                 .await;
 
@@ -412,7 +412,7 @@ pub(crate) async fn glob(
                                             state.current_fragment_idx,
                                             stream_dir_count,
                                         ),
-                                        io_stats,
+                                        io_stats.clone(),
                                     );
                                 }
                                 // Return any Files that match
@@ -506,7 +506,7 @@ pub(crate) async fn glob(
                         .fanout_limit
                         .map(|fanout_limit| fanout_limit / state.current_fanout),
                     state.page_size,
-                    io_stats,
+                    io_stats.clone(),
                 )
                 .await;
 
@@ -529,7 +529,7 @@ pub(crate) async fn glob(
                                             stream_dir_count,
                                         )
                                         .with_wildcard_mode(),
-                                    io_stats,
+                                    io_stats.clone(),
                                 );
                             }
                             FileType::File

--- a/src/daft-io/src/object_store_glob.rs
+++ b/src/daft-io/src/object_store_glob.rs
@@ -7,7 +7,10 @@ use tokio::sync::mpsc::Sender;
 use globset::{GlobBuilder, GlobMatcher};
 use lazy_static::lazy_static;
 
-use crate::object_io::{FileMetadata, FileType, ObjectSource};
+use crate::{
+    object_io::{FileMetadata, FileType, ObjectSource},
+    stats::IOStatsRef,
+};
 
 lazy_static! {
     /// Check if a given char is considered a special glob character
@@ -229,15 +232,17 @@ async fn ls_with_prefix_fallback(
     uri: &str,
     max_dirs: Option<usize>,
     page_size: Option<i32>,
+    io_stats: Option<IOStatsRef>,
 ) -> (BoxStream<'static, super::Result<FileMetadata>>, usize) {
     // Prefix list function that only returns Files
     fn prefix_ls(
         source: Arc<dyn ObjectSource>,
         path: String,
         page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> BoxStream<'static, super::Result<FileMetadata>> {
         stream! {
-            match source.iter_dir(&path, false, page_size).await {
+            match source.iter_dir(&path, false, page_size, io_stats).await {
                 Ok(mut result_stream) => {
                     while let Some(result) = result_stream.next().await {
                         match result {
@@ -261,7 +266,7 @@ async fn ls_with_prefix_fallback(
     let mut results_buffer = vec![];
 
     let mut fm_stream = source
-        .iter_dir(uri, true, page_size)
+        .iter_dir(uri, true, page_size, io_stats.clone())
         .await
         .unwrap_or_else(|e| futures::stream::iter([Err(e)]).boxed());
 
@@ -278,7 +283,10 @@ async fn ls_with_prefix_fallback(
                     .map(|max_dirs| dir_count_so_far > max_dirs)
                     .unwrap_or(false)
                 {
-                    return (prefix_ls(source.clone(), uri.to_string(), page_size), 0);
+                    return (
+                        prefix_ls(source.clone(), uri.to_string(), page_size, io_stats),
+                        0,
+                    );
                 }
             }
         }
@@ -312,13 +320,14 @@ pub(crate) async fn glob(
     glob: &str,
     fanout_limit: Option<usize>,
     page_size: Option<i32>,
+    io_stats: Option<IOStatsRef>,
 ) -> super::Result<BoxStream<'static, super::Result<FileMetadata>>> {
     // If no special characters, we fall back to ls behavior
     let full_fragment = GlobFragment::new(glob);
     if !full_fragment.has_special_character() {
         let glob = full_fragment.escaped_str().to_string();
         return Ok(stream! {
-            let mut results = source.iter_dir(glob.as_str(), true, page_size).await?;
+            let mut results = source.iter_dir(glob.as_str(), true, page_size, io_stats).await?;
             while let Some(result) = results.next().await {
                 match result {
                     Ok(fm) => {
@@ -364,6 +373,7 @@ pub(crate) async fn glob(
         result_tx: Sender<super::Result<FileMetadata>>,
         source: Arc<dyn ObjectSource>,
         state: GlobState,
+        io_stats: Option<IOStatsRef>,
     ) {
         tokio::spawn(async move {
             log::debug!(
@@ -383,6 +393,7 @@ pub(crate) async fn glob(
                         .fanout_limit
                         .map(|fanout_limit| fanout_limit / state.current_fanout),
                     state.page_size,
+                    io_stats,
                 )
                 .await;
 
@@ -401,6 +412,7 @@ pub(crate) async fn glob(
                                             state.current_fragment_idx,
                                             stream_dir_count,
                                         ),
+                                        io_stats,
                                     );
                                 }
                                 // Return any Files that match
@@ -424,7 +436,7 @@ pub(crate) async fn glob(
                 // Last fragment contains a wildcard: we list the last level and match against the full glob
                 if current_fragment.has_special_character() {
                     let mut results = source
-                        .iter_dir(&state.current_path, true, state.page_size)
+                        .iter_dir(&state.current_path, true, state.page_size, io_stats)
                         .await
                         .unwrap_or_else(|e| futures::stream::iter([Err(e)]).boxed());
 
@@ -448,7 +460,13 @@ pub(crate) async fn glob(
                 } else {
                     let full_dir_path = state.current_path.clone() + current_fragment.escaped_str();
                     let single_file_ls = source
-                        .ls(full_dir_path.as_str(), true, None, state.page_size)
+                        .ls(
+                            full_dir_path.as_str(),
+                            true,
+                            None,
+                            state.page_size,
+                            io_stats,
+                        )
                         .await;
                     match single_file_ls {
                         Ok(mut single_file_ls) => {
@@ -488,6 +506,7 @@ pub(crate) async fn glob(
                         .fanout_limit
                         .map(|fanout_limit| fanout_limit / state.current_fanout),
                     state.page_size,
+                    io_stats,
                 )
                 .await;
 
@@ -510,6 +529,7 @@ pub(crate) async fn glob(
                                             stream_dir_count,
                                         )
                                         .with_wildcard_mode(),
+                                    io_stats,
                                 );
                             }
                             FileType::File
@@ -536,6 +556,7 @@ pub(crate) async fn glob(
                     state
                         .clone()
                         .advance(full_dir_path, state.current_fragment_idx + 1, 1),
+                    io_stats,
                 );
             }
         });
@@ -554,6 +575,7 @@ pub(crate) async fn glob(
             fanout_limit,
             page_size,
         },
+        io_stats,
     );
 
     let to_rtn_stream = stream! {

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -2,7 +2,7 @@ pub use common_io_config::python::{AzureConfig, GCSConfig, IOConfig};
 pub use py::register_modules;
 
 mod py {
-    use crate::{get_io_client, get_runtime, parse_url};
+    use crate::{get_io_client, get_runtime, parse_url, stats::IOStatsContext};
     use common_error::DaftResult;
     use futures::TryStreamExt;
     use pyo3::{
@@ -20,6 +20,7 @@ mod py {
         page_size: Option<i32>,
     ) -> PyResult<&PyList> {
         let multithreaded_io = multithreaded_io.unwrap_or(true);
+        let io_stats = IOStatsContext::new();
         let lsr: DaftResult<Vec<_>> = py.allow_threads(|| {
             let io_client = get_io_client(
                 multithreaded_io,
@@ -32,7 +33,7 @@ mod py {
             runtime_handle.block_on(async move {
                 let source = io_client.get_source(&scheme).await?;
                 let files = source
-                    .glob(path.as_ref(), fanout_limit, page_size)
+                    .glob(path.as_ref(), fanout_limit, page_size, Some(io_stats))
                     .await?
                     .try_collect()
                     .await?;
@@ -48,6 +49,8 @@ mod py {
             dict.set_item("size", file.size)?;
             to_rtn.push(dict);
         }
+
+        log::warn!("{:?}", io_stats);
         Ok(PyList::new(py, to_rtn))
     }
 

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -20,7 +20,9 @@ mod py {
         page_size: Option<i32>,
     ) -> PyResult<&PyList> {
         let multithreaded_io = multithreaded_io.unwrap_or(true);
-        let io_stats = IOStatsContext::new();
+        let io_stats = IOStatsContext::new(format!("io_glob for {path}"));
+        let io_stats_handle = io_stats.clone();
+
         let lsr: DaftResult<Vec<_>> = py.allow_threads(|| {
             let io_client = get_io_client(
                 multithreaded_io,
@@ -33,7 +35,12 @@ mod py {
             runtime_handle.block_on(async move {
                 let source = io_client.get_source(&scheme).await?;
                 let files = source
-                    .glob(path.as_ref(), fanout_limit, page_size, Some(io_stats))
+                    .glob(
+                        path.as_ref(),
+                        fanout_limit,
+                        page_size,
+                        Some(io_stats_handle),
+                    )
                     .await?
                     .try_collect()
                     .await?;
@@ -49,8 +56,6 @@ mod py {
             dict.set_item("size", file.size)?;
             to_rtn.push(dict);
         }
-
-        log::warn!("{:?}", io_stats);
         Ok(PyList::new(py, to_rtn))
     }
 

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -10,6 +10,8 @@ use s3::operation::list_objects_v2::ListObjectsV2Error;
 use tokio::sync::{OwnedSemaphorePermit, SemaphorePermit};
 
 use crate::object_io::{FileMetadata, FileType, LSResult};
+use crate::stats::{IOStatsContext, IOStatsRef};
+use crate::stream_utils::io_stats_on_bytestream;
 use crate::{get_io_pool_num_threads, InvalidArgumentSnafu, SourceType};
 use aws_config::SdkConfig;
 use aws_credential_types::cache::{ProvideCachedCredentials, SharedCredentialsCache};
@@ -720,24 +722,38 @@ impl S3LikeSource {
 
 #[async_trait]
 impl ObjectSource for S3LikeSource {
-    async fn get(&self, uri: &str, range: Option<Range<usize>>) -> super::Result<GetResult> {
+    async fn get(
+        &self,
+        uri: &str,
+        range: Option<Range<usize>>,
+        io_stats: Option<IOStatsRef>,
+    ) -> super::Result<GetResult> {
         let permit = self
             .connection_pool_sema
             .clone()
             .acquire_owned()
             .await
             .context(UnableToGrabSemaphoreSnafu)?;
-        self._get_impl(permit, uri, range, &self.default_region)
-            .await
+        let get_result = self
+            ._get_impl(permit, uri, range, &self.default_region)
+            .await?;
+        if let GetResult::Stream(stream, num_bytes , permit) = get_result && io_stats.is_some() {
+            io_stats.map(|is| is.mark_get_requests(1));
+            Ok(GetResult::Stream(io_stats_on_bytestream(stream, io_stats), num_bytes, permit))
+        } else {
+            Ok(get_result)
+        }
     }
 
-    async fn get_size(&self, uri: &str) -> super::Result<usize> {
+    async fn get_size(&self, uri: &str, io_stats: Option<IOStatsRef>) -> super::Result<usize> {
         let permit = self
             .connection_pool_sema
             .acquire()
             .await
             .context(UnableToGrabSemaphoreSnafu)?;
-        self._head_impl(permit, uri, &self.default_region).await
+        let head_result = self._head_impl(permit, uri, &self.default_region).await?;
+        io_stats.map(|is| is.mark_head_requests(1));
+        Ok(head_result)
     }
 
     async fn glob(
@@ -745,13 +761,21 @@ impl ObjectSource for S3LikeSource {
         glob_path: &str,
         fanout_limit: Option<usize>,
         page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<BoxStream<super::Result<FileMetadata>>> {
         use crate::object_store_glob::glob;
 
         // Ensure fanout_limit is not None to prevent runaway concurrency
         let fanout_limit = fanout_limit.or(Some(DEFAULT_GLOB_FANOUT_LIMIT));
 
-        glob(self, glob_path, fanout_limit, page_size.or(Some(1000))).await
+        glob(
+            self,
+            glob_path,
+            fanout_limit,
+            page_size.or(Some(1000)),
+            io_stats,
+        )
+        .await
     }
 
     async fn ls(
@@ -760,6 +784,7 @@ impl ObjectSource for S3LikeSource {
         posix: bool,
         continuation_token: Option<&str>,
         page_size: Option<i32>,
+        io_stats: Option<IOStatsRef>,
     ) -> super::Result<LSResult> {
         let parsed = url::Url::parse(path).with_context(|_| InvalidUrlSnafu { path })?;
         let scheme = parsed.scheme();
@@ -800,6 +825,8 @@ impl ObjectSource for S3LikeSource {
                 )
                 .await?
             };
+            io_stats.map(|is| is.mark_list_requests(1));
+
             if lsr.files.is_empty() && key.contains(S3_DELIMITER) {
                 let permit = self
                     .connection_pool_sema
@@ -820,6 +847,7 @@ impl ObjectSource for S3LikeSource {
                         page_size,
                     )
                     .await?;
+                io_stats.map(|is| is.mark_list_requests(1));
                 let target_path = format!("{scheme}://{bucket}/{key}");
                 lsr.files.retain(|f| f.filepath == target_path);
 
@@ -852,6 +880,8 @@ impl ObjectSource for S3LikeSource {
                 )
                 .await?
             };
+            io_stats.map(|is| is.mark_list_requests(1));
+
             Ok(lsr)
         }
     }
@@ -875,14 +905,14 @@ mod tests {
             ..Default::default()
         };
         let client = S3LikeSource::get_client(&config).await?;
-        let parquet_file = client.get(parquet_file_path, None).await?;
+        let parquet_file = client.get(parquet_file_path, None, None).await?;
         let bytes = parquet_file.bytes().await?;
         let all_bytes = bytes.as_ref();
         let checksum = format!("{:x}", md5::compute(all_bytes));
         assert_eq!(checksum, parquet_expected_md5);
 
         let first_bytes = client
-            .get_range(parquet_file_path, 0..10)
+            .get_range(parquet_file_path, 0..10, None)
             .await?
             .bytes()
             .await?;
@@ -890,7 +920,7 @@ mod tests {
         assert_eq!(first_bytes.as_ref(), &all_bytes[..10]);
 
         let first_bytes = client
-            .get_range(parquet_file_path, 10..100)
+            .get_range(parquet_file_path, 10..100, None)
             .await?
             .bytes()
             .await?;
@@ -901,6 +931,7 @@ mod tests {
             .get_range(
                 parquet_file_path,
                 (all_bytes.len() - 10)..(all_bytes.len() + 10),
+                None,
             )
             .await?
             .bytes()
@@ -908,7 +939,7 @@ mod tests {
         assert_eq!(last_bytes.len(), 10);
         assert_eq!(last_bytes.as_ref(), &all_bytes[(all_bytes.len() - 10)..]);
 
-        let size_from_get_size = client.get_size(parquet_file_path).await?;
+        let size_from_get_size = client.get_size(parquet_file_path, None).await?;
         assert_eq!(size_from_get_size, all_bytes.len());
 
         Ok(())
@@ -924,7 +955,7 @@ mod tests {
         };
         let client = S3LikeSource::get_client(&config).await?;
 
-        client.ls(file_path, true, None, None).await?;
+        client.ls(file_path, true, None, None, None).await?;
 
         Ok(())
     }

--- a/src/daft-io/src/stats.rs
+++ b/src/daft-io/src/stats.rs
@@ -1,0 +1,89 @@
+use std::sync::{atomic, Arc};
+
+pub type IOStatsRef = Arc<IOStatsContext>;
+
+#[derive(Default, Debug)]
+pub struct IOStatsContext {
+    num_get_requests: atomic::AtomicUsize,
+    num_head_requests: atomic::AtomicUsize,
+    num_list_requests: atomic::AtomicUsize,
+    bytes_read: atomic::AtomicUsize,
+}
+
+pub(crate) struct IOStatsByteStreamContextHandle {
+    // do not enable Copy or Clone on this struct
+    bytes_read: usize,
+    inner: IOStatsRef,
+}
+
+impl IOStatsContext {
+    pub fn new() -> IOStatsRef {
+        Arc::new(Default::default())
+    }
+
+    #[inline]
+    pub(crate) fn mark_get_requests(&self, num_requests: usize) {
+        self.num_get_requests
+            .fetch_add(num_requests, atomic::Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn mark_head_requests(&self, num_requests: usize) {
+        self.num_head_requests
+            .fetch_add(num_requests, atomic::Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn mark_list_requests(&self, num_requests: usize) {
+        self.num_list_requests
+            .fetch_add(num_requests, atomic::Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn load_get_requests(&self, num_requests: usize) {
+        self.num_get_requests.load(atomic::Ordering::Acquire);
+    }
+
+    #[inline]
+    pub fn load_head_requests(&self, num_requests: usize) {
+        self.num_head_requests.load(atomic::Ordering::Acquire);
+    }
+
+    #[inline]
+    pub fn load_list_requests(&self, num_requests: usize) {
+        self.num_list_requests.load(atomic::Ordering::Acquire);
+    }
+
+    #[inline]
+    pub(crate) fn mark_bytes_read(&self, bytes_read: usize) {
+        self.bytes_read
+            .fetch_add(bytes_read, atomic::Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub fn load_bytes_read(&self) -> usize {
+        self.bytes_read.load(atomic::Ordering::Acquire)
+    }
+}
+
+impl IOStatsByteStreamContextHandle {
+    pub fn new(io_stats: IOStatsRef) -> Self {
+        Self {
+            bytes_read: 0,
+            inner: io_stats,
+        }
+    }
+
+    #[inline]
+    pub fn mark_bytes_read(&mut self, bytes_read: usize) {
+        self.bytes_read += bytes_read;
+    }
+}
+
+impl Drop for IOStatsByteStreamContextHandle {
+    fn drop(&mut self) {
+        self.inner.mark_bytes_read(self.bytes_read);
+
+        log::warn!("Finished IOStats: {}", self.inner.load_bytes_read());
+    }
+}

--- a/src/daft-io/src/stats.rs
+++ b/src/daft-io/src/stats.rs
@@ -19,8 +19,8 @@ impl Drop for IOStatsContext {
         let bytes_read = self.load_bytes_read();
         let num_gets = self.load_get_requests();
         let mean_size = (bytes_read as f64) / (num_gets as f64);
-        log::warn!(
-            "IOStatsContext: {}, Gets: {}, Heads: {}, Lists: {}, BytesReads: {}, AvgGetSize: {}",
+        log::debug!(
+            "IOStatsContext: {}, Gets: {}, Heads: {}, Lists: {}, BytesRead: {}, AvgGetSize: {}",
             self.name,
             num_gets,
             self.load_head_requests(),

--- a/src/daft-io/src/stream_utils.rs
+++ b/src/daft-io/src/stream_utils.rs
@@ -1,0 +1,28 @@
+use bytes::Bytes;
+
+use crate::stats::{IOStatsByteStreamContextHandle, IOStatsRef};
+
+use futures::{stream::BoxStream, StreamExt};
+
+pub(crate) fn io_stats_on_bytestream(
+    mut s: impl futures::stream::Stream<Item = super::Result<Bytes>>
+        + Unpin
+        + std::marker::Send
+        + 'static,
+    io_stats: Option<IOStatsRef>,
+) -> BoxStream<'static, super::Result<Bytes>> {
+    if let Some(io_stats) = io_stats {
+        let mut context = IOStatsByteStreamContextHandle::new(io_stats);
+        async_stream::stream! {
+            while let Some(val) = s.next().await  {
+                if let Ok(ref val) = val {
+                    context.mark_bytes_read(val.len());
+                }
+                yield val
+            }
+        }
+        .boxed()
+    } else {
+        s.boxed()
+    }
+}

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -128,7 +128,7 @@ pub mod pylib {
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<Vec<PyTable>> {
         py.allow_threads(|| {
-            let io_stats = IOStatsContext::new(format!("read_parquet_bulk"));
+            let io_stats = IOStatsContext::new("read_parquet_bulk".to_string());
 
             let io_client = get_io_client(
                 multithreaded_io.unwrap_or(true),
@@ -237,7 +237,7 @@ pub mod pylib {
         multithreaded_io: Option<bool>,
     ) -> PyResult<PyTable> {
         py.allow_threads(|| {
-            let io_stats = IOStatsContext::new(format!("read_parquet_statistics"));
+            let io_stats = IOStatsContext::new("read_parquet_statistics".to_string());
 
             let io_client = get_io_client(
                 multithreaded_io.unwrap_or(true),

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -5,7 +5,7 @@ pub mod pylib {
         ffi::field_to_py,
         python::{datatype::PyTimeUnit, schema::PySchema, PySeries},
     };
-    use daft_io::{get_io_client, python::IOConfig};
+    use daft_io::{get_io_client, python::IOConfig, IOStatsContext};
     use daft_table::python::PyTable;
     use pyo3::{pyfunction, types::PyModule, PyResult, Python};
     use std::{collections::BTreeMap, sync::Arc};
@@ -26,6 +26,8 @@ pub mod pylib {
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<PyTable> {
         py.allow_threads(|| {
+            let io_stats = IOStatsContext::new(format!("read_parquet: for uri {uri}"));
+
             let io_client = get_io_client(
                 multithreaded_io.unwrap_or(true),
                 io_config.unwrap_or_default().config.into(),
@@ -33,17 +35,19 @@ pub mod pylib {
             let schema_infer_options = ParquetSchemaInferenceOptions::new(
                 coerce_int96_timestamp_unit.map(|tu| tu.timeunit),
             );
-            Ok(crate::read::read_parquet(
+            let result = crate::read::read_parquet(
                 uri,
                 columns.as_deref(),
                 start_offset,
                 num_rows,
                 row_groups,
                 io_client,
+                Some(io_stats.clone()),
                 multithreaded_io.unwrap_or(true),
                 schema_infer_options,
             )?
-            .into())
+            .into();
+            Ok(result)
         })
     }
     type PyArrowChunks = Vec<Vec<pyo3::PyObject>>;
@@ -100,6 +104,7 @@ pub mod pylib {
                 num_rows,
                 row_groups,
                 io_client,
+                None,
                 multithreaded_io.unwrap_or(true),
                 schema_infer_options,
             )
@@ -123,6 +128,8 @@ pub mod pylib {
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<Vec<PyTable>> {
         py.allow_threads(|| {
+            let io_stats = IOStatsContext::new(format!("read_parquet_bulk"));
+
             let io_client = get_io_client(
                 multithreaded_io.unwrap_or(true),
                 io_config.unwrap_or_default().config.into(),
@@ -138,6 +145,7 @@ pub mod pylib {
                 num_rows,
                 row_groups,
                 io_client,
+                Some(io_stats),
                 num_parallel_tasks.unwrap_or(128) as usize,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
@@ -178,6 +186,7 @@ pub mod pylib {
                 num_rows,
                 row_groups,
                 io_client,
+                None,
                 num_parallel_tasks.unwrap_or(128) as usize,
                 multithreaded_io.unwrap_or(true),
                 schema_infer_options,
@@ -211,6 +220,7 @@ pub mod pylib {
             Ok(Arc::new(crate::read::read_parquet_schema(
                 uri,
                 io_client,
+                None,
                 schema_infer_options,
             )?)
             .into())
@@ -229,7 +239,7 @@ pub mod pylib {
                 multithreaded_io.unwrap_or(true),
                 io_config.unwrap_or_default().config.into(),
             )?;
-            Ok(crate::read::read_parquet_statistics(&uris.series, io_client)?.into())
+            Ok(crate::read::read_parquet_statistics(&uris.series, io_client, None)?.into())
         })
     }
 }

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -49,6 +49,7 @@ impl From<ParquetSchemaInferenceOptions>
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn read_parquet_single(
     uri: &str,
     columns: Option<&[&str]>,
@@ -167,6 +168,7 @@ async fn read_parquet_single(
     Ok(table)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn read_parquet_single_into_arrow(
     uri: &str,
     columns: Option<&[&str]>,


### PR DESCRIPTION
* Implements IOStats via atomics that will track the number of:
* GetRequests
* HeadRequests
* ListRequests
* BytesRead


When the `IOStatsContext` goes out of scope it will debug log its output:
For a parquet read:
```
IOStatsContext: read_parquet: for uri s3://eventual-dev-benchmarking-fixtures/parquet-benchmarking/tpch/200MB-2RG/daft_200MB_lineitem_chunk.RG-2.parquet, Gets: 17, Heads: 1, Lists: 0, BytesRead: 213627535, AvgGetSize: 12566325
```
For our io_glob:
```
IOStatsContext: io_glob for s3://daft-segment-data/segment-logs/**, Gets: 0, Heads: 0, Lists: 237, BytesRead: 0, AvgGetSize: 0
```

Currently the context is threaded through our python Apis for `io_glob`, `read_parquet`, and `read_csv`

IOStats is currently implemented for:
* S3
* GCS
* HTTP
* Azure

