### PR TITLE
[FEAT] Add dataframe iteration on rows and change default buffer size

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -250,7 +250,11 @@ class DataFrame:
         >>>
         >>> df = daft.from_pydict({"foo": [1, 2, 3], "bar": ["a", "b", "c"]})
         >>> for row in df.iter_rows():
-        >>>     print(row)
+        ...     print(row)
+        {'foo': 1, 'bar': 'a'}
+        {'foo': 2, 'bar': 'b'}
+        {'foo': 3, 'bar': 'c'}
+
 
         Args:
             results_buffer_size: how many partitions to allow in the results buffer (defaults to the total number of CPUs
@@ -305,6 +309,39 @@ class DataFrame:
         Args:
             results_buffer_size: how many partitions to allow in the results buffer (defaults to the total number of CPUs
                 available on the machine).
+
+        >>> import daft
+        >>>
+        >>> df = daft.from_pydict({"foo": [1, 2, 3], "bar": ["a", "b", "c"]}).into_partitions(2)
+        >>> for part in df.iter_partitions():
+        ...     print(part)
+        MicroPartition with 2 rows:
+        TableState: Loaded. 1 tables
+        ╭───────┬──────╮
+        │ foo   ┆ bar  │
+        │ ---   ┆ ---  │
+        │ Int64 ┆ Utf8 │
+        ╞═══════╪══════╡
+        │ 1     ┆ a    │
+        ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+        │ 2     ┆ b    │
+        ╰───────┴──────╯
+        <BLANKLINE>
+        <BLANKLINE>
+        Statistics: missing
+        <BLANKLINE>
+        MicroPartition with 1 rows:
+        TableState: Loaded. 1 tables
+        ╭───────┬──────╮
+        │ foo   ┆ bar  │
+        │ ---   ┆ ---  │
+        │ Int64 ┆ Utf8 │
+        ╞═══════╪══════╡
+        │ 3     ┆ c    │
+        ╰───────┴──────╯
+        <BLANKLINE>
+        <BLANKLINE>
+        Statistics: missing
         """
         if results_buffer_size is not None and not results_buffer_size > 0:
             raise ValueError(f"Provided `results_buffer_size` value must be > 0, received: {results_buffer_size}")

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -342,6 +342,7 @@ class DataFrame:
         <BLANKLINE>
         <BLANKLINE>
         Statistics: missing
+        <BLANKLINE>
         """
         if results_buffer_size is not None and not results_buffer_size > 0:
             raise ValueError(f"Provided `results_buffer_size` value must be > 0, received: {results_buffer_size}")

--- a/docs/source/api_docs/dataframe.rst
+++ b/docs/source/api_docs/dataframe.rst
@@ -124,6 +124,7 @@ These methods will run the dataframe and retrieve them to where the code is bein
 
     DataFrame.to_pydict
     DataFrame.iter_partitions
+    DataFrame.iter_rows
 
 Materialization
 ***************


### PR DESCRIPTION
1. Changes default `results_buffer_size` on our dataframe iteration methods to use the total number of available CPUs on the current machine instead of `1`, which was empirically observed by users to significant slow down processing speeds
2. Adds a new `df.iter_rows()` API which is used by `__iter__`, but provides an alternative API if a user needs to configure `results_buffer_size`