### PR TITLE
[PERF] Speed up CSV Reader with SIMD and reduced allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,7 +1214,6 @@ dependencies = [
  "chrono-tz",
  "csv-async",
  "fast-float",
- "lexical-core",
  "simdutf8",
  "tokio",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfc14f5c3e34de57539a7ba9c18ecde3d9bbde48d232ea1da3e468adb307fd0"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,9 +1209,11 @@ version = "0.2.0-dev0"
 dependencies = [
  "arrow2",
  "async-compression",
+ "atoi_simd",
  "chrono",
  "chrono-tz",
  "csv-async",
+ "fast-float",
  "lexical-core",
  "simdutf8",
  "tokio",
@@ -1542,6 +1550,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fast-float"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "fastrand"

--- a/src/daft-decoding/Cargo.toml
+++ b/src/daft-decoding/Cargo.toml
@@ -1,9 +1,11 @@
 [dependencies]
 arrow2 = {workspace = true, features = ["io_csv", "io_csv_async"]}
 async-compression = {workspace = true}
+atoi_simd = "0.15.5"
 chrono = {workspace = true}
 chrono-tz = {workspace = true}
 csv-async = "1.2.6"
+fast-float = "0.2.0"
 lexical-core = {version = "0.8"}
 simdutf8 = "0.1.3"
 tokio = {workspace = true}

--- a/src/daft-decoding/Cargo.toml
+++ b/src/daft-decoding/Cargo.toml
@@ -6,7 +6,6 @@ chrono = {workspace = true}
 chrono-tz = {workspace = true}
 csv-async = "1.2.6"
 fast-float = "0.2.0"
-lexical-core = {version = "0.8"}
 simdutf8 = "0.1.3"
 tokio = {workspace = true}
 url = {workspace = true}

--- a/src/daft-decoding/src/deserialize.rs
+++ b/src/daft-decoding/src/deserialize.rs
@@ -55,7 +55,7 @@ fn deserialize_primitive<T, B: ByteRecordGeneric, F>(
     mut op: F,
 ) -> Box<dyn Array>
 where
-    T: NativeType + lexical_core::FromLexical,
+    T: NativeType,
     F: FnMut(&[u8]) -> Option<T>,
 {
     let iter = rows.iter().map(|row| match row.get(column) {

--- a/src/daft-decoding/src/deserialize.rs
+++ b/src/daft-decoding/src/deserialize.rs
@@ -83,8 +83,8 @@ fn deserialize_decimal(bytes: &[u8], precision: usize, scale: usize) -> Option<i
     let lhs = a.next();
     let rhs = a.next();
     match (lhs, rhs) {
-        (Some(lhs), Some(rhs)) => lexical_core::parse::<i128>(lhs).ok().and_then(|x| {
-            lexical_core::parse::<i128>(rhs)
+        (Some(lhs), Some(rhs)) => atoi_simd::parse_skipped::<i128>(lhs).ok().and_then(|x| {
+            atoi_simd::parse_skipped::<i128>(rhs)
                 .ok()
                 .map(|y| (x, lhs, y, rhs))
                 .and_then(|(lhs, lhs_b, rhs, rhs_b)| {
@@ -102,13 +102,13 @@ fn deserialize_decimal(bytes: &[u8], precision: usize, scale: usize) -> Option<i
             if rhs.len() != precision || rhs.len() != scale {
                 return None;
             }
-            lexical_core::parse::<i128>(rhs).ok()
+            atoi_simd::parse_skipped::<i128>(rhs).ok()
         }
         (Some(lhs), None) => {
             if lhs.len() != precision || scale != 0 {
                 return None;
             }
-            lexical_core::parse::<i128>(lhs).ok()
+            atoi_simd::parse_skipped::<i128>(lhs).ok()
         }
         (None, None) => None,
     }
@@ -226,34 +226,34 @@ pub fn deserialize_column<B: ByteRecordGeneric>(
             }
         }),
         Int8 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<i8>(bytes).ok()
+            atoi_simd::parse_skipped::<i8>(bytes).ok()
         }),
         Int16 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<i16>(bytes).ok()
+            atoi_simd::parse_skipped::<i16>(bytes).ok()
         }),
         Int32 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<i32>(bytes).ok()
+            atoi_simd::parse_skipped::<i32>(bytes).ok()
         }),
         Int64 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<i64>(bytes).ok()
+            atoi_simd::parse_skipped::<i64>(bytes).ok()
         }),
         UInt8 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<u8>(bytes).ok()
+            atoi_simd::parse_skipped::<u8>(bytes).ok()
         }),
         UInt16 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<u16>(bytes).ok()
+            atoi_simd::parse_skipped::<u16>(bytes).ok()
         }),
         UInt32 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<u32>(bytes).ok()
+            atoi_simd::parse_skipped::<u32>(bytes).ok()
         }),
         UInt64 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<u64>(bytes).ok()
+            atoi_simd::parse_skipped::<u64>(bytes).ok()
         }),
         Float32 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<f32>(bytes).ok()
+            fast_float::parse::<f32, _>(bytes).ok()
         }),
         Float64 => deserialize_primitive(rows, column, datatype, |bytes| {
-            lexical_core::parse::<f64>(bytes).ok()
+            fast_float::parse::<f64, _>(bytes).ok()
         }),
         Date32 => deserialize_primitive(rows, column, datatype, |bytes| {
             let mut last_fmt_idx = 0;

--- a/src/daft-decoding/src/deserialize.rs
+++ b/src/daft-decoding/src/deserialize.rs
@@ -148,7 +148,8 @@ fn deserialize_utf8<O: Offset, B: ByteRecordGeneric>(rows: &[B], column: usize) 
     });
     let mut mu = MutableUtf8Array::<O>::with_capacities(rows.len(), expected_size);
     mu.extend_trusted_len(iter);
-    mu.as_box()
+    let array: Utf8Array<O> = mu.into();
+    Box::new(array)
 }
 
 #[inline]

--- a/src/daft-decoding/src/inference.rs
+++ b/src/daft-decoding/src/inference.rs
@@ -58,11 +58,11 @@ fn is_boolean(bytes: &[u8]) -> bool {
 }
 
 fn is_float(bytes: &[u8]) -> bool {
-    lexical_core::parse::<f64>(bytes).is_ok()
+    fast_float::parse::<f64, _>(bytes).is_ok()
 }
 
 fn is_integer(bytes: &[u8]) -> bool {
-    lexical_core::parse::<i64>(bytes).is_ok()
+    atoi_simd::parse_skipped::<i64>(bytes).is_ok()
 }
 
 fn is_date(string: &str) -> bool {


### PR DESCRIPTION
* Leads to a 7% reduction in walltime for the local airbnb csv
* Switch to simd parsing instructions for csv
* Preallocate UTF8Array value capacity before copying slices in