### PR TITLE
[CHORE] Move code from daft-csv to daft-decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1119,6 +1119,7 @@ dependencies = [
  "common-error",
  "csv-async",
  "daft-core",
+ "daft-decoding",
  "daft-io",
  "daft-table",
  "futures",
@@ -1134,6 +1135,18 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "daft-decoding"
+version = "0.1.10"
+dependencies = [
+ "arrow2",
+ "chrono",
+ "chrono-tz",
+ "csv-async",
+ "lexical-core",
+ "simdutf8",
 ]
 
 [[package]]

--- a/src/daft-csv/Cargo.toml
+++ b/src/daft-csv/Cargo.toml
@@ -9,6 +9,7 @@ chrono-tz = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
 csv-async = "1.2.6"
 daft-core = {path = "../daft-core", default-features = false}
+daft-decoding = {path = "../daft-decoding"}
 daft-io = {path = "../daft-io", default-features = false}
 daft-table = {path = "../daft-table", default-features = false}
 futures = {workspace = true}

--- a/src/daft-csv/src/lib.rs
+++ b/src/daft-csv/src/lib.rs
@@ -4,12 +4,11 @@ use common_error::DaftError;
 use snafu::Snafu;
 
 mod compression;
-mod deserialize;
-mod inference;
 pub mod metadata;
 #[cfg(feature = "python")]
 pub mod python;
 pub mod read;
+mod schema;
 #[cfg(feature = "python")]
 pub use python::register_modules;
 

--- a/src/daft-csv/src/metadata.rs
+++ b/src/daft-csv/src/metadata.rs
@@ -12,8 +12,8 @@ use tokio::{
 };
 use tokio_util::io::StreamReader;
 
-use crate::inference::merge_schema;
-use crate::{compression::CompressionCodec, inference::infer};
+use crate::{compression::CompressionCodec, schema::merge_schema};
+use daft_decoding::inference::infer;
 
 const DEFAULT_COLUMN_PREFIX: &str = "column_";
 

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -29,9 +29,9 @@ use tokio::{
 };
 use tokio_util::io::StreamReader;
 
-use crate::deserialize::deserialize_column;
 use crate::metadata::read_csv_schema_single;
 use crate::{compression::CompressionCodec, ArrowSnafu};
+use daft_decoding::deserialize::deserialize_column;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_csv(

--- a/src/daft-csv/src/schema.rs
+++ b/src/daft-csv/src/schema.rs
@@ -1,0 +1,43 @@
+use std::collections::HashSet;
+
+/// Merges two Arrow2 schemas
+pub fn merge_schema(
+    headers: &[String],
+    column_types: &mut [HashSet<arrow2::datatypes::DataType>],
+) -> Vec<arrow2::datatypes::Field> {
+    headers
+        .iter()
+        .zip(column_types.iter_mut())
+        .map(|(field_name, possibilities)| merge_fields(field_name, possibilities))
+        .collect()
+}
+
+fn merge_fields(
+    field_name: &str,
+    possibilities: &mut HashSet<arrow2::datatypes::DataType>,
+) -> arrow2::datatypes::Field {
+    use arrow2::datatypes::DataType;
+
+    if possibilities.len() > 1 {
+        // Drop nulls from possibilities.
+        possibilities.remove(&DataType::Null);
+    }
+    // determine data type based on possible types
+    // if there are incompatible types, use DataType::Utf8
+    let data_type = match possibilities.len() {
+        1 => possibilities.drain().next().unwrap(),
+        2 => {
+            if possibilities.contains(&DataType::Int64)
+                && possibilities.contains(&DataType::Float64)
+            {
+                // we have an integer and double, fall down to double
+                DataType::Float64
+            } else {
+                // default to Utf8 for conflicting datatypes (e.g bool and int)
+                DataType::Utf8
+            }
+        }
+        _ => DataType::Utf8,
+    };
+    arrow2::datatypes::Field::new(field_name, data_type, true)
+}

--- a/src/daft-decoding/Cargo.toml
+++ b/src/daft-decoding/Cargo.toml
@@ -1,0 +1,12 @@
+[dependencies]
+arrow2 = {workspace = true, features = ["io_csv", "io_csv_async"]}
+chrono = {workspace = true}
+chrono-tz = {workspace = true}
+csv-async = "1.2.6"
+lexical-core = {version = "0.8"}
+simdutf8 = "0.1.3"
+
+[package]
+edition = {workspace = true}
+name = "daft-decoding"
+version = {workspace = true}

--- a/src/daft-decoding/src/deserialize.rs
+++ b/src/daft-decoding/src/deserialize.rs
@@ -26,7 +26,7 @@ pub(crate) const ALL_TIMESTAMP_FMTS: &[&str] = &[ISO8601, RFC3339_WITH_SPACE];
 // Ideally this trait should not be needed and both `csv` and `csv_async` crates would share
 // the same `ByteRecord` struct. Unfortunately, they do not and thus we must use generics
 // over this trait and materialize the generics for each struct.
-pub(crate) trait ByteRecordGeneric {
+pub trait ByteRecordGeneric {
     fn get(&self, index: usize) -> Option<&[u8]>;
 }
 
@@ -190,7 +190,7 @@ fn deserialize_datetime<T: chrono::TimeZone>(
 
 /// Deserializes `column` of `rows` into an [`Array`] of [`DataType`] `datatype`.
 #[inline]
-pub(crate) fn deserialize_column<B: ByteRecordGeneric>(
+pub fn deserialize_column<B: ByteRecordGeneric>(
     rows: &[B],
     column: usize,
     datatype: DataType,

--- a/src/daft-decoding/src/inference.rs
+++ b/src/daft-decoding/src/inference.rs
@@ -1,50 +1,7 @@
-use std::collections::HashSet;
-
 use arrow2::datatypes::TimeUnit;
 use chrono::Timelike;
 
 use crate::deserialize::{ALL_NAIVE_TIMESTAMP_FMTS, ALL_TIMESTAMP_FMTS};
-
-pub fn merge_schema(
-    headers: &[String],
-    column_types: &mut [HashSet<arrow2::datatypes::DataType>],
-) -> Vec<arrow2::datatypes::Field> {
-    headers
-        .iter()
-        .zip(column_types.iter_mut())
-        .map(|(field_name, possibilities)| merge_fields(field_name, possibilities))
-        .collect()
-}
-
-fn merge_fields(
-    field_name: &str,
-    possibilities: &mut HashSet<arrow2::datatypes::DataType>,
-) -> arrow2::datatypes::Field {
-    use arrow2::datatypes::DataType;
-
-    if possibilities.len() > 1 {
-        // Drop nulls from possibilities.
-        possibilities.remove(&DataType::Null);
-    }
-    // determine data type based on possible types
-    // if there are incompatible types, use DataType::Utf8
-    let data_type = match possibilities.len() {
-        1 => possibilities.drain().next().unwrap(),
-        2 => {
-            if possibilities.contains(&DataType::Int64)
-                && possibilities.contains(&DataType::Float64)
-            {
-                // we have an integer and double, fall down to double
-                DataType::Float64
-            } else {
-                // default to Utf8 for conflicting datatypes (e.g bool and int)
-                DataType::Utf8
-            }
-        }
-        _ => DataType::Utf8,
-    };
-    arrow2::datatypes::Field::new(field_name, data_type, true)
-}
 
 /// Infers [`DataType`] from `bytes`
 /// # Implementation

--- a/src/daft-decoding/src/lib.rs
+++ b/src/daft-decoding/src/lib.rs
@@ -1,0 +1,3 @@
+//! Utilities for decoding data from various sources into both array data and metadata (e.g. schema inference)
+pub mod deserialize;
+pub mod inference;


### PR DESCRIPTION
Moves code out from `daft-csv` that currently perform decoding of CSV data (bytes to typed Daft data) into a new `daft-decoding` crate so that they can be re-used