### PR TITLE
[PERF] Do not perform ScanTask merging/splitting for small limits

### DIFF
--- a/tests/benchmarks/test_interactive_reads.py
+++ b/tests/benchmarks/test_interactive_reads.py
@@ -54,8 +54,8 @@ def files(request):
     [
         pytest.param(FileRequest(num_files=1, small=True), id="1 Small File"),
         pytest.param(FileRequest(num_files=100, small=True), id="100 Small Files"),
-        pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
-        pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
+        # pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
+        # pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
     ],
     indirect=True,  # This tells pytest to pass the params to the fixture
 )
@@ -73,8 +73,8 @@ def test_show(files, io_config, benchmark):
     [
         pytest.param(FileRequest(num_files=1, small=True), id="1 Small File"),
         pytest.param(FileRequest(num_files=100, small=True), id="100 Small Files"),
-        pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
-        pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
+        # pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
+        # pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
     ],
     indirect=True,  # This tells pytest to pass the params to the fixture
 )
@@ -112,8 +112,8 @@ def test_count(files, expected_count, io_config, benchmark):
     [
         pytest.param(FileRequest(num_files=1, small=True), id="1 Small File"),
         pytest.param(FileRequest(num_files=100, small=True), id="100 Small Files"),
-        pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
-        pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
+        # pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
+        # pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
     ],
     indirect=True,  # This tells pytest to pass the params to the fixture
 )

--- a/tests/benchmarks/test_interactive_reads.py
+++ b/tests/benchmarks/test_interactive_reads.py
@@ -1,3 +1,4 @@
+import dataclasses
 import tempfile
 
 import boto3
@@ -19,26 +20,42 @@ def io_config():
     return IOConfig(s3=S3Config(anonymous=True))
 
 
+@dataclasses.dataclass(frozen=True)
+class FileRequest:
+    num_files: int
+    small: bool
+
+
 @pytest.fixture(scope="session")
 def files(request):
-    num_files = request.param
+    file_request = request.param
     s3 = boto3.client("s3", config=Config(signature_version=UNSIGNED))
-    with tempfile.TemporaryDirectory() as tmpdir:
-        local_file = f"{tmpdir}/small-fake-data.parquet.parquet"
 
-        s3.download_file("daft-public-data", "test_fixtures/parquet/small-fake-data.parquet", local_file)
-        if request.param == 1:
-            yield local_file
+    if file_request.small:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_file = f"{tmpdir}/small-fake-data.parquet.parquet"
+            s3.download_file("daft-public-data", "test_fixtures/parquet/small-fake-data.parquet", local_file)
+            if file_request.num_files == 1:
+                yield local_file
+            else:
+                yield [local_file] * file_request.num_files
+
+    else:
+        remote_large_file = "s3://daft-public-data/test_fixtures/parquet/large-fake-data.parquet"
+        if file_request.num_files == 1:
+            yield remote_large_file
         else:
-            yield [local_file] * num_files
+            yield [remote_large_file] * file_request.num_files
 
 
 @pytest.mark.benchmark(group="show")
 @pytest.mark.parametrize(
     "files",
     [
-        pytest.param(1, id="1 Small File"),
-        pytest.param(100, id="100 Small Files"),
+        pytest.param(FileRequest(num_files=1, small=True), id="1 Small File"),
+        pytest.param(FileRequest(num_files=100, small=True), id="100 Small Files"),
+        pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
+        pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
     ],
     indirect=True,  # This tells pytest to pass the params to the fixture
 )
@@ -54,8 +71,10 @@ def test_show(files, io_config, benchmark):
 @pytest.mark.parametrize(
     "files",
     [
-        pytest.param(1, id="1 Small File"),
-        pytest.param(100, id="100 Small Files"),
+        pytest.param(FileRequest(num_files=1, small=True), id="1 Small File"),
+        pytest.param(FileRequest(num_files=100, small=True), id="100 Small Files"),
+        pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
+        pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
     ],
     indirect=True,  # This tells pytest to pass the params to the fixture
 )
@@ -71,8 +90,10 @@ def test_explain(files, io_config, benchmark):
 @pytest.mark.parametrize(
     "files, expected_count",
     [
-        pytest.param(1, 1024, id="1 Small File"),
-        pytest.param(100, 102400, id="100 Small Files"),
+        pytest.param(FileRequest(num_files=1, small=True), 1024, id="1 Small File"),
+        pytest.param(FileRequest(num_files=100, small=True), 102400, id="100 Small Files"),
+        # pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
+        # pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
     ],
     indirect=True,  # This tells pytest to pass the params to the fixture
 )
@@ -89,8 +110,10 @@ def test_count(files, expected_count, io_config, benchmark):
 @pytest.mark.parametrize(
     "files",
     [
-        pytest.param(1, id="1 Small File"),
-        pytest.param(100, id="100 Small Files"),
+        pytest.param(FileRequest(num_files=1, small=True), id="1 Small File"),
+        pytest.param(FileRequest(num_files=100, small=True), id="100 Small Files"),
+        pytest.param(FileRequest(num_files=1, small=False), id="1 Large File"),
+        pytest.param(FileRequest(num_files=20, small=False), id="20 Large Files"),
     ],
     indirect=True,  # This tells pytest to pass the params to the fixture
 )

--- a/tests/io/test_merge_scan_tasks.py
+++ b/tests/io/test_merge_scan_tasks.py
@@ -61,9 +61,7 @@ def test_merge_scan_task_below_min(csv_files):
 
 
 def test_merge_scan_task_limit_override(csv_files):
-    # A LIMIT operation should override merging of scan tasks, making it only merge up-to the estimated size of the limit
-    #
-    # With a very small CSV inflation factor, the merger will think that these CSVs provide very few rows of data and will be more aggressive
+    # A LIMIT operation will turn off merging
     with daft.execution_config_ctx(
         scan_tasks_min_size_bytes=17,
         scan_tasks_max_size_bytes=20,
@@ -71,8 +69,8 @@ def test_merge_scan_task_limit_override(csv_files):
     ):
         df = daft.read_csv(str(csv_files)).limit(1)
         assert (
-            df.num_partitions() == 1
-        ), "Should have 1 partitions [(CSV1, CSV2, CSV3)] since we have a limit 1 but are underestimating the size of data of the CSVs"
+            df.num_partitions() == 3
+        ), "Should have 3 partitions, since we have a limit 1 which turns off merging of ScanTasks"
 
     # With a very large CSV inflation factor, the merger will think that these CSVs provide more rows of data and will be more conservative
     with daft.execution_config_ctx(


### PR DESCRIPTION
Skips ScanTask merging/splitting for small limits.

When we are performing operations such as `.show()`, the intention is likely to only look at the first few rows from the first few files. In that case, we should skip the splitting/merging of files entirely, because the reader itself can do this on a per-file basis.

This PR also removes logic in `merge_by_sizes` that uses the limit pushdown information. `merge_by_sizes` is much more naive now (always naively performs the merge), and the decision of whether or not to perform a pass is moved upstream to its caller (`split_and_merge_pass`).