### PR TITLE
[FEAT] Dataframe __contains__ magic method

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1176,6 +1176,20 @@ class DataFrame:
         )
         raise RuntimeError(message)
 
+    def __contains__(self, col_name: str) -> bool:
+        """Returns whether the column exists in the dataframe.
+
+        Example:
+            >>> "x" in df
+
+        Args:
+            col_name (str): column name
+
+        Returns:
+            bool: whether the column exists in the dataframe.
+        """
+        return col_name in self.column_names
+
     @DataframePublicAPI
     def to_pandas(self, cast_tensors_to_ray_tensor_dtype: bool = False) -> "pd.DataFrame":
         """Converts the current DataFrame to a pandas DataFrame.

--- a/tests/dataframe/test_accessors.py
+++ b/tests/dataframe/test_accessors.py
@@ -34,3 +34,8 @@ def test_columns(df):
     assert len(df.columns) == 1
     [ex] = df.columns
     assert ex.name() == "foo"
+
+
+def test_in(df):
+    assert "foo" in df
+    assert "bar" not in df


### PR DESCRIPTION
Closes  #1813

Add `__contains__` magic method for Dataframe so users can check if column names exist in the Dataframe using `in`, e.g. `"x" in df`