### PR TITLE
fix: coalesce panics, supertype handling, and null handling bugs

### DIFF
--- a/src/daft-core/src/utils/supertype.rs
+++ b/src/daft-core/src/utils/supertype.rs
@@ -12,6 +12,7 @@ fn get_time_units(tu_l: &TimeUnit, tu_r: &TimeUnit) -> TimeUnit {
     }
 }
 
+/// Computes the supertype of two types.
 pub fn try_get_supertype(l: &DataType, r: &DataType) -> DaftResult<DataType> {
     match get_supertype(l, r) {
         Some(dt) => Ok(dt),
@@ -19,6 +20,18 @@ pub fn try_get_supertype(l: &DataType, r: &DataType) -> DaftResult<DataType> {
             "could not determine supertype of {l:?} and {r:?}"
         ))),
     }
+}
+
+/// Computes the supertype of a collection.
+pub fn try_get_collection_supertype<'a, I>(types: I) -> DaftResult<DataType>
+where
+    I: IntoIterator<Item = &'a DataType>,
+{
+    let mut dtype = DataType::Null;
+    for type_ in types {
+        dtype = try_get_supertype(&dtype, type_)?;
+    }
+    Ok(dtype)
 }
 
 #[must_use]

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -22,7 +22,7 @@ use daft_core::{
     },
     join::JoinSide,
     prelude::*,
-    utils::supertype::try_get_supertype,
+    utils::supertype::{try_get_collection_supertype, try_get_supertype},
 };
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
@@ -1134,7 +1134,11 @@ impl Expr {
             Self::List(items) => {
                 // Use "list" as the field name, and infer list type from items.
                 let field_name = "list";
-                let field_type = try_compute_collection_supertype(items, schema)?;
+                let field_types = items
+                    .iter()
+                    .map(|e| e.get_type(schema))
+                    .collect::<DaftResult<Vec<_>>>()?;
+                let field_type = try_get_collection_supertype(&field_types)?;
                 Ok(Field::new(field_name, DataType::new_list(field_type)))
             }
             Self::Between(value, lower, upper) => {
@@ -1713,17 +1717,6 @@ fn try_compute_is_in_type(exprs: &[ExprRef], schema: &Schema) -> DaftResult<Opti
         if dtype.as_ref() != Some(&other_dtype) {
             return Err(DaftError::TypeError(format!("Expected all arguments to be of the same type {}, but found element with type {other_dtype}", dtype.unwrap())));
         }
-    }
-    Ok(dtype)
-}
-
-/// Tries to get the supertype of all exprs in the collection.
-fn try_compute_collection_supertype(exprs: &[ExprRef], schema: &Schema) -> DaftResult<DataType> {
-    let mut dtype = DataType::Null;
-    for expr in exprs {
-        let other_dtype = expr.get_type(schema)?;
-        let super_dtype = try_get_supertype(&dtype, &other_dtype)?;
-        dtype = super_dtype;
     }
     Ok(dtype)
 }

--- a/src/daft-functions/src/coalesce.rs
+++ b/src/daft-functions/src/coalesce.rs
@@ -287,7 +287,7 @@ mod tests {
             Field::new("s1", DataType::Boolean),
             Field::new("s2", DataType::UInt32),
         ]);
-        let expected = "could not determine supertype of Boolean and Date".to_string();
+        let expected = "could not determine supertype of Date and Boolean".to_string();
         let coalesce = super::Coalesce {};
         let DaftError::TypeError(e) = coalesce
             .to_field(&[col_0, col_1, col_2], &schema.unwrap())

