### PR TITLE
[CHORE] Disables anonymous mode for S3 accesses in DeltaLake

### DIFF
--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -206,7 +206,7 @@ def _s3_config_to_storage_options(s3_config: S3Config) -> dict[str, str]:
         storage_options["allow_invalid_certificates"] = "false" if s3_config.verify_ssl else "true"
     if s3_config.connect_timeout_ms is not None:
         storage_options["connect_timeout"] = str(s3_config.connect_timeout_ms) + "ms"
-    if s3_config.anonymous is not None:
+    if s3_config.anonymous:
         raise ValueError(
             "Reading from DeltaLake does not support anonymous mode! Please supply credentials via your S3Config."
         )

--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -206,6 +206,8 @@ def _s3_config_to_storage_options(s3_config: S3Config) -> dict[str, str]:
         storage_options["allow_invalid_certificates"] = "false" if s3_config.verify_ssl else "true"
     if s3_config.connect_timeout_ms is not None:
         storage_options["connect_timeout"] = str(s3_config.connect_timeout_ms) + "ms"
+    if s3_config.anonymous is not None:
+        raise ValueError("Reading from DeltaLake does not support anonymous mode! Please supply credentials correctly.")
     return storage_options
 
 

--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -207,7 +207,9 @@ def _s3_config_to_storage_options(s3_config: S3Config) -> dict[str, str]:
     if s3_config.connect_timeout_ms is not None:
         storage_options["connect_timeout"] = str(s3_config.connect_timeout_ms) + "ms"
     if s3_config.anonymous is not None:
-        raise ValueError("Reading from DeltaLake does not support anonymous mode! Please supply credentials correctly.")
+        raise ValueError(
+            "Reading from DeltaLake does not support anonymous mode! Please supply credentials via your S3Config."
+        )
     return storage_options
 
 


### PR DESCRIPTION
DeltaLake SDK does not support anonymous mode access (see: issue https://github.com/delta-io/delta-rs/issues/1554)

We throw an error if a user attempts to supply `anonymous=True`.