### PR TITLE
[BUG] Fix reading partition key columns in DeltaLake

### DIFF
--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -84,12 +84,23 @@ def test_daft_iceberg_table_renamed_column_pushdown_collect_correct(local_iceber
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
 
 
+@pytest.mark.integration()
+def test_daft_iceberg_table_read_partition_column_identity(local_iceberg_catalog):
+    tab = local_iceberg_catalog.load_table(f"default.test_partitioned_by_identity")
+    df = daft.read_iceberg(tab)
+    df = df.select("ts", "number")
+    daft_pandas = df.to_pandas()
+    iceberg_pandas = tab.scan().to_arrow().to_pandas()
+    iceberg_pandas = iceberg_pandas[["ts", "number"]]
+    assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
+
+
 @pytest.mark.skip(
     reason="Selecting just the identity-transformed partition key in an iceberg table is not yet supported. "
     "Issue: https://github.com/Eventual-Inc/Daft/issues/2129"
 )
 @pytest.mark.integration()
-def test_daft_iceberg_table_read_partition_column_identity(local_iceberg_catalog):
+def test_daft_iceberg_table_read_partition_column_identity_only(local_iceberg_catalog):
     tab = local_iceberg_catalog.load_table(f"default.test_partitioned_by_identity")
     df = daft.read_iceberg(tab)
     df = df.select("ts")

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -109,6 +109,10 @@ def test_daft_iceberg_table_read_partition_column_identity_filter(local_iceberg_
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
 
 
+@pytest.mark.skip(
+    reason="Selecting just the identity-transformed partition key in an iceberg table is not yet supported. "
+    "Issue: https://github.com/Eventual-Inc/Daft/issues/2129"
+)
 @pytest.mark.integration()
 def test_daft_iceberg_table_read_partition_column_identity_filter_on_partkey(local_iceberg_catalog):
     tab = local_iceberg_catalog.load_table("default.test_partitioned_by_identity")

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -84,6 +84,10 @@ def test_daft_iceberg_table_renamed_column_pushdown_collect_correct(local_iceber
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
 
 
+@pytest.mark.skip(
+    reason="Selecting just the identity-transformed partition key in an iceberg table is not yet supported. "
+    "Issue: https://github.com/Eventual-Inc/Daft/issues/2129"
+)
 @pytest.mark.integration()
 def test_daft_iceberg_table_read_partition_column_identity(local_iceberg_catalog):
     tab = local_iceberg_catalog.load_table(f"default.test_partitioned_by_identity")

--- a/tests/integration/iceberg/test_table_load.py
+++ b/tests/integration/iceberg/test_table_load.py
@@ -82,3 +82,25 @@ def test_daft_iceberg_table_renamed_column_pushdown_collect_correct(local_iceber
     iceberg_pandas = tab.scan().to_arrow().to_pandas()
     iceberg_pandas = iceberg_pandas[["idx_renamed"]]
     assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
+
+
+@pytest.mark.integration()
+def test_daft_iceberg_table_read_partition_column_identity(local_iceberg_catalog):
+    tab = local_iceberg_catalog.load_table(f"default.test_partitioned_by_identity")
+    df = daft.read_iceberg(tab)
+    df = df.select("ts")
+    daft_pandas = df.to_pandas()
+    iceberg_pandas = tab.scan().to_arrow().to_pandas()
+    iceberg_pandas = iceberg_pandas[["ts"]]
+    assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])
+
+
+@pytest.mark.integration()
+def test_daft_iceberg_table_read_partition_column_transformed(local_iceberg_catalog):
+    tab = local_iceberg_catalog.load_table(f"default.test_partitioned_by_bucket")
+    df = daft.read_iceberg(tab)
+    df = df.select("number")
+    daft_pandas = df.to_pandas()
+    iceberg_pandas = tab.scan().to_arrow().to_pandas()
+    iceberg_pandas = iceberg_pandas[["number"]]
+    assert_df_equals(daft_pandas, iceberg_pandas, sort_key=[])

--- a/tests/io/delta_lake/test_table_read_pushdowns.py
+++ b/tests/io/delta_lake/test_table_read_pushdowns.py
@@ -131,11 +131,14 @@ def test_read_select_partition_key(deltalake_table):
     assert df.schema().column_names() == ["part_idx", "a"]
 
     assert_pyarrow_tables_equal(
-        df.to_arrow().sort_by("a"),
-        pa.concat_tables([table for table in tables]),
+        df.to_arrow().sort_by([("part_idx", "ascending"), ("a", "ascending")]),
+        pa.concat_tables([table.select(["part_idx", "a"]) for table in tables]).sort_by(
+            [("part_idx", "ascending"), ("a", "ascending")]
+        ),
     )
 
 
+@pytest.mark.skip(reason="Selecting just the partition key in a deltalake table is not yet supported.")
 def test_read_select_only_partition_key(deltalake_table):
     path, catalog_table, io_config, tables = deltalake_table
     df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
@@ -146,5 +149,5 @@ def test_read_select_only_partition_key(deltalake_table):
 
     assert_pyarrow_tables_equal(
         df.to_arrow().sort_by("part_idx"),
-        pa.concat_tables([table for table in tables]),
+        pa.concat_tables([table.select(["part_idx"]) for table in tables]).sort_by("part_idx"),
     )

--- a/tests/io/delta_lake/test_table_read_pushdowns.py
+++ b/tests/io/delta_lake/test_table_read_pushdowns.py
@@ -155,7 +155,10 @@ def test_read_select_partition_key_with_filter(deltalake_table):
     )
 
 
-@pytest.mark.skip(reason="Selecting just the partition key in a deltalake table is not yet supported.")
+@pytest.mark.skip(
+    reason="Selecting just the partition key in a deltalake table is not yet supported. "
+    "Issue: https://github.com/Eventual-Inc/Daft/issues/2129"
+)
 def test_read_select_only_partition_key(deltalake_table):
     path, catalog_table, io_config, tables = deltalake_table
     df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)

