### PR TITLE
feat: Set batch size as morsel size for project

### DIFF
--- a/src/daft-local-execution/src/intermediate_ops/actor_pool_project.rs
+++ b/src/daft-local-execution/src/intermediate_ops/actor_pool_project.rs
@@ -20,10 +20,7 @@ use super::intermediate_op::{
     IntermediateOpExecuteResult, IntermediateOpState, IntermediateOperator,
     IntermediateOperatorResult,
 };
-use crate::{
-    dispatcher::{DispatchSpawner, RoundRobinDispatcher, UnorderedDispatcher},
-    ExecutionRuntimeContext, ExecutionTaskSpawner,
-};
+use crate::{ExecutionRuntimeContext, ExecutionTaskSpawner};
 
 struct ActorHandle {
     #[cfg(feature = "python")]
@@ -220,21 +217,8 @@ impl IntermediateOperator for ActorPoolProjectOperator {
         Ok(self.concurrency)
     }
 
-    fn dispatch_spawner(
-        &self,
-        runtime_handle: &ExecutionRuntimeContext,
-        maintain_order: bool,
-    ) -> Arc<dyn DispatchSpawner> {
-        if maintain_order {
-            Arc::new(RoundRobinDispatcher::new(Some(
-                self.batch_size
-                    .unwrap_or_else(|| runtime_handle.default_morsel_size()),
-            )))
-        } else {
-            Arc::new(UnorderedDispatcher::new(Some(
-                self.batch_size
-                    .unwrap_or_else(|| runtime_handle.default_morsel_size()),
-            )))
-        }
+    fn morsel_size(&self, runtime_handle: &ExecutionRuntimeContext) -> Option<usize> {
+        self.batch_size
+            .or_else(|| Some(runtime_handle.default_morsel_size()))
     }
 }

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -59,19 +59,19 @@ pub trait IntermediateOperator: Send + Sync {
         Ok(*NUM_CPUS)
     }
 
+    fn morsel_size(&self, runtime_handle: &ExecutionRuntimeContext) -> Option<usize> {
+        Some(runtime_handle.default_morsel_size())
+    }
+
     fn dispatch_spawner(
         &self,
         runtime_handle: &ExecutionRuntimeContext,
         maintain_order: bool,
     ) -> Arc<dyn DispatchSpawner> {
         if maintain_order {
-            Arc::new(RoundRobinDispatcher::new(Some(
-                runtime_handle.default_morsel_size(),
-            )))
+            Arc::new(RoundRobinDispatcher::new(self.morsel_size(runtime_handle)))
         } else {
-            Arc::new(UnorderedDispatcher::new(Some(
-                runtime_handle.default_morsel_size(),
-            )))
+            Arc::new(UnorderedDispatcher::new(self.morsel_size(runtime_handle)))
         }
     }
 }

--- a/src/daft-local-execution/src/intermediate_ops/project.rs
+++ b/src/daft-local-execution/src/intermediate_ops/project.rs
@@ -2,7 +2,7 @@ use std::{cmp::max, sync::Arc};
 
 use common_error::{DaftError, DaftResult};
 use daft_dsl::{
-    functions::python::{get_batch_size, get_resource_request},
+    functions::python::{get_resource_request, try_get_batch_size_from_udf},
     ExprRef,
 };
 use daft_micropartition::MicroPartition;
@@ -37,7 +37,7 @@ impl ProjectOperator {
             .map(|m| m as u64)
             .unwrap_or(0);
         let (max_concurrency, parallel_exprs) = Self::get_optimal_allocation(&projection)?;
-        let batch_size = get_batch_size(&projection);
+        let batch_size = try_get_batch_size_from_udf(&projection).unwrap_or(None);
         Ok(Self {
             projection: Arc::new(projection),
             memory_request,

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -154,7 +154,12 @@ pub fn physical_plan_to_pipeline(
             stats_state,
             ..
         }) => {
-            let proj_op = ActorPoolProjectOperator::new(projection.clone());
+            let proj_op =
+                ActorPoolProjectOperator::try_new(projection.clone()).with_context(|_| {
+                    PipelineCreationSnafu {
+                        plan_name: physical_plan.name(),
+                    }
+                })?;
             let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
             IntermediateNode::new(Arc::new(proj_op), vec![child_node], stats_state.clone()).boxed()
         }


### PR DESCRIPTION
## Summary

Set batch size as morsel size for non actor-pool projects. Provides much better control and ux over the udf. 

## Related Issues

## Changes Made

Set batch size as morsel size for non actor-pool projects.

## Checklist

- [ ] All tests have passed
- [ ] Documented in API Docs
- [ ] Documented in User Guide
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
