### PR TITLE
[FEAT] Add tracing for runner

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1819,6 +1819,7 @@ class PyDaftExecutionConfig:
         enable_aqe: bool | None = None,
         enable_native_executor: bool | None = None,
         default_morsel_size: int | None = None,
+        enable_ray_tracing: bool | None = None,
     ) -> PyDaftExecutionConfig: ...
     @property
     def scan_tasks_min_size_bytes(self) -> int: ...
@@ -1854,6 +1855,8 @@ class PyDaftExecutionConfig:
     def enable_native_executor(self) -> bool: ...
     @property
     def default_morsel_size(self) -> int: ...
+    @property
+    def enable_ray_tracing(self) -> bool: ...
 
 class PyDaftPlanningConfig:
     @staticmethod

--- a/daft/runners/ray_metrics.py
+++ b/daft/runners/ray_metrics.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import dataclasses
+import logging
+import threading
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+try:
+    import ray
+except ImportError:
+    logger.error(
+        "Error when importing Ray. Please ensure that getdaft was installed with the Ray extras tag: getdaft[ray] (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
+    )
+    raise
+
+METRICS_ACTOR_NAME = "metrics"
+METRICS_ACTOR_NAMESPACE = "daft"
+
+
+@dataclasses.dataclass(frozen=True)
+class TaskEvent:
+    task_id: str
+
+
+@dataclasses.dataclass(frozen=True)
+class StartTaskEvent(TaskEvent):
+    """Marks the start of a task, along with available metadata"""
+
+    # Start Unix timestamp
+    start: float
+
+    # What stage this task belongs to
+    stage_id: int
+
+    # Index of the node
+    node_idx: int
+
+    # Index of the worker within the node (not monotonically increasing)
+    worker_idx: int
+
+    # The resources that Ray assigned to this task
+    ray_assigned_resources: dict
+    ray_task_id: str
+
+
+@dataclasses.dataclass(frozen=True)
+class EndTaskEvent(TaskEvent):
+    """Marks the end of a task, along with available metadata"""
+
+    # End Unix timestamp
+    end: float
+
+
+class _NodeInfo:
+    """Information about nodes and their workers"""
+
+    def __init__(self):
+        self.node_to_workers = {}
+        self.node_idxs = {}
+        self.worker_idxs = {}
+
+    def get_node_and_worker_idx(self, node_id: str, worker_id: str) -> tuple[int, int]:
+        """Returns a node and worker index for the provided IDs"""
+        # Truncate to save space
+        node_id = node_id[:8]
+        worker_id = worker_id[:8]
+
+        if node_id not in self.node_to_workers:
+            self.node_to_workers[node_id] = []
+            self.node_idxs[node_id] = len(self.node_idxs)
+        node_idx = self.node_idxs[node_id]
+
+        if worker_id not in self.worker_idxs:
+            self.worker_idxs[worker_id] = len(self.worker_idxs)
+            self.node_to_workers[node_id].append(worker_id)
+        worker_idx = self.worker_idxs[worker_id]
+
+        return node_idx, worker_idx
+
+    def collect_node_info(self) -> dict[str, list[str]]:
+        """Returns a dictionary of {node_id: [worker_ids...]}"""
+        return self.node_to_workers.copy()
+
+
+@ray.remote(num_cpus=0)
+class _MetricsActor:
+    def __init__(self):
+        self._task_events: dict[str, list[TaskEvent]] = defaultdict(lambda: [])
+        self._node_info: dict[str, _NodeInfo] = defaultdict(lambda: _NodeInfo())
+
+    def ready(self):
+        """Returns when the metrics actor is ready"""
+        # Discussion on how to check if an actor is ready: https://github.com/ray-project/ray/issues/14923
+        return None
+
+    def mark_task_start(
+        self,
+        execution_id: str,
+        task_id: str,
+        start: float,
+        node_id: str,
+        worker_id: str,
+        stage_id: int,
+        ray_assigned_resources: dict,
+        ray_task_id: str,
+    ):
+        """Records a task start event"""
+        # Update node info
+        node_idx, worker_idx = self._node_info[execution_id].get_node_and_worker_idx(node_id, worker_id)
+
+        # Add a StartTaskEvent
+        self._task_events[execution_id].append(
+            StartTaskEvent(
+                task_id=task_id,
+                stage_id=stage_id,
+                start=start,
+                node_idx=node_idx,
+                worker_idx=worker_idx,
+                ray_assigned_resources=ray_assigned_resources,
+                ray_task_id=ray_task_id,
+            )
+        )
+
+    def mark_task_end(self, execution_id: str, task_id: str, end: float):
+        # Add an EndTaskEvent
+        self._task_events[execution_id].append(EndTaskEvent(task_id=task_id, end=end))
+
+    def get_task_events(self, execution_id: str, idx: int) -> tuple[list[TaskEvent], int]:
+        events = self._task_events[execution_id]
+        return (events[idx:], len(events))
+
+    def collect_and_close(self, execution_id: str) -> dict[str, list[str]]:
+        """Collect the metrics associated with this execution, cleaning up the memory used for this execution ID"""
+        # Data about the available nodes and worker IDs in those nodes
+        node_data = self._node_info[execution_id].collect_node_info()
+
+        # Clean up the stats for this execution
+        del self._task_events[execution_id]
+        del self._node_info[execution_id]
+
+        return node_data
+
+
+@dataclasses.dataclass(frozen=True)
+class MetricsActorHandle:
+    execution_id: str
+    actor: ray.actor.ActorHandle
+
+    def wait(self) -> None:
+        """Call to block until the underlying actor is ready"""
+        return ray.get(self.actor.ready.remote())
+
+    def mark_task_start(
+        self,
+        task_id: str,
+        start: float,
+        node_id: str,
+        worker_id: str,
+        stage_id: int,
+        ray_assigned_resources: dict,
+        ray_task_id: str,
+    ) -> None:
+        self.actor.mark_task_start.remote(
+            self.execution_id,
+            task_id,
+            start,
+            node_id,
+            worker_id,
+            stage_id,
+            ray_assigned_resources,
+            ray_task_id,
+        )
+
+    def mark_task_end(
+        self,
+        task_id: str,
+        end: float,
+    ) -> None:
+        self.actor.mark_task_end.remote(
+            self.execution_id,
+            task_id,
+            end,
+        )
+
+    def get_task_events(self, idx: int) -> tuple[list[TaskEvent], int]:
+        """Collect task metrics from a given logical event index
+
+        Returns the task metrics and the new logical event index (to be used as a pagination offset token on subsequent requests)
+        """
+        return ray.get(self.actor.get_task_events.remote(self.execution_id, idx))
+
+    def collect_and_close(self) -> dict[str, set[str]]:
+        """Collect node metrics and close the metrics actor for this execution"""
+        return ray.get(self.actor.collect_and_close.remote(self.execution_id))
+
+
+# Creating/getting an actor from multiple threads is not safe.
+#
+# This could be a problem because our Scheduler does multithreaded executions of plans if multiple
+# plans are submitted at once.
+#
+# Pattern from Ray Data's _StatsActor:
+# https://github.com/ray-project/ray/blob/0b1d0d8f01599796e1109060821583e270048b6e/python/ray/data/_internal/stats.py#L447-L449
+_metrics_actor_lock: threading.RLock = threading.RLock()
+
+
+def get_metrics_actor(execution_id: str) -> MetricsActorHandle:
+    """Retrieves a handle to the Actor for a given job_id"""
+    with _metrics_actor_lock:
+        actor = _MetricsActor.options(  # type: ignore[attr-defined]
+            name="daft_metrics_actor",
+            namespace=METRICS_ACTOR_NAMESPACE,
+            get_if_exists=True,
+            lifetime="detached",
+        ).remote()
+        return MetricsActorHandle(execution_id, actor)

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -492,7 +492,7 @@ def single_partition_pipeline(
 ) -> list[list[PartitionMetadata] | MicroPartition]:
     with execution_config_ctx(
         config=daft_execution_config,
-    ), ray_tracing.collect_ray_task_metrics(job_id, task_id, stage_id):
+    ), ray_tracing.collect_ray_task_metrics(job_id, task_id, stage_id, daft_execution_config):
         return build_partitions(instruction_stack, partial_metadatas, *inputs)
 
 
