### PR TITLE
[CHORE] Deprecate schema hints

### DIFF
--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -1,6 +1,5 @@
 # isort: dont-add-import: from __future__ import annotations
 
-import warnings
 from typing import Dict, List, Optional, Union
 
 from daft import context
@@ -21,7 +20,6 @@ from daft.io.common import get_tabular_files_scan
 @PublicAPI
 def read_csv(
     path: Union[str, List[str]],
-    schema_hints: Optional[Dict[str, DataType]] = None,
     infer_schema: bool = True,
     schema: Optional[Dict[str, DataType]] = None,
     has_headers: bool = True,
@@ -46,11 +44,6 @@ def read_csv(
 
     Args:
         path (str): Path to CSV (allows for wildcards)
-        schema_hints (dict[str, DataType]): A mapping between column names and datatypes - passing this option
-            will override the specified columns on the inferred schema with the specified DataTypes
-
-            .. deprecated:: 0.2.27
-                Schema hints are deprecated and will be removed in the next release. Please use `schema` and `infer_schema` instead.
         infer_schema (bool): Whether to infer the schema of the CSV, defaults to True.
         schema (dict[str, DataType]): A schema that is used as the definitive schema for the CSV if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred.
         has_headers (bool): Whether the CSV has a header or not, defaults to True
@@ -68,11 +61,6 @@ def read_csv(
     """
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of CSV filepaths")
-
-    if schema_hints is not None:
-        warnings.warn("schema_hints is deprecated and will be removed in a future release. Please use schema instead.")
-        if schema is None:
-            schema = schema_hints
 
     if not infer_schema and schema is None:
         raise ValueError(

--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -31,6 +31,7 @@ def read_csv(
     allow_variable_columns: bool = False,
     io_config: Optional["IOConfig"] = None,
     use_native_downloader: bool = True,
+    schema_hints: Optional[Dict[str, DataType]] = None,
     _buffer_size: Optional[int] = None,
     _chunk_size: Optional[int] = None,
 ) -> DataFrame:
@@ -61,6 +62,11 @@ def read_csv(
     """
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of CSV filepaths")
+
+    if schema_hints is not None:
+        raise ValueError(
+            "Specifying schema_hints is deprecated from Daft version >= 0.3.0! Instead, please use the 'schema' and 'infer_schema' arguments."
+        )
 
     if not infer_schema and schema is None:
         raise ValueError(

--- a/daft/io/_json.py
+++ b/daft/io/_json.py
@@ -1,6 +1,5 @@
 # isort: dont-add-import: from __future__ import annotations
 
-import warnings
 from typing import Dict, List, Optional, Union
 
 from daft import context
@@ -21,7 +20,6 @@ from daft.io.common import get_tabular_files_scan
 @PublicAPI
 def read_json(
     path: Union[str, List[str]],
-    schema_hints: Optional[Dict[str, DataType]] = None,
     infer_schema: bool = True,
     schema: Optional[Dict[str, DataType]] = None,
     io_config: Optional["IOConfig"] = None,
@@ -39,10 +37,6 @@ def read_json(
 
     Args:
         path (str): Path to JSON files (allows for wildcards)
-        schema_hints (dict[str, DataType]): A mapping between column names and datatypes - passing this option
-            will override the specified columns on the inferred schema with the specified DataTypes
-                    .. deprecated:: 0.2.28
-                Schema hints are deprecated and will be removed in the next release. Please use `schema` and `infer_schema` instead.
         infer_schema (bool): Whether to infer the schema of the JSON, defaults to True.
         schema (dict[str, DataType]): A schema that is used as the definitive schema for the JSON if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred.
         io_config (IOConfig): Config to be used with the native downloader
@@ -54,11 +48,6 @@ def read_json(
     """
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of JSON filepaths")
-
-    if schema_hints is not None:
-        warnings.warn("schema_hints is deprecated and will be removed in a future release. Please use schema instead.")
-        if schema is None:
-            schema = schema_hints
 
     if not infer_schema and schema is None:
         raise ValueError(

--- a/daft/io/_json.py
+++ b/daft/io/_json.py
@@ -24,6 +24,7 @@ def read_json(
     schema: Optional[Dict[str, DataType]] = None,
     io_config: Optional["IOConfig"] = None,
     use_native_downloader: bool = True,
+    schema_hints: Optional[Dict[str, DataType]] = None,
     _buffer_size: Optional[int] = None,
     _chunk_size: Optional[int] = None,
 ) -> DataFrame:
@@ -48,6 +49,11 @@ def read_json(
     """
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of JSON filepaths")
+
+    if schema_hints is not None:
+        raise ValueError(
+            "Specifying schema_hints is deprecated from Daft version >= 0.3.0! Instead, please use the 'schema' and 'infer_schema' arguments."
+        )
 
     if not infer_schema and schema is None:
         raise ValueError(

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -21,7 +21,8 @@ from daft.io.common import get_tabular_files_scan
 def read_parquet(
     path: Union[str, List[str]],
     row_groups: Optional[List[List[int]]] = None,
-    schema_hints: Optional[Dict[str, DataType]] = None,
+    infer_schema: bool = True,
+    schema: Optional[Dict[str, DataType]] = None,
     io_config: Optional["IOConfig"] = None,
     use_native_downloader: bool = True,
     coerce_int96_timestamp_unit: Optional[Union[str, TimeUnit]] = None,
@@ -39,8 +40,8 @@ def read_parquet(
     Args:
         path (str): Path to Parquet file (allows for wildcards)
         row_groups (List[int] or List[List[int]]): List of row groups to read corresponding to each file.
-        schema_hints (dict[str, DataType]): A mapping between column names and datatypes - passing this option
-            will override the specified columns on the inferred schema with the specified DataTypes
+        infer_schema (bool): Whether to infer the schema of the Parquet, defaults to True.
+        schema (dict[str, DataType]): A schema that is used as the definitive schema for the Parquet file if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred.
         io_config (IOConfig): Config to be used with the native downloader
         use_native_downloader: Whether to use the native downloader instead of PyArrow for reading Parquet.
         coerce_int96_timestamp_unit: TimeUnit to coerce Int96 TimeStamps to. e.g.: [ns, us, ms], Defaults to None.
@@ -81,8 +82,8 @@ def read_parquet(
 
     builder = get_tabular_files_scan(
         path=path,
-        infer_schema=True,
-        schema=schema_hints,
+        infer_schema=infer_schema,
+        schema=schema,
         file_format_config=file_format_config,
         storage_config=storage_config,
         is_ray_runner=is_ray_runner,

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -26,6 +26,7 @@ def read_parquet(
     io_config: Optional["IOConfig"] = None,
     use_native_downloader: bool = True,
     coerce_int96_timestamp_unit: Optional[Union[str, TimeUnit]] = None,
+    schema_hints: Optional[Dict[str, DataType]] = None,
     _multithreaded_io: Optional[bool] = None,
 ) -> DataFrame:
     """Creates a DataFrame from Parquet file(s)
@@ -56,6 +57,11 @@ def read_parquet(
 
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of Parquet filepaths")
+
+    if schema_hints is not None:
+        raise ValueError(
+            "Specifying schema_hints is deprecated from Daft version >= 0.3.0! Instead, please use the 'schema' and 'infer_schema' arguments."
+        )
 
     is_ray_runner = context.get_context().is_ray_runner
     # If running on Ray, we want to limit the amount of concurrency and requests being made.

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -982,7 +982,7 @@ def test_create_dataframe_parquet_column_projection(valid_data: list[dict[str, f
         assert len(pd_df) == len(valid_data)
 
 
-def test_create_dataframe_parquet_specify_schema(valid_data: list[dict[str, float]]) -> None:
+def test_create_dataframe_parquet_provided_schema(valid_data: list[dict[str, float]]) -> None:
     with create_temp_filename() as fname:
         with open(fname, "w") as f:
             table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
@@ -991,7 +991,8 @@ def test_create_dataframe_parquet_specify_schema(valid_data: list[dict[str, floa
 
         df = daft.read_parquet(
             fname,
-            schema_hints={
+            infer_schema=False,
+            schema={
                 "sepal_length": DataType.float64(),
                 "sepal_width": DataType.float64(),
                 "petal_length": DataType.float64(),
@@ -1006,7 +1007,7 @@ def test_create_dataframe_parquet_specify_schema(valid_data: list[dict[str, floa
         assert len(pd_df) == len(valid_data)
 
 
-def test_create_dataframe_parquet_schema_hints_partial(valid_data: list[dict[str, float]]) -> None:
+def test_create_dataframe_parquet_partial_schema(valid_data: list[dict[str, float]]) -> None:
     with create_temp_filename() as fname:
         with open(fname, "w") as f:
             table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
@@ -1015,7 +1016,8 @@ def test_create_dataframe_parquet_schema_hints_partial(valid_data: list[dict[str
 
         df = daft.read_parquet(
             fname,
-            schema_hints={
+            infer_schema=True,
+            schema={
                 "sepal_length": DataType.float64(),
                 "sepal_width": DataType.float64(),
             },
@@ -1027,7 +1029,7 @@ def test_create_dataframe_parquet_schema_hints_partial(valid_data: list[dict[str
         assert len(pd_df) == len(valid_data)
 
 
-def test_create_dataframe_parquet_schema_hints_override_types(valid_data: list[dict[str, float]]) -> None:
+def test_create_dataframe_parquet_schema_override_types(valid_data: list[dict[str, float]]) -> None:
     with create_temp_filename() as fname:
         with open(fname, "w") as f:
             table = pa.Table.from_pydict({col: [d[col] for d in valid_data] for col in COL_NAMES})
@@ -1036,7 +1038,8 @@ def test_create_dataframe_parquet_schema_hints_override_types(valid_data: list[d
 
         df = daft.read_parquet(
             fname,
-            schema_hints={
+            infer_schema=True,
+            schema={
                 "sepal_length": DataType.string(),  # Override the inferred float64 type to string
             },
         )
@@ -1059,7 +1062,8 @@ def test_create_dataframe_parquet_schema_hints_ignore_random_hint(valid_data: li
 
         df = daft.read_parquet(
             fname,
-            schema_hints={
+            infer_schema=True,
+            schema={
                 "foo": DataType.string(),  # Random column name that is not in the table
             },
         )

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -70,7 +70,7 @@ def test_parquet_read_int96_timestamps(use_deprecated_int96_timestamps, use_nati
         papq_write_table_kwargs=papq_write_table_kwargs,
     ) as f:
         expected = MicroPartition.from_pydict(data)
-        df = daft.read_parquet(f, schema_hints={k: v for k, v in schema}, use_native_downloader=use_native_downloader)
+        df = daft.read_parquet(f, schema={k: v for k, v in schema}, use_native_downloader=use_native_downloader)
         assert df.to_arrow() == expected.to_arrow(), f"Expected:\n{expected}\n\nReceived:\n{df.to_arrow()}"
 
 


### PR DESCRIPTION
Fully deprecates schema hints from read_csv / json / parquet and removes the warning. See https://github.com/Eventual-Inc/Daft/pull/2326 for origin