### PR TITLE
ci: Native doc tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -814,7 +814,6 @@ jobs:
     continue-on-error: true
     env:
       python-version: '3.10'
-      DAFT_BOLD_TABLE_HEADERS: '0'
     steps:
     - uses: actions/checkout@v4
     - uses: moonrepo/setup-rust@v1
@@ -844,9 +843,10 @@ jobs:
       run: |
         source activate
         maturin develop
-        pytest --doctest-modules --continue-on-collection-errors daft/dataframe/dataframe.py daft/expressions/expressions.py daft/convert.py daft/udf.py daft/functions/functions.py
+        DAFT_BOLD_TABLE_HEADERS=0 pytest --doctest-modules --continue-on-collection-errors daft/dataframe/dataframe.py daft/expressions/expressions.py daft/convert.py daft/udf.py daft/functions/functions.py
       env:
-        DAFT_RUNNER: py
+        DAFT_RUNNER: native
+
 
   publish-coverage-reports:
     name: Publish coverage reports to CodeCov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -841,9 +841,7 @@ jobs:
         uv pip install -r requirements-dev.txt
     - name: Run doctests
       run: |
-        source activate
-        maturin develop
-        DAFT_BOLD_TABLE_HEADERS=0 pytest --doctest-modules --continue-on-collection-errors daft/dataframe/dataframe.py daft/expressions/expressions.py daft/convert.py daft/udf.py daft/functions/functions.py
+        make doctests
       env:
         DAFT_RUNNER: native
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -831,14 +831,6 @@ jobs:
         cache-dependency-path: |
           pyproject.toml
           requirements-dev.txt
-    - name: Setup Virtual Env
-      run: |
-        python -m venv venv
-        echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
-        pip install uv
-    - name: Install dependencies
-      run: |
-        uv pip install -r requirements-dev.txt
     - name: Run doctests
       run: |
         make doctests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -831,8 +831,18 @@ jobs:
         cache-dependency-path: |
           pyproject.toml
           requirements-dev.txt
+    - name: Setup Virtual Env
+      run: |
+        python -m venv venv
+        echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
+        pip install uv
+    - name: Install dependencies
+      run: |
+        uv pip install -r requirements-dev.txt
     - name: Run doctests
       run: |
+        source activate
+        maturin develop
         make doctests
       env:
         DAFT_RUNNER: native

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ test: .venv build  ## Run tests
 	HYPOTHESIS_MAX_EXAMPLES=$(HYPOTHESIS_MAX_EXAMPLES) $(VENV_BIN)/pytest --hypothesis-seed=$(HYPOTHESIS_SEED)
 
 .PHONY: doctests
-doctests: .venv build  ## Run doctests
-	DAFT_BOLD_TABLE_HEADERS=0 $(VENV_BIN)/pytest --doctest-modules --continue-on-collection-errors daft/dataframe/dataframe.py daft/expressions/expressions.py daft/convert.py daft/udf.py daft/functions/functions.py
+doctests:
+	DAFT_BOLD_TABLE_HEADERS=0 pytest --doctest-modules --continue-on-collection-errors daft/dataframe/dataframe.py daft/expressions/expressions.py daft/convert.py daft/udf.py daft/functions/functions.py daft/datatype.py
 
 .PHONY: dsdgen
 dsdgen: .venv ## Generate TPC-DS data

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ build-release: check-toolchain .venv  ## Compile and install a faster Daft binar
 test: .venv build  ## Run tests
 	HYPOTHESIS_MAX_EXAMPLES=$(HYPOTHESIS_MAX_EXAMPLES) $(VENV_BIN)/pytest --hypothesis-seed=$(HYPOTHESIS_SEED)
 
+.PHONY: doctests
+doctests: .venv build  ## Run doctests
+	DAFT_BOLD_TABLE_HEADERS=0 $(VENV_BIN)/pytest --doctest-modules --continue-on-collection-errors daft/dataframe/dataframe.py daft/expressions/expressions.py daft/convert.py daft/udf.py daft/functions/functions.py
+
 .PHONY: dsdgen
 dsdgen: .venv ## Generate TPC-DS data
 	$(VENV_BIN)/python benchmarking/tpcds/datagen.py --scale-factor=$(SCALE_FACTOR) --tpcds-gen-folder=$(OUTPUT_DIR)

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -430,9 +430,11 @@ class DataFrame:
 
         >>> import daft
         >>>
