### PR TITLE
[BUG] Separate PartitionTask done from results

### DIFF
--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -510,6 +510,7 @@ class PyRunner(Runner[MicroPartition], ActorPoolManager):
                             self._resources.release(resources)
 
                             next_step.set_result(materialized_results)
+                            next_step.set_done()
 
                         else:
                             # Submit the task for execution.
@@ -572,6 +573,7 @@ class PyRunner(Runner[MicroPartition], ActorPoolManager):
                     )
 
                     done_task.set_result(materialized_results)
+                    done_task.set_done()
 
                 if next_step is None:
                     next_step = next(plan)

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -816,6 +816,8 @@ class Scheduler(ActorPoolManager):
                                 completed_task_ids.append(task_id)
                                 # Mark the entire task associated with the result as done.
                                 task = inflight_tasks[task_id]
+                                task.set_done()
+
                                 if isinstance(task, SingleOutputPartitionTask):
                                     del inflight_ref_to_task[ready]
                                 elif isinstance(task, MultiOutputPartitionTask):

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -750,6 +750,7 @@ class Scheduler(ActorPoolManager):
                                 next_step.set_result(
                                     [RayMaterializedResult(partition, accessor, 0) for partition in next_step.inputs]
                                 )
+                                next_step.set_done()
                                 next_step = next(tasks)
 
                             else:

--- a/tests/physical_plan/test_physical_plan_buffering.py
+++ b/tests/physical_plan/test_physical_plan_buffering.py
@@ -29,8 +29,11 @@ def test_single_non_buffered_plan():
 
     # Manually "complete" the tasks
     task1.set_result([result1])
+    task1.set_done()
     task2.set_result([result2])
+    task2.set_done()
     task3.set_result([result3])
+    task3.set_done()
 
     # Results should be as we expect
     assert next(plan) == result1
@@ -57,7 +60,9 @@ def test_single_non_buffered_plan_done_while_planning():
 
     # Manually "complete" the tasks
     task1.set_result([result1])
+    task1.set_done()
     task2.set_result([result2])
+    task2.set_done()
 
     # On the next iteration, we should receive the result
     assert next(plan) == result1
@@ -70,6 +75,7 @@ def test_single_non_buffered_plan_done_while_planning():
 
     # Manually "complete" the last task
     task3.set_result([result3])
+    task3.set_done()
 
     # Results should be as we expect
     assert next(plan) == result3
@@ -95,8 +101,10 @@ def test_single_plan_with_buffer_slow_tasks():
     # Plan cannot make forward progress until task1 finishes
     assert next(plan) is None
     task2.set_result([result2])
+    task2.set_done()
     assert next(plan) is None
     task1.set_result([result1])
+    task1.set_done()
 
     # Plan should fill its buffer with new tasks before starting to yield results again
     task3 = next(plan)
@@ -106,6 +114,7 @@ def test_single_plan_with_buffer_slow_tasks():
 
     # Finish the last task
     task3.set_result([result3])
+    task3.set_done()
     assert next(plan) == result3
 
     with pytest.raises(StopIteration):
@@ -126,6 +135,7 @@ def test_single_plan_with_buffer_saturation_fast_tasks():
 
     # Finish up on task 1 (task is "fast" and completes so quickly even before the next plan loop call)
     task1.set_result([result1])
+    task1.set_done()
 
     # Plan should fill its buffer completely with new tasks before starting to yield results again
     task2 = next(plan)
@@ -139,7 +149,9 @@ def test_single_plan_with_buffer_saturation_fast_tasks():
 
     # Finish the last task(s)
     task2.set_result([result2])
+    task2.set_done()
     task3.set_result([result3])
+    task3.set_done()
     assert next(plan) == result2
     assert next(plan) == result3
 


### PR DESCRIPTION
This PR marks `PartitionTasks` as done only after they have been explicitly marked as done by the runner.

Previously, we used the existence of the `.results` on a PartitionTask to determine whether or not it is done. However, this is not quite correct in the case of the RayRunner, which will attach a result containing a Ray ObjectRef, which is a future. This future may not (and is likely not) be completed yet at the time of PartitionTask creation.