### PR TITLE
[BUG] Register super extension on to_arrow

### DIFF
--- a/daft/logical/schema.py
+++ b/daft/logical/schema.py
@@ -8,7 +8,7 @@ from daft.daft import PySchema as _PySchema
 from daft.daft import read_csv_schema as _read_csv_schema
 from daft.daft import read_json_schema as _read_json_schema
 from daft.daft import read_parquet_schema as _read_parquet_schema
-from daft.datatype import DataType, TimeUnit
+from daft.datatype import DataType, TimeUnit, _ensure_registered_super_ext_type
 
 if TYPE_CHECKING:
     import pyarrow as pa
@@ -82,6 +82,7 @@ class Schema:
         Returns:
             pa.Schema: PyArrow schema that corresponds to the provided Daft schema
         """
+        _ensure_registered_super_ext_type()
         return self._schema.to_pyarrow_schema()
 
     @classmethod

--- a/daft/series.py
+++ b/daft/series.py
@@ -76,7 +76,7 @@ class Series:
                 falling back to Python type representation, or ``"force"`` the data to only
                 have a Python type representation. Default is ``"allow"``.
         """
-        _ensure_registered_super_ext_type()
+
         if not isinstance(data, list):
             raise TypeError(f"expected a python list, got {type(data)}")
 
@@ -213,6 +213,8 @@ class Series:
         """
         Convert this Series to an pyarrow array.
         """
+        _ensure_registered_super_ext_type()
+
         dtype = self.datatype()
         arrow_arr = self._series.to_arrow()
 

--- a/daft/series.py
+++ b/daft/series.py
@@ -76,7 +76,7 @@ class Series:
                 falling back to Python type representation, or ``"force"`` the data to only
                 have a Python type representation. Default is ``"allow"``.
         """
-
+        _ensure_registered_super_ext_type()
         if not isinstance(data, list):
             raise TypeError(f"expected a python list, got {type(data)}")
 


### PR DESCRIPTION
This is an issue where Daft Extension types were not getting converted to PyArrow properly. @jaychia discovered this while trying to write parquet with a tensor column, where the Extension metadata for tensor was getting dropped. 

A simple test to reproduce the error: 
```
import daft
import numpy as np
from daft import Series

# Create sample tensor data with some null values
tensor_data = [np.array([[1, 2], [3, 4]]), None, None]

# Uncomment this and it will work
# from daft.datatype import _ensure_registered_super_ext_type 
# _ensure_registered_super_ext_type()

df_original = daft.from_pydict({"tensor_col": Series.from_pylist(tensor_data)})
print(df_original.to_arrow().schema)
```


Output:
```
tensor_col: struct<data: large_list<item: int64>, shape: large_list<item: uint64>>
  child 0, data: large_list<item: int64>
      child 0, item: int64
  child 1, shape: large_list<item: uint64>
      child 0, item: uint64
```
It's not a tensor type! However if you uncomment the `_ensure_registered_super_ext_type()`, you will now see:
```
tensor_col: extension<daft.super_extension<DaftExtension>>
```


The issue here is that the `class DaftExtension(pa.ExtensionType):` is not imported during the FFI, as it is now a lazy import that must be called via `_ensure_registered_super_ext_type()`. 

This PR adds calls to this import in `to_arrow` for series and schema. However, I do not know if this is exhaustive, and I will give this more thought. @desmondcheongzx @samster25 