### PR TITLE
feat(core): make micropartition streamable over tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2407,6 +2407,7 @@ dependencies = [
  "parquet2",
  "pyo3",
  "snafu",
+ "tokio",
  "tracing",
 ]
 

--- a/src/daft-connect/src/execute.rs
+++ b/src/daft-connect/src/execute.rs
@@ -111,9 +111,10 @@ impl Session {
 
                         while let Some(result) = result_stream.next().await {
                             let result = result?;
-                            let tables = result.get_tables()?;
-                            for table in tables.as_slice() {
-                                let response = res.arrow_batch_response(table)?;
+                            let mut tables_stream = result.into_stream()?;
+
+                            while let Some(Ok(table)) = tables_stream.next().await {
+                                let response = res.arrow_batch_response(&table)?;
                                 if tx.send(Ok(response)).await.is_err() {
                                     return Ok(());
                                 }

--- a/src/daft-micropartition/Cargo.toml
+++ b/src/daft-micropartition/Cargo.toml
@@ -20,6 +20,7 @@ futures = {workspace = true}
 parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 snafu = {workspace = true}
+tokio = {workspace = true}
 tracing = {workspace = true}
 
 [features]

--- a/src/daft-table/src/lib.rs
+++ b/src/daft-table/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::{Display, Formatter, Result},
     hash::{Hash, Hasher},
+    sync::Arc,
 };
 
 use arrow2::array::Array;
@@ -44,14 +45,14 @@ use repr_html::html_value;
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct Table {
     pub schema: SchemaRef,
-    columns: Vec<Series>,
+    columns: Arc<Vec<Series>>,
     num_rows: usize,
 }
 
 impl Hash for Table {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.schema.hash(state);
-        for col in &self.columns {
+        for col in &*self.columns {
             let hashes = col.hash(None).expect("Failed to hash column");
             hashes.into_iter().for_each(|h| h.hash(state));
         }
@@ -159,7 +160,7 @@ impl Table {
     ) -> Self {
         Self {
             schema: schema.into(),
-            columns,
+            columns: Arc::new(columns),
             num_rows,
         }
     }
@@ -181,7 +182,8 @@ impl Table {
     /// # Arguments
     ///
     /// * `columns` - Columns to crate a table from as [`Series`] objects
-    pub fn from_nonempty_columns(columns: Vec<Series>) -> DaftResult<Self> {
+    pub fn from_nonempty_columns(columns: impl Into<Arc<Vec<Series>>>) -> DaftResult<Self> {
+        let columns = columns.into();
         assert!(!columns.is_empty(), "Cannot call Table::new() with empty columns. This indicates an internal error, please file an issue.");
 
         let schema = Schema::new(columns.iter().map(|s| s.field().clone()).collect())?;
@@ -199,7 +201,11 @@ impl Table {
             }
         }
 
-        Ok(Self::new_unchecked(schema, columns, num_rows))
+        Ok(Self {
+            schema,
+            columns,
+            num_rows,
+        })
     }
 
     pub fn num_columns(&self) -> usize {
@@ -231,11 +237,11 @@ impl Table {
 
     pub fn head(&self, num: usize) -> DaftResult<Self> {
         if num >= self.len() {
-            return Ok(Self::new_unchecked(
-                self.schema.clone(),
-                self.columns.clone(),
-                self.len(),
-            ));
+            return Ok(Self {
+                schema: self.schema.clone(),
+                columns: self.columns.clone(),
+                num_rows: self.len(),
+            });
         }
         self.slice(0, num)
     }
@@ -769,7 +775,7 @@ impl Table {
             // Begin row.
             res.push_str("<tr>");
 
-            for col in &self.columns {
+            for col in &*self.columns {
                 res.push_str(styled_td);
                 res.push_str(&html_value(col, i));
                 res.push_str("</div></td>");
@@ -781,7 +787,7 @@ impl Table {
 
         if tail_rows != 0 {
             res.push_str("<tr>");
-            for _ in &self.columns {
+            for _ in &*self.columns {
                 res.push_str("<td>...</td>");
             }
             res.push_str("</tr>\n");
@@ -791,7 +797,7 @@ impl Table {
             // Begin row.
             res.push_str("<tr>");
 
-            for col in &self.columns {
+            for col in &*self.columns {
                 res.push_str(styled_td);
                 res.push_str(&html_value(col, i));
                 res.push_str("</td>");

--- a/src/daft-table/src/ops/explode.rs
+++ b/src/daft-table/src/ops/explode.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use common_error::{DaftError, DaftResult};
 use daft_core::{
     array::ops::as_arrow::AsArrow,
@@ -79,7 +81,7 @@ impl Table {
         let capacity_expected = exploded_columns.first().unwrap().len();
         let take_idx = lengths_to_indices(&first_len, capacity_expected)?.into_series();
 
-        let mut new_series = self.columns.clone();
+        let mut new_series = Arc::unwrap_or_clone(self.columns.clone());
 
         for i in 0..self.num_columns() {
             let name = new_series.get(i).unwrap().name();

--- a/src/daft-table/src/ops/joins/mod.rs
+++ b/src/daft-table/src/ops/joins/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use common_error::{DaftError, DaftResult};
 use daft_core::{
@@ -216,7 +216,7 @@ impl Table {
             Table::concat(&vec![input; outer_len])
         }
 
-        let (left_table, mut right_table) = match outer_loop_side {
+        let (left_table, right_table) = match outer_loop_side {
             JoinSide::Left => (
                 create_outer_loop_table(self, right.len())?,
                 create_inner_loop_table(right, self.len())?,
@@ -230,8 +230,10 @@ impl Table {
         let num_rows = self.len() * right.len();
 
         let join_schema = self.schema.union(&right.schema)?;
-        let mut join_columns = left_table.columns;
-        join_columns.append(&mut right_table.columns);
+        let mut join_columns = Arc::unwrap_or_clone(left_table.columns);
+        let mut right_columns = Arc::unwrap_or_clone(right_table.columns);
+
+        join_columns.append(&mut right_columns);
 
         Self::new_with_size(join_schema, join_columns, num_rows)
     }

--- a/src/daft-table/src/ops/unpivot.rs
+++ b/src/daft-table/src/ops/unpivot.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use common_error::{DaftError, DaftResult};
 use daft_core::{prelude::*, series::cast_series_to_supertype};
 use daft_dsl::ExprRef;
@@ -52,7 +54,12 @@ impl Table {
             variable_series.field().clone(),
             value_series.field().clone(),
         ])?)?;
-        let unpivot_series = [ids_series, vec![variable_series, value_series]].concat();
+
+        let unpivot_series = [
+            Arc::unwrap_or_clone(ids_series),
+            vec![variable_series, value_series],
+        ]
+        .concat();
 
         Self::new_with_size(unpivot_schema, unpivot_series, unpivoted_len)
     }


### PR DESCRIPTION
### Description

makes Micropartition streamable over `Table`, and makes `Table` a bit cheaper to clone by wrapping the `columns` column in an `Arc`. 


The driving force for these changes is that currently the logic to go from micropartition to table does not work nicely withing a streaming context as the `get_tables` method returns `Arc<Vec<Table>>`. So you can't easily chain streaming methods when working with micropartitions and tables. 