### PR TITLE
[CHORE]: statically link liblzma

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,7 @@ dependencies = [
  "daft-stats",
  "daft-table",
  "libc",
+ "lzma-sys",
  "pyo3",
  "pyo3-log",
  "tikv-jemallocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ daft-plan = {path = "src/daft-plan", default-features = false}
 daft-scan = {path = "src/daft-scan", default-features = false}
 daft-stats = {path = "src/daft-stats", default-features = false}
 daft-table = {path = "src/daft-table", default-features = false}
+lzma-sys = {version = "*", features = ["static"]}
 pyo3 = {workspace = true, optional = true}
 pyo3-log = {workspace = true, optional = true}
 


### PR DESCRIPTION
closes #2211 

```sh
> otool -L daft/daft.abi3.so | grep 'liblzma'   
# empty
```