### PR TITLE
[FEAT] Print the results of a df.show() to stdout if running in non-interactive mode

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1011,19 +1011,8 @@ class DataFrame:
 
         return self
 
-    @DataframePublicAPI
-    def show(self, n: int = 8) -> None:
-        """Executes enough of the DataFrame in order to display the first ``n`` rows
-
-        If IPython is installed, this will use IPython's `display` utility to pretty-print in a
-        notebook/REPL environment. Otherwise, this will fall back onto a naive Python `print`.
-
-        .. NOTE::
-            This call is **blocking** and will execute the DataFrame when called
-
-        Args:
-            n: number of rows to show. Defaults to 8.
-        """
+    def _construct_show_display(self, n: int) -> "DataFrameDisplay":
+        """Helper for .show() which will construct the underlying DataFrameDisplay object"""
         preview_partition = self._preview.preview_partition
         total_rows = self._preview.dataframe_num_rows
 
@@ -1065,16 +1054,28 @@ class DataFrame:
             # Preview partition is cached and has exactly the number of rows that we need, so use it directly.
             preview = self._preview
 
-        # Display the `DataFrameDisplay`:
-        # Attempt to use `display` from IPython if available, otherwise fall-back onto `print`
-        dataframe_display = DataFrameDisplay(preview, self.schema(), num_rows=n)
+        return DataFrameDisplay(preview, self.schema(), num_rows=n)
+
+    @DataframePublicAPI
+    def show(self, n: int = 8) -> None:
+        """Executes enough of the DataFrame in order to display the first ``n`` rows
+
+        If IPython is installed, this will use IPython's `display` utility to pretty-print in a
+        notebook/REPL environment. Otherwise, this will fall back onto a naive Python `print`.
+
+        .. NOTE::
+            This call is **blocking** and will execute the DataFrame when called
+
+        Args:
+            n: number of rows to show. Defaults to 8.
+        """
+        dataframe_display = self._construct_show_display(n)
         try:
             from IPython.display import display
 
             display(dataframe_display)
         except ImportError:
             print(dataframe_display)
-
         return None
 
     def __len__(self):

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1064,7 +1064,7 @@ class DataFrame:
             assert len(preview_partition) == n
             # Preview partition is cached and has exactly the number of rows that we need, so use it directly.
             preview = self._preview
-    
+
         # Display the `DataFrameDisplay`:
         # Attempt to use `display` from IPython if available, otherwise fall-back onto `print`
         dataframe_display = DataFrameDisplay(preview, self.schema(), num_rows=n)
@@ -1073,7 +1073,7 @@ class DataFrame:
 
             display(dataframe_display)
         except ImportError:
-            print(display)
+            print(dataframe_display)
 
         return None
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -5,6 +5,7 @@
 # For technical details, see https://github.com/Eventual-Inc/Daft/pull/630
 
 import pathlib
+import sys
 import warnings
 from dataclasses import dataclass
 from functools import reduce
