### PR TITLE
[BUG]: Projection using all literals

### DIFF
--- a/src/daft-dsl/src/expr.rs
+++ b/src/daft-dsl/src/expr.rs
@@ -960,6 +960,16 @@ impl Expr {
             _ => self.children().into_iter().any(|e| e.has_agg()),
         }
     }
+
+    /// If the expression's root node is a literal, return true. Otherwise, return false.
+    pub fn is_literal(&self) -> bool {
+        match self {
+            Expr::Literal(_) => true,
+            Expr::Column(_) => false,
+            Expr::Agg(_) => false,
+            _ => self.children().into_iter().all(|e| e.is_literal()),
+        }
+    }
 }
 
 impl Display for Expr {

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -578,7 +578,7 @@ impl Table {
         let num_rows = match (has_agg_expr, self.len()) {
             // "Normal" case: the final cardinality is the max(*results_lens, self.len())
             // This correctly accounts for broadcasting of literals, which can have unit length
-            (false, self_len) if self_len > 0 => result_series
+            (false, self_len) if self_len > 0 || !result_series.is_empty() => result_series
                 .iter()
                 .map(|s| s.len())
                 .chain(std::iter::once(self.len()))

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -574,11 +574,19 @@ impl Table {
         }
         let new_schema = Schema::new(fields)?;
 
+        let are_all_literal = exprs.iter().all(|e| e.is_literal());
+
+        // Fast path for all literal expressions
+        if are_all_literal {
+            return Table::new_with_size(new_schema, result_series, 1);
+        }
+
         let has_agg_expr = exprs.iter().any(|e| matches!(e.as_ref(), Expr::Agg(..)));
+
         let num_rows = match (has_agg_expr, self.len()) {
             // "Normal" case: the final cardinality is the max(*results_lens, self.len())
             // This correctly accounts for broadcasting of literals, which can have unit length
-            (false, self_len) if self_len > 0 || !result_series.is_empty() => result_series
+            (false, self_len) if self_len > 0 => result_series
                 .iter()
                 .map(|s| s.len())
                 .chain(std::iter::once(self.len()))

--- a/tests/table/test_broadcasts.py
+++ b/tests/table/test_broadcasts.py
@@ -26,3 +26,16 @@ def test_broadcast_fixed_size_list():
 def test_broadcast_empty_table():
     df = daft.from_pydict({}).select(daft.lit(1)).collect()
     assert df.to_pydict() == {"literal": [1]}
+
+
+def test_all_literals_doesnt_broadcast():
+    df = (
+        daft.from_pydict(
+            {
+                "a": [1, 2, 3],
+            }
+        )
+        .select(daft.lit(1))
+        .collect()
+    )
+    assert df.to_pydict() == {"literal": [1]}

--- a/tests/table/test_broadcasts.py
+++ b/tests/table/test_broadcasts.py
@@ -21,3 +21,8 @@ def test_broadcast_fixed_size_list():
         [col("x"), lit(data).cast(daft.DataType.fixed_size_list(daft.DataType.int64(), 3))]
     )
     assert new_table.to_pydict() == {"x": [1, 2, 3], "literal": [data for _ in range(3)]}
+
+
+def test_broadcast_empty_table():
+    df = daft.from_pydict({}).select(daft.lit(1)).collect()
+    assert df.to_pydict() == {"literal": [1]}


### PR DESCRIPTION
added path for projection using all literals

if the projection only contains literals, or expressions that are based off of literals, the dataframe will not perform a broadcast.

```py
df.select(
  daft.lit(1),
  daft.lit('hello').str.upper().alias('HELLO')
).count_rows() # will always be 1
```

but if any expr is not composed from a literal, it'll perform the broadcast.

```py
df.select(
  daft.lit(1),
  daft.lit('hello').str.upper().alias('HELLO')
  daft.col('my_column')
).count_rows() # count remains unchanged
```
