### PR TITLE
docs: add S3 io_config usage example to read_lance docstring

### DIFF
--- a/daft/io/_lance.py
+++ b/daft/io/_lance.py
@@ -35,8 +35,16 @@ def read_lance(url: str, io_config: Optional["IOConfig"] = None) -> DataFrame:
 
         To ensure that this is installed with Daft, you may install: ``pip install daft[lance]``
 
-    Example:
+    Examples
+    --------
+    Read a local LanceDB table:
         >>> df = daft.read_lance("s3://my-lancedb-bucket/data/")
+        >>> df.show()
+    
+    Read a LanceDB table from a public S3 bucket:
+        >>> from daft.io import S3Config
+        >>> s3_config = S3Config(region="us-west-2", anonymous=True)
+        >>> df = daft.read_lance("s3://daft-public-data/lance/words-test-dataset", io_config=s3_config)
         >>> df.show()
 
     Args:


### PR DESCRIPTION
## Changes Made

This PR adds an example to the `read_lance` docstring that shows how to read from a public S3 bucket using the `io_config` parameter with `S3Config`. This makes it easier for users to understand how to use read_lance with object stores like S3 without having to search through external documentation.

## Related Issues

#2395 
