### PR TITLE
feat(sql): Adds JsonScanBuilder to daft-scan and read_json to daft-sql

### DIFF
--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -1065,6 +1065,7 @@ impl<'a> SQLPlanner<'a> {
         let func = match Path::new(path).extension() {
             Some(ext) if ext.eq_ignore_ascii_case("csv") => "read_csv",
             Some(ext) if ext.eq_ignore_ascii_case("json") => "read_json",
+            Some(ext) if ext.eq_ignore_ascii_case("jsonl") => "read_json",
             Some(ext) if ext.eq_ignore_ascii_case("parquet") => "read_parquet",
             Some(_) => invalid_operation_err!("unsupported file path extension: {}", name),
             None => invalid_operation_err!("unsupported file path, no extension: {}", name),

--- a/src/daft-sql/src/table_provider/mod.rs
+++ b/src/daft-sql/src/table_provider/mod.rs
@@ -1,10 +1,12 @@
 pub mod read_csv;
+pub mod read_json;
 pub mod read_parquet;
 use std::{collections::HashMap, sync::Arc};
 
 use daft_logical_plan::LogicalPlanBuilder;
 use once_cell::sync::Lazy;
 use read_csv::ReadCsvFunction;
+use read_json::ReadJsonFunction;
 use read_parquet::ReadParquetFunction;
 use sqlparser::ast::TableFunctionArgs;
 
@@ -17,11 +19,11 @@ use crate::{
 
 pub(crate) static SQL_TABLE_FUNCTIONS: Lazy<SQLTableFunctions> = Lazy::new(|| {
     let mut functions = SQLTableFunctions::new();
-    functions.add_fn("read_parquet", ReadParquetFunction);
     functions.add_fn("read_csv", ReadCsvFunction);
+    functions.add_fn("read_json", ReadJsonFunction);
+    functions.add_fn("read_parquet", ReadParquetFunction);
     #[cfg(feature = "python")]
     functions.add_fn("read_deltalake", ReadDeltalakeFunction);
-
     functions
 });
 

--- a/src/daft-sql/src/table_provider/read_csv.rs
+++ b/src/daft-sql/src/table_provider/read_csv.rs
@@ -16,6 +16,10 @@ impl TryFrom<SQLFunctionArguments> for CsvScanBuilder {
     type Error = PlannerError;
 
     fn try_from(args: SQLFunctionArguments) -> Result<Self, Self::Error> {
+        // TODO validations (unsure if should carry over from python API)
+        // - schema_hints is deprecated
+        // - ensure infer_schema is true if schema is None.
+
         let delimiter = args.try_get_named("delimiter")?;
         let has_headers: bool = args.try_get_named("has_headers")?.unwrap_or(true);
         let double_quote: bool = args.try_get_named("double_quote")?.unwrap_or(true);

--- a/src/daft-sql/src/table_provider/read_json.rs
+++ b/src/daft-sql/src/table_provider/read_json.rs
@@ -1,0 +1,68 @@
+use daft_scan::builder::JsonScanBuilder;
+
+use super::{expr_to_iocfg, SQLTableFunction};
+use crate::{error::PlannerError, functions::SQLFunctionArguments};
+
+pub(super) struct ReadJsonFunction;
+
+impl SQLTableFunction for ReadJsonFunction {
+    fn plan(
+        &self,
+        planner: &crate::SQLPlanner,
+        args: &sqlparser::ast::TableFunctionArgs,
+    ) -> crate::error::SQLPlannerResult<daft_logical_plan::LogicalPlanBuilder> {
+        let builder: JsonScanBuilder = planner.plan_function_args(
+            args.args.as_slice(),
+            &[
+                "path",
+                "infer_schema",
+                // "schema"
+                "io_config",
+                "file_path_column",
+                "hive_partitioning",
+                // "schema_hints",
+                "buffer_size",
+                "chunk_size",
+            ],
+            1, // (path)
+        )?;
+        let runtime = common_runtime::get_io_runtime(true);
+        let result = runtime.block_on(builder.finish())??;
+        Ok(result)
+    }
+}
+
+impl TryFrom<SQLFunctionArguments> for JsonScanBuilder {
+    type Error = PlannerError;
+
+    fn try_from(args: SQLFunctionArguments) -> Result<Self, Self::Error> {
+        // TODO validations (unsure if should carry over from python API)
+        // - schema_hints is deprecated
+        // - ensure infer_schema is true if schema is None.
+
+        let glob_paths: String = args
+            .try_get_positional(0)?
+            .ok_or_else(|| PlannerError::invalid_operation("path is required for `read_json`"))?;
+
+        let infer_schema = args.try_get_named("infer_schema")?.unwrap_or(true);
+        let chunk_size = args.try_get_named("chunk_size")?;
+        let buffer_size = args.try_get_named("buffer_size")?;
+        let file_path_column = args.try_get_named("file_path_column")?;
+        let hive_partitioning = args.try_get_named("hive_partitioning")?.unwrap_or(false);
+        let schema = None; // TODO
+        let schema_hints = None; // TODO
+        let io_config = args.get_named("io_config").map(expr_to_iocfg).transpose()?;
+
+        Ok(Self {
+            glob_paths: vec![glob_paths],
+            infer_schema,
+            schema,
+            io_config,
+            file_path_column,
+            hive_partitioning,
+            schema_hints,
+            buffer_size,
+            chunk_size,
+        })
+    }
+}

--- a/tests/sql/test_table_funcs.py
+++ b/tests/sql/test_table_funcs.py
@@ -13,14 +13,14 @@ def sample_schema():
     return {"a": daft.DataType.float32(), "b": daft.DataType.string()}
 
 
-@pytest.mark.skip("read_json table function not supported (yet) see github #3196")
+# @pytest.mark.skip("read_json table function not supported (yet) see github #3196")
 def test_sql_read_json():
     df = daft.sql("SELECT * FROM read_json('tests/assets/json-data/small.jsonl')").collect()
     expected = daft.read_json("tests/assets/json-data/small.jsonl").collect()
     assert df.to_pydict() == expected.to_pydict()
 
 
-@pytest.mark.skip("read_json table function not supported (yet) see github #3196")
+# @pytest.mark.skip("read_json table function not supported (yet) see github #3196")
 def test_sql_read_json_path():
     df = daft.sql("SELECT * FROM 'tests/assets/json-data/small.jsonl'").collect()
     expected = daft.read_json("tests/assets/json-data/small.jsonl").collect()


### PR DESCRIPTION
**Description**

This PR follows the read_csv and read_parquet pattern for adding the table-value function to SQL. This issue solves/addresses #3196 but there a couple TODOs which could be tackled in later PRs.

- support for schema as an argument
- support for mixing named and positional arguments, now only path is positional and all else must be named.
- argument validation, the python API does some validation that's missing on the SQL side.

**Issues**

- #3196 



