### PR TITLE
perf(optimizer): Infer additional join graph edges during join reordering

### DIFF
--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -903,11 +903,18 @@ mod tests {
         // - a <-> b
         // - c <-> d
         // - a <-> d
-        assert!(join_graph.num_edges() == 3);
+        // Plus 3 inferred edges:
+        // - a <-> c
+        // - b <-> c
+        // - b <-> d
+        assert!(join_graph.num_edges() == 6);
         assert!(join_graph.contains_edges(vec![
             "Source(a) <-> Source(b)",
             "Project(c) <-> Source(d)",
-            "Source(a) <-> Source(d)"
+            "Source(a) <-> Source(d)",
+            "Source(a) <-> Project(c)", // Inferred edge.
+            "Source(b) <-> Project(c)", // Inferred edge.
+            "Source(b) <-> Source(d)",  // Inferred edge.
         ]));
     }
 
@@ -974,11 +981,18 @@ mod tests {
         // - a <-> b
         // - c <-> d
         // - b <-> d
-        assert!(join_graph.num_edges() == 3);
+        // Plus 3 inferred edges:
+        // - a <-> c
+        // - b <-> c
+        // - b <-> d
+        assert!(join_graph.num_edges() == 6);
         assert!(join_graph.contains_edges(vec![
             "Source(a) <-> Source(b)",
             "Project(c) <-> Source(d)",
             "Source(b) <-> Source(d)",
+            "Source(a) <-> Project(c)", // Inferred edge.
+            "Source(b) <-> Project(c)", // Inferred edge.
+            "Source(b) <-> Source(d)",  // Inferred edge.
         ]));
     }
 
@@ -1038,10 +1052,13 @@ mod tests {
         // There should be edges between:
         // - a_beta <-> b
         // - a_beta <-> c
-        assert!(join_graph.num_edges() == 2);
+        // Plus 1 inferred edge:
+        // - b <-> c
+        assert!(join_graph.num_edges() == 3);
         assert!(join_graph.contains_edges(vec![
             "Project(a_beta) <-> Source(b)",
             "Project(a_beta) <-> Source(c)",
+            "Source(b) <-> Source(c)", // Inferred edge.
         ]));
     }
 
@@ -1109,11 +1126,18 @@ mod tests {
         // - a <-> b
         // - c <-> d
         // - a <-> d
-        assert!(join_graph.num_edges() == 3);
+        // Plus 3 inferred edges:
+        // - a <-> c
+        // - b <-> c
+        // - b <-> d
+        assert!(join_graph.num_edges() == 6);
         assert!(join_graph.contains_edges(vec![
             "Source(a) <-> Source(b)",
             "Project(c) <-> Source(d)",
-            "Source(a) <-> Source(d)"
+            "Source(a) <-> Source(d)",
+            "Source(a) <-> Project(c)", // Inferred edge.
+            "Source(b) <-> Project(c)", // Inferred edge.
+            "Source(b) <-> Source(d)",  // Inferred edge.
         ]));
     }
 
@@ -1199,11 +1223,18 @@ mod tests {
         // - a <-> b
         // - c <-> d
         // - a <-> d
-        assert!(join_graph.num_edges() == 3);
+        // Plus 3 inferred edges:
+        // - a <-> c
+        // - b <-> c
+        // - b <-> d
+        assert!(join_graph.num_edges() == 6);
         assert!(join_graph.contains_edges(vec![
             "Source(a) <-> Source(b)",
             "Filter(c) <-> Source(d)",
             "Source(a) <-> Source(d)",
+            "Source(a) <-> Filter(c)", // Inferred edge.
+            "Source(b) <-> Filter(c)", // Inferred edge.
+            "Source(b) <-> Source(d)", // Inferred edge.
         ]));
         // Check for non-join projections and filters at the end.
         // The join graph should only keep track of projections and filters that sit between joins.
@@ -1287,11 +1318,18 @@ mod tests {
         // - a <-> b
         // - c <-> d
         // - a <-> d
-        assert!(join_graph.num_edges() == 3);
+        // Plus 3 inferred edges:
+        // - a <-> c
+        // - b <-> c
+        // - b <-> d
+        assert!(join_graph.num_edges() == 6);
         assert!(join_graph.contains_edges(vec![
             "Aggregate(a) <-> Source(b)",
             "Project(c) <-> Source(d)",
-            "Aggregate(a) <-> Source(d)"
+            "Aggregate(a) <-> Source(d)",
+            "Aggregate(a) <-> Project(c)", // Inferred edge.
+            "Source(b) <-> Project(c)",    // Inferred edge.
+            "Source(b) <-> Source(d)",     // Inferred edge.
         ]));
         // Projections below the aggregation should not be part of the final projections.
         assert!(!join_graph.contains_projections_and_filters(vec![&a_proj]));

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
@@ -13,7 +13,7 @@ impl NaiveLeftDeepJoinOrderer {
         }
         for (index, candidate_node_id) in available.iter().enumerate() {
             let right = JoinOrderTree::Relation(*candidate_node_id, 0);
-            let connections = graph.adj_list.get_connections(&current_order, &right);
+            let (connections, _) = graph.adj_list.get_connections(&current_order, &right);
             if !connections.is_empty() {
                 let new_order = current_order.join(right, connections, 0);
                 available.remove(index);

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -688,7 +688,8 @@ impl ScanTask {
                 // Assume that filters filter out about 80% of the data
                 let estimated_selectivity =
                     self.pushdowns.estimated_selectivity(self.schema.as_ref());
-                approx_total_num_rows_before_pushdowns * estimated_selectivity
+                // Set the lower bound approximated number of rows to 1 to avoid underestimation.
+                (approx_total_num_rows_before_pushdowns * estimated_selectivity).max(1.0)
             } else if let Some(limit) = self.pushdowns.limit {
                 (limit as f64).min(approx_total_num_rows_before_pushdowns)
             } else {


### PR DESCRIPTION
There are three missing pieces with our join ordering implementation:
1. Infer additional join graph edges from existing edges. For example, if we have (A.x join B.x) and (B.x join C.x), then we infer (A.x join C.x). Additionally, in the absence of NDV stats, the total domain for these three columns (A.x, B.x, C.x) should be the minimal value of |A|, |B|, |C|.
2. Adjust total domain computation from `total domain = |size of relation|` to `total domain = |size of relation| / (selectivity of relation)`. `|size of relation|` does not reflect the true total domain of a join because filters reduce the size of the relation despite not affecting the selectivity of the join (assuming a primary key - foreign key join, and independence between join keys).
3. Set the lower bound estimation for the number of rows per scan task to 1. This prevents us from underestimating the number of rows for selective predicates.

Combining these three changes allows us to speed up TPC-H queries.