### PR TITLE
[FEAT] [Catalogs] [Delta Lake] Add support for AWS Glue Catalog and Databricks Unity Catalog integrations to Delta Lake reader

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -68,8 +68,8 @@ from daft.dataframe import DataFrame
 from daft.datatype import DataType, TimeUnit
 from daft.expressions import Expression, col, lit
 from daft.io import (
-    DataCatalog,
     DataCatalogTable,
+    DataCatalogType,
     from_glob_path,
     read_csv,
     read_delta_lake,
@@ -94,7 +94,7 @@ __all__ = [
     "read_parquet",
     "read_iceberg",
     "read_delta_lake",
-    "DataCatalog",
+    "DataCatalogType",
     "DataCatalogTable",
     "DataFrame",
     "Expression",

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -68,6 +68,8 @@ from daft.dataframe import DataFrame
 from daft.datatype import DataType, TimeUnit
 from daft.expressions import Expression, col, lit
 from daft.io import (
+    DataCatalog,
+    DataCatalogTable,
     from_glob_path,
     read_csv,
     read_delta_lake,
@@ -92,6 +94,8 @@ __all__ = [
     "read_parquet",
     "read_iceberg",
     "read_delta_lake",
+    "DataCatalog",
+    "DataCatalogTable",
     "DataFrame",
     "Expression",
     "col",

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -14,7 +14,7 @@ from daft.io._delta_lake import read_delta_lake
 from daft.io._iceberg import read_iceberg
 from daft.io._json import read_json
 from daft.io._parquet import read_parquet
-from daft.io.catalog import DataCatalog, DataCatalogTable
+from daft.io.catalog import DataCatalogTable, DataCatalogType
 from daft.io.file_path import from_glob_path
 
 
@@ -44,6 +44,6 @@ __all__ = [
     "AzureConfig",
     "GCSConfig",
     "set_io_pool_num_threads",
-    "DataCatalog",
+    "DataCatalogType",
     "DataCatalogTable",
 ]

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -14,6 +14,7 @@ from daft.io._delta_lake import read_delta_lake
 from daft.io._iceberg import read_iceberg
 from daft.io._json import read_json
 from daft.io._parquet import read_parquet
+from daft.io.catalog import DataCatalog, DataCatalogTable
 from daft.io.file_path import from_glob_path
 
 
@@ -43,4 +44,6 @@ __all__ = [
     "AzureConfig",
     "GCSConfig",
     "set_io_pool_num_threads",
+    "DataCatalog",
+    "DataCatalogTable",
 ]

--- a/daft/io/_delta_lake.py
+++ b/daft/io/_delta_lake.py
@@ -7,7 +7,7 @@ from daft import context
 from daft.api_annotations import PublicAPI
 from daft.daft import IOConfig, NativeStorageConfig, ScanOperatorHandle, StorageConfig
 from daft.dataframe import DataFrame
-from daft.io.catalog import DataCatalog, DataCatalogTable
+from daft.io.catalog import DataCatalogTable, DataCatalogType
 from daft.logical.builder import LogicalPlanBuilder
 
 
@@ -49,8 +49,8 @@ def read_delta_lake(
         table_uri = table
     elif isinstance(table, DataCatalogTable):
 
-        assert table.catalog == DataCatalog.GLUE or table.catalog == DataCatalog.UNITY
-        if table.catalog == DataCatalog.GLUE:
+        assert table.catalog == DataCatalogType.GLUE or table.catalog == DataCatalogType.UNITY
+        if table.catalog == DataCatalogType.GLUE:
             # Use boto3 to get the table from AWS Glue Data Catalog.
             import boto3
 
@@ -69,7 +69,7 @@ def read_delta_lake(
             glue_table = glue.get_table(DatabaseName=table.database_name, Name=table.table_name)
             # TODO(Clark): Fetch more than just the table URI from Glue Data Catalog.
             table_uri = glue_table["Table"]["StorageDescriptor"]["Location"]
-        elif table.catalog == DataCatalog.UNITY:
+        elif table.catalog == DataCatalogType.UNITY:
             # Use Databricks SDK to get the table from the Unity Catalog.
             from databricks.sdk import WorkspaceClient
 

--- a/daft/io/catalog.py
+++ b/daft/io/catalog.py
@@ -1,0 +1,32 @@
+# isort: dont-add-import: from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class DataCatalog(Enum):
+    """Supported data catalogs."""
+
+    GLUE = "glue"
+    """
+    AWS Glue Data Catalog.
+    """
+    UNITY = "unity"
+    """
+    Databricks Unity Catalog.
+    """
+
+
+@dataclass
+class DataCatalogTable:
+    """
+    A reference to a table in some database in some data catalog.
+
+    See :class:`~.DataCatalog`
+    """
+
+    catalog: DataCatalog
+    database_name: str
+    table_name: str
+    catalog_id: Optional[str] = None

--- a/daft/io/catalog.py
+++ b/daft/io/catalog.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Optional
 
 
-class DataCatalog(Enum):
+class DataCatalogType(Enum):
     """Supported data catalogs."""
 
     GLUE = "glue"
@@ -26,7 +26,7 @@ class DataCatalogTable:
     See :class:`~.DataCatalog`
     """
 
-    catalog: DataCatalog
+    catalog: DataCatalogType
     database_name: str
     table_name: str
     catalog_id: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.7"
 
 [project.optional-dependencies]
 all = ["getdaft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake]"]
-aws = ["s3fs"]
+aws = ["s3fs", "boto3"]
 azure = ["adlfs"]
 deltalake = ["deltalake"]
 gcp = ["gcsfs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ requires-python = ">=3.7"
 
 [project.optional-dependencies]
 all = ["getdaft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake]"]
-aws = ["s3fs", "boto3"]
-azure = ["adlfs"]
+aws = ["boto3"]
+azure = []
 deltalake = ["deltalake"]
-gcp = ["gcsfs"]
+gcp = []
 iceberg = ["pyiceberg >= 0.4.0", "packaging"]
 numpy = ["numpy"]
 pandas = ["pandas"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,6 +47,9 @@ deltalake==0.5.8; platform_system == "Windows"
 deltalake==0.15.3; platform_system != "Windows" and python_version >= '3.8'
 deltalake==0.13.0; platform_system != "Windows" and python_version < '3.8'
 
+# Databricks
+databricks-sdk==0.12.0
+
 # AWS
 s3fs==2023.1.0; python_version < '3.8'
 s3fs==2023.12.0; python_version >= '3.8'

--- a/tests/io/delta_lake/conftest.py
+++ b/tests/io/delta_lake/conftest.py
@@ -18,7 +18,7 @@ from azure.storage.blob import BlobServiceClient
 from pytest_lazyfixture import lazy_fixture
 
 import daft
-from daft import DataCatalog, DataCatalogTable
+from daft import DataCatalogTable, DataCatalogType
 from daft.delta_lake.delta_lake_scan import _io_config_to_storage_options
 from tests.io.delta_lake.mock_aws_server import start_service, stop_process
 
@@ -130,7 +130,7 @@ def glue_table(
         },
     )
     return DataCatalogTable(
-        catalog=DataCatalog.GLUE,
+        catalog=DataCatalogType.GLUE,
         database_name=glue_database_name,
         table_name=glue_table_name,
     )
@@ -193,7 +193,7 @@ def _unity_table(
         os.environ["DATABRICKS_HOST"] = "http://localhost"
         try:
             yield DataCatalogTable(
-                catalog=DataCatalog.UNITY,
+                catalog=DataCatalogType.UNITY,
                 database_name=unity_database_name,
                 table_name=unity_table_name,
                 catalog_id=unity_catalog_id,

--- a/tests/io/delta_lake/conftest.py
+++ b/tests/io/delta_lake/conftest.py
@@ -184,7 +184,7 @@ def _unity_table(
 ) -> Iterator[DataCatalogTable]:
     from databricks.sdk.service.catalog import TableInfo
 
-    with mock.patch("databricks.sdk.WorkspaceClient", autospec=True) as mock_workspace_client:
+    with mock.patch("databricks.sdk.WorkspaceClient") as mock_workspace_client:
         instance = mock_workspace_client.return_value
         instance.tables.get.return_value = TableInfo(storage_location=uri)
         # Set required Databricks environment variables before using SDK.

--- a/tests/io/delta_lake/mock_aws_server.py
+++ b/tests/io/delta_lake/mock_aws_server.py
@@ -17,7 +17,7 @@ _proxy_bypass = {
 }
 
 
-def start_service(service_name: str, host: str, port: int, log_file: io.IOBase):
+def start_service(host: str, port: int, log_file: io.IOBase):
     moto_svr_path = shutil.which("moto_server")
     if not moto_svr_path:
         pytest.skip("moto not installed")
@@ -30,7 +30,7 @@ def start_service(service_name: str, host: str, port: int, log_file: io.IOBase):
         output = process.poll()
         if output is not None:
             print(f"moto_server exited status {output}")
-            pytest.fail(f"Cannot start service: {service_name}")
+            pytest.fail(f"Cannot start mock AWS server")
 
         try:
             # we need to bypass the proxies due to monkeypatches
@@ -43,7 +43,7 @@ def start_service(service_name: str, host: str, port: int, log_file: io.IOBase):
         time.sleep(0.1)
     else:
         stop_process(process)  # pytest.fail doesn't call stop_process
-        pytest.fail(f"Cannot start service: {service_name}")
+        pytest.fail(f"Cannot start mock AWS server")
 
     return process
 

--- a/tests/io/delta_lake/test_table_read.py
+++ b/tests/io/delta_lake/test_table_read.py
@@ -26,8 +26,8 @@ def test_deltalake_read_basic(tmp_path, base_table):
 
 
 def test_deltalake_read_full(deltalake_table):
-    path, io_config, parts = deltalake_table
-    df = daft.read_delta_lake(str(path), io_config=io_config)
+    path, catalog_table, io_config, parts = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
     delta_schema = deltalake.DeltaTable(path, storage_options=_io_config_to_storage_options(io_config, path)).schema()
     expected_schema = Schema.from_pyarrow_schema(delta_schema.to_pyarrow())
     assert df.schema() == expected_schema
@@ -35,6 +35,6 @@ def test_deltalake_read_full(deltalake_table):
 
 
 def test_deltalake_read_show(deltalake_table):
-    path, io_config, _ = deltalake_table
-    df = daft.read_delta_lake(str(path), io_config=io_config)
+    path, catalog_table, io_config, _ = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
     df.show()

--- a/tests/io/delta_lake/test_table_read_pushdowns.py
+++ b/tests/io/delta_lake/test_table_read_pushdowns.py
@@ -20,8 +20,8 @@ pytestmark = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="deltalake only support
 
 
 def test_read_predicate_pushdown_on_data(deltalake_table):
-    path, io_config, tables = deltalake_table
-    df = daft.read_delta_lake(str(path), io_config=io_config)
+    path, catalog_table, io_config, tables = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
     df = df.where(df["a"] == 2)
     delta_schema = deltalake.DeltaTable(path, storage_options=_io_config_to_storage_options(io_config, path)).schema()
     expected_schema = Schema.from_pyarrow_schema(delta_schema.to_pyarrow())
@@ -32,8 +32,8 @@ def test_read_predicate_pushdown_on_data(deltalake_table):
 
 
 def test_read_predicate_pushdown_on_part(deltalake_table, partition_generator):
-    path, io_config, tables = deltalake_table
-    df = daft.read_delta_lake(str(path), io_config=io_config)
+    path, catalog_table, io_config, tables = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
     part_idx = 2
     partition_generator, _ = partition_generator
     part_value = partition_generator(part_idx)
@@ -50,8 +50,8 @@ def test_read_predicate_pushdown_on_part(deltalake_table, partition_generator):
 
 
 def test_read_predicate_pushdown_on_part_non_eq(deltalake_table, partition_generator):
-    path, io_config, tables = deltalake_table
-    df = daft.read_delta_lake(str(path), io_config=io_config)
+    path, catalog_table, io_config, tables = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
     part_idx = 3
     partition_generator, _ = partition_generator
     part_value = partition_generator(part_idx)
@@ -68,8 +68,8 @@ def test_read_predicate_pushdown_on_part_non_eq(deltalake_table, partition_gener
 
 
 def test_read_predicate_pushdown_on_part_and_data(deltalake_table, partition_generator):
-    path, io_config, tables = deltalake_table
-    df = daft.read_delta_lake(str(path), io_config=io_config)
+    path, catalog_table, io_config, tables = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
     part_idx = 2
     partition_generator, _ = partition_generator
     part_value = partition_generator(part_idx)
@@ -91,8 +91,8 @@ def test_read_predicate_pushdown_on_part_and_data(deltalake_table, partition_gen
 
 
 def test_read_predicate_pushdown_on_part_and_data_same_clause(deltalake_table, partition_generator):
-    path, io_config, tables = deltalake_table
-    df = daft.read_delta_lake(str(path), io_config=io_config)
+    path, catalog_table, io_config, tables = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
     partition_generator, col = partition_generator
     df = df.where(df["part_idx"] < df[col])
     delta_schema = deltalake.DeltaTable(path, storage_options=_io_config_to_storage_options(io_config, path)).schema()
@@ -106,8 +106,8 @@ def test_read_predicate_pushdown_on_part_and_data_same_clause(deltalake_table, p
 
 def test_read_predicate_pushdown_on_part_empty(deltalake_table, partition_generator, num_partitions):
     partition_generator, _ = partition_generator
-    path, io_config, tables = deltalake_table
-    df = daft.read_delta_lake(str(path), io_config=io_config)
+    path, catalog_table, io_config, tables = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
     # There should only be num_partitions partitions; see local_deltalake_table fixture.
     part_value = partition_generator(num_partitions)
     if part_value is None:


### PR DESCRIPTION
This PR adds support for reading Delta Lake tables via AWS Glue Data Catalog and Databricks Unity Catalog table references, rather than a direct data lake table URI in cloud storage.

Closes #1988 
Closes #1989 

## TODOs

- [x] Add test coverage via `moto`.