### PR TITLE
[CHORE] [Hotfix] Remove pyarrow upper bound for Windows.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,7 @@ requires = ["maturin>=1.2.0,<1.3.0"]
 [project]
 authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]
 dependencies = [
-  "pyarrow >= 6.0.1; platform_system != 'Windows'",
-  "pyarrow >= 6.0.1, < 7.0.0; platform_system == 'Windows'",
+  "pyarrow >= 6.0.1",
   "fsspec[http]",
   "psutil",
   "tqdm",


### PR DESCRIPTION
The `pyarrow < 7.0.0` upper bound is needlessly restrictive, since
1. Ray already has that upper-bound since their pickle bug workaround doesn't work for Windows, so if a Windows user is using Ray + Daft, their pyarrow should already satisfy that upper bound.
2. If a user isn't using Ray, then they shouldn't need that upper bound anyway, since we're not using pyarrow + pickle when only using the local runner.