### PR TITLE
[DOCS] Use an absolute path for the canonical link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,7 +77,9 @@ html_theme_options = {
     "show_toc_level": 2,
 }
 # Set canonical link
-html_baseurl = "/stable/"
+# Based on Google Search's recommendation, we use an absolute path here. For more details, see:
+# https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#use-rel=canonical-link-annotations
+html_baseurl = "https://www.getdaft.io/projects/docs/en/stable/"
 
 # -- Copy button configuration
 


### PR DESCRIPTION
Based on https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#use-rel=canonical-link-annotations