### PR TITLE
[FEAT][1/2] Support Iceberg renaming of columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,7 @@ dependencies = [
  "pyo3-log",
  "serde",
  "snafu",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.4"
-source = "git+https://github.com/Eventual-Inc/arrow2?rev=c0764b00cc05126c80c7ce17ebd7a95d87f815c1#c0764b00cc05126c80c7ce17ebd7a95d87f815c1"
+source = "git+https://github.com/Eventual-Inc/arrow2?rev=195649a0d9#195649a0d92e3a1d31f1ed35b0718c63069c299d"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,10 +112,11 @@ tokio-util = "0.7.8"
 url = "2.4.0"
 
 [workspace.dependencies.arrow2]
-# branch = "daft-fork"
+# TODO: Update this to daft-fork
+# branch = "jay/field-ids-in-metadata"
 git = "https://github.com/Eventual-Inc/arrow2"
 package = "arrow2"
-rev = "c0764b00cc05126c80c7ce17ebd7a95d87f815c1"
+rev = "195649a0d9"
 
 [workspace.dependencies.bincode]
 version = "1.3.3"

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -226,8 +226,13 @@ class ParquetSourceConfig:
     """
 
     coerce_int96_timestamp_unit: PyTimeUnit | None
+    field_id_to_colname_mapping: list[tuple[int, str]] | None
 
-    def __init__(self, coerce_int96_timestamp_unit: PyTimeUnit | None = None): ...
+    def __init__(
+        self,
+        coerce_int96_timestamp_unit: PyTimeUnit | None = None,
+        field_id_to_colname_mapping: list[tuple[int, str]] | None = None,
+    ): ...
 
 class CsvSourceConfig:
     """

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -231,7 +231,7 @@ class ParquetSourceConfig:
     def __init__(
         self,
         coerce_int96_timestamp_unit: PyTimeUnit | None = None,
-        field_id_to_colname_mapping: list[tuple[int, str]] | None = None,
+        field_id_mapping: dict[int, PyField] | None = None,
     ): ...
 
 class CsvSourceConfig:

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -226,7 +226,7 @@ class ParquetSourceConfig:
     """
 
     coerce_int96_timestamp_unit: PyTimeUnit | None
-    field_id_to_colname_mapping: list[tuple[int, str]] | None
+    field_id_mapping: dict[int, PyField] | None
 
     def __init__(
         self,

--- a/daft/iceberg/iceberg_scan.py
+++ b/daft/iceberg/iceberg_scan.py
@@ -88,8 +88,9 @@ class IcebergScanOperator(ScanOperator):
         iceberg_schema = iceberg_table.schema()
         arrow_schema = schema_to_pyarrow(iceberg_schema)
         self._field_id_mapping = {
-            f.field_id: PyField.create(f.name, DataType.from_arrow_type(schema_to_pyarrow(f.field_type))._dtype)
-            for f in iceberg_schema.fields
+            # NOTE: A little dangerous here to use a private API
+            field_id: PyField.create(field.name, DataType.from_arrow_type(schema_to_pyarrow(field.field_type))._dtype)
+            for field_id, field in iceberg_schema._lazy_id_to_field.items()
         }
         self._schema = Schema.from_pyarrow_schema(arrow_schema)
         self._partition_keys = iceberg_partition_spec_to_fields(self._table.schema(), self._table.spec())

--- a/src/daft-core/src/datatypes/field.rs
+++ b/src/daft-core/src/datatypes/field.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 pub type Metadata = std::collections::BTreeMap<String, String>;
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
+#[derive(Clone, Debug, Eq, Deserialize, Serialize)]
 pub struct Field {
     pub name: String,
     pub dtype: DataType,
@@ -127,5 +127,18 @@ impl From<&ArrowField> for Field {
 impl Display for Field {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "{}#{}", self.name, self.dtype)
+    }
+}
+
+impl PartialEq for Field {
+    fn eq(&self, other: &Self) -> bool {
+        self.dtype == other.dtype && self.name == other.name
+    }
+}
+
+impl std::hash::Hash for Field {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.dtype.hash(state);
     }
 }

--- a/src/daft-core/src/datatypes/field.rs
+++ b/src/daft-core/src/datatypes/field.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 pub type Metadata = std::collections::BTreeMap<String, String>;
 
-#[derive(Clone, Debug, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub struct Field {
     pub name: String,
     pub dtype: DataType,
@@ -127,18 +127,5 @@ impl From<&ArrowField> for Field {
 impl Display for Field {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "{}#{}", self.name, self.dtype)
-    }
-}
-
-impl PartialEq for Field {
-    fn eq(&self, other: &Self) -> bool {
-        self.dtype == other.dtype && self.name == other.name
-    }
-}
-
-impl std::hash::Hash for Field {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.name.hash(state);
-        self.dtype.hash(state);
     }
 }

--- a/src/daft-core/src/series/mod.rs
+++ b/src/daft-core/src/series/mod.rs
@@ -82,6 +82,7 @@ impl Series {
     pub fn field(&self) -> &Field {
         self.inner.field()
     }
+
     pub fn as_physical(&self) -> DaftResult<Series> {
         let physical_dtype = self.data_type().to_physical();
         if &physical_dtype == self.data_type() {

--- a/src/daft-core/src/series/ops/downcast.rs
+++ b/src/daft-core/src/series/ops/downcast.rs
@@ -7,6 +7,8 @@ use crate::series::array_impl::ArrayWrapper;
 use crate::series::Series;
 use common_error::DaftResult;
 
+use self::logical::MapArray;
+
 impl Series {
     pub fn downcast<Arr: DaftArrayType>(&self) -> DaftResult<&Arr> {
         match self.inner.as_any().downcast_ref() {
@@ -78,6 +80,10 @@ impl Series {
     }
 
     pub fn utf8(&self) -> DaftResult<&Utf8Array> {
+        self.downcast()
+    }
+
+    pub fn map(&self) -> DaftResult<&MapArray> {
         self.downcast()
     }
 

--- a/src/daft-micropartition/Cargo.toml
+++ b/src/daft-micropartition/Cargo.toml
@@ -18,6 +18,7 @@ pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true}
 serde = {workspace = true}
 snafu = {workspace = true}
+tokio = {workspace = true}
 
 [features]
 default = ["python"]

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -357,13 +357,8 @@ impl MicroPartition {
         // Check and validate invariants with asserts
         for table in tables.iter() {
             assert!(
-                table.schema.fields.len() == schema.fields.len()
-                    && table.schema.fields.iter().zip(schema.fields.iter()).all(
-                        |((s1, f1), (s2, f2))| s1 == s2
-                            && f1.name == f2.name
-                            && f1.dtype == f2.dtype
-                    ),
-                "Loaded MicroPartition's tables' schema must match its own schema exactly"
+                table.schema == schema,
+                "Loaded MicroPartition's tables' schema must match its own schema exactly",
             );
         }
 

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -923,8 +923,6 @@ pub(crate) fn read_parquet_into_micropartition(
         // use schema to update stats
         let stats = stats.eval_expression_list(exprs.as_slice(), daft_schema.as_ref())?;
 
-        // TODO: This is currently a BAD micropartition, because: the schema doesn't take into account the field_id mappings
-        // and the stats have not been properly renamed according to the field_id mappings.
         Ok(MicroPartition::new_unloaded(
             scan_task.materialized_schema(),
             Arc::new(scan_task),

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -876,6 +876,8 @@ pub(crate) fn read_parquet_into_micropartition(
         // use schema to update stats
         let stats = stats.eval_expression_list(exprs.as_slice(), daft_schema.as_ref())?;
 
+        // TODO: This is currently a BAD micropartition, because: the schema doesn't take into account the field_id mappings
+        // and the stats have not been properly renamed according to the field_id mappings.
         Ok(MicroPartition::new_unloaded(
             scan_task.materialized_schema(),
             Arc::new(scan_task),

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -711,7 +711,7 @@ pub(crate) fn read_parquet_into_micropartition(
     num_parallel_tasks: usize,
     multithreaded_io: bool,
     schema_infer_options: &ParquetSchemaInferenceOptions,
-    field_id_mapping: &Option<BTreeMap<i32, Field>>,
+    field_id_mapping: &Option<Arc<BTreeMap<i32, Field>>>,
 ) -> DaftResult<MicroPartition> {
     if let Some(so) = start_offset && so > 0 {
         return Err(common_error::DaftError::ValueError("Micropartition Parquet Reader does not support non-zero start offsets".to_string()));
@@ -847,7 +847,7 @@ pub(crate) fn read_parquet_into_micropartition(
                 .collect::<Vec<_>>(),
             FileFormatConfig::Parquet(ParquetSourceConfig {
                 coerce_int96_timestamp_unit: schema_infer_options.coerce_int96_timestamp_unit,
-                field_id_mapping: field_id_mapping.clone(), // TODO: consider Arcing this, could be expensive to clone
+                field_id_mapping: field_id_mapping.clone(),
             })
             .into(),
             daft_schema.clone(),

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, ops::Deref, sync::Arc};
 use common_error::DaftResult;
 use daft_core::schema::SchemaRef;
 use daft_dsl::Expr;
+use daft_scan::ScanTask;
 
 use crate::micropartition::{MicroPartition, TableState};
 
@@ -26,12 +27,24 @@ impl MicroPartition {
         let guard = self.state.lock().unwrap();
         match guard.deref() {
             // Replace schema if Unloaded, which should be applied when data is lazily loaded
-            TableState::Unloaded(scan_task) => Ok(MicroPartition::new_unloaded(
-                schema.clone(),
-                scan_task.clone(),
-                self.metadata.clone(),
-                pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
-            )),
+            TableState::Unloaded(scan_task) => {
+                let maybe_new_scan_task = if scan_task.schema == schema {
+                    scan_task.clone()
+                } else {
+                    Arc::new(ScanTask::new(
+                        scan_task.sources.clone(),
+                        scan_task.file_format_config.clone(),
+                        schema,
+                        scan_task.storage_config.clone(),
+                        scan_task.pushdowns.clone(),
+                    ))
+                };
+                Ok(MicroPartition::new_unloaded(
+                    maybe_new_scan_task,
+                    self.metadata.clone(),
+                    pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
+                ))
+            }
             // If Tables are already loaded, we map `Table::cast_to_schema` on each Table
             TableState::Loaded(tables) => Ok(MicroPartition::new_loaded(
                 schema.clone(),

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -544,6 +544,7 @@ impl PyMicroPartition {
                 1,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
+                None,
                 &None,
             )
         })?;
@@ -586,6 +587,7 @@ impl PyMicroPartition {
                 num_parallel_tasks.unwrap_or(128) as usize,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
+                None,
                 &None,
             )
         })?;

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -544,7 +544,7 @@ impl PyMicroPartition {
                 1,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
-                &None, // TODO: pass in field_id mapping
+                &None,
             )
         })?;
         Ok(mp.into())
@@ -586,7 +586,7 @@ impl PyMicroPartition {
                 num_parallel_tasks.unwrap_or(128) as usize,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
-                &None, // TODO: pass in field_id mapping
+                &None,
             )
         })?;
         Ok(mp.into())

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -544,6 +544,7 @@ impl PyMicroPartition {
                 1,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
+                &None, // TODO: pass in field_id mapping
             )
         })?;
         Ok(mp.into())
@@ -585,6 +586,7 @@ impl PyMicroPartition {
                 num_parallel_tasks.unwrap_or(128) as usize,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
+                &None, // TODO: pass in field_id mapping
             )
         })?;
         Ok(mp.into())

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -39,7 +39,7 @@ pub(crate) struct ParquetReaderBuilder {
     row_groups: Option<Vec<i64>>,
     schema_inference_options: ParquetSchemaInferenceOptions,
     predicate: Option<ExprRef>,
-    field_id_mapping: Option<BTreeMap<i32, Field>>,
+    field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
 }
 use parquet2::read::decompress;
 
@@ -274,7 +274,7 @@ impl ParquetReaderBuilder {
         self
     }
 
-    pub fn set_field_id_mapping(mut self, field_id_mapping: BTreeMap<i32, Field>) -> Self {
+    pub fn set_field_id_mapping(mut self, field_id_mapping: Arc<BTreeMap<i32, Field>>) -> Self {
         self.field_id_mapping = Some(field_id_mapping);
         self
     }
@@ -327,7 +327,7 @@ pub(crate) struct ParquetFileReader {
     metadata: Arc<parquet2::metadata::FileMetaData>,
     arrow_schema: arrow2::datatypes::SchemaRef,
     row_ranges: Arc<Vec<RowGroupRange>>,
-    field_id_mapping: Option<BTreeMap<i32, Field>>,
+    field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
 }
 
 fn get_column_name_mapping(
@@ -356,7 +356,7 @@ impl ParquetFileReader {
         metadata: parquet2::metadata::FileMetaData,
         arrow_schema: arrow2::datatypes::Schema,
         row_ranges: Vec<RowGroupRange>,
-        field_id_mapping: Option<BTreeMap<i32, Field>>,
+        field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
     ) -> super::Result<Self> {
         Ok(ParquetFileReader {
             uri,

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -160,6 +160,7 @@ pub mod pylib {
                 num_parallel_tasks.unwrap_or(128) as usize,
                 runtime_handle,
                 &schema_infer_options,
+                &None,
             )?
             .into_iter()
             .map(|v| v.into())

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -379,7 +379,7 @@ pub fn read_parquet(
             io_client,
             io_stats,
             schema_infer_options,
-            None, // TODO: Add field_id_mapping
+            None,
         )
         .await
     })

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -66,7 +66,7 @@ async fn read_parquet_single(
     io_client: Arc<IOClient>,
     io_stats: Option<IOStatsRef>,
     schema_infer_options: ParquetSchemaInferenceOptions,
-    field_id_mapping: Option<BTreeMap<i32, Field>>,
+    field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
 ) -> DaftResult<Table> {
     let original_columns = columns;
     let original_num_rows = num_rows;
@@ -427,7 +427,7 @@ pub fn read_parquet_bulk(
     num_parallel_tasks: usize,
     runtime_handle: Arc<Runtime>,
     schema_infer_options: &ParquetSchemaInferenceOptions,
-    field_id_mapping: &Option<BTreeMap<i32, Field>>,
+    field_id_mapping: &Option<Arc<BTreeMap<i32, Field>>>,
 ) -> DaftResult<Vec<Table>> {
     let _rt_guard = runtime_handle.enter();
     let owned_columns = columns.map(|s| s.iter().map(|v| String::from(*v)).collect::<Vec<_>>());

--- a/src/daft-parquet/src/statistics/table_stats.rs
+++ b/src/daft-parquet/src/statistics/table_stats.rs
@@ -1,5 +1,7 @@
+use std::{collections::BTreeMap, sync::Arc};
+
 use common_error::DaftResult;
-use daft_core::schema::Schema;
+use daft_core::{datatypes::Field, schema::Schema};
 use daft_stats::{ColumnRangeStatistics, TableStatistics};
 use snafu::ResultExt;
 
@@ -9,7 +11,8 @@ use indexmap::IndexMap;
 
 pub fn row_group_metadata_to_table_stats(
     metadata: &crate::metadata::RowGroupMetaData,
-    schema: &Schema,
+    pq_file_schema: &Schema,
+    field_id_mapping: &Option<Arc<BTreeMap<i32, Field>>>,
 ) -> DaftResult<TableStatistics> {
     // Create a map from {field_name: statistics} from the RowGroupMetaData for easy access
     let mut parquet_column_metadata: IndexMap<_, _> = metadata
@@ -26,26 +29,64 @@ pub fn row_group_metadata_to_table_stats(
         .collect();
 
     // Iterate through the schema and construct ColumnRangeStatistics per field
-    let columns = schema
-        .fields
-        .iter()
-        .map(|(field_name, field)| {
-            if ColumnRangeStatistics::supports_dtype(&field.dtype) {
-                let stats: ColumnRangeStatistics = parquet_column_metadata
-                    .remove(field_name)
-                    .expect("Cannot find parsed Daft field in Parquet rowgroup metadata")
-                    .transpose()
-                    .context(super::UnableToParseParquetColumnStatisticsSnafu)?
-                    .and_then(|v| {
-                        parquet_statistics_to_column_range_statistics(v.as_ref(), &field.dtype).ok()
-                    })
-                    .unwrap_or(ColumnRangeStatistics::Missing);
-                Ok((field_name.clone(), stats))
-            } else {
-                Ok((field_name.clone(), ColumnRangeStatistics::Missing))
-            }
-        })
-        .collect::<DaftResult<IndexMap<_, _>>>()?;
+    let columns = pq_file_schema.fields.iter().map(|(field_name, field)| {
+        if ColumnRangeStatistics::supports_dtype(&field.dtype) {
+            let stats: ColumnRangeStatistics = parquet_column_metadata
+                .remove(field_name)
+                .expect("Cannot find parsed Daft field in Parquet rowgroup metadata")
+                .transpose()
+                .context(super::UnableToParseParquetColumnStatisticsSnafu)?
+                .and_then(|v| {
+                    parquet_statistics_to_column_range_statistics(v.as_ref(), &field.dtype).ok()
+                })
+                .unwrap_or(ColumnRangeStatistics::Missing);
+            Ok((field_name.clone(), stats))
+        } else {
+            Ok((field_name.clone(), ColumnRangeStatistics::Missing))
+        }
+    });
 
-    Ok(TableStatistics { columns })
+    // Apply `field_id_mapping` against parsed statistics to rename the columns (if provided)
+    let file_to_target_colname_mapping: Option<IndexMap<&String, String>> =
+        field_id_mapping.as_ref().map(|field_id_mapping| {
+            metadata
+                .columns()
+                .iter()
+                .filter_map(|col| {
+                    if let Some(target_colname) = col
+                        .descriptor()
+                        .base_type
+                        .get_field_info()
+                        .id
+                        .and_then(|field_id| field_id_mapping.get(&field_id))
+                    {
+                        let top_level_column_name = col.descriptor().path_in_schema.first().expect(
+                            "Parquet schema should have at least one entry in path_in_schema",
+                        );
+                        Some((top_level_column_name, target_colname.name.clone()))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        });
+    let columns = columns.map(|result| {
+        if let Some(ref file_to_target_colname_mapping) = file_to_target_colname_mapping {
+            result.map(|(field_name, stats)| {
+                (
+                    file_to_target_colname_mapping
+                        .get(&field_name)
+                        .cloned()
+                        .unwrap_or(field_name.clone()),
+                    stats,
+                )
+            })
+        } else {
+            result
+        }
+    });
+
+    Ok(TableStatistics {
+        columns: columns.collect::<DaftResult<IndexMap<_, _>>>()?,
+    })
 }

--- a/src/daft-parquet/src/stream_reader.rs
+++ b/src/daft-parquet/src/stream_reader.rs
@@ -109,6 +109,7 @@ pub(crate) fn local_parquet_read_into_arrow(
         &daft_schema,
         &metadata,
         uri,
+        &None,
     )?;
 
     let columns_iters_per_rg = row_ranges

--- a/src/daft-scan/src/file_format.rs
+++ b/src/daft-scan/src/file_format.rs
@@ -111,10 +111,10 @@ impl ParquetSourceConfig {
         ));
         if let Some(mapping) = &self.field_id_mapping {
             res.push(format!(
-                "Field ID to column names = [{}]",
+                "Field ID to Fields = {{{}}}",
                 mapping
                     .iter()
-                    .map(|(f, c)| format!("{f}: {c}"))
+                    .map(|(fid, f)| format!("{fid}: {f}"))
                     .collect::<Vec<String>>()
                     .join(",")
             ));

--- a/src/daft-scan/src/file_format.rs
+++ b/src/daft-scan/src/file_format.rs
@@ -99,7 +99,7 @@ pub struct ParquetSourceConfig {
     /// data according to the provided field_ids.
     ///
     /// See: https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift#L456-L459
-    pub field_id_mapping: Option<BTreeMap<i32, Field>>,
+    pub field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
 }
 
 impl ParquetSourceConfig {
@@ -136,8 +136,11 @@ impl ParquetSourceConfig {
             coerce_int96_timestamp_unit: coerce_int96_timestamp_unit
                 .unwrap_or(TimeUnit::Nanoseconds.into())
                 .into(),
-            field_id_mapping: field_id_mapping
-                .map(|map| BTreeMap::from_iter(map.into_iter().map(|(k, v)| (k, v.field)))),
+            field_id_mapping: field_id_mapping.map(|map| {
+                Arc::new(BTreeMap::from_iter(
+                    map.into_iter().map(|(k, v)| (k, v.field)),
+                ))
+            }),
         }
     }
 

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -156,11 +156,11 @@ impl GlobScanOperator {
         let inferred_schema = match file_format_config.as_ref() {
             FileFormatConfig::Parquet(ParquetSourceConfig {
                 coerce_int96_timestamp_unit,
-                field_id_to_colname_mapping: _field_id_to_colname_mapping,
+                field_id_mapping: _field_id_mapping,
             }) => {
                 debug_assert!(
-                    _field_id_to_colname_mapping.is_none(),
-                    "`field_id_to_colname_mapping` should not be provided when inferring schema from Parquet files",
+                    _field_id_mapping.is_none(),
+                    "`field_id_mapping` should not be provided when inferring schema from Parquet files",
                 );
                 let io_stats = IOStatsContext::new(format!(
                     "GlobScanOperator constructor read_parquet_schema: for uri {first_filepath}"

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -156,7 +156,12 @@ impl GlobScanOperator {
         let inferred_schema = match file_format_config.as_ref() {
             FileFormatConfig::Parquet(ParquetSourceConfig {
                 coerce_int96_timestamp_unit,
+                field_id_to_colname_mapping: _field_id_to_colname_mapping,
             }) => {
+                debug_assert!(
+                    _field_id_to_colname_mapping.is_none(),
+                    "`field_id_to_colname_mapping` should not be provided when inferring schema from Parquet files",
+                );
                 let io_stats = IOStatsContext::new(format!(
                     "GlobScanOperator constructor read_parquet_schema: for uri {first_filepath}"
                 ));

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -255,7 +255,9 @@ impl DataFileSource {
 pub struct ScanTask {
     pub sources: Vec<DataFileSource>,
 
-    /// Schema to use when reading the DataFileSources.
+    /// Schema to use when reading the DataFileSources. This should always be passed in by the
+    /// ScanOperator implementation and should not have had any "pruning" applied.
+    ///
     /// Note that this is different than the schema of the data after pushdowns have been applied,
     /// which can be obtained with [`ScanTask::materialized_schema`] instead.
     pub schema: SchemaRef,

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -315,6 +315,7 @@ impl ScanTask {
             pushdowns,
             size_bytes_on_disk,
             metadata,
+            // TODO: I think we also need to perform field_id renaming on statistics here?
             statistics,
         }
     }

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -43,7 +43,7 @@ impl Table {
         let mut num_rows = 1;
 
         for (field, series) in schema.fields.values().zip(columns.iter()) {
-            if field != series.field() {
+            if field.name != series.field().name || field.dtype != series.field().dtype {
                 return Err(DaftError::SchemaMismatch(format!("While building a Table, we found that the Schema Field and the Series Field  did not match. schema field: {field} vs series field: {}", series.field())));
             }
             if (series.len() != 1) && (series.len() != num_rows) {

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -185,7 +185,7 @@ impl Table {
         let end = start + self.len() as u64;
         let ids = (start..end).step_by(1).collect::<Vec<_>>();
         let id_series = UInt64Array::from((column_name, ids)).into_series();
-        Self::from_columns([&[id_series], &self.columns[..]].concat())
+        Self::from_columns([&self.columns[..], &[id_series]].concat())
     }
 
     pub fn quantiles(&self, num: usize) -> DaftResult<Self> {

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -43,7 +43,7 @@ impl Table {
         let mut num_rows = 1;
 
         for (field, series) in schema.fields.values().zip(columns.iter()) {
-            if field.name != series.field().name || field.dtype != series.field().dtype {
+            if field != series.field() {
                 return Err(DaftError::SchemaMismatch(format!("While building a Table, we found that the Schema Field and the Series Field  did not match. schema field: {field} vs series field: {}", series.field())));
             }
             if (series.len() != 1) && (series.len() != num_rows) {

--- a/tests/integration/iceberg/docker-compose/provision.py
+++ b/tests/integration/iceberg/docker-compose/provision.py
@@ -362,11 +362,11 @@ spark.sql(
   CREATE OR REPLACE TABLE default.test_table_rename
   USING iceberg
   AS SELECT
-        1            AS idx
+        1            AS idx, 10  AS data
     UNION ALL SELECT
-        2            AS idx
+        2            AS idx, 20  AS data
     UNION ALL SELECT
-        3            AS idx
+        3            AS idx, 30  AS data
 """
 )
 

