### PR TITLE
[FEAT] Enable Comparison between timestamp / dates 

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -194,13 +194,17 @@ class DataType:
         return cls._from_pydatatype(PyDataType.date())
 
     @classmethod
-    def timestamp(cls, timeunit: TimeUnit, timezone: str | None = None) -> DataType:
+    def timestamp(cls, timeunit: TimeUnit | str, timezone: str | None = None) -> DataType:
         """Timestamp DataType."""
+        if isinstance(timeunit, str):
+            timeunit = TimeUnit.from_str(timeunit)
         return cls._from_pydatatype(PyDataType.timestamp(timeunit._timeunit, timezone))
 
     @classmethod
-    def duration(cls, timeunit: TimeUnit) -> DataType:
+    def duration(cls, timeunit: TimeUnit | str) -> DataType:
         """Duration DataType."""
+        if isinstance(timeunit, str):
+            timeunit = TimeUnit.from_str(timeunit)
         return cls._from_pydatatype(PyDataType.duration(timeunit._timeunit))
 
     @classmethod

--- a/src/daft-core/src/datatypes/binary_ops.rs
+++ b/src/daft-core/src/datatypes/binary_ops.rs
@@ -40,12 +40,6 @@ impl DataType {
                 (s, o) if s.is_physical() && o.is_physical() => {
                     Ok((Boolean, None, try_physical_supertype(s, o)?))
                 }
-                // To maintain existing behaviour. TODO: cleanup
-                (Date, o) | (o, Date) if o.is_physical() && o.clone() != Boolean => Ok((
-                    Boolean,
-                    None,
-                    try_physical_supertype(&Date.to_physical(), o)?,
-                )),
                 (Timestamp(..) | Date, Timestamp(..) | Date) => {
                     let intermediate_type = try_get_supertype(self, other)?;
                     let pt = intermediate_type.to_physical();

--- a/src/daft-core/src/utils/supertype.rs
+++ b/src/daft-core/src/utils/supertype.rs
@@ -168,20 +168,20 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
             (Duration(_), Date) | (Date, Duration(_)) => Some(Date),
             (Duration(lu), Duration(ru)) => Some(Duration(get_time_units(lu, ru))),
 
-            // None and Some("") timezones
+            // Some() timezones that are non equal
             // we cast from more precision to higher precision as that always fits with occasional loss of precision
-            (Timestamp(tu_l, tz_l), Timestamp(tu_r, tz_r))
-                if (tz_l.is_none() || tz_l.as_deref() == Some(""))
-                    && (tz_r.is_none() || tz_r.as_deref() == Some("")) =>
+            (Timestamp(tu_l, Some(tz_l)), Timestamp(tu_r, Some(tz_r)))
+                if !tz_l.is_empty()
+                    && !tz_r.is_empty() && tz_l != tz_r =>
             {
                 let tu = get_time_units(tu_l, tu_r);
-                Some(Timestamp(tu, None))
+                Some(Timestamp(tu, Some("UTC".to_string())))
             }
             // None and Some("<tz>") timezones
             // we cast from more precision to higher precision as that always fits with occasional loss of precision
             (Timestamp(tu_l, tz_l), Timestamp(tu_r, tz_r)) if
                 // both are none
-                tz_l.is_none() && tz_r.is_some()
+                tz_l.is_none() && tz_r.is_none()
                 // both have the same time zone
                 || (tz_l.is_some() && (tz_l == tz_r)) => {
                 let tu = get_time_units(tu_l, tu_r);

--- a/src/daft-dsl/src/expr.rs
+++ b/src/daft-dsl/src/expr.rs
@@ -436,7 +436,7 @@ impl Expr {
                     | Operator::NotEq
                     | Operator::LtEq
                     | Operator::GtEq => {
-                        let (result_type, _comp_type) =
+                        let (result_type, _intermediate, _comp_type) =
                             left_field.dtype.comparison_op(&right_field.dtype)?;
                         Ok(Field::new(left_field.name.as_str(), result_type))
                     }

--- a/tests/expressions/typing/conftest.py
+++ b/tests/expressions/typing/conftest.py
@@ -40,21 +40,6 @@ ALL_DTYPES = [
 ALL_DATATYPES_BINARY_PAIRS = list(itertools.product(ALL_DTYPES, repeat=2))
 
 
-@pytest.fixture(
-    scope="module",
-    params=ALL_DATATYPES_BINARY_PAIRS,
-    ids=[f"{dt1}-{dt2}" for (dt1, _), (dt2, _) in ALL_DATATYPES_BINARY_PAIRS],
-)
-def binary_data_fixture(request) -> tuple[Series, Series]:
-    """Returns binary permutation of Series' of all DataType pairs"""
-    (dt1, data1), (dt2, data2) = request.param
-    s1 = Series.from_arrow(data1, name="lhs")
-    assert s1.datatype() == dt1
-    s2 = Series.from_arrow(data2, name="rhs")
-    assert s2.datatype() == dt2
-    return (s1, s2)
-
-
 ALL_TEMPORAL_DTYPES = [
     (DataType.date(), pa.array([datetime.date(2021, 1, 1), datetime.date(2021, 1, 2), None], type=pa.date32())),
     *[
@@ -94,6 +79,8 @@ ALL_TEMPORAL_DTYPES = [
     ],
 ]
 
+ALL_DTYPES += ALL_TEMPORAL_DTYPES
+
 ALL_TEMPORAL_DATATYPES_BINARY_PAIRS = [
     ((dt1, data1), (dt2, data2))
     for (dt1, data1), (dt2, data2) in itertools.product(ALL_TEMPORAL_DTYPES, repeat=2)
@@ -104,13 +91,15 @@ ALL_TEMPORAL_DATATYPES_BINARY_PAIRS = [
     )
 ]
 
+ALL_DATATYPES_BINARY_PAIRS += ALL_TEMPORAL_DATATYPES_BINARY_PAIRS
+
 
 @pytest.fixture(
     scope="module",
-    params=ALL_TEMPORAL_DATATYPES_BINARY_PAIRS,
-    ids=[f"{dt1}-{dt2}" for (dt1, _), (dt2, _) in ALL_TEMPORAL_DATATYPES_BINARY_PAIRS],
+    params=ALL_DATATYPES_BINARY_PAIRS,
+    ids=[f"{dt1}-{dt2}" for (dt1, _), (dt2, _) in ALL_DATATYPES_BINARY_PAIRS],
 )
-def binary_temporal_data_fixture(request) -> tuple[Series, Series]:
+def binary_data_fixture(request) -> tuple[Series, Series]:
     """Returns binary permutation of Series' of all DataType pairs"""
     (dt1, data1), (dt2, data2) = request.param
     s1 = Series.from_arrow(data1, name="lhs")
@@ -122,8 +111,8 @@ def binary_temporal_data_fixture(request) -> tuple[Series, Series]:
 
 @pytest.fixture(
     scope="module",
-    params=ALL_DTYPES + ALL_TEMPORAL_DTYPES,
-    ids=[f"{dt}" for (dt, _) in ALL_DTYPES + ALL_TEMPORAL_DTYPES],
+    params=ALL_DTYPES,
+    ids=[f"{dt}" for (dt, _) in ALL_DTYPES],
 )
 def unary_data_fixture(request) -> Series:
     """Returns unary permutation of Series' of all DataType pairs"""

--- a/tests/expressions/typing/conftest.py
+++ b/tests/expressions/typing/conftest.py
@@ -4,6 +4,8 @@ import datetime
 import itertools
 import sys
 
+import pytz
+
 if sys.version_info < (3, 8):
     pass
 else:
@@ -33,12 +35,6 @@ ALL_DTYPES = [
     (DataType.bool(), pa.array([True, False, None], type=pa.bool_())),
     (DataType.null(), pa.array([None, None, None], type=pa.null())),
     (DataType.binary(), pa.array([b"1", b"2", None], type=pa.binary())),
-    (DataType.date(), pa.array([datetime.date(2021, 1, 1), datetime.date(2021, 1, 2), None], type=pa.date32())),
-    # TODO(jay): Some of the fixtures are broken/become very complicated when testing against timestamps
-    # (
-    #     DataType.timestamp(TimeUnit.ms()),
-    #     pa.array([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2), None], type=pa.timestamp("ms")),
-    # ),
 ]
 
 ALL_DATATYPES_BINARY_PAIRS = list(itertools.product(ALL_DTYPES, repeat=2))
@@ -59,10 +55,75 @@ def binary_data_fixture(request) -> tuple[Series, Series]:
     return (s1, s2)
 
 
+ALL_TEMPORAL_DTYPES = [
+    (DataType.date(), pa.array([datetime.date(2021, 1, 1), datetime.date(2021, 1, 2), None], type=pa.date32())),
+    *[
+        (
+            DataType.timestamp(unit),
+            pa.array([datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2), None], type=pa.timestamp(unit)),
+        )
+        for unit in ["ns", "us", "ms"]
+    ],
+    *[
+        (
+            DataType.timestamp(unit, "US/Eastern"),
+            pa.array(
+                [
+                    datetime.datetime(2021, 1, 1).astimezone(pytz.timezone("US/Eastern")),
+                    datetime.datetime(2021, 1, 2).astimezone(pytz.timezone("US/Eastern")),
+                    None,
+                ],
+                type=pa.timestamp(unit, "US/Eastern"),
+            ),
+        )
+        for unit in ["ns", "us", "ms"]
+    ],
+    *[
+        (
+            DataType.timestamp(unit, "Africa/Accra"),
+            pa.array(
+                [
+                    datetime.datetime(2021, 1, 1).astimezone(pytz.timezone("Africa/Accra")),
+                    datetime.datetime(2021, 1, 2).astimezone(pytz.timezone("Africa/Accra")),
+                    None,
+                ],
+                type=pa.timestamp(unit, "Africa/Accra"),
+            ),
+        )
+        for unit in ["ns", "us", "ms"]
+    ],
+]
+
+ALL_TEMPORAL_DATATYPES_BINARY_PAIRS = [
+    ((dt1, data1), (dt2, data2))
+    for (dt1, data1), (dt2, data2) in itertools.product(ALL_TEMPORAL_DTYPES, repeat=2)
+    if not (
+        pa.types.is_timestamp(data1.type)
+        and pa.types.is_timestamp(data2.type)
+        and (data1.type.tz is None) ^ (data2.type.tz is None)
+    )
+]
+
+
 @pytest.fixture(
     scope="module",
-    params=ALL_DTYPES,
-    ids=[f"{dt}" for (dt, _) in ALL_DTYPES],
+    params=ALL_TEMPORAL_DATATYPES_BINARY_PAIRS,
+    ids=[f"{dt1}-{dt2}" for (dt1, _), (dt2, _) in ALL_TEMPORAL_DATATYPES_BINARY_PAIRS],
+)
+def binary_temporal_data_fixture(request) -> tuple[Series, Series]:
+    """Returns binary permutation of Series' of all DataType pairs"""
+    (dt1, data1), (dt2, data2) = request.param
+    s1 = Series.from_arrow(data1, name="lhs")
+    assert s1.datatype() == dt1
+    s2 = Series.from_arrow(data2, name="rhs")
+    assert s2.datatype() == dt2
+    return (s1, s2)
+
+
+@pytest.fixture(
+    scope="module",
+    params=ALL_DTYPES + ALL_TEMPORAL_DTYPES,
+    ids=[f"{dt}" for (dt, _) in ALL_DTYPES + ALL_TEMPORAL_DTYPES],
 )
 def unary_data_fixture(request) -> Series:
     """Returns unary permutation of Series' of all DataType pairs"""

--- a/tests/expressions/typing/test_compare.py
+++ b/tests/expressions/typing/test_compare.py
@@ -26,3 +26,14 @@ def test_comparable(binary_data_fixture, op):
         run_kernel=lambda: op(lhs, rhs),
         resolvable=comparable_type_validation(lhs.datatype(), rhs.datatype()),
     )
+
+
+@pytest.mark.parametrize("op", [ops.eq, ops.ne, ops.lt, ops.le, ops.gt, ops.ge])
+def test_temporal_comparable(binary_temporal_data_fixture, op):
+    lhs, rhs = binary_temporal_data_fixture
+    assert_typing_resolve_vs_runtime_behavior(
+        data=binary_temporal_data_fixture,
+        expr=op(col(lhs.name()), col(rhs.name())),
+        run_kernel=lambda: op(lhs, rhs),
+        resolvable=comparable_type_validation(lhs.datatype(), rhs.datatype()),
+    )

--- a/tests/expressions/typing/test_compare.py
+++ b/tests/expressions/typing/test_compare.py
@@ -26,14 +26,3 @@ def test_comparable(binary_data_fixture, op):
         run_kernel=lambda: op(lhs, rhs),
         resolvable=comparable_type_validation(lhs.datatype(), rhs.datatype()),
     )
-
-
-@pytest.mark.parametrize("op", [ops.eq, ops.ne, ops.lt, ops.le, ops.gt, ops.ge])
-def test_temporal_comparable(binary_temporal_data_fixture, op):
-    lhs, rhs = binary_temporal_data_fixture
-    assert_typing_resolve_vs_runtime_behavior(
-        data=binary_temporal_data_fixture,
-        expr=op(col(lhs.name()), col(rhs.name())),
-        run_kernel=lambda: op(lhs, rhs),
-        resolvable=comparable_type_validation(lhs.datatype(), rhs.datatype()),
-    )

--- a/tests/series/test_comparisons.py
+++ b/tests/series/test_comparisons.py
@@ -682,3 +682,43 @@ def test_logicalops_pyobjects(op, expected, expected_self) -> None:
     assert op(custom_falses, values).datatype() == DataType.bool()
     assert op(custom_falses, values).to_pylist() == expected
     assert op(custom_falses, custom_falses).to_pylist() == expected_self
+
+
+def test_compare_timestamps_no_tz():
+    from datetime import datetime
+
+    tz1 = Series.from_pylist([datetime(2022, 1, 1)])
+    assert (tz1 == tz1).to_pylist() == [True]
+
+
+def test_compare_timestamps_one_tz():
+    from datetime import datetime
+
+    import pytz
+
+    tz1 = Series.from_pylist([datetime(2022, 1, 1)])
+    tz2 = Series.from_pylist([datetime(2022, 1, 1, tzinfo=pytz.utc)])
+    with pytest.raises(ValueError, match="Cannot perform comparison on types"):
+        assert (tz1 == tz2).to_pylist() == [True]
+
+
+def test_compare_timestamps_same_tz():
+    from datetime import datetime
+
+    import pytz
+
+    tz1 = Series.from_pylist([datetime(2022, 1, 1, tzinfo=pytz.utc)])
+    tz2 = Series.from_pylist([datetime(2022, 1, 1, tzinfo=pytz.utc)])
+    assert (tz1 == tz2).to_pylist() == [True]
+
+
+def test_compare_timestamps_diff_tz():
+    from datetime import datetime
+
+    import pytz
+
+    utc = datetime(2022, 1, 1, tzinfo=pytz.utc)
+    eastern = utc.astimezone(pytz.timezone("US/Eastern"))
+    tz1 = Series.from_pylist([utc])
+    tz2 = Series.from_pylist([eastern])
+    assert (tz1 == tz2).to_pylist() == [True]


### PR DESCRIPTION
* Enables comparisons between Timestamps of no / same / different timezones and units
* Enables comparisons between dates and timestamps
* Adds Date / Timestamps to expression fixtures
* However we do not allow compare a TimeStamp with no tz with one that has one.