### PR TITLE
fix(iceberg): partition field names and day transform type

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -4242,6 +4242,8 @@ class ExpressionPartitioningNamespace(ExpressionNamespace):
     def days(self) -> Expression:
         """Partitioning Transform that returns the number of days since epoch (1970-01-01).
 
+        Unlike other temporal partitioning expressions, this expression is date type instead of int. This is to conform to the behavior of other implementations of Iceberg partition transforms.
+
         Returns:
             Date Expression
         """

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -4243,7 +4243,7 @@ class ExpressionPartitioningNamespace(ExpressionNamespace):
         """Partitioning Transform that returns the number of days since epoch (1970-01-01).
 
         Returns:
-            Expression: Int32 Expression in days
+            Date Expression
         """
         return Expression._from_pyexpr(self._expr.partitioning_days())
 

--- a/daft/iceberg/iceberg_scan.py
+++ b/daft/iceberg/iceberg_scan.py
@@ -71,7 +71,7 @@ def _iceberg_partition_field_to_daft_partition_field(
         tfm = PartitionTransform.day()
         # pyiceberg uses date as the result type of a day transform, which is incorrect
         # so we cannot use transform.result_type() here
-        result_type = DataType.int32()
+        result_type = DataType.date()
     elif isinstance(transform, HourTransform):
         tfm = PartitionTransform.hour()
         result_type = DataType.int32()

--- a/daft/iceberg/iceberg_write.py
+++ b/daft/iceberg/iceberg_write.py
@@ -108,6 +108,8 @@ def partition_field_to_expr(field: "IcebergPartitionField", schema: "IcebergSche
         warnings.warn(f"{field.transform} not implemented, Please make an issue!")
         transform_expr = part_col
 
+    transform_expr = transform_expr.alias(field.name)
+
     # currently the partitioning expressions change the name of the column
     # so we need to alias it back to the original column name
     return transform_expr

--- a/src/daft-core/src/series/ops/partitioning.rs
+++ b/src/daft-core/src/series/ops/partitioning.rs
@@ -53,14 +53,11 @@ impl Series {
 
     pub fn partitioning_days(&self) -> DaftResult<Self> {
         let value = match self.data_type() {
-            DataType::Date => {
-                let date_array = self.downcast::<DateArray>()?;
-                Ok(date_array.physical.clone().into_series())
-            }
+            DataType::Date => Ok(self.clone()),
             DataType::Timestamp(tu, _) => {
                 let array = self.cast(&DataType::Timestamp(*tu, None))?;
                 let ts_array = array.downcast::<TimestampArray>()?;
-                Ok(ts_array.date()?.physical.into_series())
+                Ok(ts_array.date()?.into_series())
             }
             _ => Err(DaftError::ComputeError(format!(
                 "Can only run partitioning_days() operation on temporal types, got {}",

--- a/src/daft-dsl/src/functions/partitioning/evaluators.rs
+++ b/src/daft-dsl/src/functions/partitioning/evaluators.rs
@@ -53,12 +53,12 @@ macro_rules! impl_func_evaluator_for_partitioning {
     };
 }
 
-use DataType::Int32;
+use DataType::{Date, Int32};
 
 use crate::functions::FunctionExpr;
 impl_func_evaluator_for_partitioning!(YearsEvaluator, years, partitioning_years, Int32);
 impl_func_evaluator_for_partitioning!(MonthsEvaluator, months, partitioning_months, Int32);
-impl_func_evaluator_for_partitioning!(DaysEvaluator, days, partitioning_days, Int32);
+impl_func_evaluator_for_partitioning!(DaysEvaluator, days, partitioning_days, Date);
 impl_func_evaluator_for_partitioning!(HoursEvaluator, hours, partitioning_hours, Int32);
 
 pub(super) struct IcebergBucketEvaluator {}

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 
 import pyarrow as pa
 import pytest
@@ -100,7 +100,7 @@ def test_parquet_write_with_partitioning_readback_values(tmp_path, with_morsel_s
         (
             daft.col("date").partitioning.days(),
             "date_days",
-            [19723, 19754, 19783, 19814, 19844],
+            [date(2024, 1, 1), date(2024, 2, 1), date(2024, 3, 1), date(2024, 4, 1), date(2024, 5, 1)],
         ),
         (daft.col("date").partitioning.hours(), "date_hours", [473352, 474096, 474792, 475536, 476256]),
         (daft.col("date").partitioning.months(), "date_months", [648, 649, 650, 651, 652]),

--- a/tests/series/test_partitioning.py
+++ b/tests/series/test_partitioning.py
@@ -15,23 +15,27 @@ from daft.series import Series
 @pytest.mark.parametrize(
     "input,dtype,expected",
     [
-        ([-1], DataType.date(), [-1]),
-        ([-1, None, 17501], DataType.date(), [-1, None, 17501]),
+        ([-1], DataType.date(), [date(1969, 12, 31)]),
+        ([-1, None, 17501], DataType.date(), [date(1969, 12, 31), None, date(2017, 12, 1)]),
         ([], DataType.date(), []),
         ([None], DataType.date(), [None]),
-        ([1512151975038194111], DataType.timestamp(timeunit=TimeUnit.from_str("ns")), [17501]),
-        ([1512151975038194], DataType.timestamp(timeunit=TimeUnit.from_str("us")), [17501]),
-        ([1512151975038], DataType.timestamp(timeunit=TimeUnit.from_str("ms")), [17501]),
-        ([1512151975], DataType.timestamp(timeunit=TimeUnit.from_str("s")), [17501]),
-        ([-1], DataType.timestamp(timeunit=TimeUnit.from_str("us")), [-1]),
-        ([-1], DataType.timestamp(timeunit=TimeUnit.from_str("us"), timezone="-08:00"), [-1]),
-        ([-13 * 3_600_000_000], DataType.timestamp(timeunit=TimeUnit.from_str("us"), timezone="-12:00"), [-1]),
+        ([1512151975038194111], DataType.timestamp(timeunit=TimeUnit.from_str("ns")), [date(2017, 12, 1)]),
+        ([1512151975038194], DataType.timestamp(timeunit=TimeUnit.from_str("us")), [date(2017, 12, 1)]),
+        ([1512151975038], DataType.timestamp(timeunit=TimeUnit.from_str("ms")), [date(2017, 12, 1)]),
+        ([1512151975], DataType.timestamp(timeunit=TimeUnit.from_str("s")), [date(2017, 12, 1)]),
+        ([-1], DataType.timestamp(timeunit=TimeUnit.from_str("us")), [date(1969, 12, 31)]),
+        ([-1], DataType.timestamp(timeunit=TimeUnit.from_str("us"), timezone="-08:00"), [date(1969, 12, 31)]),
+        (
+            [-13 * 3_600_000_000],
+            DataType.timestamp(timeunit=TimeUnit.from_str("us"), timezone="-12:00"),
+            [date(1969, 12, 31)],
+        ),
     ],
 )
 def test_partitioning_days(input, dtype, expected):
     s = Series.from_pylist(input).cast(dtype)
     d = s.partitioning.days()
-    assert d.datatype() == DataType.int32()
+    assert d.datatype() == DataType.date()
     assert d.to_pylist() == expected
 
 


### PR DESCRIPTION
## Changes Made

- When constructing Iceberg partition fields for writing, use partition field name specified in Iceberg metadata
- Day partitioning expression now returns Date type, in order to conform with other Iceberg implementations

## Related Issues

Resolves #4157

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
