### PR TITLE
[CHORE] Remove enum imports daft core

### DIFF
--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -69,10 +69,13 @@ where
     // Get the result of the Arrow Logical->Target cast.
     let result_arrow_array = {
         // First, get corresponding Arrow LogicalArray of source DataArray
-        use DataType::*;
         let source_arrow_array = match source_dtype {
             // Wrapped primitives
-            Decimal128(..) | Date | Timestamp(..) | Duration(..) | Time(..) => {
+            DataType::Decimal128(..)
+            | DataType::Date
+            | DataType::Timestamp(..)
+            | DataType::Duration(..)
+            | DataType::Time(..) => {
                 with_match_daft_logical_primitive_types!(source_dtype, |$T| {
                     use arrow2::array::Array;
                     to_cast
@@ -111,11 +114,14 @@ where
     // If the target type is also Logical, get the Arrow Physical.
     let result_arrow_physical_array = {
         if dtype.is_logical() {
-            use DataType::*;
             let target_physical_type = dtype.to_physical().to_arrow()?;
             match dtype {
                 // Primitive wrapper types: change the arrow2 array's type field to primitive
-                Decimal128(..) | Date | Timestamp(..) | Duration(..) | Time(..) => {
+                DataType::Decimal128(..)
+                | DataType::Date
+                | DataType::Timestamp(..)
+                | DataType::Duration(..)
+                | DataType::Time(..) => {
                     with_match_daft_logical_primitive_types!(dtype, |$P| {
                         use arrow2::array::Array;
                         result_arrow_array

--- a/src/daft-core/src/array/ops/image.rs
+++ b/src/daft-core/src/array/ops/image.rs
@@ -57,19 +57,17 @@ macro_rules! with_method_on_image_buffer {
     (
     $key_type:expr, $method: ident
 ) => {{
-        use DaftImageBuffer::*;
-
         match $key_type {
-            L(img) => img.$method(),
-            LA(img) => img.$method(),
-            RGB(img) => img.$method(),
-            RGBA(img) => img.$method(),
-            L16(img) => img.$method(),
-            LA16(img) => img.$method(),
-            RGB16(img) => img.$method(),
-            RGBA16(img) => img.$method(),
-            RGB32F(img) => img.$method(),
-            RGBA32F(img) => img.$method(),
+            DaftImageBuffer::L(img) => img.$method(),
+            DaftImageBuffer::LA(img) => img.$method(),
+            DaftImageBuffer::RGB(img) => img.$method(),
+            DaftImageBuffer::RGBA(img) => img.$method(),
+            DaftImageBuffer::L16(img) => img.$method(),
+            DaftImageBuffer::LA16(img) => img.$method(),
+            DaftImageBuffer::RGB16(img) => img.$method(),
+            DaftImageBuffer::RGBA16(img) => img.$method(),
+            DaftImageBuffer::RGB32F(img) => img.$method(),
+            DaftImageBuffer::RGBA32F(img) => img.$method(),
         }
     }};
 }
@@ -148,19 +146,17 @@ impl From<Wrap<ImageFormat>> for image::ImageFormat {
 impl From<Wrap<ImageMode>> for image::ColorType {
     fn from(image_mode: Wrap<ImageMode>) -> image::ColorType {
         use image::ColorType;
-        use ImageMode::*;
-
         match image_mode.0 {
-            L => ColorType::L8,
-            LA => ColorType::La8,
-            RGB => ColorType::Rgb8,
-            RGBA => ColorType::Rgba8,
-            L16 => ColorType::L16,
-            LA16 => ColorType::La16,
-            RGB16 => ColorType::Rgb16,
-            RGBA16 => ColorType::Rgba16,
-            RGB32F => ColorType::Rgb32F,
-            RGBA32F => ColorType::Rgba32F,
+            ImageMode::L => ColorType::L8,
+            ImageMode::LA => ColorType::La8,
+            ImageMode::RGB => ColorType::Rgb8,
+            ImageMode::RGBA => ColorType::Rgba8,
+            ImageMode::L16 => ColorType::L16,
+            ImageMode::LA16 => ColorType::La16,
+            ImageMode::RGB16 => ColorType::Rgb16,
+            ImageMode::RGBA16 => ColorType::Rgba16,
+            ImageMode::RGB32F => ColorType::Rgb32F,
+            ImageMode::RGBA32F => ColorType::Rgba32F,
         }
     }
 }
@@ -170,19 +166,17 @@ impl TryFrom<image::ColorType> for Wrap<ImageMode> {
 
     fn try_from(color: image::ColorType) -> DaftResult<Self> {
         use image::ColorType;
-        use ImageMode::*;
-
         Ok(Wrap(match color {
-            ColorType::L8 => Ok(L),
-            ColorType::La8 => Ok(LA),
-            ColorType::Rgb8 => Ok(RGB),
-            ColorType::Rgba8 => Ok(RGBA),
-            ColorType::L16 => Ok(L16),
-            ColorType::La16 => Ok(LA16),
-            ColorType::Rgb16 => Ok(RGB16),
-            ColorType::Rgba16 => Ok(RGBA16),
-            ColorType::Rgb32F => Ok(RGB32F),
-            ColorType::Rgba32F => Ok(RGBA32F),
+            ColorType::L8 => Ok(ImageMode::L),
+            ColorType::La8 => Ok(ImageMode::LA),
+            ColorType::Rgb8 => Ok(ImageMode::RGB),
+            ColorType::Rgba8 => Ok(ImageMode::RGBA),
+            ColorType::L16 => Ok(ImageMode::L16),
+            ColorType::La16 => Ok(ImageMode::LA16),
+            ColorType::Rgb16 => Ok(ImageMode::RGB16),
+            ColorType::Rgba16 => Ok(ImageMode::RGBA16),
+            ColorType::Rgb32F => Ok(ImageMode::RGB32F),
+            ColorType::Rgba32F => Ok(ImageMode::RGBA32F),
             _ => Err(DaftError::ValueError(format!(
                 "Color type {:?} is not supported.",
                 color
@@ -201,12 +195,11 @@ impl<'a> DaftImageBuffer<'a> {
     }
 
     pub fn as_u8_slice(&'a self) -> &'a [u8] {
-        use DaftImageBuffer::*;
         match self {
-            L(img) => img.as_raw(),
-            LA(img) => img.as_raw(),
-            RGB(img) => img.as_raw(),
-            RGBA(img) => img.as_raw(),
+            DaftImageBuffer::L(img) => img.as_raw(),
+            DaftImageBuffer::LA(img) => img.as_raw(),
+            DaftImageBuffer::RGB(img) => img.as_raw(),
+            DaftImageBuffer::RGBA(img) => img.as_raw(),
             _ => unimplemented!("unimplemented {self:?}"),
         }
     }
@@ -216,19 +209,17 @@ impl<'a> DaftImageBuffer<'a> {
     }
 
     pub fn mode(&self) -> ImageMode {
-        use DaftImageBuffer::*;
-
         match self {
-            L(..) => ImageMode::L,
-            LA(..) => ImageMode::LA,
-            RGB(..) => ImageMode::RGB,
-            RGBA(..) => ImageMode::RGBA,
-            L16(..) => ImageMode::L16,
-            LA16(..) => ImageMode::LA16,
-            RGB16(..) => ImageMode::RGB16,
-            RGBA16(..) => ImageMode::RGBA16,
-            RGB32F(..) => ImageMode::RGB32F,
-            RGBA32F(..) => ImageMode::RGBA32F,
+            DaftImageBuffer::L(..) => ImageMode::L,
+            DaftImageBuffer::LA(..) => ImageMode::LA,
+            DaftImageBuffer::RGB(..) => ImageMode::RGB,
+            DaftImageBuffer::RGBA(..) => ImageMode::RGBA,
+            DaftImageBuffer::L16(..) => ImageMode::L16,
+            DaftImageBuffer::LA16(..) => ImageMode::LA16,
+            DaftImageBuffer::RGB16(..) => ImageMode::RGB16,
+            DaftImageBuffer::RGBA16(..) => ImageMode::RGBA16,
+            DaftImageBuffer::RGB32F(..) => ImageMode::RGB32F,
+            DaftImageBuffer::RGBA32F(..) => ImageMode::RGBA32F,
         }
     }
 
@@ -272,24 +263,23 @@ impl<'a> DaftImageBuffer<'a> {
     }
 
     pub fn resize(&self, w: u32, h: u32) -> Self {
-        use DaftImageBuffer::*;
         match self {
-            L(imgbuf) => {
+            DaftImageBuffer::L(imgbuf) => {
                 let result =
                     image::imageops::resize(imgbuf, w, h, image::imageops::FilterType::Triangle);
                 DaftImageBuffer::L(image_buffer_vec_to_cow(result))
             }
-            LA(imgbuf) => {
+            DaftImageBuffer::LA(imgbuf) => {
                 let result =
                     image::imageops::resize(imgbuf, w, h, image::imageops::FilterType::Triangle);
                 DaftImageBuffer::LA(image_buffer_vec_to_cow(result))
             }
-            RGB(imgbuf) => {
+            DaftImageBuffer::RGB(imgbuf) => {
                 let result =
                     image::imageops::resize(imgbuf, w, h, image::imageops::FilterType::Triangle);
                 DaftImageBuffer::RGB(image_buffer_vec_to_cow(result))
             }
-            RGBA(imgbuf) => {
+            DaftImageBuffer::RGBA(imgbuf) => {
                 let result =
                     image::imageops::resize(imgbuf, w, h, image::imageops::FilterType::Triangle);
                 DaftImageBuffer::RGBA(image_buffer_vec_to_cow(result))
@@ -638,11 +628,15 @@ impl ImageArray {
         inputs: &[Option<DaftImageBuffer<'_>>],
         image_mode: &Option<ImageMode>,
     ) -> DaftResult<Self> {
-        use DaftImageBuffer::*;
-        let is_all_u8 = inputs
-            .iter()
-            .filter_map(|b| b.as_ref())
-            .all(|b| matches!(b, L(..) | LA(..) | RGB(..) | RGBA(..)));
+        let is_all_u8 = inputs.iter().filter_map(|b| b.as_ref()).all(|b| {
+            matches!(
+                b,
+                DaftImageBuffer::L(..)
+                    | DaftImageBuffer::LA(..)
+                    | DaftImageBuffer::RGB(..)
+                    | DaftImageBuffer::RGBA(..)
+            )
+        });
         assert!(is_all_u8);
 
         let mut data_ref = Vec::with_capacity(inputs.len());
@@ -775,11 +769,15 @@ impl FixedShapeImageArray {
         height: u32,
         width: u32,
     ) -> DaftResult<Self> {
-        use DaftImageBuffer::*;
-        let is_all_u8 = inputs
-            .iter()
-            .filter_map(|b| b.as_ref())
-            .all(|b| matches!(b, L(..) | LA(..) | RGB(..) | RGBA(..)));
+        let is_all_u8 = inputs.iter().filter_map(|b| b.as_ref()).all(|b| {
+            matches!(
+                b,
+                DaftImageBuffer::L(..)
+                    | DaftImageBuffer::LA(..)
+                    | DaftImageBuffer::RGB(..)
+                    | DaftImageBuffer::RGBA(..)
+            )
+        });
         assert!(is_all_u8);
 
         let num_channels = image_mode.num_channels();

--- a/src/daft-core/src/array/ops/trigonometry.rs
+++ b/src/daft-core/src/array/ops/trigonometry.rs
@@ -26,20 +26,19 @@ pub enum TrigonometricFunction {
 
 impl TrigonometricFunction {
     pub fn fn_name(&self) -> &'static str {
-        use TrigonometricFunction::*;
         match self {
-            Sin => "sin",
-            Cos => "cos",
-            Tan => "tan",
-            Cot => "cot",
-            ArcSin => "arcsin",
-            ArcCos => "arccos",
-            ArcTan => "arctan",
-            Radians => "radians",
-            Degrees => "degrees",
-            ArcTanh => "arctanh",
-            ArcCosh => "arccosh",
-            ArcSinh => "arcsinh",
+            TrigonometricFunction::Sin => "sin",
+            TrigonometricFunction::Cos => "cos",
+            TrigonometricFunction::Tan => "tan",
+            TrigonometricFunction::Cot => "cot",
+            TrigonometricFunction::ArcSin => "arcsin",
+            TrigonometricFunction::ArcCos => "arccos",
+            TrigonometricFunction::ArcTan => "arctan",
+            TrigonometricFunction::Radians => "radians",
+            TrigonometricFunction::Degrees => "degrees",
+            TrigonometricFunction::ArcTanh => "arctanh",
+            TrigonometricFunction::ArcCosh => "arccosh",
+            TrigonometricFunction::ArcSinh => "arcsinh",
         }
     }
 }
@@ -50,20 +49,19 @@ where
     T::Native: Float,
 {
     pub fn trigonometry(&self, func: &TrigonometricFunction) -> DaftResult<Self> {
-        use TrigonometricFunction::*;
         match func {
-            Sin => self.apply(|v| v.sin()),
-            Cos => self.apply(|v| v.cos()),
-            Tan => self.apply(|v| v.tan()),
-            Cot => self.apply(|v| v.tan().powi(-1)),
-            ArcSin => self.apply(|v| v.asin()),
-            ArcCos => self.apply(|v| v.acos()),
-            ArcTan => self.apply(|v| v.atan()),
-            Radians => self.apply(|v| v.to_radians()),
-            Degrees => self.apply(|v| v.to_degrees()),
-            ArcTanh => self.apply(|v| v.atanh()),
-            ArcCosh => self.apply(|v| v.acosh()),
-            ArcSinh => self.apply(|v| v.asinh()),
+            TrigonometricFunction::Sin => self.apply(|v| v.sin()),
+            TrigonometricFunction::Cos => self.apply(|v| v.cos()),
+            TrigonometricFunction::Tan => self.apply(|v| v.tan()),
+            TrigonometricFunction::Cot => self.apply(|v| v.tan().powi(-1)),
+            TrigonometricFunction::ArcSin => self.apply(|v| v.asin()),
+            TrigonometricFunction::ArcCos => self.apply(|v| v.acos()),
+            TrigonometricFunction::ArcTan => self.apply(|v| v.atan()),
+            TrigonometricFunction::Radians => self.apply(|v| v.to_radians()),
+            TrigonometricFunction::Degrees => self.apply(|v| v.to_degrees()),
+            TrigonometricFunction::ArcTanh => self.apply(|v| v.atanh()),
+            TrigonometricFunction::ArcCosh => self.apply(|v| v.acosh()),
+            TrigonometricFunction::ArcSinh => self.apply(|v| v.asinh()),
         }
     }
 }

--- a/src/daft-core/src/count_mode.rs
+++ b/src/daft-core/src/count_mode.rs
@@ -41,9 +41,7 @@ impl_bincode_py_state_serialization!(CountMode);
 
 impl CountMode {
     pub fn iterator() -> std::slice::Iter<'static, CountMode> {
-        use CountMode::*;
-
-        static COUNT_MODES: [CountMode; 3] = [All, Valid, Null];
+        static COUNT_MODES: [CountMode; 3] = [CountMode::All, CountMode::Valid, CountMode::Null];
         COUNT_MODES.iter()
     }
 }
@@ -52,12 +50,10 @@ impl FromStr for CountMode {
     type Err = DaftError;
 
     fn from_str(count_mode: &str) -> DaftResult<Self> {
-        use CountMode::*;
-
         match count_mode {
-            "all" => Ok(All),
-            "valid" => Ok(Valid),
-            "null" => Ok(Null),
+            "all" => Ok(CountMode::All),
+            "valid" => Ok(CountMode::Valid),
+            "null" => Ok(CountMode::Null),
             _ => Err(DaftError::TypeError(format!(
                 "Count mode {} is not supported; only the following modes are supported: {:?}",
                 count_mode,

--- a/src/daft-core/src/datatypes/agg_ops.rs
+++ b/src/daft-core/src/datatypes/agg_ops.rs
@@ -6,14 +6,15 @@ use super::DataType;
 
 /// Get the data type that the sum of a column of the given data type should be casted to.
 pub fn try_sum_supertype(dtype: &DataType) -> DaftResult<DataType> {
-    use DataType::*;
     match dtype {
-        Int8 | Int16 | Int32 | Int64 => Ok(Int64),
-        UInt8 | UInt16 | UInt32 | UInt64 => Ok(UInt64),
-        Float32 => Ok(Float32),
-        Float64 => Ok(Float64),
+        DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => Ok(DataType::Int64),
+        DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
+            Ok(DataType::UInt64)
+        }
+        DataType::Float32 => Ok(DataType::Float32),
+        DataType::Float64 => Ok(DataType::Float64),
         // 38 is the maximum precision for Decimal128, while 19 is the max increase based on 2^64 rows
-        Decimal128(a, b) => Ok(Decimal128(min(38, *a + 19), *b)),
+        DataType::Decimal128(a, b) => Ok(DataType::Decimal128(min(38, *a + 19), *b)),
         other => Err(DaftError::TypeError(format!(
             "Invalid argument to sum supertype: {}",
             other
@@ -23,9 +24,8 @@ pub fn try_sum_supertype(dtype: &DataType) -> DaftResult<DataType> {
 
 /// Get the data type that the mean of a column of the given data type should be casted to.
 pub fn try_mean_supertype(dtype: &DataType) -> DaftResult<DataType> {
-    use DataType::*;
     if dtype.is_numeric() {
-        Ok(Float64)
+        Ok(DataType::Float64)
     } else {
         Err(DaftError::TypeError(format!(
             "Invalid argument to mean supertype: {}",

--- a/src/daft-core/src/join.rs
+++ b/src/daft-core/src/join.rs
@@ -42,9 +42,14 @@ impl_bincode_py_state_serialization!(JoinType);
 
 impl JoinType {
     pub fn iterator() -> std::slice::Iter<'static, JoinType> {
-        use JoinType::*;
-
-        static JOIN_TYPES: [JoinType; 6] = [Inner, Left, Right, Outer, Anti, Semi];
+        static JOIN_TYPES: [JoinType; 6] = [
+            JoinType::Inner,
+            JoinType::Left,
+            JoinType::Right,
+            JoinType::Outer,
+            JoinType::Anti,
+            JoinType::Semi,
+        ];
         JOIN_TYPES.iter()
     }
 }
@@ -53,15 +58,13 @@ impl FromStr for JoinType {
     type Err = DaftError;
 
     fn from_str(join_type: &str) -> DaftResult<Self> {
-        use JoinType::*;
-
         match join_type {
-            "inner" => Ok(Inner),
-            "left" => Ok(Left),
-            "right" => Ok(Right),
-            "outer" => Ok(Outer),
-            "anti" => Ok(Anti),
-            "semi" => Ok(Semi),
+            "inner" => Ok(JoinType::Inner),
+            "left" => Ok(JoinType::Left),
+            "right" => Ok(JoinType::Right),
+            "outer" => Ok(JoinType::Outer),
+            "anti" => Ok(JoinType::Anti),
+            "semi" => Ok(JoinType::Semi),
             _ => Err(DaftError::TypeError(format!(
                 "Join type {} is not supported; only the following types are supported: {:?}",
                 join_type,
@@ -106,9 +109,11 @@ impl_bincode_py_state_serialization!(JoinStrategy);
 
 impl JoinStrategy {
     pub fn iterator() -> std::slice::Iter<'static, JoinStrategy> {
-        use JoinStrategy::*;
-
-        static JOIN_STRATEGIES: [JoinStrategy; 3] = [Hash, SortMerge, Broadcast];
+        static JOIN_STRATEGIES: [JoinStrategy; 3] = [
+            JoinStrategy::Hash,
+            JoinStrategy::SortMerge,
+            JoinStrategy::Broadcast,
+        ];
         JOIN_STRATEGIES.iter()
     }
 }
@@ -117,12 +122,10 @@ impl FromStr for JoinStrategy {
     type Err = DaftError;
 
     fn from_str(join_strategy: &str) -> DaftResult<Self> {
-        use JoinStrategy::*;
-
         match join_strategy {
-            "hash" => Ok(Hash),
-            "sort_merge" => Ok(SortMerge),
-            "broadcast" => Ok(Broadcast),
+            "hash" => Ok(JoinStrategy::Hash),
+            "sort_merge" => Ok(JoinStrategy::SortMerge),
+            "broadcast" => Ok(JoinStrategy::Broadcast),
             _ => Err(DaftError::TypeError(format!(
                 "Join strategy {} is not supported; only the following strategies are supported: {:?}",
                 join_strategy,

--- a/src/daft-core/src/kernels/hashing.rs
+++ b/src/daft-core/src/kernels/hashing.rs
@@ -175,18 +175,21 @@ pub fn hash(array: &dyn Array, seed: Option<&PrimitiveArray<u64>>) -> Result<Pri
         }
     }
 
-    use PhysicalType::*;
     Ok(match array.data_type().to_physical_type() {
-        Null => hash_null(array.as_any().downcast_ref().unwrap(), seed),
-        Boolean => hash_boolean(array.as_any().downcast_ref().unwrap(), seed),
-        Primitive(primitive) => with_match_hashing_primitive_type!(primitive, |$T| {
+        PhysicalType::Null => hash_null(array.as_any().downcast_ref().unwrap(), seed),
+        PhysicalType::Boolean => hash_boolean(array.as_any().downcast_ref().unwrap(), seed),
+        PhysicalType::Primitive(primitive) => with_match_hashing_primitive_type!(primitive, |$T| {
             hash_primitive::<$T>(array.as_any().downcast_ref().unwrap(), seed)
         }),
-        Binary => hash_binary::<i32>(array.as_any().downcast_ref().unwrap(), seed),
-        LargeBinary => hash_binary::<i64>(array.as_any().downcast_ref().unwrap(), seed),
-        FixedSizeBinary => hash_fixed_size_binary(array.as_any().downcast_ref().unwrap(), seed),
-        Utf8 => hash_utf8::<i32>(array.as_any().downcast_ref().unwrap(), seed),
-        LargeUtf8 => hash_utf8::<i64>(array.as_any().downcast_ref().unwrap(), seed),
+        PhysicalType::Binary => hash_binary::<i32>(array.as_any().downcast_ref().unwrap(), seed),
+        PhysicalType::LargeBinary => {
+            hash_binary::<i64>(array.as_any().downcast_ref().unwrap(), seed)
+        }
+        PhysicalType::FixedSizeBinary => {
+            hash_fixed_size_binary(array.as_any().downcast_ref().unwrap(), seed)
+        }
+        PhysicalType::Utf8 => hash_utf8::<i32>(array.as_any().downcast_ref().unwrap(), seed),
+        PhysicalType::LargeUtf8 => hash_utf8::<i64>(array.as_any().downcast_ref().unwrap(), seed),
         t => {
             return Err(Error::NotYetImplemented(format!(
                 "Hash not implemented for type {t:?}"

--- a/src/daft-core/src/kernels/search_sorted.rs
+++ b/src/daft-core/src/kernels/search_sorted.rs
@@ -571,7 +571,6 @@ pub fn search_sorted(
     keys: &dyn Array,
     input_reversed: bool,
 ) -> Result<PrimitiveArray<u64>> {
-    use PhysicalType::*;
     if sorted_array.data_type() != keys.data_type() {
         let error_string = format!(
             "sorted array data type does not match keys data type: {:?} vs {:?}",
@@ -582,35 +581,37 @@ pub fn search_sorted(
     }
     Ok(match sorted_array.data_type().to_physical_type() {
         // Boolean => hash_boolean(array.as_any().downcast_ref().unwrap()),
-        Primitive(primitive) => with_match_searching_primitive_type!(primitive, |$T| {
-            search_sorted_primitive_array::<$T>(sorted_array.as_any().downcast_ref().unwrap(), keys.as_any().downcast_ref().unwrap(), input_reversed)
-        }),
-        Utf8 => search_sorted_utf_array::<i32>(
+        PhysicalType::Primitive(primitive) => {
+            with_match_searching_primitive_type!(primitive, |$T| {
+                search_sorted_primitive_array::<$T>(sorted_array.as_any().downcast_ref().unwrap(), keys.as_any().downcast_ref().unwrap(), input_reversed)
+            })
+        }
+        PhysicalType::Utf8 => search_sorted_utf_array::<i32>(
             sorted_array.as_any().downcast_ref().unwrap(),
             keys.as_any().downcast_ref().unwrap(),
             input_reversed,
         ),
-        LargeUtf8 => search_sorted_utf_array::<i64>(
+        PhysicalType::LargeUtf8 => search_sorted_utf_array::<i64>(
             sorted_array.as_any().downcast_ref().unwrap(),
             keys.as_any().downcast_ref().unwrap(),
             input_reversed,
         ),
-        Binary => search_sorted_binary_array::<i32>(
+        PhysicalType::Binary => search_sorted_binary_array::<i32>(
             sorted_array.as_any().downcast_ref().unwrap(),
             keys.as_any().downcast_ref().unwrap(),
             input_reversed,
         ),
-        LargeBinary => search_sorted_binary_array::<i64>(
+        PhysicalType::LargeBinary => search_sorted_binary_array::<i64>(
             sorted_array.as_any().downcast_ref().unwrap(),
             keys.as_any().downcast_ref().unwrap(),
             input_reversed,
         ),
-        FixedSizeBinary => search_sorted_fixed_size_binary_array(
+        PhysicalType::FixedSizeBinary => search_sorted_fixed_size_binary_array(
             sorted_array.as_any().downcast_ref().unwrap(),
             keys.as_any().downcast_ref().unwrap(),
             input_reversed,
         ),
-        Boolean => search_sorted_boolean_array(
+        PhysicalType::Boolean => search_sorted_boolean_array(
             sorted_array.as_any().downcast_ref().unwrap(),
             keys.as_any().downcast_ref().unwrap(),
             input_reversed,

--- a/src/daft-core/src/series/array_impl/binary_ops.rs
+++ b/src/daft-core/src/series/array_impl/binary_ops.rs
@@ -125,10 +125,9 @@ macro_rules! py_numeric_binary_op {
         let output_type =
             InferDataType::from($self.data_type()).$op(InferDataType::from($rhs.data_type()))?;
         let lhs = $self.into_series();
-        use DataType::*;
         match &output_type {
             #[cfg(feature = "python")]
-            Python => Ok(py_binary_op!(lhs, $rhs, $pyop)),
+            DataType::Python => Ok(py_binary_op!(lhs, $rhs, $pyop)),
             output_type if output_type.is_numeric() => {
                 with_match_numeric_daft_types!(output_type, |$T| {
                     cast_downcast_op_into_series!(
@@ -153,13 +152,16 @@ macro_rules! physical_logic_op {
         let output_type = InferDataType::from($self.data_type())
             .logical_op(&InferDataType::from($rhs.data_type()))?;
         let lhs = $self.into_series();
-        use DataType::*;
         match &output_type {
             #[cfg(feature = "python")]
-            Boolean => match (&lhs.data_type(), &$rhs.data_type()) {
+            DataType::Boolean => match (&lhs.data_type(), &$rhs.data_type()) {
                 #[cfg(feature = "python")]
-                (Python, _) | (_, Python) => Ok(py_binary_op_bool!(lhs, $rhs, $pyop)),
-                _ => cast_downcast_op_into_series!(lhs, $rhs, &Boolean, BooleanArray, $op),
+                (DataType::Python, _) | (_, DataType::Python) => {
+                    Ok(py_binary_op_bool!(lhs, $rhs, $pyop))
+                }
+                _ => {
+                    cast_downcast_op_into_series!(lhs, $rhs, &DataType::Boolean, BooleanArray, $op)
+                }
             },
             output_type if output_type.is_integer() => {
                 with_match_integer_daft_types!(output_type, |$T| {
@@ -188,11 +190,10 @@ macro_rules! physical_compare_op {
             (lhs, $rhs.clone())
         };
 
-        use DataType::*;
-        if let Boolean = output_type {
+        if let DataType::Boolean = output_type {
             match comp_type {
                 #[cfg(feature = "python")]
-                Python => py_binary_op_bool!(lhs, rhs, $pyop)
+                DataType::Python => py_binary_op_bool!(lhs, rhs, $pyop)
                     .downcast::<BooleanArray>()
                     .cloned(),
                 _ => with_match_comparable_daft_types!(comp_type, |$T| {
@@ -210,11 +211,12 @@ pub(crate) trait SeriesBinaryOps: SeriesLike {
         let output_type =
             InferDataType::from(self.data_type()).add(InferDataType::from(rhs.data_type()))?;
         let lhs = self.into_series();
-        use DataType::*;
         match &output_type {
             #[cfg(feature = "python")]
-            Python => Ok(py_binary_op!(lhs, rhs, "add")),
-            Utf8 => cast_downcast_op_into_series!(lhs, rhs, &Utf8, Utf8Array, add),
+            DataType::Python => Ok(py_binary_op!(lhs, rhs, "add")),
+            DataType::Utf8 => {
+                cast_downcast_op_into_series!(lhs, rhs, &DataType::Utf8, Utf8Array, add)
+            }
             output_type if output_type.is_numeric() => {
                 with_match_numeric_daft_types!(output_type, |$T| {
                     cast_downcast_op_into_series!(lhs, rhs, output_type, <$T as DaftDataType>::ArrayType, add)
@@ -236,11 +238,12 @@ pub(crate) trait SeriesBinaryOps: SeriesLike {
         let output_type =
             InferDataType::from(self.data_type()).div(InferDataType::from(rhs.data_type()))?;
         let lhs = self.into_series();
-        use DataType::*;
         match &output_type {
             #[cfg(feature = "python")]
-            Python => Ok(py_binary_op!(lhs, rhs, "truediv")),
-            Float64 => cast_downcast_op_into_series!(lhs, rhs, &Float64, Float64Array, div),
+            DataType::Python => Ok(py_binary_op!(lhs, rhs, "truediv")),
+            DataType::Float64 => {
+                cast_downcast_op_into_series!(lhs, rhs, &DataType::Float64, Float64Array, div)
+            }
             output_type if output_type.is_fixed_size_numeric() => {
                 fixed_sized_numeric_binary_op!(&lhs, rhs, output_type, div)
             }
@@ -305,11 +308,10 @@ impl SeriesBinaryOps for ArrayWrapper<ExtensionArray> {}
 impl SeriesBinaryOps for ArrayWrapper<Decimal128Array> {}
 impl SeriesBinaryOps for ArrayWrapper<DateArray> {
     fn add(&self, rhs: &Series) -> DaftResult<Series> {
-        use DataType::*;
         let output_type =
             (InferDataType::from(self.data_type()) + InferDataType::from(rhs.data_type()))?;
         match rhs.data_type() {
-            Duration(..) => {
+            DataType::Duration(..) => {
                 let days = rhs.duration()?.cast_to_days()?;
                 let physical_result = self.0.physical.add(&days)?;
                 physical_result.cast(&output_type)
@@ -318,15 +320,14 @@ impl SeriesBinaryOps for ArrayWrapper<DateArray> {
         }
     }
     fn sub(&self, rhs: &Series) -> DaftResult<Series> {
-        use DataType::*;
         let output_type =
             (InferDataType::from(self.data_type()) - InferDataType::from(rhs.data_type()))?;
         match rhs.data_type() {
-            Date => {
+            DataType::Date => {
                 let physical_result = self.0.physical.sub(&rhs.date()?.physical)?;
                 physical_result.cast(&output_type)
             }
-            Duration(..) => {
+            DataType::Duration(..) => {
                 let days = rhs.duration()?.cast_to_days()?;
                 let physical_result = self.0.physical.sub(&days)?;
                 physical_result.cast(&output_type)
@@ -338,20 +339,19 @@ impl SeriesBinaryOps for ArrayWrapper<DateArray> {
 impl SeriesBinaryOps for ArrayWrapper<TimeArray> {}
 impl SeriesBinaryOps for ArrayWrapper<DurationArray> {
     fn add(&self, rhs: &Series) -> DaftResult<Series> {
-        use DataType::*;
         let output_type =
             (InferDataType::from(self.data_type()) + InferDataType::from(rhs.data_type()))?;
         let lhs = self.0.clone().into_series();
         match rhs.data_type() {
-            Timestamp(..) => {
+            DataType::Timestamp(..) => {
                 let physical_result = self.0.physical.add(&rhs.timestamp()?.physical)?;
                 physical_result.cast(&output_type)
             }
-            Duration(..) => {
+            DataType::Duration(..) => {
                 let physical_result = self.0.physical.add(&rhs.duration()?.physical)?;
                 physical_result.cast(&output_type)
             }
-            Date => {
+            DataType::Date => {
                 let days = self.0.cast_to_days()?;
                 let physical_result = days.add(&rhs.date()?.physical)?;
                 physical_result.cast(&output_type)
@@ -361,11 +361,10 @@ impl SeriesBinaryOps for ArrayWrapper<DurationArray> {
     }
 
     fn sub(&self, rhs: &Series) -> DaftResult<Series> {
-        use DataType::*;
         let output_type =
             (InferDataType::from(self.data_type()) - InferDataType::from(rhs.data_type()))?;
         match rhs.data_type() {
-            Duration(..) => {
+            DataType::Duration(..) => {
                 let physical_result = self.0.physical.sub(&rhs.duration()?.physical)?;
                 physical_result.cast(&output_type)
             }
@@ -376,11 +375,10 @@ impl SeriesBinaryOps for ArrayWrapper<DurationArray> {
 
 impl SeriesBinaryOps for ArrayWrapper<TimestampArray> {
     fn add(&self, rhs: &Series) -> DaftResult<Series> {
-        use DataType::*;
         let output_type =
             (InferDataType::from(self.data_type()) + InferDataType::from(rhs.data_type()))?;
         match rhs.data_type() {
-            Duration(..) => {
+            DataType::Duration(..) => {
                 let physical_result = self.0.physical.add(&rhs.duration()?.physical)?;
                 physical_result.cast(&output_type)
             }
@@ -388,15 +386,14 @@ impl SeriesBinaryOps for ArrayWrapper<TimestampArray> {
         }
     }
     fn sub(&self, rhs: &Series) -> DaftResult<Series> {
-        use DataType::*;
         let output_type =
             (InferDataType::from(self.data_type()) - InferDataType::from(rhs.data_type()))?;
         match rhs.data_type() {
-            Duration(..) => {
+            DataType::Duration(..) => {
                 let physical_result = self.0.physical.sub(&rhs.duration()?.physical)?;
                 physical_result.cast(&output_type)
             }
-            Timestamp(..) => {
+            DataType::Timestamp(..) => {
                 let physical_result = self.0.physical.sub(&rhs.timestamp()?.physical)?;
                 physical_result.cast(&output_type)
             }

--- a/src/daft-core/src/series/ops/abs.rs
+++ b/src/daft-core/src/series/ops/abs.rs
@@ -1,20 +1,21 @@
 use crate::datatypes::DataType;
+use crate::series::array_impl::IntoSeries;
 use crate::series::Series;
 use common_error::DaftError;
 use common_error::DaftResult;
+
 impl Series {
     pub fn abs(&self) -> DaftResult<Series> {
-        use crate::series::array_impl::IntoSeries;
-
-        use DataType::*;
         match self.data_type() {
-            Int8 => Ok(self.i8().unwrap().abs()?.into_series()),
-            Int16 => Ok(self.i16().unwrap().abs()?.into_series()),
-            Int32 => Ok(self.i32().unwrap().abs()?.into_series()),
-            Int64 => Ok(self.i64().unwrap().abs()?.into_series()),
-            UInt8 | UInt16 | UInt32 | UInt64 => Ok(self.clone()),
-            Float32 => Ok(self.f32().unwrap().abs()?.into_series()),
-            Float64 => Ok(self.f64().unwrap().abs()?.into_series()),
+            DataType::Int8 => Ok(self.i8().unwrap().abs()?.into_series()),
+            DataType::Int16 => Ok(self.i16().unwrap().abs()?.into_series()),
+            DataType::Int32 => Ok(self.i32().unwrap().abs()?.into_series()),
+            DataType::Int64 => Ok(self.i64().unwrap().abs()?.into_series()),
+            DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
+                Ok(self.clone())
+            }
+            DataType::Float32 => Ok(self.f32().unwrap().abs()?.into_series()),
+            DataType::Float64 => Ok(self.f64().unwrap().abs()?.into_series()),
             dt => Err(DaftError::TypeError(format!(
                 "abs not implemented for {}",
                 dt

--- a/src/daft-core/src/series/ops/ceil.rs
+++ b/src/daft-core/src/series/ops/ceil.rs
@@ -1,16 +1,22 @@
 use crate::datatypes::DataType;
+use crate::series::array_impl::IntoSeries;
 use crate::series::Series;
 use common_error::DaftError;
 use common_error::DaftResult;
+
 impl Series {
     pub fn ceil(&self) -> DaftResult<Series> {
-        use crate::series::array_impl::IntoSeries;
-
-        use DataType::*;
         match self.data_type() {
-            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 => Ok(self.clone()),
-            Float32 => Ok(self.f32().unwrap().ceil()?.into_series()),
-            Float64 => Ok(self.f64().unwrap().ceil()?.into_series()),
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64 => Ok(self.clone()),
+            DataType::Float32 => Ok(self.f32().unwrap().ceil()?.into_series()),
+            DataType::Float64 => Ok(self.f64().unwrap().ceil()?.into_series()),
             dt => Err(DaftError::TypeError(format!(
                 "ceil not implemented for {}",
                 dt

--- a/src/daft-core/src/series/ops/exp.rs
+++ b/src/daft-core/src/series/ops/exp.rs
@@ -2,17 +2,15 @@ use common_error::DaftError;
 use common_error::DaftResult;
 
 use crate::datatypes::DataType;
+use crate::series::array_impl::IntoSeries;
 use crate::series::Series;
 
 impl Series {
     pub fn exp(&self) -> DaftResult<Series> {
-        use crate::series::array_impl::IntoSeries;
-
-        use DataType::*;
         match self.data_type() {
-            Float32 => Ok(self.f32().unwrap().exp()?.into_series()),
-            Float64 => Ok(self.f64().unwrap().exp()?.into_series()),
-            dt if dt.is_integer() => self.cast(&Float64).unwrap().exp(),
+            DataType::Float32 => Ok(self.f32().unwrap().exp()?.into_series()),
+            DataType::Float64 => Ok(self.f64().unwrap().exp()?.into_series()),
+            dt if dt.is_integer() => self.cast(&DataType::Float64).unwrap().exp(),
             dt => Err(DaftError::TypeError(format!(
                 "exp not implemented for {}",
                 dt

--- a/src/daft-core/src/series/ops/floor.rs
+++ b/src/daft-core/src/series/ops/floor.rs
@@ -1,16 +1,22 @@
 use crate::datatypes::DataType;
+use crate::series::array_impl::IntoSeries;
 use crate::series::Series;
 use common_error::DaftError;
 use common_error::DaftResult;
 
 impl Series {
     pub fn floor(&self) -> DaftResult<Series> {
-        use crate::series::array_impl::IntoSeries;
-        use DataType::*;
         match self.data_type() {
-            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 => Ok(self.clone()),
-            Float32 => Ok(self.f32().unwrap().floor()?.into_series()),
-            Float64 => Ok(self.f64().unwrap().floor()?.into_series()),
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64 => Ok(self.clone()),
+            DataType::Float32 => Ok(self.f32().unwrap().floor()?.into_series()),
+            DataType::Float64 => Ok(self.f64().unwrap().floor()?.into_series()),
             dt => Err(DaftError::TypeError(format!(
                 "floor not implemented for {}",
                 dt

--- a/src/daft-core/src/series/ops/list.rs
+++ b/src/daft-core/src/series/ops/list.rs
@@ -8,10 +8,9 @@ use common_error::DaftResult;
 
 impl Series {
     pub fn explode(&self) -> DaftResult<Series> {
-        use DataType::*;
         match self.data_type() {
-            List(_) => self.list()?.explode(),
-            FixedSizeList(..) => self.fixed_size_list()?.explode(),
+            DataType::List(_) => self.list()?.explode(),
+            DataType::FixedSizeList(..) => self.fixed_size_list()?.explode(),
             dt => Err(DaftError::TypeError(format!(
                 "explode not implemented for {}",
                 dt
@@ -20,13 +19,13 @@ impl Series {
     }
 
     pub fn list_count(&self, mode: CountMode) -> DaftResult<UInt64Array> {
-        use DataType::*;
-
         match self.data_type() {
-            List(_) => self.list()?.count(mode),
-            FixedSizeList(..) => self.fixed_size_list()?.count(mode),
-            Embedding(..) | FixedShapeImage(..) => self.as_physical()?.list_count(mode),
-            Image(..) => {
+            DataType::List(_) => self.list()?.count(mode),
+            DataType::FixedSizeList(..) => self.fixed_size_list()?.count(mode),
+            DataType::Embedding(..) | DataType::FixedShapeImage(..) => {
+                self.as_physical()?.list_count(mode)
+            }
+            DataType::Image(..) => {
                 let struct_array = self.as_physical()?;
                 let data_array = struct_array.struct_()?.children[0].list().unwrap();
                 let offsets = data_array.offsets();

--- a/src/daft-core/src/series/ops/log.rs
+++ b/src/daft-core/src/series/ops/log.rs
@@ -1,18 +1,25 @@
 use crate::datatypes::DataType;
+use crate::series::array_impl::IntoSeries;
 use crate::series::Series;
 use common_error::DaftError;
 use common_error::DaftResult;
+
 impl Series {
     pub fn log2(&self) -> DaftResult<Series> {
-        use crate::series::array_impl::IntoSeries;
-        use DataType::*;
         match self.data_type() {
-            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 => {
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64 => {
                 let s = self.cast(&DataType::Float64)?;
                 Ok(s.f64()?.log2()?.into_series())
             }
-            Float32 => Ok(self.f32()?.log2()?.into_series()),
-            Float64 => Ok(self.f64()?.log2()?.into_series()),
+            DataType::Float32 => Ok(self.f32()?.log2()?.into_series()),
+            DataType::Float64 => Ok(self.f64()?.log2()?.into_series()),
             dt => Err(DaftError::TypeError(format!(
                 "log2 not implemented for {}",
                 dt
@@ -21,15 +28,20 @@ impl Series {
     }
 
     pub fn log10(&self) -> DaftResult<Series> {
-        use crate::series::array_impl::IntoSeries;
-        use DataType::*;
         match self.data_type() {
-            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 => {
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64 => {
                 let s = self.cast(&DataType::Float64)?;
                 Ok(s.f64()?.log10()?.into_series())
             }
-            Float32 => Ok(self.f32()?.log10()?.into_series()),
-            Float64 => Ok(self.f64()?.log10()?.into_series()),
+            DataType::Float32 => Ok(self.f32()?.log10()?.into_series()),
+            DataType::Float64 => Ok(self.f64()?.log10()?.into_series()),
             dt => Err(DaftError::TypeError(format!(
                 "log10 not implemented for {}",
                 dt
@@ -38,15 +50,20 @@ impl Series {
     }
 
     pub fn log(&self, base: f64) -> DaftResult<Series> {
-        use crate::series::array_impl::IntoSeries;
-        use DataType::*;
         match self.data_type() {
-            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 => {
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64 => {
                 let s = self.cast(&DataType::Float64)?;
                 Ok(s.f64()?.log(base)?.into_series())
             }
-            Float32 => Ok(self.f32()?.log(base as f32)?.into_series()),
-            Float64 => Ok(self.f64()?.log(base)?.into_series()),
+            DataType::Float32 => Ok(self.f32()?.log(base as f32)?.into_series()),
+            DataType::Float64 => Ok(self.f64()?.log(base)?.into_series()),
             dt => Err(DaftError::TypeError(format!(
                 "log not implemented for {}",
                 dt
@@ -56,14 +73,20 @@ impl Series {
 
     pub fn ln(&self) -> DaftResult<Series> {
         use crate::series::array_impl::IntoSeries;
-        use DataType::*;
         match self.data_type() {
-            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 => {
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64 => {
                 let s = self.cast(&DataType::Float64)?;
                 Ok(s.f64()?.ln()?.into_series())
             }
-            Float32 => Ok(self.f32()?.ln()?.into_series()),
-            Float64 => Ok(self.f64()?.ln()?.into_series()),
+            DataType::Float32 => Ok(self.f32()?.ln()?.into_series()),
+            DataType::Float64 => Ok(self.f64()?.ln()?.into_series()),
             dt => Err(DaftError::TypeError(format!(
                 "ln not implemented for {}",
                 dt

--- a/src/daft-core/src/series/ops/round.rs
+++ b/src/daft-core/src/series/ops/round.rs
@@ -1,16 +1,22 @@
 use crate::datatypes::DataType;
+use crate::series::array_impl::IntoSeries;
 use crate::series::Series;
 use common_error::DaftError;
 use common_error::DaftResult;
 
 impl Series {
     pub fn round(&self, decimal: i32) -> DaftResult<Series> {
-        use crate::series::array_impl::IntoSeries;
-        use DataType::*;
         match self.data_type() {
-            Int8 | Int16 | Int32 | Int64 | UInt8 | UInt16 | UInt32 | UInt64 => Ok(self.clone()),
-            Float32 => Ok(self.f32().unwrap().round(decimal)?.into_series()),
-            Float64 => Ok(self.f64().unwrap().round(decimal)?.into_series()),
+            DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64 => Ok(self.clone()),
+            DataType::Float32 => Ok(self.f32().unwrap().round(decimal)?.into_series()),
+            DataType::Float64 => Ok(self.f64().unwrap().round(decimal)?.into_series()),
             dt => Err(DaftError::TypeError(format!(
                 "round not implemented for {}",
                 dt

--- a/src/daft-core/src/series/ops/sign.rs
+++ b/src/daft-core/src/series/ops/sign.rs
@@ -1,23 +1,22 @@
 use crate::datatypes::DataType;
+use crate::series::array_impl::IntoSeries;
 use crate::series::Series;
 use common_error::DaftError;
 use common_error::DaftResult;
 
 impl Series {
     pub fn sign(&self) -> DaftResult<Series> {
-        use crate::series::array_impl::IntoSeries;
-        use DataType::*;
         match self.data_type() {
-            UInt8 => Ok(self.u8().unwrap().sign_unsigned()?.into_series()),
-            UInt16 => Ok(self.u16().unwrap().sign_unsigned()?.into_series()),
-            UInt32 => Ok(self.u32().unwrap().sign_unsigned()?.into_series()),
-            UInt64 => Ok(self.u64().unwrap().sign_unsigned()?.into_series()),
-            Int8 => Ok(self.i8().unwrap().sign()?.into_series()),
-            Int16 => Ok(self.i16().unwrap().sign()?.into_series()),
-            Int32 => Ok(self.i32().unwrap().sign()?.into_series()),
-            Int64 => Ok(self.i64().unwrap().sign()?.into_series()),
-            Float32 => Ok(self.f32().unwrap().sign()?.into_series()),
-            Float64 => Ok(self.f64().unwrap().sign()?.into_series()),
+            DataType::UInt8 => Ok(self.u8().unwrap().sign_unsigned()?.into_series()),
+            DataType::UInt16 => Ok(self.u16().unwrap().sign_unsigned()?.into_series()),
+            DataType::UInt32 => Ok(self.u32().unwrap().sign_unsigned()?.into_series()),
+            DataType::UInt64 => Ok(self.u64().unwrap().sign_unsigned()?.into_series()),
+            DataType::Int8 => Ok(self.i8().unwrap().sign()?.into_series()),
+            DataType::Int16 => Ok(self.i16().unwrap().sign()?.into_series()),
+            DataType::Int32 => Ok(self.i32().unwrap().sign()?.into_series()),
+            DataType::Int64 => Ok(self.i64().unwrap().sign()?.into_series()),
+            DataType::Float32 => Ok(self.f32().unwrap().sign()?.into_series()),
+            DataType::Float64 => Ok(self.f64().unwrap().sign()?.into_series()),
             dt => Err(DaftError::TypeError(format!(
                 "sign not implemented for {}",
                 dt

--- a/src/daft-core/src/series/serdes.rs
+++ b/src/daft-core/src/series/serdes.rs
@@ -3,17 +3,16 @@ use std::{borrow::Cow, sync::Arc};
 use arrow2::offset::OffsetsBuffer;
 use serde::{de::Visitor, Deserializer};
 
+use crate::datatypes::*;
+
 use crate::{
     array::{
         ops::{as_arrow::AsArrow, full::FullNull},
         ListArray, StructArray,
     },
-    datatypes::{
-        logical::{
-            DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
-            FixedShapeTensorArray, ImageArray, MapArray, TensorArray, TimeArray, TimestampArray,
-        },
-        DataType,
+    datatypes::logical::{
+        DateArray, Decimal128Array, DurationArray, EmbeddingArray, FixedShapeImageArray,
+        FixedShapeTensorArray, ImageArray, MapArray, TensorArray, TimeArray, TimestampArray,
     },
     series::{IntoSeries, Series},
     with_match_daft_types,
@@ -71,92 +70,90 @@ impl<'d> serde::Deserialize<'d> for Series {
                     return Err(serde::de::Error::missing_field("values"));
                 }
                 let field = field.ok_or_else(|| serde::de::Error::missing_field("name"))?;
-                use crate::datatypes::*;
-                use DataType::*;
                 match &field.dtype {
-                    Null => Ok(NullArray::full_null(
+                    DataType::Null => Ok(NullArray::full_null(
                         &field.name,
                         &field.dtype,
                         map.next_value::<usize>()?,
                     )
                     .into_series()),
-                    Boolean => Ok(BooleanArray::from((
+                    DataType::Boolean => Ok(BooleanArray::from((
                         field.name.as_str(),
                         map.next_value::<Vec<Option<bool>>>()?.as_slice(),
                     ))
                     .into_series()),
-                    Int8 => Ok(Int8Array::from_iter(
+                    DataType::Int8 => Ok(Int8Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<i8>>>()?.into_iter(),
                     )
                     .into_series()),
-                    Int16 => Ok(Int16Array::from_iter(
+                    DataType::Int16 => Ok(Int16Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<i16>>>()?.into_iter(),
                     )
                     .into_series()),
-                    Int32 => Ok(Int32Array::from_iter(
+                    DataType::Int32 => Ok(Int32Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<i32>>>()?.into_iter(),
                     )
                     .into_series()),
-                    Int64 => Ok(Int64Array::from_iter(
+                    DataType::Int64 => Ok(Int64Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<i64>>>()?.into_iter(),
                     )
                     .into_series()),
-                    Int128 => Ok(Int128Array::from_iter(
+                    DataType::Int128 => Ok(Int128Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<i128>>>()?.into_iter(),
                     )
                     .into_series()),
-                    UInt8 => Ok(UInt8Array::from_iter(
+                    DataType::UInt8 => Ok(UInt8Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<u8>>>()?.into_iter(),
                     )
                     .into_series()),
-                    UInt16 => Ok(UInt16Array::from_iter(
+                    DataType::UInt16 => Ok(UInt16Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<u16>>>()?.into_iter(),
                     )
                     .into_series()),
-                    UInt32 => Ok(UInt32Array::from_iter(
+                    DataType::UInt32 => Ok(UInt32Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<u32>>>()?.into_iter(),
                     )
                     .into_series()),
-                    UInt64 => Ok(UInt64Array::from_iter(
+                    DataType::UInt64 => Ok(UInt64Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<u64>>>()?.into_iter(),
                     )
                     .into_series()),
-                    Float32 => Ok(Float32Array::from_iter(
+                    DataType::Float32 => Ok(Float32Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<f32>>>()?.into_iter(),
                     )
                     .into_series()),
-                    Float64 => Ok(Float64Array::from_iter(
+                    DataType::Float64 => Ok(Float64Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<f64>>>()?.into_iter(),
                     )
                     .into_series()),
-                    Utf8 => Ok(Utf8Array::from_iter(
+                    DataType::Utf8 => Ok(Utf8Array::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<Cow<str>>>>()?.into_iter(),
                     )
                     .into_series()),
-                    Binary => Ok(BinaryArray::from_iter(
+                    DataType::Binary => Ok(BinaryArray::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<Cow<[u8]>>>>()?.into_iter(),
                     )
                     .into_series()),
-                    FixedSizeBinary(size) => Ok(FixedSizeBinaryArray::from_iter(
+                    DataType::FixedSizeBinary(size) => Ok(FixedSizeBinaryArray::from_iter(
                         field.name.as_str(),
                         map.next_value::<Vec<Option<Cow<[u8]>>>>()?.into_iter(),
                         *size,
                     )
                     .into_series()),
-                    Extension(..) => {
+                    DataType::Extension(..) => {
                         let physical = map.next_value::<Series>()?;
                         let physical = physical.to_arrow();
                         let ext_array = physical.to_type(field.dtype.to_arrow().unwrap());
@@ -164,7 +161,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                             .unwrap()
                             .into_series())
                     }
-                    Map(..) => {
+                    DataType::Map(..) => {
                         let physical = map.next_value::<Series>()?;
                         Ok(MapArray::new(
                             Arc::new(field),
@@ -172,7 +169,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         )
                         .into_series())
                     }
-                    Struct(..) => {
+                    DataType::Struct(..) => {
                         let mut all_series = map.next_value::<Vec<Option<Series>>>()?;
                         let validity = all_series
                             .pop()
@@ -185,7 +182,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         let validity = validity.map(|v| v.bool().unwrap().as_bitmap().clone());
                         Ok(StructArray::new(Arc::new(field), children, validity).into_series())
                     }
-                    List(..) => {
+                    DataType::List(..) => {
                         let mut all_series = map.next_value::<Vec<Option<Series>>>()?;
                         let validity = all_series
                             .pop()
@@ -206,7 +203,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                             .unwrap();
                         Ok(ListArray::new(field, flat_child, offsets, validity).into_series())
                     }
-                    FixedSizeList(..) => {
+                    DataType::FixedSizeList(..) => {
                         let mut all_series = map.next_value::<Vec<Option<Series>>>()?;
                         let validity = all_series
                             .pop()
@@ -219,7 +216,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         let validity = validity.map(|v| v.bool().unwrap().as_bitmap().clone());
                         Ok(FixedSizeListArray::new(field, flat_child, validity).into_series())
                     }
-                    Decimal128(..) => {
+                    DataType::Decimal128(..) => {
                         type PType = <<Decimal128Type as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(Decimal128Array::new(
@@ -228,7 +225,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         )
                         .into_series())
                     }
-                    Timestamp(..) => {
+                    DataType::Timestamp(..) => {
                         type PType = <<TimestampType as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(TimestampArray::new(
@@ -237,7 +234,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         )
                         .into_series())
                     }
-                    Date => {
+                    DataType::Date => {
                         type PType = <<DateType as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(
@@ -245,7 +242,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                                 .into_series(),
                         )
                     }
-                    Time(..) => {
+                    DataType::Time(..) => {
                         type PType = <<TimeType as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(
@@ -253,7 +250,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                                 .into_series(),
                         )
                     }
-                    Duration(..) => {
+                    DataType::Duration(..) => {
                         type PType = <<DurationType as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(
@@ -264,7 +261,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                             .into_series(),
                         )
                     }
-                    Embedding(..) => {
+                    DataType::Embedding(..) => {
                         type PType = <<EmbeddingType as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(EmbeddingArray::new(
@@ -273,7 +270,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         )
                         .into_series())
                     }
-                    Image(..) => {
+                    DataType::Image(..) => {
                         type PType = <<ImageType as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(
@@ -281,7 +278,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                                 .into_series(),
                         )
                     }
-                    FixedShapeImage(..) => {
+                    DataType::FixedShapeImage(..) => {
                         type PType = <<FixedShapeImageType as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(FixedShapeImageArray::new(
@@ -290,7 +287,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         )
                         .into_series())
                     }
-                    FixedShapeTensor(..) => {
+                    DataType::FixedShapeTensor(..) => {
                         type PType = <<FixedShapeTensorType as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(FixedShapeTensorArray::new(
@@ -299,7 +296,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         )
                         .into_series())
                     }
-                    Tensor(..) => {
+                    DataType::Tensor(..) => {
                         type PType = <<TensorType as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType;
                         let physical = map.next_value::<Series>()?;
                         Ok(
@@ -307,10 +304,11 @@ impl<'d> serde::Deserialize<'d> for Series {
                                 .into_series(),
                         )
                     }
-                    Python => {
+                    #[cfg(feature = "python")]
+                    DataType::Python => {
                         panic!("python deserialization not implemented for rust Serde");
                     }
-                    Unknown => {
+                    DataType::Unknown => {
                         panic!("Unable to deserialize Unknown DataType");
                     }
                 }

--- a/src/daft-core/src/utils/supertype.rs
+++ b/src/daft-core/src/utils/supertype.rs
@@ -6,10 +6,9 @@ use common_error::DaftResult;
 // TODO: Deprecate this logic soon!
 
 fn get_time_units(tu_l: &TimeUnit, tu_r: &TimeUnit) -> TimeUnit {
-    use TimeUnit::*;
     match (tu_l, tu_r) {
-        (Nanoseconds, Microseconds) => Microseconds,
-        (_, Milliseconds) => Milliseconds,
+        (TimeUnit::Nanoseconds, TimeUnit::Microseconds) => TimeUnit::Microseconds,
+        (_, TimeUnit::Milliseconds) => TimeUnit::Milliseconds,
         _ => *tu_l,
     }
 }
@@ -25,155 +24,153 @@ pub fn try_get_supertype(l: &DataType, r: &DataType) -> DaftResult<DataType> {
 
 pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
     fn inner(l: &DataType, r: &DataType) -> Option<DataType> {
-        use DataType::*;
-
         if l == r {
             return Some(l.clone());
         }
 
         match (l, r) {
             #[cfg(feature = "python")]
-            // The supertype of anything and Python is Python.
-            (_, Python) => Some(Python),
+            // The supertype of anything and DataType::Python is DataType::Python.
+            (_, DataType::Python) => Some(DataType::Python),
 
-            (Int8, Boolean) => Some(Int8),
-            (Int8, Int16) => Some(Int16),
-            (Int8, Int32) => Some(Int32),
-            (Int8, Int64) => Some(Int64),
-            (Int8, UInt8) => Some(Int16),
-            (Int8, UInt16) => Some(Int32),
-            (Int8, UInt32) => Some(Int64),
-            (Int8, UInt64) => Some(Float64), // Follow numpy
-            (Int8, Float32) => Some(Float32),
-            (Int8, Float64) => Some(Float64),
+            (DataType::Int8, DataType::Boolean) => Some(DataType::Int8),
+            (DataType::Int8, DataType::Int16) => Some(DataType::Int16),
+            (DataType::Int8, DataType::Int32) => Some(DataType::Int32),
+            (DataType::Int8, DataType::Int64) => Some(DataType::Int64),
+            (DataType::Int8, DataType::UInt8) => Some(DataType::Int16),
+            (DataType::Int8, DataType::UInt16) => Some(DataType::Int32),
+            (DataType::Int8, DataType::UInt32) => Some(DataType::Int64),
+            (DataType::Int8, DataType::UInt64) => Some(DataType::Float64), // Follow numpy
+            (DataType::Int8, DataType::Float32) => Some(DataType::Float32),
+            (DataType::Int8, DataType::Float64) => Some(DataType::Float64),
 
-            (Int16, Boolean) => Some(Int16),
-            (Int16, Int8) => Some(Int16),
-            (Int16, Int32) => Some(Int32),
-            (Int16, Int64) => Some(Int64),
-            (Int16, UInt8) => Some(Int16),
-            (Int16, UInt16) => Some(Int32),
-            (Int16, UInt32) => Some(Int64),
-            (Int16, UInt64) => Some(Float64), // Follow numpy
-            (Int16, Float32) => Some(Float32),
-            (Int16, Float64) => Some(Float64),
+            (DataType::Int16, DataType::Boolean) => Some(DataType::Int16),
+            (DataType::Int16, DataType::Int8) => Some(DataType::Int16),
+            (DataType::Int16, DataType::Int32) => Some(DataType::Int32),
+            (DataType::Int16, DataType::Int64) => Some(DataType::Int64),
+            (DataType::Int16, DataType::UInt8) => Some(DataType::Int16),
+            (DataType::Int16, DataType::UInt16) => Some(DataType::Int32),
+            (DataType::Int16, DataType::UInt32) => Some(DataType::Int64),
+            (DataType::Int16, DataType::UInt64) => Some(DataType::Float64), // Follow numpy
+            (DataType::Int16, DataType::Float32) => Some(DataType::Float32),
+            (DataType::Int16, DataType::Float64) => Some(DataType::Float64),
 
-            (Int32, Boolean) => Some(Int32),
-            (Int32, Int8) => Some(Int32),
-            (Int32, Int16) => Some(Int32),
-            (Int32, Int64) => Some(Int64),
-            (Int32, UInt8) => Some(Int32),
-            (Int32, UInt16) => Some(Int32),
-            (Int32, UInt32) => Some(Int64),
-            (Int32, UInt64) => Some(Float64),  // Follow numpy
-            (Int32, Float32) => Some(Float64), // Follow numpy
-            (Int32, Float64) => Some(Float64),
+            (DataType::Int32, DataType::Boolean) => Some(DataType::Int32),
+            (DataType::Int32, DataType::Int8) => Some(DataType::Int32),
+            (DataType::Int32, DataType::Int16) => Some(DataType::Int32),
+            (DataType::Int32, DataType::Int64) => Some(DataType::Int64),
+            (DataType::Int32, DataType::UInt8) => Some(DataType::Int32),
+            (DataType::Int32, DataType::UInt16) => Some(DataType::Int32),
+            (DataType::Int32, DataType::UInt32) => Some(DataType::Int64),
+            (DataType::Int32, DataType::UInt64) => Some(DataType::Float64),  // Follow numpy
+            (DataType::Int32, DataType::Float32) => Some(DataType::Float64), // Follow numpy
+            (DataType::Int32, DataType::Float64) => Some(DataType::Float64),
 
-            (Int64, Boolean) => Some(Int64),
-            (Int64, Int8) => Some(Int64),
-            (Int64, Int16) => Some(Int64),
-            (Int64, Int32) => Some(Int64),
-            (Int64, UInt8) => Some(Int64),
-            (Int64, UInt16) => Some(Int64),
-            (Int64, UInt32) => Some(Int64),
-            (Int64, UInt64) => Some(Float64),  // Follow numpy
-            (Int64, Float32) => Some(Float64), // Follow numpy
-            (Int64, Float64) => Some(Float64),
+            (DataType::Int64, DataType::Boolean) => Some(DataType::Int64),
+            (DataType::Int64, DataType::Int8) => Some(DataType::Int64),
+            (DataType::Int64, DataType::Int16) => Some(DataType::Int64),
+            (DataType::Int64, DataType::Int32) => Some(DataType::Int64),
+            (DataType::Int64, DataType::UInt8) => Some(DataType::Int64),
+            (DataType::Int64, DataType::UInt16) => Some(DataType::Int64),
+            (DataType::Int64, DataType::UInt32) => Some(DataType::Int64),
+            (DataType::Int64, DataType::UInt64) => Some(DataType::Float64),  // Follow numpy
+            (DataType::Int64, DataType::Float32) => Some(DataType::Float64), // Follow numpy
+            (DataType::Int64, DataType::Float64) => Some(DataType::Float64),
 
-            (UInt16, UInt8) => Some(UInt16),
-            (UInt16, UInt32) => Some(UInt32),
-            (UInt16, UInt64) => Some(UInt64),
+            (DataType::UInt16, DataType::UInt8) => Some(DataType::UInt16),
+            (DataType::UInt16, DataType::UInt32) => Some(DataType::UInt32),
+            (DataType::UInt16, DataType::UInt64) => Some(DataType::UInt64),
 
-            (UInt8, UInt32) => Some(UInt32),
-            (UInt8, UInt64) => Some(UInt64),
-            (UInt32, UInt64) => Some(UInt64),
+            (DataType::UInt8, DataType::UInt32) => Some(DataType::UInt32),
+            (DataType::UInt8, DataType::UInt64) => Some(DataType::UInt64),
+            (DataType::UInt32, DataType::UInt64) => Some(DataType::UInt64),
 
-            (Boolean, UInt8) => Some(UInt8),
-            (Boolean, UInt16) => Some(UInt16),
-            (Boolean, UInt32) => Some(UInt32),
-            (Boolean, UInt64) => Some(UInt64),
+            (DataType::Boolean, DataType::UInt8) => Some(DataType::UInt8),
+            (DataType::Boolean, DataType::UInt16) => Some(DataType::UInt16),
+            (DataType::Boolean, DataType::UInt32) => Some(DataType::UInt32),
+            (DataType::Boolean, DataType::UInt64) => Some(DataType::UInt64),
 
-            (Float32, UInt8) => Some(Float32),
-            (Float32, UInt16) => Some(Float32),
-            (Float32, UInt32) => Some(Float64),
-            (Float32, UInt64) => Some(Float64),
+            (DataType::Float32, DataType::UInt8) => Some(DataType::Float32),
+            (DataType::Float32, DataType::UInt16) => Some(DataType::Float32),
+            (DataType::Float32, DataType::UInt32) => Some(DataType::Float64),
+            (DataType::Float32, DataType::UInt64) => Some(DataType::Float64),
 
-            (Float64, UInt8) => Some(Float64),
-            (Float64, UInt16) => Some(Float64),
-            (Float64, UInt32) => Some(Float64),
-            (Float64, UInt64) => Some(Float64),
+            (DataType::Float64, DataType::UInt8) => Some(DataType::Float64),
+            (DataType::Float64, DataType::UInt16) => Some(DataType::Float64),
+            (DataType::Float64, DataType::UInt32) => Some(DataType::Float64),
+            (DataType::Float64, DataType::UInt64) => Some(DataType::Float64),
 
-            (Float64, Float32) => Some(Float64),
+            (DataType::Float64, DataType::Float32) => Some(DataType::Float64),
 
-            (Date, UInt8) => Some(Int64),
-            (Date, UInt16) => Some(Int64),
-            (Date, UInt32) => Some(Int64),
-            (Date, UInt64) => Some(Int64),
-            (Date, Int8) => Some(Int32),
-            (Date, Int16) => Some(Int32),
-            (Date, Int32) => Some(Int32),
-            (Date, Int64) => Some(Int64),
-            (Date, Float32) => Some(Float32),
-            (Date, Float64) => Some(Float64),
-            (Date, Timestamp(tu, tz)) => Some(Timestamp(*tu, tz.clone())),
+            (DataType::Date, DataType::UInt8) => Some(DataType::Int64),
+            (DataType::Date, DataType::UInt16) => Some(DataType::Int64),
+            (DataType::Date, DataType::UInt32) => Some(DataType::Int64),
+            (DataType::Date, DataType::UInt64) => Some(DataType::Int64),
+            (DataType::Date, DataType::Int8) => Some(DataType::Int32),
+            (DataType::Date, DataType::Int16) => Some(DataType::Int32),
+            (DataType::Date, DataType::Int32) => Some(DataType::Int32),
+            (DataType::Date, DataType::Int64) => Some(DataType::Int64),
+            (DataType::Date, DataType::Float32) => Some(DataType::Float32),
+            (DataType::Date, DataType::Float64) => Some(DataType::Float64),
+            (DataType::Date, DataType::Timestamp(tu, tz)) => Some(DataType::Timestamp(*tu, tz.clone())),
 
-            (Timestamp(_, _), UInt32) => Some(Int64),
-            (Timestamp(_, _), UInt64) => Some(Int64),
-            (Timestamp(_, _), Int32) => Some(Int64),
-            (Timestamp(_, _), Int64) => Some(Int64),
-            (Timestamp(_, _), Float32) => Some(Float64),
-            (Timestamp(_, _), Float64) => Some(Float64),
-            (Timestamp(tu, tz), Date) => Some(Timestamp(*tu, tz.clone())),
+            (DataType::Timestamp(_, _), DataType::UInt32) => Some(DataType::Int64),
+            (DataType::Timestamp(_, _), DataType::UInt64) => Some(DataType::Int64),
+            (DataType::Timestamp(_, _), DataType::Int32) => Some(DataType::Int64),
+            (DataType::Timestamp(_, _), DataType::Int64) => Some(DataType::Int64),
+            (DataType::Timestamp(_, _), DataType::Float32) => Some(DataType::Float64),
+            (DataType::Timestamp(_, _), DataType::Float64) => Some(DataType::Float64),
+            (DataType::Timestamp(tu, tz), DataType::Date) => Some(DataType::Timestamp(*tu, tz.clone())),
 
-            (Duration(_), UInt32) => Some(Int64),
-            (Duration(_), UInt64) => Some(Int64),
-            (Duration(_), Int32) => Some(Int64),
-            (Duration(_), Int64) => Some(Int64),
-            (Duration(_), Float32) => Some(Float64),
-            (Duration(_), Float64) => Some(Float64),
+            (DataType::Duration(_), DataType::UInt32) => Some(DataType::Int64),
+            (DataType::Duration(_), DataType::UInt64) => Some(DataType::Int64),
+            (DataType::Duration(_), DataType::Int32) => Some(DataType::Int64),
+            (DataType::Duration(_), DataType::Int64) => Some(DataType::Int64),
+            (DataType::Duration(_), DataType::Float32) => Some(DataType::Float64),
+            (DataType::Duration(_), DataType::Float64) => Some(DataType::Float64),
 
-            (Time(_), Int32) => Some(Int64),
-            (Time(_), Int64) => Some(Int64),
-            (Time(_), Float32) => Some(Float64),
-            (Time(_), Float64) => Some(Float64),
+            (DataType::Time(_), DataType::Int32) => Some(DataType::Int64),
+            (DataType::Time(_), DataType::Int64) => Some(DataType::Int64),
+            (DataType::Time(_), DataType::Float32) => Some(DataType::Float64),
+            (DataType::Time(_), DataType::Float64) => Some(DataType::Float64),
 
-            (Duration(lu), Timestamp(ru, Some(tz))) | (Timestamp(lu, Some(tz)), Duration(ru)) => {
+            (DataType::Duration(lu), DataType::Timestamp(ru, Some(tz))) | (DataType::Timestamp(lu, Some(tz)), DataType::Duration(ru)) => {
                 if tz.is_empty() {
-                    Some(Timestamp(get_time_units(lu, ru), None))
+                    Some(DataType::Timestamp(get_time_units(lu, ru), None))
                 } else {
-                    Some(Timestamp(get_time_units(lu, ru), Some(tz.clone())))
+                    Some(DataType::Timestamp(get_time_units(lu, ru), Some(tz.clone())))
                 }
             }
-            (Duration(lu), Timestamp(ru, None)) | (Timestamp(lu, None), Duration(ru)) => {
-                Some(Timestamp(get_time_units(lu, ru), None))
+            (DataType::Duration(lu), DataType::Timestamp(ru, None)) | (DataType::Timestamp(lu, None), DataType::Duration(ru)) => {
+                Some(DataType::Timestamp(get_time_units(lu, ru), None))
             }
-            (Duration(_), Date) | (Date, Duration(_)) => Some(Date),
-            (Duration(lu), Duration(ru)) => Some(Duration(get_time_units(lu, ru))),
+            (DataType::Duration(_), DataType::Date) | (DataType::Date, DataType::Duration(_)) => Some(DataType::Date),
+            (DataType::Duration(lu), DataType::Duration(ru)) => Some(DataType::Duration(get_time_units(lu, ru))),
 
             // Some() timezones that are non equal
             // we cast from more precision to higher precision as that always fits with occasional loss of precision
-            (Timestamp(tu_l, Some(tz_l)), Timestamp(tu_r, Some(tz_r)))
+            (DataType::Timestamp(tu_l, Some(tz_l)), DataType::Timestamp(tu_r, Some(tz_r)))
                 if !tz_l.is_empty()
                     && !tz_r.is_empty() && tz_l != tz_r =>
             {
                 let tu = get_time_units(tu_l, tu_r);
-                Some(Timestamp(tu, Some("UTC".to_string())))
+                Some(DataType::Timestamp(tu, Some("UTC".to_string())))
             }
             // None and Some("<tz>") timezones
             // we cast from more precision to higher precision as that always fits with occasional loss of precision
-            (Timestamp(tu_l, tz_l), Timestamp(tu_r, tz_r)) if
+            (DataType::Timestamp(tu_l, tz_l), DataType::Timestamp(tu_r, tz_r)) if
                 // both are none
                 tz_l.is_none() && tz_r.is_none()
                 // both have the same time zone
                 || (tz_l.is_some() && (tz_l == tz_r)) => {
                 let tu = get_time_units(tu_l, tu_r);
-                Some(Timestamp(tu, tz_r.clone()))
+                Some(DataType::Timestamp(tu, tz_r.clone()))
             }
 
             //TODO(sammy): add time, struct related dtypes
-            (Boolean, Float32) => Some(Float32),
-            (Boolean, Float64) => Some(Float64),
-            (List(inner_left_dtype), List(inner_right_dtype)) => {
+            (DataType::Boolean, DataType::Float32) => Some(DataType::Float32),
+            (DataType::Boolean, DataType::Float64) => Some(DataType::Float64),
+            (DataType::List(inner_left_dtype), DataType::List(inner_right_dtype)) => {
                 let inner_st = get_supertype(inner_left_dtype.as_ref(), inner_right_dtype.as_ref())?;
                 Some(DataType::List(Box::new(inner_st)))
             }
@@ -194,17 +191,14 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
             // }
 
             // every known type can be casted to a string except binary
-            (dt, Utf8) if !matches!(&dt, &Binary | &FixedSizeBinary(_)) => Some(Utf8),
-            (dt, Null) => Some(dt.clone()), // Drop Null Type
+            (dt, DataType::Utf8) if !matches!(&dt, &DataType::Binary | &DataType::FixedSizeBinary(_)) => Some(DataType::Utf8),
+            (dt, DataType::Null) => Some(dt.clone()), // Drop DataType::Null Type
 
 
             _ => None,
         }
     }
-    match inner(l, r) {
-        Some(dt) => Some(dt),
-        None => inner(r, l),
-    }
+    inner(l, r).or_else(|| inner(r, l))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Overview
- removed all instances of `use MyEnum::*;` from `daft-core`
- using that pattern has a huge chance of hard-to-catch bugs being created in the future