### PR TITLE
feat: Add ability to broadcast daft metrics over HTTP

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -170,6 +170,7 @@ class DataFrame:
             return self._result_cache.value
 
     def _explain_broadcast(self):
+        import json
         from urllib import request
 
         from daft.dataframe.display import MermaidFormatter
@@ -195,13 +196,15 @@ class DataFrame:
         headers = {
             "Content-Type": "application/json",
         }
-        data = {
-            "id": str(uuid4()),
-            "mermaid-plan": mermaid_plan,
-            "plan-time-start": str(plan_time_start),
-            "plan-time-end": str(plan_time_end),
-        }
-        req = request.Request(f"http://{addr}:{port}", headers=headers, data=str(data).encode("utf-8"))
+        data = json.dumps(
+            {
+                "id": str(uuid4()),
+                "mermaid-plan": mermaid_plan,
+                "plan-time-start": str(plan_time_start),
+                "plan-time-end": str(plan_time_end),
+            }
+        ).encode("utf-8")
+        req = request.Request(f"http://{addr}:{port}", headers=headers, data=data)
         request.urlopen(req)
 
     @broadcast_metrics

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -179,6 +179,7 @@ class DataFrame:
         dashboard_addr = os.environ.get("DAFT_DASHBOARD")
         if not dashboard_addr:
             return
+        dashboard_http_addr = f"http://{dashboard_addr}"
 
         is_cached = self._result_cache is not None
         plan_time_start = datetime.now(timezone.utc)
@@ -198,12 +199,12 @@ class DataFrame:
                 "plan-time-end": str(plan_time_end),
             }
         ).encode("utf-8")
-        req = request.Request(f"http://{dashboard_addr}", headers=headers, data=data)
+        req = request.Request(dashboard_http_addr, headers=headers, data=data)
 
         try:
             request.urlopen(req, timeout=3)
         except URLError as e:
-            warnings.warn(f"Failed to broadcast metrics on addr {dashboard_addr}: {e}")
+            warnings.warn(f"Failed to broadcast metrics over {dashboard_http_addr}: {e}")
 
     @broadcast_metrics
     @DataframePublicAPI

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -192,13 +192,16 @@ class DataFrame:
         )._repr_markdown_()
         plan_time_end = datetime.now(timezone.utc)
 
+        headers = {
+            "Content-Type": "application/json",
+        }
         data = {
             "id": str(uuid4()),
             "mermaid-plan": mermaid_plan,
             "plan-time-start": str(plan_time_start),
             "plan-time-end": str(plan_time_end),
         }
-        req = request.Request(f"http://{addr}:{port}", data=str(data).encode("utf-8"))
+        req = request.Request(f"http://{addr}:{port}", headers=headers, data=str(data).encode("utf-8"))
         request.urlopen(req)
 
     @broadcast_metrics


### PR DESCRIPTION
# Overview

This PR adds the ability of broadcasting the serialized Mermaid query plan over port 3238.
Receiving services can listen to this TCP broadcast over 3238, read the data, and process/present it.

This will be useful for the dashboard, which will (through another proxy service) be listening over 3238 for the plan, so that it can display it to the end-user.

## Notes

This is a refreshed version of this [closed PR](https://github.com/Eventual-Inc/Daft/pull/3756).

## Port choice

The default port to broadcast on was chosen to be *3238*. The reason here being because that is `daft` spelled over the telephone's alphanumeric keypad.

![image](https://github.com/user-attachments/assets/68a707e0-acb3-401a-b71e-7e13c567e31e)