### PR TITLE
refactor: create a rust based `PartitionSet` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2364,6 +2364,7 @@ dependencies = [
  "daft-scan",
  "daft-stats",
  "daft-table",
+ "futures",
  "parquet2",
  "pyo3",
  "snafu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,7 +1989,6 @@ dependencies = [
  "daft-schema",
  "daft-table",
  "dashmap",
- "derive_more",
  "eyre",
  "futures",
  "itertools 0.11.0",

--- a/src/daft-connect/Cargo.toml
+++ b/src/daft-connect/Cargo.toml
@@ -12,7 +12,6 @@ daft-scan = {workspace = true}
 daft-schema = {workspace = true}
 daft-table = {workspace = true}
 dashmap = "6.1.0"
-derive_more = {workspace = true}
 eyre = "0.6.12"
 futures = "0.3.31"
 itertools = {workspace = true}

--- a/src/daft-connect/src/translation/logical_plan.rs
+++ b/src/daft-connect/src/translation/logical_plan.rs
@@ -1,8 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use daft_logical_plan::LogicalPlanBuilder;
-use daft_micropartition::MicroPartition;
-use derive_more::Constructor;
+use daft_micropartition::partitioning::{LocalPartitionSet, PartitionSet};
 use eyre::{bail, Context};
 use spark_connect::{relation::RelType, Limit, Relation};
 use tracing::warn;
@@ -19,17 +18,25 @@ mod range;
 mod to_df;
 mod with_columns;
 
-#[derive(Constructor)]
 pub struct Plan {
     pub builder: LogicalPlanBuilder,
-    pub psets: HashMap<String, Vec<Arc<MicroPartition>>>,
+    pub psets: Arc<dyn PartitionSet>,
+}
+
+impl Plan {
+    pub fn new(builder: LogicalPlanBuilder) -> Self {
+        Self {
+            builder,
+            psets: Arc::new(LocalPartitionSet::default()),
+        }
+    }
 }
 
 impl From<LogicalPlanBuilder> for Plan {
     fn from(builder: LogicalPlanBuilder) -> Self {
         Self {
             builder,
-            psets: HashMap::new(),
+            psets: Arc::new(LocalPartitionSet::default()),
         }
     }
 }

--- a/src/daft-connect/src/translation/logical_plan.rs
+++ b/src/daft-connect/src/translation/logical_plan.rs
@@ -1,7 +1,5 @@
-use std::sync::Arc;
-
 use daft_logical_plan::LogicalPlanBuilder;
-use daft_micropartition::partitioning::{InMemoryPartitionSet, PartitionSet};
+use daft_micropartition::partitioning::InMemoryPartitionSet;
 use eyre::{bail, Context};
 use spark_connect::{relation::RelType, Limit, Relation};
 use tracing::warn;
@@ -20,14 +18,14 @@ mod with_columns;
 
 pub struct Plan {
     pub builder: LogicalPlanBuilder,
-    pub psets: Arc<dyn PartitionSet>,
+    pub psets: InMemoryPartitionSet,
 }
 
 impl Plan {
     pub fn new(builder: LogicalPlanBuilder) -> Self {
         Self {
             builder,
-            psets: Arc::new(InMemoryPartitionSet::default()),
+            psets: InMemoryPartitionSet::default(),
         }
     }
 }
@@ -36,7 +34,7 @@ impl From<LogicalPlanBuilder> for Plan {
     fn from(builder: LogicalPlanBuilder) -> Self {
         Self {
             builder,
-            psets: Arc::new(InMemoryPartitionSet::default()),
+            psets: InMemoryPartitionSet::default(),
         }
     }
 }

--- a/src/daft-connect/src/translation/logical_plan.rs
+++ b/src/daft-connect/src/translation/logical_plan.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use daft_logical_plan::LogicalPlanBuilder;
-use daft_micropartition::partitioning::{LocalPartitionSet, PartitionSet};
+use daft_micropartition::partitioning::{InMemoryPartitionSet, PartitionSet};
 use eyre::{bail, Context};
 use spark_connect::{relation::RelType, Limit, Relation};
 use tracing::warn;
@@ -27,7 +27,7 @@ impl Plan {
     pub fn new(builder: LogicalPlanBuilder) -> Self {
         Self {
             builder,
-            psets: Arc::new(LocalPartitionSet::default()),
+            psets: Arc::new(InMemoryPartitionSet::default()),
         }
     }
 }
@@ -36,7 +36,7 @@ impl From<LogicalPlanBuilder> for Plan {
     fn from(builder: LogicalPlanBuilder) -> Self {
         Self {
             builder,
-            psets: Arc::new(LocalPartitionSet::default()),
+            psets: Arc::new(InMemoryPartitionSet::default()),
         }
     }
 }

--- a/src/daft-connect/src/translation/logical_plan/local_relation.rs
+++ b/src/daft-connect/src/translation/logical_plan/local_relation.rs
@@ -9,7 +9,7 @@ use daft_logical_plan::{
     logical_plan::Source, InMemoryInfo, LogicalPlan, LogicalPlanBuilder, PyLogicalPlanBuilder,
     SourceInfo,
 };
-use daft_micropartition::partitioning::LocalPartitionSet;
+use daft_micropartition::partitioning::InMemoryPartitionSet;
 use daft_schema::dtype::DaftDataType;
 use daft_table::Table;
 use eyre::{bail, ensure, WrapErr};
@@ -183,7 +183,7 @@ pub fn local_relation(plan: spark_connect::LocalRelation) -> eyre::Result<Plan> 
 
         let plan = Plan {
             builder: plan,
-            psets: Arc::new(LocalPartitionSet::new(psets)),
+            psets: Arc::new(InMemoryPartitionSet::new(psets)),
         };
 
         Ok(plan)

--- a/src/daft-connect/src/translation/logical_plan/local_relation.rs
+++ b/src/daft-connect/src/translation/logical_plan/local_relation.rs
@@ -183,7 +183,7 @@ pub fn local_relation(plan: spark_connect::LocalRelation) -> eyre::Result<Plan> 
 
         let plan = Plan {
             builder: plan,
-            psets: Arc::new(InMemoryPartitionSet::new(psets)),
+            psets: InMemoryPartitionSet::new(psets),
         };
 
         Ok(plan)

--- a/src/daft-connect/src/translation/logical_plan/local_relation.rs
+++ b/src/daft-connect/src/translation/logical_plan/local_relation.rs
@@ -9,6 +9,7 @@ use daft_logical_plan::{
     logical_plan::Source, InMemoryInfo, LogicalPlan, LogicalPlanBuilder, PyLogicalPlanBuilder,
     SourceInfo,
 };
+use daft_micropartition::partitioning::LocalPartitionSet;
 use daft_schema::dtype::DaftDataType;
 use daft_table::Table;
 use eyre::{bail, ensure, WrapErr};
@@ -180,7 +181,10 @@ pub fn local_relation(plan: spark_connect::LocalRelation) -> eyre::Result<Plan> 
         let mut psets = HashMap::new();
         psets.insert(cache_key, vec![micro_partition]);
 
-        let plan = Plan::new(plan, psets);
+        let plan = Plan {
+            builder: plan,
+            psets: Arc::new(LocalPartitionSet::new(psets)),
+        };
 
         Ok(plan)
     }

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -75,7 +75,7 @@ pub fn viz_pipeline(root: &dyn PipelineNode) -> String {
 
 pub fn physical_plan_to_pipeline(
     physical_plan: &LocalPhysicalPlan,
-    psets: &dyn PartitionSet,
+    psets: &(impl PartitionSet + ?Sized),
     cfg: &Arc<DaftExecutionConfig>,
 ) -> crate::Result<Box<dyn PipelineNode>> {
     use daft_local_plan::PhysicalScan;

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -102,10 +102,10 @@ pub fn physical_plan_to_pipeline(
             scan_task_source.arced().into()
         }
         LocalPhysicalPlan::InMemoryScan(InMemoryScan { info, .. }) => {
-            let partitions = psets
+            let materialized_pset = psets
                 .get_partition(&info.cache_key)
                 .unwrap_or_else(|_| panic!("Cache key not found: {:?}", info.cache_key));
-            InMemorySource::new(partitions.micropartitions(), info.source_schema.clone())
+            InMemorySource::new(materialized_pset, info.source_schema.clone())
                 .arced()
                 .into()
         }

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -12,7 +12,7 @@ use common_tracing::refresh_chrome_trace;
 use daft_local_plan::{translate, LocalPhysicalPlan};
 use daft_logical_plan::LogicalPlanBuilder;
 use daft_micropartition::{
-    partitioning::{LocalPartitionSet, PartitionSet},
+    partitioning::{InMemoryPartitionSet, PartitionSet},
     MicroPartition,
 };
 use futures::{FutureExt, Stream};
@@ -92,7 +92,7 @@ impl PyNativeExecutor {
                 )
             })
             .collect();
