### PR TITLE
[CHORE] Fix underlines in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Quickstart
 
 In this example, we load images from an AWS S3 bucket's URLs and resize each image in the dataframe:
 
-.. code:: python
+.. code::
 
     import daft
 
@@ -66,6 +66,7 @@ In this example, we load images from an AWS S3 bucket's URLs and resize each ima
     df = df.with_column("resized", df["image"].image.resize(32, 32))
 
     df.show(3)
+
 
 |Quickstart Image|
 


### PR DESCRIPTION
<img width="758" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/17691182/6b6b6eee-7958-4154-aa75-9cda24ac05b5">

Fixes the odd underlines in our README's code.

See: https://github.com/orgs/community/discussions/113792