### PR TITLE
[CHORE] Clean up string kernel code

### DIFF
--- a/src/daft-core/src/series/ops/utf8.rs
+++ b/src/daft-core/src/series/ops/utf8.rs
@@ -2,74 +2,63 @@ use crate::array::ops::PadPlacement;
 use crate::series::Series;
 use common_error::{DaftError, DaftResult};
 
-use crate::datatypes::*;
 use crate::series::array_impl::IntoSeries;
+use crate::{datatypes::*, with_match_integer_daft_types};
 
 impl Series {
-    pub fn utf8_endswith(&self, pattern: &Series) -> DaftResult<Series> {
+    fn with_utf8_array(&self, f: impl Fn(&Utf8Array) -> DaftResult<Series>) -> DaftResult<Series> {
         match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.endswith(pattern.utf8()?)?.into_series()),
+            DataType::Utf8 => f(self.utf8()?),
+            DataType::Null => Ok(self.clone()),
             dt => Err(DaftError::TypeError(format!(
-                "Endswith not implemented for type {dt}"
+                "Operation not implemented for type {dt}"
             ))),
         }
+    }
+
+    pub fn utf8_endswith(&self, pattern: &Series) -> DaftResult<Series> {
+        self.with_utf8_array(|arr| {
+            pattern.with_utf8_array(|pattern_arr| Ok(arr.endswith(pattern_arr)?.into_series()))
+        })
     }
 
     pub fn utf8_startswith(&self, pattern: &Series) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.startswith(pattern.utf8()?)?.into_series()),
-            dt => Err(DaftError::TypeError(format!(
-                "Startswith not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| {
+            pattern.with_utf8_array(|pattern_arr| Ok(arr.startswith(pattern_arr)?.into_series()))
+        })
     }
 
     pub fn utf8_contains(&self, pattern: &Series) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.contains(pattern.utf8()?)?.into_series()),
-            dt => Err(DaftError::TypeError(format!(
-                "Contains not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| {
+            pattern.with_utf8_array(|pattern_arr| Ok(arr.contains(pattern_arr)?.into_series()))
+        })
     }
 
     pub fn utf8_match(&self, pattern: &Series) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.match_(pattern.utf8()?)?.into_series()),
-            dt => Err(DaftError::TypeError(format!(
-                "Match not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| {
+            pattern.with_utf8_array(|pattern_arr| Ok(arr.match_(pattern_arr)?.into_series()))
+        })
     }
 
     pub fn utf8_split(&self, pattern: &Series, regex: bool) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.split(pattern.utf8()?, regex)?.into_series()),
-            dt => Err(DaftError::TypeError(format!(
-                "Split not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| {
+            pattern.with_utf8_array(|pattern_arr| Ok(arr.split(pattern_arr, regex)?.into_series()))
+        })
     }
 
     pub fn utf8_extract(&self, pattern: &Series, index: usize) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.extract(pattern.utf8()?, index)?.into_series()),
-            dt => Err(DaftError::TypeError(format!(
-                "Extract not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| {
+            pattern
+                .with_utf8_array(|pattern_arr| Ok(arr.extract(pattern_arr, index)?.into_series()))
+        })
     }
 
     pub fn utf8_extract_all(&self, pattern: &Series, index: usize) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self
-                .utf8()?
-                .extract_all(pattern.utf8()?, index)?
-                .into_series()),
-            dt => Err(DaftError::TypeError(format!(
-                "ExtractAll not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| {
+            pattern.with_utf8_array(|pattern_arr| {
+                Ok(arr.extract_all(pattern_arr, index)?.into_series())
+            })
+        })
     }
 
     pub fn utf8_replace(
@@ -78,258 +67,137 @@ impl Series {
         replacement: &Series,
         regex: bool,
     ) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self
-                .utf8()?
-                .replace(pattern.utf8()?, replacement.utf8()?, regex)?
-                .into_series()),
-            dt => Err(DaftError::TypeError(format!(
-                "Replace not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| {
+            pattern.with_utf8_array(|pattern_arr| {
+                replacement.with_utf8_array(|replacement_arr| {
+                    Ok(arr
+                        .replace(pattern_arr, replacement_arr, regex)?
+                        .into_series())
+                })
+            })
+        })
     }
 
     pub fn utf8_length(&self) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.length()?.into_series()),
