### PR TITLE
[BUG] Fix red line in Jupyter notebook

### DIFF
--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -16,12 +16,20 @@ class ProgressBar:
         self.use_ray_tqdm = use_ray_tqdm
         if use_ray_tqdm:
             from ray.experimental.tqdm_ray import tqdm
-
-            self.tqdm_mod = tqdm
         else:
-            from tqdm.auto import tqdm
+            import sys
 
-            self.tqdm_mod = tqdm
+            from tqdm.auto import tqdm as _tqdm
+
+            class tqdm(_tqdm):  # type: ignore[no-redef]
+                def __init__(self, *args, **kwargs):
+                    kwargs = kwargs.copy()
+                    if "file" not in kwargs:
+                        kwargs["file"] = sys.stdout  # avoid the red block in IPython
+
+                    super().__init__(*args, **kwargs)
+
+        self.tqdm_mod = tqdm
 
         self.pbars: dict[int, tqdm] = dict()
         self.disable = (

--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -21,13 +21,23 @@ class ProgressBar:
 
             from tqdm.auto import tqdm as _tqdm
 
-            class tqdm(_tqdm):  # type: ignore[no-redef]
-                def __init__(self, *args, **kwargs):
-                    kwargs = kwargs.copy()
-                    if "file" not in kwargs:
-                        kwargs["file"] = sys.stdout  # avoid the red block in IPython
+            try:
+                from tqdm.notebook import IProgress
 
-                    super().__init__(*args, **kwargs)
+                # write to sys.stdout if in IPython
+                if IProgress is None:
+
+                    class tqdm(_tqdm):  # type: ignore[no-redef]
+                        def __init__(self, *args, **kwargs):
+                            kwargs = kwargs.copy()
+                            if "file" not in kwargs:
+                                kwargs["file"] = sys.stdout  # avoid the red block in IPython
+
+                            super().__init__(*args, **kwargs)
+                else:
+                    tqdm = _tqdm
+            except ImportError:
+                tqdm = _tqdm
 
         self.tqdm_mod = tqdm
 

--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -27,6 +27,7 @@ class ProgressBar:
                 ipython = get_ipython()
 
                 # write to sys.stdout if in jupyter notebook
+                # source: https://github.com/tqdm/tqdm/blob/74722959a8626fd2057be03e14dcf899c25a3fd5/tqdm/autonotebook.py#L14
                 if ipython is not None and "IPKernelApp" in ipython.config:
 
                     class tqdm(_tqdm):  # type: ignore[no-redef]

--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -17,15 +17,17 @@ class ProgressBar:
         if use_ray_tqdm:
             from ray.experimental.tqdm_ray import tqdm
         else:
-            import sys
-
             from tqdm.auto import tqdm as _tqdm
 
             try:
-                from tqdm.notebook import IProgress
+                import sys
 
-                # write to sys.stdout if in IPython
-                if IProgress is None:
+                from IPython import get_ipython
+
+                ipython = get_ipython()
+
+                # write to sys.stdout if in jupyter notebook
+                if ipython is not None and "IPKernelApp" in ipython.config:
 
                     class tqdm(_tqdm):  # type: ignore[no-redef]
                         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Finally figured out the issue! When using `tqdm.auto`, the library does correctly fall back to regular tqdm if the `ipywidgets` library is not present, but the thing is that `tqdm` by default actually writes to STDERR instead of STDOUT, which shows up in a notebook but no the command line. 

This fix changes the default file from `sys.stderr` to `sys.stdout` for tqdm when we are in an IPython environment.

Resolves #2083