### PR TITLE
fix: Disable warc merging

### DIFF
--- a/src/daft-scan/src/scan_task_iters/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/mod.rs
@@ -323,6 +323,9 @@ fn split_and_merge_pass(
     if scan_tasks
         .iter()
         .all(|st| st.as_any().downcast_ref::<ScanTask>().is_some())
+        && !scan_tasks
+            .iter()
+            .any(|st| matches!(st.file_format_config().as_ref(), FileFormatConfig::Warc(_)))
     {
         // TODO(desmond): Here we downcast Arc<dyn ScanTaskLike> to Arc<ScanTask>. ScanTask and DummyScanTask (test only) are
         // the only non-test implementer of ScanTaskLike. It might be possible to avoid the downcast by implementing merging

--- a/tests/io/test_merge_scan_tasks.py
+++ b/tests/io/test_merge_scan_tasks.py
@@ -96,7 +96,7 @@ def test_merge_scan_task_up_to_max_sources(csv_files):
 
 
 @pytest.mark.parametrize(
-    "size_byte_configs",
+    "min_size_bytes, max_size_bytes",
     [
         (0, 0),
         (0, 10000),
@@ -104,10 +104,10 @@ def test_merge_scan_task_up_to_max_sources(csv_files):
         (10000, 10000),
     ],
 )
-def test_merge_scan_tasks_does_not_merge_warc(size_byte_configs):
+def test_merge_scan_tasks_does_not_merge_warc(min_size_bytes, max_size_bytes):
     with daft.execution_config_ctx(
-        scan_tasks_min_size_bytes=size_byte_configs[0],
-        scan_tasks_max_size_bytes=size_byte_configs[1],
+        scan_tasks_min_size_bytes=min_size_bytes,
+        scan_tasks_max_size_bytes=max_size_bytes,
     ):
         path = ["tests/assets/example.warc"] * 3
         df = daft.read_warc(path)

--- a/tests/io/test_merge_scan_tasks.py
+++ b/tests/io/test_merge_scan_tasks.py
@@ -93,3 +93,22 @@ def test_merge_scan_task_up_to_max_sources(csv_files):
         assert (
             df.num_partitions() == 2
         ), "Should have 2 partitions [(CSV1, CSV2), (CSV3)] since the third CSV is too large to merge with the first two, and max_sources_per_scan_task is set to 2"
+
+
+@pytest.mark.parametrize(
+    "size_byte_configs",
+    [
+        (0, 0),
+        (0, 10000),
+        (10000, 0),
+        (10000, 10000),
+    ],
+)
+def test_merge_scan_tasks_does_not_merge_warc(size_byte_configs):
+    with daft.execution_config_ctx(
+        scan_tasks_min_size_bytes=size_byte_configs[0],
+        scan_tasks_max_size_bytes=size_byte_configs[1],
+    ):
+        path = ["tests/assets/example.warc"] * 3
+        df = daft.read_warc(path)
+        assert df.num_partitions() == 3, "Should have 3 partitions since WARC files are not merged"


### PR DESCRIPTION
## Changes Made

Disable scan task merging for warcs. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
