### PR TITLE
perf: Refactor selectivity estimates

### DIFF
--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -1589,14 +1589,16 @@ pub fn estimated_selectivity(expr: &Expr, schema: &Schema) -> f64 {
             let right_selectivity = estimated_selectivity(right, schema);
             match op {
                 // Fixed selectivity for all common comparisons
-                Operator::Eq => 0.05,
-                Operator::EqNullSafe => 0.05,
-                Operator::NotEq => 0.95,
-                Operator::Lt | Operator::LtEq | Operator::Gt | Operator::GtEq => 0.5,
+                Operator::Eq => 0.2,
+                Operator::EqNullSafe => 0.2,
+                Operator::NotEq => 0.8,
+                Operator::Lt | Operator::LtEq | Operator::Gt | Operator::GtEq => 0.3,
 
                 // Logical operators with fixed estimates
-                // P(A and B) = P(A) * P(B)
-                Operator::And => left_selectivity * right_selectivity,
+                // Use the minimum selectivity of the two operands for AND
+                // This is a more conservative estimate than the product of the two selectivities,
+                // because we cannot assume independence between the two operands.
+                Operator::And => left_selectivity.min(right_selectivity),
                 // P(A or B) = P(A) + P(B) - P(A and B)
                 Operator::Or => left_selectivity
                     .mul_add(-right_selectivity, left_selectivity + right_selectivity),


### PR DESCRIPTION
## Summary

Refactors a few selectivity estimates, notably the AND estimate to use `min(left_selectivity, right_selectivity)`, so as to be more conservative given that predicates may not be independent.

Question | Before | After | Difference | % Difference
-- | -- | -- | -- | --
Q1 | 508.29 | 506.38 | -1.91 | -0.38%
Q2 | 108.34 | 117.91 | 9.57 | 8.83%
Q3 | 473.53 | 477.83 | 4.30 | 0.91%
Q4 | 263.18 | 268.82 | 5.64 | 2.14%
Q5 | 429.79 | 449.23 | 19.44 | 4.52%
Q6 | 150.14 | 154.94 | 4.80 | 3.20%
Q7 | 465.79 | 474.59 | 8.80 | 1.89%
Q8 | 596.81 | 635.88 | 39.07 | 6.55%
Q9 | 1063.30 | 1079.90 | 16.60 | 1.56%
Q10 | 2308.10 | 678.97 | -1629.13 | -70.58%
Q11 | 218.64 | 223.40 | 4.76 | 2.18%
Q12 | 322.70 | 329.32 | 6.62 | 2.05%
Q13 | 937.53 | 922.74 | -14.79 | -1.58%
Q14 | 533.22 | 551.91 | 18.69 | 3.51%
Q15 | 388.43 | 410.76 | 22.33 | 5.75%
Q16 | 191.41 | 190.69 | -0.72 | -0.38%
Q17 | 337.21 | 361.25 | 24.04 | 7.13%
Q18 | 3520.80 | 840.79 | -2680.01 | -76.12%
Q19 | 413.47 | 415.02 | 1.55 | 0.37%
Q20 | 423.56 | 445.11 | 21.55 | 5.09%
Q21 | 4521.20 | 4581.50 | 60.30 | 1.33%
Q22 | 186.72 | 194.03 | 7.31 | 3.91%
Total | 18362.16 | 14310.97 | -4051.19 | -22.06%

## Related Issues

None

## Changes Made

Refactors the AND selectivity estimate, as well as other comparisons to be more generous.

## Checklist

- [ ] All tests have passed
- [ ] Documented in API Docs
- [ ] Documented in User Guide
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
