### PR TITLE
[FEAT] Enable MicroPartitions by default

### DIFF
--- a/benchmarking/parquet/conftest.py
+++ b/benchmarking/parquet/conftest.py
@@ -41,7 +41,7 @@ def boto3_get_object_read(path: str, columns: list[str] | None = None) -> pa.Tab
 
 
 def daft_native_read(path: str, columns: list[str] | None = None) -> pa.Table:
-    tbl = daft.table.Table.read_parquet(path, columns=columns)
+    tbl = daft.table.MicroPartition.read_parquet(path, columns=columns)
     return tbl.to_arrow()
 
 

--- a/benchmarking/parquet/conftest.py
+++ b/benchmarking/parquet/conftest.py
@@ -76,7 +76,7 @@ def bulk_read_adapter(func):
 
 
 def daft_bulk_read(paths: list[str], columns: list[str] | None = None) -> list[pa.Table]:
-    tables = daft.table.LegacyTable.read_parquet_bulk(paths, columns=columns)
+    tables = daft.table.Table.read_parquet_bulk(paths, columns=columns)
     return [t.to_arrow() for t in tables]
 
 

--- a/daft/dataframe/preview.py
+++ b/daft/dataframe/preview.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 @dataclass(frozen=True)
 class DataFramePreview:
     """A class containing all the metadata/data required to preview a dataframe."""
 
-    preview_partition: Table | None
+    preview_partition: MicroPartition | None
     dataframe_num_rows: int | None

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -33,7 +33,7 @@ from daft.runners.partitioning import (
     TableParseCSVOptions,
     TableReadOptions,
 )
-from daft.table import Table, table_io
+from daft.table import MicroPartition, table_io
 
 ID_GEN = itertools.count()
 
