### PR TITLE
fix: Grab Daft config from environment variables for new contexts

### DIFF
--- a/src/daft-context/src/lib.rs
+++ b/src/daft-context/src/lib.rs
@@ -45,6 +45,15 @@ pub struct Config {
     pub planning: Arc<DaftPlanningConfig>,
 }
 
+impl Config {
+    pub fn from_env() -> Self {
+        Self {
+            execution: Arc::new(DaftExecutionConfig::from_env()),
+            planning: Arc::new(DaftPlanningConfig::from_env()),
+        }
+    }
+}
+
 #[cfg(feature = "python")]
 impl ContextState {
     /// Retrieves the runner.
@@ -170,7 +179,7 @@ pub fn get_context() -> DaftContext {
         Some(ctx) => ctx.clone(),
         None => {
             let state = ContextState {
-                config: Default::default(),
+                config: Config::from_env(),
                 runner: None,
             };
             let state = RwLock::new(state);


### PR DESCRIPTION
This PR makes it so that we call the `from_env` methods for `DaftExecutionConfig` and `DaftPlanningConfig` when creating a new context.