### PR TITLE
[BUG] Add better handling for case where glob of parquet files returns empty

### DIFF
--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -434,7 +434,7 @@ class Table:
         multithreaded_io: bool | None = None,
     ) -> Table:
         if not isinstance(paths, Series):
-            paths = Series.from_pylist(paths, name="uris")
+            paths = Series.from_pylist(paths, name="uris").cast(DataType.string())
         assert paths.name() == "uris", f"Expected input series to have name 'uris', but found: {paths.name()}"
         return Table._from_pytable(
             _read_parquet_statistics(

--- a/tests/integration/io/parquet/test_reads_s3_minio.py
+++ b/tests/integration/io/parquet/test_reads_s3_minio.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pyarrow as pa
 import pytest
 from pyarrow import parquet as pq
@@ -34,5 +36,10 @@ def test_minio_parquet_read_no_files(minio_io_config):
     with minio_create_bucket(minio_io_config, bucket_name=bucket_name) as fs:
         fs.touch("s3://data-engineering-prod/foo/file.txt")
 
-        with pytest.raises(FileNotFoundError, match="No files found at s3://data-engineering-prod/foo/\\*\\*.parquet"):
+        msg = (
+            "Glob path had no matches:"
+            if os.getenv("DAFT_MICROPARTITIONS") == "1"
+            else "No files found at s3://data-engineering-prod/foo/\\*\\*.parquet"
+        )
+        with pytest.raises(FileNotFoundError, match=msg):
             daft.read_parquet("s3://data-engineering-prod/foo/**.parquet", io_config=minio_io_config)

--- a/tests/integration/io/parquet/test_reads_s3_minio.py
+++ b/tests/integration/io/parquet/test_reads_s3_minio.py
@@ -26,3 +26,13 @@ def test_minio_parquet_bulk_readback(minio_io_config):
         assert len(readback) == len(target_paths)
         for tab in readback:
             assert tab.to_pydict() == data
+
+
+@pytest.mark.integration()
+def test_minio_parquet_read_no_files(minio_io_config):
+    bucket_name = "data-engineering-prod"
+    with minio_create_bucket(minio_io_config, bucket_name=bucket_name) as fs:
+        fs.touch("s3://data-engineering-prod/foo/file.txt")
+
+        with pytest.raises(FileNotFoundError, match="No files found at s3://data-engineering-prod/foo/\\*\\*.parquet"):
+            daft.read_parquet("s3://data-engineering-prod/foo/**.parquet", io_config=minio_io_config)


### PR DESCRIPTION
Before this fix, empty returns would error out in `Table.read_parquet_statistics` because we wrongly create a `Series.from_pylist([])` of a Null DataType.

