### PR TITLE
[CHORE]: remove trait aliases

### DIFF
--- a/src/daft-json/src/read.rs
+++ b/src/daft-json/src/read.rs
@@ -24,20 +24,16 @@ use crate::{
 };
 use daft_compression::CompressionCodec;
 
-trait LineChunkStream = Stream<Item = super::Result<Vec<String>>>;
-trait ColumnArrayChunkStream = Stream<
-    Item = super::Result<
-        Context<
-            JoinHandle<DaftResult<Vec<Box<dyn arrow2::array::Array>>>>,
-            super::JoinSnafu,
-            super::Error,
-        >,
-    >,
->;
+type TableChunkResult =
+    super::Result<Context<JoinHandle<DaftResult<Table>>, super::JoinSnafu, super::Error>>;
 
-trait TableChunkStream = Stream<
-    Item = super::Result<Context<JoinHandle<DaftResult<Table>>, super::JoinSnafu, super::Error>>,
->;
+type LineChunkResult = super::Result<Vec<String>>;
+
+trait TableChunkStream: Stream<Item = TableChunkResult> {}
+impl<T> TableChunkStream for T where T: Stream<Item = TableChunkResult> {}
+
+trait LineChunkStream: Stream<Item = LineChunkResult> {}
+impl<T> LineChunkStream for T where T: Stream<Item = LineChunkResult> {}
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_json(
@@ -170,13 +166,6 @@ fn tables_concat(mut tables: Vec<Table>) -> DaftResult<Table> {
     Table::new(first_table.schema.clone(), new_series)
 }
 
-#[inline]
-fn assert_stream_send<'u, R>(
-    s: impl 'u + Send + Stream<Item = R>,
-) -> impl 'u + Send + Stream<Item = R> {
-    s
-}
-
 async fn read_json_single_into_table(
     uri: &str,
     convert_options: Option<JsonConvertOptions>,
@@ -234,7 +223,7 @@ async fn read_json_single_into_table(
         // Limit the number of chunks we have in flight at any given time.
         .try_buffered(max_chunks_in_flight);
 
-    let filtered_tables = assert_stream_send(tables.map_ok(move |table| {
+    let filtered_tables = tables.map_ok(move |table| {
         if let Some(predicate) = &predicate {
             let filtered = table?.filter(&[predicate.clone()])?;
             if let Some(include_columns) = &include_columns {
@@ -245,7 +234,7 @@ async fn read_json_single_into_table(
         } else {
             table
         }
-    }));
+    });
     let mut remaining_rows = limit.map(|limit| limit as i64);
     let collected_tables = filtered_tables
         .try_take_while(|result| {


### PR DESCRIPTION
this is just a small change to remove the usage of unstable [trait_aliases](https://doc.rust-lang.org/unstable-book/language-features/trait-alias.html) in favor of trait impls. 

This greatly improves the developer experience because rust-analyzer can now properly detect the types. 

## before
![image](https://github.com/Eventual-Inc/Daft/assets/21327470/c09a2508-b510-4189-bf9a-8d446401af73)

## after
![image](https://github.com/Eventual-Inc/Daft/assets/21327470/11019ae9-d7c6-4d2a-95ff-49e29c56fe49)
