### PR TITLE
[FEAT] Propagate buffer size during dataframe partition iteration

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,6 +87,9 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '7.0.0') }}
       run: pip install deltalake==0.10.0
 
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
+
     - name: Build library and Test with pytest (unix)
       if: ${{ (runner.os != 'Windows') }}
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,9 +87,6 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '7.0.0') }}
       run: pip install deltalake==0.10.0
 
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
-
     - name: Build library and Test with pytest (unix)
       if: ${{ (runner.os != 'Windows') }}
       run: |

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -212,14 +212,16 @@ class DataFrame:
                     yield row
 
     @DataframePublicAPI
-    def iter_partitions(self, results_buffer_size: Optional[int] = 1) -> Iterator[Union[MicroPartition, "ray.ObjectRef[MicroPartition]"]]:
+    def iter_partitions(
+        self, results_buffer_size: Optional[int] = 1
+    ) -> Iterator[Union[MicroPartition, "ray.ObjectRef[MicroPartition]"]]:
         """Begin executing this dataframe and return an iterator over the partitions.
 
         Each partition will be returned as a daft.Table object (if using Python runner backend)
         or a ray ObjectRef (if using Ray runner backend).
 
         Args:
-            results_buffer_size: how many partitions to allow in the results buffer (only affects execution with Ray).
+            results_buffer_size: how many partitions to allow in the results buffer (defaults to 1).
                 Setting this value value will buffer results up to the provided size and provide backpressure
                 to dataframe execution based on the rate of consumption from the returned iterator. Setting this to
                 `None` will result in a buffer of unbounded size, causing the dataframe run asynchronously

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -219,12 +219,15 @@ class DataFrame:
         or a ray ObjectRef (if using Ray runner backend).
 
         Args:
-            results_buffer_size: how many partitions to allow in the results buffer. Setting this value
-                value will buffer results up to the provided size and provide backpressure to dataframe
-                execution based on the rate of consumption from the returned iterator. Setting this to
+            results_buffer_size: how many partitions to allow in the results buffer (only affects execution with Ray).
+                Setting this value value will buffer results up to the provided size and provide backpressure
+                to dataframe execution based on the rate of consumption from the returned iterator. Setting this to
                 `None` will result in a buffer of unbounded size, causing the dataframe run asynchronously
                 to completion.
         """
+        if results_buffer_size is not None and not results_buffer_size > 0:
+            raise ValueError(f"Provided `results_buffer_size` value must be > 0, received: {results_buffer_size}")
+
         if self._result is not None:
             # If the dataframe has already finished executing,
             # use the precomputed results.

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import pathlib
+import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Generic, Protocol
 
@@ -170,13 +171,25 @@ class SingleOutputPartitionTask(PartitionTask[PartitionT]):
     # When available, the partition created from running the PartitionTask.
     _result: None | MaterializedResult[PartitionT] = None
 
+    # Condition variable to allow for waiting on result
+    _done_cv: threading.Condition = threading.Condition()
+
     def set_result(self, result: list[MaterializedResult[PartitionT]]) -> None:
         assert self._result is None, f"Cannot set result twice. Result is already {self._result}"
         [partition] = result
-        self._result = partition
+
+        with self._done_cv:
+            self._result = partition
+            self._done_cv.notify_all()
 
     def done(self) -> bool:
         return self._result is not None
+
+    def result_or_wait(self) -> MaterializedResult[PartitionT]:
+        with self._done_cv:
+            while not self.done():
+                self._done_cv.wait()
+            return self.result()
 
     def result(self) -> MaterializedResult[PartitionT]:
         assert self._result is not None, "Cannot call .result() on a PartitionTask that is not done"

--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -19,7 +19,7 @@ import logging
 import math
 import pathlib
 from collections import deque
