### PR TITLE
ci: add bun run build to property based testing

### DIFF
--- a/.github/workflows/property-based-tests.yml
+++ b/.github/workflows/property-based-tests.yml
@@ -44,6 +44,11 @@ jobs:
     - uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
+    - name: Build dashboard with Bun
+      working-directory: ./src/daft-dashboard/frontend
+      run: |
+        bun install
+        bun run build
     - name: Build Rust Library
       run: |
         source activate


### PR DESCRIPTION
## Changes Made

fix property based test by adding bun build for dashboard

## Related Issues

none

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
