### PR TITLE
[BUG] Schema hints not working properly for json reads

### DIFF
--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -187,7 +187,7 @@ fn materialize_scan_task(
                         column_names
                             .as_ref()
                             .map(|cols| cols.iter().map(|col| col.to_string()).collect()),
-                        None,
+                        Some(scan_task.schema.clone()),
                         scan_task.pushdowns.filters.clone(),
                     );
                     let parse_options = JsonParseOptions::new_internal();

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -814,6 +814,10 @@ def test_create_dataframe_json_schema_hints_large_file() -> None:
                 f.write("\n")
             f.flush()
 
+        # Without schema hints, schema inference should not pick up the key value pair at the bottom of the file
+        assert daft.read_json(fname).schema()["column"].dtype == DataType.struct({"test_key": DataType.string()})
+
+        # With schema hints, the bottom kv pair should be included
         df = daft.read_json(
             fname,
             schema_hints={

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -801,7 +801,7 @@ def test_create_dataframe_json_schema_hints_large_file() -> None:
     # First assemble data that will be larger than 1MB, because our schema inference will max out at 1MB.
     item = {"column": {"test_key": "test_value"}}
     item_size = len(json.dumps(item).encode("utf-8"))
-    entries_needed = (1 * 1024 * 1024) // item_size + 1
+    entries_needed = (1024 * 1024) // item_size + 1
     data = [item] * entries_needed
 
     # Add a row at the end of the file with a different key to ensure that the schema inference doesn't pick it up


### PR DESCRIPTION
Schema hints were not being propagated, leading to fields being dropped. 

This stemmed from an issue when reading large jsons from s3 where the fields changed only late into the file, so schema inference doesn't pick it up.