### PR TITLE
feat: Add column format option to iter rows

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -267,8 +267,8 @@ class DataFrame:
         Each row will be a Python dictionary of the form { "key" : value, ... }. If you are instead looking to iterate over
         entire partitions of data, see: :meth:`df.iter_partitions() <daft.DataFrame.iter_partitions>`.
 
-        By default, Daft will convert the columns to Python lists for easy consumption. However, for nested data such as List or Struct arrays, this can be expensive.
-        You may wish to set `column_format` to "arrow" such that the nested data is returned as Arrow scalars.
+        By default, Daft will convert the columns to Python lists for easy consumption. Datatypes with Python equivalents will be converted accordingly, e.g. timestamps to datetime, tensors to numpy arrays.
+        For nested data such as List or Struct arrays, however, this can be expensive. You may wish to set `column_format` to "arrow" such that the nested data is returned as Arrow scalars.
 
         .. NOTE::
             A quick note on configuring asynchronous/parallel execution using `results_buffer_size`.

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -268,7 +268,7 @@ class DataFrame:
         entire partitions of data, see: :meth:`df.iter_partitions() <daft.DataFrame.iter_partitions>`.
 
         By default, Daft will convert the columns to Python lists for easy consumption. However, for nested data such as List or Struct arrays, this can be expensive.
-        You may wish to set `column_format` to "arrow" such that the nested data is returned as an Arrow array.
+        You may wish to set `column_format` to "arrow" such that the nested data is returned as Arrow scalars.
 
         .. NOTE::
             A quick note on configuring asynchronous/parallel execution using `results_buffer_size`.
@@ -296,7 +296,7 @@ class DataFrame:
         Args:
             results_buffer_size: how many partitions to allow in the results buffer (defaults to the total number of CPUs
                 available on the machine).
-            column_format: the format of the columns to iterate over. One of "python", "arrow", or "numpy". Defaults to "python".
+            column_format: the format of the columns to iterate over. One of "python" or "arrow". Defaults to "python".
 
         .. seealso::
             :meth:`df.iter_partitions() <daft.DataFrame.iter_partitions>`: iterator over entire partitions instead of single rows

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -7,6 +7,8 @@ import pytest
 import daft
 from tests.conftest import get_tests_daft_runner_name
 
+PYARROW_GE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (8, 0, 0)
+
 
 class MockException(Exception):
     pass
@@ -126,7 +128,7 @@ def test_iter_rows_column_formats(make_df, format, data, expected):
     ],
 )
 def test_iter_rows_column_format_not_compatible(format):
-    df = daft.from_pydict({"a": [object()]})
+    df = daft.from_pydict({"a": [object()]})  # Object type is not supported by arrow or numpy
 
     with pytest.raises(ValueError):
         list(df.iter_rows(column_format=format))

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -36,7 +36,6 @@ def test_iter_rows(make_df, materialized):
             [pa.scalar(1), pa.scalar(2), pa.scalar(3)],
             id="arrow_ints",
         ),
-        pytest.param("numpy", [1, 2, 3], [1, 2, 3], id="numpy_ints"),
         ### Strings
         pytest.param("python", ["a", "b", "c"], ["a", "b", "c"], id="python_strs"),
         pytest.param(
@@ -49,7 +48,6 @@ def test_iter_rows(make_df, materialized):
             ],
             id="arrow_strs",
         ),
-        pytest.param("numpy", ["a", "b", "c"], ["a", "b", "c"], id="numpy_strs"),
         ### Lists
         pytest.param("python", [[1, 2], [3, 4]], [[1, 2], [3, 4]], id="python_lists"),
         pytest.param(
@@ -60,12 +58,6 @@ def test_iter_rows(make_df, materialized):
                 pa.scalar([3, 4], pa.large_list(pa.int64())),
             ],
             id="arrow_lists",
-        ),
-        pytest.param(
-            "numpy",
-            [[1, 2], [3, 4]],
-            [np.array([1, 2]), np.array([3, 4])],
-            id="numpy_lists",
         ),
         ### Structs
         pytest.param(
@@ -88,12 +80,6 @@ def test_iter_rows(make_df, materialized):
                 ),
             ],
             id="arrow_structs",
-        ),
-        pytest.param(
-            "numpy",
-            [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
-            [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
-            id="numpy_structs",
         ),
     ],
 )

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -7,8 +7,6 @@ import pytest
 import daft
 from tests.conftest import get_tests_daft_runner_name
 
-PYARROW_GE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (8, 0, 0)
-
 
 class MockException(Exception):
     pass
@@ -100,9 +98,6 @@ def test_iter_rows(make_df, materialized):
     ],
 )
 def test_iter_rows_column_formats(make_df, format, data, expected):
