### PR TITLE
[BUG] improve error reporting for multistatement sql

### DIFF
--- a/tests/sql/test_sql.py
+++ b/tests/sql/test_sql.py
@@ -199,3 +199,9 @@ def test_sql_function_raises_when_cant_get_frame(monkeypatch):
     monkeypatch.setattr("inspect.currentframe", lambda: None)
     with pytest.raises(DaftCoreException, match="Cannot get caller environment"):
         daft.sql("SELECT * FROM df")
+
+
+def test_sql_multi_statement_sql_error():
+    catalog = SQLCatalog({})
+    with pytest.raises(Exception, match="one SQL statement allowed"):
+        daft.sql("SELECT * FROM df; SELECT * FROM df", catalog)


### PR DESCRIPTION
Called it a bug because the error is confusing, this fixes error behavior of multistatement sql. Before:

```py
daft.sql('''SELECT * FROM df; SELECT count(*) FROM df''', cat)
```

results in this error:
```py
daft.exceptions.InvalidSQLException: Unsupported SQL: 'SELECT * FROM df'
```

but of course that SQL is supported! With this change, error becomes:

```py
daft.exceptions.InvalidSQLException: Unsupported SQL: 'Only exactly one SQL statement allowed, found 2'
```

which I believe is at least currently correct, and any future support of multiple statements would have to touch this area of code anyway.