### PR TITLE
[CHORE][ScanOperator 2/3] Refactor ScanTask to be multi-file and removes ScanTaskBatch

### DIFF
--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -378,14 +378,6 @@ class ScanTask:
     A batch of scan tasks for reading data from an external source.
     """
 
-    def __len__(self) -> int:
-        """Returns the number of files in this ScanTask"""
-        ...
-    def slice(self, start: int, end: int) -> ScanTask:
-        """
-        Slices the files in this ScanTask and returns a new one with just those files
-        """
-        ...
     def num_rows(self) -> int:
         """
         Get number of rows that will be scanned by this ScanTask.

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -373,27 +373,27 @@ class StorageConfig:
     @property
     def config(self) -> NativeStorageConfig | PythonStorageConfig: ...
 
-class ScanTaskBatch:
+class ScanTask:
     """
     A batch of scan tasks for reading data from an external source.
     """
 
     def __len__(self) -> int:
-        """Returns the numer of ScanTasks in this batch"""
+        """Returns the number of files in this ScanTask"""
         ...
-    def slice(self, start: int, end: int) -> ScanTaskBatch:
+    def slice(self, start: int, end: int) -> ScanTask:
         """
-        Slices the ScanTaskBatch and returns a new one with just the tasks in the specified slice
+        Slices the files in this ScanTask and returns a new one with just those files
         """
         ...
     def num_rows(self) -> int:
         """
-        Get number of rows that will be scanned by all tasks in this batch.
+        Get number of rows that will be scanned by this ScanTask.
         """
         ...
     def size_bytes(self) -> int:
         """
-        Get number of bytes that will be scanned by all tasks in this batch.
+        Get number of bytes that will be scanned by this ScanTask.
         """
         ...
 
@@ -765,7 +765,7 @@ class PyMicroPartition:
     @staticmethod
     def empty(schema: PySchema | None = None) -> PyMicroPartition: ...
     @staticmethod
-    def from_scan_task_batch(scan_task_batch: ScanTaskBatch) -> PyMicroPartition: ...
+    def from_scan_task(scan_task: ScanTask) -> PyMicroPartition: ...
     @staticmethod
     def from_tables(tables: list[PyTable]) -> PyMicroPartition: ...
     @staticmethod

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -373,22 +373,17 @@ class StorageConfig:
     @property
     def config(self) -> NativeStorageConfig | PythonStorageConfig: ...
 
-class ScanTask:
-    """
-    A scan task for reading data from an external source.
-    """
-
-    ...
-
 class ScanTaskBatch:
     """
     A batch of scan tasks for reading data from an external source.
     """
 
-    @staticmethod
-    def from_scan_tasks(scan_tasks: list[ScanTask]) -> ScanTaskBatch:
+    def __len__(self) -> int:
+        """Returns the numer of ScanTasks in this batch"""
+        ...
+    def slice(self, start: int, end: int) -> ScanTaskBatch:
         """
-        Create a scan task batch from a list of scan tasks.
+        Slices the ScanTaskBatch and returns a new one with just the tasks in the specified slice
         """
         ...
     def num_rows(self) -> int:

--- a/daft/execution/rust_physical_plan_shim.py
+++ b/daft/execution/rust_physical_plan_shim.py
@@ -25,22 +25,20 @@ PartitionT = TypeVar("PartitionT")
 
 
 def scan_with_tasks(
-    scan_task: ScanTask,
+    scan_tasks: list[ScanTask],
 ) -> physical_plan.InProgressPhysicalPlan[PartitionT]:
     """child_plan represents partitions with filenames.
 
     Yield a plan to read those filenames.
     """
