### PR TITLE
[CHORE] Decouple Ray tensor types from main Daft logic

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -11,30 +11,6 @@ from daft.daft import ImageMode, PyDataType, PyTimeUnit
 if TYPE_CHECKING:
     import numpy as np
 
-_RAY_DATA_EXTENSIONS_AVAILABLE = True
-_TENSOR_EXTENSION_TYPES = []
-try:
-    import ray
-except ImportError:
-    _RAY_DATA_EXTENSIONS_AVAILABLE = False
-else:
-    _RAY_VERSION = tuple(int(s) for s in ray.__version__.split(".")[0:3])
-    try:
-        # Variable-shaped tensor column support was added in Ray 2.1.0.
-        if _RAY_VERSION >= (2, 2, 0):
-            from ray.data.extensions import (
-                ArrowTensorType,
-                ArrowVariableShapedTensorType,
-            )
-
-            _TENSOR_EXTENSION_TYPES = [ArrowTensorType, ArrowVariableShapedTensorType]
-        else:
-            from ray.data.extensions import ArrowTensorType
-
-            _TENSOR_EXTENSION_TYPES = [ArrowTensorType]
-    except ImportError:
-        _RAY_DATA_EXTENSIONS_AVAILABLE = False
-
 
 class TimeUnit:
     _timeunit: PyTimeUnit
@@ -412,10 +388,6 @@ class DataType:
                 key_type=cls.from_arrow_type(arrow_type.key_type),
                 value_type=cls.from_arrow_type(arrow_type.item_type),
             )
-        elif _RAY_DATA_EXTENSIONS_AVAILABLE and isinstance(arrow_type, tuple(_TENSOR_EXTENSION_TYPES)):
-            scalar_dtype = cls.from_arrow_type(arrow_type.scalar_type)
-            shape = arrow_type.shape if isinstance(arrow_type, ArrowTensorType) else None
-            return cls.tensor(scalar_dtype, shape)
         elif isinstance(arrow_type, getattr(pa, "FixedShapeTensorType", ())):
             scalar_dtype = cls.from_arrow_type(arrow_type.value_type)
             return cls.tensor(scalar_dtype, tuple(arrow_type.shape))

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -202,7 +202,8 @@ def _micropartition_from_arrow_with_ray_data_extensions(arrow_table: pa.Table) -
         or dt._is_fixed_shape_tensor_type()
     ]
     if non_native_fields:
-        # If there are any contained Arrow types that are not natively supported, go through Table.from_pydict() path.
+        # If there are any contained Arrow types that are not natively supported, convert each
+        # series while checking for ray data extension types.
         logger.debug("Unsupported Arrow types detected for columns: %s", non_native_fields)
         series_dict = dict()
         for name, column in zip(arrow_table.column_names, arrow_table.columns):

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -179,6 +179,9 @@ def _series_from_arrow_with_ray_data_extensions(
     array: pa.Array | pa.ChunkedArray, name: str = "arrow_series"
 ) -> Series:
     if isinstance(array, pa.Array):
+        # TODO(desmond): This might be dead code since `ArrayTensorType`s are `numpy.ndarray` under
+        # the hood and are not instances of `pyarrow.Array`. Should follow up and check if this code
+        # can be removed.
         array = ensure_array(array)
         if _RAY_DATA_EXTENSIONS_AVAILABLE and isinstance(array.type, ArrowTensorType):
             storage_series = _series_from_arrow_with_ray_data_extensions(array.storage, name=name)


### PR DESCRIPTION
Prior to this PR, Ray data extension tensor types are handled in Daft's importing logic from Arrow. This PR moves this logic to Ray runner code when creating a partition set from a Ray dataset.