### PR TITLE
Add pipe to DataFrame

### DIFF
--- a/tests/dataframe/test_pipe.py
+++ b/tests/dataframe/test_pipe.py
@@ -1,0 +1,11 @@
+def test_pipe_with_join(make_df):
+    df1 = make_df({"A": [1, 2, 3], "B": [1, 2, 3]})
+    df2 = make_df({"A": [1, 2, 3], "C": [1, 2, 3]})
+
+    def left_join(dfa, dfb, on):
+        return dfa.join(dfb, on=on)
+
+    joined_by_join = df1.join(df2, on="A")
+    joined_by_pipe = df1.pipe(left_join, df2, on="A")
+
+    assert joined_by_join.to_pydict() == joined_by_pipe.to_pydict()


### PR DESCRIPTION
## Changes Made

Adds `DataFrame.pipe` to extend method-chaining to DataFrame-ingesting functions.

The functionality's trivial (just syntactic sugar). I added a basic test too. I haven't touched the docs though; it wasn't clear which category of methods `pipe` belongs to.

## Related Issues

[<!-- Link to related GitHub issues, e.g., "Closes #123" -->
](https://github.com/Eventual-Inc/Daft/issues/4107)

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
