### PR TITLE
[BUG] Remove enum imports from match statements

### DIFF
--- a/src/daft-core/src/datatypes/matching.rs
+++ b/src/daft-core/src/datatypes/matching.rs
@@ -1,293 +1,340 @@
 #[macro_export]
-macro_rules! with_match_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    #[allow(unused_imports)]
-    use $crate::datatypes::*;
+macro_rules! with_match_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::*;
 
-    match $key_type {
-        // Float16 => unimplemented!("Array for Float16 DataType not implemented"),
-        Binary => __with_ty__! { BinaryType },
-        Boolean => __with_ty__! { BooleanType },
-        Date => __with_ty__! { DateType },
-        Decimal128(..) => __with_ty__! { Decimal128Type },
-        Duration(_) => __with_ty__! { DurationType },
-        Embedding(..) => __with_ty__! { EmbeddingType },
-        Extension(_, _, _) => __with_ty__! { ExtensionType },
-        FixedShapeImage(..) => __with_ty__! { FixedShapeImageType },
-        FixedShapeSparseTensor(..) => __with_ty__! { FixedShapeSparseTensorType },
-        FixedShapeTensor(..) => __with_ty__! { FixedShapeTensorType },
-        FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
-        FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        Image(..) => __with_ty__! { ImageType },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        Int8 => __with_ty__! { Int8Type },
-        Interval => __with_ty__! { IntervalType },
-        List(_) => __with_ty__! { ListType },
-        Map{..} => __with_ty__! { MapType },
-        Null => __with_ty__! { NullType },
-        SparseTensor(..) => __with_ty__! { SparseTensorType },
-        Struct(_) => __with_ty__! { StructType },
-        Tensor(..) => __with_ty__! { TensorType },
-        Time(_) => __with_ty__! { TimeType },
-        Timestamp(_, _) => __with_ty__! { TimestampType },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        Unknown => unimplemented!("Array for Unknown DataType not implemented"),
-        Utf8 => __with_ty__! { Utf8Type },
-        #[cfg(feature = "python")]
-        Python => __with_ty__! { PythonType },
+        match $key_type {
+            // Float16 => unimplemented!("Array for Float16 DataType not implemented"),
+            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
+            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
+            $crate::datatypes::DataType::Date => __with_ty__! { DateType },
+            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            $crate::datatypes::DataType::Duration(_) => __with_ty__! { DurationType },
+            $crate::datatypes::DataType::Embedding(..) => __with_ty__! { EmbeddingType },
+            $crate::datatypes::DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
+            $crate::datatypes::DataType::FixedShapeImage(..) => __with_ty__! { FixedShapeImageType },
+            $crate::datatypes::DataType::FixedShapeSparseTensor(..) => __with_ty__! { FixedShapeSparseTensorType },
+            $crate::datatypes::DataType::FixedShapeTensor(..) => __with_ty__! { FixedShapeTensorType },
+            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            $crate::datatypes::DataType::FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
+            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
+            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            $crate::datatypes::DataType::Image(..) => __with_ty__! { ImageType },
+            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
+            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
+            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
+            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
+            $crate::datatypes::DataType::Interval => __with_ty__! { IntervalType },
+            $crate::datatypes::DataType::List(_) => __with_ty__! { ListType },
+            $crate::datatypes::DataType::Map{..} => __with_ty__! { MapType },
+            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
+            $crate::datatypes::DataType::SparseTensor(..) => __with_ty__! { SparseTensorType },
+            $crate::datatypes::DataType::Struct(_) => __with_ty__! { StructType },
+            $crate::datatypes::DataType::Tensor(..) => __with_ty__! { TensorType },
+            $crate::datatypes::DataType::Time(_) => __with_ty__! { TimeType },
+            $crate::datatypes::DataType::Timestamp(_, _) => __with_ty__! { TimestampType },
+            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
+            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
+            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
+            $crate::datatypes::DataType::Unknown => unimplemented!("array for unknown datatype not implemented"),
+            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
+            #[cfg(feature = "python")]
+            $crate::datatypes::DataType::Python => __with_ty__! { PythonType },
 
-        // NOTE: We should not implement a default for match here, because this is meant to be
-        // an exhaustive match across **all** Daft types.
-        // _ => panic!("{:?} not implemented for with_match_daft_types", $key_type)
-    }
-})}
-#[macro_export]
-macro_rules! with_match_physical_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    #[allow(unused_imports)]
-    use $crate::datatypes::*;
-
-    match $key_type {
-        Null => __with_ty__! { NullType },
-        Boolean => __with_ty__! { BooleanType },
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        Decimal128(_, _) => __with_ty__! { Decimal128Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        // Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        Binary => __with_ty__! { BinaryType },
-        FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
-        Utf8 => __with_ty__! { Utf8Type },
-        FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
-        List(_) => __with_ty__! { ListType },
-        Struct(_) => __with_ty__! { StructType },
-        Extension(_, _, _) => __with_ty__! { ExtensionType },
-        Interval => __with_ty__! { IntervalType },
-        #[cfg(feature = "python")]
-        Python => __with_ty__! { PythonType },
-        _ => panic!("{:?} not implemented for with_match_physical_daft_types", $key_type)
-    }
-})}
+            // NOTE: We should not implement a default for match here, because this is meant to be
+            // an exhaustive match across **all** Daft types.
+            // _ => panic!("{:?} not implemented for with_match_daft_types", $key_type)
+        }
+    }};
+}
 
 #[macro_export]
