### PR TITLE
[FEAT] [Scan Operator] Add Python I/O support (+ JSON) to `MicroPartition` reads

### DIFF
--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    num::NonZeroUsize,
-    sync::Arc,
-};
+use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 
 use arrow2::{
     datatypes::Field,
@@ -283,8 +279,14 @@ where
     .await?;
     // Truncate fields to only contain projected columns.
     if let Some(include_columns) = include_columns {
-        let include_columns: HashSet<&str> = include_columns.into_iter().collect();
-        fields.retain(|f| include_columns.contains(f.name.as_str()))
+        let field_map = fields
+            .into_iter()
+            .map(|field| (field.name.clone(), field))
+            .collect::<HashMap<String, Field>>();
+        fields = include_columns
+            .into_iter()
+            .map(|col| field_map[col].clone())
+            .collect::<Vec<_>>();
     }
     // Concatenate column chunks and convert into Daft Series.
     // Note that this concatenation is done in parallel on the rayon threadpool.

--- a/src/daft-micropartition/src/lib.rs
+++ b/src/daft-micropartition/src/lib.rs
@@ -17,10 +17,14 @@ pub use python::register_modules;
 pub enum Error {
     #[snafu(display("DaftCoreComputeError: {}", source))]
     DaftCoreCompute { source: DaftError },
+
     #[cfg(feature = "python")]
+    #[snafu(display("PyIOError: {}", source))]
     PyIO { source: PyErr },
+
     #[snafu(display("Duplicate name found when evaluating expressions: {}", name))]
     DuplicatedField { name: String },
+
     #[snafu(display(
         "Field: {} not found in Parquet File:  Available Fields: {:?}",
         field,

--- a/src/daft-micropartition/src/lib.rs
+++ b/src/daft-micropartition/src/lib.rs
@@ -9,13 +9,16 @@ mod ops;
 #[cfg(feature = "python")]
 pub mod python;
 #[cfg(feature = "python")]
+use pyo3::PyErr;
+#[cfg(feature = "python")]
 pub use python::register_modules;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("DaftCoreComputeError: {}", source))]
     DaftCoreCompute { source: DaftError },
-
+    #[cfg(feature = "python")]
+    PyIO { source: PyErr },
     #[snafu(display("Duplicate name found when evaluating expressions: {}", name))]
     DuplicatedField { name: String },
     #[snafu(display(

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -12,7 +12,7 @@ use daft_core::{
 use daft_dsl::python::PyExpr;
 use daft_io::{python::IOConfig, IOStatsContext};
 use daft_parquet::read::ParquetSchemaInferenceOptions;
-use daft_scan::{python::pylib::PyScanTask, ScanTask};
+use daft_scan::{python::pylib::PyScanTask, storage_config::PyStorageConfig, ScanTask};
 use daft_stats::TableStatistics;
 use daft_table::python::PyTable;
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyBytes, Python};
@@ -332,6 +332,31 @@ impl PyMicroPartition {
         })
     }
 
+    #[staticmethod]
+    pub fn read_json(
+        py: Python,
+        uri: &str,
+        schema: PySchema,
+        storage_config: PyStorageConfig,
+        include_columns: Option<Vec<String>>,
+        num_rows: Option<usize>,
+    ) -> PyResult<Self> {
+        let py_table = read_json_into_py_table(
+            py,
+            uri,
+            schema.clone(),
+            storage_config,
+            include_columns,
+            num_rows,
+        )?;
+        let mp = crate::micropartition::MicroPartition::new_loaded(
+            schema.into(),
+            Arc::new(vec![py_table.into()]),
+            None,
+        );
+        Ok(mp.into())
+    }
+
     #[allow(clippy::too_many_arguments)]
     #[staticmethod]
     pub fn read_csv(
@@ -552,6 +577,99 @@ impl PyMicroPartition {
             unreachable!()
         }
     }
