### PR TITLE
[BUG] Fix anti-join on different column names

### DIFF
--- a/tests/table/test_joins.py
+++ b/tests/table/test_joins.py
@@ -282,3 +282,23 @@ def test_table_join_single_column_name_null(join_impl) -> None:
     result_sorted = result_table.sort([col("x")])
     assert result_sorted.get_column("y").to_pylist() == []
     assert result_sorted.get_column("right.y").to_pylist() == []
+
+
+def test_table_join_anti() -> None:
+    left_table = MicroPartition.from_pydict({"x": [1, 2, 3, 4], "y": [3, 4, 5, 6]})
+    right_table = MicroPartition.from_pydict({"x": [2, 3, 5]})
+
+    result_table = left_table.hash_join(right_table, left_on=[col("x")], right_on=[col("x")], how=JoinType.Anti)
+    assert result_table.column_names() == ["x", "y"]
+    result_sorted = result_table.sort([col("x")])
+    assert result_sorted.get_column("y").to_pylist() == [3, 6]
+
+
+def test_table_join_anti_different_names() -> None:
+    left_table = MicroPartition.from_pydict({"x": [1, 2, 3, 4], "y": [3, 4, 5, 6]})
+    right_table = MicroPartition.from_pydict({"z": [2, 3, 5]})
+
+    result_table = left_table.hash_join(right_table, left_on=[col("x")], right_on=[col("z")], how=JoinType.Anti)
+    assert result_table.column_names() == ["x", "y"]
+    result_sorted = result_table.sort([col("x")])
+    assert result_sorted.get_column("y").to_pylist() == [3, 6]


### PR DESCRIPTION
Closes #2475.

A bit of a bandaid fix. The issue was, while selecting the join strategy, for checking whether sort-merge join works, the joined columns need to be primitive types. However, in the plan we only have access to the output schema (as far as I know, maybe we can extract it from the children?). In a semi- or anti-join, the right column does not end up in the output schema, so the primitive type check panicked while looking for it. This issue does not appear if the left column has the same name as the right.

My fix is that, since we only support SMJ for inner joins, I move the join type check before the primitive check. This will need to be fixed later if we support SMJ for anti-joins, so I added a comment.