### PR TITLE
[FEAT] Estimate materialized size of ScanTask better from Parquet reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,6 +2413,7 @@ dependencies = [
  "futures",
  "indexmap 2.5.0",
  "itertools 0.11.0",
+ "log",
  "parquet2",
  "pyo3",
  "serde",

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -1216,6 +1216,7 @@ pub fn read_parquet_into_micropartition<T: AsRef<str>>(
                 num_rows,
             ),
             generated_fields,
+            None, // TODO: Add estimations of size in bytes (Parquet metadata)
         );
 
         let fill_map = scan_task.partition_spec().map(|pspec| pspec.to_fill_map());

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -29,9 +29,9 @@ impl MicroPartition {
                         scan_task.storage_config.clone(),
                         scan_task.pushdowns.clone(),
                         scan_task.generated_fields.clone(),
-                        // Assume that the schema casting doesn't change the sizes too much
-                        // Also, it's really messy to pass the execution config this deep so we naively pass in None here. This could be very bug-prone.
-                        scan_task.estimate_in_memory_size_bytes(None),
+                        // NOTE: Skip propagating estimated size for lazily-materialized MicroPartitions
+                        // since this information is not actually leveraged beyond planning time
+                        None,
                     ))
                 };
                 Ok(Self::new_unloaded(

--- a/src/daft-micropartition/src/ops/cast_to_schema.rs
+++ b/src/daft-micropartition/src/ops/cast_to_schema.rs
@@ -29,6 +29,9 @@ impl MicroPartition {
                         scan_task.storage_config.clone(),
                         scan_task.pushdowns.clone(),
                         scan_task.generated_fields.clone(),
+                        // Assume that the schema casting doesn't change the sizes too much
+                        // Also, it's really messy to pass the execution config this deep so we naively pass in None here. This could be very bug-prone.
+                        scan_task.estimate_in_memory_size_bytes(None),
                     ))
                 };
                 Ok(Self::new_unloaded(

--- a/src/daft-scan/Cargo.toml
+++ b/src/daft-scan/Cargo.toml
@@ -21,6 +21,7 @@ daft-table = {path = "../daft-table", default-features = false}
 futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
+log = {workspace = true}
 parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 serde = {workspace = true}

--- a/src/daft-scan/src/anonymous.rs
+++ b/src/daft-scan/src/anonymous.rs
@@ -114,6 +114,7 @@ impl ScanOperator for AnonymousScanOperator {
                     storage_config.clone(),
                     pushdowns.clone(),
                     None,
+                    None,
                 )
                 .into())
             }));

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -461,6 +461,7 @@ impl ScanOperator for GlobScanOperator {
                     storage_config.clone(),
                     pushdowns.clone(),
                     generated_fields,
+                    None, // TODO: Add estimations of size in bytes (GlobScanOperator)
                 )))
             })();
             match scan_task_result {

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -490,7 +490,7 @@ impl ScanOperator for GlobScanOperator {
                     pushdowns.clone(),
                     generated_fields,
                     self.size_estimator.as_ref().and_then(|size_estimator| {
-                        size_bytes.and_then(|size_bytes| {
+                        size_bytes.map(|size_bytes| {
                             size_estimator.estimate_from_size_on_disk(size_bytes, &pushdowns)
                         })
                     }),

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -249,7 +249,7 @@ impl GlobScanOperator {
                 let final_schema = apply_user_provided_schema(schema_from_file)?;
                 let size_estimator =
                     FileInferredEstimator::from_parquet_metadata(final_schema.clone(), &metadata);
-                (final_schema, Some(size_estimator))
+                (final_schema, size_estimator)
             }
 
             FileFormatConfig::Csv(CsvSourceConfig {

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -19,6 +19,7 @@ mod hive;
 use common_daft_config::DaftExecutionConfig;
 pub mod builder;
 pub mod scan_task_iters;
+pub mod size_estimations;
 
 #[cfg(feature = "python")]
 pub mod python;
@@ -445,7 +446,7 @@ impl ScanTask {
         storage_config: Arc<StorageConfig>,
         pushdowns: Pushdowns,
         generated_fields: Option<SchemaRef>,
-        estimated_size_bytes_in_memory: Option<usize>,
+        estimated_materialized_size_bytes: Option<usize>,
     ) -> Self {
         assert!(!sources.is_empty());
         debug_assert!(
@@ -487,7 +488,7 @@ impl ScanTask {
             metadata,
             statistics,
             generated_fields,
-            estimated_materialized_size_bytes: estimated_size_bytes_in_memory,
+            estimated_materialized_size_bytes,
         }
     }
 

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -372,7 +372,7 @@ pub struct ScanTask {
     pub generated_fields: Option<SchemaRef>,
 
     /// The estimated amount of bytes this ScanTask will take up in memory once materialized
-    estimated_materialized_size_bytes: Option<usize>,
+    calculated_estimated_materialized_size_bytes: Option<usize>,
 }
 
 #[typetag::serde]
@@ -488,7 +488,7 @@ impl ScanTask {
             metadata,
             statistics,
             generated_fields,
-            estimated_materialized_size_bytes,
+            calculated_estimated_materialized_size_bytes: estimated_materialized_size_bytes,
         }
     }
 
@@ -540,10 +540,11 @@ impl ScanTask {
             sc1.storage_config.clone(),
             sc1.pushdowns.clone(),
             sc1.generated_fields.clone(),
-            sc1.estimated_materialized_size_bytes.and_then(|est1| {
-                sc2.estimated_materialized_size_bytes
-                    .map(|est2| est1 + est2)
-            }),
+            sc1.calculated_estimated_materialized_size_bytes
+                .and_then(|est1| {
+                    sc2.calculated_estimated_materialized_size_bytes
+                        .map(|est2| est1 + est2)
+                }),
         ))
     }
 
@@ -662,7 +663,7 @@ impl ScanTask {
     ) -> Option<usize> {
         // If the ScanTask is populated with an estimation (this is provided by the ScanOperator), then
         // we can just return that
-        if let Some(est) = self.estimated_materialized_size_bytes {
+        if let Some(est) = self.calculated_estimated_materialized_size_bytes {
             return Some(est);
         }
 

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -660,6 +660,13 @@ impl ScanTask {
         &self,
         config: Option<&DaftExecutionConfig>,
     ) -> Option<usize> {
+        // If the ScanTask is populated with an estimation (this is provided by the ScanOperator), then
+        // we can just return that
+        if let Some(est) = self.estimated_materialized_size_bytes {
+            return Some(est);
+        }
+
+        // Otherwise, we fall-back to trying to estimate using some (very) naive logic based on the schema/stats
         let mat_schema = self.materialized_schema();
         self.statistics
             .as_ref()

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -378,6 +378,7 @@ pub mod pylib {
                 storage_config.into(),
                 pushdowns.map(|p| p.0.as_ref().clone()).unwrap_or_default(),
                 None,
+                None, // TODO: Add estimations of size in bytes (Catalog)
             );
             Ok(Some(Self(scan_task.into())))
         }
@@ -411,6 +412,7 @@ pub mod pylib {
                 storage_config.into(),
                 pushdowns.map(|p| p.0.as_ref().clone()).unwrap_or_default(),
                 None,
+                None, // TODO: Add estimations of size in bytes (SQL)
             );
             Ok(Self(scan_task.into()))
         }
@@ -456,6 +458,7 @@ pub mod pylib {
                 ))),
                 pushdowns.map(|p| p.0.as_ref().clone()).unwrap_or_default(),
                 None,
+                None, // TODO: Add estimations of size in bytes (Python)
             );
             Ok(Self(scan_task.into()))
         }

--- a/src/daft-scan/src/scan_task_iters.rs
+++ b/src/daft-scan/src/scan_task_iters.rs
@@ -254,6 +254,7 @@ pub(crate) fn split_by_row_groups(
 
                             if curr_size_bytes >= min_size_bytes || i == num_row_groups - 1 {
                                 let mut new_source = source.clone();
+                                let new_estimated_size_bytes_in_memory;
 
                                 if let DataSource::File {
                                     chunk_spec,
@@ -269,6 +270,9 @@ pub(crate) fn split_by_row_groups(
 
                                     *chunk_spec = Some(ChunkSpec::Parquet(curr_row_group_indices));
                                     *size_bytes = Some(curr_size_bytes as u64);
+
+                                    // Re-estimate the size bytes in memory
+                                    new_estimated_size_bytes_in_memory = t.estimated_materialized_size_bytes.map(|est| (est as f64 * (curr_num_rows as f64 / file.num_rows as f64)) as usize);
                                 } else {
                                     unreachable!("Parquet file format should only be used with DataSource::File");
                                 }
@@ -294,6 +298,7 @@ pub(crate) fn split_by_row_groups(
                                     t.storage_config.clone(),
                                     t.pushdowns.clone(),
                                     t.generated_fields.clone(),
+                                    new_estimated_size_bytes_in_memory,
                                 )
                                 .into()));
                             }

--- a/src/daft-scan/src/scan_task_iters.rs
+++ b/src/daft-scan/src/scan_task_iters.rs
@@ -272,7 +272,7 @@ pub(crate) fn split_by_row_groups(
                                     *size_bytes = Some(curr_size_bytes as u64);
 
                                     // Re-estimate the size bytes in memory
-                                    new_estimated_size_bytes_in_memory = t.estimated_materialized_size_bytes.map(|est| (est as f64 * (curr_num_rows as f64 / file.num_rows as f64)) as usize);
+                                    new_estimated_size_bytes_in_memory = t.calculated_estimated_materialized_size_bytes.map(|est| (est as f64 * (curr_num_rows as f64 / file.num_rows as f64)) as usize);
                                 } else {
                                     unreachable!("Parquet file format should only be used with DataSource::File");
                                 }

--- a/src/daft-scan/src/size_estimations.rs
+++ b/src/daft-scan/src/size_estimations.rs
@@ -4,6 +4,7 @@ use common_scan_info::Pushdowns;
 use daft_core::prelude::*;
 
 /// An estimator that can be derived/inferred from reading a file (e.g. CSV, JSON or Parquet)
+#[derive(Debug)]
 pub struct FileInferredEstimator {
     /// Schema of the data
     schema: SchemaRef,

--- a/src/daft-scan/src/size_estimations.rs
+++ b/src/daft-scan/src/size_estimations.rs
@@ -1,0 +1,154 @@
+use std::collections::HashMap;
+
+use common_scan_info::Pushdowns;
+use daft_core::prelude::*;
+
+/// An estimator that can be derived/inferred from reading a file (e.g. CSV, JSON or Parquet)
+pub struct FileInferredEstimator {
+    /// Schema of the data
+    schema: SchemaRef,
+
+    /// Estimate how much large each row is at rest (compressed)
+    estimated_row_size: usize,
+
+    /// Fraction of total size taken up by each column at rest (compressed)
+    column_size_fraction: HashMap<usize, f32>,
+
+    /// How much we expect each column to inflate when decompressed and decoded into memory
+    column_inflation: HashMap<usize, f32>,
+}
+
+impl FileInferredEstimator {
+    /// Creates a FileInferredEstimator from Parquet metadata
+    ///
+    /// NOTE: Currently has strong assumptions about the names in the provided `daft_schema` matching names in the Parquet metadata.
+    /// This might not be an accurate mapping, especially if field IDs are being used (for example in Apache Iceberg).
+    pub fn from_parquet_metadata(
+        daft_schema: SchemaRef,
+        parquet_meta: &parquet2::metadata::FileMetaData,
+    ) -> Self {
+        let total_rg_compressed_size: i64 = parquet_meta
+            .row_groups
+            .iter()
+            .map(|(_, rg)| (rg.compressed_size() as i64))
+            .sum();
+        let total_num_rows: usize = parquet_meta
+            .row_groups
+            .iter()
+            .map(|(_, rg)| rg.num_rows())
+            .sum();
+
+        // Accumulate statistics per-column
+        // We only consider columns with names that match the field names in the provided `daft_schema`
+        let mut total_compressed_size_per_column = HashMap::new();
+        let mut total_uncompressed_size_per_column = HashMap::new();
+        for (_, rg) in &parquet_meta.row_groups {
+            for cc_meta in rg.columns() {
+                match cc_meta.descriptor().path_in_schema.first() {
+                    Some(topmost_schema_name) => {
+                        if let Some(field_idx) = daft_schema
+                            .as_ref()
+                            .fields
+                            .get_index_of(topmost_schema_name)
+                        {
+                            let total_column_compressed_size =
+                                if let Some(existing_accumulated_size) =
+                                    total_compressed_size_per_column.get(&field_idx)
+                                {
+                                    existing_accumulated_size + cc_meta.compressed_size()
+                                } else {
+                                    cc_meta.compressed_size()
+                                };
+                            let total_column_uncompressed_size =
+                                if let Some(existing_accumulated_size) =
+                                    total_uncompressed_size_per_column.get(&field_idx)
+                                {
+                                    existing_accumulated_size + cc_meta.uncompressed_size()
+                                } else {
+                                    cc_meta.uncompressed_size()
+                                };
+                            total_compressed_size_per_column
+                                .insert(field_idx, total_column_compressed_size);
+                            total_uncompressed_size_per_column
+                                .insert(field_idx, total_column_uncompressed_size);
+                        } else {
+                            continue;
+                        }
+                    }
+                    None => {
+                        continue;
+                    }
+                }
+            }
+        }
+
+        Self {
+            schema: daft_schema,
+            estimated_row_size: (total_rg_compressed_size as usize) / total_num_rows,
+            column_size_fraction: total_compressed_size_per_column
+                .iter()
+                .map(|(&field_idx, &column_compressed_size)| {
+                    (
+                        field_idx,
+                        (column_compressed_size as f32) / (total_rg_compressed_size as f32),
+                    )
+                })
+                .collect(),
+            column_inflation: total_compressed_size_per_column
+                .iter()
+                .map(|(&field_idx, &col_compressed_size)| {
+                    (
+                        field_idx,
+                        (*total_uncompressed_size_per_column.get(&field_idx).unwrap() as f32)
+                            / (col_compressed_size as f32),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl FileInferredEstimator {
+    /// Runs the estimator based on the size of a file on disk
+    pub fn estimate_from_size_on_disk(
+        &self,
+        size_bytes_on_disk: usize,
+        pushdowns: &Pushdowns,
+    ) -> Option<usize> {
+        // We can only estimate the in memory size if provided with size of the ScanTask on disk
+        let size_on_disk = size_bytes_on_disk;
+
+        // If we have column pushdowns, only consider those columns
+        let columns_to_consider: Vec<usize> =
+            if let Some(column_pushdowns) = pushdowns.columns.as_ref() {
+                column_pushdowns
+                    .iter()
+                    .map(|name| self.schema.as_ref().fields.get_index_of(name).unwrap())
+                    .collect()
+            } else {
+                (0..self.schema.as_ref().len()).collect()
+            };
+
+        // Grab the uncompressed size of each column, and then inflate it to add to the total size
+        let total_uncompressed_size: f32 = columns_to_consider
+            .iter()
+            .map(|col_idx| {
+                let fraction = self.column_size_fraction.get(col_idx).unwrap();
+                let inflation = self.column_inflation.get(col_idx).unwrap();
+
+                (size_on_disk as f32) * fraction * inflation
+            })
+            .sum();
+
+        // Apply limit pushdown if present
+        let total_uncompressed_size = if let Some(limit) = pushdowns.limit {
+            let estimated_num_rows = (size_on_disk as f32) / self.estimated_row_size as f32;
+            let limit_fraction = (limit as f32 / estimated_num_rows).min(1.0);
+            total_uncompressed_size * limit_fraction
+        } else {
+            total_uncompressed_size
+        };
+
+        Some(total_uncompressed_size as usize)
+    }
+}

--- a/src/daft-scan/src/size_estimations.rs
+++ b/src/daft-scan/src/size_estimations.rs
@@ -79,6 +79,10 @@ impl FileInferredEstimator {
                             total_uncompressed_size_per_column
                                 .insert(field_idx, total_column_uncompressed_size);
                         } else {
+                            log::warn!(
+                                "Parquet file contained column that was not in schema: {}",
+                                topmost_schema_name
+                            );
                             continue;
                         }
                     }
@@ -125,7 +129,7 @@ impl FileInferredEstimator {
         &self,
         size_bytes_on_disk: u64,
         pushdowns: &Pushdowns,
-    ) -> Option<usize> {
+    ) -> usize {
         // If we have column pushdowns, only consider those columns
         let columns_to_consider: Vec<usize> =
             if let Some(column_pushdowns) = pushdowns.columns.as_ref() {
@@ -157,6 +161,261 @@ impl FileInferredEstimator {
             total_uncompressed_size
         };
 
-        Some(total_uncompressed_size as usize)
+        total_uncompressed_size as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use daft_core::datatypes::Field;
+    use indexmap::IndexMap;
+    use parquet2::{
+        metadata::{
+            ColumnChunkMetaData, ColumnDescriptor, Descriptor, FileMetaData, RowGroupMetaData,
+            SchemaDescriptor,
+        },
+        schema::types::{
+            FieldInfo, ParquetType, PhysicalType, PrimitiveLogicalType, PrimitiveType,
+        },
+        thrift_format::{ColumnChunk, ColumnMetaData, CompressionCodec, Encoding, Type},
+    };
+
+    use super::*;
+
+    fn make_simple_string_column(
+        name: String,
+        num_rows: usize,
+    ) -> (ParquetType, ColumnChunkMetaData) {
+        let primitive_type = PrimitiveType {
+            field_info: FieldInfo {
+                name: name.clone(),
+                repetition: parquet2::schema::Repetition::Optional,
+                id: None,
+            },
+            logical_type: Some(PrimitiveLogicalType::String),
+            converted_type: None,
+            physical_type: PhysicalType::ByteArray,
+        };
+        let parquet_type = ParquetType::PrimitiveType(primitive_type.clone());
+        let total_byte_size = 1000;
+        let compression_ratio = 1000;
+        let column_metadata = ColumnMetaData::new(
+            Type::BYTE_ARRAY,
+            vec![Encoding::PLAIN],
+            vec![name.clone()],
+            CompressionCodec::SNAPPY,
+            num_rows as i64,
+            total_byte_size * compression_ratio,
+            total_byte_size,
+            None,
+            -1, // Fudge the data page offset
+            None,
+            None,
+            None,
+            None, // Assume no page encoding stats for now, but this could be useful especially for estimating size of dictionary encodings
+            None,
+        );
+        let column_chunk_metadata = ColumnChunkMetaData::new(
+            ColumnChunk::new(None, 0, column_metadata, None, None, None, None, None, None),
+            ColumnDescriptor::new(
+                Descriptor {
+                    primitive_type,
+                    max_def_level: 0,
+                    max_rep_level: 0,
+                },
+                vec![name.clone()],
+                parquet_type.clone(),
+            ),
+        );
+
+        (parquet_type, column_chunk_metadata)
+    }
+
+    #[test]
+    fn test_from_parquet_metadata() {
+        // We create all the necessary thrift-level data to represent this Parquet file:
+        //
+        // 1. One Rowgroup
+        // 2. 10 rows
+        // 3. 1 column called "foo"
+        //   * String type
+        //   * Pretend to be snappy compressed
+        //   * 1000x compression ratio (1000_000 bytes uncompressed, 1000 bytes compressed)
+        //   * Plain encoding
+        let num_rows = 10;
+        let colname = "foo";
+        let (parquet_type, column_chunk_metadata) =
+            make_simple_string_column(colname.to_string(), num_rows);
+        let mut row_groups = IndexMap::new();
+        row_groups.insert(
+            0,
+            RowGroupMetaData::new(
+                vec![column_chunk_metadata.clone()],
+                num_rows,
+                column_chunk_metadata.compressed_size() as usize,
+            ),
+        );
+        let parquet_meta = FileMetaData {
+            version: 0,
+            num_rows: num_rows,
+            created_by: None,
+            row_groups,
+            key_value_metadata: None,
+            schema_descr: SchemaDescriptor::new("schema".to_string(), vec![parquet_type]),
+            column_orders: None,
+        };
+        let schema = Schema::new(vec![Field::new(colname.to_string(), DataType::Utf8)]).unwrap();
+
+        // Check that estimator correctly understands the 1000x inflation
+        let pushdowns = Pushdowns::new(None, None, None, None);
+        let estimator =
+            FileInferredEstimator::from_parquet_metadata(Arc::new(schema), &parquet_meta);
+        match estimator {
+            None => panic!("Cannot construct estimator from metadata"),
+            Some(estimator) => {
+                assert_eq!(estimator.estimate_from_size_on_disk(1, &pushdowns), 1000)
+            }
+        }
+    }
+
+    #[test]
+    fn test_from_parquet_metadata_with_column_pushdown() {
+        // We create all the necessary thrift-level data to represent this Parquet file:
+        //
+        // 1. One Rowgroup
+        // 2. 10 rows
+        // 3. 2 columns, with identical characteristics, foo1 and foo2
+        //   * String type
+        //   * Pretend to be snappy compressed
+        //   * 1000x compression ratio (1000_000 bytes uncompressed, 1000 bytes compressed)
+        //   * Plain encoding
+        let num_rows = 10;
+        let (parquet_type1, column_chunk_metadata1) =
+            make_simple_string_column("foo1".to_string(), num_rows);
+        let (parquet_type2, column_chunk_metadata2) =
+            make_simple_string_column("foo2".to_string(), num_rows);
+        let mut row_groups = IndexMap::new();
+        row_groups.insert(
+            0,
+            RowGroupMetaData::new(
+                vec![
+                    column_chunk_metadata1.clone(),
+                    column_chunk_metadata2.clone(),
+                ],
+                num_rows,
+                (column_chunk_metadata1.compressed_size()
+                    + column_chunk_metadata2.compressed_size()) as usize,
+            ),
+        );
+        let parquet_meta = FileMetaData {
+            version: 0,
+            num_rows: num_rows,
+            created_by: None,
+            row_groups,
+            key_value_metadata: None,
+            schema_descr: SchemaDescriptor::new(
+                "schema".to_string(),
+                vec![parquet_type1, parquet_type2],
+            ),
+            column_orders: None,
+        };
+        let schema = Schema::new(vec![
+            Field::new("foo1".to_string(), DataType::Utf8),
+            Field::new("foo2".to_string(), DataType::Utf8),
+        ])
+        .unwrap();
+
+        // Check that estimator correctly understands the 1000x inflation, but with pushdowns halving the estimations
+        let pushdowns = Pushdowns::new(None, None, Some(Arc::new(vec!["foo1".to_string()])), None);
+        let estimator =
+            FileInferredEstimator::from_parquet_metadata(Arc::new(schema), &parquet_meta);
+        match estimator {
+            None => panic!("Cannot construct estimator from metadata"),
+            // Estimations should be (2 * 1000) / 2, since only one column is read
+            Some(estimator) => {
+                assert_eq!(estimator.estimate_from_size_on_disk(2, &pushdowns), 1000)
+            }
+        }
+    }
+
+    #[test]
+    fn test_from_parquet_metadata_with_limit_pushdown() {
+        let num_rows = 100;
+        let (parquet_type, column_chunk_metadata) =
+            make_simple_string_column("foo".to_string(), num_rows);
+        let mut row_groups = IndexMap::new();
+        row_groups.insert(
+            0,
+            RowGroupMetaData::new(
+                vec![column_chunk_metadata.clone()],
+                num_rows,
+                column_chunk_metadata.compressed_size() as usize,
+            ),
+        );
+        let parquet_meta = FileMetaData {
+            version: 0,
+            num_rows: num_rows,
+            created_by: None,
+            row_groups,
+            key_value_metadata: None,
+            schema_descr: SchemaDescriptor::new("schema".to_string(), vec![parquet_type]),
+            column_orders: None,
+        };
+        let schema = Schema::new(vec![Field::new("foo".to_string(), DataType::Utf8)]).unwrap();
+
+        let estimator =
+            FileInferredEstimator::from_parquet_metadata(Arc::new(schema), &parquet_meta).unwrap();
+
+        // Test with no limit
+        let pushdowns_no_limit = Pushdowns::new(None, None, None, None);
+        assert_eq!(
+            estimator.estimate_from_size_on_disk(1000, &pushdowns_no_limit),
+            1000000
+        );
+
+        // Test with limit of 50% of rows
+        let pushdowns_half_limit = Pushdowns::new(None, None, None, Some(50));
+        assert_eq!(
+            estimator.estimate_from_size_on_disk(1000, &pushdowns_half_limit),
+            500000
+        );
+
+        // Test with limit greater than number of rows
+        let pushdowns_large_limit = Pushdowns::new(None, None, None, Some(200));
+        assert_eq!(
+            estimator.estimate_from_size_on_disk(1000, &pushdowns_large_limit),
+            1000000
+        );
+    }
+
+    #[test]
+    fn test_from_parquet_metadata_with_zero_rows() {
+        let num_rows = 0;
+        let (parquet_type, column_chunk_metadata) =
+            make_simple_string_column("foo".to_string(), num_rows);
+        let mut row_groups = IndexMap::new();
+        row_groups.insert(
+            0,
+            RowGroupMetaData::new(vec![column_chunk_metadata.clone()], num_rows, 0),
+        );
+        let parquet_meta = FileMetaData {
+            version: 0,
+            num_rows: num_rows,
+            created_by: None,
+            row_groups,
+            key_value_metadata: None,
+            schema_descr: SchemaDescriptor::new("schema".to_string(), vec![parquet_type]),
+            column_orders: None,
+        };
+        let schema = Schema::new(vec![Field::new("foo".to_string(), DataType::Utf8)]).unwrap();
+
+        let estimator =
+            FileInferredEstimator::from_parquet_metadata(Arc::new(schema), &parquet_meta);
+        assert!(
+            estimator.is_none(),
+            "Estimator should be None for zero rows"
+        );
     }
 }

--- a/src/daft-scan/src/size_estimations.rs
+++ b/src/daft-scan/src/size_estimations.rs
@@ -126,9 +126,6 @@ impl FileInferredEstimator {
         size_bytes_on_disk: u64,
         pushdowns: &Pushdowns,
     ) -> Option<usize> {
-        // We can only estimate the in memory size if provided with size of the ScanTask on disk
-        let size_on_disk = size_bytes_on_disk;
-
         // If we have column pushdowns, only consider those columns
         let columns_to_consider: Vec<usize> =
             if let Some(column_pushdowns) = pushdowns.columns.as_ref() {
@@ -147,13 +144,13 @@ impl FileInferredEstimator {
                 let fraction = self.column_size_fraction.get(col_idx)?;
                 let inflation = self.column_inflation.get(col_idx)?;
 
-                Some((size_on_disk as f64) * fraction * inflation)
+                Some((size_bytes_on_disk as f64) * fraction * inflation)
             })
             .sum();
 
         // Apply limit pushdown if present
         let total_uncompressed_size = if let Some(limit) = pushdowns.limit {
-            let estimated_num_rows = (size_on_disk as f64) / self.estimated_row_size as f64;
+            let estimated_num_rows = (size_bytes_on_disk as f64) / self.estimated_row_size as f64;
             let limit_fraction = (limit as f64 / estimated_num_rows).min(1.0);
             total_uncompressed_size * limit_fraction
         } else {

--- a/src/parquet2/src/lib.rs
+++ b/src/parquet2/src/lib.rs
@@ -19,7 +19,8 @@ pub mod statistics;
 pub mod types;
 pub mod write;
 
-use parquet_format_safe as thrift_format;
+// Re-export because this is used in some of the external-facing APIs
+pub use parquet_format_safe as thrift_format;
 
 pub use streaming_decompression::fallible_streaming_iterator;
 pub use streaming_decompression::FallibleStreamingIterator;


### PR DESCRIPTION
Adds better estimation of the materialized bytes in memory for a given Parquet ScanTask.

We do this by making use of the same Parquet metadata that we use for schema inference. We take a look at the metadata and make use of various fields such as the reported uncompressed_size, compressed_size of each column. Then we use these statistics to estimate the materialized size of data for reading a Parquet file, using its size on disk.

TODOs:

- [ ] Account for dictionary encoding (and potentially other forms of encoding) -- when we read Parquet we go from `compressed -> uncompressed -> decoded`, and I think we still need to account for encoding here when thinking about how much memory this data will take up when decoded into Daft Series.