### PR TITLE
[CHORE] Refactor string kernels

### DIFF
--- a/src/daft-core/src/array/ops/utf8.rs
+++ b/src/daft-core/src/array/ops/utf8.rs
@@ -1,7 +1,10 @@
+use std::borrow::Cow;
+
 use crate::{
     array::{DataArray, ListArray},
     datatypes::{
-        BooleanArray, DaftIntegerType, DaftNumericType, Field, Int64Array, UInt64Array, Utf8Array,
+        BooleanArray, DaftArrayType, DaftIntegerType, DaftNumericType, DaftPhysicalType, Field,
+        Int64Array, UInt64Array, Utf8Array,
     },
     DataType, Series,
 };
@@ -60,6 +63,48 @@ fn is_valid_input_lengths(lengths: &[usize]) -> bool {
     }
 }
 
+fn check_valid_inputs<T, I>(
+    self_arr: &Utf8Array,
+    arrs: &[&DataArray<I>],
+    op_name: &str,
+    dtype: &DataType,
+) -> Option<DaftResult<T>>
+where
+    T: DaftArrayType + FullNull,
+    I: DaftPhysicalType,
+{
+    assert!(!arrs.is_empty());
+    let self_len = self_arr.len();
+
+    // check valid input lengths
+    let lengths = std::iter::once(self_len)
+        .chain(arrs.iter().map(|arr| arr.len()))
+        .collect::<Vec<_>>();
+    if !is_valid_input_lengths(&lengths) {
+        let lengths_str = lengths
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<_>>()
+            .join(" vs ");
+        return Some(Err(DaftError::ValueError(format!(
+            "Error in {op_name}: inputs have different lengths: {lengths_str}"
+        ))));
+    }
+
+    // check if all arrays are empty
+    if lengths.iter().all(|&x| x == 0) {
+        return Some(Ok(T::empty(arrs[0].name(), dtype)));
+    }
+
+    // check if any array has all nulls
+    if arrs.iter().any(|arr| arr.null_count() == arr.len()) || self_arr.null_count() == self_len {
+        let result_len = lengths.iter().max().unwrap();
+        return Some(Ok(T::full_null(arrs[0].name(), dtype, *result_len)));
+    }
+
+    None
+}
+
 fn split_array_on_literal<'a>(
     arr_iter: impl Iterator<Item = Option<&'a str>>,
     pattern_iter: impl Iterator<Item = Option<&'a str>>,
@@ -110,18 +155,6 @@ fn split_array_on_regex<'a>(
         offsets.try_push(num_splits)?;
     }
     Ok(())
-}
-
-fn right_most_chars(val: &str, nchar: usize) -> &str {
-    let len = val.chars().count();
-    if nchar == 0 || len == 0 {
-        ""
-    } else if nchar >= len {
-        val
-    } else {
-        let skip = len.saturating_sub(nchar);
-        val.char_indices().nth(skip).map_or("", |(i, _)| &val[i..])
-    }
 }
 
 fn regex_extract_first_match<'a>(
