### PR TITLE
[BUG] Protect Global Context With Mutex

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -14,6 +14,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 import threading
+
+
 class _RunnerConfig:
     name = ClassVar[str]
 
@@ -72,7 +74,7 @@ class DaftContext:
     _lock = threading.Lock()
 
     def __new__(cls):
-        if cls._instance is None: 
+        if cls._instance is None:
             with cls._lock:
                 # Another thread could have created the instance
                 # before we acquired the lock. So check that the
@@ -80,7 +82,6 @@ class DaftContext:
                 if not cls._instance:
                     cls._instance = super().__new__(cls)
         return cls._instance
-
 
     def runner(self) -> Runner:
         with self._lock:
@@ -134,8 +135,10 @@ class DaftContext:
 
 _DaftContext = DaftContext()
 
+
 def get_context() -> DaftContext:
     return _DaftContext
+
 
 def set_runner_ray(
     address: str | None = None,

--- a/daft/context.py
+++ b/daft/context.py
@@ -70,8 +70,8 @@ class DaftContext:
     disallow_set_runner: bool = False
     _runner: Runner | None = None
 
-    _instance = None
-    _lock = threading.Lock()
+    _instance: ClassVar[DaftContext | None] = None
+    _lock: ClassVar[threading.Lock] = threading.Lock()
 
     def __new__(cls):
         if cls._instance is None:

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -148,11 +148,7 @@ class PyRunner(Runner[MicroPartition]):
         # Finalize the logical plan and get a physical plan scheduler for translating the
         # physical plan to executable tasks.
         plan_scheduler = builder.to_physical_plan_scheduler(daft_execution_config)
-        psets = {
-            key: entry.value.values()
-            for key, entry in self._part_set_cache._uuid_to_partition_set.items()
-            if entry.value is not None
-        }
+        psets = {k: v.values() for k, v in self._part_set_cache.get_all_partition_sets().items()}
         # Get executable tasks from planner.
         tasks = plan_scheduler.to_partition_tasks(psets, is_ray_runner=False)
         with profiler("profile_PyRunner.run_{datetime.now().isoformat()}.json"):

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -727,11 +727,8 @@ class RayRunner(Runner[ray.ObjectRef]):
         # physical plan to executable tasks.
         plan_scheduler = builder.to_physical_plan_scheduler(daft_execution_config)
 
-        psets = {
-            key: entry.value.values()
-            for key, entry in self._part_set_cache._uuid_to_partition_set.items()
-            if entry.value is not None
-        }
+        psets = {k: v.values() for k, v in self._part_set_cache.get_all_partition_sets().items()}
+
         result_uuid = str(uuid.uuid4())
         if isinstance(self.ray_context, ray.client_builder.ClientContext):
             ray.get(


### PR DESCRIPTION
* Fixes race condition with Daft is being ran with multiple threads and creates multiple Runners. This leads to the issue of cached partition sets being dropped. Like we see in https://github.com/Eventual-Inc/Daft/issues/1843
closes: https://github.com/Eventual-Inc/Daft/issues/1843