### PR TITLE
ci: Increase timeout for the broken link checker

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Check getdaft.io
       uses: nick-fields/retry@v3
       with:
-        timeout_minutes: 10
+        timeout_minutes: 30
         retry_wait_seconds: 60
         max_attempts: 3
         retry_on: error


### PR DESCRIPTION
## Changes Made

10 mins is not sufficient.
