### PR TITLE
ci: Fix uv issues for nightly TPCH benchmarks

### DIFF
--- a/.github/workflows/benchmark-distributed-tpch.yml
+++ b/.github/workflows/benchmark-distributed-tpch.yml
@@ -75,6 +75,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
+        version: "0.6.17"
     - name: Install Daft and dev dependencies
       run: |
         rm -rf daft

--- a/.github/workflows/benchmark-local-tpch.yml
+++ b/.github/workflows/benchmark-local-tpch.yml
@@ -58,6 +58,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
+        version: "0.6.17"
     - name: Install Daft and dev dependencies
       run: |
         rm -rf daft


### PR DESCRIPTION
## Changes Made

uv currently has issues with our nightly tests (see https://github.com/astral-sh/uv/issues/13248). Temporarily fix this by using an earlier version of uv