### PR TITLE
[FEAT] Add support for pyiceberg v0.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.10']
         daft-runner: [py, ray]
-        pyarrow-version: [7.0.0, 13.0.0]
+        pyarrow-version: [7.0.0, 17.0.0]
         enable-aqe: [0, 1]
         os: [ubuntu-20.04, windows-latest]
         exclude:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.8', '3.10']
         daft-runner: [py, ray]
-        pyarrow-version: [7.0.0, 17.0.0]
+        pyarrow-version: [7.0.0, 15.0.0]
         enable-aqe: [0, 1]
         os: [ubuntu-20.04, windows-latest]
         exclude:

--- a/benchmarking/parquet/benchmark-requirements.txt
+++ b/benchmarking/parquet/benchmark-requirements.txt
@@ -1,5 +1,5 @@
 pytest==7.4.0
 pytest-benchmark==4.0.0
 pytest-memray==1.4.1
-pyarrow==13.0.0
+pyarrow==17.0.0
 boto3==1.28.3

--- a/benchmarking/parquet/benchmark-requirements.txt
+++ b/benchmarking/parquet/benchmark-requirements.txt
@@ -1,5 +1,5 @@
 pytest==7.4.0
 pytest-benchmark==4.0.0
 pytest-memray==1.4.1
-pyarrow==17.0.0
+pyarrow==15.0.0
 boto3==1.28.3

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -560,13 +560,6 @@ class DataFrame:
 
             tx = table.transaction()
 
-            if unsupported_partitions := [
-                field for field in tx.table_metadata.spec().fields if not field.transform.supports_pyarrow_transform
-            ]:
-                raise ValueError(
-                    f"Not all partition types are supported for writes. Following partitions cannot be written using pyarrow: {unsupported_partitions}."
-                )
-
             if mode == "overwrite":
                 tx.delete(delete_filter=ALWAYS_TRUE)
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -521,24 +521,13 @@ class DataFrame:
                 f"Write Iceberg is only supported on pyarrow>=12.0.1, found {pa.__version__}. See this issue for more information: https://github.com/apache/arrow/issues/37054#issuecomment-1668644887"
             )
 
-        from pyiceberg.table import _MergingSnapshotProducer
-        from pyiceberg.table.snapshots import Operation
+        if mode not in ["append", "overwrite"]:
+            raise ValueError(f"Only support `append` or `overwrite` mode. {mode} is unsupported")
 
         operations = []
         path = []
         rows = []
         size = []
-
-        if mode == "append":
-            operation = Operation.APPEND
-        elif mode == "overwrite":
-            operation = Operation.OVERWRITE
-        else:
-            raise ValueError(f"Only support `append` or `overwrite` mode. {mode} is unsupported")
-
-        # We perform the merge here since table is not pickle-able
-        # We should be able to move to a transaction API for iceberg 0.7.0
-        merge = _MergingSnapshotProducer(operation=operation, table=table)
 
         builder = self._builder.write_iceberg(table)
         write_df = DataFrame(builder)
@@ -548,13 +537,12 @@ class DataFrame:
         assert "data_file" in write_result
         data_files = write_result["data_file"]
 
-        if operation == Operation.OVERWRITE:
+        if mode == "overwrite":
             deleted_files = table.scan().plan_files()
         else:
             deleted_files = []
 
         for data_file in data_files:
-            merge.append_data_file(data_file)
             operations.append("ADD")
             path.append(data_file.file_path)
             rows.append(data_file.record_count)
@@ -567,7 +555,59 @@ class DataFrame:
             rows.append(data_file.record_count)
             size.append(data_file.file_size_in_bytes)
 
