### PR TITLE
chore!: drop support for Python 3.8

### DIFF
--- a/.github/workflows/build-artifact-s3.yml
+++ b/.github/workflows/build-artifact-s3.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   PACKAGE_NAME: getdaft
-  PYTHON_VERSION: 3.8
+  PYTHON_VERSION: 3.9
 
 jobs:
   build-and-push:

--- a/.github/workflows/nightlies-tests.yml
+++ b/.github/workflows/nightlies-tests.yml
@@ -12,7 +12,7 @@ on:
 env:
   DAFT_ANALYTICS_ENABLED: '0'
   UV_SYSTEM_PYTHON: 1
-  PYTHON_VERSION: '3.8'
+  PYTHON_VERSION: '3.9'
 
 jobs:
   integration-test-tpch:

--- a/.github/workflows/notebook-checker.yml
+++ b/.github/workflows/notebook-checker.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/property-based-tests.yml
+++ b/.github/workflows/property-based-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
         daft_runner: [py]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.10']
+        python-version: ['3.9', '3.10']
         daft-runner: [py, ray, native]
         pyarrow-version: [7.0.0, 16.0.0]
         os: [ubuntu-20.04, windows-latest]
@@ -40,10 +40,10 @@ jobs:
           python-version: '3.10'
           pyarrow-version: 7.0.0
           os: ubuntu-20.04
-        - python-version: '3.8'
+        - python-version: '3.9'
           pyarrow-version: 16.0.0
         - os: windows-latest
-          python-version: '3.8'
+          python-version: '3.9'
         - os: windows-latest
           pyarrow-version: 7.0.0
     steps:
@@ -181,7 +181,7 @@ jobs:
       package-name: getdaft
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
     steps:
     - uses: actions/checkout@v4
       with:
@@ -219,7 +219,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
         daft-runner: [py, ray, native]
     steps:
     - uses: actions/checkout@v4
@@ -294,7 +294,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
+        python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray, native]
     steps:
     - uses: actions/checkout@v4
@@ -372,7 +372,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
+        python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray, native]
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     # This is used in the step "Assume GitHub Actions AWS Credentials"
@@ -466,7 +466,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
+        python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray, native]
     steps:
     - uses: actions/checkout@v4
@@ -543,7 +543,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8'] # can't use 3.7 due to requiring anon mode for adlfs
+        python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
         daft-runner: [py, ray, native]
     steps:
     - uses: actions/checkout@v4
@@ -854,7 +854,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, Windows]
-        python-version: ['3.8']
+        python-version: ['3.9']
     steps:
     - uses: actions/checkout@v4
     - uses: moonrepo/setup-rust@v1
@@ -946,7 +946,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      python-version: '3.8'
+      python-version: '3.9'
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ env.python-version }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -162,7 +162,7 @@ jobs:
       with:
         # Really doesn't matter what version we upload with
         # just the version we test with
-        python-version: '3.8'
+        python-version: '3.9'
         channels: conda-forge
         channel-priority: true
 

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,7 +1,7 @@
 fix = true
 indent-width = 4
 line-length = 120
-target-version = "py38"
+target-version = "py39"
 
 [format]
 docstring-code-format = true

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,7 +1,8 @@
 fix = true
 indent-width = 4
 line-length = 120
-target-version = "py39"
+# TODO: clean up typing code and update to py39
+target-version = "py38"
 
 [format]
 docstring-code-format = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ features = ['async']
 path = "src/parquet2"
 
 [workspace.dependencies.pyo3]
