### PR TITLE
ci: compile release build with glibc 2.24

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -44,7 +44,6 @@ jobs:
     - uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
-      if: ${{ (inputs.os == 'macos') || (inputs.os == 'windows') }} # bun installed on linux in container during build step
     - run: pip install uv
     - run: uv pip install twine yq setuptools_scm
 
@@ -74,6 +73,12 @@ jobs:
           echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe -mtune=skylake" >> $GITHUB_ENV
         fi
 
+    - name: Build dashboard with Bun
+      working-directory: ./src/daft-dasboard/frontend
+      run: |
+        bun install
+        bun run build
+
     - name: Build wheels - Mac and Windows x86
       if: ${{ ((inputs.os == 'macos') || (inputs.os == 'windows')) && (inputs.arch == 'x86_64')  }}
       uses: PyO3/maturin-action@v1
@@ -89,10 +94,6 @@ jobs:
         manylinux: 2_24
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
-        before-script-linux: |
-          curl -fsSL https://bun.sh/install | bash
-          export BUN_INSTALL="$HOME/.bun"
-          export PATH="$BUN_INSTALL/bin:$PATH"
 
     - name: Build wheels - Linux aarch64
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
@@ -102,12 +103,7 @@ jobs:
         manylinux: 2_24
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
-        before-script-linux: |
-          export JEMALLOC_SYS_WITH_LG_PAGE=16
-          apt install -y unzip
-          curl -fsSL https://bun.sh/install | bash
-          export BUN_INSTALL="$HOME/.bun"
-          export PATH="$BUN_INSTALL/bin:$PATH"
+        before-script-linux: export JEMALLOC_SYS_WITH_LG_PAGE=16
 
     - name: Build wheels - Mac aarch64
       if: ${{ (inputs.os == 'macos') && (inputs.arch == 'aarch64')  }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -81,48 +81,20 @@ jobs:
         target: x86_64
         args: --profile release-lto --out dist
 
-    - name: Build wheels - Linux x86 (manylinux_2_28)
+    - name: Build wheels - Linux x86
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'x86_64') }}
       uses: PyO3/maturin-action@v1
       with:
         target: x86_64
-        manylinux: 2_28
+        manylinux: 2_24
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
         before-script-linux: |
-          dnf install -y perl-IPC-Cmd
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"
 
-    # - name: Build wheels - Linux aarch64 (manylinux_2_28)
-    #   if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
-    #   uses: PyO3/maturin-action@v1
-    #   with:
-    #     target: aarch64-unknown-linux-gnu
-    #     manylinux: 2_28
-    #     args: --profile release-lto --out dist
-    #     before-script-linux: |
-    #       export JEMALLOC_SYS_WITH_LG_PAGE=16
-    #       apt install -y unzip
-    #       curl -fsSL https://bun.sh/install | bash
-    #       export BUN_INSTALL="$HOME/.bun"
-    #       export PATH="$BUN_INSTALL/bin:$PATH"
-
-    # - name: Build wheels - Linux x86 (manylinux_2_24)
-    #   if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'x86_64') }}
-    #   uses: PyO3/maturin-action@v1
-    #   with:
-    #     target: x86_64
-    #     manylinux: 2_24
-    #     # only produce sdist for linux x86 to avoid multiple copies
-    #     args: --profile release-lto --out dist --sdist
-    #     before-script-linux: |
-    #       curl -fsSL https://bun.sh/install | bash
-    #       export BUN_INSTALL="$HOME/.bun"
-    #       export PATH="$BUN_INSTALL/bin:$PATH"
-
-    - name: Build wheels - Linux aarch64 (manylinux_2_24)
+    - name: Build wheels - Linux aarch64
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
       uses: PyO3/maturin-action@v1
       with:

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -74,7 +74,7 @@ jobs:
         fi
 
     - name: Build dashboard with Bun
-      working-directory: ./src/daft-dasboard/frontend
+      working-directory: ./src/daft-dashboard/frontend
       run: |
         bun install
         bun run build

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -81,27 +81,55 @@ jobs:
         target: x86_64
         args: --profile release-lto --out dist
 
-    - name: Build wheels - Linux x86
+    - name: Build wheels - Linux x86 (manylinux_2_28)
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'x86_64') }}
       uses: PyO3/maturin-action@v1
       with:
         target: x86_64
-        manylinux: 2_17
+        manylinux: 2_28
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
         before-script-linux: |
-          yum install -y perl-IPC-Cmd
+          dnf install -y perl-IPC-Cmd
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"
 
-    - name: Build wheels - Linux aarch64
+    - name: Build wheels - Linux aarch64 (manylinux_2_28)
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
       uses: PyO3/maturin-action@v1
       with:
         target: aarch64-unknown-linux-gnu
-        manylinux: 2_17
+        manylinux: 2_28
         args: --profile release-lto --out dist
