### PR TITLE
[FEAT] Add support for sum aggregation for decimal128 type

### DIFF
--- a/src/daft-core/src/array/ops/sum.rs
+++ b/src/daft-core/src/array/ops/sum.rs
@@ -54,6 +54,7 @@ macro_rules! impl_daft_numeric_agg {
 }
 
 impl_daft_numeric_agg!(Int64Type, i64);
+impl_daft_numeric_agg!(Int128Type, i128);
 impl_daft_numeric_agg!(UInt64Type, u64);
 impl_daft_numeric_agg!(Float32Type, f32);
 impl_daft_numeric_agg!(Float64Type, f64);

--- a/src/daft-core/src/datatypes/agg_ops.rs
+++ b/src/daft-core/src/datatypes/agg_ops.rs
@@ -1,3 +1,5 @@
+use std::cmp::min;
+
 use common_error::{DaftError, DaftResult};
 
 use super::DataType;
@@ -10,7 +12,8 @@ pub fn try_sum_supertype(dtype: &DataType) -> DaftResult<DataType> {
         UInt8 | UInt16 | UInt32 | UInt64 => Ok(UInt64),
         Float32 => Ok(Float32),
         Float64 => Ok(Float64),
-        Decimal128(a, b) => Ok(Decimal128(*a, *b)),
+        // 38 is the maximum precision for Decimal128, while 19 is the max increase based on 2^64 rows
+        Decimal128(a, b) => Ok(Decimal128(min(38, *a + 19), *b)),
         other => Err(DaftError::TypeError(format!(
             "Invalid argument to sum supertype: {}",
             other

--- a/src/daft-core/src/datatypes/agg_ops.rs
+++ b/src/daft-core/src/datatypes/agg_ops.rs
@@ -10,6 +10,7 @@ pub fn try_sum_supertype(dtype: &DataType) -> DaftResult<DataType> {
         UInt8 | UInt16 | UInt32 | UInt64 => Ok(UInt64),
         Float32 => Ok(Float32),
         Float64 => Ok(Float64),
+        Decimal128(a, b) => Ok(Decimal128(*a, *b)),
         other => Err(DaftError::TypeError(format!(
             "Invalid argument to sum supertype: {}",
             other

--- a/src/daft-core/src/series/ops/agg.rs
+++ b/src/daft-core/src/series/ops/agg.rs
@@ -1,3 +1,5 @@
+use std::cmp::min;
+
 use crate::array::ListArray;
 use crate::count_mode::CountMode;
 use crate::series::IntoSeries;
@@ -62,9 +64,12 @@ impl Series {
                 .into_series()),
                 None => Ok(DaftSumAggable::sum(&self.downcast::<Float64Array>()?)?.into_series()),
             },
-            Decimal128(_, _) => match groups {
+            Decimal128(a, b) => match groups {
                 Some(groups) => Ok(Decimal128Array::new(
-                    self.field().clone(),
+                    Field {
+                        dtype: Decimal128(min(38, *a + 19), *b),
+                        ..self.field().clone()
+                    },
                     DaftSumAggable::grouped_sum(
                         &self.as_physical()?.downcast::<Int128Array>()?,
                         groups,
@@ -72,7 +77,10 @@ impl Series {
                 )
                 .into_series()),
                 None => Ok(Decimal128Array::new(
-                    self.field().clone(),
+                    Field {
+                        dtype: Decimal128(min(38, *a + 19), *b),
+                        ..self.field().clone()
+                    },
                     DaftSumAggable::sum(&self.as_physical()?.downcast::<Int128Array>()?)?,
                 )
                 .into_series()),

--- a/src/daft-core/src/series/ops/agg.rs
+++ b/src/daft-core/src/series/ops/agg.rs
@@ -1,5 +1,3 @@
-use std::cmp::min;
-
 use crate::array::ListArray;
 use crate::count_mode::CountMode;
 use crate::series::IntoSeries;
@@ -64,10 +62,10 @@ impl Series {
                 .into_series()),
                 None => Ok(DaftSumAggable::sum(&self.downcast::<Float64Array>()?)?.into_series()),
             },
-            Decimal128(a, b) => match groups {
+            Decimal128(_, _) => match groups {
                 Some(groups) => Ok(Decimal128Array::new(
                     Field {
-                        dtype: Decimal128(min(38, *a + 19), *b),
+                        dtype: try_sum_supertype(self.data_type())?,
                         ..self.field().clone()
                     },
                     DaftSumAggable::grouped_sum(
@@ -78,7 +76,7 @@ impl Series {
                 .into_series()),
                 None => Ok(Decimal128Array::new(
                     Field {
-                        dtype: Decimal128(min(38, *a + 19), *b),
+                        dtype: try_sum_supertype(self.data_type())?,
                         ..self.field().clone()
                     },
                     DaftSumAggable::sum(&self.as_physical()?.downcast::<Int128Array>()?)?,

--- a/tests/expressions/typing/conftest.py
+++ b/tests/expressions/typing/conftest.py
@@ -97,6 +97,12 @@ ALL_TEMPORAL_DATATYPES_BINARY_PAIRS = [
 ALL_DATATYPES_BINARY_PAIRS += ALL_TEMPORAL_DATATYPES_BINARY_PAIRS
 
 
+DECIMAL_DTYPES = [
+    (DataType.decimal128(7, 2), pa.array([1, 2, None], type=pa.decimal128(7, 2))),
+    (DataType.decimal128(4, 3), pa.array([1, 2, None], type=pa.decimal128(4, 3))),
+]
+
+
 @pytest.fixture(
     scope="module",
     params=ALL_DATATYPES_BINARY_PAIRS,
@@ -119,6 +125,19 @@ def binary_data_fixture(request) -> tuple[Series, Series]:
 )
 def unary_data_fixture(request) -> Series:
     """Returns unary permutation of Series' of all DataType pairs"""
+    (dt, data) = request.param
+    s = Series.from_arrow(data, name="arg")
+    assert s.datatype() == dt
+    return s
+
+
+@pytest.fixture(
+    scope="module",
+    params=DECIMAL_DTYPES,
+    ids=[f"{dt}" for (dt, _) in DECIMAL_DTYPES],
+)
+def decimal_unary_data_fixture(request) -> Series:
+    """Returns unary permutation of Series' of select decimal DataType pairs"""
     (dt, data) = request.param
     s = Series.from_arrow(data, name="arg")
     assert s.datatype() == dt

--- a/tests/expressions/typing/test_aggs.py
+++ b/tests/expressions/typing/test_aggs.py
@@ -45,6 +45,9 @@ def test_numeric_aggs(unary_data_fixture, op):
 
 
 def test_decimal_sum(decimal_unary_data_fixture):
+    """a copy of the above but for decimal types that do not more widely support
+    numeric operations. When they do and can be added to ALL_DTYPES and resolve
+    is_numeric to True, this test can be removed."""
     arg = decimal_unary_data_fixture
 
     def op(x):

--- a/tests/expressions/typing/test_aggs.py
+++ b/tests/expressions/typing/test_aggs.py
@@ -44,6 +44,20 @@ def test_numeric_aggs(unary_data_fixture, op):
     )
 
 
+def test_decimal_sum(decimal_unary_data_fixture):
+    arg = decimal_unary_data_fixture
+
+    def op(x):
+        return x.sum()
+
+    assert_typing_resolve_vs_runtime_behavior(
+        data=(decimal_unary_data_fixture,),
+        expr=op(col(arg.name())),
+        run_kernel=lambda: op(arg),
+        resolvable=True,
+    )
+
+
 def test_count(unary_data_fixture):
     arg = unary_data_fixture
     assert_typing_resolve_vs_runtime_behavior(


### PR DESCRIPTION
Resolves #2527. 

~Might need another test, I don't think the sum test (which is a decimal-specific copy of other sum aggregation test) does anything to actually confirm the sum itself produces correct numbers.~ (added)

With this, one can do like:
```pyimport daft

df = daft.from_pydict({"foo": [1, 1, 2, 2, 3, 3]})
df = df.with_column("foo_decimal", df["foo"].cast(daft.DataType.decimal128(7, 2)))
df = df.sum("foo_decimal")

df.collect()
```

yields 
```
╭──────────────────╮                                                                                                                               
│ foo_decimal      │
│ ---              │
│ Decimal128(7, 2) │
╞══════════════════╡
│ 12.00            │
╰──────────────────╯

(Showing first 1 of 1 rows)
```