### PR TITLE
[BUG] Autodetect AWS region during deltalake scan

### DIFF
--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -46,10 +46,13 @@ class DeltaLakeScanOperator(ScanOperator):
         if scheme == "s3" or scheme == "s3a":
             # Try to get region from boto3
             if deltalake_sdk_io_config.s3.region_name is None:
+                from botocore.exceptions import BotoCoreError
+
                 try:
                     client = boto3_client_from_s3_config("s3", deltalake_sdk_io_config.s3)
                     response = client.get_bucket_location(Bucket=urlparse(table_uri).netloc)
-                except Exception:
+                except BotoCoreError:
+                    # If bucket location request fails, ignore error because S3 config may be correctly populated later from environment
                     pass
                 else:
                     deltalake_sdk_io_config = deltalake_sdk_io_config.replace(

--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -49,11 +49,12 @@ class DeltaLakeScanOperator(ScanOperator):
                 try:
                     client = boto3_client_from_s3_config("s3", deltalake_sdk_io_config.s3)
                     response = client.get_bucket_location(Bucket=urlparse(table_uri).netloc)
+                except Exception:
+                    pass
+                else:
                     deltalake_sdk_io_config = deltalake_sdk_io_config.replace(
                         s3=deltalake_sdk_io_config.s3.replace(region_name=response["LocationConstraint"])
                     )
-                except Exception:
-                    pass
 
             # Try to get config from the environment
             if any([deltalake_sdk_io_config.s3.key_id is None, deltalake_sdk_io_config.s3.region_name is None]):

--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -51,9 +51,11 @@ class DeltaLakeScanOperator(ScanOperator):
                 try:
                     client = boto3_client_from_s3_config("s3", deltalake_sdk_io_config.s3)
                     response = client.get_bucket_location(Bucket=urlparse(table_uri).netloc)
-                except BotoCoreError:
-                    # If bucket location request fails, ignore error because S3 config may be correctly populated later from environment
-                    pass
+                except BotoCoreError as e:
+                    logger.warning(
+                        "Failed to get the S3 bucket region using existing storage config, will attempt to get it from the environment instead. Error from boto3: %s",
+                        e,
+                    )
                 else:
                     deltalake_sdk_io_config = deltalake_sdk_io_config.replace(
                         s3=deltalake_sdk_io_config.s3.replace(region_name=response["LocationConstraint"])

--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -82,7 +82,6 @@ class DeltaLakeScanOperator(ScanOperator):
                                 region_name=s3_config_from_env.region_name,
                             )
                         )
-
         elif scheme == "gcs" or scheme == "gs":
             # TO-DO: Handle any key-value replacements in `io_config` if there are missing elements
             pass

--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -46,11 +46,14 @@ class DeltaLakeScanOperator(ScanOperator):
         if scheme == "s3" or scheme == "s3a":
             # Try to get region from boto3
             if deltalake_sdk_io_config.s3.region_name is None:
-                client = boto3_client_from_s3_config("s3", deltalake_sdk_io_config.s3)
-                response = client.get_bucket_location(Bucket=urlparse(table_uri).netloc)
-                deltalake_sdk_io_config = deltalake_sdk_io_config.replace(
-                    s3=deltalake_sdk_io_config.s3.replace(region_name=response["LocationConstraint"])
-                )
+                try:
+                    client = boto3_client_from_s3_config("s3", deltalake_sdk_io_config.s3)
+                    response = client.get_bucket_location(Bucket=urlparse(table_uri).netloc)
+                    deltalake_sdk_io_config = deltalake_sdk_io_config.replace(
+                        s3=deltalake_sdk_io_config.s3.replace(region_name=response["LocationConstraint"])
+                    )
+                except Exception:
+                    pass
 
             # Try to get config from the environment
             if any([deltalake_sdk_io_config.s3.key_id is None, deltalake_sdk_io_config.s3.region_name is None]):

--- a/daft/io/aws_config.py
+++ b/daft/io/aws_config.py
@@ -1,0 +1,21 @@
+from typing import TYPE_CHECKING
+
+from daft.daft import S3Config
+
+if TYPE_CHECKING:
+    import boto3
+
+
+def boto3_client_from_s3_config(service: str, s3_config: S3Config) -> "boto3.client":
+    import boto3
+
+    return boto3.client(
+        service,
+        region_name=s3_config.region_name,
+        use_ssl=s3_config.use_ssl,
+        verify=s3_config.verify_ssl,
+        endpoint_url=s3_config.endpoint_url,
+        aws_access_key_id=s3_config.key_id,
+        aws_secret_access_key=s3_config.access_key,
+        aws_session_token=s3_config.session_token,
+    )

--- a/daft/io/catalog.py
+++ b/daft/io/catalog.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import Optional
 
 from daft.daft import IOConfig
+from daft.io.aws_config import boto3_client_from_s3_config
 
 
 class DataCatalogType(Enum):
@@ -42,20 +43,8 @@ class DataCatalogTable:
         """
         if self.catalog == DataCatalogType.GLUE:
             # Use boto3 to get the table from AWS Glue Data Catalog.
-            import boto3
+            glue = boto3_client_from_s3_config("glue", io_config.s3)
 
-            s3_config = io_config.s3
-
-            glue = boto3.client(
-                "glue",
-                region_name=s3_config.region_name,
-                use_ssl=s3_config.use_ssl,
-                verify=s3_config.verify_ssl,
-                endpoint_url=s3_config.endpoint_url,
-                aws_access_key_id=s3_config.key_id,
-                aws_secret_access_key=s3_config.access_key,
-                aws_session_token=s3_config.session_token,
-            )
             if self.catalog_id is not None:
                 # Allow cross account access, table.catalog_id should be the target account id
                 glue_table = glue.get_table(


### PR DESCRIPTION
We do this already when we read from S3, but delta-rs does not, so their metadata reads fail. This is especially an issue for unity catalog tables, where the region is not specified anywhere.

Tested locally, it works but I'm unsure how I would test this in unit tests since this is sort of unity+aws behavior specific

Fix for #2903