### PR TITLE
ci: Add new script to run an arbitrary "entrypoint" script

### DIFF
--- a/.github/workflows/run-script.yaml
+++ b/.github/workflows/run-script.yaml
@@ -1,0 +1,105 @@
+name: run-script
+
+on:
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: Python version
+        type: string
+        required: false
+        default: "3.9"
+      entrypoint:
+        description: Entrypoint script
+        type: string
+        required: true
+
+jobs:
+  run-command:
+    runs-on: [self-hosted, linux, x64, ci-dev]
+    timeout-minutes: 15 # Remove for ssh debugging
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      RUN_MODE: ci
+    steps:
+    - name: Log workflow inputs
+      run: echo "${{ toJson(github.event.inputs) }}"
+    - name: Checkout repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-west-2
+        role-session-name: run-cluster-workflow
+    - name: Install uv, rust, python
+      uses: ./.github/actions/install
+      with:
+        python_version: ${{ inputs.python_version }}
+    - name: Download private ssh key
+      run: |
+        KEY=$(aws secretsmanager get-secret-value --secret-id ci-github-actions-ray-cluster-key-3 --query SecretString --output text)
+        echo "$KEY" >> ~/.ssh/ci-github-actions-ray-cluster-key.pem
+        chmod 600 ~/.ssh/ci-github-actions-ray-cluster-key.pem
+    - name: Setup uv venv
+      run: |
+        uv v --python ${{ inputs.python_version }}
+    - name: Download daft
+      run: |
+        rm -rf daft
+        uv pip install getdaft
+    - name: Spin up ray cluster
+      run: |
+        source .venv/bin/activate
+        uv pip install ray[default] boto3
+        ray up ci/assets/medium-x86.yaml -y
+    - name: Setup connection to ray cluster
+      run: |
+        source .venv/bin/activate
+        ray dashboard ci/assets/medium-x86.yaml &
+    - name: Run the entrypoint script
+      run: |
+        set +e
+        source .venv/bin/activate
+        if [[ -z '${{ inputs.entrypoint }}' ]]; then
+          echo 'Invalid entrypoint submitted'
+          exit 1
+        fi
+        chmod +x ${{ inputs.entrypoint }}
+        ${{ inputs.entrypoint }}
+    - name: Download log files from ray cluster
+      run: |
+        source .venv/bin/activate
+        ray rsync-down ci/assets/medium-x86.yaml /tmp/ray/session_latest/logs ray-daft-logs
+        find ray-daft-logs -depth -name '*:*' -exec bash -c '
+        for filepath; do
+          dir=$(dirname "$filepath")
+          base=$(basename "$filepath")
+          new_base=${base//:/_}
+          mv "$filepath" "$dir/$new_base"
+        done
+        ' _ {} +
+    - name: Kill connection to ray cluster
+      run: |
+        PID=$(lsof -t -i:8265)
+        if [[ -n "$PID" ]]; then
+            echo "Process $PID is listening on port 8265; killing it..."
+            kill -9 "$PID"
+            if [[ $? -eq 0 ]]; then
+                echo "Process $PID killed successfully"
+            else
+                echo "Failed to kill process $PID"
+            fi
+        fi
+    - name: Spin down ray cluster
+      if: always()
+      run: |
+        source .venv/bin/activate
+        ray down ci/assets/medium-x86.yaml -y
+    - name: Upload log files
+      uses: actions/upload-artifact@v4
+      with:
+        name: ray-daft-logs
+        path: ray-daft-logs

--- a/benchmarking/tpcds/__main__.py
+++ b/benchmarking/tpcds/__main__.py
@@ -72,13 +72,16 @@ def run_query_on_ray(
                     "entrypoint": f"python {ray_entrypoint_script} --tpcds-gen-folder 'data/0.01' --question {query_index} {'--dry-run' if run_args.dry_run else ''}",
                     "runtime_env": {
                         "working_dir": working_dir,
+                        "env_vars": {
+                            "DAFT_ENABLE_RAY_TRACING": "1",
+                        },
                     },
                 },
             )
             end = datetime.now()
             duration = end - start
-        except Exception as e:
-            error_msg = str(e)
+        except Exception:
+            error_msg = "Failed"
 
         results.append(Result(index=query_index, duration=duration, error_msg=error_msg))
 

