### PR TITLE
[FEAT] Add IO runtime for Parquet schema reading

### DIFF
--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -524,13 +524,17 @@ pub mod pylib {
         columns: Option<Vec<String>>,
         has_metadata: Option<bool>,
     ) -> PyResult<usize> {
-        let (schema, metadata) = daft_parquet::read::read_parquet_schema(
-            uri,
-            default::Default::default(),
-            None,
-            default::Default::default(),
-            None,
-        )?;
+        let runtime = common_runtime::get_io_runtime(true);
+
+        let (schema, metadata) =
+            runtime.block_on_current_thread(daft_parquet::read::read_parquet_schema(
+                uri,
+                default::Default::default(),
+                None,
+                default::Default::default(),
+                None,
+            ))?;
+
         let data_source = DataSource::File {
             path: uri.to_string(),
             chunk_spec: None,


### PR DESCRIPTION
Add `get_io_runtime` to properly handle async operations when reading Parquet schemas. This was preventing code from compiling.