### PR TITLE
feat(optimizer): Add join reordering as an optimizer rule

### DIFF
--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -10,12 +10,20 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Serialize, Deserialize, Default, Debug)]
 pub struct DaftPlanningConfig {
     pub default_io_config: IOConfig,
+    pub enable_join_reordering: bool,
 }
 
 impl DaftPlanningConfig {
     #[must_use]
     pub fn from_env() -> Self {
-        Default::default()
+        let mut cfg: Self = Default::default();
+        let aqe_env_var_name = "ENABLE_JOIN_REORDERING";
+        if let Ok(val) = std::env::var(aqe_env_var_name)
+            && matches!(val.trim().to_lowercase().as_str(), "1" | "true")
+        {
+            cfg.enable_join_reordering = true;
+        }
+        cfg
     }
 }
 

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -17,8 +17,8 @@ impl DaftPlanningConfig {
     #[must_use]
     pub fn from_env() -> Self {
         let mut cfg: Self = Default::default();
-        let aqe_env_var_name = "ENABLE_JOIN_REORDERING";
-        if let Ok(val) = std::env::var(aqe_env_var_name)
+        let join_reordering_var_name = "DAFT_DEV_ENABLE_JOIN_REORDERING";
+        if let Ok(val) = std::env::var(join_reordering_var_name)
             && matches!(val.trim().to_lowercase().as_str(), "1" | "true")
         {
             cfg.enable_join_reordering = true;

--- a/src/daft-logical-plan/src/builder.rs
+++ b/src/daft-logical-plan/src/builder.rs
@@ -619,9 +619,9 @@ impl LogicalPlanBuilder {
         if let Some(conf) = &self.config
             && conf.enable_join_reordering
         {
-            optimizer_builder.reorder_joins();
+            optimizer_builder = optimizer_builder.reorder_joins();
         }
-        optimizer_builder.simplify_expressions();
+        optimizer_builder = optimizer_builder.simplify_expressions();
         let optimizer = optimizer_builder.build();
 
         // Run LogicalPlan optimizations

--- a/src/daft-logical-plan/src/builder.rs
+++ b/src/daft-logical-plan/src/builder.rs
@@ -25,7 +25,7 @@ use {
 use crate::{
     logical_plan::LogicalPlan,
     ops,
-    optimization::Optimizer,
+    optimization::{Optimizer, OptimizerConfig},
     partitioning::{
         HashRepartitionConfig, IntoPartitionsConfig, RandomShuffleConfig, RepartitionSpec,
     },
@@ -381,8 +381,7 @@ impl LogicalPlanBuilder {
         Ok(self.with_new_plan(pivot_logical_plan))
     }
 
-    // Helper function to create inner joins more ergonimically in tests.
-    #[cfg(test)]
+    // Helper function to create inner joins more ergonimically.
     pub(crate) fn inner_join<Right: Into<LogicalPlanRef>>(
         &self,
         right: Right,
@@ -616,7 +615,8 @@ impl LogicalPlanBuilder {
     }
 
     pub fn optimize(&self) -> DaftResult<Self> {
-        let optimizer = Optimizer::new(Default::default());
+        let optimizer_conf = OptimizerConfig::from(&self.config);
+        let optimizer = Optimizer::new(optimizer_conf);
 
         // Run LogicalPlan optimizations
         let unoptimized_plan = self.build();

--- a/src/daft-logical-plan/src/builder.rs
+++ b/src/daft-logical-plan/src/builder.rs
@@ -615,14 +615,15 @@ impl LogicalPlanBuilder {
     }
 
     pub fn optimize(&self) -> DaftResult<Self> {
-        let mut optimizer_builder = OptimizerBuilder::default();
-        if let Some(conf) = &self.config
-            && conf.enable_join_reordering
-        {
-            optimizer_builder = optimizer_builder.reorder_joins();
-        }
-        optimizer_builder = optimizer_builder.simplify_expressions();
-        let optimizer = optimizer_builder.build();
+        let optimizer = OptimizerBuilder::default()
+            .when(
+                self.config
+                    .as_ref()
+                    .map_or(false, |conf| conf.enable_join_reordering),
+                |builder| builder.reorder_joins(),
+            )
+            .simplify_expressions()
+            .build();
 
         // Run LogicalPlan optimizations
         let unoptimized_plan = self.build();

--- a/src/daft-logical-plan/src/optimization/mod.rs
+++ b/src/daft-logical-plan/src/optimization/mod.rs
@@ -5,4 +5,4 @@ mod rules;
 #[cfg(test)]
 mod test;
 
-pub use optimizer::{Optimizer, OptimizerConfig};
+pub use optimizer::{Optimizer, OptimizerBuilder, OptimizerConfig};

--- a/src/daft-logical-plan/src/optimization/optimizer.rs
+++ b/src/daft-logical-plan/src/optimization/optimizer.rs
@@ -177,6 +177,14 @@ impl OptimizerBuilder {
             config: self.config,
         }
     }
+
+    pub fn when(self, condition: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if condition {
+            f(self)
+        } else {
+            self
+        }
+    }
 }
 
 /// Logical rule-based optimizer.

--- a/src/daft-logical-plan/src/optimization/optimizer.rs
+++ b/src/daft-logical-plan/src/optimization/optimizer.rs
@@ -146,7 +146,7 @@ impl Default for OptimizerBuilder {
 }
 
 impl OptimizerBuilder {
-    pub fn reorder_joins(&mut self) {
+    pub fn reorder_joins(mut self) -> Self {
         self.rule_batches.push(RuleBatch::new(
             vec![
                 Box::new(ReorderJoins::new()),
@@ -154,18 +154,21 @@ impl OptimizerBuilder {
             ],
             RuleExecutionStrategy::Once,
         ));
+        self
     }
 
-    pub fn simplify_expressions(&mut self) {
-        // try to simplify expressions again as other rules could introduce new exprs
+    pub fn simplify_expressions(mut self) -> Self {
+        // Try to simplify expressions again as other rules could introduce new exprs.
         self.rule_batches.push(RuleBatch::new(
             vec![Box::new(SimplifyExpressionsRule::new())],
             RuleExecutionStrategy::FixedPoint(Some(3)),
         ));
+        self
     }
 
-    pub fn with_optimizer_config(&mut self, config: OptimizerConfig) {
+    pub fn with_optimizer_config(mut self, config: OptimizerConfig) -> Self {
         self.config = config;
+        self
     }
 
     pub fn build(self) -> Optimizer {

--- a/src/daft-logical-plan/src/optimization/rules/mod.rs
+++ b/src/daft-logical-plan/src/optimization/rules/mod.rs
@@ -22,6 +22,7 @@ pub use materialize_scans::MaterializeScans;
 pub use push_down_filter::PushDownFilter;
 pub use push_down_limit::PushDownLimit;
 pub use push_down_projection::PushDownProjection;
+pub use reorder_joins::ReorderJoins;
 pub use rule::OptimizerRule;
 pub use simplify_expressions::SimplifyExpressionsRule;
 pub use split_actor_pool_projects::SplitActorPoolProjects;

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -26,9 +26,8 @@ pub(super) enum JoinOrderTree {
 }
 
 impl JoinOrderTree {
-    #[allow(clippy::unnecessary_box_returns)]
-    pub(super) fn join(self: Box<Self>, right: Box<Self>) -> Box<Self> {
-        Box::new(Self::Join(self, right))
+    pub(super) fn join(self, right: Self) -> Self {
+        Self::Join(Box::new(self), Box::new(right))
     }
 
     // Helper function that checks if the join order tree contains a given id.
@@ -49,8 +48,7 @@ impl JoinOrderTree {
 }
 
 pub(super) trait JoinOrderer {
-    #[allow(clippy::unnecessary_box_returns)]
-    fn order(&self, graph: &JoinGraph) -> Box<JoinOrderTree>;
+    fn order(&self, graph: &JoinGraph) -> JoinOrderTree;
 }
 
 #[derive(Clone, Debug)]
@@ -304,10 +302,7 @@ impl JoinGraph {
     }
 
     /// Takes a `JoinOrderTree` and creates a logical plan from the current join graph.
-    pub(super) fn to_logical_plan(
-        &self,
-        join_order: Box<JoinOrderTree>,
-    ) -> DaftResult<LogicalPlanRef> {
+    pub(super) fn to_logical_plan(&self, join_order: JoinOrderTree) -> DaftResult<LogicalPlanRef> {
         let (mut plan_builder, relation_mask) = self.build_joins_from_join_order(&join_order)?;
         // After we've rebuilt all the joins, every relation should be contained in the final logical plan builder.
         assert_eq!(relation_mask, self.adj_list.max_id - 1);

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -550,7 +550,7 @@ impl JoinGraphBuilder {
             }) if *join_type == JoinType::Inner && !left_on.is_empty() => {
                 for l in left_on {
                     let name = l.name();
-                    if self.final_name_map.contains_key(name) {
+                    if !self.final_name_map.contains_key(name) {
                         self.final_name_map.insert(name.to_string(), col(name));
                     }
                     self.join_conds_to_resolve
@@ -563,7 +563,7 @@ impl JoinGraphBuilder {
                 }
                 for r in right_on {
                     let name = r.name();
-                    if self.final_name_map.contains_key(name) {
+                    if !self.final_name_map.contains_key(name) {
                         self.final_name_map.insert(name.to_string(), col(name));
                     }
                     self.join_conds_to_resolve

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -246,7 +246,7 @@ impl JoinGraph {
                     }
                 }
                 ProjectionOrFilter::Filter(predicate) => {
-                    plan_builder = plan_builder.filter(predicate.clone())?;
+                    plan_builder = plan_builder.filter(predicate)?;
                 }
             }
         }

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -26,11 +26,13 @@ pub(super) enum JoinOrderTree {
 }
 
 impl JoinOrderTree {
-    pub(super) fn join(self: Box<Self>, right: Box<JoinOrderTree>) -> Box<Self> {
-        Box::new(JoinOrderTree::Join(self, right))
+    #[allow(clippy::unnecessary_box_returns)]
+    pub(super) fn join(self: Box<Self>, right: Box<Self>) -> Box<Self> {
+        Box::new(Self::Join(self, right))
     }
 
     // Helper function that checks if the join order tree contains a given id.
+    #[cfg(test)]
     pub(super) fn contains(&self, target_id: usize) -> bool {
         match self {
             Self::Relation(id) => *id == target_id,
@@ -40,13 +42,14 @@ impl JoinOrderTree {
 
     fn iter(&self) -> Box<dyn Iterator<Item = usize> + '_> {
         match self {
-            JoinOrderTree::Relation(id) => Box::new(std::iter::once(*id)),
-            JoinOrderTree::Join(left, right) => Box::new(left.iter().chain(right.iter())),
+            Self::Relation(id) => Box::new(std::iter::once(*id)),
+            Self::Join(left, right) => Box::new(left.iter().chain(right.iter())),
         }
     }
 }
 
 pub(super) trait JoinOrderer {
+    #[allow(clippy::unnecessary_box_returns)]
     fn order(&self, graph: &JoinGraph) -> Box<JoinOrderTree>;
 }
 
@@ -184,25 +187,25 @@ impl JoinAdjList {
         for left_node in left.iter() {
             if let Some(neighbors) = self.edges.get(&left_node) {
                 for right_node in right.iter() {
-                    if let Some(_) = neighbors.get(&right_node) {
+                    if neighbors.get(&right_node).is_some() {
                         return true;
                     }
                 }
             }
         }
-        return false;
+        false
     }
 }
 
 #[derive(Debug)]
-pub(crate) enum ProjectionOrFilter {
+pub(super) enum ProjectionOrFilter {
     Projection(Vec<ExprRef>),
     Filter(ExprRef),
 }
 
 /// Representation of a logical plan as edges between relations, along with additional information needed to
 /// reconstruct a logcial plan that's equivalent to the plan that produced this graph.
-pub(crate) struct JoinGraph {
+pub(super) struct JoinGraph {
     pub adj_list: JoinAdjList,
     // List of projections and filters that should be applied after join reordering. This list respects
     // pre-order traversal of projections and filters in the query tree, so we should apply these operators
@@ -211,7 +214,7 @@ pub(crate) struct JoinGraph {
 }
 
 impl JoinGraph {
-    pub(crate) fn new(
+    pub(super) fn new(
         adj_list: JoinAdjList,
         final_projections_and_filters: Vec<ProjectionOrFilter>,
     ) -> Self {
@@ -221,10 +224,100 @@ impl JoinGraph {
         }
     }
 
+    fn apply_projections_and_filters_to_plan_builder(
+        &self,
+        mut plan_builder: LogicalPlanBuilder,
+    ) -> DaftResult<LogicalPlanBuilder> {
+        // Apply projections and filters in post-traversal order.
+        let mut reversed_items = self.final_projections_and_filters.iter().rev().peekable();
+        while let Some(projection_or_filter) = reversed_items.next() {
+            let is_last = reversed_items.peek().is_none();
+
+            match projection_or_filter {
+                ProjectionOrFilter::Projection(projections) => {
+                    if is_last {
+                        // The final projection is the output projection, so here we select the final projection.
+                        plan_builder = plan_builder.select(projections.clone())?;
+                    } else {
+                        // Intermediate projections might only transform a subset of columns, so we use `with_columns()` instead of `select()`.
+                        plan_builder = plan_builder.with_columns(projections.clone())?;
+                    }
+                }
+                ProjectionOrFilter::Filter(predicate) => {
+                    plan_builder = plan_builder.filter(predicate.clone())?;
+                }
+            }
+        }
+        Ok(plan_builder)
+    }
+
+    fn build_joins_from_join_order(
+        &self,
+        join_order: &JoinOrderTree,
+    ) -> DaftResult<(LogicalPlanBuilder, usize)> {
+        match join_order {
+            JoinOrderTree::Relation(id) => {
+                let relation = self
+                    .adj_list
+                    .id_to_plan
+                    .get(id)
+                    .expect("Join order contains non-existent plan id");
+                Ok((LogicalPlanBuilder::from(relation.clone()), 1 << id))
+            }
+            JoinOrderTree::Join(left_tree, right_tree) => {
+                let (left_builder, left_mask) = self.build_joins_from_join_order(left_tree)?;
+                let (right_builder, right_mask) = self.build_joins_from_join_order(right_tree)?;
+                let mut left_remaining = left_mask;
+                let mut left_cols = vec![];
+                let mut right_cols = vec![];
+                for _ in 0..left_remaining.count_ones() {
+                    let left_id = left_remaining.trailing_zeros();
+                    left_remaining ^= 1 << left_id;
+                    let mut right_remaining = right_mask;
+                    for _ in 0..right_remaining.count_ones() {
+                        let right_id = right_remaining.trailing_zeros();
+                        right_remaining ^= 1 << right_id;
+                        for cond in self
+                            .adj_list
+                            .edges
+                            .get(&(left_id as usize))
+                            .expect("Join order contains non-existent plan id")
+                            .get(&(right_id as usize))
+                            .expect("Join order contains non-existent plan id")
+                        {
+                            left_cols.push(col(cond.left_on.clone()));
+                            right_cols.push(col(cond.right_on.clone()));
+                        }
+                    }
+                }
+                let join = left_builder.inner_join(right_builder, left_cols, right_cols)?;
+
+                Ok((join, left_mask | right_mask))
+            }
+        }
+    }
+
+    pub(super) fn to_logical_plan(
+        &self,
+        join_order: Box<JoinOrderTree>,
+    ) -> DaftResult<LogicalPlanRef> {
+        let (mut plan_builder, relation_mask) = self.build_joins_from_join_order(&join_order)?;
+        assert_eq!(relation_mask, self.adj_list.max_id - 1);
+        plan_builder = self.apply_projections_and_filters_to_plan_builder(plan_builder)?;
+        Ok(plan_builder.build())
+    }
+
+    pub(super) fn could_reorder(&self) -> bool {
+        // For this join graph to reorder joins, there must be at least 3 relations to join. Otherwise
+        // there is only one join to perform and no reordering is needed.
+        self.adj_list.max_id >= 3
+    }
+
     /// Test helper function to get the number of edges that the current graph contains.
-    pub(crate) fn num_edges(&self) -> usize {
+    #[cfg(test)]
+    fn num_edges(&self) -> usize {
         let mut num_edges = 0;
-        for (_, edges) in &self.adj_list.edges {
+        for edges in self.adj_list.edges.values() {
             num_edges += edges.len();
         }
         // Each edge is bidirectional, so we divide by 2 to get the correct number of edges.
@@ -232,7 +325,8 @@ impl JoinGraph {
     }
 
     /// Test helper function to check that all relations in this graph are connected.
-    pub(crate) fn fully_connected(&self) -> bool {
+    #[cfg(test)]
+    fn fully_connected(&self) -> bool {
         let start = if let Some((node, _)) = self.adj_list.edges.iter().next() {
             node
         } else {
@@ -261,7 +355,8 @@ impl JoinGraph {
 
     /// Test helper function that checks if the graph contains the given projection/filter expressions
     /// in the given order.
-    pub(crate) fn contains_projections_and_filters(&self, to_check: Vec<&ExprRef>) -> bool {
+    #[cfg(test)]
+    fn contains_projections_and_filters(&self, to_check: Vec<&ExprRef>) -> bool {
         let all_exprs: Vec<_> = self
             .final_projections_and_filters
             .iter()
@@ -282,6 +377,7 @@ impl JoinGraph {
         false
     }
 
+    #[cfg(test)]
     fn get_node_by_id(&self, id: usize) -> &LogicalPlanRef {
         self.adj_list
             .id_to_plan
@@ -291,7 +387,8 @@ impl JoinGraph {
 
     /// Helper function that loosely checks if a given edge (represented by a simple string)
     /// exists in the current graph.
-    pub(crate) fn contains_edges(&self, to_check: Vec<&str>) -> bool {
+    #[cfg(test)]
+    fn contains_edges(&self, to_check: Vec<&str>) -> bool {
         let mut edge_strings = HashSet::new();
         for (left_id, neighbors) in &self.adj_list.edges {
             for (right_id, join_conds) in neighbors {
@@ -318,7 +415,7 @@ impl JoinGraph {
 }
 
 /// JoinGraphBuilder takes in a logical plan. On .build(), it returns a JoinGraph that represents the given logical plan.
-struct JoinGraphBuilder {
+pub(super) struct JoinGraphBuilder {
     plan: LogicalPlanRef,
     join_conds_to_resolve: Vec<(String, LogicalPlanRef, bool)>,
     final_name_map: HashMap<String, ExprRef>,
@@ -327,12 +424,12 @@ struct JoinGraphBuilder {
 }
 
 impl JoinGraphBuilder {
-    pub(crate) fn build(mut self) -> JoinGraph {
+    pub(super) fn build(mut self) -> JoinGraph {
         self.process_node(&self.plan.clone());
         JoinGraph::new(self.adj_list, self.final_projections_and_filters)
     }
 
-    pub(crate) fn from_logical_plan(plan: LogicalPlanRef) -> Self {
+    pub(super) fn from_logical_plan(plan: LogicalPlanRef) -> Self {
         let output_schema = plan.schema();
         // During join reordering, we might produce an output schema that differs from the initial output schema. For example,
         // columns might be rearranged, or columns that were not originally selected might now be in the output schema.
@@ -363,9 +460,9 @@ impl JoinGraphBuilder {
     /// Joins that added conditions to `join_conds_to_resolve` will pop them off the stack after they have been resolved.
     /// Combining each of their resolved `left_on` conditions with their respective resolved `right_on` conditions produces
     /// a join edge between the relation used in the left condition and the relation used in the right condition.
-    fn process_node<'a>(&mut self, plan: &'a LogicalPlanRef) {
+    fn process_node(&mut self, plan: &LogicalPlanRef) {
         let schema = plan.schema();
-        for (name, node, done) in self.join_conds_to_resolve.iter_mut() {
+        for (name, node, done) in &mut self.join_conds_to_resolve {
             if !*done && schema.has_field(name) {
                 *node = plan.clone();
             }
@@ -390,7 +487,7 @@ impl JoinGraphBuilder {
                     });
                 if reorderable_project {
                     let mut non_join_names: HashSet<String> = schema.names().into_iter().collect();
-                    for (name, _, done) in self.join_conds_to_resolve.iter_mut() {
+                    for (name, _, done) in &mut self.join_conds_to_resolve {
                         if !*done {
                             if let Some(new_expr) = projection_input_mapping.get(name) {
                                 // Remove the current name from the list of schema names so that we can produce
@@ -418,7 +515,7 @@ impl JoinGraphBuilder {
                     // Continue to children.
                     self.process_node(input);
                 } else {
-                    for (name, _, done) in self.join_conds_to_resolve.iter_mut() {
+                    for (name, _, done) in &mut self.join_conds_to_resolve {
                         if schema.has_field(name) {
                             *done = true;
                         }
@@ -445,7 +542,7 @@ impl JoinGraphBuilder {
             }) if *join_type == JoinType::Inner && !left_on.is_empty() => {
                 for l in left_on {
                     let name = l.name();
-                    if self.final_name_map.get(name).is_none() {
+                    if self.final_name_map.contains_key(name) {
                         self.final_name_map.insert(name.to_string(), col(name));
                     }
                     self.join_conds_to_resolve
@@ -458,7 +555,7 @@ impl JoinGraphBuilder {
                 }
                 for r in right_on {
                     let name = r.name();
-                    if self.final_name_map.get(name).is_none() {
+                    if self.final_name_map.contains_key(name) {
                         self.final_name_map.insert(name.to_string(), col(name));
                     }
                     self.join_conds_to_resolve
@@ -497,7 +594,7 @@ impl JoinGraphBuilder {
                 let mut projections = vec![];
                 let mut needs_projection = false;
                 let mut seen_names = HashSet::new();
-                for (name, _, done) in self.join_conds_to_resolve.iter_mut() {
+                for (name, _, done) in &mut self.join_conds_to_resolve {
                     if schema.has_field(name) && !*done && !seen_names.contains(name) {
                         if let Some(final_name) = self.final_name_map.get(name) {
                             let final_name = final_name.name().to_string();
@@ -523,7 +620,7 @@ impl JoinGraphBuilder {
                 } else {
                     plan.clone()
                 };
-                for (name, node, done) in self.join_conds_to_resolve.iter_mut() {
+                for (name, node, done) in &mut self.join_conds_to_resolve {
                     if schema.has_field(name) && !*done {
                         *done = true;
                         *node = projected_plan.clone();

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/mod.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/mod.rs
@@ -1,4 +1,61 @@
-#[cfg(test)]
 mod join_graph;
-#[cfg(test)]
 mod naive_left_deep_join_order;
+
+#[derive(Default, Debug)]
+pub struct ReorderJoins {}
+
+impl ReorderJoins {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+use std::sync::Arc;
+
+use common_error::DaftResult;
+use common_treenode::{Transformed, TreeNode};
+use join_graph::JoinGraphBuilder;
+use naive_left_deep_join_order::NaiveLeftDeepJoinOrderer;
+
+use crate::{
+    optimization::rules::{reorder_joins::join_graph::JoinOrderer, OptimizerRule},
+    LogicalPlan,
+};
+
+// Reorder joins in a query tree.
+impl OptimizerRule for ReorderJoins {
+    fn try_optimize(&self, plan: Arc<LogicalPlan>) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+        if let LogicalPlan::Join(_) = &*plan {
+            let join_graph = JoinGraphBuilder::from_logical_plan(plan.clone()).build();
+            // Return early if the join graph won't reorder joins.
+            // TODO(desmond): We also want to check if we can potentially reorder joins within relations themselves.
+            // E.g., we might have a query plan like:
+            //              Join
+            //             /    \
+            //         Join      Join
+            //        /    \     /   \
+            //      ...    ...  Agg  ...
+            //                   |
+            //         More reorderable joins
+            //
+            // In this example, the Agg is considered non-reorderable, so we treat it as a relation and reorder
+            // the top 3 joins. In theory, below the Agg, there could be more joins to reorder. In this case
+            // we would need to reorder the nodes below the Agg then reorder/reconstruct the logical plan with
+            // this reordered relation. We don't consider this case for now.
+            if !join_graph.could_reorder() {
+                return Ok(Transformed::no(plan));
+            }
+            let orderer = NaiveLeftDeepJoinOrderer {};
+            let join_order = orderer.order(&join_graph);
+            join_graph.to_logical_plan(join_order).map(Transformed::yes)
+        } else {
+            rewrite_children(self, plan)
+        }
+    }
+}
+
+fn rewrite_children(
+    optimizer: &impl OptimizerRule,
+    plan: Arc<LogicalPlan>,
+) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
+    plan.map_children(|input| optimizer.try_optimize(input))
+}

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
@@ -13,8 +13,9 @@ impl NaiveLeftDeepJoinOrderer {
         }
         for (index, candidate_node_id) in available.iter().enumerate() {
             let right = JoinOrderTree::Relation(*candidate_node_id);
-            if graph.adj_list.connected_join_trees(&current_order, &right) {
-                let new_order = current_order.join(right);
+            let connections = graph.adj_list.get_connections(&current_order, &right);
+            if !connections.is_empty() {
+                let new_order = current_order.join(right, connections);
                 available.remove(index);
                 return Self::extend_order(graph, new_order, available);
             }

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
@@ -3,6 +3,7 @@ use super::join_graph::{JoinGraph, JoinOrderTree, JoinOrderer};
 pub(crate) struct NaiveLeftDeepJoinOrderer {}
 
 impl NaiveLeftDeepJoinOrderer {
+    #[allow(clippy::unnecessary_box_returns)]
     fn extend_order(
         graph: &JoinGraph,
         current_order: Box<JoinOrderTree>,

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
@@ -3,17 +3,16 @@ use super::join_graph::{JoinGraph, JoinOrderTree, JoinOrderer};
 pub(crate) struct NaiveLeftDeepJoinOrderer {}
 
 impl NaiveLeftDeepJoinOrderer {
-    #[allow(clippy::unnecessary_box_returns)]
     fn extend_order(
         graph: &JoinGraph,
-        current_order: Box<JoinOrderTree>,
+        current_order: JoinOrderTree,
         mut available: Vec<usize>,
-    ) -> Box<JoinOrderTree> {
+    ) -> JoinOrderTree {
         if available.is_empty() {
             return current_order;
         }
         for (index, candidate_node_id) in available.iter().enumerate() {
-            let right = Box::new(JoinOrderTree::Relation(*candidate_node_id));
+            let right = JoinOrderTree::Relation(*candidate_node_id);
             if graph.adj_list.connected_join_trees(&current_order, &right) {
                 let new_order = current_order.join(right);
                 available.remove(index);
@@ -25,10 +24,10 @@ impl NaiveLeftDeepJoinOrderer {
 }
 
 impl JoinOrderer for NaiveLeftDeepJoinOrderer {
-    fn order(&self, graph: &JoinGraph) -> Box<JoinOrderTree> {
+    fn order(&self, graph: &JoinGraph) -> JoinOrderTree {
         let available: Vec<usize> = (1..graph.adj_list.max_id).collect();
         // Take a starting order of the node with id 0.
-        let starting_order = Box::new(JoinOrderTree::Relation(0));
+        let starting_order = JoinOrderTree::Relation(0);
         Self::extend_order(graph, starting_order, available)
     }
 }
@@ -46,7 +45,7 @@ mod tests {
         LogicalPlanRef,
     };
 
-    fn assert_order_contains_all_nodes(order: &Box<JoinOrderTree>, graph: &JoinGraph) {
+    fn assert_order_contains_all_nodes(order: &JoinOrderTree, graph: &JoinGraph) {
         for id in 0..graph.adj_list.max_id {
             assert!(
                 order.contains(id),

--- a/src/daft-physical-plan/src/physical_planner/planner.rs
+++ b/src/daft-physical-plan/src/physical_planner/planner.rs
@@ -7,7 +7,7 @@ use common_treenode::{
 };
 use daft_logical_plan::{
     ops::Source,
-    optimization::Optimizer,
+    optimization::OptimizerBuilder,
     source_info::{InMemoryInfo, PlaceHolderInfo, SourceInfo},
     LogicalPlan, LogicalPlanRef,
 };
@@ -358,7 +358,9 @@ impl AdaptivePlanner {
 
         self.logical_plan = result.data;
 
-        let optimizer = Optimizer::new(Default::default());
+        let mut optimizer_builder = OptimizerBuilder::default();
+        optimizer_builder.simplify_expressions();
+        let optimizer = optimizer_builder.build();
 
         self.logical_plan = optimizer.optimize(
             self.logical_plan.clone(),

--- a/src/daft-physical-plan/src/physical_planner/planner.rs
+++ b/src/daft-physical-plan/src/physical_planner/planner.rs
@@ -358,8 +358,7 @@ impl AdaptivePlanner {
 
         self.logical_plan = result.data;
 
-        let mut optimizer_builder = OptimizerBuilder::default();
-        optimizer_builder.simplify_expressions();
+        let optimizer_builder = OptimizerBuilder::default().simplify_expressions();
         let optimizer = optimizer_builder.build();
 
         self.logical_plan = optimizer.optimize(

--- a/src/daft-physical-plan/src/physical_planner/planner.rs
+++ b/src/daft-physical-plan/src/physical_planner/planner.rs
@@ -358,8 +358,7 @@ impl AdaptivePlanner {
 
         self.logical_plan = result.data;
 
-        let optimizer_builder = OptimizerBuilder::default().simplify_expressions();
-        let optimizer = optimizer_builder.build();
+        let optimizer = OptimizerBuilder::default().simplify_expressions().build();
 
         self.logical_plan = optimizer.optimize(
             self.logical_plan.clone(),


### PR DESCRIPTION
Applies the naive left deep join order from #3616 as an optimizer rule.
This optimizer rule is gated behind an environment variable that allows us to validate the rule on our current workloads.

Currently join reordering results in errors for 50% of TPC-H queries during join graph building. We'll tackle these in a follow-up PR.