### PR TITLE
[BUG] Fix ray wait in RayPartitionSet

### DIFF
--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -339,7 +339,7 @@ class RayPartitionSet(PartitionSet[ray.ObjectRef]):
 
     def wait(self) -> None:
         deduped_object_refs = {r.partition() for r in self._results.values()}
-        ray.wait(list(deduped_object_refs))
+        ray.wait(list(deduped_object_refs), fetch_local=False, num_returns=len(deduped_object_refs))
 
 
 def _from_arrow_type_with_ray_data_extensions(arrow_type: pa.lib.DataType) -> DataType:


### PR DESCRIPTION
Ray's `ray.wait` is supposed to:

1. Defaults to `fetch_local=True` which will supposedly fetch data to wherever the wait is called before returning
2. Defaults to `num_returns=1` which will wait until only the first item is ready before returning

This seems to not be the intended behavior here, where `RayPartitionSet` is trying to wait on ALL the partitions to be ready, and does not want to pull any data down to the calling site.