### PR TITLE
WIP: wrap all Parquet metadata accesses in Daft wrappers

### DIFF
--- a/src/daft-parquet/src/statistics/table_stats.rs
+++ b/src/daft-parquet/src/statistics/table_stats.rs
@@ -3,12 +3,14 @@ use daft_core::schema::Schema;
 use daft_stats::{ColumnRangeStatistics, TableStatistics};
 use snafu::ResultExt;
 
+use crate::metadata::ParquetRowGroupMetadata;
+
 use super::column_range::parquet_statistics_to_column_range_statistics;
 
 use indexmap::IndexMap;
 
 pub fn row_group_metadata_to_table_stats(
-    metadata: &crate::metadata::RowGroupMetaData,
+    metadata: &ParquetRowGroupMetadata,
     schema: &Schema,
 ) -> DaftResult<TableStatistics> {
     // Create a map from {field_name: statistics} from the RowGroupMetaData for easy access


### PR DESCRIPTION
In this PR, I attempt to wrap all Parquet metadata accessing in Daft-side wrappers, to provide an opportunity for us to intercept these metadata objects and inject our own information (e.g. renaming certain columns based on field IDs).

After having attempted this, I think it might be a fool's errand.

* A lot of our reading functionality uses `arrow2`, which has a pretty tight/strong dependency on taking as input `parquet2` types such as `ColumnDescriptor`.
* We'd be duplicating a lot of logic and code