### PR TITLE
fix: apply derived aliases to resolved tables without explicit aliases

### DIFF
--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -822,18 +822,18 @@ impl<'a> SQLPlanner<'a> {
                     self.plan_relation_table(name)?
                 };
 
-                // we require all logical plans to be named, apply the name from the identifier used to resolve this relation.
-                let alias = if let Some(alias) = alias {
-                    Some(alias.clone())
-                } else {
+                // we require all logical plans to be named, apply the name from the identifier used to resolve this table.
+                let alias = alias.clone().or_else(|| {
                     let name = name
                         .0
                         .last()
-                        .expect("table name must have at least 1 identifier part")
+                        .expect("table name must have at least one identifier")
                         .clone();
-                    let columns = vec![];
-                    Some(TableAlias { name, columns })
-                };
+                    Some(TableAlias {
+                        name,
+                        columns: vec![],
+                    })
+                });
 
                 (plan, alias)
             }
@@ -996,6 +996,7 @@ impl<'a> SQLPlanner<'a> {
         if let Some(parent) = self.parent {
             parent.plan_identifier(idents)
         } else {
+            // err: "column <col> not found in current scope"
             column_not_found_err!(full_name, "current scope")
         }
     }


### PR DESCRIPTION
Small PR to patch something encountered by https://github.com/Eventual-Inc/Daft/pull/3825 where the planner would resolve a table name to a logical plan, but the plan would need to be wrapped in a SubqueryAlias.

This was handled before by [wrapping all logical plans in a SubqueryAlias when they were registered to the session](https://github.com/Eventual-Inc/Daft/commit/8c6e5b1407893d1a59add399d62a716e8ab27558#diff-b7d5555f4ccf802aac2f60ff51d0e0da0b49bea897f16cf299783c249184d7ffR91), which works for the current situation where logical plan builders are held in the session.

Now that tables and plans are being provided externally via a `get_logical_plan` which could be implemented in any way, we apply the name on resolution in the planner. This means a customer does not need to be aware of wrapping their logical plans in a SubqueryAlias when producing a relation and these name resolution requirements are contained to planner.rs

Wrapping before makes us have a double SubqueryAlias wrap which resolves things that should be errors, and doesn't allow us to re-assign an alias.

```python
# this should err but does not since `df2` is not a valid binding, it's been aliased
daft.sql("select * from df1, df2 as x where df2.y = 'u'", catalog).show()

# this does not error
daft.sql("select * from df1 as df2, df2 as df1", catalog).show()


# this will error because "DaftError::ValueError Plan must not have duplicate aliases in the same scope, found: df1"
# it should succeed since we have two valid aliases, https://www.db-fiddle.com/f/ozA9JfdWG49iipkvk9JdER/0
daft.sql("select df1.y from df1 as df2, df2 as df1", catalog).show()
```