@@ -17,6 +18,7 @@ from typing import (
     List,
     Optional,
     Set,
+    TextIO,
     Tuple,
     TypeVar,
     Union,
@@ -26,7 +28,7 @@ from daft.api_annotations import DataframePublicAPI
 from daft.context import get_context
 from daft.convert import InputListType
 from daft.daft import FileFormat, IOConfig, JoinType, PartitionScheme, ResourceRequest
-from daft.dataframe.preview import DataFramePreview
+from daft.dataframe.preview import DataFramePreview, is_interactive_session
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
 from daft.expressions import Expression, ExpressionsProjection, col, lit

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1015,6 +1015,9 @@ class DataFrame:
     def show(self, n: int = 8) -> None:
         """Executes enough of the DataFrame in order to display the first ``n`` rows
 
+        If IPython is installed, this will use IPython's `display` utility to pretty-print in a
+        notebook/REPL environment. Otherwise, this will fall back onto a naive Python `print`.
+
         .. NOTE::
             This call is **blocking** and will execute the DataFrame when called
 

--- a/daft/dataframe/preview.py
+++ b/daft/dataframe/preview.py
@@ -5,6 +5,20 @@ from dataclasses import dataclass
 from daft.table import Table
 
 
+def is_interactive_session():
+    """Helper utility to return whether or not the current Python session is an interactive
+    iPython session
+    """
+    is_interactive = False
+    try:
+        from IPython import get_ipython
+
+        is_interactive = get_ipython() is not None
+    except ImportError:
+        pass
+    return is_interactive
+
+
 @dataclass(frozen=True)
 class DataFramePreview:
     """A class containing all the metadata/data required to preview a dataframe."""

--- a/daft/dataframe/preview.py
+++ b/daft/dataframe/preview.py
@@ -5,20 +5,6 @@ from dataclasses import dataclass
 from daft.table import Table
 
 
-def is_interactive_session():
-    """Helper utility to return whether or not the current Python session is an interactive
-    iPython session
-    """
-    is_interactive = False
-    try:
-        from IPython import get_ipython
-
-        is_interactive = get_ipython() is not None
-    except ImportError:
-        pass
-    return is_interactive
-
-
 @dataclass(frozen=True)
 class DataFramePreview:
     """A class containing all the metadata/data required to preview a dataframe."""

--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -69,5 +69,6 @@ class ProgressBar:
 
     def close(self) -> None:
         for p in self.pbars.values():
+            p.clear()
             p.close()
             del p

--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -4,17 +4,25 @@ import os
 import time
 from typing import Any
 
-from tqdm.auto import tqdm
-
 from daft.execution.execution_step import PartitionTask
 
 
 class ProgressBar:
     def __init__(self, use_ray_tqdm: bool, show_tasks_bar: bool = False, disable: bool = False) -> None:
-        self.use_ray_tqdm = use_ray_tqdm
         self.show_tasks_bar = show_tasks_bar
-        self.tqdm_mod = tqdm
         self._maxinterval = 5.0
+
+        # Choose the appropriate tqdm module depending on whether we need to use Ray's tqdm
+        self.use_ray_tqdm = use_ray_tqdm
+        if use_ray_tqdm:
+            from ray.experimental.tqdm_ray import tqdm
+
+            self.tqdm_mod = tqdm
+        else:
+            from tqdm.auto import tqdm
+
+            self.tqdm_mod = tqdm
+
         self.pbars: dict[int, tqdm] = dict()
         self.disable = (
             disable
@@ -69,6 +77,7 @@ class ProgressBar:
 
     def close(self) -> None:
         for p in self.pbars.values():
-            p.clear()
+            if not self.use_ray_tqdm:
+                p.clear()
             p.close()
             del p

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -5,7 +5,7 @@ import daft
 
 def test_show_default(valid_data):
     df = daft.from_pylist(valid_data)
-    df_display = df.show()
+    df_display = df._construct_show_display(8)
 
     assert df_display.schema == df.schema()
     assert len(df_display.preview.preview_partition) == len(valid_data)
@@ -15,7 +15,7 @@ def test_show_default(valid_data):
 
 def test_show_some(valid_data):
     df = daft.from_pylist(valid_data)
-    df_display = df.show(1)
+    df_display = df._construct_show_display(1)
 
     assert df_display.schema == df.schema()
     assert len(df_display.preview.preview_partition) == 1
@@ -28,7 +28,7 @@ def test_show_from_cached_collect(valid_data):
     df = daft.from_pylist(valid_data)
     df = df.collect()
     collected_preview = df._preview
-    df_display = df.show()
+    df_display = df._construct_show_display(8)
 
     # Check that cached preview from df.collect() was used.
     assert df_display.preview is collected_preview
@@ -41,7 +41,7 @@ def test_show_from_cached_collect(valid_data):
 def test_show_from_cached_collect_prefix(valid_data):
     df = daft.from_pylist(valid_data)
     df = df.collect(3)
-    df_display = df.show(2)
+    df_display = df._construct_show_display(2)
 
     assert df_display.schema == df.schema()
     assert len(df_display.preview.preview_partition) == 2
@@ -54,7 +54,7 @@ def test_show_not_from_cached_collect(valid_data):
     df = daft.from_pylist(valid_data)
     df = df.collect(2)
     collected_preview = df._preview
-    df_display = df.show()
+    df_display = df._construct_show_display(8)
 
     # Check that cached preview from df.collect() was NOT used, since it didn't have enough rows.
     assert df_display.preview != collected_preview


### PR DESCRIPTION
On the pyrunner:
<img width="404" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/17691182/f7910928-f0e3-47db-add6-2ec2866b3d6b">

On the local RayRunner:
<img width="922" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/17691182/8d8b5e22-71b5-4641-982d-06cb95487e8c">


On the remote RayRunner:
<img width="1072" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/17691182/7ad00016-b348-4adb-a3e1-638a9d9fe443">

When executed from a python script (tested also across py, local-ray and remote-ray):
<img width="548" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/17691182/efc50fe7-e5fe-42d1-b61c-3486f2b41edc">

