### PR TITLE
fix: allow decimal precision equal to scale

### DIFF
--- a/src/parquet2/src/schema/types/spec.rs
+++ b/src/parquet2/src/schema/types/spec.rs
@@ -14,9 +14,9 @@ fn check_decimal_invariants(
             precision,
         )));
     }
-    if scale >= precision {
+    if scale > precision {
         return Err(Error::oos(format!(
-            "Invalid DECIMAL: scale ({}) cannot be greater than or equal to precision \
+            "Invalid DECIMAL: scale ({}) cannot be greater than precision \
             ({})",
             scale, precision
         )));


### PR DESCRIPTION
This PR cherry-picks [parquet2#231](https://github.com/jorgecarleitao/parquet2/pull/231) to allow decimal precisions equal to the scale.