### PR TITLE
[FEAT] Better ScanTask sizing estimations

### DIFF
--- a/src/daft-physical-plan/src/physical_planner/translate.rs
+++ b/src/daft-physical-plan/src/physical_planner/translate.rs
@@ -53,6 +53,7 @@ pub(super) fn translate_single_logical_node(
                     cfg.parquet_split_row_groups_max_files,
                     cfg.scan_tasks_min_size_bytes,
                     cfg.scan_tasks_max_size_bytes,
+                    scan_op.0.data_size_estimator(),
                 );
 
                 // Apply transformations on the ScanTasks to optimize

--- a/src/daft-scan/src/anonymous.rs
+++ b/src/daft-scan/src/anonymous.rs
@@ -38,7 +38,9 @@ impl ScanOperator for AnonymousScanOperator {
         self.schema.clone()
     }
 
-    fn data_size_estimator(&self) -> Option<&dyn crate::data_size_estimator::DataSizeEstimator> {
+    fn data_size_estimator(
+        &self,
+    ) -> Option<Arc<dyn crate::data_size_estimator::DataSizeEstimator>> {
         None
     }
 

--- a/src/daft-scan/src/anonymous.rs
+++ b/src/daft-scan/src/anonymous.rs
@@ -38,6 +38,10 @@ impl ScanOperator for AnonymousScanOperator {
         self.schema.clone()
     }
 
+    fn data_size_estimator(&self) -> Option<&dyn crate::data_size_estimator::DataSizeEstimator> {
+        None
+    }
+
     fn partitioning_keys(&self) -> &[PartitionField] {
         &[]
     }

--- a/src/daft-scan/src/data_size_estimator.rs
+++ b/src/daft-scan/src/data_size_estimator.rs
@@ -1,0 +1,155 @@
+use std::{collections::HashMap, fmt::Debug};
+
+use daft_schema::schema::SchemaRef;
+
+use crate::ScanTaskRef;
+
+pub trait DataSizeEstimator: Debug + Sync + Send {
+    /// Estimate how much memory a given ScanTask is going to be when fully materialized given the size on disk
+    fn estimate_in_memory_size_bytes(&self, scan_task: ScanTaskRef) -> Option<usize>;
+}
+
+#[derive(Debug)]
+pub(crate) struct ParquetDataSizeEstimator {
+    /// Schema of the data
+    schema: SchemaRef,
+
+    /// Estimate how much large each row is at rest (compressed)
+    estimated_row_size: usize,
+
+    /// Fraction of total size taken up by each column at rest (compressed)
+    column_size_fraction: HashMap<usize, f32>,
+
+    /// How much we expect each column to inflate when decompressed and decoded into memory
+    column_inflation: HashMap<usize, f32>,
+}
+
+impl ParquetDataSizeEstimator {
+    /// Creates a ParquetDataSizeEstimator from Parquet metadata
+    ///
+    /// NOTE: Currently has strong assumptions about the names in the provided `daft_schema` matching names in the Parquet metadata.
+    /// This might not be an accurate mapping, especially if field IDs are being used (for example in Apache Iceberg).
+    pub fn from_parquet_metadata(
+        daft_schema: SchemaRef,
+        parquet_meta: &parquet2::metadata::FileMetaData,
+    ) -> Self {
+        let total_rg_compressed_size: i64 = parquet_meta
+            .row_groups
+            .iter()
+            .map(|(_, rg)| (rg.compressed_size() as i64))
+            .sum();
+        let total_num_rows: usize = parquet_meta
+            .row_groups
+            .iter()
+            .map(|(_, rg)| rg.num_rows())
+            .sum();
+
+        // Accumulate statistics per-column
+        // We only consider columns with names that match the field names in the provided `daft_schema`
+        let mut total_compressed_size_per_column = HashMap::new();
+        let mut total_uncompressed_size_per_column = HashMap::new();
+        for (_, rg) in &parquet_meta.row_groups {
+            for cc_meta in rg.columns() {
+                match cc_meta.descriptor().path_in_schema.first() {
+                    Some(topmost_schema_name) => {
+                        if let Some(field_idx) = daft_schema
+                            .as_ref()
+                            .fields
+                            .get_index_of(topmost_schema_name)
+                        {
+                            let total_column_compressed_size =
+                                if let Some(existing_accumulated_size) =
+                                    total_compressed_size_per_column.get(&field_idx)
+                                {
+                                    existing_accumulated_size + cc_meta.compressed_size()
+                                } else {
+                                    cc_meta.compressed_size()
+                                };
+                            let total_column_uncompressed_size =
+                                if let Some(existing_accumulated_size) =
+                                    total_uncompressed_size_per_column.get(&field_idx)
+                                {
+                                    existing_accumulated_size + cc_meta.uncompressed_size()
+                                } else {
+                                    cc_meta.uncompressed_size()
+                                };
+                            total_compressed_size_per_column
+                                .insert(field_idx, total_column_compressed_size);
+                            total_uncompressed_size_per_column
+                                .insert(field_idx, total_column_uncompressed_size);
+                        } else {
+                            continue;
+                        }
+                    }
+                    None => {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        Self {
+            schema: daft_schema,
+            estimated_row_size: (total_rg_compressed_size as usize) / total_num_rows,
+            column_size_fraction: total_compressed_size_per_column
+                .iter()
+                .map(|(&field_idx, &column_compressed_size)| {
+                    (
+                        field_idx,
+                        (column_compressed_size as f32) / (total_rg_compressed_size as f32),
+                    )
+                })
+                .collect(),
+            column_inflation: total_compressed_size_per_column
+                .iter()
+                .map(|(&field_idx, &col_compressed_size)| {
+                    (
+                        field_idx,
+                        (*total_uncompressed_size_per_column.get(&field_idx).unwrap() as f32)
+                            / (col_compressed_size as f32),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl DataSizeEstimator for ParquetDataSizeEstimator {
+    fn estimate_in_memory_size_bytes(&self, scan_task: ScanTaskRef) -> Option<usize> {
+        // We can only estimate the in memory size if provided with size of the ScanTask on disk
+        let size_on_disk = scan_task.size_bytes_on_disk()?;
+
+        // If we have column pushdowns, only consider those columns
+        let columns_to_consider: Vec<usize> =
+            if let Some(column_pushdowns) = scan_task.pushdowns.columns.as_ref() {
+                column_pushdowns
+                    .iter()
+                    .map(|name| self.schema.as_ref().fields.get_index_of(name).unwrap())
+                    .collect()
+            } else {
+                (0..self.schema.as_ref().len()).collect()
+            };
+
+        // Grab the uncompressed size of each column, and then inflate it to add to the total size
+        let total_uncompressed_size: f32 = columns_to_consider
+            .iter()
+            .map(|col_idx| {
+                let fraction = self.column_size_fraction.get(col_idx).unwrap();
+                let inflation = self.column_inflation.get(col_idx).unwrap();
+
+                (size_on_disk as f32) * fraction * inflation
+            })
+            .sum();
+
+        // Apply limit pushdown if present
+        let total_uncompressed_size = if let Some(limit) = scan_task.pushdowns.limit {
+            let estimated_num_rows = (size_on_disk as f32) / self.estimated_row_size as f32;
+            let limit_fraction = (limit as f32 / estimated_num_rows).min(1.0);
+            total_uncompressed_size * limit_fraction
+        } else {
+            total_uncompressed_size
+        };
+
+        Some(total_uncompressed_size as usize)
+    }
+}

--- a/src/daft-scan/src/data_size_estimator.rs
+++ b/src/daft-scan/src/data_size_estimator.rs
@@ -2,11 +2,11 @@ use std::{collections::HashMap, fmt::Debug};
 
 use daft_schema::schema::SchemaRef;
 
-use crate::ScanTaskRef;
+use crate::ScanTask;
 
 pub trait DataSizeEstimator: Debug + Sync + Send {
     /// Estimate how much memory a given ScanTask is going to be when fully materialized given the size on disk
-    fn estimate_in_memory_size_bytes(&self, scan_task: ScanTaskRef) -> Option<usize>;
+    fn estimate_in_memory_size_bytes(&self, scan_task: &ScanTask) -> Option<usize>;
 }
 
 #[derive(Debug)]
@@ -115,7 +115,7 @@ impl ParquetDataSizeEstimator {
 }
 
 impl DataSizeEstimator for ParquetDataSizeEstimator {
-    fn estimate_in_memory_size_bytes(&self, scan_task: ScanTaskRef) -> Option<usize> {
+    fn estimate_in_memory_size_bytes(&self, scan_task: &ScanTask) -> Option<usize> {
         // We can only estimate the in memory size if provided with size of the ScanTask on disk
         let size_on_disk = scan_task.size_bytes_on_disk()?;
 

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -33,7 +33,7 @@ pub struct GlobScanOperator {
     hive_partitioning: bool,
     partitioning_keys: Vec<PartitionField>,
     generated_fields: SchemaRef,
-    data_size_estimator: Option<Box<dyn DataSizeEstimator>>,
+    data_size_estimator: Option<Arc<dyn DataSizeEstimator>>,
 }
 
 /// Wrapper struct that implements a sync Iterator for a BoxStream
@@ -232,10 +232,10 @@ impl GlobScanOperator {
 
                         (
                             schema.clone(),
-                            Some(Box::new(ParquetDataSizeEstimator::from_parquet_metadata(
+                            Some(Arc::new(ParquetDataSizeEstimator::from_parquet_metadata(
                                 schema,
                                 &parquet_meta,
-                            )) as Box<dyn DataSizeEstimator>),
+                            )) as Arc<dyn DataSizeEstimator>),
                         )
                     }
                     FileFormatConfig::Csv(CsvSourceConfig {
@@ -318,8 +318,8 @@ impl ScanOperator for GlobScanOperator {
         self.schema.clone()
     }
 
-    fn data_size_estimator(&self) -> Option<&dyn DataSizeEstimator> {
-        self.data_size_estimator.as_ref().map(|dse| dse.as_ref())
+    fn data_size_estimator(&self) -> Option<Arc<dyn DataSizeEstimator>> {
+        self.data_size_estimator.as_ref().map(|dse| dse.clone())
     }
 
     fn partitioning_keys(&self) -> &[PartitionField] {

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -825,7 +825,7 @@ pub trait ScanOperator: Send + Sync + Debug {
     fn generated_fields(&self) -> Option<SchemaRef>;
 
     /// Retrieve a DataSizeEstimator that can provide more accurate estimations of data from file sizes on disk
-    fn data_size_estimator(&self) -> Option<&dyn DataSizeEstimator>;
+    fn data_size_estimator(&self) -> Option<Arc<dyn DataSizeEstimator>>;
 
     fn can_absorb_filter(&self) -> bool;
     fn can_absorb_select(&self) -> bool;

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -16,11 +16,13 @@ use daft_schema::{
     schema::{Schema, SchemaRef},
 };
 use daft_stats::{PartitionSpec, TableMetadata, TableStatistics};
+use data_size_estimator::DataSizeEstimator;
 use itertools::Itertools;
 use parquet2::metadata::FileMetaData;
 use serde::{Deserialize, Serialize};
 
 mod anonymous;
+mod data_size_estimator;
 pub use anonymous::AnonymousScanOperator;
 pub mod glob;
 mod hive;
@@ -821,6 +823,9 @@ pub trait ScanOperator: Send + Sync + Debug {
     // in ScanTask::materialized_schema), while generated fields require special handling.
     // Thus, we maintain separate representations for partitioning keys and generated fields.
     fn generated_fields(&self) -> Option<SchemaRef>;
+
+    /// Retrieve a DataSizeEstimator that can provide more accurate estimations of data from file sizes on disk
+    fn data_size_estimator(&self) -> Option<&dyn DataSizeEstimator>;
 
     fn can_absorb_filter(&self) -> bool;
     fn can_absorb_select(&self) -> bool;

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -219,7 +219,7 @@ pub mod pylib {
         }
         fn data_size_estimator(
             &self,
-        ) -> Option<&dyn crate::data_size_estimator::DataSizeEstimator> {
+        ) -> Option<Arc<dyn crate::data_size_estimator::DataSizeEstimator>> {
             // TODO(jay): have the Python ScanOperators return an appropriate DataSizeEstimator from stats
             // obtained from table formats/catalogs
             None

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -217,6 +217,13 @@ pub mod pylib {
         fn schema(&self) -> daft_schema::schema::SchemaRef {
             self.schema.clone()
         }
+        fn data_size_estimator(
+            &self,
+        ) -> Option<&dyn crate::data_size_estimator::DataSizeEstimator> {
+            // TODO(jay): have the Python ScanOperators return an appropriate DataSizeEstimator from stats
+            // obtained from table formats/catalogs
+            None
+        }
         fn file_path_column(&self) -> Option<&str> {
             None
         }


### PR DESCRIPTION
Add capabilities for performing better sizing of our ScanTasks.

When reading data, we often just have a "size on disk" to try and understand how much data would actually be materialized in memory. This PR adds a new `DataSizeEstimator` trait that can be implemented to provide a mechanism for Daft to better estimate the size in memory of a ScanTask.