### PR TITLE
perf: lazily import pyiceberg and unity catalog if available

### DIFF
--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -45,21 +45,12 @@ from daft.logical.builder import LogicalPlanBuilder
 
 from daft.dataframe import DataFrame
 
-_PYICEBERG_AVAILABLE = False
-try:
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
     from pyiceberg.catalog import Catalog as PyIcebergCatalog
-
-    _PYICEBERG_AVAILABLE = True
-except ImportError:
-    pass
-
-_UNITY_AVAILABLE = False
-try:
     from daft.unity_catalog import UnityCatalog
 
-    _UNITY_AVAILABLE = True
-except ImportError:
-    pass
 
 __all__ = [
     "read_table",
@@ -136,6 +127,22 @@ def register_python_catalog(catalog: PyIcebergCatalog | UnityCatalog, name: str 
         >>> daft.catalog.register_python_catalog(catalog, "my_daft_catalog")
 
     """
+    _PYICEBERG_AVAILABLE = False
+    try:
+        from pyiceberg.catalog import Catalog as PyIcebergCatalog
+
+        _PYICEBERG_AVAILABLE = True
+    except ImportError:
+        pass
+
+    _UNITY_AVAILABLE = False
+    try:
+        from daft.unity_catalog import UnityCatalog
+
+        _UNITY_AVAILABLE = True
+    except ImportError:
+        pass
+
     python_catalog: PyIcebergCatalog
     if _PYICEBERG_AVAILABLE and isinstance(catalog, PyIcebergCatalog):
         from daft.catalog.pyiceberg import PyIcebergCatalogAdaptor


### PR DESCRIPTION
`memray` reports that a not-insignificant amount of memory is being taken by our catalog module at import-time

<img width="1179" alt="image" src="https://github.com/user-attachments/assets/f2b88810-bc6b-4631-bbdc-b75f0848b63c" />

This PR makes those imports lazy