@@ -196,7 +196,7 @@ class SingleOutputPartitionTask(PartitionTask[PartitionT]):
         """
         return self.result().metadata()
 
-    def vpartition(self) -> Table:
+    def vpartition(self) -> MicroPartition:
         """Get the raw vPartition of the result."""
         return self.result().vpartition()
 
@@ -241,7 +241,7 @@ class MultiOutputPartitionTask(PartitionTask[PartitionT]):
         assert self._results is not None
         return [result.metadata() for result in self._results]
 
-    def vpartition(self, index: int) -> Table:
+    def vpartition(self, index: int) -> MicroPartition:
         """Get the raw vPartition of the result."""
         assert self._results is not None
         return self._results[index].vpartition()
@@ -262,7 +262,7 @@ class Instruction(Protocol):
     To accomodate these, instructions are typed as list[Table] -> list[Table].
     """
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         """Run the Instruction over the input partitions.
 
         Note: Dispatching a descriptively named helper here will aid profiling.
@@ -295,10 +295,10 @@ class ReadFile(SingleOutputInstruction):
     columns_to_read: list[str] | None
     file_format_config: FileFormatConfig
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._read_file(inputs)
 
-    def _read_file(self, inputs: list[Table]) -> list[Table]:
+    def _read_file(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         assert len(inputs) == 1
         [filepaths_partition] = inputs
         partition = self._handle_tabular_files_scan(
@@ -323,8 +323,8 @@ class ReadFile(SingleOutputInstruction):
 
     def _handle_tabular_files_scan(
         self,
-        filepaths_partition: Table,
-    ) -> Table:
+        filepaths_partition: MicroPartition,
+    ) -> MicroPartition:
         data = filepaths_partition.to_pydict()
         filepaths = data["path"]
 
@@ -341,7 +341,7 @@ class ReadFile(SingleOutputInstruction):
         format_config = self.file_format_config.config
         if file_format == FileFormat.Csv:
             assert isinstance(format_config, CsvSourceConfig)
-            table = Table.concat(
+            table = MicroPartition.concat(
                 [
                     table_io.read_csv(
                         file=fp,
@@ -364,7 +364,7 @@ class ReadFile(SingleOutputInstruction):
             )
         elif file_format == FileFormat.Json:
             assert isinstance(format_config, JsonSourceConfig)
-            table = Table.concat(
+            table = MicroPartition.concat(
                 [
                     table_io.read_json(
                         file=fp,
@@ -377,7 +377,7 @@ class ReadFile(SingleOutputInstruction):
             )
         elif file_format == FileFormat.Parquet:
             assert isinstance(format_config, ParquetSourceConfig)
-            table = Table.concat(
+            table = MicroPartition.concat(
                 [
                     table_io.read_parquet(
                         file=fp,
@@ -411,10 +411,10 @@ class WriteFile(SingleOutputInstruction):
     partition_cols: ExpressionsProjection | None
     io_config: IOConfig | None
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._write_file(inputs)
 
-    def _write_file(self, inputs: list[Table]) -> list[Table]:
+    def _write_file(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         partition = self._handle_file_write(
             input=input,
@@ -430,7 +430,7 @@ class WriteFile(SingleOutputInstruction):
             )
         ]
 
-    def _handle_file_write(self, input: Table) -> Table:
+    def _handle_file_write(self, input: MicroPartition) -> MicroPartition:
         if self.file_format == FileFormat.Parquet:
             file_names = table_io.write_parquet(
                 input,
@@ -453,7 +453,7 @@ class WriteFile(SingleOutputInstruction):
             )
 
         assert len(self.schema) == 1
-        return Table.from_pydict(
+        return MicroPartition.from_pydict(
             {
                 self.schema.column_names()[0]: file_names,
             }
@@ -464,10 +464,10 @@ class WriteFile(SingleOutputInstruction):
 class Filter(SingleOutputInstruction):
     predicate: ExpressionsProjection
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._filter(inputs)
 
-    def _filter(self, inputs: list[Table]) -> list[Table]:
+    def _filter(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         return [input.filter(self.predicate)]
 
@@ -485,10 +485,10 @@ class Filter(SingleOutputInstruction):
 class Project(SingleOutputInstruction):
     projection: ExpressionsProjection
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._project(inputs)
 
-    def _project(self, inputs: list[Table]) -> list[Table]:
+    def _project(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         return [input.eval_expression_list(self.projection)]
 
@@ -506,12 +506,12 @@ class Project(SingleOutputInstruction):
 class LocalCount(SingleOutputInstruction):
     schema: Schema
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._count(inputs)
 
-    def _count(self, inputs: list[Table]) -> list[Table]:
+    def _count(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
-        partition = Table.from_pydict({"count": [len(input)]})
+        partition = MicroPartition.from_pydict({"count": [len(input)]})
         assert partition.schema() == self.schema
         return [partition]
 
@@ -528,10 +528,10 @@ class LocalCount(SingleOutputInstruction):
 class LocalLimit(SingleOutputInstruction):
     limit: int
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._limit(inputs)
 
-    def _limit(self, inputs: list[Table]) -> list[Table]:
+    def _limit(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         return [input.head(self.limit)]
 
@@ -554,10 +554,10 @@ class GlobalLimit(LocalLimit):
 class MapPartition(SingleOutputInstruction):
     map_op: MapPartitionOp
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._map_partition(inputs)
 
-    def _map_partition(self, inputs: list[Table]) -> list[Table]:
+    def _map_partition(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         return [self.map_op.run(input)]
 
@@ -576,10 +576,10 @@ class Sample(SingleOutputInstruction):
     sort_by: ExpressionsProjection
     num_samples: int = 20
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._sample(inputs)
 
-    def _sample(self, inputs: list[Table]) -> list[Table]:
+    def _sample(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         result = (
             input.sample(self.num_samples)
@@ -603,10 +603,10 @@ class Aggregate(SingleOutputInstruction):
     to_agg: list[Expression]
     group_by: ExpressionsProjection | None
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._aggregate(inputs)
 
-    def _aggregate(self, inputs: list[Table]) -> list[Table]:
+    def _aggregate(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         return [input.agg(self.to_agg, self.group_by)]
 
@@ -626,10 +626,10 @@ class Join(SingleOutputInstruction):
     right_on: ExpressionsProjection
     how: JoinType
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._join(inputs)
 
-    def _join(self, inputs: list[Table]) -> list[Table]:
+    def _join(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [left, right] = inputs
         result = left.join(
             right,
@@ -655,11 +655,11 @@ class ReduceInstruction(SingleOutputInstruction):
 
 @dataclass(frozen=True)
 class ReduceMerge(ReduceInstruction):
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._reduce_merge(inputs)
 
-    def _reduce_merge(self, inputs: list[Table]) -> list[Table]:
-        return [Table.concat(inputs)]
+    def _reduce_merge(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
+        return [MicroPartition.concat(inputs)]
 
     def run_partial_metadata(self, input_metadatas: list[PartialPartitionMetadata]) -> list[PartialPartitionMetadata]:
         input_rows = [_.num_rows for _ in input_metadatas]
@@ -677,11 +677,11 @@ class ReduceMergeAndSort(ReduceInstruction):
     sort_by: ExpressionsProjection
     descending: list[bool]
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._reduce_merge_and_sort(inputs)
 
-    def _reduce_merge_and_sort(self, inputs: list[Table]) -> list[Table]:
-        partition = Table.concat(inputs).sort(self.sort_by, descending=self.descending)
+    def _reduce_merge_and_sort(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
+        partition = MicroPartition.concat(inputs).sort(self.sort_by, descending=self.descending)
         return [partition]
 
     def run_partial_metadata(self, input_metadatas: list[PartialPartitionMetadata]) -> list[PartialPartitionMetadata]:
@@ -701,11 +701,11 @@ class ReduceToQuantiles(ReduceInstruction):
     sort_by: ExpressionsProjection
     descending: list[bool]
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._reduce_to_quantiles(inputs)
 
-    def _reduce_to_quantiles(self, inputs: list[Table]) -> list[Table]:
-        merged = Table.concat(inputs)
+    def _reduce_to_quantiles(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
+        merged = MicroPartition.concat(inputs)
 
         # Skip evaluation of expressions by converting to Column Expression, since evaluation was done in Sample
         merged_sorted = merged.sort(self.sort_by.to_column_expressions(), descending=self.descending)
@@ -744,10 +744,10 @@ class FanoutInstruction(Instruction):
 class FanoutRandom(FanoutInstruction):
     seed: int
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._fanout_random(inputs)
 
-    def _fanout_random(self, inputs: list[Table]) -> list[Table]:
+    def _fanout_random(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         return input.partition_by_random(num_partitions=self._num_outputs, seed=self.seed)
 
@@ -756,10 +756,10 @@ class FanoutRandom(FanoutInstruction):
 class FanoutHash(FanoutInstruction):
     partition_by: ExpressionsProjection
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._fanout_hash(inputs)
 
-    def _fanout_hash(self, inputs: list[Table]) -> list[Table]:
+    def _fanout_hash(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         return input.partition_by_hash(self.partition_by, num_partitions=self._num_outputs)
 
@@ -769,23 +769,23 @@ class FanoutRange(FanoutInstruction, Generic[PartitionT]):
     sort_by: ExpressionsProjection
     descending: list[bool]
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._fanout_range(inputs)
 
-    def _fanout_range(self, inputs: list[Table]) -> list[Table]:
+    def _fanout_range(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [boundaries, input] = inputs
         if self._num_outputs == 1:
             return [input]
 
-        boundaries = boundaries.to_table()
-        partitioned_tables = input.partition_by_range(self.sort_by, boundaries, self.descending)
+        table_boundaries = boundaries.to_table()
+        partitioned_tables = input.partition_by_range(self.sort_by, table_boundaries, self.descending)
 
         # Pad the partitioned_tables with empty tables if fewer than self._num_outputs were returned
         # This can happen when all values are null or empty, which leads to an empty `boundaries` input
         assert len(partitioned_tables) >= 1, "Should have at least one returned table"
         schema = partitioned_tables[0].schema()
         partitioned_tables = partitioned_tables + [
-            Table.empty(schema=schema) for _ in range(self._num_outputs - len(partitioned_tables))
+            MicroPartition.empty(schema=schema) for _ in range(self._num_outputs - len(partitioned_tables))
         ]
 
         return partitioned_tables
@@ -795,10 +795,10 @@ class FanoutRange(FanoutInstruction, Generic[PartitionT]):
 class FanoutSlices(FanoutInstruction):
     slices: list[tuple[int, int]]  # start inclusive, end exclusive
 
-    def run(self, inputs: list[Table]) -> list[Table]:
+    def run(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         return self._multislice(inputs)
 
-    def _multislice(self, inputs: list[Table]) -> list[Table]:
+    def _multislice(self, inputs: list[MicroPartition]) -> list[MicroPartition]:
         [input] = inputs
         results = []
 

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -19,7 +19,7 @@ from pyarrow.fs import FileSystem, LocalFileSystem, S3FileSystem
 from pyarrow.fs import _resolve_filesystem_and_path as pafs_resolve_filesystem_and_path
 
 from daft.daft import FileFormat, FileInfos, IOConfig, io_glob
-from daft.table import Table
+from daft.table import MicroPartition
 
 logger = logging.getLogger(__name__)
 
@@ -305,7 +305,7 @@ def glob_path_with_stats(
 
     # Set number of rows if available.
     if file_format is not None and file_format == FileFormat.Parquet:
-        parquet_statistics = Table.read_parquet_statistics(
+        parquet_statistics = MicroPartition.read_parquet_statistics(
             list(filepaths_to_infos.keys()),
             io_config=io_config,
         ).to_pydict()

--- a/daft/io/common.py
+++ b/daft/io/common.py
@@ -48,7 +48,7 @@ def _get_tabular_files_scan(
     ### FEATURE_FLAG: $DAFT_MICROPARTITIONS
     #
     # This environment variable will make Daft use the new "v2 scans" and MicroPartitions when building Daft logical plans
-    if os.getenv("DAFT_MICROPARTITIONS", "0") == "1":
+    if os.getenv("DAFT_MICROPARTITIONS", "1") == "1":
         scan_op: ScanOperatorHandle
         if isinstance(path, list):
             scan_op = ScanOperatorHandle.glob_scan(

--- a/daft/io/file_path.py
+++ b/daft/io/file_path.py
@@ -9,7 +9,7 @@ from daft.daft import IOConfig
 from daft.dataframe import DataFrame
 from daft.logical.builder import LogicalPlanBuilder
 from daft.runners.pyrunner import LocalPartitionSet
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 @PublicAPI
@@ -45,7 +45,7 @@ def from_glob_path(path: str, io_config: Optional[IOConfig] = None) -> DataFrame
     context = get_context()
     runner_io = context.runner().runner_io()
     file_infos = runner_io.glob_paths_details([path], io_config=io_config)
-    file_infos_table = Table._from_pytable(file_infos.to_table())
+    file_infos_table = MicroPartition._from_pytable(file_infos.to_table())
     partition = LocalPartitionSet({0: file_infos_table})
     cache_entry = context.runner().put_partition_set_into_cache(partition)
     builder = LogicalPlanBuilder.from_in_memory_scan(

--- a/daft/logical/map_partition_ops.py
+++ b/daft/logical/map_partition_ops.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 
 from daft.expressions import ExpressionsProjection
 from daft.logical.schema import Schema
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 class MapPartitionOp:
@@ -13,7 +13,7 @@ class MapPartitionOp:
         """Returns the output schema after running this MapPartitionOp"""
 
     @abstractmethod
-    def run(self, input_partition: Table) -> Table:
+    def run(self, input_partition: MicroPartition) -> MicroPartition:
         """Runs this MapPartitionOp on the supplied vPartition"""
 
 
@@ -39,5 +39,5 @@ class ExplodeOp(MapPartitionOp):
     def get_output_schema(self) -> Schema:
         return self.output_schema
 
-    def run(self, input_partition: Table) -> Table:
+    def run(self, input_partition: MicroPartition) -> MicroPartition:
         return input_partition.explode(self.explode_columns)

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -11,7 +11,7 @@ import pyarrow as pa
 
 from daft.datatype import TimeUnit
 from daft.logical.schema import Schema
-from daft.table import Table
+from daft.table import MicroPartition
 
 if sys.version_info < (3, 8):
     pass
@@ -82,7 +82,7 @@ class PartitionMetadata(PartialPartitionMetadata):
     size_bytes: int | None
 
     @classmethod
-    def from_table(cls, table: Table) -> PartitionMetadata:
+    def from_table(cls, table: MicroPartition) -> PartitionMetadata:
         return PartitionMetadata(
             num_rows=len(table),
             size_bytes=table.size_bytes(),
@@ -104,7 +104,7 @@ class MaterializedResult(Generic[PartitionT]):
         ...
 
     @abstractmethod
-    def vpartition(self) -> Table:
+    def vpartition(self) -> MicroPartition:
         """Get the vPartition of this result."""
         ...
 
@@ -127,7 +127,7 @@ class MaterializedResult(Generic[PartitionT]):
 
 
 class PartitionSet(Generic[PartitionT]):
-    def _get_merged_vpartition(self) -> Table:
+    def _get_merged_vpartition(self) -> MicroPartition:
         raise NotImplementedError()
 
     def to_pydict(self) -> dict[str, list[Any]]:

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -32,28 +32,28 @@ from daft.runners.partitioning import (
 from daft.runners.profiler import profiler
 from daft.runners.progress_bar import ProgressBar
 from daft.runners.runner import Runner
-from daft.table import Table
+from daft.table import MicroPartition
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass
-class LocalPartitionSet(PartitionSet[Table]):
-    _partitions: dict[PartID, Table]
+class LocalPartitionSet(PartitionSet[MicroPartition]):
+    _partitions: dict[PartID, MicroPartition]
 
-    def items(self) -> list[tuple[PartID, Table]]:
+    def items(self) -> list[tuple[PartID, MicroPartition]]:
         return sorted(self._partitions.items())
 
-    def _get_merged_vpartition(self) -> Table:
+    def _get_merged_vpartition(self) -> MicroPartition:
         ids_and_partitions = self.items()
         assert ids_and_partitions[0][0] == 0
         assert ids_and_partitions[-1][0] + 1 == len(ids_and_partitions)
-        return Table.concat([part for id, part in ids_and_partitions])
+        return MicroPartition.concat([part for id, part in ids_and_partitions])
 
-    def get_partition(self, idx: PartID) -> Table:
+    def get_partition(self, idx: PartID) -> MicroPartition:
         return self._partitions[idx]
 
-    def set_partition(self, idx: PartID, part: MaterializedResult[Table]) -> None:
+    def set_partition(self, idx: PartID, part: MaterializedResult[MicroPartition]) -> None:
         self._partitions[idx] = part.partition()
 
     def delete_partition(self, idx: PartID) -> None:
@@ -103,7 +103,7 @@ class PyRunnerIO(runner_io.RunnerIO):
         return runner_io.sample_schema(file_infos[0].file_path, file_format_config, storage_config)
 
 
-class PyRunner(Runner[Table]):
+class PyRunner(Runner[MicroPartition]):
     def __init__(self, use_thread_pool: bool | None) -> None:
         super().__init__()
         self._use_thread_pool: bool = use_thread_pool if use_thread_pool is not None else True
@@ -147,12 +147,14 @@ class PyRunner(Runner[Table]):
             results_gen = self._physical_plan_to_partitions(tasks)
             yield from results_gen
 
-    def run_iter_tables(self, builder: LogicalPlanBuilder, results_buffer_size: int | None = None) -> Iterator[Table]:
+    def run_iter_tables(
+        self, builder: LogicalPlanBuilder, results_buffer_size: int | None = None
+    ) -> Iterator[MicroPartition]:
         for result in self.run_iter(builder, results_buffer_size=results_buffer_size):
             yield result.partition()
 
     def _physical_plan_to_partitions(
-        self, plan: physical_plan.MaterializedPhysicalPlan[Table]
+        self, plan: physical_plan.MaterializedPhysicalPlan[MicroPartition]
     ) -> Iterator[PyMaterializedResult]:
         inflight_tasks: dict[str, PartitionTask] = dict()
         inflight_tasks_resources: dict[str, ResourceRequest] = dict()
@@ -269,7 +271,7 @@ class PyRunner(Runner[Table]):
         return all((cpus_okay, gpus_okay, memory_okay))
 
     @staticmethod
-    def build_partitions(instruction_stack: list[Instruction], *inputs: Table) -> list[Table]:
+    def build_partitions(instruction_stack: list[Instruction], *inputs: MicroPartition) -> list[MicroPartition]:
         partitions = list(inputs)
         for instruction in instruction_stack:
             partitions = instruction.run(partitions)
@@ -278,13 +280,13 @@ class PyRunner(Runner[Table]):
 
 
 @dataclass(frozen=True)
-class PyMaterializedResult(MaterializedResult[Table]):
-    _partition: Table
+class PyMaterializedResult(MaterializedResult[MicroPartition]):
+    _partition: MicroPartition
 
-    def partition(self) -> Table:
+    def partition(self) -> MicroPartition:
         return self._partition
 
-    def vpartition(self) -> Table:
+    def vpartition(self) -> MicroPartition:
         return self._partition
 
     def metadata(self) -> PartitionMetadata:
@@ -293,5 +295,5 @@ class PyMaterializedResult(MaterializedResult[Table]):
     def cancel(self) -> None:
         return None
 
-    def _noop(self, _: Table) -> None:
+    def _noop(self, _: MicroPartition) -> None:
         return None

--- a/daft/runners/runner.py
+++ b/daft/runners/runner.py
@@ -12,7 +12,7 @@ from daft.runners.partitioning import (
     PartitionT,
 )
 from daft.runners.runner_io import RunnerIO
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 class Runner(Generic[PartitionT]):
@@ -47,8 +47,10 @@ class Runner(Generic[PartitionT]):
         ...
 
     @abstractmethod
-    def run_iter_tables(self, builder: LogicalPlanBuilder, results_buffer_size: int | None = None) -> Iterator[Table]:
-        """Similar to run_iter(), but always dereference and yield Table objects.
+    def run_iter_tables(
+        self, builder: LogicalPlanBuilder, results_buffer_size: int | None = None
+    ) -> Iterator[MicroPartition]:
+        """Similar to run_iter(), but always dereference and yield MicroPartition objects.
 
         Args:
             builder: the builder for the LogicalPlan that is to be executed

--- a/daft/table/__init__.py
+++ b/daft/table/__init__.py
@@ -10,7 +10,7 @@ from .micropartition import MicroPartition as _MicroPartition  # isort:skip
 
 # Use $DAFT_MICROPARTITIONS envvar as a feature flag to turn on MicroPartitions
 LegacyTable = Table
-if os.getenv("DAFT_MICROPARTITIONS", "0") == "1":
+if os.getenv("DAFT_MICROPARTITIONS", "1") == "1":
     Table = _MicroPartition  # type: ignore
 
 

--- a/daft/table/__init__.py
+++ b/daft/table/__init__.py
@@ -2,19 +2,17 @@ from __future__ import annotations
 
 import os
 
-from .table import Table as _Table
-from .table import read_parquet_into_pyarrow, read_parquet_into_pyarrow_bulk
+from .table import Table, read_parquet_into_pyarrow, read_parquet_into_pyarrow_bulk
 
 # Need to import after `.table` due to circular dep issue otherwise
 from .micropartition import MicroPartition as _MicroPartition  # isort:skip
 
 
-LegacyTable = _Table
 MicroPartition = _MicroPartition
 
 # Use $DAFT_MICROPARTITIONS envvar as a feature flag to turn off MicroPartitions
 if os.getenv("DAFT_MICROPARTITIONS", "1") != "1":
-    MicroPartition = LegacyTable  # type: ignore
+    MicroPartition = Table  # type: ignore
 
 
-__all__ = ["MicroPartition", "LegacyTable", "read_parquet_into_pyarrow", "read_parquet_into_pyarrow_bulk"]
+__all__ = ["MicroPartition", "Table", "read_parquet_into_pyarrow", "read_parquet_into_pyarrow_bulk"]

--- a/daft/table/__init__.py
+++ b/daft/table/__init__.py
@@ -2,16 +2,19 @@ from __future__ import annotations
 
 import os
 
-from .table import Table, read_parquet_into_pyarrow, read_parquet_into_pyarrow_bulk
+from .table import Table as _Table
+from .table import read_parquet_into_pyarrow, read_parquet_into_pyarrow_bulk
 
 # Need to import after `.table` due to circular dep issue otherwise
 from .micropartition import MicroPartition as _MicroPartition  # isort:skip
 
 
-# Use $DAFT_MICROPARTITIONS envvar as a feature flag to turn on MicroPartitions
-LegacyTable = Table
-if os.getenv("DAFT_MICROPARTITIONS", "1") == "1":
-    Table = _MicroPartition  # type: ignore
+LegacyTable = _Table
+MicroPartition = _MicroPartition
+
+# Use $DAFT_MICROPARTITIONS envvar as a feature flag to turn off MicroPartitions
+if os.getenv("DAFT_MICROPARTITIONS", "1") != "1":
+    MicroPartition = LegacyTable  # type: ignore
 
 
-__all__ = ["Table", "LegacyTable", "read_parquet_into_pyarrow", "read_parquet_into_pyarrow_bulk"]
+__all__ = ["MicroPartition", "LegacyTable", "read_parquet_into_pyarrow", "read_parquet_into_pyarrow_bulk"]

--- a/daft/table/micropartition.py
+++ b/daft/table/micropartition.py
@@ -19,7 +19,7 @@ from daft.datatype import DataType, TimeUnit
 from daft.expressions import Expression, ExpressionsProjection
 from daft.logical.schema import Schema
 from daft.series import Series
-from daft.table import Table
+from daft.table.table import Table
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/daft/table/schema_inference.py
+++ b/daft/table/schema_inference.py
@@ -16,7 +16,7 @@ from daft.datatype import DataType
 from daft.filesystem import _resolve_paths_and_filesystem
 from daft.logical.schema import Schema
 from daft.runners.partitioning import TableParseCSVOptions
-from daft.table import Table
+from daft.table import MicroPartition
 from daft.table.table_io import FileInput, _open_stream
 
 
@@ -96,7 +96,7 @@ def from_json(
     with _open_stream(file, io_config) as f:
         table = pajson.read_json(f)
 
-    return Table.from_arrow(table).schema()
+    return MicroPartition.from_arrow(table).schema()
 
 
 def from_parquet(

--- a/daft/table/table_io.py
+++ b/daft/table/table_io.py
@@ -29,7 +29,7 @@ from daft.runners.partitioning import (
     TableParseParquetOptions,
     TableReadOptions,
 )
-from daft.table import Table
+from daft.table import MicroPartition
 
 FileInput = Union[pathlib.Path, str, IO[bytes]]
 
@@ -50,14 +50,14 @@ def _open_stream(
         yield file
 
 
-def _cast_table_to_schema(table: Table, read_options: TableReadOptions, schema: Schema) -> pa.Table:
-    """Performs a cast of a Daft Table to the requested Schema/Data. This is required because:
+def _cast_table_to_schema(table: MicroPartition, read_options: TableReadOptions, schema: Schema) -> pa.Table:
+    """Performs a cast of a Daft MicroPartition to the requested Schema/Data. This is required because:
 
     1. Data read from the datasource may have types that do not match the inferred global schema
     2. Data read from the datasource may have columns that are out-of-order with the inferred schema
     3. We may need only a subset of columns, or differently-ordered columns, in `read_options`
 
-    This helper function takes care of all that, ensuring that the resulting Table has all column types matching
+    This helper function takes care of all that, ensuring that the resulting MicroPartition has all column types matching
     their corresponding dtype in `schema`, and column ordering/inclusion matches `read_options.column_names` (if provided).
     """
     pruned_schema = schema
@@ -75,8 +75,8 @@ def read_json(
     schema: Schema,
     storage_config: StorageConfig | None = None,
     read_options: TableReadOptions = TableReadOptions(),
-) -> Table:
-    """Reads a Table from a JSON file
+) -> MicroPartition:
+    """Reads a MicroPartition from a JSON file
 
     Args:
         file (str | IO): either a file-like object or a string file path (potentially prefixed with a protocol such as "s3://")
