### PR TITLE
[BUG] Fix build commit workflow

### DIFF
--- a/.github/ci-scripts/get_wheel_name_from_s3.py
+++ b/.github/ci-scripts/get_wheel_name_from_s3.py
@@ -14,15 +14,20 @@ echo $WHEELNAME
 ```
 """
 
-import sys
+import argparse
 from pathlib import Path
 
 import boto3
 import wheellib
 
 if __name__ == "__main__":
-    commit_hash = sys.argv[1]
-    platform_substring = sys.argv[2]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--commit-hash", required=True)
+    parser.add_argument("--platform-substring", required=True, choices=["x86", "aarch", "arm"])
+    args = parser.parse_args()
+
+    commit_hash = args.commit_hash
+    platform_substring = args.platform_substring
 
     s3 = boto3.client("s3")
     response = s3.list_objects_v2(Bucket="github-actions-artifacts-bucket", Prefix=f"builds/{commit_hash}/")
@@ -34,11 +39,8 @@ if __name__ == "__main__":
             matches.append(wheelname)
 
     if len(matches) > 1:
-        raise Exception(
+        raise RuntimeError(
             f"Multiple wheels found that match the given platform substring: {platform_substring}; expected just 1"
         )
 
-    try:
-        print(next(iter(matches)))
-    except StopIteration:
-        pass
+    print(matches[0]) if matches else None

--- a/.github/workflows/build-commit.yaml
+++ b/.github/workflows/build-commit.yaml
@@ -62,7 +62,10 @@ jobs:
     - name: Check if build already exists in AWS S3
       run: |
         source .venv/bin/activate
-        wheel_name=$(python .github/ci-scripts/get_wheel_name_from_s3.py ${{ github.sha }} $platform_substring)
+        wheel_name=$(python .github/ci-scripts/get_wheel_name_from_s3.py \
+          --commit-hash "${{ github.sha }}" \
+          --platform-substring "$platform_substring" \
+        )
         if [ "$wheel_name" ]; then
           echo "Python wheel for this commit already built and uploaded"
         else
@@ -86,7 +89,11 @@ jobs:
           exit 0
         fi
         source .venv/bin/activate
-        wheel_name=$(python .github/ci-scripts/upload_wheel_to_s3.py ${{ github.sha }} $platform_substring ~/target/wheels)
+        wheel_name=$(python .github/ci-scripts/upload_wheel_to_s3.py \
+          --commit-hash "${{ github.sha }}" \
+          --platform-substring "$platform_substring" \
+          --path-to-wheel-dir ~/target/wheels \
+        )
         echo "wheel_name=$wheel_name" >> $GITHUB_ENV
     - name: Print url of the built wheel to GitHub Actions Summary Page
       run: |


### PR DESCRIPTION
# Overview
`upload_wheel_to_s3.py` script was updated to use the `argparse` module. However, consumers of this script were not updated; they were still using the old calling syntax.

This PR fixes that bug.