### PR TITLE
fix: Collect iterators in read_generator to list

### DIFF
--- a/daft/io/_generator.py
+++ b/daft/io/_generator.py
@@ -76,7 +76,7 @@ class GeneratorScanOperator(ScanOperator):
         generators: Iterator[Callable[[], Iterator["RecordBatch"]]],
         schema: Schema,
     ):
-        self._generators = generators
+        self._generators = list(generators)
         self._schema = schema
 
     def name(self) -> str:

--- a/tests/io/test_range.py
+++ b/tests/io/test_range.py
@@ -36,3 +36,9 @@ def test_with_start_end_and_step_kwargs():
 def test_with_no_args_raises_error():
     with pytest.raises(TypeError):
         daft.range()
+
+
+def test_range_called_multiple_times():
+    df = daft.range(10)
+    assert df.count_rows() == 10
+    assert df.count_rows() == 10

--- a/tests/io/test_range.py
+++ b/tests/io/test_range.py
@@ -42,3 +42,4 @@ def test_range_called_multiple_times():
     df = daft.range(10)
     assert df.count_rows() == 10
     assert df.count_rows() == 10
+    assert df.count_rows() == 10

--- a/tests/io/test_range.py
+++ b/tests/io/test_range.py
@@ -42,4 +42,12 @@ def test_range_called_multiple_times():
     df = daft.range(10)
     assert df.count_rows() == 10
     assert df.count_rows() == 10
-    assert df.count_rows() == 10
+    assert len(df.collect()) == 10
+    assert len(df.collect()) == 10
+
+    # test with op
+    df_with_filter = df.filter(daft.col("id") >= 5)
+    assert df_with_filter.count_rows() == 5
+    assert df_with_filter.count_rows() == 5
+    assert len(df_with_filter.collect()) == 5
+    assert len(df_with_filter.collect()) == 5


### PR DESCRIPTION
## Summary

Collect iterators in `read_generator` to list. This is so that dataframes that use `read_generator` can be called multiple times.

## Related Issues

Closes https://github.com/Eventual-Inc/Daft/issues/4041

## Changes Made

Collects iterators in `read_generator` to list.

## Checklist

- [ ] All tests have passed
- [ ] Documented in API Docs
- [ ] Documented in User Guide
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
