### PR TITLE
[FEAT] Enable UDF to handle arbitrary number of Daft series

### DIFF
--- a/daft/udf.py
+++ b/daft/udf.py
@@ -34,9 +34,10 @@ class PartialUDF:
         for key, val in self.bound_args.arguments.items():
             if isinstance(val, Expression):
                 parsed_expressions[key] = val
-            elif isinstance(val, tuple) and all(isinstance(x, Expression) for x in val):
+            elif isinstance(val, tuple):
                 for idx, x in enumerate(val):
-                    parsed_expressions[f"{key}{idx}"] = x
+                    if isinstance(x, Expression):
+                        parsed_expressions[f"{key}-{idx}"] = x
 
         return parsed_expressions
 
@@ -47,7 +48,7 @@ class PartialUDF:
                 continue
             if isinstance(value, tuple):
                 for idx, _ in enumerate(value):
-                    parsed_arg_keys.append(f"{key}{idx}")
+                    parsed_arg_keys.append(f"{key}-{idx}")
             else:
                 parsed_arg_keys.append(key)
 

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -31,17 +31,16 @@ class PartialUDF:
 
     def expressions(self) -> dict[str, Expression]:
         parsed_expressions = {}
-
         for key, val in self.bound_args.arguments.items():
             if isinstance(val, Expression):
                 parsed_expressions[key] = val
             elif isinstance(val, tuple) and all(isinstance(x, Expression) for x in val):
                 for idx, x in enumerate(val):
                     parsed_expressions[f"{key}{idx}"] = x
+
         return parsed_expressions
 
     def arg_keys(self) -> list[str]:
-        """Gets argument keys."""
         parsed_arg_keys = []
         for key, value in self.bound_args.arguments.items():
             if key in self.bound_args.kwargs:


### PR DESCRIPTION
Enables using `*args` to pass an arbitrary number of Daft series to a UDF.