### PR TITLE
fix: fix error when casting monotonically_increasing_id directly

### DIFF
--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -1291,6 +1291,7 @@ impl Expr {
             },
             Self::ScalarFunction(func) => match func.name() {
                 "struct" => "struct", // FIXME: make struct its own expr variant
+                "monotonically_increasing_id" => "monotonically_increasing_id", // Special case for functions with no inputs
                 _ => func.inputs.first().unwrap().name(),
             },
             Self::BinaryOp {


### PR DESCRIPTION
Fixed a bug that caused a PanicException when directly casting `monotonically_increasing_id()` to string, allowing users to write more concise code without needing a two-step workaround.