### PR TITLE
[FEAT] Pin optional dependency deltalake version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.8"
 all = ["getdaft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake, sql, unity]"]
 aws = ["boto3"]
 azure = []
-deltalake = ["deltalake"]
+deltalake = ["deltalake < 0.19.0"]
 gcp = []
 hudi = ["pyarrow >= 8.0.0"]
 iceberg = ["pyiceberg >= 0.4.0", "packaging"]


### PR DESCRIPTION
With deltalake 1.9.0 the `getdaft[deltalake]` package installation results in an incompatible configuration, where `df.write_deltalake()` fails because of the changes introduced in this PR: https://github.com/delta-io/delta-rs/pull/2738

This PR puts a version contraint on the optional dependency.