### PR TITLE
[BUG] Cleanup context side-effects

### DIFF
--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -216,7 +216,7 @@ def warmup_environment(requirements: str | None, parquet_folder: str):
         runtime_env = get_ray_runtime_env(requirements)
 
         ray.init(
-            address=ctx.runner_config.address,
+            address=ctx._runner_config.address,
             runtime_env=runtime_env,
         )
 

--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -131,7 +131,7 @@ def run_all_benchmarks(
     get_df = get_df_with_parquet_folder(parquet_folder)
 
     daft_context = get_context()
-    metrics_builder = MetricsBuilder(daft_context.get_runner_config_name())
+    metrics_builder = MetricsBuilder(daft_context.get_or_create_runner().name)
 
     for i in questions:
         # Run as a Ray Job if dashboard URL is provided
@@ -212,7 +212,7 @@ def warmup_environment(requirements: str | None, parquet_folder: str):
     """Performs necessary setup of Daft on the current benchmarking environment"""
     ctx = daft.context.get_context()
 
-    if ctx.get_runner_config_name() == "ray":
+    if ctx.get_or_create_runner().name == "ray":
         runtime_env = get_ray_runtime_env(requirements)
 
         ray.init(

--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -131,7 +131,7 @@ def run_all_benchmarks(
     get_df = get_df_with_parquet_folder(parquet_folder)
 
     daft_context = get_context()
-    metrics_builder = MetricsBuilder(daft_context.runner_config.name)
+    metrics_builder = MetricsBuilder(daft_context.get_runner_config_name())
 
     for i in questions:
         # Run as a Ray Job if dashboard URL is provided
@@ -212,7 +212,7 @@ def warmup_environment(requirements: str | None, parquet_folder: str):
     """Performs necessary setup of Daft on the current benchmarking environment"""
     ctx = daft.context.get_context()
 
-    if ctx.runner_config.name == "ray":
+    if ctx.get_runner_config_name() == "ray":
         runtime_env = get_ray_runtime_env(requirements)
 
         ray.init(

--- a/daft/analytics.py
+++ b/daft/analytics.py
@@ -136,12 +136,10 @@ class AnalyticsClient:
             self._buffer = []
 
     def track_import(self) -> None:
-        runner_config = context.get_context().runner_config
-        runner_name = runner_config and runner_config.name
         self._append_to_log(
             "Imported Daft",
             {
-                "runner": runner_name,
+                "runner": context.get_context().get_runner_config_name(),
                 "platform": platform.platform(),
                 "python_version": platform.python_version(),
                 "DAFT_ANALYTICS_ENABLED": os.getenv("DAFT_ANALYTICS_ENABLED"),

--- a/daft/analytics.py
+++ b/daft/analytics.py
@@ -136,10 +136,12 @@ class AnalyticsClient:
             self._buffer = []
 
     def track_import(self) -> None:
+        runner_config = context.get_context().runner_config
+        runner_name = runner_config and runner_config.name
         self._append_to_log(
             "Imported Daft",
             {
-                "runner": context.get_context().runner_config.name,
+                "runner": runner_name,
                 "platform": platform.platform(),
                 "python_version": platform.python_version(),
                 "DAFT_ANALYTICS_ENABLED": os.getenv("DAFT_ANALYTICS_ENABLED"),

--- a/daft/analytics.py
+++ b/daft/analytics.py
@@ -15,8 +15,6 @@ import urllib.error
 import urllib.request
 from typing import Any, Callable
 
-from daft import context
-
 _ANALYTICS_CLIENT = None
 _WRITE_KEY = "ZU2LLq6HFW0kMEY6TiGZoGnRzogXBUwa"
 _SEGMENT_BATCH_ENDPOINT = "https://api.segment.io/v1/batch"
@@ -139,7 +137,6 @@ class AnalyticsClient:
         self._append_to_log(
             "Imported Daft",
             {
-                "runner": context.get_context().get_runner_config_name(),
                 "platform": platform.platform(),
                 "python_version": platform.python_version(),
                 "DAFT_ANALYTICS_ENABLED": os.getenv("DAFT_ANALYTICS_ENABLED"),

--- a/daft/context.py
+++ b/daft/context.py
@@ -164,12 +164,6 @@ class DaftContext:
         with self._lock:
             return self._daft_planning_config
 
-    @property
-    def runner_config(self) -> _RunnerConfig | None:
-        """Retrieve the currently active runner config, or None if it has not yet been set"""
-        with self._lock:
-            return self._runner_config
-
     def _get_or_create_runner_config(self) -> _RunnerConfig:
         """Gets the runner config."""
         if self._runner_config is not None:

--- a/daft/context.py
+++ b/daft/context.py
@@ -146,7 +146,7 @@ class DaftContext:
                     cls._instance = super().__new__(cls)
         return cls._instance
 
-    def runner(self) -> Runner:
+    def get_or_create_runner(self) -> Runner:
         """Retrieves the runner.
 
         WARNING: This will set the runner if it has not yet been set.
@@ -179,22 +179,14 @@ class DaftContext:
                 return self._runner_config.name
 
     def _get_or_create_runner_config(self) -> _RunnerConfig:
-        """Gets the runner config.
-
-        WARNING: This function has side-effects and will set the runner config if it has not yet been set. Do not call this
-        from APIs that don't expect side-effects.
-        """
+        """Gets the runner config."""
         if self._runner_config is not None:
             return self._runner_config
         self._runner_config = _get_runner_config_from_env()
         return self._runner_config
 
     def _get_or_create_runner(self) -> Runner:
-        """Gets the runner.
-
-        WARNING: This function has side-effects and will set the runner if it has not yet been set. Do not call this
-        from APIs that don't expect side-effects.
-        """
+        """Gets the runner."""
         if self._runner is not None:
             return self._runner
 
@@ -223,14 +215,6 @@ class DaftContext:
             raise NotImplementedError(f"Runner config not implemented: {runner_config.name}")
 
         return self._runner
-
-    @property
-    def is_ray_runner(self) -> bool | None:
-        """Checks if running in the Ray Runner. Returns `None` if the runner is not yet set."""
-        with self._lock:
-            if self._runner_config is None:
-                return None
-            return self._runner_config.name == "ray"
 
     def _can_set_runner(self, new_runner_name: str) -> bool:
         # If the runner has not been set yet, we can set it

--- a/daft/context.py
+++ b/daft/context.py
@@ -221,7 +221,7 @@ class DaftContext:
         if self._runner_config is None:
             return True
         # If the runner has been set to the ray runner, we can't set it again
-        elif self._runner_config.name == "ray" and self._runner is not None:
+        elif self._runner_config.name == "ray":
             return False
         # If the runner has been set to a local runner, we can set it to a new local runner
         else:

--- a/daft/context.py
+++ b/daft/context.py
@@ -170,10 +170,11 @@ class DaftContext:
         with self._lock:
             return self._runner_config
 
-    def get_runner_config_name(self) -> Literal["ray"] | Literal["py"] | Literal["native"]:
+    def get_runner_config_name(self) -> Literal["ray"] | Literal["py"] | Literal["native"] | None:
+        """Retrieves the Runner Config name, or None if not yet set"""
         with self._lock:
             if self._runner_config is None:
-                return _get_runner_config_from_env().name
+                return None
             else:
                 return self._runner_config.name
 

--- a/daft/context.py
+++ b/daft/context.py
@@ -170,14 +170,6 @@ class DaftContext:
         with self._lock:
             return self._runner_config
 
-    def get_runner_config_name(self) -> Literal["ray"] | Literal["py"] | Literal["native"] | None:
-        """Retrieves the Runner Config name, or None if not yet set"""
-        with self._lock:
-            if self._runner_config is None:
-                return None
-            else:
-                return self._runner_config.name
-
     def _get_or_create_runner_config(self) -> _RunnerConfig:
         """Gets the runner config."""
         if self._runner_config is not None:

--- a/daft/context.py
+++ b/daft/context.py
@@ -170,7 +170,7 @@ class DaftContext:
         with self._lock:
             return self._runner_config
 
-    def get_runner_config_name(self) -> Literal["ray"] | Literal["py"] | Literal["native"] | None:
+    def get_runner_config_name(self) -> Literal["ray"] | Literal["py"] | Literal["native"]:
         with self._lock:
             if self._runner_config is None:
                 return _get_runner_config_from_env().name

--- a/daft/context.py
+++ b/daft/context.py
@@ -5,7 +5,7 @@ import dataclasses
 import logging
 import os
 import warnings
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 from daft import get_build_type
 from daft.daft import IOConfig, PyDaftExecutionConfig, PyDaftPlanningConfig
@@ -19,7 +19,7 @@ import threading
 
 
 class _RunnerConfig:
-    name: ClassVar[str]
+    name: ClassVar[Literal["ray"] | Literal["py"] | Literal["native"]]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -169,6 +169,13 @@ class DaftContext:
         """Retrieve the currently active runner config, or None if it has not yet been set"""
         with self._lock:
             return self._runner_config
+
+    def get_runner_config_name(self) -> Literal["ray"] | Literal["py"] | Literal["native"] | None:
+        with self._lock:
+            if self._runner_config is None:
+                return None
+            else:
+                return self._runner_config.name
 
     def _get_or_create_runner_config(self) -> _RunnerConfig:
         """Gets the runner config.

--- a/daft/context.py
+++ b/daft/context.py
@@ -173,7 +173,7 @@ class DaftContext:
     def get_runner_config_name(self) -> Literal["ray"] | Literal["py"] | Literal["native"] | None:
         with self._lock:
             if self._runner_config is None:
-                return None
+                return _get_runner_config_from_env().name
             else:
                 return self._runner_config.name
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2762,7 +2762,7 @@ class DataFrame:
         from ray.exceptions import RayTaskError
 
         context = get_context()
-        if context.runner_config and context.runner_config.name != "ray":
+        if context.runner_config and context.get_runner_config_name() != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO
@@ -2864,7 +2864,7 @@ class DataFrame:
         # TODO(Clark): Support Dask DataFrame conversion for the local runner if
         # Dask is using a non-distributed scheduler.
         context = get_context()
-        if context.runner_config and context.runner_config.name != "ray":
+        if context.runner_config and context.get_runner_config_name() != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2762,7 +2762,7 @@ class DataFrame:
         from ray.exceptions import RayTaskError
 
         context = get_context()
-        if context.runner_config.name != "ray":
+        if context.runner_config and context.runner_config.name != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO
@@ -2864,7 +2864,7 @@ class DataFrame:
         # TODO(Clark): Support Dask DataFrame conversion for the local runner if
         # Dask is using a non-distributed scheduler.
         context = get_context()
-        if context.runner_config.name != "ray":
+        if context.runner_config and context.runner_config.name != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2762,7 +2762,7 @@ class DataFrame:
         from ray.exceptions import RayTaskError
 
         context = get_context()
-        if context.runner_config and context.get_runner_config_name() != "ray":
+        if context.get_runner_config_name() != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO
@@ -2864,7 +2864,7 @@ class DataFrame:
         # TODO(Clark): Support Dask DataFrame conversion for the local runner if
         # Dask is using a non-distributed scheduler.
         context = get_context()
-        if context.runner_config and context.get_runner_config_name() != "ray":
+        if context.get_runner_config_name() != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -274,7 +274,9 @@ class DataFrame:
         else:
             # Execute the dataframe in a streaming fashion.
             context = get_context()
-            partitions_iter = context.runner().run_iter_tables(self._builder, results_buffer_size=results_buffer_size)
+            partitions_iter = context.get_or_create_runner().run_iter_tables(
+                self._builder, results_buffer_size=results_buffer_size
+            )
 
             # Iterate through partitions.
             for partition in partitions_iter:
@@ -311,7 +313,9 @@ class DataFrame:
         else:
             # Execute the dataframe in a streaming fashion.
             context = get_context()
-            partitions_iter = context.runner().run_iter_tables(self._builder, results_buffer_size=results_buffer_size)
+            partitions_iter = context.get_or_create_runner().run_iter_tables(
+                self._builder, results_buffer_size=results_buffer_size
+            )
 
             # Iterate through partitions.
             for partition in partitions_iter:
@@ -390,7 +394,9 @@ class DataFrame:
         else:
             # Execute the dataframe in a streaming fashion.
             context = get_context()
-            results_iter = context.runner().run_iter(self._builder, results_buffer_size=results_buffer_size)
+            results_iter = context.get_or_create_runner().run_iter(
+                self._builder, results_buffer_size=results_buffer_size
+            )
             for result in results_iter:
                 yield result.partition()
 
@@ -489,7 +495,7 @@ class DataFrame:
             result_pset.set_partition_from_table(i, part)
 
         context = get_context()
-        cache_entry = context.runner().put_partition_set_into_cache(result_pset)
+        cache_entry = context.get_or_create_runner().put_partition_set_into_cache(result_pset)
         size_bytes = result_pset.size_bytes()
         num_rows = len(result_pset)
 
@@ -2478,7 +2484,7 @@ class DataFrame:
         """Materializes the results of for this DataFrame and hold a pointer to the results."""
         context = get_context()
         if self._result is None:
-            self._result_cache = context.runner().run(self._builder)
+            self._result_cache = context.get_or_create_runner().run(self._builder)
             result = self._result
             assert result is not None
             result.wait()
@@ -2524,7 +2530,7 @@ class DataFrame:
             # Iteratively retrieve partitions until enough data has been materialized
             tables = []
             seen = 0
-            for table in get_context().runner().run_iter_tables(builder, results_buffer_size=1):
+            for table in get_context().get_or_create_runner().run_iter_tables(builder, results_buffer_size=1):
                 tables.append(table)
                 seen += len(table)
                 if seen >= n:
@@ -2767,11 +2773,11 @@ class DataFrame:
 
         from daft.runners.ray_runner import RayRunnerIO
 
-        ray_runner_io = context.runner().runner_io()
+        ray_runner_io = context.get_or_create_runner().runner_io()
         assert isinstance(ray_runner_io, RayRunnerIO)
 
         partition_set, schema = ray_runner_io.partition_set_from_ray_dataset(ds)
-        cache_entry = context.runner().put_partition_set_into_cache(partition_set)
+        cache_entry = context.get_or_create_runner().put_partition_set_into_cache(partition_set)
         try:
             size_bytes = partition_set.size_bytes()
         except RayTaskError as e:
@@ -2869,11 +2875,11 @@ class DataFrame:
 
         from daft.runners.ray_runner import RayRunnerIO
 
-        ray_runner_io = context.runner().runner_io()
+        ray_runner_io = context.get_or_create_runner().runner_io()
         assert isinstance(ray_runner_io, RayRunnerIO)
 
         partition_set, schema = ray_runner_io.partition_set_from_dask_dataframe(ddf)
-        cache_entry = context.runner().put_partition_set_into_cache(partition_set)
+        cache_entry = context.get_or_create_runner().put_partition_set_into_cache(partition_set)
         size_bytes = partition_set.size_bytes()
         num_rows = len(partition_set)
         assert size_bytes is not None, "In-memory data should always have non-None size in bytes"

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2768,7 +2768,7 @@ class DataFrame:
         from ray.exceptions import RayTaskError
 
         context = get_context()
-        if context.get_runner_config_name() != "ray":
+        if context.get_or_create_runner().name != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO
@@ -2870,7 +2870,7 @@ class DataFrame:
         # TODO(Clark): Support Dask DataFrame conversion for the local runner if
         # Dask is using a non-distributed scheduler.
         context = get_context()
-        if context.get_runner_config_name() != "ray":
+        if context.get_or_create_runner().name != "ray":
             raise ValueError("Daft needs to be running on the Ray Runner for this operation")
 
         from daft.runners.ray_runner import RayRunnerIO

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -431,8 +431,7 @@ class DataType:
         elif isinstance(arrow_type, pa.BaseExtensionType):
             name = arrow_type.extension_name
 
-            runner_config = get_context().runner_config
-            if (runner_config and runner_config.name == "ray") and (
+            if (get_context().get_or_create_runner().name == "ray") and (
                 type(arrow_type).__reduce__ == pa.BaseExtensionType.__reduce__
             ):
                 raise ValueError(

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -431,7 +431,8 @@ class DataType:
         elif isinstance(arrow_type, pa.BaseExtensionType):
             name = arrow_type.extension_name
 
-            if (get_context().runner_config.name == "ray") and (
+            runner_config = get_context().runner_config
+            if (runner_config and runner_config.name == "ray") and (
                 type(arrow_type).__reduce__ == pa.BaseExtensionType.__reduce__
             ):
                 raise ValueError(

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -1281,7 +1281,7 @@ class ExpressionUrlNamespace(ExpressionNamespace):
         For local execution, we run in a single process which means that it all shares the same tokio I/O runtime and connection pool.
         Thus we just have `(multithreaded=N_CPU * max_connections)` number of open connections, which is usually reasonable as well.
         """
-        using_ray_runner = context.get_context().is_ray_runner
+        using_ray_runner = context.get_context().get_or_create_runner().name == "ray"
         return not using_ray_runner
 
     @staticmethod

--- a/daft/io/_deltalake.py
+++ b/daft/io/_deltalake.py
@@ -55,7 +55,9 @@ def read_deltalake(
 
     # If running on Ray, we want to limit the amount of concurrency and requests being made.
     # This is because each Ray worker process receives its own pool of thread workers and connections
-    multithreaded_io = not context.get_context().is_ray_runner if _multithreaded_io is None else _multithreaded_io
+    multithreaded_io = (
+        (context.get_context().get_or_create_runner().name != "ray") if _multithreaded_io is None else _multithreaded_io
+    )
 
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
     storage_config = StorageConfig.native(NativeStorageConfig(multithreaded_io, io_config))

--- a/daft/io/_hudi.py
+++ b/daft/io/_hudi.py
@@ -32,7 +32,7 @@ def read_hudi(
 
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
 
-    multithreaded_io = not context.get_context().is_ray_runner
+    multithreaded_io = context.get_context().get_or_create_runner().name != "ray"
     storage_config = StorageConfig.native(NativeStorageConfig(multithreaded_io, io_config))
 
     hudi_operator = HudiScanOperator(table_uri, storage_config=storage_config)

--- a/daft/io/_iceberg.py
+++ b/daft/io/_iceberg.py
@@ -122,7 +122,7 @@ def read_iceberg(
     )
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
 
-    multithreaded_io = not context.get_context().is_ray_runner
+    multithreaded_io = context.get_context().get_or_create_runner().name != "ray"
     storage_config = StorageConfig.native(NativeStorageConfig(multithreaded_io, io_config))
 
     iceberg_operator = IcebergScanOperator(pyiceberg_table, snapshot_id=snapshot_id, storage_config=storage_config)

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -68,10 +68,11 @@ def read_parquet(
             "Specifying schema_hints is deprecated from Daft version >= 0.3.0! Instead, please use the 'schema' and 'infer_schema' arguments."
         )
 
-    is_ray_runner = context.get_context().is_ray_runner
     # If running on Ray, we want to limit the amount of concurrency and requests being made.
     # This is because each Ray worker process receives its own pool of thread workers and connections
-    multithreaded_io = not is_ray_runner if _multithreaded_io is None else _multithreaded_io
+    multithreaded_io = (
+        (context.get_context().get_or_create_runner().name != "ray") if _multithreaded_io is None else _multithreaded_io
+    )
 
     if isinstance(coerce_int96_timestamp_unit, str):
         coerce_int96_timestamp_unit = TimeUnit.from_str(coerce_int96_timestamp_unit)

--- a/daft/io/file_path.py
+++ b/daft/io/file_path.py
@@ -44,12 +44,12 @@ def from_glob_path(path: str, io_config: Optional[IOConfig] = None) -> DataFrame
     """
     context = get_context()
     io_config = context.daft_planning_config.default_io_config if io_config is None else io_config
-    runner_io = context.runner().runner_io()
+    runner_io = context.get_or_create_runner().runner_io()
     file_infos = runner_io.glob_paths_details([path], io_config=io_config)
     file_infos_table = MicroPartition._from_pytable(file_infos.to_table())
     partition = LocalPartitionSet()
     partition.set_partition_from_table(0, file_infos_table)
-    cache_entry = context.runner().put_partition_set_into_cache(partition)
+    cache_entry = context.get_or_create_runner().put_partition_set_into_cache(partition)
     size_bytes = partition.size_bytes()
     num_rows = len(partition)
 

--- a/daft/runners/native_runner.py
+++ b/daft/runners/native_runner.py
@@ -44,6 +44,8 @@ class NativeRunnerIO(runner_io.RunnerIO):
 
 
 class NativeRunner(Runner[MicroPartition]):
+    name = "native"
+
     def __init__(self) -> None:
         super().__init__()
 

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -289,6 +289,8 @@ class PyRunnerIO(runner_io.RunnerIO):
 
 
 class PyRunner(Runner[MicroPartition], ActorPoolManager):
+    name = "py"
+
     def __init__(self, use_thread_pool: bool | None) -> None:
         super().__init__()
 

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -1184,6 +1184,8 @@ class RayRoundRobinActorPool:
 
 
 class RayRunner(Runner[ray.ObjectRef]):
+    name = "ray"
+
     def __init__(
         self,
         address: str | None,

--- a/daft/runners/runner.py
+++ b/daft/runners/runner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Generic, Iterator
+from typing import TYPE_CHECKING, ClassVar, Generic, Iterator, Literal
 
 from daft.runners.partitioning import (
     MaterializedResult,
@@ -20,6 +20,8 @@ LOCAL_PARTITION_SET_CACHE = PartitionSetCache()
 
 
 class Runner(Generic[PartitionT]):
+    name: ClassVar[Literal["ray"] | Literal["py"] | Literal["native"]]
+
     def __init__(self) -> None:
         self._part_set_cache = self.initialize_partition_set_cache()
 

--- a/daft/utils.py
+++ b/daft/utils.py
@@ -134,4 +134,6 @@ def pyarrow_supports_fixed_shape_tensor() -> bool:
     """Whether pyarrow supports the fixed_shape_tensor canonical extension type."""
     from daft.context import get_context
 
-    return hasattr(pa, "fixed_shape_tensor") and (not get_context().is_ray_runner or get_arrow_version() >= (13, 0, 0))
+    return hasattr(pa, "fixed_shape_tensor") and (
+        (get_context().get_or_create_runner().name != "ray") or get_arrow_version() >= (13, 0, 0)
+    )

--- a/tests/actor_pool/test_actor_cuda_devices.py
+++ b/tests/actor_pool/test_actor_cuda_devices.py
@@ -13,7 +13,7 @@ from daft.datatype import DataType
 from daft.internal.gpu import cuda_visible_devices
 
 pytestmark = pytest.mark.skipif(
-    get_context().runner_config.name == "native", reason="Native runner does not support GPU tests yet"
+    get_context().get_runner_config_name() == "native", reason="Native runner does not support GPU tests yet"
 )
 
 
@@ -34,7 +34,7 @@ def enable_actor_pool():
 def reset_runner_with_gpus(num_gpus, monkeypatch):
     """If current runner does not have enough GPUs, create a new runner with mocked GPU resources"""
     if len(cuda_visible_devices()) < num_gpus:
-        if get_context().runner_config.name == "ray":
+        if get_context().get_runner_config_name() == "ray":
             try:
                 ray.shutdown()
                 ray.init(num_gpus=num_gpus)
@@ -119,7 +119,7 @@ def test_stateful_udf_fractional_gpu(enable_actor_pool, monkeypatch):
         assert len(unique_visible_devices) == 1
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "py", reason="Test can only be run on PyRunner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "py", reason="Test can only be run on PyRunner")
 def test_stateful_udf_no_cuda_devices(enable_actor_pool, monkeypatch):
     monkeypatch.setattr(daft.internal.gpu, "_raw_device_count_nvml", lambda: 0)
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
@@ -148,7 +148,7 @@ def test_stateful_udf_no_cuda_devices(enable_actor_pool, monkeypatch):
         daft.context.get_context()._runner = original_runner
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "py", reason="Test can only be run on PyRunner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "py", reason="Test can only be run on PyRunner")
 def test_stateful_udf_no_cuda_visible_device_envvar(enable_actor_pool, monkeypatch):
     monkeypatch.setattr(daft.internal.gpu, "_raw_device_count_nvml", lambda: 1)
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)

--- a/tests/actor_pool/test_actor_cuda_devices.py
+++ b/tests/actor_pool/test_actor_cuda_devices.py
@@ -11,9 +11,10 @@ from daft import udf
 from daft.context import get_context, set_planning_config
 from daft.datatype import DataType
 from daft.internal.gpu import cuda_visible_devices
+from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
-    get_context().get_runner_config_name() == "native", reason="Native runner does not support GPU tests yet"
+    get_tests_daft_runner_name() == "native", reason="Native runner does not support GPU tests yet"
 )
 
 
@@ -34,7 +35,7 @@ def enable_actor_pool():
 def reset_runner_with_gpus(num_gpus, monkeypatch):
     """If current runner does not have enough GPUs, create a new runner with mocked GPU resources"""
     if len(cuda_visible_devices()) < num_gpus:
-        if get_context().get_runner_config_name() == "ray":
+        if get_tests_daft_runner_name() == "ray":
             try:
                 ray.shutdown()
                 ray.init(num_gpus=num_gpus)
@@ -119,7 +120,7 @@ def test_stateful_udf_fractional_gpu(enable_actor_pool, monkeypatch):
         assert len(unique_visible_devices) == 1
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "py", reason="Test can only be run on PyRunner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "py", reason="Test can only be run on PyRunner")
 def test_stateful_udf_no_cuda_devices(enable_actor_pool, monkeypatch):
     monkeypatch.setattr(daft.internal.gpu, "_raw_device_count_nvml", lambda: 0)
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
@@ -148,7 +149,7 @@ def test_stateful_udf_no_cuda_devices(enable_actor_pool, monkeypatch):
         daft.context.get_context()._runner = original_runner
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "py", reason="Test can only be run on PyRunner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "py", reason="Test can only be run on PyRunner")
 def test_stateful_udf_no_cuda_visible_device_envvar(enable_actor_pool, monkeypatch):
     monkeypatch.setattr(daft.internal.gpu, "_raw_device_count_nvml", lambda: 1)
     monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)

--- a/tests/actor_pool/test_pyactor_pool.py
+++ b/tests/actor_pool/test_pyactor_pool.py
@@ -68,7 +68,7 @@ def test_pyactor_pool_not_enough_resources():
     cpu_count = multiprocessing.cpu_count()
     projection = ExpressionsProjection([MyStatefulUDF(daft.col("x"))])
 
-    runner = get_context().runner()
+    runner = get_context().get_or_create_runner()
     assert isinstance(runner, PyRunner)
 
     original_resources = deepcopy(runner._resources.available_resources)

--- a/tests/actor_pool/test_pyactor_pool.py
+++ b/tests/actor_pool/test_pyactor_pool.py
@@ -60,7 +60,7 @@ def test_pyactor_pool():
     assert result_data.partition().to_pydict() == {"x": [4, 4, 4]}
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "py", reason="Test can only be run on PyRunner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "py", reason="Test can only be run on PyRunner")
 def test_pyactor_pool_not_enough_resources():
     from copy import deepcopy
 

--- a/tests/actor_pool/test_pyactor_pool.py
+++ b/tests/actor_pool/test_pyactor_pool.py
@@ -11,6 +11,7 @@ from daft.expressions import ExpressionsProjection
 from daft.runners.partitioning import PartialPartitionMetadata
 from daft.runners.pyrunner import AcquiredResources, PyActorPool, PyRunner
 from daft.table import MicroPartition
+from tests.conftest import get_tests_daft_runner_name
 
 
 @daft.udf(return_dtype=DataType.int64())
@@ -60,7 +61,7 @@ def test_pyactor_pool():
     assert result_data.partition().to_pydict() == {"x": [4, 4, 4]}
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "py", reason="Test can only be run on PyRunner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "py", reason="Test can only be run on PyRunner")
 def test_pyactor_pool_not_enough_resources():
     from copy import deepcopy
 

--- a/tests/benchmarks/test_local_tpch.py
+++ b/tests/benchmarks/test_local_tpch.py
@@ -14,6 +14,7 @@ if sys.platform == "win32":
 import itertools
 
 import daft.context
+from tests.conftest import get_tests_daft_runner_name
 from tests.integration.conftest import check_answer  # noqa F401
 
 ENGINES = ["native"] if IS_CI else ["native", "python"]
@@ -22,7 +23,7 @@ TPCH_QUESTIONS = list(range(1, 11))
 
 
 @pytest.mark.skipif(
-    daft.context.get_context().get_runner_config_name() not in {"py", "native"},
+    get_tests_daft_runner_name() not in {"py", "native"},
     reason="requires PyRunner to be in use",
 )
 @pytest.mark.benchmark(group="tpch")

--- a/tests/benchmarks/test_local_tpch.py
+++ b/tests/benchmarks/test_local_tpch.py
@@ -22,7 +22,7 @@ TPCH_QUESTIONS = list(range(1, 11))
 
 
 @pytest.mark.skipif(
-    daft.context.get_context().runner_config.name not in {"py", "native"},
+    daft.context.get_context().get_runner_config_name() not in {"py", "native"},
     reason="requires PyRunner to be in use",
 )
 @pytest.mark.benchmark(group="tpch")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,7 +175,7 @@ def assert_df_equals(
 
 @pytest.fixture(
     scope="function",
-    params=[1, None] if daft.context.get_context().runner_config.name == "native" else [None],
+    params=[1, None] if daft.context.get_context().get_runner_config_name() == "native" else [None],
 )
 def with_morsel_size(request):
     morsel_size = request.param

--- a/tests/cookbook/conftest.py
+++ b/tests/cookbook/conftest.py
@@ -44,7 +44,7 @@ def service_requests_csv_pd_df():
 
 @pytest.fixture(
     scope="module",
-    params=[1, 2] if daft.context.get_context().runner_config.name != "native" else [1],
+    params=[1, 2] if daft.context.get_context().get_runner_config_name() != "native" else [1],
 )
 def repartition_nparts(request):
     """Adds a `n_repartitions` parameter to test cases which provides the number of

--- a/tests/cookbook/conftest.py
+++ b/tests/cookbook/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 import daft
 from daft.expressions import col
+from tests.conftest import get_tests_daft_runner_name
 from tests.cookbook.assets import COOKBOOK_DATA_CSV
 
 COLUMNS = [
@@ -44,7 +45,7 @@ def service_requests_csv_pd_df():
 
 @pytest.fixture(
     scope="module",
-    params=[1, 2] if daft.context.get_context().get_runner_config_name() != "native" else [1],
+    params=[1, 2] if get_tests_daft_runner_name() != "native" else [1],
 )
 def repartition_nparts(request):
     """Adds a `n_repartitions` parameter to test cases which provides the number of

--- a/tests/cookbook/test_joins.py
+++ b/tests/cookbook/test_joins.py
@@ -8,7 +8,7 @@ from tests.conftest import assert_df_equals
 
 
 def skip_invalid_join_strategies(join_strategy):
-    if context.get_context().runner_config.name == "native":
+    if context.get_context().get_runner_config_name() == "native":
         if join_strategy not in [None, "hash"]:
             pytest.skip("Native executor fails for these tests")
 

--- a/tests/cookbook/test_joins.py
+++ b/tests/cookbook/test_joins.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import pytest
 
-from daft import context
 from daft.expressions import col
-from tests.conftest import assert_df_equals
+from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 
 
 def skip_invalid_join_strategies(join_strategy):
-    if context.get_context().get_runner_config_name() == "native":
+    if get_tests_daft_runner_name() == "native":
         if join_strategy not in [None, "hash"]:
             pytest.skip("Native executor fails for these tests")
 

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import daft
+from tests.conftest import get_tests_daft_runner_name
 
 
 class MockException(Exception):
@@ -34,7 +35,7 @@ def test_iter_partitions(make_df, materialized):
             df = df.collect()
 
         parts = list(df.iter_partitions())
-        if daft.context.get_context().get_runner_config_name() == "ray":
+        if get_tests_daft_runner_name() == "ray":
             import ray
 
             parts = ray.get(parts)
@@ -72,7 +73,7 @@ def test_iter_exception(make_df):
             list(it)
 
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
-        if daft.context.get_context().get_runner_config_name() == "ray":
+        if get_tests_daft_runner_name() == "ray":
             assert "MockException" in str(exc_info.value)
         else:
             assert isinstance(exc_info.value.__cause__, MockException)
@@ -95,7 +96,7 @@ def test_iter_partitions_exception(make_df):
 
         it = df.iter_partitions()
         part = next(it)
-        if daft.context.get_context().get_runner_config_name() == "ray":
+        if get_tests_daft_runner_name() == "ray":
             import ray
 
             part = ray.get(part)
@@ -106,11 +107,11 @@ def test_iter_partitions_exception(make_df):
         # Ensure the exception does trigger if execution continues.
         with pytest.raises(RuntimeError) as exc_info:
             res = list(it)
-            if daft.context.get_context().get_runner_config_name() == "ray":
+            if get_tests_daft_runner_name() == "ray":
                 ray.get(res)
 
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
-        if daft.context.get_context().get_runner_config_name() == "ray":
+        if get_tests_daft_runner_name() == "ray":
             assert "MockException" in str(exc_info.value)
         else:
             assert isinstance(exc_info.value.__cause__, MockException)

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -34,7 +34,7 @@ def test_iter_partitions(make_df, materialized):
             df = df.collect()
 
         parts = list(df.iter_partitions())
-        if daft.context.get_context().runner_config.name == "ray":
+        if daft.context.get_context().get_runner_config_name() == "ray":
             import ray
 
             parts = ray.get(parts)
@@ -72,7 +72,7 @@ def test_iter_exception(make_df):
             list(it)
 
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
-        if daft.context.get_context().runner_config.name == "ray":
+        if daft.context.get_context().get_runner_config_name() == "ray":
             assert "MockException" in str(exc_info.value)
         else:
             assert isinstance(exc_info.value.__cause__, MockException)
@@ -95,7 +95,7 @@ def test_iter_partitions_exception(make_df):
 
         it = df.iter_partitions()
         part = next(it)
-        if daft.context.get_context().runner_config.name == "ray":
+        if daft.context.get_context().get_runner_config_name() == "ray":
             import ray
 
             part = ray.get(part)
@@ -106,11 +106,11 @@ def test_iter_partitions_exception(make_df):
         # Ensure the exception does trigger if execution continues.
         with pytest.raises(RuntimeError) as exc_info:
             res = list(it)
-            if daft.context.get_context().runner_config.name == "ray":
+            if daft.context.get_context().get_runner_config_name() == "ray":
                 ray.get(res)
 
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
-        if daft.context.get_context().runner_config.name == "ray":
+        if daft.context.get_context().get_runner_config_name() == "ray":
             assert "MockException" in str(exc_info.value)
         else:
             assert isinstance(exc_info.value.__cause__, MockException)

--- a/tests/dataframe/test_joins.py
+++ b/tests/dataframe/test_joins.py
@@ -11,7 +11,7 @@ from tests.utils import sort_arrow_table
 
 
 def skip_invalid_join_strategies(join_strategy, join_type):
-    if context.get_context().runner_config.name == "native":
+    if context.get_context().get_runner_config_name() == "native":
         if join_strategy not in [None, "hash"]:
             pytest.skip("Native executor fails for these tests")
     else:

--- a/tests/dataframe/test_joins.py
+++ b/tests/dataframe/test_joins.py
@@ -4,14 +4,15 @@ import pyarrow as pa
 import pytest
 
 import daft
-from daft import col, context
+from daft import col
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
+from tests.conftest import get_tests_daft_runner_name
 from tests.utils import sort_arrow_table
 
 
 def skip_invalid_join_strategies(join_strategy, join_type):
-    if context.get_context().get_runner_config_name() == "native":
+    if get_tests_daft_runner_name() == "native":
         if join_strategy not in [None, "hash"]:
             pytest.skip("Native executor fails for these tests")
     else:

--- a/tests/dataframe/test_monotonically_increasing_id.py
+++ b/tests/dataframe/test_monotonically_increasing_id.py
@@ -6,7 +6,7 @@ from daft import context
 from daft.datatype import DataType
 
 pytestmark = pytest.mark.skipif(
-    context.get_context().runner_config.name == "native",
+    context.get_context().get_runner_config_name() == "native",
     reason="Native executor fails for these tests",
 )
 

--- a/tests/dataframe/test_monotonically_increasing_id.py
+++ b/tests/dataframe/test_monotonically_increasing_id.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from daft import context
 from daft.datatype import DataType
+from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
-    context.get_context().get_runner_config_name() == "native",
+    get_tests_daft_runner_name() == "native",
     reason="Native executor fails for these tests",
 )
 

--- a/tests/io/delta_lake/test_table_write.py
+++ b/tests/io/delta_lake/test_table_write.py
@@ -111,7 +111,7 @@ def test_deltalake_write_overwrite_cloud(cloud_paths):
 
 
 @pytest.mark.skipif(
-    context.get_context().runner_config.name == "native",
+    context.get_context().get_runner_config_name() == "native",
     reason="Native executor does not support repartitioning",
 )
 def test_deltalake_write_overwrite_multi_partition(tmp_path):
@@ -184,7 +184,7 @@ def test_deltalake_write_ignore(tmp_path):
 
 
 @pytest.mark.skipif(
-    context.get_context().runner_config.name == "native",
+    context.get_context().get_runner_config_name() == "native",
     reason="Native executor does not support repartitioning",
 )
 def test_deltalake_write_with_empty_partition(tmp_path, base_table):

--- a/tests/io/delta_lake/test_table_write.py
+++ b/tests/io/delta_lake/test_table_write.py
@@ -9,9 +9,9 @@ import pyarrow as pa
 import pytest
 
 import daft
-from daft import context
 from daft.io.object_store_options import io_config_to_storage_options
 from daft.logical.schema import Schema
+from tests.conftest import get_tests_daft_runner_name
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (
     8,
@@ -111,7 +111,7 @@ def test_deltalake_write_overwrite_cloud(cloud_paths):
 
 
 @pytest.mark.skipif(
-    context.get_context().get_runner_config_name() == "native",
+    get_tests_daft_runner_name() == "native",
     reason="Native executor does not support repartitioning",
 )
 def test_deltalake_write_overwrite_multi_partition(tmp_path):
@@ -184,7 +184,7 @@ def test_deltalake_write_ignore(tmp_path):
 
 
 @pytest.mark.skipif(
-    context.get_context().get_runner_config_name() == "native",
+    get_tests_daft_runner_name() == "native",
     reason="Native executor does not support repartitioning",
 )
 def test_deltalake_write_with_empty_partition(tmp_path, base_table):

--- a/tests/io/iceberg/test_iceberg_writes.py
+++ b/tests/io/iceberg/test_iceberg_writes.py
@@ -6,7 +6,7 @@ import decimal
 import pyarrow as pa
 import pytest
 
-from daft import context
+from tests.conftest import get_tests_daft_runner_name
 
 pyiceberg = pytest.importorskip("pyiceberg")
 
@@ -204,7 +204,7 @@ def test_read_after_write_nested_fields(local_catalog):
 
 
 @pytest.mark.skipif(
-    context.get_context().get_runner_config_name() == "native",
+    get_tests_daft_runner_name() == "native",
     reason="Native executor does not support into_partitions",
 )
 def test_read_after_write_with_empty_partition(local_catalog):

--- a/tests/io/iceberg/test_iceberg_writes.py
+++ b/tests/io/iceberg/test_iceberg_writes.py
@@ -204,7 +204,7 @@ def test_read_after_write_nested_fields(local_catalog):
 
 
 @pytest.mark.skipif(
-    context.get_context().runner_config.name == "native",
+    context.get_context().get_runner_config_name() == "native",
     reason="Native executor does not support into_partitions",
 )
 def test_read_after_write_with_empty_partition(local_catalog):

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -7,7 +7,7 @@ import daft
 from daft import context
 
 native_executor_skip = pytest.mark.skipif(
-    context.get_context().runner_config.name == "native",
+    context.get_context().get_runner_config_name() == "native",
     reason="Native executor fails for these tests",
 )
 

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -4,10 +4,10 @@ import pyarrow as pa
 import pytest
 
 import daft
-from daft import context
+from tests.conftest import get_tests_daft_runner_name
 
 native_executor_skip = pytest.mark.skipif(
-    context.get_context().get_runner_config_name() == "native",
+    get_tests_daft_runner_name() == "native",
     reason="Native executor fails for these tests",
 )
 

--- a/tests/microbenchmarks/test_file_read.py
+++ b/tests/microbenchmarks/test_file_read.py
@@ -8,12 +8,7 @@ import pytest
 
 import daft
 from daft import DataFrame
-from daft.context import _RayRunnerConfig, get_context
-
-
-def is_using_remote_runner() -> bool:
-    runner_config = get_context().runner_config
-    return isinstance(runner_config, _RayRunnerConfig) and runner_config.address is not None
+from tests.conftest import get_tests_daft_runner_name
 
 
 @pytest.fixture(scope="module", params=[(1, 64), (8, 8), (64, 1)], ids=["1x64mib", "8x8mib", "64x1mib"])
@@ -43,7 +38,7 @@ def gen_simple_csvs(request) -> str:
         yield tmpdirname, num_files * mibs_per_file * 1024 * 128
 
 
-@pytest.mark.skipif(is_using_remote_runner(), reason="requires local runner")
+@pytest.mark.skipif(get_tests_daft_runner_name(), reason="requires local runner")
 @pytest.mark.benchmark(group="file_read")
 def test_csv_read(gen_simple_csvs, benchmark):
     csv_dir, num_rows = gen_simple_csvs

--- a/tests/ray/runner.py
+++ b/tests/ray/runner.py
@@ -16,7 +16,7 @@ def test_active_plan_clean_up_df_show():
         path = "tests/assets/parquet-data/mvp.parquet"
         df = daft.read_parquet([path, path])
         df.show()
-        runner = get_context().runner()
+        runner = get_context().get_or_create_runner()
         assert len(runner.active_plans()) == 0
 
 
@@ -30,7 +30,7 @@ def test_active_plan_single_iter_partitions():
         df = daft.read_parquet([path, path])
         iter = df.iter_partitions()
         next(iter)
-        runner = get_context().runner()
+        runner = get_context().get_or_create_runner()
         assert len(runner.active_plans()) == 1
         del iter
         assert len(runner.active_plans()) == 0
@@ -46,7 +46,7 @@ def test_active_plan_multiple_iter_partitions():
         df = daft.read_parquet([path, path])
         iter = df.iter_partitions()
         next(iter)
-        runner = get_context().runner()
+        runner = get_context().get_or_create_runner()
         assert len(runner.active_plans()) == 1
 
         df2 = daft.read_parquet([path, path])
@@ -71,7 +71,7 @@ def test_active_plan_with_show_and_write_parquet(tmpdir):
         df = df.into_partitions(8)
         df = df.join(df, on="a")
         df.show()
-        runner = get_context().runner()
+        runner = get_context().get_or_create_runner()
         assert len(runner.active_plans()) == 0
         df.write_parquet(tmpdir.dirname)
         assert len(runner.active_plans()) == 0

--- a/tests/ray/runner.py
+++ b/tests/ray/runner.py
@@ -4,9 +4,10 @@ import pytest
 
 import daft
 from daft.context import get_context
+from tests.conftest import get_tests_daft_runner_name
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 def test_active_plan_clean_up_df_show():
     with daft.execution_config_ctx(
         scan_tasks_min_size_bytes=0,
@@ -19,7 +20,7 @@ def test_active_plan_clean_up_df_show():
         assert len(runner.active_plans()) == 0
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 def test_active_plan_single_iter_partitions():
     with daft.execution_config_ctx(
         scan_tasks_min_size_bytes=0,
@@ -35,7 +36,7 @@ def test_active_plan_single_iter_partitions():
         assert len(runner.active_plans()) == 0
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 def test_active_plan_multiple_iter_partitions():
     with daft.execution_config_ctx(
         scan_tasks_min_size_bytes=0,
@@ -60,7 +61,7 @@ def test_active_plan_multiple_iter_partitions():
         assert len(runner.active_plans()) == 0
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 def test_active_plan_with_show_and_write_parquet(tmpdir):
     with daft.execution_config_ctx(
         scan_tasks_min_size_bytes=0,

--- a/tests/ray/runner.py
+++ b/tests/ray/runner.py
@@ -6,7 +6,7 @@ import daft
 from daft.context import get_context
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 def test_active_plan_clean_up_df_show():
     with daft.execution_config_ctx(
         scan_tasks_min_size_bytes=0,
@@ -19,7 +19,7 @@ def test_active_plan_clean_up_df_show():
         assert len(runner.active_plans()) == 0
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 def test_active_plan_single_iter_partitions():
     with daft.execution_config_ctx(
         scan_tasks_min_size_bytes=0,
@@ -35,7 +35,7 @@ def test_active_plan_single_iter_partitions():
         assert len(runner.active_plans()) == 0
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 def test_active_plan_multiple_iter_partitions():
     with daft.execution_config_ctx(
         scan_tasks_min_size_bytes=0,
@@ -60,7 +60,7 @@ def test_active_plan_multiple_iter_partitions():
         assert len(runner.active_plans()) == 0
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 def test_active_plan_with_show_and_write_parquet(tmpdir):
     with daft.execution_config_ctx(
         scan_tasks_min_size_bytes=0,

--- a/tests/ray/test_dask.py
+++ b/tests/ray/test_dask.py
@@ -9,7 +9,7 @@ import pytest
 
 import daft
 from daft import DataType
-from daft.context import get_context
+from tests.conftest import get_tests_daft_runner_name
 
 
 class MyObj:
@@ -26,7 +26,7 @@ DATA = {
 }
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_all_arrow(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -44,7 +44,7 @@ def test_to_dask_dataframe_all_arrow(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_all_arrow_with_schema(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -62,7 +62,7 @@ def test_to_dask_dataframe_all_arrow_with_schema(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_with_py(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -80,7 +80,7 @@ def test_to_dask_dataframe_with_py(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_with_numpy(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -101,7 +101,7 @@ def test_to_dask_dataframe_with_numpy(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_with_numpy_variable_shaped(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -122,7 +122,7 @@ def test_to_dask_dataframe_with_numpy_variable_shaped(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_dask_dataframe_all_arrow(n_partitions: int):
     df = pd.DataFrame(DATA)
@@ -134,7 +134,7 @@ def test_from_dask_dataframe_all_arrow(n_partitions: int):
     pd.testing.assert_frame_equal(out_df, df)
 
 
-# @pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+# @pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.skip()  # dask doesn't seem to work with object types anymore
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_dask_dataframe_tensor(n_partitions: int):
@@ -147,7 +147,7 @@ def test_from_dask_dataframe_tensor(n_partitions: int):
     pd.testing.assert_frame_equal(out_df, df)
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_dask_dataframe_preview(n_partitions: int):
     df = pd.DataFrame(DATA)
@@ -158,7 +158,7 @@ def test_from_dask_dataframe_preview(n_partitions: int):
     assert len(daft_df._preview.preview_partition) == 3
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_dask_dataframe_data_longer_than_preview(n_partitions: int):
     df = pd.DataFrame(

--- a/tests/ray/test_dask.py
+++ b/tests/ray/test_dask.py
@@ -26,7 +26,7 @@ DATA = {
 }
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_all_arrow(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -44,7 +44,7 @@ def test_to_dask_dataframe_all_arrow(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_all_arrow_with_schema(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -62,7 +62,7 @@ def test_to_dask_dataframe_all_arrow_with_schema(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_with_py(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -80,7 +80,7 @@ def test_to_dask_dataframe_with_py(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_with_numpy(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -101,7 +101,7 @@ def test_to_dask_dataframe_with_numpy(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_dask_dataframe_with_numpy_variable_shaped(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -122,7 +122,7 @@ def test_to_dask_dataframe_with_numpy_variable_shaped(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_dask_dataframe_all_arrow(n_partitions: int):
     df = pd.DataFrame(DATA)
@@ -134,7 +134,7 @@ def test_from_dask_dataframe_all_arrow(n_partitions: int):
     pd.testing.assert_frame_equal(out_df, df)
 
 
-# @pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+# @pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.skip()  # dask doesn't seem to work with object types anymore
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_dask_dataframe_tensor(n_partitions: int):
@@ -147,7 +147,7 @@ def test_from_dask_dataframe_tensor(n_partitions: int):
     pd.testing.assert_frame_equal(out_df, df)
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_dask_dataframe_preview(n_partitions: int):
     df = pd.DataFrame(DATA)
@@ -158,7 +158,7 @@ def test_from_dask_dataframe_preview(n_partitions: int):
     assert len(daft_df._preview.preview_partition) == 3
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_dask_dataframe_data_longer_than_preview(n_partitions: int):
     df = pd.DataFrame(

--- a/tests/ray/test_datasets.py
+++ b/tests/ray/test_datasets.py
@@ -11,7 +11,7 @@ import ray
 
 import daft
 from daft import DataType
-from daft.context import get_context
+from tests.conftest import get_tests_daft_runner_name
 
 RAY_VERSION = tuple(int(s) for s in ray.__version__.split(".")[0:3])
 
@@ -36,7 +36,7 @@ def _row_to_pydict(row: ray.data.row.TableRow | dict) -> dict:
     return row.as_pydict()
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_all_arrow(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -60,7 +60,7 @@ def test_to_ray_dataset_all_arrow(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.skipif(
     RAY_VERSION >= (2, 5, 0), reason="Ray Datasets versions >= 2.5.0 no longer support Python objects as rows"
 )
@@ -87,7 +87,7 @@ def test_to_ray_dataset_with_py(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_with_numpy(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -119,7 +119,7 @@ def test_to_ray_dataset_with_numpy(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.skipif(RAY_VERSION < (2, 2, 0), reason="Variable-shaped tensor columns not supported in Ray < 2.1.0")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_with_numpy_variable_shaped(n_partitions: int):
@@ -151,7 +151,7 @@ def test_to_ray_dataset_with_numpy_variable_shaped(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_all_arrow(n_partitions: int):
     def add_float(table: pa.Table) -> pa.Table:
@@ -182,7 +182,7 @@ def test_from_ray_dataset_all_arrow(n_partitions: int):
     assert out_table.equals(expected_table), (out_table, expected_table)
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_simple(n_partitions: int):
     ds = ray.data.range(8, parallelism=n_partitions)
@@ -195,7 +195,7 @@ def test_from_ray_dataset_simple(n_partitions: int):
     assert sorted(out[key]) == list(range(8))
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_tensor(n_partitions: int):
     ds = ray.data.range(8)
@@ -220,7 +220,7 @@ def test_from_ray_dataset_tensor(n_partitions: int):
     np.testing.assert_equal(out_sorted, expected)
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_pandas(n_partitions: int):
     def add_float(df: pd.DataFrame) -> pd.DataFrame:
@@ -242,7 +242,7 @@ def test_from_ray_dataset_pandas(n_partitions: int):
     pd.testing.assert_frame_equal(df.to_pandas(), expected_df)
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_preview(n_partitions: int):
     ds = ray.data.range(3, parallelism=n_partitions)
@@ -252,7 +252,7 @@ def test_from_ray_dataset_preview(n_partitions: int):
     assert len(df._preview.preview_partition) == 3
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_data_longer_than_preview(n_partitions: int):
     ds = ray.data.range(10, parallelism=n_partitions)

--- a/tests/ray/test_datasets.py
+++ b/tests/ray/test_datasets.py
@@ -36,7 +36,7 @@ def _row_to_pydict(row: ray.data.row.TableRow | dict) -> dict:
     return row.as_pydict()
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_all_arrow(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -60,7 +60,7 @@ def test_to_ray_dataset_all_arrow(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.skipif(
     RAY_VERSION >= (2, 5, 0), reason="Ray Datasets versions >= 2.5.0 no longer support Python objects as rows"
 )
@@ -87,7 +87,7 @@ def test_to_ray_dataset_with_py(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_with_numpy(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -119,7 +119,7 @@ def test_to_ray_dataset_with_numpy(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.skipif(RAY_VERSION < (2, 2, 0), reason="Variable-shaped tensor columns not supported in Ray < 2.1.0")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_with_numpy_variable_shaped(n_partitions: int):
@@ -151,7 +151,7 @@ def test_to_ray_dataset_with_numpy_variable_shaped(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_all_arrow(n_partitions: int):
     def add_float(table: pa.Table) -> pa.Table:
@@ -182,7 +182,7 @@ def test_from_ray_dataset_all_arrow(n_partitions: int):
     assert out_table.equals(expected_table), (out_table, expected_table)
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_simple(n_partitions: int):
     ds = ray.data.range(8, parallelism=n_partitions)
@@ -195,7 +195,7 @@ def test_from_ray_dataset_simple(n_partitions: int):
     assert sorted(out[key]) == list(range(8))
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_tensor(n_partitions: int):
     ds = ray.data.range(8)
@@ -220,7 +220,7 @@ def test_from_ray_dataset_tensor(n_partitions: int):
     np.testing.assert_equal(out_sorted, expected)
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_pandas(n_partitions: int):
     def add_float(df: pd.DataFrame) -> pd.DataFrame:
@@ -242,7 +242,7 @@ def test_from_ray_dataset_pandas(n_partitions: int):
     pd.testing.assert_frame_equal(df.to_pandas(), expected_df)
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_preview(n_partitions: int):
     ds = ray.data.range(3, parallelism=n_partitions)
@@ -252,7 +252,7 @@ def test_from_ray_dataset_preview(n_partitions: int):
     assert len(df._preview.preview_partition) == 3
 
 
-@pytest.mark.skipif(get_context().runner_config.name != "ray", reason="Needs to run on Ray runner")
+@pytest.mark.skipif(get_context().get_runner_config_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_from_ray_dataset_data_longer_than_preview(n_partitions: int):
     ds = ray.data.range(10, parallelism=n_partitions)

--- a/tests/series/test_concat.py
+++ b/tests/series/test_concat.py
@@ -168,7 +168,7 @@ def test_series_concat_tensor_array_canonical(chunks) -> None:
 
 
 @pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
+    get_context().get_runner_config_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 @pytest.mark.parametrize("chunks", [1, 2, 3, 10])

--- a/tests/series/test_concat.py
+++ b/tests/series/test_concat.py
@@ -7,9 +7,8 @@ import pyarrow as pa
 import pytest
 
 from daft import DataType, Series
-from daft.context import get_context
 from daft.utils import pyarrow_supports_fixed_shape_tensor
-from tests.conftest import UuidType
+from tests.conftest import UuidType, get_tests_daft_runner_name
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES, ARROW_STRING_TYPES
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
@@ -168,7 +167,7 @@ def test_series_concat_tensor_array_canonical(chunks) -> None:
 
 
 @pytest.mark.skipif(
-    get_context().get_runner_config_name() == "ray",
+    get_tests_daft_runner_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 @pytest.mark.parametrize("chunks", [1, 2, 3, 10])

--- a/tests/series/test_filter.py
+++ b/tests/series/test_filter.py
@@ -117,7 +117,7 @@ def test_series_filter_on_struct_array() -> None:
 
 
 @pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
+    get_context().get_runner_config_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 def test_series_filter_on_extension_array(uuid_ext_type) -> None:

--- a/tests/series/test_filter.py
+++ b/tests/series/test_filter.py
@@ -4,10 +4,10 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from daft.context import get_context
 from daft.datatype import DataType
 from daft.series import Series
 from daft.utils import pyarrow_supports_fixed_shape_tensor
+from tests.conftest import get_tests_daft_runner_name
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES, ARROW_STRING_TYPES
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
@@ -117,7 +117,7 @@ def test_series_filter_on_struct_array() -> None:
 
 
 @pytest.mark.skipif(
-    get_context().get_runner_config_name() == "ray",
+    get_tests_daft_runner_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 def test_series_filter_on_extension_array(uuid_ext_type) -> None:

--- a/tests/series/test_if_else.py
+++ b/tests/series/test_if_else.py
@@ -5,9 +5,9 @@ import pyarrow as pa
 import pytest
 
 from daft import Series
-from daft.context import get_context
 from daft.datatype import DataType
 from daft.utils import pyarrow_supports_fixed_shape_tensor
+from tests.conftest import get_tests_daft_runner_name
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
 
@@ -368,7 +368,7 @@ def test_series_if_else_struct(if_true, if_false, expected) -> None:
 
 
 @pytest.mark.skipif(
-    get_context().get_runner_config_name() == "ray",
+    get_tests_daft_runner_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 @pytest.mark.parametrize(

--- a/tests/series/test_if_else.py
+++ b/tests/series/test_if_else.py
@@ -368,7 +368,7 @@ def test_series_if_else_struct(if_true, if_false, expected) -> None:
 
 
 @pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
+    get_context().get_runner_config_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 @pytest.mark.parametrize(

--- a/tests/series/test_size_bytes.py
+++ b/tests/series/test_size_bytes.py
@@ -221,7 +221,7 @@ def test_series_struct_size_bytes(size, with_nulls) -> None:
 
 
 @pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
+    get_context().get_runner_config_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 @pytest.mark.parametrize("size", [1, 2, 8, 9, 16])

--- a/tests/series/test_size_bytes.py
+++ b/tests/series/test_size_bytes.py
@@ -7,10 +7,10 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from daft.context import get_context
 from daft.datatype import DataType
 from daft.series import Series
 from daft.utils import pyarrow_supports_fixed_shape_tensor
+from tests.conftest import get_tests_daft_runner_name
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
@@ -221,7 +221,7 @@ def test_series_struct_size_bytes(size, with_nulls) -> None:
 
 
 @pytest.mark.skipif(
-    get_context().get_runner_config_name() == "ray",
+    get_tests_daft_runner_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 @pytest.mark.parametrize("size", [1, 2, 8, 9, 16])

--- a/tests/series/test_take.py
+++ b/tests/series/test_take.py
@@ -4,10 +4,10 @@ import numpy as np
 import pyarrow as pa
 import pytest
 
-from daft.context import get_context
 from daft.datatype import DataType
 from daft.series import Series
 from daft.utils import pyarrow_supports_fixed_shape_tensor
+from tests.conftest import get_tests_daft_runner_name
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES, ARROW_STRING_TYPES
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
@@ -139,7 +139,7 @@ def test_series_struct_take() -> None:
 
 
 @pytest.mark.skipif(
-    get_context().get_runner_config_name() == "ray",
+    get_tests_daft_runner_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 def test_series_extension_type_take(uuid_ext_type) -> None:

--- a/tests/series/test_take.py
+++ b/tests/series/test_take.py
@@ -139,7 +139,7 @@ def test_series_struct_take() -> None:
 
 
 @pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
+    get_context().get_runner_config_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 def test_series_extension_type_take(uuid_ext_type) -> None:

--- a/tests/table/test_from_py.py
+++ b/tests/table/test_from_py.py
@@ -11,10 +11,10 @@ import pytest
 
 import daft
 from daft import DataType, TimeUnit
-from daft.context import get_context
 from daft.series import Series
 from daft.table import MicroPartition
 from daft.utils import pyarrow_supports_fixed_shape_tensor
+from tests.conftest import get_tests_daft_runner_name
 
 ARROW_VERSION = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric())
 
@@ -180,7 +180,7 @@ if pyarrow_supports_fixed_shape_tensor():
 
 
 def _with_uuid_ext_type(uuid_ext_type) -> tuple[dict, dict]:
-    if get_context().get_runner_config_name() == "ray":
+    if get_tests_daft_runner_name() == "ray":
         # pyarrow extension types aren't supported in Ray clusters yet.
         return ARROW_ROUNDTRIP_TYPES, ARROW_TYPE_ARRAYS
     arrow_roundtrip_types = ARROW_ROUNDTRIP_TYPES.copy()
@@ -319,7 +319,7 @@ def test_from_pydict_arrow_struct_array() -> None:
 
 
 @pytest.mark.skipif(
-    get_context().get_runner_config_name() == "ray",
+    get_tests_daft_runner_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 def test_from_pydict_arrow_extension_array(uuid_ext_type) -> None:
@@ -528,7 +528,7 @@ def test_from_arrow_map_array() -> None:
 
 
 @pytest.mark.skipif(
-    get_context().get_runner_config_name() == "ray",
+    get_tests_daft_runner_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 def test_from_arrow_extension_array(uuid_ext_type) -> None:

--- a/tests/table/test_from_py.py
+++ b/tests/table/test_from_py.py
@@ -180,7 +180,7 @@ if pyarrow_supports_fixed_shape_tensor():
 
 
 def _with_uuid_ext_type(uuid_ext_type) -> tuple[dict, dict]:
-    if get_context().runner_config.name == "ray":
+    if get_context().get_runner_config_name() == "ray":
         # pyarrow extension types aren't supported in Ray clusters yet.
         return ARROW_ROUNDTRIP_TYPES, ARROW_TYPE_ARRAYS
     arrow_roundtrip_types = ARROW_ROUNDTRIP_TYPES.copy()
@@ -319,7 +319,7 @@ def test_from_pydict_arrow_struct_array() -> None:
 
 
 @pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
+    get_context().get_runner_config_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 def test_from_pydict_arrow_extension_array(uuid_ext_type) -> None:
@@ -528,7 +528,7 @@ def test_from_arrow_map_array() -> None:
 
 
 @pytest.mark.skipif(
-    get_context().runner_config.name == "ray",
+    get_context().get_runner_config_name() == "ray",
     reason="pyarrow extension types aren't supported on Ray clusters.",
 )
 def test_from_arrow_extension_array(uuid_ext_type) -> None:

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -11,8 +11,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import daft
-from daft import context
 from daft.analytics import AnalyticsClient
+from tests.conftest import get_tests_daft_runner_name
 
 PUBLISHER_THREAD_SLEEP_INTERVAL_SECONDS = 0.1
 MOCK_DATETIME = datetime.datetime(2021, 1, 1, 0, 0, 0)
@@ -54,7 +54,7 @@ def test_analytics_client_track_import(mock_datetime: MagicMock, mock_analytics:
                     "anonymousId": analytics_client._session_key,
                     "event": "Imported Daft",
                     "properties": {
-                        "runner": context.get_context().get_runner_config_name(),
+                        "runner": get_tests_daft_runner_name(),
                         "platform": platform.platform(),
                         "python_version": platform.python_version(),
                         "DAFT_ANALYTICS_ENABLED": os.getenv("DAFT_ANALYTICS_ENABLED"),

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -54,7 +54,7 @@ def test_analytics_client_track_import(mock_datetime: MagicMock, mock_analytics:
                     "anonymousId": analytics_client._session_key,
                     "event": "Imported Daft",
                     "properties": {
-                        "runner": context.get_context().runner_config.name,
+                        "runner": context.get_context().get_runner_config_name(),
                         "platform": platform.platform(),
                         "python_version": platform.python_version(),
                         "DAFT_ANALYTICS_ENABLED": os.getenv("DAFT_ANALYTICS_ENABLED"),

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -12,7 +12,6 @@ import pytest
 
 import daft
 from daft.analytics import AnalyticsClient
-from tests.conftest import get_tests_daft_runner_name
 
 PUBLISHER_THREAD_SLEEP_INTERVAL_SECONDS = 0.1
 MOCK_DATETIME = datetime.datetime(2021, 1, 1, 0, 0, 0)
@@ -54,7 +53,6 @@ def test_analytics_client_track_import(mock_datetime: MagicMock, mock_analytics:
                     "anonymousId": analytics_client._session_key,
                     "event": "Imported Daft",
                     "properties": {
-                        "runner": get_tests_daft_runner_name(),
                         "platform": platform.platform(),
                         "python_version": platform.python_version(),
                         "DAFT_ANALYTICS_ENABLED": os.getenv("DAFT_ANALYTICS_ENABLED"),

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -14,7 +14,8 @@ from daft.expressions import col
 from daft.internal.gpu import cuda_visible_devices
 
 pytestmark = pytest.mark.skipif(
-    context.get_context().runner_config.name == "native", reason="Native runner does not support resource requests"
+    context.get_context().get_runner_config_name() == "native",
+    reason="Native runner does not support resource requests",
 )
 
 
@@ -80,7 +81,7 @@ def test_resource_request_pickle_roundtrip():
 ###
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"py"}, reason="requires PyRunner to be in use")
 def test_requesting_too_many_cpus():
     df = daft.from_pydict(DATA)
     system_info = SystemInfo()
@@ -95,7 +96,7 @@ def test_requesting_too_many_cpus():
         df.collect()
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"py"}, reason="requires PyRunner to be in use")
 def test_requesting_too_many_gpus():
     df = daft.from_pydict(DATA)
 
@@ -106,7 +107,7 @@ def test_requesting_too_many_gpus():
         df.collect()
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"py"}, reason="requires PyRunner to be in use")
 def test_requesting_too_much_memory():
     df = daft.from_pydict(DATA)
     system_info = SystemInfo()
@@ -177,7 +178,7 @@ RAY_VERSION_LT_2 = int(ray.__version__.split(".")[0]) < 2
 @pytest.mark.skipif(
     RAY_VERSION_LT_2, reason="The ray.get_runtime_context().get_assigned_resources() was only added in Ray >= 2.0"
 )
-@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
 def test_with_column_rayrunner():
     df = daft.from_pydict(DATA).repartition(2)
 
@@ -193,7 +194,7 @@ def test_with_column_rayrunner():
 @pytest.mark.skipif(
     RAY_VERSION_LT_2, reason="The ray.get_runtime_context().get_assigned_resources() was only added in Ray >= 2.0"
 )
-@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
 def test_with_column_folded_rayrunner():
     df = daft.from_pydict(DATA).repartition(2)
 
@@ -220,7 +221,7 @@ def test_with_column_folded_rayrunner():
 @pytest.mark.skipif(
     RAY_VERSION_LT_2, reason="The ray.get_runtime_context().get_assigned_resources() was only added in Ray >= 2.0"
 )
-@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
 def test_with_column_rayrunner_class(enable_actor_pool):
     assert_resources = AssertResourcesStateful.with_concurrency(1)
 
@@ -238,7 +239,7 @@ def test_with_column_rayrunner_class(enable_actor_pool):
 @pytest.mark.skipif(
     RAY_VERSION_LT_2, reason="The ray.get_runtime_context().get_assigned_resources() was only added in Ray >= 2.0"
 )
-@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
 def test_with_column_folded_rayrunner_class(enable_actor_pool):
     assert_resources = AssertResourcesStateful.with_concurrency(1)
 
@@ -282,7 +283,7 @@ def assert_num_cuda_visible_devices(c, num_gpus: int = 0):
     return c
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"py"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"py"}, reason="requires PyRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 def test_with_column_pyrunner_gpu():
     df = daft.from_pydict(DATA).repartition(5)
@@ -296,7 +297,7 @@ def test_with_column_pyrunner_gpu():
     df.collect()
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 @pytest.mark.parametrize("num_gpus", [None, 1])
 def test_with_column_rayrunner_gpu(num_gpus):
@@ -311,7 +312,7 @@ def test_with_column_rayrunner_gpu(num_gpus):
     df.collect()
 
 
-@pytest.mark.skipif(get_context().runner_config.name not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 def test_with_column_max_resources_rayrunner_gpu():
     df = daft.from_pydict(DATA).repartition(2)

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -7,14 +7,15 @@ import pytest
 import ray
 
 import daft
-from daft import context, udf
+from daft import udf
 from daft.context import get_context, set_planning_config
 from daft.daft import SystemInfo
 from daft.expressions import col
 from daft.internal.gpu import cuda_visible_devices
+from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
-    context.get_context().get_runner_config_name() == "native",
+    get_tests_daft_runner_name() == "native",
     reason="Native runner does not support resource requests",
 )
 
@@ -81,7 +82,7 @@ def test_resource_request_pickle_roundtrip():
 ###
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"py"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"py"}, reason="requires PyRunner to be in use")
 def test_requesting_too_many_cpus():
     df = daft.from_pydict(DATA)
     system_info = SystemInfo()
@@ -96,7 +97,7 @@ def test_requesting_too_many_cpus():
         df.collect()
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"py"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"py"}, reason="requires PyRunner to be in use")
 def test_requesting_too_many_gpus():
     df = daft.from_pydict(DATA)
 
@@ -107,7 +108,7 @@ def test_requesting_too_many_gpus():
         df.collect()
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"py"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"py"}, reason="requires PyRunner to be in use")
 def test_requesting_too_much_memory():
     df = daft.from_pydict(DATA)
     system_info = SystemInfo()
@@ -178,7 +179,7 @@ RAY_VERSION_LT_2 = int(ray.__version__.split(".")[0]) < 2
 @pytest.mark.skipif(
     RAY_VERSION_LT_2, reason="The ray.get_runtime_context().get_assigned_resources() was only added in Ray >= 2.0"
 )
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"ray"}, reason="requires RayRunner to be in use")
 def test_with_column_rayrunner():
     df = daft.from_pydict(DATA).repartition(2)
 
@@ -194,7 +195,7 @@ def test_with_column_rayrunner():
 @pytest.mark.skipif(
     RAY_VERSION_LT_2, reason="The ray.get_runtime_context().get_assigned_resources() was only added in Ray >= 2.0"
 )
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"ray"}, reason="requires RayRunner to be in use")
 def test_with_column_folded_rayrunner():
     df = daft.from_pydict(DATA).repartition(2)
 
@@ -221,7 +222,7 @@ def test_with_column_folded_rayrunner():
 @pytest.mark.skipif(
     RAY_VERSION_LT_2, reason="The ray.get_runtime_context().get_assigned_resources() was only added in Ray >= 2.0"
 )
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"ray"}, reason="requires RayRunner to be in use")
 def test_with_column_rayrunner_class(enable_actor_pool):
     assert_resources = AssertResourcesStateful.with_concurrency(1)
 
@@ -239,7 +240,7 @@ def test_with_column_rayrunner_class(enable_actor_pool):
 @pytest.mark.skipif(
     RAY_VERSION_LT_2, reason="The ray.get_runtime_context().get_assigned_resources() was only added in Ray >= 2.0"
 )
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"ray"}, reason="requires RayRunner to be in use")
 def test_with_column_folded_rayrunner_class(enable_actor_pool):
     assert_resources = AssertResourcesStateful.with_concurrency(1)
 
@@ -283,7 +284,7 @@ def assert_num_cuda_visible_devices(c, num_gpus: int = 0):
     return c
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"py"}, reason="requires PyRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"py"}, reason="requires PyRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 def test_with_column_pyrunner_gpu():
     df = daft.from_pydict(DATA).repartition(5)
@@ -297,7 +298,7 @@ def test_with_column_pyrunner_gpu():
     df.collect()
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 @pytest.mark.parametrize("num_gpus", [None, 1])
 def test_with_column_rayrunner_gpu(num_gpus):
@@ -312,7 +313,7 @@ def test_with_column_rayrunner_gpu(num_gpus):
     df.collect()
 
 
-@pytest.mark.skipif(get_context().get_runner_config_name() not in {"ray"}, reason="requires RayRunner to be in use")
+@pytest.mark.skipif(get_tests_daft_runner_name() not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(no_gpu_available(), reason="requires GPUs to be available")
 def test_with_column_max_resources_rayrunner_gpu():
     df = daft.from_pydict(DATA).repartition(2)

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -9,7 +9,7 @@ import pytest
 
 import daft
 from daft.expressions import col
-from tests.conftest import assert_df_equals
+from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 
 
 def _get_filename():
@@ -91,7 +91,7 @@ def test_download_with_missing_urls_reraise_errors(files, use_native_downloader)
                 df.collect()
 
             # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
-            if daft.context.get_context().get_runner_config_name() == "ray":
+            if get_tests_daft_runner_name() == "ray":
                 assert "FileNotFoundError" in str(exc_info.value)
             else:
                 assert isinstance(exc_info.value.__cause__, FileNotFoundError)

--- a/tests/udf_library/test_url_udfs.py
+++ b/tests/udf_library/test_url_udfs.py
@@ -91,7 +91,7 @@ def test_download_with_missing_urls_reraise_errors(files, use_native_downloader)
                 df.collect()
 
             # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
-            if daft.context.get_context().runner_config.name == "ray":
+            if daft.context.get_context().get_runner_config_name() == "ray":
                 assert "FileNotFoundError" in str(exc_info.value)
             else:
                 assert isinstance(exc_info.value.__cause__, FileNotFoundError)


### PR DESCRIPTION
Cleans up public-facing APIs on our context object that has side-effects.

We should be very explicit in our context code when making state changes. Eventually I think I want to deprecate the usage of `daft.context.*` from users, and instead expose a `daft.connect(...)` which will prevent user footguns.

Tests added in: https://github.com/Eventual-Inc/Daft/pull/3275

## Changes

1. In tests, use `get_tests_daft_runner_name` for checking the runner instead of relying on the context
2. Refactors our context to be VERY explicit about when the runner is created (`get_context().get_or_create_runner`)
3. I then refactored everywhere that was asking about state in the context to first call `get_or_create_runner`, then access information about the state.

Note that this might be a behavior change in some cases, but I think that this is for the better. I.e. in order to access information about the runner (mostly about what type of runner it is), we force clients to materialize the runner.

I think in the future we should (after more testing) also refactor to:

- [ ] Let's remove the concept of RunnerConfig. When `daft.context.set_runner_*` is called, we can just straight up set the runner. Not sure why we need to lazily initialize the runner here.
- [ ] We can force initialization of the Runner at various key entrypoints, namely `DataFrame.__init__`, `Expression.__init__` etc. This is in effect saying -- when you use any Daft APIs, we are going to capture the state of runner configurations and setting the runner.