### PR TITLE
ci: Add "build" label type to accepted PR titles

### DIFF
--- a/.github/workflows/pr-labeller.yml
+++ b/.github/workflows/pr-labeller.yml
@@ -16,5 +16,5 @@ jobs:
     - name: PR Conventional Commit Validation
       uses: ytanikin/pr-conventional-commits@1.4.0
       with:
-        task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+        task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","build"]'
         add_label: 'true'


### PR DESCRIPTION
# Overview
This PR adds the "build" label type to the accepted "Conventional Types" labels that are accepted.

This is specifically for build-related things (e.g., `Makefile`s). The existing labels did not really address certain types of possible changes, in my opinion.