### PR TITLE
fix: improve column error messages + add PlanRef to outer column

### DIFF
--- a/src/daft-logical-plan/src/optimization/rules/unnest_subquery.rs
+++ b/src/daft-logical-plan/src/optimization/rules/unnest_subquery.rs
@@ -393,11 +393,13 @@ fn pull_up_correlated_cols(
                                 ))),
                                 Expr::Column(Column::Resolved(ResolvedColumn::OuterRef(
                                     outer_field,
+                                    _,
                                 ))),
                             )
                             | (
                                 Expr::Column(Column::Resolved(ResolvedColumn::OuterRef(
                                     outer_field,
+                                    _,
                                 ))),
                                 Expr::Column(Column::Resolved(ResolvedColumn::Basic(
                                     subquery_col_name,
@@ -555,7 +557,7 @@ mod tests {
 
     use common_error::DaftResult;
     use daft_core::join::JoinType;
-    use daft_dsl::{unresolved_col, Column, Expr, ResolvedColumn, Subquery};
+    use daft_dsl::{unresolved_col, Column, Expr, PlanRef, ResolvedColumn, Subquery};
     use daft_schema::{dtype::DataType, field::Field};
 
     use super::{UnnestPredicateSubquery, UnnestScalarSubquery};
@@ -653,7 +655,10 @@ mod tests {
         let subquery = tbl2
             .filter(
                 unresolved_col("inner_key").eq(Arc::new(Expr::Column(Column::Resolved(
-                    ResolvedColumn::OuterRef(Field::new("inner_key", DataType::Int64)),
+                    ResolvedColumn::OuterRef(
+                        Field::new("inner_key", DataType::Int64),
+                        PlanRef::Unqualified,
+                    ),
                 )))),
             )?
             .aggregate(vec![unresolved_col("outer_key").max()], vec![])?;
@@ -747,7 +752,10 @@ mod tests {
         let subquery = tbl2
             .filter(
                 unresolved_col("key").eq(Arc::new(Expr::Column(Column::Resolved(
-                    ResolvedColumn::OuterRef(Field::new("key", DataType::Int64)),
+                    ResolvedColumn::OuterRef(
+                        Field::new("key", DataType::Int64),
+                        PlanRef::Unqualified,
+                    ),
                 )))),
             )?
             .build();

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -691,8 +691,8 @@ impl RecordBatch {
             Expr::Exists(_subquery) => Err(DaftError::ComputeError(
                 "EXISTS <SUBQUERY> should be optimized away before evaluation. This indicates a bug in the query optimizer.".to_string(),
             )),
-            Expr::Column(Column::Resolved(ResolvedColumn::OuterRef(Field { name, .. }))) => Err(DaftError::ComputeError(
-                format!("Outer reference columns should be eliminated before evaluation. This indicates either that column {name} does not exist in the table, or there is a bug in the query optimizer."),
+            Expr::Column(Column::Resolved(ResolvedColumn::OuterRef(..))) => Err(DaftError::ComputeError(
+                format!("Column {expr} could not be resolved. This indicates either that the column is referencing a different table from the one it is being used in, or a bug in the query optimizer."),
             )),
             Expr::Column(Column::Resolved(ResolvedColumn::JoinSide(..))) => Err(DaftError::ComputeError(
                 "Join side columns cannot be evaluated directly. This indicates a bug in the executor.".to_string(),

--- a/src/daft-sql/src/lib.rs
+++ b/src/daft-sql/src/lib.rs
@@ -33,7 +33,7 @@ mod tests {
     use std::sync::Arc;
 
     use daft_core::prelude::*;
-    use daft_dsl::{lit, unresolved_col, Expr, Subquery};
+    use daft_dsl::{lit, unresolved_col, Expr, PlanRef, Subquery};
     use daft_logical_plan::{
         logical_plan::Source, source_info::PlaceHolderInfo, ClusteringSpec, JoinOptions,
         LogicalPlan, LogicalPlanBuilder, LogicalPlanRef, SourceInfo,
@@ -457,6 +457,7 @@ mod tests {
 
         let outer_col = Arc::new(Expr::Column(Column::Resolved(ResolvedColumn::OuterRef(
             Field::new("i32", DataType::Int32),
+            PlanRef::Unqualified,
         ))));
         let subquery = LogicalPlanBuilder::from(tbl_2)
             .alias("tbl2")


### PR DESCRIPTION
## Summary

Some cleanup on the unresolved/resolved column stuff. 
- more understandable errors if you just mistype the name of a column or you pass in a column from a different dataframe
- add PlanRef to `ResolvedColumn::OuterRef`. currently not being used for anything because we just assume that the column exists in the immediate scope of the outer query. However, that may not be true, and with ordinals we can support cases like this:
```python
df1 = daft.from_pydict({"a": [1, 2, 3], "b": [1, 2, 3]})
df2 = daft.from_pydict({"a": [2, 3, 4], "b": [2, 3, 4]})
subquery_df = daft.from_pydict({"b": [3, 4, 5]})

# if we could do this in dataframe at the moment, this would currently actually be incorrect
# because we just look for "b" in the schema, which is actually df1.b and not df2.b
df1.join(df2, on="a", how="outer").where(df2["b"] == subquery_df.agg(col("b").min()))
```

## Related Issues

none

## Changes Made

see above

## Checklist

- [x] All tests have passed
- [x] Documented in API Docs
- [x] Documented in User Guide
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
