### PR TITLE
[CHORE] [ScanOperator-Follow-Ons-1] Pointer Equality using Arc newtype instead of on `dyn ScanOperator` trait object

### DIFF
--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -71,8 +71,8 @@ impl LogicalPlanBuilder {
         scan_operator: ScanOperatorRef,
         schema_hint: Option<SchemaRef>,
     ) -> DaftResult<Self> {
-        let schema = schema_hint.unwrap_or_else(|| scan_operator.schema());
-        let partitioning_keys = scan_operator.partitioning_keys();
+        let schema = schema_hint.unwrap_or_else(|| scan_operator.0.schema());
+        let partitioning_keys = scan_operator.0.partitioning_keys();
         let source_info =
             SourceInfo::ExternalInfo(ExternalSourceInfo::Scan(ScanExternalInfo::new(
                 scan_operator.clone(),

--- a/src/daft-plan/src/optimization/rules/push_down_limit.rs
+++ b/src/daft-plan/src/optimization/rules/push_down_limit.rs
@@ -76,7 +76,7 @@ impl OptimizerRule for PushDownLimit {
                             (SourceInfo::ExternalInfo(ExternalInfo::Scan(ScanExternalInfo { scan_op, .. })), _) => {
                                 let new_source =
                                     LogicalPlan::Source(source.with_limit(Some(limit))).into();
-                                let out_plan = if scan_op.can_absorb_limit() {
+                                let out_plan = if scan_op.0.can_absorb_limit() {
                                     // Scan can fully absorb the limit, so we can drop the Limit op from the logical plan.
                                     new_source
                                 } else {

--- a/src/daft-plan/src/planner.rs
+++ b/src/daft-plan/src/planner.rs
@@ -81,6 +81,7 @@ pub fn plan(logical_plan: &LogicalPlan) -> DaftResult<PhysicalPlan> {
                 ..
             })) => {
                 let scan_tasks = scan_op
+                    .0
                     .to_scan_tasks(pushdowns.clone())?
                     .collect::<DaftResult<Vec<_>>>()?;
                 let partition_spec = Arc::new(PartitionSpec::new_internal(

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -41,7 +41,9 @@ pub mod pylib {
                 file_format_config.into(),
                 storage_config.into(),
             ));
-            Ok(ScanOperatorHandle { scan_op: operator })
+            Ok(ScanOperatorHandle {
+                scan_op: ScanOperatorRef(operator),
+            })
         }
     }
 


### PR DESCRIPTION
Performs equality on the Arc pointer instead of relying on logic to check the underlying `dyn ScanOperator` trait object for equality, which could be tricky because of some custom vtable logic.