### PR TITLE
feat: Enable capturing and broadcasting logs when running on the `Native` runner

### DIFF
--- a/daft/dashboard.py
+++ b/daft/dashboard.py
@@ -82,10 +82,7 @@ log_capturer = None
 
 
 def _get_logs():
-    if not log_capturer:
-        return ""
-
-    return log_capturer.buffer
+    return log_capturer.buffer if log_capturer else ""
 
 
 try:

--- a/daft/dashboard.py
+++ b/daft/dashboard.py
@@ -70,7 +70,6 @@ def broadcast_query_information(
     plan_time_end: datetime,
 ):
     dashboard = _dashboard_module()
-
     dashboard.broadcast_query_information(
         mermaid_plan=mermaid_plan,
         plan_time_start=plan_time_start,

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -95,6 +95,10 @@ def to_logical_plan_builder(*parts: MicroPartition) -> LogicalPlanBuilder:
     )
 
 
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
 class DataFrame:
     """A Daft DataFrame is a table of data.
 
@@ -160,24 +164,24 @@ class DataFrame:
         else:
             return self._result_cache.value
 
-    def _broadcast_query_plan(self):
+    def _broadcast_query_plan(self, plan_time_start: datetime, plan_time_end: datetime):
         from daft.dataframe.display import MermaidFormatter
 
-        if not dashboard._should_run():
+        if not dashboard.should_run():
             return
 
         is_cached = self._result_cache is not None
-        plan_time_start = datetime.now(timezone.utc)
         mermaid_plan: str = MermaidFormatter(
-            builder=self.__builder, show_all=True, simple=False, is_cached=is_cached
+            builder=self.__builder,
+            show_all=True,
+            simple=False,
+            is_cached=is_cached,
         )._repr_markdown_()
-        plan_time_end = datetime.now(timezone.utc)
 
         dashboard.broadcast_query_information(
             mermaid_plan=mermaid_plan,
             plan_time_start=plan_time_start,
             plan_time_end=plan_time_end,
-            logs=dashboard.nlb.buffer,
         )
 
     @DataframePublicAPI
@@ -2868,8 +2872,11 @@ class DataFrame:
         Returns:
             DataFrame: DataFrame with materialized results.
         """
+        plan_time_start = _utc_now()
         self._materialize_results()
-        self._broadcast_query_plan()
+        plan_time_end = _utc_now()
+
+        self._broadcast_query_plan(plan_time_start, plan_time_end)
 
         assert self._result is not None
         dataframe_len = len(self._result)
@@ -2940,8 +2947,11 @@ class DataFrame:
         Args:
             n: number of rows to show. Defaults to 8.
         """
+        plan_time_start = _utc_now()
         dataframe_display = self._construct_show_display(n)
-        self._broadcast_query_plan()
+        plan_time_end = _utc_now()
+
+        self._broadcast_query_plan(plan_time_start, plan_time_end)
 
         try:
             from IPython.display import display

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -30,6 +30,7 @@ from typing import (
     Union,
 )
 
+from daft import dashboard
 from daft.api_annotations import DataframePublicAPI
 from daft.context import get_context
 from daft.convert import InputListType
@@ -160,7 +161,6 @@ class DataFrame:
             return self._result_cache.value
 
     def _broadcast_query_plan(self):
-        from daft import dashboard
         from daft.dataframe.display import MermaidFormatter
 
         if not dashboard._should_run():
@@ -173,10 +173,11 @@ class DataFrame:
         )._repr_markdown_()
         plan_time_end = datetime.now(timezone.utc)
 
-        dashboard._broadcast_query_plan(
-            mermaid_plan,
-            plan_time_start,
-            plan_time_end,
+        dashboard.broadcast_query_information(
+            mermaid_plan=mermaid_plan,
+            plan_time_start=plan_time_start,
+            plan_time_end=plan_time_end,
+            logs=dashboard.nlb.buffer,
         )
 
     @DataframePublicAPI


### PR DESCRIPTION
# Overview

This PR enables capturing logs when running on the native runner and broadcasting it over HTTP to port 3238.

Now, all printouts directed towards `STDOUT` will be captured and stored in some internal buffer. When the HTTP broadcast message is emitted, all of the captured logs for *that query* will be sent alongside the rest of the query information.

## Usage

Create a python file with the following contents:

```py
# my_daft_script.py

import daft

print("Hello, world!")
daft.from_pydict({}).collect()
```

Start your dashboard and run the python script:

```sh
daft-dashboard launch
# don't forget to run `daft-dashboard shutdown` at the end!

DAFT_DASHBOARD=1 python my_daft_script.py
```

The logs should be captured. You can test that this is true (without using the UI) by running:

```sh
curl http://localhost:3238/api/queries
```

This should return to you a list with one object in it. That object should contain the key-pair `"logs": "Hello, world!\n"` inside of it.

## Notes

Although the functionality on the backend is implemented, the UI will still not display any logs just yet. *That* functionality will be coming in a separate PR. However, this PR will *not* break *any* existing functionality! This is because the new key-pair will just be ignored by the frontend.

One of the nice things of full-stack development is that sometimes changes to the backend/frontend can be made incrementally and merged in without affecting the other.