### PR TITLE
[CHORE] Implement dispatcher for intermediate ops and streaming sink

### DIFF
--- a/src/daft-local-execution/src/sinks/concat.rs
+++ b/src/daft-local-execution/src/sinks/concat.rs
@@ -7,7 +7,10 @@ use tracing::instrument;
 use super::streaming_sink::{
     DynStreamingSinkState, StreamingSink, StreamingSinkOutput, StreamingSinkState,
 };
-use crate::pipeline::PipelineResultType;
+use crate::{
+    dispatcher::{Dispatcher, RoundRobinBufferedDispatcher},
+    pipeline::PipelineResultType,
+};
 
 struct ConcatSinkState {
     // The index of the last morsel of data that was received, which should be strictly non-decreasing.
@@ -63,5 +66,12 @@ impl StreamingSink for ConcatSink {
     /// Since the ConcatSink does not do any computation, it does not need to spawn multiple workers.
     fn max_concurrency(&self) -> usize {
         1
+    }
+
+    fn make_dispatcher(
+        &self,
+        _runtime_handle: &crate::ExecutionRuntimeHandle,
+    ) -> Arc<dyn Dispatcher> {
+        Arc::new(RoundRobinBufferedDispatcher::new(None))
     }
 }

--- a/src/daft-local-execution/src/sinks/limit.rs
+++ b/src/daft-local-execution/src/sinks/limit.rs
@@ -7,7 +7,7 @@ use tracing::instrument;
 use super::streaming_sink::{
     DynStreamingSinkState, StreamingSink, StreamingSinkOutput, StreamingSinkState,
 };
-use crate::pipeline::PipelineResultType;
+use crate::{dispatcher::Dispatcher, pipeline::PipelineResultType};
 
 struct LimitSinkState {
     remaining: usize,
@@ -89,5 +89,12 @@ impl StreamingSink for LimitSink {
 
     fn max_concurrency(&self) -> usize {
         1
+    }
+
+    fn make_dispatcher(
+        &self,
+        _runtime_handle: &crate::ExecutionRuntimeHandle,
+    ) -> Arc<dyn Dispatcher> {
+        Arc::new(crate::dispatcher::RoundRobinBufferedDispatcher::new(None))
     }
 }

--- a/src/daft-local-execution/src/sinks/outer_hash_join_probe.rs
+++ b/src/daft-local-execution/src/sinks/outer_hash_join_probe.rs
@@ -18,7 +18,7 @@ use tracing::{info_span, instrument};
 use super::streaming_sink::{
     DynStreamingSinkState, StreamingSink, StreamingSinkOutput, StreamingSinkState,
 };
-use crate::pipeline::PipelineResultType;
+use crate::{dispatcher::RoundRobinBufferedDispatcher, pipeline::PipelineResultType};
 
 struct IndexBitmapBuilder {
     mutable_bitmaps: Vec<MutableBitmap>,
@@ -412,5 +412,14 @@ impl StreamingSink for OuterHashJoinProbeSink {
         } else {
             Ok(None)
         }
+    }
+
+    fn make_dispatcher(
+        &self,
+        runtime_handle: &crate::ExecutionRuntimeHandle,
+    ) -> Arc<dyn crate::dispatcher::Dispatcher> {
+        Arc::new(RoundRobinBufferedDispatcher::new(Some(
+            runtime_handle.default_morsel_size(),
+        )))
     }
 }

--- a/src/daft-local-execution/src/sinks/write.rs
+++ b/src/daft-local-execution/src/sinks/write.rs
@@ -129,9 +129,9 @@ impl BlockingSink for WriteSink {
         if let Some(partition_by) = &self.partition_by {
             Arc::new(PartitionedDispatcher::new(partition_by.clone()))
         } else {
-            Arc::new(RoundRobinBufferedDispatcher::new(
+            Arc::new(RoundRobinBufferedDispatcher::new(Some(
                 runtime_handle.default_morsel_size(),
-            ))
+            )))
         }
     }
 


### PR DESCRIPTION
In the streaming physical writes PR, we introduced a `dispatcher` trait, which allows a blocking sink to define how to distribute work across workers: https://github.com/Eventual-Inc/Daft/pull/2992, i.e. partitioned by hash, round robin, etc.

This PR enables intermediate ops and streaming sinks to use `dispatcher` as well. In the future, we can add a `unordered dispatcher` which allows workers to accept input on demand instead of round robin.

Stacked on https://github.com/Eventual-Inc/Daft/pull/3235
