### PR TITLE
feat(parquet): Limit parallel tasks in remote parquet reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,7 +2363,6 @@ dependencies = [
  "common-arrow-ffi",
  "common-error",
  "common-runtime",
- "crossbeam-channel",
  "daft-core",
  "daft-dsl",
  "daft-io",

--- a/benchmarking/parquet/conftest.py
+++ b/benchmarking/parquet/conftest.py
@@ -48,6 +48,7 @@ def daft_native_read(path: str, columns: list[str] | None = None) -> pa.Table:
 def daft_native_read_to_arrow(path: str, columns: list[str] | None = None) -> pa.Table:
     return daft.table.read_parquet_into_pyarrow(path, columns=columns)
 
+
 def daft_dataframe_read(path: str, columns: list[str] | None = None) -> pa.Table:
     df = daft.read_parquet(path)
     if columns is not None:

--- a/benchmarking/parquet/conftest.py
+++ b/benchmarking/parquet/conftest.py
@@ -48,6 +48,12 @@ def daft_native_read(path: str, columns: list[str] | None = None) -> pa.Table:
 def daft_native_read_to_arrow(path: str, columns: list[str] | None = None) -> pa.Table:
     return daft.table.read_parquet_into_pyarrow(path, columns=columns)
 
+def daft_dataframe_read(path: str, columns: list[str] | None = None) -> pa.Table:
+    df = daft.read_parquet(path)
+    if columns is not None:
+        df = df.select(*columns)
+    return df.to_arrow()
+
 
 @pytest.fixture(
     params=[
@@ -55,12 +61,14 @@ def daft_native_read_to_arrow(path: str, columns: list[str] | None = None) -> pa
         daft_native_read_to_arrow,
         pyarrow_read,
         boto3_get_object_read,
+        daft_dataframe_read,
     ],
     ids=[
         "daft_native_read",
         "daft_native_read_to_arrow",
         "pyarrow",
         "boto3_get_object",
+        "daft_dataframe_read",
     ],
 )
 def read_fn(request):

--- a/src/daft-parquet/Cargo.toml
+++ b/src/daft-parquet/Cargo.toml
@@ -6,7 +6,6 @@ bytes = {workspace = true}
 common-arrow-ffi = {path = "../common/arrow-ffi", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-runtime = {path = "../common/runtime", default-features = false}
-crossbeam-channel = "0.5.1"
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-io = {path = "../daft-io", default-features = false}

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -1,10 +1,13 @@
 use std::{
+    cmp::max,
     collections::{BTreeMap, HashSet},
+    num::NonZeroUsize,
     sync::Arc,
 };
 
 use arrow2::io::parquet::read::{column_iter_to_arrays, schema::infer_schema_with_options};
 use common_error::DaftResult;
+use common_runtime::get_compute_runtime;
 use daft_core::{prelude::*, utils::arrow::cast_array_for_daft_if_needed};
 use daft_dsl::ExprRef;
 use daft_io::{IOClient, IOStatsRef};
@@ -17,13 +20,14 @@ use parquet2::{
     FallibleStreamingIterator,
 };
 use snafu::ResultExt;
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::{
     metadata::read_parquet_metadata,
     read::ParquetSchemaInferenceOptions,
     read_planner::{CoalescePass, RangesContainer, ReadPlanner, SplitLargeRequestPass},
     statistics,
-    stream_reader::arrow_column_iters_to_table_iter,
+    stream_reader::spawn_column_iters_to_table_task,
     JoinSnafu, OneShotRecvSnafu, UnableToConvertRowGroupMetadataToStatsSnafu,
     UnableToConvertSchemaToDaftSnafu, UnableToCreateParquetPageStreamSnafu,
     UnableToParseSchemaFromMetadataSnafu, UnableToRunExpressionOnStatsSnafu,
@@ -403,159 +407,162 @@ impl ParquetFileReader {
             self.arrow_schema.as_ref(),
         )?);
 
-        let chunk_size = self.chunk_size.unwrap_or(Self::DEFAULT_CHUNK_SIZE);
+        // We use a semaphore to limit the number of concurrent row group deserialization tasks.
+        // Set the maximum number of concurrent tasks to ceil(number of available threads / columns).
+        let num_parallel_tasks = (std::thread::available_parallelism()
+            .unwrap_or(NonZeroUsize::new(2).unwrap())
+            .checked_mul(2.try_into().unwrap())
+            .unwrap()
+            .get() as f64
+            / max(daft_schema.fields.len(), 1) as f64)
+            .ceil() as usize;
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(num_parallel_tasks));
+
         let (senders, receivers): (Vec<_>, Vec<_>) = self
             .row_ranges
             .iter()
-            .map(|rg_range| {
-                let expected_num_chunks =
-                    f32::ceil(rg_range.num_rows as f32 / chunk_size as f32) as usize;
-                crossbeam_channel::bounded(expected_num_chunks)
-            })
+            .map(|_| tokio::sync::mpsc::channel(1))
             .unzip();
 
-        let table_iter_handles =
-            self.row_ranges
-                .iter()
-                .zip(senders.into_iter())
-                .map(|(row_range, sender)| {
-                    let uri = self.uri.clone();
-                    let metadata = self.metadata.clone();
-                    let arrow_schema = self.arrow_schema.clone();
-                    let daft_schema = daft_schema.clone();
-                    let ranges = ranges.clone();
-                    let predicate = predicate.clone();
-                    let original_columns = original_columns.clone();
-                    let delete_rows = delete_rows.clone();
-                    let row_range = *row_range;
-
-                    tokio::task::spawn(async move {
-                        let arr_iter_handles = arrow_schema.fields.iter().map(|field| {
-                            let rt_handle = tokio::runtime::Handle::current();
-                            let ranges = ranges.clone();
-                            let uri = uri.clone();
-                            let field = field.clone();
-                            let metadata = metadata.clone();
-
-                            tokio::task::spawn(async move {
-                                let rg = metadata
-                                    .row_groups
-                                    .get(&row_range.row_group_index)
-                                    .expect("Row Group index should be in bounds");
-                                let num_rows =
-                                    rg.num_rows().min(row_range.start + row_range.num_rows);
-                                let chunk_size =
-                                    self.chunk_size.unwrap_or(Self::DEFAULT_CHUNK_SIZE);
-                                let filtered_columns = rg
-                                    .columns()
-                                    .iter()
-                                    .filter(|x| x.descriptor().path_in_schema[0] == field.name)
-                                    .collect::<Vec<_>>();
-                                let mut decompressed_iters =
-                                    Vec::with_capacity(filtered_columns.len());
-                                let mut ptypes = Vec::with_capacity(filtered_columns.len());
-                                let mut num_values = Vec::with_capacity(filtered_columns.len());
-                                for col in filtered_columns {
-                                    num_values.push(col.metadata().num_values as usize);
-                                    ptypes.push(col.descriptor().descriptor.primitive_type.clone());
-
-                                    let byte_range = {
-                                        let (start, len) = col.byte_range();
-                                        let end: u64 = start + len;
-                                        start as usize..end as usize
-                                    };
-                                    let range_reader =
-                                        Box::pin(ranges.get_range_reader(byte_range).await?);
-                                    let compressed_page_stream =
-                                        get_owned_page_stream_from_column_start(
-                                            col,
-                                            range_reader,
-                                            vec![],
-                                            Arc::new(|_, _| true),
-                                            Self::MAX_PAGE_SIZE,
-                                        )
-                                        .with_context(
-                                            |_| UnableToCreateParquetPageStreamSnafu::<String> {
-                                                path: uri.clone(),
-                                            },
-                                        )?;
-                                    let page_stream =
-                                        streaming_decompression(compressed_page_stream);
-                                    let pinned_stream = Box::pin(page_stream);
-                                    decompressed_iters.push(StreamIterator::new(
-                                        pinned_stream,
-                                        rt_handle.clone(),
-                                    ));
-                                }
-                                let arr_iter = column_iter_to_arrays(
-                                    decompressed_iters,
-                                    ptypes.iter().collect(),
-                                    field,
-                                    Some(chunk_size),
-                                    num_rows,
-                                    num_values,
-                                )?;
-                                Ok(arr_iter)
-                            })
-                        });
-
-                        let arr_iters = try_join_all(arr_iter_handles)
-                            .await
-                            .context(JoinSnafu { path: uri.clone() })?
-                            .into_iter()
-                            .collect::<DaftResult<Vec<_>>>()?;
-
-                        rayon::spawn(move || {
-                            // Even if there are no columns to read, we still need to create a empty table with the correct number of rows
-                            // This is because the columns may be present in other files. See https://github.com/Eventual-Inc/Daft/pull/2514
-                            let table_iter = arrow_column_iters_to_table_iter(
-                                arr_iters,
-                                row_range.start,
-                                daft_schema.clone(),
-                                uri,
-                                predicate,
-                                original_columns,
-                                original_num_rows,
-                                delete_rows,
-                            );
-                            if table_iter.is_none() {
-                                let table =
-                                    Table::new_with_size(daft_schema, vec![], row_range.num_rows);
-                                if let Err(crossbeam_channel::TrySendError::Full(_)) =
-                                    sender.try_send(table)
-                                {
-                                    panic!("Parquet stream channel should not be full")
-                                }
-                                return;
-                            }
-                            for table_result in table_iter.unwrap() {
-                                let is_err = table_result.is_err();
-                                if let Err(crossbeam_channel::TrySendError::Full(_)) =
-                                    sender.try_send(table_result)
-                                {
-                                    panic!("Parquet stream channel should not be full")
-                                }
-                                if is_err {
-                                    break;
-                                }
-                            }
-                        });
-                        Ok(())
-                    })
-                });
-
-        let _ = try_join_all(table_iter_handles)
-            .await
-            .context(JoinSnafu { path: self.uri })?
+        let uri = self.uri.clone();
+        let chunk_iter_handles = <Vec<RowGroupRange> as Clone>::clone(&self.row_ranges)
             .into_iter()
-            .collect::<DaftResult<Vec<_>>>()?;
+            .map(move |row_range| {
+                let metadata = self.metadata.clone();
+                let arrow_schema = self.arrow_schema.clone();
+                let ranges = ranges.clone();
+                let uri = uri.clone();
 
-        let combined_stream =
-            futures::stream::iter(receivers.into_iter().map(futures::stream::iter));
-        match maintain_order {
-            true => Ok(Box::pin(combined_stream.flatten())),
-            false => Ok(Box::pin(combined_stream.flatten_unordered(None))),
-        }
+                let chunk_iter_task = tokio::task::spawn(async move {
+                    let arr_iter_handles = arrow_schema.fields.iter().map(|field| {
+                        let rt_handle = tokio::runtime::Handle::current();
+                        let ranges = ranges.clone();
+                        let uri = uri.clone();
+                        let field = field.clone();
+                        let metadata = metadata.clone();
+
+                        tokio::task::spawn(async move {
+                            let rg = metadata
+                                .row_groups
+                                .get(&row_range.row_group_index)
+                                .expect("Row Group index should be in bounds");
+                            let num_rows = rg.num_rows().min(row_range.start + row_range.num_rows);
+                            let chunk_size = self.chunk_size.unwrap_or(Self::DEFAULT_CHUNK_SIZE);
+                            let filtered_columns = rg
+                                .columns()
+                                .iter()
+                                .filter(|x| x.descriptor().path_in_schema[0] == field.name)
+                                .collect::<Vec<_>>();
+                            let mut decompressed_iters = Vec::with_capacity(filtered_columns.len());
+                            let mut ptypes = Vec::with_capacity(filtered_columns.len());
+                            let mut num_values = Vec::with_capacity(filtered_columns.len());
+                            for col in filtered_columns {
+                                num_values.push(col.metadata().num_values as usize);
+                                ptypes.push(col.descriptor().descriptor.primitive_type.clone());
+
+                                let byte_range = {
+                                    let (start, len) = col.byte_range();
+                                    let end: u64 = start + len;
+                                    start as usize..end as usize
+                                };
+                                let range_reader =
+                                    Box::pin(ranges.get_range_reader(byte_range).await?);
+                                let compressed_page_stream =
+                                    get_owned_page_stream_from_column_start(
+                                        col,
+                                        range_reader,
+                                        vec![],
+                                        Arc::new(|_, _| true),
+                                        Self::MAX_PAGE_SIZE,
+                                    )
+                                    .with_context(|_| {
+                                        UnableToCreateParquetPageStreamSnafu::<String> {
+                                            path: uri.clone(),
+                                        }
+                                    })?;
+                                let page_stream = streaming_decompression(compressed_page_stream);
+                                let pinned_stream = Box::pin(page_stream);
+                                decompressed_iters
+                                    .push(StreamIterator::new(pinned_stream, rt_handle.clone()));
+                            }
+                            let arr_iter = column_iter_to_arrays(
+                                decompressed_iters,
+                                ptypes.iter().collect(),
+                                field,
+                                Some(chunk_size),
+                                num_rows,
+                                num_values,
+                            )?;
+                            Ok(arr_iter)
+                        })
+                    });
+
+                    let arr_iters = try_join_all(arr_iter_handles)
+                        .await
+                        .context(JoinSnafu { path: uri.clone() })?
+                        .into_iter()
+                        .collect::<DaftResult<Vec<_>>>()?;
+
+                    DaftResult::Ok(arr_iters)
+                });
+                (row_range, chunk_iter_task)
+            });
+
+        let compute_runtime = get_compute_runtime();
+        let uri = self.uri.clone();
+        let parquet_task = compute_runtime.spawn(async move {
+            let mut table_tasks = Vec::with_capacity(chunk_iter_handles.len());
+            for ((row_range, chunk_iter_handle), output_sender) in chunk_iter_handles.zip(senders) {
+                let chunk_iter = chunk_iter_handle
+                    .await
+                    .context(JoinSnafu { path: uri.clone() })??;
+
+                let permit = semaphore.clone().acquire_owned().await.unwrap();
+                let table_task = spawn_column_iters_to_table_task(
+                    chunk_iter,
+                    row_range,
+                    daft_schema.clone(),
+                    uri.clone(),
+                    predicate.clone(),
+                    original_columns.clone(),
+                    original_num_rows,
+                    delete_rows.clone(),
+                    output_sender,
+                    permit,
+                );
+                table_tasks.push(table_task);
+            }
+
+            try_join_all(table_tasks)
+                .await?
+                .into_iter()
+                .collect::<DaftResult<()>>()?;
+            DaftResult::Ok(())
+        });
+
+        let stream_of_streams =
+            futures::stream::iter(receivers.into_iter().map(ReceiverStream::new));
+        let flattened = match maintain_order {
+            true => stream_of_streams.flatten().boxed(),
+            false => stream_of_streams.flatten_unordered(None).boxed(),
+        };
+        let combined_stream = futures::stream::unfold(
+            (Some(parquet_task), flattened),
+            |(task, mut stream)| async move {
+                task.as_ref()?;
+                match stream.next().await {
+                    Some(v) => Some((v, (task, stream))),
+                    None => {
+                        if let Err(e) = task.unwrap().await {
+                            Some((Err(e), (None, stream)))
+                        } else {
+                            None
+                        }
+                    }
+                }
+            },
+        );
+        Ok(combined_stream.boxed())
     }
 
     pub async fn read_from_ranges_into_table(

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -63,7 +63,7 @@ fn streaming_decompression<S: futures::Stream<Item = parquet2::error::Result<Com
 
 pub struct StreamIterator<S> {
     curr: Option<Page>,
-    src: Arc<tokio::sync::Mutex<S>>,
+    src: tokio::sync::Mutex<S>,
     handle: tokio::runtime::Handle,
 }
 
@@ -74,7 +74,7 @@ where
     pub fn new(src: S, handle: tokio::runtime::Handle) -> Self {
         Self {
             curr: None,
-            src: Arc::new(tokio::sync::Mutex::new(src)),
+            src: tokio::sync::Mutex::new(src),
             handle,
         }
     }
@@ -87,11 +87,9 @@ where
     type Error = parquet2::error::Error;
     type Item = Page;
     fn advance(&mut self) -> Result<(), Self::Error> {
-        let handle = self.handle.clone();
-        let src = self.src.clone();
-        let val = tokio::task::block_in_place(move || {
-            handle.block_on(async {
-                let mut s_guard = src.lock().await;
+        let val = tokio::task::block_in_place(|| {
+            self.handle.block_on(async {
+                let mut s_guard = self.src.lock().await;
                 s_guard.next().await
             })
         });

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -62,7 +62,7 @@ fn streaming_decompression<S: futures::Stream<Item = parquet2::error::Result<Com
 
 pub struct StreamIterator<S> {
     curr: Option<Page>,
-    src: Arc<tokio::sync::Mutex<S>>,
+    src: tokio::sync::Mutex<S>,
     handle: tokio::runtime::Handle,
 }
 
@@ -73,7 +73,7 @@ where
     pub fn new(src: S, handle: tokio::runtime::Handle) -> Self {
         Self {
             curr: None,
-            src: Arc::new(tokio::sync::Mutex::new(src)),
+            src: tokio::sync::Mutex::new(src),
             handle,
         }
     }
@@ -86,13 +86,9 @@ where
     type Error = parquet2::error::Error;
     type Item = Page;
     fn advance(&mut self) -> Result<(), Self::Error> {
-        let handle = self.handle.clone();
-        let src = self.src.clone();
-        let val = tokio::task::block_in_place(move || {
-            handle.block_on(async {
-                let mut s_guard = src.lock().await;
-                s_guard.next().await
-            })
+        let val = self.handle.block_on(async {
+            let mut s_guard = self.src.lock().await;
+            s_guard.next().await
         });
         if let Some(val) = val {
             let val = val?;

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -511,9 +511,8 @@ impl ParquetFileReader {
             for ((row_range, chunk_iter_handle), output_sender) in chunk_iter_handles.zip(senders) {
                 // We want to ensure that the channel capacity can hold one morsel worth of data for better deserialization performance.
                 let channel_size = {
-                    let chunks_per_morsel =
-                        max((PARQUET_MORSEL_SIZE + chunk_size - 1) / chunk_size, 1);
-                    let max_num_chunks = max((row_range.num_rows + chunk_size - 1) / chunk_size, 1);
+                    let chunks_per_morsel = max(PARQUET_MORSEL_SIZE / chunk_size, 1);
+                    let max_num_chunks = max(row_range.num_rows / chunk_size, 1);
                     min(chunks_per_morsel, max_num_chunks)
                 };
 

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -27,14 +27,13 @@ const PARQUET_MORSEL_SIZE: usize = 128 * 1024;
 // It is calculated by taking 2x the number of cores available (to ensure pipelining), and dividing
 // by the number of columns in the schema.
 fn determine_parquet_parallelism(daft_schema: &SchemaRef) -> usize {
-    let num_parallel_tasks = (std::thread::available_parallelism()
+    (std::thread::available_parallelism()
         .unwrap_or(NonZeroUsize::new(2).unwrap())
         .checked_mul(2.try_into().unwrap())
         .unwrap()
         .get() as f64
         / max(daft_schema.fields.len(), 1) as f64)
-        .ceil() as usize;
-    num_parallel_tasks
+        .ceil() as usize
 }
 
 #[derive(Debug, Snafu)]

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -17,6 +17,8 @@ mod statistics;
 pub use statistics::row_group_metadata_to_table_stats;
 mod read_planner;
 mod stream_reader;
+mod utils;
+
 #[cfg(feature = "python")]
 pub use python::register_modules;
 

--- a/src/daft-parquet/src/stream_reader.rs
+++ b/src/daft-parquet/src/stream_reader.rs
@@ -1,5 +1,9 @@
 use std::{
-    cmp::max, collections::HashSet, fs::File, io::{Read, Seek}, sync::Arc
+    cmp::max,
+    collections::HashSet,
+    fs::File,
+    io::{Read, Seek},
+    sync::Arc,
 };
 
 use arrow2::{bitmap::Bitmap, io::parquet::read};

--- a/src/daft-parquet/src/stream_reader.rs
+++ b/src/daft-parquet/src/stream_reader.rs
@@ -1,8 +1,5 @@
 use std::{
-    collections::HashSet,
-    fs::File,
-    io::{Read, Seek},
-    sync::Arc,
+    cmp::max, collections::HashSet, fs::File, io::{Read, Seek}, sync::Arc
 };
 
 use arrow2::{bitmap::Bitmap, io::parquet::read};
@@ -647,7 +644,7 @@ pub async fn local_parquet_stream(
                 delete_rows.clone(),
                 sender,
                 permit,
-                1,
+                max(PARQUET_MORSEL_SIZE / chunk_size, 1),
             );
             table_tasks.push(table_task);
         }

--- a/src/daft-parquet/src/utils.rs
+++ b/src/daft-parquet/src/utils.rs
@@ -1,0 +1,26 @@
+use std::future::Future;
+
+use futures::{Stream, StreamExt};
+
+// Helper function to combine a stream with a future that returns a result
+pub(crate) fn combine_stream<T, E>(
+    stream: impl Stream<Item = Result<T, E>> + Unpin,
+    future: impl Future<Output = Result<Result<(), E>, E>>,
+) -> impl Stream<Item = Result<T, E>> {
+    use futures::stream::unfold;
+
+    let initial_state = (Some(future), stream);
+
+    unfold(initial_state, |(future, mut stream)| async move {
+        future.as_ref()?;
+
+        match stream.next().await {
+            Some(item) => Some((item, (future, stream))),
+            None => match future.unwrap().await {
+                Err(error) => Some((Err(error), (None, stream))),
+                Ok(Err(error)) => Some((Err(error), (None, stream))),
+                Ok(Ok(())) => None,
+            },
+        }
+    })
+}


### PR DESCRIPTION
Implement a parallelism cap on remote parquet tasks, and use compute runtime instead of rayon (swordfish reads only). Follow on from https://github.com/Eventual-Inc/Daft/pull/3310 which implemented it for local.

Benchmarks in comments below