### PR TITLE
[BUG] Fix reading of logical types from Parquet files in s3

### DIFF
--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -733,10 +733,9 @@ impl ParquetFileReader {
             })?
             .into_iter()
             .collect::<DaftResult<Vec<_>>>()?;
-        let daft_schema = daft_core::prelude::Schema::try_from(self.arrow_schema.as_ref())?;
 
         Table::new_with_size(
-            daft_schema,
+            Schema::new(all_series.iter().map(|s| s.field().clone()).collect())?,
             all_series,
             self.row_ranges.as_ref().iter().map(|rr| rr.num_rows).sum(),
         )


### PR DESCRIPTION
* The inferred schema from a Parquet file includes logical types
* However, when reading Series from the Parquet file, we read the "arrow types" from the Parquet schema
* This causes the Table to crap itself because the schemas don't match (we try to pass in the inferred schema with logical types but it doesn't match the Series types which are inferred from arrow types on the Parquet file)