### PR TITLE
feat(treenode): add TreeNodeRecursion::Repeat

### DIFF
--- a/src/common/treenode/src/lib.rs
+++ b/src/common/treenode/src/lib.rs
@@ -541,12 +541,12 @@ pub enum TreeNodeRecursionNoRepeat {
     Stop,
 }
 
-impl Into<TreeNodeRecursion> for TreeNodeRecursionNoRepeat {
-    fn into(self) -> TreeNodeRecursion {
-        match self {
-            Self::Continue => TreeNodeRecursion::Continue,
-            Self::Jump => TreeNodeRecursion::Jump,
-            Self::Stop => TreeNodeRecursion::Stop,
+impl From<TreeNodeRecursionNoRepeat> for TreeNodeRecursion {
+    fn from(value: TreeNodeRecursionNoRepeat) -> Self {
+        match value {
+            TreeNodeRecursionNoRepeat::Continue => Self::Continue,
+            TreeNodeRecursionNoRepeat::Jump => Self::Jump,
+            TreeNodeRecursionNoRepeat::Stop => Self::Stop,
         }
     }
 }
@@ -557,7 +557,7 @@ impl TreeNodeRecursion {
     ) -> Result<TreeNodeRecursionNoRepeat> {
         let mut tnr = Self::Repeat;
         while tnr == Self::Repeat {
-            tnr = f()?
+            tnr = f()?;
         }
 
         Ok(tnr.into_no_repeat())
@@ -636,9 +636,9 @@ pub struct TransformedNoRepeat<T> {
     pub tnr: TreeNodeRecursionNoRepeat,
 }
 
-impl<T> Into<Transformed<T>> for TransformedNoRepeat<T> {
-    fn into(self) -> Transformed<T> {
-        Transformed::new(self.data, self.transformed, self.tnr.into())
+impl<T> From<TransformedNoRepeat<T>> for Transformed<T> {
+    fn from(val: TransformedNoRepeat<T>) -> Self {
+        Transformed::new(val.data, val.transformed, val.tnr.into())
     }
 }
 

--- a/src/daft-logical-plan/src/optimization/rules/eliminate_cross_join.rs
+++ b/src/daft-logical-plan/src/optimization/rules/eliminate_cross_join.rs
@@ -126,6 +126,7 @@ fn rewrite_children(
     plan: Arc<LogicalPlan>,
 ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
     plan.map_children(|input| optimizer.try_optimize(input))
+        .map(Into::into)
 }
 
 fn flatten_join_inputs(

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/mod.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/mod.rs
@@ -62,4 +62,5 @@ fn rewrite_children(
     plan: Arc<LogicalPlan>,
 ) -> DaftResult<Transformed<Arc<LogicalPlan>>> {
     plan.map_children(|input| optimizer.try_optimize(input))
+        .map(Into::into)
 }


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

With `TreeNodeRecursion::Repeat`, we can now use the treenode abstraction to rerun an optimization rule on the same node. Previously, we would have had to manually recurse, which breaks out of the treenode paradigm.

This will be useful, for example, in our PushDownFilter rule, which does a top-down traversal of the plan tree to push the filters. Naively, this would not merge a sequence of three filters (Filter 1 -> Filter 2 -> Filter 3) into one, because Filter 1 and 2 would be merged, and then we would traverse down into Filter 3. Currently, we solve this by calling the rule recursively when we see two filters, but it can be much more naturally down by simply returning `Transformed::new(new_node, true, TreeNodeRecursion::Repeat)`. That way, we only need to think about one recursion path instead of two.

With this change, I added `TreeNodeRecursionNoRepeat` and `TransformedNoRepeat` types, which will help prevent bugs where we receive a repeat when we do not expect one via type enforcement. They are a little bit of a mouthful, but generally they are not used outside of common-treenode anyway so I feel okay with it.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
