### PR TITLE
perf: Favor smaller relations on the left for join ordering

### DIFF
--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -66,10 +66,7 @@ impl JoinOrderTree {
             (
                 JoinOrderTree::Join(left1, right1, _, _),
                 JoinOrderTree::Join(left2, right2, _, _),
-            ) => {
-                (Self::order_eq(left1, left2) && Self::order_eq(right1, right2))
-                    || (Self::order_eq(left1, right2) && Self::order_eq(right1, left2))
-            }
+            ) => (Self::order_eq(left1, left2) && Self::order_eq(right1, right2)),
             _ => false,
         }
     }

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -558,7 +558,8 @@ impl JoinGraph {
     pub(super) fn could_reorder(&self) -> bool {
         // For this join graph to reorder joins, there must be at least 3 relations to join. Otherwise
         // there is only one join to perform and no reordering is needed.
-        self.adj_list.max_id >= 3
+        // TODO: We should raise the limit once we implement a DP-based join ordering algorithm.
+        self.adj_list.max_id >= 3 && self.adj_list.max_id <= 7
     }
 
     /// Test helper function to get the number of edges that the current graph contains.


### PR DESCRIPTION
## Summary

Two changes:

- Previously the brute force join ordering algorithm was agnostic to which relation was on the left. We should pick the smaller one to be on the left.

- Additionally, limit join ordering to when there are 7 or less joins to reorder. This is temporary until we implement faster join reordering algorithms.

These are the last two pieces we need before we can turn on join reordering.

## Checklist

- [x] All tests have passed