### PR TITLE
[BUG] Fix bug with multi-partition `any_value`

### DIFF
--- a/src/daft-plan/src/physical_planner/translate.rs
+++ b/src/daft-plan/src/physical_planner/translate.rs
@@ -851,6 +851,7 @@ pub fn populate_aggregation_stages(
                         col(any_id.clone()).alias(any_of_any_id.clone()),
                         *ignore_nulls,
                     ));
+                final_exprs.push(col(any_of_any_id.clone()).alias(output_name));
             }
             List(e) => {
                 let list_id = agg_expr.semantic_id(schema).id;


### PR DESCRIPTION
Previously, putting an any_value in an aggregate function would result in no output column:
```python
>>> df = daft.from_pydict({
...     "a": [1, 3, 2],
...     "b": [1, 2, 2],
... }).into_partitions(2)
>>> res = df.groupby("b").agg(col("a").any_value())
>>> res.show()
╭───────╮    
│ b     │                                   
│ ---   │                            
│ Int64 │                           
╞═══════╡
│ 1     │
├╌╌╌╌╌╌╌┤
│ 2     │
╰───────╯
```

New output:

```python
>>> df = daft.from_pydict({
...     "a": [1, 3, 2],
...     "b": [1, 2, 2],
... }).into_partitions(2)
>>> res = df.groupby("b").agg(col("a").any_value())
>>> res.show()
╭───────┬───────╮ 
│ b     ┆ a     │
│ ---   ┆ ---   │
│ Int64 ┆ Int64 │
╞═══════╪═══════╡
│ 1     ┆ 1     │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 2     ┆ 3     │
╰───────┴───────╯
```