### PR TITLE
feat: Expose parquet chunk size to swordfish reads

### DIFF
--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -253,6 +253,7 @@ async fn stream_scan_task(
         FileFormatConfig::Parquet(ParquetSourceConfig {
             coerce_int96_timestamp_unit,
             field_id_mapping,
+            chunk_size,
             ..
         }) => {
             let inference_options =
@@ -281,6 +282,7 @@ async fn stream_scan_task(
                 metadata,
                 maintain_order,
                 delete_rows,
+                *chunk_size,
             )
             .await?
         }

--- a/src/daft-parquet/src/stream_reader.rs
+++ b/src/daft-parquet/src/stream_reader.rs
@@ -599,11 +599,12 @@ pub async fn local_parquet_stream(
     metadata: Option<Arc<parquet2::metadata::FileMetaData>>,
     maintain_order: bool,
     io_stats: Option<IOStatsRef>,
+    chunk_size: Option<usize>,
 ) -> DaftResult<(
     Arc<parquet2::metadata::FileMetaData>,
     BoxStream<'static, DaftResult<Table>>,
 )> {
-    let chunk_size = PARQUET_MORSEL_SIZE;
+    let chunk_size = chunk_size.unwrap_or(PARQUET_MORSEL_SIZE);
     let (metadata, schema_ref, row_ranges, column_iters) = local_parquet_read_into_column_iters(
         uri,
         columns.as_deref(),


### PR DESCRIPTION
Parquet reads in swordfish currently do not respect the `_chunk_size` parameter that users pass in.