### PR TITLE
feat(swordfish): Enable left/right joins to build probe table on either side

### DIFF
--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -349,30 +349,10 @@ pub fn physical_plan_to_pipeline(
                 _ => true,
             };
 
-            // TODO(desmond): We might potentially want to flip the probe table side for
-            // left/right outer joins if one side is significantly larger. Needs to be tuned.
-            //
-            // In greater detail, consider a right outer join where the left side is several orders
-            // of magnitude larger than the right. An extreme example might have 1B rows on the left,
-            // and 10 rows on the right.
-            //
-            // Typically we would build the probe table on the left, then stream rows from the right
-            // to match against the probe table. But in this case we would have a giant intermediate
-            // probe table.
-            //
-            // An alternative 2-pass algorithm would be to:
-            // 1. Build the probe table on the right, but add a second data structure to keep track of
-            //    which rows on the right have been matched.
-            // 2. Stream rows on the left until all rows have been seen.
-            // 3. Finally, emit all unmatched rows from the right.
             let build_on_left = match join_type {
-                JoinType::Inner => build_on_left,
-                JoinType::Outer => build_on_left,
-                // For left outer joins, we build on right so we can stream the left side.
-                JoinType::Left => false,
-                // For right outer joins, we build on left so we can stream the right side.
-                JoinType::Right => true,
+                // Anti and semi joins should always build on the right side.
                 JoinType::Anti | JoinType::Semi => false,
+                _ => build_on_left,
             };
             let (build_on, probe_on, build_child, probe_child) = match build_on_left {
                 true => (left_on, right_on, left, right),

--- a/src/daft-local-execution/src/sinks/outer_hash_join_probe.rs
+++ b/src/daft-local-execution/src/sinks/outer_hash_join_probe.rs
@@ -201,8 +201,8 @@ impl OuterHashJoinProbeSink {
         left_non_join_columns: &[String],
         right_non_join_columns: &[String],
     ) -> DaftResult<Arc<MicroPartition>> {
-        let probe_table = probe_state.get_probeable().clone();
-        let tables = probe_state.get_tables().clone();
+        let probe_table = probe_state.get_probeable();
+        let tables = probe_state.get_tables();
 
         let _growables = info_span!("OuterHashJoinProbeSink::build_growables").entered();
         let mut build_side_growable = GrowableTable::new(
@@ -268,8 +268,8 @@ impl OuterHashJoinProbeSink {
         left_non_join_columns: &[String],
         right_non_join_columns: &[String],
     ) -> DaftResult<Arc<MicroPartition>> {
-        let probe_table = probe_state.get_probeable().clone();
-        let tables = probe_state.get_tables().clone();
+        let probe_table = probe_state.get_probeable();
+        let tables = probe_state.get_tables();
 
         let _growables = info_span!("OuterHashJoinProbeSink::build_growables").entered();
         let mut build_side_growable = GrowableTable::new(
@@ -339,8 +339,8 @@ impl OuterHashJoinProbeSink {
         right_non_join_columns: &[String],
         build_on_left: bool,
     ) -> DaftResult<Arc<MicroPartition>> {
-        let probe_table = probe_state.get_probeable().clone();
-        let tables = probe_state.get_tables().clone();
+        let probe_table = probe_state.get_probeable();
+        let tables = probe_state.get_tables();
 
         let _growables = info_span!("OuterHashJoinProbeSink::build_growables").entered();
         // Need to set use_validity to true here because we add nulls to the build side

--- a/tests/sql/test_joins.py
+++ b/tests/sql/test_joins.py
@@ -98,7 +98,8 @@ def test_joins_with_duplicate_columns():
         """
         SELECT *
         FROM table1 t1
-        LEFT JOIN table2 t2 on t2.id = t1.id;
+        LEFT JOIN table2 t2 on t2.id = t1.id
+        ORDER BY t1.id;
         """,
         catalog,
     ).collect()


### PR DESCRIPTION
Enable left/right joins to build on either side. E.g. if left join, we can build on left and save used values in a bitmap (same as outer join), then emit the unmatched rows from the finalize.

Total tpch time after this pr: 65s, down from 88s
