### PR TITLE
build: Publish A Long Term Support CPU Release of Daft

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,12 +32,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: [ubuntu, macos, windows]
-        os: [ubuntu]
-        # compile_arch: [x86_64, aarch64]
-        compile_arch: [x86_64]
-        # lts: [0, 1] # LongTerm Support CPUs
-        lts: [1] # LongTerm Support CPUs
+        os: [ubuntu, macos, windows]
+        compile_arch: [x86_64, aarch64]
+        lts: [0, 1] # LongTerm Support CPUs
         exclude:
         - os: windows
           compile_arch: aarch64
@@ -55,7 +52,7 @@ jobs:
     - run: pip install uv
     - run: uv pip install twine toml yq
     - run: python tools/patch_package_version.py
-    - name: Patch name is LTS
+    - name: Patch name to daft-lts if LTS
       if: ${{ matrix.lts }}
       run: tomlq -i -t ".project.name = \"daft-lts\"" pyproject.toml
 
@@ -130,9 +127,84 @@ jobs:
         name: wheels-${{ matrix.os }}-${{ matrix.compile_arch }}
         path: dist
 
+    - name: Send Slack notification on failure
+      uses: slackapi/slack-github-action@v2.0.0
+      if: ${{ failure() && (github.ref == 'refs/heads/main') }}
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: Release: Building Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+
+  publish:
+    name: Publish wheels to PYPI and Anaconda
+    runs-on: ubuntu-latest
+    needs:
+    - build-and-test
+    steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+        architecture: x64
+    - run: pip install -U twine
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: wheels-*
+        merge-multiple: true
+        path: dist
+    - run: ls -R ./dist
+    - name: Publish bdist package to PYPI
+      if: ${{ success() && (env.IS_PUSH == 'true') }}
+      run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
+      env:
+        TWINE_USERNAME: __token__
+        # TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        # Really doesn't matter what version we upload with
+        # just the version we test with
+        python-version: '3.9'
+        channels: conda-forge
+        channel-priority: true
+
+    - name: Install anaconda client
+      shell: bash -el {0}
+      run: conda install -q -y anaconda-client "urllib3<2.0"
+
+    - name: Upload wheels to anaconda nightly
+      if: ${{ success() && (((env.IS_SCHEDULE_DISPATCH == 'true') && (github.ref == 'refs/heads/main')) || env.IS_PUSH == 'true') }}
+      shell: bash -el {0}
+      env:
+        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+      run: |
+        source ci/upload_wheels.sh
+        # set_upload_vars
+        # # trigger an upload to
+        # # https://anaconda.org/daft-nightly/getdaft
+        # # for cron jobs or "Run workflow" (restricted to main branch).
+        # # Tags will upload to
+        # # https://anaconda.org/daft/getdaft
+        # # The tokens were originally generated at anaconda.org
+        # upload_wheels
+
     # - name: Send Slack notification on failure
     #   uses: slackapi/slack-github-action@v2.0.0
-    #   if: ${{ failure() && (github.ref == 'refs/heads/main') }}
+    #   if: failure()
     #   with:
     #     payload: |
     #       {
@@ -141,7 +213,7 @@ jobs:
     #             "type": "section",
     #             "text": {
     #               "type": "mrkdwn",
-    #               "text": ":rotating_light: Release: Building Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+    #               "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
     #             }
     #           }
     #         ]
@@ -149,78 +221,3 @@ jobs:
     #   env:
     #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-
