### PR TITLE
docs: add usage examples to Catalog class and from_ methods

### DIFF
--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -270,6 +270,7 @@ class Catalog(ABC):
     def from_iceberg(catalog: object) -> Catalog:
         """Create a Daft Catalog from a PyIceberg catalog object.
 
+        
         Example:
             >>> from pyiceberg.catalog import load_catalog
             >>> iceberg_catalog = load_catalog("my_iceberg_catalog")
@@ -292,6 +293,7 @@ class Catalog(ABC):
     def from_unity(catalog: object) -> Catalog:
         """Create a Daft Catalog from a Unity Catalog client.
 
+        
         Example:
             >>> from unity_sdk import UnityCatalogClient
             >>> unity_client = UnityCatalogClient(...)
@@ -318,6 +320,7 @@ class Catalog(ABC):
     ) -> Catalog:
         """Creates a Daft Catalog from S3 Tables bucket ARN, with optional client or session.
 
+        
         If neither a boto3 client nor session is provided, the Iceberg REST
         client will be used under the hood.
 

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -211,7 +211,21 @@ class NotFoundError(Exception):
 
 
 class Catalog(ABC):
-    """Interface for python catalog implementations."""
+    """
+    Interface for Python catalog implementations.
+
+    A Catalog is a service for discovering, accessing, and querying
+    tabular and non-tabular data. You can instantiate a Catalog using
+    one of the static `from_` methods.
+
+    Example:
+        >>> import daft
+        >>> from daft.catalog import Catalog
+        >>> data = {"users": {"id": [1, 2, 3], "name": ["a", "b", "c"]}}
+        >>> catalog = Catalog.from_pydict(data)
+        >>> catalog.list_tables()
+        ['users']
+    """
 
     @property
     @abstractmethod
@@ -255,13 +269,19 @@ class Catalog(ABC):
 
     @staticmethod
     def from_iceberg(catalog: object) -> Catalog:
-        """Creates a Daft Catalog instance from an Iceberg catalog.
+        """
+        Create a Daft Catalog from a PyIceberg catalog object.
+
+        Example:
+            >>> from pyiceberg.catalog import load_catalog
+            >>> iceberg_catalog = load_catalog("my_iceberg_catalog")
+            >>> catalog = Catalog.from_iceberg(iceberg_catalog)
 
         Args:
-            catalog (object): pyiceberg catalog object
+            catalog (object): a PyIceberg catalog instance
 
         Returns:
-            Catalog: new daft catalog instance from the pyiceberg catalog object.
+            Catalog: a new Catalog instance backed by the Iceberg catalog.
         """
         try:
             from daft.catalog.__iceberg import IcebergCatalog
@@ -272,13 +292,19 @@ class Catalog(ABC):
 
     @staticmethod
     def from_unity(catalog: object) -> Catalog:
-        """Creates a Daft Catalog instance from a Unity catalog.
+        """
+        Create a Daft Catalog from a Unity Catalog client.
+
+        Example:
+            >>> from unity_sdk import UnityCatalogClient
+            >>> unity_client = UnityCatalogClient(...)
+            >>> catalog = Catalog.from_unity(unity_client)
 
         Args:
-            catalog (object): unity catalog object
+            catalog (object): a Unity Catalog client instance
 
         Returns:
-            Catalog: new daft catalog instance from the unity catalog object.
+            Catalog: a new Catalog instance backed by the Unity catalog.
         """
         try:
             from daft.catalog.__unity import UnityCatalog
@@ -295,15 +321,21 @@ class Catalog(ABC):
     ) -> Catalog:
         """Creates a Daft Catalog from S3 Tables bucket ARN, with optional client or session.
 
-        If neither a boto3 client nor session is given, an Iceberg REST client is used.
+        If neither a boto3 client nor session is provided, the Iceberg REST
+        client will be used under the hood.
+
+        Example:
+            >>> arn = "arn:aws:s3:::my-s3tables-bucket"
+            >>> catalog = Catalog.from_s3tables(arn)
+            >>> catalog.list_tables()
 
         Args:
-            table_bucket_arn (str): s3tables bucket arn
-            client: optional boto3 client
-            session: optional boto3 session
+            table_bucket_arn (str): ARN of the S3 Tables bucket
+            client (object, optional): a boto3 client
+            session (object, optional): a boto3 session
 
         Returns:
-            Catalog: new daft catalog instance backed by S3 Tables.
+            Catalog: a new Catalog instance backed by S3 Tables.
         """
         try:
             from daft.catalog.__s3tables import S3Catalog

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -211,8 +211,7 @@ class NotFoundError(Exception):
 
 
 class Catalog(ABC):
-    """
-    Interface for Python catalog implementations.
+    """Interface for Python catalog implementations.
 
     A Catalog is a service for discovering, accessing, and querying
     tabular and non-tabular data. You can instantiate a Catalog using
@@ -269,8 +268,7 @@ class Catalog(ABC):
 
     @staticmethod
     def from_iceberg(catalog: object) -> Catalog:
-        """
-        Create a Daft Catalog from a PyIceberg catalog object.
+        """Create a Daft Catalog from a PyIceberg catalog object.
 
         Example:
             >>> from pyiceberg.catalog import load_catalog
@@ -292,8 +290,7 @@ class Catalog(ABC):
 
     @staticmethod
     def from_unity(catalog: object) -> Catalog:
-        """
-        Create a Daft Catalog from a Unity Catalog client.
+        """Create a Daft Catalog from a Unity Catalog client.
 
         Example:
             >>> from unity_sdk import UnityCatalogClient

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -270,7 +270,6 @@ class Catalog(ABC):
     def from_iceberg(catalog: object) -> Catalog:
         """Create a Daft Catalog from a PyIceberg catalog object.
 
-        
         Example:
             >>> from pyiceberg.catalog import load_catalog
             >>> iceberg_catalog = load_catalog("my_iceberg_catalog")
@@ -280,7 +279,7 @@ class Catalog(ABC):
             catalog (object): a PyIceberg catalog instance
 
         Returns:
-            Catalog: a new Catalog instance backed by the Iceberg catalog.
+            Catalog: a new Catalog instance backed by the PyIceberg catalog.
         """
         try:
             from daft.catalog.__iceberg import IcebergCatalog
@@ -293,7 +292,6 @@ class Catalog(ABC):
     def from_unity(catalog: object) -> Catalog:
         """Create a Daft Catalog from a Unity Catalog client.
 
-        
         Example:
             >>> from unity_sdk import UnityCatalogClient
             >>> unity_client = UnityCatalogClient(...)
@@ -320,7 +318,6 @@ class Catalog(ABC):
     ) -> Catalog:
         """Creates a Daft Catalog from S3 Tables bucket ARN, with optional client or session.
 
-        
         If neither a boto3 client nor session is provided, the Iceberg REST
         client will be used under the hood.
 


### PR DESCRIPTION
## Changes Made

This PR improves the docstrings for the Catalog class and its associated static from_ methods:

- Added a usage example to the Catalog class docstring to clarify how to instantiate a catalog.

Provided code examples for the following static methods:

- from_iceberg
- from_unity
- from_s3tables

## Related Issues

#4166 
## Checklist

- [x] Documented in API Docs (docstrings for Catalog class and its methods)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
