### PR TITLE
feat: Support pairwise cosine distance

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -4356,7 +4356,29 @@ class ExpressionEmbeddingNamespace(ExpressionNamespace):
     """The following methods are available under the `expr.embedding` attribute."""
 
     def cosine_distance(self, other: Expression) -> Expression:
-        """Compute the cosine distance between two embeddings."""
+        """Compute the cosine distance between two embeddings.
+
+        Example:
+            >>> import daft
+            >>> df = daft.from_pydict({"e1": [[1, 2, 3], [1, 2, 3]], "e2": [[1, 2, 3], [-1, -2, -3]]})
+            >>> dtype = daft.DataType.fixed_size_list(daft.DataType.float32(), 3)
+            >>> df = df.with_column("dist", df["e1"].cast(dtype).embedding.cosine_distance(df["e2"].cast(dtype)))
+            >>> df.show()
+            ╭─────────────┬──────────────┬─────────╮
+            │ e1          ┆ e2           ┆ dist    │
+            │ ---         ┆ ---          ┆ ---     │
+            │ List[Int64] ┆ List[Int64]  ┆ Float64 │
+            ╞═════════════╪══════════════╪═════════╡
+            │ [1, 2, 3]   ┆ [1, 2, 3]    ┆ 0       │
+            ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
+            │ [1, 2, 3]   ┆ [-1, -2, -3] ┆ 2       │
+            ╰─────────────┴──────────────┴─────────╯
+            <BLANKLINE>
+            (Showing first 2 of 2 rows)
+
+        Returns:
+            Expression: a Float64 Expression with the cosine distance between the two embeddings.
+        """
         return Expression._from_pyexpr(native.cosine_distance(self._expr, other._expr))
 
 

--- a/tests/expressions/test_cosine_distance.py
+++ b/tests/expressions/test_cosine_distance.py
@@ -39,3 +39,15 @@ def test_cosine():
     # check if they are approximately equal
     for a, b in zip(res["a"], expected):
         assert pytest.approx(b) == pytest.approx(a, abs=1e-5)
+
+
+def test_pairwise_cosine_distance():
+    data = {
+        "e1": [[1, 2, 3], [1, 2, 3]],
+        "e2": [[1, 2, 3], [-1, -2, -3]],
+    }
+    df = daft.from_pydict(data)
+    dtype = DataType.fixed_size_list(DataType.float32(), 3)
+    res = df.with_column("distance", df["e1"].cast(dtype).embedding.cosine_distance(df["e2"].cast(dtype))).collect()
+    res = res.to_pydict()
+    assert res["distance"] == [0.0, 2.0]


### PR DESCRIPTION
## Changes Made

Currently, `expr1.embedding.cosine_distance(expr2)` only works when `expr2` is a literal. We should be able to take a column reference and compute the pairwise cosine distance in a given record. i.e. we should be able to do

```
df = df.with_column(
    "cosine_distance",
    col("a").embedding.cosine_distance(col("b"))
)
```

This PR enables this behaviour.

## Related Issues

Closes #4211 

## Checklist

- [x] Documented in API Docs (if applicable)
