### PR TITLE
fix: Fix list sort with groupby

### DIFF
--- a/src/daft-core/src/array/ops/list.rs
+++ b/src/daft-core/src/array/ops/list.rs
@@ -639,7 +639,11 @@ impl ListArray {
         };
 
         let child_refs: Vec<&Series> = child_series.iter().collect();
-        let child = Series::concat(&child_refs)?;
+        let child = if child_refs.is_empty() {
+            Series::empty(self.name(), self.child_data_type())
+        } else {
+            Series::concat(&child_refs)?
+        };
         Ok(Self::new(
             self.field.clone(),
             child,
@@ -1015,7 +1019,11 @@ impl FixedSizeListArray {
         };
 
         let child_refs: Vec<&Series> = child_series.iter().collect();
-        let child = Series::concat(&child_refs)?;
+        let child = if child_refs.is_empty() {
+            Series::empty(self.name(), self.child_data_type())
+        } else {
+            Series::concat(&child_refs)?
+        };
         Ok(Self::new(
             self.field.clone(),
             child,

--- a/tests/recordbatch/list/test_list_sort.py
+++ b/tests/recordbatch/list/test_list_sort.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import daft
 from daft.datatype import DataType
 from daft.expressions import col
 from daft.recordbatch import MicroPartition
@@ -49,3 +50,24 @@ def test_list_sort_fixed_size():
         "desc": [[3, 1], [6, 2], [3, 3], [11, 6], None, [None, 2], None],
         "mixed": [[3, 1], [2, 6], [3, 3], [11, 6], None, [2, None], None],
     }
+
+
+def test_list_sort_with_groupby():
+    df = daft.from_pydict({"group_col": [1, 1, 1, 2, 2, 2], "id_col": ["c", "a", "b", "e", "d", "a"]})
+
+    # Group by group_col, aggregate id_col as a list.
+    grouped_df = df.groupby("group_col").agg(daft.col("id_col").agg_list().alias("ids_col"))
+
+    # Sort the list.
+    result = grouped_df.select(col("group_col"), col("ids_col").list.sort()).sort("group_col", desc=False)
+    result_dict = result.to_pydict()
+    expected = {"group_col": [1, 2], "ids_col": [["a", "b", "c"], ["a", "d", "e"]]}
+    assert result_dict == expected
+
+    # Cast to fixed size list and sort.
+    result = grouped_df.select(
+        col("group_col"), col("ids_col").cast(DataType.fixed_size_list(DataType.string(), 3)).list.sort()
+    ).sort("group_col", desc=False)
+    result_dict = result.to_pydict()
+    expected = {"group_col": [1, 2], "ids_col": [["a", "b", "c"], ["a", "d", "e"]]}
+    assert result_dict == expected


### PR DESCRIPTION
## Summary

```
(
    daft.from_pydict(
        {"group_col": [1, 1, 1, 2, 2], "id_col": ["c", "a", "b", "e", "d"]}
    )
    .groupby("group_col")
    .agg(daft.col("id_col").agg_list().list.sort().alias("ids_col"))
    .show()
)
```
was reported as failing with `DaftCoreException: DaftError::ValueError Need at least 1 series to perform concat`

This happens when the number of partitions in our groupby is greater than the actual number of partitions needed. This results in some empty partitions with nothing to sort. We should handle these cases accordingly.

The same happens for fixed size lists.

This PR fixes the issue.

## Related Issues

Closes #3969 

## Checklist

- [x] All tests have passed