@@ -299,72 +332,60 @@ impl Utf8Array {
     }
 
     pub fn split(&self, pattern: &Utf8Array, regex: bool) -> DaftResult<ListArray> {
-        let self_arrow = self.as_arrow();
-        let pattern_arrow = pattern.as_arrow();
-        // Handle all-null cases.
-        if self_arrow
-            .validity()
-            .map_or(false, |v| v.unset_bits() == v.len())
-            || pattern_arrow
-                .validity()
-                .map_or(false, |v| v.unset_bits() == v.len())
-        {
-            return Ok(ListArray::full_null(
-                self.name(),
-                &DataType::List(Box::new(DataType::Utf8)),
-                std::cmp::max(self.len(), pattern.len()),
-            ));
-        // Handle empty data and pattern case.
-        } else if self.is_empty() && pattern.is_empty() {
-            return Ok(ListArray::empty(
-                self.name(),
-                &DataType::List(Box::new(DataType::Utf8)),
-            ));
+        let is_valid = check_valid_inputs(
+            self,
+            &[pattern],
+            "split",
+            &DataType::List(Box::new(DataType::Utf8)),
+        );
+        if let Some(result) = is_valid {
+            return result;
         }
-        let buffer_len = self_arrow.values().len();
 
+        let result_len = std::cmp::max(self.len(), pattern.len());
+        let self_arrow = self.as_arrow();
+        let buffer_len = self_arrow.values().len();
         // This will overallocate by pattern_len * N_i, where N_i is the number of pattern occurences in the ith string in arr_iter.
         let mut splits = arrow2::array::MutableUtf8Array::with_capacity(buffer_len);
         let mut offsets = arrow2::offset::Offsets::new();
         let mut validity = arrow2::bitmap::MutableBitmap::with_capacity(self.len());
 
-        match (self.len(), pattern.len()) {
-            // Matching len case:
-            (self_len, pattern_len) if self_len == pattern_len => {
-                if regex {
-                    let regex_iter = pattern_arrow.iter().map(|pat| pat.map(regex::Regex::new));
-                    split_array_on_regex(self_arrow.iter(), regex_iter, &mut splits, &mut offsets, &mut validity)?
-                } else {
-                    split_array_on_literal(self_arrow.iter(), pattern_arrow.iter(), &mut splits, &mut offsets, &mut validity)?
-                }
-            },
-            // Broadcast pattern case:
-            (self_len, 1) => {
-                let pattern_scalar_value = pattern.get(0).unwrap();
-                if regex {
-                    let re = Some(regex::Regex::new(pattern_scalar_value));
-                    let regex_iter = std::iter::repeat(re).take(self_len);
-                    split_array_on_regex(self_arrow.iter(), regex_iter, &mut splits, &mut offsets, &mut validity)?
-                } else {
-                    let pattern_iter = std::iter::repeat(Some(pattern_scalar_value)).take(self_len);
-                    split_array_on_literal(self_arrow.iter(), pattern_iter, &mut splits, &mut offsets, &mut validity)?
-                }
+        let self_iter = create_broadcasted_str_iter(self, result_len);
+        match (regex, pattern.len()) {
+            (true, 1) => {
+                let regex = regex::Regex::new(pattern.get(0).unwrap());
+                let regex_iter = std::iter::repeat(Some(regex)).take(result_len);
+                split_array_on_regex(
+                    self_iter,
+                    regex_iter,
+                    &mut splits,
+                    &mut offsets,
+                    &mut validity,
+                )?
             }
-            // Broadcast self case:
-            (1, pattern_len) => {
-                let self_scalar_value = self.get(0).unwrap();
-                let arr_iter = std::iter::repeat(Some(self_scalar_value)).take(pattern_len);
-                if regex {
-                    let regex_iter = pattern_arrow.iter().map(|pat| pat.map(regex::Regex::new));
-                    split_array_on_regex(arr_iter, regex_iter, &mut splits, &mut offsets, &mut validity)?
-                } else {
-                    split_array_on_literal(arr_iter, pattern_arrow.iter(), &mut splits, &mut offsets, &mut validity)?
-                }
+            (true, _) => {
+                let regex_iter = pattern
+                    .as_arrow()
+                    .iter()
+                    .map(|pat| pat.map(regex::Regex::new));
+                split_array_on_regex(
+                    self_iter,
+                    regex_iter,
+                    &mut splits,
+                    &mut offsets,
+                    &mut validity,
+                )?
             }
-            // Mismatched len case:
-            (self_len, pattern_len) => Err(DaftError::ComputeError(format!(
-                "Error in split: lhs and rhs have different length arrays: {self_len} vs {pattern_len}"
-            )))?,
+            (false, _) => {
+                let pattern_iter = create_broadcasted_str_iter(pattern, result_len);
+                split_array_on_literal(
+                    self_iter,
+                    pattern_iter,
+                    &mut splits,
+                    &mut offsets,
+                    &mut validity,
+                )?
+            }
         }
         // Shrink splits capacity to current length, since we will have overallocated if any of the patterns actually occurred in the strings.
         splits.shrink_to_fit();
@@ -384,113 +405,55 @@ impl Utf8Array {
     }
 
     pub fn extract(&self, pattern: &Utf8Array, index: usize) -> DaftResult<Utf8Array> {
-        let self_arrow = self.as_arrow();
-        let pattern_arrow = pattern.as_arrow();
-
-        // Handle empty data and pattern case.
-        if self.is_empty() && pattern.is_empty() {
-            return Ok(Utf8Array::empty(self.name(), self.data_type()));
+        let is_valid = check_valid_inputs(self, &[pattern], "extract", &DataType::Utf8);
+        if let Some(result) = is_valid {
+            return result;
         }
 
-        match (self.len(), pattern.len()) {
-            // Matching len case:
-            (self_len, pattern_len) if self_len == pattern_len => {
-                let regex_iter = pattern_arrow.iter().map(|pat| pat.map(regex::Regex::new));
-                regex_extract_first_match(self_arrow.iter(), regex_iter, index, self.name())
+        let result_len = std::cmp::max(self.len(), pattern.len());
+        let self_iter = create_broadcasted_str_iter(self, result_len);
+        match pattern.len() {
+            1 => {
+                let regex = regex::Regex::new(pattern.get(0).unwrap());
+                let regex_iter = std::iter::repeat(Some(regex)).take(result_len);
+                regex_extract_first_match(self_iter, regex_iter, index, self.name())
             }
-            // Broadcast pattern case:
-            (self_len, 1) => {
-                let pattern_scalar_value = pattern.get(0);
-                match pattern_scalar_value {
-                    None => Ok(Utf8Array::full_null(
-                        self.name(),
-                        self.data_type(),
-                        self_len,
-                    )),
-                    Some(pattern_v) => {
-                        let re = Some(regex::Regex::new(pattern_v));
-                        let regex_iter = std::iter::repeat(re).take(self_len);
-                        regex_extract_first_match(self_arrow.iter(), regex_iter, index, self.name())
-                    }
-                }
+            _ => {
+                let regex_iter = pattern
+                    .as_arrow()
+                    .iter()
+                    .map(|pat| pat.map(regex::Regex::new));
+                regex_extract_first_match(self_iter, regex_iter, index, self.name())
             }
-            // Broadcast self case
-            (1, pattern_len) => {
-                let self_scalar_value = self.get(0);
-                match self_scalar_value {
-                    None => Ok(Utf8Array::full_null(
-                        self.name(),
-                        self.data_type(),
-                        pattern_len,
-                    )),
-                    Some(self_v) => {
-                        let arr_iter = std::iter::repeat(Some(self_v)).take(pattern_len);
-                        let regex_iter = pattern_arrow.iter().map(|pat| pat.map(regex::Regex::new));
-                        regex_extract_first_match(arr_iter, regex_iter, index, self.name())
-                    }
-                }
-            }
-            // Mismatched len case:
-            (self_len, pattern_len) => Err(DaftError::ComputeError(format!(
-                "Error in extract: lhs and rhs have different length arrays: {self_len} vs {pattern_len}"
-            ))),
         }
     }
 
     pub fn extract_all(&self, pattern: &Utf8Array, index: usize) -> DaftResult<ListArray> {
-        let self_arrow = self.as_arrow();
-        let pattern_arrow = pattern.as_arrow();
-
-        // Handle empty data and pattern case.
-        if self.is_empty() && pattern.is_empty() {
-            return Ok(ListArray::empty(
-                self.name(),
-                &DataType::List(Box::new(DataType::Utf8)),
-            ));
+        let is_valid = check_valid_inputs(
+            self,
+            &[pattern],
+            "extract_all",
+            &DataType::List(Box::new(DataType::Utf8)),
+        );
+        if let Some(result) = is_valid {
+            return result;
         }
 
-        match (self.len(), pattern.len()) {
-            // Matching len case:
-            (self_len, pattern_len) if self_len == pattern_len => {
-                let regex_iter = pattern_arrow.iter().map(|pat| pat.map(regex::Regex::new));
-                regex_extract_all_matches(self_arrow.iter(), regex_iter, index, self_len, self.name())
+        let result_len = std::cmp::max(self.len(), pattern.len());
+        let self_iter = create_broadcasted_str_iter(self, result_len);
+        match pattern.len() {
+            1 => {
+                let regex = regex::Regex::new(pattern.get(0).unwrap());
+                let regex_iter = std::iter::repeat(Some(regex)).take(result_len);
+                regex_extract_all_matches(self_iter, regex_iter, index, result_len, self.name())
             }
-            // Broadcast pattern case:
-            (self_len, 1) => {
-                let pattern_scalar_value = pattern.get(0);
-                match pattern_scalar_value {
-                    None => Ok(ListArray::full_null(
-                        self.name(),
-                        &DataType::List(Box::new(DataType::Utf8)),
-                        self_len,
-                    )),
-                    Some(pattern_v) => {
-                        let re = Some(regex::Regex::new(pattern_v));
-                        let regex_iter = std::iter::repeat(re).take(self_len);
-                        regex_extract_all_matches(self_arrow.iter(), regex_iter, index, self_len, self.name())
-                    }
-                }
+            _ => {
+                let regex_iter = pattern
+                    .as_arrow()
+                    .iter()
+                    .map(|pat| pat.map(regex::Regex::new));
+                regex_extract_all_matches(self_iter, regex_iter, index, result_len, self.name())
             }
-            // Broadcast self case
-            (1, pattern_len) => {
-                let self_scalar_value = self.get(0);
-                match self_scalar_value {
-                    None => Ok(ListArray::full_null(
-                        self.name(),
-                        &DataType::List(Box::new(DataType::Utf8)),
-                        pattern_len,
-                    )),
-                    Some(self_v) => {
-                        let arr_iter = std::iter::repeat(Some(self_v)).take(pattern_len);
-                        let regex_iter = pattern_arrow.iter().map(|pat| pat.map(regex::Regex::new));
-                        regex_extract_all_matches(arr_iter, regex_iter, index, pattern_len, self.name())
-                    }
-                }
-            }
-            // Mismatched len case:
-            (self_len, pattern_len) => Err(DaftError::ComputeError(format!(
-                "Error in extract_all: lhs and rhs have different length arrays: {self_len} vs {pattern_len}"
-            ))),
         }
     }
 
@@ -500,38 +463,20 @@ impl Utf8Array {
         replacement: &Utf8Array,
         regex: bool,
     ) -> DaftResult<Utf8Array> {
-        let self_len = self.len();
-        let pattern_len = pattern.len();
-        let replacement_len = replacement.len();
-
-        if !is_valid_input_lengths(&[self_len, pattern_len, replacement_len]) {
-            return Err(DaftError::ValueError(format!(
-                "Error in replace: lhs, pattern, and replacement have different length arrays: {self_len} vs {pattern_len} vs {replacement_len}"
-            )));
-        }
-        if self.is_empty() && pattern.is_empty() && replacement.is_empty() {
-            return Ok(Utf8Array::empty(self.name(), &DataType::Utf8));
+        let is_valid =
+            check_valid_inputs(self, &[pattern, replacement], "replace", &DataType::Utf8);
+        if let Some(result) = is_valid {
+            return result;
         }
 
-        let result_len = std::cmp::max(self_len, std::cmp::max(pattern_len, replacement_len));
-        if self.null_count() == self_len
-            || pattern.null_count() == pattern_len
-            || replacement.null_count() == replacement_len
-        {
-            return Ok(Utf8Array::full_null(
-                self.name(),
-                &DataType::Utf8,
-                result_len,
-            ));
-        }
-
+        let result_len = std::cmp::max(self.len(), std::cmp::max(pattern.len(), replacement.len()));
         let self_iter = create_broadcasted_str_iter(self, result_len);
         let replacement_iter = create_broadcasted_str_iter(replacement, result_len);
 
-        match (regex, pattern_len) {
+        match (regex, pattern.len()) {
             (true, 1) => {
-                let regex_iter =
-                    std::iter::repeat(pattern.get(0).map(regex::Regex::new)).take(result_len);
+                let regex = regex::Regex::new(pattern.get(0).unwrap());
+                let regex_iter = std::iter::repeat(Some(regex)).take(result_len);
                 regex_replace(self_iter, regex_iter, replacement_iter, self.name())
             }
             (true, _) => {
@@ -562,201 +507,107 @@ impl Utf8Array {
     }
 
     pub fn lower(&self) -> DaftResult<Utf8Array> {
-        let self_arrow = self.as_arrow();
-        let arrow_result = self_arrow
-            .iter()
-            .map(|val| {
-                let v = val?;
-                Some(v.to_lowercase())
-            })
-            .collect::<arrow2::array::Utf8Array<i64>>()
-            .with_validity(self_arrow.validity().cloned());
-        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
+        self.unary_broadcasted_op(|val| val.to_lowercase().into())
     }
 
     pub fn upper(&self) -> DaftResult<Utf8Array> {
-        let self_arrow = self.as_arrow();
-        let arrow_result = self_arrow
-            .iter()
-            .map(|val| {
-                let v = val?;
-                Some(v.to_uppercase())
-            })
-            .collect::<arrow2::array::Utf8Array<i64>>()
-            .with_validity(self_arrow.validity().cloned());
-        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
+        self.unary_broadcasted_op(|val| val.to_uppercase().into())
     }
 
     pub fn lstrip(&self) -> DaftResult<Utf8Array> {
-        let self_arrow = self.as_arrow();
-        let arrow_result = self_arrow
-            .iter()
-            .map(|val| {
-                let v = val?;
-                Some(v.trim_start())
-            })
-            .collect::<arrow2::array::Utf8Array<i64>>()
-            .with_validity(self_arrow.validity().cloned());
-        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
+        self.unary_broadcasted_op(|val| val.trim_start().into())
     }
 
     pub fn rstrip(&self) -> DaftResult<Utf8Array> {
-        let self_arrow = self.as_arrow();
-        let arrow_result = self_arrow
-            .iter()
-            .map(|val| {
-                let v = val?;
-                Some(v.trim_end())
-            })
-            .collect::<arrow2::array::Utf8Array<i64>>()
-            .with_validity(self_arrow.validity().cloned());
-        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
+        self.unary_broadcasted_op(|val| val.trim_end().into())
     }
 
     pub fn reverse(&self) -> DaftResult<Utf8Array> {
-        let self_arrow = self.as_arrow();
-        let arrow_result = self_arrow
-            .iter()
-            .map(|val| {
-                let v = val?;
-                Some(v.chars().rev().collect::<String>())
-            })
-            .collect::<arrow2::array::Utf8Array<i64>>()
-            .with_validity(self_arrow.validity().cloned());
-        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
+        self.unary_broadcasted_op(|val| val.chars().rev().collect::<String>().into())
     }
 
     pub fn capitalize(&self) -> DaftResult<Utf8Array> {
-        let self_arrow = self.as_arrow();
-        let arrow_result = self_arrow
-            .iter()
-            .map(|val| {
-                let v = val?;
-                let mut chars = v.chars();
-                match chars.next() {
-                    None => Some(String::new()),
-                    Some(first) => {
-                        let first_char_uppercased = first.to_uppercase();
-                        let mut res = String::with_capacity(v.len());
-                        res.extend(first_char_uppercased);
-                        res.extend(chars.flat_map(|c| c.to_lowercase()));
-                        Some(res)
-                    }
+        self.unary_broadcasted_op(|val| {
+            let mut chars = val.chars();
+            match chars.next() {
+                None => "".into(),
+                Some(first) => {
+                    let first_char_uppercased = first.to_uppercase();
+                    let mut res = String::with_capacity(val.len());
+                    res.extend(first_char_uppercased);
+                    res.extend(chars.flat_map(|c| c.to_lowercase()));
+                    res.into()
                 }
-            })
-            .collect::<arrow2::array::Utf8Array<i64>>()
-            .with_validity(self_arrow.validity().cloned());
-        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
+            }
+        })
     }
 
     pub fn find(&self, substr: &Utf8Array) -> DaftResult<Int64Array> {
-        let self_arrow = self.as_arrow();
-        let substr_arrow = substr.as_arrow();
-        // Handle empty data and pattern case.
-        if self.is_empty() && substr.is_empty() {
-            return Ok(Int64Array::empty(self.name(), self.data_type()));
+        let is_valid = check_valid_inputs(self, &[substr], "find", &DataType::Int64);
+        if let Some(result) = is_valid {
+            return result;
         }
-        match (self.len(), substr.len()) {
-            // matching len case
-            (self_len, substr_len) if self_len == substr_len => {
-                let arrow_result = self_arrow
-                    .iter()
-                    .zip(substr_arrow.iter())
-                    .map(|(val, substr)| match (val, substr) {
-                        (Some(val), Some(substr)) => {
-                            Some(val.find(substr).map(|pos| pos as i64).unwrap_or(-1))
-                        }
-                        _ => None,
-                    })
-                    .collect::<arrow2::array::Int64Array>();
 
-                Ok(Int64Array::from((self.name(), Box::new(arrow_result))))
-            }
-            // broadcast pattern case
-            (self_len, 1) => {
-                let substr_scalar_value = substr.get(0);
-                match substr_scalar_value {
-                    None => Ok(Int64Array::full_null(
-                        self.name(),
-                        &DataType::Int64,
-                        self_len,
-                    )),
-                    Some(substr_scalar_value) => {
-                        let arrow_result = self_arrow
-                            .iter()
-                            .map(|val| {
-                                let v = val?;
-                                Some(
-                                    v.find(substr_scalar_value)
-                                        .map(|pos| pos as i64)
-                                        .unwrap_or(-1),
-                                )
-                            })
-                            .collect::<arrow2::array::Int64Array>();
-
-                        Ok(Int64Array::from((self.name(), Box::new(arrow_result))))
-                    }
+        let result_len = std::cmp::max(self.len(), substr.len());
+        let self_iter = create_broadcasted_str_iter(self, result_len);
+        let substr_iter = create_broadcasted_str_iter(substr, result_len);
+        let arrow_result = self_iter
+            .zip(substr_iter)
+            .map(|(val, substr)| match (val, substr) {
+                (Some(val), Some(substr)) => {
+                    Some(val.find(substr).map(|pos| pos as i64).unwrap_or(-1))
                 }
-            }
-            // broadcast self case
-            (1, substr_len) => {
-                let self_scalar_value = self.get(0);
-                match self_scalar_value {
-                    None => Ok(Int64Array::full_null(
-                        self.name(),
-                        &DataType::Int64,
-                        substr_len,
-                    )),
-                    Some(self_scalar_value) => {
-                        let arrow_result = substr_arrow
-                            .iter()
-                            .map(|substr| {
-                                let substr = substr?;
-                                Some(
-                                    self_scalar_value
-                                        .find(substr)
-                                        .map(|pos| pos as i64)
-                                        .unwrap_or(-1),
-                                )
-                            })
-                            .collect::<arrow2::array::Int64Array>();
+                _ => None,
+            })
+            .collect::<arrow2::array::Int64Array>();
 
-                        Ok(Int64Array::from((self.name(), Box::new(arrow_result))))
-                    }
-                }
-            }
-            // Mismatched len case:
-            (self_len, substr_len) => Err(DaftError::ComputeError(format!(
-                "lhs and rhs have different length arrays: {self_len} vs {substr_len}"
-            ))),
-        }
+        Ok(Int64Array::from((self.name(), Box::new(arrow_result))))
     }
 
-    pub fn left<I>(&self, n: &DataArray<I>) -> DaftResult<Utf8Array>
+    pub fn left<I>(&self, nchars: &DataArray<I>) -> DaftResult<Utf8Array>
     where
         I: DaftIntegerType,
         <I as DaftNumericType>::Native: Ord,
     {
-        let self_arrow = self.as_arrow();
-        let n_arrow = n.as_arrow();
-        // Handle empty cases data and pattern case.
-        if self.is_empty() && n_arrow.is_empty() {
-            return Ok(Utf8Array::empty(self.name(), self.data_type()));
+        let is_valid = check_valid_inputs(self, &[nchars], "left", &DataType::Utf8);
+        if let Some(result) = is_valid {
+            return result;
         }
-        match (self.len(), n_arrow.len()) {
-            // Matching len case:
-            (self_len, n_len) if self_len == n_len => {
-                let arrow_result = self_arrow
-                    .iter()
-                    .zip(n_arrow.iter())
+
+        fn left_most_chars(val: &str, n: usize) -> &str {
+            if n == 0 || val.is_empty() {
+                ""
+            } else {
+                val.char_indices().nth(n).map_or(val, |(i, _)| &val[..i])
+            }
+        }
+
+        let result_len = std::cmp::max(self.len(), nchars.len());
+        let self_iter = create_broadcasted_str_iter(self, result_len);
+        match nchars.len() {
+            1 => {
+                let n = nchars.get(0).unwrap();
+                let n: usize = NumCast::from(n).ok_or_else(|| {
+                    DaftError::ComputeError(format!("failed to cast rhs as usize {n}"))
+                })?;
+                let nchars_iter = std::iter::repeat(n).take(result_len);
+                let arrow_result = self_iter
+                    .zip(nchars_iter)
+                    .map(|(val, n)| Some(left_most_chars(val?, n)))
+                    .collect::<arrow2::array::Utf8Array<i64>>();
+                Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
+            }
+            _ => {
+                let arrow_result = self_iter
+                    .zip(nchars.as_arrow().iter())
                     .map(|(val, n)| match (val, n) {
                         (Some(val), Some(nchar)) => {
                             let nchar: usize = NumCast::from(*nchar).ok_or_else(|| {
                                 DaftError::ComputeError(format!(
-                                    "Error in left: failed to cast rhs as usize {nchar}"
+                                    "failed to cast rhs as usize {nchar}"
                                 ))
                             })?;
-                            Ok(Some(val.chars().take(nchar).collect::<String>()))
+                            Ok(Some(left_most_chars(val, nchar)))
                         }
                         _ => Ok(None),
                     })
@@ -764,83 +615,46 @@ impl Utf8Array {
 
                 Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
             }
-            // Broadcast pattern case:
-            (self_len, 1) => {
-                let n_scalar_value = n.get(0);
-                match n_scalar_value {
-                    None => Ok(Utf8Array::full_null(
-                        self.name(),
-                        self.data_type(),
-                        self_len,
-                    )),
-                    Some(n_scalar_value) => {
-                        let n_scalar_value: usize =
-                            NumCast::from(n_scalar_value).ok_or_else(|| {
-                                DaftError::ComputeError(format!(
-                                    "Error in left: failed to cast rhs as usize {n_scalar_value}"
-                                ))
-                            })?;
-                        let arrow_result = self_arrow
-                            .iter()
-                            .map(|val| {
-                                let v = val?;
-                                Some(v.chars().take(n_scalar_value).collect::<String>())
-                            })
-                            .collect::<arrow2::array::Utf8Array<i64>>();
-
-                        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
-                    }
-                }
-            }
-            // broadcast self case:
-            (1, n_len) => {
-                let self_scalar_value = self.get(0);
-                match self_scalar_value {
-                    None => Ok(Utf8Array::full_null(self.name(), self.data_type(), n_len)),
-                    Some(self_scalar_value) => {
-                        let arrow_result = n_arrow
-                            .iter()
-                            .map(|n| match n {
-                                None => Ok(None),
-                                Some(n) => {
-                                    let n: usize = NumCast::from(*n).ok_or_else(|| {
-                                        DaftError::ComputeError(format!(
-                                            "Error in left: failed to cast rhs as usize {n}"
-                                        ))
-                                    })?;
-                                    Ok(Some(self_scalar_value.chars().take(n).collect::<String>()))
-                                }
-                            })
-                            .collect::<DaftResult<arrow2::array::Utf8Array<i64>>>()?;
-
-                        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
-                    }
-                }
-            }
-            // Mismatched len case:
-            (self_len, n_len) => Err(DaftError::ComputeError(format!(
-                "Error in left: lhs and rhs have different length arrays: {self_len} vs {n_len}"
-            ))),
         }
     }
 
-    pub fn right<I>(&self, n: &DataArray<I>) -> DaftResult<Utf8Array>
+    pub fn right<I>(&self, nchars: &DataArray<I>) -> DaftResult<Utf8Array>
     where
         I: DaftIntegerType,
         <I as DaftNumericType>::Native: Ord,
     {
-        let self_arrow = self.as_arrow();
-        let n_arrow = n.as_arrow();
-        // Handle empty data and pattern case.
-        if self.is_empty() && n_arrow.is_empty() {
-            return Ok(Utf8Array::empty(self.name(), self.data_type()));
+        let is_valid = check_valid_inputs(self, &[nchars], "right", &DataType::Utf8);
+        if let Some(result) = is_valid {
+            return result;
         }
-        match (self.len(), n_arrow.len()) {
-            // Matching len case:
-            (self_len, n_len) if self_len == n_len => {
-                let arrow_result = self_arrow
-                    .iter()
-                    .zip(n_arrow.iter())
+
+        fn right_most_chars(val: &str, nchar: usize) -> &str {
+            if nchar == 0 || val.is_empty() {
+                ""
+            } else {
+                let skip = val.chars().count().saturating_sub(nchar);
+                val.char_indices().nth(skip).map_or(val, |(i, _)| &val[i..])
+            }
+        }
+
+        let result_len = std::cmp::max(self.len(), nchars.len());
+        let self_iter = create_broadcasted_str_iter(self, result_len);
+        match nchars.len() {
+            1 => {
+                let n = nchars.get(0).unwrap();
+                let n: usize = NumCast::from(n).ok_or_else(|| {
+                    DaftError::ComputeError(format!("failed to cast rhs as usize {n}"))
+                })?;
+                let nchars_iter = std::iter::repeat(n).take(result_len);
+                let arrow_result = self_iter
+                    .zip(nchars_iter)
+                    .map(|(val, n)| Some(right_most_chars(val?, n)))
+                    .collect::<arrow2::array::Utf8Array<i64>>();
+                Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
+            }
+            _ => {
+                let arrow_result = self_iter
+                    .zip(nchars.as_arrow().iter())
                     .map(|(val, n)| match (val, n) {
                         (Some(val), Some(nchar)) => {
                             let nchar: usize = NumCast::from(*nchar).ok_or_else(|| {
@@ -856,63 +670,6 @@ impl Utf8Array {
 
                 Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
             }
-            // Broadcast pattern case:
-            (self_len, 1) => {
-                let n_scalar_value = n.get(0);
-                match n_scalar_value {
-                    None => Ok(Utf8Array::full_null(
-                        self.name(),
-                        self.data_type(),
-                        self_len,
-                    )),
-                    Some(n_scalar_value) => {
-                        let n_scalar_value: usize =
-                            NumCast::from(n_scalar_value).ok_or_else(|| {
-                                DaftError::ComputeError(format!(
-                                    "failed to cast rhs as usize {n_scalar_value}"
-                                ))
-                            })?;
-                        let arrow_result = self_arrow
-                            .iter()
-                            .map(|val| {
-                                let v = val?;
-                                Some(right_most_chars(v, n_scalar_value))
-                            })
-                            .collect::<arrow2::array::Utf8Array<i64>>();
-
-                        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
-                    }
-                }
-            }
-            // broadcast self
-            (1, n_len) => {
-                let self_scalar_value = self.get(0);
-                match self_scalar_value {
-                    None => Ok(Utf8Array::full_null(self.name(), self.data_type(), n_len)),
-                    Some(self_scalar_value) => {
-                        let arrow_result = n_arrow
-                            .iter()
-                            .map(|n| match n {
-                                None => Ok(None),
-                                Some(n) => {
-                                    let n: usize = NumCast::from(*n).ok_or_else(|| {
-                                        DaftError::ComputeError(format!(
-                                            "failed to cast rhs as usize {n}"
-                                        ))
-                                    })?;
-                                    Ok(Some(right_most_chars(self_scalar_value, n)))
-                                }
-                            })
-                            .collect::<DaftResult<arrow2::array::Utf8Array<i64>>>()?;
-
-                        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
-                    }
-                }
-            }
-            // Mismatched len case:
-            (self_len, n_len) => Err(DaftError::ComputeError(format!(
-                "lhs and rhs have different length arrays: {self_len} vs {n_len}"
-            ))),
         }
     }
 
@@ -925,68 +682,36 @@ impl Utf8Array {
     where
         ScalarKernel: Fn(&str, &str) -> DaftResult<bool>,
     {
-        let self_arrow = self.as_arrow();
-        let other_arrow = other.as_arrow();
-        match (self.len(), other.len()) {
-            // Matching len case:
-            (self_len, other_len) if self_len == other_len => {
-                let arrow_result: DaftResult<arrow2::array::BooleanArray> = self_arrow
-                    .into_iter()
-                    .zip(other_arrow)
-                    .map(|(self_v, other_v)| match (self_v, other_v) {
-                        (Some(self_v), Some(other_v)) => operation(self_v, other_v).map(Some),
-                        _ => Ok(None),
-                    })
-                    .collect();
-                Ok(BooleanArray::from((self.name(), arrow_result?)))
-            }
-            // Broadcast other case:
-            (self_len, 1) => {
-                let other_scalar_value = other.get(0);
-                match other_scalar_value {
-                    None => Ok(BooleanArray::full_null(
-                        self.name(),
-                        &DataType::Boolean,
-                        self_len,
-                    )),
-                    Some(other_v) => {
-                        let arrow_result: DaftResult<arrow2::array::BooleanArray> = self_arrow
-                            .into_iter()
-                            .map(|self_v| match self_v {
-                                Some(self_v) => operation(self_v, other_v).map(Some),
-                                None => Ok(None),
-                            })
-                            .collect();
-                        Ok(BooleanArray::from((self.name(), arrow_result?)))
-                    }
-                }
-            }
-            // Broadcast self case
-            (1, other_len) => {
-                let self_scalar_value = self.get(0);
-                match self_scalar_value {
-                    None => Ok(BooleanArray::full_null(
-                        self.name(),
-                        &DataType::Boolean,
-                        other_len,
-                    )),
-                    Some(self_v) => {
-                        let arrow_result: DaftResult<arrow2::array::BooleanArray> = other_arrow
-                            .into_iter()
-                            .map(|other_v| match other_v {
-                                Some(other_v) => operation(self_v, other_v).map(Some),
-                                None => Ok(None),
-                            })
-                            .collect();
-                        Ok(BooleanArray::from((self.name(), arrow_result?)))
-                    }
-                }
-            }
-            // Mismatched len case:
-            (self_len, other_len) => Err(DaftError::ComputeError(format!(
-                "Error in {op_name}: lhs and rhs have different length arrays: {self_len} vs {other_len}"
-            ))),
+        let is_valid = check_valid_inputs(self, &[other], op_name, &DataType::Boolean);
+        if let Some(result) = is_valid {
+            return result;
         }
+
+        let result_len = std::cmp::max(self.len(), other.len());
+        let self_iter = create_broadcasted_str_iter(self, result_len);
+        let other_iter = create_broadcasted_str_iter(other, result_len);
+        let arrow_result = self_iter
+            .zip(other_iter)
+            .map(|(self_v, other_v)| match (self_v, other_v) {
+                (Some(self_v), Some(other_v)) => operation(self_v, other_v).map(Some),
+                _ => Ok(None),
+            })
+            .collect::<DaftResult<arrow2::array::BooleanArray>>();
+
+        Ok(BooleanArray::from((self.name(), arrow_result?)))
+    }
+
+    fn unary_broadcasted_op<ScalarKernel>(&self, operation: ScalarKernel) -> DaftResult<Utf8Array>
+    where
+        ScalarKernel: Fn(&str) -> Cow<'_, str>,
+    {
+        let self_arrow = self.as_arrow();
+        let arrow_result = self_arrow
+            .iter()
+            .map(|val| Some(operation(val?)))
+            .collect::<arrow2::array::Utf8Array<i64>>()
+            .with_validity(self_arrow.validity().cloned());
+        Ok(Utf8Array::from((self.name(), Box::new(arrow_result))))
     }
 }
 

--- a/src/daft-core/src/array/ops/utf8.rs
+++ b/src/daft-core/src/array/ops/utf8.rs
@@ -3,8 +3,7 @@ use std::borrow::Cow;
 use crate::{
     array::{DataArray, ListArray},
     datatypes::{
-        BooleanArray, DaftArrayType, DaftIntegerType, DaftNumericType, DaftPhysicalType, Field,
-        Int64Array, UInt64Array, Utf8Array,
+        BooleanArray, DaftIntegerType, DaftNumericType, Field, Int64Array, UInt64Array, Utf8Array,
     },
     DataType, Series,
 };
@@ -61,48 +60,6 @@ fn is_valid_input_lengths(lengths: &[usize]) -> bool {
     } else {
         false
     }
-}
-
-fn check_valid_inputs<T, I>(
-    self_arr: &Utf8Array,
-    arrs: &[&DataArray<I>],
-    op_name: &str,
-    dtype: &DataType,
-) -> Option<DaftResult<T>>
-where
-    T: DaftArrayType + FullNull,
-    I: DaftPhysicalType,
-{
-    assert!(!arrs.is_empty());
-    let self_len = self_arr.len();
-
-    // check valid input lengths
-    let lengths = std::iter::once(self_len)
-        .chain(arrs.iter().map(|arr| arr.len()))
-        .collect::<Vec<_>>();
-    if !is_valid_input_lengths(&lengths) {
-        let lengths_str = lengths
-            .iter()
-            .map(|x| x.to_string())
-            .collect::<Vec<_>>()
-            .join(" vs ");
-        return Some(Err(DaftError::ValueError(format!(
-            "Error in {op_name}: inputs have different lengths: {lengths_str}"
-        ))));
-    }
-
-    // check if all arrays are empty
-    if lengths.iter().all(|&x| x == 0) {
-        return Some(Ok(T::empty(arrs[0].name(), dtype)));
-    }
-
-    // check if any array has all nulls
-    if arrs.iter().any(|arr| arr.null_count() == arr.len()) || self_arr.null_count() == self_len {
-        let result_len = lengths.iter().max().unwrap();
-        return Some(Ok(T::full_null(arrs[0].name(), dtype, *result_len)));
-    }
-
-    None
 }
 
 fn split_array_on_literal<'a>(
@@ -332,26 +289,38 @@ impl Utf8Array {
     }
 
     pub fn split(&self, pattern: &Utf8Array, regex: bool) -> DaftResult<ListArray> {
-        let is_valid = check_valid_inputs(
-            self,
-            &[pattern],
-            "split",
-            &DataType::List(Box::new(DataType::Utf8)),
-        );
-        if let Some(result) = is_valid {
-            return result;
+        let self_len = self.len();
+        let pattern_len = pattern.len();
+        let result_len = std::cmp::max(self_len, pattern_len);
+
+        if !is_valid_input_lengths(&[self_len, pattern_len]) {
+            return Err(DaftError::ValueError(format!(
+                "Error in split: inputs have different lengths: {self_len} vs {pattern_len}"
+            )));
+        }
+        if self.is_empty() && pattern.is_empty() {
+            return Ok(ListArray::empty(
+                self.name(),
+                &DataType::List(Box::new(DataType::Utf8)),
+            ));
+        }
+        if self.null_count() == self_len || pattern.null_count() == pattern_len {
+            return Ok(ListArray::full_null(
+                self.name(),
+                &DataType::List(Box::new(DataType::Utf8)),
+                result_len,
+            ));
         }
 
-        let result_len = std::cmp::max(self.len(), pattern.len());
         let self_arrow = self.as_arrow();
         let buffer_len = self_arrow.values().len();
         // This will overallocate by pattern_len * N_i, where N_i is the number of pattern occurences in the ith string in arr_iter.
         let mut splits = arrow2::array::MutableUtf8Array::with_capacity(buffer_len);
         let mut offsets = arrow2::offset::Offsets::new();
-        let mut validity = arrow2::bitmap::MutableBitmap::with_capacity(self.len());
+        let mut validity = arrow2::bitmap::MutableBitmap::with_capacity(self_len);
 
         let self_iter = create_broadcasted_str_iter(self, result_len);
-        match (regex, pattern.len()) {
+        match (regex, pattern_len) {
             (true, 1) => {
                 let regex = regex::Regex::new(pattern.get(0).unwrap());
                 let regex_iter = std::iter::repeat(Some(regex)).take(result_len);
@@ -405,14 +374,28 @@ impl Utf8Array {
     }
 
     pub fn extract(&self, pattern: &Utf8Array, index: usize) -> DaftResult<Utf8Array> {
-        let is_valid = check_valid_inputs(self, &[pattern], "extract", &DataType::Utf8);
-        if let Some(result) = is_valid {
-            return result;
+        let self_len = self.len();
+        let pattern_len = pattern.len();
+        let result_len = std::cmp::max(self_len, pattern_len);
+
+        if !is_valid_input_lengths(&[self_len, pattern_len]) {
+            return Err(DaftError::ValueError(format!(
+                "Error in extract: inputs have different lengths: {self_len} vs {pattern_len}"
+            )));
+        }
+        if self.is_empty() && pattern.is_empty() {
+            return Ok(Utf8Array::empty(self.name(), &DataType::Utf8));
+        }
+        if self.null_count() == self_len || pattern.null_count() == pattern_len {
+            return Ok(Utf8Array::full_null(
+                self.name(),
+                &DataType::Utf8,
+                result_len,
+            ));
         }
 
-        let result_len = std::cmp::max(self.len(), pattern.len());
         let self_iter = create_broadcasted_str_iter(self, result_len);
-        match pattern.len() {
+        match pattern_len {
             1 => {
                 let regex = regex::Regex::new(pattern.get(0).unwrap());
                 let regex_iter = std::iter::repeat(Some(regex)).take(result_len);
@@ -429,19 +412,31 @@ impl Utf8Array {
     }
 
     pub fn extract_all(&self, pattern: &Utf8Array, index: usize) -> DaftResult<ListArray> {
-        let is_valid = check_valid_inputs(
-            self,
-            &[pattern],
-            "extract_all",
-            &DataType::List(Box::new(DataType::Utf8)),
-        );
-        if let Some(result) = is_valid {
-            return result;
+        let self_len = self.len();
+        let pattern_len = pattern.len();
+        let result_len = std::cmp::max(self_len, pattern_len);
+
+        if !is_valid_input_lengths(&[self_len, pattern_len]) {
+            return Err(DaftError::ValueError(format!(
+                "Error in extract_all: inputs have different lengths: {self_len} vs {pattern_len}"
+            )));
+        }
+        if self.is_empty() && pattern.is_empty() {
+            return Ok(ListArray::empty(
+                self.name(),
+                &DataType::List(Box::new(DataType::Utf8)),
+            ));
+        }
+        if self.null_count() == self_len || pattern.null_count() == pattern_len {
+            return Ok(ListArray::full_null(
+                self.name(),
+                &DataType::List(Box::new(DataType::Utf8)),
+                result_len,
+            ));
         }
 
-        let result_len = std::cmp::max(self.len(), pattern.len());
         let self_iter = create_broadcasted_str_iter(self, result_len);
-        match pattern.len() {
+        match pattern_len {
             1 => {
                 let regex = regex::Regex::new(pattern.get(0).unwrap());
                 let regex_iter = std::iter::repeat(Some(regex)).take(result_len);
@@ -463,17 +458,34 @@ impl Utf8Array {
         replacement: &Utf8Array,
         regex: bool,
     ) -> DaftResult<Utf8Array> {
-        let is_valid =
-            check_valid_inputs(self, &[pattern, replacement], "replace", &DataType::Utf8);
-        if let Some(result) = is_valid {
-            return result;
+        let self_len = self.len();
+        let pattern_len = pattern.len();
+        let replacement_len = replacement.len();
+        let result_len = std::cmp::max(self_len, std::cmp::max(pattern_len, replacement_len));
+
+        if !is_valid_input_lengths(&[self_len, pattern_len, replacement_len]) {
+            return Err(DaftError::ValueError(format!(
+                "Error in replace: inputs have different lengths: {self_len} vs {pattern_len} vs {replacement_len}"
+            )));
+        }
+        if self.is_empty() && pattern.is_empty() && replacement.is_empty() {
+            return Ok(Utf8Array::empty(self.name(), &DataType::Utf8));
+        }
+        if self.null_count() == self_len
+            || pattern.null_count() == pattern_len
+            || replacement.null_count() == replacement_len
+        {
+            return Ok(Utf8Array::full_null(
+                self.name(),
+                &DataType::Utf8,
+                result_len,
+            ));
         }
 
-        let result_len = std::cmp::max(self.len(), std::cmp::max(pattern.len(), replacement.len()));
         let self_iter = create_broadcasted_str_iter(self, result_len);
         let replacement_iter = create_broadcasted_str_iter(replacement, result_len);
 
-        match (regex, pattern.len()) {
+        match (regex, pattern_len) {
             (true, 1) => {
                 let regex = regex::Regex::new(pattern.get(0).unwrap());
                 let regex_iter = std::iter::repeat(Some(regex)).take(result_len);
@@ -543,12 +555,26 @@ impl Utf8Array {
     }
 
     pub fn find(&self, substr: &Utf8Array) -> DaftResult<Int64Array> {
-        let is_valid = check_valid_inputs(self, &[substr], "find", &DataType::Int64);
-        if let Some(result) = is_valid {
-            return result;
+        let self_len = self.len();
+        let substr_len = substr.len();
+        let result_len = std::cmp::max(self_len, substr_len);
+
+        if !is_valid_input_lengths(&[self_len, substr_len]) {
+            return Err(DaftError::ValueError(format!(
+                "Error in find: inputs have different lengths: {self_len} vs {substr_len}"
+            )));
+        }
+        if self.is_empty() && substr.is_empty() {
+            return Ok(Int64Array::empty(self.name(), &DataType::Int64));
+        }
+        if self.null_count() == self_len || substr.null_count() == substr_len {
+            return Ok(Int64Array::full_null(
+                self.name(),
+                &DataType::Int64,
+                result_len,
+            ));
         }
 
-        let result_len = std::cmp::max(self.len(), substr.len());
         let self_iter = create_broadcasted_str_iter(self, result_len);
         let substr_iter = create_broadcasted_str_iter(substr, result_len);
         let arrow_result = self_iter
@@ -569,9 +595,24 @@ impl Utf8Array {
         I: DaftIntegerType,
         <I as DaftNumericType>::Native: Ord,
     {
-        let is_valid = check_valid_inputs(self, &[nchars], "left", &DataType::Utf8);
-        if let Some(result) = is_valid {
-            return result;
+        let self_len = self.len();
+        let nchars_len = nchars.len();
+        let result_len = std::cmp::max(self_len, nchars_len);
+
+        if !is_valid_input_lengths(&[self_len, nchars_len]) {
+            return Err(DaftError::ValueError(format!(
+                "Error in left: inputs have different lengths: {self_len} vs {nchars_len}"
+            )));
+        }
+        if self.is_empty() && nchars.is_empty() {
+            return Ok(Utf8Array::empty(self.name(), &DataType::Utf8));
+        }
+        if self.null_count() == self_len || nchars.null_count() == nchars_len {
+            return Ok(Utf8Array::full_null(
+                self.name(),
+                &DataType::Utf8,
+                result_len,
+            ));
         }
 
         fn left_most_chars(val: &str, n: usize) -> &str {
@@ -582,9 +623,8 @@ impl Utf8Array {
             }
         }
 
-        let result_len = std::cmp::max(self.len(), nchars.len());
         let self_iter = create_broadcasted_str_iter(self, result_len);
-        match nchars.len() {
+        match nchars_len {
             1 => {
                 let n = nchars.get(0).unwrap();
                 let n: usize = NumCast::from(n).ok_or_else(|| {
@@ -623,9 +663,24 @@ impl Utf8Array {
         I: DaftIntegerType,
         <I as DaftNumericType>::Native: Ord,
     {
-        let is_valid = check_valid_inputs(self, &[nchars], "right", &DataType::Utf8);
-        if let Some(result) = is_valid {
-            return result;
+        let self_len = self.len();
+        let nchars_len = nchars.len();
+        let result_len = std::cmp::max(self_len, nchars_len);
+
+        if !is_valid_input_lengths(&[self_len, nchars_len]) {
+            return Err(DaftError::ValueError(format!(
+                "Error in right: inputs have different lengths: {self_len} vs {nchars_len}"
+            )));
+        }
+        if self.is_empty() && nchars.is_empty() {
+            return Ok(Utf8Array::empty(self.name(), &DataType::Utf8));
+        }
+        if self.null_count() == self_len || nchars.null_count() == nchars_len {
+            return Ok(Utf8Array::full_null(
+                self.name(),
+                &DataType::Utf8,
+                result_len,
+            ));
         }
 
         fn right_most_chars(val: &str, nchar: usize) -> &str {
@@ -637,9 +692,8 @@ impl Utf8Array {
             }
         }
 
-        let result_len = std::cmp::max(self.len(), nchars.len());
         let self_iter = create_broadcasted_str_iter(self, result_len);
-        match nchars.len() {
+        match nchars_len {
             1 => {
                 let n = nchars.get(0).unwrap();
                 let n: usize = NumCast::from(n).ok_or_else(|| {
@@ -682,12 +736,26 @@ impl Utf8Array {
     where
         ScalarKernel: Fn(&str, &str) -> DaftResult<bool>,
     {
-        let is_valid = check_valid_inputs(self, &[other], op_name, &DataType::Boolean);
-        if let Some(result) = is_valid {
-            return result;
+        let self_len = self.len();
+        let other_len = other.len();
+        let result_len = std::cmp::max(self_len, other_len);
+
+        if !is_valid_input_lengths(&[self_len, other_len]) {
+            return Err(DaftError::ValueError(format!(
+                "Error in {op_name}: inputs have different lengths: {self_len} vs {other_len}"
+            )));
+        }
+        if self.is_empty() && other.is_empty() {
+            return Ok(BooleanArray::empty(self.name(), &DataType::Boolean));
+        }
+        if self.null_count() == self_len || other.null_count() == other_len {
+            return Ok(BooleanArray::full_null(
+                self.name(),
+                &DataType::Boolean,
+                result_len,
+            ));
         }
 
-        let result_len = std::cmp::max(self.len(), other.len());
         let self_iter = create_broadcasted_str_iter(self, result_len);
         let other_iter = create_broadcasted_str_iter(other, result_len);
         let arrow_result = self_iter

--- a/src/daft-core/src/array/ops/utf8.rs
+++ b/src/daft-core/src/array/ops/utf8.rs
@@ -72,8 +72,6 @@ fn parse_inputs<T>(
 where
     T: DaftPhysicalType,
 {
-    assert!(!other_arrs.is_empty());
-
     let lengths = std::iter::once(self_arr.len())
         .chain(other_arrs.iter().map(|arr| arr.len()))
         .collect::<Vec<_>>();

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -203,9 +203,9 @@ def test_series_utf8_split_nulls(data, patterns, expected, regex) -> None:
     ["data", "patterns"],
     [
         # Empty data.
-        ([[], [","] * 4, []]),
+        ([[], [","] * 4]),
         # Empty patterns.
-        ([["foo"] * 4, [], []]),
+        ([["foo"] * 4, []]),
     ],
 )
 @pytest.mark.parametrize("regex", [False, True])

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -210,8 +210,8 @@ def test_series_utf8_split_nulls(data, patterns, expected, regex) -> None:
 def test_series_utf8_split_empty_arrs(data, patterns, expected, regex) -> None:
     s = Series.from_arrow(pa.array(data, type=pa.string()))
     patterns = Series.from_arrow(pa.array(patterns, type=pa.string()))
-    result = s.str.split(patterns)
-    assert result.to_pylist() == expected
+    with pytest.raises(ValueError):
+        s.str.split(patterns, regex=regex)
 
 
 @pytest.mark.parametrize(
@@ -437,6 +437,22 @@ def test_series_utf8_left(data, nchars, expected) -> None:
     assert result.to_pylist() == expected
 
 
+@pytest.mark.parametrize(
+    ["data", "nchars"],
+    [
+        # empty data
+        ([[], [0, 1]]),
+        # empty nchars
+        ([["foo"] * 4, []]),
+    ],
+)
+def test_series_utf8_left_empty_arrs(data, nchars) -> None:
+    s = Series.from_arrow(pa.array(data, type=pa.string()))
+    nchars = Series.from_arrow(pa.array(nchars, type=pa.uint32()))
+    with pytest.raises(ValueError):
+        s.str.left(nchars)
+
+
 def test_series_utf8_left_mismatch_len() -> None:
     s = Series.from_arrow(pa.array(["foo", "barbaz", "quux"]))
     nchars = Series.from_arrow(pa.array([1, 2], type=pa.uint32()))
@@ -486,6 +502,22 @@ def test_series_utf8_right(data, nchars, expected) -> None:
     nchars = Series.from_arrow(pa.array(nchars, type=pa.uint32()))
     result = s.str.right(nchars)
     assert result.to_pylist() == expected
+
+
+@pytest.mark.parametrize(
+    ["data", "nchars"],
+    [
+        # empty data
+        ([[], [0, 1]]),
+        # empty nchars
+        ([["foo"] * 4, []]),
+    ],
+)
+def test_series_utf8_right_empty_arrs(data, nchars) -> None:
+    s = Series.from_arrow(pa.array(data, type=pa.string()))
+    nchars = Series.from_arrow(pa.array(nchars, type=pa.uint32()))
+    with pytest.raises(ValueError):
+        s.str.right(nchars)
 
 
 def test_series_utf8_right_mismatch_len() -> None:
@@ -639,6 +671,22 @@ def test_series_utf8_find(data, substrs, expected) -> None:
     substrs = Series.from_arrow(pa.array(substrs, type=pa.string()))
     result = s.str.find(substrs)
     assert result.to_pylist() == expected
+
+
+@pytest.mark.parametrize(
+    ["data", "substrs"],
+    [
+        # Empty data.
+        ([[], ["foo", "bar"]]),
+        # Empty substrs
+        ([["foo"] * 4, []]),
+    ],
+)
+def test_series_utf8_find_empty_arrs(data, substrs) -> None:
+    s = Series.from_arrow(pa.array(data, type=pa.string()))
+    substrs = Series.from_arrow(pa.array(substrs, type=pa.string()))
+    with pytest.raises(ValueError):
+        s.str.find(substrs)
 
 
 def test_series_utf8_find_mismatch_len() -> None:

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -200,14 +200,16 @@ def test_series_utf8_split_nulls(data, patterns, expected, regex) -> None:
 
 
 @pytest.mark.parametrize(
-    ["data", "patterns", "expected"],
+    ["data", "patterns"],
     [
-        # Empty data and pattern
-        ([[], [], []]),
+        # Empty data.
+        ([[], [","] * 4, []]),
+        # Empty patterns.
+        ([["foo"] * 4, [], []]),
     ],
 )
 @pytest.mark.parametrize("regex", [False, True])
-def test_series_utf8_split_empty_arrs(data, patterns, expected, regex) -> None:
+def test_series_utf8_split_empty_arrs(data, patterns, regex) -> None:
     s = Series.from_arrow(pa.array(data, type=pa.string()))
     patterns = Series.from_arrow(pa.array(patterns, type=pa.string()))
     with pytest.raises(ValueError):


### PR DESCRIPTION
Currently a lot of our string kernels have duplicated code to check for empty arrs and null arrs. They also have giant match statements to determine if broadcasting is needed. 

This PR unifies the empty arr checks, null arr checks, and broadcastable length checks into a single helper function. The actual broadcasting logic is simplified by an enum that wraps either a broadcasted repeat iter, or a normal non-broadcastet iter. 

Prior work on this was done in the [str.replace](https://github.com/Eventual-Inc/Daft/pull/2048/files#diff-42205d5e909fe98537eb8d32b1d41037aec1a24e5cded377d0544304551ae070R15-R62) PR, which otherwise would have had like a 12 way match statement or smth.

Additionally, this PR adds a `unary_broadcasted_op` helper function to simplify the code for single argument kernels.