### PR TITLE
chore: Upgrade supported pyarrow version to 19.0.0

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10']
         daft-runner: [py, ray, native]
-        pyarrow-version: [8.0.0, 16.0.0]
+        pyarrow-version: [8.0.0, 19.0.0]
         enable-aqe: [1, 0]
         os: [ubuntu-latest, macos-latest]
         exclude:

--- a/benchmarking/parquet/benchmark-requirements.txt
+++ b/benchmarking/parquet/benchmark-requirements.txt
@@ -1,5 +1,5 @@
 pytest==7.4.0
 pytest-benchmark==4.0.0
 pytest-memray==1.4.1
-pyarrow==16.0.0
+pyarrow==19.0.0
 boto3==1.28.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["maturin>=1.5.0,<2.0.0"]
 [project]
 authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]
 dependencies = [
-  "pyarrow >= 8.0.0, <= 16.0.0",
+  "pyarrow >= 8.0.0",
   "fsspec",
   "tqdm",
   "typing-extensions >= 4.0.0; python_version < '3.10'",
@@ -28,7 +28,7 @@ aws = ["boto3"]
 azure = []
 deltalake = ["deltalake", "packaging"]
 gcp = []
-hudi = ["pyarrow >= 8.0.0, <= 16.0.0"]
+hudi = ["pyarrow >= 8.0.0"]
 iceberg = ["pyiceberg >= 0.7.0", "packaging"]
 lance = ["pylance"]
 numpy = ["numpy"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,7 +40,7 @@ duckdb==1.1.2
 tqdm
 
 # Pyarrow
-pyarrow==16.0.0
+pyarrow==19.0.0
 # Ray
 ray[data, client]==2.34.0
 

--- a/src/daft-schema/src/dtype.rs
+++ b/src/daft-schema/src/dtype.rs
@@ -242,24 +242,12 @@ impl DataType {
                 arrow2::datatypes::Field::new("item", field.to_arrow()?, true),
             ))),
             Self::Map { key, value } => {
+                // To comply with the Arrow spec, Neither the "entries" field nor the "key" field may be nullable.
+                // See https://github.com/apache/arrow/blob/apache-arrow-20.0.0/format/Schema.fbs#L138
                 let struct_type = ArrowType::Struct(vec![
-                    // We never allow null keys in maps for several reasons:
-                    // 1. Null typically represents the absence of a value, which doesn't make sense for a key.
-                    // 2. Null comparisons can be problematic (similar to how f64::NAN != f64::NAN).
-                    // 3. It maintains consistency with common map implementations in arrow (no null keys).
-                    // 4. It simplifies map operations
-                    //
-                    // This decision aligns with the thoughts of team members like Jay and Sammy, who argue that:
-                    // - Nulls in keys could lead to unintuitive behavior
-                    // - If users need to count or group by null values, they can use other constructs like
-                    //   group_by operations on non-map types, which offer more explicit control.
-                    //
-                    // By disallowing null keys, we encourage more robust data modeling practices and
-                    // provide a clearer semantic meaning for map types in our system.
                     arrow2::datatypes::Field::new("key", key.to_arrow()?, false),
                     arrow2::datatypes::Field::new("value", value.to_arrow()?, true),
                 ]);
-
                 let struct_field = arrow2::datatypes::Field::new("entries", struct_type, false);
 
                 Ok(ArrowType::map(struct_field, false))

--- a/src/daft-schema/src/dtype.rs
+++ b/src/daft-schema/src/dtype.rs
@@ -256,11 +256,11 @@ impl DataType {
                     //
                     // By disallowing null keys, we encourage more robust data modeling practices and
                     // provide a clearer semantic meaning for map types in our system.
-                    arrow2::datatypes::Field::new("key", key.to_arrow()?, true),
+                    arrow2::datatypes::Field::new("key", key.to_arrow()?, false),
                     arrow2::datatypes::Field::new("value", value.to_arrow()?, true),
                 ]);
 
-                let struct_field = arrow2::datatypes::Field::new("entries", struct_type, true);
+                let struct_field = arrow2::datatypes::Field::new("entries", struct_type, false);
 
                 Ok(ArrowType::map(struct_field, false))
             }

--- a/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
+++ b/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
@@ -17,7 +17,7 @@ uvicorn==0.23.2
 uvloop==0.17.0
 watchfiles==0.19.0
 websockets==11.0.3
-pyarrow==16.0.0
+pyarrow==19.0.0
 slowapi==0.1.8
 
 # Pin numpy version otherwise pyarrow doesn't work


### PR DESCRIPTION
## Changes Made

Upgrades our pyarrow version in tests to 19.0.0, additionally removes the pin in `pyproject.toml`

In order to support 19.0.0, this PR also fixes our map type conversion code, which is the only thing that failed. See https://github.com/Eventual-Inc/Daft/issues/4206

Map types are required to be annotated with `not null` for the keys, and currently this is not propagated from daft datatype to arrow. This PR modifies the `to_arrow` conversion for map types and arrays to obey this constraint. Previous version of pyarrow did not have this error as they auto-added the annotation when importing from the C data interface.


## Related Issues

Closes https://github.com/Eventual-Inc/Daft/issues/4256

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
