### PR TITLE
[FEAT] Add new workflow to build commits and output to s3

### DIFF
--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -1,0 +1,31 @@
+name: Install uv, rust, and python
+description: Install uv, rust, and python
+runs:
+  using: composite
+  steps:
+  - name: Install rust
+    shell: bash
+    run: |
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      CARGO_BIN="$HOME/.cargo/bin"
+      echo 'export PATH="$CARGO_BIN:$PATH"' >> $HOME/.bashrc
+      echo "$CARGO_BIN" >> $GITHUB_PATH
+
+  - name: Install uv
+    shell: bash
+    run: |
+      curl -LsSf https://astral.sh/uv/install.sh | sh
+      UV_BIN="$HOME/.local/bin"
+      echo 'export PATH="$UV_BIN:$PATH"' >> $HOME/.bashrc
+      echo "$UV_BIN" >> $GITHUB_PATH
+
+  - name: Source .bashrc
+    shell: bash
+    run: |
+      source $HOME/.bashrc
+
+  - name: Install python (version 3.9)
+    shell: bash
+    run: |
+      uv python install 3.9
+      uv python pin 3.9

--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -1,31 +1,29 @@
 name: Install uv, rust, and python
 description: Install uv, rust, and python
+inputs:
+  python_version:
+    description: The version of python to install
+    required: false
+    default: '3.9'
 runs:
   using: composite
   steps:
-  - name: Install rust
-    shell: bash
+  - shell: bash
     run: |
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       CARGO_BIN="$HOME/.cargo/bin"
       echo 'export PATH="$CARGO_BIN:$PATH"' >> $HOME/.bashrc
       echo "$CARGO_BIN" >> $GITHUB_PATH
-
-  - name: Install uv
-    shell: bash
+  - shell: bash
     run: |
       curl -LsSf https://astral.sh/uv/install.sh | sh
       UV_BIN="$HOME/.local/bin"
       echo 'export PATH="$UV_BIN:$PATH"' >> $HOME/.bashrc
       echo "$UV_BIN" >> $GITHUB_PATH
-
-  - name: Source .bashrc
-    shell: bash
+  - shell: bash
     run: |
       source $HOME/.bashrc
-
-  - name: Install python (version 3.9)
-    shell: bash
+  - shell: bash
     run: |
-      uv python install 3.9
-      uv python pin 3.9
+      uv python install ${{ inputs.python_version }}
+      uv python pin ${{ inputs.python_version }}

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -54,8 +54,16 @@ jobs:
           maturin build --release
         fi
 
