### PR TITLE
[FEAT] Support for correlated subqueries in SQL (not yet executable)

### DIFF
--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -149,12 +149,15 @@ pub enum Expr {
     #[display("{_0}")]
     ScalarFunction(ScalarFunction),
 
-    #[display("{_0}")]
+    #[display("subquery {_0}")]
     Subquery(Subquery),
-    #[display("{_0}, {_1}")]
+    #[display("{_0} in {_1}")]
     InSubquery(ExprRef, Subquery),
-    #[display("{_0}")]
+    #[display("exists {_0}")]
     Exists(Subquery),
+
+    #[display("{_0}")]
+    OuterReferenceColumn(OuterReferenceColumn),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash, Eq)]
@@ -162,6 +165,20 @@ pub struct ApproxPercentileParams {
     pub child: ExprRef,
     pub percentiles: Vec<FloatWrapper<f64>>,
     pub force_list_output: bool,
+}
+
+/// Reference to a qualified field in a parent query, used for correlated subqueries.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Hash, Eq)]
+pub struct OuterReferenceColumn {
+    pub field: Field,
+    /// The parent query that the column refers to, with depth=1 denoting the direct parent.
+    pub depth: u64,
+}
+
+impl Display for OuterReferenceColumn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "outer_col({}, {})", self.field.name, self.depth)
+    }
 }
 
 #[derive(Display, Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -717,6 +734,11 @@ impl Expr {
             Self::Subquery(..) | Self::InSubquery(..) | Self::Exists(..) => {
                 FieldID::new("__subquery__")
             } // todo: better/unique id
+            Self::OuterReferenceColumn(c) => {
+                let name = &c.field.name;
+                let depth = c.depth;
+                FieldID::new(format!("outer_col({name}, {depth})"))
+            }
         }
     }
 
