### PR TITLE
[BUG] Add timeout to analytics client

### DIFF
--- a/daft/analytics.py
+++ b/daft/analytics.py
@@ -78,7 +78,7 @@ def _post_segment_track_endpoint(payload: dict[str, Any]) -> None:
         req,
         # Timeout after 10 seconds
         # Arbitrarily chosen; can be changed later
-        timeout=10,
+        timeout=1,
     )
     if resp.status != 200:
         raise RuntimeError(f"HTTP request to segment returned status code: {resp.status}")

--- a/daft/analytics.py
+++ b/daft/analytics.py
@@ -74,7 +74,12 @@ def _post_segment_track_endpoint(payload: dict[str, Any]) -> None:
         },
         data=json.dumps(payload).encode("utf-8"),
     )
-    resp = urllib.request.urlopen(req)
+    resp = urllib.request.urlopen(
+        req,
+        # Timeout after 10 seconds
+        # Arbitrarily chosen; can be changed later
+        timeout=10,
+    )
     if resp.status != 200:
         raise RuntimeError(f"HTTP request to segment returned status code: {resp.status}")
 

--- a/daft/analytics.py
+++ b/daft/analytics.py
@@ -10,7 +10,6 @@ import logging
 import os
 import platform
 import random
-import socket
 import time
 import urllib.error
 import urllib.request
@@ -80,9 +79,8 @@ def _post_segment_track_endpoint(analytics_client: AnalyticsClient, payload: dic
             req,
             timeout=1,
         )
-    except urllib.error.URLError as error:
-        if isinstance(error.reason, socket.timeout):
-            analytics_client._is_active = False
+    except urllib.error.URLError:
+        analytics_client._is_active = False
     if resp.status != 200:
         raise RuntimeError(f"HTTP request to segment returned status code: {resp.status}")
 

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -12,7 +12,7 @@ import pytest
 
 import daft
 from daft import context
-from daft.analytics import AnalyticsClient, _enable_analytics
+from daft.analytics import AnalyticsClient
 
 PUBLISHER_THREAD_SLEEP_INTERVAL_SECONDS = 0.1
 MOCK_DATETIME = datetime.datetime(2021, 1, 1, 0, 0, 0)
@@ -46,6 +46,7 @@ def test_analytics_client_track_import(mock_datetime: MagicMock, mock_analytics:
     time.sleep(PUBLISHER_THREAD_SLEEP_INTERVAL_SECONDS + 0.5)
 
     mock_publish.assert_called_once_with(
+        analytics_client,
         {
             "batch": [
                 {
@@ -68,7 +69,7 @@ def test_analytics_client_track_import(mock_datetime: MagicMock, mock_analytics:
                     },
                 }
             ],
-        }
+        },
     )
 
 
@@ -76,7 +77,6 @@ def test_analytics_client_track_import(mock_datetime: MagicMock, mock_analytics:
 def test_analytics_client_timeout(
     mock_urlopen: MagicMock,
 ):
-    _enable_analytics()
     mock_urlopen.side_effect = urllib.error.URLError(socket.timeout("Timeout"))
     analytics_client = AnalyticsClient(
         daft.get_version(),
@@ -94,7 +94,6 @@ def test_analytics_client_timeout(
 def test_analytics_client_timeout_2(
     mock_urlopen: MagicMock,
 ):
-    _enable_analytics()
     mock_urlopen.return_value.status = 408
     analytics_client = AnalyticsClient(
         daft.get_version(),
@@ -123,6 +122,7 @@ def test_analytics_client_track_dataframe_method(
     time.sleep(PUBLISHER_THREAD_SLEEP_INTERVAL_SECONDS + 0.5)
 
     mock_publish.assert_called_once_with(
+        analytics_client,
         {
             "batch": [
                 {
@@ -144,5 +144,5 @@ def test_analytics_client_track_dataframe_method(
                     },
                 }
             ],
-        }
+        },
     )


### PR DESCRIPTION
## Overview
Add a simple timeout to the `urllib.request.urlopen` invocation made inside of `_post_segment_track_endpoint`.