### PR TITLE
docs: Specify what script the debug config uses in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ This file is usually found in the `.vscode` folder of your project root. See the
 
 2. Set breakpoints in any `.rs` or `.py` file.
 
-3. In the `Run and Debug` panel on the left, select `Debug Rust/Python` from the drop-down menu on top and click the `Start Debugging` button.
+3. In the `Run and Debug` panel on the left, select `Debug Rust/Python` from the drop-down menu on top and click the `Start Debugging` button. This will start a debugging session using the file that is currently opened in the VSCode editor.
 
 At this point, your debugger should stop on breakpoints in any .rs file located within the codebase.
 

--- a/tools/attach_debugger.py
+++ b/tools/attach_debugger.py
@@ -24,7 +24,7 @@ def launch_debugging() -> None:
         msg = (
             "launch.py is not meant to be executed directly; please use the `Python: "
             "Debug Rust` debugging configuration to run a python script that uses the "
-            "polars library."
+            "daft library."
         )
         raise RuntimeError(msg)
 


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
The docs for setting up the debugger in `CONTRIBUTING.md` don't specify what python code it will debug. I quickly figured it out after skimming the given `launch.json` and `tools/attach_debugger.py`, but I can imagine others not figuring it out very quickly. This PR adds that small detail to the docs to make it immediately clear.

```json
    "configurations": [
        {
            "name": "Debug Rust/Python",
            ...
            "args": [
                "${file}"
            ],
            ...
        },
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

