### PR TITLE
feat(sql): namespace support with in-memory catalog

### DIFF
--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -94,7 +94,9 @@ def test_from_pydict_namespaced():
     assert cat.list_namespaces("XXX") == []
     assert cat.list_namespaces("ns1") == [Identifier("ns1")]
     assert cat.list_namespaces("ns2") == [Identifier("ns2")]
-    assert cat.list_namespaces("ns") == [Identifier("ns1"), Identifier("ns2")]
+    namespaces = cat.list_namespaces("ns")
+    assert Identifier("ns1") in namespaces
+    assert Identifier("ns2") in namespaces
 
     # session name resolution should still work
     sess = Session()


### PR DESCRIPTION
## Summary

This PR allows you to use namespaces with the `Catalog.from_pydict(..)` factory method. We still lookup the string as-is like SQLCatalog (resolution unchanged) but we split out the table name when we create a table, and we can list namespaces by splitting out the namespace component from the in-memory map.

## Related Issues

We've had several issues in this regard, and now we are appropriately setup to handle this with the Catalog interface.

* https://github.com/Eventual-Inc/Daft/pull/3760
* https://github.com/Eventual-Inc/Daft/issues/3758


## Changes Made

* Treat keys of the the from_pydict argument as (possibly) qualified identifiers (dot-delimited)
* Parse namespaces from keys when doing a list_namespaces.

## Checklist

- [x] All tests have passed
- [n/a] Documented in API Docs
- [n/a] Documented in User Guide
- [n/a] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [n/a] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
