### PR TITLE
[CHORE] Initial work on batched + treenode-based plan optimizer

### DIFF
--- a/src/daft-plan/src/lib.rs
+++ b/src/daft-plan/src/lib.rs
@@ -8,6 +8,7 @@ pub mod display;
 mod logical_ops;
 mod logical_optimization;
 pub mod logical_plan;
+mod optimizer;
 mod partitioning;
 pub mod physical_ops;
 mod physical_optimization;

--- a/src/daft-plan/src/logical_optimization/mod.rs
+++ b/src/daft-plan/src/logical_optimization/mod.rs
@@ -4,5 +4,5 @@ mod rules;
 #[cfg(test)]
 mod test;
 
-pub use optimizer::{Optimizer, OptimizerConfig};
+pub use optimizer::{LogicalOptimizer, Optimizer, OptimizerConfig};
 pub use rules::Transformed;

--- a/src/daft-plan/src/logical_optimization/optimizer.rs
+++ b/src/daft-plan/src/logical_optimization/optimizer.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, ops::ControlFlow, sync::Arc};
 
 use common_error::DaftResult;
 
-use crate::LogicalPlan;
+use crate::{optimizer::RuleBatchStrategy, LogicalPlan};
 
 use super::{
     logical_plan_tracker::LogicalPlanTracker,
@@ -150,7 +150,7 @@ impl Optimizer {
         // --- Bulk of our rules ---
         rule_batches.push(RuleBatch::new(
             vec![
-                Box::new(DropRepartition::new()),
+                // Box::new(DropRepartition::new()),
                 Box::new(PushDownFilter::new()),
                 Box::new(PushDownProjection::new()),
             ],
@@ -332,6 +332,24 @@ impl Optimizer {
         Ok(Transformed::Yes(
             plan.with_new_children(&new_children).into(),
         ))
+    }
+}
+
+pub struct LogicalOptimizer {}
+
+impl LogicalOptimizer {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl crate::optimizer::Optimizer<LogicalPlan> for LogicalOptimizer {
+    fn batches(&self) -> impl IntoIterator<Item = crate::optimizer::RuleBatch<LogicalPlan>> {
+        vec![crate::optimizer::RuleBatch::new(
+            "Drop Repartition",
+            vec![Box::new(DropRepartition::new())],
+            RuleBatchStrategy::Once,
+        )]
     }
 }
 

--- a/src/daft-plan/src/logical_optimization/rules/drop_repartition.rs
+++ b/src/daft-plan/src/logical_optimization/rules/drop_repartition.rs
@@ -2,17 +2,15 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 
-use crate::LogicalPlan;
+use crate::{optimizer::OptimizerRule, LogicalPlan};
 
-use super::{ApplyOrder, OptimizerRule, Transformed};
-
-use common_treenode::DynTreeNode;
+use common_treenode::{Transformed, TreeNode};
 
 /// Optimization rules for dropping unnecessary Repartitions.
 ///
 /// Dropping of Repartitions that would yield the same partitioning as their input
 /// happens during logical -> physical plan translation.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct DropRepartition {}
 
 impl DropRepartition {
@@ -21,28 +19,22 @@ impl DropRepartition {
     }
 }
 
-impl OptimizerRule for DropRepartition {
-    fn apply_order(&self) -> ApplyOrder {
-        ApplyOrder::TopDown
-    }
-
-    fn try_optimize(&self, plan: Arc<LogicalPlan>) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
-        let repartition = match plan.as_ref() {
-            LogicalPlan::Repartition(repartition) => repartition,
-            _ => return Ok(Transformed::No(plan)),
-        };
-        let child_plan = repartition.input.as_ref();
-        let new_plan = match child_plan {
-            LogicalPlan::Repartition(_) => {
+impl OptimizerRule<LogicalPlan> for DropRepartition {
+    fn apply(&self, plan: Arc<LogicalPlan>) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+        plan.transform_up(|p| {
+            if let LogicalPlan::Repartition(repart) = p.as_ref()
+                && let LogicalPlan::Repartition(input_repart) = repart.input.as_ref()
+            {
                 // Drop upstream Repartition for back-to-back Repartitions.
                 //
                 // Repartition1-Repartition2 -> Repartition1
-                plan.with_new_children(&[child_plan.arc_children()[0].clone()])
-                    .into()
+                Ok(Transformed::yes(
+                    p.with_new_children(&[input_repart.input.clone()]).into(),
+                ))
+            } else {
+                Ok(Transformed::no(p))
             }
-            _ => return Ok(Transformed::No(plan)),
-        };
-        Ok(Transformed::Yes(new_plan))
+        })
     }
 }
 
@@ -54,9 +46,9 @@ mod tests {
     use std::sync::Arc;
 
     use crate::{
-        logical_optimization::{
-            rules::drop_repartition::DropRepartition, test::assert_optimized_plan_with_rules_eq,
-        },
+        assert_optimized_plan_with_batches_eq,
+        logical_optimization::rules::DropRepartition,
+        optimizer::{RuleBatch, RuleBatchStrategy},
         test::{dummy_scan_node, dummy_scan_operator},
         LogicalPlan,
     };
@@ -68,7 +60,18 @@ mod tests {
         plan: Arc<LogicalPlan>,
         expected: Arc<LogicalPlan>,
     ) -> DaftResult<()> {
-        assert_optimized_plan_with_rules_eq(plan, expected, vec![Box::new(DropRepartition::new())])
+        assert_optimized_plan_with_batches_eq!(
+            LogicalPlan,
+            plan,
+            expected,
+            vec![RuleBatch::new(
+                "Drop Repartition",
+                vec![Box::new(DropRepartition::new())],
+                RuleBatchStrategy::Once,
+            )]
+        );
+
+        Ok(())
     }
 
     /// Tests that DropRepartition does drops the upstream Repartition in back-to-back Repartitions.
@@ -89,6 +92,31 @@ mod tests {
             .build();
         let expected = dummy_scan_node(scan_op)
             .hash_repartition(Some(num_partitions2), partition_by.clone())?
+            .build();
+        assert_optimized_plan_eq(plan, expected)?;
+        Ok(())
+    }
+
+    /// Tests that DropRepartition does drops the upstream Repartition in back-to-back-to-back Repartitions.
+    ///
+    /// Repartition1-Repartition2-Repartition3 -> Repartition1
+    #[test]
+    fn repartition_dropped_in_back_to_back_to_back() -> DaftResult<()> {
+        let num_partitions1 = 10;
+        let num_partitions2 = 5;
+        let num_partitions3 = 20;
+        let partition_by = vec![col("a")];
+        let scan_op = dummy_scan_operator(vec![
+            Field::new("a", DataType::Int64),
+            Field::new("b", DataType::Utf8),
+        ]);
+        let plan = dummy_scan_node(scan_op.clone())
+            .hash_repartition(Some(num_partitions1), partition_by.clone())?
+            .hash_repartition(Some(num_partitions2), partition_by.clone())?
+            .hash_repartition(Some(num_partitions3), partition_by.clone())?
+            .build();
+        let expected = dummy_scan_node(scan_op)
+            .hash_repartition(Some(num_partitions3), partition_by.clone())?
             .build();
         assert_optimized_plan_eq(plan, expected)?;
         Ok(())

--- a/src/daft-plan/src/optimizer.rs
+++ b/src/daft-plan/src/optimizer.rs
@@ -1,0 +1,116 @@
+use std::sync::Arc;
+
+use common_error::{DaftError, DaftResult};
+use common_treenode::Transformed;
+
+pub trait OptimizerRule<T> {
+    fn apply(&self, plan: Arc<T>) -> DaftResult<Transformed<Arc<T>>>;
+}
+
+pub struct RuleBatch<T> {
+    pub name: String,
+    pub rules: Vec<Box<dyn OptimizerRule<T>>>,
+    pub strategy: RuleBatchStrategy,
+}
+
+impl<T> RuleBatch<T> {
+    pub fn new(
+        name: impl ToString,
+        rules: Vec<Box<dyn OptimizerRule<T>>>,
+        strategy: RuleBatchStrategy,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            rules,
+            strategy,
+        }
+    }
+
+    pub fn apply_rules(&self, plan: Arc<T>) -> DaftResult<Transformed<Arc<T>>> {
+        self.rules.iter().try_fold(Transformed::no(plan), |p, r| {
+            p.transform_data(|data| r.apply(data))
+        })
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub enum RuleBatchStrategy {
+    Once,
+    FixedPoint {
+        max_passes: usize,
+        error_on_exceed: bool,
+    },
+}
+
+impl Default for RuleBatchStrategy {
+    fn default() -> Self {
+        RuleBatchStrategy::FixedPoint {
+            max_passes: 5,
+            error_on_exceed: false,
+        }
+    }
+}
+
+pub trait Optimizer<T> {
+    fn batches(&self) -> impl IntoIterator<Item = RuleBatch<T>>;
+
+    fn execute(&self, plan: Arc<T>) -> DaftResult<Arc<T>> {
+        self.batches().into_iter().try_fold(plan, |plan, batch| {
+            match batch.strategy {
+                RuleBatchStrategy::Once => {
+                    let new_plan = batch.apply_rules(plan)?;
+
+                    if new_plan.transformed {
+                        // check idempotence of batches that run once
+                        let retried_plan = batch.apply_rules(new_plan.data)?;
+
+                        if retried_plan.transformed {
+                            Err(DaftError::InternalError(format!(
+                                "Optimizer rule batch \"{}\" did not converge after one iteration",
+                                batch.name
+                            )))
+                        } else {
+                            Ok(retried_plan.data)
+                        }
+                    } else {
+                        // no need to check idempotence if not transformed
+                        Ok(new_plan.data)
+                    }
+                }
+                RuleBatchStrategy::FixedPoint {
+                    max_passes,
+                    error_on_exceed,
+                } => {
+                    let mut curr_plan = plan;
+                    let mut iterations = 0;
+
+                    loop {
+                        let new_plan = batch.apply_rules(curr_plan)?;
+
+                        curr_plan = new_plan.data;
+
+                        // exit loop early if stable
+                        if !new_plan.transformed {
+                            break;
+                        }
+
+                        iterations += 1;
+
+                        if iterations >= max_passes {
+                            if error_on_exceed {
+                                return Err(DaftError::InternalError(format!(
+                                    "Optimizer rule batch \"{}\" exceeded max iterations",
+                                    batch.name
+                                )));
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+
+                    Ok(curr_plan)
+                }
+            }
+        })
+    }
+}


### PR DESCRIPTION
I've only moved the `DropRepartition` rule into the new optimizer right now, but I'd like to first get some eyes and merge in the overall structure/API of the new optimizer before implementing more rules.

This new optimizer applies rules in the following way:
- Rules are grouped into `RuleBatch`es which are run in order in an optimizer
- Each batch specifies a `RuleBatchStrategy` which tells the optimizer how many passes should be made on the sequence of rules in the batch
- In each pass, the `OptimizerRule`s in the batch are run in order. If the plan did not change at the end of the pass, we have reached a fixed point and the batch terminates early
- Each `OptimizerRule` controls its own tree traversal pattern. AKA, we just give it the root of the plan and it should use `plan.transform_down`, `plan.transform_up`, or whatever it would like to traverse the plan tree and create a new plan.