### PR TITLE
feat: Allow GlueCatalog to be created from a botocore session

### DIFF
--- a/daft/catalog/__glue.py
+++ b/daft/catalog/__glue.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Literal
 
 import boto3
+import botocore
 from botocore.exceptions import ClientError
 
 from daft.catalog import Catalog, Identifier, NotFoundError, Table
@@ -13,7 +14,6 @@ from daft.datatype import DataType
 from daft.logical.schema import Field, Schema
 
 if TYPE_CHECKING:
-    from boto3 import Session
     from mypy_boto3_glue import GlueClient
     from mypy_boto3_glue.type_defs import ColumnOutputTypeDef as GlueColumnInfo
     from mypy_boto3_glue.type_defs import TableTypeDef as GlueTableInfo
@@ -111,11 +111,25 @@ class GlueCatalog(Catalog):
         return c
 
     @staticmethod
-    def from_session(name: str, session: Session) -> GlueCatalog:
-        """Creates a GlueCatalog using the boto3 session to get a glue client."""
+    def from_session(name: str, session: boto3.Session | botocore.session.Session) -> GlueCatalog:
+        """Creates a GlueCatalog using the provided boto3 or botocore session to get a glue client.
+
+        Args:
+            name: Name of the catalog
+            session: A boto3.Session or botocore.session.Session object
+
+        Returns:
+            A configured GlueCatalog instance
+        """
         c = GlueCatalog.__new__(GlueCatalog)
         c._name = name
-        c._client = session.client("glue")
+        if isinstance(session, boto3.Session):
+            c._client = session.client("glue")
+        elif isinstance(session, botocore.session.Session):
+            c._client = session.create_client("glue")
+        else:
+            raise TypeError(f"Expected boto3.Session or botocore.session.Session, got {type(session).__name__}")
+
         return c
 
     @property

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -41,7 +41,9 @@ def mock_boto3_session():
 @pytest.fixture
 def mock_botocore_session():
     with mock_aws():
-        yield botocore.session.Session()
+        sess = botocore.session.Session()
+        sess.set_config_variable("region", "us-west-2")
+        yield sess
 
 
 @pytest.fixture

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -83,6 +83,7 @@ def test_catalog_from_client(glue_client):
 
 
 def test_catalog_from_session(mock_boto3_session, mock_botocore_session):
+    # Test both boto3 and botocore sessions.
     assert Catalog.from_glue("gc", session=mock_boto3_session)
     assert GlueCatalog.from_session("gc", session=mock_boto3_session)
 

--- a/tests/catalog/test_glue.py
+++ b/tests/catalog/test_glue.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal
 
 import boto3
+import botocore
 import pytest
 from moto import mock_aws
 
@@ -32,9 +33,15 @@ else:
 
 
 @pytest.fixture
-def mock_session():
+def mock_boto3_session():
     with mock_aws():
         yield boto3.Session(region_name="us-west-2")
+
+
+@pytest.fixture
+def mock_botocore_session():
+    with mock_aws():
+        yield botocore.session.Session()
 
 
 @pytest.fixture
@@ -75,9 +82,12 @@ def test_catalog_from_client(glue_client):
     assert GlueCatalog.from_client("gc", glue_client)
 
 
-def test_catalog_from_session(mock_session):
-    assert Catalog.from_glue("gc", session=mock_session)
-    assert GlueCatalog.from_session("gc", session=mock_session)
+def test_catalog_from_session(mock_boto3_session, mock_botocore_session):
+    assert Catalog.from_glue("gc", session=mock_boto3_session)
+    assert GlueCatalog.from_session("gc", session=mock_boto3_session)
+
+    assert Catalog.from_glue("gc", session=mock_botocore_session)
+    assert GlueCatalog.from_session("gc", session=mock_botocore_session)
 
 
 def test_catalog_no_args():


### PR DESCRIPTION
## Changes Made

Previously `GlueCatalog.from_session()` only accepted a boto3 session. Add a runtime check so that it can accept a botocore session too.

## Checklist

- [x] Documented in API Docs (if applicable)
