### PR TITLE
docs: Make wording around distinct more consistent

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1449,13 +1449,13 @@ class DataFrame:
 
     @DataframePublicAPI
     def distinct(self) -> "DataFrame":
-        """Computes unique rows, dropping duplicates.
+        """Computes distinct rows, dropping duplicates.
 
         Example:
             >>> import daft
             >>> df = daft.from_pydict({"x": [1, 2, 2], "y": [4, 5, 5], "z": [7, 8, 8]})
-            >>> unique_df = df.distinct()
-            >>> unique_df.show()
+            >>> distinct_df = df.distinct()
+            >>> distinct_df.show()
             ╭───────┬───────┬───────╮
             │ x     ┆ y     ┆ z     │
             │ ---   ┆ ---   ┆ ---   │
@@ -1469,7 +1469,7 @@ class DataFrame:
             (Showing first 2 of 2 rows)
 
         Returns:
-            DataFrame: DataFrame that has only  unique rows.
+            DataFrame: DataFrame that has only distinct rows.
         """
         ExpressionsProjection.from_schema(self._builder.schema())
         builder = self._builder.distinct()

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1476,6 +1476,34 @@ class DataFrame:
         return DataFrame(builder)
 
     @DataframePublicAPI
+    def unique(self) -> "DataFrame":
+        """Computes distinct rows, dropping duplicates.
+
+        Alias for :func:`DataFrame.distinct`.
+
+        Example:
+            >>> import daft
+            >>> df = daft.from_pydict({"x": [1, 2, 2], "y": [4, 5, 5], "z": [7, 8, 8]})
+            >>> distinct_df = df.unique()
+            >>> distinct_df.show()
+            ╭───────┬───────┬───────╮
+            │ x     ┆ y     ┆ z     │
+            │ ---   ┆ ---   ┆ ---   │
+            │ Int64 ┆ Int64 ┆ Int64 │
+            ╞═══════╪═══════╪═══════╡
+            │ 2     ┆ 5     ┆ 8     │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 1     ┆ 4     ┆ 7     │
+            ╰───────┴───────┴───────╯
+            <BLANKLINE>
+            (Showing first 2 of 2 rows)
+
+        Returns:
+            DataFrame: DataFrame that has only distinct rows.
+        """
+        return self.distinct()
+
+    @DataframePublicAPI
     def sample(
         self,
         fraction: float,

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -3635,6 +3635,54 @@ class ExpressionListNamespace(ExpressionNamespace):
         """
         return Expression._from_pyexpr(_list_distinct(self._expr))
 
+    def unique(self) -> Expression:
+        """Returns a list of distinct elements in each list, preserving order of first occurrence and ignoring nulls.
+
+        Alias for :func:`Expression.list.distinct`.
+
+        Example:
+            >>> import daft
+            >>> df = daft.from_pydict({"a": [[1, 2, 2, 3], [4, 4, 6, 2], [6, 7, 1], [None, 1, None, 1]]})
+            >>> df.select(df["a"].list.unique()).show()
+            ╭─────────────╮
+            │ a           │
+            │ ---         │
+            │ List[Int64] │
+            ╞═════════════╡
+            │ [1, 2, 3]   │
+            ├╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+            │ [4, 6, 2]   │
+            ├╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+            │ [6, 7, 1]   │
+            ├╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+            │ [1]         │
+            ╰─────────────╯
+            <BLANKLINE>
+            (Showing first 4 of 4 rows)
+
+            Note that null values are ignored:
+
+            >>> df = daft.from_pydict({"a": [[None, None], [1, None, 1], [None]]})
+            >>> df.select(df["a"].list.unique()).show()
+            ╭─────────────╮
+            │ a           │
+            │ ---         │
+            │ List[Int64] │
+            ╞═════════════╡
+            │ []          │
+            ├╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+            │ [1]         │
+            ├╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+            │ []          │
+            ╰─────────────╯
+            <BLANKLINE>
+            (Showing first 3 of 3 rows)
+
+        Returns:
+            Expression: An expression with lists containing only distinct elements
+        """
+        return self.distinct()
+
 
 class ExpressionStructNamespace(ExpressionNamespace):
     def get(self, name: str) -> Expression:

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -984,7 +984,7 @@ class Expression:
         return Expression._from_pyexpr(expr)
 
     def approx_count_distinct(self) -> Expression:
-        """Calculates the approximate number of non-`NULL` unique values in the expression.
+        """Calculates the approximate number of non-`NULL` distinct values in the expression.
 
         Approximation is performed using the `HyperLogLog <https://en.wikipedia.org/wiki/HyperLogLog>`_ algorithm.
 
@@ -1175,33 +1175,33 @@ class Expression:
         Example:
             >>> import daft
             >>> df = daft.from_pydict({"values": [1, 1, None, 2, 2, None]})
