### PR TITLE
fix: depend on pylance instead of lancedb

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -101,6 +101,9 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '8.0.0') }}
       run: uv pip install deltalake==0.10.0
 
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
+
     - name: Build library and Test with pytest (unix)
       if: ${{ (runner.os != 'Windows') }}
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -101,9 +101,6 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '8.0.0') }}
       run: uv pip install deltalake==0.10.0
 
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
-
     - name: Build library and Test with pytest (unix)
       if: ${{ (runner.os != 'Windows') }}
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ deltalake = ["deltalake", "packaging"]
 gcp = []
 hudi = ["pyarrow >= 8.0.0"]
 iceberg = ["pyiceberg >= 0.7.0", "packaging"]
-lance = ["lancedb"]
+lance = ["pylance"]
 numpy = ["numpy"]
 pandas = ["pandas"]
 ray = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -42,7 +42,7 @@ pyarrow==16.0.0
 ray[data, client]==2.34.0
 
 # Lance
-lancedb>=0.6.10
+pylance>=0.10.12
 
 #Iceberg
 pyiceberg==0.7.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,6 +36,9 @@ opencv-python==4.10.0.84
 tiktoken==0.7.0
 duckdb==1.1.2
 
+# TQDM
+tqdm
+
 # Pyarrow
 pyarrow==16.0.0
 # Ray


### PR DESCRIPTION
We don't actually use `lancedb` in Daft, we just use `pylance`. It used to work since `lancedb` depended on `pylance`, but it no longer does.

Also fixes test failures caused by issue here https://github.com/lancedb/lancedb/issues/2202