### PR TITLE
[FEAT] hide stack traces of wrappers for pytest / ipython

### DIFF
--- a/daft/analytics.py
+++ b/daft/analytics.py
@@ -207,9 +207,9 @@ def time_func(fn):
 
     @functools.wraps(fn)
     def tracked_fn(*args, **kwargs):
+        __tracebackhide__ = True
         if _ANALYTICS_CLIENT is None:
             return fn(*args, **kwargs)
-
         start = time.time()
         try:
             result = fn(*args, **kwargs)

--- a/daft/api_annotations.py
+++ b/daft/api_annotations.py
@@ -38,6 +38,7 @@ def PublicAPI(func: Callable[P, T]) -> Callable[P, T]:
 
     @functools.wraps(func)
     def _wrap(*args: P.args, **kwargs: P.kwargs) -> T:
+        __tracebackhide__ = True
         type_check_function(func, *args, **kwargs)
         timed_func = time_func(func)
         return timed_func(*args, **kwargs)


### PR DESCRIPTION
before:
<img width="979" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/2550285/24879393-be54-4e94-84eb-68e62e8f8d36">

after:
<img width="984" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/2550285/7f537892-97ad-4939-9c2e-1dd79f8c75e5">
