### PR TITLE
[FEAT][ScanOperator 1/3] Add MVP e2e `ScanOperator` integration.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,7 @@ dependencies = [
  "common-io-config",
  "daft-core",
  "daft-dsl",
+ "daft-scan",
  "daft-table",
  "indexmap 2.0.2",
  "log",
@@ -1284,7 +1285,9 @@ dependencies = [
 name = "daft-scan"
 version = "0.1.10"
 dependencies = [
+ "bincode",
  "common-error",
+ "common-io-config",
  "daft-core",
  "daft-csv",
  "daft-dsl",
@@ -1295,6 +1298,7 @@ dependencies = [
  "pyo3",
  "pyo3-log",
  "serde",
+ "serde_json",
  "snafu",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,7 @@ dependencies = [
  "daft-stats",
  "daft-table",
  "indexmap 2.0.2",
+ "log",
  "parquet2",
  "pyo3",
  "pyo3-log",

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -414,6 +414,13 @@ class ScanOperatorHandle:
         file_format_config: FileFormatConfig,
         storage_config: StorageConfig,
     ) -> ScanOperatorHandle: ...
+    @staticmethod
+    def glob_scan(
+        glob_path: str,
+        file_format_config: FileFormatConfig,
+        storage_config: StorageConfig,
+        schema: PySchema | None = None,
+    ) -> ScanOperatorHandle: ...
 
 def read_parquet(
     uri: str,

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -375,30 +375,17 @@ class StorageConfig:
 
 class ScanTask:
     """
-    A scan task for reading data from an external source.
-    """
-
-    ...
-
-class ScanTaskBatch:
-    """
     A batch of scan tasks for reading data from an external source.
     """
 
-    @staticmethod
-    def from_scan_tasks(scan_tasks: list[ScanTask]) -> ScanTaskBatch:
-        """
-        Create a scan task batch from a list of scan tasks.
-        """
-        ...
     def num_rows(self) -> int:
         """
-        Get number of rows that will be scanned by all tasks in this batch.
+        Get number of rows that will be scanned by this ScanTask.
         """
         ...
     def size_bytes(self) -> int:
         """
-        Get number of bytes that will be scanned by all tasks in this batch.
+        Get number of bytes that will be scanned by this ScanTask.
         """
         ...
 
@@ -770,7 +757,7 @@ class PyMicroPartition:
     @staticmethod
     def empty(schema: PySchema | None = None) -> PyMicroPartition: ...
     @staticmethod
-    def from_scan_task_batch(scan_task_batch: ScanTaskBatch) -> PyMicroPartition: ...
+    def from_scan_task(scan_task: ScanTask) -> PyMicroPartition: ...
     @staticmethod
     def from_tables(tables: list[PyTable]) -> PyMicroPartition: ...
     @staticmethod

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -404,7 +404,6 @@ class ReadFile(SingleOutputInstruction):
                         schema=self.schema,
                         storage_config=self.storage_config,
                         read_options=read_options,
-                        multithreaded_io=format_config.multithreaded_io,
                     )
                     for fp in filepaths
                 ]

--- a/daft/execution/rust_physical_plan_shim.py
+++ b/daft/execution/rust_physical_plan_shim.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Iterator, TypeVar, cast
 
 from daft.daft import (
@@ -10,15 +11,59 @@ from daft.daft import (
     PySchema,
     PyTable,
     ResourceRequest,
+    ScanTask,
+    ScanTaskBatch,
     StorageConfig,
 )
 from daft.execution import execution_step, physical_plan
 from daft.expressions import Expression, ExpressionsProjection
 from daft.logical.map_partition_ops import MapPartitionOp
 from daft.logical.schema import Schema
+from daft.runners.partitioning import PartialPartitionMetadata
 from daft.table import Table
 
 PartitionT = TypeVar("PartitionT")
+
+
+def scan_with_tasks(
+    scan_tasks: Iterator[ScanTask],
+) -> physical_plan.InProgressPhysicalPlan[PartitionT]:
+    """child_plan represents partitions with filenames.
+
+    Yield a plan to read those filenames.
+    """
+    # TODO(Clark): Bundle scan tasks into single-instruction bulk reads.
+    for scan_task in scan_tasks:
+        scan_task_batch = ScanTaskBatch.from_scan_tasks([scan_task])
+        scan_step = execution_step.PartitionTaskBuilder[PartitionT](inputs=[], partial_metadatas=None,).add_instruction(
+            instruction=ScanWithTask(scan_task_batch),
+            # Set the filesize as the memory request.
+            # (Note: this is very conservative; file readers empirically use much more peak memory than 1x file size.)
+            resource_request=ResourceRequest(memory_bytes=scan_task_batch.size_bytes()),
+        )
+        yield scan_step
+
+
+@dataclass(frozen=True)
+class ScanWithTask(execution_step.SingleOutputInstruction):
+    scan_task_batch: ScanTaskBatch
+
+    def run(self, inputs: list[Table]) -> list[Table]:
+        return self._scan(inputs)
+
+    def _scan(self, inputs: list[Table]) -> list[Table]:
+        assert len(inputs) == 0
+        return [Table._from_scan_task_batch(self.scan_task_batch)]
+
+    def run_partial_metadata(self, input_metadatas: list[PartialPartitionMetadata]) -> list[PartialPartitionMetadata]:
+        assert len(input_metadatas) == 0
+
+        return [
+            PartialPartitionMetadata(
+                num_rows=self.scan_task_batch.num_rows(),
+                size_bytes=None,
+            )
+        ]
 
 
 def tabular_scan(

--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -70,7 +70,7 @@ def read_csv(
     )
     file_format_config = FileFormatConfig.from_csv_config(csv_config)
     if use_native_downloader:
-        storage_config = StorageConfig.native(NativeStorageConfig(io_config))
+        storage_config = StorageConfig.native(NativeStorageConfig(True, io_config))
     else:
         storage_config = StorageConfig.python(PythonStorageConfig(None, io_config=io_config))
     builder = _get_tabular_files_scan(path, schema_hints, file_format_config, storage_config=storage_config)

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -54,13 +54,9 @@ def read_parquet(
     # This is because each Ray worker process receives its own pool of thread workers and connections
     multithreaded_io = not context.get_context().is_ray_runner if _multithreaded_io is None else _multithreaded_io
 
-    file_format_config = FileFormatConfig.from_parquet_config(
-        ParquetSourceConfig(
-            multithreaded_io=multithreaded_io,
-        )
-    )
+    file_format_config = FileFormatConfig.from_parquet_config(ParquetSourceConfig())
     if use_native_downloader:
-        storage_config = StorageConfig.native(NativeStorageConfig(io_config))
+        storage_config = StorageConfig.native(NativeStorageConfig(multithreaded_io, io_config))
     else:
         storage_config = StorageConfig.python(PythonStorageConfig(None, io_config=io_config))
 

--- a/daft/io/common.py
+++ b/daft/io/common.py
@@ -46,7 +46,10 @@ def _get_tabular_files_scan(
     else:
         raise NotImplementedError(f"Tabular scan with config not implemented: {storage_config.config}")
     # TODO(Clark): Move this flag check to the global Daft context.
-    if os.getenv("DAFT_MICROPARTITIONS", "0") == "1":
+    if os.getenv("DAFT_V2_SCANS", "0") == "1":
+        assert (
+            os.getenv("DAFT_MICROPARTITIONS", "0") == "1"
+        ), "DAFT_V2_SCANS=1 requires DAFT_MICROPARTITIONS=1 to be set as well"
         # TODO(Clark): Add globbing scan, once implemented.
         runner_io = get_context().runner().runner_io()
         file_infos = runner_io.glob_paths_details(paths, file_format_config=file_format_config, io_config=io_config)

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING
 
 from daft.daft import CountMode, FileFormat, FileFormatConfig, FileInfos, JoinType
 from daft.daft import LogicalPlanBuilder as _LogicalPlanBuilder
-from daft.daft import PartitionScheme, ResourceRequest, StorageConfig
+from daft.daft import (
+    PartitionScheme,
+    ResourceRequest,
+    ScanOperatorHandle,
+    StorageConfig,
+)
 from daft.expressions import Expression, col
 from daft.logical.schema import Schema
 from daft.runners.partitioning import PartitionCacheEntry
@@ -64,6 +69,17 @@ class LogicalPlanBuilder:
         cls, partition: PartitionCacheEntry, schema: Schema, num_partitions: int
     ) -> LogicalPlanBuilder:
         builder = _LogicalPlanBuilder.in_memory_scan(partition.key, partition, schema._schema, num_partitions)
+        return cls(builder)
+
+    @classmethod
+    def from_tabular_scan_with_scan_operator(
+        cls,
+        *,
+        scan_operator: ScanOperatorHandle,
+        schema_hint: Schema | None,
+    ) -> LogicalPlanBuilder:
+        pyschema = schema_hint._schema if schema_hint is not None else None
+        builder = _LogicalPlanBuilder.table_scan_with_scan_operator(scan_operator, pyschema)
         return cls(builder)
 
     @classmethod

--- a/daft/table/micropartition.py
+++ b/daft/table/micropartition.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 from daft.daft import IOConfig, JoinType
 from daft.daft import PyMicroPartition as _PyMicroPartition
 from daft.daft import PyTable as _PyTable
+from daft.daft import ScanTaskBatch as _ScanTaskBatch
 from daft.datatype import DataType, TimeUnit
 from daft.expressions import Expression, ExpressionsProjection
 from daft.logical.schema import Schema
@@ -63,6 +64,11 @@ class MicroPartition:
     def empty(schema: Schema | None = None) -> MicroPartition:
         pyt = _PyMicroPartition.empty(None) if schema is None else _PyMicroPartition.empty(schema._schema)
         return MicroPartition._from_pymicropartition(pyt)
+
+    @staticmethod
+    def _from_scan_task_batch(scan_task_batch: _ScanTaskBatch) -> MicroPartition:
+        assert isinstance(scan_task_batch, _ScanTaskBatch)
+        return MicroPartition._from_pymicropartition(_PyMicroPartition.from_scan_task_batch(scan_task_batch))
 
     @staticmethod
     def _from_pytable(pyt: _PyTable) -> MicroPartition:

--- a/daft/table/micropartition.py
+++ b/daft/table/micropartition.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 from daft.daft import IOConfig, JoinType
 from daft.daft import PyMicroPartition as _PyMicroPartition
 from daft.daft import PyTable as _PyTable
-from daft.daft import ScanTaskBatch as _ScanTaskBatch
+from daft.daft import ScanTask as _ScanTask
 from daft.datatype import DataType, TimeUnit
 from daft.expressions import Expression, ExpressionsProjection
 from daft.logical.schema import Schema
@@ -66,9 +66,9 @@ class MicroPartition:
         return MicroPartition._from_pymicropartition(pyt)
 
     @staticmethod
-    def _from_scan_task_batch(scan_task_batch: _ScanTaskBatch) -> MicroPartition:
-        assert isinstance(scan_task_batch, _ScanTaskBatch)
-        return MicroPartition._from_pymicropartition(_PyMicroPartition.from_scan_task_batch(scan_task_batch))
+    def _from_scan_task(scan_task: _ScanTask) -> MicroPartition:
+        assert isinstance(scan_task, _ScanTask)
+        return MicroPartition._from_pymicropartition(_PyMicroPartition.from_scan_task(scan_task))
 
     @staticmethod
     def _from_pytable(pyt: _PyTable) -> MicroPartition:

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 from daft.arrow_utils import ensure_table
 from daft.daft import JoinType
 from daft.daft import PyTable as _PyTable
+from daft.daft import ScanTaskBatch as _ScanTaskBatch
 from daft.daft import read_csv as _read_csv
 from daft.daft import read_parquet as _read_parquet
 from daft.daft import read_parquet_bulk as _read_parquet_bulk
@@ -77,6 +78,10 @@ class Table:
     def empty(schema: Schema | None = None) -> Table:
         pyt = _PyTable.empty(None) if schema is None else _PyTable.empty(schema._schema)
         return Table._from_pytable(pyt)
+
+    @staticmethod
+    def _from_scan_task_batch(_: _ScanTaskBatch) -> Table:
+        raise NotImplementedError("_from_scan_task_batch is not implemented for legacy Python Table.")
 
     @staticmethod
     def _from_pytable(pyt: _PyTable) -> Table:

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 from daft.arrow_utils import ensure_table
 from daft.daft import JoinType
 from daft.daft import PyTable as _PyTable
-from daft.daft import ScanTaskBatch as _ScanTaskBatch
+from daft.daft import ScanTask as _ScanTask
 from daft.daft import read_csv as _read_csv
 from daft.daft import read_parquet as _read_parquet
 from daft.daft import read_parquet_bulk as _read_parquet_bulk
@@ -80,8 +80,8 @@ class Table:
         return Table._from_pytable(pyt)
 
     @staticmethod
-    def _from_scan_task_batch(_: _ScanTaskBatch) -> Table:
-        raise NotImplementedError("_from_scan_task_batch is not implemented for legacy Python Table.")
+    def _from_scan_task(_: _ScanTask) -> Table:
+        raise NotImplementedError("_from_scan_task is not implemented for legacy Python Table.")
 
     @staticmethod
     def _from_pytable(pyt: _PyTable) -> Table:

--- a/daft/table/table_io.py
+++ b/daft/table/table_io.py
@@ -106,7 +106,6 @@ def read_parquet(
     storage_config: StorageConfig | None = None,
     read_options: TableReadOptions = TableReadOptions(),
     parquet_options: TableParseParquetOptions = TableParseParquetOptions(),
-    multithreaded_io: bool | None = None,
 ) -> Table:
     """Reads a Table from a Parquet file
 
@@ -131,7 +130,7 @@ def read_parquet(
                 num_rows=read_options.num_rows,
                 io_config=config.io_config,
                 coerce_int96_timestamp_unit=parquet_options.coerce_int96_timestamp_unit,
-                multithreaded_io=multithreaded_io,
+                multithreaded_io=config.multithreaded_io,
             )
             return _cast_table_to_schema(tbl, read_options=read_options, schema=schema)
 

--- a/src/daft-micropartition/Cargo.toml
+++ b/src/daft-micropartition/Cargo.toml
@@ -11,6 +11,7 @@ daft-scan = {path = "../daft-scan", default-features = false}
 daft-stats = {path = "../daft-stats", default-features = false}
 daft-table = {path = "../daft-table", default-features = false}
 indexmap = {workspace = true, features = ["serde"]}
+log = {workspace = true}
 parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true}

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -129,7 +129,7 @@ fn materialize_scan_task_batch(
         _ => todo!("TODO: Implement MicroPartition reads for other file formats."),
     };
 
-    let cast_to_schema = cast_to_schema.unwrap_or(scan_task_batch.schema.clone());
+    let cast_to_schema = cast_to_schema.unwrap_or_else(|| scan_task_batch.schema.clone());
     let casted_table_values = table_values
         .iter()
         .map(|tbl| tbl.cast_to_schema(cast_to_schema.as_ref()))

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -13,7 +13,7 @@ use daft_parquet::read::{
 };
 use daft_scan::file_format::{FileFormatConfig, ParquetSourceConfig};
 use daft_scan::storage_config::{NativeStorageConfig, StorageConfig};
-use daft_scan::{DataFileSource, ScanTaskBatch};
+use daft_scan::{DataFileSource, ScanTask};
 use daft_table::Table;
 
 use snafu::ResultExt;
@@ -25,18 +25,18 @@ use daft_stats::TableMetadata;
 use daft_stats::TableStatistics;
 
 pub(crate) enum TableState {
-    Unloaded(Arc<ScanTaskBatch>),
+    Unloaded(Arc<ScanTask>),
     Loaded(Arc<Vec<Table>>),
 }
 
 impl Display for TableState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TableState::Unloaded(scan_task_batch) => {
+            TableState::Unloaded(scan_task) => {
                 write!(
                     f,
                     "TableState: Unloaded. To load from: {:#?}",
-                    scan_task_batch
+                    scan_task
                         .sources
                         .iter()
                         .map(|s| s.get_path())
@@ -60,25 +60,25 @@ pub(crate) struct MicroPartition {
     pub(crate) statistics: Option<TableStatistics>,
 }
 
-/// Helper to run all the IO and compute required to materialize a ScanTaskBatch into a Vec<Table>
+/// Helper to run all the IO and compute required to materialize a ScanTask into a Vec<Table>
 ///
 /// # Arguments
 ///
-/// * `scan_task_batch` - a batch of ScanTasks to materialize as Tables
+/// * `scan_task` - a batch of ScanTasks to materialize as Tables
 /// * `cast_to_schema` - an Optional schema to cast all the resulting Tables to. If not provided, will use the schema
-///     provided by the ScanTaskBatch
+///     provided by the ScanTask
 /// * `io_stats` - an optional IOStats object to record the IO operations performed
-fn materialize_scan_task_batch(
-    scan_task_batch: Arc<ScanTaskBatch>,
+fn materialize_scan_task(
+    scan_task: Arc<ScanTask>,
     cast_to_schema: Option<SchemaRef>,
     io_stats: Option<IOStatsRef>,
 ) -> crate::Result<Vec<Table>> {
-    let table_values = match scan_task_batch.file_format_config.as_ref() {
+    let table_values = match scan_task.file_format_config.as_ref() {
         FileFormatConfig::Parquet(ParquetSourceConfig {
             coerce_int96_timestamp_unit,
             // TODO(Clark): Support different row group specification per file.
             row_groups,
-        }) => match scan_task_batch.storage_config.as_ref() {
+        }) => match scan_task.storage_config.as_ref() {
             StorageConfig::Native(native_storage_config) => {
                 let runtime_handle =
                     daft_io::get_runtime(native_storage_config.multithreaded_io).unwrap();
@@ -94,11 +94,11 @@ fn materialize_scan_task_batch(
                 let io_client =
                     daft_io::get_io_client(native_storage_config.multithreaded_io, io_config)
                         .unwrap();
-                let column_names = scan_task_batch
+                let column_names = scan_task
                     .columns
                     .as_ref()
                     .map(|v| v.iter().map(|s| s.as_ref()).collect::<Vec<_>>());
-                let urls = scan_task_batch
+                let urls = scan_task
                     .sources
                     .iter()
                     .map(|s| s.get_path())
@@ -109,7 +109,7 @@ fn materialize_scan_task_batch(
                     urls.as_slice(),
                     column_names.as_deref(),
                     None,
-                    scan_task_batch.limit,
+                    scan_task.limit,
                     row_groups
                         .as_ref()
                         .map(|row_groups| vec![row_groups.clone(); urls.len()]),
@@ -129,7 +129,7 @@ fn materialize_scan_task_batch(
         _ => todo!("TODO: Implement MicroPartition reads for other file formats."),
     };
 
-    let cast_to_schema = cast_to_schema.unwrap_or_else(|| scan_task_batch.schema.clone());
+    let cast_to_schema = cast_to_schema.unwrap_or_else(|| scan_task.schema.clone());
     let casted_table_values = table_values
         .iter()
         .map(|tbl| tbl.cast_to_schema(cast_to_schema.as_ref()))
@@ -141,7 +141,7 @@ fn materialize_scan_task_batch(
 impl MicroPartition {
     pub fn new_unloaded(
         schema: SchemaRef,
-        scan_task_batch: Arc<ScanTaskBatch>,
+        scan_task: Arc<ScanTask>,
         metadata: TableMetadata,
         statistics: TableStatistics,
     ) -> Self {
@@ -159,7 +159,7 @@ impl MicroPartition {
 
         MicroPartition {
             schema,
-            state: Mutex::new(TableState::Unloaded(scan_task_batch)),
+            state: Mutex::new(TableState::Unloaded(scan_task)),
             metadata,
             statistics: Some(statistics),
         }
@@ -181,22 +181,78 @@ impl MicroPartition {
         }
     }
 
-    pub fn from_scan_task_batch(
-        scan_task_batch: Arc<ScanTaskBatch>,
+    pub fn from_scan_task(
+        scan_task: Arc<ScanTask>,
         io_stats: Option<IOStatsRef>,
     ) -> crate::Result<Self> {
-        let schema = scan_task_batch.schema.clone();
-        let statistics = scan_task_batch.statistics.clone();
-        match (&scan_task_batch.metadata, &scan_task_batch.statistics) {
-            (Some(metadata), Some(statistics)) => Ok(Self::new_unloaded(
+        let schema = scan_task.schema.clone();
+        let statistics = scan_task.statistics.clone();
+        match (
+            &scan_task.metadata,
+            &scan_task.statistics,
+            scan_task.file_format_config.as_ref(),
+        ) {
+            // If the scan_task provides metadata (e.g. retrieved from a catalog) use it and create an unloaded MicroPartition
+            (Some(metadata), Some(statistics), _) => Ok(Self::new_unloaded(
                 schema,
-                scan_task_batch.clone(),
+                scan_task.clone(),
                 metadata.clone(),
                 statistics.clone(),
             )),
-            // If any metadata or statistics are missing, we need to perform an eager read
+
+            // If the scan_task is from files that support reading metadata, we can perform an eager **metadata** read to create an unloaded MicroPartition
+            (
+                _,
+                _,
+                FileFormatConfig::Parquet(ParquetSourceConfig {
+                    coerce_int96_timestamp_unit,
+                    row_groups,
+                }),
+            ) => {
+                let (io_config, multithreaded_io) = match scan_task.storage_config.as_ref() {
+                    StorageConfig::Native(cfg) => (
+                        cfg.io_config.clone().map(|c| Arc::new(c.clone())),
+                        cfg.multithreaded_io,
+                    ),
+                    #[cfg(feature = "python")]
+                    StorageConfig::Python(cfg) => {
+                        (cfg.io_config.clone().map(|c| Arc::new(c.clone())), true)
+                    }
+                };
+                let columns = scan_task
+                    .columns
+                    .as_ref()
+                    .map(|cols| cols.iter().map(|s| s.as_str()).collect::<Vec<&str>>());
+
+                read_parquet_into_micropartition(
+                    scan_task
+                        .sources
+                        .iter()
+                        .map(|s| s.get_path())
+                        .collect::<Vec<_>>()
+                        .as_slice(),
+                    columns.as_deref(),
+                    None,
+                    scan_task.limit,
+                    row_groups.clone().map(|rg| {
+                        std::iter::repeat(rg)
+                            .take(scan_task.sources.len())
+                            .collect::<Vec<_>>()
+                    }), // HACK: Properly propagate multi-file row_groups
+                    io_config.unwrap_or_default(),
+                    io_stats,
+                    if scan_task.sources.len() == 1 { 1 } else { 128 }, // Hardcoded for to 128 bulk reads
+                    multithreaded_io,
+                    &ParquetSchemaInferenceOptions {
+                        coerce_int96_timestamp_unit: *coerce_int96_timestamp_unit,
+                    },
+                )
+                .context(DaftCoreComputeSnafu)
+            }
+
+            // Lastly as a fallback, perform an eager **data** read
             _ => {
-                let tables = materialize_scan_task_batch(scan_task_batch, None, io_stats)?;
+                let tables = materialize_scan_task(scan_task, None, io_stats)?;
                 Ok(Self::new_loaded(schema, Arc::new(tables), statistics))
             }
         }
@@ -244,9 +300,9 @@ impl MicroPartition {
     ) -> crate::Result<Arc<Vec<Table>>> {
         let mut guard = self.state.lock().unwrap();
         match guard.deref() {
-            TableState::Unloaded(scan_task_batch) => {
-                let table_values = Arc::new(materialize_scan_task_batch(
-                    scan_task_batch.clone(),
+            TableState::Unloaded(scan_task) => {
+                let table_values = Arc::new(materialize_scan_task(
+                    scan_task.clone(),
                     Some(self.schema.clone()),
                     io_stats,
                 )?);
@@ -463,7 +519,7 @@ pub(crate) fn read_parquet_into_micropartition(
         let owned_urls = uris.iter().map(|s| s.to_string()).collect::<Vec<_>>();
 
         let daft_schema = Arc::new(daft_schema);
-        let scan_task_batch = ScanTaskBatch::new(
+        let scan_task = ScanTask::new(
             owned_urls
                 .into_iter()
                 .map(|url| DataFileSource::AnonymousDataFile {
@@ -500,8 +556,8 @@ pub(crate) fn read_parquet_into_micropartition(
         let stats = stats.eval_expression_list(exprs.as_slice(), daft_schema.as_ref())?;
 
         Ok(MicroPartition::new_unloaded(
-            scan_task_batch.schema.clone(),
-            Arc::new(scan_task_batch),
+            scan_task.schema.clone(),
+            Arc::new(scan_task),
             TableMetadata { length: total_rows },
             stats,
         ))

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -32,9 +32,16 @@ pub(crate) enum TableState {
 impl Display for TableState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TableState::Unloaded(_) => {
-                write!(f, "TableState: Unloaded")
-                // write!(f, "TableState: Unloaded. To load from: {:?}", params.urls)
+            TableState::Unloaded(scan_task_batch) => {
+                write!(
+                    f,
+                    "TableState: Unloaded. To load from: {:#?}",
+                    scan_task_batch
+                        .sources
+                        .iter()
+                        .map(|s| s.get_path())
+                        .collect::<Vec<_>>()
+                )
             }
             TableState::Loaded(tables) => {
                 writeln!(f, "TableState: Loaded. {} tables", tables.len())?;

--- a/src/daft-micropartition/src/ops/agg.rs
+++ b/src/daft-micropartition/src/ops/agg.rs
@@ -18,7 +18,7 @@ impl MicroPartition {
                 Ok(MicroPartition::new(
                     agged.schema.clone(),
                     TableState::Loaded(vec![agged].into()),
-                    TableMetadata { length: agged_len },
+                    Some(TableMetadata { length: agged_len }),
                     None,
                 ))
             }
@@ -28,7 +28,7 @@ impl MicroPartition {
                 Ok(MicroPartition::new(
                     agged.schema.clone(),
                     TableState::Loaded(vec![agged].into()),
-                    TableMetadata { length: agged_len },
+                    Some(TableMetadata { length: agged_len }),
                     None,
                 ))
             }

--- a/src/daft-micropartition/src/ops/agg.rs
+++ b/src/daft-micropartition/src/ops/agg.rs
@@ -2,9 +2,7 @@ use common_error::DaftResult;
 use daft_dsl::Expr;
 use daft_table::Table;
 
-use crate::micropartition::{MicroPartition, TableState};
-
-use daft_stats::TableMetadata;
+use crate::micropartition::MicroPartition;
 
 impl MicroPartition {
     pub fn agg(&self, to_agg: &[Expr], group_by: &[Expr]) -> DaftResult<Self> {
@@ -14,21 +12,17 @@ impl MicroPartition {
             [] => {
                 let empty_table = Table::empty(Some(self.schema.clone()))?;
                 let agged = empty_table.agg(to_agg, group_by)?;
-                let agged_len = agged.len();
-                Ok(MicroPartition::new(
+                Ok(MicroPartition::new_loaded(
                     agged.schema.clone(),
-                    TableState::Loaded(vec![agged].into()),
-                    Some(TableMetadata { length: agged_len }),
+                    vec![agged].into(),
                     None,
                 ))
             }
             [t] => {
                 let agged = t.agg(to_agg, group_by)?;
-                let agged_len = agged.len();
-                Ok(MicroPartition::new(
+                Ok(MicroPartition::new_loaded(
                     agged.schema.clone(),
-                    TableState::Loaded(vec![agged].into()),
-                    Some(TableMetadata { length: agged_len }),
+                    vec![agged].into(),
                     None,
                 ))
             }

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -20,22 +20,21 @@ impl MicroPartition {
         let guard = self.state.lock().unwrap();
         match guard.deref() {
             // Replace schema if Unloaded, which should be applied when data is lazily loaded
-            TableState::Unloaded(scan_task_batch) => Ok(MicroPartition::new(
+            TableState::Unloaded(scan_task_batch) => Ok(MicroPartition::new_unloaded(
                 schema.clone(),
-                TableState::Unloaded(scan_task_batch.clone()),
+                scan_task_batch.clone(),
                 self.metadata.clone(),
-                pruned_statistics,
+                pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
             )),
             // If Tables are already loaded, we map `Table::cast_to_schema` on each Table
-            TableState::Loaded(tables) => Ok(MicroPartition::new(
+            TableState::Loaded(tables) => Ok(MicroPartition::new_loaded(
                 schema.clone(),
-                TableState::Loaded(Arc::new(
+                Arc::new(
                     tables
                         .iter()
                         .map(|tbl| tbl.cast_to_schema(schema.as_ref()))
                         .collect::<DaftResult<Vec<_>>>()?,
-                )),
-                self.metadata.clone(),
+                ),
                 pruned_statistics,
             )),
         }

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -20,9 +20,9 @@ impl MicroPartition {
         let guard = self.state.lock().unwrap();
         match guard.deref() {
             // Replace schema if Unloaded, which should be applied when data is lazily loaded
-            TableState::Unloaded(scan_task_batch) => Ok(MicroPartition::new_unloaded(
+            TableState::Unloaded(scan_task) => Ok(MicroPartition::new_unloaded(
                 schema.clone(),
-                scan_task_batch.clone(),
+                scan_task.clone(),
                 self.metadata.clone(),
                 pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
             )),

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -20,9 +20,9 @@ impl MicroPartition {
         let guard = self.state.lock().unwrap();
         match guard.deref() {
             // Replace schema if Unloaded, which should be applied when data is lazily loaded
-            TableState::Unloaded(params) => Ok(MicroPartition::new(
+            TableState::Unloaded(scan_task_batch) => Ok(MicroPartition::new(
                 schema.clone(),
-                TableState::Unloaded(params.clone()),
+                TableState::Unloaded(scan_task_batch.clone()),
                 self.metadata.clone(),
                 pruned_statistics,
             )),

--- a/src/daft-micropartition/src/ops/concat.rs
+++ b/src/daft-micropartition/src/ops/concat.rs
@@ -48,7 +48,7 @@ impl MicroPartition {
         Ok(MicroPartition {
             schema: mps.first().unwrap().schema.clone(),
             state: Mutex::new(TableState::Loaded(all_tables.into())),
-            metadata: Some(TableMetadata { length: new_len }),
+            metadata: TableMetadata { length: new_len },
             statistics: all_stats,
         })
     }

--- a/src/daft-micropartition/src/ops/concat.rs
+++ b/src/daft-micropartition/src/ops/concat.rs
@@ -48,7 +48,7 @@ impl MicroPartition {
         Ok(MicroPartition {
             schema: mps.first().unwrap().schema.clone(),
             state: Mutex::new(TableState::Loaded(all_tables.into())),
-            metadata: TableMetadata { length: new_len },
+            metadata: Some(TableMetadata { length: new_len }),
             statistics: all_stats,
         })
     }

--- a/src/daft-micropartition/src/ops/eval_expressions.rs
+++ b/src/daft-micropartition/src/ops/eval_expressions.rs
@@ -51,7 +51,7 @@ impl MicroPartition {
         Ok(MicroPartition::new(
             expected_schema.into(),
             TableState::Loaded(Arc::new(evaluated_tables)),
-            TableMetadata { length: self.len() },
+            Some(TableMetadata { length: self.len() }),
             eval_stats,
         ))
     }
@@ -92,7 +92,7 @@ impl MicroPartition {
         Ok(MicroPartition::new(
             Arc::new(expected_schema),
             TableState::Loaded(Arc::new(evaluated_tables)),
-            TableMetadata { length: new_len },
+            Some(TableMetadata { length: new_len }),
             eval_stats,
         ))
     }

--- a/src/daft-micropartition/src/ops/eval_expressions.rs
+++ b/src/daft-micropartition/src/ops/eval_expressions.rs
@@ -5,14 +5,9 @@ use daft_core::schema::Schema;
 use daft_dsl::Expr;
 use snafu::ResultExt;
 
-use crate::{
-    micropartition::{MicroPartition, TableState},
-    DaftCoreComputeSnafu,
-};
+use crate::{micropartition::MicroPartition, DaftCoreComputeSnafu};
 
 use daft_stats::{ColumnRangeStatistics, TableStatistics};
-
-use daft_stats::TableMetadata;
 
 fn infer_schema(exprs: &[Expr], schema: &Schema) -> DaftResult<Schema> {
     let fields = exprs
@@ -48,10 +43,9 @@ impl MicroPartition {
             .map(|s| s.eval_expression_list(exprs, &expected_schema))
             .transpose()?;
 
-        Ok(MicroPartition::new(
+        Ok(MicroPartition::new_loaded(
             expected_schema.into(),
-            TableState::Loaded(Arc::new(evaluated_tables)),
-            Some(TableMetadata { length: self.len() }),
+            Arc::new(evaluated_tables),
             eval_stats,
         ))
     }
@@ -87,12 +81,9 @@ impl MicroPartition {
             }
         }
 
-        let new_len = evaluated_tables.iter().map(|t| t.len()).sum();
-
-        Ok(MicroPartition::new(
+        Ok(MicroPartition::new_loaded(
             Arc::new(expected_schema),
-            TableState::Loaded(Arc::new(evaluated_tables)),
-            Some(TableMetadata { length: new_len }),
+            Arc::new(evaluated_tables),
             eval_stats,
         ))
     }

--- a/src/daft-micropartition/src/ops/filter.rs
+++ b/src/daft-micropartition/src/ops/filter.rs
@@ -42,7 +42,7 @@ impl MicroPartition {
         Ok(Self::new(
             self.schema.clone(),
             TableState::Loaded(tables.into()),
-            TableMetadata { length: new_len },
+            Some(TableMetadata { length: new_len }),
             self.statistics.clone(), // update these values based off the filter we just ran
         ))
     }

--- a/src/daft-micropartition/src/ops/filter.rs
+++ b/src/daft-micropartition/src/ops/filter.rs
@@ -2,14 +2,9 @@ use common_error::DaftResult;
 use daft_dsl::Expr;
 use snafu::ResultExt;
 
-use crate::{
-    micropartition::{MicroPartition, TableState},
-    DaftCoreComputeSnafu,
-};
+use crate::{micropartition::MicroPartition, DaftCoreComputeSnafu};
 
 use daft_stats::TruthValue;
-
-use daft_stats::TableMetadata;
 
 impl MicroPartition {
     pub fn filter(&self, predicate: &[Expr]) -> DaftResult<Self> {
@@ -37,12 +32,9 @@ impl MicroPartition {
             .collect::<DaftResult<Vec<_>>>()
             .context(DaftCoreComputeSnafu)?;
 
-        let new_len = tables.iter().map(|t| t.len()).sum();
-
-        Ok(Self::new(
+        Ok(Self::new_loaded(
             self.schema.clone(),
-            TableState::Loaded(tables.into()),
-            Some(TableMetadata { length: new_len }),
+            tables.into(),
             self.statistics.clone(), // update these values based off the filter we just ran
         ))
     }

--- a/src/daft-micropartition/src/ops/join.rs
+++ b/src/daft-micropartition/src/ops/join.rs
@@ -3,11 +3,9 @@ use daft_core::array::ops::DaftCompare;
 use daft_dsl::Expr;
 use daft_table::infer_join_schema;
 
-use crate::micropartition::{MicroPartition, TableState};
+use crate::micropartition::MicroPartition;
 
 use daft_stats::TruthValue;
-
-use daft_stats::TableMetadata;
 
 impl MicroPartition {
     pub fn join(&self, right: &Self, left_on: &[Expr], right_on: &[Expr]) -> DaftResult<Self> {
@@ -43,11 +41,9 @@ impl MicroPartition {
             ([], _) | (_, []) => Ok(Self::empty(Some(join_schema.into()))),
             ([lt], [rt]) => {
                 let joined_table = lt.join(rt, left_on, right_on)?;
-                let joined_len = joined_table.len();
-                Ok(MicroPartition::new(
+                Ok(MicroPartition::new_loaded(
                     join_schema.into(),
-                    TableState::Loaded(vec![joined_table].into()),
-                    Some(TableMetadata { length: joined_len }),
+                    vec![joined_table].into(),
                     None,
                 ))
             }

--- a/src/daft-micropartition/src/ops/join.rs
+++ b/src/daft-micropartition/src/ops/join.rs
@@ -47,7 +47,7 @@ impl MicroPartition {
                 Ok(MicroPartition::new(
                     join_schema.into(),
                     TableState::Loaded(vec![joined_table].into()),
-                    TableMetadata { length: joined_len },
+                    Some(TableMetadata { length: joined_len }),
                     None,
                 ))
             }

--- a/src/daft-micropartition/src/ops/partition.rs
+++ b/src/daft-micropartition/src/ops/partition.rs
@@ -4,9 +4,7 @@ use common_error::DaftResult;
 use daft_dsl::Expr;
 use daft_table::Table;
 
-use crate::micropartition::{MicroPartition, TableState};
-
-use daft_stats::TableMetadata;
+use crate::micropartition::MicroPartition;
 
 fn transpose2<T>(v: Vec<Vec<T>>) -> Vec<Vec<T>> {
     if v.is_empty() {
@@ -33,11 +31,9 @@ impl MicroPartition {
         Ok(part_tables
             .into_iter()
             .map(|v| {
-                let new_len = v.iter().map(|t| t.len()).sum();
-                MicroPartition::new(
+                MicroPartition::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(v)),
-                    Some(TableMetadata { length: new_len }),
+                    Arc::new(v),
                     self.statistics.clone(),
                 )
             })

--- a/src/daft-micropartition/src/ops/partition.rs
+++ b/src/daft-micropartition/src/ops/partition.rs
@@ -37,7 +37,7 @@ impl MicroPartition {
                 MicroPartition::new(
                     self.schema.clone(),
                     TableState::Loaded(Arc::new(v)),
-                    TableMetadata { length: new_len },
+                    Some(TableMetadata { length: new_len }),
                     self.statistics.clone(),
                 )
             })

--- a/src/daft-micropartition/src/ops/slice.rs
+++ b/src/daft-micropartition/src/ops/slice.rs
@@ -1,8 +1,6 @@
 use common_error::DaftResult;
 
-use crate::micropartition::{MicroPartition, TableState};
-
-use daft_stats::TableMetadata;
+use crate::micropartition::MicroPartition;
 
 impl MicroPartition {
     pub fn slice(&self, start: usize, end: usize) -> DaftResult<Self> {
@@ -34,14 +32,11 @@ impl MicroPartition {
             }
         }
 
-        let new_len = slices_tables.iter().map(|t| t.len()).sum();
-
-        Ok(MicroPartition {
-            schema: self.schema.clone(),
-            state: TableState::Loaded(slices_tables.into()).into(),
-            metadata: Some(TableMetadata { length: new_len }),
-            statistics: self.statistics.clone(),
-        })
+        Ok(MicroPartition::new_loaded(
+            self.schema.clone(),
+            slices_tables.into(),
+            self.statistics.clone(),
+        ))
     }
 
     pub fn head(&self, num: usize) -> DaftResult<Self> {

--- a/src/daft-micropartition/src/ops/slice.rs
+++ b/src/daft-micropartition/src/ops/slice.rs
@@ -39,7 +39,7 @@ impl MicroPartition {
         Ok(MicroPartition {
             schema: self.schema.clone(),
             state: TableState::Loaded(slices_tables.into()).into(),
-            metadata: TableMetadata { length: new_len },
+            metadata: Some(TableMetadata { length: new_len }),
             statistics: self.statistics.clone(),
         })
     }

--- a/src/daft-micropartition/src/ops/sort.rs
+++ b/src/daft-micropartition/src/ops/sort.rs
@@ -5,7 +5,7 @@ use daft_core::Series;
 use daft_dsl::Expr;
 use daft_table::Table;
 
-use crate::micropartition::{MicroPartition, TableState};
+use crate::micropartition::MicroPartition;
 
 impl MicroPartition {
     pub fn sort(&self, sort_keys: &[Expr], descending: &[bool]) -> DaftResult<Self> {
@@ -14,10 +14,9 @@ impl MicroPartition {
             [] => Ok(Self::empty(Some(self.schema.clone()))),
             [single] => {
                 let sorted = single.sort(sort_keys, descending)?;
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![sorted])),
-                    self.metadata.clone(),
+                    Arc::new(vec![sorted]),
                     self.statistics.clone(),
                 ))
             }

--- a/src/daft-micropartition/src/ops/take.rs
+++ b/src/daft-micropartition/src/ops/take.rs
@@ -18,7 +18,7 @@ impl MicroPartition {
                 Ok(Self::new(
                     self.schema.clone(),
                     TableState::Loaded(Arc::new(vec![taken])),
-                    TableMetadata { length: idx.len() },
+                    Some(TableMetadata { length: idx.len() }),
                     self.statistics.clone(),
                 ))
             }
@@ -27,7 +27,7 @@ impl MicroPartition {
                 Ok(Self::new(
                     self.schema.clone(),
                     TableState::Loaded(Arc::new(vec![taken])),
-                    TableMetadata { length: idx.len() },
+                    Some(TableMetadata { length: idx.len() }),
                     self.statistics.clone(),
                 ))
             }
@@ -46,7 +46,7 @@ impl MicroPartition {
                 Ok(Self::new(
                     self.schema.clone(),
                     TableState::Loaded(Arc::new(vec![taken])),
-                    TableMetadata { length: taken_len },
+                    Some(TableMetadata { length: taken_len }),
                     self.statistics.clone(),
                 ))
             }
@@ -64,7 +64,7 @@ impl MicroPartition {
                 Ok(Self::new(
                     self.schema.clone(),
                     TableState::Loaded(Arc::new(vec![taken])),
-                    TableMetadata { length: taken_len },
+                    Some(TableMetadata { length: taken_len }),
                     self.statistics.clone(),
                 ))
             }

--- a/src/daft-micropartition/src/ops/take.rs
+++ b/src/daft-micropartition/src/ops/take.rs
@@ -4,8 +4,7 @@ use common_error::DaftResult;
 use daft_core::Series;
 use daft_table::Table;
 
-use crate::micropartition::{MicroPartition, TableState};
-use daft_stats::TableMetadata;
+use crate::micropartition::MicroPartition;
 
 impl MicroPartition {
     pub fn take(&self, idx: &Series) -> DaftResult<Self> {
@@ -15,19 +14,17 @@ impl MicroPartition {
             [] => {
                 let empty_table = Table::empty(Some(self.schema.clone()))?;
                 let taken = empty_table.take(idx)?;
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![taken])),
-                    Some(TableMetadata { length: idx.len() }),
+                    Arc::new(vec![taken]),
                     self.statistics.clone(),
                 ))
             }
             [single] => {
                 let taken = single.take(idx)?;
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![taken])),
-                    Some(TableMetadata { length: idx.len() }),
+                    Arc::new(vec![taken]),
                     self.statistics.clone(),
                 ))
             }
@@ -42,11 +39,9 @@ impl MicroPartition {
             [] => Ok(Self::empty(Some(self.schema.clone()))),
             [single] => {
                 let taken = single.sample(num)?;
-                let taken_len = taken.len();
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![taken])),
-                    Some(TableMetadata { length: taken_len }),
+                    Arc::new(vec![taken]),
                     self.statistics.clone(),
                 ))
             }
@@ -60,11 +55,9 @@ impl MicroPartition {
             [] => Ok(Self::empty(Some(self.schema.clone()))),
             [single] => {
                 let taken = single.quantiles(num)?;
-                let taken_len = taken.len();
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![taken])),
-                    Some(TableMetadata { length: taken_len }),
+                    Arc::new(vec![taken]),
                     self.statistics.clone(),
                 ))
             }

--- a/src/daft-plan/Cargo.toml
+++ b/src/daft-plan/Cargo.toml
@@ -5,6 +5,7 @@ common-error = {path = "../common/error", default-features = false}
 common-io-config = {path = "../common/io-config", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
+daft-scan = {path = "../daft-scan", default-features = false}
 daft-table = {path = "../daft-table", default-features = false}
 indexmap = {workspace = true}
 log = {workspace = true}

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -71,8 +71,8 @@ impl LogicalPlanBuilder {
         scan_operator: ScanOperatorRef,
         schema_hint: Option<SchemaRef>,
     ) -> DaftResult<Self> {
-        let schema = schema_hint.unwrap_or_else(|| scan_operator.schema());
-        let partitioning_keys = scan_operator.partitioning_keys();
+        let schema = schema_hint.unwrap_or_else(|| scan_operator.0.schema());
+        let partitioning_keys = scan_operator.0.partitioning_keys();
         let source_info =
             SourceInfo::ExternalInfo(ExternalSourceInfo::Scan(ScanExternalInfo::new(
                 scan_operator.clone(),

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -7,24 +7,27 @@ use crate::{
     planner::plan,
     sink_info::{OutputFileInfo, SinkInfo},
     source_info::{
-        ExternalInfo as ExternalSourceInfo, FileFormatConfig, FileInfos as InputFileInfos,
-        PyStorageConfig, SourceInfo, StorageConfig,
+        ExternalInfo as ExternalSourceInfo, FileInfos as InputFileInfos, LegacyExternalInfo,
+        SourceInfo,
     },
-    FileFormat, JoinType, PartitionScheme, PhysicalPlanScheduler, ResourceRequest,
+    JoinType, PartitionScheme, PhysicalPlanScheduler, ResourceRequest,
 };
 use common_error::{DaftError, DaftResult};
 use daft_core::schema::SchemaRef;
 use daft_core::{datatypes::Field, schema::Schema, DataType};
 use daft_dsl::Expr;
+use daft_scan::{
+    file_format::{FileFormat, FileFormatConfig},
+    storage_config::{PyStorageConfig, StorageConfig},
+    ScanExternalInfo, ScanOperatorRef,
+};
 
 #[cfg(feature = "python")]
 use {
-    crate::{
-        physical_plan::PhysicalPlan,
-        source_info::{InMemoryInfo, PyFileFormatConfig},
-    },
+    crate::{physical_plan::PhysicalPlan, source_info::InMemoryInfo},
     daft_core::python::schema::PySchema,
     daft_dsl::python::PyExpr,
+    daft_scan::{file_format::PyFileFormatConfig, python::pylib::ScanOperatorHandle},
     pyo3::prelude::*,
 };
 
@@ -64,6 +67,24 @@ impl LogicalPlanBuilder {
         Ok(logical_plan.into())
     }
 
+    pub fn table_scan_with_scan_operator(
+        scan_operator: ScanOperatorRef,
+        schema_hint: Option<SchemaRef>,
+    ) -> DaftResult<Self> {
+        let schema = schema_hint.unwrap_or_else(|| scan_operator.schema());
+        let partitioning_keys = scan_operator.partitioning_keys();
+        let source_info =
+            SourceInfo::ExternalInfo(ExternalSourceInfo::Scan(ScanExternalInfo::new(
+                scan_operator.clone(),
+                schema.clone(),
+                partitioning_keys.into(),
+                Default::default(),
+            )));
+        let logical_plan: LogicalPlan =
+            logical_ops::Source::new(schema.clone(), source_info.into(), None).into();
+        Ok(logical_plan.into())
+    }
+
     pub fn table_scan(
         file_infos: InputFileInfos,
         schema: Arc<Schema>,
@@ -80,12 +101,13 @@ impl LogicalPlanBuilder {
         storage_config: Arc<StorageConfig>,
         limit: Option<usize>,
     ) -> DaftResult<Self> {
-        let source_info = SourceInfo::ExternalInfo(ExternalSourceInfo::new(
-            schema.clone(),
-            file_infos.into(),
-            file_format_config,
-            storage_config,
-        ));
+        let source_info =
+            SourceInfo::ExternalInfo(ExternalSourceInfo::Legacy(LegacyExternalInfo::new(
+                schema.clone(),
+                file_infos.into(),
+                file_format_config,
+                storage_config,
+            )));
         let logical_plan: LogicalPlan =
             logical_ops::Source::new(schema.clone(), source_info.into(), limit).into();
         Ok(logical_plan.into())
@@ -261,6 +283,18 @@ impl PyLogicalPlanBuilder {
             cache_entry.to_object(cache_entry.py()),
             schema.into(),
             num_partitions,
+        )?
+        .into())
+    }
+
+    #[staticmethod]
+    pub fn table_scan_with_scan_operator(
+        scan_operator: ScanOperatorHandle,
+        schema_hint: Option<PySchema>,
+    ) -> PyResult<Self> {
+        Ok(LogicalPlanBuilder::table_scan_with_scan_operator(
+            scan_operator.into(),
+            schema_hint.map(|s| s.into()),
         )?
         .into())
     }

--- a/src/daft-plan/src/lib.rs
+++ b/src/daft-plan/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(let_chains)]
 #![feature(assert_matches)]
+#![feature(if_let_guard)]
 
 mod builder;
 mod display;
@@ -18,18 +19,23 @@ mod source_info;
 mod test;
 
 pub use builder::{LogicalPlanBuilder, PyLogicalPlanBuilder};
+use daft_scan::{
+    file_format::{
+        CsvSourceConfig, FileFormat, JsonSourceConfig, ParquetSourceConfig, PyFileFormatConfig,
+    },
+    storage_config::{NativeStorageConfig, PyStorageConfig},
+};
 pub use join::JoinType;
 pub use logical_plan::LogicalPlan;
 pub use partitioning::{PartitionScheme, PartitionSpec};
 pub use physical_plan::PhysicalPlanScheduler;
 pub use resource_request::ResourceRequest;
-pub use source_info::{
-    CsvSourceConfig, FileFormat, FileInfo, FileInfos, JsonSourceConfig, NativeStorageConfig,
-    ParquetSourceConfig, PyFileFormatConfig, PyStorageConfig,
-};
+pub use source_info::{FileInfo, FileInfos};
 
 #[cfg(feature = "python")]
-use {pyo3::prelude::*, source_info::PythonStorageConfig};
+use daft_scan::storage_config::PythonStorageConfig;
+#[cfg(feature = "python")]
+use pyo3::prelude::*;
 
 #[cfg(feature = "python")]
 pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {

--- a/src/daft-plan/src/optimization/optimizer.rs
+++ b/src/daft-plan/src/optimization/optimizer.rs
@@ -536,7 +536,7 @@ mod tests {
         let expected = "\
         Filter: [[[col(a) < lit(2)] | lit(false)] | lit(false)] & lit(true)\
         \n  Project: col(a) + lit(3) AS c, col(a) + lit(1), col(a) + lit(2) AS b\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64)";
         assert_eq!(opt_plan.repr_indent(), expected);
         Ok(())
     }

--- a/src/daft-plan/src/optimization/rules/drop_repartition.rs
+++ b/src/daft-plan/src/optimization/rules/drop_repartition.rs
@@ -98,7 +98,7 @@ mod tests {
         .build();
         let expected = "\
         Repartition: Scheme = Hash, Number of partitions = 5, Partition by = col(a)\
-        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }

--- a/src/daft-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_filter.rs
@@ -261,7 +261,7 @@ mod tests {
         .build();
         let expected = "\
         Filter: [col(b) == lit(\"foo\")] & [col(a) < lit(2)]\
-        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -279,7 +279,7 @@ mod tests {
         let expected = "\
         Project: col(a)\
         \n  Filter: col(a) < lit(2)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -297,7 +297,7 @@ mod tests {
         let expected = "\
         Project: col(a), col(b)\
         \n  Filter: [col(a) < lit(2)] & [col(b) == lit(\"foo\")]\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -317,7 +317,7 @@ mod tests {
         let expected = "\
         Filter: col(a) < lit(2)\
         \n  Project: col(a) + lit(1)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -338,7 +338,7 @@ mod tests {
         let expected = "\
         Project: col(a) + lit(1)\
         \n  Filter: [col(a) + lit(1)] < lit(2)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -356,7 +356,7 @@ mod tests {
         let expected = "\
         Sort: Sort by = (col(a), descending)\
         \n  Filter: col(a) < lit(2)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         // TODO(Clark): For tests in which we only care about reordering of operators, maybe switch to a form that leverages the single-node display?
         // let expected = format!("{sort}\n  {filter}\n    {source}");
         assert_optimized_plan_eq(plan, expected)?;
@@ -376,7 +376,7 @@ mod tests {
         let expected = "\
         Repartition: Scheme = Hash, Number of partitions = 1, Partition by = col(a)\
         \n  Filter: col(a) < lit(2)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -395,9 +395,9 @@ mod tests {
         let expected = "\
         Concat\
         \n  Filter: col(a) < lit(2)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)\
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)\
         \n  Filter: col(a) < lit(2)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -423,8 +423,8 @@ mod tests {
         let expected = "\
         Join: Type = Inner, On = col(b), Output schema = a (Int64), b (Utf8), c (Float64)\
         \n  Filter: col(a) < lit(2)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)\
-        \n  Source: Json, File paths = [/foo], File schema = b (Utf8), c (Float64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = b (Utf8), c (Float64)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)\
+        \n  Source: Json, File paths = [/foo], File schema = b (Utf8), c (Float64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = b (Utf8), c (Float64)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -449,9 +449,9 @@ mod tests {
         .build();
         let expected = "\
         Join: Type = Inner, On = col(b), Output schema = a (Int64), b (Utf8), c (Float64)\
-        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)\
+        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)\
         \n  Filter: col(c) < lit(2.0)\
-        \n    Source: Json, File paths = [/foo], File schema = b (Utf8), c (Float64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = b (Utf8), c (Float64)";
+        \n    Source: Json, File paths = [/foo], File schema = b (Utf8), c (Float64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = b (Utf8), c (Float64)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -475,9 +475,9 @@ mod tests {
         let expected = "\
         Join: Type = Inner, On = col(b), Output schema = a (Int64), b (Int64), c (Float64)\
         \n  Filter: col(b) < lit(2)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), c (Float64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Int64), c (Float64)\
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), c (Float64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Int64), c (Float64)\
         \n  Filter: col(b) < lit(2)\
-        \n    Source: Json, File paths = [/foo], File schema = b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = b (Int64)";
+        \n    Source: Json, File paths = [/foo], File schema = b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = b (Int64)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }

--- a/src/daft-plan/src/optimization/rules/push_down_limit.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_limit.rs
@@ -76,7 +76,7 @@ impl OptimizerRule for PushDownLimit {
                             (SourceInfo::ExternalInfo(ExternalInfo::Scan(ScanExternalInfo { scan_op, .. })), _) => {
                                 let new_source =
                                     LogicalPlan::Source(source.with_limit(Some(limit))).into();
-                                let out_plan = if scan_op.can_absorb_limit() {
+                                let out_plan = if scan_op.0.can_absorb_limit() {
                                     // Scan can fully absorb the limit, so we can drop the Limit op from the logical plan.
                                     new_source
                                 } else {

--- a/src/daft-plan/src/optimization/rules/push_down_limit.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_limit.rs
@@ -151,7 +151,7 @@ mod tests {
         .build();
         let expected = "\
         Limit: 5\
-        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8), Limit = 5";
+        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8), Limit = 5";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -172,7 +172,7 @@ mod tests {
         .build();
         let expected = "\
         Limit: 5\
-        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8), Limit = 3";
+        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8), Limit = 3";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -193,7 +193,7 @@ mod tests {
         .build();
         let expected = "\
         Limit: 5\
-        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8), Limit = 5";
+        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8), Limit = 5";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -211,7 +211,7 @@ mod tests {
             .build();
         let expected = "\
         Limit: 5\
-        \n . Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8)";
+        \n . Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8)";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -231,7 +231,7 @@ mod tests {
         let expected = "\
         Repartition: Scheme = Hash, Number of partitions = 1, Partition by = col(a)\
         \n  Limit: 5\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8), Limit = 5";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8), Limit = 5";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }
@@ -251,7 +251,7 @@ mod tests {
         let expected = "\
         Project: col(a)\
         \n  Limit: 5\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Utf8), Limit = 5";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Utf8), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Utf8), Limit = 5";
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())
     }

--- a/src/daft-plan/src/optimization/rules/push_down_limit.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_limit.rs
@@ -1,8 +1,13 @@
 use std::sync::Arc;
 
 use common_error::DaftResult;
+use daft_scan::{Pushdowns, ScanExternalInfo};
 
-use crate::{logical_ops::Limit as LogicalLimit, source_info::SourceInfo, LogicalPlan};
+use crate::{
+    logical_ops::Limit as LogicalLimit,
+    source_info::{ExternalInfo, SourceInfo},
+    LogicalPlan,
+};
 
 use super::{ApplyOrder, OptimizerRule, Transformed};
 
@@ -41,19 +46,43 @@ impl OptimizerRule for PushDownLimit {
                             // Limit pushdown is not supported for in-memory sources.
                             #[cfg(feature = "python")]
                             (SourceInfo::InMemoryInfo(_), _) => Ok(Transformed::No(plan)),
+
+                            // Legacy external info handling.
+
                             // Do not pushdown if Source node is already more limited than `limit`
-                            (SourceInfo::ExternalInfo(_), Some(existing_source_limit))
+                            (SourceInfo::ExternalInfo(ExternalInfo::Legacy(_)), Some(existing_source_limit))
                                 if (existing_source_limit <= limit) =>
                             {
                                 Ok(Transformed::No(plan))
                             }
                             // Pushdown limit into the Source node as a "local" limit
-                            (SourceInfo::ExternalInfo(_), _) => {
+                            (SourceInfo::ExternalInfo(ExternalInfo::Legacy(_)), _) => {
                                 let new_source =
                                     LogicalPlan::Source(source.with_limit(Some(limit))).into();
                                 let limit_with_local_limited_source =
                                     plan.with_new_children(&[new_source]);
                                 Ok(Transformed::Yes(limit_with_local_limited_source))
+                            }
+
+                            // Scan operator external info handling.
+
+                            // Do not pushdown if Source node is already more limited than `limit`
+                            (SourceInfo::ExternalInfo(ExternalInfo::Scan(ScanExternalInfo { pushdowns: Pushdowns { limit: existing_source_limit, .. }, .. })), _)
+                                if let Some(existing_source_limit) = existing_source_limit && existing_source_limit <= &limit =>
+                            {
+                                Ok(Transformed::No(plan))
+                            }
+                            // Pushdown limit into the Source node as a "local" limit
+                            (SourceInfo::ExternalInfo(ExternalInfo::Scan(ScanExternalInfo { scan_op, .. })), _) => {
+                                let new_source =
+                                    LogicalPlan::Source(source.with_limit(Some(limit))).into();
+                                let out_plan = if scan_op.can_absorb_limit() {
+                                    // Scan can fully absorb the limit, so we can drop the Limit op from the logical plan.
+                                    new_source
+                                } else {
+                                    plan.with_new_children(&[new_source])
+                                };
+                                Ok(Transformed::Yes(out_plan))
                             }
                         }
                     }

--- a/src/daft-plan/src/optimization/rules/push_down_projection.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_projection.rs
@@ -560,7 +560,7 @@ mod tests {
 
         let expected = "\
         Project: [col(a) + lit(1)] + lit(3), col(b) + lit(2), col(a) + lit(4)\
-        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Int64)";
+        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Int64)";
         assert_optimized_plan_eq(unoptimized, expected)?;
         Ok(())
     }
@@ -576,7 +576,7 @@ mod tests {
         .build();
 
         let expected = "\
-        Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Int64)";
+        Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Int64)";
         assert_optimized_plan_eq(unoptimized, expected)?;
 
         Ok(())
@@ -593,7 +593,7 @@ mod tests {
 
         let expected = "\
         Project: col(b), col(a)\
-        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Int64)";
+        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Int64)";
         assert_optimized_plan_eq(unoptimized, expected)?;
 
         Ok(())
@@ -611,7 +611,7 @@ mod tests {
 
         let expected = "\
         Project: col(b) + lit(3)\
-        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = b (Int64)";
+        \n  Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = b (Int64)";
         assert_optimized_plan_eq(unoptimized, expected)?;
 
         Ok(())
@@ -637,7 +637,7 @@ mod tests {
         let expected = "\
         Project: col(a), col(b), col(b) AS c\
         \n  Project: col(b) + lit(3), col(a)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Int64)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Int64)";
         assert_optimized_plan_eq(unoptimized, expected)?;
 
         Ok(())
@@ -658,7 +658,7 @@ mod tests {
         let expected = "\
         Project: col(a)\
         \n  Aggregation: mean(col(a)), Group by = col(c), Output schema = c (Int64), a (Float64)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), c (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), c (Int64)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Int64), c (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), c (Int64)";
         assert_optimized_plan_eq(unoptimized, expected)?;
 
         Ok(())
@@ -679,7 +679,7 @@ mod tests {
         let expected = "\
         Project: col(a)\
         \n  Filter: col(b)\
-        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Boolean), c (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None }), Output schema = a (Int64), b (Boolean)";
+        \n    Source: Json, File paths = [/foo], File schema = a (Int64), b (Boolean), c (Int64), Format-specific config = Json(JsonSourceConfig), Storage config = Native(NativeStorageConfig { io_config: None, multithreaded_io: true }), Output schema = a (Int64), b (Boolean)";
         assert_optimized_plan_eq(unoptimized, expected)?;
 
         Ok(())

--- a/src/daft-plan/src/physical_ops/csv.rs
+++ b/src/daft-plan/src/physical_ops/csv.rs
@@ -4,7 +4,7 @@ use daft_core::schema::SchemaRef;
 use daft_dsl::ExprRef;
 
 use crate::{
-    physical_plan::PhysicalPlan, sink_info::OutputFileInfo, source_info::ExternalInfo,
+    physical_plan::PhysicalPlan, sink_info::OutputFileInfo, source_info::LegacyExternalInfo,
     PartitionSpec,
 };
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TabularScanCsv {
     pub projection_schema: SchemaRef,
-    pub external_info: ExternalInfo,
+    pub external_info: LegacyExternalInfo,
     pub partition_spec: Arc<PartitionSpec>,
     pub limit: Option<usize>,
     pub filters: Vec<ExprRef>,
@@ -21,7 +21,7 @@ pub struct TabularScanCsv {
 impl TabularScanCsv {
     pub(crate) fn new(
         projection_schema: SchemaRef,
-        external_info: ExternalInfo,
+        external_info: LegacyExternalInfo,
         partition_spec: Arc<PartitionSpec>,
         limit: Option<usize>,
         filters: Vec<ExprRef>,

--- a/src/daft-plan/src/physical_ops/json.rs
+++ b/src/daft-plan/src/physical_ops/json.rs
@@ -4,7 +4,7 @@ use daft_core::schema::SchemaRef;
 use daft_dsl::ExprRef;
 
 use crate::{
-    physical_plan::PhysicalPlan, sink_info::OutputFileInfo, source_info::ExternalInfo,
+    physical_plan::PhysicalPlan, sink_info::OutputFileInfo, source_info::LegacyExternalInfo,
     PartitionSpec,
 };
 use serde::{Deserialize, Serialize};
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TabularScanJson {
     pub projection_schema: SchemaRef,
-    pub external_info: ExternalInfo,
+    pub external_info: LegacyExternalInfo,
     pub partition_spec: Arc<PartitionSpec>,
     pub limit: Option<usize>,
     pub filters: Vec<ExprRef>,
@@ -21,7 +21,7 @@ pub struct TabularScanJson {
 impl TabularScanJson {
     pub(crate) fn new(
         projection_schema: SchemaRef,
-        external_info: ExternalInfo,
+        external_info: LegacyExternalInfo,
         partition_spec: Arc<PartitionSpec>,
         limit: Option<usize>,
         filters: Vec<ExprRef>,

--- a/src/daft-plan/src/physical_ops/mod.rs
+++ b/src/daft-plan/src/physical_ops/mod.rs
@@ -14,6 +14,7 @@ mod limit;
 mod parquet;
 mod project;
 mod reduce;
+mod scan;
 mod sort;
 mod split;
 
@@ -33,5 +34,6 @@ pub use limit::Limit;
 pub use parquet::{TabularScanParquet, TabularWriteParquet};
 pub use project::Project;
 pub use reduce::ReduceMerge;
+pub use scan::TabularScan;
 pub use sort::Sort;
 pub use split::Split;

--- a/src/daft-plan/src/physical_ops/parquet.rs
+++ b/src/daft-plan/src/physical_ops/parquet.rs
@@ -5,7 +5,7 @@ use daft_dsl::ExprRef;
 
 use crate::{
     physical_plan::PhysicalPlan, sink_info::OutputFileInfo,
-    source_info::ExternalInfo as ExternalSourceInfo, PartitionSpec,
+    source_info::LegacyExternalInfo as ExternalSourceInfo, PartitionSpec,
 };
 use serde::{Deserialize, Serialize};
 

--- a/src/daft-plan/src/physical_ops/scan.rs
+++ b/src/daft-plan/src/physical_ops/scan.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TabularScan {
-    pub scan_tasks: Vec<ScanTask>,
+    pub scan_tasks: Vec<Arc<ScanTask>>,
     pub partition_spec: Arc<PartitionSpec>,
 }
 
 impl TabularScan {
     pub(crate) fn new(scan_tasks: Vec<ScanTask>, partition_spec: Arc<PartitionSpec>) -> Self {
         Self {
-            scan_tasks,
+            scan_tasks: scan_tasks.into_iter().map(Arc::new).collect(),
             partition_spec,
         }
     }

--- a/src/daft-plan/src/physical_ops/scan.rs
+++ b/src/daft-plan/src/physical_ops/scan.rs
@@ -1,0 +1,21 @@
+use std::sync::Arc;
+
+use daft_scan::ScanTask;
+
+use crate::PartitionSpec;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TabularScan {
+    pub scan_tasks: Vec<ScanTask>,
+    pub partition_spec: Arc<PartitionSpec>,
+}
+
+impl TabularScan {
+    pub(crate) fn new(scan_tasks: Vec<ScanTask>, partition_spec: Arc<PartitionSpec>) -> Self {
+        Self {
+            scan_tasks,
+            partition_spec,
+        }
+    }
+}

--- a/src/daft-plan/src/physical_plan.rs
+++ b/src/daft-plan/src/physical_plan.rs
@@ -308,14 +308,13 @@ impl PhysicalPlan {
                 Ok(py_iter.into())
             }
             PhysicalPlan::TabularScan(TabularScan { scan_tasks, .. }) => {
-                let py_scan_tasks = scan_tasks
-                    .iter()
-                    .map(|scan_task| PyScanTask::from(Arc::new(scan_task.clone())))
-                    .collect::<Vec<_>>();
                 let py_iter = py
                     .import(pyo3::intern!(py, "daft.execution.rust_physical_plan_shim"))?
                     .getattr(pyo3::intern!(py, "scan_with_tasks"))?
-                    .call1((py_scan_tasks,))?;
+                    .call1((scan_tasks
+                        .iter()
+                        .map(|scan_task| PyScanTask(scan_task.clone()))
+                        .collect::<Vec<PyScanTask>>(),))?;
                 Ok(py_iter.into())
             }
             PhysicalPlan::TabularScanParquet(TabularScanParquet {

--- a/src/daft-plan/src/planner.rs
+++ b/src/daft-plan/src/planner.rs
@@ -84,6 +84,7 @@ pub fn plan(logical_plan: &LogicalPlan) -> DaftResult<PhysicalPlan> {
                     .0
                     .to_scan_tasks(pushdowns.clone())?
                     .collect::<DaftResult<Vec<_>>>()?;
+
                 let partition_spec = Arc::new(PartitionSpec::new_internal(
                     PartitionScheme::Unknown,
                     scan_tasks.len(),

--- a/src/daft-plan/src/planner.rs
+++ b/src/daft-plan/src/planner.rs
@@ -81,6 +81,7 @@ pub fn plan(logical_plan: &LogicalPlan) -> DaftResult<PhysicalPlan> {
                 ..
             })) => {
                 let scan_tasks = scan_op
+                    .0
                     .to_scan_tasks(pushdowns.clone())?
                     .collect::<DaftResult<Vec<_>>>()?;
                 let partition_spec = Arc::new(PartitionSpec::new_internal(

--- a/src/daft-plan/src/source_info/mod.rs
+++ b/src/daft-plan/src/source_info/mod.rs
@@ -1,23 +1,14 @@
-pub mod file_format;
 pub mod file_info;
-#[cfg(feature = "python")]
-mod py_object_serde;
-pub mod storage_config;
-
 use daft_core::schema::SchemaRef;
-pub use file_format::{
-    CsvSourceConfig, FileFormat, FileFormatConfig, JsonSourceConfig, ParquetSourceConfig,
-    PyFileFormatConfig,
-};
+use daft_scan::file_format::FileFormatConfig;
+use daft_scan::storage_config::StorageConfig;
+use daft_scan::ScanExternalInfo;
 pub use file_info::{FileInfo, FileInfos};
 use serde::{Deserialize, Serialize};
 use std::{hash::Hash, sync::Arc};
 #[cfg(feature = "python")]
-pub use storage_config::PythonStorageConfig;
-pub use storage_config::{NativeStorageConfig, PyStorageConfig, StorageConfig};
-#[cfg(feature = "python")]
 use {
-    py_object_serde::{deserialize_py_object, serialize_py_object},
+    daft_scan::py_object_serde::{deserialize_py_object, serialize_py_object},
     pyo3::{PyObject, Python},
     std::hash::Hasher,
 };
@@ -89,15 +80,21 @@ impl Hash for InMemoryInfo {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ExternalInfo {
+    Scan(ScanExternalInfo),
+    Legacy(LegacyExternalInfo),
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct ExternalInfo {
+pub struct LegacyExternalInfo {
     pub source_schema: SchemaRef,
     pub file_infos: Arc<FileInfos>,
     pub file_format_config: Arc<FileFormatConfig>,
     pub storage_config: Arc<StorageConfig>,
 }
 
-impl ExternalInfo {
+impl LegacyExternalInfo {
     pub fn new(
         source_schema: SchemaRef,
         file_infos: Arc<FileInfos>,

--- a/src/daft-plan/src/test/mod.rs
+++ b/src/daft-plan/src/test/mod.rs
@@ -1,11 +1,10 @@
 use std::sync::Arc;
 
 use daft_core::{datatypes::Field, schema::Schema};
+use daft_scan::{file_format::FileFormatConfig, storage_config::StorageConfig};
 
 use crate::{
-    builder::LogicalPlanBuilder,
-    source_info::{FileFormatConfig, FileInfos, StorageConfig},
-    JsonSourceConfig, NativeStorageConfig,
+    builder::LogicalPlanBuilder, source_info::FileInfos, JsonSourceConfig, NativeStorageConfig,
 };
 
 /// Create a dummy scan node containing the provided fields in its schema.
@@ -15,7 +14,7 @@ pub fn dummy_scan_node(fields: Vec<Field>) -> LogicalPlanBuilder {
         FileInfos::new_internal(vec!["/foo".to_string()], vec![None], vec![None]),
         schema,
         FileFormatConfig::Json(JsonSourceConfig {}).into(),
-        StorageConfig::Native(NativeStorageConfig::new_internal(None).into()).into(),
+        StorageConfig::Native(NativeStorageConfig::new_internal(true, None).into()).into(),
     )
     .unwrap()
 }
@@ -27,7 +26,7 @@ pub fn dummy_scan_node_with_limit(fields: Vec<Field>, limit: Option<usize>) -> L
         FileInfos::new_internal(vec!["/foo".to_string()], vec![None], vec![None]),
         schema,
         FileFormatConfig::Json(JsonSourceConfig {}).into(),
-        StorageConfig::Native(NativeStorageConfig::new_internal(None).into()).into(),
+        StorageConfig::Native(NativeStorageConfig::new_internal(true, None).into()).into(),
         limit,
     )
     .unwrap()

--- a/src/daft-scan/Cargo.toml
+++ b/src/daft-scan/Cargo.toml
@@ -18,7 +18,7 @@ tokio = {workspace = true}
 
 [features]
 default = ["python"]
-python = ["dep:pyo3", "common-error/python", "daft-core/python", "daft-dsl/python", "daft-table/python", "daft-stats/python"]
+python = ["dep:pyo3", "common-error/python", "daft-core/python", "daft-dsl/python", "daft-table/python", "daft-stats/python", "common-io-config/python"]
 
 [package]
 edition = {workspace = true}

--- a/src/daft-scan/Cargo.toml
+++ b/src/daft-scan/Cargo.toml
@@ -1,5 +1,7 @@
 [dependencies]
+bincode = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
+common-io-config = {path = "../common/io-config", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-csv = {path = "../daft-csv", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
@@ -10,6 +12,7 @@ daft-table = {path = "../daft-table", default-features = false}
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true}
 serde = {workspace = true}
+serde_json = {workspace = true}
 snafu = {workspace = true}
 tokio = {workspace = true}
 

--- a/src/daft-scan/src/anonymous.rs
+++ b/src/daft-scan/src/anonymous.rs
@@ -7,7 +7,7 @@ use crate::{
     file_format::FileFormatConfig, storage_config::StorageConfig, DataFileSource, PartitionField,
     Pushdowns, ScanOperator, ScanTask,
 };
-#[derive(Debug, PartialEq, Hash)]
+#[derive(Debug)]
 pub struct AnonymousScanOperator {
     files: Vec<String>,
     schema: SchemaRef,

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -83,7 +83,7 @@ impl GlobScanOperator {
                 let inferred_schema = match file_format_config.as_ref() {
                     FileFormatConfig::Parquet(ParquetSourceConfig {
                         coerce_int96_timestamp_unit,
-                        row_groups: _,
+                        ..
                     }) => {
                         let io_stats = IOStatsContext::new(format!(
                             "GlobScanOperator constructor read_parquet_schema: for uri {first_filepath}"

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -101,8 +101,7 @@ impl GlobScanOperator {
                         delimiter,
                         has_headers,
                         double_quote,
-                        buffer_size: _,
-                        chunk_size: _,
+                        ..
                     }) => {
                         let io_stats = IOStatsContext::new(format!(
                             "GlobScanOperator constructor read_csv_schema: for uri {first_filepath}"

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, sync::Arc};
 
 use common_error::DaftResult;
 use daft_core::schema::SchemaRef;
-use daft_io::{get_io_client, get_runtime, IOClient, IOStatsContext};
+use daft_io::{get_io_client, get_runtime, parse_url, IOClient, IOStatsContext};
 use daft_parquet::read::ParquetSchemaInferenceOptions;
 
 use crate::{
@@ -24,11 +24,12 @@ fn run_glob(
     io_client: Arc<IOClient>,
     runtime: Arc<tokio::runtime::Runtime>,
 ) -> DaftResult<Vec<String>> {
+    let (_, parsed_glob_path) = parse_url(glob_path)?;
     let _rt_guard = runtime.enter();
     runtime.block_on(async {
         Ok(io_client
             .as_ref()
-            .glob(glob_path, None, None, limit, None)
+            .glob(&parsed_glob_path, None, None, limit, None)
             .await?
             .into_iter()
             .map(|fm| fm.filepath)

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -61,32 +61,20 @@ impl DataFileSource {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ScanTask {
-    // Micropartition will take this in as an input
-    pub source: DataFileSource,
+    pub sources: Vec<DataFileSource>,
     pub file_format_config: Arc<FileFormatConfig>,
     pub schema: SchemaRef,
     pub storage_config: Arc<StorageConfig>,
     // TODO(Clark): Directly use the Pushdowns struct as part of the ScanTask struct?
     pub columns: Option<Arc<Vec<String>>>,
     pub limit: Option<usize>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ScanTaskBatch {
-    pub sources: Vec<DataFileSource>,
-    pub file_format_config: Arc<FileFormatConfig>,
-    pub schema: SchemaRef,
-    pub storage_config: Arc<StorageConfig>,
-    // TODO(Clark): Directly use the Pushdowns struct as part of the ScanTaskBatch struct?
-    pub columns: Option<Arc<Vec<String>>>,
-    pub limit: Option<usize>,
     pub metadata: Option<TableMetadata>,
     pub statistics: Option<TableStatistics>,
 }
 
-impl ScanTaskBatch {
+impl ScanTask {
     pub fn new(
         sources: Vec<DataFileSource>,
         file_format_config: Arc<FileFormatConfig>,
@@ -135,29 +123,6 @@ impl ScanTaskBatch {
             self.num_rows()
                 .and_then(|num_rows| Some(num_rows * s.estimate_row_size().ok()?))
         })
-    }
-}
-
-impl From<Vec<ScanTask>> for ScanTaskBatch {
-    fn from(value: Vec<ScanTask>) -> Self {
-        if value.is_empty() {
-            panic!("Must have at least one ScanTask to create a ScanTaskBatch.");
-        }
-        let mut scan_task_iter = value.into_iter();
-        let first_scan_task = scan_task_iter.next().unwrap();
-        let first_scan_task_source = first_scan_task.source;
-        let sources = vec![first_scan_task_source]
-            .into_iter()
-            .chain(scan_task_iter.map(|t| t.source))
-            .collect::<Vec<_>>();
-        Self::new(
-            sources,
-            first_scan_task.file_format_config,
-            first_scan_task.schema,
-            first_scan_task.storage_config,
-            first_scan_task.columns,
-            first_scan_task.limit,
-        )
     }
 }
 

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -1,62 +1,39 @@
 use std::{
+    any::Any,
     fmt::{Debug, Display},
-    str::FromStr,
+    hash::{Hash, Hasher},
+    sync::Arc,
 };
 
-use common_error::{DaftError, DaftResult};
+use common_error::DaftResult;
 use daft_core::{datatypes::Field, schema::SchemaRef};
-use daft_dsl::Expr;
+use daft_dsl::{Expr, ExprRef};
 use daft_stats::{PartitionSpec, TableMetadata, TableStatistics};
+use file_format::FileFormatConfig;
 use serde::{Deserialize, Serialize};
 
 mod anonymous;
+pub mod file_format;
 mod glob;
 #[cfg(feature = "python")]
+pub mod py_object_serde;
+
+#[cfg(feature = "python")]
 pub mod python;
+pub mod storage_config;
 #[cfg(feature = "python")]
 pub use python::register_modules;
+use storage_config::StorageConfig;
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
-pub enum FileType {
-    Parquet,
-    Avro,
-    Orc,
-    Csv,
-}
-
-impl FromStr for FileType {
-    type Err = DaftError;
-
-    fn from_str(file_type: &str) -> DaftResult<Self> {
-        use FileType::*;
-        if file_type.trim().eq_ignore_ascii_case("parquet") {
-            Ok(Parquet)
-        } else if file_type.trim().eq_ignore_ascii_case("avro") {
-            Ok(Avro)
-        } else if file_type.trim().eq_ignore_ascii_case("orc") {
-            Ok(Orc)
-        } else if file_type.trim().eq_ignore_ascii_case("csv") {
-            Ok(Csv)
-        } else {
-            Err(DaftError::TypeError(format!(
-                "FileType {} not supported!",
-                file_type
-            )))
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum DataFileSource {
     AnonymousDataFile {
-        file_type: FileType,
         path: String,
         metadata: Option<TableMetadata>,
         partition_spec: Option<PartitionSpec>,
         statistics: Option<TableStatistics>,
     },
     CatalogDataFile {
-        file_type: FileType,
         path: String,
         metadata: TableMetadata,
         partition_spec: PartitionSpec,
@@ -64,31 +41,279 @@ pub enum DataFileSource {
     },
 }
 
-#[derive(Serialize, Deserialize)]
+impl DataFileSource {
+    pub fn get_path(&self) -> &str {
+        match self {
+            Self::AnonymousDataFile { path, .. } | Self::CatalogDataFile { path, .. } => path,
+        }
+    }
+    pub fn get_metadata(&self) -> Option<&TableMetadata> {
+        match self {
+            Self::AnonymousDataFile { metadata, .. } => metadata.as_ref(),
+            Self::CatalogDataFile { metadata, .. } => Some(metadata),
+        }
+    }
+
+    pub fn get_statistics(&self) -> Option<&TableStatistics> {
+        match self {
+            Self::AnonymousDataFile { statistics, .. }
+            | Self::CatalogDataFile { statistics, .. } => statistics.as_ref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScanTask {
     // Micropartition will take this in as an input
-    source: DataFileSource,
-    columns: Option<Vec<String>>,
-    limit: Option<usize>,
+    pub source: DataFileSource,
+    pub file_format_config: Arc<FileFormatConfig>,
+    pub schema: SchemaRef,
+    pub storage_config: Arc<StorageConfig>,
+    // TODO(Clark): Directly use the Pushdowns struct as part of the ScanTask struct?
+    pub columns: Option<Arc<Vec<String>>>,
+    pub limit: Option<usize>,
 }
-#[derive(Serialize, Deserialize)]
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScanTaskBatch {
+    pub sources: Vec<DataFileSource>,
+    pub file_format_config: Arc<FileFormatConfig>,
+    pub schema: SchemaRef,
+    pub storage_config: Arc<StorageConfig>,
+    // TODO(Clark): Directly use the Pushdowns struct as part of the ScanTaskBatch struct?
+    pub columns: Option<Arc<Vec<String>>>,
+    pub limit: Option<usize>,
+    pub metadata: Option<TableMetadata>,
+    pub statistics: Option<TableStatistics>,
+}
+
+impl ScanTaskBatch {
+    pub fn new(
+        sources: Vec<DataFileSource>,
+        file_format_config: Arc<FileFormatConfig>,
+        schema: SchemaRef,
+        storage_config: Arc<StorageConfig>,
+        columns: Option<Arc<Vec<String>>>,
+        limit: Option<usize>,
+    ) -> Self {
+        assert!(!sources.is_empty());
+        let (length, statistics) = sources
+            .iter()
+            .map(|s| {
+                (
+                    s.get_metadata().map(|m| m.length),
+                    s.get_statistics().cloned(),
+                )
+            })
+            .reduce(|(acc_len, acc_stats), (curr_len, curr_stats)| {
+                (
+                    acc_len.and_then(|acc_len| curr_len.map(|curr_len| acc_len + curr_len)),
+                    acc_stats.and_then(|acc_stats| {
+                        curr_stats.map(|curr_stats| acc_stats.union(&curr_stats).unwrap())
+                    }),
+                )
+            })
+            .unwrap();
+        let metadata = length.map(|l| TableMetadata { length: l });
+        Self {
+            sources,
+            file_format_config,
+            schema,
+            storage_config,
+            columns,
+            limit,
+            metadata,
+            statistics,
+        }
+    }
+
+    pub fn num_rows(&self) -> Option<usize> {
+        self.metadata.as_ref().map(|m| m.length)
+    }
+
+    pub fn size_bytes(&self) -> Option<usize> {
+        self.statistics.as_ref().and_then(|s| {
+            self.num_rows()
+                .and_then(|num_rows| Some(num_rows * s.estimate_row_size().ok()?))
+        })
+    }
+}
+
+impl From<Vec<ScanTask>> for ScanTaskBatch {
+    fn from(value: Vec<ScanTask>) -> Self {
+        if value.is_empty() {
+            panic!("Must have at least one ScanTask to create a ScanTaskBatch.");
+        }
+        let mut scan_task_iter = value.into_iter();
+        let first_scan_task = scan_task_iter.next().unwrap();
+        let first_scan_task_source = first_scan_task.source;
+        let sources = vec![first_scan_task_source]
+            .into_iter()
+            .chain(scan_task_iter.map(|t| t.source))
+            .collect::<Vec<_>>();
+        Self::new(
+            sources,
+            first_scan_task.file_format_config,
+            first_scan_task.schema,
+            first_scan_task.storage_config,
+            first_scan_task.columns,
+            first_scan_task.limit,
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct PartitionField {
     field: Field,
     source_field: Option<Field>,
     transform: Option<Expr>,
 }
 
-pub trait ScanOperator: Send + Display {
+pub trait ScanOperator: Send + Sync + Display + Debug + DynHash {
     fn schema(&self) -> SchemaRef;
     fn partitioning_keys(&self) -> &[PartitionField];
-    fn num_partitions(&self) -> DaftResult<usize>;
+    // fn statistics(&self) -> &TableStatistics;
+    // fn clustering_spec(&self) -> &ClusteringSpec;
 
-    // also returns a bool to indicate if the scan operator can "absorb" the predicate
-    fn filter(self: Box<Self>, predicate: &Expr) -> DaftResult<(bool, ScanOperatorRef)>;
-    fn select(self: Box<Self>, columns: &[&str]) -> DaftResult<ScanOperatorRef>;
-    fn limit(self: Box<Self>, num: usize) -> DaftResult<ScanOperatorRef>;
-    fn to_scan_tasks(self: Box<Self>)
-        -> DaftResult<Box<dyn Iterator<Item = DaftResult<ScanTask>>>>;
+    fn can_absorb_filter(&self) -> bool;
+    fn can_absorb_select(&self) -> bool;
+    fn can_absorb_limit(&self) -> bool;
+    fn to_scan_tasks(
+        &self,
+        pushdowns: Pushdowns,
+    ) -> DaftResult<Box<dyn Iterator<Item = DaftResult<ScanTask>>>>;
 }
 
-pub type ScanOperatorRef = Box<dyn ScanOperator>;
+// The following implements PartialEq, Eq, and Hash for trait objects.
+
+pub trait DynEq: Any {
+    fn as_any(&self) -> &dyn Any;
+    fn dyn_eq(&self, that: &dyn DynEq) -> bool;
+}
+
+impl<T: Any + PartialEq<Self>> DynEq for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn dyn_eq(&self, that: &dyn DynEq) -> bool {
+        if let Some(that) = that.as_any().downcast_ref::<Self>() {
+            self == that
+        } else {
+            false
+        }
+    }
+}
+
+pub trait DynHash: DynEq {
+    fn dyn_hash(&self, hasher: &mut dyn Hasher);
+
+    fn as_dyn_eq(&self) -> &dyn DynEq;
+}
+
+impl<H: Hash + DynEq> DynHash for H {
+    fn dyn_hash(&self, mut hasher: &mut dyn Hasher) {
+        H::hash(self, &mut hasher)
+    }
+
+    fn as_dyn_eq(&self) -> &dyn DynEq {
+        self
+    }
+}
+
+impl PartialEq for dyn ScanOperator + '_ {
+    fn eq(&self, that: &dyn ScanOperator) -> bool {
+        self.dyn_eq(that.as_dyn_eq())
+    }
+}
+
+impl PartialEq<dyn ScanOperator> for Box<dyn ScanOperator + '_> {
+    fn eq(&self, that: &dyn ScanOperator) -> bool {
+        self.dyn_eq(that.as_dyn_eq())
+    }
+}
+
+impl PartialEq<dyn ScanOperator> for Arc<dyn ScanOperator + '_> {
+    fn eq(&self, that: &dyn ScanOperator) -> bool {
+        self.dyn_eq(that.as_dyn_eq())
+    }
+}
+
+impl Eq for dyn ScanOperator + '_ {}
+
+impl Hash for dyn ScanOperator + '_ {
+    fn hash<H: Hasher>(&self, hasher: &mut H) {
+        self.dyn_hash(hasher)
+    }
+}
+
+pub type ScanOperatorRef = Arc<dyn ScanOperator>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ScanExternalInfo {
+    pub scan_op: Arc<dyn ScanOperator>,
+    pub source_schema: SchemaRef,
+    pub partitioning_keys: Vec<PartitionField>,
+    pub pushdowns: Pushdowns,
+}
+
+impl ScanExternalInfo {
+    pub fn new(
+        scan_op: Arc<dyn ScanOperator>,
+        source_schema: SchemaRef,
+        partitioning_keys: Vec<PartitionField>,
+        pushdowns: Pushdowns,
+    ) -> Self {
+        Self {
+            scan_op,
+            source_schema,
+            partitioning_keys,
+            pushdowns,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Pushdowns {
+    /// Optional filters to apply to the source data.
+    pub filters: Option<Arc<Vec<ExprRef>>>,
+    /// Optional columns to select from the source data.
+    pub columns: Option<Arc<Vec<String>>>,
+    /// Optional number of rows to read.
+    pub limit: Option<usize>,
+}
+
+impl Default for Pushdowns {
+    fn default() -> Self {
+        Self::new(None, None, None)
+    }
+}
+
+impl Pushdowns {
+    pub fn new(
+        filters: Option<Arc<Vec<ExprRef>>>,
+        columns: Option<Arc<Vec<String>>>,
+        limit: Option<usize>,
+    ) -> Self {
+        Self {
+            filters,
+            columns,
+            limit,
+        }
+    }
+
+    pub fn with_limit(&self, limit: Option<usize>) -> Self {
+        Self {
+            filters: self.filters.clone(),
+            columns: self.columns.clone(),
+            limit,
+        }
+    }
+
+    pub fn with_filters(&self, filters: Option<Arc<Vec<ExprRef>>>) -> Self {
+        Self {
+            filters,
+            columns: self.columns.clone(),
+            limit: self.limit,
+        }
+    }
+}

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -246,4 +246,12 @@ impl Pushdowns {
             limit: self.limit,
         }
     }
+
+    pub fn with_columns(&self, columns: Option<Arc<Vec<String>>>) -> Self {
+        Self {
+            filters: self.filters.clone(),
+            columns,
+            limit: self.limit,
+        }
+    }
 }

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -171,8 +171,6 @@ pub struct PartitionField {
 pub trait ScanOperator: Send + Sync + Display + Debug {
     fn schema(&self) -> SchemaRef;
     fn partitioning_keys(&self) -> &[PartitionField];
-    // fn statistics(&self) -> &TableStatistics;
-    // fn clustering_spec(&self) -> &ClusteringSpec;
 
     fn can_absorb_filter(&self) -> bool;
     fn can_absorb_select(&self) -> bool;
@@ -186,7 +184,7 @@ pub trait ScanOperator: Send + Sync + Display + Debug {
 /// Light transparent wrapper around an Arc<dyn ScanOperator> that implements Eq/PartialEq/Hash
 /// functionality to be performed on the **pointer** instead of on the value in the pointer.
 ///
-/// This lets us get around having to implement fiull hashing/equality on [`ScanOperator`]`, which
+/// This lets us get around having to implement full hashing/equality on [`ScanOperator`]`, which
 /// is difficult because we sometimes have weird Python implementations that can be hard to check.
 ///
 /// [`ScanOperatorRef`] should be thus held by structs that need to check the "sameness" of the

--- a/src/daft-scan/src/py_object_serde.rs
+++ b/src/daft-scan/src/py_object_serde.rs
@@ -4,7 +4,7 @@ use serde::{
 };
 use std::fmt;
 
-pub(super) fn serialize_py_object<S>(obj: &PyObject, s: S) -> Result<S::Ok, S::Error>
+pub fn serialize_py_object<S>(obj: &PyObject, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -56,7 +56,7 @@ impl<'de> Visitor<'de> for PyObjectVisitor {
 }
 
 #[cfg(feature = "python")]
-pub(super) fn deserialize_py_object<'de, D>(d: D) -> Result<PyObject, D::Error>
+pub fn deserialize_py_object<'de, D>(d: D) -> Result<PyObject, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -69,10 +69,7 @@ where
 struct PyObjSerdeWrapper<'a>(#[serde(serialize_with = "serialize_py_object")] &'a PyObject);
 
 #[cfg(feature = "python")]
-pub(super) fn serialize_py_object_optional<S>(
-    obj: &Option<PyObject>,
-    s: S,
-) -> Result<S::Ok, S::Error>
+pub fn serialize_py_object_optional<S>(obj: &Option<PyObject>, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -108,7 +105,7 @@ impl<'de> Visitor<'de> for OptPyObjectVisitor {
 }
 
 #[cfg(feature = "python")]
-pub(super) fn deserialize_py_object_optional<'de, D>(d: D) -> Result<Option<PyObject>, D::Error>
+pub fn deserialize_py_object_optional<'de, D>(d: D) -> Result<Option<PyObject>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -12,6 +12,7 @@ pub mod pylib {
 
     use crate::anonymous::AnonymousScanOperator;
     use crate::file_format::PyFileFormatConfig;
+    use crate::glob::GlobScanOperator;
     use crate::storage_config::PyStorageConfig;
     use crate::{ScanOperatorRef, ScanTask, ScanTaskBatch};
 
@@ -44,6 +45,22 @@ pub mod pylib {
             Ok(ScanOperatorHandle {
                 scan_op: ScanOperatorRef(operator),
             })
+        }
+
+        #[staticmethod]
+        pub fn glob_scan(
+            glob_path: &str,
+            file_format_config: PyFileFormatConfig,
+            storage_config: PyStorageConfig,
+            schema: Option<PySchema>,
+        ) -> PyResult<Self> {
+            let operator = Arc::new(GlobScanOperator::try_new(
+                glob_path,
+                file_format_config.into(),
+                storage_config.into(),
+                schema.map(|s| s.schema),
+            )?);
+            Ok(ScanOperatorHandle { scan_op: operator })
         }
     }
 

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -1,46 +1,119 @@
 use pyo3::prelude::*;
 
 pub mod pylib {
+    use std::sync::Arc;
+
     use pyo3::prelude::*;
-    use std::str::FromStr;
 
     use daft_core::python::schema::PySchema;
 
     use pyo3::pyclass;
+    use serde::{Deserialize, Serialize};
 
     use crate::anonymous::AnonymousScanOperator;
-    use crate::FileType;
-    use crate::ScanOperatorRef;
+    use crate::file_format::PyFileFormatConfig;
+    use crate::storage_config::PyStorageConfig;
+    use crate::{ScanOperatorRef, ScanTask, ScanTaskBatch};
 
     #[pyclass(module = "daft.daft", frozen)]
-    pub(crate) struct ScanOperator {
+    #[derive(Debug, Clone)]
+    pub struct ScanOperatorHandle {
         scan_op: ScanOperatorRef,
     }
 
     #[pymethods]
-    impl ScanOperator {
+    impl ScanOperatorHandle {
         pub fn __repr__(&self) -> PyResult<String> {
             Ok(format!("{}", self.scan_op))
         }
 
         #[staticmethod]
         pub fn anonymous_scan(
-            schema: PySchema,
-            file_type: &str,
             files: Vec<String>,
+            schema: PySchema,
+            file_format_config: PyFileFormatConfig,
+            storage_config: PyStorageConfig,
         ) -> PyResult<Self> {
             let schema = schema.schema;
-            let operator = Box::new(AnonymousScanOperator::new(
-                schema,
-                FileType::from_str(file_type)?,
+            let operator = Arc::new(AnonymousScanOperator::new(
                 files,
+                schema,
+                file_format_config.into(),
+                storage_config.into(),
             ));
-            Ok(ScanOperator { scan_op: operator })
+            Ok(ScanOperatorHandle { scan_op: operator })
+        }
+    }
+
+    impl From<ScanOperatorRef> for ScanOperatorHandle {
+        fn from(value: ScanOperatorRef) -> Self {
+            Self { scan_op: value }
+        }
+    }
+
+    impl From<ScanOperatorHandle> for ScanOperatorRef {
+        fn from(value: ScanOperatorHandle) -> Self {
+            value.scan_op
+        }
+    }
+
+    #[pyclass(module = "daft.daft", name = "ScanTask", frozen)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct PyScanTask(Arc<ScanTask>);
+
+    impl From<Arc<ScanTask>> for PyScanTask {
+        fn from(value: Arc<ScanTask>) -> Self {
+            Self(value)
+        }
+    }
+
+    impl From<PyScanTask> for Arc<ScanTask> {
+        fn from(value: PyScanTask) -> Self {
+            value.0
+        }
+    }
+
+    #[pyclass(module = "daft.daft", name = "ScanTaskBatch", frozen)]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct PyScanTaskBatch(Arc<ScanTaskBatch>);
+
+    #[pymethods]
+    impl PyScanTaskBatch {
+        #[staticmethod]
+        pub fn from_scan_tasks(scan_tasks: Vec<PyScanTask>) -> PyResult<Self> {
+            let scan_tasks: Vec<ScanTask> = scan_tasks
+                .into_iter()
+                .map(|st| st.0.as_ref().clone())
+                .collect();
+            let scan_task_batch: ScanTaskBatch = scan_tasks.into();
+            Ok(Self(Arc::new(scan_task_batch)))
+        }
+
+        pub fn num_rows(&self) -> PyResult<Option<i64>> {
+            Ok(self.0.num_rows().map(i64::try_from).transpose()?)
+        }
+
+        pub fn size_bytes(&self) -> PyResult<Option<i64>> {
+            Ok(self.0.size_bytes().map(i64::try_from).transpose()?)
+        }
+    }
+
+    impl From<Arc<ScanTaskBatch>> for PyScanTaskBatch {
+        fn from(value: Arc<ScanTaskBatch>) -> Self {
+            Self(value)
+        }
+    }
+
+    impl From<PyScanTaskBatch> for Arc<ScanTaskBatch> {
+        fn from(value: PyScanTaskBatch) -> Self {
+            value.0
         }
     }
 }
 
 pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
-    parent.add_class::<pylib::ScanOperator>()?;
+    parent.add_class::<pylib::ScanOperatorHandle>()?;
+    parent.add_class::<pylib::PyScanTask>()?;
+    parent.add_class::<pylib::PyScanTaskBatch>()?;
     Ok(())
 }

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -60,7 +60,9 @@ pub mod pylib {
                 storage_config.into(),
                 schema.map(|s| s.schema),
             )?);
-            Ok(ScanOperatorHandle { scan_op: operator })
+            Ok(ScanOperatorHandle {
+                scan_op: ScanOperatorRef(operator),
+            })
         }
     }
 

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -41,7 +41,9 @@ pub mod pylib {
                 file_format_config.into(),
                 storage_config.into(),
             ));
-            Ok(ScanOperatorHandle { scan_op: operator })
+            Ok(ScanOperatorHandle {
+                scan_op: ScanOperatorRef(operator),
+            })
         }
     }
 

--- a/src/daft-scan/src/storage_config.rs
+++ b/src/daft-scan/src/storage_config.rs
@@ -29,11 +29,15 @@ pub enum StorageConfig {
 #[cfg_attr(feature = "python", pyclass(module = "daft.daft"))]
 pub struct NativeStorageConfig {
     pub io_config: Option<IOConfig>,
+    pub multithreaded_io: bool,
 }
 
 impl NativeStorageConfig {
-    pub fn new_internal(io_config: Option<IOConfig>) -> Self {
-        Self { io_config }
+    pub fn new_internal(multithreaded_io: bool, io_config: Option<IOConfig>) -> Self {
+        Self {
+            io_config,
+            multithreaded_io,
+        }
     }
 }
 
@@ -41,13 +45,18 @@ impl NativeStorageConfig {
 #[pymethods]
 impl NativeStorageConfig {
     #[new]
-    pub fn new(io_config: Option<python::IOConfig>) -> Self {
-        Self::new_internal(io_config.map(|c| c.config))
+    pub fn new(multithreaded_io: bool, io_config: Option<python::IOConfig>) -> Self {
+        Self::new_internal(multithreaded_io, io_config.map(|c| c.config))
     }
 
     #[getter]
     pub fn io_config(&self) -> Option<python::IOConfig> {
         self.io_config.clone().map(|c| c.into())
+    }
+
+    #[getter]
+    pub fn multithreaded_io(&self) -> bool {
+        self.multithreaded_io
     }
 }
 

--- a/src/daft-stats/src/partition_spec.rs
+++ b/src/daft-stats/src/partition_spec.rs
@@ -1,6 +1,6 @@
 use daft_table::Table;
 
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PartitionSpec {
     keys: Table,
 }

--- a/src/daft-stats/src/table_metadata.rs
+++ b/src/daft-stats/src/table_metadata.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TableMetadata {
     pub length: usize,
 }

--- a/tests/table/table_io/test_csv.py
+++ b/tests/table/table_io/test_csv.py
@@ -18,7 +18,7 @@ from daft.table import Table, schema_inference, table_io
 
 def storage_config_from_use_native_downloader(use_native_downloader: bool) -> StorageConfig:
     if use_native_downloader:
-        return StorageConfig.native(NativeStorageConfig(None))
+        return StorageConfig.native(NativeStorageConfig(True, None))
     else:
         return StorageConfig.python(PythonStorageConfig(None))
 

--- a/tests/table/table_io/test_parquet.py
+++ b/tests/table/table_io/test_parquet.py
@@ -23,7 +23,7 @@ PYARROW_GE_13_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumer
 
 def storage_config_from_use_native_downloader(use_native_downloader: bool) -> StorageConfig:
     if use_native_downloader:
-        return StorageConfig.native(NativeStorageConfig(None))
+        return StorageConfig.native(NativeStorageConfig(True, None))
     else:
         return StorageConfig.python(PythonStorageConfig(None))
 


### PR DESCRIPTION
This PR adds an e2e integration for the new `ScanOperator` for reading from external sources, integrating with logical plan building, logical -> physical plan translation, physical plan scheduling, physical task execution, and the actual `MicroPartition`-based reading.

## TODOs (possibly before merging)

- [ ] Implement Python I/O backend at `MicroPartition` level.
- [ ] Implement reads for non-Parquet formats at `MicroPartition` level.
- [x] Consolidate filter/limit pushdowns to use the same `Pushdown` struct.
- [x] Look to reinstate non-optional `TableMetadata` at the `MicroPartition` level. (#1563)
- [x] Look to reinstate non-optional `TableStatistics` when data is unloaded at the `MicroPartition` level. (#1563)
- [x] Integrate with globbing `ScanOperator` implementation. (#1564)
- [ ] Support different row group selection per Parquet file (currently applies a single row group selection to all files in a scan task bundle).
- [ ] Misc. cleanup.
- [ ] (?) Add basic validation that `ScanTask` configurations are compatible when merging into a `ScanTaskBatch` bundle.