### PR TITLE
fix: bun install in build-wheel.yml

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -101,10 +101,10 @@ jobs:
       with:
         target: aarch64-unknown-linux-gnu
         manylinux: 2_28
+        container: quay.io/pypa/manylinux_2_28_aarch64
         args: --profile release-lto --out dist
         before-script-linux: |
           export JEMALLOC_SYS_WITH_LG_PAGE=16
-          dnf install -y unzip
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -90,6 +90,7 @@ jobs:
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
         before-script-linux: |
+          dnf install -y perl-IPC-Cmd
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"
@@ -103,6 +104,7 @@ jobs:
         args: --profile release-lto --out dist
         before-script-linux: |
           export JEMALLOC_SYS_WITH_LG_PAGE=16
+          dnf install -y unzip
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -101,10 +101,10 @@ jobs:
       with:
         target: aarch64-unknown-linux-gnu
         manylinux: 2_28
-        container: quay.io/pypa/manylinux_2_28_aarch64
         args: --profile release-lto --out dist
         before-script-linux: |
           export JEMALLOC_SYS_WITH_LG_PAGE=16
+          apt install -y unzip
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -90,7 +90,6 @@ jobs:
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
         before-script-linux: |
-          yum -y install perl-IPC-Cmd
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"
@@ -104,7 +103,6 @@ jobs:
         args: --profile release-lto --out dist
         before-script-linux: |
           export JEMALLOC_SYS_WITH_LG_PAGE=16
-          apt install -y unzip
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -106,6 +106,7 @@ jobs:
         args: --profile release-lto --out dist
         before-script-linux: |
           export JEMALLOC_SYS_WITH_LG_PAGE=16
+          apt install -y unzip
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -76,17 +76,17 @@ jobs:
 
     - name: Build wheels - Mac and Windows x86
       if: ${{ ((inputs.os == 'macos') || (inputs.os == 'windows')) && (inputs.arch == 'x86_64')  }}
-      uses: messense/maturin-action@v1
+      uses: PyO3/maturin-action@v1
       with:
         target: x86_64
         args: --profile release-lto --out dist
 
     - name: Build wheels - Linux x86
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'x86_64') }}
-      uses: messense/maturin-action@v1
+      uses: PyO3/maturin-action@v1
       with:
         target: x86_64
-        manylinux: auto
+        manylinux: 2_28
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
         before-script-linux: |
@@ -97,12 +97,10 @@ jobs:
 
     - name: Build wheels - Linux aarch64
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
-      uses: messense/maturin-action@v1
+      uses: PyO3/maturin-action@v1
       with:
         target: aarch64-unknown-linux-gnu
-        manylinux: auto
-        # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic. This caused issues with the `ring` crate that causes TLS to fail
-        container: messense/manylinux_2_24-cross:aarch64
+        manylinux: 2_28
         args: --profile release-lto --out dist
         before-script-linux: |
           export JEMALLOC_SYS_WITH_LG_PAGE=16
@@ -113,10 +111,9 @@ jobs:
 
     - name: Build wheels - Mac aarch64
       if: ${{ (inputs.os == 'macos') && (inputs.arch == 'aarch64')  }}
-      uses: messense/maturin-action@v1
+      uses: PyO3/maturin-action@v1
       with:
         target: aarch64
-        manylinux: auto
         args: --profile release-lto --out dist
       env:
         RUSTFLAGS: -Ctarget-cpu=apple-m1

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -104,7 +104,11 @@ jobs:
         # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic. This caused issues with the `ring` crate that causes TLS to fail
         container: messense/manylinux_2_24-cross:aarch64
         args: --profile release-lto --out dist
-        before-script-linux: export JEMALLOC_SYS_WITH_LG_PAGE=16 curl -fsSL https://bun.sh/install | bash export BUN_INSTALL="$HOME/.bun" export PATH="$BUN_INSTALL/bin:$PATH"
+        before-script-linux: |
+          export JEMALLOC_SYS_WITH_LG_PAGE=16
+          curl -fsSL https://bun.sh/install | bash
+          export BUN_INSTALL="$HOME/.bun"
+          export PATH="$BUN_INSTALL/bin:$PATH"
 
     - name: Build wheels - Mac aarch64
       if: ${{ (inputs.os == 'macos') && (inputs.arch == 'aarch64')  }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -44,6 +44,7 @@ jobs:
     - uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
+      if: ${{ (inputs.os == 'macos') || (inputs.os == 'windows') }} # bun installed on linux in container during build step
     - run: pip install uv
     - run: uv pip install twine yq setuptools_scm
 
@@ -79,6 +80,7 @@ jobs:
       with:
         target: x86_64
         args: --profile release-lto --out dist
+
     - name: Build wheels - Linux x86
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'x86_64') }}
       uses: messense/maturin-action@v1
@@ -87,7 +89,11 @@ jobs:
         manylinux: auto
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
-        before-script-linux: yum -y install perl-IPC-Cmd
+        before-script-linux: |
+          yum -y install perl-IPC-Cmd
+          curl -fsSL https://bun.sh/install | bash
+          export BUN_INSTALL="$HOME/.bun"
+          export PATH="$BUN_INSTALL/bin:$PATH"
 
     - name: Build wheels - Linux aarch64
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
@@ -98,7 +104,7 @@ jobs:
         # GCC 4.8.5 in manylinux2014 container doesn't support c11 atomic. This caused issues with the `ring` crate that causes TLS to fail
         container: messense/manylinux_2_24-cross:aarch64
         args: --profile release-lto --out dist
-        before-script-linux: export JEMALLOC_SYS_WITH_LG_PAGE=16
+        before-script-linux: export JEMALLOC_SYS_WITH_LG_PAGE=16 curl -fsSL https://bun.sh/install | bash export BUN_INSTALL="$HOME/.bun" export PATH="$BUN_INSTALL/bin:$PATH"
 
     - name: Build wheels - Mac aarch64
       if: ${{ (inputs.os == 'macos') && (inputs.arch == 'aarch64')  }}


### PR DESCRIPTION
Also upgrades the manylinux version since Bun expects a higher glibc version than the one provided in the manylinux2014 container. This does remove support for certain ancient versions of linux but I'm not particularly concerned. 

> Built wheels are also expected to be compatible with other distros using glibc 2.28 or later, including:
> * Debian 10+
> * Ubuntu 18.10+
> * Fedora 29+
> * CentOS/RHEL 8+

https://github.com/pypa/manylinux
