### PR TITLE
feat: adds case-sensitive and case-normalized catalog and table identifiers [1/3]

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
       - SHOW: sql/statements/show.md
       - USE: sql/statements/use.md
     - Data Types: sql/datatypes.md
+    - Identifiers: sql/identifiers.md
   - Sessions: sessions.md
   - Catalogs: catalogs.md
   - Spark Connect: spark_connect.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -29,7 +29,8 @@ nav:
       - SHOW: sql/statements/show.md
       - USE: sql/statements/use.md
     - Data Types: sql/datatypes.md
-    - Identifiers: sql/identifiers.md
+    # Disabled until identifier modes are supported.
+    # - Identifiers: sql/identifiers.md
   - Sessions: sessions.md
   - Catalogs: catalogs.md
   - Spark Connect: spark_connect.md

--- a/docs/mkdocs/sql/identifiers.md
+++ b/docs/mkdocs/sql/identifiers.md
@@ -14,16 +14,23 @@ fits your preferences and current systems. When working across multiple systems,
 ```sql
 -- regular identifier
 abc
+```
 
+```sql
 -- delimited identifier
 "abc"
 
+```sql
 -- qualified identifier
 abc.xyz
+```
 
+```sql
 -- qualified identifier with mixed parts
 a."b".c
+```
 
+```sql
 -- delimited identifier with special characters
 SELECT "🍺" FROM "🍻"
 ```
@@ -33,7 +40,7 @@ SELECT "🍺" FROM "🍻"
 * Identifiers may be unquoted (regular) or double-quoted (delimited).
 * Identifiers must be double-quoted if the text is a keyword or the text contains special characters.
 * Regular identifiers must start with either an [alphabetic character](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt) or an underscore `'_'` character.
-* Regular identifiers must contain only alphabetic, `[0-9]`, `'$'` and `'_'` characters.
+* Regular identifiers must contain only alphanumeric, `'$'` and `'_'` characters.
 
 ## Modes
 

--- a/docs/mkdocs/sql/identifiers.md
+++ b/docs/mkdocs/sql/identifiers.md
@@ -1,0 +1,71 @@
+# Identifiers
+
+Daft's SQL identifiers are **case-insensitive by default**, but support a case-sensitive and a case-normalize mode. For both the case-insensitive and case-sensitive modes, identifiers are case-preserved and are matched based upon the mode. For the case-normalize mode, unquoted (regular) identifiers are normalized to lowercase and double-quoted (delimited) identifiers are case-preserved. You can configure these modes by setting the `identifer_mode` session option. These modes apply when resolving attached catalogs, attached tables, and columns via the session.
+
+!!! warning "Warning"
+
+    Catalogs such as Iceberg and Unity have incompatible resolution rules which means we cannot guarantee consistency across catalog implementations.
+
+It is currently not feasible to ensure consistent casing semantics across catalogs, so we recommend using the different modes to find which best
+fits your preferences and current systems. When working across multiple systems, using all lowercase names for namespace and tables with `identifier_mode = 'normalize'` provides the most consistent experience.
+
+## Syntax
+
+```sql
+-- regular identifier
+abc
+
+-- delimited identifier
+"abc"
+
+-- qualified identifier
+abc.xyz
+
+-- qualified identifier with mixed parts
+a."b".c
+
+-- delimited identifier with special characters
+SELECT "🍺" FROM "🍻"
+```
+
+**Rules**
+
+* Identifiers may be unquoted (regular) or double-quoted (delimited).
+* Identifiers must be double-quoted if the text is a keyword or the text contains special characters.
+* Regular identifiers must start with either an [alphabetic character](https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt) or an underscore `'_'` character.
+* Regular identifiers must contain only alphabetic, `[0-9]`, `'$'` and `'_'` characters.
+
+## Modes
+
+!!! tip ""
+
+    We recommend trying these settings to determine which works best for your workloads.
+
+| Mode          | Behavior                                                                     | Compatibility                     |
+|---------------|------------------------------------------------------------------------------|-----------------------------------|
+| `insensitive` | All identifiers are matched case-insensitively and names are case-preserved. | `duckdb`, `spark`, `unity`        |
+| `sensitive`   | All identifiers are matched case-sensitively and names are case-preserved.   | `python`, `iceberg`               |
+| `normalize`   | Unquoted (regular) identifiers and names are case-normalized to lowercase.   | `trino`, `postgres`, `datafusion` |
+
+
+
+## Configuration
+
+You can configure the mode using the `identifier_mode` session option.
+
+```python
+# python
+
+from daft import Session
+
+sess = Session()
+sess.set_option("identifier_mode", "sensitive")
+```
+
+```SQL
+-- SQL
+
+SET identifier_mode = 'insensitive';  -- duckdb, spark, unity
+SET identifier_mode = 'sensitive';    -- python, iceberg
+SET identifier_mode = 'normalized';   -- postgres, datafusion, standard
+```

--- a/src/daft-catalog/src/bindings.rs
+++ b/src/daft-catalog/src/bindings.rs
@@ -1,46 +1,87 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-/// Bindings
-///
-/// Notes:
-///  - Currently using Clone because all references are arcs.
-///  - This is intentionally lightweight and everything is exact-case.
-///  - All APIs are non-fallible because callers determine what is an error.
-///  - It does not necessarily have map semantics.
-///  - Callers are responsible for case-normalization hence String, &str.
-///  - Intentionally using String and &str rather than Into and AsRef.
+/// Bindings are stored case-normalized with the case-preserved bindings.
 #[derive(Debug)]
-pub struct Bindings<T>(HashMap<String, T>);
+pub struct Bindings<T> {
+    /// case-preserved bindings (default)
+    bindings: HashMap<String, T>,
+    /// case-normalized binding aliases for insensitive lookups.
+    aliases: HashMap<String, HashSet<String>>,
+}
 
+/// Bind mode is for lvalue handling which is currently out of scope.
+#[derive(Debug, Clone, Copy)]
+pub enum BindMode {
+    Preserve,
+    Normalize,
+}
+
+/// Find mode is for rvalue handling.
+#[derive(Debug, Clone, Copy)]
+pub enum FindMode {
+    Insensitive,
+    Sensitive,
+}
+
+/// Bindings implements "bind" and "find" for handling various identifier modes.
 impl<T> Bindings<T> {
-    /// Creates an empty catalog provider.
+    /// Creates an empty bindings object.
     pub fn empty() -> Self {
-        Self(HashMap::new())
+        Self {
+            bindings: HashMap::new(),
+            aliases: HashMap::new(),
+        }
     }
 
-    /// Inserts a new binding with ownership.
-    pub fn insert(&mut self, name: String, object: T) {
-        self.0.insert(name, object);
+    /// Bind an object to the name (lvalue), overwriting any existing binding.
+    pub fn bind(&mut self, name: String, object: T) {
+        self.bindings.insert(name.clone(), object);
+        self.aliases.entry(alias(&name)).or_default().insert(name);
     }
 
-    /// Removes the binding if it exists.
+    /// Find all object by name (rvalue).
+    pub fn find(&self, name: &str, mode: FindMode) -> Vec<&T> {
+        match mode {
+            FindMode::Insensitive => self.find_aliased(name),
+            FindMode::Sensitive => self.find_binding(name),
+        }
+    }
+    /// Finds this binding by exact case.
+    #[inline]
+    fn find_binding(&self, name: &str) -> Vec<&T> {
+        self.bindings
+            .get(name)
+            .map(|binding| vec![binding])
+            .unwrap_or_default()
+    }
+
+    /// Finds all bindings mapped to this alias.
+    #[inline]
+    fn find_aliased(&self, name: &str) -> Vec<&T> {
+        self.aliases
+            .get(&alias(name))
+            .map(|names| {
+                names
+                    .iter()
+                    .filter_map(|name| self.bindings.get(name))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Removes the binding if it exists (exact-case).
     pub fn remove(&mut self, name: &str) {
-        self.0.remove(name);
+        self.bindings.remove(name);
     }
 
-    /// Returns true if the binding exists.
-    pub fn exists(&self, name: &str) -> bool {
-        self.0.contains_key(name)
-    }
-
-    /// Get an object reference by name.
-    pub fn get(&self, name: &str) -> Option<&T> {
-        self.0.get(name)
+    /// Returns true if the binding exists (exact-case).
+    pub fn contains(&self, name: &str) -> bool {
+        self.bindings.contains_key(name)
     }
 
     /// List all objects matching the pattern.
     pub fn list(&self, pattern: Option<&str>) -> Vec<String> {
-        self.0
+        self.bindings
             .keys()
             .map(|k| k.as_str())
             .filter(|k| pattern.is_none() || k.contains(pattern.unwrap_or("")))
@@ -50,6 +91,11 @@ impl<T> Bindings<T> {
 
     /// Returns true iff there are no bindings.
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.bindings.is_empty()
     }
+}
+
+/// Using the unicode lowercase to normalize
+fn alias(name: &str) -> String {
+    name.to_lowercase()
 }

--- a/src/daft-catalog/src/catalog.rs
+++ b/src/daft-catalog/src/catalog.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use crate::{bindings::Bindings, error::Result, Identifier, Table};
+use crate::{error::Result, Identifier, Table};
 
 /// Catalog implementation reference.
 pub type CatalogRef = Arc<dyn Catalog>;
-
-/// CatalogProvider is a collection of referenceable catalogs.
-pub type CatalogProvider = Bindings<CatalogRef>;
 
 /// A catalog provides object metadata such as namespaces, tables, and functions.
 pub trait Catalog: Sync + Send + std::fmt::Debug {

--- a/src/daft-catalog/src/error.rs
+++ b/src/daft-catalog/src/error.rs
@@ -25,6 +25,9 @@ pub enum Error {
     #[snafu(display("{type_} with name {ident} not found!"))]
     ObjectNotFound { type_: String, ident: String },
 
+    #[snafu(display("Ambgiuous identifier {input}, found {options}!"))]
+    AmbiguousIdentifier { input: String, options: String },
+
     #[snafu(display("Invalid identifier {input}!"))]
     InvalidIdentifier { input: String },
 
@@ -37,13 +40,6 @@ pub enum Error {
 }
 
 impl Error {
-    #[inline]
-    pub fn invalid_identifier<S: Into<String>>(input: S) -> Error {
-        Error::InvalidIdentifier {
-            input: input.into(),
-        }
-    }
-
     #[inline]
     pub fn unsupported<S: Into<String>>(message: S) -> Error {
         Error::Unsupported {
@@ -65,6 +61,28 @@ impl Error {
         Error::ObjectNotFound {
             type_: typ_.into(),
             ident: ident.to_string(),
+        }
+    }
+
+    pub fn ambiguous_identifier<O, I>(input: I, options: O) -> Self
+    where
+        O: IntoIterator<Item = I>,
+        I: Into<String>,
+    {
+        Error::AmbiguousIdentifier {
+            input: input.into(),
+            options: options
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>()
+                .join("."),
+        }
+    }
+
+    #[inline]
+    pub fn invalid_identifier<S: Into<String>>(input: S) -> Error {
+        Error::InvalidIdentifier {
+            input: input.into(),
         }
     }
 }

--- a/src/daft-catalog/src/identifier.rs
+++ b/src/daft-catalog/src/identifier.rs
@@ -142,16 +142,23 @@ impl Display for Identifier {
 }
 
 impl From<String> for Identifier {
-    /// Returns an unqualified delimited identifier.
+    /// Returns an unqualified identifier.
     fn from(name: String) -> Self {
         Self::simple(name)
     }
 }
 
 impl From<&str> for Identifier {
-    /// Returns an unqualified delmited identifier.
+    /// Returns an unqualified identifier.
     fn from(name: &str) -> Self {
         Self::simple(name.to_string())
+    }
+}
+
+impl From<Vec<&str>> for Identifier {
+    /// Returns an identifier from vec literal like vec!["a", "b"].into()
+    fn from(path: Vec<&str>) -> Self {
+        Self::new(path)
     }
 }
 

--- a/src/daft-catalog/src/table.rs
+++ b/src/daft-catalog/src/table.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use daft_core::prelude::SchemaRef;
 use daft_logical_plan::{LogicalPlanBuilder, LogicalPlanRef};
 
-use crate::{bindings::Bindings, error::Result};
+use crate::error::Result;
 
 /// Table implementation reference.
 pub type TableRef = Arc<dyn Table>;
@@ -34,9 +34,6 @@ impl From<LogicalPlanBuilder> for TableSource {
         TableSource::View(view.build())
     }
 }
-
-/// TableProvider is a collection of referenceable tables.
-pub type TableProvider = Bindings<TableRef>;
 
 /// TODO consider moving out to daft-table, but this isn't necessary or helpful right now.
 pub trait Table: Sync + Send + std::fmt::Debug {

--- a/src/daft-session/src/error.rs
+++ b/src/daft-session/src/error.rs
@@ -34,3 +34,13 @@ macro_rules! obj_not_found_err {
         ))
     };
 }
+
+#[macro_export]
+macro_rules! ambiguous_identifier_err {
+    ($typ_:literal, $name:expr) => {
+        return Err($crate::error::Error::ambiguous_identifier(
+            $typ_.to_string(),
+            $name,
+        ))
+    };
+}

--- a/src/daft-session/src/options.rs
+++ b/src/daft-session/src/options.rs
@@ -1,10 +1,39 @@
+use daft_catalog::FindMode;
+
 // TODO make env variables
 pub(crate) const _DAFT_SESSION: &str = "default";
 pub(crate) const _DAFT_SESSION_USER: &str = "daft";
 pub(crate) const _DAFT_SESSION_TEMP_DIR: &str = "/tmp";
 
+/// Session state variables.
 #[derive(Debug, Default)]
 pub(crate) struct Options {
+    pub identifier_mode: IdentifierMode,
     pub curr_catalog: Option<String>,
     pub curr_namespace: Option<Vec<String>>,
+}
+
+/// Identifier mode controls identifier resolution and name binding logic (tables, columns, views, etc).
+#[derive(Debug, Default)]
+#[allow(dead_code)]
+pub enum IdentifierMode {
+    /// Find case-insensitive (rvalue) and bind case-preserved (lvalue).
+    Insensitive,
+    /// Find case-sensitive (rvalue) and bind case-preserved (lvalue).
+    #[default]
+    Sensitive,
+    /// Find case-sensitive (rvalue) and bind (lower) case-normalized (lvalue).
+    Normalize,
+}
+
+/// Options helpers to convert session
+impl Options {
+    /// Returns the `FindMode` for the current `IdentifierMode`.
+    pub fn find_mode(&self) -> FindMode {
+        match self.identifier_mode {
+            IdentifierMode::Insensitive => FindMode::Insensitive,
+            IdentifierMode::Sensitive => FindMode::Sensitive,
+            IdentifierMode::Normalize => FindMode::Sensitive,
+        }
+    }
 }

--- a/src/daft-session/src/options.rs
+++ b/src/daft-session/src/options.rs
@@ -1,4 +1,4 @@
-use daft_catalog::FindMode;
+use daft_catalog::LookupMode;
 
 // TODO make env variables
 pub(crate) const _DAFT_SESSION: &str = "default";
@@ -17,23 +17,23 @@ pub(crate) struct Options {
 #[derive(Debug, Default)]
 #[allow(dead_code)]
 pub enum IdentifierMode {
-    /// Find case-insensitive (rvalue) and bind case-preserved (lvalue).
+    /// For `ident AS alias` -> lookup 'ident' case-insensitively and bind to 'alias' case-preserved.
     Insensitive,
-    /// Find case-sensitive (rvalue) and bind case-preserved (lvalue).
+    /// For `ident AS alias` -> lookup 'ident' case-sensitively and bind to 'alias' case-preserved.
     #[default]
     Sensitive,
-    /// Find case-sensitive (rvalue) and bind (lower) case-normalized (lvalue).
+    /// For `ident AS aLiAs` -> lookup 'ident' case-sensitively and bind to `lowercase('aLiAs') -> 'alias'`.
     Normalize,
 }
 
 /// Options helpers to convert session
 impl Options {
-    /// Returns the `FindMode` for the current `IdentifierMode`.
-    pub fn find_mode(&self) -> FindMode {
+    /// Returns the binding `LookupMode` for the current `IdentifierMode`.
+    pub fn find_mode(&self) -> LookupMode {
         match self.identifier_mode {
-            IdentifierMode::Insensitive => FindMode::Insensitive,
-            IdentifierMode::Sensitive => FindMode::Sensitive,
-            IdentifierMode::Normalize => FindMode::Sensitive,
+            IdentifierMode::Insensitive => LookupMode::Insensitive,
+            IdentifierMode::Sensitive => LookupMode::Sensitive,
+            IdentifierMode::Normalize => LookupMode::Sensitive,
         }
     }
 }

--- a/src/daft-session/src/session.rs
+++ b/src/daft-session/src/session.rs
@@ -248,7 +248,7 @@ impl Session {
 impl SessionState {
     /// Get an attached catalog by name using the session's identifier mode.
     pub fn get_attached_catalog(&self, name: &str) -> Result<Option<CatalogRef>> {
-        match self.catalogs.find(name, self.options.find_mode()) {
+        match self.catalogs.lookup(name, self.options.find_mode()) {
             catalogs if catalogs.is_empty() => Ok(None),
             catalogs if catalogs.len() == 1 => Ok(Some(catalogs[0].clone())),
             _ => panic!("ambiguous catalog identifier"),
@@ -257,7 +257,7 @@ impl SessionState {
 
     /// Get an attached table by name using the session's identifier mode.
     pub fn get_attached_table(&self, name: &str) -> Result<Option<TableRef>> {
-        match self.tables.find(name, self.options.find_mode()) {
+        match self.tables.lookup(name, self.options.find_mode()) {
             tables if tables.is_empty() => Ok(None),
             tables if tables.len() == 1 => Ok(Some(tables[0].clone())),
             _ => panic!("ambiguous table identifier"),

--- a/src/daft-sql/src/modules/aggs.rs
+++ b/src/daft-sql/src/modules/aggs.rs
@@ -9,7 +9,7 @@ use crate::{
     ensure,
     error::SQLPlannerResult,
     functions::{SQLFunction, SQLFunctions},
-    normalize,
+    object_name_to_identifier,
     planner::SQLPlanner,
     table_not_found_err, unsupported_sql_err,
 };
@@ -88,7 +88,7 @@ fn handle_count(inputs: &[FunctionArg], planner: &SQLPlanner) -> SQLPlannerResul
             None => unsupported_sql_err!("Wildcard is not supported in this context"),
         },
         [FunctionArg::Unnamed(FunctionArgExpr::QualifiedWildcard(name))] => {
-            let ident = normalize(name);
+            let ident = object_name_to_identifier(name);
 
             match &planner.current_plan {
                 Some(plan) => {

--- a/tests/sql/test_sql_identifiers.py
+++ b/tests/sql/test_sql_identifiers.py
@@ -1,0 +1,60 @@
+import pytest
+
+import daft
+from daft import Session
+
+
+def _df(name):
+    """Create some table whose only column the case-preserved name so we know exactly which was found."""
+    return daft.from_pydict({name: []})
+
+
+def assert_ok(sess: Session, ident: str, find: str):
+    """Assert that 'ident' is resolved to 'find'."""
+    assert sess.sql(f"SELECT * FROM {ident.strip()}").to_pydict() == {find: []}
+
+
+def assert_err(sess: Session, ident: str, match: str):
+    """Assert that 'ident' fails to resolve with the given message match."""
+    with pytest.raises(Exception, match=match):
+        sess.sql(f"SELECT * FROM {ident}")
+
+
+def test_case_sensitive_identifiers():
+    sess = Session()
+
+    # unambiguous uppercase name
+    sess.create_temp_table("T", _df("T"))
+
+    # ok since regular and delimited are both case-sensitive.
+    assert_ok(sess, """  T  """, find="T")
+    assert_ok(sess, """ "T" """, find="T")
+
+    # fails since case-sensitive cannot find 'T'
+    assert_err(sess, """  t  """, match="Table not found")
+    assert_err(sess, """ "t" """, match="Table not found")
+    # unambiguous lowercase name
+    sess.create_temp_table("s", _df("s"))
+
+    # ok since regular and delimited are both case-sensitive.
+    assert_ok(sess, """  s  """, find="s")
+    assert_ok(sess, """ "s" """, find="s")
+
+    # fails since case-sensitive cannot find 's'
+    assert_err(sess, """  S  """, match="Table not found")
+    assert_err(sess, """ "S" """, match="Table not found")
+
+    # possibly ambiguous names depending on mode
+    sess.create_temp_table("abc", _df("abc"))
+    sess.create_temp_table("ABC", _df("ABC"))
+    sess.create_temp_table("aBc", _df("aBc"))
+
+    # delimited identifiers are case-sensitive
+    assert_ok(sess, """ "abc" """, find="abc")
+    assert_ok(sess, """ "ABC" """, find="ABC")
+    assert_ok(sess, """ "aBc" """, find="aBc")
+
+    # regular identifiers are also case-sensitive
+    assert_ok(sess, """ abc """, find="abc")
+    assert_ok(sess, """ ABC """, find="ABC")
+    assert_ok(sess, """ aBc """, find="aBc")

--- a/tests/sql/test_sql_identifiers.py
+++ b/tests/sql/test_sql_identifiers.py
@@ -27,22 +27,22 @@ def test_case_sensitive_identifiers():
     sess.create_temp_table("T", _df("T"))
 
     # ok since regular and delimited are both case-sensitive.
-    assert_ok(sess, """  T  """, find="T")
-    assert_ok(sess, """ "T" """, find="T")
+    assert_ok(sess, "  T  ", find="T")
+    assert_ok(sess, ' "T" ', find="T")
 
     # fails since case-sensitive cannot find 'T'
-    assert_err(sess, """  t  """, match="Table not found")
-    assert_err(sess, """ "t" """, match="Table not found")
+    assert_err(sess, "  t  ", match="Table not found")
+    assert_err(sess, ' "t" ', match="Table not found")
     # unambiguous lowercase name
     sess.create_temp_table("s", _df("s"))
 
     # ok since regular and delimited are both case-sensitive.
-    assert_ok(sess, """  s  """, find="s")
-    assert_ok(sess, """ "s" """, find="s")
+    assert_ok(sess, "  s  ", find="s")
+    assert_ok(sess, ' "s" ', find="s")
 
     # fails since case-sensitive cannot find 's'
-    assert_err(sess, """  S  """, match="Table not found")
-    assert_err(sess, """ "S" """, match="Table not found")
+    assert_err(sess, "  S  ", match="Table not found")
+    assert_err(sess, ' "S" ', match="Table not found")
 
     # possibly ambiguous names depending on mode
     sess.create_temp_table("abc", _df("abc"))
@@ -50,11 +50,11 @@ def test_case_sensitive_identifiers():
     sess.create_temp_table("aBc", _df("aBc"))
 
     # delimited identifiers are case-sensitive
-    assert_ok(sess, """ "abc" """, find="abc")
-    assert_ok(sess, """ "ABC" """, find="ABC")
-    assert_ok(sess, """ "aBc" """, find="aBc")
+    assert_ok(sess, ' "abc" ', find="abc")
+    assert_ok(sess, ' "ABC" ', find="ABC")
+    assert_ok(sess, ' "aBc" ', find="aBc")
 
     # regular identifiers are also case-sensitive
-    assert_ok(sess, """ abc """, find="abc")
-    assert_ok(sess, """ ABC """, find="ABC")
-    assert_ok(sess, """ aBc """, find="aBc")
+    assert_ok(sess, " abc ", find="abc")
+    assert_ok(sess, " ABC ", find="ABC")
+    assert_ok(sess, " aBc ", find="aBc")


### PR DESCRIPTION
## Changes Made

This PR extends the bindings to support both case-sensitive and case-normalized identifier handling for attached catalogs and tables. It does not modify column resolution (yet) and it does not add case-insensitive matching (yet). This PR also includes documentation for the goal state which will be [linked once built](https://www.getdaft.io/projects/docs/en/rchowell-identifiers/sql/identifiers/). I have also implemented case-insensitive for the attached catalogs and attached tables, but it is not possible to use yet since I have the exact-case hardcoded as default as to not break things.

[Documentation](https://www.getdaft.io/projects/docs/en/rchowell-identifiers/sql/identifiers/)

**Whats next?**

* Case-insensitive as default mode.
* Session options with SET statement.
* Session option for identifier mode.
* Column resolution with the modes.

## Related Issues

* Closes #3765 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
