### PR TITLE
[CHORE] Add native executor to CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -221,10 +221,6 @@ jobs:
       matrix:
         python-version: ['3.8']
         daft-runner: [py, ray]
-        enable-native-executor: [0, 1]
-        exclude:
-        - daft-runner: ray
-          enable-native-executor: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -267,7 +263,6 @@ jobs:
         pytest tests/integration/test_tpch.py --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
 
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
@@ -301,10 +296,6 @@ jobs:
       matrix:
         python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
-        enable-native-executor: [0, 1]
-        exclude:
-        - daft-runner: ray
-          enable-native-executor: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -349,7 +340,6 @@ jobs:
         pytest tests/io -m 'integration' --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
       if: ${{ failure() && (github.ref == 'refs/heads/main') }}
@@ -384,10 +374,6 @@ jobs:
       matrix:
         python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
-        enable-native-executor: [0, 1]
-        exclude:
-        - daft-runner: ray
-          enable-native-executor: 1
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     # This is used in the step "Assume GitHub Actions AWS Credentials"
     permissions:
@@ -450,7 +436,6 @@ jobs:
         pytest tests/integration/io -m 'integration and not benchmark' --credentials --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
       if: ${{ failure() }}
@@ -483,10 +468,6 @@ jobs:
       matrix:
         python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
-        enable-native-executor: [0, 1]
-        exclude:
-        - daft-runner: ray
-          enable-native-executor: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -532,7 +513,6 @@ jobs:
         pytest tests/integration/iceberg -m 'integration' --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
       if: ${{ failure() && (github.ref == 'refs/heads/main') }}
@@ -565,10 +545,6 @@ jobs:
       matrix:
         python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
-        enable-native-executor: [0, 1]
-        exclude:
-        - daft-runner: ray
-          enable-native-executor: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -607,7 +583,6 @@ jobs:
         pytest tests/integration/sql -m 'integration or not integration' --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
       if: ${{ failure() && (github.ref == 'refs/heads/main') }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,8 +27,11 @@ jobs:
         python-version: ['3.8', '3.10']
         daft-runner: [py, ray]
         pyarrow-version: [7.0.0, 16.0.0]
+        enable-native-executor: [0, 1]
         os: [ubuntu-20.04, windows-latest]
         exclude:
+        - daft-runner: ray
+          enable-native-executor: 1
         - daft-runner: ray
           pyarrow-version: 7.0.0
           os: ubuntu-20.04
@@ -115,6 +118,7 @@ jobs:
         CARGO_TARGET_DIR: ./target
 
         DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
 
     - name: Build library and Test with pytest (Windows)
       if: ${{ (runner.os == 'Windows') }}
@@ -217,6 +221,10 @@ jobs:
       matrix:
         python-version: ['3.8']
         daft-runner: [py, ray]
+        enable-native-executor: [0, 1]
+        exclude:
+        - daft-runner: ray
+          enable-native-executor: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -259,6 +267,7 @@ jobs:
         pytest tests/integration/test_tpch.py --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
 
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
@@ -292,6 +301,10 @@ jobs:
       matrix:
         python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
+        enable-native-executor: [0, 1]
+        exclude:
+        - daft-runner: ray
+          enable-native-executor: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -336,6 +349,7 @@ jobs:
         pytest tests/io -m 'integration' --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
       if: ${{ failure() && (github.ref == 'refs/heads/main') }}
@@ -370,6 +384,10 @@ jobs:
       matrix:
         python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
+        enable-native-executor: [0, 1]
+        exclude:
+        - daft-runner: ray
+          enable-native-executor: 1
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     # This is used in the step "Assume GitHub Actions AWS Credentials"
     permissions:
@@ -432,6 +450,7 @@ jobs:
         pytest tests/integration/io -m 'integration and not benchmark' --credentials --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
       if: ${{ failure() }}
@@ -464,6 +483,10 @@ jobs:
       matrix:
         python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
+        enable-native-executor: [0, 1]
+        exclude:
+        - daft-runner: ray
+          enable-native-executor: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -509,6 +532,7 @@ jobs:
         pytest tests/integration/iceberg -m 'integration' --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
       if: ${{ failure() && (github.ref == 'refs/heads/main') }}
@@ -541,6 +565,10 @@ jobs:
       matrix:
         python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray]
+        enable-native-executor: [0, 1]
+        exclude:
+        - daft-runner: ray
+          enable-native-executor: 1
     steps:
     - uses: actions/checkout@v4
       with:
