### PR TITLE
feat: Overwrite partitions mode

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -566,7 +566,7 @@ class DataFrame:
         Args:
             root_dir (str): root file path to write parquet files to.
             compression (str, optional): compression algorithm. Defaults to "snappy".
-            write_mode (str, optional): Operation mode of the write. `append` will add new data, `overwrite` will replace table with new data. `overwrite-partitions` will overwrite only the partitions that are being written. Defaults to "append".
+            write_mode (str, optional): Operation mode of the write. `append` will add new data, `overwrite` will replace the contents of the root directory with new data. `overwrite-partitions` will replace only the contents in the partitions that are being written to. Defaults to "append".
             partition_cols (Optional[List[ColumnInputType]], optional): How to subpartition each partition further. Defaults to None.
             io_config (Optional[IOConfig], optional): configurations to use when interacting with remote storage.
 
@@ -643,7 +643,7 @@ class DataFrame:
 
         Args:
             root_dir (str): root file path to write parquet files to.
-            write_mode (str, optional): Operation mode of the write. `append` will add new data, `overwrite` will replace table with new data. `overwrite-partitions` will overwrite only the partitions that are being written. Defaults to "append".
+            write_mode (str, optional): Operation mode of the write. `append` will add new data, `overwrite` will replace the contents of the root directory with new data. `overwrite-partitions` will replace only the contents in the partitions that are being written to. Defaults to "append".
             partition_cols (Optional[List[ColumnInputType]], optional): How to subpartition each partition further. Defaults to None.
             io_config (Optional[IOConfig], optional): configurations to use when interacting with remote storage.
 

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -387,7 +387,6 @@ def overwrite_files(
                     [info.path for info in fs.get_file_info(file_selector) if info.type == pafs.FileType.File]
                 )
             except FileNotFoundError:
-                # The root directory does not exist, so there are no files to delete.
                 continue
     else:
         # Get all files in the root directory.

--- a/tests/io/test_write_modes.py
+++ b/tests/io/test_write_modes.py
@@ -7,6 +7,20 @@ import s3fs
 import daft
 
 
