### PR TITLE
feat: add a daft.ai module with vllm functionality

### DIFF
--- a/daft/ai/__init__.py
+++ b/daft/ai/__init__.py
@@ -1,0 +1,3 @@
+from .vllm import vLLM
+
+__all__ = ["vLLM"]

--- a/daft/ai/vllm.py
+++ b/daft/ai/vllm.py
@@ -9,6 +9,8 @@ from daft import Series, udf
 class vLLM:
     """A simple expression that runs vLLM over an input column of strings.
 
+    NOTE: This requires `vllm` to be installed. See: [vllm documentation](https://docs.vllm.ai/en/latest/getting_started/installation/index.html).
+
     ## Concurrency
 
     By default, this will run only 1 instance of a vLLM model for the entire query.

--- a/daft/ai/vllm.py
+++ b/daft/ai/vllm.py
@@ -1,0 +1,85 @@
+from daft import Series, udf
+
+
+@udf(
+    return_dtype=str,
+    concurrency=1,
+    batch_size=1024,
+)
+class vLLM:
+    """A simple expression that runs vLLM over an input column of strings.
+
+    ## Concurrency
+
+    By default, this will run only 1 instance of a vLLM model for the entire query.
+
+    To override this behavior, call `vllm = vLLM.with_concurrency(N)`. This is especially useful if you have `N` number of GPUs on your
+    cluster and you wish to have each replica of vLLM use 1 GPU:
+
+    ```python
+    vllm = vLLM.override_options(num_gpus=1).with_concurrency(8)
+    ```
+
+
+    ## Choosing a model
+
+    [Full list of supported models from vllm](https://docs.vllm.ai/en/latest/models/supported_models.html#supported-models)
+
+    This UDF uses the `"facebook/opt-125m"` model by default. To select the model you intend to use, you can parametrize this UDF like so:
+
+    ```python
+    vllm = vLLM.with_init_args(model="facebook/opt-125m")
+    ```
+
+    Please note that you need to ensure that your model fits on your GPUs.
+
+    ## Tuning batch size
+
+    By default, this UDF has a batch size of 1024. Depending on your model/GPU, you may wish to tune this parameter for memory.
+
+    Setting a smaller batch size can reduce memory usage, trading off performance as the model will be called more times.
+
+    ```python
+    vllm = vLLM.with_init_args(batch_size=128)
+    ```
+
+    ## GPUs
+
+    To use GPUs, create a new overridden instance of this with `vllm = vLLM.override_options(num_gpus=1)`. Note that if you do not do this,
+    vLLM may fail to find the GPUs on your machine and you will get errors that look like: `RuntimeError: No CUDA GPUs are available`.
+
+    Usage:
+
+    >>> # CPU-based usage:
+    >>> import daft
+    >>>
+    >>> df = daft.read_csv("prompts.csv")
+    >>> df = df.with_column("response", vLLM(df["prompt"]))
+    >>>
+    >>> # Runs 1 replica of vLLM on CPUs by default
+    >>> df.collect()
+
+    >>> # GPU-based usage:
+    >>> import daft
+    >>>
+    >>> # Tells Daft to run 4 replicas of vLLM, each using 1 GPU
+    >>> vllm_gpu = vLLM.override_options(num_gpus=1).with_concurrency(4)
+    >>>
+    >>> df = daft.read_csv("prompts.csv")
+    >>> df = df.with_column("response", vllm_gpu(df["prompt"]))
+    >>>
+    >>> # Runs 4 replicas of vLLM on 1 GPU each as specified
+    >>> df.collect()
+    """
+
+    def __init__(self, model: str = "facebook/opt-125m", sampling_params: dict = {}):
+        from vllm import LLM, SamplingParams
+
+        self.llm = LLM(model=model)
+        self.sampling_params = SamplingParams(**sampling_params)
+
+    def __call__(self, input_prompt_column: Series):
+        prompts = input_prompt_column.to_pylist()
+        outputs = self.llm.generate(prompts, self.sampling_params)
+
+        return [output.outputs[0].text for output in outputs]

--- a/daft/ai/vllm.py
+++ b/daft/ai/vllm.py
@@ -11,41 +11,41 @@ class vLLM:
 
     NOTE: This requires `vllm` to be installed. See: [vllm documentation](https://docs.vllm.ai/en/latest/getting_started/installation/index.html).
 
-    ## Concurrency
+    Concurrency
+    -----------
 
     By default, this will run only 1 instance of a vLLM model for the entire query.
 
     To override this behavior, call `vllm = vLLM.with_concurrency(N)`. This is especially useful if you have `N` number of GPUs on your
     cluster and you wish to have each replica of vLLM use 1 GPU:
 
-    ```python
-    vllm = vLLM.override_options(num_gpus=1).with_concurrency(8)
-    ```
+    >>> vllm = vLLM.override_options(num_gpus=1).with_concurrency(8)
 
-
-    ## Choosing a model
+    Choosing a model
+    ----------------
 
     [Full list of supported models from vllm](https://docs.vllm.ai/en/latest/models/supported_models.html#supported-models)
 
     This UDF uses the `"facebook/opt-125m"` model by default. To select the model you intend to use, you can parametrize this UDF like so:
 
-    ```python
-    vllm = vLLM.with_init_args(model="facebook/opt-125m")
-    ```
+    >>> vllm = vLLM.with_init_args(model="facebook/opt-125m")
 
     Please note that you need to ensure that your model fits on your GPUs.
 
-    ## Tuning batch size
+    Tuning batch size
+    -----------------
 
     By default, this UDF has a batch size of 1024. Depending on your model/GPU, you may wish to tune this parameter for memory.
 
-    Setting a smaller batch size can reduce memory usage, trading off performance as the model will be called more times.
+    Setting a smaller batch size can reduce memory usage, trading off performance as the UDF will be called more times.
 
-    ```python
-    vllm = vLLM.with_init_args(batch_size=128)
-    ```
+    Note that vLLM also performs its own batching under the hood. This batch_size parameter controls the size of the batches that are
+    being processed by the UDF and that are materialized as Python strings.
 
-    ## GPUs
+    >>> vllm = vLLM.with_init_args(batch_size=128)
+
+    GPUs
+    ----
 
     To use GPUs, create a new overridden instance of this with `vllm = vLLM.override_options(num_gpus=1)`. Note that if you do not do this,
     vLLM may fail to find the GPUs on your machine and you will get errors that look like: `RuntimeError: No CUDA GPUs are available`.

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -399,6 +399,7 @@ def udf(
     num_gpus: float | None = None,
     memory_bytes: int | None = None,
     batch_size: int | None = None,
+    concurrency: int | None = None,
 ) -> Callable[[UserDefinedPyFuncLike], UDF]:
     """`@udf` Decorator to convert a Python function/class into a `UDF`.
 
@@ -446,7 +447,7 @@ def udf(
     -----------------
 
     You can also hint Daft about the resources that your UDF will require to run. For example, the following UDF requires 2 CPUs to run. On a
-    machine/cluster with 8 CPUs, Daft will be able to run up to 4 instances of this UDF at once, giving you a concurrency of 4!
+    machine/cluster with 8 CPUs, Daft will be able to run up to 4 instances of this UDF at once!
 
     >>> import daft
     >>> @daft.udf(return_dtype=daft.DataType.int64(), num_cpus=2)
@@ -507,6 +508,9 @@ def udf(
         memory_bytes: Amount of memory to allocate each running instance of your UDF in bytes. If your UDF is experiencing out-of-memory errors,
             this parameter can help hint Daft that each UDF requires a certain amount of heap memory for execution.
         batch_size: Enables batching of the input into batches of at most this size. Results between batches are concatenated.
+        concurrency: Spin up `N` number of persistent replicas of the UDF to process all partitions. Defaults to `None` which will spin up one
+            UDF per partition. This is especially useful for expensive initializations that need to be amortized across partitions such as
+            loading model weights for model batch inference.
 
     Returns:
         Callable[[UserDefinedPyFuncLike], UDF]: UDF decorator - converts a user-provided Python function as a UDF that can be called on Expressions
@@ -538,6 +542,7 @@ def udf(
             return_dtype=inferred_return_dtype,
             resource_request=resource_request,
             batch_size=batch_size,
+            concurrency=concurrency,
         )
 
     return _udf

--- a/docs/sphinx/source/ai.rst
+++ b/docs/sphinx/source/ai.rst
@@ -1,0 +1,10 @@
+AI
+==
+
+.. currentmodule:: daft
+
+.. autosummary::
+    :nosignatures:
+    :toctree: doc_gen/ai
+
+    ai.vLLM

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -17,6 +17,7 @@ Welcome to Daft API Documentation. For Daft User Guide, head to `User Guide <../
    datatype
    groupby
    udf
+   ai
    series
    configs
    misc


### PR DESCRIPTION
Adds an "us-defined-function" for vLLM.

NOTE: as a drive-by, also adds `concurrency` as a kwarg on `@udf`. This is because it kind of makes sense for there to be some sane default for this "us-defined-function" I think.

## Testing on Swordfish

<img width="1369" alt="image" src="https://github.com/user-attachments/assets/bd8a890b-cbb6-4055-bd62-954abb05a5cb" />

<img width="583" alt="image" src="https://github.com/user-attachments/assets/bb65c992-51e9-4bd5-84bd-fa32adcd4097" />

## Testing on Ray Runner

This works as well on the RayRunner with multiple partitions, on a GPU cluster.

```
vllm = vLLM.override_options(num_gpus=1).with_concurrency(7)  # we have 7 worker nodes

df = daft.from_pydict({"meal": ["chicken", "beef", "fish", "lamb", "rice"] * 32})
df = df.into_partitions(16)
df = df.with_column("recipe", vllm("Produce a recipe with ingredients: " + df["meal"] + "\n\n"))
df.collect()
```

<img width="1449" alt="image" src="https://github.com/user-attachments/assets/6e8fabe5-3681-479a-8c05-c28f9b06064e" />

