### PR TITLE
docs: change all mentions of getdaft -> daft

### DIFF
--- a/.github/assets/tpch-bench.yaml
+++ b/.github/assets/tpch-bench.yaml
@@ -45,4 +45,4 @@ setup_commands:
 - echo "source ~/.venv/bin/activate" >> ~/.bashrc
 - source .venv/bin/activate
 - uv pip install pip ray[default] --no-progress
-- uv pip install getdaft --no-progress --pre --extra-index-url ${DAFT_INDEX_URL}
+- uv pip install daft --no-progress --pre --extra-index-url ${DAFT_INDEX_URL}

--- a/.github/ci-scripts/templatize_ray_config.py
+++ b/.github/ci-scripts/templatize_ray_config.py
@@ -99,9 +99,9 @@ if __name__ == "__main__":
     elif args.daft_wheel_url:
         daft_install = args.daft_wheel_url
     elif args.daft_version:
-        daft_install = f"getdaft=={args.daft_version}"
+        daft_install = f"daft=={args.daft_version}"
     else:
-        daft_install = "getdaft"
+        daft_install = "daft"
     content = content.replace(DAFT_INSTALL_PLACEHOLDER, daft_install)
 
     content = content.replace(PYTHON_VERSION_PLACEHOLDER, args.python_version)

--- a/.github/workflows/benchmark-local-tpch.yml
+++ b/.github/workflows/benchmark-local-tpch.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Install Daft and dev dependencies
       run: |
         rm -rf daft
-        uv pip install getdaft --pre --extra-index-url ${{ env.DAFT_INDEX_URL }}
+        uv pip install daft --pre --extra-index-url ${{ env.DAFT_INDEX_URL }}
         uv pip install gspread
     - name: Write service account secret file
       run: |

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,5 +1,5 @@
 name: build-wheel
-run-name: 'Build Daft wheel for ${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}-newname=${{ inputs.use_new_name }}'
+run-name: 'Build Daft wheel for ${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}-newname=${{ inputs.use_old_name }}'
 
 on:
   workflow_call:
@@ -16,8 +16,8 @@ on:
       build_type:
         description: Value to set RUST_DAFT_PKG_BUILD_TYPE to (release, dev, nightly, etc.)
         type: string
-      use_new_name:
-        description: Set to true to build as `daft` instead of `getdaft`
+      use_old_name:
+        description: Set to true to build as `getdaft` instead of `daft`
         type: boolean
 
 env:
@@ -56,8 +56,8 @@ jobs:
         tomlq -i -t ".workspace.package.version = \"$VERSION\"" Cargo.toml
 
     - name: Patch name to daft if using new name
-      if: ${{ inputs.use_new_name }}
-      run: tomlq -i -t ".project.name = \"daft\"" pyproject.toml
+      if: ${{ inputs.use_old_name }}
+      run: tomlq -i -t ".project.name = \"getdaft\"" pyproject.toml
 
     - name: Patch name to daft-lts if LTS
       if: ${{ inputs.lts }}
@@ -122,5 +122,5 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}-newname=${{ inputs.use_new_name }}
+        name: wheels-${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}-newname=${{ inputs.use_old_name }}
         path: dist

--- a/.github/workflows/nightly-publish-s3.yml
+++ b/.github/workflows/nightly-publish-s3.yml
@@ -30,14 +30,14 @@ jobs:
       arch: ${{ matrix.arch }}
       lts: ${{ matrix.lts }}
       build_type: release
