### PR TITLE
feat: Flotilla running stage logic

### DIFF
--- a/src/daft-distributed/src/pipeline_node/collect.rs
+++ b/src/daft-distributed/src/pipeline_node/collect.rs
@@ -61,7 +61,7 @@ impl DistributedPipelineNode for CollectNode {
     }
 
     fn start(&mut self, stage_context: &mut StageContext) -> RunningPipelineNode {
-        let task_dispatcher_handle = stage_context.task_dispatcher_handle.clone();
+        let task_dispatcher_handle = stage_context.get_task_dispatcher_handle();
         let input_node = if let Some(mut input_node) = self.children.pop() {
             assert!(self.children.is_empty());
             let input_running_node = input_node.start(stage_context);
@@ -77,7 +77,7 @@ impl DistributedPipelineNode for CollectNode {
             input_node,
             result_tx,
         );
-        stage_context.joinset.spawn(execution_loop);
+        stage_context.spawn_task_on_joinset(execution_loop);
 
         RunningPipelineNode::new(result_rx)
     }

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -64,7 +64,7 @@ impl DistributedPipelineNode for LimitNode {
     }
 
     fn start(&mut self, stage_context: &mut StageContext) -> RunningPipelineNode {
-        let task_dispatcher_handle = stage_context.task_dispatcher_handle.clone();
+        let task_dispatcher_handle = stage_context.get_task_dispatcher_handle();
         let input_node = if let Some(mut input_node) = self.children.pop() {
             assert!(self.children.is_empty());
             let input_running_node = input_node.start(stage_context);
@@ -80,7 +80,7 @@ impl DistributedPipelineNode for LimitNode {
             std::mem::take(&mut self.input_psets),
             result_tx,
         );
-        stage_context.joinset.spawn(execution_loop);
+        stage_context.spawn_task_on_joinset(execution_loop);
 
         RunningPipelineNode::new(result_rx)
     }

--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -17,7 +17,7 @@ use translate::translate_pipeline_plan_to_local_physical_plans;
 
 use crate::{
     channel::Receiver,
-    scheduling::task::{SwordfishTask, SwordfishTaskResultHandle},
+    scheduling::{dispatcher::SubmittedTask, task::SwordfishTask},
     stage::StageContext,
 };
 
@@ -63,7 +63,7 @@ impl Stream for RunningPipelineNode {
 pub(crate) enum PipelineOutput {
     Materialized(PartitionRef),
     Task(SwordfishTask),
-    Running(Box<dyn SwordfishTaskResultHandle>),
+    Running(SubmittedTask),
 }
 
 #[allow(dead_code)]

--- a/src/daft-distributed/src/stage/running_stage.rs
+++ b/src/daft-distributed/src/stage/running_stage.rs
@@ -73,7 +73,9 @@ impl Stream for RunningStage {
                 RunningStageState::Finishing(joinset) => match joinset.poll_join_next(cx) {
                     // Received a result from the joinset
                     Poll::Ready(Some(result)) => match result {
-                        Ok(Ok(())) => Some(Poll::Ready(None)),
+                        // Joinset finished a task successfully, return None to poll again
+                        Ok(Ok(())) => None,
+                        // Joinset finished a task with an error, return the error
                         Ok(Err(e)) => Some(Poll::Ready(Some(Err(e)))),
                         Err(e) => Some(Poll::Ready(Some(Err(DaftError::External(e.into()))))),
                     },

--- a/src/daft-distributed/src/stage/running_stage.rs
+++ b/src/daft-distributed/src/stage/running_stage.rs
@@ -1,0 +1,182 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use common_error::{DaftError, DaftResult};
+use common_partitioning::PartitionRef;
+use futures::{Stream, StreamExt};
+
+use super::StageContext;
+use crate::{
+    channel::{create_channel, Receiver},
+    pipeline_node::{PipelineOutput, RunningPipelineNode},
+    runtime::JoinSet,
+    scheduling::dispatcher::{SubmittedTask, TaskDispatcherHandle},
+};
+
+enum RunningStageState {
+    // Running: Stage is running and we are waiting for the result from the receiver
+    Running(Receiver<PartitionRef>, Option<StageContext>),
+    // Finishing: No more results will be produced, and we are waiting for the joinset to finish
+    Finishing(JoinSet<DaftResult<()>>),
+    // Finished: No more results will be produced, and the joinset has finished
+    Finished,
+}
+
+#[allow(dead_code)]
+pub(crate) struct RunningStage {
+    running_stage_state: RunningStageState,
+}
+
+impl RunningStage {
+    pub fn new(result_materializer: Receiver<PartitionRef>, stage_context: StageContext) -> Self {
+        Self {
+            running_stage_state: RunningStageState::Running(
+                result_materializer,
+                Some(stage_context),
+            ),
+        }
+    }
+}
+
+impl Stream for RunningStage {
+    type Item = DaftResult<PartitionRef>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        fn poll_inner(
+            state: &mut RunningStageState,
+            cx: &mut Context<'_>,
+        ) -> Option<Poll<Option<DaftResult<PartitionRef>>>> {
+            match state {
+                // Running: Stage is running and we are waiting for the result from the receiver
+                RunningStageState::Running(result_receiver, stage_context) => {
+                    match result_receiver.poll_recv(cx) {
+                        // Received a result from the receiver
+                        Poll::Ready(Some(result)) => Some(Poll::Ready(Some(Ok(result)))),
+                        // No more results will be produced, transition to finishing state where we wait for the joinset to finish
+                        Poll::Ready(None) => {
+                            let (task_dispatcher_handle, joinset) = stage_context
+                                .take()
+                                .expect("StageContext should exist")
+                                .into_inner();
+                            // No more tasks to dispatch, drop the handle
+                            drop(task_dispatcher_handle);
+                            *state = RunningStageState::Finishing(joinset);
+                            None
+                        }
+                        // Still waiting for a result from the receiver
+                        Poll::Pending => Some(Poll::Pending),
+                    }
+                }
+                // Finishing: No more results will be produced, and we are waiting for the joinset to finish
+                RunningStageState::Finishing(joinset) => match joinset.poll_join_next(cx) {
+                    // Received a result from the joinset
+                    Poll::Ready(Some(result)) => match result {
+                        Ok(Ok(())) => Some(Poll::Ready(None)),
+                        Ok(Err(e)) => Some(Poll::Ready(Some(Err(e)))),
+                        Err(e) => Some(Poll::Ready(Some(Err(DaftError::External(e.into()))))),
+                    },
+                    // Joinset is empty, transition to finished state
+                    Poll::Ready(None) => {
+                        *state = RunningStageState::Finished;
+                        None
+                    }
+                    // Still waiting for a result from the joinset
+                    Poll::Pending => Some(Poll::Pending),
+                },
+                // Finished: No more results will be produced, and the joinset has finished
+                RunningStageState::Finished => Some(Poll::Ready(None)),
+            }
+        }
+
+        loop {
+            if let Some(poll) = poll_inner(&mut self.running_stage_state, cx) {
+                return poll;
+            }
+        }
+    }
+}
+
+pub(crate) fn materialize_stage_results(
+    running_node: RunningPipelineNode,
+    stage_context: &mut StageContext,
+) -> DaftResult<Receiver<PartitionRef>> {
+    // This task is responsible for submitting any unsubmitted tasks
+    fn spawn_task_finalizer(
+        joinset: &mut JoinSet<DaftResult<()>>,
+        mut running_node: RunningPipelineNode,
+        task_dispatcher_handle: TaskDispatcherHandle,
+    ) -> DaftResult<Receiver<FinalizedTask>> {
+        let (tx, rx) = create_channel(1);
+        joinset.spawn(async move {
+            while let Some(pipeline_result) = running_node.next().await {
+                let pipeline_output = pipeline_result?;
+                let to_send = match pipeline_output {
+                    // If the pipeline output is a materialized partition, we can just send it through the channel
+                    PipelineOutput::Materialized(partition) => {
+                        FinalizedTask::Materialized(partition)
+                    }
+                    // If the pipeline output is a task, we need to submit it to the task dispatcher
+                    PipelineOutput::Task(task) => {
+                        let task_result_handle = task_dispatcher_handle.submit_task(task).await?;
+                        FinalizedTask::Running(task_result_handle)
+                    }
+                    // If the task is already running, we can just send it through the channel
+                    PipelineOutput::Running(submitted_task) => {
+                        FinalizedTask::Running(submitted_task)
+                    }
+                };
+                if tx.send(to_send).await.is_err() {
+                    break;
+                }
+            }
+            Ok(())
+        });
+        Ok(rx)
+    }
+
+    // This task is responsible for materializing the results of finalized tasks
+    fn spawn_task_materializer(
+        joinset: &mut JoinSet<DaftResult<()>>,
+        mut finalized_tasks_receiver: Receiver<FinalizedTask>,
+    ) -> DaftResult<Receiver<PartitionRef>> {
+        let (tx, rx) = create_channel(1);
+        joinset.spawn(async move {
+            while let Some(finalized_task) = finalized_tasks_receiver.recv().await {
+                match finalized_task {
+                    // If the pipeline output is a materialized partition, we can just send it through the channel
+                    FinalizedTask::Materialized(partition) => {
+                        if tx.send(partition).await.is_err() {
+                            break;
+                        }
+                    }
+                    FinalizedTask::Running(submitted_task) => {
+                        if let Some(result) = submitted_task.await {
+                            if tx.send(result?).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            Ok(())
+        });
+        Ok(rx)
+    }
+
+    enum FinalizedTask {
+        Materialized(PartitionRef),
+        Running(SubmittedTask),
+    }
+
+    let task_dispatcher_handle = stage_context.get_task_dispatcher_handle();
+    let finalized_tasks_receiver = spawn_task_finalizer(
+        &mut stage_context.joinset,
+        running_node,
+        task_dispatcher_handle,
+    )?;
+    let materialized_results_receiver =
+        spawn_task_materializer(&mut stage_context.joinset, finalized_tasks_receiver)?;
+    Ok(materialized_results_receiver)
+}


### PR DESCRIPTION
## Changes Made

This PR implements running stages. There are 2 parts:

### Materializing the outputs of a stage's pipeline. 

The pipeline output can be either: `materialized`, `running`, or an unsubmitted `task`. First, we need to submit any unsubmitted tasks. Then, we need to materialize the results of the tasks. We can do this concurrently by spawning a task for both submitting and materializing.

### Yielding materialized results from a stage

We do this by implementing `stream` on running_stage. First, we yield any result from the result receiver. Once the receiver is exhausted, we cleanup all spawned tasks from this stage by awaiting the joinset. This also allows us to surface any errors. If in the case the running_stage is dropped, the joinset should be dropped as well and all tasks will be cancelled, allowing for graceful shutdown.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
