### PR TITLE
[FEAT] Add hashing and groupby on structs

### DIFF
--- a/src/daft-core/src/array/ops/groups.rs
+++ b/src/daft-core/src/array/ops/groups.rs
@@ -4,7 +4,7 @@ use arrow2::array::Array;
 use fnv::FnvHashMap;
 
 use crate::{
-    array::{DataArray, FixedSizeListArray, ListArray},
+    array::{DataArray, FixedSizeListArray, ListArray, StructArray},
     datatypes::{
         BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeBinaryArray,
         Float32Array, Float64Array, NullArray, Utf8Array,
@@ -178,6 +178,12 @@ impl IntoGroups for ListArray {
 }
 
 impl IntoGroups for FixedSizeListArray {
+    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+        self.hash(None)?.make_groups()
+    }
+}
+
+impl IntoGroups for StructArray {
     fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
         self.hash(None)?.make_groups()
     }

--- a/src/daft-core/src/array/ops/hash.rs
+++ b/src/daft-core/src/array/ops/hash.rs
@@ -11,8 +11,8 @@ use crate::{
     Series,
 };
 
-use arrow2::{trusted_len::TrustedLen, types::Index};
-use common_error::DaftResult;
+use arrow2::types::Index;
+use common_error::{DaftError, DaftResult};
 use xxhash_rust::xxh3::{xxh3_64, xxh3_64_with_seed};
 
 use super::as_arrow::AsArrow;
@@ -186,75 +186,21 @@ impl FixedSizeListArray {
     }
 }
 
-fn struct_hash_helper(
-    validity_iter: impl TrustedLen<Item = bool>,
-    seed_iter: impl TrustedLen<Item = Option<u64>>,
-    name: &str,
-    child_hashes: &[UInt64Array],
-) -> UInt64Array {
-    let hash_iter = validity_iter
-        .zip(seed_iter)
-        .enumerate()
-        .map(|(i, (valid, seed))| {
-            if valid {
-                let row_hashes: Vec<u8> = child_hashes
-                    .iter()
-                    .flat_map(|c| c.get(i).unwrap().to_le_bytes())
-                    .collect();
-                if let Some(seed) = seed {
-                    Some(xxh3_64_with_seed(&row_hashes, seed))
-                } else {
-                    Some(xxh3_64(&row_hashes))
-                }
-            } else {
-                None
-            }
-        });
-    UInt64Array::from_iter(name, hash_iter)
-}
-
 impl StructArray {
     pub fn hash(&self, seed: Option<&UInt64Array>) -> DaftResult<UInt64Array> {
-        // hash children individually, then hash the hashes
-        let child_hashes: Vec<UInt64Array> = self
-            .children
-            .iter()
-            .map(|c| c.hash(seed))
-            .collect::<DaftResult<_>>()?;
+        // seed first child with input seed,
+        // then seed each child after with the output of the previous
+        if self.children.is_empty() {
+            return Err(DaftError::ValueError(
+                "Cannot hash struct with no children".into(),
+            ));
+        }
+        let mut res = self.children.first().unwrap().hash(seed)?;
 
-        let row_count = self.len();
-        let res = if let Some(validity) = self.validity() {
-            if let Some(seed) = seed {
-                struct_hash_helper(
-                    validity.iter(),
-                    seed.as_arrow().values_iter().map(|x| Some(*x)),
-                    self.name(),
-                    &child_hashes,
-                )
-            } else {
-                struct_hash_helper(
-                    validity.iter(),
-                    std::iter::repeat(None).take(row_count),
-                    self.name(),
-                    &child_hashes,
-                )
-            }
-        } else if let Some(seed) = seed {
-            struct_hash_helper(
-                std::iter::repeat(true).take(row_count),
-                seed.as_arrow().values_iter().map(|x| Some(*x)),
-                self.name(),
-                &child_hashes,
-            )
-        } else {
-            struct_hash_helper(
-                std::iter::repeat(true).take(row_count),
-                std::iter::repeat(None).take(row_count),
-                self.name(),
-                &child_hashes,
-            )
-        };
-        Ok(res)
+        for child in self.children.iter().skip(1) {
+            res = child.hash(Some(&res))?;
+        }
+        res.with_validity(self.validity().cloned())
     }
 }
 

--- a/src/daft-core/src/datatypes/matching.rs
+++ b/src/daft-core/src/datatypes/matching.rs
@@ -180,6 +180,7 @@ macro_rules! with_match_hashable_daft_types {(
         FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
         List(_) => __with_ty__! { ListType },
         FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
+        Struct(_) => __with_ty__! { StructType },
         _ => panic!("{:?} not implemented", $key_type)
     }
 })}

--- a/tests/series/test_hash.py
+++ b/tests/series/test_hash.py
@@ -438,6 +438,33 @@ def test_hash_struct_sublist(dtype, seed):
             assert hashed[different_inds[i]] != hashed[different_inds[j]]
 
 
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+@pytest.mark.parametrize("seed", [None, 123])
+def test_hash_struct_with_nones(dtype, seed):
+    data = [
+        {"a": 1, "b": 2},
+        {"a": None, "b": 2},
+        {"a": 0, "b": 2},
+        {"a": None, "b": None},
+        {"a": 0, "b": 0},
+        None,
+        {"a": None, "b": 2},
+        None,
+    ]
+    arr = Series.from_pylist(data).cast(DataType.struct({"a": dtype, "b": dtype}))
+
+    seeds = None if seed is None else Series.from_pylist([seed] * len(data)).cast(DataType.uint64())
+
+    hashed = arr.hash(seeds).to_pylist()
+    assert hashed[1] == hashed[6]
+    assert hashed[5] is None and hashed[-1] is None
+
+    different_inds = [0, 1, 2, 3, 4]
+    for i in range(len(different_inds)):
+        for j in range(i):
+            assert hashed[different_inds[i]] != hashed[different_inds[j]]
+
+
 @pytest.mark.parametrize(
     "dtype",
     [

--- a/tests/table/test_table_aggs.py
+++ b/tests/table/test_table_aggs.py
@@ -852,3 +852,25 @@ def test_groupby_fixed_size_list(dtype) -> None:
     expected = [[0, 1, 4], [2, 6], [3, 5]]
     for lt in expected:
         assert lt in res["b"]
+
+
+@pytest.mark.parametrize("dtype", daft_numeric_types)
+def test_groupby_struct(dtype) -> None:
+    df = from_pydict(
+        {
+            "a": [
+                {"c": 1, "d": "hi"},
+                {"c": 1, "d": "hi"},
+                {"c": 1, "d": "hello"},
+                {"c": 2, "d": "hello"},
+                {"c": 1, "d": "hi"},
+                {"c": 2, "d": "hello"},
+                {"c": 1, "d": "hello"},
+            ],
+            "b": [0, 1, 2, 3, 4, 5, 6],
+        }
+    ).with_column("a", col("a").cast(DataType.struct({"c": dtype, "d": DataType.string()})))
+    res = df.groupby("a").agg_list("b").to_pydict()
+    expected = [[0, 1, 4], [2, 6], [3, 5]]
+    for lt in expected:
+        assert lt in res["b"]


### PR DESCRIPTION
This only works within a given schema - structs with different field names are not guaranteed to be hashed differently. Hashes may also be different depending on the ordering of the fields.