### PR TITLE
[CHORE] [Catalogs] [Delta Lake] Add test coverage for Delta Lake reads on Azure.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -295,6 +295,7 @@ jobs:
     - name: Run IO integration tests
       run: |
         pytest tests/integration/io -m 'integration' --durations=50
+        pytest tests/io -m 'integration'
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
     - name: Send Slack notification on failure

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -502,12 +502,24 @@ class AzureConfig:
     storage_account: str | None
     access_key: str | None
     anonymous: str | None
+    endpoint_url: str | None = None
+    use_ssl: bool | None = None
 
     def __init__(
-        self, storage_account: str | None = None, access_key: str | None = None, anonymous: str | None = None
+        self,
+        storage_account: str | None = None,
+        access_key: str | None = None,
+        anonymous: str | None = None,
+        endpoint_url: str | None = None,
+        use_ssl: bool | None = None,
     ): ...
     def replace(
-        self, storage_account: str | None = None, access_key: str | None = None, anonymous: str | None = None
+        self,
+        storage_account: str | None = None,
+        access_key: str | None = None,
+        anonymous: str | None = None,
+        endpoint_url: str | None = None,
+        use_ssl: bool | None = None,
     ) -> AzureConfig:
         """Replaces values if provided, returning a new AzureConfig"""
         ...

--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -215,6 +215,10 @@ def _azure_config_to_storage_options(azure_config: AzureConfig) -> dict[str, str
         storage_options["account_name"] = azure_config.storage_account
     if azure_config.access_key is not None:
         storage_options["access_key"] = azure_config.access_key
+    if azure_config.endpoint_url is not None:
+        storage_options["endpoint"] = azure_config.endpoint_url
+    if azure_config.use_ssl is not None:
+        storage_options["allow_http"] = "false" if azure_config.use_ssl else "true"
     return storage_options
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -61,6 +61,7 @@ moto[s3,server]==5.0.2; python_version >= '3.8'
 # Azure
 adlfs==2022.2.0; python_version < '3.8'
 adlfs==2023.10.0; python_version >= '3.8'
+azure-storage-blob==12.17.0
 
 # GCS
 gcsfs==2023.1.0; python_version < '3.8'

--- a/src/common/io-config/src/azure.rs
+++ b/src/common/io-config/src/azure.rs
@@ -4,11 +4,25 @@ use std::fmt::Formatter;
 use serde::Deserialize;
 use serde::Serialize;
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct AzureConfig {
     pub storage_account: Option<String>,
     pub access_key: Option<String>,
     pub anonymous: bool,
+    pub endpoint_url: Option<String>,
+    pub use_ssl: bool,
+}
+
+impl Default for AzureConfig {
+    fn default() -> Self {
+        Self {
+            storage_account: None,
+            access_key: None,
+            anonymous: false,
+            endpoint_url: None,
+            use_ssl: true,
+        }
+    }
 }
 
 impl AzureConfig {
@@ -21,6 +35,10 @@ impl AzureConfig {
             res.push(format!("Access key = {}", access_key));
         }
         res.push(format!("Anoynmous = {}", self.anonymous));
+        if let Some(endpoint_url) = &self.endpoint_url {
+            res.push(format!("Endpoint URL = {}", endpoint_url));
+        }
+        res.push(format!("Use SSL = {}", self.use_ssl));
         res
     }
 }
@@ -32,8 +50,10 @@ impl Display for AzureConfig {
             "AzureConfig
     storage_account: {:?}
     access_key: {:?}
-    anonymous: {:?}",
-            self.storage_account, self.access_key, self.anonymous
+    anonymous: {:?}
+    endpoint_url: {:?}
+    use_ssl: {:?}",
+            self.storage_account, self.access_key, self.anonymous, self.endpoint_url, self.use_ssl
         )
     }
 }

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -365,6 +365,8 @@ impl AzureConfig {
         storage_account: Option<String>,
         access_key: Option<String>,
         anonymous: Option<bool>,
+        endpoint_url: Option<String>,
+        use_ssl: Option<bool>,
     ) -> Self {
         let def = crate::AzureConfig::default();
         AzureConfig {
@@ -372,6 +374,8 @@ impl AzureConfig {
                 storage_account: storage_account.or(def.storage_account),
                 access_key: access_key.or(def.access_key),
                 anonymous: anonymous.unwrap_or(def.anonymous),
+                endpoint_url: endpoint_url.or(def.endpoint_url),
+                use_ssl: use_ssl.unwrap_or(def.use_ssl),
             },
         }
     }
