### PR TITLE
fix: Reduce number of nodes in random join graph test

### DIFF
--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
@@ -175,7 +175,7 @@ mod tests {
         edges
     }
 
-    const NUM_RANDOM_NODES: usize = 100;
+    const NUM_RANDOM_NODES: usize = 10;
 
     #[test]
     fn test_order_random_join_graph() {


### PR DESCRIPTION
The random graph generator for testing join graph creation occasionally runs into a stack overflow. We reduce the size of the test case to avoid this.