### PR TITLE
[CHORE] Remove user-facing arguments for casting to Ray's tensor type

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2460,14 +2460,11 @@ class DataFrame:
         return col_name in self.column_names
 
     @DataframePublicAPI
-    def to_pandas(
-        self, cast_tensors_to_ray_tensor_dtype: bool = False, coerce_temporal_nanoseconds: bool = False
-    ) -> "pandas.DataFrame":
+    def to_pandas(self, coerce_temporal_nanoseconds: bool = False) -> "pandas.DataFrame":
         """Converts the current DataFrame to a `pandas DataFrame <https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html>`__.
         If results have not computed yet, collect will be called.
 
         Args:
-            cast_tensors_to_ray_tensor_dtype (bool): Whether to cast tensors to Ray tensor dtype. Defaults to False.
             coerce_temporal_nanoseconds (bool): Whether to coerce temporal columns to nanoseconds. Only applicable to pandas version >= 2.0 and pyarrow version >= 13.0.0. Defaults to False. See `pyarrow.Table.to_pandas <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html#pyarrow.Table.to_pandas>`__ for more information.
 
         Returns:
@@ -2482,13 +2479,12 @@ class DataFrame:
 
         pd_df = result.to_pandas(
             schema=self._builder.schema(),
-            cast_tensors_to_ray_tensor_dtype=cast_tensors_to_ray_tensor_dtype,
             coerce_temporal_nanoseconds=coerce_temporal_nanoseconds,
         )
         return pd_df
 
     @DataframePublicAPI
-    def to_arrow(self, cast_tensors_to_ray_tensor_dtype: bool = False) -> "pyarrow.Table":
+    def to_arrow(self) -> "pyarrow.Table":
         """Converts the current DataFrame to a `pyarrow Table <https://arrow.apache.org/docs/python/generated/pyarrow.Table.html>`__.
         If results have not computed yet, collect will be called.
 
@@ -2502,7 +2498,7 @@ class DataFrame:
         result = self._result
         assert result is not None
 
