### PR TITLE
fix: small fix for pyspark+ray.

### DIFF
--- a/daft/pyspark/__init__.py
+++ b/daft/pyspark/__init__.py
@@ -48,8 +48,7 @@ class Builder:
             if url.startswith("ray://localhost") or url.startswith("ray://127.0.0.1"):
                 daft.context.set_runner_ray(noop_if_initialized=True)
             else:
-                address = url.split("ray://")[1]
-                daft.context.set_runner_ray(address=address, noop_if_initialized=True)
+                daft.context.set_runner_ray(address=url, noop_if_initialized=True)
             self._connection = connect_start()
             url = f"sc://0.0.0.0:{self._connection.port()}"
             self._builder = PySparkSession.builder.remote(url)

--- a/daft/pyspark/__init__.py
+++ b/daft/pyspark/__init__.py
@@ -15,8 +15,9 @@ from pyspark.sql.functions import col
 spark = SparkSession.builder.local().getOrCreate()
 
 # alternatively, connect to a ray cluster
-spark = SparkSession.builder.remote("ray://<ray-ip>:10001").getOrCreate()
 
+spark = SparkSession.builder.remote("ray://<HEAD_IP>:6379").getOrCreate()
+# you can use `ray get-head-ip <cluster_config.yaml>` to get the head ip!
 # use spark as you would with the native spark library, but with a daft backend!
 
 spark.createDataFrame([{"hello": "world"}]).select(col("hello")).show()
@@ -44,10 +45,11 @@ class Builder:
         if url.startswith("ray://"):
             import daft
 
-            if url.startswith("ray://localhost"):
+            if url.startswith("ray://localhost") or url.startswith("ray://127.0.0.1"):
                 daft.context.set_runner_ray(noop_if_initialized=True)
             else:
-                daft.context.set_runner_ray(address=url, noop_if_initialized=True)
+                address = url.split("ray://")[1]
+                daft.context.set_runner_ray(address=address, noop_if_initialized=True)
             self._connection = connect_start()
             url = f"sc://0.0.0.0:{self._connection.port()}"
             self._builder = PySparkSession.builder.remote(url)

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -1179,6 +1179,11 @@ class RayRunner(Runner[ray.ObjectRef]):
     ) -> None:
         super().__init__()
 
+        # ray.init does not accept "ray://" prefix for some reason.
+        # We remove it here to avoid issues.
+        if address is not None and address.startswith("ray://"):
+            address = address.replace("ray://", "")
+
         self.ray_address = address
 
         if ray.is_initialized():


### PR DESCRIPTION
updates docstring for pyspark + ray and fixes issue when calling `ray.init` from `RayRunner` for `ray://` prefixed urls. 

closes https://github.com/Eventual-Inc/Daft/issues/3897