-      use_new_name: ${{ matrix.use_new_name }}
+      use_old_name: ${{ matrix.use_old_name }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
         arch: [x86_64, aarch64]
         lts: [false, true]
-        use_new_name: [false, true]
+        use_old_name: [false, true]
 
         exclude:
         - os: windows
@@ -45,7 +45,7 @@ jobs:
         - lts: true
           arch: aarch64
         - lts: true
-          use_new_name: true
+          use_old_name: false
 
   publish:
     name: Publish wheels to S3
@@ -86,7 +86,7 @@ jobs:
     - name: Print install instructions
       run: |
         echo "To install the nightly build, run:"
-        echo "pip install getdaft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/builds/nightly"
+        echo "pip install daft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/builds/nightly"
 
   on-failure:
     name: Send Slack notification on failure

--- a/.github/workflows/nightly-publish-s3.yml
+++ b/.github/workflows/nightly-publish-s3.yml
@@ -117,7 +117,7 @@ jobs:
     runs-on: ${{ matrix.runner-name }}
     timeout-minutes: 15
     env:
-      package-name: getdaft
+      package-name: daft
     strategy:
       fail-fast: false
       matrix:
@@ -142,7 +142,7 @@ jobs:
 
     - name: Install Daft and dev dependencies
       run: |
-        uv pip install -r requirements-dev.txt getdaft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/builds/nightly --force-reinstall
+        uv pip install -r requirements-dev.txt daft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/builds/nightly --force-reinstall
         rm -rf daft
     - uses: actions/cache@v4
       env:
@@ -181,7 +181,7 @@ jobs:
     runs-on: ${{ matrix.runner-name }}
     timeout-minutes: 30
     env:
-      package-name: getdaft
+      package-name: daft
     strategy:
       fail-fast: false
       matrix:
@@ -213,7 +213,7 @@ jobs:
         echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
     - name: Install Daft and dev dependencies
       run: |
-        uv pip install -r requirements-dev.txt getdaft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/builds/nightly --force-reinstall
+        uv pip install -r requirements-dev.txt daft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/builds/nightly --force-reinstall
         rm -rf daft
     - name: Prepare tmpdirs for IO services
       run: |

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -34,7 +34,7 @@ jobs:
         OBJECT_EXISTS=$(aws s3api head-object --bucket github-actions-artifacts-bucket --key ${{ env.S3_KEY }}/index.html > /dev/null 2>&1 && echo "true" || echo "false")
         if [[ "$OBJECT_EXISTS" = "true" ]]; then
           echo "Package already exists for this commit, skipping publish. To install, run:"
-          echo "pip install getdaft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/${{ env.S3_KEY }}"
+          echo "pip install daft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/${{ env.S3_KEY }}"
         fi
 
         echo "build_exists=$OBJECT_EXISTS" >> "$GITHUB_OUTPUT"
@@ -49,14 +49,14 @@ jobs:
       arch: ${{ matrix.arch }}
       lts: ${{ matrix.lts }}
       build_type: release
-      use_new_name: ${{ matrix.use_new_name }}
+      use_old_name: ${{ matrix.use_old_name }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu]
         arch: [x86_64, aarch64]
         lts: [false]
-        use_new_name: [false, true]
+        use_old_name: [false, true]
 
   publish:
     name: Publish wheels to S3
@@ -98,4 +98,4 @@ jobs:
     - name: Print install instructions
       run: |
         echo "To install the dev build, run:"
-        echo "pip install getdaft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/${{ env.S3_KEY }}"
+        echo "pip install daft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/${{ env.S3_KEY }}"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,14 +22,14 @@ jobs:
       arch: ${{ matrix.arch }}
       lts: ${{ matrix.lts }}
       build_type: release
-      use_new_name: ${{ matrix.use_new_name }}
+      use_old_name: ${{ matrix.use_old_name }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
         arch: [x86_64, aarch64]
         lts: [false, true]
-        use_new_name: [false, true]
+        use_old_name: [false, true]
 
         exclude:
         - os: windows
@@ -37,7 +37,7 @@ jobs:
         - lts: true
           arch: aarch64
         - lts: true
-          use_new_name: true
+          use_old_name: false
 
   publish:
     name: Publish wheels to PyPI

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -184,7 +184,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      package-name: getdaft
+      package-name: daft
     strategy:
       matrix:
         python-version: ['3.9']
@@ -225,7 +225,7 @@ jobs:
     needs:
     - integration-test-build
     env:
-      package-name: getdaft
+      package-name: daft
     strategy:
       fail-fast: false
       matrix:
@@ -305,7 +305,7 @@ jobs:
     needs:
     - integration-test-build
     env:
-      package-name: getdaft
+      package-name: daft
     strategy:
       fail-fast: false
       matrix:
@@ -389,7 +389,7 @@ jobs:
     needs:
     - integration-test-build
     env:
-      package-name: getdaft
+      package-name: daft
     strategy:
       fail-fast: false
       matrix:
@@ -489,7 +489,7 @@ jobs:
     needs:
     - integration-test-build
     env:
-      package-name: getdaft
+      package-name: daft
     strategy:
       fail-fast: false
       matrix:
@@ -572,7 +572,7 @@ jobs:
     needs:
     - integration-test-build
     env:
-      package-name: getdaft
+      package-name: daft
     strategy:
       fail-fast: false
       matrix:
@@ -670,7 +670,7 @@ jobs:
     runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 30
     env:
-      package-name: getdaft
+      package-name: daft
       RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2
     steps:
     - uses: actions/checkout@v4

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,7 @@ Daft has an Apache 2.0 license - please see the LICENSE file.
    :alt: Github Actions tests
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/getdaft.svg?label=pip&logo=PyPI&logoColor=white
-   :target: https://pypi.org/project/getdaft
+   :target: https://pypi.org/project/daft
    :alt: PyPI
 
 .. |Latest Tag| image:: https://img.shields.io/github/v/tag/Eventual-Inc/Daft?label=latest&logo=GitHub

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Getting Started
 Installation
 ^^^^^^^^^^^^
 
-Install Daft with ``pip install getdaft``.
+Install Daft with ``pip install daft``.
 
 For more advanced installations (e.g. installing from source or with extra dependencies such as Ray and AWS utilities), please see our `Installation Guide <https://www.getdaft.io/projects/docs/en/stable/install/>`_
 

--- a/benchmarking/parquet/README.md
+++ b/benchmarking/parquet/README.md
@@ -18,7 +18,7 @@ pip install -r benchmark-requirements.txt
 Now, install the version of Daft you wish to use for benchmarking (either a released wheel, or if you want, a local build)
 
 ```bash
-pip install getdaft
+pip install daft
 ```
 
 ## Running the benchmarks:

--- a/benchmarking/tpch/ray_job_runner.py
+++ b/benchmarking/tpch/ray_job_runner.py
@@ -2,7 +2,7 @@
 # requires-python = ">=3.12"
 # dependencies = [
 #   "ray[default]",
-#   "getdaft",
+#   "daft",
 # ]
 # ///
 

--- a/daft/analytics.py
+++ b/daft/analytics.py
@@ -49,7 +49,7 @@ def _build_segment_batch_payload(
                 "timestamp": event.event_time.isoformat(),
                 "context": {
                     "app": {
-                        "name": "getdaft",
+                        "name": "daft",
                         "version": daft_version,
                         "build": daft_build_type,
                     },

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -255,7 +255,7 @@ class Catalog(ABC):
 
             return IcebergCatalog._from_obj(catalog)
         except ImportError:
-            raise ImportError("Iceberg support not installed: pip install -U 'getdaft[iceberg]'")
+            raise ImportError("Iceberg support not installed: pip install -U 'daft[iceberg]'")
 
     @staticmethod
     def from_unity(catalog: object) -> Catalog:
@@ -272,7 +272,7 @@ class Catalog(ABC):
 
             return UnityCatalog._from_obj(catalog)
         except ImportError:
-            raise ImportError("Unity support not installed: pip install -U 'getdaft[unity]'")
+            raise ImportError("Unity support not installed: pip install -U 'daft[unity]'")
 
     @staticmethod
     def from_s3tables(table_bucket_arn: str, client: object | None = None, session: object | None = None):
@@ -599,7 +599,7 @@ class Table(ABC):
 
             return IcebergTable._from_obj(table)
         except ImportError:
-            raise ImportError("Iceberg support not installed: pip install -U 'getdaft[iceberg]'")
+            raise ImportError("Iceberg support not installed: pip install -U 'daft[iceberg]'")
 
     @staticmethod
     def from_unity(table: object) -> Table:
@@ -613,7 +613,7 @@ class Table(ABC):
 
             return UnityTable._from_obj(table)
         except ImportError:
-            raise ImportError("Unity support not installed: pip install -U 'getdaft[unity]'")
+            raise ImportError("Unity support not installed: pip install -U 'daft[unity]'")
 
     @staticmethod
     def _from_obj(name: str, source: object) -> Table:

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1214,7 +1214,7 @@ class DataFrame:
             import pyarrow as pa
 
         except ImportError:
-            raise ImportError("lance is not installed. Please install lance using `pip install getdaft[lance]`")
+            raise ImportError("lance is not installed. Please install lance using `pip install daft[lance]`")
 
         io_config = get_context().daft_planning_config.default_io_config if io_config is None else io_config
 

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -79,7 +79,7 @@ def get_filesystem(protocol: str, **kwargs) -> fsspec.AbstractFileSystem:
         klass = fsspec.get_filesystem_class(protocol)
     except ImportError:
         logger.error(
-            "Error when importing dependencies for accessing data with: %s. Please ensure that getdaft was installed with the appropriate extra dependencies (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)",
+            "Error when importing dependencies for accessing data with: %s. Please ensure that daft was installed with the appropriate extra dependencies (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)",
             protocol,
         )
         raise

--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -59,7 +59,7 @@ def get_filesystem(protocol: str, **kwargs) -> fsspec.AbstractFileSystem:
             import botocore.session
         except ImportError:
             logger.error(
-                "Error when importing botocore. Install getdaft[aws] for the required 3rd party dependencies to interact with AWS S3 (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
+                "Error when importing botocore. install daft[aws] for the required 3rd party dependencies to interact with AWS S3 (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
             )
             raise
 

--- a/daft/io/_lance.py
+++ b/daft/io/_lance.py
@@ -33,7 +33,7 @@ def read_lance(url: str, io_config: Optional["IOConfig"] = None) -> DataFrame:
         This function requires the use of `LanceDB <https://lancedb.github.io/lancedb/>`_, which is the Python
         library for the LanceDB project.
 
-        To ensure that this is installed with Daft, you may install: ``pip install getdaft[lance]``
+        To ensure that this is installed with Daft, you may install: ``pip install daft[lance]``
 
     Example:
         >>> df = daft.read_lance("s3://my-lancedb-bucket/data/")
@@ -50,7 +50,7 @@ def read_lance(url: str, io_config: Optional["IOConfig"] = None) -> DataFrame:
         import lance
     except ImportError as e:
         raise ImportError(
-            "Unable to import the `lance` package, please ensure that Daft is installed with the lance extra dependency: `pip install getdaft[lance]`"
+            "Unable to import the `lance` package, please ensure that Daft is installed with the lance extra dependency: `pip install daft[lance]`"
         ) from e
 
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config

--- a/daft/runners/ray_metrics.py
+++ b/daft/runners/ray_metrics.py
@@ -11,7 +11,7 @@ try:
     import ray
 except ImportError:
     logger.error(
-        "Error when importing Ray. Please ensure that getdaft was installed with the Ray extras tag: getdaft[ray] (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
+        "Error when importing Ray. Please ensure that daft was installed with the Ray extras tag: daft[ray] (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
     )
     raise
 

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -33,7 +33,7 @@ try:
     import ray
 except ImportError:
     logger.error(
-        "Error when importing Ray. Please ensure that getdaft was installed with the Ray extras tag: getdaft[ray] (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
+        "Error when importing Ray. Please ensure that daft was installed with the Ray extras tag: daft[ray] (https://www.getdaft.io/projects/docs/en/latest/learn/install.html)"
     )
     raise
 

--- a/docs/mkdocs/10min.ipynb
+++ b/docs/mkdocs/10min.ipynb
@@ -56,7 +56,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install getdaft"
+        "%pip install daft"
       ]
     },
     {

--- a/docs/mkdocs/install.md
+++ b/docs/mkdocs/install.md
@@ -3,7 +3,7 @@
 To install Daft, run this from your terminal:
 
 ```bash
-pip install -U getdaft
+pip install -U daft
 ```
 
 ## Extra Dependencies
@@ -13,19 +13,19 @@ Some Daft functionality may also require other dependencies, which are specified
 To install Daft with the extra dependencies required for interacting with AWS services, such as AWS S3, run:
 
 ```bash
-pip install -U getdaft[aws]
+pip install -U daft[aws]
 ```
 
 To install Daft with the extra dependencies required for running distributed Daft on top of a [Ray cluster](https://docs.ray.io/en/latest/index.html), run:
 
 ```bash
-pip install -U getdaft[ray]
+pip install -U daft[ray]
 ```
 
 To install Daft with all extras, run:
 
 ```bash
-pip install -U getdaft[all]
+pip install -U daft[all]
 ```
 
 ## Advanced Installation
@@ -35,7 +35,7 @@ pip install -U getdaft[all]
 If you wish to use Daft at the bleeding edge of development, you may also install the nightly build of Daft which is built every night against the `main` branch:
 
 ```bash
-pip install -U getdaft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple
+pip install -U daft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple
 ```
 
 ### Installing Daft from source

--- a/docs/mkdocs/integrations/delta_lake.md
+++ b/docs/mkdocs/integrations/delta_lake.md
@@ -12,10 +12,10 @@ Daft currently supports:
 
 ## Installing Daft with Delta Lake Support
 
-Daft internally uses the [deltalake](https://pypi.org/project/deltalake/) Python package to fetch metadata about the Delta Lake table, such as paths to the underlying Parquet files and table statistics. The `deltalake` package therefore must be installed to read Delta Lake tables with Daft, either manually or with the below `getdaft[deltalake]` extras install of Daft.
+Daft internally uses the [deltalake](https://pypi.org/project/deltalake/) Python package to fetch metadata about the Delta Lake table, such as paths to the underlying Parquet files and table statistics. The `deltalake` package therefore must be installed to read Delta Lake tables with Daft, either manually or with the below `daft[deltalake]` extras install of Daft.
 
 ```bash
-pip install -U "getdaft[deltalake]"
+pip install -U "daft[deltalake]"
 ```
 
 ## Reading a Table

--- a/docs/mkdocs/integrations/hudi.md
+++ b/docs/mkdocs/integrations/hudi.md
@@ -15,7 +15,7 @@ Daft currently supports:
 Daft supports installing Hudi through optional dependency.
 
 ```bash
-pip install -U "getdaft[hudi]"
+pip install -U "daft[hudi]"
 ```
 
 ## Reading a Table

--- a/docs/mkdocs/integrations/ray.md
+++ b/docs/mkdocs/integrations/ray.md
@@ -26,7 +26,7 @@ Here's an example of how you can use the Ray client with Daft:
     import ray
 
     # Refer to the note under "Ray Job" for details on "runtime_env"
-    ray.init("ray://<head_node_host>:10001", runtime_env={"pip": ["getdaft"]})
+    ray.init("ray://<head_node_host>:10001", runtime_env={"pip": ["daft"]})
 
     # Starts the Ray client and tells Daft to use Ray to execute queries
     # If ray.init() has already been called, it uses the existing client
@@ -85,7 +85,7 @@ To submit this script as a job, use the Ray CLI, which can be installed with `pi
 ray job submit \
     --working-dir wd \
     --address "http://<head_node_host>:8265" \
-    --runtime-env-json '{"pip": ["getdaft"]}' \
+    --runtime-env-json '{"pip": ["daft"]}' \
     -- python job.py
 ```
 

--- a/docs/mkdocs/integrations/sql.md
+++ b/docs/mkdocs/integrations/sql.md
@@ -12,10 +12,10 @@ Daft currently supports:
 
 ## Installing Daft with SQL Support
 
-Install Daft with the `getdaft[sql]` extra, or manually install the required packages: [ConnectorX](https://sfu-db.github.io/connector-x/databases.html), [SQLAlchemy](https://docs.sqlalchemy.org/en/20/orm/quickstart.html) and [SQLGlot](https://sqlglot.com/sqlglot.html).
+Install Daft with the `daft[sql]` extra, or manually install the required packages: [ConnectorX](https://sfu-db.github.io/connector-x/databases.html), [SQLAlchemy](https://docs.sqlalchemy.org/en/20/orm/quickstart.html) and [SQLGlot](https://sqlglot.com/sqlglot.html).
 
 ```bash
-pip install -U "getdaft[sql]"
+pip install -U "daft[sql]"
 ```
 
 ## Reading a SQL query

--- a/docs/mkdocs/integrations/unity_catalog.md
+++ b/docs/mkdocs/integrations/unity_catalog.md
@@ -5,7 +5,7 @@
 To use Daft with the Unity Catalog, you will need to install Daft with the `unity` option specified like so:
 
 ```bash
-pip install getdaft[unity]
+pip install daft[unity]
 ```
 
 !!! warning "Warning"

--- a/docs/mkdocs/quickstart.ipynb
+++ b/docs/mkdocs/quickstart.ipynb
@@ -28,7 +28,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "pip install getdaft"
+        "pip install daft"
       ]
     },
     {

--- a/docs/mkdocs/quickstart.md
+++ b/docs/mkdocs/quickstart.md
@@ -19,7 +19,7 @@ You can install Daft using `pip`. Run the following command in your terminal or 
 === "🐍 Python"
 
     ```python
-    pip install getdaft
+    pip install daft
     ```
 
 For more advanced installation options, please see [Installation](install.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,12 @@ maintainers = [
   {name = "Sammy Sidhu", email = "sammy@eventualcomputing.com"},
   {name = "Jay Chia", email = "jay@eventualcomputing.com"}
 ]
-name = "getdaft"
+name = "daft"
 readme = "README.rst"
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-all = ["getdaft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake, sql, unity]"]
+all = ["daft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake, sql, unity]"]
 aws = ["boto3"]
 azure = []
 deltalake = ["deltalake", "packaging"]

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -61,7 +61,7 @@ def test_analytics_client_track_import(mock_datetime: MagicMock, mock_analytics:
                     "timestamp": MOCK_DATETIME.isoformat(),
                     "context": {
                         "app": {
-                            "name": "getdaft",
+                            "name": "daft",
                             "version": daft.get_version(),
                             "build": daft.get_build_type(),
                         },
@@ -154,7 +154,7 @@ def test_analytics_client_track_dataframe_method(
                     "timestamp": MOCK_DATETIME.isoformat(),
                     "context": {
                         "app": {
-                            "name": "getdaft",
+                            "name": "daft",
                             "version": daft.get_version(),
                             "build": daft.get_build_type(),
                         },

--- a/tutorials/delta_lake/3-pytorch-ray-single-node-training.ipynb
+++ b/tutorials/delta_lake/3-pytorch-ray-single-node-training.ipynb
@@ -121,7 +121,7 @@
     "        address=RAY_ADDRESS,\n",
     "        runtime_env={\n",
     "            \"pip\": [\n",
-    "                \"getdaft\",\n",
+    "                \"daft\",\n",
     "                \"torch\",\n",
     "                \"torchvision\",\n",
     "            ]\n",

--- a/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
+++ b/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
@@ -36,7 +36,7 @@
    "outputs": [],
    "source": [
     "# Install Daft!\n",
-    "!pip install 'getdaft[aws]'\n",
+    "!pip install 'daft[aws]'\n",
     "\n",
     "# We will use sentence-transformers for computing embeddings.\n",
     "!pip install sentence-transformers"

--- a/tutorials/flyte/Dockerfile
+++ b/tutorials/flyte/Dockerfile
@@ -1,4 +1,4 @@
 FROM ghcr.io/flyteorg/flytekit:py3.9-1.7.0
 
 USER root
-RUN pip install getdaft flytekitplugins-ray
+RUN pip install daft flytekitplugins-ray

--- a/tutorials/image_querying/top_n_red_color.ipynb
+++ b/tutorials/image_querying/top_n_red_color.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install getdaft[aws,ray]\n",
+    "!pip install daft[aws,ray]\n",
     "!pip install Pillow numpy"
    ]
   },

--- a/tutorials/image_querying/top_n_red_color.ipynb
+++ b/tutorials/image_querying/top_n_red_color.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "    ray.init(\n",
     "        address=RAY_CLUSTER_ADDRESS,\n",
-    "        runtime_env={\"pip\": [\"getdaft\", \"pillow\", \"s3fs\"]},\n",
+    "        runtime_env={\"pip\": [\"daft\", \"pillow\", \"s3fs\"]},\n",
     "    )\n",
     "\n",
     "    daft.context.set_runner_ray(address=RAY_CLUSTER_ADDRESS)"

--- a/tutorials/intro.ipynb
+++ b/tutorials/intro.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install getdaft"
+    "!pip install daft"
    ]
   },
   {

--- a/tutorials/mnist.ipynb
+++ b/tutorials/mnist.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install getdaft\n",
+    "%pip install daft\n",
     "%pip install Pillow torch torchvision"
    ]
   },

--- a/tutorials/talks_and_demos/data-ai-summit-2024.ipynb
+++ b/tutorials/talks_and_demos/data-ai-summit-2024.ipynb
@@ -7,7 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install getdaft deltalake<0.17"
+    "!pip install daft deltalake<0.17"
    ]
   },
   {

--- a/tutorials/talks_and_demos/iceberg_summit_2024.ipynb
+++ b/tutorials/talks_and_demos/iceberg_summit_2024.ipynb
@@ -91,7 +91,7 @@
    "outputs": [],
    "source": [
     "!pip install 'pyiceberg[sql]'\n",
-    "!pip install 'getdaft[ray]' polars pandas\n",
+    "!pip install 'daft[ray]' polars pandas\n",
     "!pip install ray==2.20.0\n",
     "!pip install sqlalchemy ipywidgets boto3 mypy_boto3_glue"
    ]

--- a/tutorials/talks_and_demos/linkedin-03-05-2024.ipynb
+++ b/tutorials/talks_and_demos/linkedin-03-05-2024.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -U 'getdaft[iceberg,hudi,deltalake]'\n",
+    "!pip install -U 'daft[iceberg,hudi,deltalake]'\n",
     "!pip install -U ipywidgets"
    ]
   },

--- a/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -14,7 +14,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install getdaft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
+    "!pip install daft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
     "!pip install min-dalle torch Pillow"
    ]
   },

--- a/tutorials/text_to_image/using_cloud_with_ray.ipynb
+++ b/tutorials/text_to_image/using_cloud_with_ray.ipynb
@@ -25,7 +25,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install getdaft[ray]\n",
+    "!pip install daft[ray]\n",
     "!pip install Pillow"
    ]
   },


### PR DESCRIPTION
## Summary

Change all instances of getdaft to daft where appropriate

## Related Issues

#3913 

## Changes Made

I went through to cleanup all instances of:

1. `"getdaft*` - places in the code where we use Python strings to reference the package
2. `getdaft[` places in the code where we potentially use the getdaft with extras
3. `install getdaft` places in the code where we do pip installations
4. `getdaft` just a general visual audit of where we use the `getdaft` still

After this, the search for `getdaft(?!\.)` (any instances of `getdaft` that isn't suffixed with a `.` -- this helps sift through everything that isn't a mention of our website which is still getdaft.io) turns up only expected results.

## Tests

Action for builds: https://github.com/Eventual-Inc/Daft/actions/runs/13863156729

## Checklist

- [ ] All tests have passed
- [ ] Documented in API Docs
- [ ] Documented in User Guide
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
