### PR TITLE
[BUG] Allow for Parquet reading from files with differing schemas

### DIFF
--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -612,7 +612,7 @@ def read_parquet_into_pyarrow(
         return pa.table(columns, schema=schema)
     else:
         # If data contains no columns, we return an empty table with the appropriate size using `Table.drop`
-        return pa.table({"dummy_column": pa.array([None] * num_rows_read)}).drop("dummy_column")
+        return pa.table({"dummy_column": pa.array([None] * num_rows_read)}).drop(["dummy_column"])
 
 
 def read_parquet_into_pyarrow_bulk(
@@ -647,6 +647,6 @@ def read_parquet_into_pyarrow_bulk(
             )
         else:
             # If data contains no columns, we return an empty table with the appropriate size using `Table.drop`
-            table = pa.table({"dummy_col": [None] * num_rows_read}).drop("dummy_col")
+            table = pa.table({"dummy_col": [None] * num_rows_read}).drop(["dummy_col"])
         tables.append(table)
     return tables

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -168,7 +168,7 @@ fn tables_concat(mut tables: Vec<Table>) -> DaftResult<Table> {
             Series::concat(series_to_cat.as_slice())
         })
         .collect::<DaftResult<Vec<_>>>()?;
-    Table::new(
+    Table::new_with_size(
         first_table.schema.clone(),
         new_series,
         tables.iter().map(|t| t.len()).sum(),

--- a/src/daft-execution/src/task/mod.rs
+++ b/src/daft-execution/src/task/mod.rs
@@ -243,6 +243,7 @@ mod tests {
                         .boxed(),
                     )
                     .unwrap()],
+                    input_meta.num_rows.unwrap(),
                 )
                 .unwrap()]),
                 None,

