### PR TITLE
feat: spark connect set operations

### DIFF
--- a/src/daft-connect/src/spark_analyzer.rs
+++ b/src/daft-connect/src/spark_analyzer.rs
@@ -36,7 +36,8 @@ use spark_connect::{
     },
     read::ReadType,
     relation::RelType,
-    Deduplicate, Expression, Limit, Range, Relation, Sort, Sql,
+    set_operation::SetOpType,
+    Deduplicate, Expression, Limit, Range, Relation, SetOperation, Sort, Sql,
 };
 use tracing::debug;
 
@@ -153,6 +154,7 @@ impl SparkAnalyzer<'_> {
             RelType::Deduplicate(rel) => self.deduplicate(*rel).await,
             RelType::Sort(rel) => self.sort(*rel).await,
             RelType::Sql(sql) => self.sql(sql).await,
+            RelType::SetOp(set_op) => self.set_op(*set_op).await,
             plan => not_yet_implemented!(r#"relation type: "{}""#, rel_name(&plan)),
         }
     }
@@ -604,6 +606,29 @@ impl SparkAnalyzer<'_> {
             .select(column_names)
             .wrap_err("Failed to add columns to logical plan")?;
         Ok(plan)
+    }
+
+    async fn set_op(&self, set_op: SetOperation) -> ConnectResult<LogicalPlanBuilder> {
+        let set_op_type = set_op.set_op_type;
+        let left = set_op.left_input.required("left_input")?;
+        let right = set_op.right_input.required("right_input")?;
+        let is_all = set_op.is_all.required("is_all")?;
+
+        let set_op_type =
+            SetOpType::try_from(set_op_type).wrap_err("Invalid set operation type")?;
+
+        let left = Box::pin(self.to_logical_plan(*left)).await?;
+        let right = Box::pin(self.to_logical_plan(*right)).await?;
+
+        match set_op_type {
+            SetOpType::Except => left.except(&right, is_all),
+            SetOpType::Intersect => left.intersect(&right, is_all),
+            SetOpType::Union => left.union(&right, is_all),
+            SetOpType::Unspecified => {
+                invalid_argument_err!("SetOpType must be specified; got Unspecified")
+            }
+        }
+        .map_err(Into::into)
     }
 
     pub async fn relation_to_spark_schema(

--- a/tests/connect/test_spark_set_ops.py
+++ b/tests/connect/test_spark_set_ops.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import daft
+from tests.conftest import check_answer
+
+
+def make_spark_df(spark, data: dict[str, Any]):
+    fields = [name for name in data]
+    rows = list(zip(*[data[name] for name in fields]))
+    return spark.createDataFrame(rows, fields)
+
+
+def helper(spark, make_df, op: str, left: dict[str, Any], right: dict[str, Any], expected: dict[str, Any]):
+    df1 = make_spark_df(spark, left)
+    df2 = make_spark_df(spark, right)
+    df_helper(op, df1, df2, expected)
+
+
+def df_helper(op: str, df1, df2, expected: dict[str, Any]):
+    if op == "intersect":
+        result = df1.intersect(df2)
+    elif op == "intersect_all":
+        result = df1.intersectAll(df2)
+    else:
+        result = df1.exceptAll(df2)
+    result = daft.from_pandas(result.toPandas())
+    check_answer(result, expected)
+
+
+@pytest.mark.parametrize(
+    "op, left, right, expected",
+    [
+        ("intersect", {"foo": [1, 2, 3]}, {"bar": [2, 3, 4]}, {"foo": [2, 3]}),
+        ("intersect_all", {"foo": [1, 2, 2]}, {"bar": [2, 2, 4]}, {"foo": [2, 2]}),
+        ("except_all", {"foo": [1, 2, 2]}, {"bar": [2, 4]}, {"foo": [1, 2]}),
+    ],
+)
+def test_simple_intersect_or_except(spark_session, make_df, op, left, right, expected):
+    helper(spark_session, make_df, op, left, right, expected)
+
+
+@pytest.mark.parametrize(
+    "op, left, right, expected",
+    [
+        ("intersect", {"foo": [1, 2, 2, 3]}, {"bar": [2, 3, 3]}, {"foo": [2, 3]}),
+        ("intersect_all", {"foo": [1, 2, 2, 3]}, {"bar": [2, 3, 3]}, {"foo": [2, 3]}),
+        ("except_all", {"foo": [1, 2, 2, 3]}, {"bar": [2, 3, 3]}, {"foo": [1, 2]}),
+    ],
+)
+def test_with_duplicate(spark_session, make_df, op, left, right, expected):
+    helper(spark_session, make_df, op, left, right, expected)
+
+
+@pytest.mark.parametrize(
+    "op, df, expected",
+    [
+        ("intersect", {"foo": [1, 2, 3]}, {"foo": [1, 2, 3]}),
+        ("intersect_all", {"foo": [1, 2, 3]}, {"foo": [1, 2, 3]}),
+        ("except_all", {"foo": [1, 2, 2]}, {"foo": []}),
+    ],
+)
+def test_with_self(spark_session, make_df, op, df, expected):
+    df = make_spark_df(spark_session, df)
+    df_helper(op, df, df, expected)
+
+
+@pytest.mark.parametrize(
+    "op, left, right, expected",
+    [
+        ("intersect", {"foo": [1, 2, None]}, {"foo": [2, 3, None]}, {"foo": [2, None]}),
+        ("intersect_all", {"foo": [1, 2, None]}, {"foo": [2, 3, None]}, {"foo": [2, None]}),
+        ("intersect", {"foo": [1, 2]}, {"foo": [2, 3, None]}, {"foo": [2]}),
+        ("intersect_all", {"foo": [1, 2]}, {"foo": [2, 3, None]}, {"foo": [2]}),
+        ("intersect", {"foo": [1, 2, None]}, {"foo": [2, 3]}, {"foo": [2]}),
+        ("intersect_all", {"foo": [1, 2, None]}, {"foo": [2, 3]}, {"foo": [2]}),
+    ],
+)
+def test_intersect_with_nulls(spark_session, make_df, op, left, right, expected):
+    helper(spark_session, make_df, op, left, right, expected)
+
+
+@pytest.mark.parametrize(
+    "op, left, right, expected",
+    [
+        ("except_all", {"foo": [1, 2, None]}, {"foo": [2, 3, None]}, {"foo": [1]}),
+        ("except_all", {"foo": [1, 2]}, {"foo": [2, 3, None]}, {"foo": [1]}),
+        ("except_all", {"foo": [1, 2, None]}, {"foo": [2, 3]}, {"foo": [1, None]}),
+    ],
+)
+def test_except_with_nulls(spark_session, make_df, op, left, right, expected):
+    helper(spark_session, make_df, op, left, right, expected)
+
+
+@pytest.mark.parametrize(
+    "op, left, right, expected",
+    [
+        (
+            "intersect_all",
+            {"foo": [1, 2, 2], "bar": [2, 3, 3]},
+            {"a": [2, 2, 4], "b": [3, 3, 4]},
+            {"foo": [2, 2], "bar": [3, 3]},
+        ),
+        (
+            "except_all",
+            {"foo": [1, 2, 2], "bar": [2, 3, 3]},
+            {"a": [2, 2, 4], "b": [3, 3, 4]},
+            {"foo": [1], "bar": [2]},
+        ),
+    ],
+)
+def test_multiple_fields(spark_session, make_df, op, left, right, expected):
+    helper(spark_session, make_df, op, left, right, expected)


### PR DESCRIPTION

## note for reviewers 

pyspark does not seem to have an `except` op, only `exceptAll`