### PR TITLE
[BUG] Explicitly set IO config in unity catalog load table

### DIFF
--- a/daft/.ruff.toml
+++ b/daft/.ruff.toml
@@ -2,7 +2,6 @@ extend = "../.ruff.toml"
 
 [lint]
 extend-select = [
-  "F823",
   "PYI030",  # unnecessary-literal-union, derived from flake8-pyi
   "TID253",  # banned-module-level-imports, derived from flake8-tidy-imports
   "TCH"  # flake8-type-checking

--- a/daft/.ruff.toml
+++ b/daft/.ruff.toml
@@ -2,6 +2,7 @@ extend = "../.ruff.toml"
 
 [lint]
 extend-select = [
+  "F823",
   "PYI030",  # unnecessary-literal-union, derived from flake8-pyi
   "TID253",  # banned-module-level-imports, derived from flake8-tidy-imports
   "TCH"  # flake8-type-checking

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import warnings
 from typing import Callable
 from urllib.parse import urlparse
 
@@ -114,12 +115,14 @@ class UnityCatalog:
             )
         elif scheme == "gcs" or scheme == "gs":
             # TO-DO: gather GCS credential vending assets from Unity and construct 'io_config``
+            warnings.warn("GCS credential vending from Unity Catalog is not yet supported.")
             io_config = None
         elif scheme == "az" or scheme == "abfs" or scheme == "abfss":
             io_config = IOConfig(
                 azure=AzureConfig(sas_token=temp_table_credentials.azure_user_delegation_sas.get("sas_token"))
             )
         else:
+            warnings.warn(f"Credentials for scheme {scheme} are not yet supported.")
             io_config = None
 
         return UnityCatalogTable(

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -114,11 +114,13 @@ class UnityCatalog:
             )
         elif scheme == "gcs" or scheme == "gs":
             # TO-DO: gather GCS credential vending assets from Unity and construct 'io_config``
-            pass
+            io_config = None
         elif scheme == "az" or scheme == "abfs" or scheme == "abfss":
             io_config = IOConfig(
                 azure=AzureConfig(sas_token=temp_table_credentials.azure_user_delegation_sas.get("sas_token"))
             )
+        else:
+            io_config = None
 
         return UnityCatalogTable(
             table_uri=storage_location,


### PR DESCRIPTION
Linters don't seem to catch unbound local variables if they are defined in multiple branches.