--- a/src/daft-execution/src/task/mod.rs
+++ b/src/daft-execution/src/task/mod.rs
@@ -231,9 +231,8 @@ mod tests {
             let schema = Arc::new(Schema::new(vec![field.clone()]).unwrap());
             let data = MicroPartition::new_loaded(
                 schema.clone(),
-                Arc::new(vec![Table::new(
-                    schema.clone(),
-                    vec![Series::from_arrow(
+                Arc::new(vec![Table::from_nonempty_columns(vec![
+                    Series::from_arrow(
                         field.into(),
                         arrow2::array::Int64Array::from_vec(
                             (0..input_meta.num_rows.unwrap())
@@ -242,9 +241,8 @@ mod tests {
                         )
                         .boxed(),
                     )
-                    .unwrap()],
-                    input_meta.num_rows.unwrap(),
-                )
+                    .unwrap(),
+                ])
                 .unwrap()]),
                 None,
             );

--- a/src/daft-execution/src/test/mod.rs
+++ b/src/daft-execution/src/test/mod.rs
@@ -42,6 +42,7 @@ pub(crate) fn mock_micropartition(num_rows: usize) -> MicroPartition {
                     .boxed(),
             )
             .unwrap()],
+            num_rows,
         )
         .unwrap()]),
         None,

--- a/src/daft-execution/src/test/mod.rs
+++ b/src/daft-execution/src/test/mod.rs
@@ -34,16 +34,14 @@ pub(crate) fn mock_micropartition(num_rows: usize) -> MicroPartition {
     let schema = Arc::new(Schema::new(vec![field.clone()]).unwrap());
     MicroPartition::new_loaded(
         schema.clone(),
-        Arc::new(vec![Table::new(
-            schema.clone(),
-            vec![Series::from_arrow(
+        Arc::new(vec![Table::from_nonempty_columns(vec![
+            Series::from_arrow(
                 field.into(),
                 arrow2::array::Int64Array::from_vec((0..num_rows).map(|n| n as i64).collect())
                     .boxed(),
             )
-            .unwrap()],
-            num_rows,
-        )
+            .unwrap(),
+        ])
         .unwrap()]),
         None,
     )

--- a/src/daft-json/src/local.rs
+++ b/src/daft-json/src/local.rs
@@ -193,6 +193,7 @@ impl<'a> JsonReader<'a> {
             })
             .collect::<IndexMap<_, _>>();
 
+        let mut num_rows = 0;
         for record in iter {
             let value = record.map_err(|e| super::Error::JsonDeserializationError {
                 string: e.to_string(),
@@ -221,6 +222,8 @@ impl<'a> JsonReader<'a> {
                     .into());
                 }
             }
+
+            num_rows += 1;
         }
         let columns = columns
             .into_values()
@@ -234,7 +237,7 @@ impl<'a> JsonReader<'a> {
             })
             .collect::<DaftResult<Vec<_>>>()?;
 
-        let tbl = Table::new_unchecked(self.schema.clone(), columns);
+        let tbl = Table::new_unchecked(self.schema.clone(), columns, num_rows);
 
         if let Some(pred) = &self.predicate {
             tbl.filter(&[pred.clone()])

--- a/src/daft-json/src/read.rs
+++ b/src/daft-json/src/read.rs
@@ -163,7 +163,7 @@ pub(crate) fn tables_concat(mut tables: Vec<Table>) -> DaftResult<Table> {
             Series::concat(series_to_cat.as_slice())
         })
         .collect::<DaftResult<Vec<_>>>()?;
-    Table::new(
+    Table::new_with_size(
         first_table.schema.clone(),
         new_series,
         tables.iter().map(|t| t.len()).sum(),

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -559,7 +559,7 @@ impl ParquetFileReader {
     pub async fn read_from_ranges_into_arrow_arrays(
         self,
         ranges: Arc<RangesContainer>,
-    ) -> DaftResult<Vec<Vec<Box<dyn arrow2::array::Array>>>> {
+    ) -> DaftResult<(Vec<Vec<Box<dyn arrow2::array::Array>>>, usize)> {
         let metadata = self.metadata;
         let all_handles = self
             .arrow_schema
@@ -706,6 +706,9 @@ impl ParquetFileReader {
             })?
             .into_iter()
             .collect::<DaftResult<Vec<_>>>()?;
-        Ok(all_field_arrays)
+        Ok((
+            all_field_arrays,
+            self.row_ranges.as_ref().iter().map(|rr| rr.num_rows).sum(),
+        ))
     }
 }

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -549,7 +549,11 @@ impl ParquetFileReader {
             .collect::<DaftResult<Vec<_>>>()?;
         let daft_schema = daft_core::schema::Schema::try_from(self.arrow_schema.as_ref())?;
 
-        Table::new(daft_schema, all_series)
+        Table::new(
+            daft_schema,
+            all_series,
+            self.row_ranges.as_ref().iter().map(|rr| rr.num_rows).sum(),
+        )
     }
 
     pub async fn read_from_ranges_into_arrow_arrays(

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -235,12 +235,6 @@ impl ParquetReaderBuilder {
         for col_name in columns {
             if avail_names.contains(col_name.as_ref()) {
                 names_to_keep.insert(col_name.to_string());
-            } else {
-                return Err(super::Error::FieldNotFound {
-                    field: col_name.to_string(),
-                    available_fields: avail_names.iter().map(|v| v.to_string()).collect(),
-                    path: self.uri,
-                });
             }
         }
         self.selected_columns = Some(names_to_keep);

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -549,7 +549,7 @@ impl ParquetFileReader {
             .collect::<DaftResult<Vec<_>>>()?;
         let daft_schema = daft_core::schema::Schema::try_from(self.arrow_schema.as_ref())?;
 
-        Table::new(
+        Table::new_with_size(
             daft_schema,
             all_series,
             self.row_ranges.as_ref().iter().map(|rr| rr.num_rows).sum(),

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -83,28 +83,19 @@ pub enum Error {
     UnableToConvertSchemaToDaft { path: String, source: DaftError },
 
     #[snafu(display(
-        "Field: {} not found in Parquet File: {} Available Fields: {:?}",
-        field,
-        path,
-        available_fields
-    ))]
-    FieldNotFound {
-        field: String,
-        available_fields: Vec<String>,
-        path: String,
-    },
-    #[snafu(display(
         "File: {} is not a valid parquet file. Has incorrect footer: {:?}",
         path,
         footer
     ))]
     InvalidParquetFile { path: String, footer: Vec<u8> },
+
     #[snafu(display(
         "File: {} is not a valid parquet file and is only {} bytes, smaller than the minimum size of 12 bytes",
         path,
         file_size
     ))]
     FileTooSmall { path: String, file_size: usize },
+
     #[snafu(display(
         "File: {} has a footer size: {} greater than the file size: {}",
         path,

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -725,15 +725,12 @@ pub fn read_parquet_statistics(
         )),
     ));
 
-    Table::from_columns(
-        vec![
-            uris.clone(),
-            row_count_series.into_series(),
-            row_group_series.into_series(),
-            version_series.into_series(),
-        ],
-        uris.len(),
-    )
+    Table::from_nonempty_columns(vec![
+        uris.clone(),
+        row_count_series.into_series(),
+        row_group_series.into_series(),
+        version_series.into_series(),
+    ])
 }
 
 #[cfg(test)]

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -725,12 +725,15 @@ pub fn read_parquet_statistics(
         )),
     ));
 
-    Table::from_columns(vec![
-        uris.clone(),
-        row_count_series.into_series(),
-        row_group_series.into_series(),
-        version_series.into_series(),
-    ])
+    Table::from_columns(
+        vec![
+            uris.clone(),
+            row_count_series.into_series(),
+            row_group_series.into_series(),
+            version_series.into_series(),
+        ],
+        uris.len(),
+    )
 }
 
 #[cfg(test)]

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -208,8 +208,11 @@ async fn read_parquet_single(
         metadata_num_columns
     };
 
-    if (!field_id_mapping_provided && table.num_columns() != expected_num_columns)
+    if (!field_id_mapping_provided
+        && requested_columns.is_none()
+        && table.num_columns() != expected_num_columns)
         || (field_id_mapping_provided && table.num_columns() > expected_num_columns)
