### PR TITLE
[CHORE] add ray client to deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ numpy = ["numpy"]
 pandas = ["pandas"]
 ray = [
   # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
-  "ray[data]>=2.0.0",
+  "ray[data, client]>=2.0.0",
   # Explicitly install packaging. See issue: https://github.com/ray-project/ray/issues/34806
   "packaging"
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ opencv-python==4.8.1.78
 pyarrow==12; platform_system != "Windows"
 pyarrow==6.0.1; platform_system === "Windows"
 # Ray
-ray[data]==2.6.3
+ray[data, client]==2.6.3
 
 #Iceberg
 pyiceberg==0.5.1; python_version >= '3.8'


### PR DESCRIPTION
failure when running on remote clusters:
```
  File "/runner/_work/daft-benchmarking/daft-benchmarking/.venv/lib/python3.10/site-packages/ray/client_builder.py", line 99, in __init__
    raise ValueError(
ValueError: Ray Client requires pip package `ray[client]`. If you installed the minimal Ray (e.g. `pip install ray`), please reinstall by executing `pip install ray[client]`.
```