### PR TITLE
[FEAT] Add group_by.map_groups

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -896,6 +896,10 @@ class DataFrame:
         builder = self._builder.agg(exprs_to_agg, list(group_by) if group_by is not None else None)
         return DataFrame(builder)
 
+    def _map_groups(self, udf: Expression, group_by: Optional[ExpressionsProjection] = None) -> "DataFrame":
+        builder = self._builder.map_groups(udf, list(group_by) if group_by is not None else None)
+        return DataFrame(builder)
+
     @DataframePublicAPI
     def sum(self, *cols: ColumnInputType) -> "DataFrame":
         """Performs a global sum on the DataFrame
@@ -1554,3 +1558,14 @@ class GroupedDataFrame:
             DataFrame: DataFrame with grouped aggregations
         """
         return self.df._agg(to_agg, group_by=self.group_by)
+
+    def map_groups(self, udf: Expression) -> "DataFrame":
+        """Apply a user-defined function to each group.
+
+        Args:
+            udf (Expression): User-defined function to apply to each group.
+
+        Returns:
+            DataFrame: DataFrame with grouped aggregations
+        """
+        return self.df._map_groups(udf, group_by=self.group_by)

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1562,6 +1562,27 @@ class GroupedDataFrame:
     def map_groups(self, udf: Expression) -> "DataFrame":
         """Apply a user-defined function to each group.
 
+        Example:
+            >>> df = daft.from_pydict({"group": ["a", "a", "a", "b", "b", "b"], "data": [1, 20, 30, 4, 50, 600]})
+            >>>
+            >>> @daft.udf(return_dtype=daft.DataType.float64())
+            ... def std_dev(data):
+            ...     return [statistics.stdev(data.to_pylist())]
+            >>>
+            >>> df = df.groupby("group").map_groups(std_dev(df["data"]))
+            >>> df.show()
+            ╭───────┬────────────────────╮
+            │ group ┆ data               │
+            │ ---   ┆ ---                │
+            │ Utf8  ┆ Float64            │
+            ╞═══════╪════════════════════╡
+            │ a     ┆ 14.730919862656235 │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+            │ b     ┆ 331.62026476076517 │
+            ╰───────┴────────────────────╯
+
+            (Showing first 2 of 2 rows)
+
         Args:
             udf (Expression): User-defined function to apply to each group.
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1560,7 +1560,7 @@ class GroupedDataFrame:
         return self.df._agg(to_agg, group_by=self.group_by)
 
     def map_groups(self, udf: Expression) -> "DataFrame":
-        """Apply a user-defined function to each group.
+        """Apply a user-defined function to each group. The name of the resultant column will default to the name of the first input column.
 
         Example:
             >>> df = daft.from_pydict({"group": ["a", "a", "a", "b", "b", "b"], "data": [1, 20, 30, 4, 50, 600]})

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -181,6 +181,11 @@ class LogicalPlanBuilder:
         builder = self._builder.aggregate([expr._expr for expr in exprs], group_by_pyexprs)
         return LogicalPlanBuilder(builder)
 
+    def map_groups(self, udf: Expression, group_by: list[Expression] | None) -> LogicalPlanBuilder:
+        group_by_pyexprs = [expr._expr for expr in group_by] if group_by is not None else []
+        builder = self._builder.aggregate([udf._expr], group_by_pyexprs)
+        return LogicalPlanBuilder(builder)
+
     def join(  # type: ignore[override]
         self,
         right: LogicalPlanBuilder,

--- a/src/daft-dsl/src/expr.rs
+++ b/src/daft-dsl/src/expr.rs
@@ -128,7 +128,7 @@ impl AggExpr {
         }
     }
 
-    pub fn child(&self) -> Vec<ExprRef> {
+    pub fn children(&self) -> Vec<ExprRef> {
         use AggExpr::*;
         match self {
             Count(expr, ..)
@@ -405,7 +405,7 @@ impl Expr {
             Not(expr) | IsNull(expr) | NotNull(expr) | Cast(expr, ..) | Alias(expr, ..) => {
                 vec![expr.clone()]
             }
-            Agg(agg_expr) => agg_expr.child(),
+            Agg(agg_expr) => agg_expr.children(),
 
             // Multiple children.
             Function { inputs, .. } => inputs.iter().map(|e| e.clone().into()).collect(),

--- a/src/daft-dsl/src/functions/python/udf.rs
+++ b/src/daft-dsl/src/functions/python/udf.rs
@@ -32,6 +32,12 @@ impl FunctionEvaluator for PythonUDF {
     }
 
     fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+        self.call_udf(inputs)
+    }
+}
+
+impl PythonUDF {
+    pub fn call_udf(&self, inputs: &[Series]) -> DaftResult<Series> {
         use pyo3::Python;
 
         if inputs.len() != self.num_expressions {

--- a/src/daft-dsl/src/treenode.rs
+++ b/src/daft-dsl/src/treenode.rs
@@ -23,6 +23,7 @@ impl TreeNode for Expr {
                     | Max(expr)
                     | List(expr)
                     | Concat(expr) => vec![expr.as_ref()],
+                    MapGroups { func: _, inputs } => inputs.iter().collect::<Vec<_>>(),
                 }
             }
             BinaryOp { op: _, left, right } => vec![left.as_ref(), right.as_ref()],
@@ -66,6 +67,13 @@ impl TreeNode for Expr {
                     Max(expr) => transform(expr.as_ref().clone())?.max(),
                     List(expr) => transform(expr.as_ref().clone())?.agg_list(),
                     Concat(expr) => transform(expr.as_ref().clone())?.agg_concat(),
+                    MapGroups { func, inputs } => Expr::Agg(MapGroups {
+                        func,
+                        inputs: inputs
+                            .into_iter()
+                            .map(transform)
+                            .collect::<DaftResult<Vec<_>>>()?,
+                    }),
                 }
             }
             Not(expr) => Not(transform(expr.as_ref().clone())?.into()),

--- a/src/daft-plan/src/builder.rs
+++ b/src/daft-plan/src/builder.rs
@@ -195,6 +195,10 @@ impl LogicalPlanBuilder {
             .iter()
             .map(|expr| match expr {
                 Expr::Agg(agg_expr) => Ok(agg_expr.clone()),
+                Expr::Function { func, inputs } => Ok(daft_dsl::AggExpr::MapGroups {
+                    func: func.clone(),
+                    inputs: inputs.clone(),
+                }),
                 _ => Err(DaftError::ValueError(format!(
                     "Expected aggregation expression, but got: {expr}"
                 ))),

--- a/src/daft-plan/src/planner.rs
+++ b/src/daft-plan/src/planner.rs
@@ -456,14 +456,30 @@ pub fn plan(logical_plan: &LogicalPlan, cfg: Arc<DaftExecutionConfig>) -> DaftRe
                                 final_exprs
                                     .push(Column(concat_of_concat_id.clone()).alias(output_name));
                             }
+                            MapGroups { func, inputs } => {
+                                let func_id = agg_expr.semantic_id(&schema).id;
+                                // No first stage aggregation for MapGroups, do all the work in the second stage.
+                                second_stage_aggs
+                                    .entry(func_id.clone())
+                                    .or_insert(MapGroups {
+                                        func: func.clone(),
+                                        inputs: inputs.to_vec(),
+                                    });
+                                let final_id = inputs.first().unwrap().semantic_id(&schema).id;
+                                final_exprs.push(Column(final_id.clone()).alias(output_name));
+                            }
                         }
                     }
 
-                    let first_stage_agg = PhysicalPlan::Aggregate(Aggregate::new(
-                        input_plan.into(),
-                        first_stage_aggs.values().cloned().collect(),
-                        groupby.clone(),
-                    ));
+                    let first_stage_agg = if first_stage_aggs.is_empty() {
+                        input_plan
+                    } else {
+                        PhysicalPlan::Aggregate(Aggregate::new(
+                            input_plan.into(),
+                            first_stage_aggs.values().cloned().collect(),
+                            groupby.clone(),
+                        ))
+                    };
                     let gather_plan = if groupby.is_empty() {
                         PhysicalPlan::Coalesce(Coalesce::new(
                             first_stage_agg.into(),

--- a/src/daft-plan/src/planner.rs
+++ b/src/daft-plan/src/planner.rs
@@ -465,8 +465,7 @@ pub fn plan(logical_plan: &LogicalPlan, cfg: Arc<DaftExecutionConfig>) -> DaftRe
                                         func: func.clone(),
                                         inputs: inputs.to_vec(),
                                     });
-                                let final_id = inputs.first().unwrap().semantic_id(&schema).id;
-                                final_exprs.push(Column(final_id.clone()).alias(output_name));
+                                final_exprs.push(Column(output_name.into()));
                             }
                         }
                     }

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -313,7 +313,7 @@ impl Table {
             List(expr) => Series::agg_list(&self.eval_expression(expr)?, groups),
             Concat(expr) => Series::agg_concat(&self.eval_expression(expr)?, groups),
             MapGroups { .. } => Err(DaftError::ValueError(
-                "MapGroups not supported in eval_agg_expression".to_string(),
+                "MapGroups not supported via aggregation, use map_groups instead".to_string(),
             )),
         }
     }

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -312,6 +312,9 @@ impl Table {
             Max(expr) => Series::max(&self.eval_expression(expr)?, groups),
             List(expr) => Series::agg_list(&self.eval_expression(expr)?, groups),
             Concat(expr) => Series::agg_concat(&self.eval_expression(expr)?, groups),
+            MapGroups { .. } => Err(DaftError::ValueError(
+                "MapGroups not supported in eval_agg_expression".to_string(),
+            )),
         }
     }
 

--- a/src/daft-table/src/ops/agg.rs
+++ b/src/daft-table/src/ops/agg.rs
@@ -30,7 +30,7 @@ impl Table {
             .collect::<DaftResult<Vec<_>>>()?;
 
         #[cfg(feature = "python")]
-        if let Some(AggExpr::MapGroups { func, inputs }) = agg_exprs.first() {
+        if let [AggExpr::MapGroups { func, inputs }] = &agg_exprs[..] {
             return self.map_groups(func, inputs, group_by);
         }
 

--- a/src/daft-table/src/ops/agg.rs
+++ b/src/daft-table/src/ops/agg.rs
@@ -1,5 +1,5 @@
-use daft_core::{array::ops::IntoGroups, datatypes::UInt64Array, series::IntoSeries};
-use daft_dsl::Expr;
+use daft_core::{array::ops::IntoGroups, datatypes::UInt64Array, series::IntoSeries, Series};
+use daft_dsl::{functions::FunctionExpr, AggExpr, Expr};
 
 use common_error::{DaftError, DaftResult};
 
@@ -19,6 +19,21 @@ impl Table {
     }
 
     pub fn agg_groupby(&self, to_agg: &[Expr], group_by: &[Expr]) -> DaftResult<Table> {
+        let agg_exprs = to_agg
+            .iter()
+            .map(|e| match e {
+                Expr::Agg(e) => Ok(e),
+                _ => Err(DaftError::ValueError(format!(
+                    "Trying to run non-Agg expression in Grouped Agg! {e}"
+                ))),
+            })
+            .collect::<DaftResult<Vec<_>>>()?;
+
+        #[cfg(feature = "python")]
+        if let Some(AggExpr::MapGroups { func, inputs }) = agg_exprs.first() {
+            return self.map_groups(func, inputs, group_by);
+        }
+
         // Table with just the groupby columns.
         let groupby_table = self.eval_expression_list(group_by)?;
 
@@ -31,15 +46,6 @@ impl Table {
             let indices_as_series = UInt64Array::from(("", groupkey_indices)).into_series();
             groupby_table.take(&indices_as_series)?
         };
-        let agg_exprs = to_agg
-            .iter()
-            .map(|e| match e {
-                Expr::Agg(e) => Ok(e),
-                _ => Err(DaftError::ValueError(format!(
-                    "Trying to run non-Agg expression in Grouped Agg! {e}"
-                ))),
-            })
-            .collect::<DaftResult<Vec<_>>>()?;
 
         // Take fast path short circuit if there is only 1 group
         let group_idx_input = if groupvals_indices.len() == 1 {
@@ -55,5 +61,96 @@ impl Table {
 
         // Combine the groupkey columns and the aggregation result columns.
         Self::from_columns([&groupkeys_table.columns[..], &grouped_cols].concat())
+    }
+
+    #[cfg(feature = "python")]
+    pub fn map_groups(
+        &self,
+        func: &FunctionExpr,
+        inputs: &[Expr],
+        group_by: &[Expr],
+    ) -> DaftResult<Table> {
+        let udf = match func {
+            FunctionExpr::Python(udf) => udf,
+            _ => {
+                return Err(DaftError::ComputeError(
+                    "Trying to run non-UDF function in MapGroups!".to_string(),
+                ))
+            }
+        };
+
+        // Table with just the groupby columns.
+        let groupby_table = self.eval_expression_list(group_by)?;
+
+        // Get the unique group keys (by indices)
+        // and the grouped values (also by indices, one array of indices per group).
+        let (groupkey_indices, groupvals_indices) = groupby_table.make_groups()?;
+
+        let evaluated_inputs = inputs
+            .iter()
+            .map(|e| self.eval_expression(e))
+            .collect::<DaftResult<Vec<_>>>()?;
+
+        // Take fast path short circuit if there is only 1 group
+        let (groupkeys_table, grouped_col) = if groupvals_indices.len() <= 1 {
+            let grouped_col = udf.call_udf(evaluated_inputs.as_slice())?;
+            let groupkeys_table = {
+                let indices_as_series = UInt64Array::from(("", groupkey_indices)).into_series();
+                groupby_table.take(&indices_as_series)?
+            };
+            (groupkeys_table, grouped_col)
+        } else {
+            let grouped_results = groupkey_indices
+                .iter()
+                .zip(groupvals_indices.iter())
+                .map(|(groupkey_index, groupval_indices)| {
+                    let evaluated_grouped_col = {
+                        // Convert group indices to Series
+                        let indices_as_series =
+                            UInt64Array::from(("", groupval_indices.clone())).into_series();
+
+                        // Take each input Series by the group indices
+                        let input_groups = evaluated_inputs
+                            .iter()
+                            .map(|s| s.take(&indices_as_series))
+                            .collect::<DaftResult<Vec<_>>>()?;
+
+                        // Call the UDF on the grouped inputs
+                        udf.call_udf(input_groups.as_slice())?
+                    };
+
+                    let broadcasted_groupkeys_table = {
+                        // Convert groupkey indices to Series
+                        let groupkey_indices_as_series =
+                            UInt64Array::from(("", vec![*groupkey_index])).into_series();
+
+                        // Take the group keys by the groupkey indices
+                        let groupkeys_table = groupby_table.take(&groupkey_indices_as_series)?;
+
+                        // Broadcast the group keys to the length of the grouped column, because output of UDF can be more than one row
+                        let broacasted_groupkeys = groupkeys_table
+                            .columns
+                            .iter()
+                            .map(|c| c.broadcast(evaluated_grouped_col.len()))
+                            .collect::<DaftResult<Vec<_>>>()?;
+
+                        // Combine the broadcasted group keys into a Table
+                        Table::from_columns(broacasted_groupkeys)?
+                    };
+
+                    Ok((broadcasted_groupkeys_table, evaluated_grouped_col))
+                })
+                .collect::<DaftResult<Vec<_>>>()?;
+
+            let series_refs = grouped_results.iter().map(|(_, s)| s).collect::<Vec<_>>();
+            let concatenated_grouped_col = Series::concat(series_refs.as_slice())?;
+
+            let table_refs = grouped_results.iter().map(|(t, _)| t).collect::<Vec<_>>();
+            let concatenated_groupkeys_table = Table::concat(table_refs.as_slice())?;
+
+            (concatenated_groupkeys_table, concatenated_grouped_col)
+        };
+
+        Self::from_columns([&groupkeys_table.columns[..], &[grouped_col]].concat())
     }
 }

--- a/tests/cookbook/conftest.py
+++ b/tests/cookbook/conftest.py
@@ -10,7 +10,7 @@ import daft
 from daft.expressions import col
 from tests.cookbook.assets import COOKBOOK_DATA_CSV
 
-COLUMNS = ["Unique Key", "Complaint Type", "Borough", "Created Date", "Descriptor"]
+COLUMNS = ["Unique Key", "Complaint Type", "Borough", "Created Date", "Descriptor", "Closed Date"]
 CsvPathAndColumns = Tuple[str, List[str]]
 
 

--- a/tests/dataframe/test_map_groups.py
+++ b/tests/dataframe/test_map_groups.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
+def test_map_groups(make_df, repartition_nparts):
+    daft_df = make_df(
+        {
+            "group": [1, 1, 2],
+            "a": [1, 3, 3],
+            "b": [5, 6, 7],
+        },
+        repartition=repartition_nparts,
+    )
+
+    @daft.udf(return_dtype=daft.DataType.list(daft.DataType.float64()))
+    def udf(a, b):
+        a, b = a.to_pylist(), b.to_pylist()
+        res = []
+        for i in range(len(a)):
+            res.append(a[i] / sum(a) + b[i])
+        res.sort()
+        return [res]
+
+    daft_df = daft_df.groupby("group").map_groups(udf(daft_df["a"], daft_df["b"])).sort("group", desc=False)
+    expected = {
+        "group": [1, 2],
+        "a": [[5.25, 6.75], [8.0]],
+    }
+
+    daft_cols = daft_df.to_pydict()
+
+    assert daft_cols == expected
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 3])
+def test_map_groups_more_than_one_output_row(make_df, repartition_nparts):
+    daft_df = make_df(
+        {
+            "group": [1, 2],
+            "a": [1, 3],
+        },
+        repartition=repartition_nparts,
+    )
+
+    @daft.udf(return_dtype=daft.DataType.int64())
+    def udf(a):
+        a = a.to_pylist()
+        if len(a) == 0:
+            return []
+        return [a[0]] * 3
+
+    daft_df = daft_df.groupby("group").map_groups(udf(daft_df["a"])).sort("group", desc=False)
+    expected = {"group": [1, 1, 1, 2, 2, 2], "a": [1, 1, 1, 3, 3, 3]}
+
+    daft_cols = daft_df.to_pydict()
+
+    assert daft_cols == expected
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
+def test_map_groups_single_group(make_df, repartition_nparts):
+    daft_df = make_df(
+        {
+            "group": [1, 1, 1],
+            "a": [1, 2, 3],
+        },
+        repartition=repartition_nparts,
+    )
+
+    @daft.udf(return_dtype=daft.DataType.int64())
+    def udf(a):
+        a = a.to_pylist()
+        if len(a) == 0:
+            return []
+        return [sum(x**2 for x in a)]
+
+    daft_df = daft_df.groupby("group").map_groups(udf(daft_df["a"]))
+    expected = {"group": [1], "a": [14]}
+
+    daft_cols = daft_df.to_pydict()
+
+    assert daft_cols == expected
+
+
+@pytest.mark.parametrize("repartition_nparts", [1, 5, 11])
+def test_map_groups_double_group_by(make_df, repartition_nparts):
+    daft_df = make_df(
+        {
+            "group_1": [1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
+            "group_2": [1, 1, 1, 2, 2, 1, 1, 1, 2, 2],
+            "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        },
+        repartition=repartition_nparts,
+    )
+
+    @daft.udf(return_dtype=daft.DataType.int64())
+    def udf(a):
+        a = a.to_pylist()
+        if len(a) == 0:
+            return []
+        return [sum(x**2 for x in a)]
+
+    daft_df = daft_df.groupby("group_1", "group_2").map_groups(udf(daft_df["a"]))
+    expected = {"group_1": [2, 2, 1, 1], "group_2": [1, 2, 1, 2], "a": [149, 181, 14, 41]}
+
+    rows = set()
+    for i in range(4):
+        rows.add((expected["group_1"][i], expected["group_2"][i], expected["a"][i]))
+
+    daft_cols = daft_df.to_pydict()
+    for i in range(4):
+        assert (daft_cols["group_1"][i], daft_cols["group_2"][i], daft_cols["a"][i]) in rows


### PR DESCRIPTION
Closes #1630 

Added the `map_groups` method which allows for custom aggregation logic using a UDF in a group_by context. Usage: `df.group_by('group').map_groups(udf(col('a'), col('b')))`

Changes:
- Added map_groups API
- Added map_groups expression
- Implemented map_groups logic
- Added tests