### PR TITLE
[FEAT] Implement hashing and groupby on lists

### DIFF
--- a/src/daft-core/src/array/ops/groups.rs
+++ b/src/daft-core/src/array/ops/groups.rs
@@ -4,7 +4,7 @@ use arrow2::array::Array;
 use fnv::FnvHashMap;
 
 use crate::{
-    array::DataArray,
+    array::{DataArray, FixedSizeListArray, ListArray},
     datatypes::{
         BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeBinaryArray,
         Float32Array, Float64Array, NullArray, Utf8Array,
@@ -168,5 +168,17 @@ impl IntoGroups for NullArray {
         }
         let v = (0u64..l).collect::<Vec<u64>>();
         Ok((vec![0], vec![v]))
+    }
+}
+
+impl IntoGroups for ListArray {
+    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+        self.hash(None)?.make_groups()
+    }
+}
+
+impl IntoGroups for FixedSizeListArray {
+    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+        self.hash(None)?.make_groups()
     }
 }

--- a/src/daft-core/src/array/ops/hash.rs
+++ b/src/daft-core/src/array/ops/hash.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     kernels,
     utils::arrow::arrow_bitmap_and_helper,
-    DataType, Series,
+    Series,
 };
 
 use arrow2::types::Index;
@@ -172,10 +172,7 @@ impl ListArray {
 
 impl FixedSizeListArray {
     pub fn hash(&self, seed: Option<&UInt64Array>) -> DaftResult<UInt64Array> {
-        let size = match self.field.dtype {
-            DataType::FixedSizeList(_, s) => s,
-            _ => panic!("dtype is not FixedSizeList"),
-        };
+        let size = self.fixed_element_len();
         let len = self.flat_child.len() as i64;
         // see comment on hash_list for why we are collecting
         let offsets: Vec<i64> = (0..=len).step_by(size).collect();

--- a/src/daft-core/src/datatypes/matching.rs
+++ b/src/daft-core/src/datatypes/matching.rs
@@ -152,6 +152,38 @@ macro_rules! with_match_comparable_daft_types {(
 })}
 
 #[macro_export]
+macro_rules! with_match_hashable_daft_types {(
+    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    #[allow(unused_imports)]
+    use $crate::datatypes::*;
+
+    match $key_type {
+        Null => __with_ty__! { NullType },
+        Boolean => __with_ty__! { BooleanType },
+        Int8 => __with_ty__! { Int8Type },
+        Int16 => __with_ty__! { Int16Type },
+        Int32 => __with_ty__! { Int32Type },
+        Int64 => __with_ty__! { Int64Type },
+        Int128 => __with_ty__! { Int128Type },
+        UInt8 => __with_ty__! { UInt8Type },
+        UInt16 => __with_ty__! { UInt16Type },
+        UInt32 => __with_ty__! { UInt32Type },
+        UInt64 => __with_ty__! { UInt64Type },
+        // Float16 => __with_ty__! { Float16Type },
+        Float32 => __with_ty__! { Float32Type },
+        Float64 => __with_ty__! { Float64Type },
+        Utf8 => __with_ty__! { Utf8Type },
+        Binary => __with_ty__! { BinaryType },
+        FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+        List(_) => __with_ty__! { ListType },
+        _ => panic!("{:?} not implemented", $key_type)
+    }
+})}
+
+#[macro_export]
 macro_rules! with_match_numeric_daft_types {(
     $key_type:expr, | $_:tt $T:ident | $($body:tt)*
 ) => ({

--- a/src/daft-core/src/datatypes/matching.rs
+++ b/src/daft-core/src/datatypes/matching.rs
@@ -179,6 +179,7 @@ macro_rules! with_match_hashable_daft_types {(
         Binary => __with_ty__! { BinaryType },
         FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
         List(_) => __with_ty__! { ListType },
+        FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
         _ => panic!("{:?} not implemented", $key_type)
     }
 })}

--- a/src/daft-core/src/series/ops/groups.rs
+++ b/src/daft-core/src/series/ops/groups.rs
@@ -1,14 +1,14 @@
 use crate::{
     array::ops::{GroupIndicesPair, IntoGroups},
     series::Series,
-    with_match_comparable_daft_types,
+    with_match_hashable_daft_types,
 };
 use common_error::DaftResult;
 
 impl IntoGroups for Series {
     fn make_groups(&self) -> DaftResult<GroupIndicesPair> {
         let s = self.as_physical()?;
-        with_match_comparable_daft_types!(s.data_type(), |$T| {
+        with_match_hashable_daft_types!(s.data_type(), |$T| {
             let array = s.downcast::<<$T as DaftDataType>::ArrayType>()?;
             array.make_groups()
         })

--- a/src/daft-core/src/series/ops/hash.rs
+++ b/src/daft-core/src/series/ops/hash.rs
@@ -1,14 +1,14 @@
 use crate::{
     datatypes::{Int32Array, UInt64Array},
     series::Series,
-    with_match_comparable_daft_types,
+    with_match_hashable_daft_types,
 };
 use common_error::DaftResult;
 
 impl Series {
     pub fn hash(&self, seed: Option<&UInt64Array>) -> DaftResult<UInt64Array> {
         let s = self.as_physical()?;
-        with_match_comparable_daft_types!(s.data_type(), |$T| {
+        with_match_hashable_daft_types!(s.data_type(), |$T| {
             let downcasted = s.downcast::<<$T as DaftDataType>::ArrayType>()?;
             downcasted.hash(seed)
         })

--- a/tests/series/test_hash.py
+++ b/tests/series/test_hash.py
@@ -256,6 +256,102 @@ def test_hash_list_array_consistency(dtype):
     assert hashed1 == hashed2
 
 
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_hash_fixed_size_list_array_no_seed(dtype):
+    arr = Series.from_pylist([[1, 2], [1, 3], [1, 2], [1, 4], [5, 5], [5, 5], [2, 1]]).cast(
+        DataType.fixed_size_list(dtype, 2)
+    )
+
+    hashed = arr.hash().to_pylist()
+    assert hashed[0] == hashed[2]
+    assert hashed[4] == hashed[5]
+
+    different_inds = [0, 1, 3, 4, 6]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+@pytest.mark.parametrize("seed", [1, 2, 42])
+def test_hash_fixed_size_list_array_seeded(dtype, seed):
+    arr = Series.from_pylist([[1, 2], [1, 3], [1, 2], [1, 4], [5, 5], [5, 5], [2, 1]]).cast(
+        DataType.fixed_size_list(dtype, 2)
+    )
+    seeds = Series.from_pylist([seed] * 9).cast(DataType.uint64())
+
+    hashed = arr.hash(seeds).to_pylist()
+    assert hashed[0] == hashed[2]
+    assert hashed[4] == hashed[5]
+
+    different_inds = [0, 1, 3, 4, 6]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_hash_fixed_size_list_array_no_seed_with_invalid(dtype):
+    arr = Series.from_pylist([[1, 2], [1, 3], [1, 2], [1, 4], [5, 5], [5, 5], None, [2, 1], None]).cast(
+        DataType.fixed_size_list(dtype, 2)
+    )
+
+    hashed = arr.hash().to_pylist()
+    assert hashed[0] == hashed[2]
+    assert hashed[4] == hashed[5]
+    assert hashed[6] is None
+    assert hashed[8] is None
+
+    different_inds = [0, 1, 3, 4, 7]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+@pytest.mark.parametrize("seed", [1, 2, 42])
+def test_hash_fixed_size_list_array_seeded_with_invalid(dtype, seed):
+    arr = Series.from_pylist([[1, 2], [1, 3], [1, 2], [1, 4], [5, 5], [5, 5], None, [2, 1], None]).cast(
+        DataType.fixed_size_list(dtype, 2)
+    )
+    seeds = Series.from_pylist([seed] * 9).cast(DataType.uint64())
+
+    hashed = arr.hash(seeds).to_pylist()
+    assert hashed[0] == hashed[2]
+    assert hashed[4] == hashed[5]
+    assert hashed[6] is None
+    assert hashed[8] is None
+
+    different_inds = [0, 1, 3, 4, 7]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_hash_fixed_size_list_array_different_seeds(dtype):
+    arr = Series.from_pylist([[1, 2], [1, 2], [1, 2], [1, 2]]).cast(DataType.fixed_size_list(dtype, 2))
+    seeds = Series.from_pylist([1, 2, 3, 4]).cast(DataType.uint64())
+
+    hashed = arr.hash(seeds).to_pylist()
+
+    different_inds = [0, 1, 2, 3]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_hash_fixed_size_list_array_consistency(dtype):
+    data = [[1, 2], [1, 3], [1, 2], [1, 4], [5, 5], [5, 5], None, [2, 1], None]
+    arr1 = Series.from_pylist(data).cast(DataType.fixed_size_list(dtype, 2))
+    arr2 = Series.from_pylist(data).cast(DataType.fixed_size_list(dtype, 2))
+
+    hashed1 = arr1.hash().to_pylist()
+    hashed2 = arr2.hash().to_pylist()
+    assert hashed1 == hashed2
+
+
 @pytest.mark.parametrize(
     "dtype",
     [

--- a/tests/series/test_hash.py
+++ b/tests/series/test_hash.py
@@ -10,6 +10,7 @@ import xxhash
 
 from daft.datatype import DataType
 from daft.series import Series
+from tests.test_datatypes import daft_numeric_types
 
 
 @pytest.mark.parametrize(
@@ -139,6 +140,120 @@ def test_hash_int_array_with_bad_length():
 
     with pytest.raises(ValueError, match="seed length does not match array length"):
         arr.hash(bad_seed)
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_hash_list_array_no_seed(dtype):
+    arr = Series.from_pylist([[1, 2], [1, 3], [1, 2], [1, 2, 3], [], [], [2, 1]]).cast(DataType.list(dtype))
+
+    hashed = arr.hash().to_pylist()
+    assert hashed[0] == hashed[2]
+    assert hashed[4] == hashed[5]
+
+    different_inds = [0, 1, 3, 4, 6]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+@pytest.mark.parametrize("seed", [1, 2, 42])
+def test_hash_list_array_seeded(dtype, seed):
+    arr = Series.from_pylist([[1, 2], [1, 3], [1, 2], [1, 2, 3], [], [], [2, 1]]).cast(DataType.list(dtype))
+    seeds = Series.from_pylist([seed] * 9).cast(DataType.uint64())
+
+    hashed = arr.hash(seeds).to_pylist()
+    assert hashed[0] == hashed[2]
+    assert hashed[4] == hashed[5]
+
+    different_inds = [0, 1, 3, 4, 6]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_hash_list_array_no_seed_with_invalid(dtype):
+    arr = Series.from_pylist([[1, 2], [1, 3], [1, 2], [1, 2, 3], [], [], None, [2, 1], None]).cast(DataType.list(dtype))
+
+    hashed = arr.hash().to_pylist()
+    assert hashed[0] == hashed[2]
+    assert hashed[4] == hashed[5]
+    assert hashed[6] is None
+    assert hashed[8] is None
+
+    different_inds = [0, 1, 3, 4, 7]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+@pytest.mark.parametrize("seed", [1, 2, 42])
+def test_hash_list_array_seeded_with_invalid(dtype, seed):
+    arr = Series.from_pylist([[1, 2], [1, 3], [1, 2], [1, 2, 3], [], [], None, [2, 1], None]).cast(DataType.list(dtype))
+    seeds = Series.from_pylist([seed] * 9).cast(DataType.uint64())
+
+    hashed = arr.hash(seeds).to_pylist()
+    assert hashed[0] == hashed[2]
+    assert hashed[4] == hashed[5]
+    assert hashed[6] is None
+    assert hashed[8] is None
+
+    different_inds = [0, 1, 3, 4, 7]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_hash_list_array_different_seeds(dtype):
+    arr = Series.from_pylist([[1, 2], [1, 2], [1, 2], [1, 2]]).cast(DataType.list(dtype))
+    seeds = Series.from_pylist([1, 2, 3, 4]).cast(DataType.uint64())
+
+    hashed = arr.hash(seeds).to_pylist()
+
+    different_inds = [0, 1, 2, 3]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_hash_list_array_nested_lists(dtype):
+    arr = Series.from_pylist(
+        [
+            [[1, 2], [3, 4]],
+            [[1, 2], [3, 5]],
+            [[1, 2], [3, 4]],
+            [[3, 4], [1, 2]],
+            [[1], [2]],
+            [[], []],
+            [[]],
+            [],
+            [[1, 2, 3]],
+            [[1], [2], [3]],
+        ]
+    ).cast(DataType.list(DataType.list(dtype)))
+
+    hashed = arr.hash().to_pylist()
+    assert hashed[0] == hashed[2]
+
+    different_inds = [0, 1, 3, 4, 5, 6, 7, 8, 9]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_hash_list_array_consistency(dtype):
+    data = [[1, 2], [1, 3], [1, 2], [1, 2, 3], [], [], None, [2, 1], None]
+    arr1 = Series.from_pylist(data).cast(DataType.list(dtype))
+    arr2 = Series.from_pylist(data).cast(DataType.list(dtype))
+
+    hashed1 = arr1.hash().to_pylist()
+    hashed2 = arr2.hash().to_pylist()
+    assert hashed1 == hashed2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implements hashing and groupby on lists and fixed-size lists. Works by recursively hashing the inner items and then hashing the hashes.

Closes #1983

Example:
```
>>> df = daft.from_pydict({"a": [[1, 2], [1, 2], [1, 3, 4], [1, 2], [1, 3, 4]], "b": [1, 2, 3, 4, 5]})
>>> df.groupby("a").agg_list("b").show()
╭─────────────┬─────────────╮
│ a           ┆ b           │
│ ---         ┆ ---         │
│ List[Int64] ┆ List[Int64] │
╞═════════════╪═════════════╡
│ [1, 3, 4]   ┆ [3, 5]      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ [1, 2]      ┆ [1, 2, 4]   │
╰─────────────┴─────────────╯
```