### PR TITLE
[BUG] Add an allowlist of DataTypes that ColumnRangeStatistics supports and validation of TableStatistics

### DIFF
--- a/src/daft-core/src/schema.rs
+++ b/src/daft-core/src/schema.rs
@@ -86,10 +86,21 @@ impl Schema {
         }
     }
 
-    /// Checks if [`self`] is a strict subset of `other`
-    /// The types and names of each Field have to match exactly.
-    pub fn is_subset(&self, _other: &Schema) -> bool {
-        todo!("Implement Schema::is_subset");
+    /// Checks if [`self`] is a strict subset of `other` based on their fields' equality
+    pub fn is_subset(&self, other: &Schema) -> bool {
+        for (field_name, self_field) in self.fields.iter() {
+            match other.fields.get(field_name) {
+                None => {
+                    return false;
+                }
+                Some(other_field) => {
+                    if self_field != other_field {
+                        return false;
+                    }
+                }
+            }
+        }
+        true
     }
 
     pub fn to_arrow(&self) -> DaftResult<arrow2::datatypes::Schema> {

--- a/src/daft-core/src/schema.rs
+++ b/src/daft-core/src/schema.rs
@@ -86,23 +86,6 @@ impl Schema {
         }
     }
 
-    /// Checks if [`self`] is a strict subset of `other` based on their fields' equality
-    pub fn is_subset(&self, other: &Schema) -> bool {
-        for (field_name, self_field) in self.fields.iter() {
-            match other.fields.get(field_name) {
-                None => {
-                    return false;
-                }
-                Some(other_field) => {
-                    if self_field != other_field {
-                        return false;
-                    }
-                }
-            }
-        }
-        true
-    }
-
     pub fn to_arrow(&self) -> DaftResult<arrow2::datatypes::Schema> {
         let arrow_fields: DaftResult<Vec<arrow2::datatypes::Field>> =
             self.fields.iter().map(|(_, f)| f.to_arrow()).collect();

--- a/src/daft-core/src/schema.rs
+++ b/src/daft-core/src/schema.rs
@@ -86,6 +86,12 @@ impl Schema {
         }
     }
 
+    /// Checks if [`self`] is a strict subset of `other`
+    /// The types and names of each Field have to match exactly.
+    pub fn is_subset(&self, _other: &Schema) -> bool {
+        todo!("Implement Schema::is_subset");
+    }
+
     pub fn to_arrow(&self) -> DaftResult<arrow2::datatypes::Schema> {
         let arrow_fields: DaftResult<Vec<arrow2::datatypes::Field>> =
             self.fields.iter().map(|(_, f)| f.to_arrow()).collect();

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -278,8 +278,8 @@ impl MicroPartition {
     /// Create a new "unloaded" MicroPartition using an associated [`ScanTask`]
     ///
     /// Schema invariants:
-    /// 1. `schema` must be a strict subset of the `scan_task` schema (applying "column pruning")
-    /// 2. Check that each Loaded column in the statistics is compatible with the MicroPartition's schema
+    /// 1. All columns in `schema` must be exist in the `scan_task` schema
+    /// 2. Each Loaded column statistic in `statistics` must be castable to the corresponding column in the MicroPartition's schema
     pub fn new_unloaded(
         schema: SchemaRef,
         scan_task: Arc<ScanTask>,
@@ -311,7 +311,7 @@ impl MicroPartition {
     ///
     /// Schema invariants:
     /// 1. `schema` must match each Table's schema exactly
-    /// 2. If `statistics` is provided, we check that each Loaded column in the statistics is compatible with the MicroPartition's schema
+    /// 2. If `statistics` is provided, each Loaded column statistic must be castable to the corresponding column in the MicroPartition's schema
     pub fn new_loaded(
         schema: SchemaRef,
         tables: Arc<Vec<Table>>,

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -382,7 +382,6 @@ impl MicroPartition {
 
                 let row_groups = parquet_sources_to_row_groups(scan_task.sources.as_slice());
 
-                // TODO: validate schema
                 read_parquet_into_micropartition(
                     uris.as_slice(),
                     columns.as_deref(),

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -23,8 +23,8 @@ use crate::PyIOSnafu;
 use crate::{DaftCSVSnafu, DaftCoreComputeSnafu};
 
 use daft_io::{IOConfig, IOStatsRef};
-use daft_stats::TableMetadata;
 use daft_stats::TableStatistics;
+use daft_stats::{ColumnRangeStatistics, TableMetadata};
 
 pub(crate) enum TableState {
     Unloaded(Arc<ScanTask>),
@@ -274,22 +274,47 @@ fn materialize_scan_task(
     Ok((casted_table_values, cast_to_schema))
 }
 
+/// Helper that validates [`TableStatistics`] against a MicroPartition's schema
+///
+/// If any columns in `statistics` are "Loaded", and there is a match with a field in the MicroPartition's schema,
+/// we need to assert that the types are compatible.
+fn _validate_statistics(statistics: &TableStatistics, schema: &Schema) {
+    for (stats_col_name, stats) in statistics.columns.iter() {
+        match (stats, schema.fields.get(stats_col_name)) {
+            // Missing stats: statistics are trivially redundant
+            (ColumnRangeStatistics::Missing, _) => (),
+            // No column name matched for provided statistic: the statistic is redundant
+            (_, None) => (),
+            // Both statistics and MicroPartition field exist: we assert type compatibility
+            (ColumnRangeStatistics::Loaded(l, r), Some(mp_schema_field)) => {
+                for stats_data in [l, r] {
+                    assert!(
+                        // TODO: Is this too strict of a bound/is there a different criteria for compatibility?
+                        stats_data.data_type() == &mp_schema_field.dtype,
+                        "Unloaded MicroPartition's schema must be be compatible with statistics' types: expected field {} but received type {}",
+                        mp_schema_field,
+                        stats_data.data_type(),
+                    );
+                }
+            }
+        }
+    }
+}
+
 impl MicroPartition {
     /// Create a new "unloaded" MicroPartition using an associated [`ScanTask`]
     ///
     /// Schema invariants:
     /// 1. `schema` must be a strict subset of the `scan_task` schema (applying "column pruning")
-    /// 2. `schema` must be a strict subset of the `statistics` schema
+    /// 2. Check that each Loaded column in the statistics is compatible with the MicroPartition's schema
     pub fn new_unloaded(
         schema: SchemaRef,
         scan_task: Arc<ScanTask>,
         metadata: TableMetadata,
         statistics: TableStatistics,
     ) -> Self {
-        assert!(
-            schema.is_subset(&statistics.schema()),
-            "Unloaded MicroPartition's schema must be a subset of its statistics' schema"
-        );
+        // Check and validate invariants with asserts
+        _validate_statistics(&statistics, schema.as_ref());
         assert!(
             schema.is_subset(&scan_task.schema),
             "Unloaded MicroPartition's schema must be a subset of its ScanTask's schema"
@@ -316,19 +341,16 @@ impl MicroPartition {
     ///
     /// Schema invariants:
     /// 1. `schema` must match each Table's schema exactly
-    /// 2. `schema` must be a strict subset of the `statistics` schema exactly, if provided
+    /// 2. If `statistics` is provided, we check that each Loaded column in the statistics is compatible with the MicroPartition's schema
     pub fn new_loaded(
         schema: SchemaRef,
         tables: Arc<Vec<Table>>,
         statistics: Option<TableStatistics>,
     ) -> Self {
-        assert!(
-            statistics
-                .as_ref()
-                .map(|stats| schema.is_subset(&stats.schema()))
-                .unwrap_or(true),
-            "Loaded MicroPartition's statistics' schema must be a subset of its statistics' schema"
-        );
+        // Check and validate invariants with asserts
+        if let Some(statistics) = &statistics {
+            _validate_statistics(statistics, schema.as_ref());
+        }
         for table in tables.iter() {
             assert!(
                 table.schema == schema,

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -281,6 +281,7 @@ impl MicroPartition {
         metadata: TableMetadata,
         statistics: TableStatistics,
     ) -> Self {
+        // TODO: Validate schemas on statistics
         if statistics.columns.len() != schema.fields.len() {
             panic!("MicroPartition: TableStatistics and Schema have differing lengths")
         }
@@ -306,6 +307,7 @@ impl MicroPartition {
         tables: Arc<Vec<Table>>,
         statistics: Option<TableStatistics>,
     ) -> Self {
+        // TODO: Validate schemas on tables and statistics
         let tables_len_sum = tables.iter().map(|t| t.len()).sum();
         MicroPartition {
             schema,
@@ -356,6 +358,8 @@ impl MicroPartition {
                     .map(|cols| cols.iter().map(|s| s.as_str()).collect::<Vec<&str>>());
 
                 let row_groups = parquet_sources_to_row_groups(scan_task.sources.as_slice());
+
+                // TODO: validate schema
                 read_parquet_into_micropartition(
                     uris.as_slice(),
                     columns.as_deref(),
@@ -644,6 +648,7 @@ pub(crate) fn read_parquet_into_micropartition(
             .iter()
             .flat_map(|fm| {
                 fm.row_groups.iter().map(|rgm| {
+                    // TODO: pass in each file's schema instead of unified schema
                     daft_parquet::row_group_metadata_to_table_stats(rgm, &full_daft_schema)
                 })
             })

--- a/src/daft-parquet/src/statistics/table_stats.rs
+++ b/src/daft-parquet/src/statistics/table_stats.rs
@@ -12,6 +12,7 @@ pub fn row_group_metadata_to_table_stats(
     schema: &Schema,
 ) -> DaftResult<TableStatistics> {
     let mut columns = IndexMap::new();
+    // TODO: Iterate over schema instead
     for col in metadata.columns() {
         let top_level_column_name = col
             .descriptor()

--- a/src/daft-parquet/src/statistics/table_stats.rs
+++ b/src/daft-parquet/src/statistics/table_stats.rs
@@ -11,28 +11,39 @@ pub fn row_group_metadata_to_table_stats(
     metadata: &crate::metadata::RowGroupMetaData,
     schema: &Schema,
 ) -> DaftResult<TableStatistics> {
-    let mut columns = IndexMap::new();
-    // TODO: Iterate over schema instead
-    for col in metadata.columns() {
-        let top_level_column_name = col
-            .descriptor()
-            .path_in_schema
-            .first()
-            .expect("Parquet schema should have at least one entry in path_in_schema");
-        let daft_field = schema.get_field(top_level_column_name)?;
-        let col_stats = if ColumnRangeStatistics::supports_dtype(&daft_field.dtype) {
-            let stats = col
-                .statistics()
-                .transpose()
-                .context(super::UnableToParseParquetColumnStatisticsSnafu)?;
-            let col_stats: Option<Wrap<ColumnRangeStatistics>> =
-                stats.and_then(|v| v.as_ref().try_into().ok());
-            col_stats.unwrap_or(ColumnRangeStatistics::Missing.into())
-        } else {
-            ColumnRangeStatistics::Missing.into()
-        };
-        columns.insert(top_level_column_name.clone(), col_stats.0);
-    }
+    // Create a map from {field_name: statistics} from the RowGroupMetaData for easy access
+    let mut parquet_column_metadata: IndexMap<_, _> = metadata
+        .columns()
+        .iter()
+        .map(|col| {
+            let top_level_column_name = col
+                .descriptor()
+                .path_in_schema
+                .first()
+                .expect("Parquet schema should have at least one entry in path_in_schema");
+            (top_level_column_name, col.statistics())
+        })
+        .collect();
+
+    // Iterate through the schema and construct ColumnRangeStatistics per field
+    let columns = schema
+        .fields
+        .iter()
+        .map(|(field_name, field)| {
+            if ColumnRangeStatistics::supports_dtype(&field.dtype) {
+                let stats: Wrap<ColumnRangeStatistics> = parquet_column_metadata
+                    .remove(field_name)
+                    .expect("Cannot find parsed Daft field in Parquet rowgroup metadata")
+                    .transpose()
+                    .context(super::UnableToParseParquetColumnStatisticsSnafu)?
+                    .and_then(|v| v.as_ref().try_into().ok())
+                    .unwrap_or(ColumnRangeStatistics::Missing.into());
+                Ok((field_name.clone(), stats.0))
+            } else {
+                Ok((field_name.clone(), ColumnRangeStatistics::Missing))
+            }
+        })
+        .collect::<DaftResult<IndexMap<_, _>>>()?;
 
     Ok(TableStatistics { columns })
 }

--- a/src/daft-stats/src/column_stats/mod.rs
+++ b/src/daft-stats/src/column_stats/mod.rs
@@ -7,7 +7,7 @@ use std::string::FromUtf8Error;
 use daft_core::{
     array::ops::full::FullNull,
     datatypes::{BooleanArray, NullArray},
-    IntoSeries, Series,
+    DataType, IntoSeries, Series,
 };
 use snafu::{ResultExt, Snafu};
 
@@ -44,7 +44,29 @@ impl ColumnRangeStatistics {
                 assert_eq!(l.len(), 1);
                 assert_eq!(u.len(), 1);
                 assert_eq!(l.data_type(), u.data_type());
-                Ok(ColumnRangeStatistics::Loaded(l, u))
+
+                match l.data_type() {
+                    // SUPPORTED TYPES:
+                    // Null
+                    DataType::Null |
+
+                    // Numeric types
+                    DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::Int128 |
+                    DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 |
+                    DataType::Float32 | DataType::Float64 | DataType::Decimal128(..) | DataType::Boolean |
+
+                    // String types
+                    DataType::Utf8 | DataType::Binary |
+
+                    // Temporal types
+                    DataType::Date | DataType::Time(..) | DataType::Timestamp(..) | DataType::Duration(..) => Ok(ColumnRangeStatistics::Loaded(l, u)),
+
+                    // UNSUPPORTED TYPES:
+                    // Types that don't support comparisons and can't be used as ColumnRangeStatistics
+                    DataType::List(..) | DataType::FixedSizeList(..) | DataType::Image(..) | DataType::FixedShapeImage(..) | DataType::Tensor(..) | DataType::FixedShapeTensor(..) | DataType::Struct(..) | DataType::Extension(..) | DataType::Embedding(..) | DataType::Unknown => Ok(ColumnRangeStatistics::Missing),
+                    #[cfg(feature = "python")]
+                    DataType::Python => Ok(ColumnRangeStatistics::Missing),
+                }
             }
             _ => Ok(ColumnRangeStatistics::Missing),
         }

--- a/src/daft-stats/src/column_stats/mod.rs
+++ b/src/daft-stats/src/column_stats/mod.rs
@@ -142,6 +142,17 @@ impl ColumnRangeStatistics {
         let _num_bytes = series.size_bytes().unwrap();
         Self::Loaded(lower, upper)
     }
+
+    /// Casts the internal [`Series`] objects to the specified DataType
+    pub fn cast(&self, dtype: &DataType) -> crate::Result<Self> {
+        match self {
+            ColumnRangeStatistics::Missing => Ok(ColumnRangeStatistics::Missing),
+            ColumnRangeStatistics::Loaded(l, r) => Ok(ColumnRangeStatistics::Loaded(
+                l.cast(dtype).context(DaftCoreComputeSnafu)?,
+                r.cast(dtype).context(DaftCoreComputeSnafu)?,
+            )),
+        }
+    }
 }
 
 impl std::fmt::Display for ColumnRangeStatistics {

--- a/src/daft-stats/src/column_stats/mod.rs
+++ b/src/daft-stats/src/column_stats/mod.rs
@@ -44,31 +44,35 @@ impl ColumnRangeStatistics {
                 assert_eq!(l.len(), 1);
                 assert_eq!(u.len(), 1);
                 assert_eq!(l.data_type(), u.data_type());
-
-                match l.data_type() {
-                    // SUPPORTED TYPES:
-                    // Null
-                    DataType::Null |
-
-                    // Numeric types
-                    DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::Int128 |
-                    DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 |
-                    DataType::Float32 | DataType::Float64 | DataType::Decimal128(..) | DataType::Boolean |
-
-                    // String types
-                    DataType::Utf8 | DataType::Binary |
-
-                    // Temporal types
-                    DataType::Date | DataType::Time(..) | DataType::Timestamp(..) | DataType::Duration(..) => Ok(ColumnRangeStatistics::Loaded(l, u)),
-
-                    // UNSUPPORTED TYPES:
-                    // Types that don't support comparisons and can't be used as ColumnRangeStatistics
-                    DataType::List(..) | DataType::FixedSizeList(..) | DataType::Image(..) | DataType::FixedShapeImage(..) | DataType::Tensor(..) | DataType::FixedShapeTensor(..) | DataType::Struct(..) | DataType::Extension(..) | DataType::Embedding(..) | DataType::Unknown => Ok(ColumnRangeStatistics::Missing),
-                    #[cfg(feature = "python")]
-                    DataType::Python => Ok(ColumnRangeStatistics::Missing),
-                }
+                assert!(ColumnRangeStatistics::supports_dtype(l.data_type()));
+                Ok(ColumnRangeStatistics::Loaded(l, u))
             }
             _ => Ok(ColumnRangeStatistics::Missing),
+        }
+    }
+
+    pub fn supports_dtype(dtype: &DataType) -> bool {
+        match dtype {
+            // SUPPORTED TYPES:
+            // Null
+            DataType::Null |
+
+            // Numeric types
+            DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::Int128 |
+            DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 |
+            DataType::Float32 | DataType::Float64 | DataType::Decimal128(..) | DataType::Boolean |
+
+            // String types
+            DataType::Utf8 | DataType::Binary |
+
+            // Temporal types
+            DataType::Date | DataType::Time(..) | DataType::Timestamp(..) | DataType::Duration(..) => true,
+
+            // UNSUPPORTED TYPES:
+            // Types that don't support comparisons and can't be used as ColumnRangeStatistics
+            DataType::List(..) | DataType::FixedSizeList(..) | DataType::Image(..) | DataType::FixedShapeImage(..) | DataType::Tensor(..) | DataType::FixedShapeTensor(..) | DataType::Struct(..) | DataType::Extension(..) | DataType::Embedding(..) | DataType::Unknown => false,
+            #[cfg(feature = "python")]
+            DataType::Python => false,
         }
     }
 

--- a/src/daft-stats/src/table_stats.rs
+++ b/src/daft-stats/src/table_stats.rs
@@ -26,6 +26,14 @@ impl TableStatistics {
 }
 
 impl TableStatistics {
+    /// Returns the associated Schema
+    ///
+    /// NOTE: Even if a given column's statistics are [`ColumnRangeStatistics::Missing`], we will still
+    /// return the column's field name and dtype appropriately
+    pub fn schema(&self) -> Schema {
+        todo!("Implement schema functionality for TableStatistics");
+    }
+
     pub fn union(&self, other: &Self) -> crate::Result<Self> {
         // maybe use the schema from micropartition instead
         let unioned_columns = self

--- a/src/daft-stats/src/table_stats.rs
+++ b/src/daft-stats/src/table_stats.rs
@@ -112,7 +112,9 @@ impl TableStatistics {
         let mut columns = IndexMap::new();
         for (field_name, field) in schema.fields.iter() {
             let crs = match self.columns.get(field_name) {
-                Some(column_stat) => column_stat.cast(&field.dtype)?,
+                Some(column_stat) => column_stat
+                    .cast(&field.dtype)
+                    .unwrap_or(ColumnRangeStatistics::Missing),
                 None => ColumnRangeStatistics::Missing,
             };
             columns.insert(field_name.clone(), crs);


### PR DESCRIPTION
1. We should disallow creation of ColumnRangeStatistics from non-comparable types to avoid issues at runtime
2. We also add validation when creating MicroPartitions:
    * The column names in a MicroPartition's schema must be found in its ScanTask's schema
    * When creating Statistics for a MicroPartition, we cast those Statistics to the MicroPartition's schema to ensure type compatibility
