### PR TITLE
[PROTOTYPE] IOClient/Runtime refactors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,7 @@ dependencies = [
  "pyo3-log",
  "serde",
  "snafu",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+
 [dependencies]
 daft-core = {path = "src/daft-core", default-features = false}
 daft-csv = {path = "src/daft-csv", default-features = false}

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -2,7 +2,6 @@
 
 from typing import Dict, List, Optional, Union
 
-from daft import context
 from daft.api_annotations import PublicAPI
 from daft.daft import (
     FileFormatConfig,
@@ -52,7 +51,7 @@ def read_parquet(
 
     # If running on Ray, we want to limit the amount of concurrency and requests being made.
     # This is because each Ray worker process receives its own pool of thread workers and connections
-    multithreaded_io = not context.get_context().is_ray_runner if _multithreaded_io is None else _multithreaded_io
+    multithreaded_io = True
 
     file_format_config = FileFormatConfig.from_parquet_config(ParquetSourceConfig())
     if use_native_downloader:

--- a/daft/io/common.py
+++ b/daft/io/common.py
@@ -48,11 +48,7 @@ def _get_tabular_files_scan(
     ### FEATURE_FLAG: $DAFT_V2_SCANS
     #
     # This environment variable will make Daft use the new "v2 scans" and MicroPartitions when building Daft logical plans
-    if os.getenv("DAFT_V2_SCANS", "0") == "1":
-        assert (
-            os.getenv("DAFT_MICROPARTITIONS", "0") == "1"
-        ), "DAFT_V2_SCANS=1 requires DAFT_MICROPARTITIONS=1 to be set as well"
-
+    if os.getenv("DAFT_MICROPARTITIONS", "0") == "1":
         scan_op: ScanOperatorHandle
         if isinstance(path, list):
             scan_op = ScanOperatorHandle.glob_scan(

--- a/daft/io/common.py
+++ b/daft/io/common.py
@@ -45,7 +45,7 @@ def _get_tabular_files_scan(
 
     schema_hint = _get_schema_from_hints(schema_hints) if schema_hints is not None else None
 
-    ### FEATURE_FLAG: $DAFT_V2_SCANS
+    ### FEATURE_FLAG: $DAFT_MICROPARTITIONS
     #
     # This environment variable will make Daft use the new "v2 scans" and MicroPartitions when building Daft logical plans
     if os.getenv("DAFT_MICROPARTITIONS", "0") == "1":

--- a/src/daft-csv/src/metadata.rs
+++ b/src/daft-csv/src/metadata.rs
@@ -27,8 +27,8 @@ pub fn read_csv_schema(
     io_stats: Option<IOStatsRef>,
 ) -> DaftResult<(Schema, usize, usize, f64, f64)> {
     let runtime_handle = tokio::runtime::Handle::current();
-    let io_client = daft_io::get_io_client(&runtime_handle, io_config)?;
     runtime_handle.block_on(async {
+        let io_client = daft_io::get_io_client(io_config).await?;
         read_csv_schema_single(
             uri,
             has_header,

--- a/src/daft-csv/src/metadata.rs
+++ b/src/daft-csv/src/metadata.rs
@@ -5,7 +5,7 @@ use async_compat::CompatExt;
 use common_error::DaftResult;
 use csv_async::ByteRecord;
 use daft_core::schema::Schema;
-use daft_io::{get_runtime, GetResult, IOClient, IOStatsRef};
+use daft_io::{GetResult, IOClient, IOConfig, IOStatsRef};
 use tokio::{
     fs::File,
     io::{AsyncBufRead, AsyncRead, BufReader},
@@ -23,11 +23,11 @@ pub fn read_csv_schema(
     delimiter: Option<u8>,
     double_quote: bool,
     max_bytes: Option<usize>,
-    io_client: Arc<IOClient>,
+    io_config: Arc<IOConfig>,
     io_stats: Option<IOStatsRef>,
 ) -> DaftResult<(Schema, usize, usize, f64, f64)> {
-    let runtime_handle = get_runtime(true)?;
-    let _rt_guard = runtime_handle.enter();
+    let runtime_handle = tokio::runtime::Handle::current();
+    let io_client = daft_io::get_io_client(&runtime_handle, io_config)?;
     runtime_handle.block_on(async {
         read_csv_schema_single(
             uri,
@@ -296,7 +296,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, total_bytes_read, num_records_read, _, _) = read_csv_schema(
             file.as_ref(),
@@ -304,7 +303,7 @@ mod tests {
             None,
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         )?;
         assert_eq!(
@@ -332,7 +331,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, total_bytes_read, num_records_read, _, _) = read_csv_schema(
             file.as_ref(),
@@ -340,7 +338,7 @@ mod tests {
             Some(b'|'),
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         )?;
         assert_eq!(
@@ -365,7 +363,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (_, total_bytes_read, num_records_read, _, _) = read_csv_schema(
             file.as_ref(),
@@ -373,7 +370,7 @@ mod tests {
             None,
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         )?;
         assert_eq!(total_bytes_read, 328);
@@ -391,7 +388,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, total_bytes_read, num_records_read, _, _) = read_csv_schema(
             file.as_ref(),
@@ -399,7 +395,7 @@ mod tests {
             None,
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         )?;
         assert_eq!(
@@ -427,7 +423,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, total_bytes_read, num_records_read, _, _) = read_csv_schema(
             file.as_ref(),
@@ -435,7 +430,7 @@ mod tests {
             None,
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         )?;
         assert_eq!(
@@ -460,7 +455,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, total_bytes_read, num_records_read, _, _) = read_csv_schema(
             file.as_ref(),
@@ -468,7 +462,7 @@ mod tests {
             None,
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         )?;
         assert_eq!(
@@ -496,7 +490,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, total_bytes_read, num_records_read, _, _) = read_csv_schema(
             file.as_ref(),
@@ -504,7 +497,7 @@ mod tests {
             None,
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         )?;
         assert_eq!(
@@ -530,7 +523,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, total_bytes_read, num_records_read, _, _) = read_csv_schema(
             file.as_ref(),
@@ -538,7 +530,7 @@ mod tests {
             None,
             true,
             Some(100),
-            io_client.clone(),
+            io_config.into(),
             None,
         )?;
         assert_eq!(
@@ -567,7 +559,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let err = read_csv_schema(
             file.as_ref(),
@@ -575,7 +566,7 @@ mod tests {
             None,
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         );
         assert!(err.is_err());
@@ -600,7 +591,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let err = read_csv_schema(
             file.as_ref(),
@@ -608,7 +598,7 @@ mod tests {
             None,
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         );
         assert!(err.is_err());
@@ -655,7 +645,6 @@ mod tests {
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, _, _, _, _) = read_csv_schema(
             file.as_ref(),
@@ -663,7 +652,7 @@ mod tests {
             None,
             true,
             None,
-            io_client.clone(),
+            io_config.into(),
             None,
         )?;
         assert_eq!(

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -12,7 +12,7 @@ use daft_core::{
     utils::arrow::cast_array_for_daft_if_needed,
     Series,
 };
-use daft_io::{get_runtime, GetResult, IOClient, IOStatsRef};
+use daft_io::{GetResult, IOClient, IOConfig, IOStatsRef};
 use daft_table::Table;
 use futures::TryStreamExt;
 use rayon::prelude::{
@@ -38,16 +38,15 @@ pub fn read_csv(
     has_header: bool,
     delimiter: Option<u8>,
     double_quote: bool,
-    io_client: Arc<IOClient>,
+    io_config: Arc<IOConfig>,
     io_stats: Option<IOStatsRef>,
-    multithreaded_io: bool,
     schema: Option<SchemaRef>,
     buffer_size: Option<usize>,
     chunk_size: Option<usize>,
     max_chunks_in_flight: Option<usize>,
 ) -> DaftResult<Table> {
-    let runtime_handle = get_runtime(multithreaded_io)?;
-    let _rt_guard = runtime_handle.enter();
+    let runtime_handle = tokio::runtime::Handle::current();
+    let io_client = daft_io::get_io_client(&runtime_handle, io_config)?;
     runtime_handle.block_on(async {
         read_csv_single(
             uri,
@@ -455,7 +454,7 @@ mod tests {
         utils::arrow::{cast_array_for_daft_if_needed, cast_array_from_daft_if_needed},
         DataType,
     };
-    use daft_io::{IOClient, IOConfig};
+    use daft_io::{get_runtime, IOClient, IOConfig};
     use daft_table::Table;
     use rstest::rstest;
 
@@ -540,7 +539,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -550,9 +549,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -587,7 +585,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let column_names = vec![
             "sepal.length",
@@ -604,9 +602,8 @@ mod tests {
             false,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -648,7 +645,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -658,9 +655,8 @@ mod tests {
             true,
             Some(b'|'),
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -702,7 +698,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -712,9 +708,8 @@ mod tests {
             true,
             None,
             false,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -753,7 +748,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -763,9 +758,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -795,7 +789,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -805,9 +799,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -846,7 +839,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let column_names = vec![
             "sepal.length",
@@ -863,9 +856,8 @@ mod tests {
             false,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -901,7 +893,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -911,9 +903,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             Some(128),
             None,
@@ -943,7 +934,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -953,9 +944,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             Some(100),
@@ -985,7 +975,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -995,9 +985,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1027,7 +1016,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -1037,9 +1026,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1072,7 +1060,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -1082,9 +1070,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1127,7 +1114,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
         let schema = Schema::new(vec![
             Field::new("sepal.length", DataType::Float64),
             Field::new("sepal.width", DataType::Float64),
@@ -1144,9 +1131,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             Some(schema.into()),
             None,
             None,
@@ -1189,7 +1175,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -1199,9 +1185,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1231,7 +1216,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let schema = Schema::new(vec![
             // Conversion to all of these types should fail, resulting in nulls.
@@ -1249,9 +1234,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             Some(schema.into()),
             None,
             None,
@@ -1278,7 +1262,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let err = read_csv(
             file.as_ref(),
@@ -1288,9 +1272,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1319,7 +1302,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let err = read_csv(
             file.as_ref(),
@@ -1329,9 +1312,8 @@ mod tests {
             false,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1382,7 +1364,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file.as_ref(),
@@ -1392,9 +1374,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1420,7 +1401,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let column_names = vec!["a", "b"];
         let table = read_csv(
@@ -1431,9 +1412,8 @@ mod tests {
             false,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1459,7 +1439,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let column_names = vec!["a", "b"];
         let table = read_csv(
@@ -1470,9 +1450,8 @@ mod tests {
             false,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1494,7 +1473,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file,
@@ -1504,9 +1483,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1532,7 +1510,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file,
@@ -1542,9 +1520,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,
@@ -1566,7 +1543,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file,
@@ -1576,9 +1553,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             Some(100),
             None,
@@ -1596,7 +1572,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file,
@@ -1606,9 +1582,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             Some(100),
@@ -1626,7 +1601,7 @@ mod tests {
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
 
-        let io_client = Arc::new(IOClient::new(io_config.into())?);
+        let _rt_guard = get_runtime(true)?.enter();
 
         let table = read_csv(
             file,
@@ -1636,9 +1611,8 @@ mod tests {
             true,
             None,
             true,
-            io_client,
+            io_config.into(),
             None,
-            true,
             None,
             None,
             None,

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -46,8 +46,8 @@ pub fn read_csv(
     max_chunks_in_flight: Option<usize>,
 ) -> DaftResult<Table> {
     let runtime_handle = tokio::runtime::Handle::current();
-    let io_client = daft_io::get_io_client(&runtime_handle, io_config)?;
     runtime_handle.block_on(async {
+        let io_client = daft_io::get_io_client(io_config).await?;
         read_csv_single(
             uri,
             column_names,

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -25,13 +25,13 @@ mod py {
         let io_stats_handle = io_stats.clone();
 
         let lsr: DaftResult<Vec<_>> = py.allow_threads(|| {
+            let runtime_handle = get_runtime(multithreaded_io)?;
+            let _rt_guard = runtime_handle.enter();
             let io_client = get_io_client(
-                multithreaded_io,
+                runtime_handle.handle(),
                 io_config.unwrap_or_default().config.into(),
             )?;
             let (scheme, path) = parse_url(&path)?;
-            let runtime_handle = get_runtime(multithreaded_io)?;
-            let _rt_guard = runtime_handle.enter();
 
             runtime_handle.block_on(async move {
                 let source = io_client.get_source(&scheme).await?;

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -27,13 +27,10 @@ mod py {
         let lsr: DaftResult<Vec<_>> = py.allow_threads(|| {
             let runtime_handle = get_runtime(multithreaded_io)?;
             let _rt_guard = runtime_handle.enter();
-            let io_client = get_io_client(
-                runtime_handle.handle(),
-                io_config.unwrap_or_default().config.into(),
-            )?;
             let (scheme, path) = parse_url(&path)?;
 
             runtime_handle.block_on(async move {
+                let io_client = get_io_client(io_config.unwrap_or_default().config.into()).await?;
                 let source = io_client.get_source(&scheme).await?;
                 let files = source
                     .glob(

--- a/src/daft-micropartition/Cargo.toml
+++ b/src/daft-micropartition/Cargo.toml
@@ -17,6 +17,7 @@ pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true}
 serde = {workspace = true}
 snafu = {workspace = true}
+tokio = {workspace = true}
 
 [features]
 default = ["python"]

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -523,8 +523,6 @@ pub(crate) fn read_csv_into_micropartition(
     buffer_size: Option<usize>,
     chunk_size: Option<usize>,
 ) -> DaftResult<MicroPartition> {
-    let runtime_handle = tokio::runtime::Handle::current();
-    let _io_client = daft_io::get_io_client(&runtime_handle, io_config.clone())?;
     let mut remaining_rows = num_rows;
 
     match uris {

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -665,10 +665,15 @@ pub(crate) fn read_parquet_into_py_table(
         .import(pyo3::intern!(py, "daft.runners.partitioning"))?
         .getattr(pyo3::intern!(py, "TableReadOptions"))?
         .call1((num_rows, include_columns))?;
+    let py_coerce_int96_timestamp_unit = py
+        .import(pyo3::intern!(py, "daft.datatype"))?
+        .getattr(pyo3::intern!(py, "TimeUnit"))?
+        .getattr(pyo3::intern!(py, "_from_pytimeunit"))?
+        .call1((coerce_int96_timestamp_unit,))?;
     let parse_options = py
         .import(pyo3::intern!(py, "daft.runners.partitioning"))?
         .getattr(pyo3::intern!(py, "TableParseParquetOptions"))?
-        .call1((coerce_int96_timestamp_unit,))?;
+        .call1((py_coerce_int96_timestamp_unit,))?;
     py.import(pyo3::intern!(py, "daft.table.table_io"))?
         .getattr(pyo3::intern!(py, "read_parquet"))?
         .call1((uri, py_schema, storage_config, read_options, parse_options))?

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -671,7 +671,7 @@ pub(crate) fn read_parquet_into_py_table(
         .call1((coerce_int96_timestamp_unit,))?;
     py.import(pyo3::intern!(py, "daft.table.table_io"))?
         .getattr(pyo3::intern!(py, "read_parquet"))?
-        .call1((uri, py_schema, storage_config, parse_options, read_options))?
+        .call1((uri, py_schema, storage_config, read_options, parse_options))?
         .getattr(pyo3::intern!(py, "to_table"))?
         .call0()?
         .getattr(pyo3::intern!(py, "_table"))?

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -392,6 +392,8 @@ impl PyMicroPartition {
         let mp = py.allow_threads(|| {
             let io_stats = IOStatsContext::new(format!("read_csv: for uri {uri}"));
             let io_config = io_config.unwrap_or_default().config.into();
+            let runtime = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
+            let _rt_guard = runtime.enter();
 
             crate::micropartition::read_csv_into_micropartition(
                 [uri].as_ref(),
@@ -402,7 +404,6 @@ impl PyMicroPartition {
                 delimiter,
                 double_quote.unwrap_or(true),
                 io_config,
-                multithreaded_io.unwrap_or(true),
                 Some(io_stats),
                 schema.map(|s| s.schema),
                 buffer_size,
@@ -427,6 +428,8 @@ impl PyMicroPartition {
     ) -> PyResult<Self> {
         let mp = py.allow_threads(|| {
             let io_stats = IOStatsContext::new(format!("read_parquet: for uri {uri}"));
+            let runtime = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
+            let _rt_guard = runtime.enter();
 
             let io_config = io_config.unwrap_or_default().config.into();
             let schema_infer_options = ParquetSchemaInferenceOptions::new(
@@ -442,7 +445,6 @@ impl PyMicroPartition {
                 io_config,
                 Some(io_stats),
                 1,
-                multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
             )
         })?;
@@ -465,6 +467,8 @@ impl PyMicroPartition {
     ) -> PyResult<Self> {
         let mp = py.allow_threads(|| {
             let io_stats = IOStatsContext::new(format!("read_parquet: for uri {uris:?}"));
+            let runtime = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
+            let _rt_guard = runtime.enter();
 
             let io_config = io_config.unwrap_or_default().config.into();
             let schema_infer_options = ParquetSchemaInferenceOptions::new(
@@ -480,7 +484,6 @@ impl PyMicroPartition {
                 io_config,
                 Some(io_stats),
                 num_parallel_tasks.unwrap_or(128) as usize,
-                multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
             )
         })?;

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -5,7 +5,7 @@ pub mod pylib {
         ffi::field_to_py,
         python::{datatype::PyTimeUnit, schema::PySchema, PySeries},
     };
-    use daft_io::{get_io_client, python::IOConfig, IOStatsContext};
+    use daft_io::{python::IOConfig, IOStatsContext};
     use daft_table::python::PyTable;
     use pyo3::{pyfunction, types::PyModule, PyResult, Python};
     use std::{collections::BTreeMap, sync::Arc};
@@ -26,16 +26,13 @@ pub mod pylib {
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<PyTable> {
         py.allow_threads(|| {
+            let runtime = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
+            let _rt_guard = runtime.enter();
             let io_stats = IOStatsContext::new(format!("read_parquet: for uri {uri}"));
 
-            let io_client = get_io_client(
-                multithreaded_io.unwrap_or(true),
-                io_config.unwrap_or_default().config.into(),
-            )?;
             let schema_infer_options = ParquetSchemaInferenceOptions::new(
                 coerce_int96_timestamp_unit.map(|tu| tu.timeunit),
             );
-            let runtime_handle = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
 
             let result = crate::read::read_parquet(
                 uri,
@@ -43,9 +40,8 @@ pub mod pylib {
                 start_offset,
                 num_rows,
                 row_groups,
-                io_client,
+                io_config.unwrap_or_default().config.into(),
                 Some(io_stats.clone()),
-                runtime_handle,
                 schema_infer_options,
             )?
             .into();
@@ -92,15 +88,11 @@ pub mod pylib {
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<PyArrowParquetType> {
         let read_parquet_result = py.allow_threads(|| {
-            let io_client = get_io_client(
-                multithreaded_io.unwrap_or(true),
-                io_config.unwrap_or_default().config.into(),
-            )?;
+            let runtime = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
+            let _rt_guard = runtime.enter();
             let schema_infer_options = ParquetSchemaInferenceOptions::new(
                 coerce_int96_timestamp_unit.map(|tu| tu.timeunit),
             );
-
-            let runtime_handle = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
 
             crate::read::read_parquet_into_pyarrow(
                 uri,
@@ -108,9 +100,8 @@ pub mod pylib {
                 start_offset,
                 num_rows,
                 row_groups,
-                io_client,
+                io_config.unwrap_or_default().config.into(),
                 None,
-                runtime_handle,
                 schema_infer_options,
             )
         })?;
@@ -134,15 +125,11 @@ pub mod pylib {
     ) -> PyResult<Vec<PyTable>> {
         py.allow_threads(|| {
             let io_stats = IOStatsContext::new("read_parquet_bulk".to_string());
-
-            let io_client = get_io_client(
-                multithreaded_io.unwrap_or(true),
-                io_config.unwrap_or_default().config.into(),
-            )?;
+            let runtime = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
+            let _rt_guard = runtime.enter();
             let schema_infer_options = ParquetSchemaInferenceOptions::new(
                 coerce_int96_timestamp_unit.map(|tu| tu.timeunit),
             );
-            let runtime_handle = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
 
             Ok(crate::read::read_parquet_bulk(
                 uris.as_ref(),
@@ -150,10 +137,9 @@ pub mod pylib {
                 start_offset,
                 num_rows,
                 row_groups,
-                io_client,
+                io_config.unwrap_or_default().config.into(),
                 Some(io_stats),
                 num_parallel_tasks.unwrap_or(128) as usize,
-                runtime_handle,
                 &schema_infer_options,
             )?
             .into_iter()
@@ -177,10 +163,8 @@ pub mod pylib {
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<Vec<PyArrowParquetType>> {
         let parquet_read_results = py.allow_threads(|| {
-            let io_client = get_io_client(
-                multithreaded_io.unwrap_or(true),
-                io_config.unwrap_or_default().config.into(),
-            )?;
+            let runtime = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
+            let _rt_guard = runtime.enter();
             let schema_infer_options = ParquetSchemaInferenceOptions::new(
                 coerce_int96_timestamp_unit.map(|tu| tu.timeunit),
             );
@@ -191,10 +175,9 @@ pub mod pylib {
                 start_offset,
                 num_rows,
                 row_groups,
-                io_client,
+                io_config.unwrap_or_default().config.into(),
                 None,
                 num_parallel_tasks.unwrap_or(128) as usize,
-                multithreaded_io.unwrap_or(true),
                 schema_infer_options,
             )
         })?;
@@ -217,17 +200,14 @@ pub mod pylib {
     ) -> PyResult<PySchema> {
         py.allow_threads(|| {
             let io_stats = IOStatsContext::new(format!("read_parquet_schema: for uri {uri}"));
-
+            let runtime = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
+            let _rt_guard = runtime.enter();
             let schema_infer_options = ParquetSchemaInferenceOptions::new(
                 coerce_int96_timestamp_unit.map(|tu| tu.timeunit),
             );
-            let io_client = get_io_client(
-                multithreaded_io.unwrap_or(true),
-                io_config.unwrap_or_default().config.into(),
-            )?;
             Ok(Arc::new(crate::read::read_parquet_schema(
                 uri,
-                io_client,
+                io_config.unwrap_or_default().config.into(),
                 Some(io_stats),
                 schema_infer_options,
             )?)
@@ -244,15 +224,14 @@ pub mod pylib {
     ) -> PyResult<PyTable> {
         py.allow_threads(|| {
             let io_stats = IOStatsContext::new("read_parquet_statistics".to_string());
-
-            let io_client = get_io_client(
-                multithreaded_io.unwrap_or(true),
+            let runtime = daft_io::get_runtime(multithreaded_io.unwrap_or(true))?;
+            let _rt_guard = runtime.enter();
+            Ok(crate::read::read_parquet_statistics(
+                &uris.series,
                 io_config.unwrap_or_default().config.into(),
-            )?;
-            Ok(
-                crate::read::read_parquet_statistics(&uris.series, io_client, Some(io_stats))?
-                    .into(),
-            )
+                Some(io_stats),
+            )?
+            .into())
         })
     }
 }

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -64,13 +64,13 @@ fn run_glob(
 ) -> DaftResult<Box<dyn Iterator<Item = DaftResult<String>>>> {
     let runtime_handle = runtime.handle();
     let _rt_guard = runtime_handle.enter();
-    let io_client = get_io_client(runtime_handle, io_config)?;
 
     let (_, parsed_glob_path) = parse_url(glob_path)?;
 
     // Construct a static-lifetime BoxStream returning the FileMetadata
     let glob_input = parsed_glob_path.as_ref().to_string();
     let boxstream = runtime_handle.block_on(async move {
+        let io_client = get_io_client(io_config).await?;
         io_client
             .glob(glob_input, None, None, limit, io_stats)
             .await

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -62,6 +62,8 @@ pub mod pylib {
             schema: Option<PySchema>,
         ) -> PyResult<Self> {
             py.allow_threads(|| {
+                let runtime = daft_io::get_runtime(true)?;
+                let _rt_guard = runtime.enter();
                 let operator = Arc::new(GlobScanOperator::try_new(
                     glob_path.as_slice(),
                     file_format_config.into(),

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -3,7 +3,10 @@ use pyo3::prelude::*;
 pub mod pylib {
     use std::sync::Arc;
 
+    use daft_core::impl_bincode_py_state_serialization;
     use pyo3::prelude::*;
+    use pyo3::types::PyBytes;
+    use pyo3::PyTypeInfo;
 
     use daft_core::python::schema::PySchema;
 
@@ -110,6 +113,8 @@ pub mod pylib {
             value.0
         }
     }
+
+    impl_bincode_py_state_serialization!(PyScanTask);
 
     pub(crate) fn read_json_schema(
         py: Python,

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -401,7 +401,7 @@ def test_create_dataframe_csv_generate_headers(valid_data: list[dict[str, float]
 
         cnames = (
             [f"column_{i}" for i in range(1, 6)]
-            if use_native_downloader or os.environ.get("DAFT_V2_SCANS", "0") == "1"
+            if use_native_downloader or os.environ.get("DAFT_MICROPARTITIONS", "0") == "1"
             else [f"f{i}" for i in range(5)]
         )
         df = daft.read_csv(fname, has_headers=False, use_native_downloader=use_native_downloader)


### PR DESCRIPTION
**Note that code in this PR must be compiled with `RUSTFLAGS="--cfg tokio_unstable"`**

1. Change our IOClient cache to use the runtime handle as a cache key
2. Changes our code to not pass runtimes through in function signatures
3. Whenever code needs access to the runtime (e.g. to spawn, block_on etc) it will access the runtime via `tokio::runtime::Handle::current()` which panics if no runtime has been entered
4. We get the runtime and enter it at the top-level functions, including in our `python.rs` files and in places where we need to override the current runtime (e.g. when materializing MicroPartitions etc)