### PR TITLE
[DOCS] Shorten union of Literals

### DIFF
--- a/daft/.ruff.toml
+++ b/daft/.ruff.toml
@@ -2,6 +2,7 @@ extend = "../.ruff.toml"
 
 [lint]
 extend-select = [
+  "PYI030",  # unnecessary-literal-union, derived from flake8-pyi
   "TID253",  # banned-module-level-imports, derived from flake8-tidy-imports
   "TCH"  # flake8-type-checking
 ]

--- a/daft/context.py
+++ b/daft/context.py
@@ -19,7 +19,7 @@ import threading
 
 
 class _RunnerConfig:
-    name: ClassVar[Literal["ray"] | Literal["py"] | Literal["native"]]
+    name: ClassVar[Literal["ray", "py", "native"]]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -870,7 +870,7 @@ def read_parquet_into_pyarrow(
     io_config: IOConfig | None = None,
     multithreaded_io: bool | None = None,
     coerce_int96_timestamp_unit: PyTimeUnit | None = None,
-    string_encoding: Literal["utf-8"] | Literal["raw"] = "utf-8",
+    string_encoding: Literal["utf-8", "raw"] = "utf-8",
     file_timeout_ms: int | None = None,
 ): ...
 def read_parquet_into_pyarrow_bulk(

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -520,7 +520,7 @@ class DataFrame:
         self,
         root_dir: Union[str, pathlib.Path],
         compression: str = "snappy",
-        write_mode: Union[Literal["append"], Literal["overwrite"]] = "append",
+        write_mode: Literal["append", "overwrite"] = "append",
         partition_cols: Optional[List[ColumnInputType]] = None,
         io_config: Optional[IOConfig] = None,
     ) -> "DataFrame":
@@ -592,7 +592,7 @@ class DataFrame:
     def write_csv(
         self,
         root_dir: Union[str, pathlib.Path],
-        write_mode: Union[Literal["append"], Literal["overwrite"]] = "append",
+        write_mode: Literal["append", "overwrite"] = "append",
         partition_cols: Optional[List[ColumnInputType]] = None,
         io_config: Optional[IOConfig] = None,
     ) -> "DataFrame":

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -781,9 +781,7 @@ class Expression:
         expr = Expression._to_expression(other)
         return Expression._from_pyexpr(self._expr >> expr._expr)
 
-    def count(
-        self, mode: Literal["all"] | Literal["valid"] | Literal["null"] | CountMode = CountMode.Valid
-    ) -> Expression:
+    def count(self, mode: Literal["all", "valid", "null"] | CountMode = CountMode.Valid) -> Expression:
         """Counts the number of values in the expression.
 
         Args:
@@ -1302,7 +1300,7 @@ class ExpressionUrlNamespace(ExpressionNamespace):
     def download(
         self,
         max_connections: int = 32,
-        on_error: Literal["raise"] | Literal["null"] = "raise",
+        on_error: Literal["raise", "null"] = "raise",
         io_config: IOConfig | None = None,
         use_native_downloader: bool = True,
     ) -> Expression:
@@ -3013,9 +3011,7 @@ class ExpressionListNamespace(ExpressionNamespace):
         """
         return Expression._from_pyexpr(native.list_value_counts(self._expr))
 
-    def count(
-        self, mode: Literal["all"] | Literal["valid"] | Literal["null"] | CountMode = CountMode.Valid
-    ) -> Expression:
+    def count(self, mode: Literal["all", "valid", "null"] | CountMode = CountMode.Valid) -> Expression:
         """Counts the number of elements in each list
 
         Args:
@@ -3322,7 +3318,7 @@ class ExpressionImageNamespace(ExpressionNamespace):
 
     def decode(
         self,
-        on_error: Literal["raise"] | Literal["null"] = "raise",
+        on_error: Literal["raise", "null"] = "raise",
         mode: str | ImageMode | None = None,
     ) -> Expression:
         """

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -44,7 +44,7 @@ def _put_fs_in_cache(protocol: str, fs: pafs.FileSystem, io_config: IOConfig | N
 class ListingInfo:
     path: str
     size: int
-    type: Literal["file"] | Literal["directory"]
+    type: Literal["file", "directory"]
     rows: int | None = None
 
 

--- a/daft/runners/runner.py
+++ b/daft/runners/runner.py
@@ -20,7 +20,7 @@ LOCAL_PARTITION_SET_CACHE = PartitionSetCache()
 
 
 class Runner(Generic[PartitionT]):
-    name: ClassVar[Literal["ray"] | Literal["py"] | Literal["native"]]
+    name: ClassVar[Literal["ray", "py", "native"]]
 
     def __init__(self) -> None:
         self._part_set_cache = self.initialize_partition_set_cache()

--- a/daft/series.py
+++ b/daft/series.py
@@ -984,7 +984,7 @@ class SeriesMapNamespace(SeriesNamespace):
 class SeriesImageNamespace(SeriesNamespace):
     def decode(
         self,
-        on_error: Literal["raise"] | Literal["null"] = "raise",
+        on_error: Literal["raise", "null"] = "raise",
         mode: str | ImageMode | None = None,
     ) -> Series:
         raise_on_error = False

--- a/daft/table/table.py
+++ b/daft/table/table.py
@@ -562,7 +562,7 @@ def read_parquet_into_pyarrow(
     io_config: IOConfig | None = None,
     multithreaded_io: bool | None = None,
     coerce_int96_timestamp_unit: TimeUnit = TimeUnit.ns(),
-    string_encoding: Literal["utf-8"] | Literal["raw"] = "utf-8",
+    string_encoding: Literal["utf-8", "raw"] = "utf-8",
     file_timeout_ms: int | None = 900_000,  # 15 minutes
 ) -> pa.Table:
     fields, metadata, columns, num_rows_read = _read_parquet_into_pyarrow(

--- a/daft/udf_library/url_udfs.py
+++ b/daft/udf_library/url_udfs.py
@@ -21,7 +21,7 @@ def _worker_thread_initializer() -> None:
     thread_local.filesystems_cache = {}
 
 
-def _download(path: str | None, on_error: Literal["raise"] | Literal["null"]) -> bytes | None:
+def _download(path: str | None, on_error: Literal["raise", "null"]) -> bytes | None:
     if path is None:
         return None
     protocol = filesystem.get_protocol_from_path(path)
@@ -64,7 +64,7 @@ def _warmup_fsspec_registry(urls_pylist: list[str | None]) -> None:
 def download_udf(
     urls,
     max_worker_threads: int = 8,
-    on_error: Literal["raise"] | Literal["null"] = "raise",
+    on_error: Literal["raise", "null"] = "raise",
 ):
     """Downloads the contents of the supplied URLs.
 


### PR DESCRIPTION
Small clean up to simplify docs by banning unnecessary union on literals.

For example, in `DataFrame.write_parquet`, the `write_mode` argument has the following signature:
```
write_mode: Union[Literal['append'], Literal['overwrite']] = 'append',
```

But according to [PEP 586 --- Literal Types](https://peps.python.org/pep-0586/#shortening-unions-of-literals), this can be equivalently written as
```
write_mode: Literal['append', 'overwrite'] = 'append',
```
which is much easier for users to follow.