### PR TITLE
[PERF] enable metadata preservation across materialization points

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1271,6 +1271,61 @@ class DataFrame:
         """
         return GroupedDataFrame(self, ExpressionsProjection(self._inputs_to_expressions(group_by)))
 
+    @DataframePublicAPI
+    def pivot(
+        self,
+        group_by: ColumnInputType,
+        pivot_col: ColumnInputType,
+        value_col: ColumnInputType,
+        agg_fn: str,
+        names: Optional[List[str]] = None,
+    ) -> "DataFrame":
+        """Pivots a column of the DataFrame and performs an aggregation on the values.
+
+        .. NOTE::
+            You may wish to provide a list of distinct values to pivot on, which is more efficient as it avoids
+            a distinct operation. Without this list, Daft will perform a distinct operation on the pivot column to
+            determine the unique values to pivot on.
+
+        Example:
+            >>> data = {
+                "id": [1, 2, 3, 4],
+                "version": ["3.8", "3.8", "3.9", "3.9"],
+                "platform": ["macos", "macos", "macos", "windows"],
+                "downloads": [100, 200, 150, 250],
+            }
+            >>> df = daft.from_pydict(data)
+            >>> df = df.pivot("version", "platform", "downloads", "sum")
+            >>> df.show()
+            ╭─────────┬─────────┬───────╮
+            │ version ┆ windows ┆ macos │
+            │ ---     ┆ ---     ┆ ---   │
+            │ Utf8    ┆ Int64   ┆ Int64 │
+            ╞═════════╪═════════╪═══════╡
+            │ 3.9     ┆ 250     ┆ 150   │
+            ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 3.8     ┆ None    ┆ 300   │
+            ╰─────────┴─────────┴───────╯
+
+        Args:
+            group_by (Union[str, Expression]): column to group by
+            pivot_col (Union[str, Expression]): column to pivot
+            value_col (Union[str, Expression]): column to aggregate
+            agg_fn (str): aggregation function to apply
+            names (Optional[List[str]]): names of the pivoted columns
+
+        Returns:
+            DataFrame: DataFrame with pivoted columns
+
+        """
+        group_by, pivot_col, value_col = self.__column_input_to_expression([group_by, pivot_col, value_col])
+        agg_expr = self._agg_tuple_to_expression((value_col, agg_fn))
+        if names is None:
+            names = self.select(pivot_col).distinct().to_pydict()[pivot_col.name()]
+            names = [str(x) for x in names]
+        builder = self._builder.pivot(group_by, pivot_col, value_col, agg_expr, names)
+        return DataFrame(builder)
+
     def _materialize_results(self) -> None:
         """Materializes the results of for this DataFrame and hold a pointer to the results."""
         context = get_context()

--- a/daft/io/file_path.py
+++ b/daft/io/file_path.py
@@ -47,7 +47,8 @@ def from_glob_path(path: str, io_config: Optional[IOConfig] = None) -> DataFrame
     runner_io = context.runner().runner_io()
     file_infos = runner_io.glob_paths_details([path], io_config=io_config)
     file_infos_table = MicroPartition._from_pytable(file_infos.to_table())
-    partition = LocalPartitionSet({0: file_infos_table})
+    partition = LocalPartitionSet()
+    partition.set_partition_from_table(0, file_infos_table)
     cache_entry = context.runner().put_partition_set_into_cache(partition)
     size_bytes = partition.size_bytes()
     assert size_bytes is not None, "In-memory data should always have non-None size in bytes"

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -232,18 +232,18 @@ class PartitionSet(Generic[PartitionT]):
         merged_partition = self._get_merged_vpartition()
         return merged_partition.to_arrow(cast_tensors_to_ray_tensor_dtype)
 
-    def items(self) -> list[tuple[PartID, PartitionT]]:
+    def items(self) -> list[tuple[PartID, MaterializedResult[PartitionT]]]:
         """
         Returns all (partition id, partition) in this PartitionSet,
         ordered by partition ID.
         """
         raise NotImplementedError()
 
-    def values(self) -> list[PartitionT]:
+    def values(self) -> list[MaterializedResult[PartitionT]]:
         return [value for _, value in self.items()]
 
     @abstractmethod
-    def get_partition(self, idx: PartID) -> PartitionT:
+    def get_partition(self, idx: PartID) -> MaterializedResult[PartitionT]:
         raise NotImplementedError()
 
     @abstractmethod

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -152,9 +152,9 @@ class PyRunner(Runner[MicroPartition]):
 
         # Optimize the logical plan.
         builder = builder.optimize()
+
         # Finalize the logical plan and get a physical plan scheduler for translating the
         # physical plan to executable tasks.
-
         plan_scheduler = builder.to_physical_plan_scheduler(daft_execution_config)
         psets = {k: v.values() for k, v in self._part_set_cache.get_all_partition_sets().items()}
         # Get executable tasks from planner.

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -15,6 +15,7 @@ from daft.logical.builder import LogicalPlanBuilder
 from daft.runners import runner_io
 from daft.runners.partitioning import (
     MaterializedResult,
+    PartialPartitionMetadata,
     PartID,
     PartitionCacheEntry,
     PartitionMetadata,
@@ -28,23 +29,27 @@ from daft.table import MicroPartition
 logger = logging.getLogger(__name__)
 
 
-@dataclass
 class LocalPartitionSet(PartitionSet[MicroPartition]):
-    _partitions: dict[PartID, MicroPartition]
+    _partitions: dict[PartID, MaterializedResult[MicroPartition]]
 
-    def items(self) -> list[tuple[PartID, MicroPartition]]:
+    def __init__(self) -> None:
+        super().__init__()
+        self._partitions = {}
+
+    def items(self) -> list[tuple[PartID, MaterializedResult[MicroPartition]]]:
         return sorted(self._partitions.items())
 
     def _get_merged_vpartition(self) -> MicroPartition:
         ids_and_partitions = self.items()
         assert ids_and_partitions[0][0] == 0
         assert ids_and_partitions[-1][0] + 1 == len(ids_and_partitions)
-        return MicroPartition.concat([part for id, part in ids_and_partitions])
+        return MicroPartition.concat([part.partition() for id, part in ids_and_partitions])
 
     def _get_preview_vpartition(self, num_rows: int) -> list[MicroPartition]:
         ids_and_partitions = self.items()
         preview_parts = []
-        for _, part in ids_and_partitions:
+        for _, mat_result in ids_and_partitions:
+            part: MicroPartition = mat_result.partition()
             part_len = len(part)
             if part_len >= num_rows:  # if this part has enough rows, take what we need and break
                 preview_parts.append(part.slice(0, num_rows))
@@ -54,11 +59,14 @@ class LocalPartitionSet(PartitionSet[MicroPartition]):
                 preview_parts.append(part)
         return preview_parts
 
-    def get_partition(self, idx: PartID) -> MicroPartition:
+    def get_partition(self, idx: PartID) -> MaterializedResult[MicroPartition]:
         return self._partitions[idx]
 
     def set_partition(self, idx: PartID, part: MaterializedResult[MicroPartition]) -> None:
-        self._partitions[idx] = part.partition()
+        self._partitions[idx] = part
+
+    def set_partition_from_table(self, idx: PartID, part: MicroPartition) -> None:
+        self._partitions[idx] = PyMaterializedResult(part, PartitionMetadata.from_table(part))
 
     def delete_partition(self, idx: PartID) -> None:
         del self._partitions[idx]
@@ -67,10 +75,10 @@ class LocalPartitionSet(PartitionSet[MicroPartition]):
         return idx in self._partitions
 
     def __len__(self) -> int:
-        return sum(len(partition) for partition in self._partitions.values())
+        return sum(len(partition.partition()) for partition in self._partitions.values())
 
     def size_bytes(self) -> int | None:
-        size_bytes_ = [partition.size_bytes() for partition in self._partitions.values()]
+        size_bytes_ = [partition.partition().size_bytes() for partition in self._partitions.values()]
         size_bytes: list[int] = [size for size in size_bytes_ if size is not None]
         if len(size_bytes) != len(size_bytes_):
             return None
@@ -126,7 +134,7 @@ class PyRunner(Runner[MicroPartition]):
     def run(self, builder: LogicalPlanBuilder) -> PartitionCacheEntry:
         results = list(self.run_iter(builder))
 
-        result_pset = LocalPartitionSet({})
+        result_pset = LocalPartitionSet()
         for i, result in enumerate(results):
             result_pset.set_partition(i, result)
 
@@ -146,6 +154,7 @@ class PyRunner(Runner[MicroPartition]):
         builder = builder.optimize()
         # Finalize the logical plan and get a physical plan scheduler for translating the
         # physical plan to executable tasks.
+
         plan_scheduler = builder.to_physical_plan_scheduler(daft_execution_config)
         psets = {k: v.values() for k, v in self._part_set_cache.get_all_partition_sets().items()}
         # Get executable tasks from planner.
@@ -209,8 +218,10 @@ class PyRunner(Runner[MicroPartition]):
                                 )
                             ):
                                 logger.debug("Running task synchronously in main thread: %s", next_step)
-                                partitions = self.build_partitions(next_step.instructions, *next_step.inputs)
-                                next_step.set_result([PyMaterializedResult(partition) for partition in partitions])
+                                materialized_results = self.build_partitions(
+                                    next_step.instructions, next_step.inputs, next_step.partial_metadatas
+                                )
+                                next_step.set_result(materialized_results)
 
                             else:
                                 # Submit the task for execution.
@@ -220,7 +231,10 @@ class PyRunner(Runner[MicroPartition]):
                                 pbar.mark_task_start(next_step)
 
                                 future = thread_pool.submit(
-                                    self.build_partitions, next_step.instructions, *next_step.inputs
+                                    self.build_partitions,
+                                    next_step.instructions,
+                                    next_step.inputs,
+                                    next_step.partial_metadatas,
                                 )
                                 # Register the inflight task and resources used.
                                 future_to_task[future] = next_step.id()
@@ -239,12 +253,13 @@ class PyRunner(Runner[MicroPartition]):
                         done_id = future_to_task.pop(done_future)
                         del inflight_tasks_resources[done_id]
                         done_task = inflight_tasks.pop(done_id)
-                        partitions = done_future.result()
+                        materialized_results = done_future.result()
 
                         pbar.mark_task_done(done_task)
 
-                        logger.debug("Task completed: %s -> <%s partitions>", done_id, len(partitions))
-                        done_task.set_result([PyMaterializedResult(partition) for partition in partitions])
+                        logger.debug("Task completed: %s -> <%s partitions>", done_id, len(materialized_results))
+
+                        done_task.set_result(materialized_results)
 
                     if next_step is None:
                         next_step = next(plan)
@@ -278,17 +293,23 @@ class PyRunner(Runner[MicroPartition]):
         return all((cpus_okay, gpus_okay, memory_okay))
 
     @staticmethod
-    def build_partitions(instruction_stack: list[Instruction], *inputs: MicroPartition) -> list[MicroPartition]:
-        partitions = list(inputs)
+    def build_partitions(
+        instruction_stack: list[Instruction],
+        partitions: list[MicroPartition],
+        final_metadata: list[PartialPartitionMetadata],
+    ) -> list[MaterializedResult[MicroPartition]]:
         for instruction in instruction_stack:
             partitions = instruction.run(partitions)
+        return [
+            PyMaterializedResult(part, PartitionMetadata.from_table(part).merge_with_partial(partial))
+            for part, partial in zip(partitions, final_metadata)
+        ]
 
-        return partitions
 
-
-@dataclass(frozen=True)
+@dataclass
 class PyMaterializedResult(MaterializedResult[MicroPartition]):
     _partition: MicroPartition
+    _metadata: PartitionMetadata | None = None
 
     def partition(self) -> MicroPartition:
         return self._partition
@@ -297,7 +318,9 @@ class PyMaterializedResult(MaterializedResult[MicroPartition]):
         return self._partition
 
     def metadata(self) -> PartitionMetadata:
-        return PartitionMetadata.from_table(self._partition)
+        if self._metadata is None:
+            self._metadata = PartitionMetadata.from_table(self._partition)
+        return self._metadata
 
     def cancel(self) -> None:
         return None


### PR DESCRIPTION
* When enabling AQE, we introduce intermediate materializations for a query with multiple shuffles.
* The problem with this is that metadata is not preserved across materialization boundaries. 
* So if we are running a SortMergeJoin and we draw a boundary after the sort and before the join, the algorithm errors out because the `boundaries` value is not set on the `MaterializedResult`.
* This happens because at the `.collect()` point, we place `Micropartitions` into the cache rather than the `MaterializedResult` which contains both the data and `PartitionMetadata`.

We already do this behavior for the ray runner, this PR formalizes it for all runners.