### PR TITLE
ci: Allow TPCH benchmarks to use ARM cluster profile

### DIFF
--- a/tools/tpch.py
+++ b/tools/tpch.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-partitions", type=int, required=True, help="The number of partitions")
     parser.add_argument(
         "--cluster-profile",
-        choices=["debug_xs-x86", "medium-x86"],
+        choices=["debug_xs-x86", "medium-x86", "benchmarking-arm"],
         type=str,
         required=False,
         help="The ray cluster configuration to run on",


### PR DESCRIPTION
TPCDS benchmarks allow this. We should do the same for TPCH.