### PR TITLE
[BUG] Fix `count("*")` behavior

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2101,7 +2101,7 @@ class DataFrame:
             >>> import daft
             >>> from daft import col
             >>> df = daft.from_pydict({"foo": [1, None, None], "bar": [None, 2, 2], "baz": [3, 4, 5]})
-            >>> df.count().show()
+            >>> df.count().show()  # equivalent to df.count("*").show()
             ╭────────╮
             │ count  │
             │ ---    │

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2094,12 +2094,13 @@ class DataFrame:
     def count(self, *cols: ColumnInputType) -> "DataFrame":
         """Performs a global count on the DataFrame
 
-        If no columns are specified (i.e. in the case you call `df.count()`) this functions very
-        similarly to a COUNT(*) operation in SQL and will return a new dataframe with a single column
-        with the name "count".
+        If no columns are specified (i.e. in the case you call `df.count()`), or only the literal string "*",
+        this functions very similarly to a COUNT(*) operation in SQL and will return a new dataframe with a
+        single column with the name "count".
 
             >>> import daft
-            >>> df = daft.from_pydict({"foo": [1, None, None], "bar": [None, 2, 2]})
+            >>> from daft import col
+            >>> df = daft.from_pydict({"foo": [1, None, None], "bar": [None, 2, 2], "baz": [3, 4, 5]})
             >>> df.count().show()
             ╭────────╮
             │ count  │
@@ -2112,7 +2113,8 @@ class DataFrame:
             (Showing first 1 of 1 rows)
 
         However, specifying some column names would instead change the behavior to count all non-null values,
-        similar to a SQL command for `SELECT COUNT(foo), COUNT(bar) FROM df`
+        similar to a SQL command for `SELECT COUNT(foo), COUNT(bar) FROM df`. Also, using `df.count(col("*"))`
+        will expand out into count() for each column.
 
             >>> df.count("foo", "bar").show()
             ╭────────┬────────╮
@@ -2124,6 +2126,16 @@ class DataFrame:
             ╰────────┴────────╯
             <BLANKLINE>
             (Showing first 1 of 1 rows)
+            >>> df.count(col("*")).show()
+            ╭────────┬────────┬────────╮
+            │ foo    ┆ bar    ┆ baz    │
+            │ ---    ┆ ---    ┆ ---    │
+            │ UInt64 ┆ UInt64 ┆ UInt64 │
+            ╞════════╪════════╪════════╡
+            │ 1      ┆ 2      ┆ 3      │
+            ╰────────┴────────┴────────╯
+            <BLANKLINE>
+            (Showing first 1 of 1 rows)
 
         Args:
             *cols (Union[str, Expression]): columns to count
@@ -2131,9 +2143,14 @@ class DataFrame:
             DataFrame: Globally aggregated count. Should be a single row.
         """
         # Special case: treat this as a COUNT(*) operation which is likely what most people would expect
-        if len(cols) == 0:
+        # If user passes in "*", also do this behavior (by default it would count each column individually)
+        if len(cols) == 0 or (len(cols) == 1 and isinstance(cols[0], str) and cols[0] == "*"):
             builder = self._builder.count()
             return DataFrame(builder)
+
+        if any(isinstance(c, str) and c == "*" for c in cols):
+            # we do not support hybrid count-all and count-nonnull
+            raise ValueError("Cannot call count() with both * and column names")
 
         # Otherwise, perform a column-wise count on the specified columns
         return self._apply_agg_fn(Expression.count, cols)

--- a/tests/dataframe/test_count.py
+++ b/tests/dataframe/test_count.py
@@ -1,0 +1,30 @@
+# corner cases for df.count()
+
+import pytest
+
+import daft
+from daft import col
+
+
+def test_count_star() -> None:
+    df = daft.from_pydict({"a": [1, 2, 3, 4], "b": [1, None, 3, None]})
+    res = df.count("*").to_pydict()
+    assert res == {"count": [4]}
+
+
+def test_count_col_star() -> None:
+    df = daft.from_pydict({"a": [1, 2, 3, 4], "b": [1, None, 3, None]})
+    res = df.count(col("*")).to_pydict()
+    assert res == {"a": [4], "b": [2]}
+
+
+def test_count_mixed_col_star() -> None:
+    df = daft.from_pydict({"a": [1, 2, 3, 4], "b": [1, None, 3, None]})
+    res = df.count(col("*"), col("a").alias("new_a")).to_pydict()
+    assert res == {"a": [4], "b": [2], "new_a": [4]}
+
+
+def test_count_mixed_star() -> None:
+    df = daft.from_pydict({"a": [1, 2, 3, 4], "b": [1, None, 3, None]})
+    with pytest.raises(ValueError, match=r"Cannot call count\(\) with both \* and column names"):
+        df.count("*", "a")

--- a/tests/dataframe/test_count.py
+++ b/tests/dataframe/test_count.py
@@ -20,8 +20,8 @@ def test_count_col_star() -> None:
 
 def test_count_mixed_col_star() -> None:
     df = daft.from_pydict({"a": [1, 2, 3, 4], "b": [1, None, 3, None]})
-    res = df.count(col("*"), col("a").alias("new_a")).to_pydict()
-    assert res == {"a": [4], "b": [2], "new_a": [4]}
+    res = df.count(col("*"), col("a").alias("c")).to_pydict()
+    assert res == {"a": [4], "b": [2], "c": [4]}
 
 
 def test_count_mixed_star() -> None:


### PR DESCRIPTION
By adding wildcard expansion, this started expanding out into all columns, which is not the expected behavior from SQL.