### PR TITLE
fix: Add httpx pin for `daft[unity]` install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ ray = [
   "packaging"
 ]
 sql = ["connectorx", "sqlalchemy", "sqlglot"]
-unity = ["unitycatalog"]
+unity = ["unitycatalog", "httpx <= 0.27.2"]
 viz = []
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ ray = [
   "packaging"
 ]
 sql = ["connectorx", "sqlalchemy", "sqlglot"]
-unity = ["unitycatalog", "httpx <= 0.27.2"]
+unity = ["httpx <= 0.27.2", "unitycatalog"]
 viz = []
 
 [project.scripts]


### PR DESCRIPTION
## Changes Made

Pins httpx to 0.27.2 for `daft[unity]` install

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
