### PR TITLE
[DOCS] Add docs pointing to `daft-launcher`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ requirements.txt
 build
 .cython_build
 .hypothesis
+.ropeproject
 
 **/.ipynb_checkpoints/
 
@@ -35,7 +36,6 @@ log/
 
 # Added by pyenv
 .python-version
-
 
 # Zed editor
 .zed/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,7 +96,7 @@ redirects = {
     "learn/install": "../install.html",
     "learn/user_guides/dataframes": "intro-dataframes.html",
     "learn/user_guides/types_and_ops": "intro-dataframes.html",
-    "learn/user_guides/remote_cluster_execution": "distributed-computing.html",
+    "learn/user_guides/remote_cluster_execution": "user_guide/distributed-computing",
     "learn/quickstart": "learn/10-min.html",
     "learn/10-min": "../10-min.html",
     "user_guide/basic_concepts/expressions": "user_guide/expressions",

--- a/docs/source/migration_guides/coming_from_dask.rst
+++ b/docs/source/migration_guides/coming_from_dask.rst
@@ -118,7 +118,7 @@ Dask supports the same data types as pandas. Daft is built to support many more 
 Distributed Computing and Remote Clusters
 -----------------------------------------
 
-Both Dask and Daft support distributed computing on remote clusters. In Dask, you create a Dask cluster either locally or remotely and perform computations in parallel there. Currently, Daft supports distributed cluster computing :doc:`with Ray <../user_guide/poweruser/distributed-computing>`. Support for running Daft computations on Dask clusters is on the roadmap.
+Both Dask and Daft support distributed computing on remote clusters. In Dask, you create a Dask cluster either locally or remotely and perform computations in parallel there. Currently, Daft supports distributed cluster computing :doc:`with Ray <../user_guide/distributed-computing>`. Support for running Daft computations on Dask clusters is on the roadmap.
 
 Cloud support for both Dask and Daft is the same.
 

--- a/docs/source/user_guide/distributed-computing.rst
+++ b/docs/source/user_guide/distributed-computing.rst
@@ -67,3 +67,7 @@ You can take the IP address and port and pass it to Daft:
     ╰───────╯
 
     (Showing first 2 of 2 rows)
+
+.. toctree::
+
+    distributed-computing/daft-launcher

--- a/docs/source/user_guide/distributed-computing/daft-launcher.rst
+++ b/docs/source/user_guide/distributed-computing/daft-launcher.rst
@@ -1,0 +1,10 @@
+Daft Launcher
+=====================
+
+Getting started with running daft at a distributed scale can be tough.
+Therefore, we've created a simple, open-sourced launcher to help you get started.
+
+The tool, `daft-launcher <https://github.com/Eventual-Inc/daft-launcher>`_, is open-sourced and available to be run today!
+To install it, you can run ``pip install daft-launcher`` (or using ``uv``, you can run ``uv pip install daft-launcher``).
+
+To get started with it, please refer to our MDBook documentation, available `here <https://eventual-inc.github.io/daft-launcher/>`_.

--- a/docs/source/user_guide/distributed-computing/daft-launcher.rst
+++ b/docs/source/user_guide/distributed-computing/daft-launcher.rst
@@ -2,9 +2,9 @@ Daft Launcher
 =====================
 
 Getting started with running daft at a distributed scale can be tough.
-Therefore, we've created a simple, open-sourced launcher to help you get started.
+Therefore, we've created a simple, open-source launcher to help you get started.
 
-The tool, `daft-launcher <https://github.com/Eventual-Inc/daft-launcher>`_, is open-sourced and available to be run today!
+The tool, `daft-launcher <https://github.com/Eventual-Inc/daft-launcher>`_, is open-source and available to be run today!
 To install it, you can run ``pip install daft-launcher`` (or using ``uv``, you can run ``uv pip install daft-launcher``).
 
 To get started with it, please refer to our MDBook documentation, available `here <https://eventual-inc.github.io/daft-launcher/>`_.

--- a/docs/source/user_guide/distributed-computing/daft-launcher.rst
+++ b/docs/source/user_guide/distributed-computing/daft-launcher.rst
@@ -1,3 +1,5 @@
+.. _daft_launcher:
+
 Daft Launcher
 =====================
 

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -10,6 +10,7 @@ Daft User Guide
     expressions
     datatypes
     dataframe-operations
+    distributed-computing
     sql
     aggregations
     udf

--- a/docs/source/user_guide/integrations/ray.rst
+++ b/docs/source/user_guide/integrations/ray.rst
@@ -90,7 +90,7 @@ To submit this script as a job, use the Ray CLI, which can be installed with `pi
 For more information about Ray jobs, see `Ray docs -> Ray Jobs Overview  <https://docs.ray.io/en/latest/cluster/running-applications/job-submission/index.html>`_.
 
 Daft Launcher
------
+-------------
 Running Ray manually, especially if it's your first time, may be cumbersome.
 In order to help with the getting-started process, we've built an easy-to-use *launcher* which can help you abstract away some of the complexities of running Ray.
 To learn more about our launcher, "daft-launcher", read more :ref:`here <daft_launcher>`.

--- a/docs/source/user_guide/integrations/ray.rst
+++ b/docs/source/user_guide/integrations/ray.rst
@@ -88,3 +88,9 @@ To submit this script as a job, use the Ray CLI, which can be installed with `pi
 
 
 For more information about Ray jobs, see `Ray docs -> Ray Jobs Overview  <https://docs.ray.io/en/latest/cluster/running-applications/job-submission/index.html>`_.
+
+Daft Launcher
+-----
+Running Ray manually, especially if it's your first time, may be cumbersome.
+In order to help with the getting-started process, we've built an easy-to-use *launcher* which can help you abstract away some of the complexities of running Ray.
+To learn more about our launcher, "daft-launcher", read more :ref:`here <daft_launcher>`.

--- a/docs/source/user_guide/poweruser.rst
+++ b/docs/source/user_guide/poweruser.rst
@@ -5,4 +5,3 @@ The Daft Poweruser
 
     poweruser/memory
     poweruser/partitioning
-    poweruser/distributed-computing


### PR DESCRIPTION
# Overview
- added a small section pointing towards daft-launcher and how to install/use it
- placed underneath the distributed-computing section
- also added a small note to the ray section pointing towards the daft-launcher docs