### PR TITLE
feat: Simplify is ins to an OR chain of eqs

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -10,6 +10,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Iterable,
     Iterator,
     Literal,
@@ -1337,11 +1338,15 @@ class Expression:
         Returns:
             Expression: Boolean Expression indicating whether values are in the provided list
         """
-        if not isinstance(other, Expression):
+        if isinstance(other, Collection):
+            other = [Expression._to_expression(item) for item in other]
+        elif not isinstance(other, Expression):
             series = item_to_series("items", other)
-            other = Expression._to_expression(series)
+            other = [Expression._to_expression(series)]
+        else:
+            other = [other]
 
-        expr = self._expr.is_in([other._expr])
+        expr = self._expr.is_in([item._expr for item in other])
         return Expression._from_pyexpr(expr)
 
     def between(self, lower: Any, upper: Any) -> Expression:

--- a/src/daft-algebra/src/simplify/mod.rs
+++ b/src/daft-algebra/src/simplify/mod.rs
@@ -5,7 +5,7 @@ mod numeric;
 use boolean::{simplify_binary_compare, simplify_boolean_expr};
 use common_error::DaftResult;
 use common_treenode::{Transformed, TreeNode};
-use daft_dsl::{lit, Expr, ExprRef};
+use daft_dsl::{lit, Expr, ExprRef, LiteralValue};
 use daft_schema::schema::SchemaRef;
 use null::simplify_expr_with_null;
 use numeric::simplify_numeric_expr;
@@ -18,6 +18,7 @@ pub fn simplify_expr(expr: ExprRef, schema: &SchemaRef) -> DaftResult<Transforme
         simplify_expr_with_null,
         simplify_numeric_expr,
         simplify_misc_expr,
+        simplify_is_in_expr,
     ];
 
     // Our simplify rules currently require bottom-up traversal to work
@@ -52,14 +53,31 @@ fn simplify_misc_expr(expr: ExprRef, schema: &SchemaRef) -> DaftResult<Transform
                 .lt_eq(high.clone())
                 .and(between.clone().gt_eq(low.clone())),
         ),
-        // e IN () --> false
-        Expr::IsIn(_, list) if list.is_empty() => Transformed::yes(lit(false)),
         // CAST(e AS dtype) -> e if e.dtype == dtype
         Expr::Cast(e, dtype) if e.get_type(schema)? == *dtype => Transformed::yes(e.clone()),
         _ => Transformed::no(expr),
     })
 }
 
+const MAX_IS_IN_CHAIN_LENGTH: usize = 5;
+
+fn simplify_is_in_expr(expr: ExprRef, _schema: &SchemaRef) -> DaftResult<Transformed<ExprRef>> {
+    Ok(match expr.as_ref() {
+        Expr::IsIn(_, list) if list.is_empty() => Transformed::yes(lit(false)),
+        // If the list is a small literal list, we can just make it an OR chain of eqs, e.g.
+        // e IN (1, 2, 3) -> e = 1 OR e = 2 OR e = 3
+        Expr::IsIn(e, list)
+            if list.len() <= MAX_IS_IN_CHAIN_LENGTH
+                && list.iter().all(|e| matches!(e.as_ref(), Expr::Literal(l) if !matches!(l, LiteralValue::Series(_)))) =>
+        {
+            let chain_of_eqs = list
+                .iter()
+                .map(|item| e.clone().eq(item.clone()));
+            Transformed::yes(chain_of_eqs.reduce(|a, b| a.or(b)).unwrap())
+        }
+        _ => Transformed::no(expr),
+    })
+}
 #[cfg(test)]
 mod test {
     use std::sync::Arc;
@@ -159,6 +177,40 @@ mod test {
         let optimized = simplify_expr(input, &schema)?;
 
         assert!(optimized.transformed);
+        assert_eq!(optimized.data, expected);
+        Ok(())
+    }
+
+    #[rstest]
+    // One element list, can transform to eq
+    // e IN (1) --> e = 1
+    #[case(col("int").is_in(vec![lit(1)]), col("int").eq(lit(1)))]
+    // Small list, can transform to ORs
+    // e IN (1, 2, 3, 4, 5) --> e = 1 OR e = 2 OR e = 3 OR e = 4 OR e = 5
+    #[case(col("int").is_in(vec![lit(1), lit(2), lit(3), lit(4), lit(5)]), col("int").eq(lit(1)).or(col("int").eq(lit(2))).or(col("int").eq(lit(3))).or(col("int").eq(lit(4))).or(col("int").eq(lit(5))))]
+    fn test_is_in_exprs_can_chain_or_clauses(
+        #[case] input: ExprRef,
+        #[case] expected: ExprRef,
+        schema: SchemaRef,
+    ) -> DaftResult<()> {
+        let optimized = simplify_expr(input, &schema)?;
+
+        assert!(optimized.transformed);
+        assert_eq!(optimized.data, expected);
+        Ok(())
+    }
+
+    #[rstest]
+    // e IN (1, 2, 3, 4, 5, 6) --> e IN (1, 2, 3, 4, 5, 6)
+    #[case(col("int").is_in(vec![lit(1), lit(2), lit(3), lit(4), lit(5), lit(6)]), col("int").is_in(vec![lit(1), lit(2), lit(3), lit(4), lit(5), lit(6)]))]
+    fn test_is_in_exprs_more_than_max_chain_length(
+        #[case] input: ExprRef,
+        #[case] expected: ExprRef,
+        schema: SchemaRef,
+    ) -> DaftResult<()> {
+        let optimized = simplify_expr(input, &schema)?;
+
+        assert!(!optimized.transformed);
         assert_eq!(optimized.data, expected);
         Ok(())
     }

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -548,6 +548,9 @@ impl RecordBatch {
                 self.eval_expression(child)?.fill_null(&fill_value)
             }
             Expr::IsIn(child, items) => {
+                if items.is_empty() {
+                    return BooleanArray::from_iter(child.name(), std::iter::once(Some(false))).into_series().broadcast(self.len());
+                }
                 let items = items.iter().map(|i| self.eval_expression(i)).collect::<DaftResult<Vec<_>>>()?;
 
                 let items = items.iter().collect::<Vec<&Series>>();


### PR DESCRIPTION
Implement simplify expr rule to transform `is_in` into an OR chain of `eq`, e.g. `e IN (1, 2, 3) -> e = 1 OR e = 2 OR e = 3`.

This can be faster than using the `is_in` kernel, which has to hash the items and does a lookup per row in the base column.

Results on Q12 and Q19 of TPCH SF 10:
Q12: 410.57s -> 313.44s
Q19: 489.13s -> 401.24s

I configured the threshold for max number of items to transform into the OR chain is 5. I chose the number 5 because of the significant symbolism it has in nature and culture. Humans have 5 fingers on each hand and 5 toes on each foot. Most flowering plants have 5 petals. It's the number of Platonic solids (regular polyhedra). Many animals have pentameral (5-fold) symmetry, like starfish. In Chinese culture, there are five blessings (longevity, happiness, wealth, luck and prosperity), as well as five elements (wood, water, fire, Earth and metal).