### PR TITLE
fix: simplify and fix creating tables from dataframes

### DIFF
--- a/daft/catalog/__memory.py
+++ b/daft/catalog/__memory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from daft.catalog import Catalog, Identifier, NotFoundError, Table, TableSource
+from daft.catalog import Catalog, Identifier, NotFoundError, Schema, Table
 from daft.dataframe.dataframe import DataFrame
 
 
@@ -36,7 +36,7 @@ class MemoryCatalog(Catalog):
     def create_namespace(self, identifier: Identifier | str):
         raise NotImplementedError("Memory create_namespace not yet supported.")
 
-    def create_table(self, identifier: Identifier | str, source: TableSource | object) -> Table:
+    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
         raise NotImplementedError("Memory create_table not yet supported.")
 
     ###

--- a/daft/catalog/__unity.py
+++ b/daft/catalog/__unity.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal
 
 from unitycatalog import NotFoundError as UnityNotFoundError
 
-from daft.catalog import Catalog, Identifier, NotFoundError, Table, TableSource
+from daft.catalog import Catalog, Identifier, NotFoundError, Schema, Table
 from daft.io._deltalake import read_deltalake
 from daft.unity_catalog import UnityCatalog as InnerCatalog  # noqa: TID253
 from daft.unity_catalog import UnityCatalogTable as InnerTable  # noqa: TID253
@@ -48,7 +48,7 @@ class UnityCatalog(Catalog):
     def create_namespace(self, identifier: Identifier | str):
         raise NotImplementedError("Unity create_namespace not yet supported.")
 
-    def create_table(self, identifier: Identifier | str, source: TableSource | object) -> Table:
+    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
         raise NotImplementedError("Unity create_table not yet supported.")
 
     ###

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2037,8 +2037,11 @@ class PyTable:
 
 class PyTableSource:
     @staticmethod
-    def from_builder(builder: LogicalPlanBuilder):
-        PyTable
+    def from_pyschema(schema: PySchema):
+        PyTableSource
+    @staticmethod
+    def from_pybuilder(builder: LogicalPlanBuilder):
+        PyTableSource
 
 ###
 # daft-session

--- a/daft/session.py
+++ b/daft/session.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from typing import Literal
 
-from daft.catalog import Catalog, Identifier, Table, TableSource
+from daft.catalog import Catalog, Identifier, Table
 from daft.context import get_context
 from daft.daft import LogicalPlanBuilder as PyBuilder
-from daft.daft import PySession, sql_exec
+from daft.daft import PySession, PyTableSource, sql_exec
 from daft.dataframe import DataFrame
 from daft.logical.builder import LogicalPlanBuilder
