### PR TITLE
[CHORE] Add tests for parquet size estimations

### DIFF
--- a/daft/daft/testing.pyi
+++ b/daft/daft/testing.pyi
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+def estimate_in_memory_size_bytes(
+    uri: str, file_size: int, columns: list[str] | None = None, has_metadata: bool = False
+) -> int: ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,11 @@ pub mod pylib {
         let catalog_module = daft_catalog::python::register_modules(m)?;
         daft_catalog_python_catalog::python::register_modules(&catalog_module)?;
 
+        // Register testing module
+        let testing_module = PyModule::new_bound(m.py(), "testing")?;
+        m.add_submodule(&testing_module)?;
+        daft_scan::python::register_testing_modules(&testing_module)?;
+
         m.add_wrapped(wrap_pyfunction!(version))?;
         m.add_wrapped(wrap_pyfunction!(build_type))?;
         m.add_wrapped(wrap_pyfunction!(refresh_logger))?;

--- a/tests/test_size_estimations.py
+++ b/tests/test_size_estimations.py
@@ -2,6 +2,7 @@ import pathlib
 
 import pyarrow as pa
 import pyarrow.parquet as papq
+import pytest
 
 from daft.table.micropartition import MicroPartition
 
@@ -20,12 +21,29 @@ def get_actual_size(pq_path: pathlib.Path, columns: list[str] | None = None) -> 
 
 
 def assert_close(expected: int, actual: int, pct: float = 0.05):
-    assert abs(actual - expected) / expected < pct, f"Expected {expected} to be within {pct} of: {actual}"
+    assert (
+        abs(actual - expected) / expected < pct
+    ), f"Expected estimations {expected} to be within {pct} of actual: {actual}"
 
 
-def test_estimations_strings(tmpdir):
+@pytest.mark.parametrize("compression", ["snappy", None])
+@pytest.mark.parametrize("use_dictionary", [True, False])
+@pytest.mark.parametrize("unique", [True, False])
+def test_estimations_strings(tmpdir, use_dictionary, compression, unique):
     pq_path = tmpdir / "strings.pq"
+    data = [f"{'a' * 100}{i}" for i in range(1000)] if unique else ["a" * 100 for _ in range(1000)]
+    tbl = pa.table({"foo": data})
+    papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
+    assert assert_close(get_scantask_estimated_size(pq_path), get_actual_size(pq_path))
 
-    tbl = pa.table({"foo": ["a" * 100 for _ in range(100)]})
-    papq.write_table(tbl, pq_path)
+
+@pytest.mark.parametrize("compression", ["snappy", None])
+@pytest.mark.parametrize("use_dictionary", [True, False])
+@pytest.mark.parametrize("unique", [True, False])
+def test_estimations_ints(tmpdir, use_dictionary, compression, unique):
+    pq_path = tmpdir / "ints.pq"
+
+    data = [i for i in range(1000)] if unique else [1 for _ in range(1000)]
+    tbl = pa.table({"foo": data})
+    papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
     assert assert_close(get_scantask_estimated_size(pq_path), get_actual_size(pq_path))

--- a/tests/test_size_estimations.py
+++ b/tests/test_size_estimations.py
@@ -1,0 +1,31 @@
+import pathlib
+
+import pyarrow as pa
+import pyarrow.parquet as papq
+
+from daft.table.micropartition import MicroPartition
+
+
+def get_scantask_estimated_size(pq_path: pathlib.Path, columns: list[str] | None = None) -> int:
+    """Retrieve the estimated size for reading a given Parquet file"""
+    # HACK: use MicroPartition.read_parquet as a way to do this, but perhaps can expose
+    # a better API from Rust here. This should be an unloaded MicroPartition.
+    mp = MicroPartition.read_parquet(str(pq_path), columns=columns)
+    return mp.size_bytes()
+
+
+def get_actual_size(pq_path: pathlib.Path, columns: list[str] | None = None) -> int:
+    # Force materializationm of the MicroPartition using `.slice`
+    return MicroPartition.read_parquet(str(pq_path), columns=columns).slice(0, 100).size_bytes()
+
+
+def assert_close(expected: int, actual: int, pct: float = 0.05):
+    assert abs(actual - expected) / expected < pct, f"Expected {expected} to be within {pct} of: {actual}"
+
+
+def test_estimations_strings(tmpdir):
+    pq_path = tmpdir / "strings.pq"
+
+    tbl = pa.table({"foo": ["a" * 100 for _ in range(100)]})
+    papq.write_table(tbl, pq_path)
+    assert assert_close(get_scantask_estimated_size(pq_path), get_actual_size(pq_path))

--- a/tests/test_size_estimations.py
+++ b/tests/test_size_estimations.py
@@ -4,15 +4,13 @@ import pyarrow as pa
 import pyarrow.parquet as papq
 import pytest
 
+from daft.daft import testing as native_testing_utils
 from daft.table.micropartition import MicroPartition
 
 
 def get_scantask_estimated_size(pq_path: pathlib.Path, columns: list[str] | None = None) -> int:
     """Retrieve the estimated size for reading a given Parquet file"""
-    # HACK: use MicroPartition.read_parquet as a way to do this, but perhaps can expose
-    # a better API from Rust here. This should be an unloaded MicroPartition.
-    mp = MicroPartition.read_parquet(str(pq_path), columns=columns)
-    return mp.size_bytes()
+    return native_testing_utils.estimate_in_memory_size_bytes(str(pq_path), pq_path.stat().size, columns=columns)
 
 
 def get_actual_size(pq_path: pathlib.Path, columns: list[str] | None = None) -> int:

--- a/tests/test_size_estimations.py
+++ b/tests/test_size_estimations.py
@@ -25,24 +25,43 @@ def assert_close(filepath: pathlib.Path, estimated: int, actual: int, pct: float
     ), f"Expected {filepath.stat().size / 1_000_000:.2f}MB file estimated vs actual to be within {pct * 100}%: {estimated / 1_000_000:.2f}MB vs {actual / 1000_000:.2f}MB ({((estimated - actual) / estimated) * 100:.2f}%)"
 
 
-@pytest.mark.parametrize("compression", ["snappy", None])
-@pytest.mark.parametrize("use_dictionary", [True, False])
-@pytest.mark.parametrize("unique", [True, False])
-def test_estimations_strings(tmpdir, use_dictionary, compression, unique):
-    pq_path = tmpdir / f"strings.use_dictionary={use_dictionary}.unique={unique}.compression={compression}.pq"
-    data = [f"{'a' * 100}{i}" for i in range(1000_000)] if unique else ["a" * 100 for _ in range(1000_000)]
+@pytest.mark.parametrize("compression", ["snappy", None], ids=["snappy", "no_compression"])
+@pytest.mark.parametrize("use_dictionary", [True, False], ids=["dict", "no_dict"])
+def test_estimations_unique_strings(tmpdir, use_dictionary, compression):
+    pq_path = tmpdir / f"unique_strings.use_dictionary={use_dictionary}.compression={compression}.pq"
+    data = [f"{'a' * 100}{i}" for i in range(1000_000)]
     tbl = pa.table({"foo": data})
     papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
     assert assert_close(pq_path, get_scantask_estimated_size(pq_path), get_actual_size(pq_path))
 
 
-@pytest.mark.parametrize("compression", ["snappy", None])
-@pytest.mark.parametrize("use_dictionary", [True, False])
-@pytest.mark.parametrize("unique", [True, False])
-def test_estimations_ints(tmpdir, use_dictionary, compression, unique):
-    pq_path = tmpdir / f"ints.use_dictionary={use_dictionary}.unique={unique}.compression={compression}.pq"
+@pytest.mark.parametrize("compression", ["snappy", None], ids=["snappy", "no_compression"])
+@pytest.mark.parametrize("use_dictionary", [True, False], ids=["dict", "no_dict"])
+def test_estimations_dup_strings(tmpdir, use_dictionary, compression):
+    pq_path = tmpdir / f"dup_strings.use_dictionary={use_dictionary}.compression={compression}.pq"
+    data = ["a" * 100 for _ in range(1000_000)]
+    tbl = pa.table({"foo": data})
+    papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
+    assert assert_close(pq_path, get_scantask_estimated_size(pq_path), get_actual_size(pq_path))
 
-    data = [i for i in range(1000_000)] if unique else [1 for _ in range(1000_000)]
+
+@pytest.mark.parametrize("compression", ["snappy", None], ids=["snappy", "no_compression"])
+@pytest.mark.parametrize("use_dictionary", [True, False], ids=["dict", "no_dict"])
+def test_estimations_unique_ints(tmpdir, use_dictionary, compression):
+    pq_path = tmpdir / f"unique_ints.use_dictionary={use_dictionary}.compression={compression}.pq"
+
+    data = [i for i in range(1000_000)]
+    tbl = pa.table({"foo": data})
+    papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
+    assert assert_close(pq_path, get_scantask_estimated_size(pq_path), get_actual_size(pq_path))
+
+
+@pytest.mark.parametrize("compression", ["snappy", None], ids=["snappy", "no_compression"])
+@pytest.mark.parametrize("use_dictionary", [True, False], ids=["dict", "no_dict"])
+def test_estimations_dup_ints(tmpdir, use_dictionary, compression):
+    pq_path = tmpdir / f"dup_ints.use_dictionary={use_dictionary}.compression={compression}.pq"
+
+    data = [1 for _ in range(1000_000)]
     tbl = pa.table({"foo": data})
     papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
     assert assert_close(pq_path, get_scantask_estimated_size(pq_path), get_actual_size(pq_path))

--- a/tests/test_size_estimations.py
+++ b/tests/test_size_estimations.py
@@ -15,33 +15,34 @@ def get_scantask_estimated_size(pq_path: pathlib.Path, columns: list[str] | None
 
 def get_actual_size(pq_path: pathlib.Path, columns: list[str] | None = None) -> int:
     # Force materializationm of the MicroPartition using `.slice`
-    return MicroPartition.read_parquet(str(pq_path), columns=columns).slice(0, 100).size_bytes()
+    mp = MicroPartition.read_parquet(str(pq_path), columns=columns)
+    return mp.slice(0, len(mp)).size_bytes()
 
 
-def assert_close(expected: int, actual: int, pct: float = 0.05):
+def assert_close(filepath: pathlib.Path, estimated: int, actual: int, pct: float = 0.05):
     assert (
-        abs(actual - expected) / expected < pct
-    ), f"Expected estimations {expected} to be within {pct} of actual: {actual}"
+        abs(actual - estimated) / estimated < pct
+    ), f"Expected {filepath.stat().size / 1_000_000:.2f}MB file at {filepath} estimated vs actual to be within {pct * 100}%: {estimated / 1_000_000:.2f}MB vs {actual / 1000_000:.2f}MB ({((estimated - actual) / estimated) * 100:.2f}%)"
 
 
 @pytest.mark.parametrize("compression", ["snappy", None])
 @pytest.mark.parametrize("use_dictionary", [True, False])
 @pytest.mark.parametrize("unique", [True, False])
 def test_estimations_strings(tmpdir, use_dictionary, compression, unique):
-    pq_path = tmpdir / "strings.pq"
-    data = [f"{'a' * 100}{i}" for i in range(1000)] if unique else ["a" * 100 for _ in range(1000)]
+    pq_path = tmpdir / f"strings.use_dictionary={use_dictionary}.unique={unique}.compression={compression}.pq"
+    data = [f"{'a' * 100}{i}" for i in range(1000_000)] if unique else ["a" * 100 for _ in range(1000_000)]
     tbl = pa.table({"foo": data})
     papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
-    assert assert_close(get_scantask_estimated_size(pq_path), get_actual_size(pq_path))
+    assert assert_close(pq_path, get_scantask_estimated_size(pq_path), get_actual_size(pq_path))
 
 
 @pytest.mark.parametrize("compression", ["snappy", None])
 @pytest.mark.parametrize("use_dictionary", [True, False])
 @pytest.mark.parametrize("unique", [True, False])
 def test_estimations_ints(tmpdir, use_dictionary, compression, unique):
-    pq_path = tmpdir / "ints.pq"
+    pq_path = tmpdir / f"ints.use_dictionary={use_dictionary}.unique={unique}.compression={compression}.pq"
 
-    data = [i for i in range(1000)] if unique else [1 for _ in range(1000)]
+    data = [i for i in range(1000_000)] if unique else [1 for _ in range(1000_000)]
     tbl = pa.table({"foo": data})
     papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
-    assert assert_close(get_scantask_estimated_size(pq_path), get_actual_size(pq_path))
+    assert assert_close(pq_path, get_scantask_estimated_size(pq_path), get_actual_size(pq_path))

--- a/tests/test_size_estimations.py
+++ b/tests/test_size_estimations.py
@@ -34,7 +34,7 @@ def test_estimations_unique_strings(tmpdir, use_dictionary, compression):
     papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
 
     size_on_disk = pq_path.stat().size
-    assert assert_close(size_on_disk, get_scantask_estimated_size(pq_path, size_on_disk), get_actual_size(pq_path))
+    assert_close(size_on_disk, get_scantask_estimated_size(pq_path, size_on_disk), get_actual_size(pq_path))
 
 
 @pytest.mark.parametrize("compression", ["snappy", None], ids=["snappy", "no_compression"])
@@ -46,7 +46,7 @@ def test_estimations_dup_strings(tmpdir, use_dictionary, compression):
     papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
 
     size_on_disk = pq_path.stat().size
-    assert assert_close(size_on_disk, get_scantask_estimated_size(pq_path, size_on_disk), get_actual_size(pq_path))
+    assert_close(size_on_disk, get_scantask_estimated_size(pq_path, size_on_disk), get_actual_size(pq_path))
 
 
 @pytest.mark.parametrize("compression", ["snappy", None], ids=["snappy", "no_compression"])
@@ -59,7 +59,7 @@ def test_estimations_unique_ints(tmpdir, use_dictionary, compression):
     papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
 
     size_on_disk = pq_path.stat().size
-    assert assert_close(size_on_disk, get_scantask_estimated_size(pq_path, size_on_disk), get_actual_size(pq_path))
+    assert_close(size_on_disk, get_scantask_estimated_size(pq_path, size_on_disk), get_actual_size(pq_path))
 
 
 @pytest.mark.parametrize("compression", ["snappy", None], ids=["snappy", "no_compression"])
@@ -72,7 +72,7 @@ def test_estimations_dup_ints(tmpdir, use_dictionary, compression):
     papq.write_table(tbl, pq_path, use_dictionary=use_dictionary, compression=compression)
 
     size_on_disk = pq_path.stat().size
-    assert assert_close(size_on_disk, get_scantask_estimated_size(pq_path, size_on_disk), get_actual_size(pq_path))
+    assert_close(size_on_disk, get_scantask_estimated_size(pq_path, size_on_disk), get_actual_size(pq_path))
 
 
 @pytest.mark.parametrize(
@@ -100,4 +100,4 @@ def test_canonical_files_in_hf(path):
     response = requests.head(path, allow_redirects=True)
     size_on_disk = int(response.headers["Content-Length"])
 
-    assert assert_close(size_on_disk, get_scantask_estimated_size(path, size_on_disk), get_actual_size(path))
+    assert_close(size_on_disk, get_scantask_estimated_size(path, size_on_disk), get_actual_size(path))

--- a/tests/test_size_estimations.py
+++ b/tests/test_size_estimations.py
@@ -22,7 +22,7 @@ def get_actual_size(pq_path: pathlib.Path, columns: list[str] | None = None) -> 
 def assert_close(filepath: pathlib.Path, estimated: int, actual: int, pct: float = 0.05):
     assert (
         abs(actual - estimated) / estimated < pct
-    ), f"Expected {filepath.stat().size / 1_000_000:.2f}MB file at {filepath} estimated vs actual to be within {pct * 100}%: {estimated / 1_000_000:.2f}MB vs {actual / 1000_000:.2f}MB ({((estimated - actual) / estimated) * 100:.2f}%)"
+    ), f"Expected {filepath.stat().size / 1_000_000:.2f}MB file estimated vs actual to be within {pct * 100}%: {estimated / 1_000_000:.2f}MB vs {actual / 1000_000:.2f}MB ({((estimated - actual) / estimated) * 100:.2f}%)"
 
 
 @pytest.mark.parametrize("compression", ["snappy", None])


### PR DESCRIPTION
Unskipping the tests produces failures with 2 passing cases:

```
FAILED tests/test_size_estimations.py::test_estimations_unique_strings[dict-snappy] - AssertionError: Expected 8.16MB file estimated vs actual to be within 30.0%: 24.47MB vs 113.89MB (-365.40%)
FAILED tests/test_size_estimations.py::test_estimations_unique_strings[dict-no_compression] - AssertionError: Expected 109.93MB file estimated vs actual to be within 30.0%: 329.80MB vs 113.89MB (65.47%)
FAILED tests/test_size_estimations.py::test_estimations_unique_strings[no_dict-snappy] - AssertionError: Expected 8.14MB file estimated vs actual to be within 30.0%: 24.42MB vs 113.89MB (-366.43%)
FAILED tests/test_size_estimations.py::test_estimations_unique_strings[no_dict-no_compression] - AssertionError: Expected 109.91MB file estimated vs actual to be within 30.0%: 329.74MB vs 113.89MB (65.46%)
FAILED tests/test_size_estimations.py::test_estimations_dup_strings[dict-snappy] - AssertionError: Expected 0.00MB file estimated vs actual to be within 30.0%: 0.00MB vs 108.00MB (-3345625.15%)
FAILED tests/test_size_estimations.py::test_estimations_dup_strings[dict-no_compression] - AssertionError: Expected 0.00MB file estimated vs actual to be within 30.0%: 0.00MB vs 108.00MB (-3082092.01%)
FAILED tests/test_size_estimations.py::test_estimations_dup_strings[no_dict-snappy] - AssertionError: Expected 4.92MB file estimated vs actual to be within 30.0%: 14.76MB vs 108.00MB (-631.79%)
FAILED tests/test_size_estimations.py::test_estimations_dup_strings[no_dict-no_compression] - AssertionError: Expected 104.02MB file estimated vs actual to be within 30.0%: 312.07MB vs 108.00MB (65.39%)
FAILED tests/test_size_estimations.py::test_estimations_unique_ints[dict-snappy] - AssertionError: Expected 4.28MB file estimated vs actual to be within 30.0%: 12.85MB vs 8.00MB (37.72%)
FAILED tests/test_size_estimations.py::test_estimations_unique_ints[dict-no_compression] - AssertionError: Expected 8.28MB file estimated vs actual to be within 30.0%: 24.84MB vs 8.00MB (67.79%)
FAILED tests/test_size_estimations.py::test_estimations_unique_ints[no_dict-snappy] - AssertionError: Expected 4.00MB file estimated vs actual to be within 30.0%: 12.01MB vs 8.00MB (33.40%)
FAILED tests/test_size_estimations.py::test_estimations_unique_ints[no_dict-no_compression] - AssertionError: Expected 8.00MB file estimated vs actual to be within 30.0%: 24.00MB vs 8.00MB (66.67%)
FAILED tests/test_size_estimations.py::test_estimations_dup_ints[dict-snappy] - AssertionError: Expected 0.00MB file estimated vs actual to be within 30.0%: 0.00MB vs 8.00MB (-454962.57%)
FAILED tests/test_size_estimations.py::test_estimations_dup_ints[dict-no_compression] - AssertionError: Expected 0.00MB file estimated vs actual to be within 30.0%: 0.00MB vs 8.00MB (-458090.15%)
FAILED tests/test_size_estimations.py::test_estimations_dup_ints[no_dict-snappy] - AssertionError: Expected 0.38MB file estimated vs actual to be within 30.0%: 1.13MB vs 8.00MB (-607.74%)
FAILED tests/test_size_estimations.py::test_estimations_dup_ints[no_dict-no_compression] - AssertionError: Expected 8.00MB file estimated vs actual to be within 30.0%: 24.00MB vs 8.00MB (66.67%)
FAILED tests/test_size_estimations.py::test_canonical_files_in_hf[smoktalk] - AssertionError: Expected 105.42MB file estimated vs actual to be within 30.0%: 316.26MB vs 213.66MB (32.44%)
FAILED tests/test_size_estimations.py::test_canonical_files_in_hf[cifar10] - AssertionError: Expected 23.94MB file estimated vs actual to be within 30.0%: 71.82MB vs 22.85MB (68.18%)
FAILED tests/test_size_estimations.py::test_canonical_files_in_hf[standfordnlp-imdb] - AssertionError: Expected 42.00MB file estimated vs actual to be within 30.0%: 125.99MB vs 67.31MB (46.58%)
FAILED tests/test_size_estimations.py::test_canonical_files_in_hf[jat-dataset-tokenized] - AssertionError: Expected 7.34MB file estimated vs actual to be within 30.0%: 22.01MB vs 499.57MB (-2169.79%)
```

Follow-on fixes for the worst cases:
1. Duplicate strings/ints with dictionary encodings (`-3345625.15%`)
2. Duplicate strings/ints with no dictionary encodings, but with snappy compression (`-631%`)
3. `jat-dataset-tokenized`: tokenization dataset with lots of lists-of-ints (`-2169%`), likely highly compressed