### PR TITLE
fix: Use _name for shared memory unregistration

### DIFF
--- a/daft/execution/actor_pool_udf.py
+++ b/daft/execution/actor_pool_udf.py
@@ -18,6 +18,12 @@ logger = logging.getLogger(__name__)
 
 _SENTINEL = ("__EXIT__", 0)
 
+# Disable python's resource tracking of shared memory objects. Instead, we rely on our own cleanup.
+# The multiprocessing library's resource tracker is does not properly track shared memory objects when the objects are created and
+# unlinked in different processes, although it is allowed to be used in this way.
+# For reference, see these issues:
+# https://github.com/vllm-project/vllm/issues/5468
+# https://stackoverflow.com/questions/62748654/python-3-8-shared-memory-resource-tracker-producing-unexpected-warnings-at-appli
 resource_tracker.unregister = lambda *args, **kwargs: None
 resource_tracker.register = lambda *args, **kwargs: None
 

--- a/daft/execution/actor_pool_udf.py
+++ b/daft/execution/actor_pool_udf.py
@@ -22,6 +22,8 @@ _SENTINEL = ("__EXIT__", 0)
 class SharedMemoryTransport:
     def write_and_close(self, data: bytes) -> tuple[str, int]:
         shm = shared_memory.SharedMemory(create=True, size=len(data))
+        # DO NOT REMOVE OR CHANGE THIS LINE. It is necessary to prevent the resource tracker from tracking the shared memory object.
+        # This is because we are creating and unlinking the shared memory object in different processes.
         resource_tracker.unregister(shm._name, "shared_memory")  # type: ignore[attr-defined]
         shm.buf[: len(data)] = data
         shm.close()


### PR DESCRIPTION
## Changes Made

Fix the unregistration for actor pool shared memory.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