@@ -85,7 +85,7 @@ def read_json(
         read_options (TableReadOptions, optional): Options for reading the file
 
     Returns:
-        Table: Parsed Table from JSON
+        MicroPartition: Parsed MicroPartition from JSON
     """
     io_config = None
     if storage_config is not None:
@@ -103,7 +103,7 @@ def read_json(
     if read_options.num_rows is not None:
         table = table[: read_options.num_rows]
 
-    return _cast_table_to_schema(Table.from_arrow(table), read_options=read_options, schema=schema)
+    return _cast_table_to_schema(MicroPartition.from_arrow(table), read_options=read_options, schema=schema)
 
 
 def read_parquet(
@@ -112,8 +112,8 @@ def read_parquet(
     storage_config: StorageConfig | None = None,
     read_options: TableReadOptions = TableReadOptions(),
     parquet_options: TableParseParquetOptions = TableParseParquetOptions(),
-) -> Table:
-    """Reads a Table from a Parquet file
+) -> MicroPartition:
+    """Reads a MicroPartition from a Parquet file
 
     Args:
         file (str | IO): either a file-like object or a string file path (potentially prefixed with a protocol such as "s3://")
@@ -122,7 +122,7 @@ def read_parquet(
         read_options (TableReadOptions, optional): Options for reading the file
 
     Returns:
-        Table: Parsed Table from Parquet
+        MicroPartition: Parsed MicroPartition from Parquet
     """
     io_config = None
     if storage_config is not None:
