### PR TITLE
[FEAT] Support null equal safe join in SQL

### DIFF
--- a/src/daft-plan/src/logical_optimization/rules/eliminate_cross_join.rs
+++ b/src/daft-plan/src/logical_optimization/rules/eliminate_cross_join.rs
@@ -41,6 +41,8 @@ impl OptimizerRule for EliminateCrossJoin {
                 LogicalPlan::Join(Join {
                     join_type: JoinType::Inner,
                     join_strategy: None,
+                    // TODO: consider support eliminate cross join with null_equals_nulls
+                    null_equals_nulls: None,
                     ..
                 })
             );
@@ -63,6 +65,8 @@ impl OptimizerRule for EliminateCrossJoin {
             LogicalPlan::Join(Join {
                 join_type: JoinType::Inner,
                 join_strategy: None,
+                // TODO: consider support eliminate cross join with null_equals_nulls
+                null_equals_nulls: None,
                 ..
             })
         ) {
@@ -306,8 +310,8 @@ fn find_inner_join(
                 left: left_input,
                 right: right_input,
                 left_on: left_keys,
-                null_equals_nulls: None,
                 right_on: right_keys,
+                null_equals_nulls: None,
                 join_type: JoinType::Inner,
                 join_strategy: None,
                 output_schema: Arc::new(join_schema),

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -592,27 +592,31 @@ impl SQLPlanner {
             expression: &sqlparser::ast::Expr,
             left_rel: &Relation,
             right_rel: &Relation,
-        ) -> SQLPlannerResult<(Vec<ExprRef>, Vec<ExprRef>)> {
-            // TODO: support null safe equal, a.k.a. <=>.
+        ) -> SQLPlannerResult<(Vec<ExprRef>, Vec<ExprRef>, Vec<bool>)> {
             if let sqlparser::ast::Expr::BinaryOp { left, op, right } = expression {
                 match *op {
-                    BinaryOperator::Eq => {
+                    BinaryOperator::Eq | BinaryOperator::Spaceship => {
                         if let (
                             sqlparser::ast::Expr::CompoundIdentifier(left),
                             sqlparser::ast::Expr::CompoundIdentifier(right),
                         ) = (left.as_ref(), right.as_ref())
                         {
+                            let null_equals_null = *op == BinaryOperator::Spaceship;
                             collect_compound_identifiers(left, right, left_rel, right_rel)
+                                .map(|(left, right)| (left, right, vec![null_equals_null]))
                         } else {
-                            unsupported_sql_err!("JOIN clauses support '=' constraints on identifiers; found lhs={:?}, rhs={:?}", left, right);
+                            unsupported_sql_err!("JOIN clauses support '='/'<=>' constraints on identifiers; found lhs={:?}, rhs={:?}", left, right);
                         }
                     }
                     BinaryOperator::And => {
-                        let (mut left_i, mut right_i) = process_join_on(left, left_rel, right_rel)?;
-                        let (mut left_j, mut right_j) = process_join_on(left, left_rel, right_rel)?;
+                        let (mut left_i, mut right_i, mut null_equals_nulls_i) =
+                            process_join_on(left, left_rel, right_rel)?;
+                        let (mut left_j, mut right_j, mut null_equals_nulls_j) =
+                            process_join_on(left, left_rel, right_rel)?;
                         left_i.append(&mut left_j);
                         right_i.append(&mut right_j);
-                        Ok((left_i, right_i))
+                        null_equals_nulls_i.append(&mut null_equals_nulls_j);
+                        Ok((left_i, right_i, null_equals_nulls_i))
                     }
                     _ => {
                         unsupported_sql_err!("JOIN clauses support '=' constraints combined with 'AND'; found op = '{:?}'", op);
@@ -645,12 +649,14 @@ impl SQLPlanner {
 
             match &join.join_operator {
                 Inner(JoinConstraint::On(expr)) => {
-                    let (left_on, right_on) = process_join_on(expr, &left_rel, &right_rel)?;
+                    let (left_on, right_on, null_equals_nulls) =
+                        process_join_on(expr, &left_rel, &right_rel)?;
 
-                    left_rel.inner = left_rel.inner.join(
+                    left_rel.inner = left_rel.inner.join_with_null_safe_equal(
                         right_rel.inner,
                         left_on,
                         right_on,
+                        Some(null_equals_nulls),
                         JoinType::Inner,
                         None,
                         None,
@@ -674,12 +680,14 @@ impl SQLPlanner {
                     )?;
                 }
                 LeftOuter(JoinConstraint::On(expr)) => {
-                    let (left_on, right_on) = process_join_on(expr, &left_rel, &right_rel)?;
+                    let (left_on, right_on, null_equals_nulls) =
+                        process_join_on(expr, &left_rel, &right_rel)?;
 
-                    left_rel.inner = left_rel.inner.join(
+                    left_rel.inner = left_rel.inner.join_with_null_safe_equal(
                         right_rel.inner,
                         left_on,
                         right_on,
+                        Some(null_equals_nulls),
                         JoinType::Left,
                         None,
                         None,
@@ -687,12 +695,14 @@ impl SQLPlanner {
                     )?;
                 }
                 RightOuter(JoinConstraint::On(expr)) => {
-                    let (left_on, right_on) = process_join_on(expr, &left_rel, &right_rel)?;
+                    let (left_on, right_on, null_equals_nulls) =
+                        process_join_on(expr, &left_rel, &right_rel)?;
 
-                    left_rel.inner = left_rel.inner.join(
+                    left_rel.inner = left_rel.inner.join_with_null_safe_equal(
                         right_rel.inner,
                         left_on,
                         right_on,
+                        Some(null_equals_nulls),
                         JoinType::Right,
                         None,
                         None,
@@ -701,12 +711,14 @@ impl SQLPlanner {
                 }
 
                 FullOuter(JoinConstraint::On(expr)) => {
-                    let (left_on, right_on) = process_join_on(expr, &left_rel, &right_rel)?;
+                    let (left_on, right_on, null_equals_nulls) =
+                        process_join_on(expr, &left_rel, &right_rel)?;
 
-                    left_rel.inner = left_rel.inner.join(
+                    left_rel.inner = left_rel.inner.join_with_null_safe_equal(
                         right_rel.inner,
                         left_on,
                         right_on,
+                        Some(null_equals_nulls),
                         JoinType::Outer,
                         None,
                         None,

--- a/tests/sql/test_joins.py
+++ b/tests/sql/test_joins.py
@@ -1,5 +1,6 @@
 import daft
 from daft import col
+from daft.sql import SQLCatalog
 
 
 def test_joins_using():
@@ -23,6 +24,20 @@ def test_joins_with_alias():
     actual = df_sql.collect().to_pydict()
 
     expected = df1.join(df2, on="idx").filter(col("score") > 0.1).collect().to_pydict()
+
+    assert actual == expected
+
+
+def test_joins_with_spaceship():
+    df1 = daft.from_pydict({"idx": [1, 2, None], "val": [10, 20, 30]})
+    df2 = daft.from_pydict({"idx": [1, 2, None], "score": [0.1, 0.2, None]})
+
+    catalog = SQLCatalog({"df1": df1, "df2": df2})
+    df_sql = daft.sql("select idx, val, score from df1 join df2 on (df1.idx<=>df2.idx)", catalog=catalog)
+
+    actual = df_sql.collect().to_pydict()
+
+    expected = {"idx": [1, 2, None], "val": [10, 20, 30], "score": [0.1, 0.2, None]}
 
     assert actual == expected
 


### PR DESCRIPTION
One follow-up of #3161: add `on a <=> b` support for SQL's Join operation.