-  # publish:
-  #   name: Publish wheels to PYPI and Anaconda
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #   - build-and-test
-  #   steps:
-  #   - uses: actions/setup-python@v5
-  #     with:
-  #       python-version: ${{ env.PYTHON_VERSION }}
-  #       architecture: x64
-  #   - run: pip install -U twine
-  #   - uses: actions/checkout@v4
-  #   - uses: actions/download-artifact@v4
-  #     with:
-  #       pattern: wheels-*
-  #       merge-multiple: true
-  #       path: dist
-  #   - run: ls -R ./dist
-  #   - name: Publish bdist package to PYPI
-  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
-  #     run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
-  #     env:
-  #       TWINE_USERNAME: __token__
-  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-
-  #   - uses: conda-incubator/setup-miniconda@v3
-  #     with:
-  #       # Really doesn't matter what version we upload with
-  #       # just the version we test with
-  #       python-version: '3.9'
-  #       channels: conda-forge
-  #       channel-priority: true
-
-  #   - name: Install anaconda client
-  #     shell: bash -el {0}
-  #     run: conda install -q -y anaconda-client "urllib3<2.0"
-
-  #   - name: Upload wheels to anaconda nightly
-  #     if: ${{ success() && (((env.IS_SCHEDULE_DISPATCH == 'true') && (github.ref == 'refs/heads/main')) || env.IS_PUSH == 'true') }}
-  #     shell: bash -el {0}
-  #     env:
-  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-  #     run: |
-  #       source ci/upload_wheels.sh
-  #       set_upload_vars
-  #       # trigger an upload to
-  #       # https://anaconda.org/daft-nightly/getdaft
-  #       # for cron jobs or "Run workflow" (restricted to main branch).
-  #       # Tags will upload to
-  #       # https://anaconda.org/daft/getdaft
-  #       # The tokens were originally generated at anaconda.org
-  #       upload_wheels
-
-  #   - name: Send Slack notification on failure
-  #     uses: slackapi/slack-github-action@v2.0.0
-  #     if: failure()
-  #     with:
-  #       payload: |
-  #         {
-  #           "blocks": [
-  #             {
-  #               "type": "section",
-  #               "text": {
-  #                 "type": "mrkdwn",
-  #                 "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-  #               }
-  #             }
-  #           ]
-  #         }
-  #     env:
-  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -62,11 +62,11 @@ jobs:
     - name: Configure RUSTFLAGS
       run: |
         if [[ ${{ matrix.lts }} ]]; then
-          echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b" >> $GITHUB_ENV \
-          echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16" >> $GITHUB_ENV \
-        else \
-          echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe -Z tune-cpu=skylake" >> $GITHUB_ENV \
-          echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe" >> $GITHUB_ENV \
+          echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b" >> $GITHUB_ENV && \
+          echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16" >> $GITHUB_ENV
+        else
+          echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe -Z tune-cpu=skylake" >> $GITHUB_ENV && \
+          echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe" >> $GITHUB_ENV
         fi
 
     - name: Build wheels - Mac and Windows x86

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,9 +32,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
-        compile_arch: [x86_64, aarch64]
-        lts: [0, 1] # LongTerm Support CPUs
+        # os: [ubuntu, macos, windows]
+        os: [ubuntu]
+        # compile_arch: [x86_64, aarch64]
+        compile_arch: [x86_64]
+        # lts: [0, 1] # LongTerm Support CPUs
+        lts: [1] # LongTerm Support CPUs
         exclude:
         - os: windows
           compile_arch: aarch64
@@ -57,7 +60,14 @@ jobs:
       run: tomlq -i -t ".project.name = \"daft-lts\"" pyproject.toml
 
     - name: Configure RUSTFLAGS
-      run: if [[ ${{ matrix.lts }}  ]]; then echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b" >> $GITHUB_ENV echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16" >> $GITHUB_ENV else echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe -Z tune-cpu=skylake" >> $GITHUB_ENV echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe" >> $GITHUB_ENV fi
+      run: |
+        if [[ ${{ matrix.lts }} ]]; then
+          echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b" >> $GITHUB_ENV \
+          echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16" >> $GITHUB_ENV \
+        else \
+          echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe -Z tune-cpu=skylake" >> $GITHUB_ENV \
+          echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe" >> $GITHUB_ENV \
+        fi
 
     - name: Build wheels - Mac and Windows x86
       if: ${{ ((matrix.os == 'macos') || (matrix.os == 'windows')) && (matrix.compile_arch == 'x86_64')  }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,6 +24,10 @@ env:
   IS_SCHEDULE_DISPATCH: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
   RUST_DAFT_PKG_BUILD_TYPE: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && ( ! endsWith(github.ref, 'dev0'))) && 'release' || 'nightly' }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build-and-test:
 