+        count=$(ls ~/target/wheels/*.whl 2> /dev/null | wc -l)
+        if [ "$count" -gt 1 ]; then
+          echo "Found more than 1 wheel"
+          exit 1
+        elif [ "$count" -eq 0 ]; then
+          echo "Found no wheel files"
+          exit 1
+        fi
+
         # Upload wheel
-        # (there should only be one output wheel in this directory)
         for file in ~/target/wheels/*.whl; do
           aws s3 cp $file s3://github-actions-artifacts-bucket/builds/${{ inputs.commit || github.sha }}/ --acl public-read --no-progress;
           file_basename=$(basename $file)

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -1,0 +1,65 @@
+name: Build a Daft commit and store the outputted wheel in AWS S3
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      ACTIONS_AWS_ROLE_ARN:
+        description: The ARN of the AWS role to assume
+        required: true
+    inputs:
+      commit:
+        type: string
+        description: The commit hash to build
+        required: true
+    outputs:
+      wheel:
+        description: The wheel file that was built
+        value: ${{ jobs.build-commit.outputs.wheel }}
+
+jobs:
+  build-commit:
+    runs-on: buildjet-8vcpu-ubuntu-2004
+    timeout-minutes: 15 # Remove for ssh debugging
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      wheel: ${{ steps.build_and_upload.outputs.wheel }}
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-west-2
+        role-to-assume: ${{ secrets.ACTIONS_AWS_ROLE_ARN }}
+        role-session-name: daft-performance-comparisons-build
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.commit || github.sha }}
+        fetch-depth: 1
+    - uses: ./.github/actions/install
+    - uses: buildjet/cache@v4
+      with:
+        path: ~/target
+        key: ${{ runner.os }}-cargo-deps-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-deps-
+    - name: Build the python wheel and upload it to AWS S3
+      id: build_and_upload
+      run: |
+        if ! ls ~/target/wheels/*.whl 1> /dev/null 2>&1; then
+          # Build wheel
+          export CARGO_TARGET_DIR=~/target
+          uv v
+          source .venv/bin/activate
+          uv pip install pip maturin
+          maturin build --release
+        fi
+
+        # Upload wheel
+        # (there should only be one output wheel in this directory)
+        for file in ~/target/wheels/*.whl; do
+          aws s3 cp $file s3://github-actions-artifacts-bucket/builds/${{ inputs.commit || github.sha }}/ --acl public-read --no-progress;
+          file_basename=$(basename $file)
+          echo "wheel=$file_basename" >> $GITHUB_OUTPUT
+          echo "Output wheel has been built and stored in S3 at the following location:" >> $GITHUB_STEP_SUMMARY
+          echo "https://us-west-2.console.aws.amazon.com/s3/buckets/github-actions-artifacts-bucket?prefix=builds/${{ inputs.commit || github.sha }}/" >> $GITHUB_STEP_SUMMARY
+        done

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -2,15 +2,6 @@ name: Build a Daft commit and store the outputted wheel in AWS S3
 
 on:
   workflow_dispatch:
-    inputs:
-      x86:
-        description: Build for x86
-        required: false
-        default: false
-      arm:
-        description: Build for ARM
-        required: false
-        default: false
   workflow_call:
     secrets:
       ACTIONS_AWS_ROLE_ARN:
@@ -28,10 +19,6 @@ on:
 
 jobs:
   build-commit:
-    strategy:
-      fail-fast: false
-      matrix:
-        compile_arch: [x86, arm]
     runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 15 # Remove for ssh debugging
     permissions:
@@ -40,10 +27,6 @@ jobs:
     outputs:
       wheel: ${{ steps.build_and_upload.outputs.wheel }}
     steps:
-    - if: ${{ (matrix.compile_arch == 'x86') && (github.event.inputs.x86 == 'false') }}
-      run: exit 0
-    - if: ${{ (matrix.compile_arch == 'arm') && (github.event.inputs.arm == 'false') }}
-      run: exit 0
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: us-west-2

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -2,6 +2,15 @@ name: Build a Daft commit and store the outputted wheel in AWS S3
 
 on:
   workflow_dispatch:
+    inputs:
+      x86:
+        description: Build for x86
+        required: false
+        default: false
+      arm:
+        description: Build for ARM
+        required: false
+        default: false
   workflow_call:
     secrets:
       ACTIONS_AWS_ROLE_ARN:
@@ -19,6 +28,10 @@ on:
 
 jobs:
   build-commit:
+    strategy:
+      fail-fast: true
+      matrix:
+        compile_arch: [x86, arm]
     runs-on: buildjet-8vcpu-ubuntu-2004
     timeout-minutes: 15 # Remove for ssh debugging
     permissions:
@@ -27,6 +40,10 @@ jobs:
     outputs:
       wheel: ${{ steps.build_and_upload.outputs.wheel }}
     steps:
+    - if: ${{ (matrix.compile_arch == 'x86') && (github.event.inputs.x86 == 'false') }}
+      run: exit 78
+    - if: ${{ (matrix.compile_arch == 'arm') && (github.event.inputs.arm == 'false') }}
+      run: exit 78
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: us-west-2

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -29,7 +29,7 @@ on:
 jobs:
   build-commit:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         compile_arch: [x86, arm]
     runs-on: buildjet-8vcpu-ubuntu-2004
@@ -41,9 +41,9 @@ jobs:
       wheel: ${{ steps.build_and_upload.outputs.wheel }}
     steps:
     - if: ${{ (matrix.compile_arch == 'x86') && (github.event.inputs.x86 == 'false') }}
-      run: exit 78
+      run: exit 0
     - if: ${{ (matrix.compile_arch == 'arm') && (github.event.inputs.arm == 'false') }}
-      run: exit 78
+      run: exit 0
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: us-west-2

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -7,11 +7,6 @@ on:
       ACTIONS_AWS_ROLE_ARN:
         description: The ARN of the AWS role to assume
         required: true
-    inputs:
-      commit:
-        type: string
-        description: The commit hash to build
-        required: true
     outputs:
       wheel:
         description: The wheel file that was built
@@ -27,23 +22,22 @@ jobs:
     outputs:
       wheel: ${{ steps.build_and_upload.outputs.wheel }}
     steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.sha }}
+        fetch-depth: 1
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: us-west-2
         role-to-assume: ${{ secrets.ACTIONS_AWS_ROLE_ARN }}
         role-session-name: daft-performance-comparisons-build
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.commit || github.sha }}
-        fetch-depth: 1
     - uses: ./.github/actions/install
     - uses: buildjet/cache@v4
       with:
         path: ~/target
         key: ${{ runner.os }}-cargo-deps-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-deps-
-    - name: Build the python wheel and upload it to AWS S3
-      id: build_and_upload
+    - id: build_and_upload
       run: |
         if ! ls ~/target/wheels/*.whl 1> /dev/null 2>&1; then
           # Build wheel
@@ -65,9 +59,9 @@ jobs:
 
         # Upload wheel
         for file in ~/target/wheels/*.whl; do
-          aws s3 cp $file s3://github-actions-artifacts-bucket/builds/${{ inputs.commit || github.sha }}/ --acl public-read --no-progress;
+          aws s3 cp $file s3://github-actions-artifacts-bucket/builds/${{ github.sha }}/ --acl public-read --no-progress;
           file_basename=$(basename $file)
           echo "wheel=$file_basename" >> $GITHUB_OUTPUT
           echo "Output wheel has been built and stored in S3 at the following location:" >> $GITHUB_STEP_SUMMARY
-          echo "https://us-west-2.console.aws.amazon.com/s3/buckets/github-actions-artifacts-bucket?prefix=builds/${{ inputs.commit || github.sha }}/" >> $GITHUB_STEP_SUMMARY
+          echo "https://us-west-2.console.aws.amazon.com/s3/buckets/github-actions-artifacts-bucket?prefix=builds/${{ github.sha }}/" >> $GITHUB_STEP_SUMMARY
         done


### PR DESCRIPTION
# Overview
Given a commit hash and a build machine, outputs a python wheel to s3. This is slightly different than existing one. Differences:
- machine type is configurable
- machine types are not matrixified
- is able to be triggered manually or via another workflow
- commit is specifiable