### PR TITLE
[BUG] Fix struct getters on logical types

### DIFF
--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -44,7 +44,8 @@ macro_rules! impl_series_like_for_logical_array {
                 &self,
                 validity: Option<arrow2::bitmap::Bitmap>,
             ) -> DaftResult<Series> {
-                Ok(self.0.physical.with_validity(validity)?.into_series())
+                let new_array = self.0.physical.with_validity(validity)?;
+                Ok($da::new(self.0.field.clone(), new_array).into_series())
             }
 
             fn validity(&self) -> Option<&arrow2::bitmap::Bitmap> {

--- a/tests/table/struct/test_struct_get.py
+++ b/tests/table/struct/test_struct_get.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime
+
 import pytest
 
 from daft.expressions import col
@@ -21,6 +23,23 @@ def test_struct_get():
     result = table.eval_expression_list([col("col").struct.get("foo"), col("col").struct.get("bar")])
 
     assert result.to_pydict() == {"foo": [1, None, None, 4], "bar": ["a", "b", None, None]}
+
+
+def test_struct_get_logical_type():
+    table = MicroPartition.from_pydict(
+        {
+            "col": [
+                {"foo": datetime.date(2022, 1, 1)},
+                {"foo": datetime.date(2022, 1, 2)},
+                {"foo": None},
+                None,
+            ]
+        }
+    )
+
+    result = table.eval_expression_list([col("col").struct.get("foo")])
+
+    assert result.to_pydict() == {"foo": [datetime.date(2022, 1, 1), datetime.date(2022, 1, 2), None, None]}
 
 
 def test_struct_get_bad_field():


### PR DESCRIPTION
Struct getters on logical types were failing with:

```
Mismatch of expected expression data type and data type from computed series, <logical> vs <physical>
```

This PR fixes this by fixing the implementation of `.with_validity` on our logical arrays, which previously were erroneously returning Series of the physical type.