### PR TITLE
[FEAT] Build release python wheels and upload to AWS S3

### DIFF
--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -1,0 +1,29 @@
+name: Install uv, rust, and python
+description: Install uv, rust, and python
+inputs:
+  python_version:
+    description: The version of python to install
+    required: false
+    default: '3.9'
+runs:
+  using: composite
+  steps:
+  - shell: bash
+    run: |
+      curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      CARGO_BIN="$HOME/.cargo/bin"
+      echo 'export PATH="$CARGO_BIN:$PATH"' >> $HOME/.bashrc
+      echo "$CARGO_BIN" >> $GITHUB_PATH
+  - shell: bash
+    run: |
+      curl -LsSf https://astral.sh/uv/install.sh | sh
+      UV_BIN="$HOME/.local/bin"
+      echo 'export PATH="$UV_BIN:$PATH"' >> $HOME/.bashrc
+      echo "$UV_BIN" >> $GITHUB_PATH
+  - shell: bash
+    run: |
+      source $HOME/.bashrc
+  - shell: bash
+    run: |
+      uv python install ${{ inputs.python_version }}
+      uv python pin ${{ inputs.python_version }}

--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -22,10 +22,6 @@ runs:
       UV_BIN="$HOME/.local/bin"
       echo 'export PATH="$UV_BIN:$PATH"' >> $HOME/.bashrc
       echo "$UV_BIN" >> $GITHUB_PATH
-  - name: Source changes to add new installs to path
-    shell: bash
-    run: |
-      source $HOME/.bashrc
   - name: Install (and pin) python version ${{ inputs.python_version }}
     shell: bash
     run: |

--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -8,22 +8,26 @@ inputs:
 runs:
   using: composite
   steps:
-  - shell: bash
+  - name: Install rust
+    shell: bash
     run: |
       curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       CARGO_BIN="$HOME/.cargo/bin"
       echo 'export PATH="$CARGO_BIN:$PATH"' >> $HOME/.bashrc
       echo "$CARGO_BIN" >> $GITHUB_PATH
-  - shell: bash
+  - name: Install uv
+    shell: bash
     run: |
       curl -LsSf https://astral.sh/uv/install.sh | sh
       UV_BIN="$HOME/.local/bin"
       echo 'export PATH="$UV_BIN:$PATH"' >> $HOME/.bashrc
       echo "$UV_BIN" >> $GITHUB_PATH
-  - shell: bash
+  - name: Source changes to add new installs to path
+    shell: bash
     run: |
       source $HOME/.bashrc
