### PR TITLE
fix: dashboard flaking

### DIFF
--- a/src/daft-dashboard/build.rs
+++ b/src/daft-dashboard/build.rs
@@ -1,7 +1,8 @@
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-changed=frontend");
+    println!("cargo:rerun-if-changed=frontend/src/");
+    println!("cargo:rerun-if-changed=frontend/bun.lockb");
     let out_dir = std::env::var("OUT_DIR")?;
 
     // always set the env var so that the include_dir! macro doesn't panic


### PR DESCRIPTION
## Summary

the `rerun-if-changed` was incorrect, so it was always rebuilding, so if you had rust-analyzer or anything else running in the background, it was thrashing the `.next` directory, causing the flakes.

closes https://github.com/Eventual-Inc/Daft/issues/4049
