### PR TITLE
[BUG] Fix connector-x and psycopg dependencies for CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -53,6 +53,7 @@ databricks-sdk==0.12.0
 #SQL
 sqlalchemy==2.0.25; python_version >= '3.8'
 connectorx==0.3.2; python_version >= '3.8'
+connectorx==0.2.3; platform_system == "Linux" and platform_machine == "aarch64" and python_version >= '3.8'
 trino[sqlalchemy]==0.328.0; python_version >= '3.8'
 PyMySQL==1.1.0; python_version >= '3.8'
 psycopg2-binary==2.9.9; python_version >= '3.8'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -53,7 +53,7 @@ databricks-sdk==0.12.0
 #SQL
 sqlalchemy==2.0.25; python_version >= '3.8'
 connectorx==0.2.3; platform_system == "Linux" and platform_machine == "aarch64" and python_version >= '3.8'
-connectorx==0.3.2; !(platform_system == "Linux" and platform_machine == "aarch64") and python_version >= '3.8'
+connectorx==0.3.2; not (platform_system == "Linux" and platform_machine == "aarch64") and python_version >= '3.8'
 trino[sqlalchemy]==0.328.0; python_version >= '3.8'
 PyMySQL==1.1.0; python_version >= '3.8'
 psycopg2-binary==2.9.9; python_version >= '3.8'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -53,7 +53,7 @@ databricks-sdk==0.12.0
 #SQL
 sqlalchemy==2.0.25; python_version >= '3.8'
 connectorx==0.2.3; platform_system == "Linux" and platform_machine == "aarch64" and python_version >= '3.8'
-connectorx==0.3.2; python_version >= '3.8'
+connectorx==0.3.2; !(platform_system == "Linux" and platform_machine == "aarch64") and python_version >= '3.8'
 trino[sqlalchemy]==0.328.0; python_version >= '3.8'
 PyMySQL==1.1.0; python_version >= '3.8'
 psycopg2-binary==2.9.9; python_version >= '3.8'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -55,7 +55,7 @@ sqlalchemy==2.0.25; python_version >= '3.8'
 connectorx==0.3.2; python_version >= '3.8'
 trino[sqlalchemy]==0.328.0; python_version >= '3.8'
 PyMySQL==1.1.0; python_version >= '3.8'
-psycopg2==2.9.9; python_version >= '3.8'
+psycopg2-binary==2.9.9; python_version >= '3.8'
 
 # AWS
 s3fs==2023.1.0; python_version < '3.8'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -53,7 +53,7 @@ databricks-sdk==0.12.0
 #SQL
 sqlalchemy==2.0.25; python_version >= '3.8'
 connectorx==0.2.3; platform_system == "Linux" and platform_machine == "aarch64" and python_version >= '3.8'
-connectorx==0.3.2; not (platform_system == "Linux" and platform_machine == "aarch64") and python_version >= '3.8'
+connectorx==0.3.2; (platform_system != "Linux" or platform_machine != "aarch64") and python_version >= '3.8'
 trino[sqlalchemy]==0.328.0; python_version >= '3.8'
 PyMySQL==1.1.0; python_version >= '3.8'
 psycopg2-binary==2.9.9; python_version >= '3.8'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -52,8 +52,8 @@ databricks-sdk==0.12.0
 
 #SQL
 sqlalchemy==2.0.25; python_version >= '3.8'
-connectorx==0.3.2; python_version >= '3.8'
 connectorx==0.2.3; platform_system == "Linux" and platform_machine == "aarch64" and python_version >= '3.8'
+connectorx==0.3.2; python_version >= '3.8'
 trino[sqlalchemy]==0.328.0; python_version >= '3.8'
 PyMySQL==1.1.0; python_version >= '3.8'
 psycopg2-binary==2.9.9; python_version >= '3.8'


### PR DESCRIPTION
Use psycopg-binary as benchmarking runner does not have required libraries installed. Fixed here: https://github.com/Eventual-Inc/daft-benchmarking/actions/runs/8291353023

Use connector-x 0.2.3 on linux on aarch-64. Fixed here: https://github.com/Eventual-Inc/Daft/actions/runs/8291745511