### PR TITLE
[BUG] Check env in benchmarking script

### DIFF
--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -220,13 +220,10 @@ def get_ray_runtime_env(requirements: str | None) -> dict:
 
 def warmup_environment(requirements: str | None, parquet_folder: str):
     """Performs necessary setup of Daft on the current benchmarking environment"""
-    ctx = daft.context.get_context()
-
     if get_daft_benchmark_runner_name() == "ray":
         runtime_env = get_ray_runtime_env(requirements)
 
         ray.init(
-            address=ctx._runner.ray_address,
             runtime_env=runtime_env,
         )
 

--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -19,7 +19,6 @@ import ray
 import daft
 from benchmarking.tpch import answers, data_generation
 from daft import DataFrame
-from daft.context import get_context
 from daft.runners.profiler import profiler
 
 logger = logging.getLogger(__name__)
@@ -130,8 +129,7 @@ def run_all_benchmarks(
 ):
     get_df = get_df_with_parquet_folder(parquet_folder)
 
-    daft_context = get_context()
-    metrics_builder = MetricsBuilder(daft_context.get_or_create_runner().name)
+    metrics_builder = MetricsBuilder(get_daft_benchmark_runner_name())
 
     for i in questions:
         # Run as a Ray Job if dashboard URL is provided


### PR DESCRIPTION
Using `ctx.get_or_create_runner` in benchmarking warmup code / metrics builder causes subsequent `ray.inits` to crash. Just check the `DAFT_RUNNER` environment var instead, which should be set.

Tested:
- local -> https://github.com/Eventual-Inc/daft-benchmarking/actions/runs/11838323155
- remote -> https://github.com/Eventual-Inc/daft-benchmarking/actions/runs/11838783067