### PR TITLE
fix: Propagate set runner errors

### DIFF
--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -124,7 +124,7 @@ daft.context.set_runner_ray()
 """
     with with_null_env():
         result = subprocess.run([sys.executable, "-c", script], capture_output=True)
-        assert "RuntimeError: Cannot set runner more than once" in result.stderr.decode().strip()
+        assert "DaftError::InternalError Cannot set runner more than once" in result.stderr.decode().strip()
 
 
 @pytest.mark.parametrize(
@@ -144,7 +144,7 @@ daft.context.set_runner_ray()
 """
     with with_null_env():
         result = subprocess.run([sys.executable, "-c", script], capture_output=True)
-        assert "RuntimeError: Cannot set runner more than once" in result.stderr.decode().strip()
+        assert "DaftError::InternalError  Cannot set runner more than once" in result.stderr.decode().strip()
 
 
 @pytest.mark.parametrize("daft_runner_envvar", ["py", "ray", "native"])
@@ -243,4 +243,4 @@ daft.context.set_runner_ray()
     with with_null_env():
         result = subprocess.run([sys.executable, "-c", cannot_set_runner_ray_after_py_script], capture_output=True)
         assert result.stdout.decode().strip() in {"py", "native"}
-        assert "RuntimeError: Cannot set runner more than once" in result.stderr.decode().strip()
+        assert "DaftError::InternalError  Cannot set runner more than once" in result.stderr.decode().strip()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -144,7 +144,7 @@ daft.context.set_runner_ray()
 """
     with with_null_env():
         result = subprocess.run([sys.executable, "-c", script], capture_output=True)
-        assert "DaftError::InternalError  Cannot set runner more than once" in result.stderr.decode().strip()
+        assert "DaftError::InternalError Cannot set runner more than once" in result.stderr.decode().strip()
 
 
 @pytest.mark.parametrize("daft_runner_envvar", ["py", "ray", "native"])
@@ -243,4 +243,4 @@ daft.context.set_runner_ray()
     with with_null_env():
         result = subprocess.run([sys.executable, "-c", cannot_set_runner_ray_after_py_script], capture_output=True)
         assert result.stdout.decode().strip() in {"py", "native"}
-        assert "DaftError::InternalError  Cannot set runner more than once" in result.stderr.decode().strip()
+        assert "DaftError::InternalError Cannot set runner more than once" in result.stderr.decode().strip()


### PR DESCRIPTION
## Changes Made

Propagates set runner errors instead of overriding them with `PyRuntimeError::new_err("Cannot set runner more than once")`, as there could be an actual error when setting the runner.

For example, a ray error when initializing ray.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