-        return result.to_arrow(cast_tensors_to_ray_tensor_dtype)
+        return result.to_arrow()
 
     @DataframePublicAPI
     def to_pydict(self) -> Dict[str, List[Any]]:

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2494,6 +2494,12 @@ class DataFrame:
             .. NOTE::
                 This call is **blocking** and will execute the DataFrame when called
         """
+        for name in self.schema().column_names():
+            if self.schema()[name].dtype._is_python_type():
+                raise ValueError(
+                    f"Cannot convert column {name} to Arrow type, found Python type: {self.schema()[name].dtype}"
+                )
+
         self.collect()
         result = self._result
         assert result is not None

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -462,8 +462,8 @@ class DataType:
         arrow_type = pa.from_numpy_dtype(np_type)
         return cls.from_arrow_type(arrow_type)
 
-    def to_arrow_dtype(self, cast_tensor_to_ray_type: builtins.bool = False) -> pa.DataType:
-        return self._dtype.to_arrow(cast_tensor_to_ray_type)
+    def to_arrow_dtype(self) -> pa.DataType:
+        return self._dtype.to_arrow()
 
     @classmethod
     def python(cls) -> DataType:

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -216,19 +216,17 @@ class PartitionSet(Generic[PartitionT]):
     def to_pandas(
         self,
         schema: Schema | None = None,
-        cast_tensors_to_ray_tensor_dtype: bool = False,
         coerce_temporal_nanoseconds: bool = False,
     ) -> pd.DataFrame:
         merged_partition = self._get_merged_micropartition()
         return merged_partition.to_pandas(
             schema=schema,
-            cast_tensors_to_ray_tensor_dtype=cast_tensors_to_ray_tensor_dtype,
             coerce_temporal_nanoseconds=coerce_temporal_nanoseconds,
         )
 
-    def to_arrow(self, cast_tensors_to_ray_tensor_dtype: bool = False) -> pa.Table:
+    def to_arrow(self) -> pa.Table:
         merged_partition = self._get_merged_micropartition()
-        return merged_partition.to_arrow(cast_tensors_to_ray_tensor_dtype)
+        return merged_partition.to_arrow()
 
     def items(self) -> list[tuple[PartID, MaterializedResult[PartitionT]]]:
         """

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -95,7 +95,31 @@ def _glob_path_into_file_infos(
 @ray.remote
 def _make_ray_block_from_micropartition(partition: MicroPartition) -> RayDatasetBlock:
     try:
-        return partition.to_arrow(cast_tensors_to_ray_tensor_dtype=True)
+        return partition.to_arrow()
+        # TODO: Apply conversions here!!
+        # if dtype._is_tensor_type() or dtype._is_fixed_shape_tensor_type():
+        # if not _RAY_DATA_EXTENSIONS_AVAILABLE:
+        #     raise ValueError("Trying to convert tensors to Ray tensor dtypes, but Ray is not installed.")
+        # pyarrow_dtype = dtype.to_arrow_dtype(cast_tensor_to_ray_type=True)
+        # if isinstance(pyarrow_dtype, ArrowTensorType):
+        #     assert dtype._is_fixed_shape_tensor_type()
+        #     arrow_series = self._series.to_arrow()
+        #     storage = arrow_series.storage
+        #     list_size = storage.type.list_size
+        #     storage = pa.ListArray.from_arrays(
+        #         pa.array(
+        #             list(range(0, (len(arrow_series) + 1) * list_size, list_size)),
+        #             pa.int32(),
+        #         ),
+        #         storage.values,
+        #     )
+        #     return pa.ExtensionArray.from_storage(pyarrow_dtype, storage)
+        # else:
+        #     # Variable-shaped tensor columns can't be converted directly to Ray's variable-shaped tensor extension
+        #     # type since it expects all tensor elements to have the same number of dimensions, which Daft does not enforce.
+        #     # TODO(Clark): Convert directly to Ray's variable-shaped tensor extension type when all tensor
+        #     # elements have the same number of dimensions, without going through pylist roundtrip.
+        #     return ArrowTensorArray.from_numpy(self.to_pylist())
     except pa.ArrowInvalid:
         return partition.to_pylist()
 

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -96,32 +96,33 @@ def _glob_path_into_file_infos(
 def _make_ray_block_from_micropartition(partition: MicroPartition) -> RayDatasetBlock:
     try:
         return partition.to_arrow()
-        # TODO: Apply conversions here!!
-        # if dtype._is_tensor_type() or dtype._is_fixed_shape_tensor_type():
-        # if not _RAY_DATA_EXTENSIONS_AVAILABLE:
-        #     raise ValueError("Trying to convert tensors to Ray tensor dtypes, but Ray is not installed.")
-        # pyarrow_dtype = dtype.to_arrow_dtype(cast_tensor_to_ray_type=True)
-        # if isinstance(pyarrow_dtype, ArrowTensorType):
-        #     assert dtype._is_fixed_shape_tensor_type()
-        #     arrow_series = self._series.to_arrow()
-        #     storage = arrow_series.storage
-        #     list_size = storage.type.list_size
-        #     storage = pa.ListArray.from_arrays(
-        #         pa.array(
-        #             list(range(0, (len(arrow_series) + 1) * list_size, list_size)),
-        #             pa.int32(),
-        #         ),
-        #         storage.values,
-        #     )
-        #     return pa.ExtensionArray.from_storage(pyarrow_dtype, storage)
-        # else:
-        #     # Variable-shaped tensor columns can't be converted directly to Ray's variable-shaped tensor extension
-        #     # type since it expects all tensor elements to have the same number of dimensions, which Daft does not enforce.
-        #     # TODO(Clark): Convert directly to Ray's variable-shaped tensor extension type when all tensor
-        #     # elements have the same number of dimensions, without going through pylist roundtrip.
-        #     return ArrowTensorArray.from_numpy(self.to_pylist())
     except pa.ArrowInvalid:
         return partition.to_pylist()
+
+    # TODO: Implement this for Ray
+    # if dtype._is_tensor_type() or dtype._is_fixed_shape_tensor_type():
+    # if not _RAY_DATA_EXTENSIONS_AVAILABLE:
+    #     raise ValueError("Trying to convert tensors to Ray tensor dtypes, but Ray is not installed.")
+    # pyarrow_dtype = dtype.to_arrow_dtype(cast_tensor_to_ray_type=True)
+    # if isinstance(pyarrow_dtype, ArrowTensorType):
+    #     assert dtype._is_fixed_shape_tensor_type()
+    #     arrow_series = self._series.to_arrow()
+    #     storage = arrow_series.storage
+    #     list_size = storage.type.list_size
+    #     storage = pa.ListArray.from_arrays(
+    #         pa.array(
+    #             list(range(0, (len(arrow_series) + 1) * list_size, list_size)),
+    #             pa.int32(),
+    #         ),
+    #         storage.values,
+    #     )
+    #     return pa.ExtensionArray.from_storage(pyarrow_dtype, storage)
+    # else:
+    #     # Variable-shaped tensor columns can't be converted directly to Ray's variable-shaped tensor extension
+    #     # type since it expects all tensor elements to have the same number of dimensions, which Daft does not enforce.
+    #     # TODO(Clark): Convert directly to Ray's variable-shaped tensor extension type when all tensor
+    #     # elements have the same number of dimensions, without going through pylist roundtrip.
+    #     return ArrowTensorArray.from_numpy(self.to_pylist())
 
 
 @ray.remote

--- a/daft/series.py
+++ b/daft/series.py
@@ -251,7 +251,7 @@ class Series:
         # Special-case for PyArrow FixedShapeTensor if it is supported by the version of PyArrow
         # TODO: Push this down into self._series.to_arrow()?
         if dtype._is_fixed_shape_tensor_type() and pyarrow_supports_fixed_shape_tensor():
-            pyarrow_dtype = dtype.to_arrow_dtype(cast_tensor_to_ray_type=False)
+            pyarrow_dtype = dtype.to_arrow_dtype()
             arrow_series = self._series.to_arrow()
             return pa.ExtensionArray.from_storage(pyarrow_dtype, arrow_series.storage)
 

--- a/daft/table/micropartition.py
+++ b/daft/table/micropartition.py
@@ -139,10 +139,8 @@ class MicroPartition:
     def to_table(self) -> Table:
         return Table._from_pytable(self._micropartition.to_table())
 
-    def to_arrow(self, cast_tensors_to_ray_tensor_dtype: bool = False, convert_large_arrays: bool = False) -> pa.Table:
-        return self.to_table().to_arrow(
-            cast_tensors_to_ray_tensor_dtype=cast_tensors_to_ray_tensor_dtype, convert_large_arrays=convert_large_arrays
-        )
+    def to_arrow(self) -> pa.Table:
+        return self.to_table().to_arrow()
 
     def to_pydict(self) -> dict[str, list]:
         return self.to_table().to_pydict()
@@ -153,12 +151,10 @@ class MicroPartition:
     def to_pandas(
         self,
         schema: Schema | None = None,
-        cast_tensors_to_ray_tensor_dtype: bool = False,
         coerce_temporal_nanoseconds: bool = False,
     ) -> pd.DataFrame:
         return self.to_table().to_pandas(
             schema=schema,
-            cast_tensors_to_ray_tensor_dtype=cast_tensors_to_ray_tensor_dtype,
             coerce_temporal_nanoseconds=coerce_temporal_nanoseconds,
         )
 

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -29,12 +29,6 @@ from daft.expressions import Expression, ExpressionsProjection
 from daft.logical.schema import Schema
 from daft.series import Series, item_to_series
 
-_NUMPY_AVAILABLE = True
-try:
-    import numpy as np
-except ImportError:
-    _NUMPY_AVAILABLE = False
-
 _PANDAS_AVAILABLE = True
 try:
     import pandas as pd
@@ -42,7 +36,6 @@ except ImportError:
     _PANDAS_AVAILABLE = False
 
 if TYPE_CHECKING:
-    import numpy as np
     import pandas as pd
     import pyarrow as pa
 
@@ -176,36 +169,26 @@ class Table:
         """For compatibility with MicroPartition"""
         return self
 
-    def to_arrow(self, cast_tensors_to_ray_tensor_dtype: bool = False, convert_large_arrays: bool = False) -> pa.Table:
+    def to_arrow(self, convert_large_arrays: bool = False) -> pa.Table:
         python_fields = set()
-        tensor_fields = set()
         for field in self.schema():
             if field.dtype._is_python_type():
                 python_fields.add(field.name)
-            elif field.dtype._is_tensor_type() or field.dtype._is_fixed_shape_tensor_type():
-                tensor_fields.add(field.name)
-        if python_fields or tensor_fields:
+        if python_fields:
             table = {}
             for colname in self.column_names():
                 column_series = self.get_column(colname)
                 if colname in python_fields:
                     column = column_series.to_pylist()
                 else:
-                    column = column_series.to_arrow(cast_tensors_to_ray_tensor_dtype)
+                    column = column_series.to_arrow()
                 table[colname] = column
 
             tab = pa.Table.from_pydict(table)
         else:
             tab = pa.Table.from_batches([self._table.to_arrow_record_batch()])
 
-        if not convert_large_arrays:
-            return tab
-
-        new_columns = []
-        for col in tab.columns:
-            new_columns.append(_trim_pyarrow_large_arrays(col))
-
-        return pa.Table.from_arrays(new_columns, names=tab.column_names)
+        return tab
 
     def to_pydict(self) -> dict[str, list]:
         return {colname: self.get_column(colname).to_pylist() for colname in self.column_names()}
@@ -220,7 +203,6 @@ class Table:
     def to_pandas(
         self,
         schema: Schema | None = None,
-        cast_tensors_to_ray_tensor_dtype: bool = False,
         coerce_temporal_nanoseconds: bool = False,
     ) -> pd.DataFrame:
         from packaging.version import parse
@@ -228,22 +210,19 @@ class Table:
         if not _PANDAS_AVAILABLE:
             raise ImportError("Unable to import Pandas - please ensure that it is installed.")
         python_fields = set()
-        tensor_fields = set()
         for field in self.schema():
             if field.dtype._is_python_type():
                 python_fields.add(field.name)
-            elif field.dtype._is_tensor_type() or field.dtype._is_fixed_shape_tensor_type():
-                tensor_fields.add(field.name)
-        if python_fields or tensor_fields:
+        if python_fields:
             # Use Python list representation for Python typed columns.
             table = {}
             for colname in self.column_names():
                 column_series = self.get_column(colname)
-                if colname in python_fields or (colname in tensor_fields and not cast_tensors_to_ray_tensor_dtype):
+                if colname in python_fields:
                     column = column_series.to_pylist()
                 else:
                     # Arrow-native field, so provide column as Arrow array.
-                    column_arrow = column_series.to_arrow(cast_tensors_to_ray_tensor_dtype)
+                    column_arrow = column_series.to_arrow()
                     if parse(pa.__version__) < parse("13.0.0"):
                         column = column_arrow.to_pandas()
                     else:
@@ -252,7 +231,7 @@ class Table:
 
             return pd.DataFrame.from_dict(table)
         else:
-            arrow_table = self.to_arrow(cast_tensors_to_ray_tensor_dtype)
+            arrow_table = self.to_arrow()
             if parse(pa.__version__) < parse("13.0.0"):
                 return arrow_table.to_pandas()
             else:
@@ -557,30 +536,6 @@ class Table:
                 max_chunks_in_flight=max_chunks_in_flight,
             )
         )
