### PR TITLE
fix: Set filter selectivity estimate lower bound

### DIFF
--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -1336,7 +1336,7 @@ pub fn count_actor_pool_udfs(exprs: &[ExprRef]) -> usize {
 }
 
 pub fn estimated_selectivity(expr: &Expr, schema: &Schema) -> f64 {
-    match expr {
+    let estimate = match expr {
         // Boolean operations that filter rows
         Expr::BinaryOp { op, left, right } => {
             let left_selectivity = estimated_selectivity(left, schema);
@@ -1406,5 +1406,8 @@ pub fn estimated_selectivity(expr: &Expr, schema: &Schema) -> f64 {
         // Everything else doesn't filter
         Expr::Subquery(_) => 1.0,
         Expr::Agg(_) => panic!("Aggregates are not allowed in WHERE clauses"),
-    }
+    };
+
+    // Lower bound to 1% to prevent overly selective estimate
+    estimate.max(0.01)
 }


### PR DESCRIPTION
Set filter selectivity estimate lower bound to 1%, to prevent overly selective and likely inaccurate estimations.