### PR TITLE
[FEAT] Add input batching for UDFs

### DIFF
--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -1188,6 +1188,7 @@ def stateless_udf(
     expressions: list[PyExpr],
     return_dtype: PyDataType,
     resource_request: ResourceRequest | None,
+    batch_size: int | None,
 ) -> PyExpr: ...
 def stateful_udf(
     name: str,
@@ -1196,6 +1197,7 @@ def stateful_udf(
     return_dtype: PyDataType,
     resource_request: ResourceRequest | None,
     init_args: tuple[tuple[Any, ...], dict[str, Any]] | None,
+    batch_size: int | None,
 ) -> PyExpr: ...
 def resolve_expr(expr: PyExpr, schema: PySchema) -> tuple[PyExpr, PyField]: ...
 def hash(expr: PyExpr, seed: Any | None = None) -> PyExpr: ...

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -237,9 +237,12 @@ class Expression:
         expressions: builtins.list[Expression],
         return_dtype: DataType,
         resource_request: ResourceRequest | None,
+        batch_size: int | None,
     ) -> Expression:
         return Expression._from_pyexpr(
-            _stateless_udf(name, partial, [e._expr for e in expressions], return_dtype._dtype, resource_request)
+            _stateless_udf(
+                name, partial, [e._expr for e in expressions], return_dtype._dtype, resource_request, batch_size
+            )
         )
 
     @staticmethod
@@ -250,10 +253,17 @@ class Expression:
         return_dtype: DataType,
         resource_request: ResourceRequest | None,
         init_args: tuple[tuple[Any, ...], dict[builtins.str, Any]] | None,
+        batch_size: int | None,
     ) -> Expression:
         return Expression._from_pyexpr(
             _stateful_udf(
-                name, partial, [e._expr for e in expressions], return_dtype._dtype, resource_request, init_args
+                name,
+                partial,
+                [e._expr for e in expressions],
+                return_dtype._dtype,
+                resource_request,
+                init_args,
+                batch_size,
             )
         )
 
@@ -819,7 +829,13 @@ class Expression:
             name = name + "."
         name = name + getattr(func, "__qualname__")  # type: ignore[call-overload]
 