+        || (requested_columns.is_some() && table.num_columns() > expected_num_columns)
     {
         return Err(super::Error::ParquetNumColumnMismatch {
             path: uri.into(),
@@ -354,8 +357,9 @@ async fn read_parquet_single_into_arrow(
         metadata_num_columns
     };
 
-    if (!field_id_mapping_provided && table_ncol != expected_num_columns)
+    if (!field_id_mapping_provided && columns.is_none() && table_ncol != expected_num_columns)
         || (field_id_mapping_provided && table_ncol > expected_num_columns)
+        || (columns.is_some() && table_ncol > expected_num_columns)
     {
         return Err(super::Error::ParquetNumColumnMismatch {
             path: uri.into(),

--- a/src/daft-parquet/src/stream_reader.rs
+++ b/src/daft-parquet/src/stream_reader.rs
@@ -226,7 +226,7 @@ pub(crate) async fn local_parquet_read_async(
                 .collect::<Result<Vec<_>, _>>()?;
             Ok((
                 metadata,
-                Table::new(
+                Table::new_with_size(
                     Schema::new(converted_arrays.iter().map(|s| s.field().clone()).collect())?,
                     converted_arrays,
                     num_rows_read,

--- a/src/daft-plan/src/source_info/file_info.rs
+++ b/src/daft-plan/src/source_info/file_info.rs
@@ -1,6 +1,6 @@
 use arrow2::array::Array;
 use common_error::DaftResult;
-use daft_core::{impl_bincode_py_state_serialization, schema::Schema, Series};
+use daft_core::{impl_bincode_py_state_serialization, Series};
 use daft_table::Table;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "python")]
@@ -173,12 +173,7 @@ impl FileInfos {
                 arrow2::array::PrimitiveArray::<i64>::from(&self.num_rows).to_boxed(),
             ))?,
         ];
-        let num_rows = columns.first().map(|s| s.len()).unwrap();
-        Table::new(
-            Schema::new(columns.iter().map(|s| s.field().clone()).collect())?,
-            columns,
-            num_rows,
-        )
+        Table::from_nonempty_columns(columns)
     }
 }
 

--- a/src/daft-plan/src/source_info/file_info.rs
+++ b/src/daft-plan/src/source_info/file_info.rs
@@ -173,9 +173,11 @@ impl FileInfos {
                 arrow2::array::PrimitiveArray::<i64>::from(&self.num_rows).to_boxed(),
             ))?,
         ];
+        let num_rows = columns.first().map(|s| s.len()).unwrap();
         Table::new(
             Schema::new(columns.iter().map(|s| s.field().clone()).collect())?,
             columns,
+            num_rows,
         )
     }
 }

--- a/src/daft-stats/src/table_stats.rs
+++ b/src/daft-stats/src/table_stats.rs
@@ -190,8 +190,8 @@ impl Display for TableStatistics {
             .iter()
             .map(|(s, c)| c.combined_series().unwrap().rename(s))
             .collect::<Vec<_>>();
-
-        let tab = Table::from_columns(columns, 2).unwrap();
+        let tbl_schema = Schema::new(columns.iter().map(|s| s.field().clone()).collect()).unwrap();
+        let tab = Table::new_with_size(tbl_schema, columns, 2).unwrap();
         write!(f, "{tab}")
     }
 }
