### PR TITLE
fix: Use empty str instead of tuple for iceberg list tables

### DIFF
--- a/daft/catalog/__iceberg.py
+++ b/daft/catalog/__iceberg.py
@@ -110,7 +110,7 @@ class IcebergCatalog(Catalog):
 
     def list_tables(self, pattern: str | None = None) -> list[str]:
         """List tables under the given namespace (pattern) in the catalog, or all tables if no namespace is provided."""
-        return [".".join(tup) for tup in self._inner.list_tables(pattern or ())]
+        return [".".join(tup) for tup in self._inner.list_tables(pattern or "")]
 
 
 class IcebergTable(Table):


### PR DESCRIPTION
## Summary

Fix iceberg list tables for all namespaces

## Related Issues

Fixes https://github.com/Eventual-Inc/Daft/issues/4035

## Changes Made

In the pyiceberg list_tables code, they check for valid namespace like this:

```py
@staticmethod
    def identifier_to_tuple(identifier: Union[str, Identifier]) -> Identifier:
        """Parse an identifier to a tuple.

        If the identifier is a string, it is split into a tuple on '.'. If it is a tuple, it is used as-is.

        Args:
            identifier (str | Identifier): an identifier, either a string or tuple of strings.

        Returns:
            Identifier: a tuple of strings.
        """
        return identifier if isinstance(identifier, tuple) else tuple(str.split(identifier, "."))

def _check_valid_namespace_identifier(self, identifier: Union[str, Identifier]) -> Identifier:
        """Check if the identifier has at least one element."""
        identifier_tuple = Catalog.identifier_to_tuple(identifier)
        if len(identifier_tuple) < 1:
            raise NoSuchNamespaceError(f"Empty namespace identifier: {identifier}")
        return identifier_tuple
```

Currently in our code we pass in `()` for all namespaces, but this errors because they require at least one. Instead we can just pass in empty string.

## Checklist

- [ ] All tests have passed
- [ ] Documented in API Docs
- [ ] Documented in User Guide
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
