### PR TITLE
[BUG] Fix writes for empty dataframes if target directory does not exist

### DIFF
--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -367,7 +367,12 @@ def overwrite_files(
 ) -> None:
     [resolved_path], fs = _resolve_paths_and_filesystem(root_dir, io_config=io_config)
     file_selector = pafs.FileSelector(resolved_path, recursive=True)
-    paths = [info.path for info in fs.get_file_info(file_selector) if info.type == pafs.FileType.File]
+    try:
+        paths = [info.path for info in fs.get_file_info(file_selector) if info.type == pafs.FileType.File]
+    except FileNotFoundError:
+        # The root directory does not exist, so there are no files to delete.
+        return
+
     all_file_paths_df = from_pydict({"path": paths})
 
     assert manifest._result is not None

--- a/daft/table/table_io.py
+++ b/daft/table/table_io.py
@@ -779,6 +779,10 @@ def write_empty_tabular(
     table = pa.Table.from_pylist([], schema=schema.to_pyarrow_schema())
 
     [resolved_path], fs = _resolve_paths_and_filesystem(path, io_config=io_config)
+    is_local_fs = canonicalize_protocol(get_protocol_from_path(path if isinstance(path, str) else str(path))) == "file"
+    if is_local_fs:
+        fs.create_dir(resolved_path, recursive=True)
+
     basename_template = _generate_basename_template(file_format.ext())
     file_path = f"{resolved_path}/{basename_template.format(i=0)}"
 

--- a/daft/table/table_io.py
+++ b/daft/table/table_io.py
@@ -796,7 +796,8 @@ def write_empty_tabular(
                 filesystem=fs,
             )
         elif file_format == FileFormat.Csv:
-            pacsv.write_csv(table, file_path)
+            output_file = fs.open_output_stream(file_path)
+            pacsv.write_csv(table, output_file)
         else:
             raise ValueError(f"Unsupported file format {file_format}")
 

--- a/tests/io/test_write_modes.py
+++ b/tests/io/test_write_modes.py
@@ -93,10 +93,10 @@ def test_write_modes_local(tmp_path, write_mode, format, num_partitions, partiti
 @pytest.mark.parametrize("format", ["csv", "parquet"])
 def test_write_modes_local_empty_data(tmp_path, write_mode, format):
     path = str(tmp_path)
-    existing_data = {"a": ["a", "a", "b", "b"], "b": [1, 2, 3, 4]}
+    existing_data = {"a": ["a", "a", "b", "b"], "b": ["1", "2", "3", "4"]}
     new_data = {
         "a": ["a", "a", "b", "b"],
-        "b": [5, 6, 7, 8],
+        "b": ["5", "6", "7", "8"],
     }
 
     read_back = arrange_write_mode_test(
@@ -113,7 +113,7 @@ def test_write_modes_local_empty_data(tmp_path, write_mode, format):
     if write_mode == "append":
         # The data should be the same as the existing data
         assert read_back["a"] == ["a", "a", "b", "b"]
-        assert read_back["b"] == [1, 2, 3, 4]
+        assert read_back["b"] == ["1", "2", "3", "4"]
     elif write_mode == "overwrite":
         # The data should be empty because we are overwriting the existing data
         assert read_back["a"] == []
@@ -187,10 +187,10 @@ def test_write_modes_s3_minio_empty_data(
     format,
 ):
     path = f"s3://{bucket}/{str(uuid.uuid4())}"
-    existing_data = {"a": ["a", "a", "b", "b"], "b": [1, 2, 3, 4]}
+    existing_data = {"a": ["a", "a", "b", "b"], "b": ["1", "2", "3", "4"]}
     new_data = {
         "a": ["a", "a", "b", "b"],
-        "b": [5, 6, 7, 8],
+        "b": ["5", "6", "7", "8"],
     }
 
     read_back = arrange_write_mode_test(
@@ -207,7 +207,7 @@ def test_write_modes_s3_minio_empty_data(
     if write_mode == "append":
         # The data should be the same as the existing data
         assert read_back["a"] == ["a", "a", "b", "b"]
-        assert read_back["b"] == [1, 2, 3, 4]
+        assert read_back["b"] == ["1", "2", "3", "4"]
     elif write_mode == "overwrite":
         # The data should be empty because we are overwriting the existing data
         assert read_back["a"] == []

--- a/tests/io/test_write_modes.py
+++ b/tests/io/test_write_modes.py
@@ -93,10 +93,10 @@ def test_write_modes_local(tmp_path, write_mode, format, num_partitions, partiti
 @pytest.mark.parametrize("format", ["csv", "parquet"])
 def test_write_modes_local_empty_data(tmp_path, write_mode, format):
     path = str(tmp_path)
-    existing_data = {"a": ["a", "a", "b", "b"], "b": ["1", "2", "3", "4"]}
+    existing_data = {"a": ["a", "a", "b", "b"], "b": ["c", "d", "e", "f"]}
     new_data = {
         "a": ["a", "a", "b", "b"],
-        "b": ["5", "6", "7", "8"],
+        "b": ["g", "h", "i", "j"],
     }
 
     read_back = arrange_write_mode_test(
@@ -113,7 +113,7 @@ def test_write_modes_local_empty_data(tmp_path, write_mode, format):
     if write_mode == "append":
         # The data should be the same as the existing data
         assert read_back["a"] == ["a", "a", "b", "b"]
-        assert read_back["b"] == ["1", "2", "3", "4"]
+        assert read_back["b"] == ["c", "d", "e", "f"]
     elif write_mode == "overwrite":
         # The data should be empty because we are overwriting the existing data
         assert read_back["a"] == []
@@ -187,10 +187,10 @@ def test_write_modes_s3_minio_empty_data(
     format,
 ):
     path = f"s3://{bucket}/{str(uuid.uuid4())}"
-    existing_data = {"a": ["a", "a", "b", "b"], "b": ["1", "2", "3", "4"]}
+    existing_data = {"a": ["a", "a", "b", "b"], "b": ["c", "d", "e", "f"]}
     new_data = {
         "a": ["a", "a", "b", "b"],
-        "b": ["5", "6", "7", "8"],
+        "b": ["g", "h", "i", "j"],
     }
 
     read_back = arrange_write_mode_test(
@@ -207,7 +207,7 @@ def test_write_modes_s3_minio_empty_data(
     if write_mode == "append":
         # The data should be the same as the existing data
         assert read_back["a"] == ["a", "a", "b", "b"]
-        assert read_back["b"] == ["1", "2", "3", "4"]
+        assert read_back["b"] == ["c", "d", "e", "f"]
     elif write_mode == "overwrite":
         # The data should be empty because we are overwriting the existing data
         assert read_back["a"] == []


### PR DESCRIPTION
Writes for empty dataframes currently error out if the target directory does not exist. This happens in the `overwrite_files` method when looking for files to delete, and also in `write_empty_tabular` when trying to write a file in a non-existent directory.