### PR TITLE
[CHORE] drop ray default dep to make room for Pydantic > 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.rst"
 requires-python = ">=3.7"
 
 [project.optional-dependencies]
-all = ["getdaft[aws, azure, gcp, ray, pandas, numpy, viz]"]
+all = ["getdaft[aws, azure, gcp, ray, pandas, numpy]"]
 aws = ["s3fs"]
 azure = ["adlfs"]
 gcp = ["gcsfs"]
@@ -31,11 +31,11 @@ numpy = ["numpy"]
 pandas = ["pandas"]
 ray = [
   # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
-  "ray[data, default]>=2.0.0",
+  "ray[data]>=2.0.0",
   # Explicitly install packaging. See issue: https://github.com/ray-project/ray/issues/34806
   "packaging"
 ]
-viz = ["pydot"]
+viz = []
 
 [project.urls]
 homepage = "https://www.getdaft.io"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,8 +32,7 @@ opencv-python==4.8.1.78
 pyarrow==12; platform_system != "Windows"
 pyarrow==6.0.1; platform_system === "Windows"
 # Ray
-ray[data, default]==2.6.3
-pydantic<2  # pin pydantic because Ray uses broken APIs
+ray[data]==2.6.3
 
 # AWS
 s3fs==2023.1.0; python_version < '3.8'


### PR DESCRIPTION
* Drop ray default feature due to the fact that pyiceberg requires pydantic > 2.0
* for context: https://github.com/ray-project/ray/issues/37019