### PR TITLE
[PERF] Evaluate only true/false side of if_else if predicate is boolean

### DIFF
--- a/src/daft-dsl/src/expr.rs
+++ b/src/daft-dsl/src/expr.rs
@@ -735,7 +735,9 @@ impl Expr {
                 }
                 match predicate.as_ref() {
                     Expr::Literal(lit::LiteralValue::Boolean(true)) => if_true.to_field(schema),
-                    Expr::Literal(lit::LiteralValue::Boolean(false)) => if_false.to_field(schema),
+                    Expr::Literal(lit::LiteralValue::Boolean(false)) => {
+                        Ok(if_false.to_field(schema)?.rename(if_true.name()?))
+                    }
                     _ => {
                         let if_true_field = if_true.to_field(schema)?;
                         let if_false_field = if_false.to_field(schema)?;

--- a/src/daft-dsl/src/expr.rs
+++ b/src/daft-dsl/src/expr.rs
@@ -730,8 +730,8 @@ impl Expr {
                 let predicate_field = predicate.to_field(schema)?;
                 if predicate_field.dtype != DataType::Boolean {
                     return Err(DaftError::TypeError(format!(
-                                "Expected predicate for if_else to be boolean but received {predicate_field}",
-                            )));
+                        "Expected predicate for if_else to be boolean but received {predicate_field}",
+                    )));
                 }
                 match predicate.as_ref() {
                     Expr::Literal(lit::LiteralValue::Boolean(true)) => if_true.to_field(schema),

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -17,7 +17,7 @@ use daft_core::schema::{Schema, SchemaRef};
 use daft_core::series::{IntoSeries, Series};
 
 use daft_dsl::functions::FunctionEvaluator;
-use daft_dsl::{col, null_lit, AggExpr, ApproxPercentileParams, Expr, ExprRef};
+use daft_dsl::{col, null_lit, AggExpr, ApproxPercentileParams, Expr, ExprRef, LiteralValue};
 #[cfg(feature = "python")]
 pub mod ffi;
 mod ops;
@@ -400,12 +400,16 @@ impl Table {
                 if_true,
                 if_false,
                 predicate,
-            } => {
-                let if_true_series = self.eval_expression(if_true)?;
-                let if_false_series = self.eval_expression(if_false)?;
-                let predicate_series = self.eval_expression(predicate)?;
-                Ok(if_true_series.if_else(&if_false_series, &predicate_series)?)
-            }
+            } => match predicate.as_ref() {
+                Expr::Literal(LiteralValue::Boolean(true)) => self.eval_expression(if_true),
+                Expr::Literal(LiteralValue::Boolean(false)) => self.eval_expression(if_false),
+                _ => {
+                    let if_true_series = self.eval_expression(if_true)?;
+                    let if_false_series = self.eval_expression(if_false)?;
+                    let predicate_series = self.eval_expression(predicate)?;
+                    Ok(if_true_series.if_else(&if_false_series, &predicate_series)?)
+                }
+            },
         }?;
         if expected_field.name != series.field().name {
             return Err(DaftError::ComputeError(format!(

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -402,7 +402,9 @@ impl Table {
                 predicate,
             } => match predicate.as_ref() {
                 Expr::Literal(LiteralValue::Boolean(true)) => self.eval_expression(if_true),
-                Expr::Literal(LiteralValue::Boolean(false)) => self.eval_expression(if_false),
+                Expr::Literal(LiteralValue::Boolean(false)) => {
+                    Ok(self.eval_expression(if_false)?.rename(if_true.name()?))
+                }
                 _ => {
                     let if_true_series = self.eval_expression(if_true)?;
                     let if_false_series = self.eval_expression(if_false)?;

--- a/tests/table/test_if_else.py
+++ b/tests/table/test_if_else.py
@@ -38,4 +38,4 @@ def test_table_expr_if_else_literal_predicate(if_else_expr) -> None:
     daft_table = daft_table.eval_expression_list([if_else_expr])
     pydict = daft_table.to_pydict()
 
-    assert pydict == {"key": ["value"]}
+    assert pydict == {if_else_expr.name(): ["value"]}


### PR DESCRIPTION
Closes #2190 

If the predicate for an if_else statement is a boolean, i.e true/false, we only need to evaluate one side of the expression.