### PR TITLE
feat: Make serialization code not unwrap and panic on failures

### DIFF
--- a/benchmarking/tpcds/ray_entrypoint.py
+++ b/benchmarking/tpcds/ray_entrypoint.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 from pathlib import Path
 
 import helpers
@@ -17,12 +16,9 @@ def run(
     with open(query_file) as f:
         query = f.read()
 
-    try:
-        daft.sql(query, catalog=catalog).explain(show_all=True)
-        if not dry_run:
-            daft.sql(query, catalog=catalog).collect()
-    except Exception as e:
-        print(str(e), file=sys.stderr)
+    daft.sql(query, catalog=catalog).explain(show_all=True)
+    if not dry_run:
+        daft.sql(query, catalog=catalog).collect()
 
 
 if __name__ == "__main__":

--- a/src/common/py-serde/src/python.rs
+++ b/src/common/py-serde/src/python.rs
@@ -84,7 +84,7 @@ macro_rules! impl_bincode_py_state_serialization {
                 py: Python<'py>,
             ) -> PyResult<(PyObject, (pyo3::Bound<'py, pyo3::types::PyBytes>,))> {
                 use pyo3::{
-                    exceptions::PyTypeError,
+                    exceptions::PyRuntimeError,
                     types::{PyAnyMethods, PyBytes},
                     PyErr, PyTypeInfo, ToPyObject,
                 };
@@ -95,7 +95,7 @@ macro_rules! impl_bincode_py_state_serialization {
                     (PyBytes::new_bound(
                         py,
                         &$crate::bincode::serialize(&self)
-                            .map_err(|_| PyErr::new::<PyTypeError, _>("Failed to serialize"))?,
+                            .map_err(|_| PyErr::new::<PyRuntimeError, _>("Failed to serialize"))?,
                     ),),
                 ))
             }

--- a/src/common/py-serde/src/python.rs
+++ b/src/common/py-serde/src/python.rs
@@ -94,8 +94,12 @@ macro_rules! impl_bincode_py_state_serialization {
                         .into(),
                     (PyBytes::new_bound(
                         py,
-                        &$crate::bincode::serialize(&self)
-                            .map_err(|_| PyErr::new::<PyRuntimeError, _>("Failed to serialize"))?,
+                        &$crate::bincode::serialize(&self).map_err(|error| {
+                            PyErr::new::<PyRuntimeError, _>(format!(
+                                "Failed to serialize: {}",
+                                error.to_string()
+                            ))
+                        })?,
                     ),),
                 ))
             }

--- a/src/common/py-serde/src/python.rs
+++ b/src/common/py-serde/src/python.rs
@@ -84,8 +84,9 @@ macro_rules! impl_bincode_py_state_serialization {
                 py: Python<'py>,
             ) -> PyResult<(PyObject, (pyo3::Bound<'py, pyo3::types::PyBytes>,))> {
                 use pyo3::{
+                    exceptions::PyTypeError,
                     types::{PyAnyMethods, PyBytes},
-                    PyTypeInfo, ToPyObject,
+                    PyErr, PyTypeInfo, ToPyObject,
                 };
                 Ok((
                     Self::type_object_bound(py)
@@ -93,7 +94,8 @@ macro_rules! impl_bincode_py_state_serialization {
                         .into(),
                     (PyBytes::new_bound(
                         py,
-                        &$crate::bincode::serialize(&self).unwrap(),
+                        &$crate::bincode::serialize(&self)
+                            .map_err(|_| PyErr::new::<PyTypeError, _>("Failed to serialize"))?,
                     ),),
                 ))
             }


### PR DESCRIPTION
# Overview
Serialization of subqueries currently fails. Thus, when ray tries to serialize subqueries, the ray-task fails and *indefinitely* hangs.

This PR updates the failure mechanism of serialization of subqueries. Instead of unwrapping the `Err` in rust, it is passed through instead.