### PR TITLE
feat: adds gz as gzip alias for encode, decode methods

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -1511,7 +1511,7 @@ class Expression:
 
         return Expression._from_pyexpr(native.minhash(self._expr, num_hashes, ngram_size, seed, hash_function))
 
-    def encode(self, codec: Literal["deflate", "gzip", "zlib"]) -> Expression:
+    def encode(self, codec: Literal["deflate", "gzip", "gz", "zlib"]) -> Expression:
         r"""Encodes the expression (binary strings) using the specified codec.
 
         Example:
@@ -1553,7 +1553,7 @@ class Expression:
         expr = native.encode(self._expr, codec)
         return Expression._from_pyexpr(expr)
 
-    def decode(self, codec: Literal["deflate", "gzip", "zlib"]) -> Expression:
+    def decode(self, codec: Literal["deflate", "gzip", "gz", "zlib"]) -> Expression:
         """Decodes the expression (binary strings) using the specified codec.
 
         Example:

--- a/src/daft-functions/src/binary/codecs.rs
+++ b/src/daft-functions/src/binary/codecs.rs
@@ -40,7 +40,7 @@ impl TryFrom<&str> for Codec {
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         match s.to_lowercase().as_str() {
             "deflate" => Ok(Self::Deflate),
-            "gzip" => Ok(Self::Gzip),
+            "gzip" | "gz" => Ok(Self::Gzip),
             "zlib" => Ok(Self::Zlib),
             _ => Err(DaftError::not_implemented(format!(
                 "unsupported codec: {}",
@@ -129,6 +129,8 @@ mod tests {
     fn test_codec_from_str() {
         assert_eq!(Codec::try_from("DEFLATE").unwrap(), Codec::Deflate);
         assert_eq!(Codec::try_from("deflate").unwrap(), Codec::Deflate);
+        assert_eq!(Codec::try_from("gz").unwrap(), Codec::Gzip);
+        assert_eq!(Codec::try_from("GZ").unwrap(), Codec::Gzip);
         assert_eq!(Codec::try_from("gzip").unwrap(), Codec::Gzip);
         assert_eq!(Codec::try_from("GZIP").unwrap(), Codec::Gzip);
         assert_eq!(Codec::try_from("GzIp").unwrap(), Codec::Gzip);

--- a/tests/functions/test_codecs.py
+++ b/tests/functions/test_codecs.py
@@ -92,6 +92,7 @@ def test_codec_deflate():
 def test_codec_gzip():
     import gzip
 
+    _test_codec("gz", buff=gzip.compress(UTF8))
     _test_codec("gzip", buff=gzip.compress(UTF8))
 
 


### PR DESCRIPTION
## Summary

You can do `expr.encode("gz")` and `expr.decode("gz")` now, which was a hackathon feature request.

## Related Issues

#3907 

## Changes Made

* Adds another extension alias.

## Checklist

- [x] All tests have passed
- [x] Documented in API Docs
- [n/a] Documented in User Guide
- [n/a] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [n/a] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