-    for i in range(len(scan_task)):
-        # TODO(Clark): We currently hardcode this to have len-1-ScanTaskes per instruction.
-        # We can instead right-size and bundle the ScanTask into single-instruction bulk reads.
-        single_task_batch = scan_task.slice(i, i + 1)
-
+    # TODO(Clark): Currently hardcoded to have 1 file per instruction
+    # We can instead right-size and bundle the ScanTask into single-instruction bulk reads.
+    for scan_task in scan_tasks:
         scan_step = execution_step.PartitionTaskBuilder[PartitionT](inputs=[], partial_metadatas=None,).add_instruction(
-            instruction=ScanWithTask(single_task_batch),
+            instruction=ScanWithTask(scan_task),
             # Set the filesize as the memory request.
             # (Note: this is very conservative; file readers empirically use much more peak memory than 1x file size.)
-            resource_request=ResourceRequest(memory_bytes=single_task_batch.size_bytes()),
+            resource_request=ResourceRequest(memory_bytes=scan_task.size_bytes()),
         )
         yield scan_step
 

--- a/daft/table/micropartition.py
+++ b/daft/table/micropartition.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 from daft.daft import IOConfig, JoinType
 from daft.daft import PyMicroPartition as _PyMicroPartition
 from daft.daft import PyTable as _PyTable
-from daft.daft import ScanTaskBatch as _ScanTaskBatch
+from daft.daft import ScanTask as _ScanTask
 from daft.datatype import DataType, TimeUnit
 from daft.expressions import Expression, ExpressionsProjection
 from daft.logical.schema import Schema
@@ -66,9 +66,9 @@ class MicroPartition:
         return MicroPartition._from_pymicropartition(pyt)
 
     @staticmethod
-    def _from_scan_task_batch(scan_task_batch: _ScanTaskBatch) -> MicroPartition:
-        assert isinstance(scan_task_batch, _ScanTaskBatch)
-        return MicroPartition._from_pymicropartition(_PyMicroPartition.from_scan_task_batch(scan_task_batch))
+    def _from_scan_task(scan_task: _ScanTask) -> MicroPartition:
+        assert isinstance(scan_task, _ScanTask)
+        return MicroPartition._from_pymicropartition(_PyMicroPartition.from_scan_task(scan_task))
 
     @staticmethod
     def _from_pytable(pyt: _PyTable) -> MicroPartition:

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -8,7 +8,7 @@ import pyarrow as pa
 from daft.arrow_utils import ensure_table
 from daft.daft import JoinType
 from daft.daft import PyTable as _PyTable
-from daft.daft import ScanTaskBatch as _ScanTaskBatch
+from daft.daft import ScanTask as _ScanTask
 from daft.daft import read_csv as _read_csv
 from daft.daft import read_parquet as _read_parquet
 from daft.daft import read_parquet_bulk as _read_parquet_bulk
@@ -80,8 +80,8 @@ class Table:
         return Table._from_pytable(pyt)
 
     @staticmethod
