### PR TITLE
[PERF] Spread scan tasks over Ray cluster.

### DIFF
--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -645,13 +645,19 @@ def _build_partitions(
         ray_options = {**ray_options, **_get_ray_task_options(task.resource_request)}
 
     if isinstance(task.instructions[0], ReduceInstruction):
-        build_remote = reduce_and_fanout if task.instructions and isinstance(task.instructions[-1], FanoutInstruction) else reduce_pipeline
+        build_remote = (
+            reduce_and_fanout
+            if task.instructions and isinstance(task.instructions[-1], FanoutInstruction)
+            else reduce_pipeline
+        )
         build_remote = build_remote.options(**ray_options)
         [metadatas_ref, *partitions] = build_remote.remote(daft_execution_config_objref, task.instructions, task.inputs)
 
     else:
         build_remote = (
-            fanout_pipeline if task.instructions and isinstance(task.instructions[-1], FanoutInstruction) else single_partition_pipeline
+            fanout_pipeline
+            if task.instructions and isinstance(task.instructions[-1], FanoutInstruction)
+            else single_partition_pipeline
         )
         if task.instructions and isinstance(task.instructions[0], ScanWithTask):
             ray_options["scheduling_strategy"] = "SPREAD"

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -40,6 +40,7 @@ from daft.execution.execution_step import (
     MultiOutputPartitionTask,
     PartitionTask,
     ReduceInstruction,
+    ScanWithTask,
     SingleOutputPartitionTask,
 )
 from daft.filesystem import glob_path_with_stats
@@ -652,6 +653,8 @@ def _build_partitions(
         build_remote = (
             fanout_pipeline if isinstance(task.instructions[-1], FanoutInstruction) else single_partition_pipeline
         )
+        if isinstance(task.instructions[0], ScanWithTask):
+            ray_options["scheduling_strategy"] = "SPREAD"
         build_remote = build_remote.options(**ray_options)
         [metadatas_ref, *partitions] = build_remote.remote(
             daft_execution_config_objref, task.instructions, *task.inputs

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -645,15 +645,15 @@ def _build_partitions(
         ray_options = {**ray_options, **_get_ray_task_options(task.resource_request)}
 
     if isinstance(task.instructions[0], ReduceInstruction):
-        build_remote = reduce_and_fanout if isinstance(task.instructions[-1], FanoutInstruction) else reduce_pipeline
+        build_remote = reduce_and_fanout if task.instructions and isinstance(task.instructions[-1], FanoutInstruction) else reduce_pipeline
         build_remote = build_remote.options(**ray_options)
         [metadatas_ref, *partitions] = build_remote.remote(daft_execution_config_objref, task.instructions, task.inputs)
 
     else:
         build_remote = (
-            fanout_pipeline if isinstance(task.instructions[-1], FanoutInstruction) else single_partition_pipeline
+            fanout_pipeline if task.instructions and isinstance(task.instructions[-1], FanoutInstruction) else single_partition_pipeline
         )
-        if isinstance(task.instructions[0], ScanWithTask):
+        if task.instructions and isinstance(task.instructions[0], ScanWithTask):
             ray_options["scheduling_strategy"] = "SPREAD"
         build_remote = build_remote.options(**ray_options)
         [metadatas_ref, *partitions] = build_remote.remote(


### PR DESCRIPTION
This PR forces a `SPREAD` scheduling strategy for scan tasks when using the Ray runner. This should result in better load balancing of read tasks across the Ray cluster, yielding:
- better utilization of the aggregate network bandwidth of the cluster,
- better memory stability due to a more even post-read object distribution,
- better performance of downstream parallel compute operations due to a more even distribution of data over the compute bandwidth of the cluster.

Closes #1940 