### PR TITLE
feat(catalog): support arbitrary properties in create_table

### DIFF
--- a/daft/catalog/__glue.py
+++ b/daft/catalog/__glue.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import boto3
 from botocore.exceptions import ClientError
 
-from daft.catalog import Catalog, Identifier, NotFoundError, Table
+from daft.catalog import Catalog, Identifier, NotFoundError, Properties, Table
 from daft.datatype import DataType
 from daft.logical.schema import Field, Schema
 
@@ -140,12 +140,15 @@ class GlueCatalog(Catalog):
         except self._client.exceptions.AlreadyExistsException:
             raise ValueError(f"Namespace {identifier} already exists")
 
-    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+    def create_table(
+        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+    ) -> Table:
         """Creates a table in AWS Glue.
 
         Args:
             identifier (Identifier | str): The name of the table to create.
-            source (TableSource | object): The source data for the table.
+            source (Schema | DataFrame): The source data for the table.
+            properties (Properties): Additional table properties.
 
         Returns:
             Table: The created table.

--- a/daft/catalog/__glue.py
+++ b/daft/catalog/__glue.py
@@ -141,7 +141,10 @@ class GlueCatalog(Catalog):
             raise ValueError(f"Namespace {identifier} already exists")
 
     def create_table(
-        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+        self,
+        identifier: Identifier | str,
+        source: Schema | DataFrame,
+        properties: Properties | None = None,
     ) -> Table:
         """Creates a table in AWS Glue.
 

--- a/daft/catalog/__iceberg.py
+++ b/daft/catalog/__iceberg.py
@@ -53,7 +53,10 @@ class IcebergCatalog(Catalog):
         self._inner.create_namespace(ident)
 
     def create_table(
-        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+        self,
+        identifier: Identifier | str,
+        source: Schema | DataFrame,
+        properties: Properties | None = None,
     ) -> Table:
         if isinstance(source, DataFrame):
             return self._create_table_from_df(identifier, source)

--- a/daft/catalog/__iceberg.py
+++ b/daft/catalog/__iceberg.py
@@ -9,7 +9,7 @@ from pyiceberg.catalog import load_catalog
 from pyiceberg.exceptions import NoSuchNamespaceError, NoSuchTableError
 from pyiceberg.table import Table as InnerTable
 
-from daft.catalog import Catalog, Identifier, NotFoundError, Schema, Table
+from daft.catalog import Catalog, Identifier, NotFoundError, Properties, Schema, Table
 from daft.dataframe import DataFrame
 from daft.io._iceberg import read_iceberg
 
@@ -52,7 +52,9 @@ class IcebergCatalog(Catalog):
         ident = _to_pyiceberg_ident(identifier)
         self._inner.create_namespace(ident)
 
-    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+    def create_table(
+        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+    ) -> Table:
         if isinstance(source, DataFrame):
             return self._create_table_from_df(identifier, source)
         elif isinstance(source, Schema):

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -400,7 +400,10 @@ class Catalog(ABC):
 
     @abstractmethod
     def create_table(
-        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+        self,
+        identifier: Identifier | str,
+        source: Schema | DataFrame,
+        properties: Properties | None = None,
     ) -> Table:
         """Creates a table in this catalog.
 
@@ -414,7 +417,10 @@ class Catalog(ABC):
         raise NotImplementedError
 
     def create_table_if_not_exists(
-        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+        self,
+        identifier: Identifier | str,
+        source: Schema | DataFrame,
+        properties: Properties | None = None,
     ) -> Table:
         """Creates a table in this catalog if it does not already exist.
 

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -203,6 +203,9 @@ def register_python_catalog(catalog: object, name: str | None = None) -> str:
     return name
 
 
+Properties = dict[str, Any]
+
+
 class NotFoundError(Exception):
     """Raised when some catalog object is not able to be found."""
 
@@ -396,7 +399,9 @@ class Catalog(ABC):
             self.create_namespace(identifier)
 
     @abstractmethod
-    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+    def create_table(
+        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+    ) -> Table:
         """Creates a table in this catalog.
 
         Args:
@@ -408,7 +413,9 @@ class Catalog(ABC):
         """
         raise NotImplementedError
 
