### PR TITLE
[CHORE] Edit 'make-hooks' command to install pre-commit script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 
 .PHONY: hooks
 hooks: venv
-	source $(VENV_BIN)/activate && pre-commit install-hooks
+	source $(VENV_BIN)/activate && pre-commit install --install-hooks
 
 .PHONY: build
 build: venv  ## Compile and install Daft for development


### PR DESCRIPTION
I noticed after following the [contributing guide](https://github.com/Eventual-Inc/Daft/blob/main/CONTRIBUTING.md#development-environment) and running 'make hooks', the pre-commit hooks did not run when I commit changes. 

Not sure if this was intended, but looking at https://pre-commit.com/#pre-commit-install-hooks:
```
pre-commit install-hooks does not install the pre-commit script. 
To install the script along with the hook environments in one command, use pre-commit install --install-hooks.
```

See also: https://github.com/pre-commit/pre-commit.com/issues/255