### PR TITLE
[FEAT] Enable anonymous S3 access for Delta

### DIFF
--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -209,9 +209,7 @@ def _s3_config_to_storage_options(s3_config: S3Config) -> dict[str, str]:
     if s3_config.connect_timeout_ms is not None:
         storage_options["connect_timeout"] = str(s3_config.connect_timeout_ms) + "ms"
     if s3_config.anonymous:
-        raise ValueError(
-            "Reading from DeltaLake does not support anonymous mode! Please supply credentials via your S3Config."
-        )
+        storage_options["skip_signature"] = "true"
     return storage_options
 
 


### PR DESCRIPTION
Enables anonymous mode for deltalake reading

Verified that this works:

```
df = daft.read_delta_lake("s3://daft-public-data/nyc-taxi-dataset-2023-jan-deltalake/", io_config=daft.io.IOConfig(s3=daft.io.S3Config(anonymous=True, region_name="us-west-2")))
```