### PR TITLE
feat(catalog): adds native s3tables read and catalog apis

### DIFF
--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -275,6 +275,34 @@ class Catalog(ABC):
             raise ImportError("Unity support not installed: pip install -U 'getdaft[unity]'")
 
     @staticmethod
+    def from_s3tables(table_bucket_arn: str, client: object | None = None, session: object | None = None):
+        """Creates a Daft Catalog from S3 Tables bucket ARN, with optional client or session.
+
+        If neither a client nor session is given, the default boto3 client is used.
+
+        Args:
+            table_bucket_arn (str): s3tables bucket arn
+            client: optional boto3 client
+            session: optional boto3 session
+
+        Returns:
+            Catalog: new daft catalog instance backed by S3 Tables.
+        """
+        try:
+            from daft.catalog.__s3tables import S3Catalog
+
+            if client is not None and session is not None:
+                raise ValueError("Can provide either a client or session but not both.")
+            elif client is not None:
+                return S3Catalog.from_client(table_bucket_arn, client)
+            elif session is not None:
+                return S3Catalog.from_session(table_bucket_arn, session)
+            else:
+                return S3Catalog.from_arn(table_bucket_arn)
+        except ImportError:
+            raise ImportError("S3 Tables support not installed: pip install -U 'getdaft[aws]'")
+
+    @staticmethod
     def _from_obj(obj: object) -> Catalog:
         """Returns a Daft Catalog from a supported object type or raises a ValueError."""
         for factory in (Catalog.from_iceberg, Catalog.from_unity):