-macro_rules! with_match_arrow_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    use $crate::datatypes::*;
+macro_rules! with_match_physical_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::*;
 
-    match $key_type {
-        Null => __with_ty__! { NullType },
-        Boolean => __with_ty__! { BooleanType },
-        Binary => __with_ty__! { BinaryType },
-        FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        // Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        Decimal128(..) => __with_ty__! { Decimal128Type },
-
-        // Date => __with_ty__! { DateType },
-        // Timestamp(_, _) => __with_ty__! { TimestampType },
-        List(_) => __with_ty__! { ListType },
-        Extension(_, _, _) => __with_ty__! { ExtensionType },
-        Utf8 => __with_ty__! { Utf8Type },
-        _ => panic!("{:?} not implemented", $key_type)
-    }
-})}
-
-#[macro_export]
-macro_rules! with_match_comparable_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    #[allow(unused_imports)]
-    use $crate::datatypes::*;
-
-    match $key_type {
-        Null => __with_ty__! { NullType },
-        Boolean => __with_ty__! { BooleanType },
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        Decimal128(..) => __with_ty__! { Decimal128Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        // Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        Utf8 => __with_ty__! { Utf8Type },
-        Binary => __with_ty__! { BinaryType },
-        FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
-        _ => panic!("{:?} not implemented", $key_type)
-    }
-})}
+        match $key_type {
+            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
+            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
+            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
+            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
+            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
+            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
+            $crate::datatypes::DataType::Decimal128(_, _) => __with_ty__! { Decimal128Type },
+            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
+            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
+            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
+            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
+            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
+            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
+            $crate::datatypes::DataType::FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
+            $crate::datatypes::DataType::List(_) => __with_ty__! { ListType },
+            $crate::datatypes::DataType::Struct(_) => __with_ty__! { StructType },
+            $crate::datatypes::DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
+            $crate::datatypes::DataType::Interval => __with_ty__! { IntervalType },
+            #[cfg(feature = "python")]
+            $crate::datatypes::DataType::Python => __with_ty__! { PythonType },
+            _ => panic!("{:?} not implemented for with_match_physical_daft_types", $key_type)
+        }
+    }};
+}
 
 #[macro_export]
-macro_rules! with_match_hashable_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    #[allow(unused_imports)]
-    use $crate::datatypes::*;
+macro_rules! with_match_arrow_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::*;
 
