### PR TITLE
[BUG] Use os.path.join in read_hudi only for local fs

### DIFF
--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 import pathlib
 import sys
 import urllib.parse
@@ -320,3 +321,19 @@ def glob_path_with_stats(
         num_rows.append(infos.get("rows"))
 
     return FileInfos.from_infos(file_paths=file_paths, file_sizes=file_sizes, num_rows=num_rows)
+
+
+###
+# Path joining
+###
+
+
+def join_path(fs: FileSystem, base_path: str, *sub_paths: str) -> str:
+    """
+    Join a base path with sub-paths using the appropriate path separator
+    for the given filesystem.
+    """
+    if isinstance(fs, LocalFileSystem):
+        return os.path.join(base_path, *sub_paths)
+    else:
+        return f"{base_path.rstrip('/')}/{'/'.join(sub_paths)}"

--- a/daft/hudi/pyhudi/table.py
+++ b/daft/hudi/pyhudi/table.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import os
 from collections import defaultdict
 from dataclasses import dataclass
 
 import pyarrow as pa
 import pyarrow.fs as pafs
 
+from daft.filesystem import join_path
 from daft.hudi.pyhudi.filegroup import BaseFile, FileGroup, FileSlice
 from daft.hudi.pyhudi.timeline import Timeline
 from daft.hudi.pyhudi.utils import (
@@ -92,7 +92,7 @@ class FileSystemView:
 class HudiTableProps:
     def __init__(self, fs: pafs.FileSystem, base_path: str):
         self._props = {}
-        hoodie_properties_file = os.path.join(base_path, ".hoodie", "hoodie.properties")
+        hoodie_properties_file = join_path(fs, base_path, ".hoodie", "hoodie.properties")
         with fs.open_input_file(hoodie_properties_file) as f:
             lines = f.readall().decode("utf-8").splitlines()
             for line in lines:

--- a/daft/hudi/pyhudi/utils.py
+++ b/daft/hudi/pyhudi/utils.py
@@ -7,6 +7,8 @@ import pyarrow as pa
 import pyarrow.fs as pafs
 import pyarrow.parquet as pq
 
+from daft.filesystem import join_path
+
 
 @dataclass(init=False)
 class FsFileMetadata:
@@ -14,7 +16,7 @@ class FsFileMetadata:
         self.base_path = base_path
         self.path = path
         self.base_name = base_name
-        with fs.open_input_file(os.path.join(base_path, path)) as f:
+        with fs.open_input_file(join_path(fs, base_path, path)) as f:
             metadata = pq.read_metadata(f)
         self.size = metadata.serialized_size
         self.num_records = metadata.num_rows
@@ -70,7 +72,7 @@ class FsFileMetadata:
 def list_relative_file_paths(
     base_path: str, sub_path: str, fs: pafs.FileSystem, includes: list[str] | None
 ) -> list[FsFileMetadata]:
-    listed_paths: list[pafs.FileInfo] = fs.get_file_info(pafs.FileSelector(os.path.join(base_path, sub_path)))
+    listed_paths: list[pafs.FileInfo] = fs.get_file_info(pafs.FileSelector(join_path(fs, base_path, sub_path)))
     file_paths = []
     common_prefix_len = len(base_path) + 1
     for listed_path in listed_paths:


### PR DESCRIPTION
Closes https://github.com/Eventual-Inc/Daft/issues/2295

This PR modifies the path joining logic in read_hudi to only use `os.path.join` if the file system is a local filesystem, and otherwise manually join paths using `/`. This fixes the issue of reading Hudi from S3 on a Windows machine.

Simulated a hudi read from Windows with:
```
from unittest.mock import patch
import daft

with patch("os.path.join", side_effect=lambda *args: "\\".join(args)):
    df = daft.read_hudi("s3://daft-public-data/hudi/v6_simplekeygen_nonhivestyle/")
    df.show()
```