### PR TITLE
fix: Allow aliased monotonically increasing id functions to coexist with columns named "id"

### DIFF
--- a/src/daft-logical-plan/src/ops/monotonically_increasing_id.rs
+++ b/src/daft-logical-plan/src/ops/monotonically_increasing_id.rs
@@ -18,11 +18,13 @@ pub struct MonotonicallyIncreasingId {
 }
 
 impl MonotonicallyIncreasingId {
+    pub(crate) const DEFAULT_COLUMN_NAME: &str = "id";
+
     pub(crate) fn try_new(
         input: Arc<LogicalPlan>,
         column_name: Option<&str>,
     ) -> logical_plan::Result<Self> {
-        let column_name = column_name.unwrap_or("id");
+        let column_name = column_name.unwrap_or(Self::DEFAULT_COLUMN_NAME);
 
         let fields_with_id = std::iter::once(Field::new(column_name, DataType::UInt64))
             .chain(input.schema().fields.values().cloned())


### PR DESCRIPTION
## Changes Made

Currently, using a monotonically increasing id function was not allowed with a dataframe that also has an "id" column.

For example,
```
import daft;
from daft.functions import monotonically_increasing_id;
df = daft.from_pydict({"id": ["a", "b", "c"]});
df = df.with_column("partition", monotonically_increasing_id());
df.show()
```
does not work.

We fix this by not reusing "id" as a column name during logical plan optimization. This is a temporary workaround until we use ordinals to refer to columns.
