### PR TITLE
docs: Update configuration docs to show `set_runner_native`

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -67,6 +67,20 @@ def set_runner_ray(
     max_task_backlog: int | None = None,
     force_client_mode: bool = False,
 ) -> DaftContext:
+    """Configure Daft to execute dataframes using the Ray distributed computing framework.
+
+    Args:
+        address: Ray cluster address to connect to. If None, connects to or starts a local Ray instance.
+        noop_if_initialized: If True, skip initialization if Ray is already running.
+        max_task_backlog: Maximum number of tasks that can be queued. None means Daft will automatically determine a good default.
+        force_client_mode: If True, forces Ray to run in client mode.
+
+    Returns:
+        DaftContext: Updated Daft execution context configured for Ray.
+
+    Note:
+        Can also be configured via environment variable: DAFT_RUNNER=ray
+    """
     py_ctx = _set_runner_ray(
         address=address,
         noop_if_initialized=noop_if_initialized,
@@ -78,12 +92,21 @@ def set_runner_ray(
 
 
 def set_runner_py(use_thread_pool: bool | None = None) -> DaftContext:
-    """Set the runner for executing Daft dataframes to your local Python interpreter - this is the default behavior.
+    """Configure Daft to execute dataframes in the local Python interpreter.
 
-    Alternatively, users can set this behavior via an environment variable: DAFT_RUNNER=py
+    Args:
+        use_thread_pool: If True, uses a thread pool for parallel execution.
+            If False, runs single-threaded. If None, uses system default.
 
     Returns:
-        DaftContext: Daft context after setting the Py runner
+        DaftContext: Updated Daft execution context configured for local Python.
+
+    Note:
+        Can also be configured via environment variable: DAFT_RUNNER=py
+
+    Deprecated:
+        This execution mode is deprecated. Use set_runner_native() instead for
+        improved local performance with native multi-threading.
     """
     py_ctx = _set_runner_py(
         use_thread_pool=use_thread_pool,
@@ -93,12 +116,15 @@ def set_runner_py(use_thread_pool: bool | None = None) -> DaftContext:
 
 
 def set_runner_native() -> DaftContext:
-    """Set the runner for executing Daft dataframes to the native runner.
+    """Configure Daft to execute dataframes using native multi-threaded processing.
 
-    Alternatively, users can set this behavior via an environment variable: DAFT_RUNNER=native
+    This is the default execution mode for Daft.
 
     Returns:
-        DaftContext: Daft context after setting the native runner
+        DaftContext: Updated Daft execution context configured for native execution.
+
+    Note:
+        Can also be configured via environment variable: DAFT_RUNNER=native
     """
     py_ctx = _set_runner_native()
 

--- a/docs/mkdocs/advanced/memory.md
+++ b/docs/mkdocs/advanced/memory.md
@@ -41,7 +41,7 @@ While Daft is built to be extremely memory-efficient, there will inevitably be s
 
 Even with object spilling enabled, you may still sometimes see errors indicating OOMKill behavior on various levels such as your operating system, Ray or a higher-level cluster orchestrator such as Kubernetes:
 
-1. On the local PyRunner, you may see that your operating system kills the process with an error message `OOMKilled`.
+1. On the local runner, you may see that your operating system kills the process with an error message `OOMKilled`.
 
 2. On the RayRunner, you may notice Ray logs indicating that workers are aggressively being killed by the Raylet with log messages such as: `Workers (tasks / actors) killed due to memory pressure (OOM)`
 

--- a/docs/mkdocs/integrations/iceberg.md
+++ b/docs/mkdocs/integrations/iceberg.md
@@ -4,7 +4,7 @@
 
 Daft currently natively supports:
 
-1. **Distributed Reads:** Daft will fully distribute the I/O of reads over your compute resources (whether Ray or on multithreading on the local PyRunner)
+1. **Distributed Reads:** Daft will fully distribute the I/O of reads over your compute resources (whether Ray or on local multithreading)
 2. **Skipping Filtered Data:** Daft uses [`df.where(...)`](../{{ api_path }}/dataframe_methods/daft.DataFrame.where.html) filter calls to only read data that matches your predicates
 3. **All Catalogs From PyIceberg:** Daft is natively integrated with PyIceberg, and supports all the catalogs that PyIceberg does
 

--- a/docs/mkdocs/resources/architecture.md
+++ b/docs/mkdocs/resources/architecture.md
@@ -65,7 +65,7 @@ These modules can also be understood as:
 2. **PhysicalPlan:** how to run it
 3. **Runner:** when and where to run it
 
-By default, Daft runs on the PyRunner which uses Python multithreading as its backend. Daft also includes other runners including the RayRunner which can run the PhysicalPlan on a distributed Ray cluster.
+By default, Daft runs on the Native Runner which uses native multithreading as its backend. Daft also includes other runners including the RayRunner which can run the PhysicalPlan on a distributed Ray cluster.
 
 ## DataFrame Partitioning
 

--- a/docs/sphinx/source/configs.rst
+++ b/docs/sphinx/source/configs.rst
@@ -10,7 +10,7 @@ Control the execution backend that Daft will run on by calling these functions o
     :nosignatures:
     :toctree: doc_gen/configuration_functions
 
-    daft.context.set_runner_py
+    daft.context.set_runner_native
     daft.context.set_runner_ray
 
 Setting configurations

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -32,7 +32,21 @@ print(daft.context.get_context()._runner.name)
         assert result.stdout.decode().strip() == "None\npy"
 
 
-def test_implicit_set_runner_py():
+def test_explicit_set_runner_native():
+    """Test that a freshly imported context doesn't have a runner config set and can be set explicitly to Native."""
+    explicit_set_runner_script_native = """
+import daft
+print(daft.context.get_context()._runner)
+daft.context.set_runner_native()
+print(daft.context.get_context()._runner.name)
+    """
+
+    with with_null_env():
+        result = subprocess.run([sys.executable, "-c", explicit_set_runner_script_native], capture_output=True)
+        assert result.stdout.decode().strip() == "None\nnative"
+
+
+def test_implicit_set_runner_native():
     """Test that a freshly imported context doesn't have a runner config set and can be set implicitly to Python."""
     implicit_set_runner_script = """
 import daft
@@ -43,7 +57,7 @@ print(daft.context.get_context()._runner.name)
 
     with with_null_env():
         result = subprocess.run([sys.executable, "-c", implicit_set_runner_script], capture_output=True)
-        assert result.stdout.decode().strip() == "None\npy" or result.stdout.decode().strip() == "None\nnative"
+        assert result.stdout.decode().strip() == "None\nnative"
 
 
 def test_explicit_set_runner_ray():

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -47,7 +47,7 @@ print(daft.context.get_context()._runner.name)
 
 
 def test_implicit_set_runner_native():
-    """Test that a freshly imported context doesn't have a runner config set and can be set implicitly to Python."""
+    """Test that a freshly imported context doesn't have a runner config set and is set implicitly to Native."""
     implicit_set_runner_script = """
 import daft
 print(daft.context.get_context()._runner)

--- a/tutorials/intro.ipynb
+++ b/tutorials/intro.ipynb
@@ -165,8 +165,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## Use the Python multithreaded local runner (default behavior)\n",
-    "# daft.context.set_runner_py()\n",
+    "## Use the Native multithreaded local runner (default behavior)\n",
+    "# daft.context.set_runner_native()\n",
     "\n",
     "## Connect to a Ray cluster and use the Ray runner\n",
     "# daft.context.set_runner_ray(address=\"ray://...\")"

--- a/tutorials/talks_and_demos/linkedin-03-05-2024.ipynb
+++ b/tutorials/talks_and_demos/linkedin-03-05-2024.ipynb
@@ -233,8 +233,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## Use the Python multithreaded local runner (default behavior)\n",
-    "# daft.context.set_runner_py()\n",
+    "## Use the Native multithreaded local runner (default behavior)\n",
+    "# daft.context.set_runner_native()\n",
     "\n",
     "## Connect to a Ray cluster and use the Ray runner\n",
     "# daft.context.set_runner_ray(address=\"ray://...\")"

--- a/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -108,8 +108,6 @@
    "source": [
     "import daft\n",
     "\n",
-    "daft.context.set_runner_py(use_thread_pool=False)\n",
-    "\n",
     "parquet_df = daft.read_parquet(PARQUET_PATH, io_config=IO_CONFIG)"
    ]
   },


### PR DESCRIPTION
Edit the configuration docs to show `set_runner_native` instead of the pyrunner. Additionally combed through our docs to replace any instances of the pyrunner with the native runner.

<img width="839" alt="Screenshot 2025-02-19 at 3 42 45 PM" src="https://github.com/user-attachments/assets/a7bac309-505a-4c12-9d70-522185bb16f2" />
