### PR TITLE
[BUG] Allow nulls in partition column

### DIFF
--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -329,8 +329,8 @@ pub mod pylib {
                 assert_eq!(boolean.len(), 1);
                 let value = boolean.get(0);
                 match value {
-                    Some(false) => return Ok(None),
-                    None | Some(true) => {}
+                    None | Some(false) => return Ok(None),
+                    Some(true) => {}
                 }
             }
             // TODO(Clark): Filter out scan tasks with pushed down filters + table stats?

--- a/src/daft-stats/src/partition_spec.rs
+++ b/src/daft-stats/src/partition_spec.rs
@@ -47,12 +47,11 @@ impl PartialEq for PartitionSpec {
                     return false;
                 }
             } else {
-                let both_null = self_column
-                    .is_null()
-                    .unwrap()
-                    .and(&other_column.is_null().unwrap())
-                    .unwrap();
-                if !both_null.get(0).unwrap() {
+                // For partition spec, we treat null as equal to null, in order to allow for
+                // partitioning on columns that may have nulls.
+                let self_null = self_column.is_null().unwrap();
+                let other_null = other_column.is_null().unwrap();
+                if self_null.xor(&other_null).unwrap().get(0).unwrap() {
                     return false;
                 }
             }

--- a/src/daft-stats/src/partition_spec.rs
+++ b/src/daft-stats/src/partition_spec.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use daft_core::array::ops::DaftCompare;
+use daft_core::array::ops::{DaftCompare, DaftLogical};
 use daft_dsl::{ExprRef, Literal};
 use daft_table::Table;
 
@@ -42,9 +42,19 @@ impl PartialEq for PartitionSpec {
         for field_name in self.keys.schema.as_ref().fields.keys() {
             let self_column = self.keys.get_column(field_name).unwrap();
             let other_column = other.keys.get_column(field_name).unwrap();
-            let value_eq = self_column.equal(other_column).unwrap().get(0).unwrap();
-            if !value_eq {
-                return false;
+            if let Some(value_eq) = self_column.equal(other_column).unwrap().get(0) {
+                if !value_eq {
+                    return false;
+                }
+            } else {
+                let both_null = self_column
+                    .is_null()
+                    .unwrap()
+                    .and(&other_column.is_null().unwrap())
+                    .unwrap();
+                if !both_null.get(0).unwrap() {
+                    return false;
+                }
             }
         }
 

--- a/tests/io/delta_lake/test_table_read.py
+++ b/tests/io/delta_lake/test_table_read.py
@@ -48,7 +48,7 @@ def test_deltalake_read_full(deltalake_table):
     delta_schema = deltalake.DeltaTable(path, storage_options=io_config_to_storage_options(io_config, path)).schema()
     expected_schema = Schema.from_pyarrow_schema(delta_schema.to_pyarrow())
     assert df.schema() == expected_schema
-    assert_pyarrow_tables_equal(df.to_arrow().sort_by("part_idx"), pa.concat_tables(parts))
+    assert_pyarrow_tables_equal(df.to_arrow().sort_by("part_idx"), pa.concat_tables(parts).sort_by("part_idx"))
 
 
 def test_deltalake_read_show(deltalake_table):

--- a/tests/io/delta_lake/test_table_read_pushdowns.py
+++ b/tests/io/delta_lake/test_table_read_pushdowns.py
@@ -33,7 +33,8 @@ def test_read_predicate_pushdown_on_data(deltalake_table):
     expected_schema = Schema.from_pyarrow_schema(delta_schema.to_pyarrow())
     assert df.schema() == expected_schema
     assert_pyarrow_tables_equal(
-        df.to_arrow().sort_by("part_idx"), pa.concat_tables([table.filter(pc.field("a") == 2) for table in tables])
+        df.to_arrow().sort_by("part_idx"),
+        pa.concat_tables([table.filter(pc.field("a") == 2) for table in tables]).sort_by("part_idx"),
     )
 
 


### PR DESCRIPTION
Closes https://github.com/Eventual-Inc/Daft/issues/2292

Currently Daft panics if there are nulls in a partition column, the detailed error message can be found in the linked issue.

A simple reproduction:
```
from deltalake import write_deltalake
import pandas as pd
import daft

df = pd.DataFrame(
    {
        "group": [1, 2, 3, None],
        "num": list(range(4)),
    }
)
write_deltalake("z", df, partition_by="group", mode="overwrite")

df = daft.read_deltalake("z")
df.show()
```

This PR modifies the partition spec equality logic and partition pruning semantics to allow reading nulls in partition columns.