--- a/benchmarking/tpcds/ray_entrypoint.py
+++ b/benchmarking/tpcds/ray_entrypoint.py
@@ -16,9 +16,10 @@ def run(
     with open(query_file) as f:
         query = f.read()
 
-    daft.sql(query, catalog=catalog).explain(show_all=True)
+    query = daft.sql(query, catalog=catalog)
+    query.explain(show_all=True)
     if not dry_run:
-        daft.sql(query, catalog=catalog).collect()
+        query.collect()
 
 
 if __name__ == "__main__":

--- a/ci/assets/medium-x86.yaml
+++ b/ci/assets/medium-x86.yaml
@@ -1,0 +1,46 @@
+cluster_name: medium-x86
+
+provider:
+  type: aws
+  region: us-west-2
+  cache_stopped_nodes: false
+  security_group:
+    GroupName: ray-autoscaler-c1
+
+auth:
+  ssh_user: ubuntu
+  ssh_private_key: ~/.ssh/ci-github-actions-ray-cluster-key.pem
+
+max_workers: 2
+available_node_types:
+  ray.head.default:
+    resources: {"CPU": 0}
+    node_config:
+      KeyName: ci-github-actions-ray-cluster-key
+      InstanceType: i3.2xlarge
+      ImageId: ami-04dd23e62ed049936
+      IamInstanceProfile:
+        Name: ray-autoscaler-v1
+
+  ray.worker.default:
+    min_workers: 2
+    max_workers: 2
+    resources: {}
+    node_config:
+      KeyName: ci-github-actions-ray-cluster-key
+      InstanceType: i3.2xlarge
+      ImageId: ami-04dd23e62ed049936
+      IamInstanceProfile:
+        Name: ray-autoscaler-v1
+
+setup_commands:
+- sudo snap install aws-cli --classic
+- curl -LsSf https://astral.sh/uv/install.sh | sh
+- echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+- source ~/.bashrc
+- uv python install 3.9
+- uv python pin 3.9
+- uv v
+- echo "source $HOME/.venv/bin/activate" >> $HOME/.bashrc
+- source .venv/bin/activate
+- uv pip install pip ray[default] py-spy getdaft

--- a/ci/assets/template.yaml
+++ b/ci/assets/template.yaml
@@ -1,0 +1,51 @@
+# Note:
+# GitHub Actions workflow will replace all parameters between `{{...}}` with the
+# actual values as determined dynamically during runtime of the actual workflow.
+
+cluster_name: \{{CLUSTER_NAME}}
+
+provider:
+  type: aws
+  region: us-west-2
+  cache_stopped_nodes: false
+  security_group:
+    GroupName: ray-autoscaler-c1
+
+auth:
+  ssh_user: \{{CLUSTER_PROFILE/ssh_user}}
+  ssh_private_key: ~/.ssh/ci-github-actions-ray-cluster-key.pem
+
+max_workers: \{{CLUSTER_PROFILE/node_count}}
+available_node_types:
+  ray.head.default:
+    resources: {"CPU": 0}
+    node_config:
+      KeyName: ci-github-actions-ray-cluster-key
+      InstanceType: \{{CLUSTER_PROFILE/instance_type}}
+      ImageId: \{{CLUSTER_PROFILE/image_id}}
+      IamInstanceProfile:
+        Name: ray-autoscaler-v1
+
+  ray.worker.default:
+    min_workers: \{{CLUSTER_PROFILE/node_count}}
+    max_workers: \{{CLUSTER_PROFILE/node_count}}
+    resources: {}
+    node_config:
+      KeyName: ci-github-actions-ray-cluster-key
+      InstanceType: \{{CLUSTER_PROFILE/instance_type}}
+      ImageId: \{{CLUSTER_PROFILE/image_id}}
+      IamInstanceProfile:
+        Name: ray-autoscaler-v1
+
+setup_commands:
+- \{{CLUSTER_PROFILE/volume_mount}}
+- sudo snap install aws-cli --classic
+- curl -LsSf https://astral.sh/uv/install.sh | sh
+- echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+- source ~/.bashrc
+- uv python install \{{PYTHON_VERSION}}
+- uv python pin \{{PYTHON_VERSION}}
+- uv v
+- echo "source $HOME/.venv/bin/activate" >> $HOME/.bashrc
+- source .venv/bin/activate
+- uv pip install pip ray[default] py-spy \{{DAFT_INSTALL}} \{{OTHER_INSTALLS}}

--- a/ci/entrypoints/tpcds.sh
+++ b/ci/entrypoints/tpcds.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script should only be run in CI.
+# CI should set `RUN_MODE="ci"` prior to running this script.
+#
+# This script should not be run locally.
+if [ "$RUN_MODE" != "ci" ]; then
+    echo "Looks like you're running this script locally on your laptop." >&2
+    echo "This script is meant to run in CI only." >&2
+    echo "Failing..." >&2
+    exit 1
+fi
+
+uv pip install duckdb
+DAFT_RUNNER=ray python -m benchmarking.tpcds --questions '3' --scale-factor '0.01'

--- a/scripts/run-build.sh
+++ b/scripts/run-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+echo "Running a build on the branch $current_branch"
+
+gh workflow run build-commit.yaml --ref $current_branch -f arch='x86'

--- a/scripts/run-tpcds-benchmarks.sh
+++ b/scripts/run-tpcds-benchmarks.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+gh workflow run run-script.yaml \
+    --ref refactor/run-cluster \
+    -f entrypoint="ci/entrypoints/tpcds.sh"


### PR DESCRIPTION
# Overview

The existing `run-cluster.yaml` script is quite opinionated on certain things:
- the entrypoint script must be a python script
- it must be invoked as a standalone script (i.e., no running modules via `python -m module.sub_module`)
- `ray job submit ...` is a hard-coded step in the workflow

These things make the `run-cluster.yaml` workflow nice for more opinionated workflows. However, a more generic script which is not as opinionated will allow us to run a wider variety of commands (e.g., custom bash scripts which can submit jobs in the way it wants to).

This PR introduces a new workflow, `run-script.yaml`, which provides this interface.

## Usage

You can pass in any arbitrary command as the input. Even try `ls -las`.

A more useful command to pass in would be `ci/entrypoints/tpcds.sh` (i.e., `gh workflow run run-script.yaml --ref refactor/run-cluster -f entrypoint="ci/entrypoints/tpcds.sh"`.

(As a shortcut, instead of running the above command manually, you can just run `scripts/run-tpcds-benchmarking.sh` instead, which runs that exact command).

## Limitations

- cluster-profiles not yet implemented (small deliverables!)
  - only runs `medium-x86`; will expand to more in a follow-up PR
- currently only runs latest released version of daft
  - will update to run a specific wheel