@@ -209,10 +209,9 @@ mod test {
 
     #[test]
     fn test_equal() -> crate::Result<()> {
-        let table = Table::from_columns(
-            vec![Int64Array::from(("a", vec![1, 2, 3, 4])).into_series()],
-            4,
-        )
+        let table = Table::from_nonempty_columns(vec![
+            Int64Array::from(("a", vec![1, 2, 3, 4])).into_series()
+        ])
         .unwrap();
         let table_stats = TableStatistics::from_table(&table);
 
@@ -227,11 +226,11 @@ mod test {
         assert_eq!(result.to_truth_value(), TruthValue::Maybe);
 
         // True case
-        let table = Table::from_columns(
-            vec![Int64Array::from(("a", vec![0, 0, 0])).into_series()],
-            4,
-        )
-        .unwrap();
+        let table =
+            Table::from_nonempty_columns(
+                vec![Int64Array::from(("a", vec![0, 0, 0])).into_series()],
+            )
+            .unwrap();
         let table_stats = TableStatistics::from_table(&table);
 
         let expr = col("a").eq(lit(0));

--- a/src/daft-stats/src/table_stats.rs
+++ b/src/daft-stats/src/table_stats.rs
@@ -191,7 +191,7 @@ impl Display for TableStatistics {
             .map(|(s, c)| c.combined_series().unwrap().rename(s))
             .collect::<Vec<_>>();
 
-        let tab = Table::from_columns(columns).unwrap();
+        let tab = Table::from_columns(columns, 2).unwrap();
         write!(f, "{tab}")
     }
 }
@@ -209,9 +209,11 @@ mod test {
 
     #[test]
     fn test_equal() -> crate::Result<()> {
-        let table =
-            Table::from_columns(vec![Int64Array::from(("a", vec![1, 2, 3, 4])).into_series()])
-                .unwrap();
+        let table = Table::from_columns(
+            vec![Int64Array::from(("a", vec![1, 2, 3, 4])).into_series()],
+            4,
+        )
+        .unwrap();
         let table_stats = TableStatistics::from_table(&table);
 
         // False case
@@ -225,8 +227,11 @@ mod test {
         assert_eq!(result.to_truth_value(), TruthValue::Maybe);
 
         // True case
-        let table = Table::from_columns(vec![Int64Array::from(("a", vec![0, 0, 0])).into_series()])
-            .unwrap();
+        let table = Table::from_columns(
+            vec![Int64Array::from(("a", vec![0, 0, 0])).into_series()],
+            4,
+        )
+        .unwrap();
         let table_stats = TableStatistics::from_table(&table);
 
         let expr = col("a").eq(lit(0));

--- a/src/daft-table/src/ffi.rs
+++ b/src/daft-table/src/ffi.rs
@@ -49,7 +49,8 @@ pub fn record_batches_to_table(
                     Series::try_from((names.get(i).unwrap().as_str(), c))
                 })
                 .collect::<DaftResult<Vec<_>>>()?;
-            tables.push(Table::from_columns(columns)?)
+            let num_rows = columns.first().map_or(0, |first_series| first_series.len());
+            tables.push(Table::from_columns(columns, num_rows)?)
         }
         Ok(Table::concat(tables.as_slice())?)
     })

--- a/src/daft-table/src/ffi.rs
+++ b/src/daft-table/src/ffi.rs
@@ -50,7 +50,7 @@ pub fn record_batches_to_table(
                 })
                 .collect::<DaftResult<Vec<_>>>()?;
             let num_rows = columns.first().map_or(0, |first_series| first_series.len());
-            tables.push(Table::from_columns(columns, num_rows)?)
+            tables.push(Table::new_with_size(schema.clone(), columns, num_rows)?)
         }
         Ok(Table::concat(tables.as_slice())?)
     })

