### PR TITLE
[BUG] Fix ScanTask memory estimations when limits are provided

### DIFF
--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -707,7 +707,7 @@ class ScanTask:
         """
         ...
 
-    def size_bytes(self) -> int:
+    def size_bytes_on_disk(self) -> int:
         """
         Get number of bytes that will be scanned by this ScanTask.
         """

--- a/daft/daft.pyi
+++ b/daft/daft.pyi
@@ -707,12 +707,6 @@ class ScanTask:
         """
         ...
 
-    def size_bytes_on_disk(self) -> int:
-        """
-        Get number of bytes that will be scanned by this ScanTask.
-        """
-        ...
-
     def estimate_in_memory_size_bytes(self, cfg: PyDaftExecutionConfig) -> int:
         """
         Estimate the In Memory Size of this ScanTask.

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -5,6 +5,7 @@ import pathlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Generic, Protocol
 
+from daft.context import get_context
 from daft.daft import FileFormat, IOConfig, JoinType, ResourceRequest, ScanTask
 from daft.expressions import Expression, ExpressionsProjection, col
 from daft.logical.map_partition_ops import MapPartitionOp
@@ -304,10 +305,12 @@ class ScanWithTask(SingleOutputInstruction):
     def run_partial_metadata(self, input_metadatas: list[PartialPartitionMetadata]) -> list[PartialPartitionMetadata]:
         assert len(input_metadatas) == 0
 
+        cfg = get_context().daft_execution_config
+
         return [
             PartialPartitionMetadata(
                 num_rows=self.scan_task.num_rows(),
-                size_bytes=self.scan_task.size_bytes_on_disk(),
+                size_bytes=self.scan_task.estimate_in_memory_size_bytes(cfg),
             )
         ]
 

--- a/daft/execution/execution_step.py
+++ b/daft/execution/execution_step.py
@@ -307,7 +307,7 @@ class ScanWithTask(SingleOutputInstruction):
         return [
             PartialPartitionMetadata(
                 num_rows=self.scan_task.num_rows(),
-                size_bytes=self.scan_task.size_bytes(),
+                size_bytes=self.scan_task.size_bytes_on_disk(),
             )
         ]
 

--- a/src/daft-plan/src/physical_ops/scan.rs
+++ b/src/daft-plan/src/physical_ops/scan.rs
@@ -38,7 +38,7 @@ impl TreeDisplay for TabularScan {
             let total_bytes: usize = scan
                 .scan_tasks
                 .iter()
-                .map(|st| st.size_bytes().unwrap_or(0))
+                .map(|st| st.size_bytes_on_disk().unwrap_or(0))
                 .sum();
 
             let clustering_spec = scan.clustering_spec.multiline_display().join(", ");

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -469,12 +469,66 @@ impl ScanTask {
         }
     }
 
+    /// Obtain an accurate, exact num_rows from the ScanTask, or `None` if this is not possible
     pub fn num_rows(&self) -> Option<usize> {
         if self.pushdowns.filters.is_some() {
+            // Cannot obtain an accurate num_rows if there are filters
             None
         } else {
-            self.metadata.as_ref().map(|m| m.length)
+            // Only can obtain an accurate num_rows if metadata is provided
+            self.metadata.as_ref().map(|m| {
+                // Account for any limit pushdowns
+                if let Some(limit) = self.pushdowns.limit {
+                    m.length.min(limit)
+                } else {
+                    m.length
+                }
+            })
         }
+    }
+
+    /// Obtain an approximate num_rows from the ScanTask, or `None` if this is not possible
+    pub fn approx_num_rows(&self, config: Option<&DaftExecutionConfig>) -> Option<usize> {
+        let approx_total_num_rows_before_pushdowns = self
+            .metadata
+            .as_ref()
+            .map(|metadata| {
+                // Use accurate metadata if available
+                metadata.length
+            })
+            .or_else(|| {
+                // Otherwise, we fall back on estimations based on the file size
+                // use inflation factor from config and estimate number of rows from the schema
+                self.size_bytes_on_disk.map(|file_size| {
+                    let config = config
+                        .map_or_else(|| Cow::Owned(DaftExecutionConfig::default()), Cow::Borrowed);
+                    let inflation_factor = match self.file_format_config.as_ref() {
+                        FileFormatConfig::Parquet(_) => config.parquet_inflation_factor,
+                        FileFormatConfig::Csv(_) | FileFormatConfig::Json(_) => {
+                            config.csv_inflation_factor
+                        }
+                        #[cfg(feature = "python")]
+                        FileFormatConfig::Database(_) => 1.0,
+                        #[cfg(feature = "python")]
+                        FileFormatConfig::PythonFunction => 1.0,
+                    };
+                    let in_mem_size: f64 = (file_size as f64) * inflation_factor;
+                    let read_row_size = self.schema.estimate_row_size_bytes();
+                    (in_mem_size / read_row_size) as usize
+                })
+            });
+
+        approx_total_num_rows_before_pushdowns.map(|approx_total_num_rows_before_pushdowns| {
+            if self.pushdowns.filters.is_some() {
+                // HACK: This might not be a good idea? We could also just return None here
+                // Assume that filters filter out about 80% of the data
+                approx_total_num_rows_before_pushdowns / 5
+            } else if let Some(limit) = self.pushdowns.limit {
+                limit.min(approx_total_num_rows_before_pushdowns)
+            } else {
+                approx_total_num_rows_before_pushdowns
+            }
+        })
     }
 
     pub fn upper_bound_rows(&self) -> Option<usize> {
@@ -501,38 +555,11 @@ impl ScanTask {
                 })
             })
             .or_else(|| {
-                // if num rows is provided, use that to estimate row size bytes
-                self.num_rows().map(|num_rows| {
+                // use approximate number of rows multiplied by an approximate bytes-per-row
+                self.approx_num_rows(config).map(|approx_num_rows| {
                     let row_size = mat_schema.estimate_row_size_bytes();
-                    let estimate = (num_rows as f64) * row_size;
+                    let estimate = (approx_num_rows as f64) * row_size;
                     estimate as usize
-                })
-            })
-            // Fall back on on-disk size.
-            .or_else(|| {
-                self.size_bytes_on_disk.map(|file_size| {
-                    // use inflation factor from config
-                    let config = config
-                        .map_or_else(|| Cow::Owned(DaftExecutionConfig::default()), Cow::Borrowed);
-                    let inflation_factor = match self.file_format_config.as_ref() {
-                        FileFormatConfig::Parquet(_) => config.parquet_inflation_factor,
-                        FileFormatConfig::Csv(_) | FileFormatConfig::Json(_) => {
-                            config.csv_inflation_factor
-                        }
-                        #[cfg(feature = "python")]
-                        FileFormatConfig::Database(_) => 1.0,
-                        #[cfg(feature = "python")]
-                        FileFormatConfig::PythonFunction => 1.0,
-                    };
-
-                    // estimate number of rows from read schema
-                    let in_mem_size: f64 = (file_size as f64) * inflation_factor;
-                    let read_row_size = self.schema.estimate_row_size_bytes();
-                    let approx_rows = in_mem_size / read_row_size;
-
-                    // estimate in memory size using mat schema estimate
-                    let proj_schema_size = mat_schema.estimate_row_size_bytes();
-                    (approx_rows * proj_schema_size) as usize
                 })
             })
     }

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -531,11 +531,18 @@ impl ScanTask {
         })
     }
 
+    /// Obtain the absolute maximum number of rows this ScanTask can give, or None if not possible to derive
     pub fn upper_bound_rows(&self) -> Option<usize> {
-        self.metadata.as_ref().map(|m| m.length)
+        self.metadata.as_ref().map(|m| {
+            if let Some(limit) = self.pushdowns.limit {
+                limit.min(m.length)
+            } else {
+                m.length
+            }
+        })
     }
 
-    pub fn size_bytes(&self) -> Option<usize> {
+    pub fn size_bytes_on_disk(&self) -> Option<usize> {
         self.size_bytes_on_disk.map(|s| s as usize)
     }
 

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -285,8 +285,8 @@ pub mod pylib {
             Ok(self.0.num_rows().map(i64::try_from).transpose()?)
         }
 
-        pub fn size_bytes(&self) -> PyResult<Option<i64>> {
-            Ok(self.0.size_bytes().map(i64::try_from).transpose()?)
+        pub fn size_bytes_on_disk(&self) -> PyResult<Option<i64>> {
+            Ok(self.0.size_bytes_on_disk().map(i64::try_from).transpose()?)
         }
 
         pub fn estimate_in_memory_size_bytes(

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -285,10 +285,6 @@ pub mod pylib {
             Ok(self.0.num_rows().map(i64::try_from).transpose()?)
         }
 
-        pub fn size_bytes_on_disk(&self) -> PyResult<Option<i64>> {
-            Ok(self.0.size_bytes_on_disk().map(i64::try_from).transpose()?)
-        }
-
         pub fn estimate_in_memory_size_bytes(
             &self,
             cfg: PyDaftExecutionConfig,


### PR DESCRIPTION
Fixes memory estimations for ScanTask when limits are pushed down

* Adds a new`approx_num_rows` API to ScanTask, which is distinct from the `num_rows` API which is expected to provide an exact number of rows if available
* Adds some heuristics for determining the approximate number of rows with the available information, including accounting for limits
* Fixes `num_rows` to account for limit pushdowns as well