### PR TITLE
[DOCS] the project currently uses ray which is not compatible with python 3.12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ When proposing features, please include:
 
 To set up your development environment:
 
-1. Ensure that your system has a suitable Python version installed (>=3.7)
+1. Ensure that your system has a suitable Python version installed (>=3.7, <=3.11)
 2. [Install the Rust compilation toolchain](https://www.rust-lang.org/tools/install)
 3. Clone the Daft repo: `git clone git@github.com:Eventual-Inc/Daft.git`
 4. Run `make .venv` from your new cloned Daft repository to create a new virtual environment with all of Daft's development dependencies installed


### PR DESCRIPTION
I was setting up daft dev environment on my local and was following along the contribution guidelines. my default python env is currently at `3.12` and noticed that the `make .venv` keeps failing due to dependency on `ray[data]==2.10.0`. the failure happens because the current `ray-data` is only compatible till `python3.11`.
