### PR TITLE
[BUG] Propagate errors when hitting them in parquet byte stream

### DIFF
--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -133,6 +133,18 @@ impl From<Error> for DaftError {
             ReadTimeout { .. } => DaftError::ReadTimeout(err.into()),
             UnableToReadBytes { .. } => DaftError::ByteStreamError(err.into()),
             SocketError { .. } => DaftError::SocketError(err.into()),
+            // We have to repeat everything above for the case we have an Arc since we can't move the error.
+            CachedError { ref source } => match source.as_ref() {
+                NotFound { path, source: _ } => DaftError::FileNotFound {
+                    path: path.clone(),
+                    source: err.into(),
+                },
+                ConnectTimeout { .. } => DaftError::ConnectTimeout(err.into()),
+                ReadTimeout { .. } => DaftError::ReadTimeout(err.into()),
+                UnableToReadBytes { .. } => DaftError::ByteStreamError(err.into()),
+                SocketError { .. } => DaftError::SocketError(err.into()),
+                _ => DaftError::External(err.into()),
+            },
             _ => DaftError::External(err.into()),
         }
     }

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -31,10 +31,10 @@ where
         None => Ok(first),
         Some(second) => {
             let size_hint = size_hint.unwrap_or_else(|| first.len() + second.len());
-
             let mut buf = Vec::with_capacity(size_hint);
             buf.extend_from_slice(&first);
             buf.extend_from_slice(&second);
+
             while let Some(maybe_bytes) = stream.next().await {
                 buf.extend_from_slice(&maybe_bytes?);
             }


### PR DESCRIPTION
* Wait on errors for the first chunk to finish in the parquet reader
* No longer panic on error when encountering them in the byte reader
* Unwrap cached error when exporting