### PR TITLE
chore: Pin sql server version in docker compose

### DIFF
--- a/tests/integration/sql/docker-compose/docker-compose.yml
+++ b/tests/integration/sql/docker-compose/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     - mysql_data:/var/lib/mysql
 
   azuresqledge:
-    image: mcr.microsoft.com/azure-sql-edge:1.0.7
+    image: mcr.microsoft.com/azure-sql-edge:2.0.0
     container_name: azuresqledge
     environment:
       ACCEPT_EULA: "Y"

--- a/tests/integration/sql/docker-compose/docker-compose.yml
+++ b/tests/integration/sql/docker-compose/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     - mysql_data:/var/lib/mysql
 
   azuresqledge:
-    image: mcr.microsoft.com/azure-sql-edge
+    image: mcr.microsoft.com/azure-sql-edge:1.0.7
     container_name: azuresqledge
     environment:
       ACCEPT_EULA: "Y"


### PR DESCRIPTION
SQL server tests are failing sporadically, pin the version in the docker compose to prevent this.