### PR TITLE
[CHORE] Fix autolabeller CI step for forks

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,12 +8,12 @@ on:
     branches:
     - main
   # pull_request event is required only for autolabeler
-  pull_request:
+  # pull_request:
     # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+    # types: [opened, reopened, synchronize, edited, labeled, unlabeled]
   # pull_request_target event is required for autolabeler to support PRs from forks
-  # pull_request_target:
-  #   types: [opened, reopened, synchronize]
+  pull_request_target:
+    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,6 +13,7 @@ on:
     # types: [opened, reopened, synchronize, edited, labeled, unlabeled]
   # pull_request_target event is required for autolabeler to support PRs from forks
   pull_request_target:
+    branches: [main]
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
Triggers the auto-labelling CI using the `pull_request_target` trigger instead of `pull_request`, which should fix issues relating to that CI step not passing from PRs initiated from forks.