### PR TITLE
fix: only install vllm in requirements-dev.txt for linux

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -99,4 +99,4 @@ grpcio==1.68.1
 grpcio-status==1.67.0
 
 # ai
-vllm
+vllm; platform_system == "Linux" # for other systems, see install instructions: https://docs.vllm.ai/en/latest/getting_started/installation.html


### PR DESCRIPTION
## Summary

`uv pip install vllm` does not work for certain platforms and needs to be manually installed. Restricting it so that the dependency install does not fail on local MacOS development

## Related Issues

none

## Changes Made

requirements-dev.txt

## Checklist

- [x] All tests have passed
- [x] Documented in API Docs
- [x] Documented in User Guide
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
