### PR TITLE
[CHORE] Set `Expression.str.normalize()` options to False by default

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -2564,15 +2564,15 @@ class ExpressionStringNamespace(ExpressionNamespace):
     def normalize(
         self,
         *,
-        remove_punct: bool = True,
-        lowercase: bool = True,
-        nfd_unicode: bool = True,
-        white_space: bool = True,
+        remove_punct: bool = False,
+        lowercase: bool = False,
+        nfd_unicode: bool = False,
+        white_space: bool = False,
     ):
         """Normalizes a string for more useful deduplication.
 
         .. NOTE::
-            All processing options are on by default.
+            All processing options are off by default.
 
         Example:
             >>> import daft

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -2577,7 +2577,7 @@ class ExpressionStringNamespace(ExpressionNamespace):
         Example:
             >>> import daft
             >>> df = daft.from_pydict({"x": ["hello world", "Hello, world!", "HELLO,   \\nWORLD!!!!"]})
-            >>> df = df.with_column("normalized", df["x"].str.normalize())
+            >>> df = df.with_column("normalized", df["x"].str.normalize(remove_punct=True, lowercase=True, white_space=True))
             >>> df.show()
             ╭───────────────┬─────────────╮
             │ x             ┆ normalized  │

--- a/daft/series.py
+++ b/daft/series.py
@@ -888,10 +888,10 @@ class SeriesStringNamespace(SeriesNamespace):
     def normalize(
         self,
         *,
-        remove_punct: bool = True,
-        lowercase: bool = True,
-        nfd_unicode: bool = True,
-        white_space: bool = True,
+        remove_punct: bool = False,
+        lowercase: bool = False,
+        nfd_unicode: bool = False,
+        white_space: bool = False,
     ) -> Series:
         if not isinstance(remove_punct, bool):
             raise ValueError(f"expected bool for remove_punct but got {type(remove_punct)}")


### PR DESCRIPTION
This is a **breaking change**. Now every option needs to be toggled on, instead of off, which I feel is slightly more usable.