### PR TITLE
[FEAT] Dynamic Responsive Printing of Tables, Schema and Series

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1117,6 +1117,7 @@ dependencies = [
  "bincode",
  "chrono",
  "chrono-tz",
+ "comfy-table",
  "common-error",
  "dyn-clone",
  "fnv",
@@ -1129,7 +1130,6 @@ dependencies = [
  "num-derive",
  "num-traits",
  "numpy",
- "prettytable-rs",
  "pyo3",
  "pyo3-log",
  "rand 0.8.5",
@@ -1366,7 +1366,6 @@ dependencies = [
  "daft-dsl",
  "html-escape",
  "num-traits",
- "prettytable-rs",
  "pyo3",
  "pyo3-log",
  "rand 0.8.5",
@@ -1411,27 +1410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,12 +1426,6 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2101,17 +2073,6 @@ name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys",
-]
 
 [[package]]
 name = "itertools"
@@ -2848,20 +2809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "prettytable-rs"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
-dependencies = [
- "csv",
- "encode_unicode",
- "is-terminal",
- "lazy_static",
- "term",
- "unicode-width",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3060,15 +3007,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -3083,17 +3021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom 0.2.10",
- "redox_syscall 0.2.16",
- "thiserror",
 ]
 
 [[package]]
@@ -3646,17 +3573,6 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix",
  "windows-sys",
-]
-
-[[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -889,6 +889,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "comfy-table"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
+dependencies = [
+ "crossterm",
+ "strum",
+ "strum_macros",
+ "unicode-width",
+]
+
+[[package]]
 name = "common-error"
 version = "0.1.10"
 dependencies = [
@@ -996,6 +1008,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.0",
+ "crossterm_winapi",
+ "libc",
+ "parking_lot",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -1326,6 +1360,7 @@ name = "daft-table"
 version = "0.1.10"
 dependencies = [
  "arrow2",
+ "comfy-table",
  "common-error",
  "daft-core",
  "daft-dsl",
@@ -3519,6 +3554,25 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.38",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ tokio = {version = "1.32.0", features = ["net", "time", "bytes", "process", "sig
 tokio-stream = {version = "0.1.14", features = ["fs"]}
 tokio-util = "0.7.8"
 url = "2.4.0"
+comfy-table = "7.1.0"
 
 [workspace.dependencies.arrow2]
 # branch = "jay/fix-parquet-timezone-parsing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,13 +86,13 @@ async-stream = "0.3.5"
 bytes = "1.4.0"
 chrono = "0.4.26"
 chrono-tz = "0.8.3"
+comfy-table = "7.1.0"
 futures = "0.3.28"
 html-escape = "0.2.13"
 indexmap = "2.0.0"
 itertools = "0.11"
 num-derive = "0.3.3"
 num-traits = "0.2"
-prettytable-rs = "0.10"
 rand = "^0.8"
 rayon = "1.7.0"
 rstest = "0.18.2"
@@ -102,7 +102,6 @@ tokio = {version = "1.32.0", features = ["net", "time", "bytes", "process", "sig
 tokio-stream = {version = "0.1.14", features = ["fs"]}
 tokio-util = "0.7.8"
 url = "2.4.0"
-comfy-table = "7.1.0"
 
 [workspace.dependencies.arrow2]
 # branch = "jay/fix-parquet-timezone-parsing"

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1078,7 +1078,7 @@ class DataFrame:
         except ImportError:
             print(dataframe_display)
         return None
-    
+
     def __len__(self):
         """Returns the count of rows when dataframe is materialized.
         If dataframe is not materialized yet, raises a runtime error.

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1078,7 +1078,6 @@ class DataFrame:
         except ImportError:
             print(dataframe_display)
         return None
-
     def __len__(self):
         """Returns the count of rows when dataframe is materialized.
         If dataframe is not materialized yet, raises a runtime error.

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1074,10 +1074,11 @@ class DataFrame:
         try:
             from IPython.display import display
 
-            display(dataframe_display)
+            display(dataframe_display, clear=True)
         except ImportError:
             print(dataframe_display)
         return None
+    
     def __len__(self):
         """Returns the count of rows when dataframe is materialized.
         If dataframe is not materialized yet, raises a runtime error.

--- a/src/daft-core/Cargo.toml
+++ b/src/daft-core/Cargo.toml
@@ -4,6 +4,7 @@ base64 = "0.21.5"
 bincode = {workspace = true}
 chrono = {workspace = true}
 chrono-tz = {workspace = true}
+comfy-table = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
 dyn-clone = "1.0.16"
 fnv = "1.0.7"
@@ -14,7 +15,6 @@ log = {workspace = true}
 ndarray = "0.15.6"
 num-derive = {workspace = true}
 num-traits = {workspace = true}
-prettytable-rs = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true}
 rand = {workspace = true}

--- a/src/daft-core/src/schema.rs
+++ b/src/daft-core/src/schema.rs
@@ -177,7 +177,7 @@ impl Display for Schema {
             None,
             None,
         );
-        write!(f, "{table}")
+        writeln!(f, "{table}")
     }
 }
 

--- a/src/daft-core/src/schema.rs
+++ b/src/daft-core/src/schema.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::{hash_map::DefaultHasher, HashSet},
     fmt::{Display, Formatter, Result},
     hash::{Hash, Hasher},
@@ -8,7 +9,7 @@ use std::{
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-use crate::datatypes::Field;
+use crate::{datatypes::Field, utils::display_table::make_comfy_table, Series};
 
 use common_error::{DaftError, DaftResult};
 
@@ -167,14 +168,15 @@ impl Default for Schema {
 impl Display for Schema {
     // Produces an ASCII table.
     fn fmt(&self, f: &mut Formatter) -> Result {
-        let mut table = prettytable::Table::new();
-
-        let header = self
-            .fields
-            .iter()
-            .map(|(name, field)| format!("{}\n{}", name, field.dtype))
-            .collect();
-        table.add_row(header);
+        let table = make_comfy_table(
+            self.fields
+                .values()
+                .map(|f| Cow::Borrowed(f))
+                .collect::<Vec<_>>()
+                .as_slice(),
+            None,
+            None,
+        );
         write!(f, "{table}")
     }
 }

--- a/src/daft-core/src/schema.rs
+++ b/src/daft-core/src/schema.rs
@@ -9,7 +9,7 @@ use std::{
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-use crate::{datatypes::Field, utils::display_table::make_comfy_table, Series};
+use crate::{datatypes::Field, utils::display_table::make_comfy_table};
 
 use common_error::{DaftError, DaftResult};
 
@@ -171,7 +171,7 @@ impl Display for Schema {
         let table = make_comfy_table(
             self.fields
                 .values()
-                .map(|f| Cow::Borrowed(f))
+                .map(Cow::Borrowed)
                 .collect::<Vec<_>>()
                 .as_slice(),
             None,

--- a/src/daft-core/src/series/mod.rs
+++ b/src/daft-core/src/series/mod.rs
@@ -83,7 +83,7 @@ impl Series {
         make_comfy_table(
             vec![Cow::Borrowed(self.field())].as_slice(),
             Some([self].as_slice()),
-            Some(32),
+            Some(80),
         )
     }
 }

--- a/src/daft-core/src/series/mod.rs
+++ b/src/daft-core/src/series/mod.rs
@@ -92,7 +92,7 @@ impl Display for Series {
     // `f` is a buffer, and this method must write the formatted string into it
     fn fmt(&self, f: &mut Formatter) -> Result {
         let table = self.to_comfy_table();
-        write!(f, "{table}")
+        writeln!(f, "{table}")
     }
 }
 

--- a/src/daft-core/src/utils/display_table.rs
+++ b/src/daft-core/src/utils/display_table.rs
@@ -20,22 +20,7 @@ pub fn make_comfy_table<F: AsRef<Field>>(
         .width()
         .expect("should have already been set with default") as usize;
 
-    let expected_col_width: usize = if columns.is_some() || fields.is_empty() {
-        24usize
-    } else {
-        let mut all_lens = fields
-            .iter()
-            .map(|f| f.as_ref().name.len() + 3)
-            .collect::<Vec<_>>();
-        all_lens.sort();
-
-        // get 90 percentile
-        let index = ((9 * all_lens.len()) / 10).min(all_lens.len() - 1);
-        let expected_len = all_lens
-            .get(index)
-            .expect("we clamped so this shouldnt happen");
-        *expected_len
-    };
+    let expected_col_width = 24usize;
 
     let max_cols = (terminal_width + expected_col_width - 1) / expected_col_width;
     const DOTS: &str = "…";

--- a/src/daft-core/src/utils/display_table.rs
+++ b/src/daft-core/src/utils/display_table.rs
@@ -1,0 +1,147 @@
+use crate::{datatypes::Field, Series};
+
+pub fn make_comfy_table<F: AsRef<Field>>(
+    fields: &[F],
+    columns: Option<&[&Series]>,
+    max_col_width: Option<usize>,
+) -> comfy_table::Table {
+    let mut table = comfy_table::Table::new();
+
+    let default_width_if_no_tty = 120;
+
+    table
+        .load_preset(comfy_table::presets::UTF8_FULL)
+        .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
+        .set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
+    if table.width().is_none() && !table.is_tty() {
+        table.set_width(default_width_if_no_tty);
+    }
+    let terminal_width = table
+        .width()
+        .expect("should have already been set with default");
+
+    const EXPECTED_COL_WIDTH: u16 = 24;
+
+    let max_cols = ((terminal_width + EXPECTED_COL_WIDTH - 1) / EXPECTED_COL_WIDTH) as usize;
+    const DOTS: &str = "…";
+    let num_columns = fields.len();
+
+    let head_cols;
+    let tail_cols;
+    let total_cols;
+    if num_columns > max_cols {
+        head_cols = (max_cols + 1) / 2;
+        tail_cols = max_cols / 2;
+        total_cols = head_cols + tail_cols + 1;
+    } else {
+        head_cols = num_columns;
+        tail_cols = 0;
+        total_cols = head_cols;
+    }
+    let mut header = fields
+        .iter()
+        .take(head_cols)
+        .map(|field| {
+            comfy_table::Cell::new(
+                format!("{}\n---\n{}", field.as_ref().name, field.as_ref().dtype).as_str(),
+            )
+            .add_attribute(comfy_table::Attribute::Bold)
+        })
+        .collect::<Vec<_>>();
+    if tail_cols > 0 {
+        header.push(comfy_table::Cell::new(DOTS));
+        header.extend(fields.iter().skip(num_columns - tail_cols).map(|field| {
+            comfy_table::Cell::new(
+                format!("{}\n---\n{}", field.as_ref().name, field.as_ref().dtype).as_str(),
+            )
+            .add_attribute(comfy_table::Attribute::Bold)
+        }))
+    }
+    table.add_row(header);
+
+    if let Some(columns) = columns && columns.len() > 0 {
+        let len = columns.first().unwrap().len();
+        const TOTAL_ROWS: usize = 10;
+        let head_rows;
+        let tail_rows;
+
+        if len > TOTAL_ROWS {
+            head_rows = TOTAL_ROWS / 2;
+            tail_rows = TOTAL_ROWS / 2;
+        } else {
+            head_rows = len;
+            tail_rows = 0;
+        }
+
+
+
+        for i in 0..head_rows {
+            let all_cols  = columns
+                .iter()
+                .map(|s| {
+                    let mut str_val = s.str_value(i).unwrap();
+                    if let Some(max_col_width) = max_col_width {
+                        if str_val.len() > max_col_width - DOTS.len() {
+                            str_val = format!(
+                                "{}{DOTS}",
+                                &str_val[..max_col_width - DOTS.len()]
+                            );
+                        }
+                    }
+                    str_val
+                }).collect::<Vec<_>>();
+
+            if tail_cols > 0 {
+                let mut final_row = all_cols.iter().take(head_cols).cloned().collect::<Vec<_>>();
+                final_row.push(DOTS.into());
+                final_row.extend(
+                    all_cols
+                    .iter()
+                    .skip(num_columns - tail_cols)
+                    .cloned()
+                );
+                table.add_row(final_row);
+
+            } else {
+                table.add_row(all_cols);
+            }
+
+
+        }
+        if tail_rows != 0 {
+            table.add_row((0..total_cols).map(|_| DOTS).collect::<Vec<_>>());
+        }
+
+        for i in (len - tail_rows)..(len) {
+            let all_cols  = columns
+                .iter()
+                .map(|s| {
+                    let mut str_val = s.str_value(i).unwrap();
+                    if let Some(max_col_width) = max_col_width {
+                        if str_val.len() > max_col_width - DOTS.len() {
+                            str_val = format!(
+                                "{}{DOTS}",
+                                &str_val[..max_col_width - DOTS.len()]
+                            );
+                        }
+                    }
+                    str_val
+                }).collect::<Vec<_>>();
+
+            if tail_cols > 0 {
+                let mut final_row = all_cols.iter().take(head_cols).cloned().collect::<Vec<_>>();
+                final_row.push(DOTS.into());
+                final_row.extend(
+                    all_cols
+                    .iter()
+                    .skip(num_columns - tail_cols)
+                    .cloned()
+                );
+                table.add_row(final_row);
+            } else {
+                table.add_row(all_cols);
+            }
+        }
+    }
+    table
+}

--- a/src/daft-core/src/utils/display_table.rs
+++ b/src/daft-core/src/utils/display_table.rs
@@ -20,7 +20,7 @@ pub fn make_comfy_table<F: AsRef<Field>>(
         .width()
         .expect("should have already been set with default") as usize;
 
-    let expected_col_width = 24usize;
+    let expected_col_width = 18usize;
 
     let max_cols = (terminal_width + expected_col_width - 1) / expected_col_width;
     const DOTS: &str = "…";

--- a/src/daft-core/src/utils/display_table.rs
+++ b/src/daft-core/src/utils/display_table.rs
@@ -59,7 +59,7 @@ pub fn make_comfy_table<F: AsRef<Field>>(
     }
     table.add_row(header);
 
-    if let Some(columns) = columns && columns.len() > 0 {
+    if let Some(columns) = columns && !columns.is_empty() {
         let len = columns.first().unwrap().len();
         const TOTAL_ROWS: usize = 10;
         let head_rows;

--- a/src/daft-core/src/utils/display_table.rs
+++ b/src/daft-core/src/utils/display_table.rs
@@ -37,7 +37,7 @@ pub fn make_comfy_table<F: AsRef<Field>>(
         *expected_len
     };
 
-    let max_cols = ((terminal_width + expected_col_width - 1) / expected_col_width);
+    let max_cols = (terminal_width + expected_col_width - 1) / expected_col_width;
     const DOTS: &str = "…";
     let num_columns = fields.len();
 

--- a/src/daft-core/src/utils/mod.rs
+++ b/src/daft-core/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod arrow;
+pub mod display_table;
 pub mod hashable_float_wrapper;
 pub mod supertype;
 

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -1543,7 +1543,7 @@ mod tests {
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
-        let column_names = vec!["a", "b"];
+        let column_names = ["a", "b"];
         let table = read_csv(
             file,
             Some(
@@ -1579,7 +1579,7 @@ mod tests {
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
-        let column_names = vec!["a", "b"];
+        let column_names = ["a", "b"];
         let table = read_csv(
             file,
             Some(

--- a/src/daft-table/Cargo.toml
+++ b/src/daft-table/Cargo.toml
@@ -1,13 +1,11 @@
 [dependencies]
 arrow2 = {workspace = true}
+comfy-table = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
 html-escape = {workspace = true}
 num-traits = {workspace = true}
-prettytable-rs = {workspace = true}
-comfy-table = {workspace = true}
-
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true}
 rand = {workspace = true}

--- a/src/daft-table/Cargo.toml
+++ b/src/daft-table/Cargo.toml
@@ -6,6 +6,8 @@ daft-dsl = {path = "../daft-dsl", default-features = false}
 html-escape = {workspace = true}
 num-traits = {workspace = true}
 prettytable-rs = {workspace = true}
+comfy-table = {workspace = true}
+
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true}
 rand = {workspace = true}

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -488,7 +488,7 @@ impl Display for Table {
     // `f` is a buffer, and this method must write the formatted string into it
     fn fmt(&self, f: &mut Formatter) -> Result {
         let table = self.to_comfy_table(Some(32));
-        write!(f, "{table}")
+        writeln!(f, "{table}")
     }
 }
 

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -475,10 +475,10 @@ impl Table {
             self.schema
                 .fields
                 .values()
-                .map(|f| Cow::Borrowed(f))
+                .map(Cow::Borrowed)
                 .collect::<Vec<_>>()
                 .as_slice(),
-            Some(&self.columns.iter().collect::<Vec<_>>().as_slice()),
+            Some(self.columns.iter().collect::<Vec<_>>().as_slice()),
             max_col_width,
         )
     }

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -470,7 +470,7 @@ impl Table {
         res
     }
 
-    pub fn to_comfytable(&self, max_col_width: Option<usize>) -> comfy_table::Table {
+    pub fn to_comfy_table(&self, max_col_width: Option<usize>) -> comfy_table::Table {
         make_comfy_table(
             self.schema
                 .fields
@@ -487,7 +487,7 @@ impl Table {
 impl Display for Table {
     // `f` is a buffer, and this method must write the formatted string into it
     fn fmt(&self, f: &mut Formatter) -> Result {
-        let table = self.to_comfytable(Some(32));
+        let table = self.to_comfy_table(Some(32));
         write!(f, "{table}")
     }
 }

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -7,13 +7,13 @@ import pandas as pd
 from PIL import Image
 
 import daft
+from tests.utils import ANSI_ESCAPE
 
 ROW_DIVIDER_REGEX = re.compile(r"╭─+┬*─*╮|├╌+┼*╌+┤")
 SHOWING_N_ROWS_REGEX = re.compile(r".*\(Showing first (\d+) of (\d+) rows\).*")
 UNMATERIALIZED_REGEX = re.compile(r".*\(No data to display: Dataframe not materialized\).*")
 MATERIALIZED_NO_ROWS_REGEX = re.compile(r".*\(No data to display: Materialized dataframe has no rows\).*")
 TD_STYLE = 'style="text-align:left; max-width:192px; max-height:64px; overflow:auto"'
-ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 
 def parse_str_table(

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -8,18 +8,21 @@ from PIL import Image
 
 import daft
 
-ROW_DIVIDER_REGEX = re.compile(r"\+-+\+")
+ROW_DIVIDER_REGEX = re.compile(r"╭─+┬*─*╮|├╌+┼*╌+┤")
 SHOWING_N_ROWS_REGEX = re.compile(r".*\(Showing first (\d+) of (\d+) rows\).*")
 UNMATERIALIZED_REGEX = re.compile(r".*\(No data to display: Dataframe not materialized\).*")
 MATERIALIZED_NO_ROWS_REGEX = re.compile(r".*\(No data to display: Materialized dataframe has no rows\).*")
 TD_STYLE = 'style="text-align:left; max-width:192px; max-height:64px; overflow:auto"'
+ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 
 def parse_str_table(
     table: str, expected_user_msg_regex: re.Pattern = SHOWING_N_ROWS_REGEX
 ) -> dict[str, tuple[str, list[str]]]:
+    table = ANSI_ESCAPE.sub("", table)
+
     def _split_table_row(row: str) -> list[str]:
-        return [cell.strip() for cell in row.split("|")[1:-1]]
+        return [cell.strip() for cell in re.split("┆|│", row)[1:-1]]
 
     lines = table.split("\n")
     assert len(lines) > 4
@@ -27,15 +30,15 @@ def parse_str_table(
     assert expected_user_msg_regex.match(lines[-1])
 
     column_names = _split_table_row(lines[1])
-    column_types = _split_table_row(lines[2])
+    column_types = _split_table_row(lines[3])
 
     data = []
-    for line in lines[4:-2]:
+    for line in lines[5:-3]:
         if ROW_DIVIDER_REGEX.match(line):
             continue
         data.append(_split_table_row(line))
-
-    return {column_names[i]: (column_types[i], [row[i] for row in data]) for i in range(len(column_names))}
+    val = {column_names[i]: (column_types[i], [row[i] for row in data]) for i in range(len(column_names))}
+    return val
 
 
 def parse_html_table(
@@ -200,23 +203,24 @@ def test_repr_html_custom_hooks():
     df.collect()
 
     assert (
-        df.__repr__().replace("\r", "")
-        == """+-------------------+-------------+----------------------------------+
-| objects           | np          | pil                              |
-| Python            | Python      | Python                           |
-+-------------------+-------------+----------------------------------+
-| myobj-custom-repr | [[1. 1. 1.] | <PIL.Image.Image image mode=L... |
-|                   |  [1. 1. 1.] |                                  |
-|                   |  [1. ...    |                                  |
-+-------------------+-------------+----------------------------------+
-| myobj-custom-repr | [[1. 1. 1.] | <PIL.Image.Image image mode=L... |
-|                   |  [1. 1. 1.] |                                  |
-|                   |  [1. ...    |                                  |
-+-------------------+-------------+----------------------------------+
-| myobj-custom-repr | [[1. 1. 1.] | <PIL.Image.Image image mode=L... |
-|                   |  [1. 1. 1.] |                                  |
-|                   |  [1. ...    |                                  |
-+-------------------+-------------+----------------------------------+
+        ANSI_ESCAPE.sub("", df.__repr__()).replace("\r", "")
+        == """╭───────────────────┬─────────────┬────────────────────────────────╮
+│ objects           ┆ np          ┆ pil                            │
+│ ---               ┆ ---         ┆ ---                            │
+│ Python            ┆ Python      ┆ Python                         │
+╞═══════════════════╪═════════════╪════════════════════════════════╡
+│ myobj-custom-repr ┆ [[1. 1. 1.] ┆ <PIL.Image.Image image mode=L… │
+│                   ┆  [1. 1. 1.] ┆                                │
+│                   ┆  [1. …      ┆                                │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ myobj-custom-repr ┆ [[1. 1. 1.] ┆ <PIL.Image.Image image mode=L… │
+│                   ┆  [1. 1. 1.] ┆                                │
+│                   ┆  [1. …      ┆                                │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ myobj-custom-repr ┆ [[1. 1. 1.] ┆ <PIL.Image.Image image mode=L… │
+│                   ┆  [1. 1. 1.] ┆                                │
+│                   ┆  [1. …      ┆                                │
+╰───────────────────┴─────────────┴────────────────────────────────╯
 
 (Showing first 3 of 3 rows)"""
     )

--- a/tests/series/test_tensor.py
+++ b/tests/series/test_tensor.py
@@ -10,6 +10,7 @@ from daft.datatype import DaftExtension, DataType
 from daft.series import Series
 from daft.utils import pyarrow_supports_fixed_shape_tensor
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES
+from tests.utils import ANSI_ESCAPE
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
 
@@ -122,20 +123,20 @@ def test_tensor_repr():
     arr = np.arange(np.prod((2, 2)), dtype=np.int64).reshape((2, 2))
     arrs = [arr, arr, None]
     s = Series.from_pylist(arrs, pyobj="allow")
+
+    out_repr = ANSI_ESCAPE.sub("", repr(s))
     assert (
-        repr(s).replace("\r", "")
-        == """
-+-----------------------+
-| list_series           |
-| Tensor(Int64)         |
-+-----------------------+
-| <Tensor shape=(2, 2)> |
-+-----------------------+
-| <Tensor shape=(2, 2)> |
-+-----------------------+
-| None                  |
-+-----------------------+
-"""[
-            1:
-        ]
+        out_repr.replace("\r", "")
+        == """╭───────────────────────╮
+│ list_series           │
+│ ---                   │
+│ Tensor(Int64)         │
+╞═══════════════════════╡
+│ <Tensor shape=(2, 2)> │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ <Tensor shape=(2, 2)> │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+│ None                  │
+╰───────────────────────╯
+"""
     )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import re
 
 import pyarrow as pa
 import pytest
@@ -20,7 +19,8 @@ DATA = {
 
 TABLE = Table.from_pydict({k: data for k, (data, _) in DATA.items()})
 EXPECTED_TYPES = {k: t for k, (_, t) in DATA.items()}
-ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+from tests.utils import ANSI_ESCAPE
 
 
 def test_schema_len():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import re
 
 import pyarrow as pa
 import pytest
@@ -19,6 +20,7 @@ DATA = {
 
 TABLE = Table.from_pydict({k: data for k, (data, _) in DATA.items()})
 EXPECTED_TYPES = {k: t for k, (_, t) in DATA.items()}
+ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 
 def test_schema_len():
@@ -63,12 +65,15 @@ def test_schema_to_name_set():
 
 def test_repr():
     schema = TABLE.schema()
+    out_repr = repr(schema)
+    without_escape = ANSI_ESCAPE.sub("", out_repr)
     assert (
-        repr(schema).replace("\r", "")
-        == """+-------+---------+--------+---------+
-| int   | float   | string | bool    |
-| Int64 | Float64 | Utf8   | Boolean |
-+-------+---------+--------+---------+
+        without_escape.replace("\r", "")
+        == """╭───────┬─────────┬────────┬─────────╮
+│ int   ┆ float   ┆ string ┆ bool    │
+│ ---   ┆ ---     ┆ ---    ┆ ---     │
+│ Int64 ┆ Float64 ┆ Utf8   ┆ Boolean │
+╰───────┴─────────┴────────┴─────────╯
 """
     )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import re
+
 import pyarrow as pa
 import pyarrow.compute as pac
+
+ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
 
 def sort_arrow_table(tbl: pa.Table, sort_by: str):


### PR DESCRIPTION
* Implements Terminal (tty) aware printing to avoid wrap arounds
* Implements dynamic column printing (the wider the terminal, the more columns print)
* factor out our printing code to be shared between table, series and schema
Closes: https://github.com/Eventual-Inc/Daft/issues/901

when showing a dataframe:
<img width="1070" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/2550285/2b9e746c-c22b-407d-91e8-6ae8737ccebf">

when performing a show:
<img width="987" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/2550285/51626719-ada3-4bf9-af19-9f1bdfb81d08">

when we resize the terminal: (second call is after zooming out in terminal)
<img width="982" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/2550285/8e7131a7-8328-4f5e-a21a-9214cf978db3">

and the case when we truncate both rows and columns:
<img width="1037" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/2550285/6169a36f-1a5a-4ff2-8529-6111702a363d">