--- a/tests/sql/test_coalesce.py
+++ b/tests/sql/test_coalesce.py
@@ -1,0 +1,117 @@
+import daft
+from daft import coalesce, col, lit
+
+
+def assert_eq(actual, expect):
+    """Asserts two dataframes are equal for tests."""
+    assert actual.to_pydict() == expect.to_pydict()
+
+
+def test_coalesce_basic():
+    df = daft.from_pydict(
+        {
+            "a": [None, 1, None, 3],
+            "b": [2, None, 4, 5],
+            "c": [6, 7, None, 9],
+        }
+    )
+    #
+    # single arg
+    expect = df.select(coalesce(col("a")).alias("result"))
+    actual = daft.sql("select coalesce(a) as result from df")
+    assert_eq(actual, expect)
+    #
+    # two args
+    expect = df.select(coalesce(col("a"), col("b")).alias("result"))
+    actual = daft.sql("select coalesce(a, b) as result from df")
+    assert_eq(actual, expect)
+    #
+    # three args
+    expect = df.select(coalesce(col("a"), col("b"), col("c")).alias("result"))
+    actual = daft.sql("select coalesce(a, b, c) as result from df")
+    assert_eq(actual, expect)
+
+
+def test_coalesce_typing():
+    """Test coalesce with arguments of different but compatible types."""
+    df = daft.from_pydict(
+        {
+            "int_col": [None, 1, None, 3],
+            "float_col": [2.5, None, 4.5, None],
+            "str_col": ["6", "7", None, "9"],
+        }
+    )
+    # ok, these are coercible
+    # https://github.com/Eventual-Inc/Daft/issues/3752
+    daft.sql("SELECT coalesce(1::bigint, 2::int) FROM df").collect()
+    daft.sql("SELECT coalesce(1::int, 2::bigint) FROM df").collect()
+    #
+    # comparable types with minimal common supertype in first position
+    actual = daft.sql("select coalesce(float_col, int_col) as result from df")
+    expect = df.select(coalesce(col("float_col"), col("int_col")).alias("result"))
+    assert_eq(actual, expect)
+    #
+    # comparable types with minimal common supertype NOT in first position
+    actual = daft.sql("select coalesce(int_col, float_col) as result from df")
+    expect = df.select(coalesce(col("int_col"), col("float_col")).alias("result"))
+    assert_eq(actual, expect)
+    #
+    # ok in Daft, but not in standard SQL (str and int not comparable).
+    #   I believe we should keep as-is because changes to the minimal common supertype logic
+    #   would impact all other operators using get_super_type and it is currently quite forgiving.
+    daft.sql("select coalesce(int_col, float_col, str_col) as result from df").collect()
+
+
+def test_coalesce_argument_order():
+    df = daft.from_pydict(
+        {
+            "a": [None, 1, None, 3, 0],
+            "b": [2, None, 4, None, 1],
+        }
+    )
+    #
+    # order: a, b
+    expect_ab = df.select(coalesce(col("a"), col("b")).alias("result"))
+    actual_ab = daft.sql("select coalesce(a, b) as result from df")
+    assert_eq(actual_ab, expect_ab)
+    #
+    # order: b, a
+    expect_ba = df.select(coalesce(col("b"), col("a")).alias("result"))
+    actual_ba = daft.sql("select coalesce(b, a) as result from df")
+    assert_eq(actual_ba, expect_ba)
+    #
+    # values should be different due to different argument order
+    assert expect_ab.to_pydict() != expect_ba.to_pydict()
+
+
+def test_coalesce_literals():
+    df = daft.from_pydict({"dummy": [1, 2, 3, 4]})
+    #
+    # all literals
+    actual = daft.sql("select coalesce(null, 1, 2) as result from df")
+    expect = daft.from_pydict({"result": [1, 1, 1, 1]})
+    assert_eq(actual, expect)
+    #
+    # mix of column and literals
+    actual = daft.sql("select coalesce(dummy, 99) as result from df")
+    expect = df.select(coalesce(col("dummy"), lit(99)).alias("result"))
+    assert_eq(actual, expect)
+
+
+def test_coalesce_with_nulls():
+    df = daft.from_pydict({"col1": [None, None, None, None]})
+    #
+    # all null arguments
+    actual = daft.sql("select coalesce(null, null, null) as result from df")
+    expect = daft.from_pydict({"result": [None, None, None, None]})
+    assert_eq(actual, expect)
+    #
+    # null last
+    actual = daft.sql("select coalesce(col1, null) as result from df")
+    expect = df.select(coalesce(col("col1")).alias("result"))
+    assert_eq(actual, expect)
+    #
+    # null first
+    actual = daft.sql("select coalesce(null, col1) as result from df")
+    expect = df.select(coalesce(col("col1")).alias("result"))
+    assert_eq(actual, expect)


### PR DESCRIPTION
Fixes some small coalesce bugs and adds additional tests related to #3752 

* use minimal common supertype logic for conformant typing rather than first arg
* null as first argument would always return null, check the type too
* use to_field checks rather than runtime panics on mistyping

Might need a follow-up to ensure our case-when has correct typing as well.