+from daft.logical.schema import Schema
 
 __all__ = [
     "Session",
@@ -15,7 +16,9 @@ __all__ = [
     "attach_catalog",
     "attach_table",
     "create_namespace",
+    "create_namespace_if_not_exists",
     "create_table",
+    "create_table_if_not_exists",
     "create_temp_table",
     "current_catalog",
     "current_namespace",
@@ -174,7 +177,7 @@ class Session:
             raise ValueError("Cannot create a namespace without a current catalog")
         return catalog.create_namespace_if_not_exists(identifier)
 
-    def create_table(self, identifier: Identifier | str, source: TableSource | object) -> Table:
+    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
         """Creates a table in the current catalog.
 
         If no namespace is specified, the current namespace is used.
@@ -193,12 +196,9 @@ class Session:
             if ns := self.current_namespace():
                 identifier = ns + identifier
 
-        if not isinstance(source, TableSource):
-            source = TableSource._from_obj(source)
-
         return catalog.create_table(identifier, source)
 
-    def create_table_if_not_exists(self, identifier: Identifier | str, source: TableSource | object) -> Table:
+    def create_table_if_not_exists(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
         """Creates a table in the current catalog if it does not already exist.
 
         If no namespace is specified, the current namespace is used.
@@ -217,12 +217,9 @@ class Session:
             if ns := self.current_namespace():
                 identifier = ns + identifier
 
-        if not isinstance(source, TableSource):
-            source = TableSource._from_obj(source)
-
         return catalog.create_table_if_not_exists(identifier, source)
 
-    def create_temp_table(self, identifier: str, source: TableSource | object = None) -> Table:
+    def create_temp_table(self, identifier: str, source: Schema | DataFrame) -> Table:
         """Creates a temp table scoped to this session's lifetime.
 
         Example:
@@ -236,13 +233,20 @@ class Session:
 
         Args:
             identifier (str): table identifier (name)
-            source (TableSource|object): table source like a schema or dataframe
+            source (Schema | DataFrame): table source is either a Schema or Dataframe
 
         Returns:
             Table: new table instance
         """
-        s = source if isinstance(source, TableSource) else TableSource._from_obj(source)
-        return self._session.create_temp_table(identifier, s._source, replace=True)
+        if isinstance(source, Schema):
+            py_source = PyTableSource.from_pyschema(source._schema)
+        elif isinstance(source, DataFrame):
+            py_source = PyTableSource.from_pybuilder(source._builder._builder)
+        else:
+            raise ValueError(
+                f"Unsupported create_temp_table source, {type(source)}, expected either Schema or DataFrame."
+            )
+        return self._session.create_temp_table(identifier, py_source, replace=True)
 
     ###
     # drop_*
@@ -545,17 +549,17 @@ def create_namespace_if_not_exists(identifier: Identifier | str):
     return _session().create_namespace_if_not_exists(identifier)
 
 
-def create_table(identifier: Identifier | str, source: TableSource | object) -> Table:
+def create_table(identifier: Identifier | str, source: Schema | DataFrame) -> Table:
     """Creates a table in the current session's active catalog and namespace."""
     return _session().create_table(identifier, source)
 
 
-def create_table_if_not_exists(identifier: Identifier | str, source: TableSource | object) -> Table:
+def create_table_if_not_exists(identifier: Identifier | str, source: Schema | DataFrame) -> Table:
     """Creates a table in the current session's active catalog and namespace if it does not already exist."""
     return _session().create_table_if_not_exists(identifier, source)
 
 
-def create_temp_table(identifier: str, source: object | TableSource = None) -> Table:
+def create_temp_table(identifier: str, source: Schema | DataFrame) -> Table:
     """Creates a temp table scoped to current session's lifetime."""
     return _session().create_temp_table(identifier, source)
 

--- a/src/daft-catalog/src/python.rs
+++ b/src/daft-catalog/src/python.rs
@@ -260,12 +260,12 @@ impl AsRef<TableSource> for PyTableSource {
 #[pymethods]
 impl PyTableSource {
     #[staticmethod]
-    pub fn from_schema(schema: PySchema) -> PyTableSource {
+    pub fn from_pyschema(schema: PySchema) -> PyTableSource {
         Self(TableSource::Schema(schema.schema))
     }
 
     #[staticmethod]
-    pub fn from_builder(view: &PyLogicalPlanBuilder) -> PyTableSource {
+    pub fn from_pybuilder(view: &PyLogicalPlanBuilder) -> PyTableSource {
         Self(TableSource::View(view.builder.build()))
     }
 }


### PR DESCRIPTION
## Changes Made

This PR simplifies how create_table works. Originally we had a source object with the intention of support diverse arguments as the table source, but in practice it's either a schema or dataframe. Also, we still need to model this union on the rust side so PyTableSource still exists as the argument for create_temp_table. This may warrant a revisit once Session logic makes its way into rust, but for now this simplification is better documented and fixes. The customers need not be aware of "TableSource" since we will always be able to construct these behind the scenes. Similarly, if we wish to support diverse table sources, we are likely better of extending DataFrame creation as to not complicate this.

## Related Issues

- Closes #4177 

## Checklist

- [x] Documented in API Docs (if applicable)
- [n/a] Documented in User Guide (if applicable)
- [n/a] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [n/a] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
