### PR TITLE
fix: Allow PNGs to be displayed notebooks

### DIFF
--- a/src/daft-image/src/ops.rs
+++ b/src/daft-image/src/ops.rs
@@ -474,7 +474,7 @@ pub fn fixed_image_html_value(arr: &FixedShapeImageArray, idx: usize) -> String 
             let thumb = image.fit_to(128, 128);
             let mut bytes: Vec<u8> = vec![];
             let mut writer = std::io::BufWriter::new(std::io::Cursor::new(&mut bytes));
-            thumb.encode(ImageFormat::JPEG, &mut writer).unwrap();
+            thumb.encode(ImageFormat::PNG, &mut writer).unwrap();
             drop(writer);
             format!(
                 "<img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, {}\" alt=\"{}\" />",

--- a/src/daft-image/src/ops.rs
+++ b/src/daft-image/src/ops.rs
@@ -452,7 +452,7 @@ pub fn image_html_value(arr: &ImageArray, idx: usize) -> String {
             let thumb = image.fit_to(128, 128);
             let mut bytes: Vec<u8> = vec![];
             let mut writer = std::io::BufWriter::new(std::io::Cursor::new(&mut bytes));
-            thumb.encode(ImageFormat::JPEG, &mut writer).unwrap();
+            thumb.encode(ImageFormat::PNG, &mut writer).unwrap();
             drop(writer);
             format!(
                 "<img style=\"max-height:128px;width:auto\" src=\"data:image/png;base64, {}\" alt=\"{}\" />",


### PR DESCRIPTION
## Changes Made

When we generate thumbnails to display in notebooks, we encoded them as JPEG by default. This does not work if images have an alpha channel.

This PR changes it so that we generate PNGs instead. This should have minimal performance impact because we're generating small 128x128 thumbnails and this only happens when previewing a small amount (typically <= 8) of results in a notebook.

## Related Issues

Closes #4072
