### PR TITLE
fix: Fix list aggregates on empty series

### DIFF
--- a/src/daft-core/src/array/ops/list.rs
+++ b/src/daft-core/src/array/ops/list.rs
@@ -1050,7 +1050,11 @@ macro_rules! impl_aggs_list_array {
 
                 let agg_refs: Vec<_> = aggs.iter().collect();
 
-                Series::concat(agg_refs.as_slice()).map(|s| s.rename(self.name()))
+                if agg_refs.is_empty() {
+                    Ok(Series::empty(self.name(), self.data_type()))
+                } else {
+                    Series::concat(agg_refs.as_slice()).map(|s| s.rename(self.name()))
+                }
             }
 
             pub fn sum(&self) -> DaftResult<Series> {

--- a/src/daft-core/src/array/ops/list.rs
+++ b/src/daft-core/src/array/ops/list.rs
@@ -1051,7 +1051,7 @@ macro_rules! impl_aggs_list_array {
                 let agg_refs: Vec<_> = aggs.iter().collect();
 
                 if agg_refs.is_empty() {
-                    Ok(Series::empty(self.name(), self.data_type()))
+                    Ok(Series::empty(self.name(), self.child_data_type()))
                 } else {
                     Series::concat(agg_refs.as_slice()).map(|s| s.rename(self.name()))
                 }

--- a/src/daft-core/src/array/ops/list.rs
+++ b/src/daft-core/src/array/ops/list.rs
@@ -15,7 +15,10 @@ use crate::{
         FixedSizeListArray, ListArray, StructArray,
     },
     count_mode::CountMode,
-    datatypes::{BooleanArray, DataType, Field, Int64Array, UInt64Array, Utf8Array},
+    datatypes::{
+        try_mean_aggregation_supertype, BooleanArray, DataType, Field, Int64Array, UInt64Array,
+        Utf8Array,
+    },
     kernels::search_sorted::build_is_valid,
     prelude::MapArray,
     series::{IntoSeries, Series},
@@ -1035,9 +1038,10 @@ impl FixedSizeListArray {
 macro_rules! impl_aggs_list_array {
     ($la:ident) => {
         impl $la {
-            fn agg_helper<T>(&self, op: T) -> DaftResult<Series>
+            fn agg_helper<T, F>(&self, op: T, target_type_getter: F) -> DaftResult<Series>
             where
                 T: Fn(&Series) -> DaftResult<Series>,
+                F: Fn(&DataType) -> DaftResult<DataType>,
             {
                 // TODO(Kevin): Currently this requires full materialization of one Series for every list. We could avoid this by implementing either sorted aggregation or an array builder
 
@@ -1051,26 +1055,27 @@ macro_rules! impl_aggs_list_array {
                 let agg_refs: Vec<_> = aggs.iter().collect();
 
                 if agg_refs.is_empty() {
-                    Ok(Series::empty(self.name(), self.child_data_type()))
+                    let target_type = target_type_getter(self.child_data_type())?;
+                    Ok(Series::empty(self.name(), &target_type))
                 } else {
                     Series::concat(agg_refs.as_slice()).map(|s| s.rename(self.name()))
                 }
             }
 
             pub fn sum(&self) -> DaftResult<Series> {
-                self.agg_helper(|s| s.sum(None))
+                self.agg_helper(|s| s.sum(None), |dtype| Ok(dtype.clone()))
             }
 
             pub fn mean(&self) -> DaftResult<Series> {
-                self.agg_helper(|s| s.mean(None))
+                self.agg_helper(|s| s.mean(None), try_mean_aggregation_supertype)
             }
 
             pub fn min(&self) -> DaftResult<Series> {
-                self.agg_helper(|s| s.min(None))
+                self.agg_helper(|s| s.min(None), |dtype| Ok(dtype.clone()))
             }
 
             pub fn max(&self) -> DaftResult<Series> {
-                self.agg_helper(|s| s.max(None))
+                self.agg_helper(|s| s.max(None), |dtype| Ok(dtype.clone()))
             }
         }
     };

--- a/tests/recordbatch/list/test_list_numeric_aggs.py
+++ b/tests/recordbatch/list/test_list_numeric_aggs.py
@@ -70,7 +70,12 @@ def test_list_numeric_aggs_empty_table():
 
 
 def test_list_numeric_aggs_with_groupby():
-    df = daft.from_pydict({"group_col": [1, 1, 1, 1, 2, 2, 2, 2], "id_col": [3, 1, 2, 2, 5, 4, 2, 1]})
+    df = daft.from_pydict(
+        {
+            "group_col": [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3],
+            "id_col": [3, 1, 2, 2, 5, 4, None, 3, None, None, None, None],
+        }
+    )
 
     # Group by and test aggregates.
     grouped_df = df.groupby("group_col").agg(daft.col("id_col").agg_list().alias("ids_col"))
@@ -83,11 +88,11 @@ def test_list_numeric_aggs_with_groupby():
     ).sort("group_col", desc=False)
     result_dict = result.to_pydict()
     expected = {
-        "group_col": [1, 2],
-        "ids_col_sum": [8, 12],
-        "ids_col_mean": [2.0, 3.0],
-        "ids_col_min": [1, 1],
-        "ids_col_max": [3, 5],
+        "group_col": [1, 2, 3],
+        "ids_col_sum": [8, 12, None],
+        "ids_col_mean": [2.0, 4.0, None],
+        "ids_col_min": [1, 3, None],
+        "ids_col_max": [3, 5, None],
     }
     assert result_dict == expected
 

--- a/tests/recordbatch/list/test_list_numeric_aggs.py
+++ b/tests/recordbatch/list/test_list_numeric_aggs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pyarrow as pa
 import pytest
 
 from daft.datatype import DataType
@@ -33,3 +34,35 @@ def test_list_min(table):
 def test_list_max(table):
     result = table.eval_expression_list([col("a").list.max()])
     assert result.to_pydict() == {"a": [2, 4, 5, None, None]}
+
+
+def test_list_numeric_aggs_empty_table():
+    empty_table = MicroPartition.from_pydict(
+        {
+            "col": pa.array([], type=pa.list_(pa.int64())),
+            "fixed_col": pa.array([], type=pa.list_(pa.int64(), 2)),
+        }
+    )
+
+    result = empty_table.eval_expression_list(
+        [
+            col("col").cast(DataType.list(DataType.int64())).list.sum().alias("col_sum"),
+            col("col").list.mean().alias("col_mean"),
+            col("col").list.min().alias("col_min"),
+            col("col").list.max().alias("col_max"),
+            col("fixed_col").list.sum().alias("fixed_col_sum"),
+            col("fixed_col").list.mean().alias("fixed_col_mean"),
+            col("fixed_col").list.min().alias("fixed_col_min"),
+            col("fixed_col").list.max().alias("fixed_col_max"),
+        ]
+    )
+    assert result.to_pydict() == {
+        "col_sum": [[]],
+        "col_mean": [[]],
+        "col_min": [[]],
+        "col_max": [[]],
+        "fixed_col_sum": [[]],
+        "fixed_col_mean": [[]],
+        "fixed_col_min": [[]],
+        "fixed_col_max": [[]],
+    }


### PR DESCRIPTION
## Changes Made

When performing a list agg on an empty partition, we throw `daft.exceptions.DaftCoreException: DaftError::ValueError Need at least 1 series to perform concat`.

To fix this, this PR adds a check if the series is empty. In this case we simply return an empty series.

## Related Issues

Addresses #4153 