### PR TITLE
[CHORE] Pin requests to fix docker-py CI issue

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -327,8 +327,6 @@ jobs:
       with:
         compose-file: ./tests/integration/io/docker-compose/docker-compose.yml
         down-flags: --volumes
-    - name: Setup ssh session
-      uses: lhotari/action-upterm@v1
     - name: Run IO integration tests
       run: |
         pytest tests/integration/io -m 'integration' --durations=50

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -327,6 +327,8 @@ jobs:
       with:
         compose-file: ./tests/integration/io/docker-compose/docker-compose.yml
         down-flags: --volumes
+    - name: Setup ssh session
+      uses: lhotari/action-upterm@v1
     - name: Run IO integration tests
       run: |
         pytest tests/integration/io -m 'integration' --durations=50

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,9 @@ maturin
 pre-commit
 docker
 
+# Pinned requests due to docker-py issue: https://github.com/docker/docker-py/issues/3256
+requests<2.32.0
+
 # Tracing
 orjson==3.9.5  # orjson recommended for viztracer
 py-spy==0.3.14


### PR DESCRIPTION
The latest version of docker-py fails on the latest version of requests

See: https://github.com/docker/docker-py/issues/3256