### PR TITLE
[DOCS] [Hotfix] [Delta Lake] Break data skipping optimizations into different section.

### DIFF
--- a/docs/source/user_guide/integrations/delta_lake.rst
+++ b/docs/source/user_guide/integrations/delta_lake.rst
@@ -49,8 +49,8 @@ After writing this local example table, we can easily read it into a Daft DataFr
 
     df = daft.read_delta_lake("some-table")
 
-Data Skipping
-*************
+Data Skipping Optimizations
+***************************
 
 Subsequent filters on the partition column ``"group"`` will efficiently skip data that doesn't match the predicate. In the below example, the ``group != 2`` partitions (files) will be pruned, i.e. they will never be read into memory.
 

--- a/docs/source/user_guide/integrations/delta_lake.rst
+++ b/docs/source/user_guide/integrations/delta_lake.rst
@@ -49,6 +49,9 @@ After writing this local example table, we can easily read it into a Daft DataFr
 
     df = daft.read_delta_lake("some-table")
 
+Data Skipping
+*************
+
 Subsequent filters on the partition column ``"group"`` will efficiently skip data that doesn't match the predicate. In the below example, the ``group != 2`` partitions (files) will be pruned, i.e. they will never be read into memory.
 
 .. code:: python


### PR DESCRIPTION
This PR breaks the data skipping optimizations into a separate section, to give it a stronger emphasis.