+        >>> daft.context.set_runner_ray()  # doctest: +SKIP
+        >>>
         >>> df = daft.from_pydict({"foo": [1, 2, 3], "bar": ["a", "b", "c"]}).into_partitions(2)
         >>> for part in df.iter_partitions():
-        ...     print(part)
+        ...     print(part)  # doctest: +SKIP
         MicroPartition with 2 rows:
         TableState: Loaded. 1 tables
         ╭───────┬──────╮
@@ -1329,9 +1331,11 @@ class DataFrame:
 
         Example:
             >>> import daft
+            >>> daft.context.set_runner_ray()  # doctest: +SKIP
+            >>>
             >>> df = daft.from_pydict({"a": [1, 2, 3, 4]}).into_partitions(2)
             >>> df = df._add_monotonically_increasing_id()
-            >>> df.show()
+            >>> df.show()  # doctest: +SKIP
             ╭─────────────┬───────╮
             │ id          ┆ a     │
             │ ---         ┆ ---   │
@@ -1434,15 +1438,16 @@ class DataFrame:
             >>> import daft
             >>> df = daft.from_pydict({"x": [1, 2, 2], "y": [4, 5, 5], "z": [7, 8, 8]})
             >>> distinct_df = df.distinct()
+            >>> distinct_df = distinct_df.sort("x")
             >>> distinct_df.show()
             ╭───────┬───────┬───────╮
             │ x     ┆ y     ┆ z     │
             │ ---   ┆ ---   ┆ ---   │
             │ Int64 ┆ Int64 ┆ Int64 │
             ╞═══════╪═══════╪═══════╡
-            │ 2     ┆ 5     ┆ 8     │
-            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
             │ 1     ┆ 4     ┆ 7     │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 2     ┆ 5     ┆ 8     │
             ╰───────┴───────┴───────╯
             <BLANKLINE>
             (Showing first 2 of 2 rows)
@@ -1464,15 +1469,16 @@ class DataFrame:
             >>> import daft
             >>> df = daft.from_pydict({"x": [1, 2, 2], "y": [4, 5, 5], "z": [7, 8, 8]})
             >>> distinct_df = df.unique()
+            >>> distinct_df = distinct_df.sort("x")
             >>> distinct_df.show()
             ╭───────┬───────┬───────╮
             │ x     ┆ y     ┆ z     │
             │ ---   ┆ ---   ┆ ---   │
             │ Int64 ┆ Int64 ┆ Int64 │
             ╞═══════╪═══════╪═══════╡
-            │ 2     ┆ 5     ┆ 8     │
-            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
             │ 1     ┆ 4     ┆ 7     │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 2     ┆ 5     ┆ 8     │
             ╰───────┴───────┴───────╯
             <BLANKLINE>
             (Showing first 2 of 2 rows)
@@ -2682,6 +2688,7 @@ class DataFrame:
             ...     col("pet").count().alias("count"),
             ...     col("name").any_value(),
             ... )
+            >>> grouped_df = grouped_df.sort("pet")
             >>> grouped_df.show()
             ╭──────┬─────────┬─────────┬────────┬────────╮
             │ pet  ┆ min_age ┆ max_age ┆ count  ┆ name   │
@@ -2729,15 +2736,17 @@ class DataFrame:
             ... }
             >>> df = daft.from_pydict(data)
             >>> df = df.pivot("version", "platform", "downloads", "sum")
+            >>>
+            >>> df = df.sort("version").select("version", "windows", "macos")
             >>> df.show()
             ╭─────────┬─────────┬───────╮
             │ version ┆ windows ┆ macos │
             │ ---     ┆ ---     ┆ ---   │
             │ Utf8    ┆ Int64   ┆ Int64 │
             ╞═════════╪═════════╪═══════╡
-            │ 3.9     ┆ 250     ┆ 150   │
-            ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
             │ 3.8     ┆ None    ┆ 300   │
+            ├╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
+            │ 3.9     ┆ 250     ┆ 150   │
             ╰─────────┴─────────┴───────╯
             <BLANKLINE>
             (Showing first 2 of 2 rows)
@@ -2893,7 +2902,9 @@ class DataFrame:
             >>> import daft
             >>> df1 = daft.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
             >>> df2 = daft.from_pydict({"a": [1, 2, 3], "b": [4, 8, 6]})
