### PR TITLE
docs: Fix tutorial notebooks

### DIFF
--- a/docs/mkdocs/resources/tutorials.md
+++ b/docs/mkdocs/resources/tutorials.md
@@ -21,7 +21,7 @@ Query the Open Images dataset to retrieve the top N "reddest" images. This tutor
 
 ## Image Generation on GPUs
 
-Generate images from text prompts using a deep learning model (Mini DALL-E) and Daft UDFs. Run Daft UDFs on GPUs for more efficient resource allocation.
+Generate images from text prompts using a deep learning model (Stable Diffusion) and Daft UDFs. Run Daft UDFs on GPUs for more efficient resource allocation.
 
 [Run this tutorial on Google Colab](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/text_to_image/text_to_image_generation.ipynb)
 

--- a/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
+++ b/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
@@ -110,7 +110,7 @@
     "df = daft.read_json(SAMPLE_DATA_PATH, io_config=IO_CONFIG)\n",
     "\n",
     "if CI:\n",
-    "    df = df.limit(500)\n",
+    "    df = df.limit(100)\n",
     "\n",
     "df"
    ]

--- a/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
+++ b/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
@@ -112,7 +112,7 @@
     "if CI:\n",
     "    df = df.limit(500)\n",
     "\n",
-    "print(df)"
+    "df"
    ]
   },
   {
@@ -316,8 +316,8 @@
     "df = df.select(\n",
     "    df[\"url\"],\n",
     "    df[\"question_score\"],\n",
-    "    df[\"search_result.related_top_question\"].alias(\"related_top_question\"),\n",
-    "    df[\"search_result.similarity\"].alias(\"similarity\"),\n",
+    "    df[\"search_result\"][\"related_top_question\"].alias(\"related_top_question\"),\n",
+    "    df[\"search_result\"][\"similarity\"].alias(\"similarity\"),\n",
     ")"
    ]
   },

--- a/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
+++ b/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
@@ -39,7 +39,7 @@
     "!pip install 'daft[aws]'\n",
     "\n",
     "# We will use sentence-transformers for computing embeddings.\n",
-    "!pip install sentence-transformers"
+    "!pip install sentence-transformers accelerate"
    ]
   },
   {

--- a/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -252,6 +252,7 @@
     "        self.pipe = StableDiffusionPipeline.from_pretrained(\n",
     "            model_id,\n",
     "            torch_dtype=torch.float32,\n",
+    "            low_cpu_mem_usage=False,\n",
     "        )\n",
     "        self.pipe.enable_attention_slicing(1)\n",
     "\n",

--- a/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -15,7 +15,7 @@
    "outputs": [],
    "source": [
     "!pip install daft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
-    "!pip install diffusers torch Pillow"
+    "!pip install transformers diffusers torch Pillow"
    ]
   },
   {

--- a/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -15,7 +15,7 @@
    "outputs": [],
    "source": [
     "!pip install daft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
-    "!pip install transformers diffusers torch Pillow"
+    "!pip install transformers diffusers accelerate torch Pillow"
    ]
   },
   {
@@ -252,7 +252,6 @@
     "        self.pipe = StableDiffusionPipeline.from_pretrained(\n",
     "            model_id,\n",
     "            torch_dtype=torch.float32,\n",
-    "            low_cpu_mem_usage=False,\n",
     "        )\n",
     "        self.pipe.enable_attention_slicing(1)\n",
     "\n",

--- a/tutorials/text_to_image/text_to_image_generation.ipynb
+++ b/tutorials/text_to_image/text_to_image_generation.ipynb
@@ -15,7 +15,7 @@
    "outputs": [],
    "source": [
     "!pip install daft --pre --extra-index-url https://pypi.anaconda.org/daft-nightly/simple\n",
-    "!pip install min-dalle torch Pillow"
+    "!pip install diffusers torch Pillow"
    ]
   },
   {
@@ -72,9 +72,9 @@
     "id": "78db424a-96b5-46f3-bd32-484f5c6b92a3"
    },
    "source": [
-    "# Generating Images from Text with DALL-E\n",
+    "# Generating Images from Text with Stable Diffusion\n",
     "\n",
-    "In this tutorial, we will be using the DALL-E model to generate images from text. We will explore how to use GPUs with Daft to accelerate computations.\n",
+    "In this tutorial, we will be using the Stable Diffusion model to generate images from text. We will explore how to use GPUs with Daft to accelerate computations.\n",
     "\n",
     "To run this tutorial:\n",
     "\n",
@@ -180,9 +180,13 @@
     "parquet_df_with_long_strings = parquet_df.where(parquet_df[\"TEXT\"].str.length() > 50)\n",
     "\n",
     "# Download images\n",
-    "images_df = parquet_df_with_long_strings.with_column(\n",
-    "    \"image\",\n",
-    "    parquet_df[\"URL\"].url.download().image.decode(),\n",
+    "images_df = (\n",
+    "    parquet_df_with_long_strings.with_column(\n",
+    "        \"image\",\n",
+    "        parquet_df[\"URL\"].url.download(on_error=\"null\").image.decode(),\n",
+    "    )\n",
+    "    .limit(5)\n",
+    "    .where(daft.col(\"image\").not_null())\n",
     ")"
    ]
   },