@@ -579,6 +607,7 @@ jobs:
         pytest tests/integration/sql -m 'integration or not integration' --durations=50
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_ENABLE_NATIVE_EXECUTOR: ${{ matrix.enable-native-executor }}
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v1.26.0
       if: ${{ failure() && (github.ref == 'refs/heads/main') }}

--- a/tests/cookbook/test_aggregations.py
+++ b/tests/cookbook/test_aggregations.py
@@ -6,10 +6,16 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from daft import context
 from daft.datatype import DataType
 from daft.expressions import col
 from daft.udf import udf
 from tests.conftest import assert_df_equals
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 def test_sum(daft_df, service_requests_csv_pd_df, repartition_nparts):

--- a/tests/cookbook/test_joins.py
+++ b/tests/cookbook/test_joins.py
@@ -2,8 +2,14 @@ from __future__ import annotations
 
 import pytest
 
+from daft import context
 from daft.expressions import col
 from tests.conftest import assert_df_equals
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/cookbook/test_pandas_cookbook.py
+++ b/tests/cookbook/test_pandas_cookbook.py
@@ -7,10 +7,15 @@ import pandas as pd
 import pytest
 
 import daft
+from daft import context
 from daft.datatype import DataType
 from daft.expressions import col, lit
 from tests.conftest import assert_df_equals
 
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 ###
 # Idioms: if-then
 ###

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -7,9 +7,14 @@ import pytest
 from pyarrow import dataset as pads
 
 import daft
+from daft import context
 from tests.conftest import assert_df_equals
 from tests.cookbook.assets import COOKBOOK_DATA_CSV
 
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 PYARROW_GE_7_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (7, 0, 0)
 
 

--- a/tests/dataframe/test_aggregations.py
+++ b/tests/dataframe/test_aggregations.py
@@ -7,12 +7,17 @@ import pyarrow as pa
 import pytest
 
 import daft
-from daft import col
+from daft import col, context
 from daft.context import get_context
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
 from daft.utils import freeze
 from tests.utils import sort_arrow_table
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])

--- a/tests/dataframe/test_approx_count_distinct.py
+++ b/tests/dataframe/test_approx_count_distinct.py
@@ -2,7 +2,12 @@ import pandas as pd
 import pytest
 
 import daft
-from daft import col
+from daft import col, context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 TESTS = [
     [[], 0],

--- a/tests/dataframe/test_approx_percentiles_aggregations.py
+++ b/tests/dataframe/test_approx_percentiles_aggregations.py
@@ -4,7 +4,12 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 
-from daft import col
+from daft import col, context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])

--- a/tests/dataframe/test_concat.py
+++ b/tests/dataframe/test_concat.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import pytest
 
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
+
 
 def test_simple_concat(make_df):
     df1 = make_df({"foo": [1, 2, 3]})

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -15,11 +15,17 @@ import pyarrow.parquet as papq
 import pytest
 
 import daft
+from daft import context
 from daft.api_annotations import APITypeError
 from daft.dataframe import DataFrame
 from daft.datatype import DataType
 from daft.utils import pyarrow_supports_fixed_shape_tensor
 from tests.conftest import UuidType
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
 

--- a/tests/dataframe/test_decimals.py
+++ b/tests/dataframe/test_decimals.py
@@ -7,6 +7,12 @@ import pyarrow as pa
 import pytest
 
 import daft
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 PYARROW_GE_7_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (7, 0, 0)
 

--- a/tests/dataframe/test_distinct.py
+++ b/tests/dataframe/test_distinct.py
@@ -3,8 +3,14 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
+from daft import context
 from daft.datatype import DataType
 from tests.utils import sort_arrow_table
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 5])

--- a/tests/dataframe/test_explode.py
+++ b/tests/dataframe/test_explode.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
+from daft import context
 from daft.expressions import col
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import pytest
 
 import daft
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 class MockException(Exception):

--- a/tests/dataframe/test_joins.py
+++ b/tests/dataframe/test_joins.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
-from daft import col
+from daft import col, context
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
 from tests.utils import sort_arrow_table
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 def skip_invalid_join_strategies(join_strategy, join_type):

--- a/tests/dataframe/test_map_groups.py
+++ b/tests/dataframe/test_map_groups.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import pytest
 
 import daft
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 4])

--- a/tests/dataframe/test_monotonically_increasing_id.py
+++ b/tests/dataframe/test_monotonically_increasing_id.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import pytest
 
