### PR TITLE
[BUG] Pass parquet2 io errors correctly into arrow2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,7 +1324,6 @@ name = "common-error"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow2",
- "parquet2",
  "pyo3",
  "regex",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,6 +1324,7 @@ name = "common-error"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow2",
+ "parquet2",
  "pyo3",
  "regex",
  "serde_json",

--- a/src/arrow2/src/io/parquet/mod.rs
+++ b/src/arrow2/src/io/parquet/mod.rs
@@ -22,6 +22,9 @@ impl From<parquet2::error::Error> for Error {
             parquet2::error::Error::Transport(msg) => {
                 Error::Io(std::io::Error::new(std::io::ErrorKind::Other, msg))
             }
+            parquet2::error::Error::IoError(msg) => {
+                Error::Io(std::io::Error::new(std::io::ErrorKind::Other, msg))
+            }
             _ => Error::ExternalFormat(error.to_string()),
         }
     }

--- a/src/common/error/Cargo.toml
+++ b/src/common/error/Cargo.toml
@@ -5,6 +5,9 @@ regex = {workspace = true}
 serde_json = {workspace = true}
 thiserror = {workspace = true}
 
+[dev-dependencies]
+parquet2 = {workspace = true}
+
 [features]
 python = ["dep:pyo3"]
 

--- a/src/common/error/Cargo.toml
+++ b/src/common/error/Cargo.toml
@@ -1,6 +1,5 @@
 [dependencies]
-arrow2 = {workspace = true}
-parquet2 = {workspace = true}
+arrow2 = {workspace = true, features = ["io_parquet"]}
 pyo3 = {workspace = true, optional = true}
 regex = {workspace = true}
 serde_json = {workspace = true}

--- a/src/common/error/Cargo.toml
+++ b/src/common/error/Cargo.toml
@@ -1,5 +1,6 @@
 [dependencies]
 arrow2 = {workspace = true}
+parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 regex = {workspace = true}
 serde_json = {workspace = true}

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -58,7 +58,6 @@ impl From<arrow2::error::Error> for DaftError {
 }
 
 #[cfg(test)]
-#[cfg(feature = "io_parquet")]
 mod tests {
     use std::io::ErrorKind;
 

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -14,7 +14,7 @@ pub enum DaftError {
     #[error("DaftError::ComputeError {0}")]
     ComputeError(String),
     #[error("DaftError::ArrowError {0}")]
-    ArrowError(#[from] arrow2::error::Error),
+    ArrowError(String),
     #[error("DaftError::ValueError {0}")]
     ValueError(String),
     #[cfg(feature = "python")]
@@ -46,4 +46,13 @@ pub enum DaftError {
     FmtError(#[from] std::fmt::Error),
     #[error("DaftError::RegexError {0}")]
     RegexError(#[from] regex::Error),
+}
+
+impl From<arrow2::error::Error> for DaftError {
+    fn from(error: arrow2::error::Error) -> Self {
+        match error {
+            arrow2::error::Error::Io(_) => Self::ByteStreamError(error.into()),
+            _ => Self::ArrowError(error.to_string()),
+        }
+    }
 }

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -58,6 +58,7 @@ impl From<arrow2::error::Error> for DaftError {
 }
 
 #[cfg(test)]
+#[cfg(feature = "io_parquet")]
 mod tests {
     use std::io::ErrorKind;
 


### PR DESCRIPTION
In https://github.com/Eventual-Inc/Daft/commit/7fe3dbceb3ca3ee0c555753f0a55bd7e0c57bba6, two changes were made that caused parquet2 io errors to be mishandled.

Firstly, a `IoError` for parquet2 was introduced.  However in the implementation of `parquet2::error::Error` for `arrow2::error:Error`, any parquet2 error that is not `FeatureNotActive` or `Transport` is transformed into an `ExternalFormat` error.

Secondly, arrow2 IO errors are intended to be marked as `ByteStreamError`s, primarily so that they are handled as transient errors and can be retried appropriately. However this special case was removed.

This PR makes now classifies parquet2 io errors as arrow2 io errors, and arrow2 io errors are now marked as `ByteStreeamError`s.