--- a/src/daft-table/src/ffi.rs
+++ b/src/daft-table/src/ffi.rs
@@ -23,8 +23,9 @@ pub fn record_batches_to_table(
     let names = schema.names();
     let num_batches = batches.len();
     // First extract all the arrays at once while holding the GIL
-    let mut extracted_arrow_arrays: Vec<Vec<Box<dyn arrow2::array::Array>>> =
+    let mut extracted_arrow_arrays: Vec<(Vec<Box<dyn arrow2::array::Array>>, usize)> =
         Vec::with_capacity(num_batches);
+
     for rb in batches {
         let pycolumns = rb.getattr(pyo3::intern!(rb.py(), "columns"))?;
         let columns = pycolumns
@@ -35,12 +36,12 @@ pub fn record_batches_to_table(
         if names.len() != columns.len() {
             return Err(PyValueError::new_err(format!("Error when converting Arrow Record Batches to Daft Table. Expected: {} columns, got: {}", names.len(), columns.len())));
         }
-        extracted_arrow_arrays.push(columns);
+        extracted_arrow_arrays.push((columns, rb.len()?));
     }
     // Now do the heavy lifting (casting and concats) without the GIL.
     py.allow_threads(|| {
         let mut tables: Vec<Table> = Vec::with_capacity(num_batches);
-        for cols in extracted_arrow_arrays {
+        for (cols, num_rows) in extracted_arrow_arrays {
             let columns = cols
                 .into_iter()
                 .enumerate()
@@ -49,7 +50,6 @@ pub fn record_batches_to_table(
                     Series::try_from((names.get(i).unwrap().as_str(), c))
                 })
                 .collect::<DaftResult<Vec<_>>>()?;
-            let num_rows = columns.first().map_or(0, |first_series| first_series.len());
             tables.push(Table::new_with_size(schema.clone(), columns, num_rows)?)
         }
         Ok(Table::concat(tables.as_slice())?)

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -335,7 +335,11 @@ impl Table {
             .iter()
             .map(|s| self.get_column(s).cloned())
             .collect::<DaftResult<Vec<_>>>()?;
-        Self::from_columns(series_by_name)
+        Self::new(
+            Schema::new(series_by_name.iter().map(|s| s.field().clone()).collect())?,
+            series_by_name,
+            self.len(),
+        )
     }
 
     pub fn get_column_by_index(&self, idx: usize) -> DaftResult<&Series> {

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -161,9 +161,9 @@ impl Table {
         _validate_schema(schema.as_ref(), columns.as_slice())?;
 
         // Infer the num_rows, assume no broadcasting
-        let mut num_rows = 0;
+        let mut num_rows = 1;
         for (field, series) in schema.fields.values().zip(columns.iter()) {
-            if num_rows == 0 && !series.is_empty() {
+            if num_rows == 1 {
                 num_rows = series.len();
             }
             if series.len() != num_rows {

--- a/src/daft-table/src/ops/agg.rs
+++ b/src/daft-table/src/ops/agg.rs
@@ -62,7 +62,10 @@ impl Table {
             .collect::<DaftResult<Vec<_>>>()?;
 
         // Combine the groupkey columns and the aggregation result columns.
-        Self::from_columns([&groupkeys_table.columns[..], &grouped_cols].concat())
+        Self::from_columns(
+            [&groupkeys_table.columns[..], &grouped_cols].concat(),
+            groupkeys_table.len(),
+        )
     }
 
     #[cfg(feature = "python")]
@@ -137,7 +140,7 @@ impl Table {
                             .collect::<DaftResult<Vec<_>>>()?;
 
                         // Combine the broadcasted group keys into a Table
-                        Table::from_columns(broacasted_groupkeys)?
+                        Table::from_columns(broacasted_groupkeys, evaluated_grouped_col.len())?
                     };
 
                     Ok((broadcasted_groupkeys_table, evaluated_grouped_col))
@@ -153,6 +156,9 @@ impl Table {
             (concatenated_groupkeys_table, concatenated_grouped_col)
         };
 
-        Self::from_columns([&groupkeys_table.columns[..], &[grouped_col]].concat())
+        Self::from_columns(
+            [&groupkeys_table.columns[..], &[grouped_col]].concat(),
+            groupkeys_table.len(),
+        )
     }
 }

--- a/src/daft-table/src/ops/agg.rs
+++ b/src/daft-table/src/ops/agg.rs
@@ -62,10 +62,7 @@ impl Table {
             .collect::<DaftResult<Vec<_>>>()?;
 
         // Combine the groupkey columns and the aggregation result columns.
-        Self::from_columns(
-            [&groupkeys_table.columns[..], &grouped_cols].concat(),
-            groupkeys_table.len(),
-        )
+        Self::from_nonempty_columns([&groupkeys_table.columns[..], &grouped_cols].concat())
     }
 
     #[cfg(feature = "python")]
@@ -133,14 +130,14 @@ impl Table {
                         let groupkeys_table = groupby_table.take(&groupkey_indices_as_series)?;
 
                         // Broadcast the group keys to the length of the grouped column, because output of UDF can be more than one row
-                        let broacasted_groupkeys = groupkeys_table
+                        let broadcasted_groupkeys = groupkeys_table
                             .columns
                             .iter()
                             .map(|c| c.broadcast(evaluated_grouped_col.len()))
                             .collect::<DaftResult<Vec<_>>>()?;
 
                         // Combine the broadcasted group keys into a Table
-                        Table::from_columns(broacasted_groupkeys, evaluated_grouped_col.len())?
+                        Table::from_nonempty_columns(broadcasted_groupkeys)?
                     };
 
                     Ok((broadcasted_groupkeys_table, evaluated_grouped_col))
@@ -156,10 +153,6 @@ impl Table {
             (concatenated_groupkeys_table, concatenated_grouped_col)
         };
 
-        let num_rows = grouped_col.len();
-        Self::from_columns(
-            [&groupkeys_table.columns[..], &[grouped_col]].concat(),
-            num_rows,
-        )
+        Self::from_nonempty_columns([&groupkeys_table.columns[..], &[grouped_col]].concat())
     }
 }

--- a/src/daft-table/src/ops/agg.rs
+++ b/src/daft-table/src/ops/agg.rs
@@ -156,9 +156,10 @@ impl Table {
             (concatenated_groupkeys_table, concatenated_grouped_col)
         };
 
+        let num_rows = grouped_col.len();
         Self::from_columns(
             [&groupkeys_table.columns[..], &[grouped_col]].concat(),
-            groupkeys_table.len(),
+            num_rows,
         )
     }
 }

--- a/src/daft-table/src/ops/agg.rs
+++ b/src/daft-table/src/ops/agg.rs
@@ -155,7 +155,11 @@ impl Table {
             (concatenated_groupkeys_table, concatenated_grouped_col)
         };
 
-        let final_len = groupkeys_table.len();
+        // Broadcast either the keys or the grouped_cols, depending on which is unit-length
+        let final_len = [groupkeys_table.len(), grouped_col.len()]
+            .into_iter()
+            .find(|&l| l != 1)
+            .unwrap_or(1);
         let final_columns = [&groupkeys_table.columns[..], &[grouped_col]].concat();
         let final_schema = Schema::new(final_columns.iter().map(|s| s.field().clone()).collect())?;
         Self::new_with_broadcast(final_schema, final_columns, final_len)

--- a/src/daft-table/src/ops/agg.rs
+++ b/src/daft-table/src/ops/agg.rs
@@ -72,6 +72,8 @@ impl Table {
         inputs: &[ExprRef],
         group_by: &[ExprRef],
     ) -> DaftResult<Table> {
+        use daft_core::schema::Schema;
+
         let udf = match func {
             FunctionExpr::Python(udf) => udf,
             _ => {
@@ -153,6 +155,9 @@ impl Table {
             (concatenated_groupkeys_table, concatenated_grouped_col)
         };
 
-        Self::from_nonempty_columns([&groupkeys_table.columns[..], &[grouped_col]].concat())
+        let final_len = groupkeys_table.len();
+        let final_columns = [&groupkeys_table.columns[..], &[grouped_col]].concat();
+        let final_schema = Schema::new(final_columns.iter().map(|s| s.field().clone()).collect())?;
+        Self::new_with_broadcast(final_schema, final_columns, final_len)
     }
 }

--- a/src/daft-table/src/ops/explode.rs
+++ b/src/daft-table/src/ops/explode.rs
@@ -97,6 +97,6 @@ impl Table {
             }
         }
         new_series.extend_from_slice(exploded_columns.as_slice());
-        Self::from_columns(new_series)
+        Self::from_columns(new_series, capacity_expected)
     }
 }

--- a/src/daft-table/src/ops/explode.rs
+++ b/src/daft-table/src/ops/explode.rs
@@ -97,6 +97,6 @@ impl Table {
             }
         }
         new_series.extend_from_slice(exploded_columns.as_slice());
