### PR TITLE
[BUG] Propogate S3Config.num_tries to pyarrow S3 filesystem

### DIFF
--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -221,6 +221,13 @@ def _infer_filesystem(
             _set_if_not_none(translated_kwargs, "session_token", s3_config.session_token)
             _set_if_not_none(translated_kwargs, "region", s3_config.region_name)
             _set_if_not_none(translated_kwargs, "anonymous", s3_config.anonymous)
+            if s3_config.num_tries is not None:
+                try:
+                    from pyarrow.fs import AwsStandardS3RetryStrategy
+
+                    translated_kwargs["retry_strategy"] = AwsStandardS3RetryStrategy(max_attempts=s3_config.num_tries)
+                except ImportError:
+                    pass  # Config does not exist in pyarrow 7.0.0
 
         resolved_filesystem = S3FileSystem(**translated_kwargs)
         resolved_path = resolved_filesystem.normalize_path(_unwrap_protocol(path))


### PR DESCRIPTION
Addresses: https://github.com/Eventual-Inc/Daft/issues/2788

Propogates the S3Config.num_tries config to the pyarrow S3 filesystem.

Note that the other relevant parameters on S3Config, `retry_mode` and `retry_initial_backoff_ms`, are ignored as pyarrow's [S3RetryStrategy](https://github.com/apache/arrow/blob/ab0a40ee34217070f14027776682074c55d0b507/python/pyarrow/_s3fs.pyx#L112) only has one parameter `max_attempts`.

Note that this only addresses S3. GCSConfig and AzureConfig do not have retry settings. 