-    match $key_type {
-        Null => __with_ty__! { NullType },
-        Boolean => __with_ty__! { BooleanType },
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        Decimal128(..) => __with_ty__! { Decimal128Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        // Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        Utf8 => __with_ty__! { Utf8Type },
-        Binary => __with_ty__! { BinaryType },
-        FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
-        List(_) => __with_ty__! { ListType },
-        FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
-        Struct(_) => __with_ty__! { StructType },
-        _ => panic!("{:?} not implemented", $key_type)
-    }
-})}
-
-#[macro_export]
-macro_rules! with_match_numeric_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    use $crate::datatypes::*;
-
-    match $key_type {
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        // Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        _ => panic!("{:?} not implemented", $key_type)
-    }
-})}
+        match $key_type {
+            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
+            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
+            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
+            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
+            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
+            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
+            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
+            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
+            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
+            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
+            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
+            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            $crate::datatypes::DataType::List(_) => __with_ty__! { ListType },
+            $crate::datatypes::DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
+            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
+            _ => panic!("{:?} not implemented", $key_type)
+        }
+    }};
+}
 
 #[macro_export]
-macro_rules! with_match_primitive_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    use $crate::datatypes::*;
+macro_rules! with_match_comparable_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::*;
 
-    match $key_type {
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        // Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        Decimal128(..) => __with_ty__! { Decimal128Type },
-        _ => panic!("{:?} not implemented", $key_type)
-    }
-})}
-
-#[macro_export]
-macro_rules! with_match_integer_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    use $crate::datatypes::*;
-
-    match $key_type {
-        Int8 => __with_ty__! { Int8Type },
-        Int16 => __with_ty__! { Int16Type },
-        Int32 => __with_ty__! { Int32Type },
-        Int64 => __with_ty__! { Int64Type },
-        UInt8 => __with_ty__! { UInt8Type },
-        UInt16 => __with_ty__! { UInt16Type },
-        UInt32 => __with_ty__! { UInt32Type },
-        UInt64 => __with_ty__! { UInt64Type },
-        _ => panic!("Only Integer Types are supported, {:?} not implemented", $key_type)
-    }
-})}
+        match $key_type {
+            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
+            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
+            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
+            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
+            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
+            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
+            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
+            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
+            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
+            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
+            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
+            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
+            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            _ => panic!("{:?} not implemented", $key_type)
+        }
+    }};
+}
 
 #[macro_export]
-macro_rules! with_match_float_and_null_daft_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    use $crate::datatypes::*;
+macro_rules! with_match_iterable_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {($_ $T:ident) => {
+                $($body)*
+            };
+        }
+        use $crate::datatypes::*;
 
-    match $key_type {
-        Null => __with_ty__! { NullType },
-        // Float16 => __with_ty__! { Float16Type },
-        Float32 => __with_ty__! { Float32Type },
-        Float64 => __with_ty__! { Float64Type },
-        _ => panic!("Only Float Types are supported, {:?} not implemented", $key_type)
-    }
-})}
+        match $key_type {
+            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
+            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
+            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
+            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
+            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
+            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
+            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
+            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
+            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
+            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            _ => panic!("{:?} not implemented", $key_type),
+        }
+    }};
+}
 
 #[macro_export]
