### PR TITLE
fix: allow resolving tables at catalog root

### DIFF
--- a/src/daft-session/src/session.rs
+++ b/src/daft-session/src/session.rs
@@ -171,14 +171,14 @@ impl Session {
             };
         }
         //
-        // The next resolution rules require a qualifier.
-        if !name.has_qualifier() {
-            obj_not_found_err!("Table", name)
-        }
-        //
         // Rule 2: try to resolve as schema-qualified using the current catalog.
         if let Some(table) = curr_catalog.get_table(name)? {
             return Ok(table.into());
+        }
+        //
+        // The next resolution rule requires a qualifier.
+        if !name.has_qualifier() {
+            obj_not_found_err!("Table", name)
         }
         //
         // Rule 3: try to resolve as catalog-qualified.


### PR DESCRIPTION
SQL name resolution was setup for 3+ level naming, so `<catalog>.<schema>+.<table>` with support for nested schemas (namespaces). However, we are coming from Python (and will migrate SQLCatalog) so this PR relaxes the restriction allow us to do things like..

```python
from daft import Session, Catalog

sess = Session()
sess.attach(Catalog.from_pydict({ 
    "T": {  
         "x": [ 1,3,5 ],
         "y": [ 2,4,6 ],
     }
}))
sess.sql("SELECT * FROM T").show()
╭───────┬───────╮
│ x     ┆ y     │
│ ---   ┆ ---   │
│ Int64 ┆ Int64 │
╞═══════╪═══════╡
│ 1     ┆ 2     │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 3     ┆ 4     │
├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
│ 5     ┆ 6     │
╰───────┴───────╯
``` 

Relaxing this restriction makes it possible to migrate `daft.sql` with SQLCatalog to `Session.sql` without breaking APIs.