### PR TITLE
[BUG] Add Retry on Streaming Errors when collecting stream into bytes

### DIFF
--- a/src/daft-csv/src/metadata.rs
+++ b/src/daft-csv/src/metadata.rs
@@ -130,7 +130,7 @@ pub(crate) async fn read_csv_schema_single(
             )
             .await
         }
-        GetResult::Stream(stream, size, _) => {
+        GetResult::Stream(stream, size, ..) => {
             read_csv_schema_from_compressed_reader(
                 StreamReader::new(stream),
                 compression_codec,

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -356,7 +356,7 @@ async fn read_csv_single_into_stream(
                         .unwrap_or(64 * 1024),
                 )
             }
-            GetResult::Stream(stream, _, _) => (
+            GetResult::Stream(stream, ..) => (
                 Box::new(StreamReader::new(stream)),
                 read_options
                     .as_ref()

--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -484,6 +484,7 @@ impl ObjectSource for AzureBlobSource {
             io_stats_on_bytestream(Box::pin(stream), io_stats),
             None,
             None,
+            None,
         ))
     }
 

--- a/src/daft-io/src/google_cloud.rs
+++ b/src/daft-io/src/google_cloud.rs
@@ -174,6 +174,7 @@ impl GCSClientWrapper {
             io_stats_on_bytestream(response, io_stats),
             size,
             None,
+            None,
         ))
     }
 

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -214,6 +214,7 @@ impl ObjectSource for HttpSource {
             io_stats_on_bytestream(stream, io_stats),
             size_bytes,
             None,
+            None,
         ))
     }
 

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(async_closure)]
 #![feature(let_chains)]
 #![feature(io_error_more)]
+#![feature(if_let_guard)]
 mod azure_blob;
 mod google_cloud;
 mod http;

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -13,7 +13,6 @@ mod stats;
 mod stream_utils;
 use azure_blob::AzureBlobSource;
 use google_cloud::GCSSource;
-use google_cloud_storage::http::object_access_controls::get;
 use lazy_static::lazy_static;
 #[cfg(feature = "python")]
 pub mod python;
