### PR TITLE
feat(sql): Adds url_download and url_upload to daft-sql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2148,7 +2148,6 @@ dependencies = [
  "bytes",
  "common-error",
  "common-hashable-float-wrapper",
- "common-io-config",
  "common-runtime",
  "daft-core",
  "daft-dsl",

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -1431,6 +1431,7 @@ class ExpressionUrlNamespace(ExpressionNamespace):
         multi_thread = ExpressionUrlNamespace._should_use_multithreading_tokio_runtime()
         # If the user specifies a single location via a string, we should upload to a single folder. Otherwise,
         # if the user gave an expression, we assume that each row has a specific url to upload to.
+        # Consider moving the check for is_single_folder to a lower IR.
         is_single_folder = isinstance(location, str)
         io_config = ExpressionUrlNamespace._override_io_config_max_connections(max_connections, io_config)
         return Expression._from_pyexpr(

--- a/src/daft-functions/Cargo.toml
+++ b/src/daft-functions/Cargo.toml
@@ -3,7 +3,6 @@ arrow2 = {workspace = true}
 base64 = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
 common-hashable-float-wrapper = {path = "../common/hashable-float-wrapper"}
-common-io-config = {path = "../common/io-config", default-features = false}
 common-runtime = {path = "../common/runtime", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
@@ -25,7 +24,6 @@ snafu.workspace = true
 [features]
 python = [
   "common-error/python",
-  "common-io-config/python",
   "daft-core/python",
   "daft-dsl/python",
   "daft-image/python",

--- a/src/daft-functions/src/python/uri.rs
+++ b/src/daft-functions/src/python/uri.rs
@@ -2,6 +2,8 @@ use daft_dsl::python::PyExpr;
 use daft_io::python::IOConfig;
 use pyo3::{exceptions::PyValueError, pyfunction, PyResult};
 
+use crate::uri::{self, download::UrlDownloadArgs, upload::UrlUploadArgs};
+
 #[pyfunction]
 pub fn url_download(
     expr: PyExpr,
@@ -15,15 +17,13 @@ pub fn url_download(
             "max_connections must be positive and non_zero: {max_connections}"
         )));
     }
-
-    Ok(crate::uri::download(
-        expr.into(),
+    let args = UrlDownloadArgs::new(
         max_connections as usize,
         raise_error_on_failure,
         multi_thread,
         Some(config.config),
-    )
-    .into())
+    );
+    Ok(uri::download(expr.into(), Some(args)).into())
 }
 
 #[pyfunction(signature = (
@@ -49,14 +49,12 @@ pub fn url_upload(
             "max_connections must be positive and non_zero: {max_connections}"
         )));
     }
-    Ok(crate::uri::upload(
-        expr.into(),
-        folder_location.into(),
+    let args = UrlUploadArgs::new(
         max_connections as usize,
         raise_error_on_failure,
         multi_thread,
         is_single_folder,
         io_config.map(|io_config| io_config.config),
-    )
-    .into())
+    );
+    Ok(uri::upload(expr.into(), folder_location.into(), Some(args)).into())
 }

--- a/src/daft-functions/src/uri/mod.rs
+++ b/src/daft-functions/src/uri/mod.rs
@@ -1,50 +1,18 @@
-mod download;
-mod upload;
+pub mod download;
+pub mod upload;
 
-use common_io_config::IOConfig;
 use daft_dsl::{functions::ScalarFunction, ExprRef};
-use download::DownloadFunction;
-use upload::UploadFunction;
+use download::UrlDownloadArgs;
+use upload::UrlUploadArgs;
 
+/// Creates a `url_download` ExprRef from the positional and optional named arguments.
 #[must_use]
