### PR TITLE
bug: Fixing timestamp types for Delta

### DIFF
--- a/docs/mkdocs/integrations/delta_lake.md
+++ b/docs/mkdocs/integrations/delta_lake.md
@@ -104,8 +104,8 @@ When reading from a Delta Lake table into Daft:
 | `double` | [`daft.DataType.float64()`](../api_docs/datatype.html#daft.DataType.float64) |
 | `decimal(precision, scale)` | [`daft.DataType.decimal128(precision, scale)`](../api_docs/datatype.html#daft.DataType.decimal128) |
 | `date` | [`daft.DataType.date()`](../api_docs/datatype.html#daft.DataType.date) |
-| `timestamp` | [`daft.DataType.timestamp(timeunit="us", timezone=None)`](../api_docs/datatype.html#daft.DataType.timestamp) |
-| `timestampz`| [`daft.DataType.timestamp(timeunit="us", timezone="UTC")`](../api_docs/datatype.html#daft.DataType.timestamp) |
+| `timestamp_ntz` | [`daft.DataType.timestamp(timeunit="us", timezone=None)`](../api_docs/datatype.html#daft.DataType.timestamp) |
+| `timestamp`| [`daft.DataType.timestamp(timeunit="us", timezone="UTC")`](../api_docs/datatype.html#daft.DataType.timestamp) |
 | `string` | [`daft.DataType.string()`](../api_docs/datatype.html#daft.DataType.string) |
 | `binary` | [`daft.DataType.binary()`](../api_docs/datatype.html#daft.DataType.binary) |
 | **Nested Types** |


### PR DESCRIPTION
## Changes Made

The timestamp types for Delta have been fixed

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
