### PR TITLE
feat(docs): Adds copy-to-clipboard to code samples

### DIFF
--- a/docs-v2/terms.md
+++ b/docs-v2/terms.md
@@ -83,9 +83,9 @@ You can examine a logical plan using [`df.explain()`](https://www.getdaft.io/pro
 |   Clustering spec = { Num partitions = 1 }
 ```
 
-## Structured Query Language (SQL)
+## SQL
 
-SQL is a common query language for expressing queries over tables of data. Daft exposes a SQL API as an alternative (but often also complementary API) to the Python [`DataFrame`](https://www.getdaft.io/projects/docs/en/stable/api_docs/doc_gen/dataframe_methods/daft.DataFrame.html#daft.DataFrame) and
+[SQL (Structured Query Language)](https://en.wikipedia.org/wiki/SQL) is a common query language for expressing queries over tables of data. Daft exposes a SQL API as an alternative (but often also complementary API) to the Python [`DataFrame`](https://www.getdaft.io/projects/docs/en/stable/api_docs/doc_gen/dataframe_methods/daft.DataFrame.html#daft.DataFrame) and
 [`Expression`](https://www.getdaft.io/projects/docs/en/stable/api_docs/expressions.html) APIs for building queries.
 
 You can use SQL in Daft via the [`daft.sql()`](https://www.getdaft.io/projects/docs/en/stable/api_docs/sql.html#daft.sql) function, and Daft will also convert many SQL-compatible strings into Expressions via [`daft.sql_expr()`](https://www.getdaft.io/projects/docs/en/stable/api_docs/sql.html#daft.sql_expr) for easy interoperability with DataFrames.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ theme:
   features:
   - search.suggest
   - search.highlight
+  - content.code.copy   # add copy button to code sections
   - content.tabs.link   # If one tab switches Python to SQL, all tabs switch
   - toc.follow
   - toc.integrate   # adds page subsections to left-hand menu (instead of right-hand menu)


### PR DESCRIPTION
Little PR to tidy up the SQL section and adds a copy-to-clipboard to all code examples.

<img width="578" alt="copy" src="https://github.com/user-attachments/assets/b83487ea-95f7-4e36-aa67-5a8bf965f577" />
