### PR TITLE
ci: add bun build step to CI profiling workflow

### DIFF
--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -44,6 +44,12 @@ jobs:
     - uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
+    - name: Build dashboard with Bun
+      working-directory: ./src/daft-dashboard/frontend
+      run: |
+        bun install
+        bun run build
+
     - name: Build Rust Library
       run: |
         source activate


### PR DESCRIPTION
## Changes Made

This should fix the CI issue on main

## Related Issues

none

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
