### PR TITLE
(draft) poc for better UC integration

### DIFF
--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -261,12 +261,15 @@ class Catalog(ABC):
         except ImportError:
             raise ImportError("Iceberg support not installed: pip install -U 'daft[iceberg]'")
 
+    # Currently daft.unity_catalog.UnityCatalog is more like a Unity Catalog client rather than a
+    # the catalog itself.
     @staticmethod
-    def from_unity(catalog: object) -> Catalog:
-        """Creates a Daft Catalog instance from a Unity catalog.
+    def from_unity(client: object, catalog_name: str = "unity") -> Catalog:
+        """Creates a Daft Catalog instance from a Unity catalog client and a catalog name.
 
         Args:
-            catalog (object): unity catalog object
+            client (object): unity catalog client
+            catalog_name (str): name of the catalog
 
         Returns:
             Catalog: new daft catalog instance from the unity catalog object.
@@ -274,7 +277,7 @@ class Catalog(ABC):
         try:
             from daft.catalog.__unity import UnityCatalog
 
-            return UnityCatalog._from_obj(catalog)
+            return UnityCatalog._from_obj(client, catalog_name)
         except ImportError:
             raise ImportError("Unity support not installed: pip install -U 'daft[unity]'")
 

--- a/daft/unity_catalog/__init__.py
+++ b/daft/unity_catalog/__init__.py
@@ -1,5 +1,5 @@
 # We ban importing from daft.unity_catalog as a module level import because it is expensive despite
 # not always being needed. Within the daft.unity_catalog module itself we ignore this restriction.
-from .unity_catalog import UnityCatalog, UnityCatalogTable  # noqa: TID253
+from .unity_catalog import UnityCatalog, UnityCatalogClient, UnityCatalogTable  # noqa: TID253
 
-__all__ = ["UnityCatalog", "UnityCatalogTable"]
+__all__ = ["UnityCatalog", "UnityCatalogClient", "UnityCatalogTable"]

--- a/daft/unity_catalog/unity_catalog.py
+++ b/daft/unity_catalog/unity_catalog.py
@@ -184,3 +184,6 @@ class UnityCatalog:
             table_uri=storage_location,
             io_config=io_config,
         )
+
+
+UnityCatalogClient = UnityCatalog


### PR DESCRIPTION
## Changes Made

Was curious as to why our APIs weren't working too hot with UC and took a look. It seems that the `daft.unity_catalog.UnityCatalog` object we pass into `from_unity` is more like a UC client rather than a UC catalog itself. 

One possibility to address this is to change our API to `from_unity(client, catalog_name)`.

With this change we can finally do this:
```
import os
import daft
from daft import Session
from daft.unity_catalog import UnityCatalogClient

unity_client = UnityCatalogClient(
    endpoint=os.environ["EVENTUAL_DATABRICKS_ENDPOINT"],
    token=os.environ["DATABRICKS_API_KEY"]
)

sess = Session()
catalog = daft.Catalog.from_unity(unity_client, "jaytest-unity")
sess.attach(catalog)
print(sess.current_catalog())
sess.sql('USE "jaytest-unity".default')
sess.sql("select * from nation").show()
```

## Related Issues

Related to #4059 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