-macro_rules! with_match_daft_logical_primitive_types {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    match $key_type {
-        Decimal128(..) => __with_ty__! { i128 },
-        Duration(..) => __with_ty__! { i64 },
-        Date => __with_ty__! { i32 },
-        Time(..) => __with_ty__! { i64 },
-        Timestamp(..) => __with_ty__! { i64 },
-        _ => panic!("no logical -> primitive conversion available for {:?}", $key_type)
-    }
-})}
+macro_rules! with_match_hashable_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::*;
+
+        match $key_type {
+            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
+            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
+            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
+            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
+            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
+            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
+            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
+            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
+            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
+            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
+            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
+            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
+            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            $crate::datatypes::DataType::List(_) => __with_ty__! { ListType },
+            $crate::datatypes::DataType::FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
+            $crate::datatypes::DataType::Struct(_) => __with_ty__! { StructType },
+            _ => panic!("{:?} not implemented", $key_type)
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! with_match_numeric_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::*;
+
+        match $key_type {
+            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
+            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
+            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
+            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
+            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
+            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
+            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
+            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
+            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            _ => panic!("{:?} not implemented", $key_type)
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! with_match_primitive_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::*;
+
+        match $key_type {
+            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
+            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
+            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
+            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
+            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
+            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
+            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
+            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
+            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            _ => panic!("{:?} not implemented", $key_type)
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! with_match_integer_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::*;
+
+        match $key_type {
+            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
+            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
+            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
+            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
+            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
+            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
+            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
+            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            _ => panic!("Only Integer Types are supported, {:?} not implemented", $key_type)
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! with_match_float_and_null_daft_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::*;
+
+        match $key_type {
+            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
+            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
+            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            _ => panic!("Only Float Types are supported, {:?} not implemented", $key_type)
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! with_match_daft_logical_primitive_types {
+    (
+        $key_type:expr
+        , |$_:tt $T:ident| $($body:tt)*
+        $(,)?
+    ) => {{
+        macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        match $key_type {
+            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { i128 },
+            $crate::datatypes::DataType::Duration(..) => __with_ty__! { i64 },
+            $crate::datatypes::DataType::Date => __with_ty__! { i32 },
+            $crate::datatypes::DataType::Time(..) => __with_ty__! { i64 },
+            $crate::datatypes::DataType::Timestamp(..) => __with_ty__! { i64 },
+            _ => panic!("no logical -> primitive conversion available for {:?}", $key_type)
+        }
+    }};
+}

--- a/src/daft-core/src/datatypes/matching.rs
+++ b/src/daft-core/src/datatypes/matching.rs
@@ -7,45 +7,46 @@ macro_rules! with_match_daft_types {
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
             // Float16 => unimplemented!("Array for Float16 DataType not implemented"),
-            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
-            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
-            $crate::datatypes::DataType::Date => __with_ty__! { DateType },
-            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
-            $crate::datatypes::DataType::Duration(_) => __with_ty__! { DurationType },
-            $crate::datatypes::DataType::Embedding(..) => __with_ty__! { EmbeddingType },
-            $crate::datatypes::DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
-            $crate::datatypes::DataType::FixedShapeImage(..) => __with_ty__! { FixedShapeImageType },
-            $crate::datatypes::DataType::FixedShapeSparseTensor(..) => __with_ty__! { FixedShapeSparseTensorType },
-            $crate::datatypes::DataType::FixedShapeTensor(..) => __with_ty__! { FixedShapeTensorType },
-            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
-            $crate::datatypes::DataType::FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
-            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
-            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
-            $crate::datatypes::DataType::Image(..) => __with_ty__! { ImageType },
-            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
-            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
-            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
-            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
-            $crate::datatypes::DataType::Interval => __with_ty__! { IntervalType },
-            $crate::datatypes::DataType::List(_) => __with_ty__! { ListType },
-            $crate::datatypes::DataType::Map{..} => __with_ty__! { MapType },
-            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
-            $crate::datatypes::DataType::SparseTensor(..) => __with_ty__! { SparseTensorType },
-            $crate::datatypes::DataType::Struct(_) => __with_ty__! { StructType },
-            $crate::datatypes::DataType::Tensor(..) => __with_ty__! { TensorType },
-            $crate::datatypes::DataType::Time(_) => __with_ty__! { TimeType },
-            $crate::datatypes::DataType::Timestamp(_, _) => __with_ty__! { TimestampType },
-            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
-            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
-            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
-            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
-            $crate::datatypes::DataType::Unknown => unimplemented!("array for unknown datatype not implemented"),
-            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
+            DataType::Binary => __with_ty__! { BinaryType },
+            DataType::Boolean => __with_ty__! { BooleanType },
+            DataType::Date => __with_ty__! { DateType },
+            DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            DataType::Duration(_) => __with_ty__! { DurationType },
+            DataType::Embedding(..) => __with_ty__! { EmbeddingType },
+            DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
+            DataType::FixedShapeImage(..) => __with_ty__! { FixedShapeImageType },
+            DataType::FixedShapeSparseTensor(..) => __with_ty__! { FixedShapeSparseTensorType },
+            DataType::FixedShapeTensor(..) => __with_ty__! { FixedShapeTensorType },
+            DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            DataType::FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
+            DataType::Float32 => __with_ty__! { Float32Type },
+            DataType::Float64 => __with_ty__! { Float64Type },
+            DataType::Image(..) => __with_ty__! { ImageType },
+            DataType::Int16 => __with_ty__! { Int16Type },
+            DataType::Int32 => __with_ty__! { Int32Type },
+            DataType::Int64 => __with_ty__! { Int64Type },
+            DataType::Int8 => __with_ty__! { Int8Type },
+            DataType::Interval => __with_ty__! { IntervalType },
+            DataType::List(_) => __with_ty__! { ListType },
+            DataType::Map{..} => __with_ty__! { MapType },
+            DataType::Null => __with_ty__! { NullType },
+            DataType::SparseTensor(..) => __with_ty__! { SparseTensorType },
+            DataType::Struct(_) => __with_ty__! { StructType },
+            DataType::Tensor(..) => __with_ty__! { TensorType },
+            DataType::Time(_) => __with_ty__! { TimeType },
+            DataType::Timestamp(_, _) => __with_ty__! { TimestampType },
+            DataType::UInt16 => __with_ty__! { UInt16Type },
+            DataType::UInt32 => __with_ty__! { UInt32Type },
+            DataType::UInt64 => __with_ty__! { UInt64Type },
+            DataType::UInt8 => __with_ty__! { UInt8Type },
+            DataType::Unknown => unimplemented!("array for unknown datatype not implemented"),
+            DataType::Utf8 => __with_ty__! { Utf8Type },
             #[cfg(feature = "python")]
-            $crate::datatypes::DataType::Python => __with_ty__! { PythonType },
+            DataType::Python => __with_ty__! { PythonType },
 
             // NOTE: We should not implement a default for match here, because this is meant to be
             // an exhaustive match across **all** Daft types.
@@ -63,31 +64,33 @@ macro_rules! with_match_physical_daft_types {
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
-            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
-            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
-            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
-            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
-            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
-            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
-            $crate::datatypes::DataType::Decimal128(_, _) => __with_ty__! { Decimal128Type },
-            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
-            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
-            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
-            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
-            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
-            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
-            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
-            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
-            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
-            $crate::datatypes::DataType::FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
-            $crate::datatypes::DataType::List(_) => __with_ty__! { ListType },
-            $crate::datatypes::DataType::Struct(_) => __with_ty__! { StructType },
-            $crate::datatypes::DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
-            $crate::datatypes::DataType::Interval => __with_ty__! { IntervalType },
+            DataType::Null => __with_ty__! { NullType },
+            DataType::Boolean => __with_ty__! { BooleanType },
+            DataType::Int8 => __with_ty__! { Int8Type },
+            DataType::Int16 => __with_ty__! { Int16Type },
+            DataType::Int32 => __with_ty__! { Int32Type },
+            DataType::Int64 => __with_ty__! { Int64Type },
+            DataType::Decimal128(_, _) => __with_ty__! { Decimal128Type },
+            DataType::UInt8 => __with_ty__! { UInt8Type },
+            DataType::UInt16 => __with_ty__! { UInt16Type },
+            DataType::UInt32 => __with_ty__! { UInt32Type },
+            DataType::UInt64 => __with_ty__! { UInt64Type },
+            DataType::Float32 => __with_ty__! { Float32Type },
+            DataType::Float64 => __with_ty__! { Float64Type },
+            DataType::Binary => __with_ty__! { BinaryType },
+            DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            DataType::Utf8 => __with_ty__! { Utf8Type },
+            DataType::FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
+            DataType::List(_) => __with_ty__! { ListType },
+            DataType::Struct(_) => __with_ty__! { StructType },
+            DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
+            DataType::Interval => __with_ty__! { IntervalType },
             #[cfg(feature = "python")]
-            $crate::datatypes::DataType::Python => __with_ty__! { PythonType },
+            DataType::Python => __with_ty__! { PythonType },
+
             _ => panic!("{:?} not implemented for with_match_physical_daft_types", $key_type)
         }
     }};
@@ -102,26 +105,28 @@ macro_rules! with_match_arrow_daft_types {
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
-            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
-            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
-            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
-            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
-            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
-            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
-            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
-            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
-            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
-            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
-            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
-            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
-            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
-            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
-            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
-            $crate::datatypes::DataType::List(_) => __with_ty__! { ListType },
-            $crate::datatypes::DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
-            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
+            DataType::Null => __with_ty__! { NullType },
+            DataType::Boolean => __with_ty__! { BooleanType },
+            DataType::Binary => __with_ty__! { BinaryType },
+            DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            DataType::Int8 => __with_ty__! { Int8Type },
+            DataType::Int16 => __with_ty__! { Int16Type },
+            DataType::Int32 => __with_ty__! { Int32Type },
+            DataType::Int64 => __with_ty__! { Int64Type },
+            DataType::UInt8 => __with_ty__! { UInt8Type },
+            DataType::UInt16 => __with_ty__! { UInt16Type },
+            DataType::UInt32 => __with_ty__! { UInt32Type },
+            DataType::UInt64 => __with_ty__! { UInt64Type },
+            DataType::Float32 => __with_ty__! { Float32Type },
+            DataType::Float64 => __with_ty__! { Float64Type },
+            DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            DataType::List(_) => __with_ty__! { ListType },
+            DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
+            DataType::Utf8 => __with_ty__! { Utf8Type },
+
             _ => panic!("{:?} not implemented", $key_type)
         }
     }};
@@ -136,24 +141,26 @@ macro_rules! with_match_comparable_daft_types {
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
-            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
-            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
-            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
-            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
-            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
-            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
-            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
-            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
-            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
-            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
-            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
-            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
-            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
-            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
-            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
-            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            DataType::Null => __with_ty__! { NullType },
+            DataType::Boolean => __with_ty__! { BooleanType },
+            DataType::Int8 => __with_ty__! { Int8Type },
+            DataType::Int16 => __with_ty__! { Int16Type },
+            DataType::Int32 => __with_ty__! { Int32Type },
+            DataType::Int64 => __with_ty__! { Int64Type },
+            DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            DataType::UInt8 => __with_ty__! { UInt8Type },
+            DataType::UInt16 => __with_ty__! { UInt16Type },
+            DataType::UInt32 => __with_ty__! { UInt32Type },
+            DataType::UInt64 => __with_ty__! { UInt64Type },
+            DataType::Float32 => __with_ty__! { Float32Type },
+            DataType::Float64 => __with_ty__! { Float64Type },
+            DataType::Utf8 => __with_ty__! { Utf8Type },
+            DataType::Binary => __with_ty__! { BinaryType },
+            DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+
             _ => panic!("{:?} not implemented", $key_type)
         }
     }};
