### PR TITLE
fix(run-cluster-workflow): Add null check when parsing metadata

### DIFF
--- a/.github/ci-scripts/templatize_ray_config.py
+++ b/.github/ci-scripts/templatize_ray_config.py
@@ -106,8 +106,9 @@ if __name__ == "__main__":
     entrypoint_script_fullpath: Path = working_dir / args.entrypoint_script
     assert entrypoint_script_fullpath.exists() and entrypoint_script_fullpath.is_file()
     with open(entrypoint_script_fullpath) as f:
-        metadata = Metadata(**read_inline_metadata.read(f.read()))
-
-    content = content.replace(OTHER_INSTALL_PLACEHOLDER, " ".join(metadata.dependencies))
+        metadata = read_inline_metadata.read(f.read())
+        if metadata:
+            metadata = Metadata(**metadata)
+            content = content.replace(OTHER_INSTALL_PLACEHOLDER, " ".join(metadata.dependencies))
 
     print(content)


### PR DESCRIPTION
# Overview
When parsing a python script's inline metadata, add a null-check if the file contains no metadata.