-  - shell: bash
+  - name: Install (and pin) python version ${{ inputs.python_version }}
+    shell: bash
     run: |
       uv python install ${{ inputs.python_version }}
       uv python pin ${{ inputs.python_version }}

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -1,0 +1,65 @@
+name: Build a Daft commit and store the outputted wheel in AWS S3
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    secrets:
+      ACTIONS_AWS_ROLE_ARN:
+        description: The ARN of the AWS role to assume
+        required: true
+    outputs:
+      wheel:
+        description: The wheel file that was built
+        value: ${{ jobs.build-commit.outputs.wheel }}
+
+jobs:
+  build-commit:
+    runs-on: buildjet-8vcpu-ubuntu-2004
+    timeout-minutes: 15 # Remove for ssh debugging
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      wheel: ${{ steps.build_and_upload.outputs.wheel }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-west-2
+        role-session-name: build-commit-workflow
+        role-to-assume: ${{ secrets.ACTIONS_AWS_ROLE_ARN }}
+    - uses: ./.github/actions/install
+    - uses: buildjet/cache@v4
+      with:
+        path: ~/target
+        key: ${{ runner.os }}-cargo-deps-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-deps-
+    - id: build_and_upload
+      run: |
+        # Build wheel
+        export CARGO_TARGET_DIR=~/target
+        uv v
+        source .venv/bin/activate
+        uv pip install pip maturin boto3
+        maturin build --release
+
+        count=$(ls ~/target/wheels/*.whl 2> /dev/null | wc -l)
+        if [ "$count" -gt 1 ]; then
+          echo "Found more than 1 wheel"
+          exit 1
+        elif [ "$count" -eq 0 ]; then
+          echo "Found no wheel files"
+          exit 1
+        fi
+
+        # Upload wheel
+        for file in ~/target/wheels/*.whl; do
+          aws s3 cp $file s3://github-actions-artifacts-bucket/builds/${{ github.sha }}/ --acl public-read --no-progress;
+          file_basename=$(basename $file)
+          echo "wheel=$file_basename" >> $GITHUB_OUTPUT
+          echo "Output wheel has been built and stored in S3 at the following location:" >> $GITHUB_STEP_SUMMARY
+          echo "https://us-west-2.console.aws.amazon.com/s3/buckets/github-actions-artifacts-bucket?prefix=builds/${{ github.sha }}/" >> $GITHUB_STEP_SUMMARY
+        done
+        python tools/generate_whl_html_manifest.py

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -69,7 +69,7 @@ jobs:
       run: |
         if [ "$COMMIT_BUILT" -eq 1 ]; then
           echo "Commit already built"
-          wheel=$(aws s3 ls s3://github-actions-artifacts-bucket/builds/0319d66afe3cf99c8281b1e1dc9cb979cfd4fba6/ | awk '{print $4}')
+          wheel=$(aws s3 ls s3://github-actions-artifacts-bucket/builds/${{ github.sha }}/ | awk '{print $4}')
           echo "wheel=$wheel" >> $GITHUB_OUTPUT
           exit 0
         fi

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -71,20 +71,20 @@ jobs:
           echo "Commit already built"
           wheel=$(aws s3 ls s3://github-actions-artifacts-bucket/builds/${{ github.sha }}/ | awk '{print $4}')
           echo "wheel=$wheel" >> $GITHUB_OUTPUT
-          exit 0
+        else
+          count=$(ls ~/target/wheels/*.whl 2> /dev/null | wc -l)
+          if [ "$count" -gt 1 ]; then
+            echo "Found more than 1 wheel"
+            exit 1
+          elif [ "$count" -eq 0 ]; then
+            echo "Found no wheels"
+            exit 1
+          fi
+          for file in ~/target/wheels/*.whl; do
+            aws s3 cp $file s3://github-actions-artifacts-bucket/builds/${{ github.sha }}/ --acl public-read --no-progress;
+            file_basename=$(basename $file)
+            echo "wheel=$file_basename" >> $GITHUB_OUTPUT
+          done
         fi
-        count=$(ls ~/target/wheels/*.whl 2> /dev/null | wc -l)
-        if [ "$count" -gt 1 ]; then
-          echo "Found more than 1 wheel"
-          exit 1
-        elif [ "$count" -eq 0 ]; then
-          echo "Found no wheels"
-          exit 1
-        fi
-        for file in ~/target/wheels/*.whl; do
-          aws s3 cp $file s3://github-actions-artifacts-bucket/builds/${{ github.sha }}/ --acl public-read --no-progress;
-          file_basename=$(basename $file)
-          echo "wheel=$file_basename" >> $GITHUB_OUTPUT
-          echo "Output wheel has been built and stored in S3 at the following location:" >> $GITHUB_STEP_SUMMARY
-          echo "https://us-west-2.console.aws.amazon.com/s3/buckets/github-actions-artifacts-bucket?prefix=builds/${{ github.sha }}/" >> $GITHUB_STEP_SUMMARY
-        done
+        echo "Output python-release-wheel location:" >> $GITHUB_STEP_SUMMARY
+        echo "https://us-west-2.console.aws.amazon.com/s3/buckets/github-actions-artifacts-bucket?prefix=builds/${{ github.sha }}/" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -22,16 +22,20 @@ jobs:
     outputs:
       wheel: ${{ steps.upload.outputs.wheel }}
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repo
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
-    - uses: aws-actions/configure-aws-credentials@v4
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: us-west-2
         role-session-name: build-commit-workflow
         role-to-assume: ${{ secrets.ACTIONS_AWS_ROLE_ARN }}
-    - uses: ./.github/actions/install
-    - uses: buildjet/cache@v4
+    - name: Install rust + uv + python
+      uses: ./.github/actions/install
+    - name: Restore cached build artifacts
+      uses: buildjet/cache@v4
       with:
         path: ~/target
         key: ${{ runner.os }}-cargo-deps-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -37,7 +37,7 @@ jobs:
         path: ~/target
         key: ${{ runner.os }}-cargo-deps-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-deps-
-    - name: Build wheel
+    - name: Build release wheel
       run: |
         export CARGO_TARGET_DIR=~/target
         uv v

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -39,7 +39,6 @@ jobs:
         restore-keys: ${{ runner.os }}-cargo-deps-
     - name: Build wheel
       run: |
-        # Build wheel
         export CARGO_TARGET_DIR=~/target
         uv v
         source .venv/bin/activate

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -1,7 +1,6 @@
 name: Build a Daft commit and store the outputted wheel in AWS S3
 
 on:
-  pull_request:
   workflow_dispatch:
   workflow_call:
     secrets:

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -1,6 +1,7 @@
 name: Build a Daft commit and store the outputted wheel in AWS S3
 
 on:
+  pull_request:
   workflow_dispatch:
   workflow_call:
     secrets:

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -37,8 +37,25 @@ jobs:
         path: ~/target
         key: ${{ runner.os }}-cargo-deps-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-deps-
+    - name: Check if build already exists in AWS S3
+      run: |
+        RESULT=$(aws s3 ls s3://github-actions-artifacts-bucket/builds/${{ github.sha }}/ | wc -l)
+        if [ "$RESULT" -gt 1 ]; then
+            echo "Error: More than one artifact found. Failing the job."
+            exit 1
+        elif [ "$RESULT" -eq 0 ]; then
+            echo "COMMIT_BUILT=0" >> $GITHUB_ENV
+            echo "No artifacts found; will proceed with building a new wheel"
+        elif [ "$RESULT" -eq 1 ]; then
+            echo "COMMIT_BUILT=1" >> $GITHUB_ENV
+            echo "Commit already built; reusing existing wheel"
+        fi
     - name: Build release wheel
       run: |
+        if [ "$COMMIT_BUILT" -eq 1 ]; then
+          echo "Commit already built"
+          exit 0
+        fi
         export CARGO_TARGET_DIR=~/target
         uv v
         source .venv/bin/activate
@@ -47,6 +64,10 @@ jobs:
     - name: Upload wheel to AWS S3
       id: upload
       run: |
+        if [ "$COMMIT_BUILT" -eq 1 ]; then
+          echo "Commit already built"
+          exit 0
+        fi
         count=$(ls ~/target/wheels/*.whl 2> /dev/null | wc -l)
         if [ "$count" -gt 1 ]; then
           echo "Found more than 1 wheel"

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -66,6 +66,8 @@ jobs:
       run: |
         if [ "$COMMIT_BUILT" -eq 1 ]; then
           echo "Commit already built"
+          wheel=$(aws s3 ls s3://github-actions-artifacts-bucket/builds/0319d66afe3cf99c8281b1e1dc9cb979cfd4fba6/ | awk '{print $4}')
+          echo "wheel=$wheel" >> $GITHUB_OUTPUT
           exit 0
         fi
         count=$(ls ~/target/wheels/*.whl 2> /dev/null | wc -l)

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -21,7 +21,7 @@ jobs:
       id-token: write
       contents: read
     outputs:
-      wheel: ${{ steps.build_and_upload.outputs.wheel }}
+      wheel: ${{ steps.upload.outputs.wheel }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -37,7 +37,7 @@ jobs:
         path: ~/target
         key: ${{ runner.os }}-cargo-deps-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-deps-
-    - id: build_and_upload
+    - name: Build wheel
       run: |
         # Build wheel
         export CARGO_TARGET_DIR=~/target
@@ -45,17 +45,17 @@ jobs:
         source .venv/bin/activate
         uv pip install pip maturin boto3
         maturin build --release
-
+    - name: Upload wheel to AWS S3
+      id: upload
+      run: |
         count=$(ls ~/target/wheels/*.whl 2> /dev/null | wc -l)
         if [ "$count" -gt 1 ]; then
           echo "Found more than 1 wheel"
           exit 1
         elif [ "$count" -eq 0 ]; then
-          echo "Found no wheel files"
+          echo "Found no wheels"
           exit 1
         fi
-
-        # Upload wheel
         for file in ~/target/wheels/*.whl; do
           aws s3 cp $file s3://github-actions-artifacts-bucket/builds/${{ github.sha }}/ --acl public-read --no-progress;
           file_basename=$(basename $file)
@@ -63,4 +63,3 @@ jobs:
           echo "Output wheel has been built and stored in S3 at the following location:" >> $GITHUB_STEP_SUMMARY
           echo "https://us-west-2.console.aws.amazon.com/s3/buckets/github-actions-artifacts-bucket?prefix=builds/${{ github.sha }}/" >> $GITHUB_STEP_SUMMARY
         done
-        python tools/generate_whl_html_manifest.py


### PR DESCRIPTION
# Overview
New workflow to build commit and upload to AWS S3.
- faster than previous
- uses buildjet
- utilizes build caching (from buildjet)