### PR TITLE
[FEAT] Support reading Parquet files with Field ID

### DIFF
--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -226,8 +226,13 @@ class ParquetSourceConfig:
     """
 
     coerce_int96_timestamp_unit: PyTimeUnit | None
+    field_id_mapping: dict[int, PyField] | None
 
-    def __init__(self, coerce_int96_timestamp_unit: PyTimeUnit | None = None): ...
+    def __init__(
+        self,
+        coerce_int96_timestamp_unit: PyTimeUnit | None = None,
+        field_id_mapping: dict[int, PyField] | None = None,
+    ): ...
 
 class CsvSourceConfig:
     """

--- a/daft/iceberg/schema_field_id_mapping_visitor.py
+++ b/daft/iceberg/schema_field_id_mapping_visitor.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from pyiceberg.io.pyarrow import schema_to_pyarrow
+from pyiceberg.schema import Schema, SchemaVisitor
+from pyiceberg.types import ListType, MapType, NestedField, PrimitiveType, StructType
+
+from daft import DataType
+from daft.daft import PyField
+
+FieldIdMapping = Dict[int, PyField]
+
+
+def _nested_field_to_daft_pyfield(field: NestedField) -> PyField:
+    return PyField.create(field.name, DataType.from_arrow_type(schema_to_pyarrow(field.field_type))._dtype)
+
+
+class SchemaFieldIdMappingVisitor(SchemaVisitor[FieldIdMapping]):
+    """Extracts a mapping of {field_id: PyField} from an Iceberg schema"""
+
+    def schema(self, schema: Schema, struct_result: FieldIdMapping) -> FieldIdMapping:
+        """Visit a Schema."""
+        return struct_result
+
+    def struct(self, struct: StructType, field_results: list[FieldIdMapping]) -> FieldIdMapping:
+        """Visit a StructType."""
+        result = {field.field_id: _nested_field_to_daft_pyfield(field) for field in struct.fields}
+        for r in field_results:
+            result.update(r)
+        return result
+
+    def field(self, field: NestedField, field_result: FieldIdMapping) -> FieldIdMapping:
+        """Visit a NestedField."""
+        field_result[field.field_id] = _nested_field_to_daft_pyfield(field)
+        return field_result
+
+    def list(self, list_type: ListType, element_result: FieldIdMapping) -> FieldIdMapping:
+        """Visit a ListType."""
+        element_result[list_type.element_id] = _nested_field_to_daft_pyfield(list_type.element_field)
+        return element_result
+
+    def map(self, map_type: MapType, key_result: FieldIdMapping, value_result: FieldIdMapping) -> FieldIdMapping:
+        result = {**key_result, **value_result}
+        result[map_type.key_id] = _nested_field_to_daft_pyfield(map_type.key_field)
+        result[map_type.value_id] = _nested_field_to_daft_pyfield(map_type.value_field)
+        return result
+
+    def primitive(self, primitive: PrimitiveType) -> FieldIdMapping:
+        """Visit a PrimitiveType."""
+        return {}

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -545,6 +545,7 @@ impl PyMicroPartition {
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
                 None,
+                None,
             )
         })?;
         Ok(mp.into())
@@ -586,6 +587,7 @@ impl PyMicroPartition {
                 num_parallel_tasks.unwrap_or(128) as usize,
                 multithreaded_io.unwrap_or(true),
                 &schema_infer_options,
+                None,
                 None,
             )
         })?;

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -1,8 +1,13 @@
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
 
 use arrow2::io::parquet::read::schema::infer_schema_with_options;
 use common_error::DaftResult;
-use daft_core::{schema::Schema, utils::arrow::cast_array_for_daft_if_needed, Series};
+use daft_core::{
+    datatypes::Field, schema::Schema, utils::arrow::cast_array_for_daft_if_needed, Series,
+};
 use daft_dsl::ExprRef;
 use daft_io::{IOClient, IOStatsRef};
 use daft_stats::TruthValue;
