### PR TITLE
[DOCS] Set canonical link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,6 +76,8 @@ html_theme_options = {
     # This is how many levels are shown on the secondary sidebar
     "show_toc_level": 2,
 }
+# Set canonical link
+html_baseurl = "/stable/"
 
 # -- Copy button configuration
 


### PR DESCRIPTION
We should set the canonical link for Daft docs so that google does not index old versions of our docs.