+from daft import context
 from daft.datatype import DataType
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 def test_monotonically_increasing_id_single_partition(make_df) -> None:

--- a/tests/dataframe/test_pivot.py
+++ b/tests/dataframe/test_pivot.py
@@ -1,5 +1,12 @@
 import pytest
 
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
+
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 5])
 def test_pivot(make_df, repartition_nparts):

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -8,7 +8,13 @@ import pytest
 from PIL import Image
 
 import daft
+from daft import context
 from tests.utils import ANSI_ESCAPE, TD_STYLE, TH_STYLE
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 ROW_DIVIDER_REGEX = re.compile(r"╭─+┬*─*╮|├╌+┼*╌+┤")
 SHOWING_N_ROWS_REGEX = re.compile(r".*\(Showing first (\d+) of (\d+) rows\).*")

--- a/tests/dataframe/test_sample.py
+++ b/tests/dataframe/test_sample.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import pytest
 
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
+
 
 def test_sample_fraction(make_df, valid_data: list[dict[str, float]]) -> None:
     df = make_df(valid_data)

--- a/tests/dataframe/test_sort.py
+++ b/tests/dataframe/test_sort.py
@@ -5,9 +5,14 @@ import math
 import pyarrow as pa
 import pytest
 
+from daft import context
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
 
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 ###
 # Validation tests
 ###

--- a/tests/dataframe/test_temporals.py
+++ b/tests/dataframe/test_temporals.py
@@ -9,7 +9,12 @@ import pytest
 import pytz
 
 import daft
-from daft import DataType, col
+from daft import DataType, col, context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 PYARROW_GE_7_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (7, 0, 0)
 

--- a/tests/dataframe/test_transform.py
+++ b/tests/dataframe/test_transform.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 import pytest
 
 import daft
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 def add_1(df):

--- a/tests/dataframe/test_unpivot.py
+++ b/tests/dataframe/test_unpivot.py
@@ -1,7 +1,12 @@
 import pytest
 
-from daft import col
+from daft import col, context
 from daft.datatype import DataType
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.mark.parametrize("n_partitions", [1, 2, 4])

--- a/tests/dataframe/test_wildcard.py
+++ b/tests/dataframe/test_wildcard.py
@@ -1,8 +1,13 @@
 import pytest
 
 import daft
-from daft import col
+from daft import col, context
 from daft.exceptions import DaftCoreException
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 def test_wildcard_select():

--- a/tests/integration/iceberg/conftest.py
+++ b/tests/integration/iceberg/conftest.py
@@ -9,12 +9,6 @@ pyiceberg = pytest.importorskip("pyiceberg")
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
 pytestmark = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="iceberg writes only supported if pyarrow >= 8.0.0")
-from daft import context
-
-pytestmark = pytest.mark.skipif(
-    context.get_context().daft_execution_config.enable_native_executor is True,
-    reason="Native executor fails for these tests",
-)
 
 import tenacity
 from pyiceberg.catalog import Catalog, load_catalog

--- a/tests/integration/iceberg/conftest.py
+++ b/tests/integration/iceberg/conftest.py
@@ -9,7 +9,12 @@ pyiceberg = pytest.importorskip("pyiceberg")
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
 pytestmark = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="iceberg writes only supported if pyarrow >= 8.0.0")
+from daft import context
 
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 import tenacity
 from pyiceberg.catalog import Catalog, load_catalog

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -8,9 +8,15 @@ from pyarrow import parquet as pq
 
 import daft
 import daft.table
+from daft import context
 from daft.exceptions import ConnectTimeoutError, ReadTimeoutError
 from daft.filesystem import get_filesystem, get_protocol_from_path
 from daft.table import MicroPartition, Table
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 def get_filesystem_from_path(path: str, **kwargs) -> fsspec.AbstractFileSystem:

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -8,15 +8,9 @@ from pyarrow import parquet as pq
 
 import daft
 import daft.table
-from daft import context
 from daft.exceptions import ConnectTimeoutError, ReadTimeoutError
 from daft.filesystem import get_filesystem, get_protocol_from_path
 from daft.table import MicroPartition, Table
-
-pytestmark = pytest.mark.skipif(
-    context.get_context().daft_execution_config.enable_native_executor is True,
-    reason="Native executor fails for these tests",
-)
 
 
 def get_filesystem_from_path(path: str, **kwargs) -> fsspec.AbstractFileSystem:

