### PR TITLE
docs: fix dataframe doc examples

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1442,6 +1442,8 @@ class DataFrame:
             ├╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
             │ 2     ┆ 5     ┆ 8     │
             ╰───────┴───────┴───────╯
+            <BLANKLINE>
+            (Showing first 2 of 2 rows)
         """
         ExpressionsProjection.from_schema(self._builder.schema())
         builder = self._builder.distinct()
@@ -1816,7 +1818,7 @@ class DataFrame:
             │ 1     ┆ 9     │
             ╰───────┴───────╯
             <BLANKLINE>
-            (Showing first 4 of 4 rows)s
+            (Showing first 4 of 4 rows)
 
             You can also specify null positioning (first/last) for each column
 


### PR DESCRIPTION
## Changes Made

quick fix for some doc examples so they pass doc tests

## Related Issues

none

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