+@pytest.fixture(scope="function")
+def bucket(minio_io_config):
+    BUCKET = "write-modes-bucket"
+
+    fs = s3fs.S3FileSystem(
+        key=minio_io_config.s3.key_id,
+        password=minio_io_config.s3.access_key,
+        client_kwargs={"endpoint_url": minio_io_config.s3.endpoint_url},
+    )
+    if not fs.exists(BUCKET):
+        fs.mkdir(BUCKET)
+    yield BUCKET
+
+
 def write(
     df: daft.DataFrame,
     path: str,
@@ -56,12 +70,14 @@ def arrange_write_mode_test(existing_data, new_data, path, format, write_mode, p
     return read_back
 
 
-@pytest.mark.parametrize("write_mode", ["append", "overwrite"])
-@pytest.mark.parametrize("format", ["csv", "parquet"])
-@pytest.mark.parametrize("num_partitions", [1, 2])
-@pytest.mark.parametrize("partition_cols", [None, ["a"]])
-def test_write_modes_local(tmp_path, write_mode, format, num_partitions, partition_cols):
-    path = str(tmp_path)
+def _run_append_overwrite_test(
+    path,
+    write_mode,
+    format,
+    num_partitions,
+    partition_cols,
+    io_config,
+):
     existing_data = {"a": ["a", "a", "b", "b"], "b": [1, 2, 3, 4]}
     new_data = {
         "a": ["a", "a", "b", "b"],
@@ -75,7 +91,7 @@ def test_write_modes_local(tmp_path, write_mode, format, num_partitions, partiti
         format,
         write_mode,
         partition_cols,
-        None,
+        io_config,
     )
 
     # Check the data
@@ -91,8 +107,48 @@ def test_write_modes_local(tmp_path, write_mode, format, num_partitions, partiti
 
 @pytest.mark.parametrize("write_mode", ["append", "overwrite"])
 @pytest.mark.parametrize("format", ["csv", "parquet"])
-def test_write_modes_local_empty_data(tmp_path, write_mode, format):
-    path = str(tmp_path)
+@pytest.mark.parametrize("num_partitions", [1, 2])
+@pytest.mark.parametrize("partition_cols", [None, ["a"]])
+def test_append_and_overwrite_local(tmp_path, write_mode, format, num_partitions, partition_cols):
+    _run_append_overwrite_test(
+        path=str(tmp_path),
+        write_mode=write_mode,
+        format=format,
+        num_partitions=num_partitions,
+        partition_cols=partition_cols,
+        io_config=None,
+    )
+
+
+@pytest.mark.integration()
+@pytest.mark.parametrize("write_mode", ["append", "overwrite"])
+@pytest.mark.parametrize("format", ["csv", "parquet"])
+@pytest.mark.parametrize("num_partitions", [1, 2])
+@pytest.mark.parametrize("partition_cols", [None, ["a"]])
+def test_append_and_overwrite_s3_minio(
+    minio_io_config,
+    bucket,
+    write_mode,
+    format,
+    num_partitions,
+    partition_cols,
+):
+    _run_append_overwrite_test(
+        path=f"s3://{bucket}/{uuid.uuid4()!s}",
+        write_mode=write_mode,
+        format=format,
+        num_partitions=num_partitions,
+        partition_cols=partition_cols,
+        io_config=minio_io_config,
+    )
+
+
+def _run_write_modes_empty_test(
+    path,
+    write_mode,
+    format,
+    io_config,
+):
     existing_data = {"a": ["a", "a", "b", "b"], "b": ["c", "d", "e", "f"]}
     new_data = {
         "a": ["a", "a", "b", "b"],
@@ -106,7 +162,7 @@ def test_write_modes_local_empty_data(tmp_path, write_mode, format):
         format,
         write_mode,
         None,
-        None,
+        io_config,
     )
 
     # Check the data
@@ -122,59 +178,15 @@ def test_write_modes_local_empty_data(tmp_path, write_mode, format):
         raise ValueError(f"Unsupported write_mode: {write_mode}")
 
 
-@pytest.fixture(scope="function")
-def bucket(minio_io_config):
-    BUCKET = "write-modes-bucket"
-
-    fs = s3fs.S3FileSystem(
-        key=minio_io_config.s3.key_id,
-        password=minio_io_config.s3.access_key,
-        client_kwargs={"endpoint_url": minio_io_config.s3.endpoint_url},
-    )
-    if not fs.exists(BUCKET):
-        fs.mkdir(BUCKET)
-    yield BUCKET
-
-
-@pytest.mark.integration()
 @pytest.mark.parametrize("write_mode", ["append", "overwrite"])
 @pytest.mark.parametrize("format", ["csv", "parquet"])
-@pytest.mark.parametrize("num_partitions", [1, 2])
-@pytest.mark.parametrize("partition_cols", [None, ["a"]])
-def test_write_modes_s3_minio(
-    minio_io_config,
-    bucket,
-    write_mode,
-    format,
-    num_partitions,
-    partition_cols,
-):
-    path = f"s3://{bucket}/{uuid.uuid4()!s}"
-    existing_data = {"a": ["a", "a", "b", "b"], "b": [1, 2, 3, 4]}
-    new_data = {
-        "a": ["a", "a", "b", "b"],
-        "b": [5, 6, 7, 8],
-    }
-
-    read_back = arrange_write_mode_test(
-        daft.from_pydict(existing_data).into_partitions(num_partitions),
-        daft.from_pydict(new_data).into_partitions(num_partitions),
-        path,
-        format,
-        write_mode,
-        partition_cols,
-        minio_io_config,
+def test_write_modes_local_empty_data(tmp_path, write_mode, format):
+    _run_write_modes_empty_test(
+        path=str(tmp_path),
+        write_mode=write_mode,
+        format=format,
+        io_config=None,
     )
-
-    # Check the data
-    if write_mode == "append":
-        assert read_back["a"] == ["a"] * 4 + ["b"] * 4
-        assert read_back["b"] == [1, 2, 5, 6, 3, 4, 7, 8]
-    elif write_mode == "overwrite":
-        assert read_back["a"] == ["a", "a", "b", "b"]
-        assert read_back["b"] == [5, 6, 7, 8]
-    else:
-        raise ValueError(f"Unsupported write_mode: {write_mode}")
 
 
 @pytest.mark.integration()
@@ -186,31 +198,101 @@ def test_write_modes_s3_minio_empty_data(
     write_mode,
     format,
 ):
-    path = f"s3://{bucket}/{uuid.uuid4()!s}"
-    existing_data = {"a": ["a", "a", "b", "b"], "b": ["c", "d", "e", "f"]}
-    new_data = {
-        "a": ["a", "a", "b", "b"],
-        "b": ["g", "h", "i", "j"],
-    }
+    _run_write_modes_empty_test(
+        path=f"s3://{bucket}/{uuid.uuid4()!s}",
+        write_mode=write_mode,
+        format=format,
+        io_config=minio_io_config,
+    )
+
+
+OVERWRITE_PARTITION_TEST_CASES = [
+    pytest.param(
+        {
+            "a": ["a", "a", "b", "b"],
+            "b": [5, 6, 7, 8],
+        },
+        {
+            "a": ["a", "a", "b", "b"],
+            "b": [5, 6, 7, 8],
+        },
+        id="overwrite-all",
+    ),
+    pytest.param(
+        {
+            "a": ["a", "a"],
+            "b": [5, 6],
+        },
+        {
+            "a": ["a", "a", "b", "b"],
+            "b": [5, 6, 3, 4],
+        },
+        id="overwrite-some",
+    ),
+    pytest.param(
+        {
+            "a": ["b", "b", "c", "c"],
+            "b": [9, 10, 11, 12],
+        },
+        {
+            "a": ["a", "a", "b", "b", "c", "c"],
+            "b": [1, 2, 9, 10, 11, 12],
+        },
+        id="overwrite-and-append",
+    ),
+]
+
+
+def _run_overwrite_partitions_test(
+    path,
+    format,
+    new_data,
+    expected_read_back,
+    io_config,
+):
+    existing_data = {"a": ["a", "a", "b", "b"], "b": [1, 2, 3, 4]}
 
     read_back = arrange_write_mode_test(
         daft.from_pydict(existing_data),
-        daft.from_pydict(new_data).where(daft.lit(False)),  # Empty data
+        daft.from_pydict(new_data),
         path,
         format,
-        write_mode,
-        None,
-        minio_io_config,
+        "overwrite-partitions",
+        ["a"],
+        io_config,
     )
 
     # Check the data
-    if write_mode == "append":
-        # The data should be the same as the existing data
-        assert read_back["a"] == ["a", "a", "b", "b"]
-        assert read_back["b"] == ["c", "d", "e", "f"]
-    elif write_mode == "overwrite":
-        # The data should be empty because we are overwriting the existing data
-        assert read_back["a"] == []
-        assert read_back["b"] == []
-    else:
-        raise ValueError(f"Unsupported write_mode: {write_mode}")
+    for col in expected_read_back:
+        assert read_back[col] == expected_read_back[col]
+
+
+@pytest.mark.parametrize("format", ["csv", "parquet"])
+@pytest.mark.parametrize("new_data, expected_read_back", OVERWRITE_PARTITION_TEST_CASES)
+def test_overwrite_partitions_local(tmp_path, format, new_data, expected_read_back):
+    _run_overwrite_partitions_test(
+        path=str(tmp_path),
+        format=format,
+        new_data=new_data,
+        expected_read_back=expected_read_back,
+        io_config=None,
+    )
+
+
+@pytest.mark.integration()
+@pytest.mark.parametrize("format", ["csv", "parquet"])
+@pytest.mark.parametrize("new_data, expected_read_back", OVERWRITE_PARTITION_TEST_CASES)
+def test_overwrite_partitions_s3_minio(
+    minio_io_config,
+    bucket,
+    format,
+    new_data,
+    expected_read_back,
+):
+    _run_overwrite_partitions_test(
+        path=f"s3://{bucket}/{uuid.uuid4()!s}",
+        format=format,
+        new_data=new_data,
+        expected_read_back=expected_read_back,
+        io_config=minio_io_config,
+    )


### PR DESCRIPTION
Closes https://github.com/Eventual-Inc/Daft/issues/1768

Overwrite-partitions mode will only overwrite files in the partition directories that were written into as part of the write operation. E.g. partition "A" will be overwritten if and only if partition "A" was written into.

This PR also refactors the test code a bit.