### PR TITLE
fix: ignore hugging face in broken link workflow

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -22,7 +22,7 @@ jobs:
         retry_wait_seconds: 60
         max_attempts: 3
         retry_on: error
-        command: blc https://www.getdaft.io -ro --exclude www.pytorch.org/ --exclude https://github.com/Eventual-Inc/Daft/ --exclude https://twitter.com/daft_dataframe --exclude https://www.linkedin.com/company/eventualcomputing/ --exclude https://x.com/daft_dataframe --exclude https://www.linkedin.com/showcase/daft-dataframe/ --exclude https://scarf.sh/ --exclude https://static.scarf.sh/*
+        command: blc https://www.getdaft.io -ro --exclude www.pytorch.org/ --exclude https://github.com/Eventual-Inc/Daft/ --exclude https://twitter.com/daft_dataframe --exclude https://www.linkedin.com/company/eventualcomputing/ --exclude https://x.com/daft_dataframe --exclude https://www.linkedin.com/showcase/daft-dataframe/ --exclude https://scarf.sh/ --exclude https://static.scarf.sh/* --exclude https://huggingface.co/docs/dataset-viewer/en/parquet
   notify_on_failure:
     runs-on: self-hosted
     if: failure()


### PR DESCRIPTION
## Changes Made

HuggingFace link is valid but gives 403. This change fixes the workflow, https://github.com/Eventual-Inc/Daft/actions/runs/14224250387

## Related Issues

n/a

## Checklist

n/a
