### PR TITLE
[FEAT] add workflow to run tpch benchmarking

### DIFF
--- a/.github/assets/ray.yaml
+++ b/.github/assets/ray.yaml
@@ -1,0 +1,60 @@
+cluster_name: performance-comparisons
+
+provider:
+  type: aws
+  region: us-west-2
+  cache_stopped_nodes: true
+  security_group:
+    GroupName: ray-autoscaler-c1
+
+auth:
+  ssh_user: ubuntu
+  ssh_private_key: ~/.ssh/ci-github-actions-ray-cluster-key.pem
+
+max_workers: 2
+available_node_types:
+  ray.head.default:
+    resources: {"CPU": 0}
+    node_config:
+      KeyName: ci-github-actions-ray-cluster-key
+      InstanceType: i3.2xlarge
+      ImageId: ami-04dd23e62ed049936
+      IamInstanceProfile:
+        Name: ray-autoscaler-v1
+
+  ray.worker.default:
+    min_workers: 2
+    max_workers: 2
+    resources: {}
+    node_config:
+      KeyName: ci-github-actions-ray-cluster-key
+      InstanceType: i3.2xlarge
+      ImageId: ami-04dd23e62ed049936
+      IamInstanceProfile:
+        Name: ray-autoscaler-v1
+
+setup_commands:
+# Mount drive
+- sudo mkfs.ext4 /dev/nvme0n1
+- sudo mount -t ext4 /dev/nvme0n1 /tmp
+- sudo chmod 777 /tmp
+# Install dependencies
+- sudo snap install aws-cli --classic
+- curl -LsSf https://astral.sh/uv/install.sh | sh
+- echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+- source ~/.bashrc
+- uv python install 3.9
+- uv python pin 3.9
+- uv v
+- echo "source $HOME/.venv/bin/activate" >> $HOME/.bashrc
+- source .venv/bin/activate
+- uv pip install pip ray[default] py-spy
+# GitHub Actions workflow will replace all parameters between `<<...>>` with the
+# actual values as determined dynamically during runtime of the actual workflow.
+- uv pip install https://github-actions-artifacts-bucket.s3.us-west-2.amazonaws.com/builds/<<SHA>>/<<WHEEL>>
+# Download benchmarking fixtures
+- |
+  aws s3 sync \
+  s3://eventual-dev-benchmarking-fixtures/uncompressed/tpch-dbgen/2_0/2/parquet/ \
+  /tmp/data/2_0/2/parquet/ \
+  --quiet

--- a/.github/assets/ray.yaml
+++ b/.github/assets/ray.yaml
@@ -55,6 +55,6 @@ setup_commands:
 # Download benchmarking fixtures
 - |
   aws s3 sync \
-  s3://eventual-dev-benchmarking-fixtures/uncompressed/tpch-dbgen/2_0/2/parquet/ \
-  /tmp/data/2_0/2/parquet/ \
+  s3://eventual-dev-benchmarking-fixtures/uncompressed/tpch-dbgen/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
+  /tmp/data/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
   --quiet

--- a/.github/assets/ray.yaml
+++ b/.github/assets/ray.yaml
@@ -55,11 +55,6 @@ setup_commands:
 # Download benchmarking fixtures
 - |
   aws s3 sync \
-  s3://eventual-dev-benchmarking-fixtures/uncompressed/tpch-dbgen/2_0/2/parquet/ \
-  /tmp/data/2_0/2/parquet/ \
+  s3://eventual-dev-benchmarking-fixtures/uncompressed/tpch-dbgen/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
+  /tmp/data/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
   --quiet
-# - |
-#   aws s3 sync \
-#   s3://eventual-dev-benchmarking-fixtures/uncompressed/tpch-dbgen/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
-#   /tmp/data/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
-#   --quiet

--- a/.github/assets/ray.yaml
+++ b/.github/assets/ray.yaml
@@ -55,6 +55,11 @@ setup_commands:
 # Download benchmarking fixtures
 - |
   aws s3 sync \
-  s3://eventual-dev-benchmarking-fixtures/uncompressed/tpch-dbgen/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
-  /tmp/data/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
+  s3://eventual-dev-benchmarking-fixtures/uncompressed/tpch-dbgen/2_0/2/parquet/ \
+  /tmp/data/2_0/2/parquet/ \
   --quiet