@@ -171,19 +178,21 @@ macro_rules! with_match_iterable_daft_types {
             };
         }
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
-            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
-            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
-            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
-            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
-            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
-            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
-            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
-            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
-            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
-            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
-            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            DataType::Boolean => __with_ty__! { BooleanType },
+            DataType::Int8 => __with_ty__! { Int8Type },
+            DataType::Int16 => __with_ty__! { Int16Type },
+            DataType::Int32 => __with_ty__! { Int32Type },
+            DataType::Int64 => __with_ty__! { Int64Type },
+            DataType::UInt8 => __with_ty__! { UInt8Type },
+            DataType::UInt16 => __with_ty__! { UInt16Type },
+            DataType::UInt32 => __with_ty__! { UInt32Type },
+            DataType::UInt64 => __with_ty__! { UInt64Type },
+            DataType::Float32 => __with_ty__! { Float32Type },
+            DataType::Float64 => __with_ty__! { Float64Type },
+
             _ => panic!("{:?} not implemented", $key_type),
         }
     }};
@@ -198,27 +207,29 @@ macro_rules! with_match_hashable_daft_types {
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
-            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
-            $crate::datatypes::DataType::Boolean => __with_ty__! { BooleanType },
-            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
-            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
-            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
-            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
-            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
-            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
-            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
-            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
-            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
-            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
-            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
-            $crate::datatypes::DataType::Utf8 => __with_ty__! { Utf8Type },
-            $crate::datatypes::DataType::Binary => __with_ty__! { BinaryType },
-            $crate::datatypes::DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
-            $crate::datatypes::DataType::List(_) => __with_ty__! { ListType },
-            $crate::datatypes::DataType::FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
-            $crate::datatypes::DataType::Struct(_) => __with_ty__! { StructType },
+            DataType::Null => __with_ty__! { NullType },
+            DataType::Boolean => __with_ty__! { BooleanType },
+            DataType::Int8 => __with_ty__! { Int8Type },
+            DataType::Int16 => __with_ty__! { Int16Type },
+            DataType::Int32 => __with_ty__! { Int32Type },
+            DataType::Int64 => __with_ty__! { Int64Type },
+            DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            DataType::UInt8 => __with_ty__! { UInt8Type },
+            DataType::UInt16 => __with_ty__! { UInt16Type },
+            DataType::UInt32 => __with_ty__! { UInt32Type },
+            DataType::UInt64 => __with_ty__! { UInt64Type },
+            DataType::Float32 => __with_ty__! { Float32Type },
+            DataType::Float64 => __with_ty__! { Float64Type },
+            DataType::Utf8 => __with_ty__! { Utf8Type },
+            DataType::Binary => __with_ty__! { BinaryType },
+            DataType::FixedSizeBinary(_) => __with_ty__! { FixedSizeBinaryType },
+            DataType::List(_) => __with_ty__! { ListType },
+            DataType::FixedSizeList(_, _) => __with_ty__! { FixedSizeListType },
+            DataType::Struct(_) => __with_ty__! { StructType },
+
             _ => panic!("{:?} not implemented", $key_type)
         }
     }};
