### PR TITLE
docs: add link to sql reference page inside cast

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -667,7 +667,7 @@ class Expression:
 
         Note:
             - Overflowing values will be wrapped, e.g. 256 will be cast to 0 for an unsigned 8-bit integer.
-            - If a string is provided, it will use the sql engine to parse the string into a data type. See the SQL documentation for more information.
+            - If a string is provided, it will use the sql engine to parse the string into a data type. See the [SQL Reference](https://www.getdaft.io/projects/docs/en/stable/sql/datatypes/) for supported datatypes.
             - a python `type` can also be provided, in which case the corresponding Daft data type will be used.
 
         The following combinations of datatype casting is valid:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -99,3 +99,4 @@ grpcio==1.68.1
 grpcio-status==1.67.0
 
 # ai
+vllm

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -99,4 +99,3 @@ grpcio==1.68.1
 grpcio-status==1.67.0
 
 # ai
-vllm


### PR DESCRIPTION
## Summary

adds a link to the sql datatypes page for `cast`

## Related Issues

Closes https://github.com/Eventual-Inc/Daft/issues/4050