### PR TITLE
docs: fix doc typos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# doc changes MUST tag ChaChan.
+# doc changes MUST tag ChanChan.
 docs/* @ccmao1130

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# doc changes MUST tag ChaChan.
+docs/* @ccmao1130

--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -217,9 +217,10 @@ class Catalog(ABC):
     tabular and non-tabular data. You can instantiate a Catalog using
     one of the static `from_` methods.
 
-    Example:
+    Examples:
         >>> import daft
         >>> from daft.catalog import Catalog
+        >>>
         >>> data = {"users": {"id": [1, 2, 3], "name": ["a", "b", "c"]}}
         >>> catalog = Catalog.from_pydict(data)
         >>> catalog.list_tables()

--- a/daft/session.py
+++ b/daft/session.py
@@ -49,23 +49,22 @@ __all__ = [
 class Session:
     """Session holds a connection's state and orchestrates execution of DataFrame and SQL queries against catalogs.
 
-    Example:
+    Examples:
         >>> import daft
         >>> from daft.session import Session
-
+        >>>
         >>> sess = Session()
-
+        >>>
         >>> # Create a temporary table from a DataFrame
         >>> sess.create_temp_table("T", daft.from_pydict({"x": [1, 2, 3]}))
-
+        >>>
         >>> # Read the table as a DataFrame
         >>> df = sess.read_table("T")
-
+        >>>
         >>> # Execute an SQL query
         >>> sess.sql("SELECT * FROM T").show()
-
-    You can also retrieve the current session without creating a new one:
-
+        >>>
+        >>> # You can also retrieve the current session without creating a new one:
         >>> from daft.session import current_session
         >>> sess = current_session()
     """


### PR DESCRIPTION
## Changes Made

* Adds ChanChan as CODEOWNER for `docs/*`
* Fixes typos in doc examples.

## Related Issues

* Closes #4165
* #4259
* #4252 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
