### PR TITLE
[BUG] Made entire test directories conditionally compiled on `python` feature flag

### DIFF
--- a/src/daft-plan/src/logical_optimization/rules/push_down_projection.rs
+++ b/src/daft-plan/src/logical_optimization/rules/push_down_projection.rs
@@ -669,6 +669,7 @@ impl OptimizerRule for PushDownProjection {
     }
 }
 
+#[cfg(not(feature = "python"))]
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -909,7 +910,6 @@ mod tests {
     }
 
     /// Projection<-ActorPoolProject prunes columns from the ActorPoolProject
-    #[cfg(not(feature = "python"))]
     #[test]
     fn test_projection_pushdown_into_actorpoolproject() -> DaftResult<()> {
         use crate::logical_ops::ActorPoolProject;
@@ -1043,7 +1043,6 @@ mod tests {
     }
 
     /// Projection<-ActorPoolProject prunes ActorPoolProject entirely if the stateful projection column is pruned
-    #[cfg(not(feature = "python"))]
     #[test]
     fn test_projection_pushdown_into_actorpoolproject_completely_removed() -> DaftResult<()> {
         use crate::logical_ops::ActorPoolProject;

--- a/src/daft-plan/src/logical_optimization/rules/split_actor_pool_projects.rs
+++ b/src/daft-plan/src/logical_optimization/rules/split_actor_pool_projects.rs
@@ -516,6 +516,7 @@ fn has_stateful_udf(e: &ExprRef) -> bool {
     })
 }
 
+#[cfg(not(feature = "python"))]
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -575,7 +576,6 @@ mod tests {
         )
     }
 
-    #[cfg(not(feature = "python"))]
     fn create_stateful_udf(inputs: Vec<ExprRef>) -> ExprRef {
         Expr::Function {
             func: FunctionExpr::Python(PythonUDF::Stateful(StatefulPythonUDF {
@@ -599,7 +599,6 @@ mod tests {
         }
     }
 
-    #[cfg(not(feature = "python"))]
     #[test]
     fn test_with_column_stateful_udf_happypath() -> DaftResult<()> {
         let scan_op = dummy_scan_operator(vec![Field::new("a", daft_core::DataType::Utf8)]);
@@ -626,7 +625,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(feature = "python"))]
     #[test]
     fn test_multiple_with_column_parallel() -> DaftResult<()> {
         let scan_op = dummy_scan_operator(vec![
@@ -715,7 +713,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(feature = "python"))]
     #[test]
     fn test_multiple_with_column_parallel_common_subtree_eliminated() -> DaftResult<()> {
         let scan_op = dummy_scan_operator(vec![Field::new("a", daft_core::DataType::Utf8)]);
@@ -783,7 +780,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(feature = "python"))]
     #[test]
     fn test_multiple_with_column_serial() -> DaftResult<()> {
         let scan_op = dummy_scan_operator(vec![Field::new("a", daft_core::DataType::Utf8)]);
@@ -860,7 +856,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(feature = "python"))]
     #[test]
     fn test_multiple_with_column_serial_multiarg() -> DaftResult<()> {
         let scan_op = dummy_scan_operator(vec![
@@ -964,7 +959,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(feature = "python"))]
     #[test]
     fn test_multiple_with_column_serial_multiarg_with_intermediate_stateless() -> DaftResult<()> {
         let scan_op = dummy_scan_operator(vec![
@@ -1085,7 +1079,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(not(feature = "python"))]
     #[test]
     fn test_nested_with_column_same_names() -> DaftResult<()> {
         let scan_op = dummy_scan_operator(vec![Field::new("a", daft_core::DataType::Int64)]);


### PR DESCRIPTION
# Overview
- instead of individual functions, since some functions were missed
- this was causing rust-analyzer errors