### PR TITLE
fix(join ordering): Fix bug with aliasing columns between joins

### DIFF
--- a/src/daft-logical-plan/src/optimization/optimizer.rs
+++ b/src/daft-logical-plan/src/optimization/optimizer.rs
@@ -172,6 +172,8 @@ impl OptimizerBuilder {
         self.rule_batches.push(RuleBatch::new(
             vec![
                 Box::new(ReorderJoins::new()),
+                Box::new(PushDownFilter::new()),
+                Box::new(PushDownProjection::new()),
                 Box::new(EnrichWithStats::new()),
             ],
             RuleExecutionStrategy::Once,


### PR DESCRIPTION
## Changes Made

In #4113 we have an alias in between join nodes. The join graph constructor has a bug where aliases of non-unique columns across different query tree branches would all be aliased. This is incorrect behaviour.

As a quick fix, we avoid reordering projects in between join nodes if the projection has any non-column-reference. A longer term fix (tracked in #4131) is to add projection and filter pushups during join ordering.

## Related Issues

Closes #4113