-        Self::from_columns(new_series, capacity_expected)
+        Self::from_nonempty_columns(new_series)
     }
 }

--- a/src/daft-table/src/ops/joins/hash_join.rs
+++ b/src/daft-table/src/ops/joins/hash_join.rs
@@ -96,10 +96,11 @@ pub(super) fn hash_inner_join(
     drop(lkeys);
     drop(rkeys);
 
+    let num_rows = lidx.len();
     join_series =
         add_non_join_key_columns(left, right, lidx, ridx, left_on, right_on, join_series)?;
 
-    Table::new(join_schema, join_series)
+    Table::new(join_schema, join_series, num_rows)
 }
 
 pub(super) fn hash_left_right_join(
@@ -218,10 +219,11 @@ pub(super) fn hash_left_right_join(
     drop(lkeys);
     drop(rkeys);
 
+    let num_rows = lidx.len();
     join_series =
         add_non_join_key_columns(left, right, lidx, ridx, left_on, right_on, join_series)?;
 
-    Table::new(join_schema, join_series)
+    Table::new(join_schema, join_series, num_rows)
 }
 
 pub(super) fn hash_semi_anti_join(
@@ -449,8 +451,9 @@ pub(super) fn hash_outer_join(
     drop(lkeys);
     drop(rkeys);
 
+    let num_rows = lidx.len();
     join_series =
         add_non_join_key_columns(left, right, lidx, ridx, left_on, right_on, join_series)?;
 
-    Table::new(join_schema, join_series)
+    Table::new(join_schema, join_series, num_rows)
 }

--- a/src/daft-table/src/ops/joins/hash_join.rs
+++ b/src/daft-table/src/ops/joins/hash_join.rs
@@ -100,7 +100,7 @@ pub(super) fn hash_inner_join(
     join_series =
         add_non_join_key_columns(left, right, lidx, ridx, left_on, right_on, join_series)?;
 
-    Table::new(join_schema, join_series, num_rows)
+    Table::new_with_size(join_schema, join_series, num_rows)
 }
 
 pub(super) fn hash_left_right_join(
@@ -223,7 +223,7 @@ pub(super) fn hash_left_right_join(
     join_series =
         add_non_join_key_columns(left, right, lidx, ridx, left_on, right_on, join_series)?;
 
-    Table::new(join_schema, join_series, num_rows)
+    Table::new_with_size(join_schema, join_series, num_rows)
 }
 
 pub(super) fn hash_semi_anti_join(
@@ -455,5 +455,5 @@ pub(super) fn hash_outer_join(
     join_series =
         add_non_join_key_columns(left, right, lidx, ridx, left_on, right_on, join_series)?;
 
-    Table::new(join_schema, join_series, num_rows)
+    Table::new_with_size(join_schema, join_series, num_rows)
 }

--- a/src/daft-table/src/ops/joins/mod.rs
+++ b/src/daft-table/src/ops/joins/mod.rs
@@ -38,7 +38,10 @@ fn match_types_for_tables(left: &Table, right: &Table) -> DaftResult<(Table, Tab
             )));
         }
     }
-    Ok((Table::from_columns(lseries)?, Table::from_columns(rseries)?))
+    Ok((
+        Table::from_columns(lseries, left.len())?,
+        Table::from_columns(rseries, right.len())?,
+    ))
 }
 
 pub fn infer_join_schema(

--- a/src/daft-table/src/ops/joins/mod.rs
+++ b/src/daft-table/src/ops/joins/mod.rs
@@ -39,8 +39,8 @@ fn match_types_for_tables(left: &Table, right: &Table) -> DaftResult<(Table, Tab
         }
     }
     Ok((
-        Table::from_columns(lseries, left.len())?,
-        Table::from_columns(rseries, right.len())?,
+        Table::from_nonempty_columns(lseries)?,
+        Table::from_nonempty_columns(rseries)?,
     ))
 }
 
@@ -302,6 +302,6 @@ impl Table {
         join_series =
             add_non_join_key_columns(self, right, lidx, ridx, left_on, right_on, join_series)?;
 
-        Table::new(join_schema, join_series, num_rows)
+        Table::new_with_size(join_schema, join_series, num_rows)
     }
 }