-from typing import TYPE_CHECKING, Generator, Generic, Iterable, Iterator, TypeVar, Union
+from typing import TYPE_CHECKING, Generator, Generic, Iterable, Iterator, Optional, Tuple, TypeVar, Union
 
 from daft.context import get_context
 from daft.daft import FileFormat, IOConfig, JoinType, ResourceRequest
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 InProgressPhysicalPlan = Iterator[Union[None, PartitionTask[PartitionT], PartitionTaskBuilder[PartitionT]]]
 
 # A PhysicalPlan that is complete and will only yield PartitionTasks or final PartitionTs.
-MaterializedPhysicalPlan = Iterator[Union[None, PartitionTask[PartitionT], MaterializedResult[PartitionT]]]
+MaterializedPhysicalPlan = Iterator[Tuple[Optional[PartitionTask[PartitionT]], bool]]
 
 
 def _stage_id_counter():
@@ -1459,47 +1459,31 @@ def fanout_random(child_plan: InProgressPhysicalPlan[PartitionT], num_partitions
 
 def materialize(
     child_plan: InProgressPhysicalPlan[PartitionT],
-    max_result_buffer_size: int | None = None,
 ) -> MaterializedPhysicalPlan:
     """Materialize the child plan.
 
-    Repeatedly yields either a PartitionTask (to produce an intermediate partition)
-    or a PartitionT (which is part of the final result).
+    Repeatedly yields either a PartitionTask (to produce an intermediate partition) and
+    a boolean indicating whether or not this is a final result.
 
     Args:
         child_plan: Child "in progress" plan
-        max_result_buffer_size: Maximum size of the result buffer, at which point no forward
-            progress will be allowed to be made
     """
 
-    materializations: deque[SingleOutputPartitionTask[PartitionT]] = deque()
     stage_id = next(stage_id_counter)
-    while True:
-        # Check if any inputs finished executing.
-        while len(materializations) > 0 and materializations[0].done():
-            done_task = materializations.popleft()
-            yield done_task.result()
 
-        # Check if maximum number of materializations has been hit
-        if max_result_buffer_size is not None and len(materializations) >= max_result_buffer_size:
-            yield None
-            continue
-
-        # Materialize a single dependency.
-        try:
-            step = next(child_plan)
-            if isinstance(step, PartitionTaskBuilder):
-                step = step.finalize_partition_task_single_output(stage_id=stage_id)
-                materializations.append(step)
-            assert isinstance(step, (PartitionTask, type(None)))
-            yield step
-
-        except StopIteration:
-            if len(materializations) > 0:
-                logger.debug("materialize blocked on completion of all sources: %s", materializations)
-                yield None
-            else:
-                return
+    # Materialize a single dependency.
+    for step in child_plan:
+        # None indicates that no forward progress can be made yet
+        if step is None:
+            yield (step, False)
+        # PartitionTaskBuilder indicates that this is a final materialization
+        elif isinstance(step, PartitionTaskBuilder):
+            step = step.finalize_partition_task_single_output(stage_id=stage_id)
+            yield (step, True)
+        # PartitionTask indicates an intermediate result
+        else:
+            assert isinstance(step, PartitionTask)
+            yield (step, False)
 
 
 def enumerate_open_executions(

--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -52,7 +52,8 @@ if TYPE_CHECKING:
 # A PhysicalPlan that is still being built - may yield both PartitionTaskBuilders and PartitionTasks.
 InProgressPhysicalPlan = Iterator[Union[None, PartitionTask[PartitionT], PartitionTaskBuilder[PartitionT]]]
 
-# A PhysicalPlan that is complete and will only yield PartitionTasks or final PartitionTs.
+# A PhysicalPlan that is complete and will only yield PartitionTasks and a boolean indicating whether
+# or not this PartitionTask is part of the final result set
 MaterializedPhysicalPlan = Iterator[Tuple[Optional[PartitionTask[PartitionT]], bool]]
 
 

--- a/daft/plan_scheduler/physical_plan_scheduler.py
+++ b/daft/plan_scheduler/physical_plan_scheduler.py
@@ -32,11 +32,9 @@ class PhysicalPlanScheduler:
     def to_partition_tasks(
         self,
         psets: dict[str, list[PartitionT]],
-        max_result_buffer_size: int | None = None,
     ) -> physical_plan.MaterializedPhysicalPlan:
         return physical_plan.materialize(
             self._scheduler.to_partition_tasks(psets),
-            max_result_buffer_size=max_result_buffer_size,
         )
 
 

--- a/daft/plan_scheduler/physical_plan_scheduler.py
+++ b/daft/plan_scheduler/physical_plan_scheduler.py
@@ -29,8 +29,15 @@ class PhysicalPlanScheduler:
     def __repr__(self) -> str:
         return self._scheduler.repr_ascii(simple=False)
 
-    def to_partition_tasks(self, psets: dict[str, list[PartitionT]]) -> physical_plan.MaterializedPhysicalPlan:
-        return physical_plan.materialize(self._scheduler.to_partition_tasks(psets))
+    def to_partition_tasks(
+        self,
+        psets: dict[str, list[PartitionT]],
+        max_result_buffer_size: int | None = None,
+    ) -> physical_plan.MaterializedPhysicalPlan:
+        return physical_plan.materialize(
+            self._scheduler.to_partition_tasks(psets),
+            max_result_buffer_size=max_result_buffer_size,
+        )
 
 
 class AdaptivePhysicalPlanScheduler:

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -231,7 +231,7 @@ class PyRunner(Runner[MicroPartition]):
                         yield materialized_result
 
                     # Skip task dispatching and go back to waiting on results if result buffer is already too full
-                    if results_buffer_size is not None and len(final_results) >= results_buffer_size:
+                    if results_buffer_size is not None and len(final_results) >= results_buffer_size + 1:
                         _await_at_least_one_task()
                         continue
 
@@ -342,7 +342,7 @@ class PyRunner(Runner[MicroPartition]):
 
         buffer_okay = True
         if results_buffer_size is not None:
-            buffer_okay = final_result_len < results_buffer_size
+            buffer_okay = final_result_len < results_buffer_size + 1
 
         return all((cpus_okay, gpus_okay, memory_okay, buffer_okay))
 

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -292,7 +292,7 @@ class PyRunner(Runner[MicroPartition]):
                             next_step, is_final = next(plan)
 
                     # Yield a result if no more dispatching is possible
-                    if num_dispatched == 0 and results_buffer and results_buffer[0].done():
+                    if results_buffer and results_buffer[0].done():
                         materialized_result = results_buffer.popleft().result()
                         assert isinstance(materialized_result, PyMaterializedResult)
                         yield materialized_result

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -246,6 +246,7 @@ class PyRunner(Runner[MicroPartition]):
                             inflight_tasks_resources.values(),
                             len(final_results),
                             results_buffer_size,
+                            is_final,
                         ):
                             # Insufficient resources; await some tasks.
                             break
@@ -330,6 +331,7 @@ class PyRunner(Runner[MicroPartition]):
         inflight_resources: Iterable[ResourceRequest],
         final_result_len: int,
         results_buffer_size: int | None,
+        is_final: bool,
     ) -> bool:
         self._check_resource_requests(resource_request)
 
