### PR TITLE
[BUG] Fix extension type display

### DIFF
--- a/src/daft-schema/src/dtype.rs
+++ b/src/daft-schema/src/dtype.rs
@@ -119,7 +119,7 @@ pub enum DataType {
     },
 
     /// Extension type.
-    #[display("{_1}")]
+    #[display("Extension[{_0}; {_1}]")]
     Extension(String, Box<DataType>, Option<String>),
 
     // Non-ArrowTypes:


### PR DESCRIPTION
Our extension type displays were changed after #2794 and do not properly show that it is an extension type