### PR TITLE
[FEAT] Fix resource accounting in PyRunner

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,6 +87,9 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '7.0.0') }}
       run: pip install deltalake==0.10.0
 
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
+
     - name: Build library and Test with pytest (unix)
       if: ${{ (runner.os != 'Windows') }}
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -87,9 +87,6 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '7.0.0') }}
       run: pip install deltalake==0.10.0
 
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
-
     - name: Build library and Test with pytest (unix)
       if: ${{ (runner.os != 'Windows') }}
       run: |

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -317,7 +317,7 @@ class PyRunner(Runner[MicroPartition]):
 
                         next_step = next(plan)
 
-                if not len(self._inflight_futures) > 0:
+                if next_step is None and not len(local_futures_to_task) > 0:
                     raise RuntimeError(
                         f"Scheduler deadlocked! This should never happen. Please file an issue. Current step: {type(next_step)}"
                     )

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -382,7 +382,7 @@ class PyRunner(Runner[MicroPartition]):
             for part, partial in zip(partitions, final_metadata)
         ]
 
-        # Release CPU and GPU resources, but not memory since the future has not been consumed yet
+        # Release CPU, GPU and memory resources
         with self._resource_accounting_lock:
             self._available_bytes_memory += resource_request.memory_bytes or 0
             self._available_cpus += resource_request.num_cpus or 0.0


### PR DESCRIPTION
Together with #2566 , closes #2561 

This PR changes the way the PyRunner performs resource accounting. Instead of updating the number of CPUs, GPUs and memory used only when futures are retrieved, we do this just before each task completes. These variables are protected with a lock to allow for concurrent access from across worker threads.

Additionally, this PR now tracks the inflight `Futures` across all executions globally in the PyRunner singleton. This is because there will be instances where a single execution might not be able to make forward progress (e.g. there are only 8 CPUs available, and there are 8 other currently-executing partitions). In this case, we need to wait for **some** execution globally to complete before attempting to make forward progress on the current execution.