-        let psets = Arc::new(LocalPartitionSet::new(native_psets));
+        let psets = Arc::new(InMemoryPartitionSet::new(native_psets));
         let out = py.allow_threads(|| {
             self.executor
                 .run(psets, cfg.config, results_buffer_size)

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -11,7 +11,10 @@ use common_error::DaftResult;
 use common_tracing::refresh_chrome_trace;
 use daft_local_plan::{translate, LocalPhysicalPlan};
 use daft_logical_plan::LogicalPlanBuilder;
-use daft_micropartition::MicroPartition;
+use daft_micropartition::{
+    partitioning::{LocalPartitionSet, PartitionSet},
+    MicroPartition,
+};
 use futures::{FutureExt, Stream};
 use loole::RecvFuture;
 use tokio_util::sync::CancellationToken;
@@ -89,9 +92,10 @@ impl PyNativeExecutor {
                 )
             })
             .collect();
+        let psets = Arc::new(LocalPartitionSet::new(native_psets));
         let out = py.allow_threads(|| {
             self.executor
-                .run(native_psets, cfg.config, results_buffer_size)
+                .run(psets, cfg.config, results_buffer_size)
                 .map(|res| res.into_iter())
         })?;
         let iter = Box::new(out.map(|part| {
@@ -121,7 +125,7 @@ impl NativeExecutor {
 
     pub fn run(
         &self,
-        psets: HashMap<String, Vec<Arc<MicroPartition>>>,
+        psets: Arc<dyn PartitionSet>,
         cfg: Arc<DaftExecutionConfig>,
         results_buffer_size: Option<usize>,
     ) -> DaftResult<ExecutionEngineResult> {
@@ -246,13 +250,13 @@ impl IntoIterator for ExecutionEngineResult {
 
 pub fn run_local(
     physical_plan: &LocalPhysicalPlan,
-    psets: HashMap<String, Vec<Arc<MicroPartition>>>,
+    psets: Arc<dyn PartitionSet>,
     cfg: Arc<DaftExecutionConfig>,
     results_buffer_size: Option<usize>,
     cancel: CancellationToken,
 ) -> DaftResult<ExecutionEngineResult> {
     refresh_chrome_trace();
-    let pipeline = physical_plan_to_pipeline(physical_plan, &psets, &cfg)?;
+    let pipeline = physical_plan_to_pipeline(physical_plan, psets.as_ref(), &cfg)?;
     let (tx, rx) = create_channel(results_buffer_size.unwrap_or(1));
     let handle = std::thread::spawn(move || {
         let runtime = tokio::runtime::Builder::new_current_thread()

--- a/src/daft-local-execution/src/sources/in_memory.rs
+++ b/src/daft-local-execution/src/sources/in_memory.rs
@@ -4,19 +4,19 @@ use async_trait::async_trait;
 use common_error::DaftResult;
 use daft_core::prelude::SchemaRef;
 use daft_io::IOStatsRef;
-use daft_micropartition::partitioning::MaterializedPartitionSetRef;
+use daft_micropartition::partitioning::PartitionBatchRef;
 use tracing::instrument;
 
 use super::source::Source;
 use crate::sources::source::SourceStream;
 
 pub struct InMemorySource {
-    data: MaterializedPartitionSetRef,
+    data: PartitionBatchRef,
     schema: SchemaRef,
 }
 
 impl InMemorySource {
-    pub fn new(data: MaterializedPartitionSetRef, schema: SchemaRef) -> Self {
+    pub fn new(data: PartitionBatchRef, schema: SchemaRef) -> Self {
         Self { data, schema }
     }
     pub fn arced(self) -> Arc<dyn Source> {
@@ -32,9 +32,7 @@ impl Source for InMemorySource {
         _maintain_order: bool,
         _io_stats: IOStatsRef,
     ) -> DaftResult<SourceStream<'static>> {
-        Ok(Box::pin(futures::stream::iter(
-            self.data.micropartitions().into_iter().map(Ok),
-        )))
+        Ok(self.data.clone().into_partition_stream())
     }
     fn name(&self) -> &'static str {
         "InMemory"

--- a/src/daft-local-execution/src/sources/in_memory.rs
+++ b/src/daft-local-execution/src/sources/in_memory.rs
@@ -4,19 +4,19 @@ use async_trait::async_trait;
 use common_error::DaftResult;
 use daft_core::prelude::SchemaRef;
 use daft_io::IOStatsRef;
-use daft_micropartition::MicroPartition;
+use daft_micropartition::partitioning::MaterializedPartitionSetRef;
 use tracing::instrument;
 
 use super::source::Source;
 use crate::sources::source::SourceStream;
 
 pub struct InMemorySource {
-    data: Vec<Arc<MicroPartition>>,
+    data: MaterializedPartitionSetRef,
     schema: SchemaRef,
 }
 
 impl InMemorySource {
-    pub fn new(data: Vec<Arc<MicroPartition>>, schema: SchemaRef) -> Self {
+    pub fn new(data: MaterializedPartitionSetRef, schema: SchemaRef) -> Self {
         Self { data, schema }
     }
     pub fn arced(self) -> Arc<dyn Source> {
@@ -33,7 +33,7 @@ impl Source for InMemorySource {
         _io_stats: IOStatsRef,
     ) -> DaftResult<SourceStream<'static>> {
         Ok(Box::pin(futures::stream::iter(
-            self.data.clone().into_iter().map(Ok),
+            self.data.micropartitions().into_iter().map(Ok),
         )))
     }
     fn name(&self) -> &'static str {

--- a/src/daft-micropartition/Cargo.toml
+++ b/src/daft-micropartition/Cargo.toml
@@ -14,6 +14,7 @@ daft-parquet = {path = "../daft-parquet", default-features = false}
 daft-scan = {path = "../daft-scan", default-features = false}
 daft-stats = {path = "../daft-stats", default-features = false}
 daft-table = {path = "../daft-table", default-features = false}
+futures = {workspace = true}
 parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 snafu = {workspace = true}

--- a/src/daft-micropartition/src/lib.rs
+++ b/src/daft-micropartition/src/lib.rs
@@ -16,6 +16,8 @@ use pyo3::PyErr;
 #[cfg(feature = "python")]
 pub use python::register_modules;
 
+pub mod partitioning;
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display("DaftCoreComputeError: {}", source))]

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -630,10 +630,12 @@ impl MicroPartition {
             TableState::Loaded(tables) => Ok(tables.clone()),
         }
     }
+
     pub fn get_tables(&self) -> crate::Result<Arc<Vec<Table>>> {
         let tables = self.tables_or_read(IOStatsContext::new("get tables"))?;
         Ok(tables)
     }
+
     pub fn concat_or_get(&self, io_stats: IOStatsRef) -> crate::Result<Arc<Vec<Table>>> {
         let tables = self.tables_or_read(io_stats)?;
         if tables.len() <= 1 {

--- a/src/daft-micropartition/src/partitioning.rs
+++ b/src/daft-micropartition/src/partitioning.rs
@@ -7,12 +7,16 @@ use futures::stream::BoxStream;
 use crate::MicroPartition;
 type PartitionId = String;
 
+/// ported over from `daft/runners/partitioning.py`
+// TODO: port over the rest of the functionality
 #[derive(Debug, Clone)]
 pub struct Boundaries {
     pub sort_by: Vec<Expr>,
     pub bounds: Arc<MicroPartition>,
 }
 
+/// ported over from `daft/runners/partitioning.py`
+// TODO: port over the rest of the functionality
 #[derive(Debug, Clone)]
 pub struct PartitionMetadata {
     pub num_rows: usize,

--- a/src/daft-micropartition/src/partitioning.rs
+++ b/src/daft-micropartition/src/partitioning.rs
@@ -1,0 +1,198 @@
+use std::{any::Any, collections::HashMap, sync::Arc};
+
+use common_error::{DaftError, DaftResult};
+use daft_dsl::Expr;
+
+use crate::MicroPartition;
+type PartId = String;
+
+#[derive(Debug, Clone)]
+pub struct Boundaries {
+    pub sort_by: Vec<Expr>,
+    pub bounds: Arc<MicroPartition>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PartitionMetadata {
+    pub num_rows: usize,
+    pub size_bytes: usize,
+    pub boundaries: Option<Boundaries>,
+}
+
+impl PartitionMetadata {
+    pub fn from_micro_partition(mp: &MicroPartition) -> Self {
+        let num_rows = mp.len();
+        let size_bytes = mp.size_bytes().unwrap_or(None).unwrap_or(0);
+        Self {
+            num_rows,
+            size_bytes,
+            boundaries: None,
+        }
+    }
+}
+
+pub trait MaterializedResult<T> {
+    fn as_any(&self) -> &dyn Any;
+    fn partition(&self) -> T;
+    /// returns the result as a single micropartition.
+    fn micropartition(&self) -> Arc<MicroPartition>;
+    /// If the result has multiple micropartitions, returns all of them
+    fn micropartitions(&self) -> Vec<Arc<MicroPartition>> {
+        vec![self.micropartition()]
+    }
+    fn metadata(&self) -> PartitionMetadata;
+}
+
+#[derive(Debug, Clone)]
+pub struct LocalMaterializedResult {
+    pub partition: Vec<Arc<MicroPartition>>,
+    pub metadata: Option<PartitionMetadata>,
+}
+
+impl MaterializedResult<Vec<Arc<MicroPartition>>> for LocalMaterializedResult {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn partition(&self) -> Vec<Arc<MicroPartition>> {
+        self.partition.clone()
+    }
+
+    fn micropartition(&self) -> Arc<MicroPartition> {
+        Arc::new(MicroPartition::concat(self.partition.clone()).unwrap())
+    }
+    fn micropartitions(&self) -> Vec<Arc<MicroPartition>> {
+        self.partition.clone()
+    }
+
+    fn metadata(&self) -> PartitionMetadata {
+        if let Some(metadata) = &self.metadata {
+            metadata.clone()
+        } else {
+            PartitionMetadata::from_micro_partition(&self.partition[0])
+        }
+    }
+}
+
+type MaterializedPartitionSet = Arc<dyn MaterializedResult<Vec<Arc<MicroPartition>>>>;
+
+pub trait PartitionSet {
+    fn get_merged_micropartitions(&self) -> DaftResult<MicroPartition>;
+    fn get_preview_micropartitions(&self, num_rows: usize) -> DaftResult<Vec<Arc<MicroPartition>>>;
+    fn items(&self) -> DaftResult<Vec<(PartId, MaterializedPartitionSet)>>;
+    fn values(&self) -> DaftResult<Vec<MaterializedPartitionSet>> {
+        let items = self.items()?;
+        Ok(items.into_iter().map(|(_, mp)| mp).collect())
+    }
+
+    fn num_partitions(&self) -> usize;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool;
+    fn size_bytes(&self) -> DaftResult<usize>;
+    fn has_partition(&self, idx: &PartId) -> bool;
+    fn delete_partition(&mut self, idx: &PartId) -> DaftResult<()>;
+    fn set_partition(&mut self, idx: PartId, part: MaterializedPartitionSet) -> DaftResult<()>;
+    fn get_partition(&self, idx: &PartId) -> DaftResult<MaterializedPartitionSet>;
+}
+
+#[derive(Debug, Default)]
+pub struct LocalPartitionSet {
+    pub partitions: HashMap<String, Vec<Arc<MicroPartition>>>,
+}
+
+impl LocalPartitionSet {
+    pub fn new(psets: HashMap<String, Vec<Arc<MicroPartition>>>) -> Self {
+        Self { partitions: psets }
+    }
+}
+
+impl PartitionSet for LocalPartitionSet {
+    fn get_merged_micropartitions(&self) -> DaftResult<MicroPartition> {
+        let parts = self.values()?;
+        let parts = parts.into_iter().map(|mat_res| mat_res.micropartition());
+
+        MicroPartition::concat(parts)
+    }
+
+    fn get_preview_micropartitions(
+        &self,
+        mut num_rows: usize,
+    ) -> DaftResult<Vec<Arc<MicroPartition>>> {
+        let mut preview_parts = vec![];
+
+        for part in self.partitions.values().flatten() {
+            let part_len = part.len();
+            if part_len >= num_rows {
+                preview_parts.push(Arc::new(part.slice(0, num_rows)?));
+                break;
+            } else {
+                num_rows -= part_len;
+                preview_parts.push(part.clone());
+            }
+        }
+        Ok(preview_parts)
+    }
+
+    fn items(&self) -> DaftResult<Vec<(PartId, MaterializedPartitionSet)>> {
+        self.partitions
+            .iter()
+            .map(|(k, v)| {
+                let partition = LocalMaterializedResult {
+                    partition: v.clone(),
+                    metadata: None,
+                };
+
+                Ok((k.clone(), Arc::new(partition) as _))
+            })
+            .collect()
+    }
+
+    fn num_partitions(&self) -> usize {
+        self.partitions.len()
+    }
+
+    fn len(&self) -> usize {
+        self.partitions.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.partitions.is_empty()
+    }
+
+    fn size_bytes(&self) -> DaftResult<usize> {
+        let partitions = self.values()?;
+        let mut partitions = partitions.into_iter().map(|mp| mp.micropartition());
+        partitions.try_fold(0, |acc, mp| Ok(acc + mp.size_bytes()?.unwrap_or(0)))
+    }
+
+    fn has_partition(&self, partition_id: &PartId) -> bool {
+        self.partitions.contains_key(partition_id)
+    }
+
+    fn delete_partition(&mut self, partition_id: &PartId) -> DaftResult<()> {
+        self.partitions.remove(partition_id);
+        Ok(())
+    }
+
+    fn set_partition(
+        &mut self,
+        partition_id: PartId,
+        part: MaterializedPartitionSet,
+    ) -> DaftResult<()> {
+        let part = part.micropartitions();
+
+        self.partitions.insert(partition_id, part);
+        Ok(())
+    }
+
+    fn get_partition(&self, idx: &PartId) -> DaftResult<MaterializedPartitionSet> {
+        let part = self
+            .partitions
+            .get(idx)
+            .ok_or(DaftError::ValueError("Partition not found".to_string()))?;
+
+        Ok(Arc::new(LocalMaterializedResult {
+            partition: part.clone(),
+            metadata: None,
+        }))
+    }
+}

--- a/src/daft-micropartition/src/partitioning.rs
+++ b/src/daft-micropartition/src/partitioning.rs
@@ -75,7 +75,7 @@ impl PartitionBatch for InMemoryPartitionBatch {
     }
 }
 
-/// an arc'd reference to a partition batch
+/// an arc'd reference to a [`PartitionBatch`]
 pub type PartitionBatchRef = Arc<dyn PartitionBatch>;
 
 pub trait PartitionSet {
@@ -107,17 +107,17 @@ pub trait PartitionSet {
 }
 
 #[derive(Debug, Default)]
-pub struct LocalPartitionSet {
+pub struct InMemoryPartitionSet {
     pub partitions: HashMap<String, Vec<Arc<MicroPartition>>>,
 }
 
-impl LocalPartitionSet {
+impl InMemoryPartitionSet {
     pub fn new(psets: HashMap<String, Vec<Arc<MicroPartition>>>) -> Self {
         Self { partitions: psets }
     }
 }
 
-impl PartitionSet for LocalPartitionSet {
+impl PartitionSet for InMemoryPartitionSet {
     fn get_merged_micropartitions(&self) -> DaftResult<MicroPartition> {
         let parts = self.values()?;
         let parts = parts


### PR DESCRIPTION
most of this is ported from the python impl inside `daft/runners/partitioning.py`. 


### Note for reviewer. 

For context around why this is needed. The `DataFrame` class uses `PartitionSet` extensively for various common operations such as `show`, and `collect`. In order to add this functionality to our spark connect implementation, we need a similar construct in rust. 

Ideally, I'd like to port over the python implementation to use this new rust one, but there are still a few things that I'm not entirely sure how to implement (such as `RayPartitionSet`)

Not all of the methods inside `partitioning.rs` are used yet, But I intend to follow up this PR with an implementation for https://github.com/Eventual-Inc/Daft/issues/3498, and this is a prerequisite as `show` relies on `get_preview_micropartitions`. 