### PR TITLE
docs: s3tables typo fixes

### DIFF
--- a/docs/mkdocs/integrations/s3tables.md
+++ b/docs/mkdocs/integrations/s3tables.md
@@ -7,7 +7,13 @@ Daft integrates with [S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/use
 ```python
 from daft import Catalog
 
-catalog = Catalog.from_arn("arn:aws:s3tables:<region>:<account>:bucket/<bucket>")
+# ensure your aws credentials are configure, for example:
+# import os
+# os.environ["AWS_ACCESS_KEY_ID"] = "<access-id>"
+# os.environ["AWS_SECRET_ACCESS_KEY"] = "<access-key>"
+# os.environ["AWS_DEFAULT_REGION"] = "<region>"
+
+catalog = Catalog.from_s3tables("arn:aws:s3tables:<region>:<account>:bucket/<bucket>")
 
 # verify we are connected
 catalog.list_tables("demo")
@@ -72,7 +78,7 @@ You can use the S3 Tables AWS API via a `boto3` client or `boto3` session.
 
 ### S3 Tables Iceberg REST API
 
-The S3 Tables service supports
+S3 Tables offers an [Iceberg REST compatible endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-integrating-open-source.html) which Daft uses when you create a catalog via `from_s3tables`.
 
 > You can connect your Iceberg REST client to the Amazon S3 Tables Iceberg REST endpoint and make REST API calls to create, update, or query tables in S3 table buckets. The endpoint implements a set of standardized Iceberg REST APIs specified in the Apache Iceberg REST Catalog Open API specification. The endpoint works by translating Iceberg REST API operations into corresponding S3 Tables operations.
 


### PR DESCRIPTION
## Changes Made

fix typos in s3tables integrations doc

## Related Issues

n/a

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