-        return StatelessUDF(name=name, func=batch_func, return_dtype=return_dtype, resource_request=None)(self)
+        return StatelessUDF(
+            name=name,
+            func=batch_func,
+            return_dtype=return_dtype,
+            resource_request=None,
+            batch_size=None,
+        )(self)
 
     def is_null(self) -> Expression:
         """Checks if values in the Expression are Null (a special value indicating missing data)

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -76,6 +76,7 @@ class BoundUDFArgs:
         return hash(frozenset(self.bound_args.arguments.items()))
 
 
+# Assumes there is at least one evaluated expression
 def run_udf(
     func: Callable,
     bound_args: BoundUDFArgs,

--- a/src/daft-dsl/src/functions/python/mod.rs
+++ b/src/daft-dsl/src/functions/python/mod.rs
@@ -39,6 +39,7 @@ pub struct StatelessPythonUDF {
     num_expressions: usize,
     pub return_dtype: DataType,
     pub resource_request: Option<ResourceRequest>,
+    pub batch_size: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -51,6 +52,7 @@ pub struct StatefulPythonUDF {
     pub resource_request: Option<ResourceRequest>,
     #[cfg(feature = "python")]
     pub init_args: Option<pyobj_serde::PyObjectWrapper>,
+    pub batch_size: Option<usize>,
 }
 
 #[cfg(feature = "python")]
@@ -60,6 +62,7 @@ pub fn stateless_udf(
     expressions: &[ExprRef],
     return_dtype: DataType,
     resource_request: Option<ResourceRequest>,
+    batch_size: Option<usize>,
 ) -> DaftResult<Expr> {
     Ok(Expr::Function {
         func: super::FunctionExpr::Python(PythonUDF::Stateless(StatelessPythonUDF {
@@ -68,6 +71,7 @@ pub fn stateless_udf(
             num_expressions: expressions.len(),
             return_dtype,
             resource_request,
+            batch_size,
         })),
         inputs: expressions.into(),
     })
@@ -79,6 +83,7 @@ pub fn stateless_udf(
     expressions: &[ExprRef],
     return_dtype: DataType,
     resource_request: Option<ResourceRequest>,
+    batch_size: Option<usize>,
 ) -> DaftResult<Expr> {
     Ok(Expr::Function {
         func: super::FunctionExpr::Python(PythonUDF::Stateless(StatelessPythonUDF {
@@ -86,6 +91,7 @@ pub fn stateless_udf(
             num_expressions: expressions.len(),
             return_dtype,
             resource_request,
+            batch_size,
         })),
         inputs: expressions.into(),
     })
@@ -99,6 +105,7 @@ pub fn stateful_udf(
     return_dtype: DataType,
     resource_request: Option<ResourceRequest>,
     init_args: Option<pyo3::PyObject>,
+    batch_size: Option<usize>,
 ) -> DaftResult<Expr> {
     Ok(Expr::Function {
         func: super::FunctionExpr::Python(PythonUDF::Stateful(StatefulPythonUDF {
@@ -108,6 +115,7 @@ pub fn stateful_udf(
             return_dtype,
             resource_request,
             init_args: init_args.map(pyobj_serde::PyObjectWrapper),
+            batch_size,
         })),
         inputs: expressions.into(),
     })
@@ -119,6 +127,7 @@ pub fn stateful_udf(
     expressions: &[ExprRef],
     return_dtype: DataType,
     resource_request: Option<ResourceRequest>,
+    batch_size: Option<usize>,
 ) -> DaftResult<Expr> {
     Ok(Expr::Function {
         func: super::FunctionExpr::Python(PythonUDF::Stateful(StatefulPythonUDF {
@@ -126,6 +135,7 @@ pub fn stateful_udf(
             num_expressions: expressions.len(),
             return_dtype,
             resource_request,
+            batch_size,
         })),
         inputs: expressions.into(),
     })

--- a/src/daft-dsl/src/functions/python/udf.rs
+++ b/src/daft-dsl/src/functions/python/udf.rs
@@ -57,6 +57,7 @@ fn run_udf(
     func: pyo3::Py<PyAny>,
     bound_args: pyo3::Py<PyAny>,
     return_dtype: &DataType,
+    batch_size: Option<usize>,
 ) -> DaftResult<Series> {
     use daft_core::python::{PyDataType, PySeries};
 
@@ -83,6 +84,7 @@ fn run_udf(
         bound_args,                             // Arguments bound to the function
         pyseries,                               // evaluated_expressions
         PyDataType::from(return_dtype.clone()), // Returned datatype
+        batch_size,
     ));
 
     match result {
@@ -118,7 +120,14 @@ impl StatelessPythonUDF {
                 .0
                 .getattr(py, pyo3::intern!(py, "bound_args"))?;
 
-            run_udf(py, inputs, func, bound_args, &self.return_dtype)
+            run_udf(
+                py,
+                inputs,
+                func,
+                bound_args,
+                &self.return_dtype,
+                self.batch_size,
+            )
         })
     }
 }
@@ -200,7 +209,14 @@ impl FunctionEvaluator for StatefulPythonUDF {
                 }
             };
 
-            run_udf(py, inputs, func, bound_args, &self.return_dtype)
+            run_udf(
+                py,
+                inputs,
+                func,
+                bound_args,
+                &self.return_dtype,
+                self.batch_size,
+            )
         })
     }
 

--- a/src/daft-dsl/src/python.rs
+++ b/src/daft-dsl/src/python.rs
@@ -155,8 +155,18 @@ pub fn stateless_udf(
     expressions: Vec<PyExpr>,
     return_dtype: PyDataType,
     resource_request: Option<ResourceRequest>,
+    batch_size: Option<i64>,
 ) -> PyResult<PyExpr> {
     use crate::functions::python::stateless_udf;
+
+    if let Some(batch_size) = batch_size {
+        if batch_size <= 0 {
+            return Err(PyValueError::new_err(format!(
+                "Error creating UDF: batch size must be positive (got {batch_size})"
+            )));
+        }
+    }
+    let batch_size = batch_size.map(|b| b as usize);
 
     // Convert &PyAny values to a GIL-independent reference to Python objects (PyObject) so that we can store them in our Rust Expr enums
     // See: https://pyo3.rs/v0.18.2/types#pyt-and-pyobject
@@ -169,6 +179,7 @@ pub fn stateless_udf(
             &expressions_map,
             return_dtype.dtype,
             resource_request,
+            batch_size,
         )?
         .into(),
     })
@@ -179,6 +190,7 @@ pub fn stateless_udf(
 // * `expressions` - an ordered list of Expressions, each representing computation that will be performed, producing a Series to pass into `func`
 // * `return_dtype` - returned column's DataType
 #[pyfunction]
+#[allow(clippy::too_many_arguments)]
 pub fn stateful_udf(
     py: Python,
     name: &str,
@@ -187,8 +199,18 @@ pub fn stateful_udf(
     return_dtype: PyDataType,
     resource_request: Option<ResourceRequest>,
     init_args: Option<&PyAny>,
+    batch_size: Option<i64>,
 ) -> PyResult<PyExpr> {
     use crate::functions::python::stateful_udf;
+
+    if let Some(batch_size) = batch_size {
+        if batch_size <= 0 {
+            return Err(PyValueError::new_err(format!(
+                "Error creating UDF: batch size must be positive (got {batch_size})"
+            )));
+        }
+    }
+    let batch_size = batch_size.map(|b| b as usize);
 
     // Convert &PyAny values to a GIL-independent reference to Python objects (PyObject) so that we can store them in our Rust Expr enums
     // See: https://pyo3.rs/v0.18.2/types#pyt-and-pyobject
@@ -203,6 +225,7 @@ pub fn stateful_udf(
             return_dtype.dtype,
             resource_request,
             init_args,
+            batch_size,
         )?
         .into(),
     })

--- a/src/daft-dsl/src/python.rs
+++ b/src/daft-dsl/src/python.rs
@@ -155,18 +155,17 @@ pub fn stateless_udf(
     expressions: Vec<PyExpr>,
     return_dtype: PyDataType,
     resource_request: Option<ResourceRequest>,
-    batch_size: Option<i64>,
+    batch_size: Option<usize>,
 ) -> PyResult<PyExpr> {
     use crate::functions::python::stateless_udf;
 
     if let Some(batch_size) = batch_size {
-        if batch_size <= 0 {
+        if batch_size == 0 {
             return Err(PyValueError::new_err(format!(
                 "Error creating UDF: batch size must be positive (got {batch_size})"
             )));
         }
     }
-    let batch_size = batch_size.map(|b| b as usize);
 
     // Convert &PyAny values to a GIL-independent reference to Python objects (PyObject) so that we can store them in our Rust Expr enums
     // See: https://pyo3.rs/v0.18.2/types#pyt-and-pyobject
@@ -199,18 +198,17 @@ pub fn stateful_udf(
     return_dtype: PyDataType,
     resource_request: Option<ResourceRequest>,
     init_args: Option<&PyAny>,
-    batch_size: Option<i64>,
+    batch_size: Option<usize>,
 ) -> PyResult<PyExpr> {
     use crate::functions::python::stateful_udf;
 
     if let Some(batch_size) = batch_size {
-        if batch_size <= 0 {
+        if batch_size == 0 {
             return Err(PyValueError::new_err(format!(
                 "Error creating UDF: batch size must be positive (got {batch_size})"
             )));
         }
     }
-    let batch_size = batch_size.map(|b| b as usize);
 
     // Convert &PyAny values to a GIL-independent reference to Python objects (PyObject) so that we can store them in our Rust Expr enums
     // See: https://pyo3.rs/v0.18.2/types#pyt-and-pyobject

--- a/src/daft-plan/src/logical_optimization/rules/push_down_projection.rs
+++ b/src/daft-plan/src/logical_optimization/rules/push_down_projection.rs
@@ -818,6 +818,7 @@ mod tests {
                 num_expressions: 1,
                 return_dtype: DataType::Utf8,
                 resource_request: Some(ResourceRequest::default_cpu()),
+                batch_size: None,
             })),
             inputs: vec![col("c")],
         }
@@ -870,6 +871,7 @@ mod tests {
                 num_expressions: 1,
                 return_dtype: DataType::Utf8,
                 resource_request: Some(ResourceRequest::default_cpu()),
+                batch_size: None,
             })),
             inputs: vec![col("c")],
         }

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -29,10 +29,11 @@ def test_udf():
     assert result.to_pydict() == {"a": ["foofoo", "barbar", "bazbaz"]}
 
 
-def test_class_udf():
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_class_udf(batch_size):
     table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
-    @udf(return_dtype=DataType.string())
+    @udf(return_dtype=DataType.string(), batch_size=batch_size)
     class RepeatN:
         def __init__(self):
             self.n = 2
@@ -49,10 +50,11 @@ def test_class_udf():
     assert result.to_pydict() == {"a": ["foofoo", "barbar", "bazbaz"]}
 
 
-def test_class_udf_init_args():
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_class_udf_init_args(batch_size):
     table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
-    @udf(return_dtype=DataType.string())
+    @udf(return_dtype=DataType.string(), batch_size=batch_size)
     class RepeatN:
         def __init__(self, initial_n: int = 2):
             self.n = initial_n
@@ -75,10 +77,11 @@ def test_class_udf_init_args():
     assert result.to_pydict() == {"a": ["foofoofoo", "barbarbar", "bazbazbaz"]}
 
 
-def test_class_udf_init_args_no_default():
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_class_udf_init_args_no_default(batch_size):
     table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
-    @udf(return_dtype=DataType.string())
+    @udf(return_dtype=DataType.string(), batch_size=batch_size)
     class RepeatN:
         def __init__(self, initial_n):
             self.n = initial_n
@@ -126,10 +129,11 @@ def test_udf_kwargs():
     assert result.to_pydict() == {"a": ["foofoo", "barbar", "bazbaz"]}
 
 
-def test_udf_tuples():
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_udf_tuples(batch_size):
     table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
-    @udf(return_dtype=DataType.string())
+    @udf(return_dtype=DataType.string(), batch_size=batch_size)
     def repeat_n(data, tuple_data):
         n = tuple_data[0]
         return Series.from_pylist([d.as_py() * n for d in data.to_arrow()])
@@ -144,10 +148,11 @@ def test_udf_tuples():
 
 
 @pytest.mark.parametrize("container", [Series, list, np.ndarray])
-def test_udf_return_containers(container):
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_udf_return_containers(container, batch_size):
     table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
 
-    @udf(return_dtype=DataType.string())
+    @udf(return_dtype=DataType.string(), batch_size=batch_size)
     def identity(data):
         if container == Series:
             return data
@@ -177,8 +182,9 @@ def test_udf_error():
     assert str(exc_info.value.__cause__) == "AN ERROR OCCURRED!"
 
 
-def test_no_args_udf_call():
-    @udf(return_dtype=DataType.int64())
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_no_args_udf_call(batch_size):
+    @udf(return_dtype=DataType.int64(), batch_size=batch_size)
     def udf_no_args():
         pass
 
@@ -227,8 +233,9 @@ def test_udf_equality():
     assert not expr_structurally_equal(udf1("x"), udf1("y"))
 
 
-def test_udf_return_tensor():
-    @udf(return_dtype=DataType.tensor(DataType.float64()))
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_udf_return_tensor(batch_size):
+    @udf(return_dtype=DataType.tensor(DataType.float64()), batch_size=batch_size)
     def np_udf(x):
         return [np.ones((3, 3)) * i for i in x.to_pylist()]
 
@@ -251,10 +258,11 @@ def test_udf_repr():
     assert single_arg_udf(col("x"), "y", z=20).__repr__() == "@udf[single_arg_udf](col('x'), 'y', z=20)"
 
 
-def test_udf_arbitrary_number_of_args():
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_udf_arbitrary_number_of_args(batch_size):
     table = MicroPartition.from_pydict({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
 
-    @udf(return_dtype=DataType.int64())
+    @udf(return_dtype=DataType.int64(), batch_size=batch_size)
     def add_cols_elementwise(*args):
         return Series.from_pylist([sum(x) for x in zip(*[arg.to_pylist() for arg in args])])
 
@@ -267,10 +275,11 @@ def test_udf_arbitrary_number_of_args():
     assert result.to_pydict() == {"a": [3, 6, 9]}
 
 
-def test_udf_arbitrary_number_of_kwargs():
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_udf_arbitrary_number_of_kwargs(batch_size):
     table = MicroPartition.from_pydict({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
 
-    @udf(return_dtype=DataType.string())
+    @udf(return_dtype=DataType.string(), batch_size=batch_size)
     def repeat_kwargs(**kwargs):
         data = {k: v.to_pylist() for k, v in kwargs.items()}
         length = len(data[list(data.keys())[0]])
@@ -285,10 +294,11 @@ def test_udf_arbitrary_number_of_kwargs():
     assert result.to_pydict() == {"a": ["abc", "aabbcc", "aaabbbccc"]}
 
 
-def test_udf_arbitrary_number_of_args_with_kwargs():
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_udf_arbitrary_number_of_args_with_kwargs(batch_size):
     table = MicroPartition.from_pydict({"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
 
-    @udf(return_dtype=DataType.int64())
+    @udf(return_dtype=DataType.int64(), batch_size=batch_size)
     def add_cols_elementwise(*args, multiplier: float):
         return Series.from_pylist([multiplier * sum(x) for x in zip(*[arg.to_pylist() for arg in args])])
 
@@ -301,12 +311,53 @@ def test_udf_arbitrary_number_of_args_with_kwargs():
     assert result.to_pydict() == {"a": [6, 12, 18]}
 
 
-def test_udf_return_pyarrow():
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+def test_udf_return_pyarrow(batch_size):
     table = MicroPartition.from_pydict({"a": [1, 2, 3]})
 
-    @udf(return_dtype=DataType.int64())
+    @udf(return_dtype=DataType.int64(), batch_size=batch_size)
     def add_1(data):
         return pa.compute.add(data.to_arrow(), 1)
 
     result = table.eval_expression_list([add_1(col("a"))])
     assert result.to_pydict() == {"a": [2, 3, 4]}
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 7, 8, 1000])
+def test_udf_batch_size(batch_size):
+    table = MicroPartition.from_pydict({"a": [1, 2, 3, 4, 5, 6, 7]})
+
+    @udf(return_dtype=DataType.int64(), batch_size=batch_size)
+    def add_1(data):
+        lt = data.to_pylist()
+        assert len(lt) <= batch_size
+        return [x + 1 for x in lt]
+
+    result = table.eval_expression_list([add_1(col("a"))])
+    assert result.to_pydict() == {"a": [2, 3, 4, 5, 6, 7, 8]}
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 7, 8, 1000])
+def test_udf_batch_size_override(batch_size):
+    table = MicroPartition.from_pydict({"a": [1, 2, 3, 4, 5, 6, 7]})
+
+    @udf(return_dtype=DataType.int64())
+    def add_1(data):
+        lt = data.to_pylist()
+        assert len(lt) <= batch_size
+        return [x + 1 for x in lt]
+
+    result = table.eval_expression_list([add_1.override_options(batch_size=batch_size)(col("a"))])
+    assert result.to_pydict() == {"a": [2, 3, 4, 5, 6, 7, 8]}
+
+
+@pytest.mark.parametrize("batch_size", [0, -1, -100])
+def test_udf_invalid_batch_sizes(batch_size):
+    table = MicroPartition.from_pydict({"a": [1, 2, 3, 4, 5, 6, 7]})
+
+    @udf(return_dtype=DataType.int64(), batch_size=batch_size)
+    def noop(data):
+        return data
+
+    with pytest.raises(ValueError, match="batch size must be positive"):
+        table.eval_expression_list([noop(col("a"))])


### PR DESCRIPTION
Lets you specify a batch size for your UDFs, and then inputs are split up into batches of at most that size before being passed in to the UDF.