### PR TITLE
feat: support for basic subquery execution

### DIFF
--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -2,6 +2,8 @@
 mod tests;
 
 use std::{
+    any::Any,
+    hash::{DefaultHasher, Hash, Hasher},
     io::{self, Write},
     sync::Arc,
 };
@@ -38,8 +40,11 @@ use crate::{
 
 pub trait SubqueryPlan: std::fmt::Debug + std::fmt::Display + Send + Sync {
     fn as_any(&self) -> &dyn std::any::Any;
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
     fn name(&self) -> &'static str;
     fn schema(&self) -> SchemaRef;
+    fn dyn_eq(&self, other: &dyn SubqueryPlan) -> bool;
+    fn dyn_hash(&self, state: &mut dyn Hasher);
 }
 
 #[derive(Display, Debug, Clone)]
@@ -60,6 +65,14 @@ impl Subquery {
     pub fn name(&self) -> &'static str {
         self.plan.name()
     }
+
+    pub fn semantic_id(&self) -> FieldID {
+        let mut s = DefaultHasher::new();
+        self.hash(&mut s);
+        let hash = s.finish();
+
+        FieldID::new(format!("subquery({}-{})", self.name(), hash))
+    }
 }
 
 impl Serialize for Subquery {
@@ -76,7 +89,7 @@ impl<'de> Deserialize<'de> for Subquery {
 
 impl PartialEq for Subquery {
     fn eq(&self, other: &Self) -> bool {
-        self.plan.name() == other.plan.name() && self.plan.schema() == other.plan.schema()
+        self.plan.dyn_eq(other.plan.as_ref())
     }
 }
 
@@ -84,8 +97,7 @@ impl Eq for Subquery {}
 
 impl std::hash::Hash for Subquery {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.plan.name().hash(state);
-        self.plan.schema().hash(state);
+        self.plan.dyn_hash(state);
     }
 }
 
@@ -177,7 +189,7 @@ pub struct OuterReferenceColumn {
 
 impl Display for OuterReferenceColumn {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "outer_col({}, {})", self.field.name, self.depth)
+        write!(f, "outer_col({}, depth={})", self.field.name, self.depth)
     }
 }
 