--- a/src/daft-table/src/ops/joins/mod.rs
+++ b/src/daft-table/src/ops/joins/mod.rs
@@ -295,9 +295,10 @@ impl Table {
         drop(ltable);
         drop(rtable);
 
+        let num_rows = lidx.len();
         join_series =
             add_non_join_key_columns(self, right, lidx, ridx, left_on, right_on, join_series)?;
 
-        Table::new(join_schema, join_series)
+        Table::new(join_schema, join_series, num_rows)
     }
 }

--- a/src/daft-table/src/ops/pivot.rs
+++ b/src/daft-table/src/ops/pivot.rs
@@ -125,6 +125,10 @@ impl Table {
             let indices_as_series = UInt64Array::from(("", group_keys_indices)).into_series();
             groupby_table.take(&indices_as_series)?
         };
-        Self::from_columns([&group_keys_table.columns[..], &pivoted_cols[..]].concat())
+
+        Self::from_columns(
+            [&group_keys_table.columns[..], &pivoted_cols[..]].concat(),
+            group_keys_table.len(),
+        )
     }
 }

--- a/src/daft-table/src/ops/pivot.rs
+++ b/src/daft-table/src/ops/pivot.rs
@@ -126,9 +126,6 @@ impl Table {
             groupby_table.take(&indices_as_series)?
         };
 
-        Self::from_columns(
-            [&group_keys_table.columns[..], &pivoted_cols[..]].concat(),
-            group_keys_table.len(),
-        )
+        Self::from_nonempty_columns([&group_keys_table.columns[..], &pivoted_cols[..]].concat())
     }
 }

--- a/src/daft-table/src/ops/unpivot.rs
+++ b/src/daft-table/src/ops/unpivot.rs
@@ -59,6 +59,6 @@ impl Table {
         ])?)?;
         let unpivot_series = [ids_series, vec![variable_series, value_series]].concat();
 
-        Table::new(unpivot_schema, unpivot_series, unpivoted_len)
+        Table::new_with_size(unpivot_schema, unpivot_series, unpivoted_len)
     }
 }

--- a/src/daft-table/src/ops/unpivot.rs
+++ b/src/daft-table/src/ops/unpivot.rs
@@ -59,6 +59,6 @@ impl Table {
         ])?)?;
         let unpivot_series = [ids_series, vec![variable_series, value_series]].concat();
 
-        Table::new(unpivot_schema, unpivot_series)
+        Table::new(unpivot_schema, unpivot_series, unpivoted_len)
     }
 }

--- a/src/daft-table/src/python.rs
+++ b/src/daft-table/src/python.rs
@@ -428,6 +428,8 @@ impl PyTable {
             fields.push(Field::new(name.clone(), series.data_type().clone()));
             columns.push(series.rename(name));
         }
+
+        let num_rows = columns.first().map(|s| s.len()).unwrap_or(0);
         if !columns.is_empty() {
             let first = columns.first().unwrap();
             for s in columns.iter().skip(1) {
@@ -443,7 +445,7 @@ impl PyTable {
         }
 
         Ok(PyTable {
-            table: Table::new(Schema::new(fields)?, columns)?,
+            table: Table::new(Schema::new(fields)?, columns, num_rows)?,
         })
     }
 

--- a/src/daft-table/src/python.rs
+++ b/src/daft-table/src/python.rs
@@ -445,7 +445,7 @@ impl PyTable {
         }
 
         Ok(PyTable {
-            table: Table::new(Schema::new(fields)?, columns, num_rows)?,
+            table: Table::new_with_broadcast(Schema::new(fields)?, columns, num_rows)?,
         })
     }
 

--- a/tests/integration/io/parquet/test_reads_s3_minio.py
+++ b/tests/integration/io/parquet/test_reads_s3_minio.py
@@ -60,3 +60,29 @@ def test_minio_parquet_ignore_marker_files(minio_io_config):
 
         read = daft.read_parquet(f"s3://{bucket_name}/**", io_config=minio_io_config)
         assert read.to_pydict() == {"x": [1, 2, 3, 4] * 3}
+
+
+@pytest.mark.integration()
+def test_minio_parquet_read_mismatched_schemas(minio_io_config):
+    # When we read files, we infer schema from the first file
+    # Then when we read subsequent files, we want to be able to read the data still but add nulls for columns
+    # that don't exist
+    bucket_name = "data-engineering-prod"
+    with minio_create_bucket(minio_io_config, bucket_name=bucket_name) as fs:
+        data_0 = pa.Table.from_pydict({"x": [1, 2, 3, 4]})
+        pq.write_table(data_0, f"s3://{bucket_name}/data_0.parquet", filesystem=fs)
+        data_1 = pa.Table.from_pydict({"y": [1, 2, 3, 4]})
+        pq.write_table(data_1, f"s3://{bucket_name}/data_1.parquet", filesystem=fs)
+
+        df = daft.read_parquet(
+            [f"s3://{bucket_name}/data_0.parquet", f"s3://{bucket_name}/data_1.parquet"], io_config=minio_io_config
+        )
+        assert df.schema().column_names() == ["x"]
+        assert df.to_pydict() == {"x": [1, 2, 3, 4, None, None, None, None]}
+
+        df = daft.read_parquet(
+            [f"s3://{bucket_name}/data_0.parquet", f"s3://{bucket_name}/data_1.parquet"], io_config=minio_io_config
+        )
+        df = df.select("x")  # Applies column selection pushdown on each read
+        assert df.schema().column_names() == ["x"]
+        assert df.to_pydict() == {"x": [1, 2, 3, 4, None, None, None, None]}