@@ -342,7 +344,7 @@ class PyRunner(Runner[MicroPartition]):
 
         buffer_okay = True
         if results_buffer_size is not None:
-            buffer_okay = final_result_len < results_buffer_size + 1
+            buffer_okay = not is_final or (final_result_len < results_buffer_size + 1)
 
         return all((cpus_okay, gpus_okay, memory_okay, buffer_okay))
 

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -226,7 +226,6 @@ class PyRunner(Runner[MicroPartition]):
                 # Dispatch->Await loop.
                 while True:
                     # Dispatch loop.
-                    num_dispatched = 0
                     while True:
                         if next_step is None:
                             # Blocked on already dispatched tasks; await some tasks.
@@ -271,7 +270,6 @@ class PyRunner(Runner[MicroPartition]):
 
                             else:
                                 # Submit the task for execution.
-                                num_dispatched += 1
                                 logger.debug("Submitting task for execution: %s", next_step)
 
                                 # update progress bar

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -460,7 +460,7 @@ class Scheduler:
             assert isinstance(result, RayMaterializedResult)
             return result
         else:
-            assert isinstance(result, StopIteration)
+            assert isinstance(partition_task, StopIteration)
             return partition_task
 
     def start_plan(

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -149,7 +149,7 @@ def test_iter_partitions_with_buffer_limit_1(tmp_path, make_df):
         next(it)
 
 
-def test_iter_partitions_with_buffer_limit_3(tmp_path, make_df):
+def test_iter_partitions_with_buffer_limit_2(tmp_path, make_df):
     files_location = tmp_path / "files"
     files_location.mkdir(exist_ok=True)
 
@@ -160,7 +160,7 @@ def test_iter_partitions_with_buffer_limit_3(tmp_path, make_df):
         return s
 
     df = make_df({"a": list(range(8))}).into_partitions(7).with_column("b", write_file(daft.col("a")))
-    it = df.iter_partitions(results_buffer_size=3)
+    it = df.iter_partitions(results_buffer_size=2)
 
     data = []
 
@@ -169,20 +169,20 @@ def test_iter_partitions_with_buffer_limit_3(tmp_path, make_df):
     data.append(next(it))
     time.sleep(0.5)
     assert (
-        len(os.listdir(files_location)) == 4
-    ), "First iteration should trigger 4 calls of write_file: 1 for the iterator result, 3 buffered"
+        len(os.listdir(files_location)) <= 3
+    ), "First iteration should trigger <=3 calls of write_file: 1 for the iterator result, 2 buffered"
 
     data.append(next(it))
     time.sleep(0.5)
     assert (
-        len(os.listdir(files_location)) == 5
+        len(os.listdir(files_location)) <= 4
     ), "Subsequent single iteration should trigger 1 call of write_file to refill the buffer"
 
     for _ in range(2):
         data.append(next(it))
     time.sleep(0.5)
     assert (
-        len(os.listdir(files_location)) == 7
+        len(os.listdir(files_location)) <= 6
     ), "Subsequent rapid iteration twice in a row should trigger 2 calls to refill buffer"
 
     for _ in range(3):

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -121,62 +121,32 @@ def test_iter_partitions_with_buffer_limit_1(tmp_path, make_df):
 
     assert os.listdir(files_location) == [], "Directory should have no files initially"
 
