### PR TITLE
refactor(ordinals): add bound column variant

### DIFF
--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -171,6 +171,7 @@ pub struct BoundColumn {
     pub index: usize,
 
     #[deprecated(since = "TBD", note = "name-referenced columns")]
+    /// Should only be used for display and debugging purposes
     pub field: Field,
 }
 

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -110,6 +110,7 @@ impl std::hash::Hash for Subquery {
 pub enum Column {
     Unresolved(UnresolvedColumn),
     Resolved(ResolvedColumn),
+    Bound(BoundColumn),
 }
 
 /// Information about the logical plan node that a column comes from.
@@ -165,7 +166,16 @@ pub enum ResolvedColumn {
     OuterRef(Field, PlanRef),
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct BoundColumn {
+    pub index: usize,
+
+    #[deprecated(since = "TBD", note = "name-referenced columns")]
+    pub field: Field,
+}
+
 impl Column {
+    #[deprecated(since = "TBD", note = "name-referenced columns")]
     pub fn name(&self) -> String {
         match self {
             Self::Unresolved(UnresolvedColumn {
@@ -181,6 +191,10 @@ impl Column {
                 PlanRef::Alias(plan_alias),
             )) => format!("{plan_alias}.{name}"),
             Self::Resolved(ResolvedColumn::OuterRef(Field { name, .. }, _)) => name.to_string(),
+            Self::Bound(BoundColumn {
+                field: Field { name, .. },
+                ..
+            }) => name.to_string(),
         }
     }
 }
@@ -382,6 +396,10 @@ pub fn unresolved_col(name: impl Into<Arc<str>>) -> ExprRef {
         plan_schema: None,
     }
     .into()
+}
+
+pub fn bound_col(index: usize, field: Field) -> ExprRef {
+    BoundColumn { index, field }.into()
 }
 
 /// Basic resolved column, refers to a singular input scope
@@ -845,6 +863,12 @@ impl From<ResolvedColumn> for ExprRef {
     }
 }
 
+impl From<BoundColumn> for ExprRef {
+    fn from(col: BoundColumn) -> Self {
+        Self::new(Expr::Column(Column::Bound(col)))
+    }
+}
+
 impl From<Column> for ExprRef {
     fn from(col: Column) -> Self {
         Self::new(Expr::Column(col))
@@ -1044,6 +1068,7 @@ impl Expr {
         Self::InSubquery(self, subquery).into()
     }
 
+    #[deprecated(since = "TBD", note = "name-referenced columns")]
     pub fn semantic_id(&self, schema: &Schema) -> FieldID {
         match self {
             // Base case - anonymous column reference.
@@ -1071,6 +1096,11 @@ impl Expr {
             Self::Column(Column::Resolved(ResolvedColumn::JoinSide(name, side))) => {
                 FieldID::new(format!("{side}.{name}"))
             }
+
+            Self::Column(Column::Bound(BoundColumn {
+                index,
+                field: Field { name, .. },
+            })) => FieldID::new(format!("{name}#{index}")),
 
             Self::Column(Column::Resolved(ResolvedColumn::OuterRef(
                 Field { name, .. },
@@ -1371,6 +1401,8 @@ impl Expr {
                 Ok(field.clone())
             }
 
+            Self::Column(Column::Bound(BoundColumn { index, .. })) => Ok(schema[*index].clone()),
+
             Self::Column(Column::Resolved(ResolvedColumn::OuterRef(field, _))) => Ok(field.clone()),
             Self::Not(expr) => {
                 let child_field = expr.to_field(schema)?;
@@ -1534,7 +1566,7 @@ impl Expr {
                         "Expected subquery to return a single column but received {subquery_schema}",
                     )));
                 }
-                let first_field = subquery_schema.get_field_at_index(0).unwrap();
+                let first_field = &subquery_schema[0];
 
                 Ok(first_field.clone())
             }
@@ -1545,6 +1577,7 @@ impl Expr {
         }
     }
 
+    #[deprecated(since = "TBD", note = "name-referenced columns")]
     pub fn name(&self) -> &str {
         match self {
             Self::Alias(.., name) => name.as_ref(),
@@ -1558,6 +1591,10 @@ impl Expr {
             Self::Column(Column::Resolved(ResolvedColumn::OuterRef(Field { name, .. }, _))) => {
                 name.as_ref()
             }
+            Self::Column(Column::Bound(BoundColumn {
+                field: Field { name, .. },
+                ..
+            })) => name.as_ref(),
             Self::Not(expr) => expr.name(),
             Self::IsNull(expr) => expr.name(),
             Self::NotNull(expr) => expr.name(),
@@ -1754,6 +1791,21 @@ impl Expr {
                 _ => Ok(Transformed::no(e)),
             })?
             .data)
+    }
+
+    pub fn bind(self: ExprRef, schema: &Schema) -> DaftResult<ExprRef> {
+        self.transform(|e| match e.as_ref() {
+            // TODO: remove ability to bind unresolved columns once we fix all tests
+            Self::Column(Column::Unresolved(UnresolvedColumn { name, .. }))
+            | Self::Column(Column::Resolved(ResolvedColumn::Basic(name))) => {
+                let index = schema.get_index(name)?;
+                let field = schema.get_field(name)?.clone();
+
+                Ok(Transformed::yes(bound_col(index, field)))
+            }
+            _ => Ok(Transformed::no(e)),
+        })
+        .map(|t| t.data)
     }
 }
 

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -21,8 +21,8 @@ use daft_core::{
     prelude::*,
 };
 use daft_dsl::{
-    functions::FunctionEvaluator, null_lit, resolved_col, AggExpr, ApproxPercentileParams, Column,
-    Expr, ExprRef, LiteralValue, PlanRef, ResolvedColumn, SketchType, UnresolvedColumn,
+    expr::BoundColumn, functions::FunctionEvaluator, null_lit, resolved_col, AggExpr,
+    ApproxPercentileParams, Column, Expr, ExprRef, LiteralValue, ResolvedColumn, SketchType,
 };
 use daft_logical_plan::FileInfos;
 use futures::{StreamExt, TryStreamExt};
@@ -381,7 +381,7 @@ impl RecordBatch {
         if predicate.is_empty() {
             Ok(self.clone())
         } else if predicate.len() == 1 {
-            let mask = self.eval_expression(predicate.first().unwrap().as_ref())?;
+            let mask = self.eval_expression(predicate.first().unwrap())?;
             self.mask_filter(&mask)
         } else {
             let mut expr = predicate
@@ -578,16 +578,17 @@ impl RecordBatch {
         }
     }
 
-    fn eval_expression(&self, expr: &Expr) -> DaftResult<Series> {
+    fn eval_expression(&self, expr: &ExprRef) -> DaftResult<Series> {
+        let expr = expr.clone().bind(&self.schema)?;
+
         let expected_field = expr.to_field(self.schema.as_ref())?;
-        let series = match expr {
+        let series = match expr.as_ref() {
             Expr::Alias(child, name) => Ok(self.eval_expression(child)?.rename(name)),
             Expr::Agg(agg_expr) => self.eval_agg_expression(agg_expr, None),
             Expr::Over(..) => Err(DaftError::ComputeError("Window expressions should be evaluated via the window operator.".to_string())),
             Expr::WindowFunction(..) => Err(DaftError::ComputeError("Window expressions cannot be directly evaluated. Please specify a window using \"over\".".to_string())),
             Expr::Cast(child, dtype) => self.eval_expression(child)?.cast(dtype),
-            // TODO: remove ability to evaluate on unresolved col once we fix all tests
-            Expr::Column(Column::Resolved(ResolvedColumn::Basic(name))) | Expr::Column(Column::Unresolved(UnresolvedColumn { name, plan_ref: PlanRef::Unqualified, plan_schema: None })) => self.get_column(name).cloned(),
+            Expr::Column(Column::Bound(BoundColumn { index, .. })) => Ok(self.columns[*index].clone()),
             Expr::Not(child) => !(self.eval_expression(child)?),
             Expr::IsNull(child) => self.eval_expression(child)?.is_null(),
             Expr::NotNull(child) => self.eval_expression(child)?.not_null(),
@@ -692,6 +693,9 @@ impl RecordBatch {
             )),
             Expr::Exists(_subquery) => Err(DaftError::ComputeError(
                 "EXISTS <SUBQUERY> should be optimized away before evaluation. This indicates a bug in the query optimizer.".to_string(),
+            )),
+            Expr::Column(Column::Resolved(ResolvedColumn::Basic(..))) => Err(DaftError::ComputeError(
+                "Resolved columns must be bound before execution and cannot be evaluated directly. This indicates a bug in the executor".to_string()
             )),
             Expr::Column(Column::Resolved(ResolvedColumn::OuterRef(..))) => Err(DaftError::ComputeError(
                 format!("Column {expr} could not be resolved. This indicates either that the column is referencing a different table from the one it is being used in, or a bug in the query optimizer."),

--- a/src/daft-schema/src/schema.rs
+++ b/src/daft-schema/src/schema.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    ops::Index,
     sync::Arc,
 };
 
@@ -68,15 +69,6 @@ impl Schema {
 
     pub fn to_struct(&self) -> DataType {
         DataType::Struct(self.fields.clone())
-    }
-
-    pub fn get_field_at_index(&self, index: usize) -> DaftResult<&Field> {
-        self.fields
-            .get(index)
-            .ok_or(DaftError::FieldNotFound(format!(
-                "Attempted to access field at out-of-bounds index {} in schema: {:?}",
-                index, self.fields
-            )))
     }
 
     pub fn fields(&self) -> &[Field] {
@@ -394,5 +386,13 @@ impl<'a> IntoIterator for &'a Schema {
 
     fn into_iter(self) -> Self::IntoIter {
         self.fields().iter()
+    }
+}
+
+impl Index<usize> for Schema {
+    type Output = Field;
+
+    fn index(&self, i: usize) -> &Self::Output {
+        &self.fields[i]
     }
 }

--- a/src/daft-sql/src/modules/aggs.rs
+++ b/src/daft-sql/src/modules/aggs.rs
@@ -81,7 +81,7 @@ fn handle_count(inputs: &[FunctionArg], planner: &SQLPlanner) -> SQLPlannerResul
         [FunctionArg::Unnamed(FunctionArgExpr::Wildcard)] => match &planner.current_plan {
             Some(plan) => {
                 let schema = plan.schema();
-                unresolved_col(schema.get_field_at_index(0)?.name.clone())
+                unresolved_col(schema[0].name.clone())
                     .count(daft_core::count_mode::CountMode::All)
                     .alias("count")
             }
@@ -95,7 +95,7 @@ fn handle_count(inputs: &[FunctionArg], planner: &SQLPlanner) -> SQLPlannerResul
                     if let Some(schema) =
                         plan.plan.clone().get_schema_for_alias(&ident.to_string())?
                     {
-                        unresolved_col(schema.get_field_at_index(0)?.name.clone())
+                        unresolved_col(schema[0].name.clone())
                             .count(daft_core::count_mode::CountMode::All)
                             .alias("count")
                     } else {


### PR DESCRIPTION
## Changes Made

Created a `BoundColumn` column variant that holds an ordinal/index and a field. 

This is not currently used anywhere except in RecordBatch for evaluating an expression. The plan is to move the binding step up the planning/execution pipeline, until it completely replaces the Resolved variant. That way, we can do this refactor incrementally and ensure that tests pass the whole time. See [the roadmap](https://github.com/Eventual-Inc/Daft/issues/4270) for more details

## Related Issues

#4270

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