--- a/tests/io/delta_lake/test_table_read_pushdowns.py
+++ b/tests/io/delta_lake/test_table_read_pushdowns.py
@@ -120,3 +120,17 @@ def test_read_predicate_pushdown_on_part_empty(deltalake_table, partition_genera
         df.to_arrow().sort_by("part_idx"),
         pa.concat_tables([table.filter(pc.field("part_idx") == part_value) for table in tables]),
     )
+
+
+def test_read_select_partition_key(deltalake_table):
+    path, catalog_table, io_config, tables = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
+
+    df = df.select("part_idx")
+
+    assert df.schema().column_names == ["part_idx"]
+
+    assert_pyarrow_tables_equal(
+        df.to_arrow().sort_by("part_idx"),
+        pa.concat_tables([table for table in tables]),
+    )

--- a/tests/io/delta_lake/test_table_read_pushdowns.py
+++ b/tests/io/delta_lake/test_table_read_pushdowns.py
@@ -126,9 +126,23 @@ def test_read_select_partition_key(deltalake_table):
     path, catalog_table, io_config, tables = deltalake_table
     df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
 
+    df = df.select("part_idx", "a")
+
+    assert df.schema().column_names() == ["part_idx", "a"]
+
+    assert_pyarrow_tables_equal(
+        df.to_arrow().sort_by("a"),
+        pa.concat_tables([table for table in tables]),
+    )
+
+
+def test_read_select_only_partition_key(deltalake_table):
+    path, catalog_table, io_config, tables = deltalake_table
+    df = daft.read_delta_lake(str(path) if catalog_table is None else catalog_table, io_config=io_config)
+
     df = df.select("part_idx")
 
-    assert df.schema().column_names == ["part_idx"]
+    assert df.schema().column_names() == ["part_idx"]
 
     assert_pyarrow_tables_equal(
         df.to_arrow().sort_by("part_idx"),


### PR DESCRIPTION
Fixes pushdowns for column selection on partition keys in DeltaLake and Iceberg.

When table formats such as Iceberg and Delta Lake store the data for a partition column, they will strip the column from the actual Parquet data files that they write out. Then when we want to select only specific columns, our Parquet reader fails when it is not able to find those columns in the file.

NOTE: Seems like Iceberg only does this for identity transformed partition columns

Follow-on issue for selection of **only** the partition keys: https://github.com/Eventual-Inc/Daft/issues/2129