### PR TITLE
[PERF] Greatly speed up Variable Length Concat

### DIFF
--- a/tests/benchmarks/test_concat.py
+++ b/tests/benchmarks/test_concat.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import uuid
+
+from daft.series import Series
+
+
+def test_string_concat(benchmark) -> None:
+    NUM_ROWS = 100_000
+    data = Series.from_pylist([str(uuid.uuid4()) for _ in range(NUM_ROWS)])
+    to_concat = [data] * 100
+
+    def bench_concat() -> Series:
+        return Series.concat(to_concat)
+
+    benchmark(bench_concat)


### PR DESCRIPTION
* before Were we using Arrow Growable for Concating UTF8 and Binary Arrays, which only allocated memory for the offset array
* Now we preallocate the value array since we know the complete size of the target array.