@@ -233,18 +244,20 @@ macro_rules! with_match_numeric_daft_types {
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
-            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
-            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
-            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
-            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
-            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
-            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
-            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
-            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
-            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
-            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            DataType::Int8 => __with_ty__! { Int8Type },
+            DataType::Int16 => __with_ty__! { Int16Type },
+            DataType::Int32 => __with_ty__! { Int32Type },
+            DataType::Int64 => __with_ty__! { Int64Type },
+            DataType::UInt8 => __with_ty__! { UInt8Type },
+            DataType::UInt16 => __with_ty__! { UInt16Type },
+            DataType::UInt32 => __with_ty__! { UInt32Type },
+            DataType::UInt64 => __with_ty__! { UInt64Type },
+            DataType::Float32 => __with_ty__! { Float32Type },
+            DataType::Float64 => __with_ty__! { Float64Type },
+
             _ => panic!("{:?} not implemented", $key_type)
         }
     }};
@@ -259,19 +272,21 @@ macro_rules! with_match_primitive_daft_types {
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
-            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
-            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
-            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
-            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
-            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
-            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
-            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
-            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
-            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
-            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
-            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+            DataType::Int8 => __with_ty__! { Int8Type },
+            DataType::Int16 => __with_ty__! { Int16Type },
+            DataType::Int32 => __with_ty__! { Int32Type },
+            DataType::Int64 => __with_ty__! { Int64Type },
+            DataType::UInt8 => __with_ty__! { UInt8Type },
+            DataType::UInt16 => __with_ty__! { UInt16Type },
+            DataType::UInt32 => __with_ty__! { UInt32Type },
+            DataType::UInt64 => __with_ty__! { UInt64Type },
+            DataType::Float32 => __with_ty__! { Float32Type },
+            DataType::Float64 => __with_ty__! { Float64Type },
+            DataType::Decimal128(..) => __with_ty__! { Decimal128Type },
+
             _ => panic!("{:?} not implemented", $key_type)
         }
     }};