@@ -381,12 +385,16 @@ impl AzureConfig {
         storage_account: Option<String>,
         access_key: Option<String>,
         anonymous: Option<bool>,
+        endpoint_url: Option<String>,
+        use_ssl: Option<bool>,
     ) -> Self {
         AzureConfig {
             config: crate::AzureConfig {
                 storage_account: storage_account.or_else(|| self.config.storage_account.clone()),
                 access_key: access_key.or_else(|| self.config.access_key.clone()),
                 anonymous: anonymous.unwrap_or(self.config.anonymous),
+                endpoint_url: endpoint_url.or_else(|| self.config.endpoint_url.clone()),
+                use_ssl: use_ssl.unwrap_or(self.config.use_ssl),
             },
         }
     }
@@ -405,6 +413,24 @@ impl AzureConfig {
     #[getter]
     pub fn access_key(&self) -> PyResult<Option<String>> {
         Ok(self.config.access_key.clone())
+    }
+
+    /// Whether access is anonymous
+    #[getter]
+    pub fn anonymous(&self) -> PyResult<bool> {
+        Ok(self.config.anonymous)
+    }
+
+    /// Azure Secret Access Key
+    #[getter]
+    pub fn endpoint_url(&self) -> PyResult<Option<String>> {
+        Ok(self.config.endpoint_url.clone())
+    }
+
+    /// Whether SSL (HTTPS) is required
+    #[getter]
+    pub fn use_ssl(&self) -> PyResult<bool> {
+        Ok(self.config.use_ssl)
     }
 }
 

--- a/tests/io/delta_lake/conftest.py
+++ b/tests/io/delta_lake/conftest.py
@@ -23,14 +23,6 @@ from tests.io.delta_lake.mock_s3_server import start_service, stop_process
 deltalake = pytest.importorskip("deltalake")
 
 
-# def pytest_collection_modifyitems(items):
-#     for item in items:
-#         if "s3" in getattr(item, "fixturenames", ()):
-#             item.add_marker("s3")
-#         elif "az" in getattr(item, "fixturenames", ()):
-#             item.add_marker("az")
-
-
 @pytest.fixture(params=[1, 2, 8])
 def num_partitions(request) -> int:
     return request.param

--- a/tests/io/delta_lake/mock_s3_server.py
+++ b/tests/io/delta_lake/mock_s3_server.py
@@ -26,7 +26,7 @@ def start_service(service_name: str, host: str, port: int, log_file: io.IOBase):
     # Use static data fetch as healthcheck API.
     url = f"http://{host}:{port}/moto-api/data.json"
 
-    for _ in range(0, 30):
+    for _ in range(0, 100):
         output = process.poll()
         if output is not None:
             print(f"moto_server exited status {output}")
@@ -40,7 +40,7 @@ def start_service(service_name: str, host: str, port: int, log_file: io.IOBase):
         except requests.exceptions.ConnectionError:
             pass
 
-        time.sleep(0.5)
+        time.sleep(0.1)
     else:
         stop_process(process)  # pytest.fail doesn't call stop_process
         pytest.fail(f"Cannot start service: {service_name}")

--- a/tests/io/test_url_download_local.py
+++ b/tests/io/test_url_download_local.py
@@ -5,7 +5,7 @@ import pathlib
 import pytest
 
 import daft
-from tests.integration.io.conftest import YieldFixture
+from tests.integration.io.conftest import *
 
 
 @pytest.fixture(scope="function")

--- a/tests/io/test_url_download_local.py
+++ b/tests/io/test_url_download_local.py
@@ -54,5 +54,5 @@ def test_url_download_local_no_read_permissions(local_image_data_fixture, tmpdir
     df = daft.from_pydict(data)
     df = df.with_column("data", df["urls"].url.download(on_error="raise"))
 
-    with pytest.raises(PermissionError):
+    with pytest.raises(ValueError, match="Permission denied"):
         df.collect()


### PR DESCRIPTION
This PR adds test coverage for reading Delta Lake tables from Azure Blob Storage (or more specifically, Azure Data Lake Storage gen2 on ABS). Since the ABS emulating server only runs on Windows, we run a session-scoped Docker container containing the cross-platform [Azurite](https://github.com/Azure/Azurite) emulator. We use a Docker container rather than a background process in order to not introduce another heavy dev dependency (`node.js`/`npm`).

Closes #1971 