### PR TITLE
[FEAT] Microsoft Fabric support in AzureConfig

### DIFF
--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -538,6 +538,7 @@ class AzureConfig:
     tenant_id: str | None
     client_id: str | None
     client_secret: str | None
+    use_fabric_endpoint: bool | None
     anonymous: bool | None
     endpoint_url: str | None = None
     use_ssl: bool | None = None
@@ -551,6 +552,7 @@ class AzureConfig:
         tenant_id: str | None = None,
         client_id: str | None = None,
         client_secret: str | None = None,
+        use_fabric_endpoint: bool | None = None,
         anonymous: bool | None = None,
         endpoint_url: str | None = None,
         use_ssl: bool | None = None,
@@ -564,6 +566,7 @@ class AzureConfig:
         tenant_id: str | None = None,
         client_id: str | None = None,
         client_secret: str | None = None,
+        use_fabric_endpoint: bool | None = None,
         anonymous: bool | None = None,
         endpoint_url: str | None = None,
         use_ssl: bool | None = None,

--- a/daft/io/object_store_options.py
+++ b/daft/io/object_store_options.py
@@ -63,6 +63,8 @@ def _azure_config_to_storage_options(azure_config: AzureConfig) -> dict[str, str
         storage_options["client_id"] = azure_config.client_id
     if azure_config.client_secret is not None:
         storage_options["client_secret"] = azure_config.client_secret
+    if azure_config.use_fabric_endpoint is not None:
+        storage_options["use_fabric_endpoint"] = "true" if azure_config.use_fabric_endpoint else "false"
     if azure_config.endpoint_url is not None:
         storage_options["endpoint"] = azure_config.endpoint_url
     if azure_config.use_ssl is not None:

--- a/docs/source/user_guide/integrations/microsoft-azure.rst
+++ b/docs/source/user_guide/integrations/microsoft-azure.rst
@@ -63,23 +63,22 @@ pass a different :class:`daft.io.AzureConfig` per function call if you wish!
     # Perform some I/O operation but override the IOConfig
     df2 = daft.read_csv("az://my_container/my_other_path/**/*", io_config=io_config)
 
-Connect to Onelake
+Connect to Microsoft Fabric/OneLake
 ****************************
-You need to register an App in Azure to get Client_id and Client_secret
+
+If you are connecting to storage in OneLake or another Microsoft Fabric service, set the `use_fabric_endpoint` parameter to ``True`` in the :class:`daft.io.AzureConfig` object.
 
 .. code:: python
 
-    from azure.identity import ClientSecretCredential, AuthenticationRequiredError
-    import daft
     from daft.io import IOConfig, AzureConfig
-    credential = ClientSecretCredential(
-                    client_id="xxxxxx",
-                    client_secret="yyyyyyy",
-                    tenant_id="zzzzzzz"
-                    )
-    access_token =       credential.get_token("https://storage.azure.com/.default").token
-    io_config = IOConfig(azure=AzureConfig(storage_account="onelake",endpoint_url="https://onelake.blob.fabric.microsoft.com",bearer_token=access_token))
-    # if your workspace has a blank, then use workspace_id then
-    xx = daft.read_deltalake('abfss://workspace_name@onelake.dfs.fabric.microsoft.com/lakehouse_name.Lakehouse/Tables/', io_config=io_config)
 
+    io_config = IOConfig(
+        azure=AzureConfig(
+            storage_account="onelake",
+            use_fabric_endpoint=True,
 
+            # Set credentials as needed
+        )
+    )
+
+    df = daft.read_deltalake('abfss://[WORKSPACE]@onelake.dfs.fabric.microsoft.com/[LAKEHOUSE].Lakehouse/Tables/[TABLE]', io_config=io_config)

--- a/docs/source/user_guide/integrations/microsoft-azure.rst
+++ b/docs/source/user_guide/integrations/microsoft-azure.rst
@@ -62,3 +62,24 @@ pass a different :class:`daft.io.AzureConfig` per function call if you wish!
 
     # Perform some I/O operation but override the IOConfig
     df2 = daft.read_csv("az://my_container/my_other_path/**/*", io_config=io_config)
+
+Connect to Onelake
+****************************
+You need to register an App in Azure to get Client_id and Client_secret
+
+.. code:: python
+
+    from azure.identity import ClientSecretCredential, AuthenticationRequiredError
+    import daft
+    from daft.io import IOConfig, AzureConfig
+    credential = ClientSecretCredential(
+                    client_id="xxxxxx",
+                    client_secret="yyyyyyy",
+                    tenant_id="zzzzzzz"
+                    )
+    access_token =       credential.get_token("https://storage.azure.com/.default").token
+    io_config = IOConfig(azure=AzureConfig(storage_account="onelake",endpoint_url="https://onelake.blob.fabric.microsoft.com",bearer_token=access_token))
+    # if your workspace has a blank, then use workspace_id then
+    xx = daft.read_deltalake('abfss://workspace_name@onelake.dfs.fabric.microsoft.com/lakehouse_name.Lakehouse/Tables/', io_config=io_config)
+
+

--- a/src/common/io-config/src/azure.rs
+++ b/src/common/io-config/src/azure.rs
@@ -13,6 +13,7 @@ pub struct AzureConfig {
     pub tenant_id: Option<String>,
     pub client_id: Option<String>,
     pub client_secret: Option<String>,
+    pub use_fabric_endpoint: bool,
     pub anonymous: bool,
     pub endpoint_url: Option<String>,
     pub use_ssl: bool,
@@ -28,6 +29,7 @@ impl Default for AzureConfig {
             tenant_id: None,
             client_id: None,
             client_secret: None,
+            use_fabric_endpoint: false,
             anonymous: false,
             endpoint_url: None,
             use_ssl: true,
@@ -59,6 +61,10 @@ impl AzureConfig {
         if let Some(client_secret) = &self.client_secret {
             res.push(format!("Client Secret = {}", client_secret));
         }
+        res.push(format!(
+            "Use Fabric Endpoint = {}",
+            self.use_fabric_endpoint
+        ));
         res.push(format!("Anonymous = {}", self.anonymous));
         if let Some(endpoint_url) = &self.endpoint_url {
             res.push(format!("Endpoint URL = {}", endpoint_url));
@@ -80,6 +86,7 @@ impl Display for AzureConfig {
     tenant_id: {:?}
     client_id: {:?}
     client_secret: {:?}
+    use_fabric_endpoint: {:?}
     anonymous: {:?}
     endpoint_url: {:?}
     use_ssl: {:?}",
@@ -90,6 +97,7 @@ impl Display for AzureConfig {
             self.tenant_id,
             self.client_id,
             self.client_secret,
+            self.use_fabric_endpoint,
             self.anonymous,
             self.endpoint_url,
             self.use_ssl

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -83,7 +83,10 @@ pub struct S3Credentials {
 ///     tenant_id (str, optional): Azure Tenant ID
 ///     client_id (str, optional): Azure Client ID
 ///     client_secret (str, optional): Azure Client Secret
+///     use_fabric_endpoint (bool, optional): Whether to use Microsoft Fabric, you may want to set this if your URLs are from "fabric.microsoft.com". Defaults to false
 ///     anonymous (bool, optional): Whether or not to use "anonymous mode", which will access Azure without any credentials
+///     endpoint_url (str, optional): Custom URL to the Azure endpoint, e.g. "https://my-account-name.blob.core.windows.net". Overrides `use_fabric_endpoint` if set
+///     use_ssl (bool, optional): Whether or not to use SSL, which require accessing Azure over HTTPS rather than HTTP, defaults to True
 ///
 /// Example:
 ///     >>> io_config = IOConfig(azure=AzureConfig(storage_account="dafttestdata", access_key="xxx"))
@@ -668,6 +671,7 @@ impl AzureConfig {
         tenant_id: Option<String>,
         client_id: Option<String>,
         client_secret: Option<String>,
+        use_fabric_endpoint: Option<bool>,
         anonymous: Option<bool>,
         endpoint_url: Option<String>,
         use_ssl: Option<bool>,
@@ -682,6 +686,7 @@ impl AzureConfig {
                 tenant_id: tenant_id.or(def.tenant_id),
                 client_id: client_id.or(def.client_id),
                 client_secret: client_secret.or(def.client_secret),
+                use_fabric_endpoint: use_fabric_endpoint.unwrap_or(def.use_fabric_endpoint),
                 anonymous: anonymous.unwrap_or(def.anonymous),
                 endpoint_url: endpoint_url.or(def.endpoint_url),
                 use_ssl: use_ssl.unwrap_or(def.use_ssl),
@@ -699,6 +704,7 @@ impl AzureConfig {
         tenant_id: Option<String>,
         client_id: Option<String>,
         client_secret: Option<String>,
+        use_fabric_endpoint: Option<bool>,
         anonymous: Option<bool>,
         endpoint_url: Option<String>,
         use_ssl: Option<bool>,
@@ -712,6 +718,7 @@ impl AzureConfig {
                 tenant_id: tenant_id.or_else(|| self.config.tenant_id.clone()),
                 client_id: client_id.or_else(|| self.config.client_id.clone()),
                 client_secret: client_secret.or_else(|| self.config.client_secret.clone()),
+                use_fabric_endpoint: use_fabric_endpoint.unwrap_or(self.config.use_fabric_endpoint),
                 anonymous: anonymous.unwrap_or(self.config.anonymous),
                 endpoint_url: endpoint_url.or_else(|| self.config.endpoint_url.clone()),
                 use_ssl: use_ssl.unwrap_or(self.config.use_ssl),
@@ -760,6 +767,12 @@ impl AzureConfig {
     #[getter]
     pub fn client_secret(&self) -> PyResult<Option<String>> {
         Ok(self.config.client_secret.clone())
+    }
+
+    /// Whether to use Microsoft Fabric
+    #[getter]
+    pub fn use_fabric_endpoint(&self) -> PyResult<bool> {
+        Ok(self.config.use_fabric_endpoint)
     }
 
     /// Whether access is anonymous

--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -212,6 +212,14 @@ impl AzureBlobSource {
                 storage_credentials,
             )
             .blob_service_client()
+        } else if config.use_fabric_endpoint {
+            ClientBuilder::with_location(
+                CloudLocation::Custom {
+                    uri: format!("https://{}.blob.fabric.microsoft.com", storage_account),
+                },
+                storage_credentials,
+            )
+            .blob_service_client()
         } else {
             BlobServiceClient::new(storage_account, storage_credentials)
         };


### PR DESCRIPTION
Adds the ability for users to connect to Microsoft Fabric without having to pass in a custom endpoint URL. Also includes updates to documentation and tutorials.

Thank you to @djouallah in #2460 for the help in updating the docs!