### PR TITLE
[BUG] Use estimated in-memory size for scan task merging and resource requests

### DIFF
--- a/daft/execution/rust_physical_plan_shim.py
+++ b/daft/execution/rust_physical_plan_shim.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from daft.context import get_context
 from daft.daft import (
     FileFormat,
     IOConfig,
@@ -32,15 +33,17 @@ def scan_with_tasks(
     """
     # TODO(Clark): Currently hardcoded to have 1 file per instruction
     # We can instead right-size and bundle the ScanTask into single-instruction bulk reads.
+
+    cfg = get_context().daft_execution_config
+
     for scan_task in scan_tasks:
         scan_step = execution_step.PartitionTaskBuilder[PartitionT](
             inputs=[],
             partial_metadatas=None,
         ).add_instruction(
             instruction=execution_step.ScanWithTask(scan_task),
-            # Set the filesize as the memory request.
-            # (Note: this is very conservative; file readers empirically use much more peak memory than 1x file size.)
-            resource_request=ResourceRequest(memory_bytes=scan_task.size_bytes()),
+            # Set the estimated in-memory size as the memory request.
+            resource_request=ResourceRequest(memory_bytes=scan_task.estimate_in_memory_size_bytes(cfg)),
         )
         yield scan_step
 

--- a/src/daft-plan/src/physical_planner/translate.rs
+++ b/src/daft-plan/src/physical_planner/translate.rs
@@ -57,11 +57,7 @@ pub(super) fn translate_single_logical_node(
                 );
 
                 // Apply transformations on the ScanTasks to optimize
-                let scan_tasks = daft_scan::scan_task_iters::merge_by_sizes(
-                    scan_tasks,
-                    cfg.scan_tasks_min_size_bytes,
-                    cfg.scan_tasks_max_size_bytes,
-                );
+                let scan_tasks = daft_scan::scan_task_iters::merge_by_sizes(scan_tasks, cfg);
                 let scan_tasks = scan_tasks.collect::<DaftResult<Vec<_>>>()?;
                 if scan_tasks.is_empty() {
                     let clustering_spec =

--- a/tests/io/test_merge_scan_tasks.py
+++ b/tests/io/test_merge_scan_tasks.py
@@ -41,7 +41,7 @@ def test_merge_scan_task_exceed_max(csv_files):
 
 
 def test_merge_scan_task_below_max(csv_files):
-    with override_merge_scan_tasks_configs(21, 22):
+    with override_merge_scan_tasks_configs(11, 12):
         df = daft.read_csv(str(csv_files))
         assert (
             df.num_partitions() == 2
@@ -49,7 +49,7 @@ def test_merge_scan_task_below_max(csv_files):
 
 
 def test_merge_scan_task_above_min(csv_files):
-    with override_merge_scan_tasks_configs(19, 40):
+    with override_merge_scan_tasks_configs(9, 20):
         df = daft.read_csv(str(csv_files))
         assert (
             df.num_partitions() == 2
@@ -57,7 +57,7 @@ def test_merge_scan_task_above_min(csv_files):
 
 
 def test_merge_scan_task_below_min(csv_files):
-    with override_merge_scan_tasks_configs(35, 40):
+    with override_merge_scan_tasks_configs(17, 20):
         df = daft.read_csv(str(csv_files))
         assert (
             df.num_partitions() == 1


### PR DESCRIPTION
Unblocks #2383, users can now set the `parquet_inflation_factor` execution config to prevent large scan tasks from merging and tasks from scheduling when there isn't enough memory

In the future we might want to read a few files/metadata to obtain a better estimate