### PR TITLE
fix: Modify ray runner switching tests to check error in stderr instead of endswith

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -144,7 +144,7 @@ daft.context.set_runner_ray()
 """
     with with_null_env():
         result = subprocess.run([sys.executable, "-c", script], capture_output=True)
-        assert result.stderr.decode().strip().endswith("RuntimeError: Cannot set runner more than once")
+        assert "RuntimeError: Cannot set runner more than once" in result.stderr.decode().strip()
 
 
 @pytest.mark.parametrize("daft_runner_envvar", ["py", "ray", "native"])


### PR DESCRIPTION
## Summary

<!-- Provide a short summary of the changes in this PR. -->

## Related Issues

<!-- Link to related GitHub issues or JIRA tickets, e.g., "Closes #123" -->

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Checklist

- [ ] All tests have passed
- [ ] Documented in API Docs
- [ ] Documented in User Guide
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
