### PR TITLE
refactor: Rework SQLPlanner to use session references

### DIFF
--- a/src/daft-catalog/src/bindings.rs
+++ b/src/daft-catalog/src/bindings.rs
@@ -20,7 +20,7 @@ use std::collections::{HashMap, HashSet};
 /// -- 'alias' is a name (lvalue) to bind the resolved reference to.
 /// -- 'T' is an identifier (rvalue) to reference a table.
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Bindings<T> {
     /// case-preserved bindings (default)
     bindings: HashMap<String, T>,

--- a/src/daft-connect/src/execute.rs
+++ b/src/daft-connect/src/execute.rs
@@ -1,4 +1,4 @@
-use std::{future::ready, rc::Rc, sync::Arc};
+use std::{future::ready, sync::Arc};
 
 use common_error::DaftResult;
 use common_file_formats::{FileFormat, WriteMode};
@@ -288,10 +288,9 @@ impl ConnectSession {
         }
 
         // TODO: converge Session and ConnectSession
-        let session = self.session().clone_ref();
-        let session = Rc::new(session);
+        let session = self.session();
 
-        let mut planner = daft_sql::SQLPlanner::new(session);
+        let mut planner = daft_sql::SQLPlanner::new(&session);
 
         let plan = planner.plan_sql(&sql).wrap_err("Error planning SQL")?;
 

--- a/src/daft-connect/src/spark_analyzer.rs
+++ b/src/daft-connect/src/spark_analyzer.rs
@@ -795,7 +795,7 @@ impl SparkAnalyzer<'_> {
         let session = self.session.session().clone_ref();
         let session = Rc::new(session);
 
-        let mut planner = SQLPlanner::new(session);
+        let mut planner = SQLPlanner::new(&session);
         let plan = planner.plan_sql(&query)?;
         Ok(plan.into())
     }

--- a/src/daft-session/src/session.rs
+++ b/src/daft-session/src/session.rs
@@ -34,51 +34,12 @@ struct SessionState {
 }
 
 impl Session {
-    /// Creates an independent copy of the Session with its own separate state.
-    ///
-    /// This method performs a complete clone of the underlying `SessionState`,
-    /// creating a new `Arc<RwLock<SessionState>>` that contains the cloned state.
-    /// Any changes made to the state of the forked session will not affect the
-    /// original session and vice versa.
-    ///
-    /// # Comparison with `clone_ref()`
-    ///
-    /// Unlike `clone_ref()` which only creates a new reference to the same underlying state,
-    /// `fork()` creates a complete copy of the state. This makes `fork()` more expensive
-    /// but ensures complete isolation between the original and new session.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// let original_session = Session::empty();
-    /// // ... configure original_session ...
-    ///
-    /// // Create an independent copy with the same initial state
-    /// let forked_session = original_session.fork();
-    ///
-    /// // Changes to forked_session won't affect original_session
-    /// ```
-    ///
-    pub fn fork(&self) -> Self {
-        let state = self.state().clone();
-        Self {
-            state: Arc::new(RwLock::new(state)),
-        }
-    }
-
     /// Creates a new session that shares the same underlying state with the original.
     ///
     /// This method creates a new `Session` instance that contains a clone of the `Arc`
     /// pointer to the same `RwLock<SessionState>`, but does not clone the state itself.
     /// This means that any changes to the state through either session will be visible
     /// to the other session.
-    ///
-    /// # Comparison with `fork()`
-    ///
-    /// Unlike `fork()` which creates a completely independent copy of the session state,
-    /// `clone_ref()` only clones the reference to the state. This makes `clone_ref()` much
-    /// cheaper but means that changes to one session will affect all sessions created
-    /// with `clone_ref()`.
     ///
     /// # Example
     ///

--- a/src/daft-sql/src/functions.rs
+++ b/src/daft-sql/src/functions.rs
@@ -323,8 +323,7 @@ impl SQLPlanner<'_> {
         // SQL function names are case-insensitive
         let fn_name = func.name.to_string().to_lowercase();
 
-        let mut fn_match = if let Some(fn_match) =
-            get_func_from_session(&self.context.borrow().session, &fn_name)?
+        let mut fn_match = if let Some(fn_match) = get_func_from_session(self.session(), &fn_name)?
         {
             fn_match
         } else {

--- a/src/daft-sql/src/statement.rs
+++ b/src/daft-sql/src/statement.rs
@@ -207,6 +207,7 @@ impl SQLPlanner<'_> {
 
 #[cfg(test)]
 mod test {
+    use daft_session::Session;
     use sqlparser::{dialect::GenericDialect, parser::Parser};
 
     use super::*;
@@ -222,8 +223,8 @@ mod test {
     fn test_use_catalog() {
         let sql = "USE mycatalog";
         let statement = parse_sql(sql);
-
-        let mut planner = SQLPlanner::new(Default::default());
+        let session = Session::default();
+        let mut planner = SQLPlanner::new(&session);
         let plan = planner.plan_statement(&statement).unwrap();
 
         if let Statement::Use(use_stmt) = plan {
@@ -238,8 +239,8 @@ mod test {
     fn test_use_catalog_with_namespace() -> SQLPlannerResult<()> {
         let sql = "USE mycatalog.myschema";
         let statement = parse_sql(sql);
-
-        let mut planner = SQLPlanner::new(Default::default());
+        let session = Session::default();
+        let mut planner = SQLPlanner::new(&session);
         let plan = planner.plan_statement(&statement).unwrap();
 
         if let Statement::Use(use_stmt) = plan {
@@ -258,8 +259,9 @@ mod test {
     fn test_use_catalog_with_multi_level_namespace() -> SQLPlannerResult<()> {
         let sql = "USE mycatalog.myschema.mysubschema";
         let statement = parse_sql(sql);
+        let session = Session::default();
 
-        let mut planner = SQLPlanner::new(Default::default());
+        let mut planner = SQLPlanner::new(&session);
         let plan = planner.plan_statement(&statement).unwrap();
 
         if let Statement::Use(use_stmt) = plan {


### PR DESCRIPTION
The commit moves SQLPlanner to use session references instead of owning the Session through Rc. This simplifies lifetime handling and state management.

## Changes Made

- `SQLPlanner` now takes `&Session` instead of `Rc<Session>`
- Removed `fork()` from Session API
- Added bound_tables to `PlannerContext` for local table bindings
- Updated all callers to pass session references



<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

closes https://github.com/Eventual-Inc/Daft/issues/4207

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