--- a/tests/integration/iceberg/docker-compose/provision.py
+++ b/tests/integration/iceberg/docker-compose/provision.py
@@ -21,7 +21,7 @@ from pyiceberg.catalog import load_catalog
 from pyiceberg.schema import Schema
 from pyiceberg.types import FixedType, NestedField, UUIDType
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import current_date, date_add, expr
+from pyspark.sql.functions import col, current_date, date_add, expr, struct
 
 spark = SparkSession.builder.getOrCreate()
 
@@ -357,17 +357,19 @@ spark.sql(
 
 spark.sql("ALTER TABLE default.test_new_column_with_no_data ADD COLUMN name STRING")
 
-spark.sql(
-    """
-  CREATE OR REPLACE TABLE default.test_table_rename
-  USING iceberg
-  AS SELECT
-        1            AS idx, 10  AS data
-    UNION ALL SELECT
-        2            AS idx, 20  AS data
-    UNION ALL SELECT
-        3            AS idx, 30  AS data
-"""
-)
 
+###
+# Renaming columns test table
+###
+
+renaming_columns_dataframe = (
+    spark.range(1, 2, 3)
+    .withColumnRenamed("id", "idx")
+    .withColumn("data", col("idx") * 10)
+    .withColumn("structcol", struct("idx"))
+    .withColumn("structcol_oldname", struct("idx"))
+)
+renaming_columns_dataframe.writeTo("default.test_table_rename").tableProperty("format-version", "2").createOrReplace()
 spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN idx TO pos")
+spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN structcol.idx TO pos")
+spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN structcol_oldname TO structcol_2")

--- a/tests/integration/iceberg/docker-compose/provision.py
+++ b/tests/integration/iceberg/docker-compose/provision.py
@@ -325,7 +325,7 @@ VALUES
 
 spark.sql(
     """
-  CREATE OR REPLACE TABLE default.add_new_column
+  CREATE OR REPLACE TABLE default.test_add_new_column
   USING iceberg
   AS SELECT
         1            AS idx
@@ -336,5 +336,38 @@ spark.sql(
 """
 )
 
-spark.sql("ALTER TABLE default.add_new_column ADD COLUMN name STRING")
-spark.sql("INSERT INTO default.add_new_column VALUES (3, 'abc'), (4, 'def')")
+spark.sql("ALTER TABLE default.test_add_new_column ADD COLUMN name STRING")
+spark.sql("INSERT INTO default.test_add_new_column VALUES (3, 'abc'), (4, 'def')")
+
+# In Iceberg the data and schema evolves independently. We can add a column
+# that should show up when querying the data, but is not yet represented in a Parquet file
+
+spark.sql(
+    """
+  CREATE OR REPLACE TABLE default.test_new_column_with_no_data
+  USING iceberg
+  AS SELECT
+        1            AS idx
+    UNION ALL SELECT
+        2            AS idx
+    UNION ALL SELECT
+        3            AS idx
+"""
+)
+
+spark.sql("ALTER TABLE default.test_new_column_with_no_data ADD COLUMN name STRING")
+
+spark.sql(
+    """
+  CREATE OR REPLACE TABLE default.test_table_rename
+  USING iceberg
+  AS SELECT
+        1            AS idx
+    UNION ALL SELECT
+        2            AS idx
+    UNION ALL SELECT
+        3            AS idx
+"""
+)
+
+spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN idx TO pos")

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -63,7 +63,7 @@ def test_daft_iceberg_table_collect_correct(table_name, local_iceberg_catalog):
 
 
 @pytest.mark.integration()
-def test_daft_iceberg_table_filtered_collect_correct(local_iceberg_catalog):
+def test_daft_iceberg_table_renamed_filtered_collect_correct(local_iceberg_catalog):
     tab = local_iceberg_catalog.load_table(f"default.test_table_rename")
     df = daft.read_iceberg(tab)
     df = df.where(df["pos"] <= 1)
@@ -74,7 +74,7 @@ def test_daft_iceberg_table_filtered_collect_correct(local_iceberg_catalog):
 
 
 @pytest.mark.integration()
-def test_daft_iceberg_table_column_pushdown_collect_correct(local_iceberg_catalog):
+def test_daft_iceberg_table_renamed_column_pushdown_collect_correct(local_iceberg_catalog):
     tab = local_iceberg_catalog.load_table(f"default.test_table_rename")
     df = daft.read_iceberg(tab)
     df = df.select("pos")

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -37,7 +37,9 @@ WORKING_SHOW_COLLECT = [
     # "test_table_sanitized_character", # Bug in scan().to_arrow().to_arrow()
     "test_table_version",  # we have bugs when loading no files
     "test_uuid_and_fixed_unpartitioned",
-    "add_new_column",
+    "test_add_new_column",
+    "test_new_column_with_no_data",
+    "test_table_rename",
 ]
 
 

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -69,5 +69,5 @@ def test_daft_iceberg_table_filtered_collect_correct(local_iceberg_catalog):
     df = df.where(df["pos"] <= 1)
     daft_pandas = df.to_pandas()
     iceberg_pandas = tab.scan().to_arrow().to_pandas()
-    iceberg_pandas = daft_pandas.where(daft_pandas["pos"] <= 1)
+    iceberg_pandas = iceberg_pandas[iceberg_pandas["pos"] <= 1]
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -60,3 +60,14 @@ def test_daft_iceberg_table_collect_correct(table_name, local_iceberg_catalog):
     daft_pandas = df.to_pandas()
     iceberg_pandas = tab.scan().to_arrow().to_pandas()
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
+
+
+@pytest.mark.integration()
+def test_daft_iceberg_table_filtered_collect_correct(local_iceberg_catalog):
+    tab = local_iceberg_catalog.load_table(f"default.test_table_rename")
+    df = daft.read_iceberg(tab)
+    df = df.where(df["pos"] <= 1)
+    daft_pandas = df.to_pandas()
+    iceberg_pandas = tab.scan().to_arrow().to_pandas()
+    iceberg_pandas = daft_pandas.where(daft_pandas["pos"] <= 1)
+    assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -71,3 +71,14 @@ def test_daft_iceberg_table_filtered_collect_correct(local_iceberg_catalog):
     iceberg_pandas = tab.scan().to_arrow().to_pandas()
     iceberg_pandas = iceberg_pandas[iceberg_pandas["pos"] <= 1]
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
+
+
+@pytest.mark.integration()
+def test_daft_iceberg_table_column_pushdown_collect_correct(local_iceberg_catalog):
+    tab = local_iceberg_catalog.load_table(f"default.test_table_rename")
+    df = daft.read_iceberg(tab)
+    df = df.select("pos")
+    daft_pandas = df.to_pandas()
+    iceberg_pandas = tab.scan().to_arrow().to_pandas()
+    iceberg_pandas = iceberg_pandas[["pos"]]
+    assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])