--- a/daft/catalog/__s3tables.py
+++ b/daft/catalog/__s3tables.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import boto3
+
+from daft.catalog import Catalog, Identifier, Table, TableSource
+from daft.daft import IOConfig, S3Config
+from daft.io import read_iceberg
+
+if TYPE_CHECKING:
+    from daft.dataframe import DataFrame
+
+
+class S3Path(Sequence):
+    #
+    _parts: tuple[str]
+
+    def __init__(self, *parts: str):
+        self._parts = tuple(parts)
+
+    @staticmethod
+    def from_ident(ident: Identifier | str) -> S3Path:
+        path = S3Path.__new__(S3Path)
+        if isinstance(ident, Identifier):
+            path._parts = tuple(ident)
+        elif isinstance(ident, str):
+            path._parts = ident.split(".")
+        else:
+            raise ValueError("expected Identifier or str")
+        return path
+
+    @staticmethod
+    def from_str(input: str) -> S3Path:
+        return S3Path(*input.split("."))
+
+    @property
+    def parent(self) -> S3Path:
+        return S3Path(*self._parts[:-1])
+
+    @property
+    def name(self) -> str:
+        return self._parts[-1]
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, S3Path):
+            return False
+        return self._parts == other._parts
+
+    def __getitem__(self, index: int | slice) -> str | Sequence[str]:
+        return self._parts.__getitem__(index)
+
+    def __len__(self) -> int:
+        return self._parts.__len__()
+
+    def __repr__(self) -> str:
+        return f"Path('{self!s}')"
+
+    def __str__(self) -> str:
+        return ".".join(self)
+
+
+class S3Catalog(Catalog):
+    #
+    _client: object
+    _table_bucket_arn: str
+    _io_config: IOConfig
+
+    def __init__(self):
+        raise ValueError("Not supported!")
+
+    @property
+    def name(self) -> str:
+        return self._table_bucket_arn.split("/")[-1]
+
+    ###
+    # from_*
+    ###
+
+    @staticmethod
+    def from_arn(table_bucket_arn: str, s3_config: S3Config | None = None) -> S3Catalog:
+        """Creates an S3Catalog from the table bucket ARN."""
+        region = table_bucket_arn.split(":")[3]  # ARN format: arn:aws:s3tables:region:account:bucket/name
+        c = S3Catalog.__new__(S3Catalog)
+        c._client = boto3.client("s3tables", region_name=region)
+        c._table_bucket_arn = table_bucket_arn
+        c._io_config = IOConfig(s3=s3_config)
+        return c
+
+    @staticmethod
+    def from_client(table_bucket_arn: str, client: object) -> S3Catalog:
+        """Creates an S3Catalog using the given boto3 client."""
+        c = S3Catalog.__new__(S3Catalog)
+        c._table_bucket_arn = table_bucket_arn
+        c._client = client
+        return c
+
+    @staticmethod
+    def from_session(table_bucket_arn: str, session: object) -> S3Catalog:
+        """Creates an S3Catalog using the boto3 session."""
+        c = S3Catalog.__new__(S3Catalog)
+        c._table_bucket_arn = table_bucket_arn
+        c._client = session.create_client("s3tables")
+        return c
+
+    ###
+    # create_*
+    ###
+
+    def create_namespace(self, identifier: Identifier | str):
+        raise ValueError("S3 Tables create_namespace not yet supported.")
+
+    def create_table(self, identifier: Identifier | str, source: TableSource) -> Table:
+        raise ValueError("S3 Tables create_table not yet supported.")
+
+    ###
+    # drop_*
+    ###
+
+    def drop_namespace(self, identifier: Identifier | str):
+        raise ValueError("S3 Tables drop_namespace not yet supported.")
+
+    def drop_table(self, identifier: Identifier | str):
+        raise ValueError("S3 Tables drop_table not yet supported.")
+
+    ###
+    # get_*
+    ###
+
+    def get_table(self, identifier: Identifier | str) -> S3Table:
+        path = S3Path.from_ident(identifier)
+        res = self._client.get_table(
+            name=path.name,
+            namespace=str(path.parent),
+            tableBucketARN=self._table_bucket_arn,
+        )
+        return S3Table(self, path, res["metadataLocation"])
+
+    ###
+    # list_*
+    ###
+
+    def list_namespaces(self, pattern: str | None = None) -> list[Identifier]:
+        raise ValueError("S3 Tables list_namespaces not yet supported.")
+
+    def list_tables(self, pattern: str | None = None) -> list[str]:
+        raise ValueError("S3 Tables list_tables not yet supported.")
+
+    ###
+    # private methods
+    ###
+
+    def _read_iceberg(self, table: S3Table) -> DataFrame:
+        return read_iceberg(table=table.metadata_location, io_config=self._io_config)
+
+
+class S3Table(Table):
+    #
+    _catalog: S3Catalog
+    _path: S3Path
+    #
+    metadata_location: str
+
+    def __init__(
+        self,
+        catalog: S3Catalog,
+        path: S3Path,
+        metadata_location: str,
+    ):
+        self._catalog = catalog
+        self._path = path
+        self.metadata_location = metadata_location
+
+    @property
+    def path(self) -> S3Path:
+        return self._path
+
+    @property
+    def name(self) -> str:
+        return self._path.name
+
+    @property
+    def namespace(self) -> S3Path:
+        return self._path.parent
+
+    def read(self) -> DataFrame:
+        return self._catalog._read_iceberg(self)
+
+    def write(self):
+        raise ValueError("S3 Table writes require using Glue Iceberg REST.")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -74,7 +74,7 @@ s3fs==2023.12.0
 # on old versions of s3fs's pinned botocore, they neglected to pin urllib3<2 which leads to:
 # "ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_'"
 boto3==1.36.20
-moto[s3,server]==5.0.26
+moto[s3,server]==5.1.1
 
 # Azure
 adlfs==2024.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -73,7 +73,7 @@ pyodbc==5.1.0
 s3fs==2023.12.0
 # on old versions of s3fs's pinned botocore, they neglected to pin urllib3<2 which leads to:
 # "ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_'"
-boto3==1.34.51
+boto3==1.36.20
 moto[s3,server]==5.0.26
 
 # Azure

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -74,6 +74,7 @@ s3fs==2023.12.0
 # on old versions of s3fs's pinned botocore, they neglected to pin urllib3<2 which leads to:
 # "ImportError: cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_'"
 boto3==1.36.20
+boto3-stubs[essential,s3,s3tables]==1.36.20
 moto[s3,server]==5.1.1
 
 # Azure

--- a/tests/catalog/test_s3tables.py
+++ b/tests/catalog/test_s3tables.py
@@ -1,25 +1,19 @@
-import pytest
-import boto3
 import os
-
-from daft import Catalog
 from typing import TYPE_CHECKING
+
+import boto3
+import pytest
 from moto import mock_aws
 
+from daft import Catalog, Identifier
+from daft.logical.schema import DataType as dt
+from daft.logical.schema import Field, Schema
+
 if TYPE_CHECKING:
