### PR TITLE
[FEAT] Add additional Azure authentication methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
@@ -185,6 +185,17 @@ dependencies = [
  "xz2",
  "zstd 0.13.0",
  "zstd-safe 7.0.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+dependencies = [
+ "event-listener 4.0.3",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -630,6 +641,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "azure_identity"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bd7ea32ca7eb66ff4757f83baac702ff11d469e5de365b6bc6f79f9c25d3436"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core",
+ "futures",
+ "log",
+ "oauth2",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tz-rs",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "azure_storage"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +929,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
@@ -1023,6 +1056,12 @@ name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
+name = "const_fn"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "core-foundation"
@@ -1331,6 +1370,8 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-client",
+ "azure_core",
+ "azure_identity",
  "azure_storage",
  "azure_storage_blobs",
  "bytes",
@@ -1656,6 +1697,27 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.3",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -2790,6 +2852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "numpy"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,6 +2873,25 @@ dependencies = [
  "num-traits",
  "pyo3",
  "rustc-hash",
+]
+
+[[package]]
+name = "oauth2"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "getrandom 0.2.10",
+ "http",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -3599,6 +3689,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,6 +4091,8 @@ dependencies = [
  "deranged",
  "itoa",
  "js-sys",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -4191,6 +4293,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.57",
+]
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
 ]
 
 [[package]]

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -503,6 +503,10 @@ class AzureConfig:
 
     storage_account: str | None
     access_key: str | None
+    sas_token: str | None
+    tenant_id: str | None
+    client_id: str | None
+    client_secret: str | None
     anonymous: str | None
     endpoint_url: str | None = None
     use_ssl: bool | None = None
@@ -511,6 +515,10 @@ class AzureConfig:
         self,
         storage_account: str | None = None,
         access_key: str | None = None,
+        sas_token: str | None = None,
+        tenant_id: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
         anonymous: str | None = None,
         endpoint_url: str | None = None,
         use_ssl: bool | None = None,
@@ -519,6 +527,10 @@ class AzureConfig:
         self,
         storage_account: str | None = None,
         access_key: str | None = None,
+        sas_token: str | None = None,
+        tenant_id: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
         anonymous: str | None = None,
         endpoint_url: str | None = None,
         use_ssl: bool | None = None,

