### PR TITLE
[CHORE] Better logging for physical plan

### DIFF
--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -150,7 +150,7 @@ class PartitionTaskBuilder(Generic[PartitionT]):
     def __str__(self) -> str:
         return (
             f"PartitionTaskBuilder\n"
-            f"  Inputs: {self.inputs}\n"
+            f"  Inputs: <{len(self.inputs)} partitions>\n"
             f"  Resource Request: {self.resource_request}\n"
             f"  Instructions: {[i.__class__.__name__ for i in self.instructions]}"
         )

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -70,7 +70,7 @@ class PartitionTask(Generic[PartitionT]):
     def __str__(self) -> str:
         return (
             f"{self.id()}\n"
-            f"  Inputs: {self.inputs}\n"
+            f"  Inputs: <{len(self.inputs)} partitions>\n"
             f"  Resource Request: {self.resource_request}\n"
             f"  Instructions: {[i.__class__.__name__ for i in self.instructions]}"
         )

--- a/daft/logging.py
+++ b/daft/logging.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import logging
+
+
+def setup_debug_logger(
+    exclude_prefix: list[str] = [],
+    daft_only: bool = True,
+):
+    logging.basicConfig(level="DEBUG")
+    root_logger = logging.getLogger()
+
+    if daft_only:
+        for handler in root_logger.handlers:
+            handler.addFilter(lambda record: record.name.startswith("daft"))
+
+    if exclude_prefix:
+        for prefix in exclude_prefix:
+            for handler in root_logger.handlers:
+                handler.addFilter(lambda record: not record.name.startswith(prefix))

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -231,7 +231,7 @@ class PyRunner(Runner[Table]):
                         done_task = inflight_tasks.pop(done_id)
                         partitions = done_future.result()
 
-                        logger.debug(f"Task completed: {done_id} -> {partitions}")
+                        logger.debug(f"Task completed: {done_id} -> <{len(partitions)} partitions>")
                         done_task.set_result([PyMaterializedResult(partition) for partition in partitions])
 
                     if next_step is None:


### PR DESCRIPTION
1. Reduces the verbosity of physical planner debug logs by logging only the number of partitions rather than printing the partition itself
2. Adds a `setup_debug_logging` function for convenience when performing local/dogfooding