### PR TITLE
docs: remove cairo

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -166,7 +166,7 @@ plugins:
 - mkdocs-simple-hooks:
     hooks:
       on_pre_build: "docs.hooks:make_api_docs"
-- social:
-    cards_layout_options:
-      background_color: "#532687"
-    cards_dir: social
+# - social:
+#     cards_layout_options:
+#       background_color: "#532687"
+#     cards_dir: social


### PR DESCRIPTION
Cairo keeps throwing an error during local docs build even though it succeeds via Github Actions. Having trouble resolving even with https://squidfunk.github.io/mkdocs-material/plugins/requirements/image-processing/?h=cairo#cairo-library-was-not-found, so commenting out for now and can revisit later.

Context: Cairo is one of the packages that generates social previews for docs, ie:
<img width="586" alt="image" src="https://github.com/user-attachments/assets/688f35db-f0ae-4364-9793-58d40a3a27a5" />

We will lose social previews by disabling Cairo but social previews are not a priority for docs at the moment.