### PR TITLE
perf: Clear task inputs upon dispatch

### DIFF
--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -1047,6 +1047,7 @@ def _build_partitions(
             *task.inputs,
         )
 
+    task.inputs.clear()
     metadatas_accessor = PartitionMetadataAccessor(metadatas_ref)
     task.set_result(
         [


### PR DESCRIPTION
Clear input object refs from task upon dispatching to ray. The scheduler doesn't need to hold the object refs once the task is dispatched. By holding it, it prevents it from being freed until after task completion, leading to unnecessary spillage. We don't need to hold it for retry purposes since Ray can automatically retry tasks.

Note: It's not guaranteed that the inputs are actually freed when we clear it. It's more like, if Ray needs to evict memory from object store to produce new objects, it is able to free these inputs.

Results:

Question | Before | After | Difference | % Change
-- | -- | -- | -- | --
1 | 27.44 | 28.07 | 0.63 | 2.30%
2 | 26.43 | 28.16 | 1.73 | 6.55%
3 | 38.06 | 39.94 | 1.88 | 4.94%
4 | 19.22 | 19.71 | 0.49 | 2.55%
5 | 153.86 | 109.42 | -44.44 | -28.88%
6 | 10.19 | 10.52 | 0.33 | 3.24%
7 | 54.36 | 51.12 | -3.24 | -5.96%
8 | 126.54 | 125.38 | -1.16 | -0.92%
9 | 253.33 | 272.71 | 19.38 | 7.65%
10 | 48.14 | 41.46 | -6.68 | -13.88%
11 | 32.72 | 23.63 | -9.09 | -27.78%
12 | 29.63 | 26.74 | -2.89 | -9.75%
13 | 32.63 | 34.98 | 2.35 | 7.20%
14 | 15.84 | 15.30 | -0.54 | -3.41%
15 | 33.82 | 35.90 | 2.08 | 6.15%
16 | 16.52 | 14.10 | -2.42 | -14.65%
17 | 147.12 | 127.27 | -19.85 | -13.49%
18 | 80.33 | 73.91 | -6.42 | -7.99%
19 | 19.60 | 20.56 | 0.96 | 4.90%
20 | 48.21 | 44.83 | -3.38 | -7.01%
21 | 436.61 | 417.34 | -19.27 | -4.41%
22 | 12.88 | 12.28 | -0.60 | -4.66%
Total | 1663.48 | 1573.33 | -90.15 | -5.42%


Spill Stats:

Question | Before (MB) | After (MB) | Change
-- | -- | -- | --
1 | 0 | 0 | -
2 | 0 | 0 | -
3 | 21,181 | 0 | -100.00%
4 | 0 | 0 | -
5 | 668,301 | 306,105 | -54.20%
6 | 0 | 0 | -
7 | 16,847 | 0 | -100.00%
8 | 517,851 | 366,905 | -29.15%
9 | 754,119 | 580,484 | -23.02%
10 | 39,049 | 0 | -100.00%
11 | 0 | 0 | -
12 | 0 | 0 | -
13 | 0 | 0 | -
14 | 0 | 0 | -
15 | 0 | 0 | -
16 | 0 | 0 | -
17 | 521,250 | 330,670 | -36.56%
18 | 261,445 | 81,971 | -68.65%
19 | 0 | 0 | -
20 | 0 | 0 | -
21 | 628,965 | 523,413 | -16.78%
22 | 0 | 0 | -
Total | 3,429,008 | 2,189,548 | -36.15%