-            >>> df.agg(df["values"].agg_set().alias("unique_values")).show()
-            ╭───────────────╮
-            │ unique_values │
-            │ ---           │
-            │ List[Int64]   │
-            ╞═══════════════╡
-            │ [1, 2]        │
-            ╰───────────────╯
+            >>> df.agg(df["values"].agg_set().alias("distinct_values")).show()
+            ╭─────────────────╮
+            │ distinct_values │
+            │ ---             │
+            │ List[Int64]     │
+            ╞═════════════════╡
+            │ [1, 2]          │
+            ╰─────────────────╯
             <BLANKLINE>
             (Showing first 1 of 1 rows)
 
             Note that null values are ignored by default:
 
             >>> df = daft.from_pydict({"values": [None, None, None]})
-            >>> df.agg(df["values"].agg_set().alias("unique_values")).show()
-            ╭───────────────╮
-            │ unique_values │
-            │ ---           │
-            │ List[Null]    │
-            ╞═══════════════╡
-            │ []            │
-            ╰───────────────╯
+            >>> df.agg(df["values"].agg_set().alias("distinct_values")).show()
+            ╭─────────────────╮
+            │ distinct_values │
+            │ ---             │
+            │ List[Null]      │
+            ╞═════════════════╡
+            │ []              │
+            ╰─────────────────╯
             <BLANKLINE>
             (Showing first 1 of 1 rows)
 
         Returns:
-            Expression: A List expression containing the unique values from the input
+            Expression: A List expression containing the distinct values from the input
         """
         expr = self._expr.agg_set()
         return Expression._from_pyexpr(expr)
@@ -3353,10 +3353,10 @@ class ExpressionListNamespace(ExpressionNamespace):
         return Expression._from_pyexpr(native.list_join(self._expr, delimiter_expr._expr))
 
     def value_counts(self) -> Expression:
-        """Counts the occurrences of each unique value in the list.
+        """Counts the occurrences of each distinct value in the list.
 
         Returns:
-            Expression: A Map<X, UInt64> expression where the keys are unique elements from the
+            Expression: A Map<X, UInt64> expression where the keys are distinct elements from the
                         original list of type X, and the values are UInt64 counts representing
                         the number of times each element appears in the list.
 
@@ -3590,7 +3590,7 @@ class ExpressionListNamespace(ExpressionNamespace):
         return Expression._from_pyexpr(_list_sort(self._expr, desc._expr, nulls_first._expr))
 
     def distinct(self) -> Expression:
-        """Returns a list of unique elements in each list, preserving order of first occurrence and ignoring nulls.
+        """Returns a list of distinct elements in each list, preserving order of first occurrence and ignoring nulls.
 
         Example:
             >>> import daft
@@ -3631,7 +3631,7 @@ class ExpressionListNamespace(ExpressionNamespace):
             (Showing first 3 of 3 rows)
 
         Returns:
-            Expression: An expression with lists containing only unique elements
+            Expression: An expression with lists containing only distinct elements
         """
         return Expression._from_pyexpr(_list_distinct(self._expr))
 

--- a/docs/sphinx/source/dataframe.rst
+++ b/docs/sphinx/source/dataframe.rst
@@ -60,12 +60,13 @@ Filtering Rows
     :toctree: doc_gen/dataframe_methods
 
     DataFrame.distinct
-    DataFrame.filter
-    DataFrame.where
-    DataFrame.limit
-    DataFrame.sample
     DataFrame.drop_nan
     DataFrame.drop_null
+    DataFrame.filter
+    DataFrame.limit
+    DataFrame.sample
+    DataFrame.unique
+    DataFrame.where
 
 Reordering
 **********

--- a/docs/sphinx/source/expressions.rst
+++ b/docs/sphinx/source/expressions.rst
@@ -258,6 +258,7 @@ List
    Expression.list.bool_or
    Expression.list.chunk
    Expression.list.count
+   Expression.list.distinct
    Expression.list.get
    Expression.list.join
    Expression.list.length
@@ -267,7 +268,7 @@ List
    Expression.list.slice
    Expression.list.sort
    Expression.list.sum
-   Expression.list.distinct
+   Expression.list.unique
    Expression.list.value_counts
 
 Struct

--- a/tests/recordbatch/list/test_list_distinct.py
+++ b/tests/recordbatch/list/test_list_distinct.py
@@ -5,6 +5,20 @@ from daft.expressions import col
 from daft.recordbatch import MicroPartition
 
 
+def compare_lists(result, expected):
+    # Check that nulls are preserved at list level.
+    assert [x is None for x in result] == [x is None for x in expected]
+    # For non-null lists, check that elements are distinct and sets match.
+    for i, (r, e) in enumerate(zip(result, expected)):
+        if r is not None:
+            assert len(r) == len(set(r)), "Elements should be distinct"
+            assert set(r) == set(e), "Sets should match"
+            # Check order preservation - first occurrence of each element should be in same order.
+            r_order = {x: i for i, x in enumerate(r) if x is not None}
+            e_order = {x: i for i, x in enumerate(e) if x is not None}
+            assert r_order == e_order, "Order of first occurrence should be preserved"
+
+
 def test_list_distinct():
     table = MicroPartition.from_pydict(
         {
@@ -22,23 +36,16 @@ def test_list_distinct():
             ],
         }
     ).eval_expression_list([col("a").cast(DataType.list(DataType.int64()))])
