### PR TITLE
[FEAT] Add cluster profiles

### DIFF
--- a/.github/assets/.template.yaml
+++ b/.github/assets/.template.yaml
@@ -2,7 +2,7 @@
 # GitHub Actions workflow will replace all parameters between `{{...}}` with the
 # actual values as determined dynamically during runtime of the actual workflow.
 
-cluster_name: '{{CLUSTER_NAME}}'
+cluster_name: \{{CLUSTER_NAME}}
 
 provider:
   type: aws
@@ -12,40 +12,40 @@ provider:
     GroupName: ray-autoscaler-c1
 
 auth:
-  ssh_user: ubuntu
+  ssh_user: \{{CLUSTER_PROFILE/ssh_user}}
   ssh_private_key: ~/.ssh/ci-github-actions-ray-cluster-key.pem
 
-max_workers: '{{CLUSTER_PROFILE/node_count}}'
+max_workers: \{{CLUSTER_PROFILE/node_count}}
 available_node_types:
   ray.head.default:
     resources: {"CPU": 0}
     node_config:
       KeyName: ci-github-actions-ray-cluster-key
-      InstanceType: '{{CLUSTER_PROFILE/instance_type}}'
-      ImageId: '{{CLUSTER_PROFILE/image_id}}'
+      InstanceType: \{{CLUSTER_PROFILE/instance_type}}
+      ImageId: \{{CLUSTER_PROFILE/image_id}}
       IamInstanceProfile:
         Name: ray-autoscaler-v1
 
   ray.worker.default:
-    min_workers: '{{CLUSTER_PROFILE/node_count}}'
-    max_workers: '{{CLUSTER_PROFILE/node_count}}'
+    min_workers: \{{CLUSTER_PROFILE/node_count}}
+    max_workers: \{{CLUSTER_PROFILE/node_count}}
     resources: {}
     node_config:
       KeyName: ci-github-actions-ray-cluster-key
-      InstanceType: '{{CLUSTER_PROFILE/instance_type}}'
-      ImageId: '{{CLUSTER_PROFILE/image_id}}'
+      InstanceType: \{{CLUSTER_PROFILE/instance_type}}
+      ImageId: \{{CLUSTER_PROFILE/image_id}}
       IamInstanceProfile:
         Name: ray-autoscaler-v1
 
 setup_commands:
-- '{{CLUSTER_PROFILE/volume_mount}}'
+- \{{CLUSTER_PROFILE/volume_mount}}
 - sudo snap install aws-cli --classic
 - curl -LsSf https://astral.sh/uv/install.sh | sh
 - echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 - source ~/.bashrc
-- uv python install {{PYTHON_VERSION}}
-- uv python pin {{PYTHON_VERSION}}
+- uv python install \{{PYTHON_VERSION}}
+- uv python pin \{{PYTHON_VERSION}}
 - uv v
 - echo "source $HOME/.venv/bin/activate" >> $HOME/.bashrc
 - source .venv/bin/activate
-- uv pip install pip ray[default] py-spy getdaft{{DAFT_VERSION}}
+- uv pip install pip ray[default] py-spy getdaft\{{DAFT_VERSION}}

--- a/.github/assets/template.yaml
+++ b/.github/assets/template.yaml
@@ -1,4 +1,8 @@
-cluster_name: '{{RAY_CLUSTER_NAME}}'
+# Note:
+# GitHub Actions workflow will replace all parameters between `{{...}}` with the
+# actual values as determined dynamically during runtime of the actual workflow.
+
+cluster_name: '{{CLUSTER_NAME}}'
 
 provider:
   type: aws
@@ -11,41 +15,30 @@ auth:
   ssh_user: ubuntu
   ssh_private_key: ~/.ssh/ci-github-actions-ray-cluster-key.pem
 
-max_workers: 2
+max_workers: '{{CLUSTER_PROFILE/node_count}}'
 available_node_types:
   ray.head.default:
     resources: {"CPU": 0}
     node_config:
       KeyName: ci-github-actions-ray-cluster-key
-      InstanceType: i3.2xlarge
-      ImageId: ami-04dd23e62ed049936
+      InstanceType: '{{CLUSTER_PROFILE/instance_type}}'
+      ImageId: '{{CLUSTER_PROFILE/image_id}}'
       IamInstanceProfile:
         Name: ray-autoscaler-v1
 
   ray.worker.default:
-    min_workers: 2
-    max_workers: 2
+    min_workers: '{{CLUSTER_PROFILE/node_count}}'
+    max_workers: '{{CLUSTER_PROFILE/node_count}}'
     resources: {}
     node_config:
       KeyName: ci-github-actions-ray-cluster-key
-      InstanceType: i3.2xlarge
-      ImageId: ami-04dd23e62ed049936
+      InstanceType: '{{CLUSTER_PROFILE/instance_type}}'
+      ImageId: '{{CLUSTER_PROFILE/image_id}}'
       IamInstanceProfile:
         Name: ray-autoscaler-v1
 
 setup_commands:
-# Mount drive
-- |
-  findmnt /tmp 1> /dev/null
-  code=$?
-  if [ $code -ne 0 ]; then
-    sudo mkfs.ext4 /dev/nvme0n1
-    sudo mount -t ext4 /dev/nvme0n1 /tmp
-    sudo chmod 777 /tmp
-  fi
-# Install dependencies
-# GitHub Actions workflow will replace all parameters between `{{...}}` with the
-# actual values as determined dynamically during runtime of the actual workflow.
+- '{{CLUSTER_PROFILE/volume_mount}}'
 - sudo snap install aws-cli --classic
 - curl -LsSf https://astral.sh/uv/install.sh | sh
 - echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc

--- a/.github/ci-scripts/templatize_ray_config.py
+++ b/.github/ci-scripts/templatize_ray_config.py
@@ -3,21 +3,23 @@ from argparse import ArgumentParser
 from dataclasses import dataclass
 from typing import Optional
 
-CLUSTER_NAME_PLACEHOLDER = "{{CLUSTER_NAME}}"
-DAFT_VERSION_PLACEHOLDER = "{{DAFT_VERSION}}"
-PYTHON_VERSION_PLACEHOLDER = "{{PYTHON_VERSION}}"
-CLUSTER_PROFILE__NODE_COUNT = "'{{CLUSTER_PROFILE/node_count}}'"
-CLUSTER_PROFILE__INSTANCE_TYPE = "{{CLUSTER_PROFILE/instance_type}}"
-CLUSTER_PROFILE__IMAGE_ID = "{{CLUSTER_PROFILE/image_id}}"
-CLUSTER_PROFILE__VOLUME_MOUNT = "'{{CLUSTER_PROFILE/volume_mount}}'"
+CLUSTER_NAME_PLACEHOLDER = "\\{{CLUSTER_NAME}}"
+DAFT_VERSION_PLACEHOLDER = "\\{{DAFT_VERSION}}"
+PYTHON_VERSION_PLACEHOLDER = "\\{{PYTHON_VERSION}}"
+CLUSTER_PROFILE__NODE_COUNT = "\\{{CLUSTER_PROFILE/node_count}}"
+CLUSTER_PROFILE__INSTANCE_TYPE = "\\{{CLUSTER_PROFILE/instance_type}}"
+CLUSTER_PROFILE__IMAGE_ID = "\\{{CLUSTER_PROFILE/image_id}}"
+CLUSTER_PROFILE__SSH_USER = "\\{{CLUSTER_PROFILE/ssh_user}}"
+CLUSTER_PROFILE__VOLUME_MOUNT = "\\{{CLUSTER_PROFILE/volume_mount}}"
 
 
 @dataclass
 class Profile:
     node_count: int