-            DataType::Null => Ok(self.clone()),
-            dt => Err(DaftError::TypeError(format!(
-                "Length not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| Ok(arr.length()?.into_series()))
     }
 
     pub fn utf8_lower(&self) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.lower()?.into_series()),
-            DataType::Null => Ok(self.clone()),
-            dt => Err(DaftError::TypeError(format!(
-                "Lower not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| Ok(arr.lower()?.into_series()))
     }
 
     pub fn utf8_upper(&self) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.upper()?.into_series()),
-            DataType::Null => Ok(self.clone()),
-            dt => Err(DaftError::TypeError(format!(
-                "Upper not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| Ok(arr.upper()?.into_series()))
     }
 
     pub fn utf8_lstrip(&self) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.lstrip()?.into_series()),
-            DataType::Null => Ok(self.clone()),
-            dt => Err(DaftError::TypeError(format!(
-                "Lstrip not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| Ok(arr.lstrip()?.into_series()))
     }
 
     pub fn utf8_rstrip(&self) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.rstrip()?.into_series()),
-            DataType::Null => Ok(self.clone()),
-            dt => Err(DaftError::TypeError(format!(
-                "Rstrip not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| Ok(arr.rstrip()?.into_series()))
     }
 
     pub fn utf8_reverse(&self) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.reverse()?.into_series()),
-            DataType::Null => Ok(self.clone()),
-            dt => Err(DaftError::TypeError(format!(
-                "Reverse not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| Ok(arr.reverse()?.into_series()))
     }
 
     pub fn utf8_capitalize(&self) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.capitalize()?.into_series()),
-            DataType::Null => Ok(self.clone()),
-            dt => Err(DaftError::TypeError(format!(
-                "Capitalize not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| Ok(arr.capitalize()?.into_series()))
     }
 
     pub fn utf8_left(&self, nchars: &Series) -> DaftResult<Series> {
-        match (self.data_type(), nchars.data_type()) {
-            (DataType::Utf8, DataType::UInt32) => {
-                Ok(self.utf8()?.left(nchars.u32()?)?.into_series())
+        self.with_utf8_array(|arr| {
+            if nchars.data_type().is_integer() {
+                with_match_integer_daft_types!(nchars.data_type(), |$T| {
+                    Ok(arr.left(nchars.downcast::<<$T as DaftDataType>::ArrayType>()?)?.into_series())
+                })
+            } else if nchars.data_type().is_null() {
+                Ok(self.clone())
+            } else {
+                Err(DaftError::TypeError(format!(
+                    "Left not implemented for nchar type {}",
+                    nchars.data_type()
+                )))
             }
-            (DataType::Utf8, DataType::Int32) => {
-                Ok(self.utf8()?.left(nchars.i32()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::UInt64) => {
-                Ok(self.utf8()?.left(nchars.u64()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::Int64) => {
-                Ok(self.utf8()?.left(nchars.i64()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::Int8) => Ok(self.utf8()?.left(nchars.i8()?)?.into_series()),
-            (DataType::Utf8, DataType::UInt8) => Ok(self.utf8()?.left(nchars.u8()?)?.into_series()),
-            (DataType::Utf8, DataType::Int16) => {
-                Ok(self.utf8()?.left(nchars.i16()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::UInt16) => {
-                Ok(self.utf8()?.left(nchars.u16()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::Int128) => {
-                Ok(self.utf8()?.left(nchars.i128()?)?.into_series())
-            }
-            (DataType::Null, dt) if dt.is_integer() => Ok(self.clone()),
-            (DataType::Utf8, dt) => Err(DaftError::TypeError(format!(
-                "Left not implemented for nchar type {dt}"
-            ))),
-            (dt, _) => Err(DaftError::TypeError(format!(
-                "Left not implemented for type {dt}"
-            ))),
-        }
+        })
     }
 
     pub fn utf8_right(&self, nchars: &Series) -> DaftResult<Series> {
-        match (self.data_type(), nchars.data_type()) {
-            (DataType::Utf8, DataType::UInt32) => {
-                Ok(self.utf8()?.right(nchars.u32()?)?.into_series())
+        self.with_utf8_array(|arr| {
+            if nchars.data_type().is_integer() {
+                with_match_integer_daft_types!(nchars.data_type(), |$T| {
+                    Ok(arr.right(nchars.downcast::<<$T as DaftDataType>::ArrayType>()?)?.into_series())
+                })
+            } else if nchars.data_type().is_null() {
+                Ok(self.clone())
+            } else {
+                Err(DaftError::TypeError(format!(
+                    "Right not implemented for nchar type {}",
+                    nchars.data_type()
+                )))
             }
-            (DataType::Utf8, DataType::Int32) => {
-                Ok(self.utf8()?.right(nchars.i32()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::UInt64) => {
-                Ok(self.utf8()?.right(nchars.u64()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::Int64) => {
-                Ok(self.utf8()?.right(nchars.i64()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::Int8) => Ok(self.utf8()?.right(nchars.i8()?)?.into_series()),
-            (DataType::Utf8, DataType::UInt8) => {
-                Ok(self.utf8()?.right(nchars.u8()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::Int16) => {
-                Ok(self.utf8()?.right(nchars.i16()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::UInt16) => {
-                Ok(self.utf8()?.right(nchars.u16()?)?.into_series())
-            }
-            (DataType::Utf8, DataType::Int128) => {
-                Ok(self.utf8()?.right(nchars.i128()?)?.into_series())
-            }
-            (DataType::Null, dt) if dt.is_integer() => Ok(self.clone()),
-            (DataType::Utf8, dt) => Err(DaftError::TypeError(format!(
-                "Right not implemented for nchar type {dt}"
-            ))),
-            (dt, _) => Err(DaftError::TypeError(format!(
-                "Right not implemented for type {dt}"
-            ))),
-        }
+        })
     }
 
     pub fn utf8_find(&self, substr: &Series) -> DaftResult<Series> {
-        match self.data_type() {
-            DataType::Utf8 => Ok(self.utf8()?.find(substr.utf8()?)?.into_series()),
-            dt => Err(DaftError::TypeError(format!(
-                "Find not implemented for type {dt}"
-            ))),
-        }
-    }
-
-    fn utf8_pad(
-        &self,
-        length: &Series,
-        pad: &Series,
-        placement: PadPlacement,
-    ) -> DaftResult<Series> {
-        if self.data_type() == &DataType::Null {
-            return Ok(self.clone());
-        }
-        if self.data_type() != &DataType::Utf8 {
-            return Err(DaftError::TypeError(format!(
-                "Pad not implemented for type {}",
-                self.data_type()
-            )));
-        }
-        if pad.data_type() != &DataType::Utf8 {
-            return Err(DaftError::TypeError(format!(
-                "Pad not implemented for pad type {}",
-                pad.data_type()
-            )));
-        }
-        match length.data_type() {
-            DataType::UInt32 => Ok(self
-                .utf8()?
-                .pad(length.u32()?, pad.utf8()?, placement)?
-                .into_series()),
-            DataType::Int32 => Ok(self
-                .utf8()?
-                .pad(length.i32()?, pad.utf8()?, placement)?
-                .into_series()),
-            DataType::UInt64 => Ok(self
-                .utf8()?
-                .pad(length.u64()?, pad.utf8()?, placement)?
-                .into_series()),
-            DataType::Int64 => Ok(self
-                .utf8()?
-                .pad(length.i64()?, pad.utf8()?, placement)?
-                .into_series()),
-            DataType::Int8 => Ok(self
-                .utf8()?
-                .pad(length.i8()?, pad.utf8()?, placement)?
-                .into_series()),
-            DataType::UInt8 => Ok(self
-                .utf8()?
-                .pad(length.u8()?, pad.utf8()?, placement)?
-                .into_series()),
-            DataType::Int16 => Ok(self
-                .utf8()?
-                .pad(length.i16()?, pad.utf8()?, placement)?
-                .into_series()),
-            DataType::UInt16 => Ok(self
-                .utf8()?
-                .pad(length.u16()?, pad.utf8()?, placement)?
-                .into_series()),
-            DataType::Int128 => Ok(self
-                .utf8()?
-                .pad(length.i128()?, pad.utf8()?, placement)?
-                .into_series()),
-            dt => Err(DaftError::TypeError(format!(
-                "Pad not implemented for length type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| {
+            substr.with_utf8_array(|substr_arr| Ok(arr.find(substr_arr)?.into_series()))
+        })
     }
 
     pub fn utf8_lpad(&self, length: &Series, pad: &Series) -> DaftResult<Series> {
-        self.utf8_pad(length, pad, PadPlacement::Left)
+        self.with_utf8_array(|arr| {
+            pad.with_utf8_array(|pad_arr| {
+                if length.data_type().is_integer() {
+                    with_match_integer_daft_types!(length.data_type(), |$T| {
+                        Ok(arr.pad(length.downcast::<<$T as DaftDataType>::ArrayType>()?, pad_arr, PadPlacement::Left)?.into_series())
+                    })
+                } else if length.data_type().is_null() {
+                    Ok(self.clone())
+                } else {
+                    Err(DaftError::TypeError(format!(
+                        "Lpad not implemented for length type {}",
+                        length.data_type()
+                    )))
+                }
+            })
+        })
     }
 
     pub fn utf8_rpad(&self, length: &Series, pad: &Series) -> DaftResult<Series> {
-        self.utf8_pad(length, pad, PadPlacement::Right)
+        self.with_utf8_array(|arr| {
+            pad.with_utf8_array(|pad_arr| {
+                if length.data_type().is_integer() {
+                    with_match_integer_daft_types!(length.data_type(), |$T| {
+                        Ok(arr.pad(length.downcast::<<$T as DaftDataType>::ArrayType>()?, pad_arr, PadPlacement::Right)?.into_series())
+                    })
+                } else if length.data_type().is_null() {
+                    Ok(self.clone())
+                } else {
+                    Err(DaftError::TypeError(format!(
+                        "Rpad not implemented for length type {}",
+                        length.data_type()
+                    )))
+                }
+            })
+        })
     }
 
     pub fn utf8_repeat(&self, n: &Series) -> DaftResult<Series> {
-        match (self.data_type(), n.data_type()) {
-            (DataType::Utf8, DataType::UInt32) => Ok(self.utf8()?.repeat(n.u32()?)?.into_series()),
-            (DataType::Utf8, DataType::Int32) => Ok(self.utf8()?.repeat(n.i32()?)?.into_series()),
-            (DataType::Utf8, DataType::UInt64) => Ok(self.utf8()?.repeat(n.u64()?)?.into_series()),
-            (DataType::Utf8, DataType::Int64) => Ok(self.utf8()?.repeat(n.i64()?)?.into_series()),
-            (DataType::Utf8, DataType::Int8) => Ok(self.utf8()?.repeat(n.i8()?)?.into_series()),
-            (DataType::Utf8, DataType::UInt8) => Ok(self.utf8()?.repeat(n.u8()?)?.into_series()),
-            (DataType::Utf8, DataType::Int16) => Ok(self.utf8()?.repeat(n.i16()?)?.into_series()),
-            (DataType::Utf8, DataType::UInt16) => Ok(self.utf8()?.repeat(n.u16()?)?.into_series()),
-            (DataType::Utf8, DataType::Int128) => Ok(self.utf8()?.repeat(n.i128()?)?.into_series()),
-            (DataType::Null, dt) if dt.is_integer() => Ok(self.clone()),
-            (DataType::Utf8, dt) => Err(DaftError::TypeError(format!(
-                "Repeat not implemented for nchar type {dt}"
-            ))),
-            (dt, _) => Err(DaftError::TypeError(format!(
-                "Repeat not implemented for type {dt}"
-            ))),
-        }
+        self.with_utf8_array(|arr| {
+            if n.data_type().is_integer() {
+                with_match_integer_daft_types!(n.data_type(), |$T| {
+                    Ok(arr.repeat(n.downcast::<<$T as DaftDataType>::ArrayType>()?)?.into_series())
+                })
+            } else if n.data_type().is_null() {
+                Ok(self.clone())
+            } else {
+                Err(DaftError::TypeError(format!(
+                    "Repeat not implemented for nchar type {}",
+                    n.data_type()
+                )))
+            }
+        })
     }
 }


### PR DESCRIPTION
A few fixes to reduce a lot of boilerplate:
- Add a method, `with_utf8_array`, that properly handles Series to Utf8Array conversion, so that string kernels have consistent behavior with NullArrays
- Convert all of the integer matching code to use the `with_match_integer_daft_types` macro.