-pub fn download(
-    input: ExprRef,
-    max_connections: usize,
-    raise_error_on_failure: bool,
-    multi_thread: bool,
-    config: Option<IOConfig>,
-) -> ExprRef {
-    ScalarFunction::new(
-        DownloadFunction {
-            max_connections,
-            raise_error_on_failure,
-            multi_thread,
-            config: config.unwrap_or_default().into(),
-        },
-        vec![input],
-    )
-    .into()
+pub fn download(input: ExprRef, args: Option<UrlDownloadArgs>) -> ExprRef {
+    ScalarFunction::new(args.unwrap_or_default(), vec![input]).into()
 }
 
+/// Creates a `url_upload` ExprRef from the positional and optional named arguments.
 #[must_use]
-pub fn upload(
-    input: ExprRef,
-    location: ExprRef,
-    max_connections: usize,
-    raise_error_on_failure: bool,
-    multi_thread: bool,
-    is_single_folder: bool,
-    config: Option<IOConfig>,
-) -> ExprRef {
-    ScalarFunction::new(
-        UploadFunction {
-            max_connections,
-            raise_error_on_failure,
-            multi_thread,
-            is_single_folder,
-            config: config.unwrap_or_default().into(),
-        },
-        vec![input, location],
-    )
-    .into()
+pub fn upload(input: ExprRef, location: ExprRef, args: Option<UrlUploadArgs>) -> ExprRef {
+    ScalarFunction::new(args.unwrap_or_default(), vec![input, location]).into()
 }

--- a/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
@@ -356,6 +356,7 @@ mod tests {
     use common_scan_info::Pushdowns;
     use daft_core::prelude::*;
     use daft_dsl::{col, lit};
+    use daft_functions::uri::download::UrlDownloadArgs;
     use rstest::rstest;
 
     use crate::{
@@ -435,7 +436,10 @@ mod tests {
     /// Tests that we can't pushdown a filter into a ScanOperator if it has an udf-ish expression.
     #[test]
     fn filter_with_udf_not_pushed_down_into_scan() -> DaftResult<()> {
-        let pred = daft_functions::uri::download(col("a"), 1, true, true, None);
+        let pred = daft_functions::uri::download(
+            col("a"),
+            Some(UrlDownloadArgs::new(1, true, true, None)),
+        );
         let plan = dummy_scan_node(dummy_scan_operator(vec![
             Field::new("a", DataType::Int64),
             Field::new("b", DataType::Utf8),

--- a/src/daft-sql/src/modules/mod.rs
+++ b/src/daft-sql/src/modules/mod.rs
@@ -15,6 +15,7 @@ pub mod python;
 pub mod sketch;
 pub mod structs;
 pub mod temporal;
+pub mod uri;
 pub mod utf8;
 
 pub use aggs::SQLModuleAggs;
@@ -30,6 +31,7 @@ pub use python::SQLModulePython;
 pub use sketch::SQLModuleSketch;
 pub use structs::SQLModuleStructs;
 pub use temporal::SQLModuleTemporal;
+pub use uri::SQLModuleUri;
 pub use utf8::SQLModuleUtf8;
 
 /// A [SQLModule] is a collection of SQL functions that can be registered with a [SQLFunctions] instance.

--- a/src/daft-sql/src/modules/uri/mod.rs
+++ b/src/daft-sql/src/modules/uri/mod.rs
@@ -1,0 +1,14 @@
+use super::SQLModule;
+use crate::functions::SQLFunctions;
+
+mod url_download;
+mod url_upload;
+
+pub struct SQLModuleUri;
+
+impl SQLModule for SQLModuleUri {
+    fn register(parent: &mut SQLFunctions) {
+        parent.add_fn("url_download", url_download::SqlUrlDownload);
+        parent.add_fn("url_upload", url_upload::SqlUrlUpload);
+    }
+}

--- a/src/daft-sql/src/modules/uri/url_download.rs
+++ b/src/daft-sql/src/modules/uri/url_download.rs
@@ -1,0 +1,58 @@
+use daft_dsl::ExprRef;
+use daft_functions::uri::{self, download::UrlDownloadArgs};
+use sqlparser::ast::FunctionArg;
+
+use crate::{
+    error::{PlannerError, SQLPlannerResult},
+    functions::{self, SQLFunction, SQLFunctionArguments},
+    unsupported_sql_err, SQLPlanner,
+};
+
+/// The Daft-SQL `url_download` definition.
+pub struct SqlUrlDownload;
+
+impl TryFrom<SQLFunctionArguments> for UrlDownloadArgs {
+    type Error = PlannerError;
+
+    fn try_from(args: SQLFunctionArguments) -> Result<Self, Self::Error> {
+        let max_connections: usize = args.try_get_named("max_connections")?.unwrap_or(32);
+        let raise_error_on_failure = functions::args::parse_on_error(&args)?;
+        let io_config = functions::args::parse_io_config(&args)?;
+        Ok(Self {
+            max_connections,
+            raise_error_on_failure,
+            multi_thread: true, // TODO always true
+            io_config: io_config.into(),
+        })
+    }
+}
+
+impl SQLFunction for SqlUrlDownload {
+    fn to_expr(&self, inputs: &[FunctionArg], planner: &SQLPlanner) -> SQLPlannerResult<ExprRef> {
+        match inputs {
+            [input] => {
+                let input = planner.plan_function_arg(input)?;
+                Ok(uri::download(input, None))
+            }
+            [input, args @ ..] => {
+                let input = planner.plan_function_arg(input)?;
+                let args = planner.plan_function_args(
+                    args,
+                    &["max_connections", "on_error", "io_config"],
+                    0,
+                )?;
+                Ok(uri::download(input, Some(args)))
+            }
+            _ => unsupported_sql_err!("Invalid arguments for url_download: '{inputs:?}'"),
+        }
+    }
+
+    fn docstrings(&self, _alias: &str) -> String {
+        "Treats each string as a URL, and downloads the bytes contents as a bytes column."
+            .to_string()
+    }
+
+    fn arg_names(&self) -> &'static [&'static str] {
+        &["input", "max_connections", "on_error", "io_config"]
+    }
+}

--- a/src/daft-sql/src/modules/uri/url_upload.rs
+++ b/src/daft-sql/src/modules/uri/url_upload.rs
@@ -1,0 +1,73 @@
+use daft_dsl::{Expr, ExprRef, LiteralValue};
+use daft_functions::uri::{self, upload::UrlUploadArgs};
+use sqlparser::ast::FunctionArg;
+
+use crate::{
+    error::{PlannerError, SQLPlannerResult},
+    functions::{self, SQLFunction, SQLFunctionArguments},
+    unsupported_sql_err, SQLPlanner,
+};
+
+/// The Daft-SQL `url_upload` definition.
+pub struct SqlUrlUpload;
+
+impl TryFrom<SQLFunctionArguments> for UrlUploadArgs {
+    type Error = PlannerError;
+
+    fn try_from(args: SQLFunctionArguments) -> Result<Self, Self::Error> {
+        let max_connections: usize = args.try_get_named("max_connections")?.unwrap_or(32);
+        let raise_error_on_failure = functions::args::parse_on_error(&args)?;
+        let io_config = functions::args::parse_io_config(&args)?;
+        Ok(Self {
+            max_connections,
+            raise_error_on_failure,
+            multi_thread: true, // TODO always true
+            is_single_folder: true,
+            io_config: io_config.into(),
+        })
+    }
+}
+
+impl SQLFunction for SqlUrlUpload {
+    fn to_expr(&self, inputs: &[FunctionArg], planner: &SQLPlanner) -> SQLPlannerResult<ExprRef> {
+        match inputs {
+            [input, location] => {
+                let input = planner.plan_function_arg(input)?;
+                let location = planner.plan_function_arg(location)?;
+                Ok(uri::upload(input, location, None))
+            }
+            [input, location, args @ ..] => {
+                let input = planner.plan_function_arg(input)?;
+                let location = planner.plan_function_arg(location)?;
+                let mut args: UrlUploadArgs = planner.plan_function_args(
+                    args,
+                    &["max_connections", "on_error", "io_config"],
+                    0,
+                )?;
+                // TODO consider moving the calculation of "is_single_folder" deeper so that both the SQL and Python sides don't compute this independently.
+                // is_single_folder = true iff the location is a string.
+                // in python, this is isinstance(location, str)
+                // We perform the check here (with mut args) because TryFrom<SQLFunctionArguments> does not have access to `location`.
+                args.is_single_folder =
+                    matches!(location.as_ref(), Expr::Literal(LiteralValue::Utf8(_)));
+                Ok(uri::upload(input, location, Some(args)))
+            }
+            _ => unsupported_sql_err!("Invalid arguments for url_upload: '{inputs:?}'"),
+        }
+    }
+
+    fn docstrings(&self, _alias: &str) -> String {
+        "Uploads a column of binary data to the provided location(s) (also supports S3, local etc)."
+            .to_string()
+    }
+
+    fn arg_names(&self) -> &'static [&'static str] {
+        &[
+            "input",
+            "location",
+            "max_connections",
+            "on_error",
+            "io_config",
+        ]
+    }
+}

--- a/tests/sql/test_uri_exprs.py
+++ b/tests/sql/test_uri_exprs.py
@@ -2,10 +2,21 @@ import os
 import tempfile
 
 import daft
-from daft import col
+from daft import col, lit
 
 
 def test_url_download():
+    df = daft.from_pydict({"one": [1]})  # just have a single row, doesn't matter what it is
+    url = "https://raw.githubusercontent.com/Eventual-Inc/Daft/refs/heads/main/LICENSE"
+
+    # download one
+    df_actual = daft.sql(f"SELECT url_download('{url}') as downloaded FROM df").collect().to_pydict()
+    df_expect = df.select(lit(url).url.download().alias("downloaded")).collect().to_pydict()
+
+    assert df_actual == df_expect
+
+
+def test_url_download_multi():
     df = daft.from_pydict(
         {
             "urls": [

--- a/tests/sql/test_uri_exprs.py
+++ b/tests/sql/test_uri_exprs.py
@@ -1,0 +1,85 @@
+import os
+import tempfile
+
+import daft
+from daft import col
+
+
+def test_url_download():
+    df = daft.from_pydict(
+        {
+            "urls": [
+                "https://raw.githubusercontent.com/Eventual-Inc/Daft/refs/heads/main/README.rst",
+                "https://raw.githubusercontent.com/Eventual-Inc/Daft/refs/heads/main/LICENSE",
+            ]
+        }
+    )
+
+    actual = (
+        daft.sql(
+            """
+        SELECT
+            url_download(urls) as downloaded,
+            url_download(urls, max_connections=>1) as downloaded_single_conn,
+            url_download(urls, on_error=>'null') as downloaded_ignore_errors
+        FROM df
+        """
+        )
+        .collect()
+        .to_pydict()
+    )
+
+    expected = (
+        df.select(
+            col("urls").url.download().alias("downloaded"),
+            col("urls").url.download(max_connections=1).alias("downloaded_single_conn"),
+            col("urls").url.download(on_error="null").alias("downloaded_ignore_errors"),
+        )
+        .collect()
+        .to_pydict()
+    )
+
+    assert actual == expected
+
+
+def test_url_upload():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        df = daft.from_pydict(
+            {
+                "data": [b"test1", b"test2"],
+                "paths": [
+                    os.path.join(tmp_dir, "test1.txt"),
+                    os.path.join(tmp_dir, "test2.txt"),
+                ],
+            }
+        )
+
+        actual = (
+            daft.sql(
+                """
+            SELECT
+                url_upload(data, paths) as uploaded,
+                url_upload(data, paths, max_connections=>1) as uploaded_single_conn,
+                url_upload(data, paths, on_error=>'null') as uploaded_ignore_errors
+            FROM df
+            """
+            )
+            .collect()
+            .to_pydict()
+        )
+
+        expected = (
+            df.select(
+                col("data").url.upload(daft.col("paths")).alias("uploaded"),
+                col("data").url.upload(daft.col("paths"), max_connections=1).alias("uploaded_single_conn"),
+                col("data").url.upload(daft.col("paths"), on_error="null").alias("uploaded_ignore_errors"),
+            )
+            .collect()
+            .to_pydict()
+        )
+
+        assert actual == expected
+
+        # Verify files were created
+        assert os.path.exists(os.path.join(tmp_dir, "test1.txt"))
+        assert os.path.exists(os.path.join(tmp_dir, "test2.txt"))


### PR DESCRIPTION
#3575 


This change is a bit larger because I had to change how url_download and url_upload handled the parsing of keyword arguments to be more like image functions. I also moved some re-usable SQL argument parsing logic to a functions::args module.

I've left some notes/TODOs regarding input validation and handling of named parameters, but addressing these is outside the scope of this PR.