### PR TITLE
feat(catalog): Defines a session for connection state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,6 +1948,7 @@ dependencies = [
  "daft-recordbatch",
  "daft-scan",
  "daft-scheduler",
+ "daft-session",
  "daft-sql",
  "daft-stats",
  "daft-writers",
@@ -2023,6 +2024,7 @@ dependencies = [
  "daft-recordbatch",
  "daft-scan",
  "daft-schema",
+ "daft-session",
  "daft-sql",
  "dashmap",
  "futures",
@@ -2606,6 +2608,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "daft-session"
+version = "0.3.0-dev0"
+dependencies = [
+ "daft-catalog",
+ "daft-logical-plan",
+]
+
+[[package]]
 name = "daft-sketch"
 version = "0.3.0-dev0"
 dependencies = [
@@ -2633,6 +2643,7 @@ dependencies = [
  "daft-functions-json",
  "daft-logical-plan",
  "daft-scan",
+ "daft-session",
  "once_cell",
  "pyo3",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ daft-py-runners = {path = "src/daft-py-runners", default-features = false}
 daft-recordbatch = {path = "src/daft-recordbatch", default-features = false}
 daft-scan = {path = "src/daft-scan", default-features = false}
 daft-scheduler = {path = "src/daft-scheduler", default-features = false}
+daft-session = {path = "src/daft-session", default-features = false}
 daft-sql = {path = "src/daft-sql", default-features = false}
 daft-stats = {path = "src/daft-stats", default-features = false}
 daft-writers = {path = "src/daft-writers", default-features = false}
@@ -58,6 +59,7 @@ python = [
   "common-system-info/python",
   "daft-catalog-python-catalog/python",
   "daft-catalog/python",
+  "daft-context/python",
   "daft-core/python",
   "daft-csv/python",
   "daft-dsl/python",
@@ -75,10 +77,10 @@ python = [
   "daft-scan/python",
   "daft-scheduler/python",
   "daft-sql/python",
+  "daft-session/python",
   "daft-stats/python",
   "daft-recordbatch/python",
   "daft-writers/python",
-  "daft-context/python",
   "dep:daft-catalog-python-catalog",
   "dep:daft-connect",
   "daft-connect/python",
@@ -144,11 +146,14 @@ members = [
   "src/common/display",
   "src/common/error",
   "src/common/io-config",
+  "src/common/partitioning",
   "src/common/scan-info",
   "src/common/system-info",
   "src/common/treenode",
   "src/daft-algebra",
   "src/daft-catalog",
+  "src/daft-connect",
+  "src/daft-context",
   "src/daft-core",
   "src/daft-csv",
   "src/daft-dsl",
@@ -164,20 +169,18 @@ members = [
   "src/daft-micropartition",
   "src/daft-parquet",
   "src/daft-physical-plan",
+  "src/daft-py-runners",
   "src/daft-scan",
   "src/daft-scheduler",
+  "src/daft-session",
   "src/daft-sketch",
   "src/daft-sql",
   "src/daft-recordbatch",
   "src/daft-writers",
   "src/hyperloglog",
-  "src/daft-connect",
   "src/parquet2",
   # "src/spark-connect-script",
-  "src/generated/spark-connect",
-  "src/common/partitioning",
-  "src/daft-py-runners",
-  "src/daft-context"
+  "src/generated/spark-connect"
 ]
 
 [workspace.dependencies]
@@ -210,6 +213,7 @@ daft-py-runners = {path = "src/daft-py-runners"}
 daft-recordbatch = {path = "src/daft-recordbatch"}
 daft-scan = {path = "src/daft-scan"}
 daft-schema = {path = "src/daft-schema"}
+daft-session = {path = "src/daft-session"}
 daft-sql = {path = "src/daft-sql"}
 derivative = "2.2.0"
 derive_builder = "0.20.2"

--- a/src/daft-catalog/python-catalog/src/python.rs
+++ b/src/daft-catalog/python-catalog/src/python.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use daft_catalog::{
-    errors::{Error as DaftCatalogError, Result},
+    error::{Error as DaftCatalogError, Result},
     DataCatalog, DataCatalogTable,
 };
 use daft_logical_plan::{LogicalPlanBuilder, PyLogicalPlanBuilder};
@@ -61,7 +61,7 @@ impl PythonTable {
 }
 
 impl DataCatalogTable for PythonTable {
-    fn to_logical_plan_builder(&self) -> daft_catalog::errors::Result<LogicalPlanBuilder> {
+    fn to_logical_plan_builder(&self) -> daft_catalog::error::Result<LogicalPlanBuilder> {
         Python::with_gil(|py| {
             let dataframe = self
                 .table_pyobj

--- a/src/daft-catalog/src/data_catalog.rs
+++ b/src/daft-catalog/src/data_catalog.rs
@@ -1,4 +1,4 @@
-use crate::{data_catalog_table::DataCatalogTable, errors::Result};
+use crate::{data_catalog_table::DataCatalogTable, error::Result};
 
 /// DataCatalog is a catalog of data sources
 ///

--- a/src/daft-catalog/src/data_catalog_table.rs
+++ b/src/daft-catalog/src/data_catalog_table.rs
@@ -1,11 +1,11 @@
 use daft_logical_plan::LogicalPlanBuilder;
 
-use crate::errors;
+use crate::error;
 
 /// A Table in a Data Catalog
 ///
 /// This is a trait because there are many different implementations of this, for example
 /// Iceberg, DeltaLake, Hive and more.
 pub trait DataCatalogTable {
-    fn to_logical_plan_builder(&self) -> errors::Result<LogicalPlanBuilder>;
+    fn to_logical_plan_builder(&self) -> error::Result<LogicalPlanBuilder>;
 }

--- a/src/daft-catalog/src/error.rs
+++ b/src/daft-catalog/src/error.rs
@@ -2,13 +2,6 @@ use snafu::Snafu;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[macro_export]
-macro_rules! unsupported {
-    ($($arg:tt)*) => {
-        return Err($crate::errors::Error::unsupported(format!($($arg)*)))
-    };
-}
-
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display(

--- a/src/daft-catalog/src/errors.rs
+++ b/src/daft-catalog/src/errors.rs
@@ -1,5 +1,14 @@
 use snafu::Snafu;
 
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[macro_export]
+macro_rules! unsupported {
+    ($($arg:tt)*) => {
+        return Err($crate::errors::Error::unsupported(format!($($arg)*)))
+    };
+}
+
 #[derive(Debug, Snafu)]
 pub enum Error {
     #[snafu(display(
@@ -29,7 +38,12 @@ pub enum Error {
     },
 }
 
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+impl Error {
+    #[inline]
+    pub fn unsupported(message: String) -> Error {
+        Error::Unsupported { message }
+    }
+}
 
 impl From<Error> for common_error::DaftError {
     fn from(err: Error) -> Self {

--- a/src/daft-catalog/src/identifier.rs
+++ b/src/daft-catalog/src/identifier.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, iter::once, vec::IntoIter};
 
-use crate::errors::{Error, Result};
+use crate::error::{Error, Result};
 
 /// An object's namespace (location).
 pub type Namespace = Vec<String>;

--- a/src/daft-catalog/src/lib.rs
+++ b/src/daft-catalog/src/lib.rs
@@ -1,8 +1,7 @@
 mod data_catalog;
 mod data_catalog_table;
-pub mod errors;
+pub mod error;
 pub mod identifier;
-pub mod session;
 
 // Export public-facing traits
 use std::{collections::HashMap, default, sync::Arc};
@@ -14,7 +13,7 @@ pub use data_catalog_table::DataCatalogTable;
 #[cfg(feature = "python")]
 pub mod python;
 
-use errors::{Error, Result};
+use error::{Error, Result};
 
 pub mod global_catalog {
     use std::sync::{Arc, RwLock};
@@ -127,7 +126,7 @@ impl DaftCatalog {
     /// 2. If the [`DaftMetaCatalog`] has a default catalog, we will attempt to resolve the `table_identifier` against the default catalog
     /// 3. If the `table_identifier` is hierarchical (delimited by "."), use the first component as the Data Catalog name and resolve the rest of the components against
     ///     the selected Data Catalog
-    pub fn read_table(&self, table_identifier: &str) -> errors::Result<LogicalPlanBuilder> {
+    pub fn read_table(&self, table_identifier: &str) -> error::Result<LogicalPlanBuilder> {
         // If the name is an exact match with a registered view, return it.
         if let Some(view) = self.named_tables.get(table_identifier) {
             return Ok(view.clone());

--- a/src/daft-catalog/src/lib.rs
+++ b/src/daft-catalog/src/lib.rs
@@ -2,6 +2,7 @@ mod data_catalog;
 mod data_catalog_table;
 pub mod errors;
 pub mod identifier;
+pub mod session;
 
 // Export public-facing traits
 use std::{collections::HashMap, default, sync::Arc};

--- a/src/daft-catalog/src/session.rs
+++ b/src/daft-catalog/src/session.rs
@@ -1,0 +1,51 @@
+use daft_logical_plan::LogicalPlanBuilder;
+
+use crate::{errors::Result, identifier::Identifier, DaftCatalog};
+
+/// Temporary rename while refactoring.
+type Metastore = DaftCatalog;
+
+/// Session holds all state for query planning and execution (e.g. connection).
+pub struct Session {
+    /// Session identifier
+    pub id: String,
+    // TODO remove DaftCatalog after all APIs are migrated.
+    pub metastore: DaftCatalog,
+    // TODO execution context
+    // TODO session options
+}
+
+impl Session {
+    /// Creates a new empty session
+    pub fn new(id: &str, metastore: Metastore) -> Self {
+        Self {
+            id: id.to_string(),
+            metastore,
+        }
+    }
+
+    /// Creates a table backed by the view
+    /// TODO support names/namespaces and other table sources.
+    pub fn create_table(&mut self, name: &str, view: impl Into<LogicalPlanBuilder>) -> Result<()> {
+        self.metastore.register_table(name, view)
+    }
+
+    /// Gets a table by ident
+    pub fn get_table(&self, ident: &Identifier) -> Result<LogicalPlanBuilder> {
+        // TODO current read_table accepts an unparsed string
+        let table_identifier = ident.to_string();
+        // if ident.has_namespace() {
+        //     unsupported!("qualified table names")
+        // }
+        self.metastore.read_table(&table_identifier)
+    }
+}
+
+impl Default for Session {
+    fn default() -> Self {
+        Self {
+            id: "default".to_string(),
+            metastore: Default::default(),
+        }
+    }
+}

--- a/src/daft-connect/Cargo.toml
+++ b/src/daft-connect/Cargo.toml
@@ -17,6 +17,7 @@ daft-micropartition = {workspace = true, optional = true, features = [
 daft-recordbatch = {workspace = true, optional = true, features = ["python"]}
 daft-scan = {workspace = true, optional = true, features = ["python"]}
 daft-schema = {workspace = true, optional = true, features = ["python"]}
+daft-session = {path = "../daft-session", optional = true, features = ["python"]}
 daft-sql = {workspace = true, optional = true, features = ["python"]}
 dashmap = "6.1.0"
 futures = "0.3.31"
@@ -42,6 +43,7 @@ python = [
   "dep:daft-micropartition",
   "dep:daft-scan",
   "dep:daft-schema",
+  "dep:daft-session",
   "dep:daft-sql",
   "dep:daft-recordbatch",
   "dep:daft-context",

--- a/src/daft-connect/src/config.rs
+++ b/src/daft-connect/src/config.rs
@@ -6,9 +6,9 @@ use spark_connect::{
 };
 use tonic::Status;
 
-use crate::session::Session;
+use crate::session::ConnectSession;
 
-impl Session {
+impl ConnectSession {
     fn config_response(&self) -> ConfigResponse {
         ConfigResponse {
             session_id: self.client_side_session_id().to_string(),

--- a/src/daft-connect/src/connect_service.rs
+++ b/src/daft-connect/src/connect_service.rs
@@ -17,14 +17,14 @@ use crate::{
     error::Context,
     invalid_argument_err, not_yet_implemented,
     response_builder::ResponseBuilder,
-    session::Session,
+    session::ConnectSession,
     spark_analyzer::{to_spark_datatype, SparkAnalyzer},
     util::FromOptionalField,
 };
 
 #[derive(Default)]
 pub struct DaftSparkConnectService {
-    client_to_session: DashMap<Uuid, Session>, // To track session data
+    client_to_session: DashMap<Uuid, ConnectSession>, // To track session data
 }
 type ExecutePlanStream = std::pin::Pin<
     Box<dyn futures::Stream<Item = Result<ExecutePlanResponse, Status>> + Send + 'static>,
@@ -34,7 +34,7 @@ impl DaftSparkConnectService {
     fn get_session(
         &self,
         session_id: &str,
-    ) -> Result<dashmap::mapref::one::RefMut<Uuid, Session>, Status> {
+    ) -> Result<dashmap::mapref::one::RefMut<Uuid, ConnectSession>, Status> {
         let Ok(uuid) = Uuid::parse_str(session_id) else {
             return Err(Status::invalid_argument(
                 "Invalid session_id format, must be a UUID",
@@ -44,7 +44,7 @@ impl DaftSparkConnectService {
         let res = self
             .client_to_session
             .entry(uuid)
-            .or_insert_with(|| Session::new(session_id.to_string()));
+            .or_insert_with(|| ConnectSession::new(session_id.to_string()));
 
         Ok(res)
     }

--- a/src/daft-connect/src/execute.rs
+++ b/src/daft-connect/src/execute.rs
@@ -1,4 +1,4 @@
-use std::{future::ready, sync::Arc};
+use std::{future::ready, rc::Rc, sync::Arc};
 
 use common_error::DaftResult;
 use common_file_formats::FileFormat;
@@ -285,7 +285,7 @@ impl ConnectSession {
 
         // TODO: converge Session and ConnectSession
         let catalog = self.catalog().clone();
-        let session = Arc::new(Session::new("spark_connect", catalog));
+        let session = Rc::new(Session::new("spark_connect", catalog));
 
         let mut planner = daft_sql::SQLPlanner::new(session);
 

--- a/src/daft-connect/src/execute.rs
+++ b/src/daft-connect/src/execute.rs
@@ -2,6 +2,7 @@ use std::{future::ready, sync::Arc};
 
 use common_error::DaftResult;
 use common_file_formats::FileFormat;
+use daft_catalog::session::Session;
 use daft_context::get_context;
 use daft_dsl::LiteralValue;
 use daft_logical_plan::LogicalPlanBuilder;
@@ -25,13 +26,13 @@ use crate::{
     error::{ConnectError, ConnectResult, Context},
     not_yet_implemented,
     response_builder::ResponseBuilder,
-    session::Session,
+    session::ConnectSession,
     spark_analyzer::SparkAnalyzer,
     util::FromOptionalField,
     ExecuteStream,
 };
 
-impl Session {
+impl ConnectSession {
     pub async fn run_query(
         &self,
         lp: LogicalPlanBuilder,
@@ -282,9 +283,11 @@ impl Session {
             not_yet_implemented!("Input");
         }
 
+        // TODO: converge Session and ConnectSession
         let catalog = self.catalog().clone();
+        let session = Arc::new(Session::new("spark_connect", catalog));
 
-        let mut planner = daft_sql::SQLPlanner::new(catalog);
+        let mut planner = daft_sql::SQLPlanner::new(session);
 
         let plan = planner.plan_sql(&sql).wrap_err("Error planning SQL")?;
 

--- a/src/daft-connect/src/execute.rs
+++ b/src/daft-connect/src/execute.rs
@@ -2,12 +2,12 @@ use std::{future::ready, sync::Arc};
 
 use common_error::DaftResult;
 use common_file_formats::FileFormat;
-use daft_catalog::session::Session;
 use daft_context::get_context;
 use daft_dsl::LiteralValue;
 use daft_logical_plan::LogicalPlanBuilder;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
+use daft_session::Session;
 use futures::{
     stream::{self, BoxStream},
     StreamExt, TryStreamExt,

--- a/src/daft-connect/src/response_builder.rs
+++ b/src/daft-connect/src/response_builder.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 use crate::{
     error::{ConnectResult, Context},
-    session::Session,
+    session::ConnectSession,
 };
 
 /// A utility for constructing responses to send back to the client,
@@ -24,7 +24,7 @@ pub struct ResponseBuilder<T> {
     pub(crate) phantom: std::marker::PhantomData<T>,
 }
 impl<T> ResponseBuilder<T> {
-    pub fn new(session: &Session, operation_id: String) -> Self {
+    pub fn new(session: &ConnectSession, operation_id: String) -> Self {
         Self::new_with_op_id(
             session.client_side_session_id(),
             session.server_side_session_id(),

--- a/src/daft-connect/src/session.rs
+++ b/src/daft-connect/src/session.rs
@@ -8,7 +8,7 @@ use daft_catalog::DaftCatalog;
 use uuid::Uuid;
 
 #[derive(Clone)]
-pub struct Session {
+pub struct ConnectSession {
     /// so order is preserved, and so we can efficiently do a prefix search
     ///
     /// Also, <https://users.rust-lang.org/t/hashmap-vs-btreemap/13804/4>
@@ -20,7 +20,7 @@ pub struct Session {
     pub catalog: Arc<RwLock<DaftCatalog>>,
 }
 
-impl Session {
+impl ConnectSession {
     pub fn config_values(&self) -> &BTreeMap<String, String> {
         &self.config_values
     }

--- a/src/daft-connect/src/spark_analyzer.rs
+++ b/src/daft-connect/src/spark_analyzer.rs
@@ -6,6 +6,7 @@ mod literal;
 use std::{io::Cursor, sync::Arc};
 
 use arrow2::io::ipc::read::{read_stream_metadata, StreamReader, StreamState};
+use daft_catalog::session::Session;
 use daft_core::series::Series;
 use daft_dsl::col;
 use daft_logical_plan::{LogicalPlanBuilder, PyLogicalPlanBuilder};
@@ -40,17 +41,17 @@ use crate::{
     error::{ConnectError, ConnectResult, Context},
     functions::CONNECT_FUNCTIONS,
     internal_err, invalid_argument_err, not_yet_implemented,
-    session::Session,
+    session::ConnectSession,
     util::FromOptionalField,
 };
 
 #[derive(Clone)]
 pub struct SparkAnalyzer<'a> {
-    pub session: &'a Session,
+    pub session: &'a ConnectSession,
 }
 
 impl SparkAnalyzer<'_> {
-    pub fn new(session: &Session) -> SparkAnalyzer<'_> {
+    pub fn new(session: &ConnectSession) -> SparkAnalyzer<'_> {
         SparkAnalyzer { session }
     }
 
@@ -659,9 +660,11 @@ impl SparkAnalyzer<'_> {
             not_yet_implemented!("pos_arguments");
         }
 
+        // TODO: converge Session and ConnectSession
         let catalog = self.session.catalog().clone();
+        let session = Arc::new(Session::new("connect", catalog));
 
-        let mut planner = SQLPlanner::new(catalog);
+        let mut planner = SQLPlanner::new(session);
         let plan = planner.plan_sql(&query)?;
         Ok(plan.into())
     }

--- a/src/daft-connect/src/spark_analyzer.rs
+++ b/src/daft-connect/src/spark_analyzer.rs
@@ -3,7 +3,7 @@
 mod datatype;
 mod literal;
 
-use std::{io::Cursor, sync::Arc};
+use std::{io::Cursor, rc::Rc, sync::Arc};
 
 use arrow2::io::ipc::read::{read_stream_metadata, StreamReader, StreamState};
 use daft_core::series::Series;
@@ -662,7 +662,7 @@ impl SparkAnalyzer<'_> {
 
         // TODO: converge Session and ConnectSession
         let catalog = self.session.catalog().clone();
-        let session = Arc::new(Session::new("connect", catalog));
+        let session = Rc::new(Session::new("connect", catalog));
 
         let mut planner = SQLPlanner::new(session);
         let plan = planner.plan_sql(&query)?;

--- a/src/daft-connect/src/spark_analyzer.rs
+++ b/src/daft-connect/src/spark_analyzer.rs
@@ -6,7 +6,6 @@ mod literal;
 use std::{io::Cursor, sync::Arc};
 
 use arrow2::io::ipc::read::{read_stream_metadata, StreamReader, StreamState};
-use daft_catalog::session::Session;
 use daft_core::series::Series;
 use daft_dsl::col;
 use daft_logical_plan::{LogicalPlanBuilder, PyLogicalPlanBuilder};
@@ -14,6 +13,7 @@ use daft_micropartition::{self, python::PyMicroPartition, MicroPartition};
 use daft_recordbatch::RecordBatch;
 use daft_scan::builder::{CsvScanBuilder, ParquetScanBuilder};
 use daft_schema::schema::{Schema, SchemaRef};
+use daft_session::Session;
 use daft_sql::SQLPlanner;
 use datatype::to_daft_datatype;
 pub use datatype::to_spark_datatype;

--- a/src/daft-session/Cargo.toml
+++ b/src/daft-session/Cargo.toml
@@ -1,0 +1,17 @@
+[dependencies]
+daft-catalog = {path = "../daft-catalog"}
+daft-logical-plan = {path = "../daft-logical-plan"}
+
+[features]
+python = [
+  "daft-catalog/python",
+  "daft-logical-plan/python"
+]
+
+[lints]
+workspace = true
+
+[package]
+name = "daft-session"
+edition.workspace = true
+version.workspace = true

--- a/src/daft-session/src/error.rs
+++ b/src/daft-session/src/error.rs
@@ -1,0 +1,9 @@
+// temporary
+pub use daft_catalog::error::*;
+
+#[macro_export]
+macro_rules! unsupported_err {
+    ($($arg:tt)*) => {
+        return Err($crate::errors::Error::unsupported(format!($($arg)*)))
+    };
+}

--- a/src/daft-session/src/lib.rs
+++ b/src/daft-session/src/lib.rs
@@ -1,6 +1,9 @@
+mod error;
+
+use daft_catalog::{identifier::Identifier, DaftCatalog};
 use daft_logical_plan::LogicalPlanBuilder;
 
-use crate::{errors::Result, identifier::Identifier, DaftCatalog};
+use crate::error::Result;
 
 /// Temporary rename while refactoring.
 type Metastore = DaftCatalog;

--- a/src/daft-sql/Cargo.toml
+++ b/src/daft-sql/Cargo.toml
@@ -11,6 +11,7 @@ daft-functions = {path = "../daft-functions"}
 daft-functions-json = {path = "../daft-functions-json"}
 daft-logical-plan = {path = "../daft-logical-plan"}
 daft-scan = {path = "../daft-scan"}
+daft-session = {path = "../daft-session"}
 once_cell = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 sqlparser = {workspace = true}
@@ -32,7 +33,8 @@ python = [
   "daft-functions/python",
   "daft-functions-json/python",
   "daft-logical-plan/python",
-  "daft-scan/python"
+  "daft-scan/python",
+  "daft-session/python"
 ]
 
 [lints]

--- a/src/daft-sql/src/lib.rs
+++ b/src/daft-sql/src/lib.rs
@@ -28,13 +28,13 @@ pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
 mod tests {
     use std::sync::Arc;
 
-    use daft_catalog::session::Session;
     use daft_core::prelude::*;
     use daft_dsl::{col, lit, Expr, OuterReferenceColumn, Subquery};
     use daft_logical_plan::{
         logical_plan::Source, source_info::PlaceHolderInfo, ClusteringSpec, JoinOptions,
         LogicalPlan, LogicalPlanBuilder, LogicalPlanRef, SourceInfo,
     };
+    use daft_session::Session;
     use error::SQLPlannerResult;
     use rstest::{fixture, rstest};
 

--- a/src/daft-sql/src/lib.rs
+++ b/src/daft-sql/src/lib.rs
@@ -113,13 +113,13 @@ mod tests {
 
     #[fixture]
     fn planner() -> SQLPlanner<'static> {
-        let mut session = Session::default();
+        let session = Session::default();
 
-        session.create_table("tbl1", tbl_1());
-        session.create_table("tbl2", tbl_2());
-        session.create_table("tbl3", tbl_3());
+        _ = session.create_table("tbl1", tbl_1());
+        _ = session.create_table("tbl2", tbl_2());
+        _ = session.create_table("tbl3", tbl_3());
 
-        SQLPlanner::new(Arc::new(session))
+        SQLPlanner::new(session.into())
     }
 
     #[rstest]

--- a/src/daft-sql/src/lib.rs
+++ b/src/daft-sql/src/lib.rs
@@ -28,7 +28,7 @@ pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
 mod tests {
     use std::sync::Arc;
 
-    use daft_catalog::DaftCatalog;
+    use daft_catalog::session::Session;
     use daft_core::prelude::*;
     use daft_dsl::{col, lit, Expr, OuterReferenceColumn, Subquery};
     use daft_logical_plan::{
@@ -113,13 +113,13 @@ mod tests {
 
     #[fixture]
     fn planner() -> SQLPlanner<'static> {
-        let mut catalog = DaftCatalog::default();
+        let mut session = Session::default();
 
-        catalog.register_table("tbl1", tbl_1());
-        catalog.register_table("tbl2", tbl_2());
-        catalog.register_table("tbl3", tbl_3());
+        session.create_table("tbl1", tbl_1());
+        session.create_table("tbl2", tbl_2());
+        session.create_table("tbl3", tbl_3());
 
-        SQLPlanner::new(catalog)
+        SQLPlanner::new(Arc::new(session))
     }
 
     #[rstest]

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -8,7 +8,7 @@ use std::{
 
 use common_error::{DaftError, DaftResult};
 use daft_algebra::boolean::combine_conjunction;
-use daft_catalog::DaftCatalog;
+use daft_catalog::{identifier::Identifier, session::Session};
 use daft_core::prelude::*;
 use daft_dsl::{
     col,
@@ -38,6 +38,35 @@ use crate::{
     column_not_found_err, error::*, invalid_operation_err, table_not_found_err, unsupported_sql_err,
 };
 
+/// Bindings are used to lookup in-scope tables, views, and columns (targets T).
+/// This is an incremental step towards proper name resolution.
+struct Bindings<T>(HashMap<String, T>);
+
+impl<T> Bindings<T> {
+    /// Gets a binding by identiifer
+    pub fn get(&self, ident: &str) -> Option<&T> {
+        // TODO use identifiers and handle case-normalization
+        self.0.get(ident)
+    }
+
+    /// Inserts a new binding by name
+    pub fn insert(&mut self, name: String, target: T) -> Option<T> {
+        // TODO use names and handle case-normalization
+        self.0.insert(name, target)
+    }
+
+    /// Clears all bound targets
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+}
+
+impl<T> Default for Bindings<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
 /// A named logical plan
 /// This is used to keep track of the table name associated with a logical plan while planning a SQL query
 #[derive(Debug, Clone)]
@@ -55,49 +84,78 @@ impl Relation {
             alias: None,
         }
     }
+
     pub fn with_alias(self, alias: TableAlias) -> Self {
         Self {
             alias: Some(alias),
             ..self
         }
     }
+
     pub fn get_name(&self) -> String {
         self.alias
             .as_ref()
             .map(|alias| ident_to_str(&alias.name))
             .unwrap_or_else(|| self.name.clone())
     }
+
     pub(crate) fn schema(&self) -> SchemaRef {
         self.inner.schema()
     }
 }
 
-/// Context that is shared across a query and its subqueries
+/// Context for the planning the statement.
+/// TODO consolidate SQLPlanner state to the single context.
+/// TODO move bound_ctes into per-planner scope since these are a scoped concept.
 #[derive(Default)]
 struct PlannerContext {
-    catalog: DaftCatalog,
-    cte_map: HashMap<String, Relation>,
+    /// Session provides access to metadata and the path for name resolution.
+    /// TODO move into SQLPlanner once state is flipped.
+    /// TODO consider decoupling session from planner via a resolver trait.
+    session: Arc<Session>,
+    /// Bindings for common table expressions (cte).
+    bound_ctes: Bindings<Relation>,
 }
 
+impl PlannerContext {
+    /// Creates a new context from the session
+    fn new(session: Arc<Session>) -> Self {
+        Self {
+            session,
+            bound_ctes: Bindings::default(),
+        }
+    }
+
+    /// Clears the entire statement context
+    fn clear(&mut self) {
+        self.bound_ctes.clear();
+    }
+}
+
+/// An SQLPlanner is created for each scope to bind names and translate to logical plans.
+/// TODO flip SQLPlanner to pass scoped state objects rather than being stateful itself.
+/// This gives us control on state management without coupling our scopes to the call stack.
+/// It also eliminates extra references on the shared context and we can remove interior mutability.
 #[derive(Default)]
 pub struct SQLPlanner<'a> {
+    /// Shared context for all planners
+    context: Rc<RefCell<PlannerContext>>,
+    /// Planner for the outer scope
+    parent: Option<&'a SQLPlanner<'a>>,
+    /// Cache of known, in-scope tables
+    bound_tables: Bindings<Relation>,
+    /// In-scope bindings introduced by the current relation's schema
     current_relation: Option<Relation>,
-    table_map: HashMap<String, Relation>,
     /// Aliases from selection that can be used in other clauses
     /// but may not yet be in the schema of `current_relation`.
-    alias_map: HashMap<String, ExprRef>,
-    /// outer query in a subquery
-    parent: Option<&'a SQLPlanner<'a>>,
-    context: Rc<RefCell<PlannerContext>>,
+    bound_columns: Bindings<ExprRef>,
 }
 
 impl<'a> SQLPlanner<'a> {
-    pub fn new(catalog: DaftCatalog) -> Self {
-        let context = Rc::new(RefCell::new(PlannerContext {
-            catalog,
-            ..Default::default()
-        }));
-
+    /// Create a new query planner for the session.
+    pub fn new(session: Arc<Session>) -> Self {
+        let context = PlannerContext::new(session);
+        let context = Rc::new(RefCell::new(context));
         Self {
             context,
             ..Default::default()
@@ -134,19 +192,27 @@ impl<'a> SQLPlanner<'a> {
         self.context.as_ref().borrow_mut()
     }
 
-    fn cte_map(&self) -> Ref<'_, HashMap<String, Relation>> {
-        Ref::map(self.context.borrow(), |i| &i.cte_map)
+    fn bound_ctes(&self) -> Ref<'_, Bindings<Relation>> {
+        Ref::map(self.context.borrow(), |i| &i.bound_ctes)
     }
 
-    fn catalog(&self) -> Ref<'_, DaftCatalog> {
-        Ref::map(self.context.borrow(), |i| &i.catalog)
+    fn get_table(&self, ident: &Identifier) -> Option<Relation> {
+        self.session()
+            .get_table(ident)
+            .ok()
+            .map(|table| Relation::new(table, ident.name.clone()))
+    }
+
+    /// Borrow the planning session
+    fn session(&self) -> Ref<'_, Arc<Session>> {
+        Ref::map(self.context.borrow(), |i| &i.session)
     }
 
     /// Clears the current context used for planning a SQL query
     fn clear_context(&mut self) {
         self.current_relation = None;
-        self.table_map.clear();
-        self.context_mut().cte_map.clear();
+        self.bound_tables.clear();
+        self.context_mut().clear();
     }
 
     fn register_cte(&self, mut rel: Relation, column_aliases: &[Ident]) -> SQLPlannerResult<()> {
@@ -169,7 +235,7 @@ impl<'a> SQLPlanner<'a> {
 
             rel.inner = rel.inner.select(projection)?;
         }
-        self.context_mut().cte_map.insert(rel.get_name(), rel);
+        self.context_mut().bound_ctes.insert(rel.get_name(), rel);
         Ok(())
     }
 
@@ -755,10 +821,10 @@ impl<'a> SQLPlanner<'a> {
 
             let first = from_iter.next().unwrap();
             let mut rel = self.plan_relation(&first.relation)?;
-            self.table_map.insert(rel.get_name(), rel.clone());
+            self.bound_tables.insert(rel.get_name(), rel.clone());
             for tbl in from_iter {
                 let right = self.plan_relation(&tbl.relation)?;
-                self.table_map.insert(right.get_name(), right.clone());
+                self.bound_tables.insert(right.get_name(), right.clone());
                 let right_join_prefix = format!("{}.", right.get_name());
 
                 rel.inner = rel.inner.cross_join(
@@ -887,7 +953,7 @@ impl<'a> SQLPlanner<'a> {
         let relation = from.relation.clone();
         let left_rel = self.plan_relation(&relation)?;
         self.current_relation = Some(left_rel.clone());
-        self.table_map.insert(left_rel.get_name(), left_rel);
+        self.bound_tables.insert(left_rel.get_name(), left_rel);
 
         for join in &from.joins {
             use sqlparser::ast::{
@@ -902,7 +968,7 @@ impl<'a> SQLPlanner<'a> {
             let mut right_planner = self.new_with_context();
             right_planner.current_relation = Some(right_rel.clone());
             right_planner
-                .table_map
+                .bound_tables
                 .insert(right_rel.get_name(), right_rel.clone());
 
             let (join_type, constraint) = match &join.join_operator {
@@ -972,7 +1038,7 @@ impl<'a> SQLPlanner<'a> {
                     .prefix(right_join_prefix)
                     .merge_matching_join_keys(merge_matching_join_keys),
             )?;
-            self.table_map.insert(right_rel_name, right_rel);
+            self.bound_tables.insert(right_rel_name, right_rel);
         }
 
         Ok(())
@@ -1070,27 +1136,21 @@ impl<'a> SQLPlanner<'a> {
 
     /// Plan a `FROM <table>` table factor.
     pub(crate) fn plan_relation_table(&self, name: &ObjectName) -> SQLPlannerResult<Relation> {
-        // Consider parsing again via Identifier::parse, but it's unnecessary at the moment.
-        let ident = &name.0;
-        if ident.len() > 1 {
+        // Convert the sqlparse ObjectName to a daft Identifier
+        let ident = ident_from_obj_name(name);
+        if ident.has_namespace() {
             unsupported_sql_err!("qualified identifier {}", name.to_string())
         }
         // Because the catalog does not support qualified identifiers, we can just use name.
-        let table_name = &ident.last().unwrap().value;
         // TODO case-normalization of regular identifiers in name position (rvalue) https://github.com/Eventual-Inc/Daft/issues/3765
         let Some(rel) = self
-            .table_map
-            .get(table_name)
+            .bound_tables
+            .get(&ident.name)
             .cloned()
-            .or_else(|| self.cte_map().get(table_name).cloned())
-            .or_else(|| {
-                self.catalog()
-                    .read_table(table_name)
-                    .ok()
-                    .map(|table| Relation::new(table, table_name.clone()))
-            })
+            .or_else(|| self.bound_ctes().get(&ident.name).cloned())
+            .or_else(|| self.get_table(&ident))
         else {
-            table_not_found_err!(table_name)
+            table_not_found_err!(ident.to_string())
         };
         Ok(rel)
     }
@@ -1142,7 +1202,7 @@ impl<'a> SQLPlanner<'a> {
             }
             // The identifier could also be in the alias map but not the schema
             // for expressions in WHERE, GROUP BY, and HAVING, which are done before project
-            if let Some(expr) = planner.alias_map.get(&full_str) {
+            if let Some(expr) = planner.bound_columns.get(&full_str) {
                 // transform expression alias map by incrementing thee depths of every column by `depth`
                 let transformed_expr = expr
                     .clone()
@@ -1164,7 +1224,7 @@ impl<'a> SQLPlanner<'a> {
 
             // If compound identifier, try to find in tables at current depth
             if !rest.is_empty()
-                && let Some(relation) = planner.table_map.get(&root_str)
+                && let Some(relation) = planner.bound_tables.get(&root_str)
             {
                 let relation_schema = relation.schema();
 
@@ -1212,7 +1272,7 @@ impl<'a> SQLPlanner<'a> {
             SelectItem::ExprWithAlias { expr, alias } => {
                 let expr = self.plan_expr(expr)?;
                 let alias = alias.value.to_string();
-                self.alias_map.insert(alias.clone(), expr.clone());
+                self.bound_columns.insert(alias.clone(), expr.clone());
                 Ok(vec![expr.alias(alias)])
             }
             SelectItem::UnnamedExpr(expr) => self.plan_expr(expr).map(|e| vec![e]),
@@ -1255,7 +1315,7 @@ impl<'a> SQLPlanner<'a> {
                 let Some(rel) = self.relation_opt() else {
                     table_not_found_err!(table_name);
                 };
-                let Some(table_rel) = self.table_map.get(&table_name) else {
+                let Some(table_rel) = self.bound_tables.get(&table_name) else {
                     table_not_found_err!(table_name);
                 };
                 let right_schema = table_rel.inner.schema();
@@ -2313,6 +2373,8 @@ pub fn sql_datatype<S: AsRef<str>>(s: S) -> SQLPlannerResult<DataType> {
 // Helper functions
 // ----------------
 
+/// TODO replace with daft identifiers in subsequent PR.
+/// TODO proper handling of other quote styles like backticks
 /// # Examples
 /// ```
 /// // Quoted identifier "MyCol" -> "MyCol"
@@ -2326,12 +2388,22 @@ fn ident_to_str(ident: &Ident) -> String {
     }
 }
 
+/// TODO replace with daft identifiers in subsequent PR.
 fn idents_to_str(idents: &[Ident]) -> String {
     idents
         .iter()
         .map(ident_to_str)
         .collect::<Vec<_>>()
         .join(".")
+}
+
+/// Returns a daft identifier from an sqlparser ObjectName
+fn ident_from_obj_name(name: &ObjectName) -> Identifier {
+    // TODO distinguish identifier parts for proper resolution (or normalization).
+    let mut parts: Vec<String> = name.0.iter().map(|i| i.value.clone()).collect();
+    let name = parts.pop().expect("object name had 0 parts");
+    let namespace = parts;
+    Identifier::new(namespace, name)
 }
 
 /// Returns true iff the ObjectName is a string literal (single-quoted identifier e.g. 'path/to/file.extension').

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -113,14 +113,14 @@ struct PlannerContext {
     /// Session provides access to metadata and the path for name resolution.
     /// TODO move into SQLPlanner once state is flipped.
     /// TODO consider decoupling session from planner via a resolver trait.
-    session: Arc<Session>,
+    session: Rc<Session>,
     /// Bindings for common table expressions (cte).
     bound_ctes: Bindings<Relation>,
 }
 
 impl PlannerContext {
     /// Creates a new context from the session
-    fn new(session: Arc<Session>) -> Self {
+    fn new(session: Rc<Session>) -> Self {
         Self {
             session,
             bound_ctes: Bindings::default(),
@@ -154,7 +154,7 @@ pub struct SQLPlanner<'a> {
 
 impl<'a> SQLPlanner<'a> {
     /// Create a new query planner for the session.
-    pub fn new(session: Arc<Session>) -> Self {
+    pub fn new(session: Rc<Session>) -> Self {
         let context = PlannerContext::new(session);
         let context = Rc::new(RefCell::new(context));
         Self {
@@ -205,7 +205,7 @@ impl<'a> SQLPlanner<'a> {
     }
 
     /// Borrow the planning session
-    fn session(&self) -> Ref<'_, Arc<Session>> {
+    fn session(&self) -> Ref<'_, Rc<Session>> {
         Ref::map(self.context.borrow(), |i| &i.session)
     }
 

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -8,7 +8,7 @@ use std::{
 
 use common_error::{DaftError, DaftResult};
 use daft_algebra::boolean::combine_conjunction;
-use daft_catalog::{identifier::Identifier, session::Session};
+use daft_catalog::identifier::Identifier;
 use daft_core::prelude::*;
 use daft_dsl::{
     col,
@@ -21,6 +21,7 @@ use daft_functions::{
     utf8::{ilike, like, to_date, to_datetime},
 };
 use daft_logical_plan::{JoinOptions, LogicalPlanBuilder, LogicalPlanRef};
+use daft_session::Session;
 use sqlparser::{
     ast::{
         self, ArrayElemTypeDef, BinaryOperator, CastKind, ColumnDef, DateTimeField, Distinct,

--- a/src/daft-sql/src/python.rs
+++ b/src/daft-sql/src/python.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
 use common_daft_config::PyDaftPlanningConfig;
-use daft_catalog::{session::Session, DaftCatalog};
+use daft_catalog::DaftCatalog;
 use daft_dsl::python::PyExpr;
 use daft_logical_plan::{LogicalPlanBuilder, PyLogicalPlanBuilder};
+use daft_session::Session;
 use pyo3::prelude::*;
 
 use crate::{functions::SQL_FUNCTIONS, planner::SQLPlanner};

--- a/src/daft-sql/src/python.rs
+++ b/src/daft-sql/src/python.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use common_daft_config::PyDaftPlanningConfig;
 use daft_catalog::DaftCatalog;
 use daft_dsl::python::PyExpr;
@@ -42,8 +40,8 @@ pub fn sql(
     daft_planning_config: PyDaftPlanningConfig,
 ) -> PyResult<PyLogicalPlanBuilder> {
     // just use a one-off session for now..
-    let session = Arc::new(Session::new("py", catalog.catalog));
-    let mut planner = SQLPlanner::new(session);
+    let session = Session::new("py", catalog.catalog);
+    let mut planner = SQLPlanner::new(session.into());
     let plan = planner.plan_sql(sql)?;
     Ok(LogicalPlanBuilder::new(plan, Some(daft_planning_config.config)).into())
 }


### PR DESCRIPTION
This defines an initial session for table resolution which simply wraps the existing meta catalog. The purpose of this PR is to (1) introduce a primary stateful object for planning and execution which is shared by frontends and (2) audit the planner's current state management and name resolution to see what is required once bridging over to python. 

**Notes**
* This PR includes many follow-up TODOs which are being converted to issues.
* This primarily introduces indirection first to keep the diff minimal, switchovers come later.
* The session will hold a reference to the global context singleton from #3767.
* This session will be converged with the ConnectSession and made available through python once stabilized.