+# - |
+#   aws s3 sync \
+#   s3://eventual-dev-benchmarking-fixtures/uncompressed/tpch-dbgen/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
+#   /tmp/data/<<SCALE_FACTOR>>/<<PARTITION_SIZE>>/parquet/ \
+#   --quiet

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -37,7 +37,7 @@ jobs:
         role-session-name: run-tpch-workflow
     - uses: ./.github/actions/install
     - run: |
-        scale_factor_str="${{ toString(inputs.scale_factor) }}_0"
+        scale_factor_str="${{ inputs.scale_factor }}_0"
 
         # Dynamically update ray config file
         sed -i 's|<<SHA>>|${{ github.sha }}|g' .github/assets/ray.yaml

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -1,7 +1,6 @@
 name: Run tpch benchmarks
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       wheel:

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -45,8 +45,6 @@ jobs:
         sed -i "s|<<SCALE_FACTOR>>|$scale_factor_str|g" .github/assets/ray.yaml
         sed -i 's|<<PARTITION_SIZE>>|${{ inputs.partition_size }}|g' .github/assets/ray.yaml
 
-        cat .github/assets/ray.yaml
-
         # Download private ssh key
         KEY=$(aws secretsmanager get-secret-value --secret-id ci-github-actions-ray-cluster-key-3 --query SecretString --output text)
         echo "$KEY" >> ~/.ssh/ci-github-actions-ray-cluster-key.pem

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -1,0 +1,60 @@
+name: Run tpch benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      wheel:
+        description: The wheel artifact to use
+        required: false
+        default: getdaft-0.3.0.dev0-cp38-abi3-manylinux_2_31_x86_64.whl
+
+jobs:
+  run-tpch:
+    runs-on: [self-hosted, linux, x64, ci-dev]
+    timeout-minutes: 15 # Remove for ssh debugging
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-west-2
+        role-session-name: run-tpch-workflow
+    - uses: ./.github/actions/install
+    - run: |
+        # Dynamically update ray config file
+        sed -i 's|<<SHA>>|${{ github.sha }}|g' .github/assets/ray.yaml
+        sed -i 's|<<WHEEL>>|${{ inputs.wheel }}|g' .github/assets/ray.yaml
+
+        # Download private ssh key
+        KEY=$(aws secretsmanager get-secret-value --secret-id ci-github-actions-ray-cluster-key-3 --query SecretString --output text)
+        echo "$KEY" >> ~/.ssh/ci-github-actions-ray-cluster-key.pem
+        chmod 600 ~/.ssh/ci-github-actions-ray-cluster-key.pem
+
+        # Install dependencies
+        uv v
+        source .venv/bin/activate
+        rm -rf daft
+        uv pip install ray[default] boto3 https://github-actions-artifacts-bucket.s3.us-west-2.amazonaws.com/builds/${{ github.sha }}/${{ inputs.wheel }}
+
+        # Boot up ray cluster
+        ray up .github/assets/ray.yaml -y
+        HEAD_NODE_IP=$(ray get-head-ip .github/assets/ray.yaml | tail -n 1)
+        ssh -o StrictHostKeyChecking=no -fN -L 8265:localhost:8265 -i ~/.ssh/ci-github-actions-ray-cluster-key.pem ubuntu@$HEAD_NODE_IP
+        DAFT_RUNNER=ray python -m benchmarking.tpch \
+          --skip_questions="2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22" \
+          --num_parts 2 \
+          --scale_factor 2 \
+          --parquet_file_cache /tmp/data \
+          --output_csv output.csv \
+          --ray_job_dashboard_url http://localhost:8265 \
+          --skip_warmup \
+          --no_pymodules
+        ray down .github/assets/ray.yaml -y
+    - uses: actions/upload-artifact@v4
+      with:
+        name: output.csv
+        path: output.csv

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -1,6 +1,7 @@
 name: Run tpch benchmarks
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       wheel:

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -14,11 +14,11 @@ on:
       scale_factor:
         description: Which scale factor to use
         required: false
-        default: 2_0
+        default: 2
       partition_size:
         description: Which partition size to use
         required: false
-        default: '2'
+        default: 2
 
 jobs:
   run-tpch:
@@ -37,10 +37,12 @@ jobs:
         role-session-name: run-tpch-workflow
     - uses: ./.github/actions/install
     - run: |
+        scale_factor_str="${{ toString(inputs.scale_factor) }}_0"
+
         # Dynamically update ray config file
         sed -i 's|<<SHA>>|${{ github.sha }}|g' .github/assets/ray.yaml
         sed -i 's|<<WHEEL>>|${{ inputs.wheel }}|g' .github/assets/ray.yaml
-        sed -i 's|<<SCALE_FACTOR>>|${{ inputs.scale_factor }}|g' .github/assets/ray.yaml
+        sed -i 's|<<SCALE_FACTOR>>|$scale_factor_str|g' .github/assets/ray.yaml
         sed -i 's|<<PARTITION_SIZE>>|${{ inputs.partition_size }}|g' .github/assets/ray.yaml
 
         # Download private ssh key

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -11,6 +11,14 @@ on:
         description: The TPC-H questions to skip
         required: false
         default: 2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22
+      scale_factor:
+        description: Which scale factor to use
+        required: false
+        default: 2_0
+      partition_size:
+        description: Which partition size to use
+        required: false
+        default: '2'
 
 jobs:
   run-tpch:
@@ -32,6 +40,8 @@ jobs:
         # Dynamically update ray config file
         sed -i 's|<<SHA>>|${{ github.sha }}|g' .github/assets/ray.yaml
         sed -i 's|<<WHEEL>>|${{ inputs.wheel }}|g' .github/assets/ray.yaml
+        sed -i 's|<<SCALE_FACTOR>>|${{ inputs.scale_factor }}|g' .github/assets/ray.yaml
+        sed -i 's|<<PARTITION_SIZE>>|${{ inputs.partition_size }}|g' .github/assets/ray.yaml
 
         # Download private ssh key
         KEY=$(aws secretsmanager get-secret-value --secret-id ci-github-actions-ray-cluster-key-3 --query SecretString --output text)
@@ -50,8 +60,8 @@ jobs:
         ssh -o StrictHostKeyChecking=no -fN -L 8265:localhost:8265 -i ~/.ssh/ci-github-actions-ray-cluster-key.pem ubuntu@$HEAD_NODE_IP
         DAFT_RUNNER=ray python -m benchmarking.tpch \
           --skip_questions=${{ inputs.skip_questions }} \
-          --num_parts 2 \
-          --scale_factor 2 \
+          --scale_factor ${{ inputs.scale_factor }} \
+          --num_parts ${{ inputs.partition_size }} \
           --parquet_file_cache /tmp/data \
           --output_csv output.csv \
           --ray_job_dashboard_url http://localhost:8265 \

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -7,6 +7,10 @@ on:
         description: The wheel artifact to use
         required: false
         default: getdaft-0.3.0.dev0-cp38-abi3-manylinux_2_31_x86_64.whl
+      skip_questions:
+        description: The TPC-H questions to skip
+        required: false
+        default: 2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22
 
 jobs:
   run-tpch:
@@ -45,7 +49,7 @@ jobs:
         HEAD_NODE_IP=$(ray get-head-ip .github/assets/ray.yaml | tail -n 1)
         ssh -o StrictHostKeyChecking=no -fN -L 8265:localhost:8265 -i ~/.ssh/ci-github-actions-ray-cluster-key.pem ubuntu@$HEAD_NODE_IP
         DAFT_RUNNER=ray python -m benchmarking.tpch \
-          --skip_questions="2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22" \
+          --skip_questions=${{ inputs.skip_questions }} \
           --num_parts 2 \
           --scale_factor 2 \
           --parquet_file_cache /tmp/data \

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -10,7 +10,7 @@ on:
       skip_questions:
         description: The TPC-H questions to skip
         required: false
-        default: 2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22
+        default: "2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22"
       scale_factor:
         description: Which scale factor to use
         required: false

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -42,7 +42,7 @@ jobs:
         # Dynamically update ray config file
         sed -i 's|<<SHA>>|${{ github.sha }}|g' .github/assets/ray.yaml
         sed -i 's|<<WHEEL>>|${{ inputs.wheel }}|g' .github/assets/ray.yaml
