### PR TITLE
refactor: move more pset logic into rust

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1701,7 +1701,6 @@ class NativeExecutor:
     def run(
         self,
         builder: LogicalPlanBuilder,
-        psets: dict[str, list[PartitionT]],
         daft_execution_config: PyDaftExecutionConfig,
         results_buffer_size: int | None,
     ) -> Iterator[PyMicroPartition]: ...

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -550,7 +550,6 @@ class DataFrame:
         if not parts:
             raise ValueError("Can't create a DataFrame from an empty list of tables.")
 
-        print("_from_tables")
         result_pset = LocalPartitionSet()
 
         for i, part in enumerate(parts):

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -550,6 +550,7 @@ class DataFrame:
         if not parts:
             raise ValueError("Can't create a DataFrame from an empty list of tables.")
 
+        print("_from_tables")
         result_pset = LocalPartitionSet()
 
         for i, part in enumerate(parts):

--- a/daft/execution/native_executor.py
+++ b/daft/execution/native_executor.py
@@ -13,8 +13,6 @@ if TYPE_CHECKING:
     from daft.logical.builder import LogicalPlanBuilder
     from daft.runners.partitioning import (
         LocalMaterializedResult,
-        MaterializedResult,
-        PartitionT,
     )
 
 
@@ -25,18 +23,14 @@ class NativeExecutor:
     def run(
         self,
         builder: LogicalPlanBuilder,
-        psets: dict[str, list[MaterializedResult[PartitionT]]],
         daft_execution_config: PyDaftExecutionConfig,
         results_buffer_size: int | None,
     ) -> Iterator[LocalMaterializedResult]:
         from daft.runners.partitioning import LocalMaterializedResult
 