--- a/tests/io/test_read_time_cast.py
+++ b/tests/io/test_read_time_cast.py
@@ -4,46 +4,47 @@ import pyarrow as pa
 import pytest
 
 import daft
-from daft import DataType
 from daft.logical.schema import Schema
-from daft.table import MicroPartition, table_io
+from daft.table import MicroPartition
 from tests.table.table_io.test_parquet import _parquet_write_helper
 
 
 @pytest.mark.parametrize(
-    ["data", "schema", "expected"],
+    ["data_with_intended_schema", "data", "expected"],
     [
         # Test that a cast occurs (in this case, int64 -> int8)
         (
+            pa.Table.from_pydict({"foo": pa.array([], type=pa.int8())}),
             pa.Table.from_pydict({"foo": pa.array([1, 2, 3], type=pa.int64())}),
-            Schema._from_field_name_and_types([("foo", DataType.int8())]),
             MicroPartition.from_pydict({"foo": daft.Series.from_arrow(pa.array([1, 2, 3], type=pa.int8()))}),
         ),
         # Test what happens if a cast should occur, but fails at runtime (in this case, a potentially bad cast from utf8->int64)
         (
+            pa.Table.from_pydict({"foo": pa.array([], type=pa.int64())}),
             pa.Table.from_pydict({"foo": pa.array(["1", "2", "FAIL"], type=pa.string())}),
-            Schema._from_field_name_and_types([("foo", DataType.int64())]),
             # NOTE: cast failures will become a Null value
             MicroPartition.from_pydict({"foo": daft.Series.from_arrow(pa.array([1, 2, None], type=pa.int64()))}),
         ),
         # Test reordering of columns
         (
+            pa.Table.from_pydict({"bar": pa.array([], type=pa.int64()), "foo": pa.array([], type=pa.int64())}),
             pa.Table.from_pydict({"foo": pa.array([1, 2, 3]), "bar": pa.array([1, 2, 3])}),
-            Schema._from_field_name_and_types([("bar", DataType.int64()), ("foo", DataType.int64())]),
             MicroPartition.from_pydict({"bar": pa.array([1, 2, 3]), "foo": pa.array([1, 2, 3])}),
         ),
         # Test automatic insertion of null values for missing column
         (
+            pa.Table.from_pydict({"bar": pa.array([], type=pa.int64()), "foo": pa.array([], type=pa.int64())}),
             pa.Table.from_pydict({"foo": pa.array([1, 2, 3])}),
-            Schema._from_field_name_and_types([("bar", DataType.int64()), ("foo", DataType.int64())]),
             MicroPartition.from_pydict(
                 {"bar": pa.array([None, None, None], type=pa.int64()), "foo": pa.array([1, 2, 3])}
             ),
         ),
     ],
 )
