### PR TITLE
fix: LogicalPlan::get_schema_for_alias should stop when it hits any alias

### DIFF
--- a/src/daft-logical-plan/src/logical_plan.rs
+++ b/src/daft-logical-plan/src/logical_plan.rs
@@ -453,16 +453,16 @@ impl LogicalPlan {
         let mut schema = None;
 
         self.apply(|node| {
-            if let Self::SubqueryAlias(SubqueryAlias { name, .. }) = node.as_ref()
-                && name.as_ref() == alias
-            {
-                if schema.is_some() {
-                    return Err(DaftError::ValueError(format!(
-                        "Plan must not have duplicate aliases in the same scope, found: {alias}"
-                    )));
-                }
+            if let Self::SubqueryAlias(SubqueryAlias { name, .. }) = node.as_ref() {
+                if name.as_ref() == alias {
+                    if schema.is_some() {
+                        return Err(DaftError::ValueError(format!(
+                            "Plan must not have duplicate aliases in the same scope, found: {alias}"
+                        )));
+                    }
 
-                schema = Some(node.schema());
+                    schema = Some(node.schema());
+                }
 
                 Ok(TreeNodeRecursion::Jump)
             } else {


### PR DESCRIPTION
This fixes an issue where a nested alias is retrieved from a place where it is out of scope:
```sql
SELECT tbl.x FROM (SELECT * FROM tbl) AS tbl2  -- should fail but does not
```
Now, we can have nested subquery aliases without issue, so I've simplified `SQLPlanner::plan_relation` as per discussion in #3846 (this PR should be merged instead of that one)