### PR TITLE
fix: tutorial code

### DIFF
--- a/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
+++ b/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
@@ -187,8 +187,8 @@
    "source": [
     "df = df.select(\n",
     "    df[\"embedding\"],\n",
-    "    df[\"meta.url\"],\n",
-    "    df[\"meta.question_score\"],\n",
+    "    df[\"meta\"].struct.get(\"url\"),\n",
+    "    df[\"meta\"].struct.get(\"question_score\"),\n",
     ")"
    ]
   },


### PR DESCRIPTION
It looks like the [notebook check workflow](https://github.com/Eventual-Inc/Daft/actions/workflows/notebook-checker.yml) has been failing for a while but we just started seeing it now that the slack notification is fixed.

In #3804, we removed the struct get syntactic sugar from DataFrame, which the notebook uses. I changed it to just use `.struct.get(..)` instead.
