### PR TITLE
[CHORE] Fix is_in docs

### DIFF
--- a/docs/source/api_docs/expressions.rst
+++ b/docs/source/api_docs/expressions.rst
@@ -67,18 +67,7 @@ Logical
     Expression.__ne__
     Expression.__gt__
     Expression.__ge__
-
-.. _api-membership-expression:
-
-Membership
-***********
-
-Checking if an expression is a member of a list of values
-
-.. autosummary::
-    :toctree: doc_gen/expression_methods
-
-    daft.expressions.Expression.is_in
+    Expression.is_in
 
 .. _expression-accessor-properties:
 .. _api-string-expression-operations:


### PR DESCRIPTION
`is_in` seems to not be very discoverable, I think this should fix it a litle.

<img width="1113" alt="Screenshot 2024-03-18 at 11 50 05 AM" src="https://github.com/Eventual-Inc/Daft/assets/77712970/a274f4a0-02a7-40af-ab5b-642876764f4a">
