### PR TITLE
fix: create series of np.datetime64['D']

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -82,6 +82,12 @@ class Series:
             pys = PySeries.from_pylist(name, data, pyobj=pyobj)
             return Series._from_pyseries(pys)
 
+        # Workaround: wrap list of np.datetime64 in an np.array
+        #   - https://github.com/apache/arrow/issues/40580
+        #   - https://github.com/Eventual-Inc/Daft/issues/3826
+        if data and isinstance(data[0], np.datetime64):
+            data = np.array(data)
+
         try:
             arrow_array = pa.array(data)
             return Series.from_arrow(arrow_array, name=name)

--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -202,3 +202,52 @@ def test_series_bincode_serdes_on_null_types() -> None:
     assert s.name() == copied_s.name()
     assert s.datatype() == copied_s.datatype()
     assert s.to_pylist() == copied_s.to_pylist()
+
+
+def test_series_numpy_datetime64_datetime():
+    from datetime import datetime
+
+    py_datetimes = [
+        datetime(2020, 10, 1, 12, 30, 45),
+        datetime(2021, 10, 2, 13, 31, 46),
+        datetime(2022, 10, 3, 14, 32, 47),
+        datetime(2023, 10, 4, 15, 33, 48),
+        datetime(2024, 10, 5, 16, 34, 49),
+        datetime(2025, 10, 6, 17, 35, 50),
+    ]
+    for format_ in ["s", "ms", "us", "ns"]:
+        list_from_datetimes = [np.datetime64(dt, format_) for dt in py_datetimes]
+        # test from_pylist
+        s1 = Series.from_pylist(list_from_datetimes)
+        assert s1.to_pylist() == py_datetimes
+        # test from_numpy
+        s2 = Series.from_numpy(np.array(list_from_datetimes))
+        assert s2.to_pylist() == py_datetimes
+
+
+def test_series_numpy_datetime64_date():
+    from datetime import datetime
+
+    py_datetimes = [
+        datetime(2020, 10, 1, 12, 30, 45),
+        datetime(2021, 10, 2, 13, 31, 46),
+        datetime(2022, 10, 3, 14, 32, 47),
+        datetime(2023, 10, 4, 15, 33, 48),
+        datetime(2024, 10, 5, 16, 34, 49),
+        datetime(2025, 10, 6, 17, 35, 50),
+    ]
+    py_dates = [dt.date() for dt in py_datetimes]
+    for format_ in ["D"]:
+        # make list of numpy datetime64
+        list_from_datetimes = [np.datetime64(dt, format_) for dt in py_datetimes]
+        list_from_dates = [np.datetime64(d, format_) for d in py_dates]
+        # test from_pylist
+        s1 = Series.from_pylist(list_from_datetimes)
+        s2 = Series.from_pylist(list_from_dates)
+        assert s1.to_pylist() == py_dates
+        assert s2.to_pylist() == py_dates
+        # test from_numpy
+        s3 = Series.from_numpy(np.array(list_from_datetimes))
+        s4 = Series.from_numpy(np.array(list_from_dates))
+        assert s3.to_pylist() == py_dates
+        assert s4.to_pylist() == py_dates


### PR DESCRIPTION
We are unable to construct a series from a python list of numpy datetime64['D'] because this is not supported by pyarrow. I was able to find an easy workaround by turning the list into a numpy array first.

**Tests**

I've added tests for the customers use-case along with other datetime types. Testing with both from_pylist and from_numpy was how I discovered the easy solution.

**Context**

* https://github.com/Eventual-Inc/Daft/issues/3826
* https://github.com/apache/arrow/issues/40580

**Example**

```python
# py list of np datetime64
data = [np.datetime64(datetime.now(), "D") for _ in range(10)]

# err! cannot create a pyarrow array from the list
# pa.array(data, type=pa_dtype)

data2 = np.array(data) # wrap with np.array and it works
print(pa.array(data2))

[
  2025-02-19,
  2025-02-19,
  2025-02-19,
  2025-02-19,
  2025-02-19,
  2025-02-19,
  2025-02-19,
  2025-02-19,
  2025-02-19,
  2025-02-19
]
```

