### PR TITLE
feat: Update unity_catalog.py to allow managed tables

### DIFF
--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -121,7 +121,7 @@ class UnityCatalog:
         except unitycatalog.NotFoundError:
             if table_type == "EXTERNAL" and not new_table_storage_path:
                 raise ValueError(
-                    f"Table {table_name} is not an existing table. If a new table needs to be created, provide 'new_table_storage_path' value."
+                    f"Table {table_name} is not an existing table. If a new table needs to be created, provide 'new_table_storage_path' value or set table_type to 'MANAGED'."
                 )
             elif table_type == "MANAGED":
                 warnings.warn(

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -119,9 +119,9 @@ class UnityCatalog:
                 )
         except unitycatalog.NotFoundError:
             if not new_table_storage_path:
-                raise ValueError(
-                    f"Table {table_name} is not an existing table. If a new table needs to be created, provide 'new_table_storage_path' value."
-                )
+                table_type = "MANAGED"
+            else:
+                table_type = "EXTERNAL"
             try:
                 three_part_namesplit = table_name.split(".")
                 if len(three_part_namesplit) != 3 or not all(three_part_namesplit):
@@ -135,7 +135,7 @@ class UnityCatalog:
                     "name": three_part_namesplit[2],
                     "columns": None,
                     "data_source_format": "DELTA",
-                    "table_type": "EXTERNAL",
+                    "table_type": table_type,
                     "storage_location": new_table_storage_path,
                     "comment": None,
                 }


### PR DESCRIPTION
## Changes Made

If a table does not exist in Unity Catalog the load_table function would attempts to create the table if a new_table_storage_path is defined. Since unity 0.3.0 the REST API allows also writing as managed table thus a managed table creation should be attempted without a new_table_storage_path location being defined. 

To be discussed 

## Related Issues

Closes #4106 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