@@ -238,12 +237,7 @@ impl IOClient {
         let get_result = source
             .get(path.as_ref(), range.clone(), io_stats.clone())
             .await?;
-        Ok(get_result.with_retry(StreamingRetryParams {
-            source,
-            input,
-            range: range,
-            io_stats: io_stats,
-        }))
+        Ok(get_result.with_retry(StreamingRetryParams::new(source, input, range, io_stats)))
     }
 
     pub async fn single_url_get_size(

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -64,7 +64,7 @@ impl GetResult {
                 drop(permit); // drop permit to ensure quota
                 for _ in 0..tries {
                     // if let Err(super::Error::SocketError { .. }) = result
-                    if let Err(err) = result
+                    if let Err(ref err) = result
                         && let Some(rp) = &retry_params
                     {
                         log::warn!("Received Socket Error, Attempting retry.\nDetails\n {err}");

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -62,6 +62,7 @@ impl GetResult {
                 let tries = 3;
                 let mut result = collect_bytes(stream, size).await;
                 drop(permit); // drop permit to ensure quota
+
                 for _ in 0..tries {
                     match result {
                         Err(super::Error::SocketError { .. })
@@ -76,8 +77,9 @@ impl GetResult {
                                 .source
                                 .get(&rp.input, rp.range.clone(), rp.io_stats.clone())
                                 .await?;
-                            if let GetResult::Stream(stream, size, ..) = get_result {
+                            if let GetResult::Stream(stream, size, permit, _) = get_result {
                                 result = collect_bytes(stream, size).await;
+                                drop(permit); // drop permit to ensure quota
                             } else {
                                 unreachable!("Retrying a stream should always be a stream");
                             }

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -63,12 +63,11 @@ impl GetResult {
                 let mut result = collect_bytes(stream, size).await;
                 drop(permit); // drop permit to ensure quota
                 for _ in 0..tries {
-                    if let Err(super::Error::SocketError { .. }) = result
+                    // if let Err(super::Error::SocketError { .. }) = result
+                    if let Err(err) = result
                         && let Some(rp) = &retry_params
                     {
-                        log::warn!(
-                            "Received Socket Error, Attempting retry.\nDetails\n {result:#?}"
-                        );
+                        log::warn!("Received Socket Error, Attempting retry.\nDetails\n {err}");
                         get_result = rp
                             .source
                             .get(&rp.input, rp.range.clone(), rp.io_stats.clone())

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -13,10 +13,10 @@ use crate::local::{collect_file, LocalFile};
 use crate::stats::IOStatsRef;
 
 pub struct StreamingRetryParams {
-    source: Arc<dyn ObjectSource>,
-    input: String,
-    range: Option<Range<usize>>,
-    io_stats: Option<IOStatsRef>,
+    pub source: Arc<dyn ObjectSource>,
+    pub input: String,
+    pub range: Option<Range<usize>>,
+    pub io_stats: Option<IOStatsRef>,
 }
 
 pub enum GetResult {
@@ -83,6 +83,15 @@ impl GetResult {
                     }
                 }
                 result
+            }
+        }
+    }
+
+    pub fn with_retry(self, params: StreamingRetryParams) -> Self {
+        match self {
+            GetResult::File(..) => self,
+            GetResult::Stream(s, size, permit, _) => {
+                GetResult::Stream(s, size, permit, Some(Box::new(params)))
             }
         }
     }

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -63,14 +63,14 @@ impl GetResult {
                 let mut result = collect_bytes(stream, size).await;
                 drop(permit); // drop permit to ensure quota
 
-                for _ in 0..tries {
+                for attempt in 1..tries {
                     match result {
                         Err(super::Error::SocketError { .. })
                         | Err(super::Error::UnableToReadBytes { .. })
                             if let Some(rp) = &retry_params =>
                         {
                             log::warn!(
-                                "Received Socket Error, Attempting retry.\nDetails\n {}",
+                                "Received Socket Error, Attempting retry attempt: {attempt}.\nDetails\n {}",
                                 result.err().unwrap()
                             );
                             get_result = rp

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -647,6 +647,7 @@ impl S3LikeSource {
                         stream,
                         Some(v.content_length as usize),
                         Some(permit),
+                        None,
                     ))
                 }
 
@@ -933,7 +934,7 @@ impl ObjectSource for S3LikeSource {
             .await?;
 
         if io_stats.is_some() {
-            if let GetResult::Stream(stream, num_bytes, permit) = get_result {
+            if let GetResult::Stream(stream, num_bytes, permit, retry_params) = get_result {
                 if let Some(is) = io_stats.as_ref() {
                     is.mark_get_requests(1)
                 }
@@ -941,6 +942,7 @@ impl ObjectSource for S3LikeSource {
                     io_stats_on_bytestream(stream, io_stats),
                     num_bytes,
                     permit,
+                    retry_params,
                 ))
             } else {
                 panic!("This should always be a stream");

--- a/src/daft-json/src/read.rs
+++ b/src/daft-json/src/read.rs
@@ -335,7 +335,7 @@ async fn read_json_single_into_stream(
                         .unwrap_or(64),
                 )
             }
-            GetResult::Stream(stream, _, _) => (
+            GetResult::Stream(stream, ..) => (
                 Box::new(StreamReader::new(stream)),
                 // Use user-provided buffer size, falling back to 8 * the user-provided chunk size if that exists, otherwise falling back to 512 KiB as the default.
                 read_options

--- a/src/daft-json/src/schema.rs
+++ b/src/daft-json/src/schema.rs
@@ -122,7 +122,7 @@ pub(crate) async fn read_json_schema_single(
             Box::new(BufReader::new(File::open(file.path).await?)),
             max_bytes,
         ),
-        GetResult::Stream(stream, size, _) => (
+        GetResult::Stream(stream, size, ..) => (
             Box::new(StreamReader::new(stream)),
             // Truncate max_bytes to size if both are set.
             max_bytes.map(|m| size.map(|s| m.min(s)).unwrap_or(m)),


### PR DESCRIPTION
```
(ScanWithTask-Aggregate [Stage:2] pid=331774) Received Socket Error when streaming bytes! Attempt 1 out of 3 tries. Trying again in 197ms
(ScanWithTask-Aggregate [Stage:2] pid=331774) Details
(ScanWithTask-Aggregate [Stage:2] pid=331774) Unable to read data from file s3://XXX/redpajama-data-v2/v1.1.0/data/2023-06/2023-06_2081_en_middle.parquet: error reading a body from connection: end of file before message length reached
```