### PR TITLE
[FEAT] Add Floor Division Support for Integer Columns

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -254,6 +254,15 @@ class Expression:
         expr = Expression._to_expression(other)
         return Expression._from_pyexpr(expr._expr / self._expr)
 
+    def __floordiv__(self, other: object) -> Expression:
+        """Performs floor division between two expressions (``e1 // e2``)"""
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(self._expr // expr._expr)
+
+    def __rfloordiv__(self, other: object) -> Expression:
+        expr = Expression._to_expression(other)
+        return Expression._from_pyexpr(expr._expr // self._expr)
+
     def __mod__(self, other: Expression) -> Expression:
         """Takes the mod of two numeric expressions (``e1 % e2``)"""
         expr = Expression._to_expression(other)

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -56,6 +56,7 @@ OPS = [
     (ops.sub, "-"),
     (ops.mul, "*"),
     (ops.truediv, "/"),
+    (ops.floordiv, "//"),
     (ops.mod, "%"),
     (ops.lt, "<"),
     (ops.le, "<="),


### PR DESCRIPTION
Tries to fix #2418 

## Changes
- Implemented the `__floordiv__` and `__rfloordiv__` methods in the `Expression` class to handle the floor division of integer columns.
- Added test for `//`

## Impact
- Users can now use the `//` operator directly in expressions involving integer columns, making code cleaner and more intuitive.

I look forward to your feedback and any suggestions for further improvements!
