### PR TITLE
fix: catalog table names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,6 +1982,7 @@ dependencies = [
  "lazy_static",
  "pyo3",
  "snafu",
+ "sqlparser",
 ]
 
 [[package]]

--- a/src/daft-catalog/Cargo.toml
+++ b/src/daft-catalog/Cargo.toml
@@ -4,6 +4,7 @@ daft-core = {path = "../daft-core", default-features = false}
 daft-logical-plan = {path = "../daft-logical-plan", default-features = false}
 lazy_static = {workspace = true}
 pyo3 = {workspace = true, optional = true}
+sqlparser = {workspace = true}
 snafu.workspace = true
 
 [features]

--- a/src/daft-catalog/src/errors.rs
+++ b/src/daft-catalog/src/errors.rs
@@ -22,10 +22,10 @@ pub enum Error {
     InvalidTableName { name: String },
 
     #[snafu(display(
-        "Compound identifiers are not yet supported. Instead use a single identifier, or wrap your table name in quotes such as `\"{}\"`",
+        "Qualified identifiers are not yet supported. Instead use a single identifier, or wrap your table name in quotes such as `\"{}\"`",
         name
     ))]
-    CompoundIdentifierNotSupported { name: String },
+    QualifiedIdentifierNotSupported { name: String },
 
     #[cfg(feature = "python")]
     #[snafu(display("Python error during {}: {}", context, source))]
@@ -43,7 +43,7 @@ impl From<Error> for common_error::DaftError {
             Error::TableNotFound { .. }
             | Error::CatalogNotFound { .. }
             | Error::InvalidTableName { .. }
-            | Error::CompoundIdentifierNotSupported { .. } => {
+            | Error::QualifiedIdentifierNotSupported { .. } => {
                 common_error::DaftError::CatalogError(err.to_string())
             }
             #[cfg(feature = "python")]

--- a/src/daft-catalog/src/errors.rs
+++ b/src/daft-catalog/src/errors.rs
@@ -16,10 +16,16 @@ pub enum Error {
     CatalogNotFound { name: String },
 
     #[snafu(display(
-        "Invalid table name (expected only alphanumeric characters and '_'): {}",
+        "Invalid table name `{}` provided. Table names must be valid identifiers.",
         name
     ))]
     InvalidTableName { name: String },
+
+    #[snafu(display(
+        "Compound identifiers are not yet supported. Instead use a single identifier, or wrap your table name in quotes such as `\"{}\"`",
+        name
+    ))]
+    CompoundIdentifierNotSupported { name: String },
 
     #[cfg(feature = "python")]
     #[snafu(display("Python error during {}: {}", context, source))]
@@ -36,7 +42,8 @@ impl From<Error> for common_error::DaftError {
         match &err {
             Error::TableNotFound { .. }
             | Error::CatalogNotFound { .. }
-            | Error::InvalidTableName { .. } => {
+            | Error::InvalidTableName { .. }
+            | Error::CompoundIdentifierNotSupported { .. } => {
                 common_error::DaftError::CatalogError(err.to_string())
             }
             #[cfg(feature = "python")]

--- a/src/daft-catalog/src/lib.rs
+++ b/src/daft-catalog/src/lib.rs
@@ -121,7 +121,7 @@ impl DaftCatalog {
         };
 
         if idents.len() != 1 {
-            return Err(Error::CompoundIdentifierNotSupported {
+            return Err(Error::QualifiedIdentifierNotSupported {
                 name: name.to_string(),
             });
         }

--- a/src/daft-catalog/src/lib.rs
+++ b/src/daft-catalog/src/lib.rs
@@ -42,6 +42,7 @@ pub mod global_catalog {
             .unregister_catalog(name)
     }
 }
+use sqlparser::{dialect::GenericDialect, parser::Parser, tokenizer::Tokenizer};
 
 /// Name of the default catalog
 static DEFAULT_CATALOG_NAME: &str = "default";
@@ -101,12 +102,31 @@ impl DaftCatalog {
         name: &str,
         view: impl Into<LogicalPlanBuilder>,
     ) -> Result<()> {
-        if !name.chars().all(|c| c.is_alphanumeric() || c == '_') {
-            return Err(Error::InvalidTableName {
+        let parser = Parser::new(&GenericDialect {});
+
+        let err = || {
+            Err(Error::InvalidTableName {
+                name: name.to_string(),
+            })
+        };
+
+        let Ok(tokens) = Tokenizer::new(&GenericDialect {}, name).tokenize() else {
+            return err();
+        };
+
+        let mut parser = parser.with_tokens(tokens);
+
+        let Ok(idents) = parser.parse_identifiers() else {
+            return err();
+        };
+
+        if idents.len() != 1 {
+            return Err(Error::CompoundIdentifierNotSupported {
                 name: name.to_string(),
             });
         }
-        self.named_tables.insert(name.to_string(), view.into());
+
+        self.named_tables.insert(idents[0].to_string(), view.into());
         Ok(())
     }
 

--- a/tests/sql/test_catalog.py
+++ b/tests/sql/test_catalog.py
@@ -1,0 +1,38 @@
+import pytest
+
+import daft
+from daft.sql import SQLCatalog
+
+
+@pytest.mark.parametrize(
+    "table_name",
+    ["a", "a_b", '"a.b"', '"a.b.c"', "a_", "a_1", '"a-b"', '"a."'],
+)
+def test_sql_catalog_table_names(table_name):
+    df1 = daft.from_pydict({"idx": [1, 2], "val": [10, 20]})
+    catalog = {table_name: df1}
+    try:
+        actual = daft.sql(f"select * from {table_name}", catalog=SQLCatalog(catalog)).to_pydict()
+        assert actual == df1.to_pydict()
+    except Exception as e:
+        assert False, f"Unexpected exception: {e}"
+
+
+@pytest.mark.parametrize("table_name", ["1", "a.", "a b", "a-b"])
+def test_sql_catalog_table_names_invalid(table_name):
+    df1 = daft.from_pydict({"idx": [1, 2], "val": [10, 20]})
+    catalog = {table_name: df1}
+    try:
+        actual = daft.sql(f"select * from {table_name}", catalog=SQLCatalog(catalog)).to_pydict()
+        assert actual == df1.to_pydict()
+    except Exception as e:
+        assert True, f"Expected exception: {e}"
+
+
+def test_sql_register_globals():
+    df1 = daft.from_pydict({"idx": [1, 2], "val": [10, 20]})
+    catalog = SQLCatalog({"df2": df1})
+    try:
+        daft.sql("select * from df1", catalog=catalog, register_globals=False).collect()
+    except Exception as e:
+        assert True, f"Expected exception: {e}"


### PR DESCRIPTION
closes https://github.com/Eventual-Inc/Daft/issues/3758

note for @ukclivecox, this is still a breaking change from 0.4.3 as it will require you to properly quote any table names that would be interpreted as multiple identifiers. 

so in your example:
```py
import daft
df1 = daft.from_pydict({"idx":[1,2],"val":[10,20]})
catalog = {"c0.t1":df1}
df_sql = daft.sql("select * from c0.t1", catalog=SQLCatalog(catalog)).show()
```
you will need to make a small modification to get it to work 

```py
import daft
df1 = daft.from_pydict({"idx":[1,2],"val":[10,20]})
catalog = {'"c0.t1"':df1} # <--- note the quotes here
df_sql = daft.sql('select * from "c0.t1"', catalog=SQLCatalog(catalog)).show()
```