### PR TITLE
[CHORE] Fix documentation build with uv

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,7 @@ build:
     rust: '1.64'
   jobs:
     pre_build:
+    - export VIRTUAL_ENV=${READTHEDOCS_VIRTUALENV_PATH}
     - make VENV=${READTHEDOCS_VIRTUALENV_PATH} build
 
 sphinx:


### PR DESCRIPTION
`uv` discovers virtual envs using:

> An activated virtual environment based on the VIRTUAL_ENV environment variable.

This PR adds this environment variable in our readthedocs environment so that `uv` can correctly discover the venv.