@@ -744,10 +756,18 @@ impl Expr {
             // Agg: Separate path.
             Self::Agg(agg_expr) => agg_expr.semantic_id(schema),
             Self::ScalarFunction(sf) => scalar_function_semantic_id(sf, schema),
+            Self::Subquery(subquery) => subquery.semantic_id(),
+            Self::InSubquery(expr, subquery) => {
+                let child_id = expr.semantic_id(schema);
+                let subquery_id = subquery.semantic_id();
 
-            Self::Subquery(..) | Self::InSubquery(..) | Self::Exists(..) => {
-                FieldID::new("__subquery__")
-            } // todo: better/unique id
+                FieldID::new(format!("({child_id} IN {subquery_id})"))
+            }
+            Self::Exists(subquery) => {
+                let subquery_id = subquery.semantic_id();
+
+                FieldID::new(format!("(EXISTS {subquery_id})"))
+            }
             Self::OuterReferenceColumn(c) => {
                 let name = &c.field.name;
                 let depth = c.depth;

--- a/src/daft-logical-plan/src/optimization/optimizer.rs
+++ b/src/daft-logical-plan/src/optimization/optimizer.rs
@@ -6,9 +6,9 @@ use common_treenode::Transformed;
 use super::{
     logical_plan_tracker::LogicalPlanTracker,
     rules::{
-        DropRepartition, EliminateCrossJoin, EliminatePredicateSubquery, EliminateScalarSubquery,
-        EnrichWithStats, LiftProjectFromAgg, MaterializeScans, OptimizerRule, PushDownFilter,
-        PushDownLimit, PushDownProjection, SimplifyExpressionsRule, SplitActorPoolProjects,
+        DropRepartition, EliminateCrossJoin, EnrichWithStats, LiftProjectFromAgg, MaterializeScans,
+        OptimizerRule, PushDownFilter, PushDownLimit, PushDownProjection, SimplifyExpressionsRule,
+        SplitActorPoolProjects, UnnestPredicateSubquery, UnnestScalarSubquery,
     },
 };
 use crate::LogicalPlan;
@@ -94,8 +94,8 @@ impl Optimizer {
             RuleBatch::new(
                 vec![
                     Box::new(LiftProjectFromAgg::new()),
-                    Box::new(EliminateScalarSubquery::new()),
-                    Box::new(EliminatePredicateSubquery::new()),
+                    Box::new(UnnestScalarSubquery::new()),
+                    Box::new(UnnestPredicateSubquery::new()),
                     Box::new(SplitActorPoolProjects::new()),
                 ],
                 RuleExecutionStrategy::FixedPoint(None),

--- a/src/daft-logical-plan/src/optimization/rules/drop_repartition.rs
+++ b/src/daft-logical-plan/src/optimization/rules/drop_repartition.rs
@@ -52,7 +52,9 @@ mod tests {
 
     use crate::{
         optimization::{
-            rules::drop_repartition::DropRepartition, test::assert_optimized_plan_with_rules_eq,
+            optimizer::{RuleBatch, RuleExecutionStrategy},
+            rules::drop_repartition::DropRepartition,
+            test::assert_optimized_plan_with_rules_eq,
         },
         test::{dummy_scan_node, dummy_scan_operator},
         LogicalPlan,
@@ -65,7 +67,14 @@ mod tests {
         plan: Arc<LogicalPlan>,
         expected: Arc<LogicalPlan>,
     ) -> DaftResult<()> {
-        assert_optimized_plan_with_rules_eq(plan, expected, vec![Box::new(DropRepartition::new())])
+        assert_optimized_plan_with_rules_eq(
+            plan,
+            expected,
+            vec![RuleBatch::new(
+                vec![Box::new(DropRepartition::new())],
+                RuleExecutionStrategy::Once,
+            )],
+        )
     }
 
     /// Tests that DropRepartition does drops the upstream Repartition in back-to-back Repartitions.

--- a/src/daft-logical-plan/src/optimization/rules/eliminate_subquery.rs
+++ b/src/daft-logical-plan/src/optimization/rules/eliminate_subquery.rs
@@ -1,0 +1,483 @@
+use std::{collections::HashSet, sync::Arc};
+
+use common_error::{DaftError, DaftResult};
+use common_treenode::{DynTreeNode, Transformed, TreeNode};
+use daft_core::{join::JoinType, prelude::SchemaRef};
+use daft_dsl::{
+    col,
+    optimization::{conjuct, split_conjuction},
+    Expr, ExprRef, Operator, OuterReferenceColumn, Subquery,
+};
+use daft_schema::field::Field;
+use itertools::multiunzip;
+use uuid::Uuid;
+
+use super::OptimizerRule;
+use crate::{
+    logical_plan::downcast_subquery,
+    ops::{Aggregate, Filter, Join, Project},
+    LogicalPlan, LogicalPlanRef,
+};
+
+/// Rewriter rule to convert scalar subqueries into joins.
+#[derive(Debug)]
+pub struct EliminateScalarSubquery {}
+
+impl EliminateScalarSubquery {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl EliminateScalarSubquery {
+    fn unnest_subqueries(
+        input: LogicalPlanRef,
+        exprs: Vec<&ExprRef>,
+    ) -> DaftResult<Transformed<(LogicalPlanRef, Vec<ExprRef>)>> {
+        let mut subqueries = HashSet::new();
+
+        let new_exprs = exprs
+            .into_iter()
+            .map(|expr| {
+                expr.clone()
+                    .transform_down(|e| {
+                        if let Expr::Subquery(subquery) = e.as_ref() {
+                            subqueries.insert(subquery.clone());
+
+                            Ok(Transformed::yes(col(subquery.semantic_id().id)))
+                        } else {
+                            Ok(Transformed::no(e))
+                        }
+                    })
+                    .unwrap()
+                    .data
+            })
+            .collect();
+
+        if subqueries.is_empty() {
+            return Ok(Transformed::no((input, new_exprs)));
+        }
+
+        let new_input = subqueries
+            .into_iter()
+            .try_fold(input, |curr_input, subquery| {
+                let subquery_alias = subquery.semantic_id().id;
+                let subquery_plan = downcast_subquery(&subquery);
+
+                let subquery_col_names = subquery_plan.schema().names();
+                let [output_col] = subquery_col_names.as_slice() else {
+                    return Err(DaftError::ValueError(format!(
+                        "Expected scalar subquery to have one output column, received: {}",
+                        subquery_col_names.len()
+                    )));
+                };
+
+                // alias output column
+                let subquery_plan = Arc::new(LogicalPlan::Project(Project::try_new(
+                    subquery_plan,
+                    vec![col(output_col.as_str()).alias(subquery_alias)],
+                )?));
+
+                let (decorrelated_subquery, subquery_on, input_on) =
+                    pull_up_correlated_cols(subquery_plan)?;
+
+                if subquery_on.is_empty() {
+                    // uncorrelated scalar subquery
+                    Ok(Arc::new(LogicalPlan::Join(Join::try_new(
+                        curr_input,
+                        decorrelated_subquery,
+                        vec![],
+                        vec![],
+                        None,
+                        JoinType::Inner,
+                        None,
+                        None,
+                        None,
+                        false,
+                    )?)))
+                } else {
+                    // correlated scalar subquery
+                    Ok(Arc::new(LogicalPlan::Join(Join::try_new(
+                        curr_input,
+                        decorrelated_subquery,
+                        input_on,
+                        subquery_on,
+                        None,
+                        JoinType::Left,
+                        None,
+                        None,
+                        None,
+                        false,
+                    )?)))
+                }
+            })?;
+
+        Ok(Transformed::yes((new_input, new_exprs)))
+    }
+}
+
+impl OptimizerRule for EliminateScalarSubquery {
+    fn try_optimize(&self, plan: Arc<LogicalPlan>) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+        plan.transform_down(|node| match node.as_ref() {
+            LogicalPlan::Filter(Filter {
+                input, predicate, ..
+            }) => {
+                let unnest_result =
+                    Self::unnest_subqueries(input.clone(), split_conjuction(predicate))?;
+
+                if !unnest_result.transformed {
+                    return Ok(Transformed::no(node));
+                }
+
+                let (new_input, new_predicates) = unnest_result.data;
+
+                let new_predicate = conjuct(new_predicates)
+                    .expect("predicates should exist in unnested subquery filter");
+
+                let new_filter = Arc::new(LogicalPlan::Filter(Filter::try_new(
+                    new_input,
+                    new_predicate,
+                )?));
+
+                // preserve original schema
+                let new_plan = Arc::new(LogicalPlan::Project(Project::new_from_schema(
+                    new_filter,
+                    input.schema(),
+                )?));
+
+                Ok(Transformed::yes(new_plan))
+            }
+            LogicalPlan::Project(Project {
+                input, projection, ..
+            }) => {
+                let unnest_result =
+                    Self::unnest_subqueries(input.clone(), projection.iter().collect())?;
+
+                if !unnest_result.transformed {
+                    return Ok(Transformed::no(node));
+                }
+
+                let (new_input, new_projection) = unnest_result.data;
+
+                // preserve original schema
+                let new_plan = Arc::new(LogicalPlan::Project(Project::try_new(
+                    new_input,
+                    new_projection,
+                )?));
+
+                Ok(Transformed::yes(new_plan))
+            }
+            _ => Ok(Transformed::no(node)),
+        })
+    }
+}
+
+/// Rewriter rule to convert IN and EXISTS subqueries into joins.
+#[derive(Debug)]
+pub struct EliminatePredicateSubquery {}
+
+impl EliminatePredicateSubquery {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[derive(Eq, Hash, PartialEq)]
+struct PredicateSubquery {
+    pub subquery: Subquery,
+    pub in_expr: Option<ExprRef>,
+    pub join_type: JoinType,
+}
+
+impl OptimizerRule for EliminatePredicateSubquery {
+    fn try_optimize(&self, plan: Arc<LogicalPlan>) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+        plan.transform_down(|node| match node.as_ref() {
+            LogicalPlan::Filter(Filter {
+                input, predicate, ..
+            }) => {
+                let mut subqueries = HashSet::new();
+
+                let new_predicates = split_conjuction(predicate)
+                    .into_iter()
+                    .filter(|expr| {
+                        match expr.as_ref() {
+                            Expr::InSubquery(in_expr, subquery) => {
+                                subqueries.insert(PredicateSubquery { subquery: subquery.clone(), in_expr: Some(in_expr.clone()), join_type: JoinType::Semi });
+                                false
+                            }
+                            Expr::Exists(subquery) => {
+                                subqueries.insert(PredicateSubquery { subquery: subquery.clone(), in_expr: None, join_type: JoinType::Semi });
+                                false
+                            }
+                            Expr::Not(e) => {
+                                match e.as_ref() {
+                                    Expr::InSubquery(in_expr, subquery) => {
+                                        subqueries.insert(PredicateSubquery { subquery: subquery.clone(), in_expr: Some(in_expr.clone()), join_type: JoinType::Anti });
+                                        false
+                                    }
+                                    Expr::Exists(subquery) => {
+                                        subqueries.insert(PredicateSubquery { subquery: subquery.clone(), in_expr: None, join_type: JoinType::Anti });
+                                        false
+                                    }
+                                    _ => true
+                                }
+                            }
+                            _ => true
+                        }
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>();
+
+                if subqueries.is_empty() {
+                    return Ok(Transformed::no(node));
+                }
+
+                let new_input = subqueries.into_iter().try_fold(input.clone(), |curr_input, PredicateSubquery { subquery, in_expr, join_type }| {
+                    let subquery_plan = downcast_subquery(&subquery);
+
+                    let (decorrelated_subquery, mut subquery_on, mut input_on) =
+                        pull_up_correlated_cols(subquery_plan.clone())?;
+
+                    if let Some(in_expr) = in_expr {
+                        let subquery_col_names = subquery_plan.schema().names();
+                        let [output_col] = subquery_col_names.as_slice() else {
+                            return Err(DaftError::ValueError(format!("Expected IN subquery to have one output column, received: {}", subquery_col_names.len())));
+                        };
+
+                        input_on.push(in_expr);
+                        subquery_on.push(col(output_col.as_str()));
+                    }
+
+                    if subquery_on.is_empty() {
+                        return Err(DaftError::ValueError("Expected IN/EXISTS subquery to be correlated, found uncorrelated subquery.".to_string()));
+                    }
+
+                    Ok(Arc::new(LogicalPlan::Join(Join::try_new(
+                        curr_input,
+                        decorrelated_subquery,
+                        input_on,
+                        subquery_on,
+                        None,
+                        join_type,
+                        None,
+                        None,
+                        None,
+                        false
+                    )?)))
+                })?;
+
+                let new_plan = if let Some(new_predicate) = conjuct(new_predicates) {
+                    // add filter back if there are non-subquery predicates
+                    Arc::new(LogicalPlan::Filter(Filter::try_new(
+                        new_input,
+                        new_predicate,
+                    )?))
+                } else {
+                    new_input
+                };
+
+                Ok(Transformed::yes(new_plan))
+            }
+            _ => Ok(Transformed::no(node)),
+        })
+    }
+}
+
+fn pull_up_correlated_cols(
+    plan: LogicalPlanRef,
+) -> DaftResult<(LogicalPlanRef, Vec<ExprRef>, Vec<ExprRef>)> {
+    let (new_inputs, subquery_on, outer_on): (Vec<_>, Vec<_>, Vec<_>) = multiunzip(
+        plan.arc_children()
+            .into_iter()
+            .map(pull_up_correlated_cols)
+            .collect::<DaftResult<Vec<_>>>()?,
+    );
+
+    let plan = if new_inputs.is_empty() {
+        plan
+    } else {
+        Arc::new(plan.with_new_children(&new_inputs))
+    };
+
+    let mut subquery_on = subquery_on.into_iter().flatten().collect::<Vec<_>>();
+    let mut outer_on = outer_on.into_iter().flatten().collect::<Vec<_>>();
+
+    match plan.as_ref() {
+        LogicalPlan::Filter(Filter {
+            input, predicate, ..
+        }) => {
+            let mut found_correlated_col = false;
+
+            let preds = split_conjuction(predicate)
+                .into_iter()
+                .filter(|expr| {
+                    if let Expr::BinaryOp {
+                        op: Operator::Eq,
+                        left,
+                        right,
+                    } = expr.as_ref()
+                    {
+                        match (left.as_ref(), right.as_ref()) {
+                            (
+                                Expr::Column(subquery_col),
+                                Expr::OuterReferenceColumn(OuterReferenceColumn {
+                                    field:
+                                        Field {
+                                            name: outer_col, ..
+                                        },
+                                    ..
+                                }),
+                            )
+                            | (
+                                Expr::OuterReferenceColumn(OuterReferenceColumn {
+                                    field:
+                                        Field {
+                                            name: outer_col, ..
+                                        },
+                                    ..
+                                }),
+                                Expr::Column(subquery_col),
+                            ) => {
+                                // remove correlated col from filter, use in join instead
+                                subquery_on.push(col(subquery_col.clone()));
+                                outer_on.push(col(outer_col.as_str()));
+
+                                found_correlated_col = true;
+                                return false;
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    true
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+
+            // no new correlated cols found
+            if !found_correlated_col {
+                return Ok((plan.clone(), subquery_on, outer_on));
+            }
+
+            if let Some(new_predicate) = conjuct(preds) {
+                let new_plan = Arc::new(LogicalPlan::Filter(Filter::try_new(
+                    input.clone(),
+                    new_predicate,
+                )?));
+
+                Ok((new_plan, subquery_on, outer_on))
+            } else {
+                // all predicates are correlated so filter can be completely removed
+                Ok((input.clone(), subquery_on, outer_on))
+            }
+        }
+        LogicalPlan::Project(Project {
+            input,
+            projection,
+            projected_schema,
+            ..
+        }) => {
+            // ensure all columns that need to be pulled up are in the projection
+
+            let (new_subquery_on, missing_exprs) =
+                get_missing_exprs(subquery_on, projection, projected_schema);
+
+            if missing_exprs.is_empty() {
+                // project already contains all necessary columns
+                Ok((plan.clone(), new_subquery_on, outer_on))
+            } else {
+                let new_projection = [projection.clone(), missing_exprs].concat();
+
+                let new_plan = Arc::new(LogicalPlan::Project(Project::try_new(
+                    input.clone(),
+                    new_projection,
+                )?));
+
+                Ok((new_plan, new_subquery_on, outer_on))
+            }
+        }
+        LogicalPlan::Aggregate(Aggregate {
+            input,
+            aggregations,
+            groupby,
+            output_schema,
+            ..
+        }) => {
+            // put columns that need to be pulled up into the groupby
+
+            let (new_subquery_on, missing_groupbys) =
+                get_missing_exprs(subquery_on, groupby, output_schema);
+
+            if missing_groupbys.is_empty() {
+                // agg already contains all necessary columns
+                Ok((plan.clone(), new_subquery_on, outer_on))
+            } else {
+                let new_groupby = [groupby.clone(), missing_groupbys].concat();
+
+                let new_plan = Arc::new(LogicalPlan::Aggregate(Aggregate::try_new(
+                    input.clone(),
+                    aggregations.clone(),
+                    new_groupby,
+                )?));
+
+                Ok((new_plan, new_subquery_on, outer_on))
+            }
+        }
+
+        // ops that can trivially pull up correlated cols
+        LogicalPlan::Distinct(..)
+        | LogicalPlan::Limit(..)
+        | LogicalPlan::MonotonicallyIncreasingId(..)
+        | LogicalPlan::Repartition(..)
+        | LogicalPlan::Sample(..)
+        | LogicalPlan::Union(..)
+        | LogicalPlan::Intersect(..)
+        | LogicalPlan::Sort(..) => Ok((plan.clone(), subquery_on, outer_on)),
+
+        // ops that cannot pull up correlated columns
+        LogicalPlan::ActorPoolProject(..)
+        | LogicalPlan::Source(..)
+        | LogicalPlan::Explode(..)
+        | LogicalPlan::Unpivot(..)
+        | LogicalPlan::Pivot(..)
+        | LogicalPlan::Concat(..)
+        | LogicalPlan::Join(..)
+        | LogicalPlan::Sink(..) => {
+            if subquery_on.is_empty() {
+                Ok((plan.clone(), vec![], vec![]))
+            } else {
+                Err(DaftError::NotImplemented(format!(
+                    "Pulling up correlated columns not supported for: {}",
+                    plan.name()
+                )))
+            }
+        }
+    }
+}
+
+fn get_missing_exprs(
+    subquery_on: Vec<ExprRef>,
+    existing_exprs: &[ExprRef],
+    schema: &SchemaRef,
+) -> (Vec<ExprRef>, Vec<ExprRef>) {
+    let (new_subquery_on, missing_exprs): (Vec<_>, Vec<_>) = subquery_on
+        .into_iter()
+        .map(|expr| {
+            if existing_exprs.contains(&expr) {
+                // column already exists in schema
+                (expr, None)
+            } else if schema.has_field(expr.name()) {
+                // another expression takes pull up column name, we rename the pull up column.
+                let unique_id = Uuid::new_v4().to_string();
+                let aliased_col = expr.alias(format!("{}_{}", expr.name(), unique_id));
+                (col(unique_id), Some(aliased_col))
+            } else {
+                (expr.clone(), Some(expr))
+            }
+        })
+        .unzip();
+
+    let missing_exprs = missing_exprs.into_iter().flatten().collect();
+
+    (new_subquery_on, missing_exprs)
+}

--- a/src/daft-logical-plan/src/optimization/rules/lift_project_from_agg.rs
+++ b/src/daft-logical-plan/src/optimization/rules/lift_project_from_agg.rs
@@ -115,7 +115,10 @@ mod tests {
 
     use super::LiftProjectFromAgg;
     use crate::{
-        optimization::test::assert_optimized_plan_with_rules_eq,
+        optimization::{
+            optimizer::{RuleBatch, RuleExecutionStrategy},
+            test::assert_optimized_plan_with_rules_eq,
+        },
         test::{dummy_scan_node, dummy_scan_operator},
         LogicalPlan,
     };
@@ -127,7 +130,10 @@ mod tests {
         assert_optimized_plan_with_rules_eq(
             plan,
             expected,
-            vec![Box::new(LiftProjectFromAgg::new())],
+            vec![RuleBatch::new(
+                vec![Box::new(LiftProjectFromAgg::new())],
+                RuleExecutionStrategy::Once,
+            )],
         )
     }
 

--- a/src/daft-logical-plan/src/optimization/rules/mod.rs
+++ b/src/daft-logical-plan/src/optimization/rules/mod.rs
@@ -1,5 +1,6 @@
 mod drop_repartition;
 mod eliminate_cross_join;
+mod eliminate_subquery;
 mod enrich_with_stats;
 mod lift_project_from_agg;
 mod materialize_scans;
@@ -12,6 +13,7 @@ mod split_actor_pool_projects;
 
 pub use drop_repartition::DropRepartition;
 pub use eliminate_cross_join::EliminateCrossJoin;
+pub use eliminate_subquery::{EliminatePredicateSubquery, EliminateScalarSubquery};
 pub use enrich_with_stats::EnrichWithStats;
 pub use lift_project_from_agg::LiftProjectFromAgg;
 pub use materialize_scans::MaterializeScans;

--- a/src/daft-logical-plan/src/optimization/rules/mod.rs
+++ b/src/daft-logical-plan/src/optimization/rules/mod.rs
@@ -1,6 +1,5 @@
 mod drop_repartition;
 mod eliminate_cross_join;
-mod eliminate_subquery;
 mod enrich_with_stats;
 mod lift_project_from_agg;
 mod materialize_scans;
@@ -10,10 +9,10 @@ mod push_down_projection;
 mod rule;
 mod simplify_expressions;
 mod split_actor_pool_projects;
+mod unnest_subquery;
 
 pub use drop_repartition::DropRepartition;
 pub use eliminate_cross_join::EliminateCrossJoin;
-pub use eliminate_subquery::{EliminatePredicateSubquery, EliminateScalarSubquery};
 pub use enrich_with_stats::EnrichWithStats;
 pub use lift_project_from_agg::LiftProjectFromAgg;
 pub use materialize_scans::MaterializeScans;
@@ -23,3 +22,4 @@ pub use push_down_projection::PushDownProjection;
 pub use rule::OptimizerRule;
 pub use simplify_expressions::SimplifyExpressionsRule;
 pub use split_actor_pool_projects::SplitActorPoolProjects;
+pub use unnest_subquery::{UnnestPredicateSubquery, UnnestScalarSubquery};

--- a/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
@@ -359,7 +359,11 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        optimization::{rules::PushDownFilter, test::assert_optimized_plan_with_rules_eq},
+        optimization::{
+            optimizer::{RuleBatch, RuleExecutionStrategy},
+            rules::PushDownFilter,
+            test::assert_optimized_plan_with_rules_eq,
+        },
         test::{dummy_scan_node, dummy_scan_node_with_pushdowns, dummy_scan_operator},
         LogicalPlan,
     };
@@ -371,7 +375,14 @@ mod tests {
         plan: Arc<LogicalPlan>,
         expected: Arc<LogicalPlan>,
     ) -> DaftResult<()> {
-        assert_optimized_plan_with_rules_eq(plan, expected, vec![Box::new(PushDownFilter::new())])
+        assert_optimized_plan_with_rules_eq(
+            plan,
+            expected,
+            vec![RuleBatch::new(
+                vec![Box::new(PushDownFilter::new())],
+                RuleExecutionStrategy::Once,
+            )],
+        )
     }
 
     /// Tests that we can't pushdown a filter into a ScanOperator that has a limit.

--- a/src/daft-logical-plan/src/optimization/rules/push_down_limit.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_limit.rs
@@ -137,7 +137,11 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        optimization::{rules::PushDownLimit, test::assert_optimized_plan_with_rules_eq},
+        optimization::{
+            optimizer::{RuleBatch, RuleExecutionStrategy},
+            rules::PushDownLimit,
+            test::assert_optimized_plan_with_rules_eq,
+        },
         test::{dummy_scan_node, dummy_scan_node_with_pushdowns, dummy_scan_operator},
         LogicalPlan, LogicalPlanBuilder,
     };
@@ -149,7 +153,14 @@ mod tests {
         plan: Arc<LogicalPlan>,
         expected: Arc<LogicalPlan>,
     ) -> DaftResult<()> {
-        assert_optimized_plan_with_rules_eq(plan, expected, vec![Box::new(PushDownLimit::new())])
+        assert_optimized_plan_with_rules_eq(
+            plan,
+            expected,
+            vec![RuleBatch::new(
+                vec![Box::new(PushDownLimit::new())],
+                RuleExecutionStrategy::Once,
+            )],
+        )
     }
 
     /// Tests that Limit pushes into external Source.

--- a/src/daft-logical-plan/src/optimization/rules/push_down_projection.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_projection.rs
@@ -680,7 +680,11 @@ mod tests {
     };
 
     use crate::{
-        optimization::{rules::PushDownProjection, test::assert_optimized_plan_with_rules_eq},
+        optimization::{
+            optimizer::{RuleBatch, RuleExecutionStrategy},
+            rules::PushDownProjection,
+            test::assert_optimized_plan_with_rules_eq,
+        },
         test::{dummy_scan_node, dummy_scan_node_with_pushdowns, dummy_scan_operator},
         LogicalPlan,
     };
@@ -695,7 +699,10 @@ mod tests {
         assert_optimized_plan_with_rules_eq(
             plan,
             expected,
-            vec![Box::new(PushDownProjection::new())],
+            vec![RuleBatch::new(
+                vec![Box::new(PushDownProjection::new())],
+                RuleExecutionStrategy::Once,
+            )],
         )
     }
 

--- a/src/daft-logical-plan/src/optimization/rules/split_actor_pool_projects.rs
+++ b/src/daft-logical-plan/src/optimization/rules/split_actor_pool_projects.rs
@@ -516,7 +516,11 @@ mod tests {
     use super::SplitActorPoolProjects;
     use crate::{
         ops::{ActorPoolProject, Project},
-        optimization::{rules::PushDownProjection, test::assert_optimized_plan_with_rules_eq},
+        optimization::{
+            optimizer::{RuleBatch, RuleExecutionStrategy},
+            rules::PushDownProjection,
+            test::assert_optimized_plan_with_rules_eq,
+        },
         test::{dummy_scan_node, dummy_scan_operator},
         LogicalPlan,
     };
@@ -531,7 +535,10 @@ mod tests {
         assert_optimized_plan_with_rules_eq(
             plan,
             expected,
-            vec![Box::new(SplitActorPoolProjects {})],
+            vec![RuleBatch::new(
+                vec![Box::new(SplitActorPoolProjects::new())],
+                RuleExecutionStrategy::Once,
+            )],
         )
     }
 
@@ -545,10 +552,13 @@ mod tests {
         assert_optimized_plan_with_rules_eq(
             plan,
             expected,
-            vec![
-                Box::new(SplitActorPoolProjects {}),
-                Box::new(PushDownProjection::new()),
-            ],
+            vec![RuleBatch::new(
+                vec![
+                    Box::new(SplitActorPoolProjects::new()),
+                    Box::new(PushDownProjection::new()),
+                ],
+                RuleExecutionStrategy::Once,
+            )],
         )
     }
 

--- a/src/daft-logical-plan/src/optimization/rules/unnest_subquery.rs
+++ b/src/daft-logical-plan/src/optimization/rules/unnest_subquery.rs
@@ -505,16 +505,16 @@ fn pull_up_correlated_cols(
 
         // ops that can trivially pull up correlated cols
         LogicalPlan::Distinct(..)
-        | LogicalPlan::Limit(..)
         | LogicalPlan::MonotonicallyIncreasingId(..)
         | LogicalPlan::Repartition(..)
-        | LogicalPlan::Sample(..)
         | LogicalPlan::Union(..)
         | LogicalPlan::Intersect(..)
         | LogicalPlan::Sort(..) => Ok((plan.clone(), subquery_on, outer_on)),
 
         // ops that cannot pull up correlated columns
         LogicalPlan::ActorPoolProject(..)
+        | LogicalPlan::Limit(..)
+        | LogicalPlan::Sample(..)
         | LogicalPlan::Source(..)
         | LogicalPlan::Explode(..)
         | LogicalPlan::Unpivot(..)

--- a/src/daft-logical-plan/src/optimization/test/mod.rs
+++ b/src/daft-logical-plan/src/optimization/test/mod.rs
@@ -17,12 +17,9 @@ use crate::{
 pub fn assert_optimized_plan_with_rules_eq(
     plan: Arc<LogicalPlan>,
     expected: Arc<LogicalPlan>,
-    rules: Vec<Box<dyn OptimizerRuleInBatch>>,
+    rule_batches: Vec<RuleBatch>,
 ) -> DaftResult<()> {
-    let optimizer = Optimizer::with_rule_batches(
-        vec![RuleBatch::new(rules, RuleExecutionStrategy::Once)],
-        Default::default(),
-    );
+    let optimizer = Optimizer::with_rule_batches(rule_batches, Default::default());
     let optimized_plan = optimizer
         .optimize_with_rules(optimizer.rule_batches[0].rules.as_slice(), plan.clone())?
         .data;

--- a/src/daft-logical-plan/src/optimization/test/mod.rs
+++ b/src/daft-logical-plan/src/optimization/test/mod.rs
@@ -2,12 +2,8 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 
-use super::optimizer::OptimizerRuleInBatch;
 use crate::{
-    optimization::{
-        optimizer::{RuleBatch, RuleExecutionStrategy},
-        Optimizer,
-    },
+    optimization::{optimizer::RuleBatch, Optimizer},
     LogicalPlan,
 };
 

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -1447,7 +1447,7 @@ impl<'a> SQLPlanner<'a> {
                 expr,
                 substring_from,
                 substring_for,
-                special: true, // We only support SUBSTRING(expr, start, length) syntax
+                ..
             } => {
                 let (Some(substring_from), Some(substring_for)) = (substring_from, substring_for)
                 else {
@@ -1458,10 +1458,10 @@ impl<'a> SQLPlanner<'a> {
                 let start = self.plan_expr(substring_from)?;
                 let length = self.plan_expr(substring_for)?;
 
+                // SQL substring is one indexed
+                let start = start.sub(lit(1));
+
                 Ok(daft_functions::utf8::substr(expr, start, length))
-            }
-            SQLExpr::Substring { special: false, .. } => {
-                unsupported_sql_err!("`SUBSTRING(expr [FROM start] [FOR len])` syntax")
             }
             SQLExpr::Trim { .. } => unsupported_sql_err!("TRIM"),
             SQLExpr::Overlay { .. } => unsupported_sql_err!("OVERLAY"),

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -1447,7 +1447,7 @@ impl<'a> SQLPlanner<'a> {
                 expr,
                 substring_from,
                 substring_for,
-                ..
+                special: true, // We only support SUBSTRING(expr, start, length) syntax
             } => {
                 let (Some(substring_from), Some(substring_for)) = (substring_from, substring_for)
                 else {
@@ -1462,6 +1462,9 @@ impl<'a> SQLPlanner<'a> {
                 let start = start.sub(lit(1));
 
                 Ok(daft_functions::utf8::substr(expr, start, length))
+            }
+            SQLExpr::Substring { special: false, .. } => {
+                unsupported_sql_err!("`SUBSTRING(expr [FROM start] [FOR len])` syntax")
             }
             SQLExpr::Trim { .. } => unsupported_sql_err!("TRIM"),
             SQLExpr::Overlay { .. } => unsupported_sql_err!("OVERLAY"),

--- a/tests/benchmarks/test_local_tpch.py
+++ b/tests/benchmarks/test_local_tpch.py
@@ -89,6 +89,6 @@ def test_tpch_sql(tmp_path, check_answer, get_df, benchmark_with_memray, engine,
         daft_df = daft.sql(query, catalog=catalog)
         return daft_df.to_arrow()
 
-    benchmark_group = f"q{q}-parts-{num_parts}"
+    benchmark_group = f"q{q}-sql-parts-{num_parts}"
     daft_pd_df = benchmark_with_memray(f, benchmark_group).to_pandas()
     check_answer(daft_pd_df, q, tmp_path)

--- a/tests/benchmarks/test_local_tpch.py
+++ b/tests/benchmarks/test_local_tpch.py
@@ -46,3 +46,49 @@ def test_tpch(tmp_path, check_answer, get_df, benchmark_with_memray, engine, q):
     benchmark_group = f"q{q}-parts-{num_parts}"
     daft_pd_df = benchmark_with_memray(f, benchmark_group).to_pandas()
     check_answer(daft_pd_df, q, tmp_path)
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() not in {"py", "native"},
+    reason="requires PyRunner to be in use",
+)
+@pytest.mark.benchmark(group="tpch")
+@pytest.mark.parametrize("engine, q", itertools.product(ENGINES, TPCH_QUESTIONS))
+def test_tpch_sql(tmp_path, check_answer, get_df, benchmark_with_memray, engine, q):  # noqa F811
+    from daft.sql import SQLCatalog
+
+    get_df, num_parts = get_df
+
+    # TODO: remove this once SQL allows case-insensitive column names
+    def lowercase_column_names(df):
+        return df.select(*[daft.col(name).alias(name.lower()) for name in df.column_names])
+
+    table_names = [
+        "part",
+        "supplier",
+        "partsupp",
+        "customer",
+        "orders",
+        "lineitem",
+        "nation",
+        "region",
+    ]
+    catalog = SQLCatalog({tbl: lowercase_column_names(get_df(tbl)) for tbl in table_names})
+
+    with open(f"benchmarking/tpch/queries/{q:02}.sql") as query_file:
+        query = query_file.read()
+
+    def f():
+        if engine == "native":
+            daft.context.set_runner_native()
+        elif engine == "python":
+            daft.context.set_runner_py()
+        else:
+            raise ValueError(f"{engine} unsupported")
+
+        daft_df = daft.sql(query, catalog=catalog)
+        return daft_df.to_arrow()
+
+    benchmark_group = f"q{q}-parts-{num_parts}"
+    daft_pd_df = benchmark_with_memray(f, benchmark_group).to_pandas()
+    check_answer(daft_pd_df, q, tmp_path)

--- a/tests/sql/test_utf8_exprs.py
+++ b/tests/sql/test_utf8_exprs.py
@@ -52,7 +52,7 @@ def test_utf8_exprs():
         repeat(a, 2) as repeat_a,
         a like 'a%' as like_a,
         a ilike 'a%' as ilike_a,
-        substring(a, 1, 3) as substring_a,
+        substring(a, 2, 3) as substring_a,
         count_matches(a, 'a') as count_matches_a_0,
         count_matches(a, 'a', case_sensitive := true) as count_matches_a_1,
         count_matches(a, 'a', case_sensitive := false, whole_words := false) as count_matches_a_2,


### PR DESCRIPTION
Subquery execution now possible through rewrite rules that convert them into joins. This only covers subqueries that can be converted into equi joins and not general subqueries. However that already gets us to 21/22 TPC-H (although Q16 is still missing count distinct implementation on the SQL side).

Also includes a drive-by fix for SQL substring.

---

Note on alternative implementations:
- Although Datafusion's optimizer rules for subqueries are more capable than these, they make use of non-equi joins yet do not allow for decorrelating all subqueries. Instead, once we have non-equi joins we should implement the [Unnesting Arbitrary Subqueries](https://cs.emis.de/LNI/Proceedings/Proceedings241/383.pdf) paper (which [duckdb also implements](https://duckdb.org/2023/05/26/correlated-subqueries-in-sql.html#performance)).

---

todo:
- [x]  add more tests