### PR TITLE
fix: skip drop_nan when no float columns

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2153,6 +2153,10 @@ class DataFrame:
             )
         ]
 
+        # avoid superfluous .where with empty iterable when nothing to filter.
+        if not float_columns:
+            return self
+
         return self.where(
             ~reduce(
                 lambda x, y: x.is_null().if_else(lit(False), x) | y.is_null().if_else(lit(False), y),

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -744,3 +744,15 @@ def test_cast_sql_string_failing(sql):
     with pytest.raises(Exception):
         expr = col("a").cast(sql)
         daft.from_pydict({"a": [1, 2, 3]}).select(expr)
+
+
+def test_drop_nan():
+    dd = {"n": [1.0, 2.0, None]}
+    df = daft.from_pydict(dd)
+    assert df.drop_nan().to_pydict() == {"n": [1.0, 2.0]}
+
+
+def test_drop_nan_no_nans():
+    dd = {"n": [1, 1, 2]}
+    df = daft.from_pydict(dd)
+    assert df.drop_nan().to_pydict() == dd


### PR DESCRIPTION
## Changes Made

avoid superfluous .where with empty iterable when nothing to filter.

## Related Issues

closes #4126 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