-        sed -i 's|<<SCALE_FACTOR>>|$scale_factor_str|g' .github/assets/ray.yaml
+        sed -i "s|<<SCALE_FACTOR>>|$scale_factor_str|g" .github/assets/ray.yaml
         sed -i 's|<<PARTITION_SIZE>>|${{ inputs.partition_size }}|g' .github/assets/ray.yaml
 
         cat .github/assets/ray.yaml

--- a/.github/workflows/run-tpch.yaml
+++ b/.github/workflows/run-tpch.yaml
@@ -45,6 +45,8 @@ jobs:
         sed -i 's|<<SCALE_FACTOR>>|$scale_factor_str|g' .github/assets/ray.yaml
         sed -i 's|<<PARTITION_SIZE>>|${{ inputs.partition_size }}|g' .github/assets/ray.yaml
 
+        cat .github/assets/ray.yaml
+
         # Download private ssh key
         KEY=$(aws secretsmanager get-secret-value --secret-id ci-github-actions-ray-cluster-key-3 --query SecretString --output text)
         echo "$KEY" >> ~/.ssh/ci-github-actions-ray-cluster-key.pem
@@ -61,7 +63,7 @@ jobs:
         HEAD_NODE_IP=$(ray get-head-ip .github/assets/ray.yaml | tail -n 1)
         ssh -o StrictHostKeyChecking=no -fN -L 8265:localhost:8265 -i ~/.ssh/ci-github-actions-ray-cluster-key.pem ubuntu@$HEAD_NODE_IP
         DAFT_RUNNER=ray python -m benchmarking.tpch \
-          --skip_questions=${{ inputs.skip_questions }} \
+          --skip_questions="${{ inputs.skip_questions }}" \
           --scale_factor ${{ inputs.scale_factor }} \
           --num_parts ${{ inputs.partition_size }} \
           --parquet_file_cache /tmp/data \

--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -126,6 +126,7 @@ def run_all_benchmarks(
     csv_output_location: str | None,
     ray_job_dashboard_url: str | None = None,
     requirements: str | None = None,
+    no_pymodules: bool = False,
 ):
     get_df = get_df_with_parquet_folder(parquet_folder)
 
@@ -143,7 +144,7 @@ def run_all_benchmarks(
                 tpch_qnum=i,
                 working_dir=working_dir,
                 entrypoint=entrypoint,
-                runtime_env=get_ray_runtime_env(requirements),
+                runtime_env=get_ray_runtime_env(requirements, no_pymodules=no_pymodules),
             )
 
             # Run once as a warmup step
@@ -202,9 +203,9 @@ def get_daft_benchmark_runner_name() -> Literal["ray"] | Literal["py"] | Literal
     return name
 
 
-def get_ray_runtime_env(requirements: str | None) -> dict:
+def get_ray_runtime_env(requirements: str | None, no_pymodules: bool = False) -> dict:
     runtime_env = {
-        "py_modules": [daft],
+        "py_modules": None if no_pymodules else [daft],
         "eager_install": True,
         "env_vars": {
             "DAFT_PROGRESS_BAR": "0",
@@ -293,6 +294,11 @@ if __name__ == "__main__":
         default=None,
         help="Ray Dashboard URL to submit jobs instead of using Ray client, most useful when running on a remote cluster",
     )
+    parser.add_argument(
+        "--no_pymodules",
+        action="store_true",
+        help="Avoid pickling any modules in the ray-environment before initializing the Ray cluster; useful in CI",
+    )
 
     args = parser.parse_args()
     if args.output_csv_headers:
@@ -331,4 +337,5 @@ if __name__ == "__main__":
         csv_output_location=args.output_csv,
         ray_job_dashboard_url=args.ray_job_dashboard_url,
         requirements=args.requirements,
+        no_pymodules=True if args.no_pymodules else False,
     )


### PR DESCRIPTION
# Overview
Add a GitHub Actions workflow to *only run* tpch benchmarks given a commit-sha and a wheel name.
- the logic will look at the appropriate AWS S3 bucket given those two inputs and find the correct wheel
- then it will spawn a ray-cluster and run daft against the given tpch benchmarks

# Note
I am merging this into `feat/build-commit-workflow`, and I will then merge that final branch into `main`. This is to help segment the purposes of each workflow, since they are highly reusable.