@@ -286,16 +301,18 @@ macro_rules! with_match_integer_daft_types {
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
-            $crate::datatypes::DataType::Int8 => __with_ty__! { Int8Type },
-            $crate::datatypes::DataType::Int16 => __with_ty__! { Int16Type },
-            $crate::datatypes::DataType::Int32 => __with_ty__! { Int32Type },
-            $crate::datatypes::DataType::Int64 => __with_ty__! { Int64Type },
-            $crate::datatypes::DataType::UInt8 => __with_ty__! { UInt8Type },
-            $crate::datatypes::DataType::UInt16 => __with_ty__! { UInt16Type },
-            $crate::datatypes::DataType::UInt32 => __with_ty__! { UInt32Type },
-            $crate::datatypes::DataType::UInt64 => __with_ty__! { UInt64Type },
+            DataType::Int8 => __with_ty__! { Int8Type },
+            DataType::Int16 => __with_ty__! { Int16Type },
+            DataType::Int32 => __with_ty__! { Int32Type },
+            DataType::Int64 => __with_ty__! { Int64Type },
+            DataType::UInt8 => __with_ty__! { UInt8Type },
+            DataType::UInt16 => __with_ty__! { UInt16Type },
+            DataType::UInt32 => __with_ty__! { UInt32Type },
+            DataType::UInt64 => __with_ty__! { UInt64Type },
+
             _ => panic!("Only Integer Types are supported, {:?} not implemented", $key_type)
         }
     }};
