### PR TITLE
[CHORE] Put empty table when building probe table

### DIFF
--- a/src/daft-local-execution/src/sinks/hash_join_build.rs
+++ b/src/daft-local-execution/src/sinks/hash_join_build.rs
@@ -85,7 +85,12 @@ impl ProbeTableState {
         } = self
         {
             let probe_table_builder = probe_table_builder.as_mut().unwrap();
-            for table in input.get_tables()?.iter() {
+            let input_tables = input.get_tables()?;
+            if input_tables.is_empty() {
+                tables.push(Table::empty(Some(input.schema()))?);
+                return Ok(());
+            }
+            for table in input_tables.iter() {
                 tables.push(table.clone());
                 let join_keys = table.eval_expression_list(projection)?;
 

--- a/tests/dataframe/test_joins.py
+++ b/tests/dataframe/test_joins.py
@@ -1114,3 +1114,104 @@ def test_join_suffix_and_prefix(suffix, prefix, expected, make_df, with_morsel_s
 
     df = df1.join(df2, on="idx").join(df3, on="idx", suffix=suffix, prefix=prefix)
     assert df.column_names == ["idx", "val", "score", expected]
+
+
+@pytest.mark.parametrize("join_type", ["inner", "left", "right", "outer", "anti", "semi"])
+@pytest.mark.parametrize("repartition_nparts", [1, 2, 4])
+@pytest.mark.parametrize(
+    "left,right,expected",
+    [
+        # Case 1: Left has data, right is empty
+        (
+            {"a": [1, 2, 3, 4], "b": ["a", "b", "c", "d"]},
+            {"c": [], "d": []},
+            {
+                "inner": {"a": [], "b": [], "c": [], "d": []},
+                "left": {
+                    "a": [1, 2, 3, 4],
+                    "b": ["a", "b", "c", "d"],
+                    "c": [None, None, None, None],
+                    "d": [None, None, None, None],
+                },
+                "right": {"a": [], "b": [], "c": [], "d": []},
+                "outer": {
+                    "a": [1, 2, 3, 4],
+                    "b": ["a", "b", "c", "d"],
+                    "c": [None, None, None, None],
+                    "d": [None, None, None, None],
+                },
+                "anti": {"a": [1, 2, 3, 4], "b": ["a", "b", "c", "d"]},
+                "semi": {"a": [], "b": []},
+            },
+        ),
+        # Case 2: Left is empty, right has data
+        (
+            {"a": [], "b": []},
+            {"c": [5, 6, 7], "d": ["e", "f", "g"]},
+            {
+                "inner": {"a": [], "b": [], "c": [], "d": []},
+                "left": {"a": [], "b": [], "c": [], "d": []},
+                "right": {"a": [None, None, None], "b": [None, None, None], "c": [5, 6, 7], "d": ["e", "f", "g"]},
+                "outer": {"a": [None, None, None], "b": [None, None, None], "c": [5, 6, 7], "d": ["e", "f", "g"]},
+                "anti": {"a": [], "b": []},
+                "semi": {"a": [], "b": []},
+            },
+        ),
+        # Case 3: Both empty
+        (
+            {"a": [], "b": []},
+            {"c": [], "d": []},
+            {
+                "inner": {"a": [], "b": [], "c": [], "d": []},
+                "left": {"a": [], "b": [], "c": [], "d": []},
+                "right": {"a": [], "b": [], "c": [], "d": []},
+                "outer": {"a": [], "b": [], "c": [], "d": []},
+                "anti": {"a": [], "b": []},
+                "semi": {"a": [], "b": []},
+            },
+        ),
+    ],
+)
+def test_join_empty(join_type, repartition_nparts, left, right, expected, make_df, with_morsel_size):
+    left = pa.Table.from_pydict(
+        left,
+        schema=pa.schema(
+            [
+                ("a", pa.int32()),
+                ("b", pa.string()),
+            ]
+        ),
+    )
+    left_df = make_df(
+        left,
+        repartition=repartition_nparts,
+        repartition_columns=["a"],
+    )
+
+    right = pa.Table.from_pydict(
+        right,
+        schema=pa.schema(
+            [
+                ("c", pa.int32()),
+                ("d", pa.string()),
+            ]
+        ),
+    )
+    right_df = make_df(
+        right,
+        repartition=repartition_nparts,
+        repartition_columns=["c"],
+    )
+
+    left_on = ["a"]
+    right_on = ["c"]
+
+    result = left_df.join(right_df, left_on=left_on, right_on=right_on, how=join_type)
+    if join_type in ["inner", "left", "right", "outer"]:
+        result = result.sort(["a", "b", "c", "d"])
+    else:
+        result = result.sort(["a", "b"])
+
+    expected_result = expected[join_type]
+
+    assert result.to_pydict() == expected_result


### PR DESCRIPTION
Add empty tables when building probe tables for hash joins such that the probing still works with empty probe tables.