@@ -508,7 +508,7 @@ def fanout_pipeline(
     *inputs: MicroPartition,
 ) -> list[list[PartitionMetadata] | MicroPartition]:
     with execution_config_ctx(config=daft_execution_config), ray_tracing.collect_ray_task_metrics(
-        job_id, task_id, stage_id
+        job_id, task_id, stage_id, daft_execution_config
     ):
         return build_partitions(instruction_stack, partial_metadatas, *inputs)
 
@@ -527,7 +527,7 @@ def reduce_pipeline(
     import ray
 
     with execution_config_ctx(config=daft_execution_config), ray_tracing.collect_ray_task_metrics(
-        job_id, task_id, stage_id
+        job_id, task_id, stage_id, daft_execution_config
     ):
         return build_partitions(instruction_stack, partial_metadatas, *ray.get(inputs))
 
@@ -546,7 +546,7 @@ def reduce_and_fanout(
     import ray
 
     with execution_config_ctx(config=daft_execution_config), ray_tracing.collect_ray_task_metrics(
-        job_id, task_id, stage_id
+        job_id, task_id, stage_id, daft_execution_config
     ):
         return build_partitions(instruction_stack, partial_metadatas, *ray.get(inputs))
 
@@ -853,7 +853,7 @@ class Scheduler(ActorPoolManager):
             f"{datetime.replace(datetime.now(), second=0, microsecond=0).isoformat()[:-3]}.json"
         )
 
-        with profiler(profile_filename), ray_tracing.ray_tracer(result_uuid) as runner_tracer:
+        with profiler(profile_filename), ray_tracing.ray_tracer(result_uuid, daft_execution_config) as runner_tracer:
             raw_tasks = plan_scheduler.to_partition_tasks(
                 psets,
                 self,

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -18,6 +18,7 @@ from daft.arrow_utils import ensure_array
 from daft.context import execution_config_ctx, get_context
 from daft.daft import PyTable as _PyTable
 from daft.dependencies import np
+from daft.runners import ray_tracing
 from daft.runners.progress_bar import ProgressBar
 from daft.series import Series, item_to_series
 from daft.table import Table
@@ -73,9 +74,9 @@ if TYPE_CHECKING:
     from ray.data.block import Block as RayDatasetBlock
     from ray.data.dataset import Dataset as RayDataset
 
-    from daft.execution.physical_plan import MaterializedPhysicalPlan
     from daft.logical.builder import LogicalPlanBuilder
     from daft.plan_scheduler import PhysicalPlanScheduler
+    from daft.runners.ray_tracing import RunnerTracer
 
 _RAY_FROM_ARROW_REFS_AVAILABLE = True
 try:
@@ -478,8 +479,12 @@ def build_partitions(
 # Give the same function different names to aid in profiling data distribution.
 
 
+@ray_tracing.RayFunctionWrapper.wrap
 @ray.remote
 def single_partition_pipeline(
+    job_id: str,
+    task_id: str,
+    stage_id: int,
     daft_execution_config: PyDaftExecutionConfig,
     instruction_stack: list[Instruction],
     partial_metadatas: list[PartitionMetadata],
@@ -487,23 +492,33 @@ def single_partition_pipeline(
 ) -> list[list[PartitionMetadata] | MicroPartition]:
     with execution_config_ctx(
         config=daft_execution_config,
-    ):
+    ), ray_tracing.collect_ray_task_metrics(job_id, task_id, stage_id):
         return build_partitions(instruction_stack, partial_metadatas, *inputs)
 
 
+@ray_tracing.RayFunctionWrapper.wrap
 @ray.remote
 def fanout_pipeline(
+    job_id: str,
+    task_id: str,
+    stage_id: int,
     daft_execution_config: PyDaftExecutionConfig,
     instruction_stack: list[Instruction],
     partial_metadatas: list[PartitionMetadata],
     *inputs: MicroPartition,
 ) -> list[list[PartitionMetadata] | MicroPartition]:
-    with execution_config_ctx(config=daft_execution_config):
+    with execution_config_ctx(config=daft_execution_config), ray_tracing.collect_ray_task_metrics(
+        job_id, task_id, stage_id
+    ):
         return build_partitions(instruction_stack, partial_metadatas, *inputs)
 
 
+@ray_tracing.RayFunctionWrapper.wrap
 @ray.remote(scheduling_strategy="SPREAD")
 def reduce_pipeline(
+    job_id: str,
+    task_id: str,
+    stage_id: int,
     daft_execution_config: PyDaftExecutionConfig,
     instruction_stack: list[Instruction],
     partial_metadatas: list[PartitionMetadata],
@@ -511,12 +526,18 @@ def reduce_pipeline(
 ) -> list[list[PartitionMetadata] | MicroPartition]:
     import ray
 
-    with execution_config_ctx(config=daft_execution_config):
+    with execution_config_ctx(config=daft_execution_config), ray_tracing.collect_ray_task_metrics(
+        job_id, task_id, stage_id
+    ):
         return build_partitions(instruction_stack, partial_metadatas, *ray.get(inputs))
 
 
+@ray_tracing.RayFunctionWrapper.wrap
 @ray.remote(scheduling_strategy="SPREAD")
 def reduce_and_fanout(
+    job_id: str,
+    task_id: str,
+    stage_id: int,
     daft_execution_config: PyDaftExecutionConfig,
     instruction_stack: list[Instruction],
     partial_metadatas: list[PartitionMetadata],
@@ -524,7 +545,9 @@ def reduce_and_fanout(
 ) -> list[list[PartitionMetadata] | MicroPartition]:
     import ray
 
-    with execution_config_ctx(config=daft_execution_config):
+    with execution_config_ctx(config=daft_execution_config), ray_tracing.collect_ray_task_metrics(
+        job_id, task_id, stage_id
+    ):
         return build_partitions(instruction_stack, partial_metadatas, *ray.get(inputs))
 
 
@@ -659,8 +682,9 @@ class Scheduler(ActorPoolManager):
     def _construct_dispatch_batch(
         self,
         execution_id: str,
-        tasks: MaterializedPhysicalPlan,
+        tasks: ray_tracing.MaterializedPhysicalPlanWrapper,
         dispatches_allowed: int,
+        runner_tracer: RunnerTracer,
     ) -> tuple[list[PartitionTask], bool]:
         """Constructs a batch of PartitionTasks that should be dispatched
 
@@ -669,84 +693,93 @@ class Scheduler(ActorPoolManager):
             execution_id: The ID of the current execution.
             tasks: The iterator over the physical plan.
             dispatches_allowed (int): The maximum number of tasks that can be dispatched in this batch.
+            runner_tracer: The tracer to capture information about the dispatch batching process
         Returns:
 
             tuple[list[PartitionTask], bool]: A tuple containing:
                 - A list of PartitionTasks to be dispatched.
                 - A pagination boolean indicating whether or not there are more tasks to be had by calling _construct_dispatch_batch again
         """
-        tasks_to_dispatch: list[PartitionTask] = []
+        with runner_tracer.dispatch_batching():
+            tasks_to_dispatch: list[PartitionTask] = []
 
-        # Loop until:
-        # - Reached the limit of the number of tasks we are allowed to dispatch
-        # - Encounter a `None` as the next step (short-circuit and return has_next=False)
-        while len(tasks_to_dispatch) < dispatches_allowed and self._is_active(execution_id):
-            next_step = next(tasks)
+            # Loop until:
+            # - Reached the limit of the number of tasks we are allowed to dispatch
+            # - Encounter a `None` as the next step (short-circuit and return has_next=False)
+            while len(tasks_to_dispatch) < dispatches_allowed and self._is_active(execution_id):
+                next_step = next(tasks)
 
-            # CASE: Blocked on already dispatched tasks
-            # Early terminate and mark has_next=False
-            if next_step is None:
-                return tasks_to_dispatch, False
+                # CASE: Blocked on already dispatched tasks
+                # Early terminate and mark has_next=False
+                if next_step is None:
+                    return tasks_to_dispatch, False
 
-            # CASE: A final result
-            # Place it in the result queue (potentially block on space to be available)
-            elif isinstance(next_step, MaterializedResult):
-                self._place_in_queue(execution_id, next_step)
+                # CASE: A final result
+                # Place it in the result queue (potentially block on space to be available)
+                elif isinstance(next_step, MaterializedResult):
+                    self._place_in_queue(execution_id, next_step)
 
-            # CASE: No-op task
-            # Just run it locally immediately.
-            elif len(next_step.instructions) == 0:
-                logger.debug("Running task synchronously in main thread: %s", next_step)
-                assert (
-                    len(next_step.partial_metadatas) == 1
-                ), "No-op tasks must have one output by definition, since there are no instructions to run"
-                [single_partial] = next_step.partial_metadatas
-                if single_partial.num_rows is None:
-                    [single_meta] = ray.get(get_metas.remote(next_step.inputs))
-                    accessor = PartitionMetadataAccessor.from_metadata_list(
-                        [single_meta.merge_with_partial(single_partial)]
+                # CASE: No-op task
+                # Just run it locally immediately.
+                elif len(next_step.instructions) == 0:
+                    logger.debug("Running task synchronously in main thread: %s", next_step)
+                    assert (
+                        len(next_step.partial_metadatas) == 1
+                    ), "No-op tasks must have one output by definition, since there are no instructions to run"
+                    [single_partial] = next_step.partial_metadatas
+                    if single_partial.num_rows is None:
+                        [single_meta] = ray.get(get_metas.remote(next_step.inputs))
+                        accessor = PartitionMetadataAccessor.from_metadata_list(
+                            [single_meta.merge_with_partial(single_partial)]
+                        )
+                    else:
+                        accessor = PartitionMetadataAccessor.from_metadata_list(
+                            [
+                                PartitionMetadata(
+                                    num_rows=single_partial.num_rows,
+                                    size_bytes=single_partial.size_bytes,
+                                    boundaries=single_partial.boundaries,
+                                )
+                            ]
+                        )
+
+                    next_step.set_result(
+                        [RayMaterializedResult(partition, accessor, 0) for partition in next_step.inputs]
                     )
+                    next_step.set_done()
+
+                # CASE: Actual task that needs to be dispatched
                 else:
-                    accessor = PartitionMetadataAccessor.from_metadata_list(
-                        [
-                            PartitionMetadata(
-                                num_rows=single_partial.num_rows,
-                                size_bytes=single_partial.size_bytes,
-                                boundaries=single_partial.boundaries,
-                            )
-                        ]
-                    )
+                    tasks_to_dispatch.append(next_step)
 
-                next_step.set_result([RayMaterializedResult(partition, accessor, 0) for partition in next_step.inputs])
-                next_step.set_done()
-
-            # CASE: Actual task that needs to be dispatched
-            else:
-                tasks_to_dispatch.append(next_step)
-
-        return tasks_to_dispatch, True
+            return tasks_to_dispatch, True
 
     def _dispatch_tasks(
         self,
+        execution_id: str,
         tasks_to_dispatch: list[PartitionTask],
         daft_execution_config: PyDaftExecutionConfig,
+        runner_tracer: RunnerTracer,
     ) -> Iterator[tuple[PartitionTask, list[ray.ObjectRef]]]:
         """Iteratively Dispatches a batch of tasks to the Ray backend"""
+        with runner_tracer.dispatching():
+            for task in tasks_to_dispatch:
+                if task.actor_pool_id is None:
+                    results = _build_partitions(execution_id, daft_execution_config, task, runner_tracer)
+                else:
+                    actor_pool = self._actor_pools.get(task.actor_pool_id)
+                    assert actor_pool is not None, "Ray actor pool must live for as long as the tasks."
+                    # TODO: Add tracing for submissions to actor pool
+                    results = _build_partitions_on_actor_pool(task, actor_pool)
+                logger.debug("%s -> %s", task, results)
 
-        for task in tasks_to_dispatch:
-            if task.actor_pool_id is None:
-                results = _build_partitions(daft_execution_config, task)
-            else:
-                actor_pool = self._actor_pools.get(task.actor_pool_id)
-                assert actor_pool is not None, "Ray actor pool must live for as long as the tasks."
-                results = _build_partitions_on_actor_pool(task, actor_pool)
-            logger.debug("%s -> %s", task, results)
-
-            yield task, results
+                yield task, results
 
     def _await_tasks(
         self,
         inflight_ref_to_task_id: dict[ray.ObjectRef, str],
+        inflight_tasks: dict[str, PartitionTask],
+        runner_tracer: RunnerTracer,
     ) -> list[ray.ObjectRef]:
         """Awaits for tasks to be completed. Returns tasks that are ready.
 
@@ -756,22 +789,30 @@ class Scheduler(ActorPoolManager):
             return []
 
         # Await on (any) task to be ready with an unlimited timeout
-        ray.wait(
-            list(inflight_ref_to_task_id.keys()),
-            num_returns=1,
-            timeout=None,
-            fetch_local=False,
-        )
+        with runner_tracer.awaiting(1, None):
+            ray.wait(
+                list(inflight_ref_to_task_id.keys()),
+                num_returns=1,
+                timeout=None,
+                fetch_local=False,
+            )
 
         # Now, grab as many ready tasks as possible with a 0.01s timeout
         timeout = 0.01
         num_returns = len(inflight_ref_to_task_id)
-        readies, _ = ray.wait(
-            list(inflight_ref_to_task_id.keys()),
-            num_returns=num_returns,
-            timeout=timeout,
-            fetch_local=False,
-        )
+        with runner_tracer.awaiting(num_returns, timeout):
+            readies, _ = ray.wait(
+                list(inflight_ref_to_task_id.keys()),
+                num_returns=num_returns,
+                timeout=timeout,
+                fetch_local=False,
+            )
+
+        # Update traces
+        for ready in readies:
+            if ready in inflight_ref_to_task_id:
+                task_id = inflight_ref_to_task_id[ready]
+                runner_tracer.task_received_as_ready(task_id, inflight_tasks[task_id].stage_id)
 
         return readies
 
@@ -812,8 +853,8 @@ class Scheduler(ActorPoolManager):
             f"{datetime.replace(datetime.now(), second=0, microsecond=0).isoformat()[:-3]}.json"
         )
 
-        with profiler(profile_filename):
-            tasks = plan_scheduler.to_partition_tasks(
+        with profiler(profile_filename), ray_tracing.ray_tracer(result_uuid) as runner_tracer:
+            raw_tasks = plan_scheduler.to_partition_tasks(
                 psets,
                 self,
                 # Attempt to subtract 1 from results_buffer_size because the return Queue size is already 1
@@ -821,6 +862,7 @@ class Scheduler(ActorPoolManager):
                 # because we have two buffers (the Queue and the buffer inside the `materialize` generator)
                 None if results_buffer_size is None else max(results_buffer_size - 1, 1),
             )
+            tasks = ray_tracing.MaterializedPhysicalPlanWrapper(raw_tasks, runner_tracer)
             try:
                 ###
                 # Scheduling Loop:
@@ -831,6 +873,7 @@ class Scheduler(ActorPoolManager):
                 #                ▲                               │
                 #                └───────────────────────────────┘
                 ###
+                wave_count = 0
                 while self._is_active(result_uuid):
                     ###
                     # Dispatch Loop:
@@ -839,70 +882,79 @@ class Scheduler(ActorPoolManager):
                     #    ▲                        │
                     #    └────────────────────────┘
                     ###
-                    while self._is_active(result_uuid):
-                        # Update available cluster resources
-                        # TODO: improve control loop code to be more understandable and dynamically adjust backlog
-                        cores: int = max(
-                            next(num_cpus_provider) - self.reserved_cores, 1
-                        )  # assume at least 1 CPU core for bootstrapping clusters that scale from zero
-                        max_inflight_tasks = cores + self.max_task_backlog
-                        dispatches_allowed = max_inflight_tasks - len(inflight_tasks)
-                        dispatches_allowed = min(cores, dispatches_allowed)
+                    wave_count += 1
+                    with runner_tracer.dispatch_wave(wave_count):
+                        while self._is_active(result_uuid):
+                            # Update available cluster resources
+                            # TODO: improve control loop code to be more understandable and dynamically adjust backlog
+                            cores: int = max(
+                                next(num_cpus_provider) - self.reserved_cores, 1
+                            )  # assume at least 1 CPU core for bootstrapping clusters that scale from zero
+                            max_inflight_tasks = cores + self.max_task_backlog
+                            dispatches_allowed = max_inflight_tasks - len(inflight_tasks)
+                            dispatches_allowed = min(cores, dispatches_allowed)
 
-                        # Dispatch Batching
-                        tasks_to_dispatch, has_next = self._construct_dispatch_batch(
-                            result_uuid,
-                            tasks,
-                            dispatches_allowed,
+                            # Dispatch Batching
+                            tasks_to_dispatch, has_next = self._construct_dispatch_batch(
+                                result_uuid,
+                                tasks,
+                                dispatches_allowed,
+                                runner_tracer,
+                            )
+
+                            logger.debug(
+                                "%ss: RayRunner dispatching %s tasks",
+                                (datetime.now() - start).total_seconds(),
+                                len(tasks_to_dispatch),
+                            )
+
+                            if not self._is_active(result_uuid):
+                                break
+
+                            # Dispatch
+                            for task, result_obj_refs in self._dispatch_tasks(
+                                result_uuid,
+                                tasks_to_dispatch,
+                                daft_execution_config,
+                                runner_tracer,
+                            ):
+                                inflight_tasks[task.id()] = task
+                                for result in result_obj_refs:
+                                    inflight_ref_to_task[result] = task.id()
+
+                                pbar.mark_task_start(task)
+
+                            # Break the dispatch batching/dispatch loop if no more dispatches allowed, or physical plan
+                            # needs work for forward progress
+                            if dispatches_allowed == 0 or not has_next:
+                                break
+
+                        ###
+                        # Await:
+                        # Wait for some work to be completed from the current wave's dispatch
+                        # Then we perform the necessary record-keeping on tasks that were retrieved as ready.
+                        ###
+                        readies = self._await_tasks(
+                            inflight_ref_to_task,
+                            inflight_tasks,
+                            runner_tracer,
                         )
+                        for ready in readies:
+                            if ready in inflight_ref_to_task:
+                                task_id = inflight_ref_to_task[ready]
 
-                        logger.debug(
-                            "%ss: RayRunner dispatching %s tasks",
-                            (datetime.now() - start).total_seconds(),
-                            len(tasks_to_dispatch),
-                        )
+                                # Mark the entire task associated with the result as done.
+                                task = inflight_tasks[task_id]
+                                task.set_done()
 
-                        if not self._is_active(result_uuid):
-                            break
+                                if isinstance(task, SingleOutputPartitionTask):
+                                    del inflight_ref_to_task[ready]
+                                elif isinstance(task, MultiOutputPartitionTask):
+                                    for partition in task.partitions():
+                                        del inflight_ref_to_task[partition]
 
-                        # Dispatch
-                        for task, result_obj_refs in self._dispatch_tasks(
-                            tasks_to_dispatch,
-                            daft_execution_config,
-                        ):
-                            inflight_tasks[task.id()] = task
-                            for result in result_obj_refs:
-                                inflight_ref_to_task[result] = task.id()
-
-                            pbar.mark_task_start(task)
-
-                        # Break the dispatch batching/dispatch loop if no more dispatches allowed, or physical plan
-                        # needs work for forward progress
-                        if dispatches_allowed == 0 or not has_next:
-                            break
-
-                    ###
-                    # Await:
-                    # Wait for some work to be completed from the current wave's dispatch
-                    # Then we perform the necessary record-keeping on tasks that were retrieved as ready.
-                    ###
-                    readies = self._await_tasks(inflight_ref_to_task)
-                    for ready in readies:
-                        if ready in inflight_ref_to_task:
-                            task_id = inflight_ref_to_task[ready]
-
-                            # Mark the entire task associated with the result as done.
-                            task = inflight_tasks[task_id]
-                            task.set_done()
-
-                            if isinstance(task, SingleOutputPartitionTask):
-                                del inflight_ref_to_task[ready]
-                            elif isinstance(task, MultiOutputPartitionTask):
-                                for partition in task.partitions():
-                                    del inflight_ref_to_task[partition]
-
-                            pbar.mark_task_done(task)
-                            del inflight_tasks[task_id]
+                                pbar.mark_task_done(task)
+                                del inflight_tasks[task_id]
 
             except StopIteration as e:
                 self._place_in_queue(result_uuid, e)
@@ -946,7 +998,10 @@ class SchedulerActor(Scheduler):
 
 
 def _build_partitions(
-    daft_execution_config_objref: ray.ObjectRef, task: PartitionTask[ray.ObjectRef]
+    job_id: str,
+    daft_execution_config_objref: ray.ObjectRef,
+    task: PartitionTask[ray.ObjectRef],
+    runner_tracer: RunnerTracer,
 ) -> list[ray.ObjectRef]:
     """Run a PartitionTask and return the resulting list of partitions."""
     ray_options: dict[str, Any] = {"num_returns": task.num_results + 1, "name": task.name()}
@@ -960,9 +1015,15 @@ def _build_partitions(
             if task.instructions and isinstance(task.instructions[-1], FanoutInstruction)
             else reduce_pipeline
         )
-        build_remote = build_remote.options(**ray_options)
+        build_remote = build_remote.options(**ray_options).with_tracing(runner_tracer, task)
         [metadatas_ref, *partitions] = build_remote.remote(
-            daft_execution_config_objref, task.instructions, task.partial_metadatas, task.inputs
+            job_id,
+            task.id(),
+            task.stage_id,
+            daft_execution_config_objref,
+            task.instructions,
+            task.partial_metadatas,
+            task.inputs,
         )
 
     else:
@@ -973,9 +1034,15 @@ def _build_partitions(
         )
         if task.instructions and isinstance(task.instructions[0], ScanWithTask):
             ray_options["scheduling_strategy"] = "SPREAD"
-        build_remote = build_remote.options(**ray_options)
+        build_remote = build_remote.options(**ray_options).with_tracing(runner_tracer, task)
         [metadatas_ref, *partitions] = build_remote.remote(
-            daft_execution_config_objref, task.instructions, task.partial_metadatas, *task.inputs
+            job_id,
+            task.id(),
+            task.stage_id,
+            daft_execution_config_objref,
+            task.instructions,
+            task.partial_metadatas,
+            *task.inputs,
         )
 
     metadatas_accessor = PartitionMetadataAccessor(metadatas_ref)

--- a/daft/runners/ray_tracing.py
+++ b/daft/runners/ray_tracing.py
@@ -1,0 +1,654 @@
+"""This module contains utilities and wrappers that instrument tracing over our RayRunner's task scheduling + execution
+
+These utilities are meant to provide light wrappers on top of Ray functionality (e.g. remote functions, actors, ray.get/ray.wait)
+which allow us to intercept these calls and perform the necessary actions for tracing the interaction between Daft and Ray.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import json
+import logging
+import os
+import pathlib
+import time
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Iterator, TextIO
+
+try:
+    import ray
+except ImportError:
+    raise
+
+from daft.execution.execution_step import PartitionTask
+from daft.runners import ray_metrics
+
+if TYPE_CHECKING:
+    from daft import ResourceRequest
+    from daft.execution.physical_plan import MaterializedPhysicalPlan
+
+logger = logging.getLogger(__name__)
+
+# We add the trace by default to the latest session logs of the Ray Runner
+# This lets us access our logs via the Ray dashboard when running Ray jobs
+DEFAULT_RAY_LOGS_LOCATION = pathlib.Path("/tmp") / "ray" / "session_latest" / "logs"
+DEFAULT_DAFT_TRACE_LOCATION = DEFAULT_RAY_LOGS_LOCATION / "daft"
+
+# IDs and names for the visualized data
+SCHEDULER_PID = 1
+STAGES_PID = 2
+NODE_PIDS_START = 100
+
+# Event Phases with human-readable const names
+PHASE_METADATA = "M"
+PHASE_DURATION_BEGIN = "B"
+PHASE_DURATION_END = "E"
+PHASE_INSTANT = "i"
+PHASE_ASYNC_BEGIN = "b"
+PHASE_ASYNC_END = "e"
+PHASE_ASYNC_INSTANT = "n"
+PHASE_FLOW_START = "s"
+PHASE_FLOW_FINISH = "f"
+
+
+def tracing_enabled():
+    """Checks if tracing is enabled in the current environment"""
+    return os.getenv("DAFT_RUNNER_TRACING") != "0"
+
+
+@contextlib.contextmanager
+def ray_tracer(execution_id: str) -> Iterator[RunnerTracer]:
+    """Instantiates a RunnerTracer for the duration of the code block"""
+    # Dump the RayRunner trace if we detect an active Ray session, otherwise we give up and do not write the trace
+    filepath: pathlib.Path | None
+    if pathlib.Path(DEFAULT_RAY_LOGS_LOCATION).exists() and tracing_enabled():
+        trace_filename = (
+            f"trace_RayRunner.{execution_id}.{datetime.replace(datetime.now(), microsecond=0).isoformat()[:-3]}.json"
+        )
+        daft_trace_location = pathlib.Path(DEFAULT_DAFT_TRACE_LOCATION)
+        daft_trace_location.mkdir(exist_ok=True, parents=True)
+        filepath = DEFAULT_DAFT_TRACE_LOCATION / trace_filename
+    else:
+        filepath = None
+
+    if filepath is not None:
+        # Get the metrics actor and block until ready
+        metrics_actor = ray_metrics.get_metrics_actor(execution_id)
+        metrics_actor.wait()
+
+        with open(filepath, "w") as f:
+            # Yield the tracer
+            runner_tracer = RunnerTracer(f, metrics_actor)
+            yield runner_tracer
+            runner_tracer.finalize()
+    else:
+        runner_tracer = RunnerTracer(None, None)
+        yield runner_tracer
+
+
+@dataclasses.dataclass
+class TraceWriter:
+    """Handles writing trace events to a JSON file in Chrome Trace Event Format"""
+
+    file: TextIO | None
+    start: float
+    has_written_event: bool = False
+
+    def write_header(self) -> None:
+        """Initialize the JSON file with an opening bracket"""
+        if self.file is not None:
+            self.file.write("[")
+
+    def write_metadata(self, event: dict[str, Any]) -> None:
+        """Write a metadata event to the trace file
+
+        Args:
+            event: The metadata event to write
+        """
+        if self.file is not None:
+            if self.has_written_event:
+                self.file.write(",\n")
+            self.file.write(json.dumps(event))
+            self.has_written_event = True
+
+    def write_event(self, event: dict[str, Any], ts: int | None = None) -> int:
+        """Write a single trace event to the file
+
+        Args:
+            event: The event data to write
+            ts: Optional timestamp override. If None, current time will be used
+
+        Returns:
+            The timestamp that was used for the event
+        """
+        if self.file is not None:
+            if ts is None:
+                ts = int((time.time() - self.start) * 1000 * 1000)
+            if self.has_written_event:
+                self.file.write(",\n")
+            self.file.write(
+                json.dumps(
+                    {
+                        **event,
+                        "ts": ts,
+                    }
+                )
+            )
+            self.has_written_event = True
+        return ts or -1
+
+    def write_footer(self) -> None:
+        if self.file is not None:
+            # Close with a closing square bracket
+            self.file.write("]")
+
+
+class RunnerTracer:
+    def __init__(self, file: TextIO | None, metrics_actor: ray_metrics.MetricsActorHandle | None):
+        start = time.time()
+        self._start = start
+        self._stage_start_end: dict[int, tuple[int, int]] = {}
+        self._task_id_to_location: dict[str, tuple[int, int]] = {}
+        self._task_event_idx = 0
+
+        self._metrics_actor = metrics_actor
+
+        self._writer = TraceWriter(file, start)
+        self._writer.write_header()
+
+    def _write_event(self, event: dict[str, Any], ts: int | None = None) -> int:
+        try:
+            return self._writer.write_event(event, ts)
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.exception("Failed to serialize event to JSON: %s", e)
+            return ts or -1
+        except OSError as e:
+            logger.exception("Failed to write trace event to file: %s", e)
+            return ts or -1
+
+    def _write_metadata(self, metadata_event: dict[str, Any]) -> None:
+        try:
+            return self._writer.write_metadata(metadata_event)
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.exception("Failed to serialize metadata to JSON: %s", e)
+            return
+        except OSError as e:
+            logger.exception("Failed to write trace metadata to file: %s", e)
+            return
+
+    def _flush_task_metrics(self):
+        if self._metrics_actor is not None:
+            task_events, new_idx = self._metrics_actor.get_task_events(self._task_event_idx)
+            self._task_event_idx = new_idx
+
+            for task_event in task_events:
+                if isinstance(task_event, ray_metrics.StartTaskEvent):
+                    # Record which pid/tid to associate this task_id with
+                    self._task_id_to_location[task_event.task_id] = (task_event.node_idx, task_event.worker_idx)
+
+                    start_ts = int((task_event.start - self._start) * 1000 * 1000)
+                    # Write to the Async view (will nest under the task creation and dispatch)
+                    self._write_event(
+                        {
+                            "id": task_event.task_id,
+                            "category": "task",
+                            "name": "task_remote_execution",
+                            "ph": PHASE_ASYNC_BEGIN,
+                            "pid": 1,
+                            "tid": 2,
+                            "args": {
+                                "ray_assigned_resources": task_event.ray_assigned_resources,
+                                "ray_task_id": task_event.ray_task_id,
+                                "stage_id": task_event.stage_id,
+                            },
+                        },
+                        ts=start_ts,
+                    )
+
+                    # Write to the node view (group by node ID)
+                    self._write_event(
+                        {
+                            "name": "task_remote_execution",
+                            "ph": PHASE_DURATION_BEGIN,
+                            "pid": task_event.node_idx + NODE_PIDS_START,
+                            "tid": task_event.worker_idx,
+                            "args": {
+                                "ray_assigned_resources": task_event.ray_assigned_resources,
+                                "ray_task_id": task_event.ray_task_id,
+                                "stage_id": task_event.stage_id,
+                            },
+                        },
+                        ts=start_ts,
+                    )
+                    self._write_event(
+                        {
+                            "name": "stage-to-node-flow",
+                            "id": task_event.stage_id,
+                            "ph": PHASE_FLOW_FINISH,
+                            "bp": "e",  # enclosed, since the stage "encloses" the execution
+                            "pid": task_event.node_idx + NODE_PIDS_START,
+                            "tid": task_event.worker_idx,
+                        },
+                        ts=start_ts,
+                    )
+                elif isinstance(task_event, ray_metrics.EndTaskEvent):
+                    end_ts = int((task_event.end - self._start) * 1000 * 1000)
+
+                    # Write to the Async view (will group by the stage ID)
+                    self._write_event(
+                        {
+                            "id": task_event.task_id,
+                            "category": "task",
+                            "name": "task_remote_execution",
+                            "ph": PHASE_ASYNC_END,
+                            "pid": 1,
+                            "tid": 2,
+                        },
+                        ts=end_ts,
+                    )
+
+                    # Write to the node view (group by node ID)
+                    node_idx, worker_idx = self._task_id_to_location.get(task_event.task_id, (None, None))
+                    if node_idx is None or worker_idx is None:
+                        logger.error(
+                            "Tracing received a EndTaskEvent without a corresponding StartTaskEvent that provides location information."
+                        )
+                    else:
+                        self._write_event(
+                            {
+                                "name": "task_remote_execution",
+                                "ph": PHASE_DURATION_END,
+                                "pid": node_idx + NODE_PIDS_START,
+                                "tid": worker_idx,
+                            },
+                            ts=end_ts,
+                        )
+                else:
+                    raise NotImplementedError(f"Unhandled TaskEvent: {task_event}")
+
+    def finalize(self) -> None:
+        # Retrieve final task metrics
+        self._flush_task_metrics()
+
+        # Retrieve metrics from the metrics actor (blocking call)
+        node_metrics = self._metrics_actor.collect_and_close() if self._metrics_actor is not None else {}
+
+        # Write out labels for the nodes and other traced events
+        nodes_to_pid_mapping = {node_id: i + NODE_PIDS_START for i, node_id in enumerate(node_metrics)}
+        nodes_workers_to_tid_mapping = {
+            (node_id, worker_id): (pid, tid)
+            for node_id, pid in nodes_to_pid_mapping.items()
+            for tid, worker_id in enumerate(node_metrics[node_id])
+        }
+        self._write_process_and_thread_names(
+            [(pid, f"Node {node_id}") for node_id, pid in nodes_to_pid_mapping.items()],
+            [(pid, tid, f"Worker {worker_id}") for (_, worker_id), (pid, tid) in nodes_workers_to_tid_mapping.items()],
+        )
+
+        # Write out stages now that everything is completed
+        self._write_stages()
+
+        # End the file with the appropriate footer
+        self._writer.write_footer()
+
+    def _write_process_and_thread_names(
+        self,
+        process_meta: list[tuple[int, str]],
+        thread_meta: list[tuple[int, int, str]],
+    ):
+        """Writes metadata for the file
+
+        Args:
+            process_meta: Pass in custom names for PIDs as a list of (pid, name).
+            thread_meta: Pass in custom names for threads a a list of (pid, tid, name).
+        """
+        for pid, name in [
+            (SCHEDULER_PID, "Scheduler"),
+            (STAGES_PID, "Stages"),
+        ] + process_meta:
+            self._write_metadata(
+                {
+                    "name": "process_name",
+                    "ph": PHASE_METADATA,
+                    "pid": pid,
+                    "args": {"name": name},
+                }
+            )
+
+        for pid, tid, name in [
+            (SCHEDULER_PID, 1, "_run_plan dispatch loop"),
+        ] + thread_meta:
+            self._write_metadata(
+                {
+                    "name": "thread_name",
+                    "ph": PHASE_METADATA,
+                    "pid": pid,
+                    "tid": tid,
+                    "args": {"name": name},
+                }
+            )
+
+    def _write_stages(self):
+        for stage_id in self._stage_start_end:
+            start_ts, end_ts = self._stage_start_end[stage_id]
+            self._write_event(
+                {
+                    "name": f"stage-{stage_id}",
+                    "ph": PHASE_DURATION_BEGIN,
+                    "pid": 2,
+                    "tid": stage_id,
+                },
+                ts=start_ts,
+            )
+
+            # Add a flow view here to point to the nodes
+            self._write_event(
+                {
+                    "name": "stage-to-node-flow",
+                    "id": stage_id,
+                    "ph": PHASE_FLOW_START,
+                    "pid": 2,
+                    "tid": stage_id,
+                },
+                ts=start_ts,
+            )
+
+            self._write_event(
+                {
+                    "name": f"stage-{stage_id}",
+                    "ph": PHASE_DURATION_END,
+                    "pid": 2,
+                    "tid": stage_id,
+                },
+                ts=end_ts,
+            )
+
+    ###
+    # Tracing of scheduler dispatching
+    ###
+
+    @contextlib.contextmanager
+    def dispatch_wave(self, wave_num: int):
+        self._write_event(
+            {
+                "name": f"wave-{wave_num}",
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_BEGIN,
+                "args": {"wave_num": wave_num},
+            }
+        )
+
+        metrics = {}
+
+        def metrics_updater(**kwargs):
+            metrics.update(kwargs)
+
+        yield metrics_updater
+
+        self._write_event(
+            {
+                "name": f"wave-{wave_num}",
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_END,
+                "args": metrics,
+            }
+        )
+
+        # On the end of every wave, perform a flush of the latest metrics from the MetricsActor
+        self._flush_task_metrics()
+
+    def count_inflight_tasks(self, count: int):
+        self._write_event(
+            {
+                "name": "dispatch_metrics",
+                "ph": "C",
+                "pid": 1,
+                "tid": 1,
+                "args": {"num_inflight_tasks": count},
+            }
+        )
+
+    @contextlib.contextmanager
+    def dispatch_batching(self):
+        self._write_event(
+            {
+                "name": "dispatch_batching",
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_BEGIN,
+            }
+        )
+        yield
+        self._write_event(
+            {
+                "name": "dispatch_batching",
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_END,
+            }
+        )
+
+    @contextlib.contextmanager
+    def dispatching(self):
+        self._write_event(
+            {
+                "name": "dispatching",
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_BEGIN,
+            }
+        )
+        yield
+        self._write_event(
+            {
+                "name": "dispatching",
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_END,
+            }
+        )
+
+    @contextlib.contextmanager
+    def awaiting(self, waiting_for_num_results: int, wait_timeout_s: float | None):
+        name = f"awaiting {waiting_for_num_results} (timeout={wait_timeout_s})"
+        self._write_event(
+            {
+                "name": name,
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_BEGIN,
+                "args": {
+                    "waiting_for_num_results": waiting_for_num_results,
+                    "wait_timeout_s": str(wait_timeout_s),
+                },
+            }
+        )
+        yield
+        self._write_event(
+            {
+                "name": name,
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_END,
+            }
+        )
+
+    @contextlib.contextmanager
+    def get_next_physical_plan(self):
+        self._write_event(
+            {
+                "name": "next(tasks)",
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_BEGIN,
+            }
+        )
+
+        args = {}
+
+        def update_args(**kwargs):
+            args.update(kwargs)
+
+        yield update_args
+
+        self._write_event(
+            {
+                "name": "next(tasks)",
+                "pid": 1,
+                "tid": 1,
+                "ph": PHASE_DURATION_END,
+                "args": args,
+            }
+        )
+
+    def task_created(self, task_id: str, stage_id: int, resource_request: ResourceRequest, instructions: str):
+        created_ts = self._write_event(
+            {
+                "id": task_id,
+                "category": "task",
+                "name": f"task_execution.stage-{stage_id}",
+                "ph": PHASE_ASYNC_BEGIN,
+                "args": {
+                    "task_id": task_id,
+                    "resource_request": {
+                        "num_cpus": resource_request.num_cpus,
+                        "num_gpus": resource_request.num_gpus,
+                        "memory_bytes": resource_request.memory_bytes,
+                    },
+                    "stage_id": stage_id,
+                    "instructions": instructions,
+                },
+                "pid": 1,
+                "tid": 1,
+            }
+        )
+
+        if stage_id not in self._stage_start_end:
+            self._stage_start_end[stage_id] = (created_ts, created_ts)
+
+    def task_dispatched(self, task_id: str):
+        self._write_event(
+            {
+                "id": task_id,
+                "category": "task",
+                "name": "task_dispatch",
+                "ph": PHASE_ASYNC_BEGIN,
+                "pid": 1,
+                "tid": 1,
+            }
+        )
+
+    def task_received_as_ready(self, task_id: str, stage_id: int):
+        self._write_event(
+            {
+                "id": task_id,
+                "category": "task",
+                "name": "task_dispatch",
+                "ph": PHASE_ASYNC_END,
+                "pid": 1,
+                "tid": 1,
+            }
+        )
+        new_end = self._write_event(
+            {
+                "id": task_id,
+                "category": "task",
+                "name": f"task_execution.stage-{stage_id}",
+                "ph": PHASE_ASYNC_END,
+                "pid": 1,
+                "tid": 1,
+            }
+        )
+
+        assert stage_id in self._stage_start_end
+        old_start, _ = self._stage_start_end[stage_id]
+        self._stage_start_end[stage_id] = (old_start, new_end)
+
+
+@dataclasses.dataclass(frozen=True)
+class RayFunctionWrapper:
+    """Wrapper around a Ray remote function that allows us to intercept calls and record the call for a given task ID"""
+
+    f: ray.remote_function.RemoteFunction
+
+    def with_tracing(self, runner_tracer: RunnerTracer, task: PartitionTask) -> RayRunnableFunctionWrapper:
+        return RayRunnableFunctionWrapper(f=self.f, runner_tracer=runner_tracer, task=task)
+
+    def options(self, *args, **kwargs) -> RayFunctionWrapper:
+        return dataclasses.replace(self, f=self.f.options(*args, **kwargs))
+
+    @classmethod
+    def wrap(cls, f: ray.remote_function.RemoteFunction):
+        return cls(f=f)
+
+
+@dataclasses.dataclass(frozen=True)
+class RayRunnableFunctionWrapper:
+    """Runnable variant of RayFunctionWrapper that supports `.remote` calls"""
+
+    f: ray.remote_function.RemoteFunction
+    runner_tracer: RunnerTracer
+    task: PartitionTask
+
+    def options(self, *args, **kwargs) -> RayRunnableFunctionWrapper:
+        return dataclasses.replace(self, f=self.f.options(*args, **kwargs))
+
+    def remote(self, *args, **kwargs):
+        self.runner_tracer.task_dispatched(self.task.id())
+        return self.f.remote(*args, **kwargs)
+
+
+@dataclasses.dataclass(frozen=True)
+class MaterializedPhysicalPlanWrapper:
+    """Wrapper around MaterializedPhysicalPlan that hooks into tracing capabilities"""
+
+    plan: MaterializedPhysicalPlan
+    runner_tracer: RunnerTracer
+
+    def __next__(self):
+        with self.runner_tracer.get_next_physical_plan() as update_args:
+            item = next(self.plan)
+
+            update_args(
+                next_item_type=type(item).__name__,
+            )
+            if isinstance(item, PartitionTask):
+                instructions_description = "-".join(type(i).__name__ for i in item.instructions)
+                self.runner_tracer.task_created(
+                    item.id(),
+                    item.stage_id,
+                    item.resource_request,
+                    instructions_description,
+                )
+                update_args(
+                    partition_task_instructions=instructions_description,
+                )
+
+        return item
+
+
+@contextlib.contextmanager
+def collect_ray_task_metrics(execution_id: str, task_id: str, stage_id: int):
+    """Context manager that will ping the metrics actor to record various execution metrics about a given task"""
+    if tracing_enabled():
+        import time
+
+        runtime_context = ray.get_runtime_context()
+
+        metrics_actor = ray_metrics.get_metrics_actor(execution_id)
+        metrics_actor.mark_task_start(
+            task_id,
+            time.time(),
+            runtime_context.get_node_id(),
+            runtime_context.get_worker_id(),
+            stage_id,
+            runtime_context.get_assigned_resources(),
+            runtime_context.get_task_id(),
+        )
+        yield
+        metrics_actor.mark_task_end(task_id, time.time())
+    else:
+        yield

--- a/daft/runners/ray_tracing.py
+++ b/daft/runners/ray_tracing.py
@@ -75,8 +75,13 @@ def ray_tracer(execution_id: str, daft_execution_config: PyDaftExecutionConfig) 
         with open(filepath, "w") as f:
             # Yield the tracer
             runner_tracer = RunnerTracer(f, metrics_actor)
-            yield runner_tracer
-            runner_tracer.finalize()
+
+            try:
+                yield runner_tracer
+
+            # Use `finally` to cleanup and finalize the JSON even in cases where the job is killed with SIGKILL
+            finally:
+                runner_tracer.finalize()
     else:
         runner_tracer = RunnerTracer(None, None)
         yield runner_tracer

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -57,6 +57,7 @@ pub struct DaftExecutionConfig {
     pub enable_aqe: bool,
     pub enable_native_executor: bool,
     pub default_morsel_size: usize,
+    pub enable_ray_tracing: bool,
 }
 
 impl Default for DaftExecutionConfig {
@@ -80,6 +81,7 @@ impl Default for DaftExecutionConfig {
             enable_aqe: false,
             enable_native_executor: false,
             default_morsel_size: 128 * 1024,
+            enable_ray_tracing: false,
         }
     }
 }
@@ -99,6 +101,12 @@ impl DaftExecutionConfig {
             && matches!(val.trim().to_lowercase().as_str(), "1" | "true")
         {
             cfg.enable_native_executor = true;
+        }
+        let ray_tracing_env_var_name = "DAFT_ENABLE_RAY_TRACING";
+        if let Ok(val) = std::env::var(ray_tracing_env_var_name)
+            && matches!(val.trim().to_lowercase().as_str(), "1" | "true")
+        {
+            cfg.enable_ray_tracing = true;
         }
         cfg
     }

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -107,6 +107,7 @@ impl PyDaftExecutionConfig {
         enable_aqe: Option<bool>,
         enable_native_executor: Option<bool>,
         default_morsel_size: Option<usize>,
+        enable_ray_tracing: Option<bool>,
     ) -> PyResult<Self> {
         let mut config = self.config.as_ref().clone();
 
@@ -168,6 +169,10 @@ impl PyDaftExecutionConfig {
         }
         if let Some(default_morsel_size) = default_morsel_size {
             config.default_morsel_size = default_morsel_size;
+        }
+
+        if let Some(enable_ray_tracing) = enable_ray_tracing {
+            config.enable_ray_tracing = enable_ray_tracing;
         }
 
         Ok(Self {
@@ -255,6 +260,11 @@ impl PyDaftExecutionConfig {
     #[getter]
     fn default_morsel_size(&self) -> PyResult<usize> {
         Ok(self.config.default_morsel_size)
+    }
+
+    #[getter]
+    fn enable_ray_tracing(&self) -> PyResult<bool> {
+        Ok(self.config.enable_ray_tracing)
     }
 }
 


### PR DESCRIPTION
Adds tracing for the RayRunner. This is turned off by default, and can be deactivated via `DAFT_ENABLE_RAY_TRACING=1`.

Visualize this with https://ui.perfetto.dev/ 

1. The RayRunner dispatch loop view gives us a good idea of what that crazy while loop is doing, as well as overall Ray metrics such as number of tasks in flight, number of cores available etc
2. The Ray Task Execution view gives us a view of the Ray Tasks that were scheduled, when they were received as completed and also their ResourceRequests.

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/cd086616-cdcc-40b6-a088-70fc3c411d3c">

3. I also added views for each node and their worker processes. These views get updated on the end of every "wave" by polling a metrics actor
4. A "Stages" view allows us to point to the tasks that were launched by each stage, into (3)

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/e366de98-1ee9-482c-b03d-d8c896d7ddc8">
