### PR TITLE
feat: allow making multiplication arithmetics with Interval data type

### DIFF
--- a/src/arrow2/src/compute/arithmetics/time.rs
+++ b/src/arrow2/src/compute/arithmetics/time.rs
@@ -600,8 +600,8 @@ pub fn mul_interval(
         interval.data_type().clone(),
         |interval, factor| {
             months_days_ns::new(
-                interval.months() * factor as i32,
-                interval.days() * factor as i32,
+                interval.months() * factor,
+                interval.days() * factor,
                 interval.ns() * factor as i64,
             )
         },
@@ -625,8 +625,8 @@ pub fn mul_interval_scalar(
         interval,
         |interval| {
             months_days_ns::new(
-                interval.months() * factor as i32,
-                interval.days() * factor as i32,
+                interval.months() * factor,
+                interval.days() * factor,
                 interval.ns() * factor as i64,
             )
         },

--- a/src/arrow2/src/compute/arithmetics/time.rs
+++ b/src/arrow2/src/compute/arithmetics/time.rs
@@ -579,7 +579,7 @@ pub fn sub_interval_scalar(
 /// Multiplies an interval by a factor.
 pub fn mul_interval(
     interval: &PrimitiveArray<months_days_ns>,
-    factor: &PrimitiveArray<u32>,
+    factor: &PrimitiveArray<i32>,
 ) -> Result<PrimitiveArray<months_days_ns>> {
     if factor.len() == 1 {
         let value = factor.get(0);
@@ -610,7 +610,7 @@ pub fn mul_interval(
 
 pub fn mul_interval_scalar(
     interval: &PrimitiveArray<months_days_ns>,
-    factor: &PrimitiveScalar<u32>,
+    factor: &PrimitiveScalar<i32>,
 ) -> Result<PrimitiveArray<months_days_ns>> {
     let factor = if let Some(factor) = *factor.value() {
         factor

--- a/src/arrow2/src/compute/arithmetics/time.rs
+++ b/src/arrow2/src/compute/arithmetics/time.rs
@@ -576,7 +576,8 @@ pub fn sub_interval_scalar(
     }
 }
 
-pub fn interval_mul_factor(
+/// Multiplies an interval by a factor.
+pub fn mul_interval(
     interval: &PrimitiveArray<months_days_ns>,
     factor: &PrimitiveArray<u32>,
 ) -> Result<PrimitiveArray<months_days_ns>> {
@@ -584,7 +585,7 @@ pub fn interval_mul_factor(
         let value = factor.get(0);
         let dtype = factor.data_type().clone();
         let scalar = PrimitiveScalar::new(dtype, value);
-        return interval_mul_factor_scalar(interval, &scalar);
+        return mul_interval_scalar(interval, &scalar);
     }
 
     if interval.len() != factor.len() {
@@ -607,7 +608,7 @@ pub fn interval_mul_factor(
     ))
 }
 
-pub fn interval_mul_factor_scalar(
+pub fn mul_interval_scalar(
     interval: &PrimitiveArray<months_days_ns>,
     factor: &PrimitiveScalar<u32>,
 ) -> Result<PrimitiveArray<months_days_ns>> {

--- a/src/daft-core/src/array/from.rs
+++ b/src/daft-core/src/array/from.rs
@@ -7,6 +7,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use common_error::{DaftError, DaftResult};
 
+use super::prelude::IntervalArray;
 use crate::{
     array::DataArray,
     datatypes::{
@@ -147,6 +148,20 @@ impl From<(&str, Box<arrow2::array::BooleanArray>)> for BooleanArray {
     fn from(item: (&str, Box<arrow2::array::BooleanArray>)) -> Self {
         let (name, arrow_array) = item;
         Self::new(Field::new(name, DataType::Boolean).into(), arrow_array).unwrap()
+    }
+}
+
+impl From<(&str, Vec<arrow2::types::months_days_ns>)> for IntervalArray {
+    fn from(item: (&str, Vec<arrow2::types::months_days_ns>)) -> Self {
+        let (name, vec) = item;
+        let arrow_array = Box::new(
+            arrow2::array::PrimitiveArray::<arrow2::types::months_days_ns>::from_vec(vec),
+        );
+        Self::new(
+            Field::new(name, DataType::Interval).into(),
+            arrow_array,
+        )
+        .unwrap()
     }
 }
 

--- a/src/daft-core/src/array/from.rs
+++ b/src/daft-core/src/array/from.rs
@@ -7,12 +7,11 @@ use std::{borrow::Cow, sync::Arc};
 
 use common_error::{DaftError, DaftResult};
 
-use super::prelude::IntervalArray;
 use crate::{
     array::DataArray,
     datatypes::{
         BinaryArray, BooleanArray, DaftNumericType, DaftPhysicalType, DataType, Field,
-        FixedSizeBinaryArray, NullArray, Utf8Array, Utf8Type,
+        FixedSizeBinaryArray, IntervalArray, NullArray, Utf8Array, Utf8Type,
     },
 };
 
@@ -154,14 +153,9 @@ impl From<(&str, Box<arrow2::array::BooleanArray>)> for BooleanArray {
 impl From<(&str, Vec<arrow2::types::months_days_ns>)> for IntervalArray {
     fn from(item: (&str, Vec<arrow2::types::months_days_ns>)) -> Self {
         let (name, vec) = item;
-        let arrow_array = Box::new(
-            arrow2::array::PrimitiveArray::<arrow2::types::months_days_ns>::from_vec(vec),
-        );
-        Self::new(
-            Field::new(name, DataType::Interval).into(),
-            arrow_array,
-        )
-        .unwrap()
+        let arrow_array =
+            Box::new(arrow2::array::PrimitiveArray::<arrow2::types::months_days_ns>::from_vec(vec));
+        Self::new(Field::new(name, DataType::Interval).into(), arrow_array).unwrap()
     }
 }
 

--- a/src/daft-core/src/array/ops/time.rs
+++ b/src/daft-core/src/array/ops/time.rs
@@ -439,10 +439,8 @@ impl IntervalArray {
     pub fn mul(&self, factor: &UInt32Array) -> DaftResult<Self> {
         let arrow_interval = self.as_arrow();
         let arrow_factor = factor.as_arrow();
-        let result = arrow2::compute::arithmetics::time::interval_mul_factor(
-            &arrow_interval,
-            &arrow_factor,
-        )?;
+        let result =
+            arrow2::compute::arithmetics::time::mul_interval(&arrow_interval, &arrow_factor)?;
         Self::new(self.field.clone(), Box::new(result))
     }
 }

--- a/src/daft-core/src/array/ops/time.rs
+++ b/src/daft-core/src/array/ops/time.rs
@@ -440,7 +440,7 @@ impl IntervalArray {
         let arrow_interval = self.as_arrow();
         let arrow_factor = factor.as_arrow();
         let result =
-            arrow2::compute::arithmetics::time::mul_interval(&arrow_interval, &arrow_factor)?;
+            arrow2::compute::arithmetics::time::mul_interval(arrow_interval, arrow_factor)?;
         Self::new(self.field.clone(), Box::new(result))
     }
 }

--- a/src/daft-core/src/array/ops/time.rs
+++ b/src/daft-core/src/array/ops/time.rs
@@ -436,7 +436,7 @@ impl TimestampArray {
 }
 
 impl IntervalArray {
-    pub fn mul(&self, factor: &UInt32Array) -> DaftResult<Self> {
+    pub fn mul(&self, factor: &Int32Array) -> DaftResult<Self> {
         let arrow_interval = self.as_arrow();
         let arrow_factor = factor.as_arrow();
         let result =

--- a/src/daft-core/src/array/ops/time.rs
+++ b/src/daft-core/src/array/ops/time.rs
@@ -435,6 +435,18 @@ impl TimestampArray {
     }
 }
 
+impl IntervalArray {
+    pub fn mul(&self, factor: &UInt32Array) -> DaftResult<Self> {
+        let arrow_interval = self.as_arrow();
+        let arrow_factor = factor.as_arrow();
+        let result = arrow2::compute::arithmetics::time::interval_mul_factor(
+            &arrow_interval,
+            &arrow_factor,
+        )?;
+        Self::new(self.field.clone(), Box::new(result))
+    }
+}
+
 impl TimeArray {
     pub fn hour(&self) -> DaftResult<UInt32Array> {
         let physical = self.physical.as_arrow();

--- a/src/daft-core/src/datatypes/infer_datatype.rs
+++ b/src/daft-core/src/datatypes/infer_datatype.rs
@@ -450,8 +450,6 @@ impl Mul for InferDataType<'_> {
                 }
                 (DataType::Interval, other) if other.is_integer() => Ok(DataType::Interval),
                 (other, DataType::Interval) if other.is_integer() => Ok(DataType::Interval),
-                (DataType::Duration(duration_unit), other) if other.is_integer() => Ok(DataType::Duration(*duration_unit)),
-                (other, DataType::Duration(duration_unit)) if other.is_integer() => Ok(DataType::Duration(*duration_unit)),
                 _ => Err(DaftError::TypeError(format!(
                     "Cannot multiply types: {}, {}",
                     self, other

--- a/src/daft-core/src/datatypes/infer_datatype.rs
+++ b/src/daft-core/src/datatypes/infer_datatype.rs
@@ -448,6 +448,7 @@ impl Mul for InferDataType<'_> {
                         Ok(DataType::Decimal128(p_prime, s_prime))
                     }
                 }
+                (DataType::Interval, other) if other.is_numeric() => Ok(DataType::Interval),
                 _ => Err(DaftError::TypeError(format!(
                     "Cannot multiply types: {}, {}",
                     self, other

--- a/src/daft-core/src/datatypes/infer_datatype.rs
+++ b/src/daft-core/src/datatypes/infer_datatype.rs
@@ -449,6 +449,7 @@ impl Mul for InferDataType<'_> {
                     }
                 }
                 (DataType::Interval, other) if other.is_integer() => Ok(DataType::Interval),
+                (other, DataType::Interval) if other.is_integer() => Ok(DataType::Interval),
                 _ => Err(DaftError::TypeError(format!(
                     "Cannot multiply types: {}, {}",
                     self, other

--- a/src/daft-core/src/datatypes/infer_datatype.rs
+++ b/src/daft-core/src/datatypes/infer_datatype.rs
@@ -450,6 +450,8 @@ impl Mul for InferDataType<'_> {
                 }
                 (DataType::Interval, other) if other.is_integer() => Ok(DataType::Interval),
                 (other, DataType::Interval) if other.is_integer() => Ok(DataType::Interval),
+                (DataType::Duration(duration_unit), other) if other.is_integer() => Ok(DataType::Duration(*duration_unit)),
+                (other, DataType::Duration(duration_unit)) if other.is_integer() => Ok(DataType::Duration(*duration_unit)),
                 _ => Err(DaftError::TypeError(format!(
                     "Cannot multiply types: {}, {}",
                     self, other

--- a/src/daft-core/src/datatypes/infer_datatype.rs
+++ b/src/daft-core/src/datatypes/infer_datatype.rs
@@ -448,7 +448,7 @@ impl Mul for InferDataType<'_> {
                         Ok(DataType::Decimal128(p_prime, s_prime))
                     }
                 }
-                (DataType::Interval, other) if other.is_numeric() => Ok(DataType::Interval),
+                (DataType::Interval, other) if other.is_integer() => Ok(DataType::Interval),
                 _ => Err(DaftError::TypeError(format!(
                     "Cannot multiply types: {}, {}",
                     self, other

--- a/src/daft-core/src/series/ops/arithmetic.rs
+++ b/src/daft-core/src/series/ops/arithmetic.rs
@@ -296,13 +296,13 @@ impl Mul for &Series {
                     // Interval
                     // ----------------
                     // Interval * numeric = Interval
-                    (DataType::Interval, dt) if dt.is_numeric() => {
+                    (DataType::Interval, dt) if dt.is_integer() => {
                         let physical_result =
                             lhs.interval()?.mul(rhs.cast(&DataType::Int32)?.i32()?)?;
                         physical_result.cast(output_type)
                     }
                     // numeric * Interval = Interval
-                    (dt, DataType::Interval) if dt.is_numeric() => {
+                    (dt, DataType::Interval) if dt.is_integer() => {
                         let physical_result =
                             rhs.interval()?.mul(lhs.cast(&DataType::Int32)?.i32()?)?;
                         physical_result.cast(output_type)
@@ -586,6 +586,25 @@ mod tests {
         let b = Int32Array::from(("b", vec![1, 2, 3]));
         let c = a.into_series() * b.into_series();
         assert_eq!(*c?.data_type(), DataType::Interval);
+        Ok(())
+    }
+    #[test]
+    fn add_interval_and_float() -> DaftResult<()> {
+        let a = IntervalArray::from((
+            "a",
+            vec![
+                months_days_ns::new(1, 2, 3),
+                months_days_ns::new(4, 5, 6),
+                months_days_ns::new(7, 8, 9),
+            ],
+        ));
+        let b = Float64Array::from(("b", vec![1., 2., 3.]));
+        let c = a.into_series() * b.into_series();
+        assert!(c.is_err());
+        assert_eq!(
+            c.unwrap_err().to_string(),
+            "DaftError::TypeError Cannot multiply types: Interval, Float64"
+        );
         Ok(())
     }
 }

--- a/src/daft-core/src/series/ops/arithmetic.rs
+++ b/src/daft-core/src/series/ops/arithmetic.rs
@@ -292,6 +292,12 @@ impl Mul for &Series {
                             .mul(lhs.cast(&DataType::Int64)?.i64()?)?;
                         physical_result.cast(output_type)
                     }
+                    // ----------------
+                    // Interval
+                    // ----------------
+                    (DataType::Interval, dt) if dt.is_numeric() => {
+                        let lhs_array = lhs.interval()?;
+                    }
                     _ => arithmetic_op_not_implemented!(self, "*", rhs, output_type),
                 }
             }

--- a/src/daft-core/src/series/ops/arithmetic.rs
+++ b/src/daft-core/src/series/ops/arithmetic.rs
@@ -298,13 +298,13 @@ impl Mul for &Series {
                     // Interval * numeric = Interval
                     (DataType::Interval, dt) if dt.is_numeric() => {
                         let physical_result =
-                            lhs.interval()?.mul(rhs.cast(&DataType::UInt32)?.u32()?)?;
+                            lhs.interval()?.mul(rhs.cast(&DataType::Int32)?.i32()?)?;
                         physical_result.cast(output_type)
                     }
                     // numeric * Interval = Interval
                     (dt, DataType::Interval) if dt.is_numeric() => {
                         let physical_result =
-                            rhs.interval()?.mul(lhs.cast(&DataType::UInt32)?.u32()?)?;
+                            rhs.interval()?.mul(lhs.cast(&DataType::Int32)?.i32()?)?;
                         physical_result.cast(output_type)
                     }
                     _ => {

--- a/src/daft-core/src/series/ops/arithmetic.rs
+++ b/src/daft-core/src/series/ops/arithmetic.rs
@@ -471,11 +471,14 @@ impl_arithmetic_ref_for_series!(Rem, rem);
 
 #[cfg(test)]
 mod tests {
+    use arrow2::types::months_days_ns;
     use common_error::DaftResult;
 
     use crate::{
         array::ops::full::FullNull,
-        datatypes::{DataType, Float32Array, Float64Array, Int32Array, Int64Array, Utf8Array},
+        datatypes::{
+            DataType, Float32Array, Float64Array, Int32Array, Int64Array, IntervalArray, Utf8Array,
+        },
         series::IntoSeries,
     };
 
@@ -568,6 +571,21 @@ mod tests {
         let b = Utf8Array::from(("b", str_array.as_slice()));
         let c = a.into_series() + b.into_series();
         assert_eq!(*c?.data_type(), DataType::Utf8);
+        Ok(())
+    }
+    #[test]
+    fn add_interval_and_int() -> DaftResult<()> {
+        let a = IntervalArray::from((
+            "a",
+            vec![
+                months_days_ns::new(1, 2, 3),
+                months_days_ns::new(4, 5, 6),
+                months_days_ns::new(7, 8, 9),
+            ],
+        ));
+        let b = Int32Array::from(("b", vec![1, 2, 3]));
+        let c = a.into_series() * b.into_series();
+        assert_eq!(*c?.data_type(), DataType::Interval);
         Ok(())
     }
 }

--- a/src/daft-core/src/series/ops/arithmetic.rs
+++ b/src/daft-core/src/series/ops/arithmetic.rs
@@ -271,27 +271,8 @@ impl Mul for &Series {
             // ----------------
             // Temporal types
             // ----------------
-            output_type if output_type.is_interval() || output_type.is_duration() => {
+            output_type if output_type.is_interval() => {
                 match (self.data_type(), rhs.data_type()) {
-                    // ----------------
-                    // Duration
-                    // ----------------
-                    // Duration * numeric = Duration
-                    (DataType::Duration(..), dt) if dt.is_integer() => {
-                        let physical_result = lhs
-                            .duration()?
-                            .physical
-                            .mul(rhs.cast(&DataType::Int64)?.i64()?)?;
-                        physical_result.cast(output_type)
-                    }
-                    // numeric * Duration = Duration
-                    (dt, DataType::Duration(..)) if dt.is_integer() => {
-                        let physical_result = rhs
-                            .duration()?
-                            .physical
-                            .mul(lhs.cast(&DataType::Int64)?.i64()?)?;
-                        physical_result.cast(output_type)
-                    }
                     // ----------------
                     // Interval
                     // ----------------
@@ -573,24 +554,6 @@ mod tests {
         let b = Utf8Array::from(("b", str_array.as_slice()));
         let c = a.into_series() + b.into_series();
         assert_eq!(*c?.data_type(), DataType::Utf8);
-        Ok(())
-    }
-    #[test]
-    fn mul_duration_and_int() -> DaftResult<()> {
-        let a_raw = Int64Array::from(("a", vec![1, 2, 3]));
-        let a = DurationArray::new(
-            Field::new(
-                "a",
-                DataType::Duration(daft_schema::prelude::TimeUnit::Microseconds),
-            ),
-            a_raw,
-        );
-        let b = Int32Array::from(("b", vec![1, 2, 3]));
-        let c = a.into_series() * b.into_series();
-        assert_eq!(
-            *c?.data_type(),
-            DataType::Duration(daft_schema::prelude::TimeUnit::Microseconds)
-        );
         Ok(())
     }
     #[test]

--- a/src/daft-sql/src/lib.rs
+++ b/src/daft-sql/src/lib.rs
@@ -177,6 +177,7 @@ mod tests {
     #[case::cte("with cte as (select * from tbl1) select * from cte")]
     #[case::double_alias("select * from tbl1 as tbl2, tbl2 as tbl1")]
     #[case::double_alias_qualified("select tbl1.val from tbl1 as tbl2, tbl2 as tbl1")]
+    #[case::interval_arithmetic("select interval '1 day' * 3 from tbl1")]
     fn test_compiles(mut planner: SQLPlanner, #[case] query: &str) -> SQLPlannerResult<()> {
         let plan = planner.plan_sql(query);
         assert!(&plan.is_ok(), "query: {query}\nerror: {plan:?}");

--- a/tests/sql/test_exprs.py
+++ b/tests/sql/test_exprs.py
@@ -193,6 +193,11 @@ def test_is_in_edge_cases():
                     datetime.datetime(2020, 3, 1, 1, 59, 59),
                     datetime.datetime(2029, 5, 15, 14, 34, 56),
                 ],
+                "ts_add_hour_mul_neg_2": [
+                    datetime.datetime(2022, 1, 1, 8, 0),
+                    datetime.datetime(2020, 2, 29, 21, 59, 59),
+                    datetime.datetime(2029, 5, 15, 10, 34, 56),
+                ],
                 "ts_add_minute_mul_2": [
                     datetime.datetime(2022, 1, 1, 10, 2, 0),
                     datetime.datetime(2020, 3, 1, 0, 1, 59),
@@ -228,6 +233,7 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             (col("ts") - interval(minutes=1, seconds=99)).alias("ts_sub_minute"),
             (col("ts") + interval(hours=1) * 2).alias("ts_add_hour_mul_2"),
             (col("ts") + 2 * interval(hours=1)).alias("ts_add_2_mul_hour"),
+            (col("ts") + interval(hours=1) * -2).alias("ts_add_hour_mul_neg_2"),
             (col("ts") + interval(minutes=1) * 2).alias("ts_add_minute_mul_2"),
             (col("ts") + interval(months=1) * 2).alias("ts_add_month_mul_2"),
             (col("ts") + interval(years=1, days=0) * 2).alias("ts_add_year_mul_2"),
@@ -246,6 +252,7 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             ts + INTERVAL '1' hour AS ts_add_hour,
             ts - INTERVAL '1 minutes 99 second' AS ts_sub_minute,
             ts + INTERVAL '1' hour * 2 AS ts_add_hour_mul_2,
+            ts + INTERVAL '1' hour * -2 AS ts_add_hour_mul_neg_2,
             ts + 2 * INTERVAL '1' hour AS ts_add_2_mul_hour,
             ts + INTERVAL '1' minute * 2 AS ts_add_minute_mul_2,
             ts + INTERVAL '1' month * 2 AS ts_add_month_mul_2,

--- a/tests/sql/test_exprs.py
+++ b/tests/sql/test_exprs.py
@@ -188,6 +188,11 @@ def test_is_in_edge_cases():
                     datetime.datetime(2020, 3, 1, 1, 59, 59),
                     datetime.datetime(2029, 5, 15, 14, 34, 56),
                 ],
+                "ts_add_2_mul_hour": [
+                    datetime.datetime(2022, 1, 1, 12, 0, 0),
+                    datetime.datetime(2020, 3, 1, 1, 59, 59),
+                    datetime.datetime(2029, 5, 15, 14, 34, 56),
+                ],
                 "ts_add_minute_mul_2": [
                     datetime.datetime(2022, 1, 1, 10, 2, 0),
                     datetime.datetime(2020, 3, 1, 0, 1, 59),
@@ -222,6 +227,7 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             (col("ts") + interval(hours=1)).alias("ts_add_hour"),
             (col("ts") - interval(minutes=1, seconds=99)).alias("ts_sub_minute"),
             (col("ts") + interval(hours=1) * 2).alias("ts_add_hour_mul_2"),
+            (col("ts") + 2 * interval(hours=1)).alias("ts_add_2_mul_hour"),
             (col("ts") + interval(minutes=1) * 2).alias("ts_add_minute_mul_2"),
             (col("ts") + interval(months=1) * 2).alias("ts_add_month_mul_2"),
             (col("ts") + interval(years=1, days=0) * 2).alias("ts_add_year_mul_2"),
@@ -240,6 +246,7 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             ts + INTERVAL '1' hour AS ts_add_hour,
             ts - INTERVAL '1 minutes 99 second' AS ts_sub_minute,
             ts + INTERVAL '1' hour * 2 AS ts_add_hour_mul_2,
+            ts + 2 * INTERVAL '1' hour AS ts_add_2_mul_hour,
             ts + INTERVAL '1' minute * 2 AS ts_add_minute_mul_2,
             ts + INTERVAL '1' month * 2 AS ts_add_month_mul_2,
             ts + INTERVAL '1' year * 2 AS ts_add_year_mul_2,

--- a/tests/sql/test_exprs.py
+++ b/tests/sql/test_exprs.py
@@ -178,15 +178,35 @@ def test_is_in_edge_cases():
                     datetime.datetime(2020, 3, 1, 0, 59, 59),
                     datetime.datetime(2029, 5, 15, 13, 34, 56),
                 ],
-                "ts_add_2_hour": [
-                    datetime.datetime(2022, 1, 1, 12, 0, 0),
-                    datetime.datetime(2020, 3, 1, 1, 59, 59),
-                    datetime.datetime(2029, 5, 15, 14, 34, 56),
-                ],
                 "ts_sub_minute": [
                     datetime.datetime(2022, 1, 1, 9, 57, 21),
                     datetime.datetime(2020, 2, 29, 23, 57, 20),
                     datetime.datetime(2029, 5, 15, 12, 32, 17),
+                ],
+                "ts_add_hour_mul_2": [
+                    datetime.datetime(2022, 1, 1, 12, 0, 0),
+                    datetime.datetime(2020, 3, 1, 1, 59, 59),
+                    datetime.datetime(2029, 5, 15, 14, 34, 56),
+                ],
+                "ts_add_hour_mul_2_float": [
+                    datetime.datetime(2022, 1, 1, 12, 0, 0),
+                    datetime.datetime(2020, 3, 1, 1, 59, 59),
+                    datetime.datetime(2029, 5, 15, 14, 34, 56),
+                ],
+                "ts_add_minute_mul_2": [
+                    datetime.datetime(2022, 1, 1, 10, 2, 0),
+                    datetime.datetime(2020, 3, 1, 0, 1, 59),
+                    datetime.datetime(2029, 5, 15, 12, 36, 56),
+                ],
+                "ts_add_month_mul_2": [
+                    datetime.datetime(2022, 3, 1, 10, 0, 0),
+                    datetime.datetime(2020, 4, 29, 23, 59, 59),
+                    datetime.datetime(2029, 7, 15, 12, 34, 56),
+                ],
+                "ts_add_year_mul_2": [
+                    datetime.datetime(2024, 1, 1, 10, 0, 0),
+                    datetime.datetime(2022, 3, 1, 23, 59, 59),
+                    datetime.datetime(2031, 5, 15, 12, 34, 56),
                 ],
             },
         ),
@@ -205,8 +225,12 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             (col("date") - interval(months=1)).alias("date_sub_month"),
             (col("ts") - interval(years=1, days=0)).alias("ts_sub_year"),
             (col("ts") + interval(hours=1)).alias("ts_add_hour"),
-            (col("ts") + interval(hours=1) * 2).alias("ts_add_2_hour"),
             (col("ts") - interval(minutes=1, seconds=99)).alias("ts_sub_minute"),
+            (col("ts") + interval(hours=1) * 2).alias("ts_add_hour_mul_2"),
+            (col("ts") + interval(hours=1) * 2.0).alias("ts_add_hour_mul_2_float"),
+            (col("ts") + interval(minutes=1) * 2).alias("ts_add_minute_mul_2"),
+            (col("ts") + interval(months=1) * 2).alias("ts_add_month_mul_2"),
+            (col("ts") + interval(years=1, days=0) * 2).alias("ts_add_year_mul_2"),
         )
         .collect()
         .to_pydict()
@@ -220,8 +244,12 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             date - INTERVAL '1 months' AS date_sub_month,
             ts - INTERVAL '1 year 0 days' AS ts_sub_year,
             ts + INTERVAL '1' hour AS ts_add_hour,
-            ts + INTERVAL '1' hour * 2 AS ts_add_2_hour,
-            ts - INTERVAL '1 minutes 99 second' AS ts_sub_minute
+            ts - INTERVAL '1 minutes 99 second' AS ts_sub_minute,
+            ts + INTERVAL '1' hour * 2 AS ts_add_hour_mul_2,
+            ts + INTERVAL '1' hour * 2.0 AS ts_add_hour_mul_2_float,
+            ts + INTERVAL '1' minute * 2 AS ts_add_minute_mul_2,
+            ts + INTERVAL '1' month * 2 AS ts_add_month_mul_2,
+            ts + INTERVAL '1' year * 2 AS ts_add_year_mul_2,
         FROM test
         """,
             catalog=catalog,

--- a/tests/sql/test_exprs.py
+++ b/tests/sql/test_exprs.py
@@ -213,7 +213,7 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             date + INTERVAL '1' day AS date_add_day,
             date - INTERVAL '1 months' AS date_sub_month,
             ts - INTERVAL '1 year 0 days' AS ts_sub_year,
-            ts + INTERVAL '1' hour AS ts_add_hour,
+            ts + INTERVAL '1' hour * 2 AS ts_add_hour,
             ts - INTERVAL '1 minutes 99 second' AS ts_sub_minute
         FROM test
         """,

--- a/tests/sql/test_exprs.py
+++ b/tests/sql/test_exprs.py
@@ -188,11 +188,6 @@ def test_is_in_edge_cases():
                     datetime.datetime(2020, 3, 1, 1, 59, 59),
                     datetime.datetime(2029, 5, 15, 14, 34, 56),
                 ],
-                "ts_add_hour_mul_2_float": [
-                    datetime.datetime(2022, 1, 1, 12, 0, 0),
-                    datetime.datetime(2020, 3, 1, 1, 59, 59),
-                    datetime.datetime(2029, 5, 15, 14, 34, 56),
-                ],
                 "ts_add_minute_mul_2": [
                     datetime.datetime(2022, 1, 1, 10, 2, 0),
                     datetime.datetime(2020, 3, 1, 0, 1, 59),
@@ -227,7 +222,6 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             (col("ts") + interval(hours=1)).alias("ts_add_hour"),
             (col("ts") - interval(minutes=1, seconds=99)).alias("ts_sub_minute"),
             (col("ts") + interval(hours=1) * 2).alias("ts_add_hour_mul_2"),
-            (col("ts") + interval(hours=1) * 2.0).alias("ts_add_hour_mul_2_float"),
             (col("ts") + interval(minutes=1) * 2).alias("ts_add_minute_mul_2"),
             (col("ts") + interval(months=1) * 2).alias("ts_add_month_mul_2"),
             (col("ts") + interval(years=1, days=0) * 2).alias("ts_add_year_mul_2"),
@@ -246,7 +240,6 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             ts + INTERVAL '1' hour AS ts_add_hour,
             ts - INTERVAL '1 minutes 99 second' AS ts_sub_minute,
             ts + INTERVAL '1' hour * 2 AS ts_add_hour_mul_2,
-            ts + INTERVAL '1' hour * 2.0 AS ts_add_hour_mul_2_float,
             ts + INTERVAL '1' minute * 2 AS ts_add_minute_mul_2,
             ts + INTERVAL '1' month * 2 AS ts_add_month_mul_2,
             ts + INTERVAL '1' year * 2 AS ts_add_year_mul_2,

--- a/tests/sql/test_exprs.py
+++ b/tests/sql/test_exprs.py
@@ -178,6 +178,11 @@ def test_is_in_edge_cases():
                     datetime.datetime(2020, 3, 1, 0, 59, 59),
                     datetime.datetime(2029, 5, 15, 13, 34, 56),
                 ],
+                "ts_add_2_hour": [
+                    datetime.datetime(2022, 1, 1, 12, 0, 0),
+                    datetime.datetime(2020, 3, 1, 1, 59, 59),
+                    datetime.datetime(2029, 5, 15, 14, 34, 56),
+                ],
                 "ts_sub_minute": [
                     datetime.datetime(2022, 1, 1, 9, 57, 21),
                     datetime.datetime(2020, 2, 29, 23, 57, 20),
@@ -200,6 +205,7 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             (col("date") - interval(months=1)).alias("date_sub_month"),
             (col("ts") - interval(years=1, days=0)).alias("ts_sub_year"),
             (col("ts") + interval(hours=1)).alias("ts_add_hour"),
+            (col("ts") + interval(hours=1) * 2).alias("ts_add_2_hour"),
             (col("ts") - interval(minutes=1, seconds=99)).alias("ts_sub_minute"),
         )
         .collect()
@@ -213,7 +219,8 @@ def test_interval_comparison(date_values, ts_values, expected_intervals):
             date + INTERVAL '1' day AS date_add_day,
             date - INTERVAL '1 months' AS date_sub_month,
             ts - INTERVAL '1 year 0 days' AS ts_sub_year,
-            ts + INTERVAL '1' hour * 2 AS ts_add_hour,
+            ts + INTERVAL '1' hour AS ts_add_hour,
+            ts + INTERVAL '1' hour * 2 AS ts_add_2_hour,
             ts - INTERVAL '1 minutes 99 second' AS ts_sub_minute
         FROM test
         """,


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

this pr allows executing multiplication arithmetics for interval data type. like:

```py
import daft

daft.sql("select interval '1 day' * 3;").collect()
```

first time submitting a PR here, appreciate the feedback!

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

fixes #4144

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