@@ -727,6 +749,7 @@ impl Expr {
             Self::Literal(..) => vec![],
             Self::Subquery(..) => vec![],
             Self::Exists(..) => vec![],
+            Self::OuterReferenceColumn(..) => vec![],
 
             // One child.
             Self::Not(expr)
@@ -763,7 +786,11 @@ impl Expr {
     pub fn with_new_children(&self, children: Vec<ExprRef>) -> Self {
         match self {
             // no children
-            Self::Column(..) | Self::Literal(..) | Self::Subquery(..) | Self::Exists(..) => {
+            Self::Column(..)
+            | Self::Literal(..)
+            | Self::Subquery(..)
+            | Self::Exists(..)
+            | Self::OuterReferenceColumn(..) => {
                 assert!(children.is_empty(), "Should have no children");
                 self.clone()
             }
@@ -1027,6 +1054,7 @@ impl Expr {
             }
             Self::InSubquery(expr, _) => Ok(Field::new(expr.name(), DataType::Boolean)),
             Self::Exists(_) => Ok(Field::new("exists", DataType::Boolean)),
+            Self::OuterReferenceColumn(c) => Ok(c.field.clone()),
         }
     }
 
@@ -1060,6 +1088,7 @@ impl Expr {
             Self::Subquery(subquery) => subquery.name(),
             Self::InSubquery(expr, _) => expr.name(),
             Self::Exists(subquery) => subquery.name(),
+            Self::OuterReferenceColumn(c) => &c.field.name,
         }
     }
 
@@ -1135,7 +1164,8 @@ impl Expr {
                 | Expr::ScalarFunction { .. }
                 | Expr::Subquery(..)
                 | Expr::InSubquery(..)
-                | Expr::Exists(..) => Err(io::Error::new(
+                | Expr::Exists(..)
+                | Expr::OuterReferenceColumn(..) => Err(io::Error::new(
                     io::ErrorKind::Other,
                     "Unsupported expression for SQL translation",
                 )),

--- a/src/daft-dsl/src/lib.rs
+++ b/src/daft-dsl/src/lib.rs
@@ -16,7 +16,8 @@ mod treenode;
 pub use common_treenode;
 pub use expr::{
     binary_op, col, has_agg, has_stateful_udf, is_partition_compatible, AggExpr,
-    ApproxPercentileParams, Expr, ExprRef, Operator, SketchType, Subquery, SubqueryPlan,
+    ApproxPercentileParams, Expr, ExprRef, Operator, OuterReferenceColumn, SketchType, Subquery,
+    SubqueryPlan,
 };
 pub use lit::{lit, literal_value, literals_to_series, null_lit, Literal, LiteralValue};
 #[cfg(feature = "python")]

--- a/src/daft-dsl/src/optimization.rs
+++ b/src/daft-dsl/src/optimization.rs
@@ -21,7 +21,7 @@ pub fn requires_computation(e: &Expr) -> bool {
     // Returns whether or not this expression runs any computation on the underlying data
     match e {
         Expr::Alias(child, _) => requires_computation(child),
-        Expr::Column(..) | Expr::Literal(_) => false,
+        Expr::Column(..) | Expr::Literal(_) | Expr::OuterReferenceColumn { .. } => false,
         Expr::Agg(..)
         | Expr::BinaryOp { .. }
         | Expr::Cast(..)

--- a/src/daft-logical-plan/src/ops/project.rs
+++ b/src/daft-logical-plan/src/ops/project.rs
@@ -202,9 +202,11 @@ fn replace_column_with_semantic_id(
         Transformed::yes(new_expr.into())
     } else {
         match e.as_ref() {
-            Expr::Column(_) | Expr::Literal(_) | Expr::Subquery(_) | Expr::Exists(_) => {
-                Transformed::no(e)
-            }
+            Expr::Column(_)
+            | Expr::Literal(_)
+            | Expr::Subquery(_)
+            | Expr::Exists(_)
+            | Expr::OuterReferenceColumn { .. } => Transformed::no(e),
             Expr::Agg(agg_expr) => replace_column_with_semantic_id_aggexpr(
                 agg_expr.clone(),
                 subexprs_to_replace,

--- a/src/daft-logical-plan/src/partitioning.rs
+++ b/src/daft-logical-plan/src/partitioning.rs
@@ -319,8 +319,8 @@ fn translate_clustering_spec_expr(
 
             Ok(expr.in_subquery(subquery.clone()))
         }
-        // Cannot have agg exprs in clustering specs.
-        Expr::Agg(_) => Err(()),
+        // Cannot have agg exprs or references to other tables in clustering specs.
+        Expr::Agg(_) | Expr::OuterReferenceColumn { .. } => Err(()),
     }
 }
 

--- a/src/daft-schema/src/schema.rs
+++ b/src/daft-schema/src/schema.rs
@@ -77,6 +77,10 @@ impl Schema {
         }
     }
 
+    pub fn has_field(&self, name: &str) -> bool {
+        self.fields.contains_key(name)
+    }
+
     pub fn get_index(&self, name: &str) -> DaftResult<usize> {
         match self.fields.get_index_of(name) {
             None => Err(DaftError::FieldNotFound(format!(

--- a/src/daft-sql/src/functions.rs
+++ b/src/daft-sql/src/functions.rs
@@ -223,7 +223,7 @@ impl Default for SQLFunctions {
     }
 }
 
-impl SQLPlanner {
+impl<'a> SQLPlanner<'a> {
     pub(crate) fn plan_function(&self, func: &Function) -> SQLPlannerResult<ExprRef> {
         // assert using only supported features
         check_features(func)?;

--- a/src/daft-sql/src/lib.rs
+++ b/src/daft-sql/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(let_chains)]
+
 pub mod catalog;
 pub mod error;
 pub mod functions;
@@ -106,7 +108,7 @@ mod tests {
     }
 
     #[fixture]
-    fn planner() -> SQLPlanner {
+    fn planner() -> SQLPlanner<'static> {
         let mut catalog = SQLCatalog::new();
 
         catalog.register_table("tbl1", tbl_1());

--- a/src/daft-sql/src/lib.rs
+++ b/src/daft-sql/src/lib.rs
@@ -27,7 +27,7 @@ mod tests {
 
     use catalog::SQLCatalog;
     use daft_core::prelude::*;
-    use daft_dsl::{col, lit};
+    use daft_dsl::{col, lit, Expr, OuterReferenceColumn, Subquery};
     use daft_logical_plan::{
         logical_plan::Source, source_info::PlaceHolderInfo, ClusteringSpec, LogicalPlan,
         LogicalPlanBuilder, LogicalPlanRef, SourceInfo,
@@ -375,6 +375,65 @@ mod tests {
             panic!("query: {query}\nerror: {e:?}");
         }
         assert!(plan.is_ok(), "query: {query}\nerror: {plan:?}");
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::with_second_select("select i32 as a from tbl1 where i32 > 0")]
+    #[case::with_where("select i32 as a from tbl1 where i32 > 0")]
+    #[case::with_where_aliased("select i32 as a from tbl1 where a > 0")]
+    #[case::with_groupby("select i32 as a from tbl1 group by i32")]
+    #[case::with_groupby_aliased("select i32 as a from tbl1 group by a")]
+    #[case::with_orderby("select i32 as a from tbl1 order by i32")]
+    #[case::with_orderby_aliased("select i32 as a from tbl1 order by a")]
+    #[case::with_many("select i32 as a from tbl1 where i32 > 0 group by i32 order by i32")]
+    #[case::with_many_aliased("select i32 as a from tbl1 where a > 0 group by a order by a")]
+    #[case::second_select("select i32 as a, a + 1 from tbl1")]
+    fn test_compiles_select_alias(
+        mut planner: SQLPlanner,
+        #[case] query: &str,
+    ) -> SQLPlannerResult<()> {
+        let plan = planner.plan_sql(query);
+        if let Err(e) = plan {
+            panic!("query: {query}\nerror: {e:?}");
+        }
+        assert!(plan.is_ok(), "query: {query}\nerror: {plan:?}");
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case::basic("select utf8 from tbl1 where i64 > (select max(id) from tbl2 where id = i32)")]
+    #[case::compound(
+        "select utf8 from tbl1 where i64 > (select max(id) from tbl2 where id = tbl1.i32)"
+    )]
+    fn test_correlated_subquery(
+        mut planner: SQLPlanner,
+        #[case] query: &str,
+        tbl_1: LogicalPlanRef,
+        tbl_2: LogicalPlanRef,
+    ) -> SQLPlannerResult<()> {
+        let plan = planner.plan_sql(query)?;
+
+        let outer_col = Arc::new(Expr::OuterReferenceColumn(OuterReferenceColumn {
+            field: Field::new("i32", DataType::Int32),
+            depth: 1,
+        }));
+        let subquery = LogicalPlanBuilder::new(tbl_2, None)
+            .filter(col("id").eq(outer_col))?
+            .aggregate(vec![col("id").max()], vec![])?
+            .select(vec![col("id")])?
+            .build();
+
+        let subquery = Arc::new(Expr::Subquery(Subquery { plan: subquery }));
+
+        let expected = LogicalPlanBuilder::new(tbl_1, None)
+            .filter(col("i64").gt(subquery))?
+            .select(vec![col("utf8")])?
+            .build();
+
+        assert_eq!(plan, expected);
 
         Ok(())
     }

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -984,7 +984,7 @@ impl<'a> SQLPlanner<'a> {
             // The identifier could also be in the alias map but not the schema
             // for expressions in WHERE, GROUP BY, and HAVING, which are done before project
             if let Some(expr) = planner.alias_map.get(&full_str) {
-                // transform expression alias map by incrementing thee depths of every column by `depth``
+                // transform expression alias map by incrementing thee depths of every column by `depth`
                 let transformed_expr = expr
                     .clone()
                     .transform(|e| match e.as_ref() {

--- a/src/daft-sql/src/table_provider/mod.rs
+++ b/src/daft-sql/src/table_provider/mod.rs
@@ -47,7 +47,7 @@ impl SQLTableFunctions {
     }
 }
 
-impl SQLPlanner {
+impl<'a> SQLPlanner<'a> {
     pub(crate) fn plan_table_function(
         &self,
         fn_name: &str,

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -512,22 +512,20 @@ impl Table {
     }
 
     fn eval_expression(&self, expr: &Expr) -> DaftResult<Series> {
-        use crate::Expr::*;
-
         let expected_field = expr.to_field(self.schema.as_ref())?;
         let series = match expr {
-            Alias(child, name) => Ok(self.eval_expression(child)?.rename(name)),
-            Agg(agg_expr) => self.eval_agg_expression(agg_expr, None),
-            Cast(child, dtype) => self.eval_expression(child)?.cast(dtype),
-            Column(name) => self.get_column(name).cloned(),
-            Not(child) => !(self.eval_expression(child)?),
-            IsNull(child) => self.eval_expression(child)?.is_null(),
-            NotNull(child) => self.eval_expression(child)?.not_null(),
-            FillNull(child, fill_value) => {
+            Expr::Alias(child, name) => Ok(self.eval_expression(child)?.rename(name)),
+            Expr::Agg(agg_expr) => self.eval_agg_expression(agg_expr, None),
+            Expr::Cast(child, dtype) => self.eval_expression(child)?.cast(dtype),
+            Expr::Column(name) => self.get_column(name).cloned(),
+            Expr::Not(child) => !(self.eval_expression(child)?),
+            Expr::IsNull(child) => self.eval_expression(child)?.is_null(),
+            Expr::NotNull(child) => self.eval_expression(child)?.not_null(),
+            Expr::FillNull(child, fill_value) => {
                 let fill_value = self.eval_expression(fill_value)?;
                 self.eval_expression(child)?.fill_null(&fill_value)
             }
-            IsIn(child, items) => {
+            Expr::IsIn(child, items) => {
                 let items = items.iter().map(|i| self.eval_expression(i)).collect::<DaftResult<Vec<_>>>()?;
 
                 let items = items.iter().collect::<Vec<&Series>>();
@@ -537,10 +535,10 @@ impl Table {
                 .is_in(&s)
             }
 
-            Between(child, lower, upper) => self
+            Expr::Between(child, lower, upper) => self
                 .eval_expression(child)?
                 .between(&self.eval_expression(lower)?, &self.eval_expression(upper)?),
-            BinaryOp { op, left, right } => {
+            Expr::BinaryOp { op, left, right } => {
                 let lhs = self.eval_expression(left)?;
                 let rhs = self.eval_expression(right)?;
                 use daft_core::array::ops::{DaftCompare, DaftLogical};
@@ -565,14 +563,14 @@ impl Table {
                     ShiftRight => lhs.shift_right(&rhs),
                 }
             }
-            Function { func, inputs } => {
+            Expr::Function { func, inputs } => {
                 let evaluated_inputs = inputs
                     .iter()
                     .map(|e| self.eval_expression(e))
                     .collect::<DaftResult<Vec<_>>>()?;
                 func.evaluate(evaluated_inputs.as_slice(), func)
             }
-            ScalarFunction(func) => {
+            Expr::ScalarFunction(func) => {
                 let evaluated_inputs = func
                     .inputs
                     .iter()
@@ -580,8 +578,8 @@ impl Table {
                     .collect::<DaftResult<Vec<_>>>()?;
                 func.udf.evaluate(evaluated_inputs.as_slice())
             }
-            Literal(lit_value) => Ok(lit_value.to_series()),
-            IfElse {
+            Expr::Literal(lit_value) => Ok(lit_value.to_series()),
+            Expr::IfElse {
                 if_true,
                 if_false,
                 predicate,
@@ -597,14 +595,17 @@ impl Table {
                     Ok(if_true_series.if_else(&if_false_series, &predicate_series)?)
                 }
             },
-            Subquery(_subquery) => Err(DaftError::ComputeError(
+            Expr::Subquery(_subquery) => Err(DaftError::ComputeError(
                 "Subquery should be optimized away before evaluation. This indicates a bug in the query optimizer.".to_string(),
             )),
-            InSubquery(_expr, _subquery) => Err(DaftError::ComputeError(
+            Expr::InSubquery(_expr, _subquery) => Err(DaftError::ComputeError(
                 "IN <SUBQUERY> should be optimized away before evaluation. This indicates a bug in the query optimizer.".to_string(),
             )),
-            Exists(_subquery) => Err(DaftError::ComputeError(
+            Expr::Exists(_subquery) => Err(DaftError::ComputeError(
                 "EXISTS <SUBQUERY> should be optimized away before evaluation. This indicates a bug in the query optimizer.".to_string(),
+            )),
+            Expr::OuterReferenceColumn { .. } => Err(DaftError::ComputeError(
+                "Outer reference columns should be optimized away before evaluation. This indicates a bug in the query optimizer.".to_string(),
             )),
         }?;
 


### PR DESCRIPTION
This PR adds support for converting SQL queries with correlated subqueries into LogicalPlans. It does not add the ability to execute queries with correlated subqueries, but if I am correct, this is the last large piece of support we need on the SQL side for TPC-H questions, and most of the remaining work is plan rewriting, optimization, and translation.

I believe with the new `alias_map` value in `SQLPlanner`, we can actually simplify a lot of the logic in `plan_aggregate_query` and `plan_non_agg_query` but I will not attempt to do that in this PR.

Relevant for TPC-H questions 4, 17, 20, 21, 22.

Todo:
- [x] tests