-    from mypy_boto3_s3 import S3Client
+    from mypy_boto3_s3tables import S3TablesClient
 else:
-    S3Client = object
+    S3TablesClient = object
 
-import pytest
-
-
-# https://github.com/Eventual-Inc/Daft/issues/3925
-@pytest.mark.skip("S3 Tables will required integration tests, for now verify manually.")
-def test_sanity():
-    table_bucket_arn = "placeholder"
-    s3tb = Catalog.from_s3tables(table_bucket_arn)
-    s3tb.read_table("demo.points").show()
 
 @pytest.fixture(scope="function")
 def aws_credentials():
@@ -27,21 +21,145 @@ def aws_credentials():
     os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
     os.environ["AWS_SECURITY_TOKEN"] = "testing"
     os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-2"
+
 
 @pytest.fixture(scope="function")
-def s3(aws_credentials):
+def client(aws_credentials):
     with mock_aws():
-        yield boto3.client("s3", region_name="us-east-1")
+        yield boto3.client("s3tables", region_name="us-west-2")
+
 
 @pytest.fixture(scope="function")
-def mocked_aws(aws_credentials):
-    with mock_aws():
-        yield
+def catalog(client: S3TablesClient):
+    res = client.create_table_bucket(name="test_bucket")
+    arn = res["arn"]
+    yield Catalog.from_s3tables(arn, client=client)
 
-def test_s3_bucket_creation(s3: S3Client):
-    s3.create_bucket(Bucket="somebucket")
 
-    result = s3.list_buckets()
-    print(result)
-    assert len(result["Buckets"]) == 1
+def schema(fields: dict[str, dt]) -> Schema:
+    return Schema._from_fields([Field.create(k, v) for k, v in fields.items()])
+
+
+def test_create_namespace(catalog: Catalog):
+    namespace = "ns"
+    catalog.create_namespace(namespace)
+    namespaces = catalog.list_namespaces()
+    assert Identifier("ns") in namespaces
+
+
+def test_create_table(catalog: Catalog):
+    ns = "create_table_ns"
+    table_name = f"{ns}.T"
+    catalog.create_namespace(ns)
+    table = catalog.create_table(
+        table_name,
+        schema(
+            {
+                "x": dt.bool(),
+                "y": dt.int64(),
+                "z": dt.string(),
+            }
+        ),
+    )
+    tables = catalog.list_tables()
+    assert len(tables) == 1
+    assert table_name in tables
+    assert table.name == "T"
+
+
+def test_drop(catalog: Catalog):
+    ns = "ns_to_drop"
+    table_name = f"{ns}.table_to_drop"
+    catalog.create_namespace(ns)
+    catalog.create_table(table_name, schema({"a": dt.bool()}))
+    #
+    assert Identifier(ns) in catalog.list_namespaces()
+    assert table_name in catalog.list_tables(ns)
+    #
+    catalog.drop_table(table_name)
+    assert table_name not in catalog.list_tables(ns)
+    #
+    catalog.drop_namespace(ns)
+    assert Identifier(ns) not in catalog.list_namespaces()
+
+
+def test_get_table(catalog: Catalog):
+    ns = "ns_to_get"
+    table_name = f"{ns}.table_to_get"
+    catalog.create_namespace(ns)
+    catalog.create_table(table_name, schema({"a": dt.bool()}))
+    # verify
+    res = catalog.get_table(table_name)
+    assert res.name == "table_to_get"
+
+
+def test_list_namespaces(catalog: Catalog):
+    namespaces = [
+        Identifier("ns1_1"),
+        Identifier("ns1_2"),
+        Identifier("ns2_1"),
+    ]
+    for ns in namespaces:
+        catalog.create_namespace(ns)
+    #
+    # list one
+    res = catalog.list_namespaces("ns1_1")
+    assert len(res) == 1
+    assert Identifier("ns1_1") == res[0]
+    #
+    # list some
+    res = catalog.list_namespaces("ns1_")
+    assert len(res) == 2
+    assert Identifier("ns1_1") in res
+    assert Identifier("ns1_2") in res
+    #
+    # list all
+    res = catalog.list_namespaces()
+    for ns in namespaces:
+        assert ns in res
+
+
+def test_list_tables(catalog: Catalog):
+    ns1 = "ns1"
+    ns2 = "ns2"
+    tables = [
+        f"{ns1}.tbl1_1",
+        f"{ns1}.tbl1_2",
+        f"{ns1}.tbl2_1",
+        f"{ns2}.tbl1_1",
+        f"{ns2}.tbl1_2",
+        f"{ns2}.tbl2_1",
+    ]
+    catalog.create_namespace(ns1)
+    catalog.create_namespace(ns2)
+    for table in tables:
+        catalog.create_table(table, schema({}))
+    #
+    # list one
+    res = catalog.list_tables(f"{ns1}.tbl1_1")
+    assert len(res) == 1
+    assert f"{ns1}.tbl1_1" == res[0]
+    #
+    # list some
+    res = catalog.list_tables(ns1)
+    assert len(res) == 3
+    assert f"{ns1}.tbl1_1" in res
+    assert f"{ns1}.tbl1_2" in res
+    assert f"{ns1}.tbl2_1" in res
+    #
+    # list all
+    res = catalog.list_tables()
+    assert len(res) == len(tables)
+    for table in tables:
+        assert table in res
+
+
+@pytest.mark.skip("S3 Tables read tests are done via integration tests.")
+def test_read_table():
+    pass  # https://github.com/Eventual-Inc/Daft/issues/3925
+
+
+@pytest.mark.skip("S3 Tables read tests are done via integration tests.")
+def test_write_table():
+    pass  # https://github.com/Eventual-Inc/Daft/issues/3925

