### PR TITLE
[BUG] Materialize Dataframes created from file writes

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -337,11 +337,16 @@ class DataFrame:
             compression=compression,
             io_config=io_config,
         )
-        # Block and write, then retrieve data and return a new disconnected DataFrame
+        # Block and write, then retrieve data
         write_df = DataFrame(builder)
         write_df.collect()
         assert write_df._result is not None
-        return DataFrame(write_df._builder)
+
+        # Populate and return a new disconnected DataFrame
+        result_df = DataFrame(write_df._builder)
+        result_df._result_cache = write_df._result_cache
+        result_df._preview = write_df._preview
+        return result_df
 
     @DataframePublicAPI
     def write_csv(
@@ -385,11 +390,16 @@ class DataFrame:
             io_config=io_config,
         )
 
-        # Block and write, then retrieve data and return a new disconnected DataFrame
+        # Block and write, then retrieve data
         write_df = DataFrame(builder)
         write_df.collect()
         assert write_df._result is not None
-        return DataFrame(write_df._builder)
+
+        # Populate and return a new disconnected DataFrame
+        result_df = DataFrame(write_df._builder)
+        result_df._result_cache = write_df._result_cache
+        result_df._preview = write_df._preview
+        return result_df
 
     ###
     # DataFrame operations

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -14,7 +14,8 @@ def test_parquet_write(tmp_path):
     read_back_pd_df = daft.read_parquet(tmp_path.as_posix() + "/*.parquet").to_pandas()
     assert_df_equals(df.to_pandas(), read_back_pd_df)
 
-    assert len(pd_df.to_pandas()) == 1
+    assert len(pd_df) == 1
+    assert len(pd_df._preview.preview_partition) == 1
 
 
 def test_parquet_write_with_partitioning(tmp_path):
@@ -25,7 +26,8 @@ def test_parquet_write_with_partitioning(tmp_path):
     read_back_pd_df = daft.read_parquet(tmp_path.as_posix() + "/**/*.parquet").to_pandas()
     assert_df_equals(df.exclude("Borough").to_pandas(), read_back_pd_df)
 
-    assert len(pd_df.to_pandas()) == 5
+    assert len(pd_df) == 5
+    assert len(pd_df._preview.preview_partition) == 5
 
 
 def test_csv_write(tmp_path):
@@ -36,7 +38,8 @@ def test_csv_write(tmp_path):
     read_back_pd_df = daft.read_csv(tmp_path.as_posix() + "/*.csv").to_pandas()
     assert_df_equals(df.to_pandas(), read_back_pd_df)
 
-    assert len(pd_df.to_pandas()) == 1
+    assert len(pd_df) == 1
+    assert len(pd_df._preview.preview_partition) == 1
 
 
 @pytest.mark.skip()


### PR DESCRIPTION
Closes #582 

**Materialize Dataframes created from file writes, i.e. write_csv and write_parquet**

Changes:
- Populate _result_cache and _preview for dataframes returned from write methods
- Modify test cases for write methods to check that len() can be called and previews are populated.

Todo:

- Edit docs, for example: https://www.getdaft.io/projects/docs/en/latest/10-min.html#writing-data. Will do this in separate PR.