### PR TITLE
[BUG] Terminate nodes instead of stopping them

### DIFF
--- a/.github/assets/benchmarking_ray_config.yaml
+++ b/.github/assets/benchmarking_ray_config.yaml
@@ -3,7 +3,7 @@ cluster_name: '{{RAY_CLUSTER_NAME}}'
 provider:
   type: aws
   region: us-west-2
-  cache_stopped_nodes: true
+  cache_stopped_nodes: false
   security_group:
     GroupName: ray-autoscaler-c1
 

--- a/.github/workflows/run-cluster.yaml
+++ b/.github/workflows/run-cluster.yaml
@@ -50,7 +50,7 @@ jobs:
         uv pip install ray[default] boto3
     - name: Dynamically update ray config file
       run: |
-        id="ray-ci-run-${{ github.run_id }}_${{ github.run_attempt }}"
+        id="github-ci-${{ github.run_id }}_${{ github.run_attempt }}"
         sed -i "s|{{RAY_CLUSTER_NAME}}|$id|g" .github/assets/benchmarking_ray_config.yaml
         sed -i 's|{{PYTHON_VERSION}}|${{ inputs.python_version }}|g' .github/assets/benchmarking_ray_config.yaml
         if [[ '${{ inputs.daft_version }}' ]]; then


### PR DESCRIPTION
# Overview
Nodes were being stopped and saved for future re-use purposes. This PR turns off caching by settings `cache_stopped_nodes` to `false`. This tells ray to shut down the nodes when `ray down ...` is invoked.