### PR TITLE
[CHORE] Add error snafus for local executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,7 @@ dependencies = [
  "daft-table",
  "futures",
  "lazy_static",
+ "log",
  "num-format",
  "pyo3",
  "snafu",

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -18,6 +18,7 @@ daft-stats = {path = "../daft-stats", default-features = false}
 daft-table = {path = "../daft-table", default-features = false}
 futures = {workspace = true}
 lazy_static = {workspace = true}
+log = {workspace = true}
 num-format = "0.4.4"
 pyo3 = {workspace = true, optional = true}
 snafu = {workspace = true}

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -166,10 +166,7 @@ impl PipelineNode for IntermediateNode {
         child.start(sender, runtime_handle).await?;
 
         let worker_senders = self.spawn_workers(&mut destination, runtime_handle).await;
-        runtime_handle.spawn(
-            Self::send_to_workers(receiver, worker_senders),
-            self.name().to_string(),
-        );
+        runtime_handle.spawn(Self::send_to_workers(receiver, worker_senders), self.name());
         Ok(())
     }
     fn as_tree_display(&self) -> &dyn TreeDisplay {

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -88,12 +88,15 @@ impl IntermediateNode {
         for _ in 0..num_senders {
             let (worker_sender, worker_receiver) = create_single_channel(1);
             let destination_sender = destination.get_next_sender();
-            runtime_handle.spawn(Self::run_worker(
-                self.intermediate_op.clone(),
-                worker_receiver,
-                destination_sender,
-                self.runtime_stats.clone(),
-            ));
+            runtime_handle.spawn(
+                Self::run_worker(
+                    self.intermediate_op.clone(),
+                    worker_receiver,
+                    destination_sender,
+                    self.runtime_stats.clone(),
+                ),
+                self.intermediate_op.name(),
+            );
             worker_senders.push(worker_sender);
         }
         worker_senders

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -152,7 +152,7 @@ impl PipelineNode for IntermediateNode {
         &mut self,
         mut destination: MultiSender,
         runtime_handle: &mut ExecutionRuntimeHandle,
-    ) -> DaftResult<()> {
+    ) -> crate::Result<()> {
         assert_eq!(
             self.children.len(),
             1,
@@ -166,7 +166,10 @@ impl PipelineNode for IntermediateNode {
         child.start(sender, runtime_handle).await?;
 
         let worker_senders = self.spawn_workers(&mut destination, runtime_handle).await;
-        runtime_handle.spawn(Self::send_to_workers(receiver, worker_senders));
+        runtime_handle.spawn(
+            Self::send_to_workers(receiver, worker_senders),
+            self.name().to_string(),
+        );
         Ok(())
     }
     fn as_tree_display(&self) -> &dyn TreeDisplay {

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -9,14 +9,14 @@ mod sources;
 use common_error::{DaftError, DaftResult};
 use lazy_static::lazy_static;
 pub use run::NativeExecutor;
+use snafu::futures::TryFutureExt;
 use snafu::Snafu;
-
 lazy_static! {
     pub static ref NUM_CPUS: usize = std::thread::available_parallelism().unwrap().get();
 }
 
 pub struct ExecutionRuntimeHandle {
-    pub worker_set: tokio::task::JoinSet<DaftResult<()>>,
+    pub worker_set: tokio::task::JoinSet<crate::Result<()>>,
 }
 
 impl Default for ExecutionRuntimeHandle {
@@ -34,11 +34,13 @@ impl ExecutionRuntimeHandle {
     pub fn spawn(
         &mut self,
         task: impl std::future::Future<Output = DaftResult<()>> + Send + 'static,
+        node_name: String,
     ) {
-        self.worker_set.spawn(task);
+        self.worker_set
+            .spawn(task.with_context(|_| PipelineExecutionSnafu { node_name }));
     }
 
-    pub async fn join_next(&mut self) -> Option<Result<DaftResult<()>, tokio::task::JoinError>> {
+    pub async fn join_next(&mut self) -> Option<Result<crate::Result<()>, tokio::task::JoinError>> {
         self.worker_set.join_next().await
     }
 
@@ -63,13 +65,30 @@ pub enum Error {
     OneShotRecvError {
         source: tokio::sync::oneshot::error::RecvError,
     },
+    #[snafu(display("Error creating pipeline from {}: {}", plan_name, source))]
+    PipelineCreationError {
+        source: DaftError,
+        plan_name: String,
+    },
+    #[snafu(display("Error when running pipeline node {}: {}", node_name, source))]
+    PipelineExecutionError {
+        source: DaftError,
+        node_name: String,
+    },
 }
 
 impl From<Error> for DaftError {
     fn from(err: Error) -> DaftError {
-        DaftError::External(err.into())
+        match err {
+            Error::PipelineCreationError { .. } | Error::PipelineExecutionError { .. } => {
+                DaftError::InternalError(err.to_string())
+            }
+            _ => DaftError::External(err.into()),
+        }
     }
 }
+
+type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[cfg(feature = "python")]
 pub fn register_modules(_py: Python, parent: &PyModule) -> PyResult<()> {

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -81,8 +81,13 @@ pub enum Error {
 impl From<Error> for DaftError {
     fn from(err: Error) -> DaftError {
         match err {
-            Error::PipelineCreationError { .. } | Error::PipelineExecutionError { .. } => {
-                DaftError::InternalError(err.to_string())
+            Error::PipelineCreationError { source, plan_name } => {
+                log::error!("Error creating pipeline from {}", plan_name);
+                source
+            }
+            Error::PipelineExecutionError { source, node_name } => {
+                log::error!("Error when running pipeline node {}", node_name);
+                source
             }
             _ => DaftError::External(err.into()),
         }

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -34,8 +34,9 @@ impl ExecutionRuntimeHandle {
     pub fn spawn(
         &mut self,
         task: impl std::future::Future<Output = DaftResult<()>> + Send + 'static,
-        node_name: String,
+        node_name: &str,
     ) {
+        let node_name = node_name.to_string();
         self.worker_set
             .spawn(task.with_context(|_| PipelineExecutionSnafu { node_name }));
     }

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -19,7 +19,6 @@ use crate::{
 
 use async_trait::async_trait;
 use common_display::{mermaid::MermaidDisplayVisitor, tree::TreeDisplay};
-use common_error::DaftResult;
 use daft_dsl::Expr;
 use daft_micropartition::MicroPartition;
 use daft_physical_plan::{
@@ -39,7 +38,7 @@ pub trait PipelineNode: Sync + Send + TreeDisplay {
         &mut self,
         destination: MultiSender,
         runtime_handle: &mut ExecutionRuntimeHandle,
-    ) -> DaftResult<()>;
+    ) -> crate::Result<()>;
 
     fn as_tree_display(&self) -> &dyn TreeDisplay;
 }

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -121,7 +121,7 @@ pub fn run_local(
         .expect("Failed to create tokio runtime");
 
     let res = runtime.block_on(async {
-        let mut pipeline = physical_plan_to_pipeline(physical_plan, &psets).unwrap();
+        let mut pipeline = physical_plan_to_pipeline(physical_plan, &psets)?;
         let (sender, mut receiver) = create_channel(1, true);
 
         let mut runtime_handle = ExecutionRuntimeHandle::default();
@@ -135,7 +135,7 @@ pub fn run_local(
             match result {
                 Ok(Err(e)) => {
                     runtime_handle.shutdown().await;
-                    return DaftResult::Err(e);
+                    return DaftResult::Err(e.into());
                 }
                 Err(e) => {
                     runtime_handle.shutdown().await;

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -82,7 +82,7 @@ impl PipelineNode for BlockingSinkNode {
         &mut self,
         mut destination: MultiSender,
         runtime_handle: &mut ExecutionRuntimeHandle,
-    ) -> DaftResult<()> {
+    ) -> crate::Result<()> {
         let (sender, mut streaming_receiver) = create_channel(*NUM_CPUS, true);
         // now we can start building the right side
         let child = self.child.as_mut();

--- a/src/daft-local-execution/src/sinks/hash_join.rs
+++ b/src/daft-local-execution/src/sinks/hash_join.rs
@@ -340,7 +340,7 @@ impl PipelineNode for HashJoinNode {
             .await;
         runtime_handle.spawn(
             IntermediateNode::send_to_workers(streaming_receiver, worker_senders),
-            self.name().to_string(),
+            self.name(),
         );
         Ok(())
     }

--- a/src/daft-local-execution/src/sinks/streaming_sink.rs
+++ b/src/daft-local-execution/src/sinks/streaming_sink.rs
@@ -89,7 +89,7 @@ impl PipelineNode for StreamingSinkNode {
         &mut self,
         mut destination: MultiSender,
         runtime_handle: &mut ExecutionRuntimeHandle,
-    ) -> DaftResult<()> {
+    ) -> crate::Result<()> {
         let (sender, mut streaming_receiver) = create_channel(*NUM_CPUS, destination.in_order());
         // now we can start building the right side
         let child = self

--- a/src/daft-local-execution/src/sinks/streaming_sink.rs
+++ b/src/daft-local-execution/src/sinks/streaming_sink.rs
@@ -99,47 +99,50 @@ impl PipelineNode for StreamingSinkNode {
         child.start(sender, runtime_handle).await?;
         let op = self.op.clone();
         let runtime_stats = self.runtime_stats.clone();
-        runtime_handle.spawn(async move {
-            // this should be a RWLock and run in concurrent workers
-            let span = info_span!("StreamingSink::execute");
+        runtime_handle.spawn(
+            async move {
+                // this should be a RWLock and run in concurrent workers
+                let span = info_span!("StreamingSink::execute");
 
-            let mut sink = op.lock().await;
-            let mut is_active = true;
-            while is_active && let Some(val) = streaming_receiver.recv().await {
-                runtime_stats.mark_rows_received(val.len() as u64);
-                loop {
-                    let result = runtime_stats.in_span(&span, || sink.execute(0, &val))?;
-                    match result {
-                        StreamSinkOutput::HasMoreOutput(mp) => {
-                            let len = mp.len() as u64;
-                            let sender = destination.get_next_sender();
-                            sender.send(mp).await.unwrap();
-                            runtime_stats.mark_rows_emitted(len);
-                        }
-                        StreamSinkOutput::NeedMoreInput(mp) => {
-                            if let Some(mp) = mp {
+                let mut sink = op.lock().await;
+                let mut is_active = true;
+                while is_active && let Some(val) = streaming_receiver.recv().await {
+                    runtime_stats.mark_rows_received(val.len() as u64);
+                    loop {
+                        let result = runtime_stats.in_span(&span, || sink.execute(0, &val))?;
+                        match result {
+                            StreamSinkOutput::HasMoreOutput(mp) => {
                                 let len = mp.len() as u64;
                                 let sender = destination.get_next_sender();
                                 sender.send(mp).await.unwrap();
                                 runtime_stats.mark_rows_emitted(len);
                             }
-                            break;
-                        }
-                        StreamSinkOutput::Finished(mp) => {
-                            if let Some(mp) = mp {
-                                let len = mp.len() as u64;
-                                let sender = destination.get_next_sender();
-                                sender.send(mp).await.unwrap();
-                                runtime_stats.mark_rows_emitted(len);
+                            StreamSinkOutput::NeedMoreInput(mp) => {
+                                if let Some(mp) = mp {
+                                    let len = mp.len() as u64;
+                                    let sender = destination.get_next_sender();
+                                    sender.send(mp).await.unwrap();
+                                    runtime_stats.mark_rows_emitted(len);
+                                }
+                                break;
                             }
-                            is_active = false;
-                            break;
+                            StreamSinkOutput::Finished(mp) => {
+                                if let Some(mp) = mp {
+                                    let len = mp.len() as u64;
+                                    let sender = destination.get_next_sender();
+                                    sender.send(mp).await.unwrap();
+                                    runtime_stats.mark_rows_emitted(len);
+                                }
+                                is_active = false;
+                                break;
+                            }
                         }
                     }
                 }
-            }
-            DaftResult::Ok(())
-        });
+                DaftResult::Ok(())
+            },
+            self.name(),
+        );
         Ok(())
     }
     fn as_tree_display(&self) -> &dyn TreeDisplay {

--- a/src/daft-local-execution/src/sources/in_memory.rs
+++ b/src/daft-local-execution/src/sources/in_memory.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use crate::{channel::MultiSender, runtime_stats::RuntimeStatsContext, ExecutionRuntimeHandle};
-use common_error::DaftResult;
 use daft_io::IOStatsRef;
 use daft_micropartition::MicroPartition;
 use tracing::instrument;
@@ -29,16 +28,19 @@ impl Source for InMemorySource {
         runtime_handle: &mut ExecutionRuntimeHandle,
         runtime_stats: Arc<RuntimeStatsContext>,
         _io_stats: IOStatsRef,
-    ) -> DaftResult<()> {
+    ) -> crate::Result<()> {
         let data = self.data.clone();
-        runtime_handle.spawn(async move {
-            for part in data {
-                let len = part.len();
-                let _ = destination.get_next_sender().send(part).await;
-                runtime_stats.mark_rows_emitted(len as u64);
-            }
-            Ok(())
-        });
+        runtime_handle.spawn(
+            async move {
+                for part in data {
+                    let len = part.len();
+                    let _ = destination.get_next_sender().send(part).await;
+                    runtime_stats.mark_rows_emitted(len as u64);
+                }
+                Ok(())
+            },
+            self.name(),
+        );
         Ok(())
     }
     fn name(&self) -> &'static str {

--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -68,19 +68,22 @@ impl Source for ScanTaskSource {
         runtime_handle: &mut ExecutionRuntimeHandle,
         runtime_stats: Arc<RuntimeStatsContext>,
         io_stats: IOStatsRef,
-    ) -> DaftResult<()> {
+    ) -> crate::Result<()> {
         let morsel_size = DEFAULT_MORSEL_SIZE;
         let maintain_order = destination.in_order();
         for scan_task in self.scan_tasks.clone() {
             let sender = destination.get_next_sender();
-            runtime_handle.spawn(Self::process_scan_task_stream(
-                scan_task,
-                sender,
-                morsel_size,
-                maintain_order,
-                io_stats.clone(),
-                runtime_stats.clone(),
-            ));
+            runtime_handle.spawn(
+                Self::process_scan_task_stream(
+                    scan_task,
+                    sender,
+                    morsel_size,
+                    maintain_order,
+                    io_stats.clone(),
+                    runtime_stats.clone(),
+                ),
+                self.name(),
+            );
         }
         Ok(())
     }

--- a/src/daft-local-execution/src/sources/source.rs
+++ b/src/daft-local-execution/src/sources/source.rs
@@ -7,7 +7,6 @@ use daft_micropartition::MicroPartition;
 use futures::stream::BoxStream;
 
 use async_trait::async_trait;
-use snafu::ResultExt;
 
 use crate::{
     channel::MultiSender, pipeline::PipelineNode, runtime_stats::RuntimeStatsContext,
@@ -24,8 +23,7 @@ pub(crate) trait Source: Send + Sync {
         runtime_handle: &mut ExecutionRuntimeHandle,
         runtime_stats: Arc<RuntimeStatsContext>,
         io_stats: IOStatsRef,
-    ) -> DaftResult<()>;
-    fn name(&self) -> &'static str;
+    ) -> crate::Result<()>;
 }
 
 struct SourceNode {
@@ -78,7 +76,7 @@ impl PipelineNode for SourceNode {
         &mut self,
         destination: MultiSender,
         runtime_handle: &mut ExecutionRuntimeHandle,
-    ) -> DaftResult<()> {
+    ) -> crate::Result<()> {
         self.source.get_data(
             destination,
             runtime_handle,

--- a/src/daft-local-execution/src/sources/source.rs
+++ b/src/daft-local-execution/src/sources/source.rs
@@ -7,6 +7,7 @@ use daft_micropartition::MicroPartition;
 use futures::stream::BoxStream;
 
 use async_trait::async_trait;
+use snafu::ResultExt;
 
 use crate::{
     channel::MultiSender, pipeline::PipelineNode, runtime_stats::RuntimeStatsContext,
@@ -24,6 +25,7 @@ pub(crate) trait Source: Send + Sync {
         runtime_stats: Arc<RuntimeStatsContext>,
         io_stats: IOStatsRef,
     ) -> DaftResult<()>;
+    fn name(&self) -> &'static str;
 }
 
 struct SourceNode {


### PR DESCRIPTION
Example:
```
df = daft.from_pydict({"a": ["foo", "bar", "baz"]})
df = df.select(df["a"].str.match("["))
df.show()
Error when running pipeline node ProjectOperator
Traceback (most recent call last):
  File "test.py", line 21, in <module>
    df.show()
  File "/Users/colinho/Desktop/Daft/daft/api_annotations.py", line 26, in _wrap
    return timed_method(*args, **kwargs)
  File "/Users/colinho/Desktop/Daft/daft/analytics.py", line 185, in tracked_method
    return method(*args, **kwargs)
  File "/Users/colinho/Desktop/Daft/daft/dataframe/dataframe.py", line 2278, in show
    dataframe_display = self._construct_show_display(n)
  File "/Users/colinho/Desktop/Daft/daft/dataframe/dataframe.py", line 2235, in _construct_show_display
    for table in get_context().runner().run_iter_tables(builder, results_buffer_size=1):
  File "/Users/colinho/Desktop/Daft/daft/runners/pyrunner.py", line 216, in run_iter_tables
    for result in self.run_iter(builder, results_buffer_size=results_buffer_size):
  File "/Users/colinho/Desktop/Daft/daft/runners/pyrunner.py", line 197, in run_iter
    results_gen = executor.run(
  File "/Users/colinho/Desktop/Daft/daft/execution/native_executor.py", line 33, in run
    PyMaterializedResult(MicroPartition._from_pymicropartition(part)) for part in self._executor.run(psets_mp)
daft.exceptions.DaftCoreException: DaftError::ValueError regex parse error:
    [
    ^
error: unclosed character class
```