### PR TITLE
ci: reduce notebook data size to avoid errors

### DIFF
--- a/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
+++ b/tutorials/embeddings/daft_tutorial_embeddings_stackexchange.ipynb
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "c4e24aa5",
    "metadata": {},
    "outputs": [
@@ -110,7 +110,7 @@
     "df = daft.read_json(SAMPLE_DATA_PATH, io_config=IO_CONFIG)\n",
     "\n",
     "if CI:\n",
-    "    df = df.limit(100)\n",
+    "    df = df.limit(10)\n",
     "\n",
     "df"
    ]


### PR DESCRIPTION
## Changes Made

our notebook checker CI run keeps failing on this notebook (ex: https://github.com/Eventual-Inc/Daft/actions/runs/14454716266/job/40535235128). This is likely a memory issue, so we'll reduce the size to fix it.

## Related Issues

none

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
