### PR TITLE
[CHORE] Refactor PartitionMetadata to remove size_bytes from estimations

### DIFF
--- a/daft/execution/physical_plan.py
+++ b/daft/execution/physical_plan.py
@@ -43,6 +43,7 @@ from daft.execution.execution_step import (
 from daft.expressions import ExpressionsProjection
 from daft.logical.schema import Schema
 from daft.runners.partitioning import (
+    EstimatedPartitionMetadataInterface,
     MaterializedResult,
     PartitionT,
 )
@@ -578,9 +579,9 @@ def _emit_merge_joins_on_window(
     for other_next_part in other_window:
         memory_bytes = _memory_bytes_for_merge(next_part, other_next_part)
         inputs = [next_part.partition(), other_next_part.partition()]
-        partial_metadatas = [
-            next_part.partition_metadata().downcast_to_partial(),
-            other_next_part.partition_metadata().downcast_to_partial(),
+        partial_metadatas: list[EstimatedPartitionMetadataInterface] = [
+            next_part.partition_metadata().downcast_to_estimated(),
+            other_next_part.partition_metadata().downcast_to_estimated(),
         ]
         # If next, other are flipped (right, left partitions), flip them back.
         if flipped:

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -72,11 +72,8 @@ class TableParseParquetOptions:
 class EstimatedPartitionMetadataInterface(Protocol):
     """PartitionMetadata"""
 
-    @property
-    def num_rows(self) -> int | None: ...
-
-    @property
-    def boundaries(self) -> Boundaries | None: ...
+    num_rows: int | None
+    boundaries: Boundaries | None
 
 
 @dataclass(frozen=True)

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -45,10 +45,10 @@ from daft.execution.execution_step import (
 from daft.filesystem import glob_path_with_stats
 from daft.runners import runner_io
 from daft.runners.partitioning import (
+    ExactPartitionMetadata,
     MaterializedResult,
     PartID,
     PartitionCacheEntry,
-    PartitionMetadata,
     PartitionSet,
 )
 from daft.runners.profiler import profiler
@@ -327,15 +327,17 @@ def _get_ray_task_options(resource_request: ResourceRequest) -> dict[str, Any]:
 
 
 def build_partitions(
-    instruction_stack: list[Instruction], partial_metadatas: list[PartitionMetadata], *inputs: MicroPartition
-) -> list[list[PartitionMetadata] | MicroPartition]:
+    instruction_stack: list[Instruction], partial_metadatas: list[ExactPartitionMetadata], *inputs: MicroPartition
+) -> list[list[ExactPartitionMetadata] | MicroPartition]:
     partitions = list(inputs)
     for instruction in instruction_stack:
         partitions = instruction.run(partitions)
 
     assert len(partial_metadatas) == len(partitions), f"{len(partial_metadatas)} vs {len(partitions)}"
 
-    metadatas = [PartitionMetadata.from_table(p).merge_with_partial(m) for p, m in zip(partitions, partial_metadatas)]
+    metadatas = [
+        ExactPartitionMetadata.from_table(p).merge_with_estimated(m) for p, m in zip(partitions, partial_metadatas)
+    ]
 
     return [metadatas, *partitions]
 
@@ -347,9 +349,9 @@ def build_partitions(
 def single_partition_pipeline(
     daft_execution_config: PyDaftExecutionConfig,
     instruction_stack: list[Instruction],
-    partial_metadatas: list[PartitionMetadata],
+    partial_metadatas: list[ExactPartitionMetadata],
     *inputs: MicroPartition,
-) -> list[list[PartitionMetadata] | MicroPartition]:
+) -> list[list[ExactPartitionMetadata] | MicroPartition]:
     with execution_config_ctx(
         config=daft_execution_config,
     ):
@@ -360,9 +362,9 @@ def single_partition_pipeline(
 def fanout_pipeline(
     daft_execution_config: PyDaftExecutionConfig,
     instruction_stack: list[Instruction],
-    partial_metadatas: list[PartitionMetadata],
+    partial_metadatas: list[ExactPartitionMetadata],
     *inputs: MicroPartition,
-) -> list[list[PartitionMetadata] | MicroPartition]:
+) -> list[list[ExactPartitionMetadata] | MicroPartition]:
     with execution_config_ctx(config=daft_execution_config):
         return build_partitions(instruction_stack, partial_metadatas, *inputs)
 
@@ -371,9 +373,9 @@ def fanout_pipeline(
 def reduce_pipeline(
     daft_execution_config: PyDaftExecutionConfig,
     instruction_stack: list[Instruction],
-    partial_metadatas: list[PartitionMetadata],
+    partial_metadatas: list[ExactPartitionMetadata],
     inputs: list,
-) -> list[list[PartitionMetadata] | MicroPartition]:
+) -> list[list[ExactPartitionMetadata] | MicroPartition]:
     import ray
 
     with execution_config_ctx(config=daft_execution_config):
@@ -384,9 +386,9 @@ def reduce_pipeline(
 def reduce_and_fanout(
     daft_execution_config: PyDaftExecutionConfig,
     instruction_stack: list[Instruction],
-    partial_metadatas: list[PartitionMetadata],
+    partial_metadatas: list[ExactPartitionMetadata],
     inputs: list,
-) -> list[list[PartitionMetadata] | MicroPartition]:
+) -> list[list[ExactPartitionMetadata] | MicroPartition]:
     import ray
 
     with execution_config_ctx(config=daft_execution_config):
@@ -394,8 +396,8 @@ def reduce_and_fanout(
 
 
 @ray.remote
-def get_metas(*partitions: MicroPartition) -> list[PartitionMetadata]:
-    return [PartitionMetadata.from_table(partition) for partition in partitions]
+def get_metas(*partitions: MicroPartition) -> list[ExactPartitionMetadata]:
+    return [ExactPartitionMetadata.from_table(partition) for partition in partitions]
 
 
 def _ray_num_cpus_provider(ttl_seconds: int = 1) -> Generator[int, None, None]:
@@ -575,23 +577,11 @@ class Scheduler:
                                 assert (
                                     len(next_step.partial_metadatas) == 1
                                 ), "No-op tasks must have one output by definition, since there are no instructions to run"
+                                [single_meta] = ray.get(get_metas.remote(next_step.inputs))
                                 [single_partial] = next_step.partial_metadatas
-                                if single_partial.num_rows is None:
-                                    [single_meta] = ray.get(get_metas.remote(next_step.inputs))
-                                    accessor = PartitionMetadataAccessor.from_metadata_list(
-                                        [single_meta.merge_with_partial(single_partial)]
-                                    )
-                                else:
-                                    accessor = PartitionMetadataAccessor.from_metadata_list(
-                                        [
-                                            PartitionMetadata(
-                                                num_rows=single_partial.num_rows,
-                                                size_bytes=single_partial.size_bytes,
-                                                boundaries=single_partial.boundaries,
-                                            )
-                                        ]
-                                    )
-
+                                accessor = PartitionMetadataAccessor.from_metadata_list(
+                                    [single_meta.merge_with_partial(single_partial)]
+                                )
                                 next_step.set_result(
                                     [RayMaterializedResult(partition, accessor, 0) for partition in next_step.inputs]
                                 )
@@ -927,7 +917,7 @@ class RayMaterializedResult(MaterializedResult[ray.ObjectRef]):
     def vpartition(self) -> MicroPartition:
         return ray.get(self._partition)
 
-    def metadata(self) -> PartitionMetadata:
+    def metadata(self) -> ExactPartitionMetadata:
         return self._metadatas.get_index(self._metadata_idx)
 
     def cancel(self) -> None:
@@ -942,18 +932,18 @@ class PartitionMetadataAccessor:
 
     def __init__(self, ref: ray.ObjectRef) -> None:
         self._ref: ray.ObjectRef = ref
-        self._metadatas: None | list[PartitionMetadata] = None
+        self._metadatas: None | list[ExactPartitionMetadata] = None
 
-    def _get_metadatas(self) -> list[PartitionMetadata]:
+    def _get_metadatas(self) -> list[ExactPartitionMetadata]:
         if self._metadatas is None:
             self._metadatas = ray.get(self._ref)
         return self._metadatas
 
-    def get_index(self, key) -> PartitionMetadata:
+    def get_index(self, key) -> ExactPartitionMetadata:
         return self._get_metadatas()[key]
 
     @classmethod
-    def from_metadata_list(cls, meta: list[PartitionMetadata]) -> PartitionMetadataAccessor:
+    def from_metadata_list(cls, meta: list[ExactPartitionMetadata]) -> PartitionMetadataAccessor:
         ref = ray.put(meta)
         accessor = cls(ref)
         accessor._metadatas = meta


### PR DESCRIPTION
## Why this change?

PartialPartitionMetadata (renamed `EstimatedPartitionMetadata` in this PR) is a class that is used to track the metadata (num_rows, boundary condition etc) across operations on a PartitionTask during physical plan generation. As we add Instructions to the task, each instruction modifies the current PartialPartitionMetadata.

PartitionMetadata (renamed `ExactPartitionMetadata` in this PR) is a class that is constructed from an **actual** partition, after work has finished computation. It is then used as the input to subsequent PartitionTasks for them to compute their own `EstimatedPartitionMetadata`.

These objects track metadata such as `num_rows` and `boundaries` on each task, which are useful during the physical plan which relies on this when scheduling work on operations such as limits and sort-merge-joins.

**However, it turns out that `size_bytes` is actually not used except in 1 location (only as a slight optimization for the RayRunner)**. Moreover this value is really just `None` (indicating "I have no idea what the new size_bytes is after running this instruction") for most instructions, which makes it fairly useless. This PR removes this to simplify the logic for propagation of metadata.

## Changes

1. Renames `PartialPartitionMetadata -> EstimatedPartitionMetadata`
2. Renames `PartitionMetadata -> ExactPartitionMetadata`
3. Some refactors around inheritance for the two dataclasses to instead inherit from the same Protocol `EstimatedPartitionMetadataInterface` (needed because otherwise I can't do 4.)
4. Removes `size_bytes` from `EstimatedPartitionMetadata`