--- a/tests/catalog/test_s3tables.py
+++ b/tests/catalog/test_s3tables.py
@@ -1,0 +1,12 @@
+import pytest
+
+from daft import Catalog
+
+# https://github.com/Eventual-Inc/Daft/issues/3925
+
+
+@pytest.mark.skip("S3 Tables will required integration tests, for now verify manually.")
+def test_sanity():
+    table_bucket_arn = "placeholder"
+    s3tb = Catalog.from_s3tables(table_bucket_arn)
+    s3tb.read_table("demo.points").show()

--- a/tests/catalog/test_s3tables.py
+++ b/tests/catalog/test_s3tables.py
@@ -1,12 +1,47 @@
 import pytest
+import boto3
+import os
 
 from daft import Catalog
+from typing import TYPE_CHECKING
+from moto import mock_aws
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+else:
+    S3Client = object
+
+import pytest
+
 
 # https://github.com/Eventual-Inc/Daft/issues/3925
-
-
 @pytest.mark.skip("S3 Tables will required integration tests, for now verify manually.")
 def test_sanity():
     table_bucket_arn = "placeholder"
     s3tb = Catalog.from_s3tables(table_bucket_arn)
     s3tb.read_table("demo.points").show()
+
+@pytest.fixture(scope="function")
+def aws_credentials():
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+@pytest.fixture(scope="function")
+def s3(aws_credentials):
+    with mock_aws():
+        yield boto3.client("s3", region_name="us-east-1")
+
+@pytest.fixture(scope="function")
+def mocked_aws(aws_credentials):
+    with mock_aws():
+        yield
+
+def test_s3_bucket_creation(s3: S3Client):
+    s3.create_bucket(Bucket="somebucket")
+
+    result = s3.list_buckets()
+    print(result)
+    assert len(result["Buckets"]) == 1


### PR DESCRIPTION
This adds our native read for S3 Tables along with the remaining catalogs APIs. Because we have implemented `get_table` and the catalog interface, we can attach to sessions and execute SQL against S3 Tables. We will raise an error on writes and suggest Glue Iceberg REST which we have demonstrated enables us to write. We are actively working on native writes or similar, but I wanted to get this read API into the latest release.

```shell
❯ python ./tests/catalog/test_s3tables.py
profile `sso-session eventual` ignored because `sso-session eventual` was not a valid identifier
╭─────────┬───────┬──────╮
│ x       ┆ y     ┆ z    │
│ ---     ┆ ---   ┆ ---  │
│ Boolean ┆ Int64 ┆ Utf8 │
╞═════════╪═══════╪══════╡
│ true    ┆ 1     ┆ a    │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ true    ┆ 2     ┆ b    │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ false   ┆ 3     ┆ c    │
╰─────────┴───────┴──────╯

(Showing first 3 of 3 rows)
```
