### PR TITLE
[BUG] Fix partitioning SQL scans on empty tables

### DIFF
--- a/daft/sql/sql_scan.py
+++ b/daft/sql/sql_scan.py
@@ -71,6 +71,8 @@ class SQLScanOperator(ScanOperator):
 
     def to_scan_tasks(self, pushdowns: Pushdowns) -> Iterator[ScanTask]:
         total_rows, total_size, num_scan_tasks = self._get_size_estimates()
+        if num_scan_tasks == 0:
+            return iter(())
         if num_scan_tasks == 1 or self._partition_col is None:
             return self._single_scan_task(pushdowns, total_rows, total_size)
 
@@ -136,6 +138,7 @@ class SQLScanOperator(ScanOperator):
             if self._num_partitions is None
             else self._num_partitions
         )
+        num_scan_tasks = min(num_scan_tasks, total_rows)
         return total_rows, total_size, num_scan_tasks
 
     def _get_num_rows(self) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,7 @@ def assert_df_equals(
         sort_key_list: list[str] = [sort_key] if isinstance(sort_key, str) else sort_key
         for key in sort_key_list:
             assert key in daft_pd_df.columns, (
-                f"DaFt Dataframe missing key: {key}\nNOTE: This doesn't necessarily mean your code is "
+                f"Daft Dataframe missing key: {key}\nNOTE: This doesn't necessarily mean your code is "
                 "breaking, but our testing utilities require sorting on this key in order to compare your "
                 "Dataframe against the expected Pandas Dataframe."
             )


### PR DESCRIPTION
When scanning an empty SQL table, if a user specifies `num_partitions > 1`, then we get `TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'` or `Failed to get partition bounds: {self._partition_col} is not a numeric or temporal type, and cannot be used for partitioning`.

These are both results of attempts to partition the scan using a column with no data. Despite the table not having rows, we attempt to fulfill the user's request to use `num_partitions > 2`, only to run into errors because there is no min and max value available compute partition range sizes on.

Furthermore, in some cases SQL databases do not return type information when a table has no rows, so an empty integer column might be read as an empty string column which cannot be used for partitioning.

We fix this by capping the number of scan tasks by the number of rows in the scan table. If there are no rows, we don't attempt partitioning, and we simply generate 0 scan tasks.