-def test_parquet_cast_at_read_time(data, schema, expected):
-    with _parquet_write_helper(data) as f:
-        table = table_io.read_parquet(f, schema)
-        assert table.schema() == schema
-        assert table.to_arrow() == expected.to_arrow()
+def test_parquet_cast_at_read_time(data_with_intended_schema, data, expected):
+    schema = Schema.from_pyarrow_schema(data_with_intended_schema.schema)
+    with _parquet_write_helper(data) as f, _parquet_write_helper(data_with_intended_schema) as f_with_schema:
+        # Place `f_with_schema` first so that it gets used for schema inference
+        df = daft.read_parquet([f_with_schema, f])
+        assert df.schema() == schema
+        assert df.to_arrow() == expected.to_arrow()


### PR DESCRIPTION
# Summary

Support field_id renaming of Parquet files along the codepath:

1. `IcebergScanOperator`
2. Generates `ScanTasks`, each containing the `field_id_mapping: Arc<{i32: Field}>`
3. Propagated to workers through the `ScanWithTask` instruction object
4. Micropartitions are created with `MicroPartition::from_scan_task`
5. This then calls into `read_parquet_into_micropartition`
    a. If statistics are available, it will create an unloaded MicroPartition by creating a new ScanTask (hydrated with statistics) and then calling `MicroPartition::new_unloaded(new_scan_task)`. 
    b. Otherwise, it falls back into `read_parquet_bulk`, which has been modified to correctly handle `field_id_mapping`

This PR ensures that when data/statistics are read from Parquet files, we correctly apply renaming according to `field_id_mapping`.

## Reviewer Notes

A lot of the errors caught/triggered by this PR has to do with mismatches between the fields (names/metadata) on our schemas and on our Series objects.

Keeping those two in sync is fairly challenging with the way our code is currently structured.

The approach taken to try and fix this is:

1. Try to use the same logic for field_id renaming across Series and Schemas
2. When reading data from `Parquet -> arrow2 -> Daft Series/Schema`, perform a post-processing step to remove any field metadata that was retrieved from the Parquet files.

However I do think that this is a fairly error-prone situation. Not sure what the best approach is though.

## Drive-By

Refactors to clean-up MicroPartitions/ScanTasks and schemas:

1. Refactored `MicroPartition::new_unloaded`: it no longer accepts a `schema` argument; instead internally it will just use the ScanTask's `.materialized_schema()`
4. Refactored `read_parquet_into_micropartition` to significantly reduce code deduplication

## Remaining todos:

- [x] Fix logic with column pruning (need to apply column pruning after applying the field ID mappings)
- [x] Perform correct renaming for statistics parsing from Parquet metadata
- [x] Perform recursive renaming for Series and for Schema