### PR TITLE
docs: Fix typo s/emedding/embedding/

### DIFF
--- a/docs/api/expressions.md
+++ b/docs/api/expressions.md
@@ -105,4 +105,4 @@ Daft Expressions allow you to express some computation that needs to happen in a
     options:
         filters: ["!^_"]
         toc_label: Expression.embedding
-        heading: Expression.emedding
+        heading: Expression.embedding


### PR DESCRIPTION
## Changes Made

Fix a typo in the section header