-    # Test that df.__iter__ produces the correct rows in the correct order.
-    # It should work regardless of whether the dataframe has already been materialized or not.
-
     df = make_df({"a": data})
 
     rows = list(df.iter_rows(column_format=format))

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -101,18 +101,11 @@ def test_iter_rows_column_formats(make_df, format, data, expected):
         assert compare_values(actual_row, expected_row)
 
 
-@pytest.mark.parametrize(
-    "format",
-    [
-        "arrow",
-        "numpy",
-    ],
-)
-def test_iter_rows_column_format_not_compatible(format):
+def test_iter_rows_arrow_column_format_not_compatible():
     df = daft.from_pydict({"a": [object()]})  # Object type is not supported by arrow or numpy
 
     with pytest.raises(ValueError):
-        list(df.iter_rows(column_format=format))
+        list(df.iter_rows(column_format="arrow"))
 
 
 @pytest.mark.parametrize("materialized", [False, True])

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numpy as np
+import pyarrow as pa
 import pytest
 
 import daft
@@ -21,6 +23,113 @@ def test_iter_rows(make_df, materialized):
 
     rows = list(iter(df))
     assert rows == [{"a": x, "b": x + 100} for x in range(10)]
+
+
+@pytest.mark.parametrize(
+    "format, data, expected",
+    [
+        ### Ints
+        pytest.param("python", [1, 2, 3], [1, 2, 3], id="python_ints"),
+        pytest.param(
+            "arrow",
+            [1, 2, 3],
+            [pa.scalar(1), pa.scalar(2), pa.scalar(3)],
+            id="arrow_ints",
+        ),
+        pytest.param("numpy", [1, 2, 3], [1, 2, 3], id="numpy_ints"),
+        ### Strings
+        pytest.param("python", ["a", "b", "c"], ["a", "b", "c"], id="python_strs"),
+        pytest.param(
+            "arrow",
+            ["a", "b", "c"],
+            [
+                pa.scalar("a", pa.large_string()),
+                pa.scalar("b", pa.large_string()),
+                pa.scalar("c", pa.large_string()),
+            ],
+            id="arrow_strs",
+        ),
+        pytest.param("numpy", ["a", "b", "c"], ["a", "b", "c"], id="numpy_strs"),
+        ### Lists
+        pytest.param("python", [[1, 2], [3, 4]], [[1, 2], [3, 4]], id="python_lists"),
+        pytest.param(
+            "arrow",
+            [[1, 2], [3, 4]],
+            [
+                pa.scalar([1, 2], pa.large_list(pa.int64())),
+                pa.scalar([3, 4], pa.large_list(pa.int64())),
+            ],
+            id="arrow_lists",
+        ),
+        pytest.param(
+            "numpy",
+            [[1, 2], [3, 4]],
+            [np.array([1, 2]), np.array([3, 4])],
+            id="numpy_lists",
+        ),
+        ### Structs
+        pytest.param(
+            "python",
+            [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
+            [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
+            id="python_structs",
+        ),
+        pytest.param(
+            "arrow",
+            [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
+            [
+                pa.scalar(
+                    {"a": 1, "b": 2},
+                    pa.struct([pa.field("a", pa.int64()), pa.field("b", pa.int64())]),
+                ),
+                pa.scalar(
+                    {"a": 3, "b": 4},
+                    pa.struct([pa.field("a", pa.int64()), pa.field("b", pa.int64())]),
+                ),
+            ],
+            id="arrow_structs",
+        ),
+        pytest.param(
+            "numpy",
+            [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
+            [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
+            id="numpy_structs",
+        ),
+    ],
+)
+def test_iter_rows_column_formats(make_df, format, data, expected):
+    # Test that df.__iter__ produces the correct rows in the correct order.
+    # It should work regardless of whether the dataframe has already been materialized or not.
+
+    df = make_df({"a": data})
+
+    rows = list(df.iter_rows(column_format=format))
+
+    def compare_values(v1, v2):
+        if isinstance(v1, np.ndarray) and isinstance(v2, np.ndarray):
+            return np.array_equal(v1, v2)
+        if isinstance(v1, dict) and isinstance(v2, dict):
+            return all(compare_values(v1[k], v2[k]) for k in v1)
+        return v1 == v2
+
+    # Compare each row
+    assert len(rows) == len(expected)
+    for actual_row, expected_row in zip(rows, [{"a": e} for e in expected]):
+        assert compare_values(actual_row, expected_row)
+
+
+@pytest.mark.parametrize(
+    "format",
+    [
+        "arrow",
+        "numpy",
+    ],
+)
+def test_iter_rows_column_format_not_compatible(format):
+    df = daft.from_pydict({"a": [object()]})
+
+    with pytest.raises(ValueError):
+        list(df.iter_rows(column_format=format))
 
 
 @pytest.mark.parametrize("materialized", [False, True])


### PR DESCRIPTION
Addresses: https://github.com/Eventual-Inc/Daft/issues/3634

Add an option to iter_rows to decude the format of columns during iteration, either Python (default), Arrow, or Numpy.

