### PR TITLE
[CHORE] FunctionEvaluator directly receive `FunctionExpr`

### DIFF
--- a/src/daft-dsl/src/expr.rs
+++ b/src/daft-dsl/src/expr.rs
@@ -190,9 +190,7 @@ impl AggExpr {
                     ))),
                 }
             }
-            MapGroups { func, inputs } => {
-                func.to_field(inputs.as_slice(), schema, &Expr::Agg(self.clone()))
-            }
+            MapGroups { func, inputs } => func.to_field(inputs.as_slice(), schema, func),
         }
     }
 
@@ -450,7 +448,7 @@ impl Expr {
                 Ok(Field::new(left_field.name.as_str(), result_type))
             }
             Literal(value) => Ok(Field::new("literal", value.get_type())),
-            Function { func, inputs } => func.to_field(inputs.as_slice(), schema, self),
+            Function { func, inputs } => func.to_field(inputs.as_slice(), schema, func),
             BinaryOp { op, left, right } => {
                 let left_field = left.to_field(schema)?;
                 let right_field = right.to_field(schema)?;

--- a/src/daft-dsl/src/functions/float/is_nan.rs
+++ b/src/daft-dsl/src/functions/float/is_nan.rs
@@ -6,6 +6,7 @@ use daft_core::{
 
 use crate::Expr;
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -17,7 +18,7 @@ impl FunctionEvaluator for IsNanEvaluator {
         "is_nan"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data] => match data.to_field(schema) {
                 Ok(data_field) => match &data_field.dtype {
@@ -38,7 +39,7 @@ impl FunctionEvaluator for IsNanEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data] => data.is_nan(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/image/crop.rs
+++ b/src/daft-dsl/src/functions/image/crop.rs
@@ -3,6 +3,7 @@ use common_error::DaftError;
 use daft_core::datatypes::DataType;
 use daft_core::{datatypes::Field, schema::Schema, series::Series};
 
+use crate::functions::FunctionExpr;
 use common_error::DaftResult;
 
 use super::super::FunctionEvaluator;
@@ -14,7 +15,12 @@ impl FunctionEvaluator for CropEvaluator {
         "crop"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _expr: &Expr) -> DaftResult<Field> {
+    fn to_field(
+        &self,
+        inputs: &[Expr],
+        schema: &Schema,
+        _expr: &FunctionExpr,
+    ) -> DaftResult<Field> {
         match inputs {
             [input, bbox] => {
                 let input_field = input.to_field(schema)?;
@@ -61,7 +67,7 @@ impl FunctionEvaluator for CropEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input, bbox] => input.image_crop(bbox),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/image/decode.rs
+++ b/src/daft-dsl/src/functions/image/decode.rs
@@ -17,7 +17,7 @@ impl FunctionEvaluator for DecodeEvaluator {
         "decode"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let field = input.to_field(schema)?;
@@ -36,15 +36,11 @@ impl FunctionEvaluator for DecodeEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         let raise_error_on_failure = match expr {
-            Expr::Function {
-                func:
-                    FunctionExpr::Image(ImageExpr::Decode {
-                        raise_error_on_failure,
-                    }),
-                inputs: _,
-            } => raise_error_on_failure,
+            FunctionExpr::Image(ImageExpr::Decode {
+                raise_error_on_failure,
+            }) => raise_error_on_failure,
             _ => panic!("DecodeEvaluator expects an Image::Decode expression"),
         };
         match inputs {

--- a/src/daft-dsl/src/functions/image/encode.rs
+++ b/src/daft-dsl/src/functions/image/encode.rs
@@ -16,7 +16,7 @@ impl FunctionEvaluator for EncodeEvaluator {
         "encode"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let field = input.to_field(schema)?;
@@ -37,12 +37,9 @@ impl FunctionEvaluator for EncodeEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         let image_format = match expr {
-            Expr::Function {
-                func: FunctionExpr::Image(ImageExpr::Encode { image_format }),
-                inputs: _,
-            } => image_format,
+            FunctionExpr::Image(ImageExpr::Encode { image_format }) => image_format,
             _ => panic!("Expected ImageEncode Expr, got {expr}"),
         };
         match inputs {

--- a/src/daft-dsl/src/functions/image/resize.rs
+++ b/src/daft-dsl/src/functions/image/resize.rs
@@ -17,7 +17,7 @@ impl FunctionEvaluator for ResizeEvaluator {
         "resize"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let field = input.to_field(schema)?;
@@ -26,10 +26,7 @@ impl FunctionEvaluator for ResizeEvaluator {
                     DataType::Image(mode) => match mode {
                         Some(mode) => {
                             let (w, h) = match expr {
-                                Expr::Function {
-                                    func: FunctionExpr::Image(ImageExpr::Resize { w, h }),
-                                    inputs: _,
-                                } => (w, h),
+                                FunctionExpr::Image(ImageExpr::Resize { w, h }) => (w, h),
                                 _ => panic!("Expected ImageResize Expr, got {expr}"),
                             };
                             Ok(Field::new(
@@ -53,12 +50,9 @@ impl FunctionEvaluator for ResizeEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         let (w, h) = match expr {
-            Expr::Function {
-                func: FunctionExpr::Image(ImageExpr::Resize { w, h }),
-                inputs: _,
-            } => (w, h),
+            FunctionExpr::Image(ImageExpr::Resize { w, h }) => (w, h),
             _ => panic!("Expected ImageResize Expr, got {expr}"),
         };
 

--- a/src/daft-dsl/src/functions/json/query.rs
+++ b/src/daft-dsl/src/functions/json/query.rs
@@ -17,7 +17,7 @@ impl FunctionEvaluator for JsonQueryEvaluator {
         "JsonQuery"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let input_field = input.to_field(schema)?;
@@ -36,14 +36,11 @@ impl FunctionEvaluator for JsonQueryEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => {
                 let query = match expr {
-                    Expr::Function {
-                        func: FunctionExpr::Json(JsonExpr::Query(query)),
-                        inputs: _,
-                    } => query,
+                    FunctionExpr::Json(JsonExpr::Query(query)) => query,
                     _ => panic!("Expected Json Query Expr, got {expr}"),
                 };
 

--- a/src/daft-dsl/src/functions/list/count.rs
+++ b/src/daft-dsl/src/functions/list/count.rs
@@ -17,17 +17,16 @@ impl FunctionEvaluator for CountEvaluator {
         "count"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let input_field = input.to_field(schema)?;
 
                 match input_field.dtype {
                     DataType::List(_) | DataType::FixedSizeList(_, _) => match expr {
-                        Expr::Function {
-                            func: FunctionExpr::List(ListExpr::Count(_)),
-                            inputs: _,
-                        } => Ok(Field::new(input.name()?, DataType::UInt64)),
+                        FunctionExpr::List(ListExpr::Count(_)) => {
+                            Ok(Field::new(input.name()?, DataType::UInt64))
+                        }
                         _ => panic!("Expected List Count Expr, got {expr}"),
                     },
                     _ => Err(DaftError::TypeError(format!(
@@ -43,14 +42,11 @@ impl FunctionEvaluator for CountEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => {
                 let mode = match expr {
-                    Expr::Function {
-                        func: FunctionExpr::List(ListExpr::Count(mode)),
-                        inputs: _,
-                    } => mode,
+                    FunctionExpr::List(ListExpr::Count(mode)) => mode,
                     _ => panic!("Expected List Count Expr, got {expr}"),
                 };
 

--- a/src/daft-dsl/src/functions/list/explode.rs
+++ b/src/daft-dsl/src/functions/list/explode.rs
@@ -1,3 +1,4 @@
+use crate::functions::FunctionExpr;
 use crate::Expr;
 use common_error::{DaftError, DaftResult};
 use daft_core::{datatypes::Field, schema::Schema, series::Series};
@@ -11,7 +12,7 @@ impl FunctionEvaluator for ExplodeEvaluator {
         "explode"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let field = input.to_field(schema)?;
@@ -24,7 +25,7 @@ impl FunctionEvaluator for ExplodeEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => input.explode(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/list/get.rs
+++ b/src/daft-dsl/src/functions/list/get.rs
@@ -1,6 +1,7 @@
 use crate::Expr;
 use daft_core::{datatypes::Field, schema::Schema, series::Series};
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -12,7 +13,7 @@ impl FunctionEvaluator for GetEvaluator {
         "get"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input, idx, default] => {
                 let input_field = input.to_field(schema)?;
@@ -38,7 +39,7 @@ impl FunctionEvaluator for GetEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input, idx, default] => Ok(input.list_get(idx, default)?),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/list/join.rs
+++ b/src/daft-dsl/src/functions/list/join.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::{IntoSeries, Series},
 };
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for JoinEvaluator {
         "join"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input, delimiter] => {
                 let input_field = input.to_field(schema)?;
@@ -50,7 +51,7 @@ impl FunctionEvaluator for JoinEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input, delimiter] => {
                 let delimiter = delimiter.utf8().unwrap();

--- a/src/daft-dsl/src/functions/list/max.rs
+++ b/src/daft-dsl/src/functions/list/max.rs
@@ -1,6 +1,7 @@
 use crate::Expr;
 use daft_core::{datatypes::Field, schema::Schema, series::Series};
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -12,7 +13,7 @@ impl FunctionEvaluator for MaxEvaluator {
         "max"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let field = input.to_field(schema)?.to_exploded_field()?;
@@ -33,7 +34,7 @@ impl FunctionEvaluator for MaxEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => Ok(input.list_max()?),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/list/mean.rs
+++ b/src/daft-dsl/src/functions/list/mean.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for MeanEvaluator {
         "mean"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let inner_field = input.to_field(schema)?.to_exploded_field()?;
@@ -32,7 +33,7 @@ impl FunctionEvaluator for MeanEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => Ok(input.list_mean()?),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/list/min.rs
+++ b/src/daft-dsl/src/functions/list/min.rs
@@ -1,6 +1,7 @@
 use crate::Expr;
 use daft_core::{datatypes::Field, schema::Schema, series::Series};
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -12,7 +13,7 @@ impl FunctionEvaluator for MinEvaluator {
         "min"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let field = input.to_field(schema)?.to_exploded_field()?;
@@ -33,7 +34,7 @@ impl FunctionEvaluator for MinEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => Ok(input.list_min()?),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/list/sum.rs
+++ b/src/daft-dsl/src/functions/list/sum.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for SumEvaluator {
         "sum"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let inner_field = input.to_field(schema)?.to_exploded_field()?;
@@ -33,7 +34,7 @@ impl FunctionEvaluator for SumEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => Ok(input.list_sum()?),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/mod.rs
+++ b/src/daft-dsl/src/functions/mod.rs
@@ -9,7 +9,7 @@ pub mod temporal;
 pub mod uri;
 pub mod utf8;
 
-use std::fmt::{Formatter, Result};
+use std::fmt::{Display, Formatter, Result};
 
 use self::image::ImageExpr;
 use self::json::JsonExpr;
@@ -50,8 +50,8 @@ pub enum FunctionExpr {
 
 pub trait FunctionEvaluator {
     fn fn_name(&self) -> &'static str;
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &Expr) -> DaftResult<Field>;
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series>;
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &FunctionExpr) -> DaftResult<Field>;
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series>;
 }
 
 impl FunctionExpr {
@@ -75,22 +75,28 @@ impl FunctionExpr {
     }
 }
 
+impl Display for FunctionExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.fn_name())
+    }
+}
+
 impl FunctionEvaluator for FunctionExpr {
     fn fn_name(&self) -> &'static str {
         self.get_evaluator().fn_name()
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &FunctionExpr) -> DaftResult<Field> {
         self.get_evaluator().to_field(inputs, schema, expr)
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         self.get_evaluator().evaluate(inputs, expr)
     }
 }
 
 pub fn function_display(f: &mut Formatter, func: &FunctionExpr, inputs: &[Expr]) -> Result {
-    write!(f, "{}(", func.fn_name())?;
+    write!(f, "{}(", func)?;
     for (i, input) in inputs.iter().enumerate() {
         if i != 0 {
             write!(f, ", ")?;

--- a/src/daft-dsl/src/functions/numeric/abs.rs
+++ b/src/daft-dsl/src/functions/numeric/abs.rs
@@ -1,6 +1,7 @@
 use common_error::{DaftError, DaftResult};
 use daft_core::{datatypes::Field, schema::Schema, series::Series};
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 
 use super::super::FunctionEvaluator;
@@ -12,7 +13,7 @@ impl FunctionEvaluator for AbsEvaluator {
         "abs"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
@@ -29,7 +30,7 @@ impl FunctionEvaluator for AbsEvaluator {
         Ok(field)
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         if inputs.len() != 1 {
             return Err(DaftError::ValueError(format!(
                 "Expected 1 input arg, got {}",

--- a/src/daft-dsl/src/functions/numeric/ceil.rs
+++ b/src/daft-dsl/src/functions/numeric/ceil.rs
@@ -1,6 +1,7 @@
 use common_error::{DaftError, DaftResult};
 use daft_core::{datatypes::Field, schema::Schema, series::Series};
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 
 use super::super::FunctionEvaluator;
@@ -12,7 +13,7 @@ impl FunctionEvaluator for CeilEvaluator {
         "ceil"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
@@ -29,7 +30,7 @@ impl FunctionEvaluator for CeilEvaluator {
         Ok(field)
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         if inputs.len() != 1 {
             return Err(DaftError::ValueError(format!(
                 "Expected 1 input arg, got {}",

--- a/src/daft-dsl/src/functions/numeric/floor.rs
+++ b/src/daft-dsl/src/functions/numeric/floor.rs
@@ -2,6 +2,7 @@ use common_error::{DaftError, DaftResult};
 use daft_core::{datatypes::Field, schema::Schema, series::Series};
 
 use super::super::FunctionEvaluator;
+use crate::functions::FunctionExpr;
 use crate::Expr;
 
 pub(super) struct FloorEvaluator {}
@@ -11,7 +12,7 @@ impl FunctionEvaluator for FloorEvaluator {
         "floor"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
@@ -28,7 +29,7 @@ impl FunctionEvaluator for FloorEvaluator {
         Ok(field)
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",

--- a/src/daft-dsl/src/functions/numeric/round.rs
+++ b/src/daft-dsl/src/functions/numeric/round.rs
@@ -14,7 +14,7 @@ impl FunctionEvaluator for RoundEvaluator {
         "round"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
@@ -31,7 +31,7 @@ impl FunctionEvaluator for RoundEvaluator {
         Ok(field)
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
@@ -39,10 +39,7 @@ impl FunctionEvaluator for RoundEvaluator {
             )));
         }
         let decimal = match expr {
-            Expr::Function {
-                func: FunctionExpr::Numeric(NumericExpr::Round(index)),
-                inputs: _,
-            } => index,
+            FunctionExpr::Numeric(NumericExpr::Round(index)) => index,
             _ => panic!("Expected Round Expr, got {expr}"),
         };
         inputs.first().unwrap().round(*decimal)

--- a/src/daft-dsl/src/functions/numeric/sign.rs
+++ b/src/daft-dsl/src/functions/numeric/sign.rs
@@ -2,6 +2,7 @@ use common_error::{DaftError, DaftResult};
 use daft_core::{datatypes::Field, schema::Schema, series::Series};
 
 use super::super::FunctionEvaluator;
+use crate::functions::FunctionExpr;
 use crate::Expr;
 
 pub(super) struct SignEvaluator {}
@@ -11,7 +12,7 @@ impl FunctionEvaluator for SignEvaluator {
         "sign"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
@@ -28,7 +29,7 @@ impl FunctionEvaluator for SignEvaluator {
         Ok(field)
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",

--- a/src/daft-dsl/src/functions/numeric/trigonometry.rs
+++ b/src/daft-dsl/src/functions/numeric/trigonometry.rs
@@ -4,7 +4,7 @@ use daft_core::datatypes::Field;
 use daft_core::schema::Schema;
 use daft_core::{DataType, Series};
 
-use crate::functions::FunctionEvaluator;
+use crate::functions::{FunctionEvaluator, FunctionExpr};
 use crate::Expr;
 
 pub(super) struct TrigonometryEvaluator(pub TrigonometricFunction);
@@ -14,7 +14,7 @@ impl FunctionEvaluator for TrigonometryEvaluator {
         self.0.fn_name()
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",
@@ -35,7 +35,7 @@ impl FunctionEvaluator for TrigonometryEvaluator {
         Ok(Field::new(field.name, dtype))
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         if inputs.len() != 1 {
             return Err(DaftError::SchemaMismatch(format!(
                 "Expected 1 input arg, got {}",

--- a/src/daft-dsl/src/functions/python/udf.rs
+++ b/src/daft-dsl/src/functions/python/udf.rs
@@ -8,6 +8,7 @@ use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
 use super::PythonUDF;
+use crate::functions::FunctionExpr;
 use daft_core::python::PySeries;
 
 impl FunctionEvaluator for PythonUDF {
@@ -15,7 +16,7 @@ impl FunctionEvaluator for PythonUDF {
         "py_udf"
     }
 
-    fn to_field(&self, inputs: &[Expr], _schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], _schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         if inputs.len() != self.num_expressions {
             return Err(DaftError::SchemaMismatch(format!(
                 "Number of inputs required by UDF {} does not match number of inputs provided: {}",
@@ -31,7 +32,7 @@ impl FunctionEvaluator for PythonUDF {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         self.call_udf(inputs)
     }
 }

--- a/src/daft-dsl/src/functions/struct_/get.rs
+++ b/src/daft-dsl/src/functions/struct_/get.rs
@@ -17,7 +17,7 @@ impl FunctionEvaluator for GetEvaluator {
         "get"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, expr: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let input_field = input.to_field(schema)?;
@@ -25,10 +25,7 @@ impl FunctionEvaluator for GetEvaluator {
                 match input_field.dtype {
                     DataType::Struct(fields) => {
                         let name = match expr {
-                            Expr::Function {
-                                func: FunctionExpr::Struct(StructExpr::Get(name)),
-                                inputs: _,
-                            } => name,
+                            FunctionExpr::Struct(StructExpr::Get(name)) => name,
                             _ => panic!("Expected Struct Get Expr, got {expr}"),
                         };
 
@@ -60,14 +57,11 @@ impl FunctionEvaluator for GetEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => {
                 let name = match expr {
-                    Expr::Function {
-                        func: FunctionExpr::Struct(StructExpr::Get(name)),
-                        inputs: _,
-                    } => name,
+                    FunctionExpr::Struct(StructExpr::Get(name)) => name,
                     _ => panic!("Expected Struct Get Expr, got {expr}"),
                 };
 

--- a/src/daft-dsl/src/functions/temporal/date.rs
+++ b/src/daft-dsl/src/functions/temporal/date.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for DateEvaluator {
         "date"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => match input.to_field(schema) {
                 Ok(field) if field.dtype.is_temporal() => {
@@ -35,7 +36,7 @@ impl FunctionEvaluator for DateEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => input.dt_date(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/temporal/day.rs
+++ b/src/daft-dsl/src/functions/temporal/day.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for DayEvaluator {
         "day"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => match input.to_field(schema) {
                 Ok(field) if field.dtype.is_temporal() => {
@@ -35,7 +36,7 @@ impl FunctionEvaluator for DayEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => input.dt_day(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/temporal/day_of_week.rs
+++ b/src/daft-dsl/src/functions/temporal/day_of_week.rs
@@ -6,6 +6,7 @@ use daft_core::{
 
 use crate::Expr;
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -17,7 +18,7 @@ impl FunctionEvaluator for DayOfWeekEvaluator {
         "day_of_week"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => match input.to_field(schema) {
                 Ok(field) if field.dtype.is_temporal() => {
@@ -36,7 +37,7 @@ impl FunctionEvaluator for DayOfWeekEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => input.dt_day_of_week(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/temporal/hour.rs
+++ b/src/daft-dsl/src/functions/temporal/hour.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for HourEvaluator {
         "hour"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => match input.to_field(schema) {
                 Ok(field) if field.dtype.is_temporal() => {
@@ -35,7 +36,7 @@ impl FunctionEvaluator for HourEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => input.dt_hour(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/temporal/month.rs
+++ b/src/daft-dsl/src/functions/temporal/month.rs
@@ -6,6 +6,7 @@ use daft_core::{
 
 use crate::Expr;
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -17,7 +18,7 @@ impl FunctionEvaluator for MonthEvaluator {
         "month"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => match input.to_field(schema) {
                 Ok(field) if field.dtype.is_temporal() => {
@@ -36,7 +37,7 @@ impl FunctionEvaluator for MonthEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => input.dt_month(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/temporal/year.rs
+++ b/src/daft-dsl/src/functions/temporal/year.rs
@@ -6,6 +6,7 @@ use daft_core::{
 
 use crate::Expr;
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -17,7 +18,7 @@ impl FunctionEvaluator for YearEvaluator {
         "year"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [input] => match input.to_field(schema) {
                 Ok(field) if field.dtype.is_temporal() => {
@@ -36,7 +37,7 @@ impl FunctionEvaluator for YearEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [input] => input.dt_year(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/uri/download.rs
+++ b/src/daft-dsl/src/functions/uri/download.rs
@@ -17,7 +17,12 @@ impl FunctionEvaluator for DownloadEvaluator {
         "download"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _expr: &Expr) -> DaftResult<Field> {
+    fn to_field(
+        &self,
+        inputs: &[Expr],
+        schema: &Schema,
+        _expr: &FunctionExpr,
+    ) -> DaftResult<Field> {
         match inputs {
             [input] => {
                 let field = input.to_field(schema)?;
@@ -37,18 +42,14 @@ impl FunctionEvaluator for DownloadEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         let (max_connections, raise_error_on_failure, multi_thread, config) = match expr {
-            Expr::Function {
-                func:
-                    FunctionExpr::Uri(UriExpr::Download {
-                        max_connections,
-                        raise_error_on_failure,
-                        multi_thread,
-                        config,
-                    }),
-                inputs: _,
-            } => (
+            FunctionExpr::Uri(UriExpr::Download {
+                max_connections,
+                raise_error_on_failure,
+                multi_thread,
+                config,
+            }) => (
                 max_connections,
                 raise_error_on_failure,
                 multi_thread,

--- a/src/daft-dsl/src/functions/utf8/capitalize.rs
+++ b/src/daft-dsl/src/functions/utf8/capitalize.rs
@@ -4,6 +4,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 use common_error::{DaftError, DaftResult};
 
@@ -16,7 +17,7 @@ impl FunctionEvaluator for CapitalizeEvaluator {
         "capitalize"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data] => match data.to_field(schema) {
                 Ok(data_field) => match &data_field.dtype {
@@ -34,7 +35,7 @@ impl FunctionEvaluator for CapitalizeEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data] => data.utf8_capitalize(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/contains.rs
+++ b/src/daft-dsl/src/functions/utf8/contains.rs
@@ -6,6 +6,7 @@ use daft_core::{
 
 use crate::Expr;
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -17,7 +18,7 @@ impl FunctionEvaluator for ContainsEvaluator {
         "contains"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, pattern] => match (data.to_field(schema), pattern.to_field(schema)) {
                 (Ok(data_field), Ok(pattern_field)) => {
@@ -39,7 +40,7 @@ impl FunctionEvaluator for ContainsEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, pattern] => data.utf8_contains(pattern),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/endswith.rs
+++ b/src/daft-dsl/src/functions/utf8/endswith.rs
@@ -4,6 +4,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 use common_error::{DaftError, DaftResult};
 
@@ -16,7 +17,7 @@ impl FunctionEvaluator for EndswithEvaluator {
         "endswith"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, pattern] => match (data.to_field(schema), pattern.to_field(schema)) {
                 (Ok(data_field), Ok(pattern_field)) => {
@@ -38,7 +39,7 @@ impl FunctionEvaluator for EndswithEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, pattern] => data.utf8_endswith(pattern),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/extract.rs
+++ b/src/daft-dsl/src/functions/utf8/extract.rs
@@ -18,7 +18,7 @@ impl FunctionEvaluator for ExtractEvaluator {
         "extract"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, pattern] => match (data.to_field(schema), pattern.to_field(schema)) {
                 (Ok(data_field), Ok(pattern_field)) => {
@@ -40,14 +40,11 @@ impl FunctionEvaluator for ExtractEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, pattern] => {
                 let index = match expr {
-                    Expr::Function {
-                        func: FunctionExpr::Utf8(Utf8Expr::Extract(index)),
-                        inputs: _,
-                    } => index,
+                    FunctionExpr::Utf8(Utf8Expr::Extract(index)) => index,
                     _ => panic!("Expected Utf8 Extract Expr, got {expr}"),
                 };
                 data.utf8_extract(pattern, *index)

--- a/src/daft-dsl/src/functions/utf8/extract_all.rs
+++ b/src/daft-dsl/src/functions/utf8/extract_all.rs
@@ -18,7 +18,7 @@ impl FunctionEvaluator for ExtractAllEvaluator {
         "extractall"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, pattern] => match (data.to_field(schema), pattern.to_field(schema)) {
                 (Ok(data_field), Ok(pattern_field)) => {
@@ -40,14 +40,11 @@ impl FunctionEvaluator for ExtractAllEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, pattern] => {
                 let index = match expr {
-                    Expr::Function {
-                        func: FunctionExpr::Utf8(Utf8Expr::ExtractAll(index)),
-                        inputs: _,
-                    } => index,
+                    FunctionExpr::Utf8(Utf8Expr::ExtractAll(index)) => index,
                     _ => panic!("Expected Utf8 ExtractAll Expr, got {expr}"),
                 };
                 data.utf8_extract_all(pattern, *index)

--- a/src/daft-dsl/src/functions/utf8/find.rs
+++ b/src/daft-dsl/src/functions/utf8/find.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for FindEvaluator {
         "find"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, substr] => match (data.to_field(schema), substr.to_field(schema)) {
                 (Ok(data_field), Ok(substr_field)) => {
@@ -38,7 +39,7 @@ impl FunctionEvaluator for FindEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, substr] => data.utf8_find(substr),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/left.rs
+++ b/src/daft-dsl/src/functions/utf8/left.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for LeftEvaluator {
         "left"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, nchars] => match (data.to_field(schema), nchars.to_field(schema)) {
                 (Ok(data_field), Ok(nchars_field)) => {
@@ -38,7 +39,7 @@ impl FunctionEvaluator for LeftEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, nchars] => data.utf8_left(nchars),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/length.rs
+++ b/src/daft-dsl/src/functions/utf8/length.rs
@@ -4,6 +4,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 use common_error::{DaftError, DaftResult};
 
@@ -16,7 +17,7 @@ impl FunctionEvaluator for LengthEvaluator {
         "length"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data] => match data.to_field(schema) {
                 Ok(data_field) => match &data_field.dtype {
@@ -34,7 +35,7 @@ impl FunctionEvaluator for LengthEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data] => data.utf8_length(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/lower.rs
+++ b/src/daft-dsl/src/functions/utf8/lower.rs
@@ -4,6 +4,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 use common_error::{DaftError, DaftResult};
 
@@ -16,7 +17,7 @@ impl FunctionEvaluator for LowerEvaluator {
         "lower"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data] => match data.to_field(schema) {
                 Ok(data_field) => match &data_field.dtype {
@@ -34,7 +35,7 @@ impl FunctionEvaluator for LowerEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data] => data.utf8_lower(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/lstrip.rs
+++ b/src/daft-dsl/src/functions/utf8/lstrip.rs
@@ -4,6 +4,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 use common_error::{DaftError, DaftResult};
 
@@ -16,7 +17,7 @@ impl FunctionEvaluator for LstripEvaluator {
         "lstrip"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data] => match data.to_field(schema) {
                 Ok(data_field) => match &data_field.dtype {
@@ -34,7 +35,7 @@ impl FunctionEvaluator for LstripEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data] => data.utf8_lstrip(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/match_.rs
+++ b/src/daft-dsl/src/functions/utf8/match_.rs
@@ -6,6 +6,7 @@ use daft_core::{
 
 use crate::Expr;
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -17,7 +18,7 @@ impl FunctionEvaluator for MatchEvaluator {
         "match"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, pattern] => match (data.to_field(schema), pattern.to_field(schema)) {
                 (Ok(data_field), Ok(pattern_field)) => {
@@ -39,7 +40,7 @@ impl FunctionEvaluator for MatchEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, pattern] => data.utf8_match(pattern),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/replace.rs
+++ b/src/daft-dsl/src/functions/utf8/replace.rs
@@ -18,7 +18,7 @@ impl FunctionEvaluator for ReplaceEvaluator {
         "replace"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, pattern, replacement] => match (
                 data.to_field(schema),
@@ -44,14 +44,11 @@ impl FunctionEvaluator for ReplaceEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, pattern, replacement] => {
                 let regex = match expr {
-                    Expr::Function {
-                        func: FunctionExpr::Utf8(Utf8Expr::Replace(regex)),
-                        inputs: _,
-                    } => regex,
+                    FunctionExpr::Utf8(Utf8Expr::Replace(regex)) => regex,
                     _ => panic!("Expected Utf8 Replace Expr, got {expr}"),
                 };
                 data.utf8_replace(pattern, replacement, *regex)

--- a/src/daft-dsl/src/functions/utf8/reverse.rs
+++ b/src/daft-dsl/src/functions/utf8/reverse.rs
@@ -4,6 +4,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 use common_error::{DaftError, DaftResult};
 
@@ -16,7 +17,7 @@ impl FunctionEvaluator for ReverseEvaluator {
         "reverse"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data] => match data.to_field(schema) {
                 Ok(data_field) => match &data_field.dtype {
@@ -34,7 +35,7 @@ impl FunctionEvaluator for ReverseEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data] => data.utf8_reverse(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/right.rs
+++ b/src/daft-dsl/src/functions/utf8/right.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for RightEvaluator {
         "right"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, nchars] => match (data.to_field(schema), nchars.to_field(schema)) {
                 (Ok(data_field), Ok(nchars_field)) => {
@@ -38,7 +39,7 @@ impl FunctionEvaluator for RightEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, nchars] => data.utf8_right(nchars),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/rstrip.rs
+++ b/src/daft-dsl/src/functions/utf8/rstrip.rs
@@ -4,6 +4,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 use common_error::{DaftError, DaftResult};
 
@@ -16,7 +17,7 @@ impl FunctionEvaluator for RstripEvaluator {
         "rstrip"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data] => match data.to_field(schema) {
                 Ok(data_field) => match &data_field.dtype {
@@ -34,7 +35,7 @@ impl FunctionEvaluator for RstripEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data] => data.utf8_rstrip(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/split.rs
+++ b/src/daft-dsl/src/functions/utf8/split.rs
@@ -16,7 +16,7 @@ impl FunctionEvaluator for SplitEvaluator {
         "split"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, pattern] => match (data.to_field(schema), pattern.to_field(schema)) {
                 (Ok(data_field), Ok(pattern_field)) => {
@@ -38,14 +38,11 @@ impl FunctionEvaluator for SplitEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], expr: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], expr: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, pattern] => {
                 let regex = match expr {
-                    Expr::Function {
-                        func: FunctionExpr::Utf8(Utf8Expr::Split(regex)),
-                        inputs: _,
-                    } => regex,
+                    FunctionExpr::Utf8(Utf8Expr::Split(regex)) => regex,
                     _ => panic!("Expected Utf8 Split Expr, got {expr}"),
                 };
                 data.utf8_split(pattern, *regex)

--- a/src/daft-dsl/src/functions/utf8/startswith.rs
+++ b/src/daft-dsl/src/functions/utf8/startswith.rs
@@ -5,6 +5,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use common_error::{DaftError, DaftResult};
 
 use super::super::FunctionEvaluator;
@@ -16,7 +17,7 @@ impl FunctionEvaluator for StartswithEvaluator {
         "startswith"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data, pattern] => match (data.to_field(schema), pattern.to_field(schema)) {
                 (Ok(data_field), Ok(pattern_field)) => {
@@ -38,7 +39,7 @@ impl FunctionEvaluator for StartswithEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data, pattern] => data.utf8_startswith(pattern),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-dsl/src/functions/utf8/upper.rs
+++ b/src/daft-dsl/src/functions/utf8/upper.rs
@@ -4,6 +4,7 @@ use daft_core::{
     series::Series,
 };
 
+use crate::functions::FunctionExpr;
 use crate::Expr;
 use common_error::{DaftError, DaftResult};
 
@@ -16,7 +17,7 @@ impl FunctionEvaluator for UpperEvaluator {
         "upper"
     }
 
-    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &Expr) -> DaftResult<Field> {
+    fn to_field(&self, inputs: &[Expr], schema: &Schema, _: &FunctionExpr) -> DaftResult<Field> {
         match inputs {
             [data] => match data.to_field(schema) {
                 Ok(data_field) => match &data_field.dtype {
@@ -34,7 +35,7 @@ impl FunctionEvaluator for UpperEvaluator {
         }
     }
 
-    fn evaluate(&self, inputs: &[Series], _: &Expr) -> DaftResult<Series> {
+    fn evaluate(&self, inputs: &[Series], _: &FunctionExpr) -> DaftResult<Series> {
         match inputs {
             [data] => data.utf8_upper(),
             _ => Err(DaftError::ValueError(format!(

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -382,7 +382,7 @@ impl Table {
                     .iter()
                     .map(|e| self.eval_expression(e))
                     .collect::<DaftResult<Vec<_>>>()?;
-                func.evaluate(evaluated_inputs.as_slice(), expr)
+                func.evaluate(evaluated_inputs.as_slice(), func)
             }
             Literal(lit_value) => Ok(lit_value.to_series()),
             IfElse {


### PR DESCRIPTION
It's sort of annoying to have to write the useless `Expr::Function` every time.