--- a/daft/io/object_store_options.py
+++ b/daft/io/object_store_options.py
@@ -53,6 +53,14 @@ def _azure_config_to_storage_options(azure_config: AzureConfig) -> dict[str, str
         storage_options["account_name"] = azure_config.storage_account
     if azure_config.access_key is not None:
         storage_options["access_key"] = azure_config.access_key
+    if azure_config.sas_token is not None:
+        storage_options["sas_token"] = azure_config.sas_token
+    if azure_config.tenant_id is not None:
+        storage_options["tenant_id"] = azure_config.tenant_id
+    if azure_config.client_id is not None:
+        storage_options["client_id"] = azure_config.client_id
+    if azure_config.client_secret is not None:
+        storage_options["client_secret"] = azure_config.client_secret
     if azure_config.endpoint_url is not None:
         storage_options["endpoint"] = azure_config.endpoint_url
     if azure_config.use_ssl is not None:

--- a/src/common/io-config/src/azure.rs
+++ b/src/common/io-config/src/azure.rs
@@ -54,7 +54,7 @@ impl AzureConfig {
         if let Some(client_secret) = &self.client_secret {
             res.push(format!("Client Secret = {}", client_secret));
         }
-        res.push(format!("Anoynmous = {}", self.anonymous));
+        res.push(format!("Anonymous = {}", self.anonymous));
         if let Some(endpoint_url) = &self.endpoint_url {
             res.push(format!("Endpoint URL = {}", endpoint_url));
         }

--- a/src/common/io-config/src/azure.rs
+++ b/src/common/io-config/src/azure.rs
@@ -8,6 +8,10 @@ use serde::Serialize;
 pub struct AzureConfig {
     pub storage_account: Option<String>,
     pub access_key: Option<String>,
+    pub sas_token: Option<String>,
+    pub tenant_id: Option<String>,
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
     pub anonymous: bool,
     pub endpoint_url: Option<String>,
     pub use_ssl: bool,
@@ -18,6 +22,10 @@ impl Default for AzureConfig {
         Self {
             storage_account: None,
             access_key: None,
+            sas_token: None,
+            tenant_id: None,
+            client_id: None,
+            client_secret: None,
             anonymous: false,
             endpoint_url: None,
             use_ssl: true,
@@ -33,6 +41,18 @@ impl AzureConfig {
         }
         if let Some(access_key) = &self.access_key {
             res.push(format!("Access key = {}", access_key));
+        }
+        if let Some(sas_token) = &self.sas_token {
+            res.push(format!("Shared Access Signature = {}", sas_token));
+        }
+        if let Some(tenant_id) = &self.tenant_id {
+            res.push(format!("Tenant ID = {}", tenant_id));
+        }
+        if let Some(client_id) = &self.client_id {
+            res.push(format!("Client ID = {}", client_id));
+        }
+        if let Some(client_secret) = &self.client_secret {
+            res.push(format!("Client Secret = {}", client_secret));
         }
         res.push(format!("Anoynmous = {}", self.anonymous));
         if let Some(endpoint_url) = &self.endpoint_url {
@@ -50,10 +70,22 @@ impl Display for AzureConfig {
             "AzureConfig
     storage_account: {:?}
     access_key: {:?}
+    sas_token: {:?}
+    tenant_id: {:?}
+    client_id: {:?}
+    client_secret: {:?}
     anonymous: {:?}
     endpoint_url: {:?}
     use_ssl: {:?}",
-            self.storage_account, self.access_key, self.anonymous, self.endpoint_url, self.use_ssl
+            self.storage_account,
+            self.access_key,
+            self.sas_token,
+            self.tenant_id,
+            self.client_id,
+            self.client_secret,
+            self.anonymous,
+            self.endpoint_url,
+            self.use_ssl
         )
     }
 }

--- a/src/common/io-config/src/gcs.rs
+++ b/src/common/io-config/src/gcs.rs
@@ -16,7 +16,7 @@ impl GCSConfig {
         if let Some(project_id) = &self.project_id {
             res.push(format!("Project ID = {}", project_id));
         }
-        res.push(format!("Anoynmous = {}", self.anonymous));
+        res.push(format!("Anonymous = {}", self.anonymous));
         res
     }
 }

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -71,12 +71,16 @@ pub struct S3Credentials {
     pub credentials: crate::S3Credentials,
 }
 
-/// Create configurations to be used when accessing Azure Blob Storage
+/// Create configurations to be used when accessing Azure Blob Storage. To authenticate with Microsoft Entra ID, `tenant_id`, `client_id`, and `client_secret` must be provided.
 ///
 /// Args:
-///     storage_account: Azure Storage Account, defaults to reading from `AZURE_STORAGE_ACCOUNT` environment variable.
-///     access_key: Azure Secret Access Key, defaults to reading from `AZURE_STORAGE_KEY` environment variable
-///     anonymous: Whether or not to use "anonymous mode", which will access Azure without any credentials
+///     storage_account (str): Azure Storage Account, defaults to reading from `AZURE_STORAGE_ACCOUNT` environment variable.
+///     access_key (str, optional): Azure Secret Access Key, defaults to reading from `AZURE_STORAGE_KEY` environment variable
+///     sas_token (str, optional): Shared Access Signature token, defaults to reading from `AZURE_STORAGE_SAS_TOKEN` environment variable
+///     tenant_id (str, optional): Azure Tenant ID
+///     client_id (str, optional): Azure Client ID
+///     client_secret (str, optional): Azure Client Secret
+///     anonymous (bool, optional): Whether or not to use "anonymous mode", which will access Azure without any credentials
 ///
 /// Example:
 ///     >>> io_config = IOConfig(azure=AzureConfig(storage_account="dafttestdata", access_key="xxx"))
@@ -621,6 +625,10 @@ impl AzureConfig {
     pub fn new(
         storage_account: Option<String>,
         access_key: Option<String>,
+        sas_token: Option<String>,
+        tenant_id: Option<String>,
+        client_id: Option<String>,
+        client_secret: Option<String>,
         anonymous: Option<bool>,
         endpoint_url: Option<String>,
         use_ssl: Option<bool>,
@@ -630,6 +638,10 @@ impl AzureConfig {
             config: crate::AzureConfig {
                 storage_account: storage_account.or(def.storage_account),
                 access_key: access_key.or(def.access_key),
+                sas_token: sas_token.or(def.sas_token),
+                tenant_id: tenant_id.or(def.tenant_id),
+                client_id: client_id.or(def.client_id),
+                client_secret: client_secret.or(def.client_secret),
                 anonymous: anonymous.unwrap_or(def.anonymous),
                 endpoint_url: endpoint_url.or(def.endpoint_url),
                 use_ssl: use_ssl.unwrap_or(def.use_ssl),
@@ -637,10 +649,15 @@ impl AzureConfig {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn replace(
         &self,
         storage_account: Option<String>,
         access_key: Option<String>,
+        sas_token: Option<String>,
+        tenant_id: Option<String>,
+        client_id: Option<String>,
+        client_secret: Option<String>,
         anonymous: Option<bool>,
         endpoint_url: Option<String>,
         use_ssl: Option<bool>,
@@ -649,6 +666,10 @@ impl AzureConfig {
             config: crate::AzureConfig {
                 storage_account: storage_account.or_else(|| self.config.storage_account.clone()),
                 access_key: access_key.or_else(|| self.config.access_key.clone()),
+                sas_token: sas_token.or_else(|| self.config.sas_token.clone()),
+                tenant_id: tenant_id.or_else(|| self.config.tenant_id.clone()),
+                client_id: client_id.or_else(|| self.config.client_id.clone()),
+                client_secret: client_secret.or_else(|| self.config.client_secret.clone()),
                 anonymous: anonymous.unwrap_or(self.config.anonymous),
                 endpoint_url: endpoint_url.or_else(|| self.config.endpoint_url.clone()),
                 use_ssl: use_ssl.unwrap_or(self.config.use_ssl),
@@ -670,6 +691,26 @@ impl AzureConfig {
     #[getter]
     pub fn access_key(&self) -> PyResult<Option<String>> {
         Ok(self.config.access_key.clone())
+    }
+
+    #[getter]
+    pub fn sas_token(&self) -> PyResult<Option<String>> {
+        Ok(self.config.sas_token.clone())
+    }
+
+    #[getter]
+    pub fn tenant_id(&self) -> PyResult<Option<String>> {
+        Ok(self.config.tenant_id.clone())
+    }
+
+    #[getter]
+    pub fn client_id(&self) -> PyResult<Option<String>> {
+        Ok(self.config.client_id.clone())
+    }
+
+    #[getter]
+    pub fn client_secret(&self) -> PyResult<Option<String>> {
+        Ok(self.config.client_secret.clone())
     }
 
     /// Whether access is anonymous

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -71,7 +71,9 @@ pub struct S3Credentials {
     pub credentials: crate::S3Credentials,
 }
 
-/// Create configurations to be used when accessing Azure Blob Storage. To authenticate with Microsoft Entra ID, `tenant_id`, `client_id`, and `client_secret` must be provided.
+/// Create configurations to be used when accessing Azure Blob Storage.
+/// To authenticate with Microsoft Entra ID, `tenant_id`, `client_id`, and `client_secret` must be provided.
+/// If no credentials are provided, Daft will attempt to fetch credentials from the environment.
 ///
 /// Args:
 ///     storage_account (str): Azure Storage Account, defaults to reading from `AZURE_STORAGE_ACCOUNT` environment variable.

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -9,6 +9,8 @@ aws-sig-auth = "0.55.3"
 aws-sigv4 = "0.55.3"
 aws-smithy-async = "0.55.3"
 aws-smithy-client = "0.55.3"
+azure_core = "0.17.0"
+azure_identity = "0.17.0"
 azure_storage = {version = "0.17.0", features = ["enable_reqwest"], default-features = false}
 azure_storage_blobs = {version = "0.17.0", features = ["enable_reqwest"], default-features = false}
 bytes = {workspace = true}


### PR DESCRIPTION
Adds:
- login via shared access signatures (SAS)
- login via Entra ID (active directory) using tenant id + client id + client secret
- fallback to environment variables using azure-sdk-for-rust

Tested locally 👍 