### PR TITLE
[FEAT]: Dataframe.filter method

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1317,7 +1317,7 @@ class DataFrame:
         Alias for daft.DataFrame.where.
 
         .. seealso::
-            :meth: `.where(predicate) <DataFrame.where>`
+            :meth:`.where(predicate) <DataFrame.where>`
 
         Args:
             predicate (Expression): expression that keeps row if evaluates to True.

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1311,6 +1311,21 @@ class DataFrame:
         return DataFrame(builder)
 
     @DataframePublicAPI
+    def filter(self, predicate: Union[Expression, str]) -> "DataFrame":
+        """Filters rows via a predicate expression, similar to SQL ``WHERE``.
+
+        Alias for DataFrame.where.
+        See DataFrame.where for more information.
+
+        Args:
+            predicate (Expression): expression that keeps row if evaluates to True.
+
+        Returns:
+            DataFrame: Filtered DataFrame.
+        """
+        return self.where(predicate)
+
+    @DataframePublicAPI
     def where(self, predicate: Union[Expression, str]) -> "DataFrame":
         """Filters rows via a predicate expression, similar to SQL ``WHERE``.
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1314,8 +1314,10 @@ class DataFrame:
     def filter(self, predicate: Union[Expression, str]) -> "DataFrame":
         """Filters rows via a predicate expression, similar to SQL ``WHERE``.
 
-        Alias for DataFrame.where.
-        See DataFrame.where for more information.
+        Alias for daft.DataFrame.where.
+
+        .. seealso::
+            :meth: `.where(predicate) <DataFrame.where>`
 
         Args:
             predicate (Expression): expression that keeps row if evaluates to True.

--- a/docs/source/api_docs/dataframe.rst
+++ b/docs/source/api_docs/dataframe.rst
@@ -58,6 +58,7 @@ Filtering Rows
     :toctree: doc_gen/dataframe_methods
 
     DataFrame.distinct
+    DataFrame.filter
     DataFrame.where
     DataFrame.limit
     DataFrame.sample

--- a/tests/dataframe/test_filter.py
+++ b/tests/dataframe/test_filter.py
@@ -41,3 +41,12 @@ def test_filter_sql() -> None:
     expected = {"x": [3], "y": [6], "z": [9]}
 
     assert df == expected
+
+
+def test_filter_alias_for_where() -> None:
+    df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6], "z": [7, 9, 9]})
+
+    expected = df.where("z = 9 AND y > 5").collect().to_pydict()
+    actual = df.filter("z = 9 AND y > 5").collect().to_pydict()
+
+    assert actual == expected


### PR DESCRIPTION
closes https://github.com/Eventual-Inc/Daft/issues/2846

Note, this does not rename 'where' to 'filter' but instead just adds an alias. We can revisit at a later date if we want to deprecate the `where` method. 