### PR TITLE
fix: TimeUnit repr format

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -84,7 +84,7 @@ class TimeUnit:
             assert False
 
     def __repr__(self) -> str:
-        return f"TimeUnit.{self.__str__()}"
+        return f"TimeUnit({self.__str__()})"
 
 
 class DataType:


### PR DESCRIPTION
Fix TimeUnit repr format
doctest was failing because it didnt match the repr. 


## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