-        merge.commit()
+        if parse(pyiceberg.__version__) >= parse("0.7.0"):
+            from pyiceberg.io.pyarrow import _check_pyarrow_schema_compatible
+            from pyiceberg.table import ALWAYS_TRUE, DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE, PropertyUtil, TableProperties
+            from pyiceberg.utils.config import Config
+
+            tx = table.transaction()
+
+            if unsupported_partitions := [
+                field for field in tx.table_metadata.spec().fields if not field.transform.supports_pyarrow_transform
+            ]:
+                raise ValueError(
+                    f"Not all partition types are supported for writes. Following partitions cannot be written using pyarrow: {unsupported_partitions}."
+                )
+            downcast_ns_timestamp_to_us = Config().get_bool(DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE) or False
+            _check_pyarrow_schema_compatible(
+                table.schema(),
+                provided_schema=self.schema().to_pyarrow_schema(),
+                downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us,
+            )
+
+            if mode == "overwrite":
+                tx.delete(delete_filter=ALWAYS_TRUE)
+
+            update_snapshot = tx.update_snapshot()
+
+            manifest_merge_enabled = mode == "append" and PropertyUtil.property_as_bool(
+                tx.table_metadata.properties,
+                TableProperties.MANIFEST_MERGE_ENABLED,
+                TableProperties.MANIFEST_MERGE_ENABLED_DEFAULT,
+            )
+
+            append_method = update_snapshot.merge_append if manifest_merge_enabled else update_snapshot.fast_append
+
+            with append_method() as append_files:
+                for data_file in data_files:
+                    append_files.append_data_file(data_file)
+
+            tx.commit_transaction()
+        else:
+            from pyiceberg.table import _MergingSnapshotProducer
+            from pyiceberg.table.snapshots import Operation
+
+            operations_map = {
+                "append": Operation.APPEND,
+                "overwrite": Operation.OVERWRITE,
+            }
+
+            merge = _MergingSnapshotProducer(operation=operations_map[mode], table=table)
+
+            for data_file in data_files:
+                merge.append_data_file(data_file)
+
+            merge.commit()
 
         from daft import from_pydict
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -556,9 +556,7 @@ class DataFrame:
             size.append(data_file.file_size_in_bytes)
 
         if parse(pyiceberg.__version__) >= parse("0.7.0"):
-            from pyiceberg.io.pyarrow import _check_pyarrow_schema_compatible
-            from pyiceberg.table import ALWAYS_TRUE, DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE, PropertyUtil, TableProperties
-            from pyiceberg.utils.config import Config
+            from pyiceberg.table import ALWAYS_TRUE, PropertyUtil, TableProperties
 
             tx = table.transaction()
 
@@ -568,12 +566,6 @@ class DataFrame:
                 raise ValueError(
                     f"Not all partition types are supported for writes. Following partitions cannot be written using pyarrow: {unsupported_partitions}."
                 )
-            downcast_ns_timestamp_to_us = Config().get_bool(DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE) or False
-            _check_pyarrow_schema_compatible(
-                table.schema(),
-                provided_schema=self.schema().to_pyarrow_schema(),
-                downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us,
-            )
 
             if mode == "overwrite":
                 tx.delete(delete_filter=ALWAYS_TRUE)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,7 @@ opencv-python==4.8.1.78
 tiktoken==0.7.0
 
 # Pyarrow
-pyarrow==17.0.0
+pyarrow==15.0.0
 # Ray
 ray[data, client]==2.7.1; python_version < '3.8'
 ray[data, client]==2.10.0; python_version >= '3.8'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -44,7 +44,7 @@ ray[data, client]==2.10.0; python_version >= '3.8'
 lancedb>=0.6.10; python_version >= '3.8'
 
 #Iceberg
-pyiceberg==0.6.0; python_version >= '3.8'
+pyiceberg==0.7.0; python_version >= '3.8'
 tenacity==8.2.3; python_version >= '3.8'
 
 # Delta Lake

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,7 @@ opencv-python==4.8.1.78
 tiktoken==0.7.0
 
 # Pyarrow
-pyarrow==13.0.0
+pyarrow==17.0.0
 # Ray
 ray[data, client]==2.7.1; python_version < '3.8'
 ray[data, client]==2.10.0; python_version >= '3.8'

--- a/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
+++ b/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
@@ -17,7 +17,7 @@ uvicorn==0.23.2
 uvloop==0.17.0
 watchfiles==0.19.0
 websockets==11.0.3
-pyarrow==13.0.0
+pyarrow==17.0.0
 slowapi==0.1.8
 
 # Pin numpy version otherwise pyarrow doesn't work

--- a/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
+++ b/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
@@ -17,7 +17,7 @@ uvicorn==0.23.2
 uvloop==0.17.0
 watchfiles==0.19.0
 websockets==11.0.3
-pyarrow==17.0.0
+pyarrow==15.0.0
 slowapi==0.1.8
 
 # Pin numpy version otherwise pyarrow doesn't work


### PR DESCRIPTION
PyIceberg v0.7.0 was [just released](https://github.com/apache/iceberg-python/releases/tag/pyiceberg-0.7.0). One of the new changes is the Transaction API, which replaces some of the private functions that we have been using. This PR adds support for those changes