### PR TITLE
fix: Run filter null join key optimization once

### DIFF
--- a/src/daft-logical-plan/src/optimization/optimizer.rs
+++ b/src/daft-logical-plan/src/optimization/optimizer.rs
@@ -106,11 +106,16 @@ impl Default for OptimizerBuilder {
                     vec![Box::new(SimplifyExpressionsRule::new())],
                     RuleExecutionStrategy::FixedPoint(Some(3)),
                 ),
+                // --- Filter out null join keys ---
+                // This rule should be run once, before any filter pushdown rules.
+                RuleBatch::new(
+                    vec![Box::new(FilterNullJoinKey::new())],
+                    RuleExecutionStrategy::Once,
+                ),
                 // --- Bulk of our rules ---
                 RuleBatch::new(
                     vec![
                         Box::new(DropRepartition::new()),
-                        Box::new(FilterNullJoinKey::new()),
                         Box::new(PushDownFilter::new()),
                         Box::new(PushDownProjection::new()),
                         Box::new(EliminateCrossJoin::new()),


### PR DESCRIPTION
Only run the filter null join key optimization once before filter pushdown, instead of 3 times together with the other rules, otherwise you end up with something like `[not(is_null(key)) & not(is_null(key))] & not(is_null(key))`. 