### PR TITLE
docs: Fix incorrect device in tutorial notebook

### DIFF
--- a/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
+++ b/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
@@ -134,7 +134,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import torch\n",
+    "\n",
     "MODEL_NAME = \"all-MiniLM-L6-v2\"\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
     "\n",
     "\n",
     "@daft.udf(return_dtype=daft.DataType.python())\n",
@@ -142,7 +145,7 @@
     "    def __init__(self):\n",
     "        from sentence_transformers import SentenceTransformer\n",
     "\n",
-    "        self.model = SentenceTransformer(MODEL_NAME)\n",
+    "        self.model = SentenceTransformer(MODEL_NAME, device=device)\n",
     "\n",
     "    def __call__(self, text_col):\n",
     "        return [self.model.encode(text, convert_to_tensor=True) for text in text_col.to_pylist()]"
@@ -278,7 +281,6 @@
     "    if len(embedding_col) == 0:\n",
     "        return []\n",
     "\n",
-    "    import torch\n",
     "    from sentence_transformers import util\n",
     "\n",
     "    # Tensor prep\n",


### PR DESCRIPTION
## Changes Made

Try setting SentenceTransformer's device explicitly to `cpu` or `cuda` depending on what is available.

## Related Issues

Fixes CI
