### PR TITLE
fix: timezone parsing in str.to_datetime

### DIFF
--- a/tests/recordbatch/utf8/test_to_datetime.py
+++ b/tests/recordbatch/utf8/test_to_datetime.py
@@ -14,3 +14,11 @@ def test_utf8_to_datetime():
             datetime.datetime(2021, 1, 2, 0, 0),
         ]
     }
+
+
+def test_to_datetime_with_tz_offset():
+    table = MicroPartition.from_pydict({"a": ["2020-01-01T00:00:00+01:00"]})
+    result = table.eval_expression_list([col("a").str.to_datetime("%Y-%m-%dT%H:%M:%S%z").dt.day_of_year()])
+    expected = {{"a": [365]}}
+
+    assert result.to_pydict() == expected


### PR DESCRIPTION
## Changes Made

changes the `to_datetime` kernel to try parsing with a timezone offset first as you can have a valid string with a timezone, but that would previously fail when trying to parse as seen in #4220



## Related Issues

closes https://github.com/Eventual-Inc/Daft/issues/4220

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
