### PR TITLE
[FEAT] annotate ray tasks with name of instructions

### DIFF
--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -82,6 +82,9 @@ class PartitionTask(Generic[PartitionT]):
     def __repr__(self) -> str:
         return self.__str__()
 
+    def name(self) -> str:
+        return f"{'-'.join(i.__class__.__name__ for i in self.instructions)}:{self.stage_id}"
+
 
 class PartitionTaskBuilder(Generic[PartitionT]):
     """Builds a PartitionTask by adding instructions to its pipeline."""

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -83,7 +83,7 @@ class PartitionTask(Generic[PartitionT]):
         return self.__str__()
 
     def name(self) -> str:
-        return f"{'-'.join(i.__class__.__name__ for i in self.instructions)}:{self.stage_id}"
+        return f"{'-'.join(i.__class__.__name__ for i in self.instructions)} [Stage:{self.stage_id}]"
 
 
 class PartitionTaskBuilder(Generic[PartitionT]):

--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -56,7 +56,7 @@ class ProgressBar:
         stage_id = step.stage_id
 
         if stage_id not in self.pbars:
-            name = "-".join(i.__class__.__name__ for i in step.instructions)
+            name = step.name()
             self._make_new_bar(stage_id, name)
         else:
             pb = self.pbars[stage_id]

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -651,9 +651,7 @@ def _build_partitions(
     daft_execution_config_objref: ray.ObjectRef, task: PartitionTask[ray.ObjectRef]
 ) -> list[ray.ObjectRef]:
     """Run a PartitionTask and return the resulting list of partitions."""
-    ray_options: dict[str, Any] = {
-        "num_returns": task.num_results + 1,
-    }
+    ray_options: dict[str, Any] = {"num_returns": task.num_results + 1, "name": task.name()}
 
     if task.resource_request is not None:
         ray_options = {**ray_options, **_get_ray_task_options(task.resource_request)}


### PR DESCRIPTION
Annotates Ray Tasks with name of instructions
Also adds stage id to TQDM bar to make it more clear that they are separate stages

![image](https://github.com/Eventual-Inc/Daft/assets/2550285/8bf25470-c755-43e4-8816-bf7357db1d1c)