@@ -59,7 +63,6 @@ jobs:
 
     - name: Configure RUSTFLAGS
       if: ${{ (matrix.compile_arch == 'x86_64') }}
-      shell: bash
       run: |
         if [[ ${{ matrix.lts }} ]]; then
           echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b" >> $GITHUB_ENV && \

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,7 +15,6 @@ on:
     - v*
   workflow_dispatch:
 env:
-  PACKAGE_NAME: getdaft
   PYTHON_VERSION: 3.11
   DAFT_ANALYTICS_ENABLED: '0'
   UV_SYSTEM_PYTHON: 1
@@ -38,8 +37,7 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         compile_arch: [x86_64, aarch64]
-        # lts: [0, 1] # LongTerm Support CPUs
-        lts: [1] # LongTerm Support CPUs
+        lts: [0, 1] # LongTerm Support CPUs
 
         exclude:
         - os: windows
@@ -119,15 +117,7 @@ jobs:
         rm -rf daft
         pytest -v
       env:
-        DAFT_RUNNER: py
-    # Disable until we figure out why are we getting FileNotFoundError: [WinError 3] Failed to open local file
-    # - name: Install and test built wheel - Windows x86_64
-    #   if: ${{ (matrix.os == 'windows') && (matrix.compile_arch == 'x86_64')  }}
-    #   run: |
-    #     $FILES = Get-ChildItem -Path .\dist\${{ env.PACKAGE_NAME }}-*-win_amd64.whl -Force -Recurse
-    #     pip install -r requirements-dev.txt $FILES[0].FullName --force-reinstall
-    #     rd -r daft
-    #     pytest -v
+        DAFT_RUNNER: native
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4
@@ -177,7 +167,7 @@ jobs:
         path: dist
     - run: ls -R ./dist
     - name: Publish package distributions to PyPI
-      # if: ${{ success() && (env.IS_PUSH == 'true') }}
+      if: ${{ success() && (env.IS_PUSH == 'true') }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         skip-existing: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -61,7 +61,7 @@ jobs:
       if: ${{ matrix.lts }}
       run: tomlq -i -t ".project.name = \"daft-lts\"" pyproject.toml
 
-    - name: Configure RUSTFLAGS
+    - name: Configure RUSTFLAGS for x86
       if: ${{ (matrix.compile_arch == 'x86_64') }}
       run: |
         if [[ ${{ matrix.lts }} ]]; then
@@ -177,7 +177,7 @@ jobs:
       run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
       env:
         TWINE_USERNAME: __token__
-        # TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
     - uses: conda-incubator/setup-miniconda@v3
       with:
@@ -191,39 +191,39 @@ jobs:
       shell: bash -el {0}
       run: conda install -q -y anaconda-client "urllib3<2.0"
 
-    # - name: Upload wheels to anaconda nightly
-    #   if: ${{ success() && (((env.IS_SCHEDULE_DISPATCH == 'true') && (github.ref == 'refs/heads/main')) || env.IS_PUSH == 'true') }}
-    #   shell: bash -el {0}
-    #   env:
-    #     DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-    #     DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-    #   run: |
-    #     source ci/upload_wheels.sh
-    #     set_upload_vars
-    #     # trigger an upload to
-    #     # https://anaconda.org/daft-nightly/getdaft
-    #     # for cron jobs or "Run workflow" (restricted to main branch).
-    #     # Tags will upload to
-    #     # https://anaconda.org/daft/getdaft
-    #     # The tokens were originally generated at anaconda.org
-    #     upload_wheels
+    - name: Upload wheels to anaconda nightly
+      if: ${{ success() && (((env.IS_SCHEDULE_DISPATCH == 'true') && (github.ref == 'refs/heads/main')) || env.IS_PUSH == 'true') }}
+      shell: bash -el {0}
+      env:
+        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+      run: |
+        source ci/upload_wheels.sh
+        set_upload_vars
+        # trigger an upload to
+        # https://anaconda.org/daft-nightly/getdaft
+        # for cron jobs or "Run workflow" (restricted to main branch).
+        # Tags will upload to
+        # https://anaconda.org/daft/getdaft
+        # The tokens were originally generated at anaconda.org
+        upload_wheels
 
-    # - name: Send Slack notification on failure
-    #   uses: slackapi/slack-github-action@v2.0.0
-    #   if: failure()
-    #   with:
-    #     payload: |
-    #       {
-    #         "blocks": [
-    #           {
-    #             "type": "section",
-    #             "text": {
-    #               "type": "mrkdwn",
-    #               "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-    #             }
-    #           }
-    #         ]
-    #       }
-    #   env:
-    #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-    #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    - name: Send Slack notification on failure
+      uses: slackapi/slack-github-action@v2.0.0
+      if: failure()
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+                }
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,8 +34,11 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         compile_arch: [x86_64, aarch64]
+        lts: [0, 1] # LongTerm Support CPUs
         exclude:
         - os: windows
