### PR TITLE
[DOCS] improve SQL docs

### DIFF
--- a/docs/source/user_guide/basic_concepts/read-and-write.rst
+++ b/docs/source/user_guide/basic_concepts/read-and-write.rst
@@ -82,10 +82,10 @@ In order to partition the data, you can specify a partition column, which will a
 
     # Read from a PostgreSQL database
     uri = "postgresql://user:password@host:port/database"
-    df = daft.read_sql(uri, "SELECT * FROM my_table")
+    df = daft.read_sql("SELECT * FROM my_table", uri)
 
     # Read with a partition column
-    df = daft.read_sql(uri, "SELECT * FROM my_table", partition_col="date")
+    df = daft.read_sql("SELECT * FROM my_table", partition_col="date", uri)
 
 To learn more, consult the API documentation on :func:`daft.read_sql`.
 

--- a/docs/source/user_guide/basic_concepts/read-and-write.rst
+++ b/docs/source/user_guide/basic_concepts/read-and-write.rst
@@ -87,7 +87,8 @@ In order to partition the data, you can specify a partition column, which will a
     # Read with a partition column
     df = daft.read_sql("SELECT * FROM my_table", partition_col="date", uri)
 
-To learn more, consult the API documentation on :func:`daft.read_sql`.
+To learn more, consult the :doc:`SQL User Guide <../integrations/sql>` or the API documentation on :func:`daft.read_sql`.
+
 
 Writing Data
 ------------

--- a/docs/source/user_guide/integrations/sql.rst
+++ b/docs/source/user_guide/integrations/sql.rst
@@ -55,7 +55,7 @@ After writing this local example table, we can easily read it into a Daft DataFr
 
     df = daft.read_sql(
         "SELECT * FROM books",
-        "sqlite:///example.db",
+        "sqlite://example.db",
     )
 
 Daft uses `ConnectorX <https://sfu-db.github.io/connector-x/databases.html>`_ under the hood to read SQL data. ConnectorX is a fast, Rust based SQL connector that reads directly into Arrow Tables, enabling zero-copy transfer into Daft dataframes.


### PR DESCRIPTION
I was having trouble using `read_sql` today because I was following the usage recommended [here](https://www.getdaft.io/projects/docs/en/latest/user_guide/basic_concepts/read-and-write.html#from-databases).

Made a few small changes to correct the syntax and make it easier for folks to find the SQL integration user guide which lists required dependencies etc.