### PR TITLE
[FEAT] Remote parquet streaming

### DIFF
--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -428,20 +428,16 @@ impl ParquetFileReader {
                                     .expect("Row Group index should be in bounds");
                                 let num_rows =
                                     rg.num_rows().min(row_range.start + row_range.num_rows);
-                                let columns = rg.columns();
-                                let filtered_cols_idx = columns
+                                let filtered_columns = rg
+                                    .columns()
                                     .iter()
-                                    .enumerate()
-                                    .filter(|(_, x)| x.descriptor().path_in_schema[0] == field.name)
-                                    .map(|(i, _)| i)
+                                    .filter(|x| x.descriptor().path_in_schema[0] == field.name)
                                     .collect::<Vec<_>>();
                                 let mut decompressed_iters =
-                                    Vec::with_capacity(filtered_cols_idx.len());
-                                let mut ptypes = Vec::with_capacity(filtered_cols_idx.len());
-                                let mut num_values = Vec::with_capacity(filtered_cols_idx.len());
-
-                                for col_idx in filtered_cols_idx.into_iter() {
-                                    let col = columns.get(col_idx).unwrap();
+                                    Vec::with_capacity(filtered_columns.len());
+                                let mut ptypes = Vec::with_capacity(filtered_columns.len());
+                                let mut num_values = Vec::with_capacity(filtered_columns.len());
+                                for col in filtered_columns.into_iter() {
                                     num_values.push(col.metadata().num_values as usize);
                                     ptypes.push(col.descriptor().descriptor.primitive_type.clone());
 

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -421,7 +421,7 @@ impl ParquetFileReader {
 
                 let mut range_readers = Vec::with_capacity(filtered_cols_idx.len());
                 for range in needed_byte_ranges.into_iter() {
-                    let range_reader = ranges.get_range_reader(range).await?;
+                    let range_reader = ranges.get_range_reader(range)?;
                     range_readers.push(Box::pin(range_reader))
                 }
 
@@ -563,7 +563,7 @@ impl ParquetFileReader {
                             let mut range_readers = Vec::with_capacity(filtered_cols_idx.len());
 
                             for range in needed_byte_ranges.into_iter() {
-                                let range_reader = ranges.get_range_reader(range).await?;
+                                let range_reader = ranges.get_range_reader(range)?;
                                 range_readers.push(Box::pin(range_reader))
                             }
 
@@ -745,7 +745,7 @@ impl ParquetFileReader {
                             let mut range_readers = Vec::with_capacity(filtered_cols_idx.len());
 
                             for range in needed_byte_ranges.into_iter() {
-                                let range_reader = ranges.get_range_reader(range).await?;
+                                let range_reader = ranges.get_range_reader(range)?;
                                 range_readers.push(Box::pin(range_reader))
                             }
 

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -401,14 +401,14 @@ impl ParquetFileReader {
             let columns = rg.columns();
 
             let mut arr_iters = Vec::with_capacity(self.arrow_schema.fields.len());
-            for field in self.arrow_schema.fields.clone().into_iter() {
+            for field in self.arrow_schema.fields.iter() {
                 let filtered_cols_idx = columns
                     .iter()
                     .enumerate()
                     .filter(|(_, x)| x.descriptor().path_in_schema[0] == field.name)
                     .map(|(i, _)| i)
                     .collect::<Vec<_>>();
-                let mut num_values = Vec::with_capacity(filtered_cols_idx.len());
+
                 let needed_byte_ranges = filtered_cols_idx
                     .iter()
                     .map(|i| {
@@ -418,8 +418,8 @@ impl ParquetFileReader {
                         start as usize..end as usize
                     })
                     .collect::<Vec<_>>();
-                let mut range_readers = Vec::with_capacity(filtered_cols_idx.len());
 
+                let mut range_readers = Vec::with_capacity(filtered_cols_idx.len());
                 for range in needed_byte_ranges.into_iter() {
                     let range_reader = ranges.get_range_reader(range).await?;
                     range_readers.push(Box::pin(range_reader))
@@ -427,7 +427,7 @@ impl ParquetFileReader {
 
                 let mut decompressed_iters = Vec::with_capacity(filtered_cols_idx.len());
                 let mut ptypes = Vec::with_capacity(filtered_cols_idx.len());
-
+                let mut num_values = Vec::with_capacity(filtered_cols_idx.len());
                 for (col_idx, range_reader) in filtered_cols_idx.into_iter().zip(range_readers) {
                     let col = rg
                         .columns()

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -22,7 +22,6 @@ use futures::{
 };
 use itertools::Itertools;
 use parquet2::metadata::FileMetaData;
-use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use snafu::ResultExt;
 use tokio::runtime::Runtime;
 
@@ -60,17 +59,6 @@ impl From<ParquetSchemaInferenceOptions>
         arrow2::io::parquet::read::schema::SchemaInferenceOptions {
             int96_coerce_to_timeunit: value.coerce_int96_timestamp_unit.to_arrow(),
         }
-    }
-}
-
-pub struct ParallelLockStepIter {
-    pub iters: ArrowChunkIters,
-}
-impl Iterator for ParallelLockStepIter {
-    type Item = arrow2::error::Result<ArrowChunk>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iters.par_iter_mut().map(|iter| iter.next()).collect()
     }
 }
 

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -1036,9 +1036,11 @@ mod tests {
 
     use super::read_parquet;
     use super::stream_parquet;
+
+    const PARQUET_FILE: &str = "s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet";
     #[test]
     fn test_parquet_read_from_s3() -> DaftResult<()> {
-        let file = "s3://daft-public-data/benchmarking/lineitem-parquet/108417bd-5bee-43d9-bf9a-d6faec6afb2d-0.parquet";
+        let file = PARQUET_FILE;
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
@@ -1059,14 +1061,14 @@ mod tests {
             Default::default(),
             None,
         )?;
-        assert_eq!(table.len(), 18751674);
+        assert_eq!(table.len(), 100);
 
         Ok(())
     }
 
     #[test]
     fn test_parquet_streaming_read_from_s3() -> DaftResult<()> {
-        let file = "s3://daft-public-data/benchmarking/lineitem-parquet/108417bd-5bee-43d9-bf9a-d6faec6afb2d-0.parquet";
+        let file = PARQUET_FILE;
 
         let mut io_config = IOConfig::default();
         io_config.s3.anonymous = true;
@@ -1094,7 +1096,7 @@ mod tests {
             .into_iter()
             .collect::<DaftResult<Vec<_>>>()?;
             let total_tables_len = tables.iter().map(|t| t.len()).sum::<usize>();
-            assert_eq!(total_tables_len, 18751674);
+            assert_eq!(total_tables_len, 100);
             Ok(())
         })
     }

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -198,7 +198,10 @@ pub(crate) struct RangesContainer {
 }
 
 impl RangesContainer {
-    pub fn get_range_reader(&self, range: Range<usize>) -> DaftResult<impl futures::AsyncRead> {
+    pub async fn get_range_reader(
+        &self,
+        range: Range<usize>,
+    ) -> DaftResult<impl futures::AsyncRead> {
         let mut current_pos = range.start;
         let mut curr_index;
         let start_point = self.ranges.binary_search_by_key(&current_pos, |e| e.start);
@@ -255,6 +258,13 @@ impl RangesContainer {
         }
 
         assert_eq!(current_pos, range.end);
+
+        // We block on the first entry so we can surface up the error. This shouldn't cause any performance issues since we have to wait for this to complete anyways
+        if let Some(entry) = needed_entries.first()
+            && let Some(range) = ranges_to_slice.first()
+        {
+            entry.get_or_wait(range.clone()).await?;
+        }
 
         let bytes_iter = tokio_stream::iter(needed_entries.into_iter().zip(ranges_to_slice))
             .then(|(e, r)| async move { e.get_or_wait(r).await })

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -198,10 +198,7 @@ pub(crate) struct RangesContainer {
 }
 
 impl RangesContainer {
-    pub async fn get_range_reader(
-        &self,
-        range: Range<usize>,
-    ) -> DaftResult<impl futures::AsyncRead> {
+    pub fn get_range_reader(&self, range: Range<usize>) -> DaftResult<impl futures::AsyncRead> {
         let mut current_pos = range.start;
         let mut curr_index;
         let start_point = self.ranges.binary_search_by_key(&current_pos, |e| e.start);
@@ -258,13 +255,6 @@ impl RangesContainer {
         }
 
         assert_eq!(current_pos, range.end);
-
-        // We block on the first entry so we can surface up the error. This shouldn't cause any performance issues since we have to wait for this to complete anyways
-        if let Some(entry) = needed_entries.first()
-            && let Some(range) = ranges_to_slice.first()
-        {
-            entry.get_or_wait(range.clone()).await?;
-        }
 
         let bytes_iter = tokio_stream::iter(needed_entries.into_iter().zip(ranges_to_slice))
             .then(|(e, r)| async move { e.get_or_wait(r).await })

--- a/src/parquet2/src/read/page/stream.rs
+++ b/src/parquet2/src/read/page/stream.rs
@@ -51,7 +51,7 @@ pub async fn get_page_stream_from_column_start<'a, R: AsyncRead + Unpin + Send>(
     ))
 }
 
-pub async fn get_owned_page_stream_from_column_start<R: AsyncRead + Unpin + Send>(
+pub fn get_owned_page_stream_from_column_start<R: AsyncRead + Unpin + Send>(
     column_metadata: &ColumnChunkMetaData,
     reader: R,
     scratch: Vec<u8>,


### PR DESCRIPTION
Adds streaming reads to remote parquet files.

The algorithm is similar to that for local parquet files:  Read bytes into memory -> get arrow chunk iterator -> emit table per chunk

Q6 Memory Profile:
<img width="1111" alt="Screenshot 2024-08-07 at 12 38 18 PM" src="https://github.com/user-attachments/assets/f6d1f7d0-ede7-4fb6-9a13-7d07275c2158">
Streaming 
<img width="1100" alt="Screenshot 2024-08-07 at 12 38 41 PM" src="https://github.com/user-attachments/assets/9c25380f-6cfc-4410-b551-02a0a053bac3">
Bulk