### PR TITLE
docs: fix broken links and clarify contributing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,4 +16,4 @@
 - [ ] Documented in API Docs
 - [ ] Documented in User Guide
 - [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
-- [ ] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
+- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,13 @@
-# Building docs locally
+# Contributing to Docs
+
+## Building the mkdocs
+
+1. Go to the `/` folder (project root)
+2. `make docs`
+3. `python -m http.server`
+3. open `localhost:8000/docs/site`
+
+## Building sphinx docs locally
 
 1. Go to the `docs/` folder
 2. `make clean`

--- a/docs/mkdocs/core_concepts.md
+++ b/docs/mkdocs/core_concepts.md
@@ -484,7 +484,7 @@ Adding a new column can be achieved with [`df.with_column()`]({{ api_path }}/dat
 
 #### Selecting Columns Using Wildcards
 
-We can select multiple columns at once using wildcards. The expression [`col(*)`]({{ api_path }}/expression_methods/daft.col.html) selects every column in a DataFrame, and you can operate on this expression in the same way as a single column:
+We can select multiple columns at once using wildcards. The expression [`col("*")`]({{ api_path }}/expression_methods/daft.col.html) selects every column in a DataFrame, and you can operate on this expression in the same way as a single column:
 
 === "🐍 Python"
     ``` python

--- a/docs/mkdocs/sql/datatypes.md
+++ b/docs/mkdocs/sql/datatypes.md
@@ -1,10 +1,10 @@
 # SQL Data Types
 
-These tables define how Daft's [DataType](../{{ api_path }}/datatype.html) maps to the common SQL types and aliases.
+These tables define how Daft's [DataType](../../api_docs/datatype.html) maps to the common SQL types and aliases.
 
 !!! note "Note"
 
-    In these tables, the **Type** column identifies the Daft [DataType](../{{ api_path }}/datatype.html), whereas the **Name** and **Aliases** columns represent supported SQL syntax.
+    In these tables, the **Type** column identifies the Daft [DataType](../../api_docs/datatype.html), whereas the **Name** and **Aliases** columns represent supported SQL syntax.
 
 ## Boolean Type
 
@@ -25,9 +25,9 @@ These tables define how Daft's [DataType](../{{ api_path }}/datatype.html) maps 
 | `uint16`     | `SMALLINT UNSIGNED`        | `UINT2`, `UINT16` | 16-bit unsigned integer |
 | `uint32`     | `INT UNSIGNED`             | `UINT4`, `UINT32` | 32-bit unsigned integer |
 | `uint64`     | `BIGINT UNSIGNED`          | `UINT8`, `UINT64` | 64-bit unsigned integer |
-| `float32`    | `REAL`                     | `FLOAT(p)`        | 32-bit floating point   |
-| `float64`    | `DOUBLE [PRECISION]`       | `FLOAT(p)`        | 64-bit floating point   |
-| `decimal128` | `DEC(p,s)`, `DECIMAL(p,s)` | `NUMERIC(p,s)`    | Fixed-point number      |
+| `float32`    | `REAL`                     | `FLOAT(P)`        | 32-bit floating point   |
+| `float64`    | `DOUBLE [PRECISION]`       | `FLOAT(P)`        | 64-bit floating point   |
+| `decimal128` | `DEC(P,S)`, `DECIMAL(P,S)` | `NUMERIC(P,S)`    | Fixed-point number      |
 
 
 ## Text Types
@@ -82,7 +82,7 @@ These tables define how Daft's [DataType](../{{ api_path }}/datatype.html) maps 
 | Type     | Syntax              | Example                 | Description                         |
 | -------- | ------------------- | ----------------------- | ----------------------------------- |
 | `map`    | `MAP(K, V)`         | `MAP(INT, BOOL)`        | Key-value pairs with the same types |
-| `struct` | `STRUCT(FIELDS...)` | `STRUCT(a INT, b BOOL)` | Named values of varying types       |
+| `struct` | `STRUCT(FIELDS...)` | `STRUCT(A INT, B BOOL)` | Named values of varying types       |
 
 
 ## Complex Types
@@ -106,7 +106,7 @@ TENSOR(INT, 10, 10, 10)
 
 ### Image Type
 
-The `IMAGE(mode, [dimensions])` type represents an array of pixels with designated pixel type. The supported modes are covered in [ImageMode](../{{ api_path }}/doc_gen/misc/daft.ImageMode.html). If the height, width, and mode are the same for all images in the array, specifying them when constructing this type is advised, since that will allow Daft to create a more optimized physical representation of the image array.
+The `IMAGE(mode, [dimensions])` type represents an array of pixels with designated pixel type. The supported modes are covered in [ImageMode](../../{{ api_path }}/misc/daft.ImageMode.html). If the height, width, and mode are the same for all images in the array, specifying them when constructing this type is advised, since that will allow Daft to create a more optimized physical representation of the image array.
 
 **Examples**
 

--- a/docs/mkdocs/sql/overview.md
+++ b/docs/mkdocs/sql/overview.md
@@ -45,7 +45,7 @@ sess.sql("SELECT * FROM T, S").show()
 
 ### SQL with DataFrames
 
-Daft's [`daft.sql`](api_docs/sql.html#daft.sql) function automatically detects any [`daft.DataFrame`]({{ api_path }}/dataframe_methods/daft.DataFrame.html) objects in your current Python environment to let you query them easily by name.
+Daft's [`daft.sql`](../api_docs/sql.html#daft.sql) function automatically detects any [`daft.DataFrame`](../{{ api_path }}/dataframe_methods/daft.DataFrame.html) objects in your current Python environment to let you query them easily by name.
 
 === "⚙️ SQL"
     ```python
@@ -126,7 +126,7 @@ In the above query, both the SQL version of the query and the DataFrame version 
 
 Under the hood, they run the same Expression `col("A") + col("B")`!
 
-One really cool trick you can do is to use the [`daft.sql_expr`]({{ api_path }}/sql.html#daft.sql_expr) function as a helper to easily create Expressions. The following are equivalent:
+One really cool trick you can do is to use the [`daft.sql_expr`](../api_docs/sql.html#daft.sql_expr) function as a helper to easily create Expressions. The following are equivalent:
 
 === "⚙️ SQL"
     ```python
@@ -187,13 +187,13 @@ Pretty sweet! Of course, this support for running Expressions on your columns ex
 
 ### SQL Functions
 
-SQL also has access to all of Daft's powerful [`daft.Expression`]({{ api_path }}/dataframe_methods/daft.DataFrame.html#daft.DataFrame) functionality through SQL functions.
+SQL also has access to all of Daft's powerful [`daft.Expression`](../{{ api_path }}/dataframe_methods/daft.DataFrame.html#daft.DataFrame) functionality through SQL functions.
 
 However, unlike the Python Expression API which encourages method-chaining (e.g. `col("a").url.download().image.decode()`), in SQL you have to do function nesting instead (e.g. `"image_decode(url_download(a))"`).
 
 !!! note "Note"
 
-    A full catalog of the available SQL Functions in Daft is available in the [`SQL API Docs`](api_docs/sql.html).
+    A full catalog of the available SQL Functions in Daft is available in the [`SQL API Docs`](../api_docs/sql.html).
 
     Note that it closely mirrors the Python API, with some function naming differences vs the available Python methods.
     We also have some aliased functions for ANSI SQL-compliance or familiarity to users coming from other common SQL dialects such as PostgreSQL and SparkSQL to easily find their functionality.


### PR DESCRIPTION
## Summary

This PR fixes broken links from moving the SQL overview into a nested folder.

## Related Issues

* #4052 
* #4027 

## Changes Made

* updates to contributing clarification
* fix relative paths for api docs
* change `col(*)` to `col("*")`

## Checklist

- [n/a] All tests have passed
- [n/a] Documented in API Docs
- [n/a] Documented in User Guide
- [n/a] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag [@ccmao1130](https://github.com/ccmao1130) for docs review)
