### PR TITLE
fix: surface non 'NotFound' errors during table resolution

### DIFF
--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -47,7 +47,7 @@ from daft.daft import PyIdentifier, PyTableSource
 
 from daft.dataframe import DataFrame
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal, final
 
 from daft.logical.schema import Schema
 
@@ -196,6 +196,10 @@ def register_python_catalog(catalog: object, name: str | None = None) -> str:
         name = "default"
     _ = attach_catalog(catalog, name)
     return name
+
+
+class NotFoundError(Exception):
+    """Raised when some catalog object is not able to be found."""
 
 
 class Catalog(ABC):

--- a/daft/catalog/__memory.py
+++ b/daft/catalog/__memory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from daft.catalog import Catalog, Identifier, Table, TableSource
+from daft.catalog import Catalog, Identifier, NotFoundError, Table, TableSource
 
 if TYPE_CHECKING:
     from daft.dataframe.dataframe import DataFrame
@@ -38,20 +38,20 @@ class MemoryCatalog(Catalog):
     ###
 
     def create_namespace(self, identifier: Identifier | str):
-        raise ValueError("Memory create_namespace not yet supported.")
+        raise NotImplementedError("Memory create_namespace not yet supported.")
 
     def create_table(self, identifier: Identifier | str, source: TableSource) -> Table:
-        raise ValueError("Memory create_table not yet supported.")
+        raise NotImplementedError("Memory create_table not yet supported.")
 
     ###
     # drop_*
     ###
 
     def drop_namespace(self, identifier: Identifier | str):
-        raise ValueError("Memory drop_namespace not yet supported.")
+        raise NotImplementedError("Memory drop_namespace not yet supported.")
 
     def drop_table(self, identifier: Identifier | str):
-        raise ValueError("Memory drop_table not yet supported.")
+        raise NotImplementedError("Memory drop_table not yet supported.")
 
     ###
     # list_*
@@ -80,7 +80,7 @@ class MemoryCatalog(Catalog):
     def get_table(self, identifier: str | Identifier) -> Table:
         path = str(identifier)
         if path not in self._tables:
-            raise ValueError(f"Table {path} does not exist.")
+            raise NotFoundError(f"Table {path} does not exist.")
         return self._tables[path]
 
 
@@ -110,4 +110,4 @@ class MemoryTable(Table):
     ###
 
     def write(self, df: DataFrame | object, mode: str = "append", **options):
-        raise ValueError("Writes to in-memory tables are not yet supported.")
+        raise NotImplementedError("Writes to in-memory tables are not yet supported.")

--- a/daft/catalog/__unity.py
+++ b/daft/catalog/__unity.py
@@ -44,20 +44,20 @@ class UnityCatalog(Catalog):
     ###
 
     def create_namespace(self, identifier: Identifier | str):
-        raise ValueError("Unity create_namespace not yet supported.")
+        raise NotImplementedError("Unity create_namespace not yet supported.")
 
     def create_table(self, identifier: Identifier | str, source: TableSource) -> Table:
-        raise ValueError("Unity create_table not yet supported.")
+        raise NotImplementedError("Unity create_table not yet supported.")
 
     ###
     # drop_*
     ###
 
     def drop_namespace(self, identifier: Identifier | str):
-        raise ValueError("Unity drop_namespace not yet supported.")
+        raise NotImplementedError("Unity drop_namespace not yet supported.")
 
     def drop_table(self, identifier: Identifier | str):
-        raise ValueError("Unity drop_table not yet supported.")
+        raise NotImplementedError("Unity drop_table not yet supported.")
 
     ###
     # get_*
@@ -73,7 +73,7 @@ class UnityCatalog(Catalog):
     ###
 
     def list_namespaces(self, pattern: str | None = None) -> list[Identifier]:
-        raise ValueError("Unity list_namespaces not yet supported.")
+        raise NotImplementedError("Unity list_namespaces not yet supported.")
 
     def list_tables(self, pattern: str | None = None) -> list[str]:
         if pattern is None or pattern == "":

--- a/daft/session.py
+++ b/daft/session.py
@@ -365,7 +365,7 @@ class Session:
             DataFrame:
 
         Raises:
-            ValueError: If the tables odes not exist.
+            ValueError: If the tables does not exist.
         """
         return self.get_table(identifier).read(**options)
 


### PR DESCRIPTION
## Changes Made

This PR introduces a daft "NotFoundError" which is descriptive for the customers, but also let's the session (via read_table) ignore this while it looks up the chain of possible table locations. This is necessary because we support unqualified, schema-qualified, and catalog-qualified identifiers **with** nested namespaces, so we check that chain in that order and return NotFound if all three fail.

The previous logical treated all errors as NotFound which was swallowing connection errors.

## Related Issues

#3984 

## Checklist

- [n/a] Documented in API Docs (if applicable)
- [n/a] Documented in User Guide (if applicable)
- [n/a] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [n/a] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
