### PR TITLE
[CHORE] [ScanOperator-Follow-Ons-2] Refactor MicroPartition to have non-optional TableMetadata

### DIFF
--- a/src/daft-micropartition/src/ops/agg.rs
+++ b/src/daft-micropartition/src/ops/agg.rs
@@ -2,9 +2,7 @@ use common_error::DaftResult;
 use daft_dsl::Expr;
 use daft_table::Table;
 
-use crate::micropartition::{MicroPartition, TableState};
-
-use daft_stats::TableMetadata;
+use crate::micropartition::MicroPartition;
 
 impl MicroPartition {
     pub fn agg(&self, to_agg: &[Expr], group_by: &[Expr]) -> DaftResult<Self> {
@@ -14,21 +12,17 @@ impl MicroPartition {
             [] => {
                 let empty_table = Table::empty(Some(self.schema.clone()))?;
                 let agged = empty_table.agg(to_agg, group_by)?;
-                let agged_len = agged.len();
-                Ok(MicroPartition::new(
+                Ok(MicroPartition::new_loaded(
                     agged.schema.clone(),
-                    TableState::Loaded(vec![agged].into()),
-                    Some(TableMetadata { length: agged_len }),
+                    vec![agged].into(),
                     None,
                 ))
             }
             [t] => {
                 let agged = t.agg(to_agg, group_by)?;
-                let agged_len = agged.len();
-                Ok(MicroPartition::new(
+                Ok(MicroPartition::new_loaded(
                     agged.schema.clone(),
-                    TableState::Loaded(vec![agged].into()),
-                    Some(TableMetadata { length: agged_len }),
+                    vec![agged].into(),
                     None,
                 ))
             }

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -20,22 +20,21 @@ impl MicroPartition {
         let guard = self.state.lock().unwrap();
         match guard.deref() {
             // Replace schema if Unloaded, which should be applied when data is lazily loaded
-            TableState::Unloaded(scan_task_batch) => Ok(MicroPartition::new(
+            TableState::Unloaded(scan_task_batch) => Ok(MicroPartition::new_unloaded(
                 schema.clone(),
-                TableState::Unloaded(scan_task_batch.clone()),
+                scan_task_batch.clone(),
                 self.metadata.clone(),
-                pruned_statistics,
+                pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
             )),
             // If Tables are already loaded, we map `Table::cast_to_schema` on each Table
-            TableState::Loaded(tables) => Ok(MicroPartition::new(
+            TableState::Loaded(tables) => Ok(MicroPartition::new_loaded(
                 schema.clone(),
-                TableState::Loaded(Arc::new(
+                Arc::new(
                     tables
                         .iter()
                         .map(|tbl| tbl.cast_to_schema(schema.as_ref()))
                         .collect::<DaftResult<Vec<_>>>()?,
-                )),
-                self.metadata.clone(),
+                ),
                 pruned_statistics,
             )),
         }

--- a/src/daft-micropartition/src/ops/concat.rs
+++ b/src/daft-micropartition/src/ops/concat.rs
@@ -48,7 +48,7 @@ impl MicroPartition {
         Ok(MicroPartition {
             schema: mps.first().unwrap().schema.clone(),
             state: Mutex::new(TableState::Loaded(all_tables.into())),
-            metadata: Some(TableMetadata { length: new_len }),
+            metadata: TableMetadata { length: new_len },
             statistics: all_stats,
         })
     }

--- a/src/daft-micropartition/src/ops/eval_expressions.rs
+++ b/src/daft-micropartition/src/ops/eval_expressions.rs
@@ -5,14 +5,9 @@ use daft_core::schema::Schema;
 use daft_dsl::Expr;
 use snafu::ResultExt;
 
-use crate::{
-    micropartition::{MicroPartition, TableState},
-    DaftCoreComputeSnafu,
-};
+use crate::{micropartition::MicroPartition, DaftCoreComputeSnafu};
 
 use daft_stats::{ColumnRangeStatistics, TableStatistics};
-
-use daft_stats::TableMetadata;
 
 fn infer_schema(exprs: &[Expr], schema: &Schema) -> DaftResult<Schema> {
     let fields = exprs
@@ -48,10 +43,9 @@ impl MicroPartition {
             .map(|s| s.eval_expression_list(exprs, &expected_schema))
             .transpose()?;
 
-        Ok(MicroPartition::new(
+        Ok(MicroPartition::new_loaded(
             expected_schema.into(),
-            TableState::Loaded(Arc::new(evaluated_tables)),
-            Some(TableMetadata { length: self.len() }),
+            Arc::new(evaluated_tables),
             eval_stats,
         ))
     }
@@ -87,12 +81,9 @@ impl MicroPartition {
             }
         }
 
-        let new_len = evaluated_tables.iter().map(|t| t.len()).sum();
-
-        Ok(MicroPartition::new(
+        Ok(MicroPartition::new_loaded(
             Arc::new(expected_schema),
-            TableState::Loaded(Arc::new(evaluated_tables)),
-            Some(TableMetadata { length: new_len }),
+            Arc::new(evaluated_tables),
             eval_stats,
         ))
     }

--- a/src/daft-micropartition/src/ops/filter.rs
+++ b/src/daft-micropartition/src/ops/filter.rs
@@ -2,14 +2,9 @@ use common_error::DaftResult;
 use daft_dsl::Expr;
 use snafu::ResultExt;
 
-use crate::{
-    micropartition::{MicroPartition, TableState},
-    DaftCoreComputeSnafu,
-};
+use crate::{micropartition::MicroPartition, DaftCoreComputeSnafu};
 
 use daft_stats::TruthValue;
-
-use daft_stats::TableMetadata;
 
 impl MicroPartition {
     pub fn filter(&self, predicate: &[Expr]) -> DaftResult<Self> {
@@ -37,12 +32,9 @@ impl MicroPartition {
             .collect::<DaftResult<Vec<_>>>()
             .context(DaftCoreComputeSnafu)?;
 
-        let new_len = tables.iter().map(|t| t.len()).sum();
-
-        Ok(Self::new(
+        Ok(Self::new_loaded(
             self.schema.clone(),
-            TableState::Loaded(tables.into()),
-            Some(TableMetadata { length: new_len }),
+            tables.into(),
             self.statistics.clone(), // update these values based off the filter we just ran
         ))
     }

--- a/src/daft-micropartition/src/ops/join.rs
+++ b/src/daft-micropartition/src/ops/join.rs
@@ -3,11 +3,9 @@ use daft_core::array::ops::DaftCompare;
 use daft_dsl::Expr;
 use daft_table::infer_join_schema;
 
-use crate::micropartition::{MicroPartition, TableState};
+use crate::micropartition::MicroPartition;
 
 use daft_stats::TruthValue;
-
-use daft_stats::TableMetadata;
 
 impl MicroPartition {
     pub fn join(&self, right: &Self, left_on: &[Expr], right_on: &[Expr]) -> DaftResult<Self> {
@@ -43,11 +41,9 @@ impl MicroPartition {
             ([], _) | (_, []) => Ok(Self::empty(Some(join_schema.into()))),
             ([lt], [rt]) => {
                 let joined_table = lt.join(rt, left_on, right_on)?;
-                let joined_len = joined_table.len();
-                Ok(MicroPartition::new(
+                Ok(MicroPartition::new_loaded(
                     join_schema.into(),
-                    TableState::Loaded(vec![joined_table].into()),
-                    Some(TableMetadata { length: joined_len }),
+                    vec![joined_table].into(),
                     None,
                 ))
             }

--- a/src/daft-micropartition/src/ops/partition.rs
+++ b/src/daft-micropartition/src/ops/partition.rs
@@ -4,9 +4,7 @@ use common_error::DaftResult;
 use daft_dsl::Expr;
 use daft_table::Table;
 
-use crate::micropartition::{MicroPartition, TableState};
-
-use daft_stats::TableMetadata;
+use crate::micropartition::MicroPartition;
 
 fn transpose2<T>(v: Vec<Vec<T>>) -> Vec<Vec<T>> {
     if v.is_empty() {
@@ -33,11 +31,9 @@ impl MicroPartition {
         Ok(part_tables
             .into_iter()
             .map(|v| {
-                let new_len = v.iter().map(|t| t.len()).sum();
-                MicroPartition::new(
+                MicroPartition::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(v)),
-                    Some(TableMetadata { length: new_len }),
+                    Arc::new(v),
                     self.statistics.clone(),
                 )
             })

--- a/src/daft-micropartition/src/ops/slice.rs
+++ b/src/daft-micropartition/src/ops/slice.rs
@@ -1,8 +1,6 @@
 use common_error::DaftResult;
 
-use crate::micropartition::{MicroPartition, TableState};
-
-use daft_stats::TableMetadata;
+use crate::micropartition::MicroPartition;
 
 impl MicroPartition {
     pub fn slice(&self, start: usize, end: usize) -> DaftResult<Self> {
@@ -34,14 +32,11 @@ impl MicroPartition {
             }
         }
 
-        let new_len = slices_tables.iter().map(|t| t.len()).sum();
-
-        Ok(MicroPartition {
-            schema: self.schema.clone(),
-            state: TableState::Loaded(slices_tables.into()).into(),
-            metadata: Some(TableMetadata { length: new_len }),
-            statistics: self.statistics.clone(),
-        })
+        Ok(MicroPartition::new_loaded(
+            self.schema.clone(),
+            slices_tables.into(),
+            self.statistics.clone(),
+        ))
     }
 
     pub fn head(&self, num: usize) -> DaftResult<Self> {

--- a/src/daft-micropartition/src/ops/sort.rs
+++ b/src/daft-micropartition/src/ops/sort.rs
@@ -5,7 +5,7 @@ use daft_core::Series;
 use daft_dsl::Expr;
 use daft_table::Table;
 
-use crate::micropartition::{MicroPartition, TableState};
+use crate::micropartition::MicroPartition;
 
 impl MicroPartition {
     pub fn sort(&self, sort_keys: &[Expr], descending: &[bool]) -> DaftResult<Self> {
@@ -14,10 +14,9 @@ impl MicroPartition {
             [] => Ok(Self::empty(Some(self.schema.clone()))),
             [single] => {
                 let sorted = single.sort(sort_keys, descending)?;
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![sorted])),
-                    self.metadata.clone(),
+                    Arc::new(vec![sorted]),
                     self.statistics.clone(),
                 ))
             }

--- a/src/daft-micropartition/src/ops/take.rs
+++ b/src/daft-micropartition/src/ops/take.rs
@@ -4,8 +4,7 @@ use common_error::DaftResult;
 use daft_core::Series;
 use daft_table::Table;
 
-use crate::micropartition::{MicroPartition, TableState};
-use daft_stats::TableMetadata;
+use crate::micropartition::MicroPartition;
 
 impl MicroPartition {
     pub fn take(&self, idx: &Series) -> DaftResult<Self> {
@@ -15,19 +14,17 @@ impl MicroPartition {
             [] => {
                 let empty_table = Table::empty(Some(self.schema.clone()))?;
                 let taken = empty_table.take(idx)?;
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![taken])),
-                    Some(TableMetadata { length: idx.len() }),
+                    Arc::new(vec![taken]),
                     self.statistics.clone(),
                 ))
             }
             [single] => {
                 let taken = single.take(idx)?;
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![taken])),
-                    Some(TableMetadata { length: idx.len() }),
+                    Arc::new(vec![taken]),
                     self.statistics.clone(),
                 ))
             }
@@ -42,11 +39,9 @@ impl MicroPartition {
             [] => Ok(Self::empty(Some(self.schema.clone()))),
             [single] => {
                 let taken = single.sample(num)?;
-                let taken_len = taken.len();
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![taken])),
-                    Some(TableMetadata { length: taken_len }),
+                    Arc::new(vec![taken]),
                     self.statistics.clone(),
                 ))
             }
@@ -60,11 +55,9 @@ impl MicroPartition {
             [] => Ok(Self::empty(Some(self.schema.clone()))),
             [single] => {
                 let taken = single.quantiles(num)?;
-                let taken_len = taken.len();
-                Ok(Self::new(
+                Ok(Self::new_loaded(
                     self.schema.clone(),
-                    TableState::Loaded(Arc::new(vec![taken])),
-                    Some(TableMetadata { length: taken_len }),
+                    Arc::new(vec![taken]),
                     self.statistics.clone(),
                 ))
             }


### PR DESCRIPTION
Also refactors `MicroPartition::new` into explicit `::new_loaded` and `::new_unloaded` variants:

1. Helps us enforce that `TableStatistics` is `Some` when the state is `TableState::Unloaded` at construction-time
2. Cleans up client code, because `TableState` no longer needs to be exposed externally and we can hide the calculations for TableMetadata inside of the `::new_loaded` constructor
3. `::from_scan_task_batch` is very explicit and clean. It tries `::new_unloaded` first, but falls back on `::new_loaded` if the ScanTaskBatch is not provided with both metadata/statistics