### PR TITLE
[PERF] Speed Up MicroPartition Ops when we know the result is empty

### DIFF
--- a/src/daft-core/src/series/ops/take.rs
+++ b/src/daft-core/src/series/ops/take.rs
@@ -11,7 +11,8 @@ impl Series {
     }
 
     pub fn slice(&self, start: usize, end: usize) -> DaftResult<Series> {
-        self.inner.slice(start, end)
+        let l = self.len();
+        self.inner.slice(start.min(l), end.min(l))
     }
 
     pub fn take(&self, idx: &Series) -> DaftResult<Series> {

--- a/src/daft-micropartition/src/ops/take.rs
+++ b/src/daft-micropartition/src/ops/take.rs
@@ -11,6 +11,10 @@ impl MicroPartition {
     pub fn take(&self, idx: &Series) -> DaftResult<Self> {
         let io_stats = IOStatsContext::new("MicroPartition::take");
 
+        if idx.is_empty() {
+            return Ok(Self::empty(Some(self.schema.clone())));
+        }
+
         let tables = self.concat_or_get(io_stats)?;
         match tables.as_slice() {
             // Fallback onto `[empty_table]` behavior
@@ -38,6 +42,10 @@ impl MicroPartition {
     pub fn sample(&self, num: usize) -> DaftResult<Self> {
         let io_stats = IOStatsContext::new(format!("MicroPartition::sample({num})"));
 
+        if num == 0 {
+            return Ok(Self::empty(Some(self.schema.clone())));
+        }
+
         let tables = self.concat_or_get(io_stats)?;
 
         match tables.as_slice() {
@@ -56,6 +64,10 @@ impl MicroPartition {
 
     pub fn quantiles(&self, num: usize) -> DaftResult<Self> {
         let io_stats = IOStatsContext::new(format!("MicroPartition::quantiles({num})"));
+
+        if num <= 1 {
+            return Ok(Self::empty(Some(self.schema.clone())));
+        }
 
         let tables = self.concat_or_get(io_stats)?;
         match tables.as_slice() {


### PR DESCRIPTION
Return empty micropartitions when we know the result is going to be empty. This allows us to avoid IO in places where it is not needed