### PR TITLE
feat(catalog): adds s3tables iceberg rest endpoint

### DIFF
--- a/daft/catalog/__iceberg.py
+++ b/daft/catalog/__iceberg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 
 from pyiceberg.catalog import Catalog as InnerCatalog
+from pyiceberg.catalog import load_catalog
 from pyiceberg.table import Table as InnerTable
 
 from daft.catalog import Catalog, Identifier, Table, TableSource
@@ -32,6 +33,12 @@ class IcebergCatalog(Catalog):
             c._inner = obj
             return c
         raise ValueError(f"Unsupported iceberg catalog type: {type(obj)}")
+
+    @staticmethod
+    def _load_catalog(name: str, **options) -> IcebergCatalog:
+        c = IcebergCatalog.__new__(IcebergCatalog)
+        c._inner = load_catalog(name, **options)
+        return c
 
     @property
     def name(self) -> str:
@@ -103,7 +110,7 @@ class IcebergCatalog(Catalog):
 
     def list_tables(self, pattern: str | None = None) -> list[str]:
         """List tables under the given namespace (pattern) in the catalog, or all tables if no namespace is provided."""
-        return [".".join(tup) for tup in self._inner.list_tables(pattern)]
+        return [".".join(tup) for tup in self._inner.list_tables(pattern or ())]
 
 
 class IcebergTable(Table):

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -275,10 +275,14 @@ class Catalog(ABC):
             raise ImportError("Unity support not installed: pip install -U 'daft[unity]'")
 
     @staticmethod
