### PR TITLE
[FEAT] Get native execution enablement from DAFT_RUNNER

### DIFF
--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -107,6 +107,12 @@ impl DaftExecutionConfig {
             log::warn!("DAFT_ENABLE_NATIVE_EXECUTOR will be deprecated and removed in the future. Please switch to using DAFT_RUNNER=NATIVE instead.");
             cfg.enable_native_executor = true;
         }
+        let daft_runner_var_name = "DAFT_RUNNER";
+        if let Ok(val) = std::env::var(daft_runner_var_name)
+            && matches!(val.trim().to_lowercase().as_str(), "native")
+        {
+            cfg.enable_native_executor = true;
+        }
         let ray_tracing_env_var_name = "DAFT_ENABLE_RAY_TRACING";
         if let Ok(val) = std::env::var(ray_tracing_env_var_name)
             && matches!(val.trim().to_lowercase().as_str(), "1" | "true")


### PR DESCRIPTION
We added a new `DAFT_RUNNER` environment variable, so we should use this environment variable when creating the execution configuration.