### PR TITLE
[BUG] Fix IO integration tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -327,8 +327,6 @@ jobs:
       with:
         compose-file: ./tests/integration/io/docker-compose/docker-compose.yml
         down-flags: --volumes
-    - name: SSH terminal
-      uses: lhotari/action-upterm@v1
     - name: Run IO integration tests
       run: |
         pytest tests/integration/io -m 'integration' --durations=50

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -327,6 +327,8 @@ jobs:
       with:
         compose-file: ./tests/integration/io/docker-compose/docker-compose.yml
         down-flags: --volumes
+    - name: SSH terminal
+      uses: lhotari/action-upterm@v1
     - name: Run IO integration tests
       run: |
         pytest tests/integration/io -m 'integration' --durations=50

--- a/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
+++ b/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
@@ -19,3 +19,6 @@ watchfiles==0.19.0
 websockets==11.0.3
 pyarrow==12.0.1
 slowapi==0.1.8
+
+# Pin numpy version otherwise pyarrow doesn't work
+numpy<2


### PR DESCRIPTION
Pins numpy version, otherwise we get an error while running Docker-compose up.

Seems like the latest numpy version dropped yesterday (v2.0.0) isn't compatible with pyarrow 12 because pyarrow was built against numpy 1.