### PR TITLE
[FEAT] Add more context when UDFs fail

### DIFF
--- a/daft/udf.py
+++ b/daft/udf.py
@@ -104,7 +104,12 @@ class PartialUDF:
         # This is not ideal and we should cache initializations across calls for the same process.
         func = self.udf.get_initialized_func()
 
-        result = func(*args, **kwargs)
+        try:
+            result = func(*args, **kwargs)
+        except Exception as user_function_exception:
+            raise RuntimeError(
+                f"User-defined function `{func.__name__}` failed when executing on inputs with lengths: {tuple(len(series) for series in evaluated_expressions)}"
+            ) from user_function_exception
 
         # HACK: Series have names and the logic for naming fields/series in a UDF is to take the first
         # Expression's name. Note that this logic is tied to the `to_field` implementation of the Rust PythonUDF

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -66,8 +66,9 @@ def test_iter_exception(make_df):
     assert next(it) == {"a": 0, "b": 0}
 
     # Ensure the exception does trigger if execution continues.
-    with pytest.raises(MockException):
+    with pytest.raises(RuntimeError) as exc_info:
         list(it)
+    assert isinstance(exc_info.value.__cause__, MockException)
 
 
 def test_iter_partitions_exception(make_df):
@@ -95,7 +96,8 @@ def test_iter_partitions_exception(make_df):
     assert part == {"a": [0, 1], "b": [0, 1]}
 
     # Ensure the exception does trigger if execution continues.
-    with pytest.raises(MockException):
+    with pytest.raises(RuntimeError) as exc_info:
         res = list(it)
         if daft.context.get_context().runner_config.name == "ray":
             ray.get(res)
+    assert isinstance(exc_info.value.__cause__, MockException)

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -68,7 +68,12 @@ def test_iter_exception(make_df):
     # Ensure the exception does trigger if execution continues.
     with pytest.raises(RuntimeError) as exc_info:
         list(it)
-    assert isinstance(exc_info.value.__cause__, MockException)
+
+    # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
+    if daft.context.get_context().runner_config.name == "ray":
+        assert "MockException" in str(exc_info.value)
+    else:
+        assert isinstance(exc_info.value.__cause__, MockException)
 
 
 def test_iter_partitions_exception(make_df):
@@ -100,4 +105,9 @@ def test_iter_partitions_exception(make_df):
         res = list(it)
         if daft.context.get_context().runner_config.name == "ray":
             ray.get(res)
-    assert isinstance(exc_info.value.__cause__, MockException)
+
+    # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
+    if daft.context.get_context().runner_config.name == "ray":
+        assert "MockException" in str(exc_info.value)
+    else:
+        assert isinstance(exc_info.value.__cause__, MockException)

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -110,8 +110,10 @@ def test_udf_error():
 
     expr = throw_value_err(col("a"))
 
-    with pytest.raises(ValueError, match="AN ERROR OCCURRED!"):
+    with pytest.raises(RuntimeError) as exc_info:
         table.eval_expression_list([expr])
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    assert str(exc_info.value.__cause__) == "AN ERROR OCCURRED!"
 
 
 def test_no_args_udf_call():

--- a/tests/integration/io/test_url_download_http.py
+++ b/tests/integration/io/test_url_download_http.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from aiohttp.client_exceptions import ClientResponseError
 
 import daft
 
