### PR TITLE
chore: clean up pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,14 @@
-## Summary
-
-<!-- Provide a short summary of the changes in this PR. -->
-
-## Related Issues
-
-<!-- Link to related GitHub issues or JIRA tickets, e.g., "Closes #123" -->
-
 ## Changes Made
 
 <!-- Describe what changes were made and why. Include implementation details if necessary. -->
 
+## Related Issues
+
+<!-- Link to related GitHub issues, e.g., "Closes #123" -->
+
 ## Checklist
 
-- [ ] All tests have passed
-- [ ] Documented in API Docs
-- [ ] Documented in User Guide
+- [ ] Documented in API Docs (if applicable)
+- [ ] Documented in User Guide (if applicable)
 - [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
 - [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)


### PR DESCRIPTION
## Summary

Clean up the PR template in various ways

## Related Issues

<!-- Link to related GitHub issues or JIRA tickets, e.g., "Closes #123" -->

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
- remove summary section (I felt that there was a large amount of redundancy between the PR title, summary, and changes made sections)
- remove JIRA mention in changes made since we do not use that
- remove "All tests have passed" from checklist since that is already a strict requirement for merging
- add "(if applicable)" to some checklist items

## Checklist

- [ ] All tests have passed
- [ ] Documented in API Docs
- [ ] Documented in User Guide
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