+}
+
+pub(crate) fn read_json_into_py_table(
+    py: Python,
+    uri: &str,
+    schema: PySchema,
+    storage_config: PyStorageConfig,
+    include_columns: Option<Vec<String>>,
+    num_rows: Option<usize>,
+) -> PyResult<PyTable> {
+    let read_options = py
+        .import(pyo3::intern!(py, "daft.runners.partitioning"))?
+        .getattr(pyo3::intern!(py, "TableReadOptions"))?
+        .call1((num_rows, include_columns))?;
+    let py_schema = py
+        .import(pyo3::intern!(py, "daft.logical.schema"))?
+        .getattr(pyo3::intern!(py, "Schema"))?
+        .getattr(pyo3::intern!(py, "_from_pyschema"))?
+        .call1((schema,))?;
+    py.import(pyo3::intern!(py, "daft.table.table_io"))?
+        .getattr(pyo3::intern!(py, "read_json"))?
+        .call1((uri, py_schema, storage_config, read_options))?
+        .getattr(pyo3::intern!(py, "to_table"))?
+        .call0()?
+        .getattr(pyo3::intern!(py, "_table"))?
+        .extract()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn read_csv_into_py_table(
+    py: Python,
+    uri: &str,
+    has_header: bool,
+    delimiter: &str,
+    double_quote: bool,
+    schema: PySchema,
+    storage_config: PyStorageConfig,
+    include_columns: Option<Vec<String>>,
+    num_rows: Option<usize>,
+) -> PyResult<PyTable> {
+    let py_schema = py
+        .import(pyo3::intern!(py, "daft.logical.schema"))?
+        .getattr(pyo3::intern!(py, "Schema"))?
+        .getattr(pyo3::intern!(py, "_from_pyschema"))?
+        .call1((schema,))?;
+    let read_options = py
+        .import(pyo3::intern!(py, "daft.runners.partitioning"))?
+        .getattr(pyo3::intern!(py, "TableReadOptions"))?
+        .call1((num_rows, include_columns))?;
+    let header_idx = if has_header { Some(0) } else { None };
+    let parse_options = py
+        .import(pyo3::intern!(py, "daft.runners.partitioning"))?
+        .getattr(pyo3::intern!(py, "TableParseCSVOptions"))?
+        .call1((delimiter, header_idx, double_quote))?;
+    py.import(pyo3::intern!(py, "daft.table.table_io"))?
+        .getattr(pyo3::intern!(py, "read_csv"))?
+        .call1((uri, py_schema, storage_config, parse_options, read_options))?
+        .getattr(pyo3::intern!(py, "to_table"))?
+        .call0()?
+        .getattr(pyo3::intern!(py, "_table"))?
+        .extract()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn read_parquet_into_py_table(
+    py: Python,
+    uri: &str,
+    schema: PySchema,
+    coerce_int96_timestamp_unit: PyTimeUnit,
+    storage_config: PyStorageConfig,
+    include_columns: Option<Vec<String>>,
+    num_rows: Option<usize>,
+) -> PyResult<PyTable> {
+    let py_schema = py
+        .import(pyo3::intern!(py, "daft.logical.schema"))?
+        .getattr(pyo3::intern!(py, "Schema"))?
+        .getattr(pyo3::intern!(py, "_from_pyschema"))?
+        .call1((schema,))?;
+    let read_options = py
+        .import(pyo3::intern!(py, "daft.runners.partitioning"))?
+        .getattr(pyo3::intern!(py, "TableReadOptions"))?
+        .call1((num_rows, include_columns))?;
+    let parse_options = py
+        .import(pyo3::intern!(py, "daft.runners.partitioning"))?
+        .getattr(pyo3::intern!(py, "TableParseParquetOptions"))?
+        .call1((coerce_int96_timestamp_unit,))?;
+    py.import(pyo3::intern!(py, "daft.table.table_io"))?
+        .getattr(pyo3::intern!(py, "read_parquet"))?
+        .call1((uri, py_schema, storage_config, parse_options, read_options))?
+        .getattr(pyo3::intern!(py, "to_table"))?
+        .call0()?
+        .getattr(pyo3::intern!(py, "_table"))?
+        .extract()
 }
 
 impl From<MicroPartition> for PyMicroPartition {

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -111,6 +111,18 @@ pub mod pylib {
             value.0
         }
     }
+
+    pub(crate) fn read_json_schema(
+        py: Python,
+        uri: &str,
+        storage_config: PyStorageConfig,
+    ) -> PyResult<PySchema> {
+        py.import(pyo3::intern!(py, "daft.table.schema_inference"))?
+            .getattr(pyo3::intern!(py, "from_json"))?
+            .call1((uri, storage_config))?
+            .getattr(pyo3::intern!(py, "_schema"))?
+            .extract()
+    }
 }
 
 pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -399,7 +399,11 @@ def test_create_dataframe_csv_generate_headers(valid_data: list[dict[str, float]
             writer.writerows([[item[col] for col in header] for item in valid_data])
             f.flush()
 
-        cnames = [f"column_{i}" for i in range(1, 6)] if use_native_downloader else [f"f{i}" for i in range(5)]
+        cnames = (
+            [f"column_{i}" for i in range(1, 6)]
+            if use_native_downloader or os.environ.get("DAFT_V2_SCANS", "0") == "1"
+            else [f"f{i}" for i in range(5)]
+        )
         df = daft.read_csv(fname, has_headers=False, use_native_downloader=use_native_downloader)
         assert df.column_names == cnames
 


### PR DESCRIPTION
This PR adds support for the Python I/O layer to `MicroPartition` reads, which thereby adds support for reading `MicroPartition`s from JSON files with the scan operator path.

As a driveby, this PR also fixes a column ordering bug when out-of-order column projections are provided to our native CSV reader.

This PR is stacked on top of https://github.com/Eventual-Inc/Daft/pull/1559