### PR TITLE
[CHORE] Simplify plan_aggregate_query and plan_non_agg_query in SQLPlanner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,6 +2488,7 @@ dependencies = [
  "daft-functions-json",
  "daft-logical-plan",
  "daft-scan",
+ "itertools 0.11.0",
  "once_cell",
  "pyo3",
  "regex",

--- a/src/daft-sql/Cargo.toml
+++ b/src/daft-sql/Cargo.toml
@@ -8,6 +8,7 @@ daft-functions = {path = "../daft-functions"}
 daft-functions-json = {path = "../daft-functions-json"}
 daft-logical-plan = {path = "../daft-logical-plan"}
 daft-scan = {path = "../daft-scan"}
+itertools = {workspace = true}
 once_cell = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 sqlparser = {workspace = true}

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::{Ref, RefCell, RefMut},
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     rc::Rc,
     sync::Arc,
 };
@@ -424,6 +424,8 @@ impl<'a> SQLPlanner<'a> {
                     .map(|e| e.alias(e.semantic_id(schema).id)),
             )
             .chain(having.iter().map(|e| e.alias(e.semantic_id(schema).id)))
+            .collect::<HashSet<_>>()
+            .into_iter()
             .collect();
 
         let rel = self.relation_mut();


### PR DESCRIPTION
With the `alias_map` in SQLPlanner I think we can simplify a lot of the query planning logic to rely on that, particularly because `SQLPlanner.plan_expr` should always return expressions that have columns in the current schema after the changes made in https://github.com/Eventual-Inc/Daft/pull/3304 for correlated subqueries