### PR TITLE
fix: unity managed table reads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ To set up your development environment:
 ### Developing
 
 1. `make build`: recompile your code after modifying any Rust code in `src/`
-2. `make test`: run tests
-3. `DAFT_RUNNER=ray make test`: set the runner to the Ray runner and run tests (DAFT_RUNNER defaults to `py`)
+2. `DAFT_RUNNER=py make test`: run tests
+3. `DAFT_RUNNER=ray make test`: set the runner to the Ray runner and run tests
 4. `make docs`: build and serve docs
 
 ### Developing with Ray

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ To set up your development environment:
 ### Developing
 
 1. `make build`: recompile your code after modifying any Rust code in `src/`
-2. `DAFT_RUNNER=py make test`: run tests
+2. `DAFT_RUNNER=native make test`: run tests
 3. `DAFT_RUNNER=ray make test`: set the runner to the Ray runner and run tests
 4. `make docs`: build and serve docs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ When proposing features, please include:
 
 To set up your development environment:
 
-1. Ensure that your system has a suitable Python version installed (>=3.7, <=3.11)
+1. Ensure that your system has a suitable Python version installed (>=3.9, <=3.11)
 2. [Install the Rust compilation toolchain](https://www.rust-lang.org/tools/install)
 3. Clone the Daft repo: `git clone git@github.com:Eventual-Inc/Daft.git`
 4. Run `make .venv` from your new cloned Daft repository to create a new virtual environment with all of Daft's development dependencies installed

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import warnings
-from typing import Callable
+from typing import Callable, Literal
 from urllib.parse import urlparse
 
 import unitycatalog
@@ -91,14 +91,14 @@ class UnityCatalog:
         return self._paginate_to_completion(_paginated_list_tables)
 
     def load_table(
-        self, table_name: str, new_table_storage_path: str | None = None, intent: str = "READ_WRITE"
+        self, table_name: str, new_table_storage_path: str | None = None, mode: Literal["r"|"rw"] = "rw"
     ) -> UnityCatalogTable:
         """Loads an existing Unity Catalog table. If the table is not found, and information is provided in the method to create a new table, a new table will be attempted to be registered.
 
         Args:
             table_name (str): Name of the table in Unity Catalog in the form of dot-separated, 3-level namespace
             new_table_storage_path (str, optional): Cloud storage path URI to register a new external table using this path. Unity Catalog will validate if the path is valid and authorized for the principal, else will raise an exception.
-            intent (str, optional): The intended use of the table, which impacts authorization. Defaults to "READ_WRITE", else can be "READ".
+            mode (Literal["r", "rw"], optional): The intended use of the table, which impacts authorization. Defaults to "rw".
 
         Returns:
             UnityCatalogTable
@@ -140,7 +140,8 @@ class UnityCatalog:
         table_id = table_info.table_id
         storage_location = table_info.storage_location
         # Grab credentials from Unity catalog and place it into the Table
-        temp_table_credentials = self._client.temporary_table_credentials.create(operation=intent, table_id=table_id)
+        operation = "READ" if mode == "r" else "READ_WRITE"
+        temp_table_credentials = self._client.temporary_table_credentials.create(operation=operation, table_id=table_id)
 
         scheme = urlparse(storage_location).scheme
         if scheme == "s3" or scheme == "s3a":

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -91,7 +91,10 @@ class UnityCatalog:
         return self._paginate_to_completion(_paginated_list_tables)
 
     def load_table(
-        self, table_name: str, new_table_storage_path: str | None = None, operation: Literal["READ"|"READ_WRITE"] = "READ_WRITE"
+        self,
+        table_name: str,
+        new_table_storage_path: str | None = None,
+        operation: Literal["READ" | "READ_WRITE"] = "READ_WRITE",
     ) -> UnityCatalogTable:
         """Loads an existing Unity Catalog table. If the table is not found, and information is provided in the method to create a new table, a new table will be attempted to be registered.
 

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -90,12 +90,15 @@ class UnityCatalog:
 
         return self._paginate_to_completion(_paginated_list_tables)
 
-    def load_table(self, table_name: str, new_table_storage_path: str | None = None) -> UnityCatalogTable:
+    def load_table(
+        self, table_name: str, new_table_storage_path: str | None = None, intent: str = "READ_WRITE"
+    ) -> UnityCatalogTable:
         """Loads an existing Unity Catalog table. If the table is not found, and information is provided in the method to create a new table, a new table will be attempted to be registered.
 
         Args:
             table_name (str): Name of the table in Unity Catalog in the form of dot-separated, 3-level namespace
             new_table_storage_path (str, optional): Cloud storage path URI to register a new external table using this path. Unity Catalog will validate if the path is valid and authorized for the principal, else will raise an exception.
+            intent (str, optional): The intended use of the table, which impacts authorization. Defaults to "READ_WRITE", else can be "READ".
 
         Returns:
             UnityCatalogTable
@@ -137,9 +140,7 @@ class UnityCatalog:
         table_id = table_info.table_id
         storage_location = table_info.storage_location
         # Grab credentials from Unity catalog and place it into the Table
-        temp_table_credentials = self._client.temporary_table_credentials.create(
-            operation="READ_WRITE", table_id=table_id
-        )
+        temp_table_credentials = self._client.temporary_table_credentials.create(operation=intent, table_id=table_id)
 
         scheme = urlparse(storage_location).scheme
         if scheme == "s3" or scheme == "s3a":

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -101,7 +101,7 @@ class UnityCatalog:
         Args:
             table_name (str): Name of the table in Unity Catalog in the form of dot-separated, 3-level namespace
             new_table_storage_path (str, optional): Cloud storage path URI to register a new external table using this path. Unity Catalog will validate if the path is valid and authorized for the principal, else will raise an exception.
-            mode ("READ" or "READ_WRITE", optional): The intended use of the table, which impacts authorization. Defaults to "READ_WRITE".
+            operation ("READ" or "READ_WRITE", optional): The intended use of the table, which impacts authorization. Defaults to "READ_WRITE".
 
         Returns:
             UnityCatalogTable

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -91,14 +91,14 @@ class UnityCatalog:
         return self._paginate_to_completion(_paginated_list_tables)
 
     def load_table(
-        self, table_name: str, new_table_storage_path: str | None = None, mode: Literal["r"|"rw"] = "rw"
+        self, table_name: str, new_table_storage_path: str | None = None, operation: Literal["READ"|"READ_WRITE"] = "READ_WRITE"
     ) -> UnityCatalogTable:
         """Loads an existing Unity Catalog table. If the table is not found, and information is provided in the method to create a new table, a new table will be attempted to be registered.
 
         Args:
             table_name (str): Name of the table in Unity Catalog in the form of dot-separated, 3-level namespace
             new_table_storage_path (str, optional): Cloud storage path URI to register a new external table using this path. Unity Catalog will validate if the path is valid and authorized for the principal, else will raise an exception.
-            mode (Literal["r", "rw"], optional): The intended use of the table, which impacts authorization. Defaults to "rw".
+            mode ("READ" or "READ_WRITE", optional): The intended use of the table, which impacts authorization. Defaults to "READ_WRITE".
 
         Returns:
             UnityCatalogTable
@@ -140,7 +140,6 @@ class UnityCatalog:
         table_id = table_info.table_id
         storage_location = table_info.storage_location
         # Grab credentials from Unity catalog and place it into the Table
-        operation = "READ" if mode == "r" else "READ_WRITE"
         temp_table_credentials = self._client.temporary_table_credentials.create(operation=operation, table_id=table_id)
 
         scheme = urlparse(storage_location).scheme


### PR DESCRIPTION
Allow user to indicate if they only intend to read a table so that read-only credentials can be obtained from Unity where read-write credential requests would be rejected. Addresses Issue #3708 