### PR TITLE
[BUG] Slice array if necessary when casting from list to fixed size list

### DIFF
--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1714,7 +1714,15 @@ impl ListArray {
                 }
 
                 // Cast child
-                let casted_child = self.flat_child.cast(child_dtype.as_ref())?;
+                let mut casted_child = self.flat_child.cast(child_dtype.as_ref())?;
+
+                // Slice child to match offsets if necessary
+                if casted_child.len() / size > self.len() {
+                    casted_child = casted_child.slice(
+                        *self.offsets().first() as usize,
+                        *self.offsets().last() as usize,
+                    )?;
+                }
 
                 // Build a FixedSizeListArray
                 match self.validity() {

--- a/tests/series/test_slice.py
+++ b/tests/series/test_slice.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
+from daft import DataType
 from daft.series import Series
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES, ARROW_STRING_TYPES
 
@@ -38,6 +39,30 @@ def test_series_slice_list_array(fixed) -> None:
 
     original_data = s.to_pylist()
     expected = original_data[2:4]
+    assert result.to_pylist() == expected
+
+
+def test_series_slice_list_array_to_fixed_size_with_nulls() -> None:
+    data = [[10, 20], [33, None], [43, 45], None, [50, 52], None]
+
+    s = Series.from_pylist(data)
+    result = s.slice(1, 4).cast(DataType.fixed_size_list(DataType.int64(), 2))
+    assert result.datatype() == DataType.fixed_size_list(DataType.int64(), 2)
+    assert len(result) == 3
+
+    expected = [[33, None], [43, 45], None]
+    assert result.to_pylist() == expected
+
+
+def test_series_slice_list_array_to_fixed_size_without_nulls() -> None:
+    data = [[10, 20], [33, 34], [43, 45], [50, 52], [60, 62]]
+
+    s = Series.from_pylist(data)
+    result = s.slice(1, 4).cast(DataType.fixed_size_list(DataType.int64(), 2))
+    assert result.datatype() == DataType.fixed_size_list(DataType.int64(), 2)
+    assert len(result) == 3
+
+    expected = [[33, 34], [43, 45], [50, 52]]
     assert result.to_pylist() == expected
 
 


### PR DESCRIPTION
Resolves https://github.com/Eventual-Inc/Daft/issues/2394

When we call `into_partitions` on a dataframe with list arrays, the list arrays are sliced. However, the implementation of [list array slice](https://github.com/Eventual-Inc/Daft/blob/main/src/daft-core/src/array/list_array.rs#L139) simply slices the offsets, and leaves the data unchanged.

If the column is then casted to a fixed size list array (and there is no validity bitmap), we will just copy the data, which leads to a series length mismatch error.

This PR makes a fix to slice the data during a cast.

Example:
```
import daft
import numpy as np
import pandas as pd

N_ROWS = 4
N_ELEMENTS_IN_LIST = 2
N_PARTITIONS = 2

# Create synthetic parquet
num = [i for i in range(N_ROWS)]
fixed_list = [np.random.randint(0, 100, size=N_ELEMENTS_IN_LIST).tolist() for _ in range(N_ROWS)]
df = pd.DataFrame({"fixed_list": fixed_list, "num": num})
df.to_parquet("fixed_list.parquet", engine="pyarrow")

# Read and cast the relevant column
df = daft.read_parquet("fixed_list.parquet").into_partitions(N_PARTITIONS)
dtype = daft.DataType.from_numpy_dtype("int8")
fixed_size_list_dtype = daft.DataType.fixed_size_list(dtype, N_ELEMENTS_IN_LIST)
df = df.with_column("fixed_list", df["fixed_list"].cast(fixed_size_list_dtype))
iter_df = iter(df)
s = next(iter_df)
print(s)
```

Todo:
- [x] - Add tests