### PR TITLE
feat(catalog): adds additional table sources for Catalog.from_pydict

### DIFF
--- a/daft/catalog/__iceberg.py
+++ b/daft/catalog/__iceberg.py
@@ -34,6 +34,10 @@ class IcebergCatalog(Catalog):
             return c
         raise ValueError(f"Unsupported iceberg catalog type: {type(obj)}")
 
+    @property
+    def name(self) -> str:
+        return self._inner.name
+
     ###
     # get_*
     ###
@@ -62,6 +66,10 @@ class IcebergTable(Table):
             category=DeprecationWarning,
         )
         self._inner = inner
+
+    @property
+    def name(self) -> str:
+        return self._inner.name[-1]
 
     @staticmethod
     def _from_obj(obj: object) -> IcebergTable | None:

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -214,7 +214,21 @@ class Catalog(ABC):
 
         Examples:
             >>> import daft
-            >>> from daft.catalog import Catalog
+            >>> from daft.catalog import Catalog, Table
+            >>>
+            >>> dictionary = {"x": [1, 2, 3]}
+            >>> dataframe = daft.from_pydict(dictionary)
+            >>> table = Table.from_df("temp", dataframe)
+            >>>
+            >>> catalog = Catalog.from_pydict(
+            ...     {
+            ...         "R": dictionary,
+            ...         "S": dataframe,
+            ...         "T": table,
+            ...     }
+            ... )
+            >>> catalog.list_tables()
+            ['R', 'S', 'T']
 
         Args:
             tables (dict[str,object]): a dictionary of table-like objects (pydicts, dataframes, and tables)

--- a/daft/catalog/__memory.py
+++ b/daft/catalog/__memory.py
@@ -13,10 +13,20 @@ if TYPE_CHECKING:
 class MemoryCatalog(Catalog):
     """An in-memory catalog is backed by a dictionary."""
 
+    _name: str
     _tables: dict[str, Table]
 
-    def __init__(self, tables: dict[str, Table]):
-        self._tables = tables
+    def __init__(self, name: str, tables: list[Table]):
+        self._name = name
+        self._tables = {t.name: t for t in tables}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @staticmethod
+    def _from_pydict(name: str, tables: dict[str, object]) -> MemoryCatalog:
+        return MemoryCatalog(name, [Table._from_obj(name, source) for name, source in tables.items()])
 
     ###
     # list_*
@@ -47,6 +57,10 @@ class MemoryTable(Table):
     def __init__(self, name: str, inner: DataFrame):
         self._name = name
         self._inner = inner
+
+    @property
+    def name(self) -> str:
+        return self._name
 
     ###
     # DataFrame Methods

--- a/daft/catalog/__unity.py
+++ b/daft/catalog/__unity.py
@@ -24,6 +24,11 @@ class UnityCatalog(Catalog):
         )
         self._inner = unity_catalog
 
+    @property
+    def name(self) -> str:
+        # TODO feat: add names to unity catalogs
+        return "unity"
+
     @staticmethod
     def _from_obj(obj: object) -> UnityCatalog:
         """Returns an UnityCatalog instance if the given object can be adapted so."""
@@ -77,6 +82,10 @@ class UnityTable(Table):
             category=DeprecationWarning,
         )
         self._inner = unity_table
+
+    @property
+    def name(self) -> str:
+        return self._inner.table_info.name
 
     @staticmethod
     def _from_obj(obj: object) -> UnityTable | None:

--- a/daft/session.py
+++ b/daft/session.py
@@ -92,7 +92,7 @@ class Session:
         else:
             raise ValueError(f"Cannot attach object with type {type(object)}")
 
-    def attach_catalog(self, catalog: object | Catalog, alias: str | None = None) -> Catalog:
+    def attach_catalog(self, catalog: Catalog | object, alias: str | None = None) -> Catalog:
         """Attaches an external catalog to this session.
 
         Args:
@@ -102,10 +102,9 @@ class Session:
         Returns:
             Catalog: new daft catalog instance
         """
-        if alias is None:
-            raise ValueError("implicit catalog aliases are not yet supported")
         c = catalog if isinstance(catalog, Catalog) else Catalog._from_obj(catalog)
-        return self._session.attach_catalog(c, alias)
+        a = alias if alias else c.name
+        return self._session.attach_catalog(c, a)
 
     def attach_table(self, table: Table | object, alias: str | None = None) -> Table:
         """Attaches an external table instance to this session.
@@ -117,10 +116,9 @@ class Session:
         Returns:
             Table: new daft table instance
         """
-        if alias is None:
-            raise ValueError("implicit table aliases are not yet supported")
         t = table if isinstance(table, Table) else Table._from_obj(table)
-        return self._session.attach_table(t, alias)
+        a = alias if alias else t.name
+        return self._session.attach_table(t, a)
 
     def detach_catalog(self, alias: str):
         """Detaches the catalog from this session or raises if the catalog does not exist.

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 import dataclasses
 import warnings
-from typing import Callable, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 from urllib.parse import urlparse
 
 import unitycatalog
 
 from daft.io import AzureConfig, IOConfig, S3Config
 
+if TYPE_CHECKING:
+    from unitycatalog.types import TableInfo
+
 
 @dataclasses.dataclass(frozen=True)
 class UnityCatalogTable:
+    table_info: TableInfo
     table_uri: str
     io_config: IOConfig | None
 
@@ -172,6 +176,7 @@ class UnityCatalog:
             io_config = None
 
         return UnityCatalogTable(
+            table_info=table_info,
             table_uri=storage_location,
             io_config=io_config,
         )

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -1,6 +1,10 @@
 from daft.catalog import Catalog
 
 
+def assert_eq(df1, df2):
+    assert df1.to_pydict() == df2.to_pydict()
+
+
 def test_try_from_iceberg(tmpdir):
     from pyiceberg.catalog.sql import SqlCatalog
 
@@ -32,3 +36,33 @@ def test_register_python_catalog():
     cat1 = daft.unity_catalog.UnityCatalog("", "")
     daft.catalog.register_python_catalog(cat1, "test")
     daft.catalog.unregister_catalog("test")
+
+
+def test_from_pydict():
+    import daft
+    from daft.catalog import Catalog, Table
+    from daft.session import Session
+
+    dictionary = {"x": [1, 2, 3]}
+    dataframe = daft.from_pydict(dictionary)
+    table = Table.from_df("temp", dataframe)
+
+    cat = Catalog.from_pydict(
+        {
+            "R": dictionary,
+            "S": dataframe,
+            "T": table,
+        }
+    )
+
+    assert len(cat.list_tables()) == 3
+    assert cat.get_table("T") is not None
+
+    sess = Session()
+    sess.attach_catalog(cat)
+    sess.attach_table(table)
+
+    assert_eq(sess.read_table("temp"), dataframe)
+    assert_eq(sess.read_table("default.R"), dataframe)
+    assert_eq(sess.read_table("default.S"), dataframe)
+    assert_eq(sess.read_table("default.T"), dataframe)


### PR DESCRIPTION
This PR adds,

* names to catalogs and tables so they're now optional when attaching
* additional table sources to the Catalog.from_pydict method providing better ergnomics

```python
import daft
from daft.catalog import Catalog, Table

dictionary = {"x": [1, 2, 3]}
dataframe = daft.from_pydict(dictionary)
table = Table.from_df("temp", dataframe)

cat = Catalog.from_pydict(
    {
        "R": dictionary,
        "S": dataframe,
        "T": table,
    }
)
```