@@ -221,9 +225,9 @@
     "id": "gCTmONUl81Vw"
    },
    "source": [
-    "# Running the Mini DALL-E model on a GPU using Daft UDFs\n",
+    "# Running the Stable Diffusion model on a GPU using Daft UDFs\n",
     "\n",
-    "Let's now run the Mini DALL-E model over the `\"TEXT\"` column, and generate images for those texts!\n",
+    "Let's now run the Stable Diffusion model over the `\"TEXT\"` column, and generate images for those texts!\n",
     "\n",
     "Using GPUs with Daft UDFs is simple. Just specify `num_gpus=N`, where `N` is the number of GPUs that your UDF is going to use."
    ]
@@ -238,34 +242,24 @@
    "outputs": [],
    "source": [
     "import torch\n",
-    "from min_dalle import MinDalle\n",
+    "from diffusers import StableDiffusionPipeline\n",
     "\n",
     "\n",
     "@daft.udf(return_dtype=daft.DataType.python())\n",
     "class GenerateImageFromText:\n",
     "    def __init__(self):\n",
-    "        self.model = MinDalle(\n",
-    "            models_root=\"./pretrained\",\n",
-    "            dtype=torch.float32,\n",
-    "            # Tell the min-dalle library to load model on GPU or GPU\n",
-    "            device=\"cuda\" if USE_GPU else \"cpu\",\n",
-    "            is_mega=False,\n",
-    "            is_reusable=True,\n",
+    "        model_id = \"runwayml/stable-diffusion-v1-5\"\n",
+    "        self.pipe = StableDiffusionPipeline.from_pretrained(\n",
+    "            model_id,\n",
+    "            torch_dtype=torch.float32,\n",
     "        )\n",
+    "        self.pipe.enable_attention_slicing(1)\n",
+    "\n",
+    "    def generate_image(self, prompt):\n",
+    "        return self.pipe(prompt, num_inference_steps=20, height=512, width=512).images[0]\n",
     "\n",
     "    def __call__(self, text_col):\n",
-    "        return [\n",
-    "            self.model.generate_image(\n",
-    "                t,\n",
-    "                seed=-1,\n",
-    "                grid_size=1,\n",
-    "                is_seamless=False,\n",
-    "                temperature=1,\n",
-    "                top_k=256,\n",
-    "                supercondition_factor=32,\n",
-    "            )\n",
-    "            for t in text_col.to_pylist()\n",
-    "        ]\n",
+    "        return [self.generate_image(t) for t in text_col]\n",
     "\n",
     "\n",
     "if USE_GPU:\n",


### PR DESCRIPTION
## Changes Made

Our tutorial notebooks were out of date due to:
- breaking changes with struct syntactic sugar
- using `Series.to_pylist()` instead of Series iterators
- mini DALL-E being too large for CI (I switched to Stable Diffusion)
- in general dataframes were too large for CI
- broken image urls

## Related Issues

Fixes CI

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)

@ccmao1130 I updated the docs but not sure if that also updates getdaft.io