@@ -191,12 +196,14 @@ impl ParquetReaderBuilder {
         uri: &str,
         io_client: Arc<daft_io::IOClient>,
         io_stats: Option<IOStatsRef>,
+        field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
     ) -> super::Result<Self> {
         // TODO(sammy): We actually don't need this since we can do negative offsets when reading the metadata
         let size = io_client
             .single_url_get_size(uri.into(), io_stats.clone())
             .await?;
-        let metadata = read_parquet_metadata(uri, size, io_client, io_stats).await?;
+        let metadata =
+            read_parquet_metadata(uri, size, io_client, io_stats, field_id_mapping).await?;
         Ok(ParquetReaderBuilder {
             uri: uri.into(),
             metadata,

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -145,6 +145,18 @@ pub enum Error {
     ParquetColumnsDontHaveEqualRows { path: String },
 
     #[snafu(display(
+        "Parquet file: {} metadata listed {} columns but only read: {} ",
+        path,
+        metadata_num_columns,
+        read_columns
+    ))]
+    ParquetNumColumnMismatch {
+        path: String,
+        metadata_num_columns: usize,
+        read_columns: usize,
+    },
+
+    #[snafu(display(
         "Parquet file: {} unable to convert row group metadata to stats\nDetails:\n{source}",
         path,
     ))]

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -145,18 +145,6 @@ pub enum Error {
     ParquetColumnsDontHaveEqualRows { path: String },
 
     #[snafu(display(
-        "Parquet file: {} metadata listed {} columns but only read: {} ",
-        path,
-        metadata_num_columns,
-        read_columns
-    ))]
-    ParquetNumColumnMismatch {
-        path: String,
-        metadata_num_columns: usize,
-        read_columns: usize,
-    },
-
-    #[snafu(display(
         "Parquet file: {} unable to convert row group metadata to stats\nDetails:\n{source}",
         path,
     ))]

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -160,6 +160,7 @@ pub mod pylib {
                 num_parallel_tasks.unwrap_or(128) as usize,
                 runtime_handle,
                 &schema_infer_options,
+                None,
             )?
             .into_iter()
             .map(|v| v.into())
@@ -235,6 +236,7 @@ pub mod pylib {
                 io_client,
                 Some(io_stats),
                 schema_infer_options,
+                None, // TODO: allow passing in of field_id_mapping through Python API?
             )?)
             .into())
         })