@@ -310,11 +327,13 @@ macro_rules! with_match_float_and_null_daft_types {
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
         use $crate::datatypes::*;
+        use $crate::datatypes::DataType;
 
         match $key_type {
-            $crate::datatypes::DataType::Null => __with_ty__! { NullType },
-            $crate::datatypes::DataType::Float32 => __with_ty__! { Float32Type },
-            $crate::datatypes::DataType::Float64 => __with_ty__! { Float64Type },
+            DataType::Null => __with_ty__! { NullType },
+            DataType::Float32 => __with_ty__! { Float32Type },
+            DataType::Float64 => __with_ty__! { Float64Type },
+
             _ => panic!("Only Float Types are supported, {:?} not implemented", $key_type)
         }
     }};
@@ -328,12 +347,15 @@ macro_rules! with_match_daft_logical_primitive_types {
         $(,)?
     ) => {{
         macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+        use $crate::datatypes::DataType;
+
         match $key_type {
-            $crate::datatypes::DataType::Decimal128(..) => __with_ty__! { i128 },
-            $crate::datatypes::DataType::Duration(..) => __with_ty__! { i64 },
-            $crate::datatypes::DataType::Date => __with_ty__! { i32 },
-            $crate::datatypes::DataType::Time(..) => __with_ty__! { i64 },
-            $crate::datatypes::DataType::Timestamp(..) => __with_ty__! { i64 },
+            DataType::Decimal128(..) => __with_ty__! { i128 },
+            DataType::Duration(..) => __with_ty__! { i64 },
+            DataType::Date => __with_ty__! { i32 },
+            DataType::Time(..) => __with_ty__! { i64 },
+            DataType::Timestamp(..) => __with_ty__! { i64 },
+
             _ => panic!("no logical -> primitive conversion available for {:?}", $key_type)
         }
     }};


### PR DESCRIPTION
# Overview
Importing enums is extremely bad style in Rust. This can lead to nasty errors in the future when enum definitions change.

Please stop doing this.