### PR TITLE
[FEAT] adding transform functionality

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1694,9 +1694,7 @@ class DataFrame:
         return self.unpivot(ids, values, variable_name, value_name)
 
     @DataframePublicAPI
-    def transform(
-        self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any
-    ) -> "DataFrame":
+    def transform(self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any) -> "DataFrame":
         """Apply a function that takes and returns a DataFrame.
 
         Allow splitting your transformation into different units of work (functions) while preserving the syntax for chaining transformations.
@@ -1739,10 +1737,9 @@ class DataFrame:
             DataFrame: Transformed DataFrame.
         """
         result = func(self, *args, **kwargs)
-        assert isinstance(result, DataFrame), (
-            "Func returned an instance of type [%s], "
-            "should have been DataFrame." % type(result)
-        )
+        assert isinstance(
+            result, DataFrame
+        ), "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)
         return result
 
     def _agg(self, to_agg: List[Expression], group_by: Optional[ExpressionsProjection] = None) -> "DataFrame":

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1694,7 +1694,9 @@ class DataFrame:
         return self.unpivot(ids, values, variable_name, value_name)
 
     @DataframePublicAPI
-    def transform(self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any) -> "DataFrame":
+    def transform(
+        self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any
+    ) -> "DataFrame":
         """Apply a function that takes and returns a DataFrame.
 
         Allow splitting your transformation into different units of work (functions) while preserving the syntax for chaining transformations.
@@ -1710,7 +1712,7 @@ class DataFrame:
             ...     df = df.select(daft.col("col_a") * x)
             ...     return df
             ...
-            >>> df = df.transform(add_1).transform(multiply_x, 4)
+            >>> df = df.trasform(add_1).transform(multiply_x, 4)
             >>> df.show()
             ╭───────╮
             │ col_a │
@@ -1729,7 +1731,7 @@ class DataFrame:
             (Showing first 4 of 4 rows)
 
         Args:
-            func: A function that takes and returns a DataFrame.
+            func: a function that takes and returns a DataFrame.
             *args: Positional arguments to pass to func.
             **kwargs: Keyword arguments to pass to func.
 
@@ -1737,9 +1739,10 @@ class DataFrame:
             DataFrame: Transformed DataFrame.
         """
         result = func(self, *args, **kwargs)
-        assert isinstance(
-            result, DataFrame
-        ), "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)
+        assert isinstance(result, DataFrame), (
+            "Func returned an instance of type [%s], "
+            "should have been DataFrame." % type(result)
+        )
         return result
 
     def _agg(self, to_agg: List[Expression], group_by: Optional[ExpressionsProjection] = None) -> "DataFrame":

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1733,9 +1733,9 @@ class DataFrame:
             DataFrame: Transformed DataFrame.
         """
         result = func(self, *args, **kwargs)
-        assert isinstance(
-            result, DataFrame
-        ), "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)
+        assert isinstance(result, DataFrame), (
+            "Func returned an instance of type [%s], " "should have been DataFrame." % type(result)
+        )
         return result
 
     def _agg(self, to_agg: List[Expression], group_by: Optional[ExpressionsProjection] = None) -> "DataFrame":

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1696,9 +1696,7 @@ class DataFrame:
     @DataframePublicAPI
     def transform(self, func: Callable[..., "DataFrame"], *args: Any, **kwargs: Any) -> "DataFrame":
         """Apply a function that takes and returns a DataFrame.
-
         Allow splitting your transformation into different units of work (functions) while preserving the syntax for chaining transformations.
-
         Example:
             >>> import daft
             >>> df = daft.from_pydict({"col_a":[1,2,3,4]})
@@ -1710,7 +1708,7 @@ class DataFrame:
             ...     df = df.select(daft.col("col_a") * x)
             ...     return df
             ...
-            >>> df = df.trasform(add_1).transform(multiply_x, 4)
+            >>> df = df.transform(add_1).transform(multiply_x, 4)
             >>> df.show()
             ╭───────╮
             │ col_a │
@@ -1727,12 +1725,10 @@ class DataFrame:
             ╰───────╯
             <BLANKLINE>
             (Showing first 4 of 4 rows)
-
         Args:
-            func: a function that takes and returns a DataFrame.
+            func: A function that takes and returns a DataFrame.
             *args: Positional arguments to pass to func.
             **kwargs: Keyword arguments to pass to func.