--- a/tests/integration/io/test_write_files_s3_minio.py
+++ b/tests/integration/io/test_write_files_s3_minio.py
@@ -6,6 +6,12 @@ import pytest
 import s3fs
 
 import daft
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/io/test_write_files_s3_minio.py
+++ b/tests/integration/io/test_write_files_s3_minio.py
@@ -6,12 +6,6 @@ import pytest
 import s3fs
 
 import daft
-from daft import context
-
-pytestmark = pytest.mark.skipif(
-    context.get_context().daft_execution_config.enable_native_executor is True,
-    reason="Native executor fails for these tests",
-)
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/sql/conftest.py
+++ b/tests/integration/sql/conftest.py
@@ -22,6 +22,12 @@ from sqlalchemy import (
     text,
 )
 
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 URLS = [
     "trino://user@localhost:8080/memory/default",
     "postgresql://username:password@localhost:5432/postgres",

--- a/tests/integration/sql/conftest.py
+++ b/tests/integration/sql/conftest.py
@@ -22,12 +22,6 @@ from sqlalchemy import (
     text,
 )
 
-from daft import context
-
-pytestmark = pytest.mark.skipif(
-    context.get_context().daft_execution_config.enable_native_executor is True,
-    reason="Native executor fails for these tests",
-)
 URLS = [
     "trino://user@localhost:8080/memory/default",
     "postgresql://username:password@localhost:5432/postgres",

--- a/tests/io/delta_lake/conftest.py
+++ b/tests/io/delta_lake/conftest.py
@@ -18,9 +18,14 @@ from azure.storage.blob import BlobServiceClient
 from pytest_lazyfixture import lazy_fixture
 
 import daft
-from daft import DataCatalogTable, DataCatalogType
+from daft import DataCatalogTable, DataCatalogType, context
 from daft.io.object_store_options import io_config_to_storage_options
 from tests.io.mock_aws_server import start_service, stop_process
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.fixture(params=[1, 2, 8])

--- a/tests/io/delta_lake/conftest.py
+++ b/tests/io/delta_lake/conftest.py
@@ -18,14 +18,9 @@ from azure.storage.blob import BlobServiceClient
 from pytest_lazyfixture import lazy_fixture
 
 import daft
-from daft import DataCatalogTable, DataCatalogType, context
+from daft import DataCatalogTable, DataCatalogType
 from daft.io.object_store_options import io_config_to_storage_options
 from tests.io.mock_aws_server import start_service, stop_process
-
-pytestmark = pytest.mark.skipif(
-    context.get_context().daft_execution_config.enable_native_executor is True,
-    reason="Native executor fails for these tests",
-)
 
 
 @pytest.fixture(params=[1, 2, 8])
@@ -40,9 +35,15 @@ def num_partitions(request) -> int:
         pytest.param((lambda i: i * 1.5, "b"), id="float_partitioned"),
         pytest.param((lambda i: f"foo_{i}", "c"), id="string_partitioned"),
         pytest.param((lambda i: f"foo_{i}".encode(), "d"), id="string_partitioned"),
-        pytest.param((lambda i: datetime.datetime(2024, 2, i + 1), "f"), id="timestamp_partitioned"),
+        pytest.param(
+            (lambda i: datetime.datetime(2024, 2, i + 1), "f"),
+            id="timestamp_partitioned",
+        ),
         pytest.param((lambda i: datetime.date(2024, 2, i + 1), "g"), id="date_partitioned"),
-        pytest.param((lambda i: decimal.Decimal(str(1000 + i) + ".567"), "h"), id="decimal_partitioned"),
+        pytest.param(
+            (lambda i: decimal.Decimal(str(1000 + i) + ".567"), "h"),
+            id="decimal_partitioned",
+        ),
         pytest.param((lambda i: i if i % 2 == 0 else None, "a"), id="partitioned_with_nulls"),
     ]
 )
@@ -59,10 +60,22 @@ def base_table() -> pa.Table:
             "c": ["foo", "bar", "baz"],
             "d": [b"foo", b"bar", b"baz"],
             "e": [True, False, True],
