### PR TITLE
[CHORE] Simplify cast to schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,7 @@ dependencies = [
  "pyo3-log",
  "serde",
  "snafu",
+ "tokio",
 ]
 
 [[package]]

--- a/src/daft-micropartition/Cargo.toml
+++ b/src/daft-micropartition/Cargo.toml
@@ -18,6 +18,7 @@ pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true}
 serde = {workspace = true}
 snafu = {workspace = true}
+tokio = {workspace = true}
 
 [features]
 default = ["python"]

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -916,10 +916,14 @@ pub(crate) fn read_parquet_into_micropartition(
             ),
         );
 
+        let fill_map = scan_task.partition_spec().map(|pspec| pspec.to_fill_map());
+        let casted_stats =
+            stats.cast_to_schema_with_fill(scan_task.materialized_schema(), fill_map.as_ref())?;
+
         Ok(MicroPartition::new_unloaded(
             Arc::new(scan_task),
             TableMetadata { length: total_rows },
-            stats,
+            casted_stats,
         ))
     } else {
         // If no TableStatistics are available, we perform an eager read

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -26,7 +26,7 @@ use snafu::ResultExt;
 use crate::PyIOSnafu;
 use crate::{DaftCSVSnafu, DaftCoreComputeSnafu};
 
-use daft_io::{IOConfig, IOStatsContext, IOStatsRef};
+use daft_io::{IOClient, IOConfig, IOStatsContext, IOStatsRef};
 use daft_stats::TableStatistics;
 use daft_stats::{PartitionSpec, TableMetadata};
 
@@ -415,7 +415,7 @@ impl MicroPartition {
                     .map(|cols| cols.iter().map(|s| s.as_str()).collect::<Vec<&str>>());
 
                 let row_groups = parquet_sources_to_row_groups(scan_task.sources.as_slice());
-                let mp = read_parquet_into_micropartition(
+                read_parquet_into_micropartition(
                     uris.as_slice(),
                     columns.as_deref(),
                     None,
@@ -433,12 +433,9 @@ impl MicroPartition {
                     &ParquetSchemaInferenceOptions {
                         coerce_int96_timestamp_unit: *coerce_int96_timestamp_unit,
                     },
+                    Some(schema.clone()),
                 )
-                .context(DaftCoreComputeSnafu)?;
-
-                let fill_map = scan_task.partition_spec().map(|pspec| pspec.to_fill_map());
-                mp.cast_to_schema_with_fill(schema, fill_map.as_ref())
-                    .context(DaftCoreComputeSnafu)
+                .context(DaftCoreComputeSnafu)
             }
 
             // CASE: Last resort fallback option
@@ -704,6 +701,68 @@ pub(crate) fn read_json_into_micropartition(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn _read_parquet_into_loaded_micropartition(
+    io_client: Arc<IOClient>,
+    runtime_handle: Arc<tokio::runtime::Runtime>,
+    uris: &[&str],
+    columns: Option<&[&str]>,
+    start_offset: Option<usize>,
+    num_rows: Option<usize>,
+    row_groups: Option<Vec<Option<Vec<i64>>>>,
+    predicate: Option<ExprRef>,
+    partition_spec: Option<&PartitionSpec>,
+    io_stats: Option<IOStatsRef>,
+    num_parallel_tasks: usize,
+    schema_infer_options: &ParquetSchemaInferenceOptions,
+    catalog_provided_schema: Option<SchemaRef>,
+) -> DaftResult<MicroPartition> {
+    let all_tables = read_parquet_bulk(
+        uris,
+        columns,
+        start_offset,
+        num_rows,
+        row_groups,
+        predicate,
+        io_client,
+        io_stats,
+        num_parallel_tasks,
+        runtime_handle,
+        schema_infer_options,
+    )?;
+
+    // Prefer using the `catalog_provided_schema` but fall back onto inferred schema from Parquet files
+    let full_daft_schema = match catalog_provided_schema {
+        Some(catalog_provided_schema) => catalog_provided_schema,
+        None => {
+            let unioned_schema = all_tables
+                .iter()
+                .map(|t| t.schema.clone())
+                .try_reduce(|l, r| DaftResult::Ok(l.union(&r)?.into()))?;
+            unioned_schema.expect("we need at least 1 schema")
+        }
+    };
+
+    // Hack to avoid to owned schema
+    let full_daft_schema = Schema {
+        fields: full_daft_schema.fields.clone(),
+    };
+    let pruned_daft_schema = prune_fields_from_schema(full_daft_schema, columns)?;
+
+    let fill_map = partition_spec.map(|pspec| pspec.to_fill_map());
+    let all_tables = all_tables
+        .into_iter()
+        .map(|t| t.cast_to_schema_with_fill(&pruned_daft_schema, fill_map.as_ref()))
+        .collect::<DaftResult<Vec<_>>>()?;
+
+    // TODO: we can pass in stats here to optimize downstream workloads such as join
+    Ok(MicroPartition::new_loaded(
+        Arc::new(pruned_daft_schema),
+        all_tables.into(),
+        None,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn read_parquet_into_micropartition(
     uris: &[&str],
     columns: Option<&[&str]>,
@@ -717,6 +776,7 @@ pub(crate) fn read_parquet_into_micropartition(
     num_parallel_tasks: usize,
     multithreaded_io: bool,
     schema_infer_options: &ParquetSchemaInferenceOptions,
+    catalog_provided_schema: Option<SchemaRef>,
 ) -> DaftResult<MicroPartition> {
     if let Some(so) = start_offset && so > 0 {
         return Err(common_error::DaftError::ValueError("Micropartition Parquet Reader does not support non-zero start offsets".to_string()));
@@ -725,52 +785,32 @@ pub(crate) fn read_parquet_into_micropartition(
     // Run the required I/O to retrieve all the Parquet FileMetaData
     let runtime_handle = daft_io::get_runtime(multithreaded_io)?;
     let io_client = daft_io::get_io_client(multithreaded_io, io_config.clone())?;
-    if let Some(predicate) = predicate {
-        // We have a predicate, so we will perform eager read only reading what row groups we need.
-        let all_tables = read_parquet_bulk(
+
+    // If we have a predicate, perform an eager read only reading what row groups we need.
+    if predicate.is_some() {
+        return _read_parquet_into_loaded_micropartition(
+            io_client,
+            runtime_handle,
             uris,
             columns,
-            None,
+            start_offset,
             num_rows,
             row_groups,
-            Some(predicate.clone()),
-            io_client,
+            predicate,
+            partition_spec,
             io_stats,
             num_parallel_tasks,
-            runtime_handle,
             schema_infer_options,
-        )?;
-
-        let unioned_schema = all_tables
-            .iter()
-            .map(|t| t.schema.clone())
-            .try_reduce(|l, r| DaftResult::Ok(l.union(&r)?.into()))?;
-        let full_daft_schema = unioned_schema.expect("we need at least 1 schema");
-        // Hack to avoid to owned schema
-        let full_daft_schema = Schema {
-            fields: full_daft_schema.fields.clone(),
-        };
-        let pruned_daft_schema = prune_fields_from_schema(full_daft_schema, columns)?;
-
-        let all_tables = all_tables
-            .into_iter()
-            .map(|t| t.cast_to_schema(&pruned_daft_schema))
-            .collect::<DaftResult<Vec<_>>>()?;
-        // TODO: we can pass in stats here to optimize downstream workloads such as join
-        return Ok(MicroPartition::new_loaded(
-            Arc::new(pruned_daft_schema),
-            all_tables.into(),
-            None,
-        ));
+            catalog_provided_schema,
+        );
     }
 
+    // Attempt to read TableStatistics from the Parquet file
     let meta_io_client = io_client.clone();
     let meta_io_stats = io_stats.clone();
     let metadata = runtime_handle.block_on(async move {
         read_parquet_metadata_bulk(uris, meta_io_client, meta_io_stats).await
     })?;
-
-    // Deserialize and collect relevant TableStatistics
     let schemas = metadata
         .iter()
         .map(|m| {
@@ -799,40 +839,45 @@ pub(crate) fn read_parquet_into_micropartition(
         None
     };
 
-    // Union and prune the schema using the specified `columns`
-    let unioned_schema = schemas.into_iter().try_reduce(|l, r| l.union(&r))?;
-    let full_daft_schema = unioned_schema.expect("we need at least 1 schema");
-    let pruned_daft_schema = prune_fields_from_schema(full_daft_schema, columns)?;
-
-    // Get total number of rows, accounting for selected `row_groups` and the indicated `num_rows`
-    let total_rows_no_limit = match &row_groups {
-        None => metadata.iter().map(|fm| fm.num_rows).sum(),
-        Some(row_groups) => metadata
-            .iter()
-            .zip(row_groups.iter())
-            .map(|(fm, rg)| match rg {
-                Some(rg) => rg
-                    .iter()
-                    .map(|rg_idx| fm.row_groups.get(*rg_idx as usize).unwrap().num_rows())
-                    .sum::<usize>(),
-                None => fm.num_rows,
-            })
-            .sum(),
-    };
-    let total_rows = num_rows
-        .map(|num_rows| num_rows.min(total_rows_no_limit))
-        .unwrap_or(total_rows_no_limit);
-
+    // If statistics are provided by the Parquet file, we create an unloaded MicroPartition
+    // by constructing an appropriate ScanTask
     if let Some(stats) = stats {
-        let owned_urls = uris.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        // Prefer using the `catalog_provided_schema` but fall back onto inferred schema from Parquet files
+        let scan_task_daft_schema = match catalog_provided_schema {
+            Some(catalog_provided_schema) => catalog_provided_schema,
+            None => {
+                let unioned_schema = schemas.into_iter().try_reduce(|l, r| l.union(&r))?;
+                Arc::new(unioned_schema.expect("we need at least 1 schema"))
+            }
+        };
 
-        let daft_schema = Arc::new(pruned_daft_schema);
+        // Get total number of rows, accounting for selected `row_groups` and the indicated `num_rows`
+        let total_rows_no_limit = match &row_groups {
+            None => metadata.iter().map(|fm| fm.num_rows).sum(),
+            Some(row_groups) => metadata
+                .iter()
+                .zip(row_groups.iter())
+                .map(|(fm, rg)| match rg {
+                    Some(rg) => rg
+                        .iter()
+                        .map(|rg_idx| fm.row_groups.get(*rg_idx as usize).unwrap().num_rows())
+                        .sum::<usize>(),
+                    None => fm.num_rows,
+                })
+                .sum(),
+        };
+        let total_rows = num_rows
+            .map(|num_rows| num_rows.min(total_rows_no_limit))
+            .unwrap_or(total_rows_no_limit);
+
+        let owned_urls = uris.iter().map(|s| s.to_string()).collect::<Vec<_>>();
         let size_bytes = metadata
             .iter()
             .map(|m| -> u64 {
                 std::iter::Sum::sum(m.row_groups.iter().map(|m| m.total_byte_size() as u64))
             })
             .sum();
+
         let scan_task = ScanTask::new(
             owned_urls
                 .into_iter()
@@ -853,7 +898,7 @@ pub(crate) fn read_parquet_into_micropartition(
                 coerce_int96_timestamp_unit: schema_infer_options.coerce_int96_timestamp_unit,
             })
             .into(),
-            daft_schema.clone(),
+            scan_task_daft_schema,
             StorageConfig::Native(
                 NativeStorageConfig::new_internal(
                     multithreaded_io,
@@ -871,42 +916,28 @@ pub(crate) fn read_parquet_into_micropartition(
             ),
         );
 
-        let exprs = daft_schema
-            .fields
-            .keys()
-            .map(|n| daft_dsl::col(n.as_str()))
-            .collect::<Vec<_>>();
-        // use schema to update stats
-        let stats = stats.eval_expression_list(exprs.as_slice(), daft_schema.as_ref())?;
-
         Ok(MicroPartition::new_unloaded(
             Arc::new(scan_task),
             TableMetadata { length: total_rows },
             stats,
         ))
     } else {
-        let all_tables = read_parquet_bulk(
+        // If no TableStatistics are available, we perform an eager read
+        _read_parquet_into_loaded_micropartition(
+            io_client,
+            runtime_handle,
             uris,
             columns,
             start_offset,
             num_rows,
             row_groups,
-            None,
-            io_client,
+            predicate,
+            partition_spec,
             io_stats,
             num_parallel_tasks,
-            runtime_handle,
             schema_infer_options,
-        )?;
-        let all_tables = all_tables
-            .into_iter()
-            .map(|t| t.cast_to_schema(&pruned_daft_schema))
-            .collect::<DaftResult<Vec<_>>>()?;
-        Ok(MicroPartition::new_loaded(
-            Arc::new(pruned_daft_schema),
-            all_tables.into(),
-            None,
-        ))
+            catalog_provided_schema,
+        )
     }
 }
 

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, ops::Deref, sync::Arc};
 use common_error::DaftResult;
 use daft_core::schema::SchemaRef;
 use daft_dsl::Expr;
+use daft_scan::ScanTask;
 
 use crate::micropartition::{MicroPartition, TableState};
 
@@ -26,12 +27,24 @@ impl MicroPartition {
         let guard = self.state.lock().unwrap();
         match guard.deref() {
             // Replace schema if Unloaded, which should be applied when data is lazily loaded
-            TableState::Unloaded(scan_task) => Ok(MicroPartition::new_unloaded(
-                schema.clone(),
-                scan_task.clone(),
-                self.metadata.clone(),
-                pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
-            )),
+            TableState::Unloaded(scan_task) => {
+                let maybe_new_scan_task = if scan_task.schema == schema {
+                    scan_task.clone()
+                } else {
+                    Arc::new(ScanTask::new(
+                        scan_task.sources.clone(),
+                        scan_task.file_format_config.clone(),
+                        schema,
+                        scan_task.storage_config.clone(),
+                        scan_task.pushdowns.clone(),
+                    ))
+                };
+                Ok(MicroPartition::new_unloaded(
+                    maybe_new_scan_task,
+                    self.metadata.clone(),
+                    pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
+                ))
+            }
             // If Tables are already loaded, we map `Table::cast_to_schema` on each Table
             TableState::Loaded(tables) => Ok(MicroPartition::new_loaded(
                 schema.clone(),

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, ops::Deref, sync::Arc};
 use common_error::DaftResult;
 use daft_core::schema::SchemaRef;
 use daft_dsl::Expr;
-use daft_scan::ScanTask;
 
 use crate::micropartition::{MicroPartition, TableState};
 
@@ -27,24 +26,11 @@ impl MicroPartition {
         let guard = self.state.lock().unwrap();
         match guard.deref() {
             // Replace schema if Unloaded, which should be applied when data is lazily loaded
-            TableState::Unloaded(scan_task) => {
-                let maybe_new_scan_task = if scan_task.schema == schema {
-                    scan_task.clone()
-                } else {
-                    Arc::new(ScanTask::new(
-                        scan_task.sources.clone(),
-                        scan_task.file_format_config.clone(),
-                        schema,
-                        scan_task.storage_config.clone(),
-                        scan_task.pushdowns.clone(),
-                    ))
-                };
-                Ok(MicroPartition::new_unloaded(
-                    maybe_new_scan_task,
-                    self.metadata.clone(),
-                    pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
-                ))
-            }
+            TableState::Unloaded(scan_task) => Ok(MicroPartition::new_unloaded(
+                scan_task.clone(),
+                self.metadata.clone(),
+                pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
+            )),
             // If Tables are already loaded, we map `Table::cast_to_schema` on each Table
             TableState::Loaded(tables) => Ok(MicroPartition::new_loaded(
                 schema.clone(),

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, ops::Deref, sync::Arc};
 use common_error::DaftResult;
 use daft_core::schema::SchemaRef;
 use daft_dsl::Expr;
+use daft_scan::ScanTask;
 
 use crate::micropartition::{MicroPartition, TableState};
 
@@ -26,11 +27,24 @@ impl MicroPartition {
         let guard = self.state.lock().unwrap();
         match guard.deref() {
             // Replace schema if Unloaded, which should be applied when data is lazily loaded
-            TableState::Unloaded(scan_task) => Ok(MicroPartition::new_unloaded(
-                scan_task.clone(),
-                self.metadata.clone(),
-                pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
-            )),
+            TableState::Unloaded(scan_task) => {
+                let maybe_new_scan_task = if scan_task.schema == schema {
+                    scan_task.clone()
+                } else {
+                    Arc::new(ScanTask::new(
+                        scan_task.sources.clone(),
+                        scan_task.file_format_config.clone(),
+                        schema,
+                        scan_task.storage_config.clone(),
+                        scan_task.pushdowns.clone(),
+                    ))
+                };
+                Ok(MicroPartition::new_unloaded(
+                    maybe_new_scan_task,
+                    self.metadata.clone(),
+                    pruned_statistics.expect("Unloaded MicroPartition should have statistics"),
+                ))
+            }
             // If Tables are already loaded, we map `Table::cast_to_schema` on each Table
             TableState::Loaded(tables) => Ok(MicroPartition::new_loaded(
                 schema.clone(),

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -544,6 +544,7 @@ impl PyMicroPartition {
                 1,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
+                None,
             )
         })?;
         Ok(mp.into())
@@ -585,6 +586,7 @@ impl PyMicroPartition {
                 num_parallel_tasks.unwrap_or(128) as usize,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
+                None,
             )
         })?;
         Ok(mp.into())

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -256,6 +256,10 @@ pub struct ScanTask {
     pub sources: Vec<DataFileSource>,
 
     /// Schema to use when reading the DataFileSources.
+    ///
+    /// Schema to use when reading the DataFileSources. This should always be passed in by the
+    /// ScanOperator implementation and should not have had any "pruning" applied.
+    ///
     /// Note that this is different than the schema of the data after pushdowns have been applied,
     /// which can be obtained with [`ScanTask::materialized_schema`] instead.
     pub schema: SchemaRef,


### PR DESCRIPTION
This PR makes some changes to how we use `cast_to_schema` in our codebase, and also some subtle fixes which makes our code easier to refactor later on for field IDs.

## Reducing user error with schemas

I added a bunch of documentation to our structs, detailing what the correct semantics for each `schema` field is on ScanTask and MicroPartition.

Additinally:

1. `MicroPartition::new_unloaded` no longer takes in as input a schema. Instead, the unloaded MicroPartition's schema is simply its ScanTask's `materialized_schema`.
2. `materialize_scan_task` now does not take as input a `cast_to_schema` argument. Instead, it just uses the ScanTask's `materialized_schema` and `partition_spec()` for the fill map to correctly coerce all the materialized Tables.

## Refactoring the `read_parquet_into_micropartition` megafunction

**Share code**: Move shared code into a `_read_parquet_into_loaded_micropartition` helper, which is called in 2 locations from `read_parquet_into_micropartition`.

**Fix the Unloaded case**: Previously in the unloaded micropartition case, we were creating a `ScanTask` using the schema inferrred from the Parquet file. This is *wrong* behavior! I added a new `catalog_provided_schema` argument that is now correctly used when creating MicroPartitions in this function, in both the loaded and unloaded case.

**Casting**: we now perform casting inside of `read_parquet_into_micropartition`:

1. When we eagerly create loaded micropartitions, we call `cast_to_schema_with_fill` on the materialized tables
2. When we create unloaded micropartitions, we correctly create the ScanTask with the right schema, partition_spec and column selection so that later on when we materialize the MicroPartition, we correctly call `cast_to_schema_with_fill` on each Table. Also called `cast_to_schema_with_fill` on the stats.