### PR TITLE
fix: Fix local to ray runner switch test

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -124,7 +124,7 @@ daft.context.set_runner_ray()
 """
     with with_null_env():
         result = subprocess.run([sys.executable, "-c", script], capture_output=True)
-        assert result.stderr.decode().strip().endswith("RuntimeError: Cannot set runner more than once")
+        assert "RuntimeError: Cannot set runner more than once" in result.stderr.decode().strip()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Check that stderr contains the `cannot set runner more than once` error instead of ends with the error. It does not always end with the error as other processes, such as ray init, may append their own errors after ours.

## Related Issues

Similar to https://github.com/Eventual-Inc/Daft/pull/4046

## Changes Made

Check that stderr contains the `cannot set runner more than once` error instead of ends with the error.

## Checklist

- [ ] All tests have passed
- [ ] Documented in API Docs
- [ ] Documented in User Guide
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
