### PR TITLE
[FEAT] migrate schema inference → async, block at py boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,7 @@ dependencies = [
  "pyo3",
  "serde",
  "snafu",
+ "tokio",
  "typetag",
  "urlencoding",
 ]
@@ -2479,6 +2480,7 @@ dependencies = [
  "common-daft-config",
  "common-error",
  "common-io-config",
+ "common-runtime",
  "daft-core",
  "daft-dsl",
  "daft-functions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,11 +194,11 @@ chrono-tz = "0.10.0"
 comfy-table = "7.1.1"
 common-daft-config = {path = "src/common/daft-config"}
 common-error = {path = "src/common/error", default-features = false}
+common-runtime = {path = "src/common/runtime", default-features = false}
 daft-core = {path = "src/daft-core"}
 daft-dsl = {path = "src/daft-dsl"}
 daft-hash = {path = "src/daft-hash"}
 daft-local-execution = {path = "src/daft-local-execution"}
-daft-local-plan = {path = "src/daft-local-plan"}
 daft-logical-plan = {path = "src/daft-logical-plan"}
 daft-scan = {path = "src/daft-scan"}
 daft-schema = {path = "src/daft-schema"}

--- a/src/daft-csv/src/python.rs
+++ b/src/daft-csv/src/python.rs
@@ -60,7 +60,7 @@ pub mod pylib {
 
             let (schema, _) = runtime.block_on_current_thread(async move {
                 crate::metadata::read_csv_schema(
-                    &uri,
+                    uri,
                     parse_options,
                     max_bytes,
                     io_client,

--- a/src/daft-csv/src/python.rs
+++ b/src/daft-csv/src/python.rs
@@ -55,13 +55,20 @@ pub mod pylib {
                 multithreaded_io.unwrap_or(true),
                 io_config.unwrap_or_default().config.into(),
             )?;
-            let (schema, _) = crate::metadata::read_csv_schema(
-                uri,
-                parse_options,
-                max_bytes,
-                io_client,
-                Some(io_stats),
-            )?;
+
+            let runtime = common_runtime::get_io_runtime(multithreaded_io.unwrap_or(true));
+
+            let (schema, _) = runtime.block_on_current_thread(async move {
+                crate::metadata::read_csv_schema(
+                    &uri,
+                    parse_options,
+                    max_bytes,
+                    io_client,
+                    Some(io_stats),
+                )
+                .await
+            })?;
+
             Ok(Arc::new(schema).into())
         })
     }

--- a/src/daft-json/src/python.rs
+++ b/src/daft-json/src/python.rs
@@ -57,13 +57,20 @@ pub mod pylib {
                 multithreaded_io.unwrap_or(true),
                 io_config.unwrap_or_default().config.into(),
             )?;
-            let schema = crate::schema::read_json_schema(
-                uri,
-                parse_options,
-                max_bytes,
-                io_client,
-                Some(io_stats),
-            )?;
+
+            let runtime_handle = common_runtime::get_io_runtime(true);
+
+            let schema = runtime_handle.block_on_current_thread(async {
+                crate::schema::read_json_schema(
+                    uri,
+                    parse_options,
+                    max_bytes,
+                    io_client,
+                    Some(io_stats),
+                )
+                .await
+            })?;
+
             Ok(Arc::new(schema).into())
         })
     }

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -225,7 +225,7 @@ pub mod pylib {
     #[pyfunction]
     pub fn read_parquet_schema(
         py: Python,
-        uri: String,
+        uri: &str,
         io_config: Option<IOConfig>,
         multithreaded_io: Option<bool>,
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
@@ -245,7 +245,7 @@ pub mod pylib {
 
             let task = async move {
                 crate::read::read_parquet_schema(
-                    &uri,
+                    uri,
                     io_client,
                     Some(io_stats),
                     schema_infer_options,
@@ -254,7 +254,7 @@ pub mod pylib {
                 .await
             };
 
-            let (schema, _) = runtime_handle.block_on(task)??;
+            let (schema, _) = runtime_handle.block_on_current_thread(task)?;
 
             Ok(Arc::new(schema).into())
         })

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -954,17 +954,15 @@ pub fn read_parquet_into_pyarrow_bulk<T: AsRef<str>>(
     Ok(collected.into_iter().map(|(_, v)| v).collect())
 }
 
-pub fn read_parquet_schema(
+pub async fn read_parquet_schema(
     uri: &str,
     io_client: Arc<IOClient>,
     io_stats: Option<IOStatsRef>,
     schema_inference_options: ParquetSchemaInferenceOptions,
     field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
 ) -> DaftResult<(Schema, FileMetaData)> {
-    let runtime_handle = get_io_runtime(true);
-    let builder = runtime_handle.block_on_current_thread(async {
-        ParquetReaderBuilder::from_uri(uri, io_client.clone(), io_stats, field_id_mapping).await
-    })?;
+    let builder =
+        ParquetReaderBuilder::from_uri(uri, io_client.clone(), io_stats, field_id_mapping).await?;
     let builder = builder.set_infer_schema_options(schema_inference_options);
 
     let metadata = builder.metadata;

--- a/src/daft-scan/Cargo.toml
+++ b/src/daft-scan/Cargo.toml
@@ -28,6 +28,9 @@ snafu = {workspace = true}
 typetag = {workspace = true}
 urlencoding = "2.1.3"
 
+[dev-dependencies]
+tokio = {workspace = true, features = ["full"]}
+
 [features]
 python = ["dep:pyo3", "common-error/python", "daft-core/python", "daft-logical-plan/python", "daft-table/python", "daft-stats/python", "common-file-formats/python", "common-io-config/python", "common-daft-config/python", "common-scan-info/python", "daft-schema/python"]
 

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -16,7 +16,7 @@ use daft_schema::{
 };
 use daft_stats::PartitionSpec;
 use daft_table::Table;
-use futures::{stream::BoxStream, StreamExt, TryStreamExt};
+use futures::{stream::BoxStream, Stream, StreamExt, TryStreamExt};
 use snafu::Snafu;
 
 use crate::{
@@ -73,32 +73,25 @@ impl From<Error> for DaftError {
     }
 }
 
-type FileInfoIterator = Box<dyn Iterator<Item = DaftResult<FileMetadata>>>;
-
-fn run_glob(
+async fn run_glob(
     glob_path: &str,
     limit: Option<usize>,
     io_client: Arc<IOClient>,
-    runtime: RuntimeRef,
     io_stats: Option<IOStatsRef>,
     file_format: FileFormat,
-) -> DaftResult<FileInfoIterator> {
+) -> DaftResult<impl Stream<Item = DaftResult<FileMetadata>> + Send> {
     let (_, parsed_glob_path) = parse_url(glob_path)?;
     // Construct a static-lifetime BoxStream returning the FileMetadata
     let glob_input = parsed_glob_path.as_ref().to_string();
-    let boxstream = runtime.block_on_current_thread(async move {
-        io_client
-            .glob(glob_input, None, None, limit, io_stats, Some(file_format))
-            .await
-    })?;
+    let stream = io_client
+        .glob(glob_input, None, None, limit, io_stats, Some(file_format))
+        .await?;
 
-    // Construct a static-lifetime BoxStreamIterator
-    let iterator = BoxStreamIterator {
-        boxstream,
-        runtime_handle: runtime.clone(),
-    };
-    let iterator = iterator.map(|fm| Ok(fm?));
-    Ok(Box::new(iterator))
+    let stream = stream.map(|fm| Ok(fm?));
+
+    let stream = stream.boxed();
+
+    Ok(stream)
 }
 
 fn run_glob_parallel(
@@ -139,7 +132,7 @@ fn run_glob_parallel(
 }
 
 impl GlobScanOperator {
-    pub fn try_new(
+    pub async fn try_new(
         glob_paths: Vec<String>,
         file_format_config: Arc<FileFormatConfig>,
         storage_config: Arc<StorageConfig>,
@@ -157,7 +150,7 @@ impl GlobScanOperator {
 
         let file_format = file_format_config.file_format();
 
-        let (io_runtime, io_client) = storage_config.get_io_client_and_runtime()?;
+        let (_, io_client) = storage_config.get_io_client_and_runtime()?;
         let io_stats = IOStatsContext::new(format!(
             "GlobScanOperator::try_new schema inference for {first_glob_path}"
         ));
@@ -165,14 +158,15 @@ impl GlobScanOperator {
             first_glob_path,
             Some(1),
             io_client.clone(),
-            io_runtime,
             Some(io_stats.clone()),
             file_format,
-        )?;
+        )
+        .await?;
+
         let FileMetadata {
             filepath: first_filepath,
             ..
-        } = match paths.next() {
+        } = match paths.next().await {
             Some(file_metadata) => file_metadata,
             None => Err(Error::GlobNoMatch {
                 glob_path: first_glob_path.to_string(),
@@ -228,7 +222,8 @@ impl GlobScanOperator {
                                 ..Default::default()
                             },
                             field_id_mapping.clone(),
-                        )?;
+                        )
+                        .await?;
 
                         schema
                     }
@@ -256,16 +251,20 @@ impl GlobScanOperator {
                             None,
                             io_client,
                             Some(io_stats),
-                        )?;
+                        )
+                        .await?;
                         schema
                     }
-                    FileFormatConfig::Json(_) => daft_json::schema::read_json_schema(
-                        first_filepath.as_str(),
-                        None,
-                        None,
-                        io_client,
-                        Some(io_stats),
-                    )?,
+                    FileFormatConfig::Json(_) => {
+                        daft_json::schema::read_json_schema(
+                            first_filepath.as_str(),
+                            None,
+                            None,
+                            io_client,
+                            Some(io_stats),
+                        )
+                        .await?
+                    }
                     #[cfg(feature = "python")]
                     FileFormatConfig::Database(_) => {
                         return Err(DaftError::ValueError(

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -87,9 +87,7 @@ async fn run_glob(
         .glob(glob_input, None, None, limit, io_stats, Some(file_format))
         .await?;
 
-    let stream = stream.map(|fm| Ok(fm?));
-
-    let stream = stream.boxed();
+    let stream = stream.map_err(|e| e.into());
 
     Ok(stream)
 }

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -813,7 +813,7 @@ mod test {
         )
     }
 
-    fn make_glob_scan_operator(num_sources: usize) -> GlobScanOperator {
+    async fn make_glob_scan_operator(num_sources: usize) -> GlobScanOperator {
         let file_format_config: FileFormatConfig = FileFormatConfig::Parquet(ParquetSourceConfig {
             coerce_int96_timestamp_unit: TimeUnit::Seconds,
             field_id_mapping: None,
@@ -838,14 +838,15 @@ mod test {
             None,
             false,
         )
+        .await
         .unwrap();
 
         glob_scan_operator
     }
 
-    #[test]
-    fn test_glob_display_condenses() -> DaftResult<()> {
-        let glob_scan_operator: GlobScanOperator = make_glob_scan_operator(8);
+    #[tokio::test]
+    async fn test_glob_display_condenses() -> DaftResult<()> {
+        let glob_scan_operator: GlobScanOperator = make_glob_scan_operator(8).await;
         let condensed_glob_paths: Vec<String> = glob_scan_operator.multiline_display();
         assert_eq!(condensed_glob_paths[1], "Glob paths = [../../tests/assets/parquet-data/mvp.parquet, ../../tests/assets/parquet-data/mvp.parquet, ../../tests/assets/parquet-data/mvp.parquet, ..., ../../tests/assets/parquet-data/mvp.parquet, ../../tests/assets/parquet-data/mvp.parquet, ../../tests/assets/parquet-data/mvp.parquet]");
         Ok(())

--- a/src/daft-sql/Cargo.toml
+++ b/src/daft-sql/Cargo.toml
@@ -2,6 +2,7 @@
 common-daft-config = {path = "../common/daft-config"}
 common-error = {path = "../common/error"}
 common-io-config = {path = "../common/io-config", default-features = false}
+common-runtime = {workspace = true}
 daft-core = {path = "../daft-core"}
 daft-dsl = {path = "../daft-dsl"}
 daft-functions = {path = "../daft-functions"}

--- a/src/daft-sql/src/table_provider/read_csv.rs
+++ b/src/daft-sql/src/table_provider/read_csv.rs
@@ -103,6 +103,8 @@ impl SQLTableFunction for ReadCsvFunction {
             1, // 1 positional argument (path)
         )?;
 
-        builder.finish().map_err(From::from)
+        let runtime = common_runtime::get_io_runtime(true);
+        let result = runtime.block_on(builder.finish())??;
+        Ok(result)
     }
 }

--- a/src/daft-sql/src/table_provider/read_parquet.rs
+++ b/src/daft-sql/src/table_provider/read_parquet.rs
@@ -77,6 +77,9 @@ impl SQLTableFunction for ReadParquetFunction {
             1, // 1 positional argument (path)
         )?;
 
-        builder.finish().map_err(From::from)
+        let runtime = common_runtime::get_io_runtime(true);
+
+        let result = runtime.block_on(builder.finish())??;
+        Ok(result)
     }
 }


### PR DESCRIPTION
Converts schema inference operations for CSV, JSON, and Parquet files to use async/await instead of synchronous runtime blocking. This architectural change ensures that blocking operations happen at the highest level possible (the Python API boundary) rather than deep within the inference logic. Key changes include:

- Making read_csv_schema, read_json_schema, and read_parquet_schema async
- Updating scan builder interfaces to use async finish() methods 
- Removing unnecessary runtime.block_on calls from schema inference paths
- Moving runtime.block_on calls to Python API layer where blocking is unavoidable
- Converting schema-related tests to use tokio async runtime
- Adding common-runtime dependency where needed
- Fixes #3423

This change improves the consistency of async IO handling and creates a cleaner architecture where blocking is consolidated at the Python interface rather than scattered throughout the codebase.