### PR TITLE
chore: Replace is_in with or clauses for tpch dataframe queries

### DIFF
--- a/benchmarking/tpch/answers.py
+++ b/benchmarking/tpch/answers.py
@@ -375,7 +375,8 @@ def q12(get_df: GetDFFunc) -> DataFrame:
     daft_df = (
         orders.join(lineitem, left_on=col("O_ORDERKEY"), right_on=col("L_ORDERKEY"))
         .where(
-            col("L_SHIPMODE").is_in(["MAIL", "SHIP"])
+            # col("L_SHIPMODE").is_in(["MAIL", "SHIP"])
+            ((col("L_SHIPMODE") == "MAIL") | (col("L_SHIPMODE") == "SHIP"))
             & (col("L_COMMITDATE") < col("L_RECEIPTDATE"))
             & (col("L_SHIPDATE") < col("L_COMMITDATE"))
             & (col("L_RECEIPTDATE") >= datetime.date(1994, 1, 1))
@@ -475,7 +476,17 @@ def q16(get_df: GetDFFunc) -> DataFrame:
         .where(
             (col("P_BRAND") != "Brand#45")
             & ~col("P_TYPE").str.startswith("MEDIUM POLISHED")
-            & (col("P_SIZE").is_in([49, 14, 23, 45, 19, 3, 36, 9]))
+            # & (col("P_SIZE").is_in([49, 14, 23, 45, 19, 3, 36, 9]))
+            & (
+                (col("P_SIZE") == 49)
+                | (col("P_SIZE") == 14)
+                | (col("P_SIZE") == 23)
+                | (col("P_SIZE") == 45)
+                | (col("P_SIZE") == 19)
+                | (col("P_SIZE") == 3)
+                | (col("P_SIZE") == 36)
+                | (col("P_SIZE") == 9)
+            )
         )
         .join(suppkeys, left_on="PS_SUPPKEY", right_on="S_SUPPKEY", how="left")
         .where(col("PS_SUPPKEY_RIGHT").is_null())
@@ -544,8 +555,8 @@ def q19(get_df: GetDFFunc) -> DataFrame:
                 & (col("L_QUANTITY") <= 11)
                 & (col("P_SIZE") >= 1)
                 & (col("P_SIZE") <= 5)
-                & col("L_SHIPMODE").is_in(["AIR", "AIR REG"])
-                & (col("L_SHIPINSTRUCT") == "DELIVER IN PERSON")
+                # & col("L_SHIPMODE").is_in(["AIR", "AIR REG"])
+                # & (col("L_SHIPINSTRUCT") == "DELIVER IN PERSON")
             )
             | (
                 (col("P_BRAND") == "Brand#23")
@@ -554,8 +565,8 @@ def q19(get_df: GetDFFunc) -> DataFrame:
                 & (col("L_QUANTITY") <= 20)
                 & (col("P_SIZE") >= 1)
                 & (col("P_SIZE") <= 10)
-                & col("L_SHIPMODE").is_in(["AIR", "AIR REG"])
-                & (col("L_SHIPINSTRUCT") == "DELIVER IN PERSON")
+                # & col("L_SHIPMODE").is_in(["AIR", "AIR REG"])
+                # & (col("L_SHIPINSTRUCT") == "DELIVER IN PERSON")
             )
             | (
                 (col("P_BRAND") == "Brand#34")
@@ -564,10 +575,12 @@ def q19(get_df: GetDFFunc) -> DataFrame:
                 & (col("L_QUANTITY") <= 30)
                 & (col("P_SIZE") >= 1)
                 & (col("P_SIZE") <= 15)
-                & col("L_SHIPMODE").is_in(["AIR", "AIR REG"])
-                & (col("L_SHIPINSTRUCT") == "DELIVER IN PERSON")
+                # & col("L_SHIPMODE").is_in(["AIR", "AIR REG"])
+                # & (col("L_SHIPINSTRUCT") == "DELIVER IN PERSON")
             )
         )
+        .where((col("L_SHIPMODE") == "AIR") | (col("L_SHIPMODE") == "AIR REG"))
+        .where(col("L_SHIPINSTRUCT") == "DELIVER IN PERSON")
         .agg((col("L_EXTENDEDPRICE") * (1 - col("L_DISCOUNT"))).sum().alias("revenue"))
     )
 