@@ -131,7 +131,7 @@ def read_parquet(
             assert isinstance(
                 file, (str, pathlib.Path)
             ), "Native downloader only works on string inputs to read_parquet"
-            tbl = Table.read_parquet(
+            tbl = MicroPartition.read_parquet(
                 str(file),
                 columns=read_options.column_names,
                 num_rows=read_options.num_rows,
@@ -178,7 +178,7 @@ def read_parquet(
             coerce_int96_timestamp_unit=str(parquet_options.coerce_int96_timestamp_unit),
         )
 
-    return _cast_table_to_schema(Table.from_arrow(table), read_options=read_options, schema=schema)
+    return _cast_table_to_schema(MicroPartition.from_arrow(table), read_options=read_options, schema=schema)
 
 
 class PACSVStreamHelper:
@@ -205,8 +205,8 @@ def read_csv(
     storage_config: StorageConfig | None = None,
     csv_options: TableParseCSVOptions = TableParseCSVOptions(),
     read_options: TableReadOptions = TableReadOptions(),
-) -> Table:
-    """Reads a Table from a CSV file
+) -> MicroPartition:
+    """Reads a MicroPartition from a CSV file
 
     Args:
         file (str | IO): either a file-like object or a string file path (potentially prefixed with a protocol such as "s3://")
@@ -217,7 +217,7 @@ def read_csv(
         read_options (TableReadOptions, optional): Options for reading the file
 
     Returns:
-        Table: Parsed Table from CSV
+        MicroPartition: Parsed MicroPartition from CSV
     """
     io_config = None
     if storage_config is not None:
@@ -242,7 +242,7 @@ def read_csv(
                 comment=csv_options.comment,
             )
             csv_read_options = CsvReadOptions(buffer_size=csv_options.buffer_size, chunk_size=csv_options.chunk_size)
-            tbl = Table.read_csv(
+            tbl = MicroPartition.read_csv(
                 str(file),
                 convert_options=csv_convert_options,
                 parse_options=csv_parse_options,
@@ -308,18 +308,18 @@ def read_csv(
             if pa_schema is None:
                 pa_schema = pa.schema([])
 
-            daft_table = Table.from_arrow_record_batches(pa_batches, pa_schema)
+            daft_table = MicroPartition.from_arrow_record_batches(pa_batches, pa_schema)
             assert len(daft_table) <= read_options.num_rows
 
         else:
             pa_table = pacsv_stream.read_all()
-            daft_table = Table.from_arrow(pa_table)
+            daft_table = MicroPartition.from_arrow(pa_table)
 
     return _cast_table_to_schema(daft_table, read_options=read_options, schema=schema)
 
 
 def write_csv(
-    table: Table,
+    table: MicroPartition,
     path: str | pathlib.Path,
     compression: str | None = None,
     partition_cols: ExpressionsProjection | None = None,
@@ -336,7 +336,7 @@ def write_csv(
 
 
 def write_parquet(
-    table: Table,
+    table: MicroPartition,
     path: str | pathlib.Path,
     compression: str | None = None,
     partition_cols: ExpressionsProjection | None = None,
@@ -353,7 +353,7 @@ def write_parquet(
 
 
 def _to_file(
-    table: Table,
+    table: MicroPartition,
     file_format: str,
     path: str | pathlib.Path,
     partition_cols: ExpressionsProjection | None = None,

--- a/tests/benchmarks/test_filter.py
+++ b/tests/benchmarks/test_filter.py
@@ -4,6 +4,7 @@ import pytest
 
 import daft
 from daft import DataFrame
+from daft.table import MicroPartition
 
 NUM_ROWS = 1_000_000
 
@@ -123,7 +124,7 @@ def generate_list_int64_keep_none() -> tuple[dict, daft.Expression, list]:
 def test_filter(test_data_generator, benchmark) -> None:
     """If_else between NUM_ROWS values"""
     data, expected = test_data_generator()
-    table = daft.table.Table.from_pydict(data)
+    table = MicroPartition.from_pydict(data)
 
     def bench_filter() -> DataFrame:
         return table.filter([daft.col("mask")])

--- a/tests/benchmarks/test_if_else.py
+++ b/tests/benchmarks/test_if_else.py
@@ -6,6 +6,7 @@ import pytest
 
 import daft
 from daft import DataFrame
+from daft.table import MicroPartition
 
 NUM_ROWS = 1_000_000
 
@@ -110,7 +111,7 @@ def generate_list_params() -> tuple[dict, daft.Expression, list]:
 def test_if_else(test_data_generator, benchmark) -> None:
     """If_else between NUM_ROWS values"""
     data, expr, expected = test_data_generator()
-    table = daft.table.Table.from_pydict(data)
+    table = MicroPartition.from_pydict(data)
 
     def bench_if_else() -> DataFrame:
         return table.eval_expression_list([expr.alias("result")])

--- a/tests/benchmarks/test_take.py
+++ b/tests/benchmarks/test_take.py
@@ -4,6 +4,7 @@ import pytest
 
 import daft
 from daft import DataFrame, Series
+from daft.table import MicroPartition
 
 NUM_ROWS = 10_000_000
 
@@ -97,7 +98,7 @@ def generate_list_int64_take_reversed() -> tuple[dict, daft.Expression, list]:
 def test_take(test_data_generator, benchmark) -> None:
     """If_else between NUM_ROWS values"""
     data, idx, expected = test_data_generator()
-    table = daft.table.Table.from_pydict(data)
+    table = MicroPartition.from_pydict(data)
 
     def bench_take() -> DataFrame:
         return table.take(idx)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pyarrow as pa
 import pytest
 
 import daft
+from daft.table import MicroPartition
 
 
 def pytest_configure(config):
@@ -78,7 +79,7 @@ def make_df(request, tmp_path) -> daft.Dataframe:
             import pyarrow.parquet as papq
 
             name = str(uuid.uuid4())
-            daft_table = daft.table.Table.from_arrow(pa_table)
+            daft_table = MicroPartition.from_arrow(pa_table)
             partitioned_tables = (
                 daft_table.partition_by_random(repartition, 0)
                 if len(repartition_columns) == 0

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -401,7 +401,7 @@ def test_create_dataframe_csv_generate_headers(valid_data: list[dict[str, float]
 
         cnames = (
             [f"column_{i}" for i in range(1, 6)]
-            if use_native_downloader or os.environ.get("DAFT_MICROPARTITIONS", "0") == "1"
+            if use_native_downloader or os.environ.get("DAFT_MICROPARTITIONS", "1") == "1"
             else [f"f{i}" for i in range(5)]
         )
         df = daft.read_csv(fname, has_headers=False, use_native_downloader=use_native_downloader)

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -9,7 +9,7 @@ import pytz
 from daft.datatype import DataType, TimeUnit
 from daft.expressions import col, lit
 from daft.expressions.testing import expr_structurally_equal
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 @pytest.mark.parametrize(
@@ -31,7 +31,7 @@ from daft.table import Table
 def test_make_lit(data, expected_dtype) -> None:
     l = lit(data)
     assert l.name() == "literal"
-    empty_table = Table.empty()
+    empty_table = MicroPartition.empty()
     lit_table = empty_table.eval_expression_list([l])
     series = lit_table.get_column("literal")
     assert series.datatype() == expected_dtype

--- a/tests/expressions/test_expressions_projection.py
+++ b/tests/expressions/test_expressions_projection.py
@@ -4,7 +4,7 @@ import pytest
 
 from daft.expressions import Expression, ExpressionsProjection, col
 from daft.expressions.testing import expr_structurally_equal
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 def test_expressions_projection_error_dup_name():
@@ -156,7 +156,7 @@ def test_expressions_projection_indexing():
 
 
 def test_resolve_schema():
-    tbl = Table.from_pydict(
+    tbl = MicroPartition.from_pydict(
         {
             "foo": [1, 2, 3],
         }
@@ -167,7 +167,7 @@ def test_resolve_schema():
 
 
 def test_resolve_schema_invalid_type():
-    tbl = Table.from_pydict(
+    tbl = MicroPartition.from_pydict(
         {
             "foo": ["a", "b", "c"],
         }
@@ -178,7 +178,7 @@ def test_resolve_schema_invalid_type():
 
 
 def test_resolve_schema_missing_col():
-    tbl = Table.from_pydict(
+    tbl = MicroPartition.from_pydict(
         {
             "foo": ["a", "b", "c"],
         }

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -8,12 +8,12 @@ from daft.datatype import DataType
 from daft.expressions import Expression
 from daft.expressions.testing import expr_structurally_equal
 from daft.series import Series
-from daft.table import Table
+from daft.table import MicroPartition
 from daft.udf import udf
 
 
 def test_udf():
-    table = Table.from_pydict({"a": ["foo", "bar", "baz"]})
+    table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
     @udf(return_dtype=DataType.string())
     def repeat_n(data, n):
@@ -29,7 +29,7 @@ def test_udf():
 
 
 def test_class_udf():
-    table = Table.from_pydict({"a": ["foo", "bar", "baz"]})
+    table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
     @udf(return_dtype=DataType.string())
     class RepeatN:
@@ -49,7 +49,7 @@ def test_class_udf():
 
 
 def test_udf_kwargs():
-    table = Table.from_pydict({"a": ["foo", "bar", "baz"]})
+    table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
     @udf(return_dtype=DataType.string())
     def repeat_n(*, data=None, n=2):
@@ -66,7 +66,7 @@ def test_udf_kwargs():
 
 @pytest.mark.parametrize("container", [Series, list, np.ndarray])
 def test_udf_return_containers(container):
-    table = Table.from_pydict({"a": ["foo", "bar", "baz"]})
+    table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
     @udf(return_dtype=DataType.string())
     def identity(data):
@@ -84,7 +84,7 @@ def test_udf_return_containers(container):
 
 
 def test_udf_error():
-    table = Table.from_pydict({"a": ["foo", "bar", "baz"]})
+    table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
     @udf(return_dtype=DataType.string())
     def throw_value_err(x):
@@ -122,7 +122,7 @@ def test_full_udf_call():
 
 
 def test_class_udf_initialization_error():
-    table = Table.from_pydict({"a": ["foo", "bar", "baz"]})
+    table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
     @udf(return_dtype=DataType.string())
     class IdentityWithInitError:
@@ -152,7 +152,7 @@ def test_udf_return_tensor():
         return [np.ones((3, 3)) * i for i in x.to_pylist()]
 
     expr = np_udf(col("x"))
-    table = Table.from_pydict({"x": [0, 1, 2]})
+    table = MicroPartition.from_pydict({"x": [0, 1, 2]})
     result = table.eval_expression_list([expr])
     assert len(result.to_pydict()["x"]) == 3
     for i in range(3):

--- a/tests/expressions/typing/conftest.py
+++ b/tests/expressions/typing/conftest.py
@@ -16,7 +16,7 @@ import pytest
 from daft.datatype import DataType
 from daft.expressions import Expression, ExpressionsProjection
 from daft.series import Series
-from daft.table import Table
+from daft.table import MicroPartition
 
 ALL_DTYPES = [
     (DataType.int8(), pa.array([1, 2, None], type=pa.int8())),
@@ -93,11 +93,11 @@ def assert_typing_resolve_vs_runtime_behavior(
 
     Args:
         data: data to test against (generated using one of the provided fixtures, `{unary, binary}_data_fixture`)
-        expr (Expression): Expression used to run the kernel in a Table (use `.name()` of the generated data to refer to columns)
+        expr (Expression): Expression used to run the kernel in a MicroPartition (use `.name()` of the generated data to refer to columns)
         run_kernel (Callable): A lambda that will run the kernel directly on the generated Series' without going through the Expressions API
         resolvable (bool): Whether this kernel should be valid, given the datatypes of the generated Series'
     """
-    table = Table.from_pydict({s.name(): s for s in data})
+    table = MicroPartition.from_pydict({s.name(): s for s in data})
     projection = ExpressionsProjection([expr.alias("result")])
     if resolvable:
         # Check that schema resolution and Series runtime return the same datatype

--- a/tests/integration/io/parquet/test_reads_local_fixtures.py
+++ b/tests/integration/io/parquet/test_reads_local_fixtures.py
@@ -4,7 +4,7 @@ import uuid
 
 import pytest
 
-from daft.table import Table
+from daft.table import MicroPartition
 
 BUCKETS = ["head-retries-parquet-bucket", "get-retries-parquet-bucket"]
 
@@ -16,7 +16,7 @@ def test_non_retryable_errors(retry_server_s3_config, status_code: tuple[int, st
     status_code, status_code_str = status_code
     data_path = f"s3://{bucket}/{status_code}/{status_code_str}/1/{uuid.uuid4()}"
     with pytest.raises((FileNotFoundError, ValueError)):
-        Table.read_parquet(data_path, io_config=retry_server_s3_config)
+        MicroPartition.read_parquet(data_path, io_config=retry_server_s3_config)
 
 
 @pytest.mark.integration()
@@ -48,4 +48,4 @@ def test_retryable_errors(retry_server_s3_config, status_code: tuple[int, str], 
     status_code, status_code_str = status_code
     data_path = f"s3://{bucket}/{status_code}/{status_code_str}/{NUM_ERRORS}/{uuid.uuid4()}"
 
-    Table.read_parquet(data_path, io_config=retry_server_s3_config)
+    MicroPartition.read_parquet(data_path, io_config=retry_server_s3_config)

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -8,7 +8,7 @@ from pyarrow import parquet as pq
 
 import daft
 from daft.filesystem import get_filesystem, get_protocol_from_path
-from daft.table import LegacyTable, MicroPartition
+from daft.table import MicroPartition, Table
 
 
 def get_filesystem_from_path(path: str, **kwargs) -> fsspec.AbstractFileSystem:
@@ -253,7 +253,7 @@ def test_parquet_read_table_bulk(parquet_file, public_storage_io_config, multith
     pa_read = MicroPartition.from_arrow(read_parquet_with_pyarrow(url))
 
     # Legacy Table returns a list[Table]
-    if MicroPartition == LegacyTable:
+    if MicroPartition == Table:
         for daft_native_read in daft_native_reads:
             assert daft_native_read.schema() == pa_read.schema()
             pd.testing.assert_frame_equal(daft_native_read.to_pandas(), pa_read.to_pandas())
@@ -337,7 +337,7 @@ def test_row_groups_selection_bulk(public_storage_io_config, multithreaded_io):
     url = ["s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet"] * 11
     row_groups = [list(range(10))] + [[i] for i in range(10)]
 
-    if MicroPartition == LegacyTable:
+    if MicroPartition == Table:
         first, *rest = MicroPartition.read_parquet_bulk(
             url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io, row_groups_per_path=row_groups
         )

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -8,7 +8,7 @@ from pyarrow import parquet as pq
 
 import daft
 from daft.filesystem import get_filesystem, get_protocol_from_path
-from daft.table import LegacyTable, Table
+from daft.table import LegacyTable, MicroPartition
 
 
 def get_filesystem_from_path(path: str, **kwargs) -> fsspec.AbstractFileSystem:
@@ -216,8 +216,10 @@ def read_parquet_with_pyarrow(path) -> pa.Table:
 )
 def test_parquet_read_table(parquet_file, public_storage_io_config, multithreaded_io):
     _, url = parquet_file
-    daft_native_read = Table.read_parquet(url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io)
-    pa_read = Table.from_arrow(read_parquet_with_pyarrow(url))
+    daft_native_read = MicroPartition.read_parquet(
+        url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io
+    )
+    pa_read = MicroPartition.from_arrow(read_parquet_with_pyarrow(url))
     assert daft_native_read.schema() == pa_read.schema()
     pd.testing.assert_frame_equal(daft_native_read.to_pandas(), pa_read.to_pandas())
 
@@ -245,20 +247,22 @@ def test_parquet_read_table_into_pyarrow(parquet_file, public_storage_io_config,
 )
 def test_parquet_read_table_bulk(parquet_file, public_storage_io_config, multithreaded_io):
     _, url = parquet_file
-    daft_native_reads = Table.read_parquet_bulk(
+    daft_native_reads = MicroPartition.read_parquet_bulk(
         [url] * 2, io_config=public_storage_io_config, multithreaded_io=multithreaded_io
     )
-    pa_read = Table.from_arrow(read_parquet_with_pyarrow(url))
+    pa_read = MicroPartition.from_arrow(read_parquet_with_pyarrow(url))
 
     # Legacy Table returns a list[Table]
-    if Table == LegacyTable:
+    if MicroPartition == LegacyTable:
         for daft_native_read in daft_native_reads:
             assert daft_native_read.schema() == pa_read.schema()
             pd.testing.assert_frame_equal(daft_native_read.to_pandas(), pa_read.to_pandas())
     # MicroPartitions returns a MicroPartition
     else:
         assert daft_native_reads.schema() == pa_read.schema()
-        pd.testing.assert_frame_equal(daft_native_reads.to_pandas(), Table.concat([pa_read, pa_read]).to_pandas())
+        pd.testing.assert_frame_equal(
+            daft_native_reads.to_pandas(), MicroPartition.concat([pa_read, pa_read]).to_pandas()
+        )
 
 
 @pytest.mark.integration()
@@ -282,7 +286,7 @@ def test_parquet_into_pyarrow_bulk(parquet_file, public_storage_io_config, multi
 def test_parquet_read_df(parquet_file, public_storage_io_config):
     _, url = parquet_file
     daft_native_read = daft.read_parquet(url, io_config=public_storage_io_config)
-    pa_read = Table.from_arrow(read_parquet_with_pyarrow(url))
+    pa_read = MicroPartition.from_arrow(read_parquet_with_pyarrow(url))
     assert daft_native_read.schema() == pa_read.schema()
     pd.testing.assert_frame_equal(daft_native_read.to_pandas(), pa_read.to_pandas())
 
@@ -294,21 +298,21 @@ def test_parquet_read_df(parquet_file, public_storage_io_config):
 )
 def test_row_groups_selection(public_storage_io_config, multithreaded_io):
     url = "s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet"
-    all_rows = Table.read_parquet(url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io)
+    all_rows = MicroPartition.read_parquet(url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io)
     assert len(all_rows) == 100
-    first = Table.read_parquet(
+    first = MicroPartition.read_parquet(
         url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io, row_groups=[0]
     )
     assert len(first) == 10
     assert all_rows.to_arrow()[:10] == first.to_arrow()
 
-    fifth = Table.read_parquet(
+    fifth = MicroPartition.read_parquet(
         url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io, row_groups=[5]
     )
     assert len(fifth) == 10
     assert all_rows.to_arrow()[50:60] == fifth.to_arrow()
 
-    repeated = Table.read_parquet(
+    repeated = MicroPartition.read_parquet(
         url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io, row_groups=[1, 1, 1]
     )
     assert len(repeated) == 30
@@ -316,7 +320,7 @@ def test_row_groups_selection(public_storage_io_config, multithreaded_io):
     assert all_rows.to_arrow()[10:20] == repeated.to_arrow()[10:20]
     assert all_rows.to_arrow()[10:20] == repeated.to_arrow()[20:]
 
-    out_of_order = Table.read_parquet(
+    out_of_order = MicroPartition.read_parquet(
         url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io, row_groups=[1, 0]
     )
     assert len(out_of_order) == 20
@@ -333,8 +337,8 @@ def test_row_groups_selection_bulk(public_storage_io_config, multithreaded_io):
     url = ["s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet"] * 11
     row_groups = [list(range(10))] + [[i] for i in range(10)]
 
-    if Table == LegacyTable:
-        first, *rest = Table.read_parquet_bulk(
+    if MicroPartition == LegacyTable:
+        first, *rest = MicroPartition.read_parquet_bulk(
             url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io, row_groups_per_path=row_groups
         )
         assert len(first) == 100
@@ -344,7 +348,7 @@ def test_row_groups_selection_bulk(public_storage_io_config, multithreaded_io):
             assert len(t) == 10
             assert first.to_arrow()[i * 10 : (i + 1) * 10] == t.to_arrow()
     else:
-        mp = Table.read_parquet_bulk(
+        mp = MicroPartition.read_parquet_bulk(
             url, io_config=public_storage_io_config, multithreaded_io=multithreaded_io, row_groups_per_path=row_groups
         )
         assert len(mp) == 100 + (

--- a/tests/integration/io/parquet/test_reads_s3_minio.py
+++ b/tests/integration/io/parquet/test_reads_s3_minio.py
@@ -38,7 +38,7 @@ def test_minio_parquet_read_no_files(minio_io_config):
 
         msg = (
             "Glob path had no matches:"
-            if os.getenv("DAFT_MICROPARTITIONS") == "1"
+            if os.getenv("DAFT_MICROPARTITIONS", "1") == "1"
             else "No files found at s3://data-engineering-prod/foo/\\*\\*.parquet"
         )
         with pytest.raises(FileNotFoundError, match=msg):

--- a/tests/table/image/test_crop.py
+++ b/tests/table/image/test_crop.py
@@ -5,7 +5,7 @@ import pyarrow as pa
 import pytest
 
 import daft
-from daft.table import Table
+from daft.table import MicroPartition
 
 MODES = ["L", "LA", "RGB", "RGBA"]
 MODE_TO_NP_DTYPE = {
@@ -79,7 +79,7 @@ def mixed_shape_data_fixture(request):
 
 
 def test_image_crop_mixed_shape_same_mode(mixed_shape_data_fixture):
-    table = Table.from_pydict({"images": mixed_shape_data_fixture})
+    table = MicroPartition.from_pydict({"images": mixed_shape_data_fixture})
     result = table.eval_expression_list([daft.col("images").image.crop((1, 1, 1, 1))])
     result = result.to_pydict()
 
@@ -93,7 +93,7 @@ def test_image_crop_mixed_shape_same_mode(mixed_shape_data_fixture):
 def test_image_crop_mixed_shape_same_mode_crop_col(mixed_shape_data_fixture):
     # TODO(jay): Need to fix nested casts -- for now we workaround by creating a nested uint32
     bboxes = pa.array([[1, 1, 1, 1], None, None], type=pa.list_(pa.uint32()))
-    table = Table.from_pydict(
+    table = MicroPartition.from_pydict(
         {
             "images": mixed_shape_data_fixture,
             "bboxes": bboxes,
@@ -110,7 +110,7 @@ def test_image_crop_mixed_shape_same_mode_crop_col(mixed_shape_data_fixture):
 
 
 def test_image_crop_fixed_shape_same_mode(fixed_shape_data_fixture):
-    table = Table.from_pydict({"images": fixed_shape_data_fixture})
+    table = MicroPartition.from_pydict({"images": fixed_shape_data_fixture})
     result = table.eval_expression_list([daft.col("images").image.crop((1, 1, 1, 1))])
     result = result.to_pydict()
 
@@ -124,7 +124,7 @@ def test_image_crop_fixed_shape_same_mode(fixed_shape_data_fixture):
 def test_image_crop_fixed_shape_same_mode_crop_col(fixed_shape_data_fixture):
     # TODO(jay): Need to fix nested casts -- for now we workaround by creating a nested uint32
     bboxes = pa.array([[1, 1, 1, 1], None, None], type=pa.list_(pa.uint32()))
-    table = Table.from_pydict(
+    table = MicroPartition.from_pydict(
         {
             "images": fixed_shape_data_fixture,
             "bboxes": bboxes,
@@ -141,7 +141,7 @@ def test_image_crop_fixed_shape_same_mode_crop_col(fixed_shape_data_fixture):
 
 
 def test_bad_expr_input():
-    table = Table.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+    table = MicroPartition.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
 
     # Test bad Expression calls
     with pytest.raises(ValueError):

--- a/tests/table/list/test_list_join.py
+++ b/tests/table/list/test_list_join.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 import pytest
 
 from daft.expressions import col
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 def test_list_join():
-    table = Table.from_pydict({"col": [None, [], ["a"], [None], ["a", "a"], ["a", None], ["a", None, "a"]]})
+    table = MicroPartition.from_pydict({"col": [None, [], ["a"], [None], ["a", "a"], ["a", None], ["a", None, "a"]]})
     result = table.eval_expression_list([col("col").list.join(",")])
     assert result.to_pydict() == {"col": [None, "", "a", "", "a,a", "a,", "a,,a"]}
 
 
 def test_list_join_other_col():
-    table = Table.from_pydict(
+    table = MicroPartition.from_pydict(
         {
             "col": [None, [], ["a"], [None], ["a", "a"], ["a", None], ["a", None, "a"]],
             "delimiter": ["1", "2", "3", "4", "5", "6", "7"],
@@ -24,10 +24,10 @@ def test_list_join_other_col():
 
 
 def test_list_join_bad_type():
-    table = Table.from_pydict({"col": [1, 2, 3]})
+    table = MicroPartition.from_pydict({"col": [1, 2, 3]})
     with pytest.raises(ValueError):
         table.eval_expression_list([col("col").list.join(",")])
 
-    table = Table.from_pydict({"col": [[1, 2, 3], [4, 5, 6], []]})
+    table = MicroPartition.from_pydict({"col": [[1, 2, 3], [4, 5, 6], []]})
     with pytest.raises(ValueError):
         table.eval_expression_list([col("col").list.join(",")])

--- a/tests/table/list/test_list_lengths.py
+++ b/tests/table/list/test_list_lengths.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from daft.expressions import col
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 def test_list_lengths():
-    table = Table.from_pydict({"col": [None, [], ["a"], [None], ["a", "a"], ["a", None], ["a", None, "a"]]})
+    table = MicroPartition.from_pydict({"col": [None, [], ["a"], [None], ["a", "a"], ["a", None], ["a", None, "a"]]})
     result = table.eval_expression_list([col("col").list.lengths()])
     assert result.to_pydict() == {"col": [None, 0, 1, 1, 2, 2, 3]}

--- a/tests/table/table_io/test_csv.py
+++ b/tests/table/table_io/test_csv.py
@@ -14,7 +14,7 @@ from daft.datatype import DataType
 from daft.logical.schema import Schema
 from daft.runners.partitioning import TableParseCSVOptions, TableReadOptions
 from daft.series import ARROW_VERSION
-from daft.table import Table, schema_inference, table_io
+from daft.table import MicroPartition, schema_inference, table_io
 
 
 def storage_config_from_use_native_downloader(use_native_downloader: bool) -> StorageConfig:
@@ -143,7 +143,7 @@ def test_csv_read_data(data, expected_data_series, use_native_downloader):
         schema = Schema._from_field_name_and_types(
             [("id", DataType.int64()), ("data", expected_data_series.datatype())]
         )
-        expected = Table.from_pydict(
+        expected = MicroPartition.from_pydict(
             {
                 "id": [1, 2, 3],
                 "data": expected_data_series,
@@ -166,7 +166,7 @@ def test_csv_read_data_csv_limit_rows(use_native_downloader):
         storage_config = storage_config_from_use_native_downloader(use_native_downloader)
 
         schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", DataType.int64())])
-        expected = Table.from_pydict(
+        expected = MicroPartition.from_pydict(
             {
                 "id": [1, 2],
                 "data": [1, 2],
@@ -194,7 +194,7 @@ def test_csv_read_data_csv_select_columns(use_native_downloader):
         storage_config = storage_config_from_use_native_downloader(use_native_downloader)
 
         schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", DataType.int64())])
-        expected = Table.from_pydict(
+        expected = MicroPartition.from_pydict(
             {
                 "data": [1, 2, None],
             }
@@ -222,7 +222,7 @@ def test_csv_read_data_csv_custom_delimiter(use_native_downloader):
         storage_config = storage_config_from_use_native_downloader(use_native_downloader)
 
         schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", DataType.int64())])
-        expected = Table.from_pydict(
+        expected = MicroPartition.from_pydict(
             {
                 "id": [1, 2, 3],
                 "data": [1, 2, None],
@@ -250,7 +250,7 @@ def test_csv_read_data_csv_no_header(use_native_downloader):
         storage_config = storage_config_from_use_native_downloader(use_native_downloader)
 
         schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", DataType.int64())])
-        expected = Table.from_pydict(
+        expected = MicroPartition.from_pydict(
             {
                 "id": [1, 2, 3],
                 "data": [1, 2, None],
@@ -279,7 +279,7 @@ def test_csv_read_data_csv_custom_quote(use_native_downloader):
         storage_config = storage_config_from_use_native_downloader(use_native_downloader)
 
         schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", DataType.string())])
-        expected = Table.from_pydict(
+        expected = MicroPartition.from_pydict(
             {
                 "id": [1, 2, 3],
                 "data": ["aa", "aa", "aa"],
@@ -313,7 +313,7 @@ def test_csv_read_data_custom_escape(use_native_downloader):
         storage_config = storage_config_from_use_native_downloader(use_native_downloader)
 
         schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", DataType.string())])
-        expected = Table.from_pydict(
+        expected = MicroPartition.from_pydict(
             {
                 "id": [1, 2, 3],
                 "data": ['a"a"a', "aa", "aa"],
@@ -345,7 +345,7 @@ def test_csv_read_data_custom_comment(use_native_downloader):
         storage_config = storage_config_from_use_native_downloader(use_native_downloader)
 
         schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", DataType.string())])
-        expected = Table.from_pydict(
+        expected = MicroPartition.from_pydict(
             {
                 "id": [1, 3],
                 "data": ["aa", "aa"],

--- a/tests/table/table_io/test_json.py
+++ b/tests/table/table_io/test_json.py
@@ -11,7 +11,7 @@ import daft
 from daft.datatype import DataType
 from daft.logical.schema import Schema
 from daft.runners.partitioning import TableReadOptions
-from daft.table import Table, schema_inference, table_io
+from daft.table import MicroPartition, schema_inference, table_io
 
 
 def test_read_input(tmpdir):
@@ -94,7 +94,7 @@ def test_json_read_data(data, expected_data_series):
     )
 
     schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", expected_data_series.datatype())])
-    expected = Table.from_pydict(
+    expected = MicroPartition.from_pydict(
         {
             "id": [1, 2, 3],
             "data": expected_data_series,
@@ -113,7 +113,7 @@ def test_json_read_data_limit_rows():
     )
 
     schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", DataType.int64())])
-    expected = Table.from_pydict(
+    expected = MicroPartition.from_pydict(
         {
             "id": [1, 2],
             "data": [1, 2],
@@ -132,7 +132,7 @@ def test_json_read_data_select_columns():
     )
 
     schema = Schema._from_field_name_and_types([("id", DataType.int64()), ("data", DataType.int64())])
-    expected = Table.from_pydict(
+    expected = MicroPartition.from_pydict(
         {
             "data": [1, 2, None],
         }

--- a/tests/table/table_io/test_read_time_cast.py
+++ b/tests/table/table_io/test_read_time_cast.py
@@ -6,7 +6,7 @@ import pytest
 import daft
 from daft import DataType
 from daft.logical.schema import Schema
-from daft.table import Table, table_io
+from daft.table import MicroPartition, table_io
 from tests.table.table_io.test_parquet import _parquet_write_helper
 
 
@@ -17,26 +17,28 @@ from tests.table.table_io.test_parquet import _parquet_write_helper
         (
             pa.Table.from_pydict({"foo": pa.array([1, 2, 3], type=pa.int64())}),
             Schema._from_field_name_and_types([("foo", DataType.int8())]),
-            Table.from_pydict({"foo": daft.Series.from_arrow(pa.array([1, 2, 3], type=pa.int8()))}),
+            MicroPartition.from_pydict({"foo": daft.Series.from_arrow(pa.array([1, 2, 3], type=pa.int8()))}),
         ),
         # Test what happens if a cast should occur, but fails at runtime (in this case, a potentially bad cast from utf8->int64)
         (
             pa.Table.from_pydict({"foo": pa.array(["1", "2", "FAIL"], type=pa.string())}),
             Schema._from_field_name_and_types([("foo", DataType.int64())]),
             # NOTE: cast failures will become a Null value
-            Table.from_pydict({"foo": daft.Series.from_arrow(pa.array([1, 2, None], type=pa.int64()))}),
+            MicroPartition.from_pydict({"foo": daft.Series.from_arrow(pa.array([1, 2, None], type=pa.int64()))}),
         ),
         # Test reordering of columns
         (
             pa.Table.from_pydict({"foo": pa.array([1, 2, 3]), "bar": pa.array([1, 2, 3])}),
             Schema._from_field_name_and_types([("bar", DataType.int64()), ("foo", DataType.int64())]),
-            Table.from_pydict({"bar": pa.array([1, 2, 3]), "foo": pa.array([1, 2, 3])}),
+            MicroPartition.from_pydict({"bar": pa.array([1, 2, 3]), "foo": pa.array([1, 2, 3])}),
         ),
         # Test automatic insertion of null values for missing column
         (
             pa.Table.from_pydict({"foo": pa.array([1, 2, 3])}),
             Schema._from_field_name_and_types([("bar", DataType.int64()), ("foo", DataType.int64())]),
-            Table.from_pydict({"bar": pa.array([None, None, None], type=pa.int64()), "foo": pa.array([1, 2, 3])}),
+            MicroPartition.from_pydict(
+                {"bar": pa.array([None, None, None], type=pa.int64()), "foo": pa.array([1, 2, 3])}
+            ),
         ),
     ],
 )

--- a/tests/table/test_blackbox_kernels.py
+++ b/tests/table/test_blackbox_kernels.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from daft.expressions import col
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 def test_pyobjects_blackbox_kernels() -> None:
     objects = [object(), None, object()]
-    table = Table.from_pydict({"keys": [0, 1, 2], "objs": objects})
+    table = MicroPartition.from_pydict({"keys": [0, 1, 2], "objs": objects})
     # Head.
     assert table.head(2).to_pydict()["objs"] == objects[:2]
     # Filter.
@@ -16,7 +16,7 @@ def test_pyobjects_blackbox_kernels() -> None:
 def test_nested_blackbox_kernels() -> None:
     structs = [{"a": 1, "b": 2}, None, {"a": 3}]
     lists = [[1, 2], None, [3]]
-    table = Table.from_pydict({"keys": [0, 1, 2], "structs": structs, "lists": lists})
+    table = MicroPartition.from_pydict({"keys": [0, 1, 2], "structs": structs, "lists": lists})
     # pyarrow fills in implicit field-internal Nones on a .to_pylist() conversion.
     structs[2]["b"] = None
     # Head.

--- a/tests/table/test_broadcasts.py
+++ b/tests/table/test_broadcasts.py
@@ -4,19 +4,19 @@ import pytest
 
 import daft
 from daft.expressions import col, lit
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 @pytest.mark.parametrize("data", [1, "a", True, b"Y", 0.5, None, [1, 2, 3], object()])
 def test_broadcast(data):
-    table = Table.from_pydict({"x": [1, 2, 3]})
+    table = MicroPartition.from_pydict({"x": [1, 2, 3]})
     new_table = table.eval_expression_list([col("x"), lit(data)])
     assert new_table.to_pydict() == {"x": [1, 2, 3], "literal": [data for _ in range(3)]}
 
 
 def test_broadcast_fixed_size_list():
     data = [1, 2, 3]
-    table = Table.from_pydict({"x": [1, 2, 3]})
+    table = MicroPartition.from_pydict({"x": [1, 2, 3]})
     new_table = table.eval_expression_list(
         [col("x"), lit(data).cast(daft.DataType.fixed_size_list(daft.DataType.int64(), 3))]
     )

--- a/tests/table/test_concat.py
+++ b/tests/table/test_concat.py
@@ -2,67 +2,67 @@ from __future__ import annotations
 
 import pytest
 
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 def test_table_concat() -> None:
     objs1 = [None, object(), object()]
     objs2 = [object(), None, object()]
     tables = [
-        Table.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"], "z": objs1}),
-        Table.from_pydict({"x": [4, 5, 6], "y": ["d", "e", "f"], "z": objs2}),
+        MicroPartition.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"], "z": objs1}),
+        MicroPartition.from_pydict({"x": [4, 5, 6], "y": ["d", "e", "f"], "z": objs2}),
     ]
 
-    result = Table.concat(tables)
+    result = MicroPartition.concat(tables)
     assert result.to_pydict() == {"x": [1, 2, 3, 4, 5, 6], "y": ["a", "b", "c", "d", "e", "f"], "z": objs1 + objs2}
 
     tables = [
-        Table.from_pydict({"x": [], "y": []}),
-        Table.from_pydict({"x": [], "y": []}),
+        MicroPartition.from_pydict({"x": [], "y": []}),
+        MicroPartition.from_pydict({"x": [], "y": []}),
     ]
 
-    result = Table.concat(tables)
+    result = MicroPartition.concat(tables)
     assert result.to_pydict() == {"x": [], "y": []}
 
 
 def test_table_concat_bad_input() -> None:
-    mix_types_table = [Table.from_pydict({"x": [1, 2, 3]}), []]
-    with pytest.raises(TypeError, match=f"Expected a {Table.__name__} for concat"):
-        Table.concat(mix_types_table)
+    mix_types_table = [MicroPartition.from_pydict({"x": [1, 2, 3]}), []]
+    with pytest.raises(TypeError, match=f"Expected a {MicroPartition.__name__} for concat"):
+        MicroPartition.concat(mix_types_table)
 
-    with pytest.raises(ValueError, match=f"Need at least 1 {Table.__name__}"):
-        Table.concat([])
+    with pytest.raises(ValueError, match=f"Need at least 1 {MicroPartition.__name__}"):
+        MicroPartition.concat([])
 
 
 def test_table_concat_schema_mismatch() -> None:
     mix_types_table = [
-        Table.from_pydict({"x": [1, 2, 3]}),
-        Table.from_pydict({"y": [1, 2, 3]}),
+        MicroPartition.from_pydict({"x": [1, 2, 3]}),
+        MicroPartition.from_pydict({"y": [1, 2, 3]}),
     ]
 
-    with pytest.raises(ValueError, match=f"{Table.__name__} concat requires all schemas to match"):
-        Table.concat(mix_types_table)
+    with pytest.raises(ValueError, match=f"{MicroPartition.__name__} concat requires all schemas to match"):
+        MicroPartition.concat(mix_types_table)
 
     mix_types_table = [
-        Table.from_pydict({"x": [1, 2, 3]}),
-        Table.from_pydict({"x": [1.0, 2.0, 3.0]}),
+        MicroPartition.from_pydict({"x": [1, 2, 3]}),
+        MicroPartition.from_pydict({"x": [1.0, 2.0, 3.0]}),
     ]
 
-    with pytest.raises(ValueError, match=f"{Table.__name__} concat requires all schemas to match"):
-        Table.concat(mix_types_table)
+    with pytest.raises(ValueError, match=f"{MicroPartition.__name__} concat requires all schemas to match"):
+        MicroPartition.concat(mix_types_table)
 
     mix_types_table = [
-        Table.from_pydict({"x": [1, 2, 3]}),
-        Table.from_pydict({"x": [object(), object(), object()]}),
+        MicroPartition.from_pydict({"x": [1, 2, 3]}),
+        MicroPartition.from_pydict({"x": [object(), object(), object()]}),
     ]
 
-    with pytest.raises(ValueError, match=f"{Table.__name__} concat requires all schemas to match"):
-        Table.concat(mix_types_table)
+    with pytest.raises(ValueError, match=f"{MicroPartition.__name__} concat requires all schemas to match"):
+        MicroPartition.concat(mix_types_table)
 
     mix_types_table = [
-        Table.from_pydict({"x": [1, 2, 3]}),
-        Table.from_pydict({"x": [1, 2, 3], "y": [2, 3, 4]}),
+        MicroPartition.from_pydict({"x": [1, 2, 3]}),
+        MicroPartition.from_pydict({"x": [1, 2, 3], "y": [2, 3, 4]}),
     ]
 
-    with pytest.raises(ValueError, match=f"{Table.__name__} concat requires all schemas to match"):
-        Table.concat(mix_types_table)
+    with pytest.raises(ValueError, match=f"{MicroPartition.__name__} concat requires all schemas to match"):
+        MicroPartition.concat(mix_types_table)

--- a/tests/table/test_eval.py
+++ b/tests/table/test_eval.py
@@ -7,13 +7,13 @@ import pyarrow as pa
 import pytest
 
 from daft import DataType, col
-from daft.table import Table
+from daft.table import MicroPartition
 from tests.table import daft_numeric_types
 
 
 def test_table_eval_expressions() -> None:
     pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 
@@ -28,7 +28,7 @@ def test_table_eval_expressions() -> None:
 
 def test_table_eval_expressions_conflict() -> None:
     pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 
@@ -48,7 +48,7 @@ def test_table_eval_expressions_conflict() -> None:
 )
 def test_table_expr_not(input, expr, expected) -> None:
     """Test logical not expression."""
-    daft_table = Table.from_pydict({"input": input})
+    daft_table = MicroPartition.from_pydict({"input": input})
     daft_table = daft_table.eval_expression_list([expr])
     pydict = daft_table.to_pydict()
 
@@ -56,7 +56,7 @@ def test_table_expr_not(input, expr, expected) -> None:
 
 
 def test_table_expr_not_wrong() -> None:
-    daft_table = Table.from_pydict({"input": [None, 0, 1]})
+    daft_table = MicroPartition.from_pydict({"input": [None, 0, 1]})
 
     with pytest.raises(ValueError):
         daft_table = daft_table.eval_expression_list([~col("input")])
@@ -73,7 +73,7 @@ def test_table_expr_not_wrong() -> None:
 )
 def test_table_expr_is_null(input, expected) -> None:
     """Test logical not expression."""
-    daft_table = Table.from_pydict({"input": input})
+    daft_table = MicroPartition.from_pydict({"input": input})
     daft_table = daft_table.eval_expression_list([col("input").is_null()])
     pydict = daft_table.to_pydict()
 
@@ -89,7 +89,7 @@ def test_table_numeric_expressions(data_dtype, op) -> None:
     a, b = [5, 6, 7, 8], [1, 2, 3, 4]
     pa_table = pa.Table.from_pydict({"a": a, "b": b})
 
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     daft_table = daft_table.eval_expression_list(
         [op(col("a").cast(data_dtype), col("b").cast(data_dtype)).alias("result")]
     )
@@ -105,7 +105,7 @@ def test_table_numeric_expressions_with_nulls(data_dtype, op) -> None:
     a, b = [5, 6, None, 8, None], [1, 2, 3, None, None]
     pa_table = pa.Table.from_pydict({"a": a, "b": b})
 
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     daft_table = daft_table.eval_expression_list(
         [op(col("a").cast(data_dtype), col("b").cast(data_dtype)).alias("result")]
     )
@@ -119,7 +119,7 @@ def test_table_numeric_expressions_with_nulls(data_dtype, op) -> None:
 
 
 def test_table_numeric_abs() -> None:
-    table = Table.from_pydict({"a": [None, -1.0, 0, 2, 3, None], "b": [-1, -2, 3, 4, None, None]})
+    table = MicroPartition.from_pydict({"a": [None, -1.0, 0, 2, 3, None], "b": [-1, -2, 3, 4, None, None]})
 
     abs_table = table.eval_expression_list([abs(col("a")), col("b").abs()])
 
@@ -132,7 +132,7 @@ def test_table_numeric_abs() -> None:
 
 
 def test_table_abs_bad_input() -> None:
-    table = Table.from_pydict({"a": ["a", "b", "c"]})
+    table = MicroPartition.from_pydict({"a": ["a", "b", "c"]})
 
     with pytest.raises(ValueError, match="Expected input to abs to be numeric"):
         table.eval_expression_list([abs(col("a"))])

--- a/tests/table/test_explodes.py
+++ b/tests/table/test_explodes.py
@@ -5,7 +5,7 @@ import pytest
 
 from daft.expressions import col
 from daft.series import Series
-from daft.table import Table
+from daft.table import MicroPartition
 
 TEST_DATA = [
     Series.from_arrow(pa.array([[1, 2], [3, 4], None, []], type=pa.list_(pa.int64()))),
@@ -19,7 +19,7 @@ TEST_DATA = [
     TEST_DATA,
 )
 def test_explode(data):
-    table = Table.from_pydict({"nested": data, "sidecar": ["a", "b", "c", "d"]})
+    table = MicroPartition.from_pydict({"nested": data, "sidecar": ["a", "b", "c", "d"]})
     table = table.explode([col("nested")._explode()])
     assert table.column_names() == ["nested", "sidecar"]
     assert table.to_pydict() == {"nested": [1, 2, 3, 4, None, None], "sidecar": ["a", "a", "b", "b", "c", "d"]}
@@ -30,7 +30,7 @@ def test_explode(data):
     TEST_DATA,
 )
 def test_explode_flipped(data):
-    table = Table.from_pydict({"sidecar": ["a", "b", "c", "d"], "nested": data})
+    table = MicroPartition.from_pydict({"sidecar": ["a", "b", "c", "d"], "nested": data})
     table = table.explode([col("nested")._explode()])
     assert table.column_names() == ["sidecar", "nested"]
     assert table.to_pydict() == {"nested": [1, 2, 3, 4, None, None], "sidecar": ["a", "a", "b", "b", "c", "d"]}
@@ -41,7 +41,7 @@ def test_explode_flipped(data):
     TEST_DATA,
 )
 def test_explode_multiple_cols(data):
-    table = Table.from_pydict({"nested": data, "nested2": data, "sidecar": ["a", "b", "c", "d"]})
+    table = MicroPartition.from_pydict({"nested": data, "nested2": data, "sidecar": ["a", "b", "c", "d"]})
     table = table.explode([col("nested")._explode(), col("nested2")._explode()])
     assert table.column_names() == ["nested", "nested2", "sidecar"]
     assert table.to_pydict() == {
@@ -54,7 +54,7 @@ def test_explode_multiple_cols(data):
 def test_explode_multiple_cols_mixed_types():
     data1 = pa.array([[1, 2], [3, 4], None, None], type=pa.list_(pa.int64()))
     data2 = pa.array([[1, 2], [3, 4], None, None], type=pa.list_(pa.int64(), list_size=2))
-    table = Table.from_pydict({"nested": data1, "nested2": data2, "sidecar": ["a", "b", "c", "d"]})
+    table = MicroPartition.from_pydict({"nested": data1, "nested2": data2, "sidecar": ["a", "b", "c", "d"]})
     table = table.explode([col("nested")._explode(), col("nested2")._explode()])
     assert table.to_pydict() == {
         "nested": [1, 2, 3, 4, None, None],
@@ -64,7 +64,7 @@ def test_explode_multiple_cols_mixed_types():
 
 
 def test_explode_bad_multiple_cols():
-    table = Table.from_pydict(
+    table = MicroPartition.from_pydict(
         {
             "nested": [[1, 2, 3], [4], None, None],
             "nested2": [[1, 2], [3, 4], None, None],
@@ -80,7 +80,7 @@ def test_explode_bad_multiple_cols():
     TEST_DATA,
 )
 def test_explode_multiple_cols_with_alias(data):
-    table = Table.from_pydict({"nested": data, "nested2": data, "sidecar": ["a", "b", "c", "d"]})
+    table = MicroPartition.from_pydict({"nested": data, "nested2": data, "sidecar": ["a", "b", "c", "d"]})
     table = table.explode([col("nested").alias("nested3")._explode(), col("nested2")._explode()])
     assert table.column_names() == ["nested", "nested2", "sidecar", "nested3"]
     data_py = data.to_pylist()
@@ -97,12 +97,12 @@ def test_explode_multiple_cols_with_alias(data):
     TEST_DATA,
 )
 def test_explode_eval_expr(data):
-    table = Table.from_pydict({"nested": data})
+    table = MicroPartition.from_pydict({"nested": data})
     table = table.eval_expression_list([col("nested")._explode()])
     assert table.to_pydict() == {"nested": [1, 2, 3, 4, None, None]}
 
 
 def test_explode_bad_col_type():
-    table = Table.from_pydict({"a": [1, 2, 3]})
+    table = MicroPartition.from_pydict({"a": [1, 2, 3]})
     with pytest.raises(ValueError, match="to be a List Type, but is"):
         table = table.explode([col("a")._explode()])

--- a/tests/table/test_head.py
+++ b/tests/table/test_head.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 def test_table_head() -> None:
     pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 

--- a/tests/table/test_joins.py
+++ b/tests/table/test_joins.py
@@ -9,7 +9,7 @@ from daft.daft import JoinType
 from daft.datatype import DataType
 from daft.expressions import col
 from daft.series import Series
-from daft.table import Table
+from daft.table import MicroPartition
 
 daft_int_types = [
     DataType.int8(),
@@ -42,10 +42,10 @@ daft_string_types = [DataType.string()]
 )
 def test_table_join_single_column(dtype, data) -> None:
     l, r, expected_pairs = data
-    left_table = Table.from_pydict({"x": l, "x_ind": list(range(len(l)))}).eval_expression_list(
+    left_table = MicroPartition.from_pydict({"x": l, "x_ind": list(range(len(l)))}).eval_expression_list(
         [col("x").cast(dtype), col("x_ind")]
     )
-    right_table = Table.from_pydict({"y": r, "y_ind": list(range(len(r)))})
+    right_table = MicroPartition.from_pydict({"y": r, "y_ind": list(range(len(r)))})
     result_table = left_table.join(right_table, left_on=[col("x")], right_on=[col("y")], how=JoinType.Inner)
 
     assert result_table.column_names() == ["x", "x_ind", "y", "y_ind"]
@@ -77,8 +77,8 @@ def test_table_join_single_column(dtype, data) -> None:
 
 
 def test_table_join_mismatch_column() -> None:
-    left_table = Table.from_pydict({"x": [1, 2, 3, 4], "y": [2, 3, 4, 5]})
-    right_table = Table.from_pydict({"a": [1, 2, 3, 4], "b": [2, 3, 4, 5]})
+    left_table = MicroPartition.from_pydict({"x": [1, 2, 3, 4], "y": [2, 3, 4, 5]})
+    right_table = MicroPartition.from_pydict({"a": [1, 2, 3, 4], "b": [2, 3, 4, 5]})
 
     with pytest.raises(ValueError, match="Mismatch of number of join keys"):
         left_table.join(right_table, left_on=[col("x"), col("y")], right_on=[col("a")])
@@ -100,10 +100,10 @@ def test_table_join_mismatch_column() -> None:
 )
 def test_table_join_multicolumn_empty_result(left, right) -> None:
     """Various multicol joins that should all produce an empty result."""
-    left_table = Table.from_pydict(left).eval_expression_list(
+    left_table = MicroPartition.from_pydict(left).eval_expression_list(
         [col("a").cast(DataType.string()), col("b").cast(DataType.int32())]
     )
-    right_table = Table.from_pydict(right).eval_expression_list(
+    right_table = MicroPartition.from_pydict(right).eval_expression_list(
         [col("x").cast(DataType.string()), col("y").cast(DataType.int32())]
     )
 
@@ -117,14 +117,14 @@ def test_table_join_multicolumn_nocross() -> None:
     Input has duplicate join values and overlapping single-column values,
     but there should only be two correct matches, both not cross.
     """
-    left_table = Table.from_pydict(
+    left_table = MicroPartition.from_pydict(
         {
             "a": ["apple", "apple", "banana", "banana", "carrot"],
             "b": [1, 2, 2, 2, 3],
             "c": [1, 2, 3, 4, 5],
         }
     )
-    right_table = Table.from_pydict(
+    right_table = MicroPartition.from_pydict(
         {
             "x": ["banana", "carrot", "apple", "banana", "apple", "durian"],
             "y": [1, 3, 2, 1, 3, 6],
@@ -146,14 +146,14 @@ def test_table_join_multicolumn_nocross() -> None:
 def test_table_join_multicolumn_cross() -> None:
     """A multicol join that should produce a cross product and a non-cross product."""
 
-    left_table = Table.from_pydict(
+    left_table = MicroPartition.from_pydict(
         {
             "a": ["apple", "apple", "banana", "banana", "banana"],
             "b": [1, 0, 1, 1, 1],
             "c": [1, 2, 3, 4, 5],
         }
     )
-    right_table = Table.from_pydict(
+    right_table = MicroPartition.from_pydict(
         {
             "x": ["apple", "apple", "banana", "banana", "banana"],
             "y": [1, 0, 1, 1, 0],
@@ -179,14 +179,14 @@ def test_table_join_multicolumn_cross() -> None:
 
 
 def test_table_join_multicolumn_all_nulls() -> None:
-    left_table = Table.from_pydict(
+    left_table = MicroPartition.from_pydict(
         {
             "a": Series.from_pylist([None, None, None]).cast(DataType.int64()),
             "b": Series.from_pylist([None, None, None]).cast(DataType.string()),
             "c": [1, 2, 3],
         }
     )
-    right_table = Table.from_pydict(
+    right_table = MicroPartition.from_pydict(
         {
             "x": Series.from_pylist([None, None, None]).cast(DataType.int64()),
             "y": Series.from_pylist([None, None, None]).cast(DataType.string()),
@@ -199,16 +199,16 @@ def test_table_join_multicolumn_all_nulls() -> None:
 
 
 def test_table_join_no_columns() -> None:
-    left_table = Table.from_pydict({"x": [1, 2, 3, 4], "y": [2, 3, 4, 5]})
-    right_table = Table.from_pydict({"a": [1, 2, 3, 4], "b": [2, 3, 4, 5]})
+    left_table = MicroPartition.from_pydict({"x": [1, 2, 3, 4], "y": [2, 3, 4, 5]})
+    right_table = MicroPartition.from_pydict({"a": [1, 2, 3, 4], "b": [2, 3, 4, 5]})
 
     with pytest.raises(ValueError, match="No columns were passed in to join on"):
         left_table.join(right_table, left_on=[], right_on=[])
 
 
 def test_table_join_single_column_name_conflicts() -> None:
-    left_table = Table.from_pydict({"x": [0, 1, 2, 3], "y": [2, 3, 4, 5]})
-    right_table = Table.from_pydict({"x": [3, 2, 1, 0], "y": [6, 7, 8, 9]})
+    left_table = MicroPartition.from_pydict({"x": [0, 1, 2, 3], "y": [2, 3, 4, 5]})
+    right_table = MicroPartition.from_pydict({"x": [3, 2, 1, 0], "y": [6, 7, 8, 9]})
 
     result_table = left_table.join(right_table, left_on=[col("x")], right_on=[col("x")])
     assert result_table.column_names() == ["x", "y", "right.y"]
@@ -219,8 +219,8 @@ def test_table_join_single_column_name_conflicts() -> None:
 
 
 def test_table_join_single_column_name_conflicts_different_named_join() -> None:
-    left_table = Table.from_pydict({"x": [0, 1, 2, 3], "y": [2, 3, 4, 5]})
-    right_table = Table.from_pydict({"y": [3, 2, 1, 0], "x": [6, 7, 8, 9]})
+    left_table = MicroPartition.from_pydict({"x": [0, 1, 2, 3], "y": [2, 3, 4, 5]})
+    right_table = MicroPartition.from_pydict({"y": [3, 2, 1, 0], "x": [6, 7, 8, 9]})
 
     result_table = left_table.join(right_table, left_on=[col("x")], right_on=[col("y")])
 
@@ -234,8 +234,8 @@ def test_table_join_single_column_name_conflicts_different_named_join() -> None:
 
 
 def test_table_join_single_column_name_multiple_conflicts() -> None:
-    left_table = Table.from_pydict({"x": [0, 1, 2, 3], "y": [2, 3, 4, 5], "right.y": [6, 7, 8, 9]})
-    right_table = Table.from_pydict({"x": [3, 2, 1, 0], "y": [10, 11, 12, 13]})
+    left_table = MicroPartition.from_pydict({"x": [0, 1, 2, 3], "y": [2, 3, 4, 5], "right.y": [6, 7, 8, 9]})
+    right_table = MicroPartition.from_pydict({"x": [3, 2, 1, 0], "y": [10, 11, 12, 13]})
 
     result_table = left_table.join(right_table, left_on=[col("x")], right_on=[col("x")])
     assert result_table.column_names() == ["x", "y", "right.y", "right.right.y"]
@@ -247,8 +247,8 @@ def test_table_join_single_column_name_multiple_conflicts() -> None:
 
 
 def test_table_join_single_column_name_boolean() -> None:
-    left_table = Table.from_pydict({"x": [False, True, None], "y": [0, 1, 2]})
-    right_table = Table.from_pydict({"x": [None, True, False, None], "y": [0, 1, 2, 3]})
+    left_table = MicroPartition.from_pydict({"x": [False, True, None], "y": [0, 1, 2]})
+    right_table = MicroPartition.from_pydict({"x": [None, True, False, None], "y": [0, 1, 2, 3]})
 
     result_table = left_table.join(right_table, left_on=[col("x")], right_on=[col("x")])
     assert result_table.column_names() == ["x", "y", "right.y"]
@@ -258,8 +258,8 @@ def test_table_join_single_column_name_boolean() -> None:
 
 
 def test_table_join_single_column_name_null() -> None:
-    left_table = Table.from_pydict({"x": [None, None, None], "y": [0, 1, 2]})
-    right_table = Table.from_pydict({"x": [None, None, None, None], "y": [0, 1, 2, 3]})
+    left_table = MicroPartition.from_pydict({"x": [None, None, None], "y": [0, 1, 2]})
+    right_table = MicroPartition.from_pydict({"x": [None, None, None, None], "y": [0, 1, 2, 3]})
 
     result_table = left_table.join(right_table, left_on=[col("x")], right_on=[col("x")])
     assert result_table.column_names() == ["x", "y", "right.y"]

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -9,7 +9,7 @@ import pytest
 from daft.datatype import DataType
 from daft.expressions import col
 from daft.logical.schema import Schema
-from daft.table import LegacyTable, Table
+from daft.table import LegacyTable, MicroPartition
 
 daft_int_types = [
     DataType.int8(),
@@ -29,8 +29,8 @@ daft_string_types = [DataType.string()]
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
-        Table.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
+        MicroPartition.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
+        MicroPartition.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
     ],
 )
 def test_partitioning_micropartitions_hash_empty(mp) -> None:
@@ -42,12 +42,12 @@ def test_partitioning_micropartitions_hash_empty(mp) -> None:
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
-        Table.concat(
+        MicroPartition.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
+        MicroPartition.concat(
             [
-                Table.from_pydict({"a": np.array([]).astype(np.int64)}),
-                Table.from_pydict({"a": [1]}),
-                Table.from_pydict({"a": [3, 2, 4]}),
+                MicroPartition.from_pydict({"a": np.array([]).astype(np.int64)}),
+                MicroPartition.from_pydict({"a": [1]}),
+                MicroPartition.from_pydict({"a": [3, 2, 4]}),
             ]
         ),  # 3 tables
     ],
@@ -62,8 +62,8 @@ def test_partitioning_micropartitions_hash(mp) -> None:
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
-        Table.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
+        MicroPartition.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
+        MicroPartition.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
     ],
 )
 def test_partitioning_micropartitions_range_empty(mp) -> None:
@@ -78,8 +78,10 @@ def test_partitioning_micropartitions_range_empty(mp) -> None:
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": pa.array([], type=pa.int64()), "b": pa.array([], type=pa.string())}),  # 1 empty table
-        Table.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64(), "b": pa.string()}))),  # No tables
+        MicroPartition.from_pydict(
+            {"a": pa.array([], type=pa.int64()), "b": pa.array([], type=pa.string())}
+        ),  # 1 empty table
+        MicroPartition.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64(), "b": pa.string()}))),  # No tables
     ],
 )
 def test_partitioning_micropartitions_range_boundaries_empty(mp) -> None:
@@ -92,12 +94,12 @@ def test_partitioning_micropartitions_range_boundaries_empty(mp) -> None:
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
-        Table.concat(
+        MicroPartition.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
+        MicroPartition.concat(
             [
-                Table.from_pydict({"a": np.array([]).astype(np.int64)}),
-                Table.from_pydict({"a": [1]}),
-                Table.from_pydict({"a": [3, 2, 4]}),
+                MicroPartition.from_pydict({"a": np.array([]).astype(np.int64)}),
+                MicroPartition.from_pydict({"a": [1]}),
+                MicroPartition.from_pydict({"a": [3, 2, 4]}),
             ]
         ),  # 3 tables
     ],
@@ -115,8 +117,8 @@ def test_partitioning_micropartitions_range(mp) -> None:
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
-        Table.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
+        MicroPartition.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
+        MicroPartition.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
     ],
 )
 def test_partitioning_micropartitions_random_empty(mp) -> None:
@@ -128,12 +130,12 @@ def test_partitioning_micropartitions_random_empty(mp) -> None:
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
-        Table.concat(
+        MicroPartition.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
+        MicroPartition.concat(
             [
-                Table.from_pydict({"a": np.array([]).astype(np.int64)}),
-                Table.from_pydict({"a": [1]}),
-                Table.from_pydict({"a": [3, 2, 4]}),
+                MicroPartition.from_pydict({"a": np.array([]).astype(np.int64)}),
+                MicroPartition.from_pydict({"a": [1]}),
+                MicroPartition.from_pydict({"a": [3, 2, 4]}),
             ]
         ),  # 3 tables
     ],
@@ -149,7 +151,7 @@ def test_partitioning_micropartitions_random(mp) -> None:
     "size, k, dtype", itertools.product([0, 1, 10, 33, 100], [1, 2, 3, 10, 40], daft_numeric_types + daft_string_types)
 )
 def test_table_partition_by_hash_single_col(size, k, dtype) -> None:
-    table = Table.from_pydict(
+    table = MicroPartition.from_pydict(
         {"x": [i % k for i in range(size)], "x_ind": [i for i in range(size)]}
     ).eval_expression_list([col("x").cast(dtype), col("x_ind")])
     split_tables = table.partition_by_hash([col("x")], k)
@@ -168,7 +170,9 @@ def test_table_partition_by_hash_single_col(size, k, dtype) -> None:
     "size, k, dtype", itertools.product([0, 1, 10, 33, 100], [1, 2, 3, 10, 40], daft_numeric_types + daft_string_types)
 )
 def test_table_partition_by_hash_two_col(size, k, dtype) -> None:
-    table = Table.from_pydict({"x": [i for i in range(size)], "x_ind": [i for i in range(size)]}).eval_expression_list(
+    table = MicroPartition.from_pydict(
+        {"x": [i for i in range(size)], "x_ind": [i for i in range(size)]}
+    ).eval_expression_list(
         [
             (col("x").cast(DataType.int8()) % k).cast(dtype),
             (col("x").cast(DataType.int8()) % (k + 1)).alias("y"),
@@ -191,7 +195,7 @@ def test_table_partition_by_hash_two_col(size, k, dtype) -> None:
 
 @pytest.mark.parametrize("size, k", itertools.product([0, 1, 10, 33, 100], [1, 2, 3, 10, 40]))
 def test_table_partition_by_random(size, k) -> None:
-    table = Table.from_pydict({"x": [i for i in range(size)]})
+    table = MicroPartition.from_pydict({"x": [i for i in range(size)]})
     split_tables = table.partition_by_random(k, 0)
     seen_so_far = set()
 
@@ -214,7 +218,7 @@ def test_table_partition_by_random(size, k) -> None:
 
 
 def test_table_partition_by_hash_bad_input() -> None:
-    table = Table.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})
+    table = MicroPartition.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})
 
     with pytest.raises(ValueError, match="negative number"):
         table.partition_by_hash([col("x")], -1)
@@ -224,7 +228,7 @@ def test_table_partition_by_hash_bad_input() -> None:
 
 
 def test_table_partition_by_random_bad_input() -> None:
-    table = Table.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})
+    table = MicroPartition.from_pydict({"x": [1, 2, 3], "b": [0, 1, 2]})
 
     with pytest.raises(ValueError, match="negative number"):
         table.partition_by_random(10, -1)
@@ -238,7 +242,7 @@ def test_table_partition_by_random_bad_input() -> None:
 
 @pytest.mark.parametrize("size, k, desc", itertools.product([0, 1, 10, 33, 100], [1, 2, 3, 10, 40], [False, True]))
 def test_table_partition_by_range_single_column(size, k, desc) -> None:
-    table = Table.from_pydict({"x": np.arange(size, dtype=np.float64()), "x_ind": list(range(size))})
+    table = MicroPartition.from_pydict({"x": np.arange(size, dtype=np.float64()), "x_ind": list(range(size))})
 
     original_boundaries = np.linspace(0, size, k)
 
@@ -274,7 +278,7 @@ def test_table_partition_by_range_multi_column(size, k, desc) -> None:
     x = np.ones(size)
     y = np.arange(size, dtype=np.float64())
 
-    table = Table.from_pydict({"x": x, "y": y})
+    table = MicroPartition.from_pydict({"x": x, "y": y})
 
     original_boundaries = np.linspace(0, size, k)
 
@@ -305,7 +309,7 @@ def test_table_partition_by_range_multi_column(size, k, desc) -> None:
 
 
 def test_table_partition_by_range_multi_column_string() -> None:
-    table = Table.from_pydict({"x": ["a", "c", "a", "c"], "y": ["1", "2", "3", "4"]})
+    table = MicroPartition.from_pydict({"x": ["a", "c", "a", "c"], "y": ["1", "2", "3", "4"]})
     boundaries = LegacyTable.from_pydict({"x": ["b"], "y": ["1"]})
     split_tables = table.partition_by_range([col("x"), col("y")], boundaries, [False, False])
     assert len(split_tables) == 2
@@ -321,7 +325,7 @@ def test_table_partition_by_range_multi_column_string() -> None:
 
 def test_table_partition_by_range_input() -> None:
     data = {"x": [1, 2, 3], "b": [0, 1, 2]}
-    table_cls = Table.from_pydict(data)
+    table_cls = MicroPartition.from_pydict(data)
     boundaries = LegacyTable.from_pydict(data)
 
     with pytest.raises(ValueError, match="Schema Mismatch"):

--- a/tests/table/test_partitioning.py
+++ b/tests/table/test_partitioning.py
@@ -9,7 +9,7 @@ import pytest
 from daft.datatype import DataType
 from daft.expressions import col
 from daft.logical.schema import Schema
-from daft.table import LegacyTable, MicroPartition
+from daft.table import MicroPartition, Table
 
 daft_int_types = [
     DataType.int8(),
@@ -67,7 +67,7 @@ def test_partitioning_micropartitions_hash(mp) -> None:
     ],
 )
 def test_partitioning_micropartitions_range_empty(mp) -> None:
-    boundaries = LegacyTable.from_pydict({"a": np.linspace(0, 10, 3)[1:]}).eval_expression_list(
+    boundaries = Table.from_pydict({"a": np.linspace(0, 10, 3)[1:]}).eval_expression_list(
         [col("a").cast(DataType.int64())]
     )
     split_tables = mp.partition_by_range([col("a")], boundaries, [True])
@@ -85,7 +85,7 @@ def test_partitioning_micropartitions_range_empty(mp) -> None:
     ],
 )
 def test_partitioning_micropartitions_range_boundaries_empty(mp) -> None:
-    boundaries = LegacyTable.from_pydict({"a": [], "b": []}).eval_expression_list([col("a").cast(DataType.int64())])
+    boundaries = Table.from_pydict({"a": [], "b": []}).eval_expression_list([col("a").cast(DataType.int64())])
     split_tables = mp.partition_by_range([col("a"), col("b")], boundaries, [False, False])
     assert len(split_tables) == 1
     assert split_tables[0].to_pydict() == {"a": [], "b": []}
@@ -105,7 +105,7 @@ def test_partitioning_micropartitions_range_boundaries_empty(mp) -> None:
     ],
 )
 def test_partitioning_micropartitions_range(mp) -> None:
-    boundaries = LegacyTable.from_pydict({"a": np.linspace(0, 5, 3)[1:]}).eval_expression_list(
+    boundaries = Table.from_pydict({"a": np.linspace(0, 5, 3)[1:]}).eval_expression_list(
         [col("a").cast(DataType.int64())]
     )
     split_tables = mp.partition_by_range([col("a")], boundaries, [True])
@@ -251,7 +251,7 @@ def test_table_partition_by_range_single_column(size, k, desc) -> None:
     if desc:
         input_boundaries = input_boundaries[::-1]
 
-    boundaries = LegacyTable.from_pydict({"x": input_boundaries}).eval_expression_list(
+    boundaries = Table.from_pydict({"x": input_boundaries}).eval_expression_list(
         [col("x").cast(table.get_column("x").datatype())]
     )
 
@@ -286,7 +286,7 @@ def test_table_partition_by_range_multi_column(size, k, desc) -> None:
     if desc:
         input_boundaries = input_boundaries[::-1]
 
-    boundaries = LegacyTable.from_pydict({"x": np.ones(k - 1), "y": input_boundaries}).eval_expression_list(
+    boundaries = Table.from_pydict({"x": np.ones(k - 1), "y": input_boundaries}).eval_expression_list(
         [col("x").cast(table.get_column("x").datatype()), col("y").cast(table.get_column("y").datatype())]
     )
 
@@ -310,7 +310,7 @@ def test_table_partition_by_range_multi_column(size, k, desc) -> None:
 
 def test_table_partition_by_range_multi_column_string() -> None:
     table = MicroPartition.from_pydict({"x": ["a", "c", "a", "c"], "y": ["1", "2", "3", "4"]})
-    boundaries = LegacyTable.from_pydict({"x": ["b"], "y": ["1"]})
+    boundaries = Table.from_pydict({"x": ["b"], "y": ["1"]})
     split_tables = table.partition_by_range([col("x"), col("y")], boundaries, [False, False])
     assert len(split_tables) == 2
 
@@ -326,7 +326,7 @@ def test_table_partition_by_range_multi_column_string() -> None:
 def test_table_partition_by_range_input() -> None:
     data = {"x": [1, 2, 3], "b": [0, 1, 2]}
     table_cls = MicroPartition.from_pydict(data)
-    boundaries = LegacyTable.from_pydict(data)
+    boundaries = Table.from_pydict(data)
 
     with pytest.raises(ValueError, match="Schema Mismatch"):
         table_cls.partition_by_range([col("x")], boundaries, [False])

--- a/tests/table/test_size_bytes.py
+++ b/tests/table/test_size_bytes.py
@@ -6,14 +6,14 @@ import pytest
 
 from daft import DataType, col
 from daft.logical.schema import Schema
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
-        Table.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
+        MicroPartition.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
+        MicroPartition.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
     ],
 )
 def test_micropartitions_size_bytes_empty(mp) -> None:
@@ -23,12 +23,12 @@ def test_micropartitions_size_bytes_empty(mp) -> None:
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
-        Table.concat(
+        MicroPartition.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
+        MicroPartition.concat(
             [
-                Table.from_pydict({"a": np.array([]).astype(np.int64)}),
-                Table.from_pydict({"a": [1]}),
-                Table.from_pydict({"a": [3, 2, 4]}),
+                MicroPartition.from_pydict({"a": np.array([]).astype(np.int64)}),
+                MicroPartition.from_pydict({"a": [1]}),
+                MicroPartition.from_pydict({"a": [3, 2, 4]}),
             ]
         ),  # 3 tables
     ],
@@ -39,9 +39,9 @@ def test_micropartitions_size_bytes(mp) -> None:
 
 def test_table_size_bytes() -> None:
 
-    data = Table.from_pydict({"a": [1, 2, 3, 4, None], "b": [False, True, False, True, None]}).eval_expression_list(
-        [col("a").cast(DataType.int64()), col("b")]
-    )
+    data = MicroPartition.from_pydict(
+        {"a": [1, 2, 3, 4, None], "b": [False, True, False, True, None]}
+    ).eval_expression_list([col("a").cast(DataType.int64()), col("b")])
     assert data.size_bytes() == (5 * 8 + 1) + (1 + 1)
 
 
@@ -50,5 +50,5 @@ def test_table_size_bytes_pyobj(length) -> None:
     import pickle
 
     size_per_obj = len(pickle.dumps(object()))
-    data = Table.from_pydict({"a": [object()] * length})
+    data = MicroPartition.from_pydict({"a": [object()] * length})
     assert data.size_bytes() == size_per_obj * length

--- a/tests/table/test_sorting.py
+++ b/tests/table/test_sorting.py
@@ -10,15 +10,15 @@ from daft import col
 from daft.datatype import DataType
 from daft.logical.schema import Schema
 from daft.series import Series
-from daft.table import Table
+from daft.table import MicroPartition
 from tests.table import daft_numeric_types, daft_string_types
 
 
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
-        Table.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
+        MicroPartition.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
+        MicroPartition.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
     ],
 )
 def test_micropartitions_sort_empty(mp) -> None:
@@ -30,12 +30,12 @@ def test_micropartitions_sort_empty(mp) -> None:
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
-        Table.concat(
+        MicroPartition.from_pydict({"a": [1, 3, 2, 4]}),  # 1 table
+        MicroPartition.concat(
             [
-                Table.from_pydict({"a": np.array([]).astype(np.int64)}),
-                Table.from_pydict({"a": [1]}),
-                Table.from_pydict({"a": [3, 2, 4]}),
+                MicroPartition.from_pydict({"a": np.array([]).astype(np.int64)}),
+                MicroPartition.from_pydict({"a": [1]}),
+                MicroPartition.from_pydict({"a": [3, 2, 4]}),
             ]
         ),  # 3 tables
     ],
@@ -56,7 +56,7 @@ def test_table_single_col_sorting(sort_dtype, value_dtype, first_col) -> None:
 
     argsort_order = Series.from_pylist([3, 2, 1, 4, 0])
 
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
 
     if first_col:
         daft_table = daft_table.eval_expression_list([col("a").cast(sort_dtype), col("b").cast(value_dtype)])
@@ -128,7 +128,7 @@ def test_table_multiple_col_sorting(sort_dtype, value_dtype, data) -> None:
 
     argsort_order = Series.from_pylist(expected)
 
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
 
     daft_table = daft_table.eval_expression_list([col("a").cast(sort_dtype), col("b").cast(value_dtype)])
 
@@ -193,7 +193,7 @@ def test_table_multiple_col_sorting_binary(data) -> None:
 
     argsort_order = Series.from_pylist(expected)
 
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     daft_table = daft_table.eval_expression_list([col("a").cast(DataType.binary()), col("b").cast(DataType.binary())])
     assert len(daft_table) == 5
     assert daft_table.column_names() == ["a", "b"]
@@ -253,7 +253,7 @@ def test_table_boolean_multiple_col_sorting(second_dtype, data) -> None:
     pa_table = pa.Table.from_pydict({"a": a, "b": b})
     argsort_order = Series.from_pylist(expected)
 
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
 
     daft_table = daft_table.eval_expression_list([col("a"), col("b").cast(second_dtype)])
 
@@ -300,7 +300,7 @@ def test_table_sample() -> None:
     pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
     source_pairs = {(1, 5), (2, 6), (3, 7), (4, 8)}
 
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 
@@ -331,7 +331,7 @@ def test_table_quantiles(size, k) -> None:
 
     second = 2 * first
 
-    daft_table = Table.from_pydict({"a": first, "b": second})
+    daft_table = MicroPartition.from_pydict({"a": first, "b": second})
     assert len(daft_table) == size
     assert daft_table.column_names() == ["a", "b"]
 
@@ -363,14 +363,14 @@ def test_table_quantiles_bad_input() -> None:
 
     pa_table = pa.Table.from_pydict({"a": first, "b": second})
 
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
 
     with pytest.raises(ValueError, match="negative number"):
         daft_table.quantiles(-1)
 
 
 def test_string_table_sorting():
-    daft_table = Table.from_pydict(
+    daft_table = MicroPartition.from_pydict(
         {
             "firstname": [
                 "bob",

--- a/tests/table/test_take.py
+++ b/tests/table/test_take.py
@@ -8,15 +8,15 @@ import pytest
 from daft import col
 from daft.logical.schema import Schema
 from daft.series import Series
-from daft.table import Table
+from daft.table import MicroPartition
 from tests.table import daft_int_types, daft_numeric_types
 
 
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
-        Table.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
+        MicroPartition.from_pydict({"a": pa.array([], type=pa.int64())}),  # 1 empty table
+        MicroPartition.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64()}))),  # No tables
     ],
 )
 def test_micropartitions_take_empty(mp) -> None:
@@ -37,17 +37,17 @@ def test_micropartitions_take_empty(mp) -> None:
 @pytest.mark.parametrize(
     "mp",
     [
-        Table.from_pydict({"a": [1, 2, 3, 4]}),  # 1 table
-        Table.concat(
+        MicroPartition.from_pydict({"a": [1, 2, 3, 4]}),  # 1 table
+        MicroPartition.concat(
             [
-                Table.from_pydict({"a": pa.array([], type=pa.int64())}),
-                Table.from_pydict({"a": [1]}),
-                Table.from_pydict({"a": [2, 3, 4]}),
+                MicroPartition.from_pydict({"a": pa.array([], type=pa.int64())}),
+                MicroPartition.from_pydict({"a": [1]}),
+                MicroPartition.from_pydict({"a": [2, 3, 4]}),
             ]
         ),  # 3 tables
     ],
 )
-def test_micropartitions_take(mp: Table) -> None:
+def test_micropartitions_take(mp: MicroPartition) -> None:
     assert mp.column_names() == ["a"]
     assert len(mp) == 4
 
@@ -73,7 +73,7 @@ def test_micropartitions_take(mp: Table) -> None:
 @pytest.mark.parametrize("data_dtype, idx_dtype", itertools.product(daft_numeric_types, daft_int_types))
 def test_table_take_numeric(data_dtype, idx_dtype) -> None:
     pa_table = pa.Table.from_pydict({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     daft_table = daft_table.eval_expression_list([col("a").cast(data_dtype), col("b")])
 
     assert len(daft_table) == 4
@@ -107,7 +107,7 @@ def test_table_take_numeric(data_dtype, idx_dtype) -> None:
 @pytest.mark.parametrize("idx_dtype", daft_int_types)
 def test_table_take_str(idx_dtype) -> None:
     pa_table = pa.Table.from_pydict({"a": ["1", "2", "3", "4"], "b": ["5", "6", "7", "8"]})
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 
@@ -139,7 +139,7 @@ def test_table_take_str(idx_dtype) -> None:
 @pytest.mark.parametrize("idx_dtype", daft_int_types)
 def test_table_take_bool(idx_dtype) -> None:
     pa_table = pa.Table.from_pydict({"a": [False, True, False, True], "b": [True, False, True, False]})
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 
@@ -171,7 +171,7 @@ def test_table_take_bool(idx_dtype) -> None:
 @pytest.mark.parametrize("idx_dtype", daft_int_types)
 def test_table_take_null(idx_dtype) -> None:
     pa_table = pa.Table.from_pydict({"a": [None, None, None, None], "b": [None, None, None, None]})
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 
@@ -186,7 +186,7 @@ def test_table_take_null(idx_dtype) -> None:
 
 def test_table_take_pyobject() -> None:
     objects = [object(), None, object(), object()]
-    daft_table = Table.from_pydict({"objs": objects})
+    daft_table = MicroPartition.from_pydict({"objs": objects})
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["objs"]
 
@@ -223,7 +223,7 @@ def test_table_take_fixed_size_list(idx_dtype) -> None:
             "b": pa.array([[4, 5], [6, None], None, [None, None]], type=pa.list_(pa.int64(), 2)),
         }
     )
-    daft_table = Table.from_arrow(pa_table)
+    daft_table = MicroPartition.from_arrow(pa_table)
     assert len(daft_table) == 4
     assert daft_table.column_names() == ["a", "b"]
 

--- a/tests/table/utf8/test_compares.py
+++ b/tests/table/utf8/test_compares.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from daft.expressions import col, lit
-from daft.table import Table
+from daft.table import MicroPartition
 
 ENDSWITH_DATA = ["x_foo", "y_foo", "z_bar"]
 STARTSWITH_DATA = ["foo_x", "foo_y", "bar_z"]
@@ -25,6 +25,6 @@ CONTAINS_DATA = ["x_foo_x", "y_foo_y", "z_bar_z"]
     ],
 )
 def test_utf8_substrs(expr, data):
-    table = Table.from_pydict({"col": data, "emptystrings": ["", "", ""]})
+    table = MicroPartition.from_pydict({"col": data, "emptystrings": ["", "", ""]})
     result = table.eval_expression_list([expr])
     assert result.to_pydict() == {"col": [True, True, False]}

--- a/tests/table/utf8/test_length.py
+++ b/tests/table/utf8/test_length.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from daft.expressions import col
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 def test_utf8_length():
-    table = Table.from_pydict({"col": ["foo", None, "barbaz", "quux"]})
+    table = MicroPartition.from_pydict({"col": ["foo", None, "barbaz", "quux"]})
     result = table.eval_expression_list([col("col").str.length()])
     assert result.to_pydict() == {"col": [3, None, 6, 4]}

--- a/tests/table/utf8/test_split.py
+++ b/tests/table/utf8/test_split.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from daft.expressions import col, lit
-from daft.table import Table
+from daft.table import MicroPartition
 
 
 @pytest.mark.parametrize(
@@ -23,6 +23,6 @@ from daft.table import Table
     ],
 )
 def test_series_utf8_split_broadcast_pattern(expr, data, expected) -> None:
-    table = Table.from_pydict({"col": data, "emptystrings": ["", "", "", ""]})
+    table = MicroPartition.from_pydict({"col": data, "emptystrings": ["", "", "", ""]})
     result = table.eval_expression_list([expr])
     assert result.to_pydict() == {"col": expected}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,7 +8,7 @@ import pytest
 from daft.datatype import DataType
 from daft.expressions import ExpressionsProjection, col
 from daft.logical.schema import Schema
-from daft.table import Table
+from daft.table import MicroPartition
 
 DATA = {
     "int": ([1, 2, None], DataType.int64()),
@@ -17,7 +17,7 @@ DATA = {
     "bool": ([True, True, None], DataType.bool()),
 }
 
-TABLE = Table.from_pydict({k: data for k, (data, _) in DATA.items()})
+TABLE = MicroPartition.from_pydict({k: data for k, (data, _) in DATA.items()})
 EXPECTED_TYPES = {k: t for k, (_, t) in DATA.items()}
 
 from tests.utils import ANSI_ESCAPE
@@ -48,13 +48,13 @@ def test_schema_iter():
 
 
 def test_schema_eq():
-    t1, t2 = Table.from_pydict({k: data for k, (data, _) in DATA.items()}), Table.from_pydict(
+    t1, t2 = MicroPartition.from_pydict({k: data for k, (data, _) in DATA.items()}), MicroPartition.from_pydict(
         {k: data for k, (data, _) in DATA.items()}
     )
     s1, s2 = t1.schema(), t2.schema()
     assert s1 == s2
 
-    t_empty = Table.empty()
+    t_empty = MicroPartition.empty()
     assert s1 != t_empty.schema()
 
 
@@ -94,7 +94,7 @@ def test_union():
         schema.union(schema)
 
     new_data = {f"{k}_": d for k, (d, _) in DATA.items()}
-    new_table = Table.from_pydict(new_data)
+    new_table = MicroPartition.from_pydict(new_data)
     unioned_schema = schema.union(new_table.schema())
 
     assert unioned_schema.column_names() == list(DATA.keys()) + list(new_data.keys())
@@ -122,7 +122,7 @@ def test_field_pickling():
 
 
 def test_schema_pickling():
-    t1, t2 = Table.from_pydict({k: data for k, (data, _) in DATA.items()}), Table.from_pydict(
+    t1, t2 = MicroPartition.from_pydict({k: data for k, (data, _) in DATA.items()}), MicroPartition.from_pydict(
         {k: data for k, (data, _) in DATA.items()}
     )
 
@@ -132,7 +132,7 @@ def test_schema_pickling():
 
     assert s1 == s2
 
-    t_empty = Table.empty()
+    t_empty = MicroPartition.empty()
     assert s1 != t_empty.schema()
     t_empty_schema_copy = copy.deepcopy(t_empty.schema())
     assert t_empty.schema() == t_empty_schema_copy


### PR DESCRIPTION
1. Switches to use `DAFT_MICROPARTITIONS=1` behavior by default
2. Renames `Table -> MicroPartition` all across the codebase
3. Renames `LegacyTable -> Table` all across the codebase