-
-
-def _trim_pyarrow_large_arrays(arr: pa.ChunkedArray) -> pa.ChunkedArray:
-    if pa.types.is_large_binary(arr.type) or pa.types.is_large_string(arr.type):
-        if pa.types.is_large_binary(arr.type):
-            target_type = pa.binary()
-        else:
-            target_type = pa.string()
-
-        all_chunks = []
-        for chunk in arr.chunks:
-            if len(chunk) == 0:
-                continue
-            offsets = np.frombuffer(chunk.buffers()[1], dtype=np.int64)
-            if offsets[-1] < 2**31:
-                all_chunks.append(chunk.cast(target_type))
-            else:
-                raise ValueError(
-                    f"Can not convert {arr.type} into {target_type} due to the offset array being too large: {offsets[-1]}. Maximum: {2**31}"
-                )
-
-        return pa.chunked_array(all_chunks, type=target_type)
-    else:
-        return arr
 
 
 def read_parquet_into_pyarrow(

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as papq
 import pytest
-from ray.data.extensions import ArrowTensorArray, TensorArray
+from ray.data.extensions import ArrowTensorArray
 
 import daft
 from daft.api_annotations import APITypeError
@@ -310,18 +310,6 @@ def test_create_dataframe_pandas_py_object(valid_data: list[dict[str, float]]) -
     assert set(df.column_names) == set(pd_df.columns)
     # Check roundtrip.
     pd.testing.assert_frame_equal(df.to_pandas(), pd_df)
-
-
-def test_create_dataframe_pandas_tensor(valid_data: list[dict[str, float]]) -> None:
-    pydict = {k: [item[k] for item in valid_data] for k in valid_data[0].keys()}
-    shape = (2, 2)
-    pydict["tensor"] = TensorArray(np.ones((len(valid_data),) + shape))
-    pd_df = pd.DataFrame(pydict)
-    df = daft.from_pandas(pd_df)
-    assert df.schema()["tensor"].dtype == DataType.tensor(DataType.float64(), shape)
-    assert set(df.column_names) == set(pd_df.columns)
-    # Check roundtrip.
-    pd.testing.assert_frame_equal(df.to_pandas(cast_tensors_to_ray_tensor_dtype=True), pd_df)
 
 
 @pytest.mark.parametrize(

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -254,10 +254,10 @@ def test_create_dataframe_arrow_unsupported_dtype(valid_data: list[dict[str, flo
     assert set(df.column_names) == set(t.column_names)
     # Type not natively supported, so should have Python object dtype.
     assert df.schema()["obj"].dtype == DataType.python()
-    casted_field = t.schema.field("variety").with_type(pa.large_string())
-    expected = t.cast(t.schema.set(t.schema.get_field_index("variety"), casted_field))
-    # Check roundtrip.
-    assert df.to_arrow() == expected
+
+    # Assert that it raises an error when trying to convert back to arrow
+    with pytest.raises(ValueError):
+        df.to_arrow()
 
 
 ###


### PR DESCRIPTION
## Summary

Cleanup PR.

1. Removes `cast_tensors_to_ray_tensor_dtype` as a user-facing argument in our export methods (e.g. `to_arrow`, `to_pandas` etc) -- this is really only intended to be used when a user is converting a Daft dataframe to a Ray dataset anyways and there isn't a need to expose this functionality to a user
2. Instead, the logic for casting `daft.DataType.tensor` data to a Ray Data tensor type is done inside of the conversion code for Ray Data (`_make_ray_block_from_micropartition`). This lets us contain the ickiness of that code without having it touch all of our `to_arrow` logic
3. Also removes `_trim_pyarrow_large_arrays` which was a legacy codepath that doesn't get hit anymore