-            "f": [datetime.datetime(2024, 2, 10), datetime.datetime(2024, 2, 11), datetime.datetime(2024, 2, 12)],
-            "g": [datetime.date(2024, 2, 10), datetime.date(2024, 2, 11), datetime.date(2024, 2, 12)],
+            "f": [
+                datetime.datetime(2024, 2, 10),
+                datetime.datetime(2024, 2, 11),
+                datetime.datetime(2024, 2, 12),
+            ],
+            "g": [
+                datetime.date(2024, 2, 10),
+                datetime.date(2024, 2, 11),
+                datetime.date(2024, 2, 12),
+            ],
             "h": pa.array(
-                [decimal.Decimal("1234.567"), decimal.Decimal("1233.456"), decimal.Decimal("1232.345")],
+                [
+                    decimal.Decimal("1234.567"),
+                    decimal.Decimal("1233.456"),
+                    decimal.Decimal("1232.345"),
+                ],
                 type=pa.decimal128(7, 3),
             ),
             "i": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
@@ -287,7 +300,11 @@ def s3_uri(tmp_path: pathlib.Path, data_dir: str) -> str:
     ],
 )
 def s3_path(
-    request, s3_uri: str, aws_server: str, aws_credentials: dict[str, str], reset_aws: None
+    request,
+    s3_uri: str,
+    aws_server: str,
+    aws_credentials: dict[str, str],
+    reset_aws: None,
 ) -> tuple[str, daft.io.IOConfig, DataCatalogTable | None]:
     s3 = boto3.resource(
         "s3",
@@ -422,13 +439,18 @@ def local_path(tmp_path: pathlib.Path, data_dir: str) -> tuple[str, None, None]:
         pytest.param(lazy_fixture("az_path"), marks=(pytest.mark.az, pytest.mark.integration)),
     ],
 )
-def cloud_paths(request) -> tuple[str, daft.io.IOConfig | None, DataCatalogTable | None]:
+def cloud_paths(
+    request,
+) -> tuple[str, daft.io.IOConfig | None, DataCatalogTable | None]:
     return request.param
 
 
 @pytest.fixture(scope="function")
 def deltalake_table(
-    cloud_paths, base_table: pa.Table, num_partitions: int, partition_generator: callable
+    cloud_paths,
+    base_table: pa.Table,
+    num_partitions: int,
+    partition_generator: callable,
 ) -> tuple[str, daft.io.IOConfig | None, dict[str, str], list[pa.Table]]:
     partition_generator, col = partition_generator
     path, io_config, catalog_table = cloud_paths

--- a/tests/io/delta_lake/test_table_write.py
+++ b/tests/io/delta_lake/test_table_write.py
@@ -6,14 +6,26 @@ import pyarrow as pa
 import pytest
 
 import daft
+from daft import context
 from daft.io.object_store_options import io_config_to_storage_options
 from daft.logical.schema import Schema
 
-PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-PYTHON_LT_3_8 = sys.version_info[:2] < (3, 8)
-pytestmark = pytest.mark.skipif(
-    PYARROW_LE_8_0_0 or PYTHON_LT_3_8, reason="deltalake only supported if pyarrow >= 8.0.0 and python >= 3.8"
+native_excutor_skip = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
 )
+
+PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (
+    8,
+    0,
+    0,
+)
+PYTHON_LT_3_8 = sys.version_info[:2] < (3, 8)
+py_version_or_arrow_skip = pytest.mark.skipif(
+    PYARROW_LE_8_0_0 or PYTHON_LT_3_8,
+    reason="deltalake only supported if pyarrow >= 8.0.0 and python >= 3.8",
+)
+pytestmark = [native_excutor_skip, py_version_or_arrow_skip]
 
 
 def test_deltalake_write_basic(tmp_path, base_table):

--- a/tests/io/iceberg/test_iceberg_writes.py
+++ b/tests/io/iceberg/test_iceberg_writes.py
@@ -5,7 +5,7 @@ import pytest
 
 from daft import context
 
-pytestmark = pytest.mark.skipif(
+native_excutor_skip = pytest.mark.skipif(
     context.get_context().daft_execution_config.enable_native_executor is True,
     reason="Native executor fails for these tests",
 )
@@ -13,7 +13,8 @@ pytestmark = pytest.mark.skipif(
 pyiceberg = pytest.importorskip("pyiceberg")
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-pytestmark = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="iceberg only supported if pyarrow >= 8.0.0")
+py_arrow_skip = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="iceberg only supported if pyarrow >= 8.0.0")
+pytestmark = [native_excutor_skip, py_arrow_skip]
 
 
 from pyiceberg.catalog.sql import SqlCatalog

--- a/tests/io/iceberg/test_iceberg_writes.py
+++ b/tests/io/iceberg/test_iceberg_writes.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 import pyarrow as pa
 import pytest
 
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
+
 pyiceberg = pytest.importorskip("pyiceberg")
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)