-    if daft.context.get_context().runner_config.name == "py":
-        data.append(next(it))
-        time.sleep(0.2)
-        assert (
-            len(os.listdir(files_location)) == 2
-        ), "First iteration should trigger 2 calls of write_file, one for the iterator result and one for the buffer"
+    data.append(next(it))
+    time.sleep(0.5)
+    assert (
+        len(os.listdir(files_location)) == 2
+    ), "First iteration should trigger 2 calls of write_file, one for the iterator result and one for the buffer"
 
-        data.append(next(it))
-        time.sleep(0.2)
-        assert (
-            len(os.listdir(files_location)) == 3
-        ), "Subsequent iteration should trigger 1 call of write_file to fill the buffer"
+    data.append(next(it))
+    time.sleep(0.5)
+    assert (
+        len(os.listdir(files_location)) == 3
+    ), "Subsequent iteration should trigger 1 call of write_file to fill the buffer"
 
-        data.append(next(it))
-        time.sleep(0.2)
-        assert (
-            len(os.listdir(files_location)) == 4
-        ), "Subsequent iteration should trigger 1 call of write_file to fill the buffer"
+    data.append(next(it))
+    time.sleep(0.5)
+    assert (
+        len(os.listdir(files_location)) == 4
+    ), "Subsequent iteration should trigger 1 call of write_file to fill the buffer"
 
-        data.append(next(it))
-        time.sleep(0.2)
-        assert (
-            len(os.listdir(files_location)) == 4
-        ), "Last iteration should not trigger anymore writes, and just consume the last item"
+    data.append(next(it))
+    time.sleep(0.5)
+    assert (
+        len(os.listdir(files_location)) == 4
+    ), "Last iteration should not trigger anymore writes, and just consume the last item"
 
