### PR TITLE
[FEAT] implement timeout for parquet reader

### DIFF
--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -759,6 +759,7 @@ def read_parquet_into_pyarrow(
     io_config: IOConfig | None = None,
     multithreaded_io: bool | None = None,
     coerce_int96_timestamp_unit: PyTimeUnit | None = None,
+    file_timeout_ms: int | None = None,
 ): ...
 def read_parquet_into_pyarrow_bulk(
     uris: list[str],

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -577,6 +577,7 @@ def read_parquet_into_pyarrow(
     io_config: IOConfig | None = None,
     multithreaded_io: bool | None = None,
     coerce_int96_timestamp_unit: TimeUnit = TimeUnit.ns(),
+    file_timeout_ms: int | None = 900_000,  # 15 minutes
 ) -> pa.Table:
     fields, metadata, columns = _read_parquet_into_pyarrow(
         uri=path,
@@ -587,6 +588,7 @@ def read_parquet_into_pyarrow(
         io_config=io_config,
         multithreaded_io=multithreaded_io,
         coerce_int96_timestamp_unit=coerce_int96_timestamp_unit._timeunit,
+        file_timeout_ms=file_timeout_ms,
     )
     schema = pa.schema(fields, metadata=metadata)
     columns = [pa.chunked_array(c, type=f.type) for f, c in zip(schema, columns)]  # type: ignore

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(async_closure)]
 #![feature(let_chains)]
 #![feature(result_flattening)]
+
 use common_error::DaftError;
 use snafu::Snafu;
 
@@ -21,6 +22,8 @@ pub enum Error {
     #[snafu(display("{source}"))]
     DaftIOError { source: daft_io::Error },
 
+    #[snafu(display("Parquet reader timed out while trying to read: {path} with a time budget of {duration_ms} ms"))]
+    FileReadTimeout { path: String, duration_ms: i64 },
     #[snafu(display("Internal IO Error when Opening: {path}:\nDetails:\n{source}"))]
     InternalIOError {
         path: String,
@@ -189,6 +192,7 @@ impl From<Error> for DaftError {
     fn from(err: Error) -> DaftError {
         match err {
             Error::DaftIOError { source } => source.into(),
+            Error::FileReadTimeout { .. } => DaftError::ReadTimeout(err.into()),
             _ => DaftError::External(err.into()),
         }
     }

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -93,6 +93,7 @@ pub mod pylib {
         io_config: Option<IOConfig>,
         multithreaded_io: Option<bool>,
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
+        file_timeout_ms: Option<i64>,
     ) -> PyResult<PyArrowParquetType> {
         let read_parquet_result = py.allow_threads(|| {
             let io_client = get_io_client(
@@ -115,6 +116,7 @@ pub mod pylib {
                 None,
                 runtime_handle,
                 schema_infer_options,
+                file_timeout_ms,
             )
         })?;
         let (schema, all_arrays) = read_parquet_result;


### PR DESCRIPTION
* This implements a file level timeout for parquet reader into pyarrow with a default of 15 minutes.