-
         Returns:
             DataFrame: Transformed DataFrame.
         """

--- a/docs/source/api_docs/dataframe.rst
+++ b/docs/source/api_docs/dataframe.rst
@@ -45,6 +45,7 @@ Manipulating Columns
     DataFrame.explode
     DataFrame.unpivot
     DataFrame.melt
+    DataFrame.transform
 
 Filtering Rows
 **************

--- a/tests/dataframe/test_transform.py
+++ b/tests/dataframe/test_transform.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from daft import col
+
+
+def add_1(df):
+    return df.with_column("foo", col("foo") + 1)
+
+
+def multiply_x(df, x):
+    return df.with_column("foo", col("foo") * x)
+
+
+def concat_dfs(df, df_2):
+    return df.concat(df_2)
+
+
+def invalid_function(df):
+    return df.to_pydict()
+
+
+def test_transform_no_args(make_df):
+    df = make_df({"foo": [1, 2, 3]})
+    with pytest.raises(ValueError):
+        df.transform(add_1)
+
+
+def test_transform_args(make_df):
+    df = make_df({"foo": [1, 2, 3]})
+    with pytest.raises(ValueError):
+        df.transform(multiply_x, 2)
+
+
+def test_transform_kwargs(make_df):
+    df = make_df({"foo": [1, 2, 3]})
+    with pytest.raises(ValueError):
+        df.transform(multiply_x, x=2)
+
+
+def test_transform_multiple_df(make_df):
+    df = make_df({"foo": [1, 2, 3]})
+    df_2 = make_df({"foo": [4, 5, 6]})
+    with pytest.raises(ValueError):
+        df.transform(concat_dfs, df_2)
+
+
+def test_transform_negative_case(make_df):
+    df = make_df({"foo": [1, 2, 3]})
+    try:
+        df.transform(invalid_function)
+    except Exception as e:
+        assert "should have been DataFrame" in str(e)

--- a/tests/dataframe/test_transform.py
+++ b/tests/dataframe/test_transform.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import pytest
 
-from daft import col
+import daft
 
 
 def add_1(df):
-    return df.with_column("foo", col("foo") + 1)
+    return df.with_column("foo", daft.col("foo") + 1)
 
 
 def multiply_x(df, x):
-    return df.with_column("foo", col("foo") * x)
+    return df.with_column("foo", daft.col("foo") * x)
 
 
 def concat_dfs(df, df_2):
@@ -23,32 +23,26 @@ def invalid_function(df):
 
 def test_transform_no_args(make_df):
     df = make_df({"foo": [1, 2, 3]})
-    with pytest.raises(ValueError):
-        df.transform(add_1)
+    assert df.transform(add_1).to_pydict() == {"foo": [2, 3, 4]}
 
 
 def test_transform_args(make_df):
     df = make_df({"foo": [1, 2, 3]})
-    with pytest.raises(ValueError):
-        df.transform(multiply_x, 2)
+    assert df.transform(multiply_x, 2).to_pydict() == {"foo": [2, 4, 6]}
 
 
 def test_transform_kwargs(make_df):
     df = make_df({"foo": [1, 2, 3]})
-    with pytest.raises(ValueError):
-        df.transform(multiply_x, x=2)
+    assert df.transform(multiply_x, x=2).to_pydict() == {"foo": [2, 4, 6]}
 
 
 def test_transform_multiple_df(make_df):
     df = make_df({"foo": [1, 2, 3]})
     df_2 = make_df({"foo": [4, 5, 6]})
-    with pytest.raises(ValueError):
-        df.transform(concat_dfs, df_2)
+    assert df.transform(concat_dfs, df_2).to_pydict() == {"foo": [1, 2, 3, 4, 5, 6]}
 
 
 def test_transform_negative_case(make_df):
     df = make_df({"foo": [1, 2, 3]})
-    try:
+    with pytest.raises(AssertionError):
         df.transform(invalid_function)
-    except Exception as e:
-        assert "should have been DataFrame" in str(e)


### PR DESCRIPTION
As in PySpark, the transform functionality allows you to split your transformations into units of work, creating a function for each, and then call them on your DataFrame, enabling the ability to chain transformations.

Having your transformations as functions helps in unit testing them.

```
def bussines_rule_1(df):
    df = (
        df
        .with_column(......)
        .with_column(......)
        .with_column(......)
    )
    return df
    
def bussines_rule_2(df):
    df = (
        df
        .with_column(......)
        .with_column(......)
    )
    return df

df = (
    df
    .transform(bussines_rule_1)
    .transform(bussines_rule_2)
)
```

[PySpark reference](https://spark.apache.org/docs/latest/api/python/_modules/pyspark/sql/dataframe.html#DataFrame.transform)