@@ -595,7 +608,6 @@ def q20(get_df: GetDFFunc) -> DataFrame:
     daft_df = (
         part.where(col("P_NAME").str.startswith("forest"))
         .select("P_PARTKEY")
-        .distinct()
         .join(partsupp, left_on="P_PARTKEY", right_on="PS_PARTKEY")
         .join(
             res_1,
@@ -604,7 +616,6 @@ def q20(get_df: GetDFFunc) -> DataFrame:
         )
         .where(col("PS_AVAILQTY") > col("sum_quantity"))
         .select("PS_SUPPKEY")
-        .distinct()
         .join(res_3, left_on="PS_SUPPKEY", right_on="S_SUPPKEY")
         .select("S_NAME", "S_ADDRESS")
         .sort("S_NAME")
@@ -621,7 +632,6 @@ def q21(get_df: GetDFFunc) -> DataFrame:
 
     res_1 = (
         lineitem.select("L_SUPPKEY", "L_ORDERKEY")
-        .distinct()
         .groupby("L_ORDERKEY")
         .agg(col("L_SUPPKEY").count().alias("nunique_col"))
         .where(col("nunique_col") > 1)
@@ -652,7 +662,16 @@ def q22(get_df: GetDFFunc) -> DataFrame:
 
     res_1 = (
         customer.with_column("cntrycode", col("C_PHONE").str.left(2))
-        .where(col("cntrycode").is_in(["13", "31", "23", "29", "30", "18", "17"]))
+        # .where(col("cntrycode").is_in(["13", "31", "23", "29", "30", "18", "17"]))
+        .where(
+            (col("cntrycode") == "13")
+            | (col("cntrycode") == "31")
+            | (col("cntrycode") == "23")
+            | (col("cntrycode") == "29")
+            | (col("cntrycode") == "30")
+            | (col("cntrycode") == "18")
+            | (col("cntrycode") == "17")
+        )
         .select("C_ACCTBAL", "C_CUSTKEY", "cntrycode")
     )
 

--- a/benchmarking/tpch/answers.py
+++ b/benchmarking/tpch/answers.py
@@ -608,6 +608,7 @@ def q20(get_df: GetDFFunc) -> DataFrame:
     daft_df = (
         part.where(col("P_NAME").str.startswith("forest"))
         .select("P_PARTKEY")
+        .distinct()
         .join(partsupp, left_on="P_PARTKEY", right_on="PS_PARTKEY")
         .join(
             res_1,
@@ -632,6 +633,7 @@ def q21(get_df: GetDFFunc) -> DataFrame:
 
     res_1 = (
         lineitem.select("L_SUPPKEY", "L_ORDERKEY")
+        .distinct()
         .groupby("L_ORDERKEY")
         .agg(col("L_SUPPKEY").count().alias("nunique_col"))
         .where(col("nunique_col") > 1)

--- a/tests/integration/test_tpch.py
+++ b/tests/integration/test_tpch.py
@@ -7,6 +7,7 @@ from fsspec.implementations.local import LocalFileSystem
 
 import daft
 from benchmarking.tpch import answers, data_generation
+from tests.conftest import get_tests_daft_runner_name
 
 if sys.platform == "win32":
     pytest.skip(allow_module_level=True)
@@ -104,84 +105,108 @@ def test_tpch_q10(tmp_path, check_answer, get_df):
     check_answer(daft_pd_df, 10, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q11(tmp_path, check_answer, get_df):
     daft_df = answers.q11(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 11, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q12(tmp_path, check_answer, get_df):
     daft_df = answers.q12(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 12, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q13(tmp_path, check_answer, get_df):
     daft_df = answers.q13(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 13, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q14(tmp_path, check_answer, get_df):
     daft_df = answers.q14(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 14, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q15(tmp_path, check_answer, get_df):
     daft_df = answers.q15(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 15, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q16(tmp_path, check_answer, get_df):
     daft_df = answers.q16(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 16, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q17(tmp_path, check_answer, get_df):
     daft_df = answers.q17(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 17, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q18(tmp_path, check_answer, get_df):
     daft_df = answers.q18(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 18, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q19(tmp_path, check_answer, get_df):
     daft_df = answers.q19(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 19, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q20(tmp_path, check_answer, get_df):
     daft_df = answers.q20(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 20, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q21(tmp_path, check_answer, get_df):
     daft_df = answers.q21(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 21, tmp_path)
 
 
-@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
+)
 def test_tpch_q22(tmp_path, check_answer, get_df):
     daft_df = answers.q22(get_df)
     daft_pd_df = daft_df.to_pandas()

--- a/tests/integration/test_tpch.py
+++ b/tests/integration/test_tpch.py
@@ -7,7 +7,6 @@ from fsspec.implementations.local import LocalFileSystem
 
 import daft
 from benchmarking.tpch import answers, data_generation
-from tests.conftest import get_tests_daft_runner_name
 
 if sys.platform == "win32":
     pytest.skip(allow_module_level=True)
@@ -105,108 +104,84 @@ def test_tpch_q10(tmp_path, check_answer, get_df):
     check_answer(daft_pd_df, 10, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q11(tmp_path, check_answer, get_df):
     daft_df = answers.q11(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 11, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q12(tmp_path, check_answer, get_df):
     daft_df = answers.q12(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 12, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q13(tmp_path, check_answer, get_df):
     daft_df = answers.q13(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 13, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q14(tmp_path, check_answer, get_df):
     daft_df = answers.q14(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 14, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q15(tmp_path, check_answer, get_df):
     daft_df = answers.q15(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 15, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q16(tmp_path, check_answer, get_df):
     daft_df = answers.q16(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 16, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q17(tmp_path, check_answer, get_df):
     daft_df = answers.q17(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 17, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q18(tmp_path, check_answer, get_df):
     daft_df = answers.q18(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 18, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q19(tmp_path, check_answer, get_df):
     daft_df = answers.q19(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 19, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q20(tmp_path, check_answer, get_df):
     daft_df = answers.q20(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 20, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q21(tmp_path, check_answer, get_df):
     daft_df = answers.q21(get_df)
     daft_pd_df = daft_df.to_pandas()
     check_answer(daft_pd_df, 21, tmp_path)
 
 
-@pytest.mark.skipif(
-    get_tests_daft_runner_name() != "native", reason="Running all tpch questions are slow unless on native"
-)
+@pytest.mark.skip(reason="Running all TPC-H queries is too slow")
 def test_tpch_q22(tmp_path, check_answer, get_df):
     daft_df = answers.q22(get_df)
     daft_pd_df = daft_df.to_pandas()


### PR DESCRIPTION
Converts `is_in` to plain old `or` clauses, so that they are properly pushed down.

Results:
Q19: 5.15s -> 0.91s