@@ -17,37 +16,16 @@ def test_url_download_http(mock_http_image_urls, image_data, use_native_download
 
 @pytest.mark.integration()
 @pytest.mark.parametrize("status_code", [400, 401, 403, 404, 429, 500, 503])
-@pytest.mark.parametrize("use_native_downloader", [True, False])
-def test_url_download_http_error_codes(nginx_config, use_native_downloader, status_code):
+def test_url_download_http_error_codes(nginx_config, status_code):
     server_url, _ = nginx_config
     data = {"urls": [f"{server_url}/{status_code}.html"]}
     df = daft.from_pydict(data)
-    df = df.with_column("data", df["urls"].url.download(on_error="raise", use_native_downloader=use_native_downloader))
+    df = df.with_column("data", df["urls"].url.download(on_error="raise", use_native_downloader=True))
 
-    skip_fsspec_downloader = daft.context.get_context().runner_config.name == "ray"
-
-    # 404 should always be corner-cased to return FileNotFoundError regardless of I/O implementation
+    # 404 should always be corner-cased to return FileNotFoundError
     if status_code == 404:
-        with pytest.raises(FileNotFoundError) as exc_info:
+        with pytest.raises(FileNotFoundError):
             df.collect()
-
-    # When using fsspec, other error codes are bubbled up to the user as aiohttp.client_exceptions.ClientResponseError
-    elif not use_native_downloader:
-        # Ray runner has a pretty catastrophic failure when raising non-pickleable exceptions (ClientResponseError is not pickleable)
-        # See Ray issue: https://github.com/ray-project/ray/issues/36893
-        if skip_fsspec_downloader:
-            pytest.skip()
-
-        with pytest.raises(RuntimeError) as exc_info:
-            df.collect()
-
-        # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
-        if daft.context.get_context().runner_config.name == "ray":
-            assert "ClientResponseError" in str(exc_info.value)
-        else:
-            assert isinstance(exc_info.value.__cause__, ClientResponseError)
-            assert exc_info.value.__cause__.code == status_code
-    # When using native downloader, we throw a ValueError
     else:
         # NOTE: We may want to add better errors in the future to provide a better
         # user-facing I/O error with the error code

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -87,11 +87,16 @@ def test_download_with_missing_urls_reraise_errors(files, use_native_downloader)
         # TODO: Change to a FileNotFound Error
 
         if not use_native_downloader:
-            with pytest.raises(RuntimeError) as err:
+            with pytest.raises(RuntimeError) as exc_info:
                 df.collect()
-            assert isinstance(err.value.__cause__, FileNotFoundError)
+
+            # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
+            if daft.context.get_context().runner_config.name == "ray":
+                assert "FileNotFoundError" in str(exc_info.value)
+            else:
+                assert isinstance(exc_info.value.__cause__, FileNotFoundError)
         else:
-            with pytest.raises(FileNotFoundError) as err:
+            with pytest.raises(FileNotFoundError):
                 df.collect()
 
 

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -85,8 +85,14 @@ def test_download_with_missing_urls_reraise_errors(files, use_native_downloader)
             "bytes", col("filenames").url.download(on_error="raise", use_native_downloader=use_native_downloader)
         )
         # TODO: Change to a FileNotFound Error
-        with pytest.raises(FileNotFoundError):
-            df.collect()
+
+        if not use_native_downloader:
+            with pytest.raises(RuntimeError) as err:
+                df.collect()
+            assert isinstance(err.value.__cause__, FileNotFoundError)
+        else:
+            with pytest.raises(FileNotFoundError) as err:
+                df.collect()
 
 
 @pytest.mark.parametrize("use_native_downloader", [False, True])


### PR DESCRIPTION
This PR adds some context around failures of UDFs, and also has the side-effect of quite nicely isolating the actual exception to just the UDF code so users can be sure that the code failed in the UDF rather than in some part of Daft.

```
In [4]: daft.from_pydict({"foo": [1]}).with_column("identity", throws_error_if_len_1(daft.col("foo"))).collect()
Project [Stage:2]:   0%|                                                                                                    | 0/1 [00:00<?, ?it/s]---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
File ~/code/Daft/daft/udf.py:108, in PartialUDF.__call__(self, evaluated_expressions)
    107 try:
--> 108     result = func(*args, **kwargs)
    109 except Exception as user_function_exception:

Cell In[2], line 4, in throws_error_if_len_1(data)
      3 if len(data) == 1:
----> 4     raise ValueError("I hate len 1 data")
      5 else:

ValueError: I hate len 1 data

The above exception was the direct cause of the following exception:

... 

RuntimeError                              Traceback (most recent call last)
...
File ~/code/Daft/daft/udf.py:110, in PartialUDF.__call__(self, evaluated_expressions)
    108     result = func(*args, **kwargs)
    109 except Exception as user_function_exception:
--> 110     raise RuntimeError(f"User-defined function `{func.__name__}` failed when executing on inputs with lengths: {tuple(len(series) for series in evaluated_expressions)}") from user_function_exception
    112 # HACK: Series have names and the logic for naming fields/series in a UDF is to take the first
    113 # Expression's name. Note that this logic is tied to the `to_field` implementation of the Rust PythonUDF
    114 # and is quite error prone! If our Series naming logic here is wrong, things will break when the UDF is run on a table.
    115 name = evaluated_expressions[0].name()

RuntimeError: User-defined function `throws_error_if_len_1` failed when executing on inputs with lengths: (1,)
```