-    def from_s3tables(table_bucket_arn: str, client: object | None = None, session: object | None = None):
+    def from_s3tables(
+        table_bucket_arn: str,
+        client: object | None = None,
+        session: object | None = None,
+    ):
         """Creates a Daft Catalog from S3 Tables bucket ARN, with optional client or session.
 
-        If neither a client nor session is given, the default boto3 client is used.
+        If neither a boto3 client nor session is given, an Iceberg REST client is used.
 
         Args:
             table_bucket_arn (str): s3tables bucket arn

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
     - Amazon Web Services: integrations/aws.md
     - SQL: integrations/sql.md
     - Hugging Face Datasets: integrations/huggingface.md
+    - S3 Tables: integrations/s3tables.md
   - Resources:
     - Architecture: resources/architecture.md
     - DataFrame Comparison: resources/dataframe_comparison.md

--- a/docs/mkdocs/integrations/s3tables.md
+++ b/docs/mkdocs/integrations/s3tables.md
@@ -1,0 +1,34 @@
+# S3 Tables
+
+Daft integrates with [S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) using its [Catalog](../catalogs.md) interface which supports both reading and writing S3 Tables via Iceberg.
+
+## Example
+
+```python
+from daft import Catalog
+
+catalog = Catalog.from_arn("arn:aws:s3tables:<region>:<account>:bucket/<bucket>")
+
+# verify we are connected
+catalog.list_tables()
+
+# read some table
+catalog.read_table("my_namespace.my_table").show()
+
+# write dataframe to table
+catalog.write_table("my_namespace.my_table", daft.read_csv("/path/to/file.csv"))
+```
+
+### S3 Tables AWS API
+
+You can use the S3 Tables AWS API via a `boto3` client or `boto3` session.
+
+### S3 Tables Iceberg REST API
+
+The S3 Tables service supports
+
+> You can connect your Iceberg REST client to the Amazon S3 Tables Iceberg REST endpoint and make REST API calls to create, update, or query tables in S3 table buckets. The endpoint implements a set of standardized Iceberg REST APIs specified in the Apache Iceberg REST Catalog Open API specification . The endpoint works by translating Iceberg REST API operations into corresponding S3 Tables operations.
+
+### Glue and LakeFormation
+
+You may also use the AWS Glue Iceberg REST endpoint, which provides unified table management, centralized governance, and fine-grained access control (table level). However this requires service enabling integrations in

--- a/docs/mkdocs/integrations/s3tables.md
+++ b/docs/mkdocs/integrations/s3tables.md
@@ -10,13 +10,60 @@ from daft import Catalog
 catalog = Catalog.from_arn("arn:aws:s3tables:<region>:<account>:bucket/<bucket>")
 
 # verify we are connected
-catalog.list_tables()
+catalog.list_tables("demo")
+"""
+['demo.points']
+"""
 
 # read some table
 catalog.read_table("my_namespace.my_table").show()
+"""
+╭─────────┬───────┬──────╮
+│ x       ┆ y     ┆ z    │
+│ ---     ┆ ---   ┆ ---  │
+│ Boolean ┆ Int64 ┆ Utf8 │
+╞═════════╪═══════╪══════╡
+│ true    ┆ 1     ┆ a    │
+├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+│ true    ┆ 2     ┆ b    │
+├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+│ false   ┆ 3     ┆ c    │
+╰─────────┴───────┴──────╯
+
+(Showing first 3 of 3 rows)
+"""
 
 # write dataframe to table
-catalog.write_table("my_namespace.my_table", daft.read_csv("/path/to/file.csv"))
+catalog.write_table(
+    "demo.points",
+    daft.from_pydict(
+        {
+            "x": [True],
+            "y": [4],
+            "z": ["d"],
+        }
+    ),
+)
+
+# check that the data was written
+catalog.read_table("my_namespace.my_table").show()
+"""
+╭─────────┬───────┬──────╮
+│ x       ┆ y     ┆ z    │
+│ ---     ┆ ---   ┆ ---  │
+│ Boolean ┆ Int64 ┆ Utf8 │
+╞═════════╪═══════╪══════╡
+│ true    ┆ 4     ┆ d    │
+├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+│ true    ┆ 1     ┆ a    │
+├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+│ true    ┆ 2     ┆ b    │
+├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
+│ false   ┆ 3     ┆ c    │
+╰─────────┴───────┴──────╯
+
+(Showing first 4 of 4 rows)
+"""
 ```
 
 ### S3 Tables AWS API

--- a/tests/catalog/test_s3tables.py
+++ b/tests/catalog/test_s3tables.py
@@ -15,6 +15,27 @@ else:
     S3TablesClient = object
 
 
+@pytest.mark.skip("skipped for integration testing")
+def test_s3tables_iceberg_rest():
+    import daft
+
+    table_bucket_arn = "..."
+    catalog = Catalog.from_s3tables(table_bucket_arn)
+    print(catalog.list_tables("demo"))
+    catalog.read_table("demo.points").show()
+    catalog.write_table(
+        "demo.points",
+        daft.from_pydict(
+            {
+                "x": [True],
+                "y": [4],
+                "z": ["d"],
+            }
+        ),
+    )
+    catalog.read_table("demo.points").show()
+
+
 @pytest.fixture(scope="function")
 def aws_credentials():
     os.environ["AWS_ACCESS_KEY_ID"] = "testing"


### PR DESCRIPTION
## Summary

Updates the `Catalog.from_s3tables` and `S3Tables.from_arn` to use the Iceberg REST endpoint which gives us write support. 

```python
import daft

    table_bucket_arn = "..."
    catalog = Catalog.from_s3tables(table_bucket_arn)
    print(catalog.list_tables("demo"))
    catalog.read_table("demo.points").show()
    catalog.write_table(
        "demo.points",
        daft.from_pydict(
            {
                "x": [True],
                "y": [4],
                "z": ["d"],
            }
        ),
    )
    catalog.read_table("demo.points").show()

tests/catalog/test_s3tables.py ['demo.points']
╭─────────┬───────┬──────╮
│ x       ┆ y     ┆ z    │
│ ---     ┆ ---   ┆ ---  │
│ Boolean ┆ Int64 ┆ Utf8 │
╞═════════╪═══════╪══════╡
│ true    ┆ 1     ┆ a    │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ true    ┆ 2     ┆ b    │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ false   ┆ 3     ┆ c    │
╰─────────┴───────┴──────╯

(Showing first 3 of 3 rows)
╭─────────┬───────┬──────╮
│ x       ┆ y     ┆ z    │
│ ---     ┆ ---   ┆ ---  │
│ Boolean ┆ Int64 ┆ Utf8 │
╞═════════╪═══════╪══════╡
│ true    ┆ 4     ┆ d    │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ true    ┆ 1     ┆ a    │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ true    ┆ 2     ┆ b    │
├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
│ false   ┆ 3     ┆ c    │
╰─────────┴───────┴──────╯

(Showing first 4 of 4 rows)
.
```

## Related Issues

#3929 

## Changes Made

* Use the ARN as the warehouse with the iceberg rest endpoint
* Adds basic documentation for S3 Tables integration

## Checklist

- [x] All tests have passed
- [x] Documented in API Docs
- [x] Documented in User Guide
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