--- a/tests/io/lancedb/test_lancedb_reads.py
+++ b/tests/io/lancedb/test_lancedb_reads.py
@@ -5,7 +5,7 @@ import pytest
 import daft
 from daft import context
 
-pytestmark = pytest.mark.skipif(
+native_executor_skip = pytest.mark.skipif(
     context.get_context().daft_execution_config.enable_native_executor is True,
     reason="Native executor fails for these tests",
 )
@@ -18,7 +18,8 @@ data = {
 }
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-pytestmark = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="lance only supported if pyarrow >= 8.0.0")
+py_arrow_skip = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="lance only supported if pyarrow >= 8.0.0")
+pytestmark = [native_executor_skip, py_arrow_skip]
 
 
 @pytest.fixture(scope="function")

--- a/tests/io/lancedb/test_lancedb_reads.py
+++ b/tests/io/lancedb/test_lancedb_reads.py
@@ -3,6 +3,12 @@ import pyarrow as pa
 import pytest
 
 import daft
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 TABLE_NAME = "my_table"
 data = {

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -4,6 +4,12 @@ import pyarrow as pa
 import pytest
 
 import daft
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 TABLE_NAME = "my_table"
 data = {

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -6,7 +6,7 @@ import pytest
 import daft
 from daft import context
 
-pytestmark = pytest.mark.skipif(
+native_executor_skip = pytest.mark.skipif(
     context.get_context().daft_execution_config.enable_native_executor is True,
     reason="Native executor fails for these tests",
 )
@@ -20,9 +20,10 @@ data = {
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
 PY_LE_3_9_0 = sys.version_info < (3, 9)
-pytestmark = pytest.mark.skipif(
+py_version_and_arrow_skip = pytest.mark.skipif(
     PYARROW_LE_8_0_0 or PY_LE_3_9_0, reason="lance only supported if pyarrow >= 8.0.0 and python >= 3.9.0"
 )
+pytestmark = [native_executor_skip, py_version_and_arrow_skip]
 
 
 @pytest.fixture(scope="function")

--- a/tests/io/test_csv_roundtrip.py
+++ b/tests/io/test_csv_roundtrip.py
@@ -7,8 +7,12 @@ import pyarrow as pa
 import pytest
 
 import daft
-from daft import DataType, TimeUnit
+from daft import DataType, TimeUnit, context
 
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 PYARROW_GE_11_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (11, 0, 0)
 
 

--- a/tests/io/test_parquet.py
+++ b/tests/io/test_parquet.py
@@ -12,6 +12,7 @@ import pyarrow.parquet as papq
 import pytest
 
 import daft
+from daft import context
 from daft.daft import NativeStorageConfig, PythonStorageConfig, StorageConfig
 from daft.datatype import DataType, TimeUnit
 from daft.expressions import col
@@ -20,6 +21,10 @@ from daft.table import MicroPartition
 
 from ..integration.io.conftest import minio_create_bucket
 
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 PYARROW_GE_11_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (11, 0, 0)
 PYARROW_GE_13_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (13, 0, 0)
 

--- a/tests/io/test_parquet_roundtrip.py
+++ b/tests/io/test_parquet_roundtrip.py
@@ -12,6 +12,13 @@ from daft import DataType, Series, TimeUnit
 
 PYARROW_GE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (8, 0, 0)
 
+from daft import context
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
+
 
 @pytest.mark.skipif(
     not PYARROW_GE_8_0_0,

--- a/tests/io/test_s3_credentials_refresh.py
+++ b/tests/io/test_s3_credentials_refresh.py
@@ -10,7 +10,13 @@ import boto3
 import pytest
 
 import daft
+from daft import context
 from tests.io.mock_aws_server import start_service, stop_process
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -7,11 +7,16 @@ import pytest
 import ray
 
 import daft
-from daft import udf
+from daft import context, udf
 from daft.context import get_context
 from daft.daft import SystemInfo
 from daft.expressions import col
 from daft.internal.gpu import cuda_device_count
+
+pytestmark = pytest.mark.skipif(
+    context.get_context().daft_execution_config.enable_native_executor is True,
+    reason="Native executor fails for these tests",
+)
 
 
 def no_gpu_available() -> bool:


### PR DESCRIPTION
Enables native executor in CI (just unit tests for now). Any tests that fail because the native executor doesn't support it yet is marked as skip. The skips will be incrementally removed as functionality gets added.