### PR TITLE
[DOCS] Adds RunLLM widget

### DIFF
--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -1,0 +1,16 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var script = document.createElement("script");
+  script.type = "module";
+  script.id = "runllm-widget-script"
+
+  script.src = "https://widget.runllm.com";
+
+  script.setAttribute("version", "stable");
+  script.setAttribute("runllm-keyboard-shortcut", "Mod+j"); // cmd-j or ctrl-j to open the widget.
+  script.setAttribute("runllm-name", "Daft");
+  script.setAttribute("runllm-position", "BOTTOM_RIGHT");
+  script.setAttribute("runllm-assistant-id", "160");
+
+  script.async = true;
+  document.head.appendChild(script);
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,6 +62,7 @@ nb_execution_mode = "off"
 html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
 html_css_files = ["header.css", "custom-function-signatures.css"]
+html_js_files = ["custom.js"]
 html_theme_options = {
     # This is how many levels are shown on the secondary sidebar
     "show_toc_level": 2,


### PR DESCRIPTION
This PR adds the RunLLM chat widget to the Daft documentation site. 

<img width="1616" alt="image" src="https://github.com/Eventual-Inc/Daft/assets/867892/6d25b268-c92e-4ec2-8402-0c4bd8702f5d">