+        before-script-linux: |
+          export JEMALLOC_SYS_WITH_LG_PAGE=16
+          apt install -y unzip
+          curl -fsSL https://bun.sh/install | bash
+          export BUN_INSTALL="$HOME/.bun"
+          export PATH="$BUN_INSTALL/bin:$PATH"
+
+    - name: Build wheels - Linux x86 (manylinux_2_24)
+      if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'x86_64') }}
+      uses: PyO3/maturin-action@v1
+      with:
+        target: x86_64
+        manylinux: 2_24
+        # only produce sdist for linux x86 to avoid multiple copies
+        args: --profile release-lto --out dist --sdist
+        before-script-linux: |
+          curl -fsSL https://bun.sh/install | bash
+          export BUN_INSTALL="$HOME/.bun"
+          export PATH="$BUN_INSTALL/bin:$PATH"
+
+    - name: Build wheels - Linux aarch64 (manylinux_2_24)
+      if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
+      uses: PyO3/maturin-action@v1
+      with:
+        target: aarch64-unknown-linux-gnu
+        manylinux: 2_24
+        # only produce sdist for linux x86 to avoid multiple copies
+        args: --profile release-lto --out dist --sdist
         before-script-linux: |
           export JEMALLOC_SYS_WITH_LG_PAGE=16
           apt install -y unzip

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -95,32 +95,32 @@ jobs:
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"
 
-    - name: Build wheels - Linux aarch64 (manylinux_2_28)
-      if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
-      uses: PyO3/maturin-action@v1
-      with:
-        target: aarch64-unknown-linux-gnu
-        manylinux: 2_28
-        args: --profile release-lto --out dist
-        before-script-linux: |
-          export JEMALLOC_SYS_WITH_LG_PAGE=16
-          apt install -y unzip
-          curl -fsSL https://bun.sh/install | bash
-          export BUN_INSTALL="$HOME/.bun"
-          export PATH="$BUN_INSTALL/bin:$PATH"
+    # - name: Build wheels - Linux aarch64 (manylinux_2_28)
+    #   if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
+    #   uses: PyO3/maturin-action@v1
+    #   with:
+    #     target: aarch64-unknown-linux-gnu
+    #     manylinux: 2_28
+    #     args: --profile release-lto --out dist
+    #     before-script-linux: |
+    #       export JEMALLOC_SYS_WITH_LG_PAGE=16
+    #       apt install -y unzip
+    #       curl -fsSL https://bun.sh/install | bash
+    #       export BUN_INSTALL="$HOME/.bun"
+    #       export PATH="$BUN_INSTALL/bin:$PATH"
 
-    - name: Build wheels - Linux x86 (manylinux_2_24)
-      if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'x86_64') }}
-      uses: PyO3/maturin-action@v1
-      with:
-        target: x86_64
-        manylinux: 2_24
-        # only produce sdist for linux x86 to avoid multiple copies
-        args: --profile release-lto --out dist --sdist
-        before-script-linux: |
-          curl -fsSL https://bun.sh/install | bash
-          export BUN_INSTALL="$HOME/.bun"
-          export PATH="$BUN_INSTALL/bin:$PATH"
+    # - name: Build wheels - Linux x86 (manylinux_2_24)
+    #   if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'x86_64') }}
+    #   uses: PyO3/maturin-action@v1
+    #   with:
+    #     target: x86_64
+    #     manylinux: 2_24
+    #     # only produce sdist for linux x86 to avoid multiple copies
+    #     args: --profile release-lto --out dist --sdist
+    #     before-script-linux: |
+    #       curl -fsSL https://bun.sh/install | bash
+    #       export BUN_INSTALL="$HOME/.bun"
+    #       export PATH="$BUN_INSTALL/bin:$PATH"
 
     - name: Build wheels - Linux aarch64 (manylinux_2_24)
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -86,11 +86,11 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         target: x86_64
-        manylinux: 2_28
+        manylinux: 2_17
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
         before-script-linux: |
-          dnf install -y perl-IPC-Cmd
+          yum install -y perl-IPC-Cmd
           curl -fsSL https://bun.sh/install | bash
           export BUN_INSTALL="$HOME/.bun"
           export PATH="$BUN_INSTALL/bin:$PATH"
@@ -100,7 +100,7 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         target: aarch64-unknown-linux-gnu
-        manylinux: 2_28
+        manylinux: 2_17
         args: --profile release-lto --out dist
         before-script-linux: |
           export JEMALLOC_SYS_WITH_LG_PAGE=16

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -185,6 +185,12 @@ jobs:
       with:
         bun-version: latest
 
+    - name: Build dashboard with Bun
+      working-directory: ./src/daft-dashboard/frontend
+      run: |
+        bun install
+        bun run build
+
     # NOTE: we don't build with all the actual release optimizations to avoid hellish CI times
     - name: Build wheels
       run: maturin build --release --compatibility linux --out dist
@@ -672,6 +678,11 @@ jobs:
     - name: Install dependencies
       run: |
         uv pip install -r requirements-dev.txt
+    - name: Build dashboard with Bun
+      working-directory: ./src/daft-dashboard/frontend
+      run: |
+        bun install
+        bun run build
     - name: Build Rust Library
       run: |
         source activate

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu]
+        os: [ubuntu, macos]
         arch: [x86_64, aarch64]
         lts: [false]
         use_old_name: [false, true]

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -53,14 +53,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos, windows]
+        os: [ubuntu]
         arch: [x86_64, aarch64]
         lts: [false]
         use_old_name: [false, true]
