### PR TITLE
[DOCS] Do not generate PDFs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,4 +14,3 @@ sphinx:
 
 formats:
 - htmlzip
-- pdf


### PR DESCRIPTION
Seems like PDFs are having an issue in readthedocs. This PR only generates HTMLzip instead