### PR TITLE
perf: Reduce memory consumption for WARC reads and improve estimates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,6 +2562,7 @@ dependencies = [
  "futures",
  "indexmap 2.7.0",
  "itertools 0.11.0",
+ "lazy_static",
  "parquet2",
  "pyo3",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,7 +2689,6 @@ dependencies = [
  "daft-recordbatch",
  "flate2",
  "futures",
- "rayon",
  "serde_json",
  "snafu",
  "tokio",

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1582,6 +1582,13 @@ class PyMicroPartition:
         io_config: IOConfig | None = None,
         multithreaded_io: bool | None = None,
     ): ...
+    @classmethod
+    def read_warc(
+        cls,
+        uri: str,
+        io_config: IOConfig | None = None,
+        multithreaded_io: bool | None = None,
+    ): ...
 
 class PhysicalPlanScheduler:
     """A work scheduler for physical query plans."""

--- a/daft/io/_warc.py
+++ b/daft/io/_warc.py
@@ -40,8 +40,9 @@ def read_warc(
             Defaults to None, which will let Daft decide based on the runner it is currently using.
 
     returns:
-        DataFrame: parsed DataFrame with mandatory metadata columns: "WARC-Record-ID", "WARC-Type", "WARC-Date", "Content-Length", one column "warc_content"
-            with the raw byte content of the WARC record, and one column "warc_headers" with the remaining headers of the WARC record stored as a JSON string.
+        DataFrame: parsed DataFrame with mandatory metadata columns ("WARC-Record-ID", "WARC-Type", "WARC-Date", "Content-Length"), one optional
+            metadata column ("WARC-Identified-Payload-Type"), one column "warc_content" with the raw byte content of the WARC record,
+            and one column "warc_headers" with the remaining headers of the WARC record stored as a JSON string.
     """
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
 
@@ -60,6 +61,7 @@ def read_warc(
         "WARC-Type": DataType.string(),
         "WARC-Date": DataType.timestamp(TimeUnit.ns(), timezone="Etc/UTC"),
         "Content-Length": DataType.int64(),
+        "WARC-Identified-Payload-Type": DataType.string(),
         "warc_content": DataType.binary(),
         "warc_headers": DataType.string(),
     }

--- a/daft/recordbatch/micropartition.py
+++ b/daft/recordbatch/micropartition.py
@@ -524,3 +524,18 @@ class MicroPartition:
                 multithreaded_io=multithreaded_io,
             )
         )
+
+    @classmethod
+    def read_warc(
+        cls,
+        path: str,
+        io_config: IOConfig | None = None,
+        multithreaded_io: bool | None = None,
+    ) -> MicroPartition:
+        return MicroPartition._from_pymicropartition(
+            _PyMicroPartition.read_warc(
+                uri=path,
+                io_config=io_config,
+                multithreaded_io=multithreaded_io,
+            )
+        )

--- a/src/daft-scan/Cargo.toml
+++ b/src/daft-scan/Cargo.toml
@@ -22,6 +22,7 @@ daft-stats = {path = "../daft-stats", default-features = false}
 futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
+lazy_static = "1.5.0"
 parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 serde = {workspace = true}

--- a/src/daft-warc/Cargo.toml
+++ b/src/daft-warc/Cargo.toml
@@ -10,7 +10,6 @@ daft-io = {path = "../daft-io", default-features = false}
 daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
 flate2 = {version = "1.1", features = ["zlib-rs"], default-features = false}
 futures = {workspace = true}
-rayon = {workspace = true}
 serde_json = {workspace = true}
 snafu = {workspace = true}
 tokio = {workspace = true}


### PR DESCRIPTION
This PR makes the following changes for `read_warc`:
- Reduce memory consumption
- Adds `WARC-Identified-Payload-Type` as an extracted metadata column
- Improve stats estimation for scan tasks that read WARC

## Reduced memory consumption

When reading a single Common Crawl file, the file size is typically 1GB, which decompresses to 5GB of data.

Before this Resident Set Size peaks at `5.15GB` while heap size peaks at `10.98GB`:

![8D239774-4801-4350-A560-05CEA1202CB5_1_201_a](https://github.com/user-attachments/assets/5931ec32-bdce-4b2b-8838-a72e5f7ad6f4)

After this PR, Resident Set Size peaks at `4.3GB` while heap size peaks at `6.6GB`, which is more in line with expectations:

![D4676719-F780-4745-8E72-A269F07B6D05_1_201_a](https://github.com/user-attachments/assets/defc2a24-38a2-4adf-9d5f-529f0a895212)

## Additional `WARC-Identified-Payload-Type` metadata column

For ease of filtering WARC records, we extract `WARC-Identified-Payload-Type` from the metadata as its own column. Since this is an optional column, it is often NULL.

## Stats estimation

A single Common Crawl .warc.gz file is typically 1GB in size, but takes up ~5GB of memory once decompressed. 

For a .warc.gz file with `145,717` records, before this PR we would estimate:

```
Stats = { Approx num rows = 9,912,769, Approx size bytes = 914.63 MiB,
Accumulated selectivity = 1.00 }
```

After this PR, we now estimate:

```
Stats = { Approx num rows = 167,773, Approx size bytes = 4.34 GiB, Accumulated
selectivity = 1.00 }
```

which is much closer to reality.

### Estimations with pushdowns

When doing `daft.read_warc("file.warc.gz").select("Content-Length")`, we estimate `1.32 MiB` and in reality store `1.13 MiB`.

When doing `daft.read_warc("cc-original.warc.gz").select("warc_content")`, we estimate `4.39 GiB` and in reality store `3.82 GiB`.