### PR TITLE
fix: add retry to getting GCS client config

### DIFF
--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -8,6 +8,7 @@ mod huggingface;
 mod local;
 mod object_io;
 mod object_store_glob;
+mod retry;
 mod s3_like;
 mod stats;
 mod stream_utils;

--- a/src/daft-io/src/retry.rs
+++ b/src/daft-io/src/retry.rs
@@ -1,0 +1,69 @@
+use std::{future::Future, time::Duration};
+
+use rand::Rng;
+
+pub enum RetryError<T> {
+    /// Error that should not be retried
+    Permanent(T),
+    /// Error that can be retried
+    Transient(T),
+}
+
+impl<T> RetryError<T> {
+    fn into_inner(self) -> T {
+        match self {
+            Self::Permanent(value) | Self::Transient(value) => value,
+        }
+    }
+}
+
+pub struct ExponentialBackoff {
+    pub max_tries: usize,
+    pub jitter_ms: u64,
+    pub max_backoff_ms: u64,
+    pub max_waittime_ms: Option<u64>,
+}
+
+impl Default for ExponentialBackoff {
+    fn default() -> Self {
+        Self {
+            max_tries: 4,
+            jitter_ms: 2_500,
+            max_backoff_ms: 20_000,
+            max_waittime_ms: None,
+        }
+    }
+}
+
+impl ExponentialBackoff {
+    pub async fn retry<T, E, Fut>(&self, f: impl Fn() -> Fut) -> Result<T, E>
+    where
+        Fut: Future<Output = Result<T, RetryError<E>>>,
+    {
+        let mut attempts = 0;
+        let start_time = std::time::Instant::now();
+
+        loop {
+            attempts += 1;
+
+            let res = f().await;
+
+            let success = res.is_ok();
+            let permanent = matches!(res, Result::Err(RetryError::Permanent(..)));
+            let exceeded_max_waittime = self
+                .max_waittime_ms
+                .is_some_and(|t| start_time.elapsed().as_millis() >= t as u128);
+            let exceeded_max_tries = attempts == self.max_tries;
+
+            if success || permanent || exceeded_max_waittime || exceeded_max_tries {
+                return res.map_err(RetryError::into_inner);
+            }
+
+            let jitter = rand::thread_rng()
+                .gen_range(0..((1 << attempts) * self.jitter_ms))
+                .min(self.max_backoff_ms);
+
+            tokio::time::sleep(Duration::from_millis(jitter)).await;
+        }
+    }
+}

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -36,6 +36,7 @@ use url::{ParseError, Position};
 use super::object_io::{GetResult, ObjectSource};
 use crate::{
     object_io::{FileMetadata, FileType, LSResult},
+    retry::{ExponentialBackoff, RetryError},
     stats::IOStatsRef,
     stream_utils::io_stats_on_bytestream,
     FileFormat, InvalidArgumentSnafu, SourceType,
@@ -500,45 +501,42 @@ async fn build_s3_conf(
 
     let builder_copy = builder.clone();
     let s3_conf = builder.build();
-    const CRED_TRIES: u64 = 4;
-    const JITTER_MS: u64 = 2_500;
-    const MAX_BACKOFF_MS: u64 = 20_000;
-    const MAX_WAITTIME_MS: u64 = 45_000;
-    let check_creds = async || -> super::Result<bool> {
-        use rand::Rng;
+
+    let backoff = ExponentialBackoff {
+        max_waittime_ms: Some(45_000),
+        ..Default::default()
+    };
+
+    let check_creds = async || {
         use CredentialsError::{CredentialsNotLoaded, ProviderTimedOut};
-        let mut attempt = 0;
-        let first_attempt_time = std::time::Instant::now();
-        loop {
-            let creds = s3_conf
-                .credentials_cache()
-                .provide_cached_credentials()
-                .await;
-            attempt += 1;
-            match creds {
-                Ok(_) => return Ok(false),
-                Err(err @ ProviderTimedOut(..)) => {
-                    let total_time_waited_ms: u64 = first_attempt_time.elapsed().as_millis().try_into().unwrap();
-                    if attempt < CRED_TRIES && (total_time_waited_ms < MAX_WAITTIME_MS) {
-                        let jitter = rand::thread_rng().gen_range(0..((1 << attempt) * JITTER_MS)) as u64;
-                        let jitter = jitter.min(MAX_BACKOFF_MS);
-                        log::warn!("S3 Credentials Provider timed out when making client for {}! Attempt {attempt} out of {CRED_TRIES} tries. Trying again in {jitter}ms. {err}", s3_conf.region().unwrap_or(&DEFAULT_REGION));
-                        tokio::time::sleep(Duration::from_millis(jitter)).await;
-                        continue;
-                    }
-                    Err(err)
-                }
-                Err(err @ CredentialsNotLoaded(..)) => {
-                    log::warn!("S3 Credentials not provided or found when making client for {}! Reverting to Anonymous mode. {err}", s3_conf.region().unwrap_or(&DEFAULT_REGION));
-                    return Ok(true);
-                }
-                Err(err) => Err(err),
-            }.with_context(|_| UnableToLoadCredentialsSnafu {})?;
+
+        let creds = s3_conf
+            .credentials_cache()
+            .provide_cached_credentials()
+            .await;
+
+        match creds {
+            Ok(_) => Ok(false),
+            Err(err @ ProviderTimedOut(..)) => {
+                log::warn!(
+                    "S3 Credentials Provider timed out when making client for {}! Retrying. {err}",
+                    s3_conf.region().unwrap_or(&DEFAULT_REGION)
+                );
+                Err(RetryError::Transient(err))
+            }
+            Err(err @ CredentialsNotLoaded(..)) => {
+                log::warn!("S3 Credentials not provided or found when making client for {}! Reverting to Anonymous mode. {err}", s3_conf.region().unwrap_or(&DEFAULT_REGION));
+                Ok(true)
+            }
+            Err(err) => Err(RetryError::Permanent(err)),
         }
     };
 
     if !config.anonymous {
-        anonymous = check_creds().await?;
+        anonymous = backoff
+            .retry(check_creds)
+            .await
+            .with_context(|_| UnableToLoadCredentialsSnafu {})?;
     }
 
     let s3_conf = if s3_conf.region().is_none() {


### PR DESCRIPTION
Also contains a tiny refactor to centralize logic for exponential backoff retry