-features = ["extension-module", "multiple-pymethods", "abi3-py38", "indexmap"]
+features = ["extension-module", "multiple-pymethods", "abi3-py39", "indexmap"]
 version = "0.21.0"
 
 [workspace.dependencies.pyo3-log]

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1094,13 +1094,9 @@ class DataFrame:
         <BLANKLINE>
         (Showing first 1 of 1 rows)
         """
-        import sys
-
         from daft import from_pydict
         from daft.io.object_store_options import io_config_to_storage_options
 
-        if sys.version_info < (3, 9):
-            raise ValueError("'write_lance' requires python 3.9 or higher")
         try:
             import lance
             import pyarrow as pa

--- a/daft/pickle/cloudpickle.py
+++ b/daft/pickle/cloudpickle.py
@@ -70,20 +70,7 @@ try:  # pragma: no branch
 except ImportError:
     _typing_extensions = Literal = Final = None
 
-if sys.version_info >= (3, 8):
-    from types import CellType
-else:
-
-    def f():
-        a = 1
-
-        def g():
-            return a
-
-        return g
-
-    CellType = type(f().__closure__[0])
-
+from types import CellType
 
 # cloudpickle is meant for inter process communication: we expect all
 # communicating processes to run the same Python version hence we favor

--- a/daft/pickle/compat.py
+++ b/daft/pickle/compat.py
@@ -4,20 +4,8 @@ Taken from: https://github.com/cloudpipe/cloudpickle/blob/master/cloudpickle/com
 
 from __future__ import annotations
 
-import sys
+import pickle  # noqa: F401
 
-if sys.version_info < (3, 8):
-    try:
-        import pickle5 as pickle
-        from pickle5 import Pickler
-    except ImportError:
-        import pickle
-
-        # Use the Python pickler for old CPython versions
-        from pickle import _Pickler as Pickler
-else:
-    import pickle  # noqa: F401
-
-    # Pickler will the C implementation in CPython and the Python
-    # implementation in PyPy
-    from pickle import Pickler  # noqa: F401
+# Pickler will the C implementation in CPython and the Python
+# implementation in PyPy
+from pickle import Pickler  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ maintainers = [
 ]
 name = "getdaft"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 all = ["getdaft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake, sql, unity]"]
@@ -64,7 +64,7 @@ features = ["python"]
 [tool.mypy]
 exclude = ['daft/pickle/*.py$']
 files = ["daft/**/*.py", "daft/**/*.pyx", "tests/**/*.py"]
-python_version = "3.8"
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,13 +36,12 @@ tiktoken==0.7.0
 duckdb==1.1.2
 
 # Pyarrow
-pyarrow==16.0.0; python_version >= '3.10'
-pyarrow==15.0.0; python_version < '3.10'
+pyarrow==16.0.0
 # Ray
 ray[data, client]==2.34.0
 
 # Lance
-lancedb>=0.6.10; python_version >= '3.8'
+lancedb>=0.6.10
 
 #Iceberg
 pyiceberg==0.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,7 +41,7 @@ pyarrow==16.0.0
 ray[data, client]==2.34.0
 
 # Lance
-lancedb>=0.6.10
+lancedb==0.6.10
 
 #Iceberg
 pyiceberg==0.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,12 +36,13 @@ tiktoken==0.7.0
 duckdb==1.1.2
 
 # Pyarrow
-pyarrow==16.0.0
+pyarrow==16.0.0; python_version >= '3.10'
+pyarrow==15.0.0; python_version < '3.10'
 # Ray
 ray[data, client]==2.34.0
 
 # Lance
-lancedb==0.11.0
+lancedb>=0.6.10; python_version >= '3.8'
 
 #Iceberg
 pyiceberg==0.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,7 +41,7 @@ pyarrow==16.0.0
 ray[data, client]==2.34.0
 
 # Lance
-lancedb==0.6.10
+lancedb==0.11.0
 
 #Iceberg
 pyiceberg==0.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,7 +50,8 @@ tenacity==8.2.3
 
 # Delta Lake
 deltalake==0.5.8; platform_system == "Windows"
-deltalake==0.19.2; platform_system != "Windows"
+deltalake==0.18.2; platform_system != "Windows" and python_version < '3.10'
+deltalake==0.19.2; platform_system != "Windows" and python_version >= '3.10'
 
 # Databricks
 databricks-sdk==0.12.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,12 +26,9 @@ pytest-codspeed==2.2.1
 
 # Testing dependencies
 lxml==5.3.0
-dask==2023.5.0; python_version == '3.8'
-dask[dataframe]==2024.4.1; python_version >= '3.9'
-numpy; python_version < '3.9'
-numpy==1.26.2; python_version >= '3.9'
-pandas==2.0.3; python_version == '3.8'
-pandas==2.1.3; python_version >= '3.9'
+dask[dataframe]==2024.4.1
+numpy==1.26.2
+pandas==2.1.3
 xxhash>=3.0.0
 Pillow==10.4.0
 opencv-python==4.10.0.84
@@ -39,60 +36,56 @@ tiktoken==0.7.0
 duckdb==1.1.2
 
 # Pyarrow
-pyarrow==16.0.0; python_version >= '3.9'
-pyarrow==15.0.0; python_version < '3.9'
+pyarrow==16.0.0
 # Ray
-ray[data, client]==2.10.0; python_version == '3.8'
-ray[data, client]==2.34.0; python_version >= '3.9'
+ray[data, client]==2.34.0
 
 # Lance
-lancedb>=0.6.10; python_version >= '3.8'
+lancedb>=0.6.10
 
 #Iceberg
-pyiceberg==0.7.0; python_version >= '3.8'
-tenacity==8.2.3; python_version >= '3.8'
+pyiceberg==0.7.0
+tenacity==8.2.3
 
 # Delta Lake
 deltalake==0.5.8; platform_system == "Windows"
-deltalake==0.18.2; platform_system != "Windows" and python_version < '3.9'
-deltalake==0.19.2; platform_system != "Windows" and python_version >= '3.9'
+deltalake==0.19.2; platform_system != "Windows"
 
 # Databricks
 databricks-sdk==0.12.0
 unitycatalog==0.1.1
 
 #SQL
-sqlalchemy==2.0.36; python_version >= '3.8'
-connectorx==0.2.3; platform_system == "Linux" and platform_machine == "aarch64" and python_version >= '3.8'
-connectorx==0.3.2; (platform_system != "Linux" or platform_machine != "aarch64") and python_version <= '3.8'
-connectorx==0.3.3; (platform_system != "Linux" or platform_machine != "aarch64") and python_version > '3.8'
-trino[sqlalchemy]==0.328.0; python_version >= '3.8'
-PyMySQL==1.1.0; python_version >= '3.8'
-psycopg2-binary==2.9.10; python_version >= '3.8'
-sqlglot==23.3.0; python_version >= '3.8'
-pyodbc==5.1.0; python_version >= '3.8'
+sqlalchemy==2.0.36
+connectorx==0.2.3; platform_system == "Linux" and platform_machine == "aarch64"
+connectorx==0.3.3; platform_system != "Linux" or platform_machine != "aarch64"
+trino[sqlalchemy]==0.328.0
+PyMySQL==1.1.0
+psycopg2-binary==2.9.10
+sqlglot==23.3.0
+pyodbc==5.1.0
 
 # AWS
-s3fs==2023.12.0; python_version >= '3.8'
+s3fs==2023.12.0
 # on old versions of s3fs's pinned botocore, they neglected to pin urllib3<2 which leads to:
 # "ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_'"
-boto3==1.34.51; python_version >= '3.8'
-moto[s3,server]==5.0.21; python_version >= '3.8'
+boto3==1.34.51
+moto[s3,server]==5.0.21
 
 # Azure
-adlfs==2024.7.0; python_version >= '3.8'
+adlfs==2024.7.0
 azure-storage-blob==12.24.0
 
 # GCS
-gcsfs==2023.12.0; python_version >= '3.8'
+gcsfs==2023.12.0
 
 # Documentation
 myst-nb>=0.16.0
 Sphinx==5.3.0
-sphinx-book-theme==1.1.0; python_version >= "3.9"
+sphinx-book-theme==1.1.0
 sphinx-reredirects>=0.1.1
 sphinx-copybutton>=0.5.2
-sphinx-autosummary-accessors==2023.4.0; python_version >= "3.9"
+sphinx-autosummary-accessors==2023.4.0
 sphinx-tabs==3.4.5
 
 # Daft connect testing

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -49,8 +49,7 @@ tenacity==8.2.3
 
 # Delta Lake
 deltalake==0.5.8; platform_system == "Windows"
-deltalake==0.18.2; platform_system != "Windows" and python_version < '3.10'
-deltalake==0.19.2; platform_system != "Windows" and python_version >= '3.10'
+deltalake==0.19.2; platform_system != "Windows"
 
 # Databricks
 databricks-sdk==0.12.0

--- a/tests/dataframe/test_intersect.py
+++ b/tests/dataframe/test_intersect.py
@@ -7,8 +7,8 @@ from daft import col
 def test_simple_intersect(make_df):
     df1 = make_df({"foo": [1, 2, 3]})
     df2 = make_df({"bar": [2, 3, 4]})
-    result = df1.intersect(df2).sort(by="foo")
-    assert result.sort("foo").to_pydict() == {"foo": [2, 3]}
+    result = df1.intersect(df2)
+    assert result.to_pydict() == {"foo": [2, 3]}
 
 
 def test_intersect_with_duplicate(make_df):

--- a/tests/dataframe/test_intersect.py
+++ b/tests/dataframe/test_intersect.py
@@ -7,8 +7,8 @@ from daft import col
 def test_simple_intersect(make_df):
     df1 = make_df({"foo": [1, 2, 3]})
     df2 = make_df({"bar": [2, 3, 4]})
-    result = df1.intersect(df2)
-    assert result.to_pydict() == {"foo": [2, 3]}
+    result = df1.intersect(df2).sort(by="foo")
+    assert result.sort("foo").to_pydict() == {"foo": [2, 3]}
 
 
 def test_intersect_with_duplicate(make_df):

--- a/tests/io/delta_lake/test_table_read.py
+++ b/tests/io/delta_lake/test_table_read.py
@@ -8,8 +8,9 @@ from daft.io.object_store_options import io_config_to_storage_options
 from daft.logical.schema import Schema
 from tests.utils import assert_pyarrow_tables_equal
 
+PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
 pytestmark = pytest.mark.skipif(
-    tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0),
+    PYARROW_LE_8_0_0,
     reason="deltalake only supported if pyarrow >= 8.0.0",
 )
 

--- a/tests/io/delta_lake/test_table_read.py
+++ b/tests/io/delta_lake/test_table_read.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-
 import pyarrow as pa
 import pytest
 
@@ -10,10 +8,9 @@ from daft.io.object_store_options import io_config_to_storage_options
 from daft.logical.schema import Schema
 from tests.utils import assert_pyarrow_tables_equal
 
-PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-PYTHON_LT_3_8 = sys.version_info[:2] < (3, 8)
 pytestmark = pytest.mark.skipif(
-    PYARROW_LE_8_0_0 or PYTHON_LT_3_8, reason="deltalake only supported if pyarrow >= 8.0.0 and python >= 3.8"
+    tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0),
+    reason="deltalake only supported if pyarrow >= 8.0.0",
 )
 
 

--- a/tests/io/delta_lake/test_table_read_pushdowns.py
+++ b/tests/io/delta_lake/test_table_read_pushdowns.py
@@ -16,8 +16,9 @@ import daft
 from daft.logical.schema import Schema
 from tests.utils import assert_pyarrow_tables_equal
 
+PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
 pytestmark = pytest.mark.skipif(
-    tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0),
+    PYARROW_LE_8_0_0,
     reason="deltalake only supported if pyarrow >= 8.0.0",
 )
 

--- a/tests/io/delta_lake/test_table_read_pushdowns.py
+++ b/tests/io/delta_lake/test_table_read_pushdowns.py
@@ -7,7 +7,6 @@ import pytest
 from daft.io.object_store_options import io_config_to_storage_options
 
 deltalake = pytest.importorskip("deltalake")
-import sys
 
 import pyarrow as pa
 import pyarrow.compute as pc
@@ -17,10 +16,9 @@ import daft
 from daft.logical.schema import Schema
 from tests.utils import assert_pyarrow_tables_equal
 
-PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-PYTHON_LT_3_8 = sys.version_info[:2] < (3, 8)
 pytestmark = pytest.mark.skipif(
-    PYARROW_LE_8_0_0 or PYTHON_LT_3_8, reason="deltalake only supported if pyarrow >= 8.0.0 and python >= 3.8"
+    tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0),
+    reason="deltalake only supported if pyarrow >= 8.0.0",
 )
 
 

--- a/tests/io/delta_lake/test_table_write.py
+++ b/tests/io/delta_lake/test_table_write.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import decimal
-import sys
 from pathlib import Path
 
 import pyarrow as pa
@@ -13,15 +12,9 @@ from daft.io.object_store_options import io_config_to_storage_options
 from daft.logical.schema import Schema
 from tests.conftest import get_tests_daft_runner_name
 
-PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (
-    8,
-    0,
-    0,
-)
-PYTHON_LT_3_8 = sys.version_info[:2] < (3, 8)
 pytestmark = pytest.mark.skipif(
-    PYARROW_LE_8_0_0 or PYTHON_LT_3_8,
-    reason="deltalake only supported if pyarrow >= 8.0.0 and python >= 3.8",
+    tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0),
+    reason="deltalake only supported if pyarrow >= 8.0.0",
 )
 
 

--- a/tests/io/delta_lake/test_table_write.py
+++ b/tests/io/delta_lake/test_table_write.py
@@ -12,8 +12,9 @@ from daft.io.object_store_options import io_config_to_storage_options
 from daft.logical.schema import Schema
 from tests.conftest import get_tests_daft_runner_name
 
+PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
 pytestmark = pytest.mark.skipif(
-    tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0),
+    PYARROW_LE_8_0_0,
     reason="deltalake only supported if pyarrow >= 8.0.0",
 )
 

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -1,5 +1,3 @@
-import sys
-
 import pyarrow as pa
 import pytest
 
@@ -14,7 +12,7 @@ data = {
 }
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-PY_LE_3_9_0 = sys.version_info < (3, 10)
+PY_LE_3_9_0 = False  # sys.version_info < (3, 10)
 pytestmark = pytest.mark.skipif(
     PYARROW_LE_8_0_0 or PY_LE_3_9_0, reason="lance only supported if pyarrow >= 8.0.0 and python >= 3.10.0"
 )

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -14,7 +14,7 @@ data = {
 }
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-PY_LE_3_9_0 = sys.version_info < (3, 9)
+PY_LE_3_9_0 = sys.version_info <= (3, 9)
 pytestmark = pytest.mark.skipif(
     PYARROW_LE_8_0_0 or PY_LE_3_9_0, reason="lance only supported if pyarrow >= 8.0.0 and python > 3.9.0"
 )

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -1,3 +1,5 @@
+import sys
+
 import pyarrow as pa
 import pytest
 
@@ -11,9 +13,10 @@ data = {
     "long": [-122.7, -74.1],
 }
 
+PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
+PY_LE_3_9_0 = sys.version_info < (3, 9)
 pytestmark = pytest.mark.skipif(
-    tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0),
-    reason="lance only supported if pyarrow >= 8.0.0",
+    PYARROW_LE_8_0_0 or PY_LE_3_9_0, reason="lance only supported if pyarrow >= 8.0.0 and python > 3.9.0"
 )
 
 

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -14,9 +14,9 @@ data = {
 }
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-PY_LE_3_9_0 = sys.version_info <= (3, 9)
+PY_LE_3_9_0 = sys.version_info < (3, 10)
 pytestmark = pytest.mark.skipif(
-    PYARROW_LE_8_0_0 or PY_LE_3_9_0, reason="lance only supported if pyarrow >= 8.0.0 and python > 3.9.0"
+    PYARROW_LE_8_0_0 or PY_LE_3_9_0, reason="lance only supported if pyarrow >= 8.0.0 and python >= 3.10.0"
 )
 
 

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -1,5 +1,3 @@
-import sys
-
 import pyarrow as pa
 import pytest
 
@@ -13,10 +11,9 @@ data = {
     "long": [-122.7, -74.1],
 }
 
-PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-PY_LE_3_9_0 = sys.version_info < (3, 9)
 pytestmark = pytest.mark.skipif(
-    PYARROW_LE_8_0_0 or PY_LE_3_9_0, reason="lance only supported if pyarrow >= 8.0.0 and python >= 3.9.0"
+    tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0),
+    reason="lance only supported if pyarrow >= 8.0.0",
 )
 
 

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -2,6 +2,7 @@ import pyarrow as pa
 import pytest
 
 import daft
+from tests.conftest import get_tests_daft_runner_name
 from tests.integration.io.conftest import minio_create_bucket
 
 TABLE_NAME = "my_table"
@@ -12,6 +13,7 @@ data = {
 }
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
+
 pytestmark = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="lance only supported if pyarrow >= 8.0.0")
 
 
@@ -28,6 +30,8 @@ def test_lancedb_roundtrip(lance_dataset_path):
     assert df.to_pydict() == data
 
 
+# TODO: re-enable test on Ray when fixed
+@pytest.mark.skipif(get_tests_daft_runner_name() == "ray", reason="Lance fails to load credentials on Ray")
 @pytest.mark.integration()
 def test_lancedb_minio(minio_io_config):
     df = daft.from_pydict(data)

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -12,10 +12,7 @@ data = {
 }
 
 PYARROW_LE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (8, 0, 0)
-PY_LE_3_9_0 = False  # sys.version_info < (3, 10)
-pytestmark = pytest.mark.skipif(
-    PYARROW_LE_8_0_0 or PY_LE_3_9_0, reason="lance only supported if pyarrow >= 8.0.0 and python >= 3.10.0"
-)
+pytestmark = pytest.mark.skipif(PYARROW_LE_8_0_0, reason="lance only supported if pyarrow >= 8.0.0")
 
 
 @pytest.fixture(scope="function")

--- a/tests/series/test_temporal_ops.py
+++ b/tests/series/test_temporal_ops.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-
 import pytest
 
 from daft.datatype import DataType, TimeUnit
@@ -279,10 +277,6 @@ def ts_with_tz_maker(y, m, d, h, mi, s, us, tz):
         return datetime(y, m, d, h, mi, s, us, pytz.timezone(tz))
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8),
-    reason="Timezone conversions via PyArrow are supported in Python 3.8+",
-)
 @pytest.mark.parametrize(
     ["input", "interval", "expected"],
     [
@@ -319,10 +313,6 @@ def test_series_timestamp_truncate_operation(input, interval, expected, tz) -> N
     assert expected_series.to_pylist() == truncated
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8),
-    reason="Timezone conversions via PyArrow are supported in Python 3.8+",
-)
 @pytest.mark.parametrize("tz", [None, "UTC", "+09:00", "-13:00"])
 @pytest.mark.parametrize(
     ["input", "interval", "expected", "relative_to"],
@@ -360,10 +350,6 @@ def test_series_timestamp_truncate_operation_with_relative_to(tz, input, interva
     assert expected_series.to_pylist() == truncated
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8),
-    reason="Timezone conversions via PyArrow are supported in Python 3.8+",
-)
 @pytest.mark.parametrize("tz", [None, "UTC", "+09:00", "-13:00"])
 @pytest.mark.parametrize(
     ["input", "interval", "expected", "relative_to"],

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import sys
 from typing import Dict, List
 
 import pytest
@@ -52,25 +51,21 @@ def test_datatype_parsing(source, expected):
     assert DataType._infer_type(source) == expected
 
 
-# These tests are only valid for more modern versions of Python, but can't be skipped in the conventional
-# way either because we cannot even run the subscripting during import-time
-if sys.version_info >= (3, 9):
-
-    @pytest.mark.parametrize(
-        ["source", "expected"],
-        [
-            # These tests must be run in later version of Python that allow for subscripting of types
-            (list[str], DataType.list(DataType.string())),
-            (dict[str, int], DataType.map(DataType.string(), DataType.int64())),
-            (
-                {"foo": list[str], "bar": int},
-                DataType.struct({"foo": DataType.list(DataType.string()), "bar": DataType.int64()}),
-            ),
-            (list[list[str]], DataType.list(DataType.list(DataType.string()))),
-        ],
-    )
-    def test_subscripted_datatype_parsing(source, expected):
-        assert DataType._infer_type(source) == expected
+@pytest.mark.parametrize(
+    ["source", "expected"],
+    [
+        # These tests must be run in later version of Python that allow for subscripting of types
+        (list[str], DataType.list(DataType.string())),
+        (dict[str, int], DataType.map(DataType.string(), DataType.int64())),
+        (
+            {"foo": list[str], "bar": int},
+            DataType.struct({"foo": DataType.list(DataType.string()), "bar": DataType.int64()}),
+        ),
+        (list[list[str]], DataType.list(DataType.list(DataType.string()))),
+    ],
+)
+def test_subscripted_datatype_parsing(source, expected):
+    assert DataType._infer_type(source) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
BREAKING CHANGE: Python 3.8 has reached EOL, set our minimum version to 3.9