+    expected = [[1, 2, 3], [], [4, 6, 2], [3], [11, 6], None, [], [1, 3], None, []]
 
     res = table.eval_expression_list([col("a").list.distinct().alias("distinct")])
     result = res.to_pydict()["distinct"]
-    expected = [[1, 2, 3], [], [4, 6, 2], [3], [11, 6], None, [], [1, 3], None, []]
+    compare_lists(result, expected)
 
-    # Check that nulls are preserved at list level
-    assert [x is None for x in result] == [x is None for x in expected]
-
-    # For non-null lists, check that elements are distinct and sets match
-    for i, (r, e) in enumerate(zip(result, expected)):
-        if r is not None:
-            assert len(r) == len(set(r)), "Elements should be distinct"
-            assert set(r) == set(e), "Sets should match"
-            # Check order preservation - first occurrence of each element should be in same order
-            r_order = {x: i for i, x in enumerate(r) if x is not None}
-            e_order = {x: i for i, x in enumerate(e) if x is not None}
-            assert r_order == e_order, "Order of first occurrence should be preserved"
+    # Test unique alias.
+    res = table.eval_expression_list([col("a").list.unique().alias("unique")])
+    result = res.to_pydict()["unique"]
+    compare_lists(result, expected)
 
 
 def test_list_distinct_fixed_size():
@@ -48,23 +55,16 @@ def test_list_distinct_fixed_size():
             "a": data,
         }
     ).eval_expression_list([col("a").cast(DataType.fixed_size_list(DataType.int64(), 2))])
+    expected = [[1, 2], [2], [3], [11], None, [2], [], [4], None]
 
     res = table.eval_expression_list([col("a").list.distinct().alias("distinct")])
     result = res.to_pydict()["distinct"]
-    expected = [[1, 2], [2], [3], [11], None, [2], [], [4], None]
+    compare_lists(result, expected)
 
-    # Check that nulls are preserved at list level
-    assert [x is None for x in result] == [x is None for x in expected]
-
-    # For non-null lists, check that elements are distinct and sets match
-    for i, (r, e) in enumerate(zip(result, expected)):
-        if r is not None:
-            assert len(r) == len(set(r)), "Elements should be distinct"
-            assert set(r) == set(e), f"Sets should match for {r} and {e} from {data[i]}"
-            # Check order preservation - first occurrence of each element should be in same order
-            r_order = {x: i for i, x in enumerate(r) if x is not None}
-            e_order = {x: i for i, x in enumerate(e) if x is not None}
-            assert r_order == e_order, "Order of first occurrence should be preserved"
+    # Test unique alias.
+    res = table.eval_expression_list([col("a").list.unique().alias("unique")])
+    result = res.to_pydict()["unique"]
+    compare_lists(result, expected)
 
 
 def test_list_distinct_list():
@@ -74,20 +74,13 @@ def test_list_distinct_list():
             "a": data,
         }
     ).eval_expression_list([col("a").cast(DataType.list(DataType.int64()))])
+    expected = [[1, 2], [2], [3], [11], None, [2], [4], None]
 
     res = table.eval_expression_list([col("a").list.distinct().alias("distinct")])
     result = res.to_pydict()["distinct"]
-    expected = [[1, 2], [2], [3], [11], None, [2], [4], None]
+    compare_lists(result, expected)
 
-    # Check that nulls are preserved at list level
-    assert [x is None for x in result] == [x is None for x in expected]
-
-    # For non-null lists, check that elements are distinct and sets match
-    for i, (r, e) in enumerate(zip(result, expected)):
-        if r is not None:
-            assert len(r) == len(set(r)), "Elements should be distinct"
-            assert set(r) == set(e), f"Sets should match for {r} and {e} from {data[i]}"
-            # Check order preservation - first occurrence of each element should be in same order
-            r_order = {x: i for i, x in enumerate(r) if x is not None}
-            e_order = {x: i for i, x in enumerate(e) if x is not None}
-            assert r_order == e_order, "Order of first occurrence should be preserved"
+    # Test unique alias.
+    res = table.eval_expression_list([col("a").list.unique().alias("unique")])
+    result = res.to_pydict()["unique"]
+    compare_lists(result, expected)


### PR DESCRIPTION
## Summary

We call the functions `distinct` but make users think of `unique`. Change the docs to use consistent wording.

Additionally, added `unique` aliases for `Dataframe.distinct` and `Expression.list.distinct`.
