### PR TITLE
[DOCS] Move df-operations to basic concepts

### DIFF
--- a/docs/source/user_guide/basic_concepts.rst
+++ b/docs/source/user_guide/basic_concepts.rst
@@ -6,4 +6,5 @@ Basic Concepts
     basic_concepts/introduction
     basic_concepts/dataframe_introduction
     basic_concepts/expressions
+    basic_concepts/dataframe-operations
     basic_concepts/read-and-write

--- a/docs/source/user_guide/basic_concepts/dataframe-operations.rst
+++ b/docs/source/user_guide/basic_concepts/dataframe-operations.rst
@@ -1,11 +1,9 @@
 DataFrame Operations
 ====================
 
-In the previous section, we covered Expressions which are ways of expressing computation on a single column.
+In the previous section, we covered Expressions which are ways of expressing computations on a single column.
 
-However, the Daft DataFrame is table containing equal-length columns. Many operations affect the entire table at once, affecting the ordering or sizes of all columns.
-
-This section of the user guide covers these operations, and how to use them.
+The following section will cover operations that transform the entire DataFrame. You will explore the core DataFrame operations and learn how to use them.
 
 Selecting Columns
 -----------------


### PR DESCRIPTION
I'm wondering if this section makes more sense in the `basic concepts` instead of hiding it away under `in depth`. The opening sentence suggests that this way maybe originally the case? Thoughts @jaychia ?