### PR TITLE
ci: fix vllm import on arm and skip test if not imported

### DIFF
--- a/.github/workflows/nightly-publish-s3.yml
+++ b/.github/workflows/nightly-publish-s3.yml
@@ -121,7 +121,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner-name: [ubuntu-latest, buildjet-8vcpu-ubuntu-2204-arm]
+        runner-name: [ubuntu-latest, ubuntu-24.04-arm]
         daft-runner: [py, ray]
     steps:
     - uses: actions/checkout@v4
@@ -185,7 +185,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner-name: [ubuntu-latest, buildjet-8vcpu-ubuntu-2204-arm]
+        runner-name: [ubuntu-latest, ubuntu-24.04-arm]
         daft-runner: [py, ray]
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     # This is used in the step "Assume GitHub Actions AWS Credentials"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
 
   unit-tests-with-coverage:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -100,4 +100,4 @@ grpcio==1.68.1
 grpcio-status==1.67.0
 
 # ai
-vllm; platform_system == "Linux" # for other systems, see install instructions: https://docs.vllm.ai/en/latest/getting_started/installation.html
+vllm; platform_system == "Linux" and platform_machine == "x86_64" # for other systems, see install instructions: https://docs.vllm.ai/en/latest/getting_started/installation.html

--- a/tests/functions/test_llm_generate.py
+++ b/tests/functions/test_llm_generate.py
@@ -5,6 +5,8 @@ import pytest
 from daft import Expression, Series, lit
 from daft.functions.llm_generate import _vLLMGenerator, llm_generate
 
+vllm = pytest.importorskip("vllm")
+
 
 @patch("vllm.LLM")
 def test_llm_generate_init(mock_llm: MagicMock):


### PR DESCRIPTION
## Changes Made

Our nightly integration tests on arm machines have been failing, this should fix it. Also move from buildjet arm to Github's recently announced arm runners.

## Related Issues

none

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