-    def create_table_if_not_exists(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+    def create_table_if_not_exists(
+        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+    ) -> Table:
         """Creates a table in this catalog if it does not already exist.
 
         Args:
@@ -421,7 +428,7 @@ class Catalog(ABC):
         try:
             return self.get_table(identifier)
         except NotFoundError:
-            return self.create_table(identifier, source)
+            return self.create_table(identifier, source, properties)
 
     ###
     # has_*

--- a/daft/catalog/__memory.py
+++ b/daft/catalog/__memory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from daft.catalog import Catalog, Identifier, NotFoundError, Schema, Table
+from daft.catalog import Catalog, Identifier, NotFoundError, Properties, Schema, Table
 from daft.dataframe.dataframe import DataFrame
 
 
@@ -36,7 +36,9 @@ class MemoryCatalog(Catalog):
     def create_namespace(self, identifier: Identifier | str):
         raise NotImplementedError("Memory create_namespace not yet supported.")
 
-    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+    def create_table(
+        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+    ) -> Table:
         raise NotImplementedError("Memory create_table not yet supported.")
 
     ###

--- a/daft/catalog/__memory.py
+++ b/daft/catalog/__memory.py
@@ -37,7 +37,10 @@ class MemoryCatalog(Catalog):
         raise NotImplementedError("Memory create_namespace not yet supported.")
 
     def create_table(
-        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+        self,
+        identifier: Identifier | str,
+        source: Schema | DataFrame,
+        properties: Properties | None = None,
     ) -> Table:
         raise NotImplementedError("Memory create_table not yet supported.")
 

--- a/daft/catalog/__s3tables.py
+++ b/daft/catalog/__s3tables.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from botocore.exceptions import ClientError
 
-from daft.catalog import Catalog, Identifier, NotFoundError, Schema, Table
+from daft.catalog import Catalog, Identifier, NotFoundError, Properties, Schema, Table
 from daft.catalog.__iceberg import IcebergCatalog
 from daft.dataframe import DataFrame
 from daft.io import read_iceberg
@@ -136,7 +136,9 @@ class S3Catalog(Catalog):
         except Exception as e:
             raise ValueError(f"Failed to create namespace: {e}") from e
 
-    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+    def create_table(
+        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+    ) -> Table:
         if isinstance(source, Schema):
             return self._create_table_from_schema(identifier, source)
         elif isinstance(source, DataFrame):

--- a/daft/catalog/__s3tables.py
+++ b/daft/catalog/__s3tables.py
@@ -137,7 +137,10 @@ class S3Catalog(Catalog):
             raise ValueError(f"Failed to create namespace: {e}") from e
 
     def create_table(
-        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+        self,
+        identifier: Identifier | str,
+        source: Schema | DataFrame,
+        properties: Properties | None = None,
     ) -> Table:
         if isinstance(source, Schema):
             return self._create_table_from_schema(identifier, source)

--- a/daft/catalog/__unity.py
+++ b/daft/catalog/__unity.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Literal
 
 from unitycatalog import NotFoundError as UnityNotFoundError
 
-from daft.catalog import Catalog, Identifier, NotFoundError, Schema, Table
+from daft.catalog import Catalog, Identifier, NotFoundError, Properties, Schema, Table
 from daft.io._deltalake import read_deltalake
 from daft.unity_catalog import UnityCatalog as InnerCatalog  # noqa: TID253
 from daft.unity_catalog import UnityCatalogTable as InnerTable  # noqa: TID253
@@ -48,7 +48,9 @@ class UnityCatalog(Catalog):
     def create_namespace(self, identifier: Identifier | str):
         raise NotImplementedError("Unity create_namespace not yet supported.")
 
-    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+    def create_table(
+        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+    ) -> Table:
         raise NotImplementedError("Unity create_table not yet supported.")
 
     ###

--- a/daft/catalog/__unity.py
+++ b/daft/catalog/__unity.py
@@ -49,7 +49,10 @@ class UnityCatalog(Catalog):
         raise NotImplementedError("Unity create_namespace not yet supported.")
 
     def create_table(
-        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+        self,
+        identifier: Identifier | str,
+        source: Schema | DataFrame,
+        properties: Properties | None = None,
     ) -> Table:
         raise NotImplementedError("Unity create_table not yet supported.")
 

--- a/daft/session.py
+++ b/daft/session.py
@@ -204,7 +204,10 @@ class Session:
         return catalog.create_table(identifier, source, properties)
 
     def create_table_if_not_exists(
-        self, identifier: Identifier | str, source: Schema | DataFrame, **properties: Any
+        self,
+        identifier: Identifier | str,
+        source: Schema | DataFrame,
+        **properties: Any,
     ) -> Table:
         """Creates a table in the current catalog if it does not already exist.
 

--- a/daft/session.py
+++ b/daft/session.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from daft.catalog import Catalog, Identifier, Table
 from daft.context import get_context
@@ -182,7 +182,7 @@ class Session:
             raise ValueError("Cannot create a namespace without a current catalog")
         return catalog.create_namespace_if_not_exists(identifier)
 
-    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+    def create_table(self, identifier: Identifier | str, source: Schema | DataFrame, **properties: Any) -> Table:
         """Creates a table in the current catalog.
 
         If no namespace is specified, the current namespace is used.
@@ -201,9 +201,11 @@ class Session:
             if ns := self.current_namespace():
                 identifier = ns + identifier
 
-        return catalog.create_table(identifier, source)
+        return catalog.create_table(identifier, source, properties)
 
-    def create_table_if_not_exists(self, identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+    def create_table_if_not_exists(
+        self, identifier: Identifier | str, source: Schema | DataFrame, **properties: Any
+    ) -> Table:
         """Creates a table in the current catalog if it does not already exist.
 
         If no namespace is specified, the current namespace is used.
@@ -222,7 +224,7 @@ class Session:
             if ns := self.current_namespace():
                 identifier = ns + identifier
 
-        return catalog.create_table_if_not_exists(identifier, source)
+        return catalog.create_table_if_not_exists(identifier, source, properties)
 
     def create_temp_table(self, identifier: str, source: Schema | DataFrame) -> Table:
         """Creates a temp table scoped to this session's lifetime.
@@ -572,14 +574,14 @@ def create_namespace_if_not_exists(identifier: Identifier | str):
     return _session().create_namespace_if_not_exists(identifier)
 
 
-def create_table(identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+def create_table(identifier: Identifier | str, source: Schema | DataFrame, **properties: Any) -> Table:
     """Creates a table in the current session's active catalog and namespace."""
-    return _session().create_table(identifier, source)
+    return _session().create_table(identifier, source, **properties)
 
 
-def create_table_if_not_exists(identifier: Identifier | str, source: Schema | DataFrame) -> Table:
+def create_table_if_not_exists(identifier: Identifier | str, source: Schema | DataFrame, **properties: Any) -> Table:
     """Creates a table in the current session's active catalog and namespace if it does not already exist."""
-    return _session().create_table_if_not_exists(identifier, source)
+    return _session().create_table_if_not_exists(identifier, source, **properties)
 
 
 def create_temp_table(identifier: str, source: Schema | DataFrame) -> Table:

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -268,11 +268,12 @@ sess.sql("SELECT * FROM example.tbl, temp LIMIT 1").show()
 
 For complete documentation, please see the [Session API docs](api/sessions.md).
 
-| Method                                                                                                                                  | Description                                                        |
-|-----------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
-| [`attach`][daft.Session.attach]                                                 | Attaches a catalog or table to this session.                       |
-| [`attach_catalog`][daft.Session.attach_catalog]                                 | Attaches (or creates) a catalog to this session                    |
-| [`attach_table`][daft.Session.attach_table]                                     | Attaches (or creates) a table to this session                      |
+| Method                                                                          | Description                                                        |
+|---------------------------------------------------------------------------------|--------------------------------------------------------------------|
+| [`attach`][daft.Session.attach]                                                 | Attaches a catalog, table, or function to this session.            |
+| [`attach_catalog`][daft.Session.attach_catalog]                                 | Attaches an exiting catalog to this session                        |
+| [`attach_table`][daft.Session.attach_table]                                     | Attaches an existing table to this session                         |
+| [`attach_function`][daft.Session.attach_function]                               | Attaches a user-defined function to this session                   |
 | [`create_namespace`][daft.Session.create_namespace]                             | Creates a new namespace                                            |
 | [`create_namespace_if_not_exists`][daft.Session.create_namespace_if_not_exists] | Creates a new namespace if it doesn't already exist                |
 | [`create_table`][daft.Session.create_table]                                     | Creates a new table from the source                                |
@@ -297,4 +298,4 @@ For complete documentation, please see the [Session API docs](api/sessions.md).
 | [`set_catalog`][daft.Session.set_catalog]                                       | Sets the current catalog.                                          |
 | [`set_namespace`][daft.Session.set_namespace]                                   | Sets the current namespace.                                        |
 | [`sql`][daft.Session.sql]                                                       | Executes SQL against the session.                                  |
-| [`use`][daft.Session.use]                                                       | Sets the current catalog and namespace.                              |
+| [`use`][daft.Session.use]                                                       | Sets the current catalog and namespace.                            |

--- a/tests/catalog/test_catalog.py
+++ b/tests/catalog/test_catalog.py
@@ -1,4 +1,11 @@
-from daft.catalog import Catalog
+from __future__ import annotations
+
+from typing import Literal
+
+from daft.catalog import Catalog, Identifier, Properties, Table
+from daft.dataframe import DataFrame
+from daft.logical.schema import DataType as dt
+from daft.logical.schema import Schema
 
 
 def assert_eq(df1, df2):
@@ -104,3 +111,95 @@ def test_from_pydict_namespaced():
     assert sess.get_table("default.T0") is not None
     assert sess.get_table("default.ns1.T1") is not None
     assert sess.get_table("default.ns2.T2") is not None
+
+
+class MockCatalog(Catalog):
+    """MockCatalog is an implementation designed to test implementing the ABC."""
+
+    _tables: dict[str, MockTable]
+
+    def __init__(self):
+        self._tables = {}
+
+    @property
+    def name(self) -> str:
+        return "test"
+
+    def create_namespace(self, identifier: Identifier | str):
+        self.create_namespace_calls.append(identifier)
+        self.namespaces.add(str(identifier))
+
+    def create_table(
+        self, identifier: Identifier | str, source: Schema | DataFrame, properties: Properties | None = None
+    ) -> Table:
+        k = str(identifier)
+        t = MockTable(k, properties)
+        self._tables[k] = t
+        return t
+
+    def drop_namespace(self, identifier: Identifier | str):
+        raise NotImplementedError
+
+    def drop_table(self, identifier: Identifier | str):
+        del self._tables[str(identifier)]
+
+    def get_table(self, identifier: Identifier | str) -> Table:
+        return self._tables[str(identifier)]
+
+    def list_namespaces(self, pattern: str | None = None) -> list[Identifier]:
+        raise NotImplementedError
+
+    def list_tables(self, pattern: str | None = None) -> list[str]:
+        raise NotImplementedError
+
+
+class MockTable(Table):
+    _name: str
+    properties: Properties
+
+    def __init__(self, name: str, properties: Properties | None = None) -> None:
+        self._name = name
+        self.properties = properties
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def read(self, **options) -> DataFrame:
+        raise NotImplementedError
+
+    def write(self, df: DataFrame, mode: Literal["append"] | Literal["overwrite"] = "append", **options) -> None:
+        raise NotImplementedError
+
+
+def test_session_create_table_with_properties():
+    from daft.session import Session
+
+    catalog = MockCatalog()
+    sess = Session()
+    sess.attach_catalog(catalog)
+
+    # properties to pass through
+    properties = {"format": "parquet", "partitioning": ["col1"], "description": "Test table with properties"}
+
+    schema = Schema._from_pydict(
+        {
+            "a": dt.bool(),
+            "b": dt.int64(),
+            "c": dt.string(),
+        }
+    )
+
+    # pass as kwargs
+    _ = sess.create_table("t1", schema, **properties)
+    t1 = sess.get_table("t1")
+    assert t1
+    assert t1.name == "t1"
+    assert t1.properties == properties
+
+    # pass as dict
+    _ = catalog.create_table("t2", schema, properties=properties)
+    t2 = catalog.get_table("t2")
+    assert t2
+    assert t2.name == "t2"
+    assert t2.properties == properties


### PR DESCRIPTION
## Changes Made

Adds a property map to the `create_table` APIs, context and use cases are linked in #4195 

## Related Issues

closes #4195

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [n/a] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [n/a] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