+          compile_arch: aarch64
+        - lts: 1
           compile_arch: aarch64
     steps:
     - uses: actions/checkout@v4
@@ -47,8 +50,15 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
         architecture: x64
     - run: pip install uv
-    - run: uv pip install twine toml
+    - run: uv pip install twine toml yq
     - run: python tools/patch_package_version.py
+    - name: Patch name is LTS
+      if: ${{ matrix.lts }}
+      run: tomlq -i -t ".project.name = \"daft-lts\"" pyproject.toml
+
+    - name: Configure RUSTFLAGS
+      run: if [[ ${{ matrix.lts }}  ]]; then echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b" >> $GITHUB_ENV echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16" >> $GITHUB_ENV else echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe -Z tune-cpu=skylake" >> $GITHUB_ENV echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe" >> $GITHUB_ENV fi
+
     - name: Build wheels - Mac and Windows x86
       if: ${{ ((matrix.os == 'macos') || (matrix.os == 'windows')) && (matrix.compile_arch == 'x86_64')  }}
       uses: messense/maturin-action@v1
@@ -56,7 +66,8 @@ jobs:
         target: x86_64
         args: --profile release-lto --out dist
       env:
-        RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2
+        RUSTFLAGS: $RUSTFLAGS
+        CFLAGS: $CFLAGS
     - name: Build wheels - Linux x86
       if: ${{ (matrix.os == 'ubuntu') && (matrix.compile_arch == 'x86_64') }}
       uses: messense/maturin-action@v1
@@ -67,7 +78,9 @@ jobs:
         args: --profile release-lto --out dist --sdist
         before-script-linux: yum -y install perl-IPC-Cmd
       env:
-        RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
+        RUSTFLAGS: $RUSTFLAGS
+        CFLAGS: $CFLAGS
+
     - name: Build wheels - Linux aarch64
       if: ${{ (matrix.os == 'ubuntu') && (matrix.compile_arch == 'aarch64') }}
       uses: messense/maturin-action@v1
@@ -92,7 +105,7 @@ jobs:
     - name: Install and test built wheel - Linux and Mac x86_64
       if: ${{ (matrix.os == 'ubuntu') && (matrix.compile_arch == 'x86_64')  }}
       run: |
