### PR TITLE
[BUG] Fix scheduler deadlock on concurrent broadcast joins.

### DIFF
--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -372,14 +372,10 @@ def broadcast_join(
     receiver_requests: deque[SingleOutputPartitionTask[PartitionT]] = deque()
 
     while True:
-        receiver_parts: deque[SingleOutputPartitionTask[PartitionT]] = deque()
-        # Moved completed partition tasks in the receiver side of the join to the materialized partition set.
-        while receiver_requests and receiver_requests[0].done():
-            receiver_parts.append(receiver_requests.popleft())
-
         # Emit join steps for newly materialized partitions.
         # Broadcast all broadcaster partitions to each new receiver partition that was materialized on this dispatch loop.
-        for receiver_part in receiver_parts:
+        while receiver_requests and receiver_requests[0].done():
+            receiver_part = receiver_requests.popleft()
             yield _create_join_step(broadcaster_parts, receiver_part, left_on, right_on, how, is_swapped)
 
         # Execute single child step to pull in more input partitions.


### PR DESCRIPTION
This PR fixes a scheduler deadlock that results from an "in-progress input tasks" state mismatch between the join operator and the runner under concurrent broadcast joins.

This closes #1793.

## Background

- Physical plan scheduling operators (such as `broadcast_join()`) yield `None` back to the runner to signal that the operator is waiting for its inputs to finish executing, telling the runner to run more tasks ([example](https://github.com/Eventual-Inc/Daft/blob/4bc895273eccfe7ab093bca48280c1993c29aaec/daft/execution/physical_plan.py#L398)).
- The Python runner was failing an assertion that there are tasks to run when it receives a None from an operator ([link to assertion](https://github.com/Eventual-Inc/Daft/blob/4bc895273eccfe7ab093bca48280c1993c29aaec/daft/runners/pyrunner.py#L239-L241)); this suggests that the runner and operators don't have a consistent view of the input task state.

## Bug Details

The particular physical plan scheduling operator pattern that can produce a deadlock is:
1. pull ready inputs from input queue into a batch;
2. dispatch work on ready input batch;
3. pull more input tasks into input queue;
4. if input has no more tasks and input queue is non-empty, tell runner to execute more tasks.

The issue appears to be that there's an implicit assumption that no tasks in the input queue will become ready between (1) and (4); this isn't always true since (2) will yield to the runner, and the runner may run a different operator coroutine, and that coroutine may yield `None`, which could then mark an input task for the other operator coroutine as done and prune it from its in-progress set. Since our "is there more work to do" check in (4) only consists of checking if the queue is non-empty, not checking if the queue is non-empty OR all tasks in the queue are done, we end up doing an out-of-protocol `yield None`, which produces the deadlock.

The `broadcast_join()` physical plan scheduling operator follows this pattern ([link](https://github.com/Eventual-Inc/Daft/blob/4bc895273eccfe7ab093bca48280c1993c29aaec/daft/execution/physical_plan.py#L372-L400)), and TPC-H Q2 involves multiple concurrent joins as inputs to another join, where the latter join alternates pulling from the left side and the right side of the join, yielding concurrent execution of the join operator coroutines, which can occasionally trigger this deadlock (~1 out of every 150 runs when the Python runner is constrained to 2 CPU cores).

## Solution

I've made a fix that unbatches (2) and pulls it into the loop for (1), so we always check if the input queue contains done tasks after we yield new work to the runner, and so far it has passed the test on 500 runs.