-            >>> df1.intersect(df2).collect()
+            >>> df = df1.intersect(df2)
+            >>> df = df.sort("a")
+            >>> df.show()
             ╭───────┬───────╮
             │ a     ┆ b     │
             │ ---   ┆ ---   │
@@ -3527,6 +3538,7 @@ class GroupedDataFrame:
             >>> import daft
             >>> df = daft.from_pydict({"keys": ["a", "a", "a", "b"], "col_a": [0, 1, 2, 100]})
             >>> df = df.groupby("keys").stddev()
+            >>> df = df.sort("keys")
             >>> df.show()
             ╭──────┬───────────────────╮
             │ keys ┆ col_a             │
@@ -3639,6 +3651,7 @@ class GroupedDataFrame:
             ...     col("pet").count().alias("count"),
             ...     col("name").any_value(),
             ... )
+            >>> grouped_df = grouped_df.sort("pet")
             >>> grouped_df.show()
             ╭──────┬─────────┬─────────┬────────┬────────╮
             │ pet  ┆ min_age ┆ max_age ┆ count  ┆ name   │
@@ -3683,6 +3696,7 @@ class GroupedDataFrame:
             ...     return [statistics.stdev(data)]
             >>>
             >>> df = df.groupby("group").map_groups(std_dev(df["data"]))
+            >>> df = df.sort("group")
             >>> df.show()
             ╭───────┬────────────────────╮
             │ group ┆ data               │

--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -273,7 +273,7 @@ class DataType:
         """Create a Struct DataType: a nested type which has names mapped to child types.
 
         Example:
-            >>> DataType.struct({"name": DataType.string(), "age": DataType.int64()})
+            >>> struct_type = DataType.struct({"name": DataType.string(), "age": DataType.int64()})
 
         Args:
             fields: Nested fields of the Struct

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -1096,9 +1096,13 @@ class Expression:
             A grouped calculation of approximate percentiles:
 
             >>> df = daft.from_pydict({"class": ["a", "a", "a", "b", "c"], "scores": [1, 2, 3, 1, None]})
-            >>> df = df.groupby("class").agg(
-            ...     df["scores"].approx_percentiles(0.5).alias("approx_median_score"),
-            ...     df["scores"].approx_percentiles([0.25, 0.5, 0.75]).alias("approx_percentiles_scores"),
+            >>> df = (
+            ...     df.groupby("class")
+            ...     .agg(
+            ...         df["scores"].approx_percentiles(0.5).alias("approx_median_score"),
+            ...         df["scores"].approx_percentiles([0.25, 0.5, 0.75]).alias("approx_percentiles_scores"),
+            ...     )
+            ...     .sort("class")
             ... )
             >>> df.show()
             ╭───────┬─────────────────────┬────────────────────────────────╮
@@ -1106,11 +1110,11 @@ class Expression:
             │ ---   ┆ ---                 ┆ ---                            │
             │ Utf8  ┆ Float64             ┆ FixedSizeList[Float64; 3]      │
             ╞═══════╪═════════════════════╪════════════════════════════════╡
-            │ c     ┆ None                ┆ None                           │
-            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
             │ a     ┆ 1.993661701417351   ┆ [0.9900000000000001, 1.993661… │
             ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
             │ b     ┆ 0.9900000000000001  ┆ [0.9900000000000001, 0.990000… │
+            ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+            │ c     ┆ None                ┆ None                           │
             ╰───────┴─────────────────────┴────────────────────────────────╯
             <BLANKLINE>
             (Showing first 3 of 3 rows)

--- a/daft/functions/functions.py
+++ b/daft/functions/functions.py
@@ -13,9 +13,11 @@ def monotonically_increasing_id() -> Expression:
     Example:
         >>> import daft
         >>> from daft.functions import monotonically_increasing_id
+        >>> daft.context.set_runner_ray()  # doctest: +SKIP
+        >>>
         >>> df = daft.from_pydict({"a": [1, 2, 3, 4]}).into_partitions(2)
         >>> df = df.with_column("id", monotonically_increasing_id())
-        >>> df.show()
+        >>> df.show()  # doctest: +SKIP
         ╭───────┬─────────────╮
         │ a     ┆ id          │
         │ ---   ┆ ---         │


### PR DESCRIPTION
## Changes Made

Use native runner for doctests. Modify code examples to add a sort if needed (e.g. groupbys) because swordfish does not have ordering guarantees without an order by.

Also, don't run them for monotonically increasing id, because it requires partitioning.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
