### PR TITLE
fix: Update dashboard import

### DIFF
--- a/daft/dashboard.py
+++ b/daft/dashboard.py
@@ -81,13 +81,13 @@ def _broadcast_query_plan(
 
 try:
     dashboard = dashboard_module()
-    from dashboard import cli, launch, shutdown
+    launch = dashboard.launch
+    shutdown = dashboard.shutdown
 
-    # re-export all of the symbols defined inside of `daft_dashboard`
+    # re-export some symbols defined inside of `daft_dashboard`
     __all__ = [
-        "cli",
         "launch",
         "shutdown",
     ]
 except Exception:
-    ...
+    pass

--- a/daft_dashboard/daft_dashboard/__init__.py
+++ b/daft_dashboard/daft_dashboard/__init__.py
@@ -57,7 +57,7 @@ def shutdown(noop_if_shutdown: bool = False):
     native.shutdown(noop_if_shutdown=noop_if_shutdown)
 
 
-def cli():
+def _cli():
     """Runs the Daft dashboard CLI."""
     import sys
 

--- a/daft_dashboard/pyproject.toml
+++ b/daft_dashboard/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.9"
 version = "0.1.0"
 
 [project.scripts]
-daft-dashboard = "daft_dashboard:cli"
+daft-dashboard = "daft_dashboard:_cli"
 
 [tool.maturin]
 features = ["python"]


### PR DESCRIPTION
# Overview

This PR fixes how dashboard imports work. The previous method threw type errors. This PR also changes the name of the `cli` function to `_cli`.