### PR TITLE
[PERF] Optimize repartitions before a hash join

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -275,6 +275,7 @@ def set_execution_config(
     broadcast_join_size_bytes_threshold: int | None = None,
     parquet_split_row_groups_max_files: int | None = None,
     sort_merge_join_sort_with_aligned_boundaries: bool | None = None,
+    hash_join_partition_size_leniency: bool | None = None,
     sample_size_for_sort: int | None = None,
     num_preview_rows: int | None = None,
     parquet_target_filesize: int | None = None,
@@ -305,6 +306,9 @@ def set_execution_config(
         sort_merge_join_sort_with_aligned_boundaries: Whether to use a specialized algorithm for sorting both sides of a
             sort-merge join such that they have aligned boundaries. This can lead to a faster merge-join at the cost of
             more skewed sorted join inputs, increasing the risk of OOMs.
+        hash_join_partition_size_leniency: If the left side of a hash join is already correctly partitioned and the right side isn't,
+            and the ratio between the left and right size is at least this value, then the right side is repartitioned to have an equal
+            number of partitions as the left. Defaults to 0.5.
         sample_size_for_sort: number of elements to sample from each partition when running sort,
             Default is 20.
         num_preview_rows: number of rows to when showing a dataframe preview,
@@ -330,6 +334,7 @@ def set_execution_config(
             broadcast_join_size_bytes_threshold=broadcast_join_size_bytes_threshold,
             parquet_split_row_groups_max_files=parquet_split_row_groups_max_files,
             sort_merge_join_sort_with_aligned_boundaries=sort_merge_join_sort_with_aligned_boundaries,
+            hash_join_partition_size_leniency=hash_join_partition_size_leniency,
             sample_size_for_sort=sample_size_for_sort,
             num_preview_rows=num_preview_rows,
             parquet_target_filesize=parquet_target_filesize,

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -1657,6 +1657,7 @@ class PyDaftExecutionConfig:
         broadcast_join_size_bytes_threshold: int | None = None,
         parquet_split_row_groups_max_files: int | None = None,
         sort_merge_join_sort_with_aligned_boundaries: bool | None = None,
+        hash_join_partition_size_leniency: float | None = None,
         sample_size_for_sort: int | None = None,
         num_preview_rows: int | None = None,
         parquet_target_filesize: int | None = None,
@@ -1677,6 +1678,8 @@ class PyDaftExecutionConfig:
     def broadcast_join_size_bytes_threshold(self) -> int: ...
     @property
     def sort_merge_join_sort_with_aligned_boundaries(self) -> bool: ...
+    @property
+    def hash_join_partition_size_leniency(self) -> float: ...
     @property
     def sample_size_for_sort(self) -> int: ...
     @property

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -30,6 +30,7 @@ pub struct DaftExecutionConfig {
     pub scan_tasks_max_size_bytes: usize,
     pub broadcast_join_size_bytes_threshold: usize,
     pub sort_merge_join_sort_with_aligned_boundaries: bool,
+    pub hash_join_partition_size_leniency: f64,
     pub sample_size_for_sort: usize,
     pub parquet_split_row_groups_max_files: usize,
     pub num_preview_rows: usize,
@@ -51,6 +52,7 @@ impl Default for DaftExecutionConfig {
             scan_tasks_max_size_bytes: 384 * 1024 * 1024, // 384MB
             broadcast_join_size_bytes_threshold: 10 * 1024 * 1024, // 10 MiB
             sort_merge_join_sort_with_aligned_boundaries: false,
+            hash_join_partition_size_leniency: 0.5,
             sample_size_for_sort: 20,
             parquet_split_row_groups_max_files: 10,
             num_preview_rows: 8,

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -90,6 +90,7 @@ impl PyDaftExecutionConfig {
         broadcast_join_size_bytes_threshold: Option<usize>,
         parquet_split_row_groups_max_files: Option<usize>,
         sort_merge_join_sort_with_aligned_boundaries: Option<bool>,
+        hash_join_partition_size_leniency: Option<f64>,
         sample_size_for_sort: Option<usize>,
         num_preview_rows: Option<usize>,
         parquet_target_filesize: Option<usize>,
@@ -121,6 +122,9 @@ impl PyDaftExecutionConfig {
         {
             config.sort_merge_join_sort_with_aligned_boundaries =
                 sort_merge_join_sort_with_aligned_boundaries;
+        }
+        if let Some(hash_join_partition_size_leniency) = hash_join_partition_size_leniency {
+            config.hash_join_partition_size_leniency = hash_join_partition_size_leniency;
         }
         if let Some(sample_size_for_sort) = sample_size_for_sort {
             config.sample_size_for_sort = sample_size_for_sort;
@@ -181,6 +185,11 @@ impl PyDaftExecutionConfig {
     #[getter]
     fn get_sort_merge_join_sort_with_aligned_boundaries(&self) -> PyResult<bool> {
         Ok(self.config.sort_merge_join_sort_with_aligned_boundaries)
+    }
+
+    #[getter]
+    fn get_hash_join_partition_size_leniency(&self) -> PyResult<f64> {
+        Ok(self.config.hash_join_partition_size_leniency)
     }
 
     #[getter]

--- a/src/daft-dsl/src/expr.rs
+++ b/src/daft-dsl/src/expr.rs
@@ -23,7 +23,7 @@ use std::{
     cmp::Ordering,
     collections::{BinaryHeap, HashMap},
     fmt::{Debug, Display, Formatter, Result},
-    hash::{DefaultHasher, Hash, Hasher},
+    hash::Hash,
     io::{self, Write},
     sync::Arc,
 };
@@ -1254,12 +1254,8 @@ pub fn resolve_aggexprs(
     itertools::process_results(resolved_iter, |res| res.unzip())
 }
 
-pub fn sort_by_hash(exprs: &mut [ExprRef]) {
-    exprs.sort_by_cached_key(|x| {
-        let mut hasher = DefaultHasher::new();
-        x.hash(&mut hasher);
-        hasher.finish()
-    })
+pub fn sort_exprs_by_name(exprs: &mut [ExprRef]) {
+    exprs.sort_by(|a, b| a.name().cmp(b.name()))
 }
 
 #[cfg(test)]

--- a/src/daft-dsl/src/expr.rs
+++ b/src/daft-dsl/src/expr.rs
@@ -23,6 +23,7 @@ use std::{
     cmp::Ordering,
     collections::{BinaryHeap, HashMap},
     fmt::{Debug, Display, Formatter, Result},
+    hash::{DefaultHasher, Hash, Hasher},
     io::{self, Write},
     sync::Arc,
 };
@@ -1251,6 +1252,14 @@ pub fn resolve_aggexprs(
 ) -> DaftResult<(Vec<AggExpr>, Vec<Field>)> {
     let resolved_iter = exprs.into_iter().map(|e| resolve_aggexpr(e, schema));
     itertools::process_results(resolved_iter, |res| res.unzip())
+}
+
+pub fn sort_by_hash(exprs: &mut [ExprRef]) {
+    exprs.sort_by_cached_key(|x| {
+        let mut hasher = DefaultHasher::new();
+        x.hash(&mut hasher);
+        hasher.finish()
+    })
 }
 
 #[cfg(test)]

--- a/src/daft-dsl/src/lib.rs
+++ b/src/daft-dsl/src/lib.rs
@@ -14,7 +14,7 @@ mod treenode;
 pub use common_treenode;
 pub use expr::binary_op;
 pub use expr::col;
-pub use expr::{resolve_aggexpr, resolve_aggexprs, resolve_expr, resolve_exprs};
+pub use expr::{resolve_aggexpr, resolve_aggexprs, resolve_expr, resolve_exprs, sort_by_hash};
 pub use expr::{AggExpr, ApproxPercentileParams, Expr, ExprRef, Operator};
 pub use lit::{lit, null_lit, Literal, LiteralValue};
 #[cfg(feature = "python")]

--- a/src/daft-dsl/src/lib.rs
+++ b/src/daft-dsl/src/lib.rs
@@ -14,7 +14,9 @@ mod treenode;
 pub use common_treenode;
 pub use expr::binary_op;
 pub use expr::col;
-pub use expr::{resolve_aggexpr, resolve_aggexprs, resolve_expr, resolve_exprs, sort_by_hash};
+pub use expr::{
+    resolve_aggexpr, resolve_aggexprs, resolve_expr, resolve_exprs, sort_exprs_by_name,
+};
 pub use expr::{AggExpr, ApproxPercentileParams, Expr, ExprRef, Operator};
 pub use lit::{lit, null_lit, Literal, LiteralValue};
 #[cfg(feature = "python")]

--- a/src/daft-plan/src/partitioning.rs
+++ b/src/daft-plan/src/partitioning.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use daft_dsl::ExprRef;
+use daft_dsl::{sort_by_hash, ExprRef};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -348,7 +348,8 @@ pub struct RangeClusteringConfig {
 }
 
 impl RangeClusteringConfig {
-    pub fn new(num_partitions: usize, by: Vec<ExprRef>, descending: Vec<bool>) -> Self {
+    pub fn new(num_partitions: usize, mut by: Vec<ExprRef>, descending: Vec<bool>) -> Self {
+        sort_by_hash(&mut by);
         Self {
             num_partitions,
             by,
@@ -377,7 +378,8 @@ pub struct HashClusteringConfig {
 }
 
 impl HashClusteringConfig {
-    pub fn new(num_partitions: usize, by: Vec<ExprRef>) -> Self {
+    pub fn new(num_partitions: usize, mut by: Vec<ExprRef>) -> Self {
+        sort_by_hash(&mut by);
         Self { num_partitions, by }
     }
 

--- a/src/daft-plan/src/physical_ops/fanout.rs
+++ b/src/daft-plan/src/physical_ops/fanout.rs
@@ -1,4 +1,4 @@
-use daft_dsl::{sort_by_hash, ExprRef};
+use daft_dsl::ExprRef;
 use itertools::Itertools;
 
 use crate::physical_plan::PhysicalPlanRef;
@@ -36,9 +36,8 @@ impl FanoutByHash {
     pub(crate) fn new(
         input: PhysicalPlanRef,
         num_partitions: usize,
-        mut partition_by: Vec<ExprRef>,
+        partition_by: Vec<ExprRef>,
     ) -> Self {
-        sort_by_hash(&mut partition_by);
         Self {
             input,
             num_partitions,

--- a/src/daft-plan/src/physical_ops/fanout.rs
+++ b/src/daft-plan/src/physical_ops/fanout.rs
@@ -1,4 +1,4 @@
-use daft_dsl::ExprRef;
+use daft_dsl::{sort_by_hash, ExprRef};
 use itertools::Itertools;
 
 use crate::physical_plan::PhysicalPlanRef;
@@ -36,8 +36,9 @@ impl FanoutByHash {
     pub(crate) fn new(
         input: PhysicalPlanRef,
         num_partitions: usize,
-        partition_by: Vec<ExprRef>,
+        mut partition_by: Vec<ExprRef>,
     ) -> Self {
+        sort_by_hash(&mut partition_by);
         Self {
             input,
             num_partitions,

--- a/src/daft-plan/src/physical_planner/translate.rs
+++ b/src/daft-plan/src/physical_planner/translate.rs
@@ -636,8 +636,16 @@ pub(super) fn translate_single_logical_node(
                     ) {
                         (true, true, a, b) | (false, false, a, b) => max(a, b),
                         (_, _, 1, x) | (_, _, x, 1) => x,
-                        (true, false, a, b) if (a as f32) >= (b as f32) * 0.5 => a,
-                        (false, true, a, b) if (b as f32) >= (a as f32) * 0.5 => b,
+                        (true, false, a, b)
+                            if (a as f64) >= (b as f64) * cfg.hash_join_partition_size_leniency =>
+                        {
+                            a
+                        }
+                        (false, true, a, b)
+                            if (b as f64) >= (a as f64) * cfg.hash_join_partition_size_leniency =>
+                        {
+                            b
+                        }
                         (_, _, a, b) => max(a, b),
                     };
 


### PR DESCRIPTION
Repartitions are now more lenient when being optimized. Previously, if a table was partitioned on `col("a"), col("b")`, it would be considered distinct from `col("b"), col("a")` and would run a repartition, so this PR sorts the columns in a repartition to fix this. 

Also, hash joins are now more lenient with the repartitioning. Consider the case where the left side is correctly partitioned with 20 partitions, but the right side is incorrectly partitioned (relative to the join) with 40 partitions. Previously, the partition count would always be set to the maximum, meaning both sides would be repartitioned to have 40 partitions. Now, the right side is the only side repartitioned, with the partition count is reduced to 20. There is a configurable limit on how much the partitions can be reduced.

Aims to fix #2280