### PR TITLE
[BUG] Fix filter pushdown into non-inner joins

### DIFF
--- a/src/daft-plan/src/logical_plan.rs
+++ b/src/daft-plan/src/logical_plan.rs
@@ -329,6 +329,12 @@ macro_rules! impl_from_data_struct_for_logical_plan {
                 Self::$name(data)
             }
         }
+
+        impl From<$name> for Arc<LogicalPlan> {
+            fn from(data: $name) -> Self {
+                Arc::new(LogicalPlan::$name(data))
+            }
+        }
     };
 }
 

--- a/tests/integration/iceberg/docker-compose/docker-compose.yml
+++ b/tests/integration/iceberg/docker-compose/docker-compose.yml
@@ -18,7 +18,6 @@ version: '3'
 
 services:
   spark-iceberg:
-    image: python-integration
     container_name: pyiceberg-spark
     build: .
     networks:

--- a/tests/integration/io/docker-compose/docker-compose.yml
+++ b/tests/integration/io/docker-compose/docker-compose.yml
@@ -18,7 +18,6 @@ services:
   # Use nginx to serve static files
   # Test fixtures should dump data in the `/tmp/daft-integration-testing/nginx` folder
   nginx:
-    image: nginx-serve-static-files
     build:
       context: .
       dockerfile: Dockerfile.nginx
@@ -29,7 +28,6 @@ services:
 
   # Custom FastAPI server which mocks an s3 endpoint and serves retryable objects
   s3-retry-server:
-    image: python-s3-retry-server
     build:
       context: .
       dockerfile: Dockerfile.s3_retry_server


### PR DESCRIPTION
There are some additional optimizations I would like to make but I decided to keep this PR minimal. Aside from splitting a filter into its conjunctions to allow for partial predicate pushdowns, this PR does the same optimizations as the original when it is correct to do so.

Also a flyby change on some `docker-compose.yaml` files to remove some image specifiers that were causing some failed tests and were probably meant to actually describe the name of the service?

TODO:
- [x] add tests