### PR TITLE
[FEAT] Changes the default count() behavior to perform a global row count instead

### DIFF
--- a/tests/cookbook/test_count_rows.py
+++ b/tests/cookbook/test_count_rows.py
@@ -11,6 +11,14 @@ def test_count_rows(daft_df, service_requests_csv_pd_df, repartition_nparts):
     assert daft_df_row_count == service_requests_csv_pd_df.shape[0]
 
 
+def test_dataframe_count_no_args(daft_df, service_requests_csv_pd_df):
+    """Counts rows using `df.count()` without any arguments"""
+    results = daft_df.count().to_pydict()
+    assert "count" in results
+    assert len(results["count"]) == 1
+    assert results["count"][0] == service_requests_csv_pd_df.shape[0]
+
+
 def test_filtered_count_rows(daft_df, service_requests_csv_pd_df, repartition_nparts):
     """Count rows on a table filtered by a certain condition"""
     daft_df_row_count = daft_df.repartition(repartition_nparts).where(col("Borough") == "BROOKLYN").count_rows()

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -208,14 +208,14 @@ def test_parquet_rows_cross_page_boundaries(tmpdir):
             after.show(10)
             after = after.sort(col("_index"))
             assert before.to_pydict() == after.to_pydict()
-            assert [x for x in before.explode(col("nested_col")).count().collect()] == [
-                x for x in after.explode(col("nested_col")).count().collect()
+            assert [x for x in before.explode(col("nested_col")).count(*before.column_names).collect()] == [
+                x for x in after.explode(col("nested_col")).count(*after.column_names).collect()
             ]
             before = before.limit(50)
             after = after.limit(50)
             assert before.to_pydict() == after.to_pydict()
-            assert [x for x in before.explode(col("nested_col")).count().collect()] == [
-                x for x in after.explode(col("nested_col")).count().collect()
+            assert [x for x in before.explode(col("nested_col")).count(*before.column_names).collect()] == [
+                x for x in after.explode(col("nested_col")).count(*after.column_names).collect()
             ]
 
         # Test Arrow write with Daft read.
@@ -242,14 +242,14 @@ def test_parquet_rows_cross_page_boundaries(tmpdir):
         assert before.to_pydict() == after.to_pydict()
         pd_table = before.to_pandas().explode("nested_col")
         assert [pd_table.count().get("nested_col")] == [
-            x["nested_col"] for x in after.explode(col("nested_col")).count().collect()
+            x["nested_col"] for x in after.explode(col("nested_col")).count(*after.column_names).collect()
         ]
         before = before.take(list(range(min(before.num_rows, 50))))
         after = after.limit(50)
         assert before.to_pydict() == after.to_pydict()
         pd_table = before.to_pandas().explode("nested_col")
         assert [pd_table.count().get("nested_col")] == [
-            x["nested_col"] for x in after.explode(col("nested_col")).count().collect()
+            x["nested_col"] for x in after.explode(col("nested_col")).count(*after.column_names).collect()
         ]
 
     # The normal case where the last row `nested.field1` is contained within a single data page.


### PR DESCRIPTION
Closes: #1996 

Our new `df.count()` behavior will be similar to `SELECT COUNT(*)` in SQL, returning a new dataframe with a single `"count"` column.