--- a/tests/table/table_io/test_parquet.py
+++ b/tests/table/table_io/test_parquet.py
@@ -351,6 +351,24 @@ def test_read_empty_parquet_file_with_pyarrow(tmpdir):
     assert tab == read_back
 
 
+def test_read_parquet_file_missing_column_with_pyarrow(tmpdir):
+    tmpdir = pathlib.Path(tmpdir)
+    file_path = tmpdir / "file.parquet"
+    tab = pa.table({"x": pa.array([1, 2, 3], type=pa.int64())})
+    papq.write_table(tab, file_path.as_posix())
+    read_back = read_parquet_into_pyarrow(file_path.as_posix(), columns=["MISSING"])
+    assert tab.drop("x") == read_back  # same length, but no columns, as original table
+
+
+def test_read_parquet_file_missing_column_partial_read_with_pyarrow(tmpdir):
+    tmpdir = pathlib.Path(tmpdir)
+    file_path = tmpdir / "file.parquet"
+    tab = pa.table({"x": pa.array([1, 2, 3], type=pa.int64()), "y": pa.array([1, 2, 3], type=pa.int64())})
+    papq.write_table(tab, file_path.as_posix())
+    read_back = read_parquet_into_pyarrow(file_path.as_posix(), columns=["x", "MISSING"])
+    assert tab.drop("y") == read_back  # only read "x"
+
+
 def test_read_empty_parquet_file_with_pyarrow_bulk(tmpdir):
     tmpdir = pathlib.Path(tmpdir)
     file_path = tmpdir / "file.parquet"
@@ -359,3 +377,23 @@ def test_read_empty_parquet_file_with_pyarrow_bulk(tmpdir):
     read_back = read_parquet_into_pyarrow_bulk([file_path.as_posix()])
     assert len(read_back) == 1
     assert tab == read_back[0]
+
+
+def test_read_parquet_file_missing_column_with_pyarrow_bulk(tmpdir):
+    tmpdir = pathlib.Path(tmpdir)
+    file_path = tmpdir / "file.parquet"
+    tab = pa.table({"x": pa.array([1, 2, 3], type=pa.int64())})
+    papq.write_table(tab, file_path.as_posix())
+    read_back = read_parquet_into_pyarrow_bulk([file_path.as_posix()], columns=["MISSING"])
+    assert len(read_back) == 1
+    assert tab.drop("x") == read_back[0]  # same length, but no columns, as original table
+
+
+def test_read_parquet_file_missing_column_partial_read_with_pyarrow_bulk(tmpdir):
+    tmpdir = pathlib.Path(tmpdir)
+    file_path = tmpdir / "file.parquet"
+    tab = pa.table({"x": pa.array([1, 2, 3], type=pa.int64()), "y": pa.array([1, 2, 3], type=pa.int64())})
+    papq.write_table(tab, file_path.as_posix())
+    read_back = read_parquet_into_pyarrow_bulk([file_path.as_posix()], columns=["x", "MISSING"])
+    assert len(read_back) == 1
+    assert tab.drop("y") == read_back[0]  # only read "x"


### PR DESCRIPTION
Fixes to allow for reading Parquet files and specifying **columns that do not exist in the Parquet file**.

This is common when we try to "apply" a schema from some external source (e.g. a data catalog). In that case, old Parquet files may not have certain columns because the schema evolved over time. We want to make sure that reads still succeed on these files, and we get back tables with the appropriate number of rows (even if no columns were read!)

## Summary of Changes

**Fixes to Parquet reader**
1. Allows for reads of Parquet files with `column` names that may not exist in the file. These columns will just be missing from the returned `Table`. Note that this potentially means we get empty `Tables` with valid number of rows.

**Fixes on `Table`**

1. Fixes `Table` to allow empty (num_rows=0) tables that still have columns of data. This lets us do reads of files without producing any data at all (e.g. reading only `col("x")` from a file that doesn't have `col("x")`).
2. During reading of Parquet files, remove our `FieldNotFound` errors. We no longer complain about a user-provided field not found, and will just return `Table` structs without the requested columns instead
3. Fix `Table::new` to not default to num_rows=1. Instead, we pass in num_rows explicitly and check against that.
4. Fix `Table::from_columns` to receive an explicit num_rows as well. This cleans up a host of bugs where we might be naively creating tables with the wrong length when a table has no columns.