### PR TITLE
fix: Add excludes to broken link checker

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -22,7 +22,7 @@ jobs:
         retry_wait_seconds: 60
         max_attempts: 3
         retry_on: error
-        command: blc https://www.getdaft.io -ro --exclude www.pytorch.org/ --exclude https://github.com/Eventual-Inc/Daft/ --exclude https://twitter.com/daft_dataframe --exclude https://www.linkedin.com/company/eventualcomputing/
+        command: blc https://www.getdaft.io -ro --exclude www.pytorch.org/ --exclude https://github.com/Eventual-Inc/Daft/ --exclude https://twitter.com/daft_dataframe --exclude https://www.linkedin.com/company/eventualcomputing/ --exclude https://x.com/daft_dataframe --exclude https://www.linkedin.com/showcase/daft-dataframe/ --exclude https://scarf.sh/ --exclude https://static.scarf.sh/*
   notify_on_failure:
     runs-on: self-hosted
     if: failure()

--- a/docs/mkdocs/migration/dask_migration.md
+++ b/docs/mkdocs/migration/dask_migration.md
@@ -109,7 +109,7 @@ You can use User-Defined Functions (UDFs) to run computations over multiple rows
 
 Dask offers some distributed Machine Learning functionality through the [dask-ml library](https://ml.dask.org/). This library provides parallel implementations of a few common scikit-learn algorithms. Note that `dask-ml` is not a core Dask library and is not as actively maintained. It also does not offer support for deep-learning algorithms or neural networks.
 
-Daft is built as a DataFrame API for distributed Machine learning. You can use Daft UDFs to apply Machine Learning tasks to the data stored in your Daft DataFrame, including deep learning algorithms from libraries like PyTorch. See [our Quickstart](../10min.ipynb) for a toy example.
+Daft is built as a DataFrame API for distributed Machine learning. You can use Daft UDFs to apply Machine Learning tasks to the data stored in your Daft DataFrame, including deep learning algorithms from libraries like PyTorch. See [our Quickstart](../quickstart.md) for a toy example.
 
 ## Daft supports Multimodal Data Types
 

--- a/docs/mkdocs/migration/dask_migration.md
+++ b/docs/mkdocs/migration/dask_migration.md
@@ -109,7 +109,7 @@ You can use User-Defined Functions (UDFs) to run computations over multiple rows
 
 Dask offers some distributed Machine Learning functionality through the [dask-ml library](https://ml.dask.org/). This library provides parallel implementations of a few common scikit-learn algorithms. Note that `dask-ml` is not a core Dask library and is not as actively maintained. It also does not offer support for deep-learning algorithms or neural networks.
 
-Daft is built as a DataFrame API for distributed Machine learning. You can use Daft UDFs to apply Machine Learning tasks to the data stored in your Daft DataFrame, including deep learning algorithms from libraries like PyTorch. See [our Quickstart](../quickstart.md) for a toy example.
+Daft is built as a DataFrame API for distributed Machine learning. You can use Daft UDFs to apply Machine Learning tasks to the data stored in your Daft DataFrame, including deep learning algorithms from libraries like PyTorch. See our [MNIST Digit Classification tutorial](../resources/tutorials.md#mnist-digit-classification) for an example.
 
 ## Daft supports Multimodal Data Types
 


### PR DESCRIPTION
Exclude a bunch of external links from the broken link checker, e.g. x.com, scarf, linkedin, etc.