-    def _from_scan_task_batch(_: _ScanTaskBatch) -> Table:
-        raise NotImplementedError("_from_scan_task_batch is not implemented for legacy Python Table.")
+    def _from_scan_task(_: _ScanTask) -> Table:
+        raise NotImplementedError("_from_scan_task is not implemented for legacy Python Table.")
 
     @staticmethod
     def _from_pytable(pyt: _PyTable) -> Table:

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -20,9 +20,9 @@ impl MicroPartition {
         let guard = self.state.lock().unwrap();
         match guard.deref() {
             // Replace schema if Unloaded, which should be applied when data is lazily loaded
-            TableState::Unloaded(scan_task_batch) => Ok(MicroPartition::new_unloaded(
+            TableState::Unloaded(scan_task) => Ok(MicroPartition::new_unloaded(
                 schema.clone(),
-                scan_task_batch.clone(),
+                scan_task.clone(),
                 self.metadata.clone(),
                 pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
             )),

--- a/src/daft-plan/src/physical_ops/scan.rs
+++ b/src/daft-plan/src/physical_ops/scan.rs
@@ -1,18 +1,18 @@
 use std::sync::Arc;
 
-use daft_scan::ScanTask;
+use daft_scan::ScanTaskBatch;
 
 use crate::PartitionSpec;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TabularScan {
-    pub scan_tasks: Vec<ScanTask>,
+    pub scan_tasks: ScanTaskBatch,
     pub partition_spec: Arc<PartitionSpec>,
 }
 
 impl TabularScan {
-    pub(crate) fn new(scan_tasks: Vec<ScanTask>, partition_spec: Arc<PartitionSpec>) -> Self {
+    pub(crate) fn new(scan_tasks: ScanTaskBatch, partition_spec: Arc<PartitionSpec>) -> Self {
         Self {
             scan_tasks,
             partition_spec,

--- a/src/daft-plan/src/physical_ops/scan.rs
+++ b/src/daft-plan/src/physical_ops/scan.rs
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TabularScan {
-    pub scan_tasks: Vec<ScanTask>,
+    pub scan_tasks: Vec<Arc<ScanTask>>,
     pub partition_spec: Arc<PartitionSpec>,
 }
 
 impl TabularScan {
     pub(crate) fn new(scan_tasks: Vec<ScanTask>, partition_spec: Arc<PartitionSpec>) -> Self {
         Self {
-            scan_tasks,
+            scan_tasks: scan_tasks.into_iter().map(Arc::new).collect(),
             partition_spec,
         }
     }

--- a/src/daft-plan/src/physical_ops/scan.rs
+++ b/src/daft-plan/src/physical_ops/scan.rs
@@ -1,18 +1,18 @@
 use std::sync::Arc;
 
-use daft_scan::ScanTaskBatch;
+use daft_scan::ScanTask;
 
 use crate::PartitionSpec;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TabularScan {
-    pub scan_tasks: ScanTaskBatch,
+    pub scan_tasks: ScanTask,
     pub partition_spec: Arc<PartitionSpec>,
 }
 
 impl TabularScan {
-    pub(crate) fn new(scan_tasks: ScanTaskBatch, partition_spec: Arc<PartitionSpec>) -> Self {
+    pub(crate) fn new(scan_tasks: ScanTask, partition_spec: Arc<PartitionSpec>) -> Self {
         Self {
             scan_tasks,
             partition_spec,

--- a/src/daft-plan/src/physical_ops/scan.rs
+++ b/src/daft-plan/src/physical_ops/scan.rs
@@ -7,12 +7,12 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TabularScan {
-    pub scan_tasks: ScanTask,
+    pub scan_tasks: Vec<ScanTask>,
     pub partition_spec: Arc<PartitionSpec>,
 }
 
 impl TabularScan {
-    pub(crate) fn new(scan_tasks: ScanTask, partition_spec: Arc<PartitionSpec>) -> Self {
+    pub(crate) fn new(scan_tasks: Vec<ScanTask>, partition_spec: Arc<PartitionSpec>) -> Self {
         Self {
             scan_tasks,
             partition_spec,

--- a/src/daft-plan/src/physical_plan.rs
+++ b/src/daft-plan/src/physical_plan.rs
@@ -10,7 +10,7 @@ use {
     daft_dsl::Expr,
     daft_scan::{
         file_format::{FileFormat, FileFormatConfig, PyFileFormatConfig},
-        python::pylib::PyScanTask,
+        python::pylib::PyScanTaskBatch,
         storage_config::{PyStorageConfig, StorageConfig},
     },
     pyo3::{
@@ -308,14 +308,10 @@ impl PhysicalPlan {
                 Ok(py_iter.into())
             }
             PhysicalPlan::TabularScan(TabularScan { scan_tasks, .. }) => {
-                let py_scan_tasks = scan_tasks
-                    .iter()
-                    .map(|scan_task| PyScanTask::from(Arc::new(scan_task.clone())))
-                    .collect::<Vec<_>>();
                 let py_iter = py
                     .import(pyo3::intern!(py, "daft.execution.rust_physical_plan_shim"))?
                     .getattr(pyo3::intern!(py, "scan_with_tasks"))?
-                    .call1((py_scan_tasks,))?;
+                    .call1((PyScanTaskBatch(Arc::new(scan_tasks.clone())),))?;
                 Ok(py_iter.into())
             }
             PhysicalPlan::TabularScanParquet(TabularScanParquet {

--- a/src/daft-plan/src/physical_plan.rs
+++ b/src/daft-plan/src/physical_plan.rs
@@ -10,7 +10,7 @@ use {
     daft_dsl::Expr,
     daft_scan::{
         file_format::{FileFormat, FileFormatConfig, PyFileFormatConfig},
-        python::pylib::PyScanTaskBatch,
+        python::pylib::PyScanTask,
         storage_config::{PyStorageConfig, StorageConfig},
     },
     pyo3::{
@@ -311,7 +311,7 @@ impl PhysicalPlan {
                 let py_iter = py
                     .import(pyo3::intern!(py, "daft.execution.rust_physical_plan_shim"))?
                     .getattr(pyo3::intern!(py, "scan_with_tasks"))?
-                    .call1((PyScanTaskBatch(Arc::new(scan_tasks.clone())),))?;
+                    .call1((PyScanTask(Arc::new(scan_tasks.clone())),))?;
                 Ok(py_iter.into())
             }
             PhysicalPlan::TabularScanParquet(TabularScanParquet {

--- a/src/daft-plan/src/physical_plan.rs
+++ b/src/daft-plan/src/physical_plan.rs
@@ -311,7 +311,10 @@ impl PhysicalPlan {
                 let py_iter = py
                     .import(pyo3::intern!(py, "daft.execution.rust_physical_plan_shim"))?
                     .getattr(pyo3::intern!(py, "scan_with_tasks"))?
-                    .call1((PyScanTask(Arc::new(scan_tasks.clone())),))?;
+                    .call1((scan_tasks
+                        .iter()
+                        .map(|scan_task| PyScanTask(Arc::new(scan_task.clone())))
+                        .collect::<Vec<PyScanTask>>(),))?;
                 Ok(py_iter.into())
             }
             PhysicalPlan::TabularScanParquet(TabularScanParquet {

--- a/src/daft-plan/src/physical_plan.rs
+++ b/src/daft-plan/src/physical_plan.rs
@@ -313,7 +313,7 @@ impl PhysicalPlan {
                     .getattr(pyo3::intern!(py, "scan_with_tasks"))?
                     .call1((scan_tasks
                         .iter()
-                        .map(|scan_task| PyScanTask(Arc::new(scan_task.clone())))
+                        .map(|scan_task| PyScanTask(scan_task.clone()))
                         .collect::<Vec<PyScanTask>>(),))?;
                 Ok(py_iter.into())
             }

--- a/src/daft-plan/src/planner.rs
+++ b/src/daft-plan/src/planner.rs
@@ -80,10 +80,7 @@ pub fn plan(logical_plan: &LogicalPlan) -> DaftResult<PhysicalPlan> {
                 scan_op,
                 ..
             })) => {
-                let scan_tasks = scan_op
-                    .0
-                    .to_scan_tasks(pushdowns.clone())?
-                    .collect::<DaftResult<Vec<_>>>()?;
+                let scan_tasks = scan_op.0.to_scan_tasks(pushdowns.clone())?;
                 let partition_spec = Arc::new(PartitionSpec::new_internal(
                     PartitionScheme::Unknown,
                     scan_tasks.len(),

--- a/src/daft-scan/src/anonymous.rs
+++ b/src/daft-scan/src/anonymous.rs
@@ -56,8 +56,11 @@ impl ScanOperator for AnonymousScanOperator {
         false
     }
 
-    fn to_scan_tasks(&self, pushdowns: Pushdowns) -> DaftResult<ScanTask> {
-        Ok(ScanTask::new(
+    fn to_scan_tasks(
+        &self,
+        pushdowns: Pushdowns,
+    ) -> DaftResult<Box<dyn Iterator<Item = DaftResult<ScanTask>>>> {
+        let scan_task = ScanTask::new(
             self.files
                 .clone()
                 .into_iter()
@@ -73,6 +76,7 @@ impl ScanOperator for AnonymousScanOperator {
             self.storage_config.clone(),
             pushdowns.columns,
             pushdowns.limit,
-        ))
+        );
+        Ok(Box::new(std::iter::once(Ok(scan_task))))
     }
 }

--- a/src/daft-scan/src/anonymous.rs
+++ b/src/daft-scan/src/anonymous.rs
@@ -5,7 +5,7 @@ use daft_core::schema::SchemaRef;
 
 use crate::{
     file_format::FileFormatConfig, storage_config::StorageConfig, DataFileSource, PartitionField,
-    Pushdowns, ScanOperator, ScanTaskBatch,
+    Pushdowns, ScanOperator, ScanTask,
 };
 #[derive(Debug)]
 pub struct AnonymousScanOperator {
@@ -56,8 +56,8 @@ impl ScanOperator for AnonymousScanOperator {
         false
     }
 
-    fn to_scan_tasks(&self, pushdowns: Pushdowns) -> DaftResult<ScanTaskBatch> {
-        Ok(ScanTaskBatch::new(
+    fn to_scan_tasks(&self, pushdowns: Pushdowns) -> DaftResult<ScanTask> {
+        Ok(ScanTask::new(
             self.files
                 .clone()
                 .into_iter()

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -8,7 +8,7 @@ use daft_parquet::read::ParquetSchemaInferenceOptions;
 use crate::{
     file_format::{CsvSourceConfig, FileFormatConfig, JsonSourceConfig, ParquetSourceConfig},
     storage_config::StorageConfig,
-    DataFileSource, PartitionField, Pushdowns, ScanOperator, ScanTaskBatch,
+    DataFileSource, PartitionField, Pushdowns, ScanOperator, ScanTask,
 };
 #[derive(Debug, PartialEq, Hash)]
 pub struct GlobScanOperator {
@@ -161,13 +161,13 @@ impl ScanOperator for GlobScanOperator {
         false
     }
 
-    fn to_scan_tasks(&self, pushdowns: Pushdowns) -> DaftResult<ScanTaskBatch> {
+fn to_scan_tasks(&self, pushdowns: Pushdowns) -> DaftResult<ScanTask> {
         let (io_runtime, io_client) = get_io_client_and_runtime(self.storage_config.as_ref())?;
 
         // TODO: This runs the glob to exhaustion, but we should return an iterator instead
         let files = run_glob(self.glob_path.as_str(), None, io_client, io_runtime)?;
 
-        Ok(ScanTaskBatch::new(
+        Ok(ScanTask::new(
             files
                 .into_iter()
                 .map(|f| DataFileSource::AnonymousDataFile {

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -114,6 +114,62 @@ impl ScanTask {
         }
     }
 
+    pub fn concat(scan_tasks: &[Self]) -> ScanTask {
+        if scan_tasks.is_empty() {
+            panic!("Must have at least one ScanTask to concat.");
+        }
+
+        // Use all metadata from the first ScanTask, but validate that the metadata matches all other ScanTasks
+        let mut scan_task_iter = scan_tasks.iter().peekable();
+        let first_scan_task = scan_task_iter.peek().unwrap();
+        let file_format_config = first_scan_task.file_format_config.clone();
+        let schema = first_scan_task.schema.clone();
+        let storage_config = first_scan_task.storage_config.clone();
+        let columns = first_scan_task.columns.clone();
+        let limit = first_scan_task.limit;
+
+        let mut sources = Vec::with_capacity(scan_tasks.iter().map(|t| t.sources.len()).sum());
+        for scan_task in scan_task_iter {
+            if scan_task.file_format_config != file_format_config {
+                panic!("ScanTasks' file_format_config must match in concat, expected {:?} but found {:?}", file_format_config, scan_task.file_format_config);
+            }
+            if scan_task.schema != schema {
+                panic!(
+                    "ScanTasks' schema must match in concat, expected {:?} but found {:?}",
+                    schema, scan_task.schema
+                );
+            }
+            if scan_task.storage_config != storage_config {
+                panic!(
+                    "ScanTasks' storage_config must match in concat, expected {:?} but found {:?}",
+                    storage_config, scan_task.storage_config
+                );
+            }
+            if scan_task.columns != columns {
+                panic!(
+                    "ScanTasks' columns must match in concat, expected {:?} but found {:?}",
+                    columns, scan_task.columns
+                );
+            }
+            if scan_task.limit != limit {
+                panic!(
+                    "ScanTasks' limit must match in concat, expected {:?} but found {:?}",
+                    limit, scan_task.limit
+                );
+            }
+            sources.extend_from_slice(scan_task.sources.as_slice());
+        }
+
+        Self::new(
+            sources,
+            file_format_config,
+            schema,
+            storage_config,
+            columns,
+            limit,
+        )
+    }
+
     pub fn num_rows(&self) -> Option<usize> {
         self.metadata.as_ref().map(|m| m.length)
     }
@@ -159,7 +215,10 @@ pub trait ScanOperator: Send + Sync + Display + Debug {
     fn can_absorb_filter(&self) -> bool;
     fn can_absorb_select(&self) -> bool;
     fn can_absorb_limit(&self) -> bool;
-    fn to_scan_tasks(&self, pushdowns: Pushdowns) -> DaftResult<ScanTask>;
+    fn to_scan_tasks(
+        &self,
+        pushdowns: Pushdowns,
+    ) -> DaftResult<Box<dyn Iterator<Item = DaftResult<ScanTask>>>>;
 }
 
 /// Light transparent wrapper around an Arc<dyn ScanOperator> that implements Eq/PartialEq/Hash

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -61,7 +61,7 @@ impl DataFileSource {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ScanTask {
     pub sources: Vec<DataFileSource>,
     pub file_format_config: Arc<FileFormatConfig>,

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -62,19 +62,19 @@ impl DataFileSource {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ScanTaskBatch {
+pub struct ScanTask {
     pub sources: Vec<DataFileSource>,
     pub file_format_config: Arc<FileFormatConfig>,
     pub schema: SchemaRef,
     pub storage_config: Arc<StorageConfig>,
-    // TODO(Clark): Directly use the Pushdowns struct as part of the ScanTaskBatch struct?
+    // TODO(Clark): Directly use the Pushdowns struct as part of the ScanTask struct?
     pub columns: Option<Arc<Vec<String>>>,
     pub limit: Option<usize>,
     pub metadata: Option<TableMetadata>,
     pub statistics: Option<TableStatistics>,
 }
 
-impl ScanTaskBatch {
+impl ScanTask {
     pub fn new(
         sources: Vec<DataFileSource>,
         file_format_config: Arc<FileFormatConfig>,
@@ -125,8 +125,8 @@ impl ScanTaskBatch {
         })
     }
 
-    pub fn slice(&self, start: usize, end: usize) -> ScanTaskBatch {
-        ScanTaskBatch::new(
+    pub fn slice(&self, start: usize, end: usize) -> ScanTask {
+        ScanTask::new(
             self.sources[start..end].to_vec(),
             self.file_format_config.clone(),
             self.schema.clone(),
@@ -159,7 +159,7 @@ pub trait ScanOperator: Send + Sync + Display + Debug {
     fn can_absorb_filter(&self) -> bool;
     fn can_absorb_select(&self) -> bool;
     fn can_absorb_limit(&self) -> bool;
-    fn to_scan_tasks(&self, pushdowns: Pushdowns) -> DaftResult<ScanTaskBatch>;
+    fn to_scan_tasks(&self, pushdowns: Pushdowns) -> DaftResult<ScanTask>;
 }
 
 /// Light transparent wrapper around an Arc<dyn ScanOperator> that implements Eq/PartialEq/Hash

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -84,14 +84,6 @@ pub mod pylib {
 
     #[pymethods]
     impl PyScanTask {
-        pub fn __len__(&self) -> PyResult<usize> {
-            Ok(self.0.sources.len())
-        }
-
-        pub fn slice(&self, start: usize, end: usize) -> PyResult<PyScanTask> {
-            Ok(PyScanTask(Arc::new(self.0.slice(start, end))))
-        }
-
         pub fn num_rows(&self) -> PyResult<Option<i64>> {
             Ok(self.0.num_rows().map(i64::try_from).transpose()?)
         }

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -14,7 +14,7 @@ pub mod pylib {
     use crate::file_format::PyFileFormatConfig;
     use crate::glob::GlobScanOperator;
     use crate::storage_config::PyStorageConfig;
-    use crate::{ScanOperatorRef, ScanTaskBatch};
+    use crate::{ScanOperatorRef, ScanTask};
 
     #[pyclass(module = "daft.daft", frozen)]
     #[derive(Debug, Clone)]
@@ -78,18 +78,18 @@ pub mod pylib {
         }
     }
 
-    #[pyclass(module = "daft.daft", name = "ScanTaskBatch", frozen)]
+    #[pyclass(module = "daft.daft", name = "ScanTask", frozen)]
     #[derive(Debug, Clone, Serialize, Deserialize)]
-    pub struct PyScanTaskBatch(pub Arc<ScanTaskBatch>);
+    pub struct PyScanTask(pub Arc<ScanTask>);
 
     #[pymethods]
-    impl PyScanTaskBatch {
+    impl PyScanTask {
         pub fn __len__(&self) -> PyResult<usize> {
             Ok(self.0.sources.len())
         }
 
-        pub fn slice(&self, start: usize, end: usize) -> PyResult<PyScanTaskBatch> {
-            Ok(PyScanTaskBatch(Arc::new(self.0.slice(start, end))))
+        pub fn slice(&self, start: usize, end: usize) -> PyResult<PyScanTask> {
+            Ok(PyScanTask(Arc::new(self.0.slice(start, end))))
         }
 
         pub fn num_rows(&self) -> PyResult<Option<i64>> {
@@ -101,14 +101,14 @@ pub mod pylib {
         }
     }
 
-    impl From<Arc<ScanTaskBatch>> for PyScanTaskBatch {
-        fn from(value: Arc<ScanTaskBatch>) -> Self {
+    impl From<Arc<ScanTask>> for PyScanTask {
+        fn from(value: Arc<ScanTask>) -> Self {
             Self(value)
         }
     }
 
-    impl From<PyScanTaskBatch> for Arc<ScanTaskBatch> {
-        fn from(value: PyScanTaskBatch) -> Self {
+    impl From<PyScanTask> for Arc<ScanTask> {
+        fn from(value: PyScanTask) -> Self {
             value.0
         }
     }
@@ -116,6 +116,6 @@ pub mod pylib {
 
 pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {
     parent.add_class::<pylib::ScanOperatorHandle>()?;
-    parent.add_class::<pylib::PyScanTaskBatch>()?;
+    parent.add_class::<pylib::PyScanTask>()?;
     Ok(())
 }


### PR DESCRIPTION
1. Replaces `ScanTask` with `ScanTaskBatch`, which mostly like `ScanTask` except that it is multi-file
2. This helps us deduplicate information representation between `ScanTask` and `ScanTaskBatch`