### PR TITLE
[FEAT] [SQL] Add global agg support for SQL

### DIFF
--- a/src/daft-sql/src/lib.rs
+++ b/src/daft-sql/src/lib.rs
@@ -152,6 +152,7 @@ mod tests {
     #[case::orderby("select * from tbl1 order by i32 asc")]
     #[case::orderby_multi("select * from tbl1 order by i32 desc, f32 asc")]
     #[case::whenthen("select case when i32 = 1 then 'a' else 'b' end from tbl1")]
+    #[case::globalagg("select max(i32) from tbl1")]
     fn test_compiles(mut planner: SQLPlanner, #[case] query: &str) -> SQLPlannerResult<()> {
         let plan = planner.plan_sql(query);
         assert!(plan.is_ok(), "query: {}\nerror: {:?}", query, plan);
@@ -314,6 +315,19 @@ mod tests {
         let plan = planner.plan_sql(query);
         assert!(plan.is_ok(), "query: {}\nerror: {:?}", query, plan);
 
+        Ok(())
+    }
+
+    #[rstest]
+    fn test_global_agg(mut planner: SQLPlanner, tbl_1: LogicalPlanRef) -> SQLPlannerResult<()> {
+        let sql = "select max(i32) from tbl1";
+        let plan = planner.plan_sql(sql)?;
+
+        let expected = LogicalPlanBuilder::new(tbl_1, None)
+            .aggregate(vec![col("i32").max()], vec![])?
+            .build();
+
+        assert_eq!(plan, expected);
         Ok(())
     }
 }

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -13,7 +13,7 @@ use daft_dsl::{
         numeric::{ceil, floor},
         utf8::{ilike, like},
     },
-    lit, literals_to_series, null_lit, Expr, ExprRef, LiteralValue, Operator,
+    has_agg, lit, literals_to_series, null_lit, Expr, ExprRef, LiteralValue, Operator,
 };
 use daft_plan::{LogicalPlanBuilder, LogicalPlanRef};
 
@@ -253,7 +253,12 @@ impl SQLPlanner {
             rel.inner = rel.inner.aggregate(to_select, groupby_exprs)?;
         } else if !to_select.is_empty() {
             let rel = self.relation_mut();
-            rel.inner = rel.inner.select(to_select)?;
+            let has_aggs = to_select.iter().any(has_agg);
+            if has_aggs {
+                rel.inner = rel.inner.aggregate(to_select, vec![])?;
+            } else {
+                rel.inner = rel.inner.select(to_select)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
This adds support to SQL to run global aggregation when there are only aggregations and no group by, which is inline with many other SQL implementations.

It is similar in nature to https://github.com/Eventual-Inc/Daft/issues/1979, but specific to SQL - depending on how that issue is resolved the SQL planner code here could be redundant.

Example:
```
d = daft.from_pydict({"i": [1,2,3,4,5]})
daft.sql('''SELECT sum(i) FROM d''', SQLCatalog({'d': d})).collect()
╭───────╮                                                                                                    
│ i     │
│ ---   │
│ Int64 │
╞═══════╡
│ 15    │
╰───────╯
```

*note*: I know the SQL support is new, so sorry if this is jumping the gun! Is it better to first create discussions or issues for this kind of change? I've been looking forward to SQL in this project and from playing around with using sqlglot on the python side to build a logical plan, I noticed a few things - now that this is here I thought I might contribute 😄 
