### PR TITLE
[CHORE] Enable debug in test profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,9 @@ lto = 'fat'
 [profile.rust-analyzer]
 inherits = "dev"
 
+[profile.test]
+debug = true
+
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 libc = {version = "^0.2.150", default-features = false}
 tikv-jemallocator = {version = "0.5.4", features = [


### PR DESCRIPTION
I'm using RustRover to code and debug Rust related code and I noticed the debug run in RustRover doesn't work out of box: there's no variable showing when breakpoint is hit.

It turns out that the RustRover IDE will launch debug process with test profile, which is inherited from dev[^1] profile. I am not sure why the dev[^2] profile in this project is configured without debug enabled. I add the test profile with debug enabled in this PR.

[^1]: https://doc.rust-lang.org/cargo/reference/profiles.html#test
[^2]: https://github.com/Eventual-Inc/Daft/blob/main/Cargo.toml#L86
