### PR TITLE
[BUG] deltalake read pq splitting bug

### DIFF
--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -842,8 +842,9 @@ pub(crate) fn read_parquet_into_micropartition(
     let runtime_handle = daft_io::get_runtime(multithreaded_io)?;
     let io_client = daft_io::get_io_client(multithreaded_io, io_config.clone())?;
 
-    // If we have a predicate, perform an eager read only reading what row groups we need.
-    if predicate.is_some() {
+    // If we have a predicate or if num_rows was specified, we no longer have an accurate accounting of required metadata
+    // on the MicroPartition (e.g. its length). Hence we need to perform an eager read.
+    if predicate.is_some() || num_rows.is_some() {
         return _read_parquet_into_loaded_micropartition(
             io_client,
             runtime_handle,

--- a/src/daft-scan/src/scan_task_iters.rs
+++ b/src/daft-scan/src/scan_task_iters.rs
@@ -169,13 +169,16 @@ pub fn split_by_row_groups(
                         let mut new_tasks: Vec<DaftResult<ScanTaskRef>> = Vec::new();
                         let mut curr_row_groups = Vec::new();
                         let mut curr_size_bytes = 0;
+                        let mut curr_num_rows = 0;
 
                         for (i, rg) in file.row_groups.iter().enumerate() {
                             curr_row_groups.push(i as i64);
                             curr_size_bytes += rg.compressed_size();
+                            curr_num_rows += rg.num_rows();
 
                             if curr_size_bytes >= min_size_bytes || i == file.row_groups.len() - 1 {
                                 let mut new_source = source.clone();
+
                                 match &mut new_source {
                                     DataFileSource::AnonymousDataFile {
                                         chunk_spec,
@@ -189,11 +192,26 @@ pub fn split_by_row_groups(
                                     } | DataFileSource::DatabaseDataSource { chunk_spec, size_bytes, .. } => {
                                         *chunk_spec = Some(ChunkSpec::Parquet(curr_row_groups));
                                         *size_bytes = Some(curr_size_bytes as u64);
-
-                                        curr_row_groups = Vec::new();
-                                        curr_size_bytes = 0;
                                     }
                                 };
+                                match &mut new_source {
+                                    DataFileSource::AnonymousDataFile {
+                                        metadata: Some(metadata),
+                                        ..
+                                    }
+                                    | DataFileSource::CatalogDataFile {
+                                        metadata,
+                                        ..
+                                    } | DataFileSource::DatabaseDataSource { metadata: Some(metadata), .. } => {
+                                        metadata.length = curr_num_rows;
+                                    }
+                                    _ => (),
+                                }
+
+                                // Reset accumulators
+                                curr_row_groups = Vec::new();
+                                curr_size_bytes = 0;
+                                curr_num_rows = 0;
 
                                 new_tasks.push(Ok(ScanTask::new(
                                     vec![new_source],

--- a/tests/io/delta_lake/test_table_read.py
+++ b/tests/io/delta_lake/test_table_read.py
@@ -64,5 +64,6 @@ def test_deltalake_read_row_group_splits(tmp_path, base_table):
     # Force file splitting
     with split_small_pq_files():
         df = daft.read_delta_lake(str(path))
+        df = df.where(df["a"] > 1)
         df.collect()
-        assert len(df._result) == 3, "Length of non-materialized data when read through deltalake should be correct"
+        assert len(df._result) == 2, "Length of non-materialized data when read through deltalake should be correct"


### PR DESCRIPTION
Fixes bugs in 3 places:

1. Our `num_rows` was not properly accounted for when performing ScanTask splitting
2. When creating unloaded MicroPartitions in the case where a data catalog provides file statistics, we inadvertently create these MicroPartitions with wrong `TableMetadata.length` in cases where a limit or a filter was applied in the pushdown
3. When running `read_parquet_into_micropartition` in the case where a data catalog does not provide file statistics, we wrongly create an unloaded MicroPartition when a limit was applied in the pushdown