-        with pytest.raises(StopIteration):
-            next(it)
-    elif daft.context.get_context().runner_config.name == "ray":
-        # NOTE: RayRunner unfortunately cannot support buffer size 1, because of the implementation detail of the queue
-        # so it behaves like a buffer size 2 instead.
-        data.append(next(it))
-        time.sleep(0.2)
-        assert (
-            len(os.listdir(files_location)) == 3
-        ), "First iteration should trigger 3 calls of write_file, one for the iterator result, one for the buffer and one in the queue"
-
-        data.append(next(it))
-        time.sleep(0.2)
-        assert (
-            len(os.listdir(files_location)) == 4
-        ), "Subsequent iteration should trigger 1 call of write_file to fill the buffer"
-
-        data.append(next(it))
-        time.sleep(0.2)
-        assert (
-            len(os.listdir(files_location)) == 4
-        ), "Subsequent iteration just consumes from the queue, does not trigger writes"
-
-        data.append(next(it))
-        time.sleep(0.2)
-        assert len(os.listdir(files_location)) == 4, "Last iteration consumes from the queue, does not trigger writes"
-
-        with pytest.raises(StopIteration):
-            next(it)
-    else:
-        raise NotImplementedError(f"Runner not implemented: {daft.context.get_context().runner_config().name}")
+    with pytest.raises(StopIteration):
+        next(it)
 
 
 def test_iter_partitions_with_buffer_limit_3(tmp_path, make_df):

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -197,27 +197,27 @@ def test_iter_partitions_with_buffer_limit_3(tmp_path, make_df):
     assert os.listdir(files_location) == [], "Directory should have no files initially"
 
     data.append(next(it))
-    time.sleep(0.2)
+    time.sleep(0.5)
     assert (
         len(os.listdir(files_location)) == 4
     ), "First iteration should trigger 4 calls of write_file: 1 for the iterator result, 3 buffered"
 
     data.append(next(it))
-    time.sleep(0.2)
+    time.sleep(0.5)
     assert (
         len(os.listdir(files_location)) == 5
     ), "Subsequent single iteration should trigger 1 call of write_file to refill the buffer"
 
     for _ in range(2):
         data.append(next(it))
-    time.sleep(0.2)
+    time.sleep(0.5)
     assert (
         len(os.listdir(files_location)) == 7
     ), "Subsequent rapid iteration twice in a row should trigger 2 calls to refill buffer"
 
     for _ in range(3):
         data.append(next(it))
-    time.sleep(0.2)
+    time.sleep(0.5)
     assert (
         len(os.listdir(files_location)) == 7
     ), "Last 3 iterations to empty everything should not trigger any more writes"


### PR DESCRIPTION
This limits the depth of the "pipeline" when Daft executes `df.iter_partitions` partitions.

The main refactor made here is that our PhysicalPlan is no longer responsible for keeping track of progress on the "final" set of PartitionTasks and yielding `MaterializedResult` when it happens to become ready. Instead, this responsibility is lifted to the Runner, where it now has much better control around how to handle the buffering of these PartitionTasks.

1. The PyRunner now keeps track of "final" PartitionTasks in a `deque`, and on every scheduling loop it will yield results from this `deque` if the results are available. Additionally, the PyRunner will early-terminate dispatching tasks if it sees that this `deque` is too large, providing us with the "buffering" behavior that we want.
2. The RayRunner now returns "final" PartitionTasks in its return `Queue`. The consumer of this queue is then responsible for waiting until each result becomes available before yielding it. This is a bounded `Queue` and this provides us with the buffering behavior that we want.

**NOTE:** The PyRunner doesn't have async execution, and thus can't always saturate the requested buffer size. The specific corner-case here is if `buffer_size > num_available_cores`, then there will be situations in which the buffer won't fill up asynchronously when the runner is blocked by consumption of its `yield`.