### PR TITLE
fix: Pass CommitProperties object custom metadata in deltalake

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -948,6 +948,22 @@ class DataFrame:
         from daft.io._deltalake import large_dtypes_kwargs
         from daft.io.object_store_options import io_config_to_storage_options
 
+        def _create_metadata_param(metadata: Optional[Dict[str, str]]):
+            """From deltalake>=0.20.0 onwards, custom_metadata has to be passed as CommitProperties.
+
+            Args:
+                metadata
+
+            Returns:
+                DataFrame: metadata for deltalake<0.20.0, otherwise CommitProperties with custom_metadata
+            """
+            if parse(deltalake.__version__) < parse("0.20.0"):
+                return metadata
+            else:
+                from deltalake import CommitProperties
+
+                return CommitProperties(custom_metadata=metadata)
+
         if schema_mode == "merge":
             raise ValueError("Schema mode' merge' is not currently supported for write_deltalake.")
 
@@ -1092,8 +1108,9 @@ class DataFrame:
                     rows.append(old_actions_dict["num_records"][i])
                     sizes.append(old_actions_dict["size_bytes"][i])
 
+            metadata_param = _create_metadata_param(custom_metadata)
             table._table.create_write_transaction(
-                add_actions, mode, partition_cols or [], delta_schema, None, custom_metadata
+                add_actions, mode, partition_cols or [], delta_schema, None, metadata_param
             )
             table.update_incremental()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.9"
 all = ["getdaft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake, sql, unity]"]
 aws = ["boto3"]
 azure = []
-deltalake = ["deltalake"]
+deltalake = ["deltalake", "packaging"]
 gcp = []
 hudi = ["pyarrow >= 8.0.0"]
 iceberg = ["pyiceberg >= 0.4.0", "packaging"]


### PR DESCRIPTION
Since deltalake>=[0.20.0](https://github.com/delta-io/delta-rs/releases/tag/python-v0.20.0), the api for providing custom metadata has changed.

Before, custom metadata could be provided as dict; now it has to be encapsulated by a `CommitProperties` object. 
See [here](https://github.com/delta-io/delta-rs/commit/507b50ecc9943f8e5e5ba87802fd97dd2acaff7b#diff-46ab267ec248467a8b23ae7e0653736fa000406afb18743cd4d3192490e09cfd).

Other commit properties not relevant atm. 

There are no version constraints used for deltalake at the moment, so i kept it untouched. 
Might be the time to add >=0.20.0.


