### PR TITLE
[DOCS] Add missing list expression entries

### DIFF
--- a/docs/source/api_docs/expressions.rst
+++ b/docs/source/api_docs/expressions.rst
@@ -215,6 +215,7 @@ List
    :template: autosummary/accessor_method.rst
 
    Expression.list.chunk
+   Expression.list.count
    Expression.list.get
    Expression.list.join
    Expression.list.length

--- a/docs/source/api_docs/expressions.rst
+++ b/docs/source/api_docs/expressions.rst
@@ -214,12 +214,16 @@ List
    :toctree: doc_gen/expression_methods
    :template: autosummary/accessor_method.rst
 
+   Expression.list.chunk
+   Expression.list.get
    Expression.list.join
    Expression.list.length
-   Expression.list.get
+   Expression.list.max
+   Expression.list.mean
+   Expression.list.min
    Expression.list.slice
-   Expression.list.chunk
    Expression.list.sort
+   Expression.list.sum
    Expression.list.value_counts
 
 Struct


### PR DESCRIPTION
Add
- list.count
- list.max
- list.mean
- list.min
- list.sum
expressions from https://github.com/Eventual-Inc/Daft/pull/2032.

Additionally, sorted the expressions in this subsection.