### PR TITLE
Upgrade python-package.yml from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,19 +27,19 @@ jobs:
         python-version: ['3.9', '3.10']
         daft-runner: [py, ray, native]
         pyarrow-version: [8.0.0, 16.0.0]
-        os: [ubuntu-20.04, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         exclude:
         - daft-runner: ray
           pyarrow-version: 8.0.0
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - daft-runner: py
           python-version: '3.10'
           pyarrow-version: 8.0.0
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - daft-runner: native
           python-version: '3.10'
           pyarrow-version: 8.0.0
-          os: ubuntu-20.04
+          os: ubuntu-22.04
         - python-version: '3.9'
           pyarrow-version: 16.0.0
         - os: windows-latest


### PR DESCRIPTION
We got a warning, so we're bumping the runner image from 20.04 to 22.04. 
```
 The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

March 4 14:00 UTC – 22:00 UTC
March 11 13:00 UTC – 21:00 UTC
March 18 13:00 UTC – 21:00 UTC
March 25 13:00 UTC – 21:00 UTC
What you need to do

Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the runner images repository. Please contact GitHub Support if you run into any problems or need help.
```
