### PR TITLE
chore: Favor OnceLock over lazy_static for WARC column sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,7 +2562,6 @@ dependencies = [
  "futures",
  "indexmap 2.7.0",
  "itertools 0.11.0",
- "lazy_static",
  "parquet2",
  "pyo3",
  "serde",

--- a/src/daft-scan/Cargo.toml
+++ b/src/daft-scan/Cargo.toml
@@ -22,7 +22,6 @@ daft-stats = {path = "../daft-stats", default-features = false}
 futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
-lazy_static = "1.5.0"
 parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 serde = {workspace = true}


### PR DESCRIPTION
Addresses this comment: https://github.com/Eventual-Inc/Daft/pull/3935#discussion_r1985934682