### PR TITLE
chore(optimizer): move join type simplification into new rule

### DIFF
--- a/src/daft-logical-plan/src/optimization/rules/mod.rs
+++ b/src/daft-logical-plan/src/optimization/rules/mod.rs
@@ -12,6 +12,7 @@ mod push_down_projection;
 mod reorder_joins;
 mod rule;
 mod simplify_expressions;
+mod simplify_null_filtered_join;
 mod split_actor_pool_projects;
 mod unnest_subquery;
 
@@ -29,5 +30,6 @@ pub use push_down_projection::PushDownProjection;
 pub use reorder_joins::ReorderJoins;
 pub use rule::OptimizerRule;
 pub use simplify_expressions::SimplifyExpressionsRule;
+pub use simplify_null_filtered_join::SimplifyNullFilteredJoin;
 pub use split_actor_pool_projects::SplitActorPoolProjects;
 pub use unnest_subquery::{UnnestPredicateSubquery, UnnestScalarSubquery};

--- a/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
@@ -6,10 +6,7 @@ use std::{
 use common_error::DaftResult;
 use common_scan_info::{rewrite_predicate_for_partitioning, PredicateGroups};
 use common_treenode::{DynTreeNode, Transformed, TreeNode};
-use daft_algebra::boolean::{
-    combine_conjunction, predicate_removes_nulls, split_conjunction, to_cnf,
-};
-use daft_core::join::JoinType;
+use daft_algebra::boolean::{combine_conjunction, split_conjunction, to_cnf};
 use daft_dsl::{
     optimization::{get_required_columns, replace_columns_with_expressions},
     resolved_col, ExprRef,
@@ -264,50 +261,6 @@ impl PushDownFilter {
                 // Example:
                 //      For `foo JOIN bar ON foo.a == (bar.b + 2) WHERE a > 0`, the filter `a > 0` is pushed down to the left side, but can also be pushed down to the right side as `(b + 2) > 0`
 
-                // Left, right, and outer joins can be simplified if there is a filter on their null-producing side.
-                //
-                // Examples:
-                // 1. select * from A left join B where B.x > 0 -> select * from A inner join B where B.x > 0
-                // 2. select * from A full outer join B where B.x > 0 -> select * from A right join B where B.x > 0
-                // 3. select * from A full outer join B where A.x > 0 and B.y > 0 -> select * from A inner join B where A.x > 0 and B.y > 0
-                let simplified_join_type = if matches!(
-                    join_type,
-                    JoinType::Left | JoinType::Right | JoinType::Outer
-                ) {
-                    let left_preserved = !join_type.left_produces_nulls() || {
-                        let left_cols: HashSet<ExprRef> = HashSet::from_iter(
-                            left.schema().fields.keys().cloned().map(resolved_col),
-                        );
-
-                        predicate_removes_nulls(
-                            filter.predicate.clone(),
-                            &child_plan.schema(),
-                            &left_cols,
-                        )?
-                    };
-
-                    let right_preserved = !join_type.right_produces_nulls() || {
-                        let right_cols: HashSet<ExprRef> = HashSet::from_iter(
-                            right.schema().fields.keys().cloned().map(resolved_col),
-                        );
-
-                        predicate_removes_nulls(
-                            filter.predicate.clone(),
-                            &child_plan.schema(),
-                            &right_cols,
-                        )?
-                    };
-
-                    match (left_preserved, right_preserved) {
-                        (true, true) => JoinType::Inner,
-                        (true, false) => JoinType::Left,
-                        (false, true) => JoinType::Right,
-                        (false, false) => JoinType::Outer,
-                    }
-                } else {
-                    *join_type
-                };
-
                 let mut left_pushdowns = vec![];
                 let mut right_pushdowns = vec![];
                 let mut kept_predicates = vec![];
@@ -333,14 +286,14 @@ impl PushDownFilter {
                             kept_predicates.push(predicate);
                         }
                         (true, false) => {
-                            if simplified_join_type.left_produces_nulls() {
+                            if join_type.left_produces_nulls() {
                                 kept_predicates.push(predicate);
                             } else {
                                 left_pushdowns.push(predicate);
                             }
                         }
                         (false, true) => {
-                            if simplified_join_type.right_produces_nulls() {
+                            if join_type.right_produces_nulls() {
                                 kept_predicates.push(predicate);
                             } else {
                                 right_pushdowns.push(predicate);
@@ -377,7 +330,7 @@ impl PushDownFilter {
                         new_left,
                         new_right,
                         on.clone(),
-                        simplified_join_type,
+                        *join_type,
                         *join_strategy,
                     )?));
 
@@ -386,19 +339,6 @@ impl PushDownFilter {
                     } else {
                         new_join
                     }
-                } else if *join_type != simplified_join_type {
-                    let new_join = Join::try_new(
-                        left.clone(),
-                        right.clone(),
-                        on.clone(),
-                        simplified_join_type,
-                        *join_strategy,
-                    )?
-                    .into();
-
-                    Filter::try_new(new_join, filter.predicate.clone())
-                        .unwrap()
-                        .into()
                 } else {
                     return Ok(Transformed::no(plan));
                 }
@@ -416,7 +356,7 @@ mod tests {
     use common_error::DaftResult;
     use common_scan_info::Pushdowns;
     use daft_core::prelude::*;
-    use daft_dsl::{lit, resolved_col, unresolved_col, ExprRef};
+    use daft_dsl::{lit, resolved_col, unresolved_col};
     use daft_functions::uri::download::UrlDownloadArgs;
     use rstest::rstest;
 
@@ -1064,76 +1004,6 @@ mod tests {
         .build();
 
         assert_optimized_plan_eq(plan, expected)?;
-
-        Ok(())
-    }
-
-    #[rstest]
-    #[case(JoinType::Left, resolved_col("b"), JoinType::Inner)]
-    #[case(JoinType::Left, resolved_col("a"), JoinType::Left)]
-    #[case(JoinType::Right, resolved_col("a"), JoinType::Inner)]
-    #[case(JoinType::Right, resolved_col("b"), JoinType::Right)]
-    #[case(JoinType::Outer, resolved_col("a").eq(resolved_col("b")), JoinType::Inner)]
-    #[case(JoinType::Outer, resolved_col("a"), JoinType::Left)]
-    #[case(JoinType::Outer, resolved_col("b"), JoinType::Right)]
-    #[case(JoinType::Outer, resolved_col("a").eq_null_safe(resolved_col("b")), JoinType::Outer)]
-    fn join_type_simplifies(
-        #[case] join_type: JoinType,
-        #[case] filter_predicate: ExprRef,
-        #[case] expected_join_type: JoinType,
-    ) -> DaftResult<()> {
-        let left_scan_op = dummy_scan_operator(vec![Field::new("a", DataType::Boolean)]);
-        let right_scan_op = dummy_scan_operator(vec![Field::new("b", DataType::Boolean)]);
-
-        let plan = dummy_scan_node(left_scan_op.clone())
-            .join(
-                dummy_scan_node(right_scan_op.clone()),
-                None,
-                vec![],
-                join_type,
-                None,
-                Default::default(),
-            )?
-            .filter(filter_predicate.clone())?
-            .build();
-
-        let pushed_into_left = filter_predicate.to_field(&left_scan_op.0.schema()).is_ok();
-        let pushed_into_right = filter_predicate.to_field(&right_scan_op.0.schema()).is_ok();
-
-        let expected_left_scan_node = if pushed_into_left {
-            dummy_scan_node_with_pushdowns(
-                left_scan_op,
-                Pushdowns::default().with_filters(Some(filter_predicate.clone())),
-            )
-        } else {
-            dummy_scan_node(left_scan_op)
-        };
-
-        let expected_right_scan_node = if pushed_into_right {
-            dummy_scan_node_with_pushdowns(
-                right_scan_op,
-                Pushdowns::default().with_filters(Some(filter_predicate.clone())),
-            )
-        } else {
-            dummy_scan_node(right_scan_op)
-        };
-
-        let expected = expected_left_scan_node.join(
-            expected_right_scan_node,
-            None,
-            vec![],
-            expected_join_type,
-            None,
-            Default::default(),
-        )?;
-
-        let expected = if !pushed_into_left && !pushed_into_right {
-            expected.filter(filter_predicate)?
-        } else {
-            expected
-        };
-
-        assert_optimized_plan_eq(plan, expected.build())?;
 
         Ok(())
     }

--- a/src/daft-logical-plan/src/optimization/rules/simplify_null_filtered_join.rs
+++ b/src/daft-logical-plan/src/optimization/rules/simplify_null_filtered_join.rs
@@ -1,0 +1,178 @@
+use std::collections::HashSet;
+
+use common_error::DaftResult;
+use common_treenode::{Transformed, TreeNode};
+use daft_algebra::boolean::predicate_removes_nulls;
+use daft_core::join::JoinType;
+use daft_dsl::{resolved_col, ExprRef};
+
+use super::OptimizerRule;
+use crate::{
+    ops::{Filter, Join},
+    LogicalPlan, LogicalPlanRef,
+};
+
+/// Left, right, and outer joins can be simplified if there is a filter on their null-producing side.
+///
+/// This is especially useful for enabling other optimizations that rely on the join type, such as join reordering.
+///
+/// Examples:
+/// 1. select * from A left join B where B.x > 0 -> select * from A inner join B where B.x > 0
+/// 2. select * from A full outer join B where B.x > 0 -> select * from A right join B where B.x > 0
+/// 3. select * from A full outer join B where A.x > 0 and B.y > 0 -> select * from A inner join B where A.x > 0 and B.y > 0
+#[derive(Debug)]
+pub struct SimplifyNullFilteredJoin {}
+
+impl SimplifyNullFilteredJoin {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for SimplifyNullFilteredJoin {
+    fn try_optimize(&self, plan: LogicalPlanRef) -> DaftResult<Transformed<LogicalPlanRef>> {
+        plan.transform(|node| {
+            if let LogicalPlan::Filter(Filter {
+                input, predicate, ..
+            }) = node.as_ref()
+            {
+                match input.as_ref() {
+                    LogicalPlan::Join(Join {
+                        left,
+                        right,
+                        on,
+                        join_type,
+                        join_strategy,
+                        ..
+                    }) if matches!(
+                        join_type,
+                        JoinType::Left | JoinType::Right | JoinType::Outer
+                    ) =>
+                    {
+                        let left_preserved = *join_type == JoinType::Left || {
+                            let left_cols: HashSet<ExprRef> = HashSet::from_iter(
+                                left.schema().fields.keys().cloned().map(resolved_col),
+                            );
+
+                            predicate_removes_nulls(predicate.clone(), &input.schema(), &left_cols)?
+                        };
+
+                        let right_preserved = *join_type == JoinType::Right || {
+                            let right_cols: HashSet<ExprRef> = HashSet::from_iter(
+                                right.schema().fields.keys().cloned().map(resolved_col),
+                            );
+
+                            predicate_removes_nulls(
+                                predicate.clone(),
+                                &input.schema(),
+                                &right_cols,
+                            )?
+                        };
+
+                        let simplified_join_type = match (left_preserved, right_preserved) {
+                            (true, true) => JoinType::Inner,
+                            (true, false) => JoinType::Left,
+                            (false, true) => JoinType::Right,
+                            (false, false) => JoinType::Outer,
+                        };
+
+                        if *join_type != simplified_join_type {
+                            let new_join = Join::try_new(
+                                left.clone(),
+                                right.clone(),
+                                on.clone(),
+                                simplified_join_type,
+                                *join_strategy,
+                            )?
+                            .into();
+                            return Ok(Transformed::yes(
+                                node.with_new_children(&[new_join]).into(),
+                            ));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            Ok(Transformed::no(node))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use daft_core::prelude::*;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::{
+        optimization::{
+            optimizer::{RuleBatch, RuleExecutionStrategy},
+            test::assert_optimized_plan_with_rules_eq,
+        },
+        test::{dummy_scan_node, dummy_scan_operator},
+    };
+
+    fn assert_optimized_plan_eq(plan: LogicalPlanRef, expected: LogicalPlanRef) -> DaftResult<()> {
+        assert_optimized_plan_with_rules_eq(
+            plan,
+            expected,
+            vec![RuleBatch::new(
+                vec![Box::new(SimplifyNullFilteredJoin::new())],
+                RuleExecutionStrategy::Once,
+            )],
+        )
+    }
+
+    #[rstest]
+    #[case(JoinType::Left, resolved_col("b"), JoinType::Inner)]
+    #[case(JoinType::Left, resolved_col("a"), JoinType::Left)]
+    #[case(JoinType::Right, resolved_col("a"), JoinType::Inner)]
+    #[case(JoinType::Right, resolved_col("b"), JoinType::Right)]
+    #[case(JoinType::Outer, resolved_col("a").eq(resolved_col("b")), JoinType::Inner)]
+    #[case(JoinType::Outer, resolved_col("a"), JoinType::Left)]
+    #[case(JoinType::Outer, resolved_col("b"), JoinType::Right)]
+    #[case(JoinType::Outer, resolved_col("a").eq_null_safe(resolved_col("b")), JoinType::Outer)]
+    fn join_type_simplifies(
+        #[case] join_type: JoinType,
+        #[case] filter_predicate: ExprRef,
+        #[case] expected_join_type: JoinType,
+    ) -> DaftResult<()> {
+        let left_scan_node = dummy_scan_node(dummy_scan_operator(vec![Field::new(
+            "a",
+            DataType::Boolean,
+        )]));
+        let right_scan_node = dummy_scan_node(dummy_scan_operator(vec![Field::new(
+            "b",
+            DataType::Boolean,
+        )]));
+
+        let plan = left_scan_node
+            .join(
+                right_scan_node.clone(),
+                None,
+                vec![],
+                join_type,
+                None,
+                Default::default(),
+            )?
+            .filter(filter_predicate.clone())?
+            .build();
+
+        let expected = left_scan_node
+            .join(
+                right_scan_node,
+                None,
+                vec![],
+                expected_join_type,
+                None,
+                Default::default(),
+            )?
+            .filter(filter_predicate.clone())?
+            .build();
+
+        assert_optimized_plan_eq(plan, expected)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Changes Made

Quick refactor of some of the logic that previously lived in PushDownFilter into its own rule. 

I previously implemented it in PushDownFilter because it could have interactions with the other filter pushdown logic. However, we should try to keep PushDownFilter as simple as we can, just for pushing filter nodes through  a plan. Thus, I am moving this logic into a new rule and using the repeated execution of the rule batch to deal with interactions between the two rules.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

Related to why we closed #4118

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
