### PR TITLE
[BUG] Manually specify region in tutorial read_json

### DIFF
--- a/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
+++ b/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
@@ -103,7 +103,7 @@
     "import daft\n",
     "\n",
     "SAMPLE_DATA_PATH = \"s3://daft-public-data/redpajama-1t-sample/stackexchange_sample.jsonl\"\n",
-    "IO_CONFIG = daft.io.IOConfig(s3=daft.io.S3Config(anonymous=True))  # Use anonymous-mode for accessing AWS S3\n",
+    "IO_CONFIG = daft.io.IOConfig(s3=daft.io.S3Config(anonymous=True, region_name=\"us-west-2\"))  # Use anonymous-mode for accessing AWS S3\n",
     "\n",
     "df = daft.read_json(SAMPLE_DATA_PATH, io_config=IO_CONFIG)\n",
     "\n",


### PR DESCRIPTION
The change in #1592 introduced a bug where the inferred PyArrow S3FileSystem doesn't correctly infer the region of the bucket

To work-around this, we can manually specify the `region_name` in our IOConfig. This problem should be less common once we move towards all-native reads.