### PR TITLE
docs: add usage examples to Session docstring

### DIFF
--- a/daft/session.py
+++ b/daft/session.py
@@ -47,7 +47,28 @@ __all__ = [
 
 
 class Session:
-    """Session holds a connection's state and orchestrates execution of DataFrame and SQL queries against catalogs."""
+    """Session holds a connection's state and orchestrates execution of DataFrame and SQL queries against catalogs.
+
+    Example:
+        >>> import daft
+        >>> from daft.session import Session
+
+        >>> sess = Session()
+
+        >>> # Create a temporary table from a DataFrame
+        >>> sess.create_temp_table("T", daft.from_pydict({"x": [1, 2, 3]}))
+
+        >>> # Read the table as a DataFrame
+        >>> df = sess.read_table("T")
+
+        >>> # Execute an SQL query
+        >>> sess.sql("SELECT * FROM T").show()
+
+    You can also retrieve the current session without creating a new one:
+
+        >>> from daft.session import current_session
+        >>> sess = current_session()
+    """
 
     _session: PySession
 


### PR DESCRIPTION
## Changes Made

Added usage examples to the Session class docstring to make it clearer how to instantiate and use a session object.
The examples show how to create a temporary table, read it as a DataFrame, execute SQL queries, and retrieve the current session.

## Related Issues

#4165 

## Checklist

- [x] Documented in API Docs (Session docstring updated)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
