### PR TITLE
[FEAT] thread through transport errors

### DIFF
--- a/src/arrow2/src/io/parquet/mod.rs
+++ b/src/arrow2/src/io/parquet/mod.rs
@@ -19,6 +19,9 @@ impl From<parquet2::error::Error> for Error {
                     .to_string();
                 Error::ExternalFormat(message)
             }
+            parquet2::error::Error::Transport(msg) => {
+                Error::Io(std::io::Error::new(std::io::ErrorKind::Other, msg))
+            }
             _ => Error::ExternalFormat(error.to_string()),
         }
     }

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -53,7 +53,10 @@ impl std::error::Error for DaftError {
 
 impl From<arrow2::error::Error> for DaftError {
     fn from(error: arrow2::error::Error) -> Self {
-        DaftError::ArrowError(error.to_string())
+        match error {
+            arrow2::error::Error::Io(_) => DaftError::ByteStreamError(error.into()),
+            _ => DaftError::ArrowError(error.to_string()),
+        }
     }
 }
 


### PR DESCRIPTION
* This allows errors raised during thrift decoding to be raised up as daft transient errors