-        uv pip install -r requirements-dev.txt dist/${{ env.PACKAGE_NAME }}-*x86_64*.whl --force-reinstall
+        uv pip install -r requirements-dev.txt dist/*-*x86_64*.whl --force-reinstall
         rm -rf daft
         pytest -v
       env:
@@ -112,97 +125,97 @@ jobs:
         name: wheels-${{ matrix.os }}-${{ matrix.compile_arch }}
         path: dist
 
-    - name: Send Slack notification on failure
-      uses: slackapi/slack-github-action@v2.0.0
-      if: ${{ failure() && (github.ref == 'refs/heads/main') }}
-      with:
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": ":rotating_light: Release: Building Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-                }
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+    # - name: Send Slack notification on failure
+    #   uses: slackapi/slack-github-action@v2.0.0
+    #   if: ${{ failure() && (github.ref == 'refs/heads/main') }}
+    #   with:
+    #     payload: |
+    #       {
+    #         "blocks": [
+    #           {
+    #             "type": "section",
+    #             "text": {
+    #               "type": "mrkdwn",
+    #               "text": ":rotating_light: Release: Building Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+    #             }
+    #           }
+    #         ]
+    #       }
+    #   env:
+    #     SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    #     SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
 
-  publish:
-    name: Publish wheels to PYPI and Anaconda
-    runs-on: ubuntu-latest
-    needs:
-    - build-and-test
-    steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
-        architecture: x64
-    - run: pip install -U twine
-    - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v4
-      with:
-        pattern: wheels-*
-        merge-multiple: true
-        path: dist
-    - run: ls -R ./dist
-    - name: Publish bdist package to PYPI
-      if: ${{ success() && (env.IS_PUSH == 'true') }}
-      run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+  # publish:
+  #   name: Publish wheels to PYPI and Anaconda
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #   - build-and-test
+  #   steps:
+  #   - uses: actions/setup-python@v5
+  #     with:
+  #       python-version: ${{ env.PYTHON_VERSION }}
+  #       architecture: x64
+  #   - run: pip install -U twine
+  #   - uses: actions/checkout@v4
+  #   - uses: actions/download-artifact@v4
+  #     with:
+  #       pattern: wheels-*
+  #       merge-multiple: true
+  #       path: dist
+  #   - run: ls -R ./dist
+  #   - name: Publish bdist package to PYPI
+  #     if: ${{ success() && (env.IS_PUSH == 'true') }}
+  #     run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
+  #     env:
+  #       TWINE_USERNAME: __token__
+  #       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 
-    - uses: conda-incubator/setup-miniconda@v3
-      with:
-        # Really doesn't matter what version we upload with
-        # just the version we test with
-        python-version: '3.9'
-        channels: conda-forge
-        channel-priority: true
+  #   - uses: conda-incubator/setup-miniconda@v3
+  #     with:
+  #       # Really doesn't matter what version we upload with
+  #       # just the version we test with
+  #       python-version: '3.9'
+  #       channels: conda-forge
+  #       channel-priority: true
 
-    - name: Install anaconda client
-      shell: bash -el {0}
-      run: conda install -q -y anaconda-client "urllib3<2.0"
+  #   - name: Install anaconda client
+  #     shell: bash -el {0}
+  #     run: conda install -q -y anaconda-client "urllib3<2.0"
 
-    - name: Upload wheels to anaconda nightly
-      if: ${{ success() && (((env.IS_SCHEDULE_DISPATCH == 'true') && (github.ref == 'refs/heads/main')) || env.IS_PUSH == 'true') }}
-      shell: bash -el {0}
-      env:
-        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-      run: |
-        source ci/upload_wheels.sh
-        set_upload_vars
-        # trigger an upload to
-        # https://anaconda.org/daft-nightly/getdaft
-        # for cron jobs or "Run workflow" (restricted to main branch).
-        # Tags will upload to
-        # https://anaconda.org/daft/getdaft
-        # The tokens were originally generated at anaconda.org
-        upload_wheels
+  #   - name: Upload wheels to anaconda nightly
+  #     if: ${{ success() && (((env.IS_SCHEDULE_DISPATCH == 'true') && (github.ref == 'refs/heads/main')) || env.IS_PUSH == 'true') }}
+  #     shell: bash -el {0}
+  #     env:
+  #       DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+  #       DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+  #     run: |
+  #       source ci/upload_wheels.sh
+  #       set_upload_vars
+  #       # trigger an upload to
+  #       # https://anaconda.org/daft-nightly/getdaft
+  #       # for cron jobs or "Run workflow" (restricted to main branch).
+  #       # Tags will upload to
+  #       # https://anaconda.org/daft/getdaft
+  #       # The tokens were originally generated at anaconda.org
+  #       upload_wheels
 
-    - name: Send Slack notification on failure
-      uses: slackapi/slack-github-action@v2.0.0
-      if: failure()
-      with:
-        payload: |
-          {
-            "blocks": [
-              {
-                "type": "section",
-                "text": {
-                  "type": "mrkdwn",
-                  "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
-                }
-              }
-            ]
-          }
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  #   - name: Send Slack notification on failure
+  #     uses: slackapi/slack-github-action@v2.0.0
+  #     if: failure()
+  #     with:
+  #       payload: |
+  #         {
+  #           "blocks": [
+  #             {
+  #               "type": "section",
+  #               "text": {
+  #                 "type": "mrkdwn",
+  #                 "text": ":rotating_light: Release: Uploading Wheels <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED* :rotating_light:"
+  #               }
+  #             }
+  #           ]
+  #         }
+  #     env:
+  #       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  #       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,7 +38,9 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         compile_arch: [x86_64, aarch64]
-        lts: [0, 1] # LongTerm Support CPUs
+        # lts: [0, 1] # LongTerm Support CPUs
+        lts: [1] # LongTerm Support CPUs
+
         exclude:
         - os: windows
           compile_arch: aarch64
@@ -153,10 +155,13 @@ jobs:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
-
   publish:
     name: Publish wheels to PYPI and Anaconda
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     needs:
     - build-and-test
     steps:
@@ -165,19 +170,17 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
         architecture: x64
     - run: pip install -U twine
-    - uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
         pattern: wheels-*
         merge-multiple: true
         path: dist
     - run: ls -R ./dist
-    - name: Publish bdist package to PYPI
-      if: ${{ success() && (env.IS_PUSH == 'true') }}
-      run: python -m twine upload --skip-existing --disable-progress-bar ./dist/*
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Publish package distributions to PyPI
+      # if: ${{ success() && (env.IS_PUSH == 'true') }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true
 
     - uses: conda-incubator/setup-miniconda@v3
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -66,7 +66,7 @@ jobs:
           echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16" >> $GITHUB_ENV
         else
           echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt,+pclmulqdq,+movbe -Z tune-cpu=skylake" >> $GITHUB_ENV && \
-          echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe" >> $GITHUB_ENV
+          echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe -mtune=skylake" >> $GITHUB_ENV
         fi
 
     - name: Build wheels - Mac and Windows x86
@@ -75,9 +75,6 @@ jobs:
       with:
         target: x86_64
         args: --profile release-lto --out dist
-      env:
-        RUSTFLAGS: $RUSTFLAGS
-        CFLAGS: $CFLAGS
     - name: Build wheels - Linux x86
       if: ${{ (matrix.os == 'ubuntu') && (matrix.compile_arch == 'x86_64') }}
       uses: messense/maturin-action@v1
@@ -87,9 +84,6 @@ jobs:
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
         before-script-linux: yum -y install perl-IPC-Cmd
-      env:
-        RUSTFLAGS: $RUSTFLAGS
-        CFLAGS: $CFLAGS
 
     - name: Build wheels - Linux aarch64
       if: ${{ (matrix.os == 'ubuntu') && (matrix.compile_arch == 'aarch64') }}
@@ -111,6 +105,7 @@ jobs:
         args: --profile release-lto --out dist
       env:
         RUSTFLAGS: -Ctarget-cpu=apple-m1
+        CFLAGS: -mtune=apple-m1
 
     - name: Install and test built wheel - Linux and Mac x86_64
       if: ${{ (matrix.os == 'ubuntu') && (matrix.compile_arch == 'x86_64')  }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   build-and-test:
 
-    name: platform wheels for ${{ matrix.os }}-${{ matrix.compile_arch }}
+    name: platform wheels for ${{ matrix.os }}-${{ matrix.compile_arch }}-lts=${{ matrix.lts }}
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -38,6 +38,8 @@ jobs:
         exclude:
         - os: windows
           compile_arch: aarch64
+        - os: windows
+          lts: 1
         - lts: 1
           compile_arch: aarch64
     steps:
@@ -124,7 +126,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ matrix.os }}-${{ matrix.compile_arch }}
+        name: wheels-${{ matrix.os }}-${{ matrix.compile_arch }}-lts-${{ matrix.lts }}
         path: dist
 
     - name: Send Slack notification on failure
@@ -185,22 +187,22 @@ jobs:
       shell: bash -el {0}
       run: conda install -q -y anaconda-client "urllib3<2.0"
 
-    - name: Upload wheels to anaconda nightly
-      if: ${{ success() && (((env.IS_SCHEDULE_DISPATCH == 'true') && (github.ref == 'refs/heads/main')) || env.IS_PUSH == 'true') }}
-      shell: bash -el {0}
-      env:
-        DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
-        DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
-      run: |
-        source ci/upload_wheels.sh
-        # set_upload_vars
-        # # trigger an upload to
-        # # https://anaconda.org/daft-nightly/getdaft
-        # # for cron jobs or "Run workflow" (restricted to main branch).
-        # # Tags will upload to
-        # # https://anaconda.org/daft/getdaft
-        # # The tokens were originally generated at anaconda.org
-        # upload_wheels
+    # - name: Upload wheels to anaconda nightly
+    #   if: ${{ success() && (((env.IS_SCHEDULE_DISPATCH == 'true') && (github.ref == 'refs/heads/main')) || env.IS_PUSH == 'true') }}
+    #   shell: bash -el {0}
+    #   env:
+    #     DAFT_STAGING_UPLOAD_TOKEN: ${{ secrets.DAFT_STAGING_UPLOAD_TOKEN }}
+    #     DAFT_NIGHTLY_UPLOAD_TOKEN: ${{ secrets.DAFT_NIGHTLY_UPLOAD_TOKEN }}
+    #   run: |
+    #     source ci/upload_wheels.sh
+    #     set_upload_vars
+    #     # trigger an upload to
+    #     # https://anaconda.org/daft-nightly/getdaft
+    #     # for cron jobs or "Run workflow" (restricted to main branch).
+    #     # Tags will upload to
+    #     # https://anaconda.org/daft/getdaft
+    #     # The tokens were originally generated at anaconda.org
+    #     upload_wheels
 
     # - name: Send Slack notification on failure
     #   uses: slackapi/slack-github-action@v2.0.0

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,10 +38,9 @@ jobs:
         exclude:
         - os: windows
           compile_arch: aarch64
-        - os: windows
-          lts: 1
         - lts: 1
           compile_arch: aarch64
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -59,6 +58,8 @@ jobs:
       run: tomlq -i -t ".project.name = \"daft-lts\"" pyproject.toml
 
     - name: Configure RUSTFLAGS
+      if: ${{ (matrix.compile_arch == 'x86_64') }}
+      shell: bash
       run: |
         if [[ ${{ matrix.lts }} ]]; then
           echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+cmpxchg16b" >> $GITHUB_ENV && \


### PR DESCRIPTION
closes: https://github.com/Eventual-Inc/Daft/issues/3564

* Create new daft release `daft-lts` that supports older cpus
* upgrade regular daft to use more modern cpu features
* move off using API token for PYPI to using identity based upload