### PR TITLE
[FEAT] [SQL] rename anonymous compound expressions in SQL plan

### DIFF
--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -453,7 +453,13 @@ impl SQLPlanner {
                 let alias = alias.value.to_string();
                 Ok(vec![expr.alias(alias)])
             }
-            SelectItem::UnnamedExpr(expr) => self.plan_expr(expr).map(|e| vec![e]),
+            SelectItem::UnnamedExpr(expr) => {
+                let expr = self.plan_expr(expr)?;
+                match *expr {
+                    Expr::Column(..) => Ok(vec![expr]),
+                    _ => Ok(vec![expr.alias(expr.to_string())]),
+                }
+            }
             SelectItem::Wildcard(WildcardAdditionalOptions {
                 opt_ilike,
                 opt_exclude,

--- a/tests/sql/test_sql.py
+++ b/tests/sql/test_sql.py
@@ -93,16 +93,26 @@ def test_fizzbuzz_sql():
         ("to_date(date_col, 'YYYY-MM-DD')", daft.col("date_col").str.to_date("YYYY-MM-DD")),
     ],
 )
-def test_sql_expr(actual, expected):
+def test_sql_expr_anon(actual, expected):
     actual = daft.sql_expr(actual)
     # Non plain-column-select expressions will be aliased with the representation
     expected = expected.alias(repr(expected))
     assert repr(actual) == repr(expected)
 
 
-def test_sql_expr_plain_col():
-    # Plain-column-select expressions are NOT aliased (in dataframe they will retain their original name)
-    assert repr(daft.sql_expr("n")) == "col(n)"
+@pytest.mark.parametrize(
+    "actual,expected",
+    [
+        # Plain-column-select expressions are NOT aliased (in dataframe they
+        # will retain their original name)
+        ("n", daft.col("n")),
+        ("abs(n) AS abs_n", daft.col("n").abs().alias("abs_n")),
+        ("n + 1 AS n_plus_1", (daft.col("n") + 1).alias("n_plus_1")),
+    ],
+)
+def test_sql_expr_plain_or_aliased(actual, expected):
+    actual = daft.sql_expr(actual)
+    assert repr(actual) == repr(expected)
 
 
 def test_sql_global_agg():

--- a/tests/sql/test_sql.py
+++ b/tests/sql/test_sql.py
@@ -95,7 +95,14 @@ def test_fizzbuzz_sql():
 )
 def test_sql_expr(actual, expected):
     actual = daft.sql_expr(actual)
+    # Non plain-column-select expressions will be aliased with the representation
+    expected = expected.alias(repr(expected))
     assert repr(actual) == repr(expected)
+
+
+def test_sql_expr_plain_col():
+    # Plain-column-select expressions are NOT aliased (in dataframe they will retain their original name)
+    assert repr(daft.sql_expr("n")) == "col(n)"
 
 
 def test_sql_global_agg():
@@ -112,4 +119,4 @@ def test_sql_groupby_agg():
     df = daft.from_pydict({"n": [1, 1, 2, 2], "v": [1, 2, 3, 4]})
     catalog = SQLCatalog({"test": df})
     df = daft.sql("SELECT sum(v) FROM test GROUP BY n ORDER BY n", catalog=catalog)
-    assert df.collect().to_pydict() == {"n": [1, 2], "v": [3, 7]}
+    assert df.collect().to_pydict() == {"n": [1, 2], "sum(col(v))": [3, 7]}


### PR DESCRIPTION
This renames columns of unaliased expressions that are not simple column selections in a manner similar to the way duckdb does. For example, `max(n)` becomes `max(col(n))`, `max(n+1)` becomes `max(col(n) + lit(1))`. This now allows multiple distinct expressions on the same column, whereas previously they would be named after the column and conflict. 