### PR TITLE
[FEAT] Support passing in column name strings to `to_struct`

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -269,8 +269,8 @@ class Expression:
         )
 
     @staticmethod
-    def to_struct(*inputs: Expression) -> Expression:
-        """Converts multiple input expressions into a struct.
+    def to_struct(*inputs: Expression | builtins.str) -> Expression:
+        """Converts multiple input expressions or column names into a struct.
 
         Example:
             >>> import daft
@@ -303,7 +303,14 @@ class Expression:
         Returns:
             An expression for a struct column with the input columns as its fields.
         """
-        pyinputs = [x._expr for x in inputs]
+        pyinputs = []
+        for x in inputs:
+            if isinstance(x, Expression):
+                pyinputs.append(x._expr)
+            elif isinstance(x, str):
+                pyinputs.append(col(x)._expr)
+            else:
+                raise TypeError("expected Expression or str as input for to_struct")
         return Expression._from_pyexpr(_to_struct(pyinputs))
 
     def __bool__(self) -> bool:

--- a/tests/table/struct/test_to_struct.py
+++ b/tests/table/struct/test_to_struct.py
@@ -41,3 +41,22 @@ def test_to_struct_subexpr():
         {"a": 12, "b": None},
         {"a": None, "b": None},
     ]
+
+
+def test_to_struct_strs():
+    df = MicroPartition.from_pydict(
+        {
+            "a": [1, 2, 3, 4, None, 6, None],
+            "b": ["a", "b", "c", "", "e", None, None],
+        }
+    )
+    res = df.eval_expression_list([daft.to_struct("a", "b")]).to_pydict()
+    assert res["struct"] == [
+        {"a": 1, "b": "a"},
+        {"a": 2, "b": "b"},
+        {"a": 3, "b": "c"},
+        {"a": 4, "b": ""},
+        {"a": None, "b": "e"},
+        {"a": 6, "b": None},
+        {"a": None, "b": None},
+    ]


### PR DESCRIPTION
e.g. `to_struct("a", "b")` instead of `to_struct(col("a"), col("b"))`