### PR TITLE
feat: syntactic sugar for Python list and struct gets

### DIFF
--- a/docs/mkdocs/core_concepts.md
+++ b/docs/mkdocs/core_concepts.md
@@ -484,7 +484,7 @@ Adding a new column can be achieved with [`df.with_column()`]({{ api_path }}/dat
 
 #### Selecting Columns Using Wildcards
 
-We can select multiple columns at once using wildcards. The expression [`.col(*)`]({{ api_path }}/expression_methods/daft.col.html) selects every column in a DataFrame, and you can operate on this expression in the same way as a single column:
+We can select multiple columns at once using wildcards. The expression [`col(*)`]({{ api_path }}/expression_methods/daft.col.html) selects every column in a DataFrame, and you can operate on this expression in the same way as a single column:
 
 === "🐍 Python"
     ``` python
@@ -506,7 +506,7 @@ We can select multiple columns at once using wildcards. The expression [`.col(*)
 ╰───────┴───────╯
 ```
 
-We can also select multiple columns within structs using `col("struct.*")`:
+We can also select multiple columns within structs using [`col("struct")["*"]`]({{ api_path }}/expression_methods/daft.Expression.__getitem__.html):
 
 === "🐍 Python"
     ``` python
@@ -516,7 +516,7 @@ We can also select multiple columns within structs using `col("struct.*")`:
             {"B": 3, "C": 4}
         ]
     })
-    df.select(col("A.*")).show()
+    df.select(col("A")["*"]).show()
     ```
 
 ``` {title="Output"}
@@ -764,7 +764,7 @@ Wildcards also work very well for accessing all members of a struct column:
     })
 
     # Access all fields of the 'person' struct
-    df.select(col("person.*")).show()
+    df.select(col("person")["*"]).show()
     ```
 
 === "⚙️ SQL"

--- a/docs/sphinx/source/expressions.rst
+++ b/docs/sphinx/source/expressions.rst
@@ -35,6 +35,7 @@ Generic
    Expression.fill_null
    Expression.hash
    Expression.apply
+   Expression.__getitem__
 
 .. _api-numeric-expression-operations:
 

--- a/tests/expressions/test_getitem.py
+++ b/tests/expressions/test_getitem.py
@@ -1,15 +1,16 @@
 import daft
+from daft import col
 
 
 def test_getitem_list():
     df = daft.from_pydict({"a": [[1, 2, 3], [1], [1, 2]]})
-    df = df.select(df["a"][0].alias("first"), df["a"][1].alias("second"))
+    df = df.select(df["a"][0].alias("first"), col("a")[1].alias("second"))
     assert df.to_pydict() == {"first": [1, 1, 1], "second": [2, None, 2]}
 
 
 def test_getitem_struct():
     df = daft.from_pydict({"a": [{"x": 1, "y": "foo"}, {"x": 2, "y": "bar"}]})
-    df = df.select(df["a"]["x"], df["a"]["y"])
+    df = df.select(col("a")["x"], df["a"]["y"])
     assert df.to_pydict() == {"x": [1, 2], "y": ["foo", "bar"]}
 
 

--- a/tests/expressions/test_getitem.py
+++ b/tests/expressions/test_getitem.py
@@ -1,0 +1,19 @@
+import daft
+
+
+def test_getitem_list():
+    df = daft.from_pydict({"a": [[1, 2, 3], [1], [1, 2]]})
+    df = df.select(df["a"][0].alias("first"), df["a"][1].alias("second"))
+    assert df.to_pydict() == {"first": [1, 1, 1], "second": [2, None, 2]}
+
+
+def test_getitem_struct():
+    df = daft.from_pydict({"a": [{"x": 1, "y": "foo"}, {"x": 2, "y": "bar"}]})
+    df = df.select(df["a"]["x"], df["a"]["y"])
+    assert df.to_pydict() == {"x": [1, 2], "y": ["foo", "bar"]}
+
+
+def test_getitem_struct_all():
+    df = daft.from_pydict({"a": [{"x": 1, "y": "foo"}, {"x": 2, "y": "bar"}]})
+    df = df.select(df["a"]["*"])
+    assert df.to_pydict() == {"x": [1, 2], "y": ["foo", "bar"]}


### PR DESCRIPTION
## Summary

Add `Expression.__getitem__`, which works as list.get for ints and struct.get for strings.

## Related Issues

none

## Changes Made

add the new method to Expresssion + fix docs to use it

## Checklist

- [x] All tests have passed
- [x] Documented in API Docs
- [x] Documented in User Guide
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
