### PR TITLE
[BUG] Update requirements for typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "pyarrow >= 6.0.1",
   "fsspec[http]",
   "psutil",
-  "typing-extensions >= 4.0.0; python_version < '3.8'",
+  "typing-extensions >= 4.0.0; python_version < '3.10'",
   "pickle5 >= 0.0.12; python_version < '3.8'"
 ]
 description = "A Distributed DataFrame library for large scale complex data processing."


### PR DESCRIPTION
We currently use `from typing import ParamSpec` and fallback onto `from typing_extensions import ParamSpec` when on a version of Python < 3.10

We need to upgrade our requirements to reflect this!