### PR TITLE
[BUG] Fix unsorted ranges bug in parquet reads

### DIFF
--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -175,15 +175,21 @@ impl ReadPlanner {
             });
             entries.push(entry);
         }
-        Ok(Arc::new(RangesContainer { ranges: entries }))
+        Ok(Arc::new(RangesContainer::new(entries)))
     }
 }
 
 pub(crate) struct RangesContainer {
+    // NOTE: Must be sorted by .start because we use it with `.binary_search_by_key`
     ranges: Vec<Arc<RangeCacheEntry>>,
 }
 
 impl RangesContainer {
+    fn new(mut ranges: Vec<Arc<RangeCacheEntry>>) -> Self {
+        ranges.sort_unstable_by_key(|e| e.start);
+        RangesContainer { ranges }
+    }
+
     pub fn get_range_reader(&self, range: Range<usize>) -> DaftResult<impl futures::AsyncRead> {
         let mut current_pos = range.start;
         let mut curr_index;


### PR DESCRIPTION
When running a Parquet read on an unsorted list of rowgroups, some users are encountering a broken assert statement [here](https://github.com/Eventual-Inc/Daft/pull/1543/files#diff-bb54f2048ffa90485b57f0155218667f7cc1678847d27a7b9c173034ab563262R215-R219)

It appears that the `binary_search_by_key` function that we call may be unhappy and returning negative indices because the underlying slice it is searching on is unsorted.

This PR adds a `RangesContainer::new` which will sort the underlying `self.ranges` so that when we run binary search on it it will be sorted.

I was unable to reproduce this bug through a unit test unfortunately for some reason.