@@ -255,8 +257,13 @@ pub mod pylib {
                 io_config.unwrap_or_default().config.into(),
             )?;
             Ok(
-                crate::read::read_parquet_statistics(&uris.series, io_client, Some(io_stats))?
-                    .into(),
+                crate::read::read_parquet_statistics(
+                    &uris.series,
+                    io_client,
+                    Some(io_stats),
+                    None,
+                )?
+                .into(),
             )
         })
     }

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -156,6 +156,7 @@ impl GlobScanOperator {
         let inferred_schema = match file_format_config.as_ref() {
             FileFormatConfig::Parquet(ParquetSourceConfig {
                 coerce_int96_timestamp_unit,
+                field_id_mapping,
             }) => {
                 let io_stats = IOStatsContext::new(format!(
                     "GlobScanOperator constructor read_parquet_schema: for uri {first_filepath}"
@@ -167,6 +168,7 @@ impl GlobScanOperator {
                     ParquetSchemaInferenceOptions {
                         coerce_int96_timestamp_unit: *coerce_int96_timestamp_unit,
                     },
+                    field_id_mapping.clone(),
                 )?
             }
             FileFormatConfig::Csv(CsvSourceConfig {

--- a/src/daft-scan/src/scan_task_iters.rs
+++ b/src/daft-scan/src/scan_task_iters.rs
@@ -5,8 +5,9 @@ use daft_io::IOStatsContext;
 use daft_parquet::read::read_parquet_metadata;
 
 use crate::{
-    file_format::FileFormatConfig, storage_config::StorageConfig, ChunkSpec, DataFileSource,
-    ScanTask, ScanTaskRef,
+    file_format::{FileFormatConfig, ParquetSourceConfig},
+    storage_config::StorageConfig,
+    ChunkSpec, DataFileSource, ScanTask, ScanTaskRef,
 };
 
 type BoxScanTaskIter = Box<dyn Iterator<Item = DaftResult<ScanTaskRef>>>;
@@ -136,7 +137,7 @@ pub fn split_by_row_groups(
                         - have size past split threshold
                     */
                     if let (
-                        FileFormatConfig::Parquet(_),
+                        FileFormatConfig::Parquet(ParquetSourceConfig{field_id_mapping, ..}),
                         StorageConfig::Native(_),
                         [source],
                         Some(None),
@@ -162,6 +163,7 @@ pub fn split_by_row_groups(
                             path,
                             io_client,
                             Some(io_stats),
+                            field_id_mapping.clone(),
                         ))?;
 
                         let mut new_tasks: Vec<DaftResult<ScanTaskRef>> = Vec::new();

--- a/tests/integration/iceberg/docker-compose/provision.py
+++ b/tests/integration/iceberg/docker-compose/provision.py
@@ -21,7 +21,7 @@ from pyiceberg.catalog import load_catalog
 from pyiceberg.schema import Schema
 from pyiceberg.types import FixedType, NestedField, UUIDType
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import col, current_date, date_add, expr, struct
+from pyspark.sql.functions import array, col, current_date, date_add, expr, struct
 
 spark = SparkSession.builder.getOrCreate()
 
@@ -368,8 +368,13 @@ renaming_columns_dataframe = (
     .withColumn("data", col("idx") * 10)
     .withColumn("structcol", struct("idx"))
     .withColumn("structcol_oldname", struct("idx"))
+    .withColumn("nested_list_struct_col", array("structcol", "structcol", "structcol"))
 )
 renaming_columns_dataframe.writeTo("default.test_table_rename").tableProperty("format-version", "2").createOrReplace()
-spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN idx TO pos")
-spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN structcol.idx TO pos")
+spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN idx TO idx_renamed")
+spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN structcol.idx TO idx_renamed")
 spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN structcol_oldname TO structcol_2")
+
+test_table_rename_tbl = catalog.load_table("default.test_table_rename")
+with test_table_rename_tbl.update_schema() as txn:
+    txn.rename_column("nested_list_struct_col.idx", "idx_renamed")

--- a/tests/integration/iceberg/docker-compose/provision.py
+++ b/tests/integration/iceberg/docker-compose/provision.py
@@ -325,7 +325,7 @@ VALUES
 
 spark.sql(
     """
-  CREATE OR REPLACE TABLE default.add_new_column
+  CREATE OR REPLACE TABLE default.test_add_new_column
   USING iceberg
   AS SELECT
         1            AS idx
@@ -336,5 +336,38 @@ spark.sql(
 """
 )
 
-spark.sql("ALTER TABLE default.add_new_column ADD COLUMN name STRING")
-spark.sql("INSERT INTO default.add_new_column VALUES (3, 'abc'), (4, 'def')")
+spark.sql("ALTER TABLE default.test_add_new_column ADD COLUMN name STRING")
+spark.sql("INSERT INTO default.test_add_new_column VALUES (3, 'abc'), (4, 'def')")
+
+# In Iceberg the data and schema evolves independently. We can add a column
+# that should show up when querying the data, but is not yet represented in a Parquet file
+
+spark.sql(
+    """
+  CREATE OR REPLACE TABLE default.test_new_column_with_no_data
+  USING iceberg
+  AS SELECT
+        1            AS idx
+    UNION ALL SELECT
+        2            AS idx
+    UNION ALL SELECT
+        3            AS idx
+"""
+)
+
+spark.sql("ALTER TABLE default.test_new_column_with_no_data ADD COLUMN name STRING")
+
+spark.sql(
+    """
+  CREATE OR REPLACE TABLE default.test_table_rename
+  USING iceberg
+  AS SELECT
+        1            AS idx
+    UNION ALL SELECT
+        2            AS idx
+    UNION ALL SELECT
+        3            AS idx
+"""
+)
+
+spark.sql("ALTER TABLE default.test_table_rename RENAME COLUMN idx TO pos")

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -37,7 +37,9 @@ WORKING_SHOW_COLLECT = [
     # "test_table_sanitized_character", # Bug in scan().to_arrow().to_arrow()
     "test_table_version",  # we have bugs when loading no files
     "test_uuid_and_fixed_unpartitioned",
-    "add_new_column",
+    "test_add_new_column",
+    "test_new_column_with_no_data",
+    "test_table_rename",
 ]
 
 

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -66,10 +66,10 @@ def test_daft_iceberg_table_collect_correct(table_name, local_iceberg_catalog):
 def test_daft_iceberg_table_renamed_filtered_collect_correct(local_iceberg_catalog):
     tab = local_iceberg_catalog.load_table(f"default.test_table_rename")
     df = daft.read_iceberg(tab)
-    df = df.where(df["pos"] <= 1)
+    df = df.where(df["idx_renamed"] <= 1)
     daft_pandas = df.to_pandas()
     iceberg_pandas = tab.scan().to_arrow().to_pandas()
-    iceberg_pandas = iceberg_pandas[iceberg_pandas["pos"] <= 1]
+    iceberg_pandas = iceberg_pandas[iceberg_pandas["idx_renamed"] <= 1]
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
 
 
@@ -77,8 +77,8 @@ def test_daft_iceberg_table_renamed_filtered_collect_correct(local_iceberg_catal
 def test_daft_iceberg_table_renamed_column_pushdown_collect_correct(local_iceberg_catalog):
     tab = local_iceberg_catalog.load_table(f"default.test_table_rename")
     df = daft.read_iceberg(tab)
-    df = df.select("pos")
+    df = df.select("idx_renamed")
     daft_pandas = df.to_pandas()
     iceberg_pandas = tab.scan().to_arrow().to_pandas()
-    iceberg_pandas = iceberg_pandas[["pos"]]
+    iceberg_pandas = iceberg_pandas[["idx_renamed"]]
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -60,3 +60,25 @@ def test_daft_iceberg_table_collect_correct(table_name, local_iceberg_catalog):
     daft_pandas = df.to_pandas()
     iceberg_pandas = tab.scan().to_arrow().to_pandas()
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
+
+
+@pytest.mark.integration()
+def test_daft_iceberg_table_renamed_filtered_collect_correct(local_iceberg_catalog):
+    tab = local_iceberg_catalog.load_table(f"default.test_table_rename")
+    df = daft.read_iceberg(tab)
+    df = df.where(df["pos"] <= 1)
+    daft_pandas = df.to_pandas()
+    iceberg_pandas = tab.scan().to_arrow().to_pandas()
+    iceberg_pandas = iceberg_pandas[iceberg_pandas["pos"] <= 1]
+    assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
+
+
+@pytest.mark.integration()
+def test_daft_iceberg_table_renamed_column_pushdown_collect_correct(local_iceberg_catalog):
+    tab = local_iceberg_catalog.load_table(f"default.test_table_rename")
+    df = daft.read_iceberg(tab)
+    df = df.select("pos")
+    daft_pandas = df.to_pandas()
+    iceberg_pandas = tab.scan().to_arrow().to_pandas()
+    iceberg_pandas = iceberg_pandas[["pos"]]
+    assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])


### PR DESCRIPTION
Adds capability for parsing Parquet files using a `field_id_mapping` supplied by table formats such as Apache Iceberg.

The approach taken by this PR is to mutate the Parquet `FileMetaData` object obtained through our `read_parquet_metadata` helper. We mutate this object, taking care to:

1. Rename all fields when we find a corresponding entry in the field_id_mapping
2. Drop all fields when we don't find a corresponding entry, or if the field_id is `None`