-        psets_mp = {
-            part_id: [part.micropartition()._micropartition for part in parts] for part_id, parts in psets.items()
-        }
         return (
             LocalMaterializedResult(MicroPartition._from_pymicropartition(part))
-            for part in self._executor.run(builder._builder, psets_mp, daft_execution_config, results_buffer_size)
+            for part in self._executor.run(builder._builder, daft_execution_config, results_buffer_size)
         )
 
     def pretty_print(

--- a/daft/runners/partitioning.py
+++ b/daft/runners/partitioning.py
@@ -387,6 +387,32 @@ class PartitionCacheEntry:
 
 
 class PartitionSetCache:
+    @abstractmethod
+    def __init__(self) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_partition_set(self, pset_id: str) -> PartitionCacheEntry:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_all_partition_sets(self) -> dict[str, PartitionSet]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def put_partition_set(self, pset: PartitionSet) -> PartitionCacheEntry:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def rm(self, pset_id: str) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def clear(self) -> None:
+        raise NotImplementedError()
+
+
+class LocalPartitionSetCache(PartitionSetCache):
     def __init__(self) -> None:
         self.__uuid_to_partition_set: weakref.WeakValueDictionary[str, PartitionCacheEntry] = (
             weakref.WeakValueDictionary()

--- a/daft/runners/pyrunner.py
+++ b/daft/runners/pyrunner.py
@@ -383,7 +383,6 @@ class PyRunner(Runner[MicroPartition], ActorPoolManager):
                 executor = NativeExecutor()
                 results_gen = executor.run(
                     builder,
-                    {k: v.values() for k, v in self._part_set_cache.get_all_partition_sets().items()},
                     daft_execution_config,
                     results_buffer_size,
                 )

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -59,6 +59,7 @@ from daft.filesystem import glob_path_with_stats
 from daft.runners import runner_io
 from daft.runners.partitioning import (
     LocalPartitionSet,
+    LocalPartitionSetCache,
     MaterializedResult,
     PartID,
     PartitionCacheEntry,
@@ -1208,7 +1209,7 @@ class RayRunner(Runner[ray.ObjectRef]):
             )
 
     def initialize_partition_set_cache(self) -> PartitionSetCache:
-        return PartitionSetCache()
+        return LocalPartitionSetCache()
 
     def active_plans(self) -> list[str]:
         if self.ray_client_mode:

--- a/daft/runners/runner.py
+++ b/daft/runners/runner.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, ClassVar, Generic, Iterator, Literal
 
 from daft.runners.partitioning import (
+    LocalPartitionSetCache,
     MaterializedResult,
     PartitionCacheEntry,
     PartitionSet,
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
     from daft.runners.runner_io import RunnerIO
     from daft.table import MicroPartition
 
-LOCAL_PARTITION_SET_CACHE = PartitionSetCache()
+LOCAL_PARTITION_SET_CACHE = LocalPartitionSetCache()
 
 
 class Runner(Generic[PartitionT]):
@@ -26,9 +27,11 @@ class Runner(Generic[PartitionT]):
         self._part_set_cache = self.initialize_partition_set_cache()
 
     def get_partition_set_from_cache(self, pset_id: str) -> PartitionCacheEntry:
+        print("RUNNER get_partition_set_from_cache")
         return self._part_set_cache.get_partition_set(pset_id=pset_id)
 
     def put_partition_set_into_cache(self, pset: PartitionSet) -> PartitionCacheEntry:
+        print("RUNNER put_partition_set_into_cache")
         return self._part_set_cache.put_partition_set(pset=pset)
 
     @abstractmethod

--- a/daft/runners/runner.py
+++ b/daft/runners/runner.py
@@ -27,11 +27,9 @@ class Runner(Generic[PartitionT]):
         self._part_set_cache = self.initialize_partition_set_cache()
 
     def get_partition_set_from_cache(self, pset_id: str) -> PartitionCacheEntry:
-        print("RUNNER get_partition_set_from_cache")
         return self._part_set_cache.get_partition_set(pset_id=pset_id)
 
     def put_partition_set_into_cache(self, pset: PartitionSet) -> PartitionCacheEntry:
-        print("RUNNER put_partition_set_into_cache")
         return self._part_set_cache.put_partition_set(pset=pset)
 
     @abstractmethod

--- a/src/common/partitioning/src/lib.rs
+++ b/src/common/partitioning/src/lib.rs
@@ -130,8 +130,8 @@ pub type PartitionSetRef<T> = Arc<dyn PartitionSet<T>>;
 pub trait PartitionSetCache<P: Partition, PS: PartitionSet<P>>:
     std::fmt::Debug + Send + Sync
 {
-    fn get_partition_set(&self, key: &str) -> Option<PartitionSetRef<P>>;
-    fn get_all_partition_sets(&self) -> Vec<PartitionSetRef<P>>;
+    fn get_partition_set(&self, key: &str) -> Option<PS>;
+    fn get_all_partition_sets(&self) -> Vec<PS>;
     fn put_partition_set(&self, key: &str, partition_set: &PS);
     fn rm_partition_set(&self, key: &str);
     fn clear(&self);

--- a/src/daft-connect/src/execute.rs
+++ b/src/daft-connect/src/execute.rs
@@ -67,9 +67,7 @@ impl Session {
 
                 let plan = lp.optimize_async().await?;
 
-                let results = this
-                    .engine
-                    .run(&plan, &*this.psets, Default::default(), None)?;
+                let results = this.engine.run(&plan, Default::default(), None)?;
                 Ok(results.into_stream().boxed())
             }
         }

--- a/src/daft-connect/src/session.rs
+++ b/src/daft-connect/src/session.rs
@@ -6,7 +6,6 @@ use std::{
 use common_runtime::RuntimeRef;
 use daft_catalog::DaftCatalog;
 use daft_local_execution::NativeExecutor;
-use daft_micropartition::partitioning::InMemoryPartitionSetCache;
 use uuid::Uuid;
 
 #[derive(Clone)]
@@ -20,7 +19,6 @@ pub struct Session {
     server_side_session_id: String,
     /// MicroPartitionSet associated with this session
     /// this will be filled up as the user runs queries
-    pub(crate) psets: Arc<InMemoryPartitionSetCache>,
     pub(crate) compute_runtime: RuntimeRef,
     pub(crate) engine: Arc<NativeExecutor>,
     pub(crate) catalog: Arc<RwLock<DaftCatalog>>,
@@ -44,7 +42,6 @@ impl Session {
             config_values: Default::default(),
             id,
             server_side_session_id,
-            psets: Arc::new(InMemoryPartitionSetCache::empty()),
             compute_runtime: rt.clone(),
             engine: Arc::new(NativeExecutor::default().with_runtime(rt.runtime.clone())),
             catalog: Arc::new(RwLock::new(DaftCatalog::default())),

--- a/src/daft-connect/src/spark_analyzer.rs
+++ b/src/daft-connect/src/spark_analyzer.rs
@@ -109,7 +109,10 @@ impl SparkAnalyzer<'_> {
                 } = pset.metadata();
                 let num_partitions = pset.num_partitions();
 
-                self.session.psets.put_partition_set(&partition_key, &pset);
+                self.session
+                    .engine
+                    .psets
+                    .put_partition_set(&partition_key, &pset);
 
                 let cache_entry = PartitionCacheEntry::new_rust(partition_key.clone(), pset);
 

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -60,10 +60,7 @@ impl LocalPartitionIterator {
 }
 
 #[cfg(feature = "python")]
-#[cfg_attr(
-    feature = "python",
-    pyclass(module = "daft.daft", name = "NativeExecutor")
-)]
+#[pyclass(module = "daft.daft", name = "NativeExecutor")]
 pub struct PyNativeExecutor {
     executor: NativeExecutor,
     part_set_cache: Arc<PyObject>,

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -59,6 +59,7 @@ impl LocalPartitionIterator {
     }
 }
 
+#[cfg(feature = "python")]
 #[cfg_attr(
     feature = "python",
     pyclass(module = "daft.daft", name = "NativeExecutor")

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -19,11 +19,6 @@ use daft_micropartition::{
 };
 use futures::{FutureExt, Stream};
 use loole::RecvFuture;
-use pyo3::{
-    ffi::c_str,
-    intern,
-    types::{PyAnyMethods, PyDict},
-};
 use tokio_util::sync::CancellationToken;
 #[cfg(feature = "python")]
 use {
@@ -31,7 +26,10 @@ use {
     daft_logical_plan::PyLogicalPlanBuilder,
     daft_micropartition::python::PyMicroPartition,
     pyo3::{
-        pyclass, pymethods, Bound, IntoPyObject, PyAny, PyObject, PyRef, PyRefMut, PyResult, Python,
+        ffi::c_str,
+        intern, pyclass, pymethods,
+        types::{PyAnyMethods, PyDict},
+        Bound, IntoPyObject, PyAny, PyObject, PyRef, PyRefMut, PyResult, Python,
     },
 };
 

--- a/src/daft-local-execution/src/sources/in_memory.rs
+++ b/src/daft-local-execution/src/sources/in_memory.rs
@@ -4,24 +4,20 @@ use async_trait::async_trait;
 use common_error::DaftResult;
 use daft_core::prelude::SchemaRef;
 use daft_io::IOStatsRef;
-use daft_micropartition::{partitioning::PartitionSetRef, MicroPartitionRef};
+use daft_micropartition::partitioning::{MicroPartitionSet, PartitionSet};
 use tracing::instrument;
 
 use super::source::Source;
 use crate::sources::source::SourceStream;
 
 pub struct InMemorySource {
-    data: Option<PartitionSetRef<MicroPartitionRef>>,
+    data: Option<Arc<MicroPartitionSet>>,
     size_bytes: usize,
     schema: SchemaRef,
 }
 
 impl InMemorySource {
-    pub fn new(
-        data: Option<PartitionSetRef<MicroPartitionRef>>,
-        schema: SchemaRef,
-        size_bytes: usize,
-    ) -> Self {
+    pub fn new(data: Option<Arc<MicroPartitionSet>>, schema: SchemaRef, size_bytes: usize) -> Self {
         Self {
             data,
             size_bytes,

--- a/src/daft-micropartition/src/partitioning.rs
+++ b/src/daft-micropartition/src/partitioning.rs
@@ -186,10 +186,14 @@ impl InMemoryPartitionSetCache {
     pub fn empty() -> Self {
         Self::default()
     }
+
+    pub fn copy_from(&mut self, other: Self) {
+        self.partition_sets.extend(other.partition_sets);
+    }
 }
 
 impl PartitionSetCache<MicroPartitionRef, Arc<MicroPartitionSet>> for InMemoryPartitionSetCache {
-    fn get_partition_set(&self, key: &str) -> Option<PartitionSetRef<MicroPartitionRef>> {
+    fn get_partition_set(&self, key: &str) -> Option<Arc<MicroPartitionSet>> {
         let weak_pset = self.partition_sets.get(key).map(|v| v.value().clone())?;
         // if the partition set has been dropped, remove it from the cache
         let Some(pset) = weak_pset.upgrade() else {
@@ -198,10 +202,10 @@ impl PartitionSetCache<MicroPartitionRef, Arc<MicroPartitionSet>> for InMemoryPa
             return None;
         };
 
-        Some(pset as _)
+        Some(pset)
     }
 
-    fn get_all_partition_sets(&self) -> Vec<PartitionSetRef<MicroPartitionRef>> {
+    fn get_all_partition_sets(&self) -> Vec<Arc<MicroPartitionSet>> {
         let psets = self.partition_sets.iter().filter_map(|v| {
             let pset = v.value().upgrade()?;
             Some(pset as _)


### PR DESCRIPTION
previously the pset logic was very leaky and not well encapsulated inside the runner. Since the runner/engine is responsible for storing it's own partition sets _(this is how it's done in python)_ it makes sense to have the same logic applied on the rust side of things. 

This makes working with the executor easier as everything is now self contained, and you don't have to manage the psets and the engine separately. 
