### PR TITLE
[CHORE] Revert "Bump pandas from 2.0.3 to 2.1.2"

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,7 +23,7 @@ dask==2023.6.0; python_version >= '3.9'
 numpy; python_version < '3.9'
 numpy==1.25.2; python_version >= '3.9'
 pandas==1.3.5; python_version < '3.8'
-pandas==2.1.2; python_version >= '3.8'
+pandas==2.0.3; python_version >= '3.8'
 xxhash>=3.0.0
 Pillow==9.5.0
 opencv-python==4.8.1.78


### PR DESCRIPTION
Reverts Eventual-Inc/Daft#1542

It appears Pandas dropped support for Python 3.8 in >=2.1.0