### PR TITLE
[FEAT] connect: remove excessive warnings from spark connect

### DIFF
--- a/src/daft-connect/src/translation/expr.rs
+++ b/src/daft-connect/src/translation/expr.rs
@@ -18,7 +18,9 @@ mod unresolved_function;
 
 pub fn to_daft_expr(expression: &Expression) -> eyre::Result<daft_dsl::ExprRef> {
     if let Some(common) = &expression.common {
-        warn!("Ignoring common metadata for relation: {common:?}; not yet implemented");
+        if common.origin.is_some() {
+            warn!("Ignoring common metadata for relation: {common:?}; not yet implemented");
+        }
     };
 
     let Some(expr) = &expression.expr_type else {

--- a/src/daft-connect/src/translation/logical_plan.rs
+++ b/src/daft-connect/src/translation/logical_plan.rs
@@ -36,7 +36,9 @@ impl From<LogicalPlanBuilder> for Plan {
 
 pub fn to_logical_plan(relation: Relation) -> eyre::Result<Plan> {
     if let Some(common) = relation.common {
-        warn!("Ignoring common metadata for relation: {common:?}; not yet implemented");
+        if common.origin.is_some() {
+            warn!("Ignoring common metadata for relation: {common:?}; not yet implemented");
+        }
     };
 
     let Some(rel_type) = relation.rel_type else {

--- a/src/daft-connect/src/translation/schema.rs
+++ b/src/daft-connect/src/translation/schema.rs
@@ -8,8 +8,10 @@ use crate::translation::{to_logical_plan, to_spark_datatype};
 
 #[tracing::instrument(skip_all)]
 pub fn relation_to_schema(input: Relation) -> eyre::Result<DataType> {
-    if input.common.is_some() {
-        warn!("We do not currently look at common fields");
+    if let Some(common) = &input.common {
+        if common.origin.is_some() {
+            warn!("Ignoring common metadata for relation: {common:?}; not yet implemented");
+        }
     }
 
     let plan = to_logical_plan(input)?;


### PR DESCRIPTION
it seems that the `common` is **always** set, producing the warning for every single operation when using spark connect. This changes it so that it'll only warn if `common.origin` is set. 