### PR TITLE
[BUG] Self-concat breaks with the RayRunner

### DIFF
--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -204,7 +204,8 @@ class RayPartitionSet(PartitionSet[ray.ObjectRef]):
         return len(self._partitions)
 
     def wait(self) -> None:
-        ray.wait([o for o in self._partitions.values()])
+        deduped_object_refs = set(self._partitions.values())
+        ray.wait(list(deduped_object_refs))
 
 
 class RayRunnerIO(runner_io.RunnerIO):

--- a/tests/dataframe/test_concat.py
+++ b/tests/dataframe/test_concat.py
@@ -17,3 +17,8 @@ def test_concat_schema_mismatch():
     df2 = daft.from_pydict({"foo": ["4", "5", "6"]})
     with pytest.raises(ValueError):
         df1.concat(df2)
+
+
+def test_self_concat():
+    df = daft.from_pydict({"foo": [1, 2, 3]})
+    assert df.concat(df).to_pydict() == {"foo": [1, 2, 3, 1, 2, 3]}


### PR DESCRIPTION
Problem: when performing a dataframe concat with itself, our RayRunner will break on a `.wait()` call which waits on some duplicate object IDs