-
-        exclude:
-        - os: windows
-          arch: aarch64
 
   publish:
     name: Publish wheels to S3

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -53,10 +53,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
+        os: [ubuntu, macos, windows]
         arch: [x86_64, aarch64]
         lts: [false]
         use_old_name: [false, true]
+
+        exclude:
+        - os: windows
+          arch: aarch64
 
   publish:
     name: Publish wheels to S3

--- a/src/daft-dashboard/build.rs
+++ b/src/daft-dashboard/build.rs
@@ -7,9 +7,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let frontend_dir = std::env::var("CARGO_MANIFEST_DIR")? + "/frontend/out";
 
     if !std::path::Path::new(&frontend_dir).is_dir() {
-        println!("Dashboard assets not found in {frontend_dir}, skipping dashboard build.");
-        println!("To build dashboard assets: `bun run build` in src/daft-dashboard/frontend.");
-        return Ok(());
+        if cfg!(debug_assertions) {
+            println!("Dashboard assets not found in {frontend_dir}, skipping dashboard build.");
+            println!("To build dashboard assets: `bun run build` in src/daft-dashboard/frontend.");
+            return Ok(());
+        } else {
+            panic!("Dashboard assets are required for release builds");
+        }
     }
 
     // if there's anything in the output directory, remove it

--- a/src/daft-dashboard/build.rs
+++ b/src/daft-dashboard/build.rs
@@ -1,62 +1,25 @@
-use std::process::Command;
+use std::path::Path;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("cargo:rerun-if-changed=frontend/src/");
-    println!("cargo:rerun-if-changed=frontend/bun.lockb");
     let out_dir = std::env::var("OUT_DIR")?;
 
     // always set the env var so that the include_dir! macro doesn't panic
     println!("cargo:rustc-env=DASHBOARD_ASSETS_DIR={}", out_dir);
 
-    // Check if bun is installed
-    let bun_available = Command::new("bun")
-        .arg("--version")
-        .output()
-        .map(|_| true)
-        .unwrap_or(false);
-
-    // if bun is not available, we can't build the frontend assets
-    // so we just print a warning and return
-    // but if we're in release mode, we panic
-    if !bun_available {
-        if cfg!(debug_assertions) {
-            println!("cargo:warning=Bun not found, skipping dashboard frontend assets");
-            return Ok(());
-        } else {
-            panic!("Bun is required for release builds");
-        }
-    }
-
-    // Install dependencies
-    let install_status = Command::new("bun")
-        .current_dir("./frontend")
-        .args(["install"])
-        .status()?;
-
-    assert!(install_status.success(), "Failed to install dependencies");
-
-    // Run `bun run build`
-    let mut cmd = Command::new("bun");
-    let status = cmd.current_dir("./frontend");
-
-    let status = if cfg!(debug_assertions) {
-        status.args(["run", "build", "--no-lint", "--no-mangling"])
-    } else {
-        status.args(["run", "build"])
-    };
-    let status = status.status()?;
-
-    assert!(status.success(), "Failed to build frontend assets");
-
     let frontend_dir = std::env::var("CARGO_MANIFEST_DIR")? + "/frontend/out";
 
+    if !Path::new(&frontend_dir).is_dir() {
+        println!("Dashboard assets not found in {frontend_dir}, skipping dashboard build.");
+        println!("To build dashboard assets: `bun run build` in src/daft-dashboard/frontend.");
+        return Ok(());
+    }
+
     // if there's anything in the output directory, remove it
-    if std::fs::metadata(&out_dir).is_ok() {
+    if Path::new(&out_dir).is_dir() {
         std::fs::remove_dir_all(&out_dir)?;
     }
 
     // move the frontend assets to the output directory
     std::fs::rename(frontend_dir, out_dir)?;
-    assert!(status.success(), "Failed to build frontend assets");
     Ok(())
 }

--- a/src/daft-dashboard/build.rs
+++ b/src/daft-dashboard/build.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = std::env::var("OUT_DIR")?;
 
@@ -8,14 +6,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let frontend_dir = std::env::var("CARGO_MANIFEST_DIR")? + "/frontend/out";
 
-    if !Path::new(&frontend_dir).is_dir() {
+    if !std::path::Path::new(&frontend_dir).is_dir() {
         println!("Dashboard assets not found in {frontend_dir}, skipping dashboard build.");
         println!("To build dashboard assets: `bun run build` in src/daft-dashboard/frontend.");
         return Ok(());
     }
 
     // if there's anything in the output directory, remove it
-    if Path::new(&out_dir).is_dir() {
+    if std::fs::exists(&out_dir)? {
         std::fs::remove_dir_all(&out_dir)?;
     }
 


### PR DESCRIPTION
## Changes Made

Downgrades our minimum supported glibc version from 2.28 to 2.24 by changing the manylinux Docker image. Also move bun build out of the rust build

## Related Issues

Requested by Amazon since they use Amazon Linux 2, which has glibc 2.26

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
