### PR TITLE
[BUG] Fix parquet timestamp tz roundtrip inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.1"
-source = "git+https://github.com/Eventual-Inc/arrow2?rev=0a6f79e0da7e32cc30381f4cc8cf5a8483909f78#0a6f79e0da7e32cc30381f4cc8cf5a8483909f78"
+source = "git+https://github.com/Eventual-Inc/arrow2?rev=3a23c780d4d59ef0c9c8751675480e07f4e1c311#3a23c780d4d59ef0c9c8751675480e07f4e1c311"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,9 +104,10 @@ tokio-util = "0.7.8"
 url = "2.4.0"
 
 [workspace.dependencies.arrow2]
+# branch = "jay/fix-parquet-timezone-parsing"
 git = "https://github.com/Eventual-Inc/arrow2"
 package = "arrow2"
-rev = "0a6f79e0da7e32cc30381f4cc8cf5a8483909f78"
+rev = "3a23c780d4d59ef0c9c8751675480e07f4e1c311"
 
 [workspace.dependencies.bincode]
 version = "1.3.3"

--- a/tests/io/test_parquet_roundtrip.py
+++ b/tests/io/test_parquet_roundtrip.py
@@ -56,8 +56,26 @@ def test_roundtrip_simple_arrow_types(tmp_path, data, pa_type, expected_dtype):
 @pytest.mark.parametrize(
     ["data", "pa_type", "expected_dtype"],
     [
-        # TODO: Fails and seems to just fall-back onto +00:00
-        # ([datetime.datetime(1994, 1, 1), datetime.datetime(1995, 1, 1), None], pa.timestamp("ms", "UTC"), DataType.timestamp(TimeUnit.ms(), "UTC")),
+        (
+            [datetime.datetime(1994, 1, 1), datetime.datetime(1995, 1, 1), None],
+            pa.timestamp("ms", None),
+            DataType.timestamp(TimeUnit.ms(), None),
+        ),
+        (
+            [datetime.datetime(1994, 1, 1), datetime.datetime(1995, 1, 1), None],
+            pa.timestamp("ms", "+00:00"),
+            DataType.timestamp(TimeUnit.ms(), "+00:00"),
+        ),
+        (
+            [datetime.datetime(1994, 1, 1), datetime.datetime(1995, 1, 1), None],
+            pa.timestamp("ms", "UTC"),
+            DataType.timestamp(TimeUnit.ms(), "UTC"),
+        ),
+        (
+            [datetime.datetime(1994, 1, 1), datetime.datetime(1995, 1, 1), None],
+            pa.timestamp("ms", "+08:00"),
+            DataType.timestamp(TimeUnit.ms(), "+08:00"),
+        ),
     ],
 )
 def test_roundtrip_temporal_arrow_types(tmp_path, data, pa_type, expected_dtype):


### PR DESCRIPTION
This required a fix in our arrow2 fork: https://github.com/Eventual-Inc/arrow2/commit/3a23c780d4d59ef0c9c8751675480e07f4e1c311

Essentially when Parquet has a type that is "timezone aware", Arrow2 will always infer it as `"+00:00"` (not `None` as previously assumed). However if the embedded Arrow schema on the Parquet file tells us that the timezone should actually be something else, we need to override `"+00:00"` with the one provided by the embedded Arrow schema.