-    instance_type: int
-    image_id: int
-    volume_mount: Optional[int]
+    instance_type: str
+    image_id: str
+    ssh_user: str
+    volume_mount: Optional[str]
 
 
 profiles: dict[str, Optional[Profile]] = {
@@ -26,6 +28,7 @@ profiles: dict[str, Optional[Profile]] = {
         instance_type="i3.2xlarge",
         image_id="ami-04dd23e62ed049936",
         node_count=4,
+        ssh_user="ubuntu",
         volume_mount=""" |
     findmnt /tmp 1> /dev/null
     code=$?
@@ -72,6 +75,7 @@ if __name__ == "__main__":
         content = content.replace(CLUSTER_PROFILE__NODE_COUNT, str(profile.node_count))
         content = content.replace(CLUSTER_PROFILE__INSTANCE_TYPE, profile.instance_type)
         content = content.replace(CLUSTER_PROFILE__IMAGE_ID, profile.image_id)
+        content = content.replace(CLUSTER_PROFILE__SSH_USER, profile.ssh_user)
         if profile.volume_mount:
             content = content.replace(CLUSTER_PROFILE__VOLUME_MOUNT, profile.volume_mount)
         else:

--- a/.github/ci-scripts/templatize_ray_config.py
+++ b/.github/ci-scripts/templatize_ray_config.py
@@ -19,7 +19,7 @@ class Profile:
     instance_type: str
     image_id: str
     ssh_user: str
-    volume_mount: Optional[str]
+    volume_mount: Optional[str] = None
 
 
 profiles: dict[str, Optional[Profile]] = {

--- a/.github/ci-scripts/templatize_ray_config.py
+++ b/.github/ci-scripts/templatize_ray_config.py
@@ -23,7 +23,12 @@ class Profile:
 
 
 profiles: dict[str, Optional[Profile]] = {
-    "debug_xs-x86": None,
+    "debug_xs-x86": Profile(
+        instance_type="t3.large",
+        image_id="ami-04dd23e62ed049936",
+        node_count=1,
+        ssh_user="ubuntu",
+    ),
     "medium-x86": Profile(
         instance_type="i3.2xlarge",
         image_id="ami-04dd23e62ed049936",

--- a/.github/workflows/run-cluster.yaml
+++ b/.github/workflows/run-cluster.yaml
@@ -65,8 +65,7 @@ jobs:
           --python-version '${{ inputs.python_version }}' \
           --cluster-profile '${{ inputs.cluster_profile }}'
         ) >> .github/assets/ray.yaml
-        echo "Ray configuration file:" >> $GITHUB_STEP_SUMMARY
-        cat .github/assets/ray.yaml >> $GITHUB_STEP_SUMMARY
+        cat .github/assets/ray.yaml
     - name: Download private ssh key
       run: |
         KEY=$(aws secretsmanager get-secret-value --secret-id ci-github-actions-ray-cluster-key-3 --query SecretString --output text)

--- a/.github/workflows/run-cluster.yaml
+++ b/.github/workflows/run-cluster.yaml
@@ -16,6 +16,7 @@ on:
         type: choice
         options:
         - medium-x86
+        - debug_xs-x86
         description: The profile to use for the cluster
         required: false
         default: medium-x86

--- a/.github/workflows/run-cluster.yaml
+++ b/.github/workflows/run-cluster.yaml
@@ -61,9 +61,9 @@ jobs:
         (cat .github/assets/template.yaml \
           | python .github/ci-scripts/templatize_ray_config.py \
           --cluster-name "ray-ci-run-${{ github.run_id }}_${{ github.run_attempt }}" \
-          --daft-version ${{ inputs.daft_version }} \
-          --python-version ${{ inputs.python_version }} \
-          --cluster-profile 'medium-x86'
+          --daft-version '${{ inputs.daft_version }}' \
+          --python-version '${{ inputs.python_version }}' \
+          --cluster-profile '${{ inputs.cluster_profile }}'
         ) >> .github/assets/ray.yaml
         echo "Ray configuration file:" >> $GITHUB_STEP_SUMMARY
         cat .github/assets/ray.yaml >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/run-cluster.yaml
+++ b/.github/workflows/run-cluster.yaml
@@ -95,7 +95,7 @@ jobs:
     - name: Download log files from ray cluster
       run: |
         source .venv/bin/activate
-        ray rsync-down .github/assets/benchmarking_ray_config.yaml /tmp/ray/session_*/logs ray-daft-logs
+        ray rsync-down .github/assets/ray.yaml /tmp/ray/session_*/logs ray-daft-logs
         find ray-daft-logs -depth -name '*:*' -exec bash -c '
         for filepath; do
           dir=$(dirname "$filepath")

--- a/.github/workflows/run-cluster.yaml
+++ b/.github/workflows/run-cluster.yaml
@@ -12,6 +12,13 @@ on:
         description: The version of python to use
         required: false
         default: "3.9"
+      cluster_profile:
+        type: choice
+        options:
+        - medium-x86
+        description: The profile to use for the cluster
+        required: false
+        default: medium-x86
       command:
         type: string
         description: The command to run on the cluster
@@ -50,14 +57,16 @@ jobs:
         uv pip install ray[default] boto3
     - name: Dynamically update ray config file
       run: |
-        id="ray-ci-run-${{ github.run_id }}_${{ github.run_attempt }}"
-        sed -i "s|{{RAY_CLUSTER_NAME}}|$id|g" .github/assets/benchmarking_ray_config.yaml
-        sed -i 's|{{PYTHON_VERSION}}|${{ inputs.python_version }}|g' .github/assets/benchmarking_ray_config.yaml
-        if [[ '${{ inputs.daft_version }}' ]]; then
-          sed -i 's|{{DAFT_VERSION}}|==${{ inputs.daft_version }}|g' .github/assets/benchmarking_ray_config.yaml
-        else
-          sed -i 's|{{DAFT_VERSION}}||g' .github/assets/benchmarking_ray_config.yaml
-        fi
+        source .venv/bin/activate
+        (cat .github/assets/template.yaml \
+          | python .github/ci-scripts/templatize_ray_config.py \
+          --cluster-name "ray-ci-run-${{ github.run_id }}_${{ github.run_attempt }}" \
+          --daft-version ${{ inputs.daft_version }} \
+          --python-version ${{ inputs.python_version }} \
+          --cluster-profile 'medium-x86'
+        ) >> .github/assets/ray.yaml
+        echo "Ray configuration file:" >> $GITHUB_STEP_SUMMARY
+        cat .github/assets/ray.yaml >> $GITHUB_STEP_SUMMARY
     - name: Download private ssh key
       run: |
         KEY=$(aws secretsmanager get-secret-value --secret-id ci-github-actions-ray-cluster-key-3 --query SecretString --output text)
@@ -66,11 +75,11 @@ jobs:
     - name: Spin up ray cluster
       run: |
         source .venv/bin/activate
-        ray up .github/assets/benchmarking_ray_config.yaml -y
+        ray up .github/assets/ray.yaml -y
     - name: Setup connection to ray cluster
       run: |
         source .venv/bin/activate
-        ray dashboard .github/assets/benchmarking_ray_config.yaml &
+        ray dashboard .github/assets/ray.yaml &
     - name: Submit job to ray cluster
       run: |
         source .venv/bin/activate
@@ -86,7 +95,7 @@ jobs:
     - name: Download log files from ray cluster
       run: |
         source .venv/bin/activate
-        ray rsync-down .github/assets/benchmarking_ray_config.yaml /tmp/ray/session_*/logs ray-daft-logs
+        ray rsync-down .github/assets/ray.yaml /tmp/ray/session_*/logs ray-daft-logs
     - name: Kill connection to ray cluster
       run: |
         PID=$(lsof -t -i:8265)
@@ -103,7 +112,7 @@ jobs:
       if: always()
       run: |
         source .venv/bin/activate
-        ray down .github/assets/benchmarking_ray_config.yaml -y
+        ray down .github/assets/ray.yaml -y
     - name: Upload log files
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/run-cluster.yaml
+++ b/.github/workflows/run-cluster.yaml
@@ -58,7 +58,7 @@ jobs:
     - name: Dynamically update ray config file
       run: |
         source .venv/bin/activate
-        (cat .github/assets/template.yaml \
+        (cat .github/assets/.template.yaml \
           | python .github/ci-scripts/templatize_ray_config.py \
           --cluster-name "ray-ci-run-${{ github.run_id }}_${{ github.run_attempt }}" \
           --daft-version '${{ inputs.daft_version }}' \


### PR DESCRIPTION
# Overview
- When running a job on a ray-cluster using GHA, we want to be able to configure the configuration of the cluster.
  - this is achieved via "cluster profiles"
  - essentially, this is a set number of configurations (e.g., `medium-x86`, `debug_xs-x86`, etc.) that end-users can select from
  - this will take care of all of the configurations without leaking the internals of the ray-configuration story

## Available Options
- `medium-x86`
- `debug_xs-x86`

I will plan on adding more in the future. For now, this should suffice.