### PR TITLE
docs: Fix broken link to SQL reference

### DIFF
--- a/docs/sql_overview.md
+++ b/docs/sql_overview.md
@@ -189,7 +189,7 @@ However, unlike the Python Expression API which encourages method-chaining (e.g.
 
 !!! note "Note"
 
-    A full catalog of the available SQL Functions in Daft is available in [`SQL Reference`](api/sql.md).
+    A full catalog of the available SQL Functions in Daft is available in [`SQL Reference`](sql/index.md).
 
     Note that it closely mirrors the Python API, with some function naming differences vs the available Python methods. We also have some aliased functions for ANSI SQL-compliance or familiarity to users coming from other common SQL dialects such as PostgreSQL and SparkSQL to easily find their functionality.
 


### PR DESCRIPTION
## Changes Made

There was an incorrect link to `api/sql.md` which doesn't exist. Changed this to `sql/index.md`.

## Checklist
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
