### PR TITLE
EXPERIMENT: Row group-parallel parquet writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,6 +2621,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
  "tokio",
  "xz2",
  "zstd 0.13.3",
- "zstd-safe 7.2.4",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -2601,6 +2601,7 @@ dependencies = [
 name = "daft-recordbatch"
 version = "0.3.0-dev0"
 dependencies = [
+ "arrow-array",
  "arrow2",
  "comfy-table 7.1.4",
  "common-arrow-ffi",
@@ -2825,7 +2826,9 @@ dependencies = [
  "daft-logical-plan",
  "daft-micropartition",
  "daft-recordbatch",
+ "parquet",
  "pyo3",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -4174,6 +4177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "inventory"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4606,6 +4615,15 @@ name = "lz4_flex"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a8cbbb2831780bc3b9c15a41f5b49222ef756b6730a95f3decfdd15903eb5a3"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash",
 ]
@@ -5056,6 +5074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5128,6 +5155,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet"
+version = "54.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88838dca3b84d41444a0341b19f347e8098a3898b0f21536654b8b799e11abd"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.22.1",
+ "brotli 7.0.0",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.15.2",
+ "lz4_flex 0.11.3",
+ "num",
+ "num-bigint 0.4.6",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap 1.1.1",
+ "thrift",
+ "twox-hash",
+ "zstd 0.13.3",
+ "zstd-sys",
+]
+
+[[package]]
 name = "parquet-format-safe"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5148,7 +5209,7 @@ dependencies = [
  "futures",
  "indexmap 2.8.0",
  "lz4",
- "lz4_flex",
+ "lz4_flex 0.9.5",
  "parquet-format-safe",
  "rand 0.8.5",
  "seq-macro",
@@ -6939,6 +7000,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8309,7 +8381,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
- "zstd-safe 7.2.4",
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -8324,18 +8396,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ dependencies = [
 name = "common-error"
 version = "0.3.0-dev0"
 dependencies = [
+ "arrow-schema",
  "arrow2",
  "parquet2",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,14 +2823,17 @@ dependencies = [
  "common-daft-config",
  "common-error",
  "common-file-formats",
+ "common-runtime",
  "daft-core",
  "daft-dsl",
  "daft-io",
  "daft-logical-plan",
  "daft-micropartition",
  "daft-recordbatch",
+ "futures",
  "parquet",
  "pyo3",
+ "tokio",
  "uuid 1.16.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,6 +2818,7 @@ dependencies = [
 name = "daft-writers"
 version = "0.3.0-dev0"
 dependencies = [
+ "arrow-schema",
  "arrow2",
  "common-daft-config",
  "common-error",

--- a/src/arrow2/src/datatypes/mod.rs
+++ b/src/arrow2/src/datatypes/mod.rs
@@ -465,6 +465,14 @@ impl From<arrow_schema::IntervalUnit> for IntervalUnit {
     }
 }
 
+#[cfg(feature = "arrow")]
+impl From<Schema> for arrow_schema::Schema {
+    fn from(schema: Schema) -> Self {
+        let fields: Vec<arrow_schema::Field> = schema.fields.into_iter().map(|f| f.into()).collect();
+        arrow_schema::Schema::new(fields)
+    }
+}
+
 impl DataType {
     /// the [`PhysicalType`] of this [`DataType`].
     pub fn to_physical_type(&self) -> PhysicalType {

--- a/src/arrow2/src/datatypes/schema.rs
+++ b/src/arrow2/src/datatypes/schema.rs
@@ -46,6 +46,11 @@ impl Schema {
             metadata: self.metadata,
         }
     }
+
+    pub fn to_arrow_rs_schema(&self) -> arrow_schema::Schema {
+        let fields: Vec<arrow_schema::Field> = self.fields.clone().into_iter().map(|f| f.into()).collect();
+        arrow_schema::Schema::new(fields)
+    }
 }
 
 impl From<Vec<Field>> for Schema {

--- a/src/arrow2/src/datatypes/schema.rs
+++ b/src/arrow2/src/datatypes/schema.rs
@@ -46,11 +46,6 @@ impl Schema {
             metadata: self.metadata,
         }
     }
-
-    pub fn to_arrow_rs_schema(&self) -> arrow_schema::Schema {
-        let fields: Vec<arrow_schema::Field> = self.fields.clone().into_iter().map(|f| f.into()).collect();
-        arrow_schema::Schema::new(fields)
-    }
 }
 
 impl From<Vec<Field>> for Schema {

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -64,6 +64,7 @@ pub struct DaftExecutionConfig {
     pub flight_shuffle_dirs: Vec<String>,
     pub enable_ray_tracing: bool,
     pub scantask_splitting_level: i32,
+    pub native_parquet_writer: bool,
 }
 
 impl Default for DaftExecutionConfig {
@@ -95,6 +96,7 @@ impl Default for DaftExecutionConfig {
             flight_shuffle_dirs: vec!["/tmp".to_string()],
             enable_ray_tracing: false,
             scantask_splitting_level: 1,
+            native_parquet_writer: true,
         }
     }
 }
@@ -135,6 +137,12 @@ impl DaftExecutionConfig {
         let enable_aggressive_scantask_splitting_env_var_name = "DAFT_SCANTASK_SPLITTING_LEVEL";
         if let Ok(val) = std::env::var(enable_aggressive_scantask_splitting_env_var_name) {
             cfg.scantask_splitting_level = val.parse::<i32>().unwrap_or(0);
+        }
+        let native_parquet_writer_env_var_name = "DAFT_NATIVE_PARQUET_WRITER";
+        if let Ok(val) = std::env::var(native_parquet_writer_env_var_name)
+            && matches!(val.trim().to_lowercase().as_str(), "1" | "true")
+        {
+            cfg.native_parquet_writer = true;
         }
         cfg
     }

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -140,9 +140,9 @@ impl DaftExecutionConfig {
         }
         let native_parquet_writer_env_var_name = "DAFT_NATIVE_PARQUET_WRITER";
         if let Ok(val) = std::env::var(native_parquet_writer_env_var_name)
-            && matches!(val.trim().to_lowercase().as_str(), "1" | "true")
+            && matches!(val.trim().to_lowercase().as_str(), "0" | "false")
         {
-            cfg.native_parquet_writer = true;
+            cfg.native_parquet_writer = false;
         }
         cfg
     }

--- a/src/common/error/Cargo.toml
+++ b/src/common/error/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+arrow-schema = {version = "54.2.1", optional = true}
 arrow2 = {workspace = true, features = ["io_parquet"]}
 pyo3 = {workspace = true, optional = true}
 regex = {workspace = true}
@@ -9,6 +10,7 @@ thiserror = {workspace = true}
 parquet2 = {workspace = true}
 
 [features]
+arrow = ["arrow2/arrow", "dep:arrow-schema"]
 python = ["dep:pyo3"]
 
 [lints]

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -17,6 +17,9 @@ pub enum DaftError {
     ComputeError(String),
     #[error("DaftError::ArrowError {0}")]
     ArrowError(arrow2::error::Error),
+    #[cfg(feature = "arrow")]
+    #[error("DaftError::ArrowRsError")]
+    ArrowRsError(arrow_schema::ArrowError),
     #[error("DaftError::ValueError {0}")]
     ValueError(String),
     #[cfg(feature = "python")]

--- a/src/common/error/src/error.rs
+++ b/src/common/error/src/error.rs
@@ -18,8 +18,13 @@ pub enum DaftError {
     #[error("DaftError::ArrowError {0}")]
     ArrowError(arrow2::error::Error),
     #[cfg(feature = "arrow")]
-    #[error("DaftError::ArrowRsError")]
-    ArrowRsError(arrow_schema::ArrowError),
+    #[error("DaftError::ArrowRsError {0}")]
+    ArrowRsError(#[from] arrow_schema::ArrowError),
+    // TODO(desmond): We can't currently implement this as a From<parquet::errors::ParquetError>
+    // because this results in infinite nesting of types in `fixed_size_binary_op` in arithmetic.rs.
+    #[cfg(feature = "arrow")]
+    #[error("DaftError::ParquetError {0}")]
+    ParquetError(String),
     #[error("DaftError::ValueError {0}")]
     ValueError(String),
     #[cfg(feature = "python")]

--- a/src/common/runtime/src/lib.rs
+++ b/src/common/runtime/src/lib.rs
@@ -124,14 +124,17 @@ impl Runtime {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
+        println!("Blocking on future");
         let (tx, rx) = oneshot::channel();
         let pool_type = self.pool_type.clone();
+        println!("Spawning task");
         let _join_handle = self.spawn(async move {
             let task_output = Self::execute_task(future, pool_type).await;
             if tx.send(task_output).is_err() {
                 log::warn!("Spawned task output ignored: receiver dropped");
             }
         });
+        println!("Waiting for task to complete");
         rx.recv().expect("Spawned task transmitter dropped")
     }
 

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -676,7 +676,7 @@ pub fn physical_plan_to_pipeline(
             ..
         }) => {
             let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
-            let writer_factory = make_physical_writer_factory(file_info, cfg);
+            let writer_factory = make_physical_writer_factory(file_info, input.schema(), cfg);
             let write_format = match (file_info.file_format, file_info.partition_cols.is_some()) {
                 (FileFormat::Parquet, true) => WriteFormat::PartitionedParquet,
                 (FileFormat::Parquet, false) => WriteFormat::Parquet,

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -567,10 +567,7 @@ impl MicroPartition {
     ///
     /// "Reading if necessary" means I/O operations only occur for unloaded data,
     /// optimizing performance by avoiding redundant reads.
-    pub(crate) fn tables_or_read(
-        &self,
-        io_stats: IOStatsRef,
-    ) -> crate::Result<Arc<Vec<RecordBatch>>> {
+    pub fn tables_or_read(&self, io_stats: IOStatsRef) -> crate::Result<Arc<Vec<RecordBatch>>> {
         let mut guard = self.state.lock().unwrap();
         match &*guard {
             TableState::Unloaded(scan_task) => {

--- a/src/daft-recordbatch/Cargo.toml
+++ b/src/daft-recordbatch/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+arrow-array = {version = "54.2.1"}
 arrow2 = {workspace = true}
 comfy-table = {workspace = true}
 common-arrow-ffi = {path = "../common/arrow-ffi", default-features = false}

--- a/src/daft-recordbatch/Cargo.toml
+++ b/src/daft-recordbatch/Cargo.toml
@@ -18,6 +18,7 @@ pyo3 = {workspace = true, optional = true}
 rand = {workspace = true}
 serde = {workspace = true}
 serde_json = {workspace = true}
+urlencoding = "2.1.3"
 
 [features]
 arrow = ["arrow2/arrow"]

--- a/src/daft-recordbatch/Cargo.toml
+++ b/src/daft-recordbatch/Cargo.toml
@@ -1,6 +1,6 @@
 [dependencies]
 arrow-array = {version = "54.2.1"}
-arrow2 = {workspace = true}
+arrow2 = {workspace = true, features = ["arrow"]}
 comfy-table = {workspace = true}
 common-arrow-ffi = {path = "../common/arrow-ffi", default-features = false}
 common-display = {path = "../common/display", default-features = false}
@@ -20,6 +20,7 @@ serde = {workspace = true}
 serde_json = {workspace = true}
 
 [features]
+arrow = ["arrow2/arrow"]
 python = ["dep:pyo3", "common-error/python", "daft-core/python", "daft-dsl/python", "common-arrow-ffi/python", "common-display/python", "daft-image/python", "daft-logical-plan/python"]
 
 [lints]

--- a/src/daft-recordbatch/Cargo.toml
+++ b/src/daft-recordbatch/Cargo.toml
@@ -4,7 +4,7 @@ arrow2 = {workspace = true, features = ["arrow"]}
 comfy-table = {workspace = true}
 common-arrow-ffi = {path = "../common/arrow-ffi", default-features = false}
 common-display = {path = "../common/display", default-features = false}
-common-error = {path = "../common/error", default-features = false}
+common-error = {path = "../common/error", default-features = false, features = ["arrow"]}
 common-runtime = {path = "../common/runtime", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -10,10 +10,7 @@ use std::{
     sync::Arc,
 };
 
-use arrow2::{
-    array::{to_data, Array},
-    chunk::Chunk,
-};
+use arrow2::{array::Array, chunk::Chunk};
 use common_display::table_display::{make_comfy_table, StrValue};
 use common_error::{DaftError, DaftResult};
 use common_runtime::get_compute_runtime;
@@ -977,10 +974,9 @@ impl TryFrom<RecordBatch> for arrow_array::RecordBatch {
         let columns = record_batch
             .columns
             .iter()
-            .map(|s| arrow_array::make_array(to_data(s.to_arrow().as_ref())))
+            .map(|s| s.to_arrow().into())
             .collect::<Vec<_>>();
-        Ok(Self::try_new(schema, columns)
-            .expect("Failed to convert Daft RecordBatch to Arrow RecordBatch"))
+        Self::try_new(schema, columns).map_err(DaftError::ArrowRsError)
     }
 }
 

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+arrow-schema = {version = "54.2.1"}
 arrow2 = {workspace = true, features = [
   "arrow",
   "io_ipc_compression"

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -11,7 +11,9 @@ daft-io = {path = "../daft-io", default-features = false}
 daft-logical-plan = {path = "../daft-logical-plan", default-features = false}
 daft-micropartition = {path = "../daft-micropartition", default-features = false}
 daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
+parquet = {version = "54.2.1"}
 pyo3 = {workspace = true, optional = true}
+uuid = {version = "1.0", features = ["v4"]}
 
 [features]
 python = ["dep:pyo3", "common-file-formats/python", "common-error/python", "daft-dsl/python", "daft-io/python", "daft-logical-plan/python", "daft-micropartition/python"]

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -7,14 +7,17 @@ arrow2 = {workspace = true, features = [
 common-daft-config = {path = "../common/daft-config", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}
+common-runtime = {path = "../common/runtime", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-io = {path = "../daft-io", default-features = false}
 daft-logical-plan = {path = "../daft-logical-plan", default-features = false}
 daft-micropartition = {path = "../daft-micropartition", default-features = false}
 daft-recordbatch = {path = "../daft-recordbatch", default-features = false, features = ["arrow"]}
+futures = {workspace = true}
 parquet = {version = "54.2.1"}
 pyo3 = {workspace = true, optional = true}
+tokio = {workspace = true}
 uuid = {version = "1.0", features = ["v4"]}
 
 [features]

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -1,5 +1,6 @@
 [dependencies]
 arrow2 = {workspace = true, features = [
+  "arrow",
   "io_ipc_compression"
 ]}
 common-daft-config = {path = "../common/daft-config", default-features = false}
@@ -10,7 +11,7 @@ daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-io = {path = "../daft-io", default-features = false}
 daft-logical-plan = {path = "../daft-logical-plan", default-features = false}
 daft-micropartition = {path = "../daft-micropartition", default-features = false}
-daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
+daft-recordbatch = {path = "../daft-recordbatch", default-features = false, features = ["arrow"]}
 parquet = {version = "54.2.1"}
 pyo3 = {workspace = true, optional = true}
 uuid = {version = "1.0", features = ["v4"]}

--- a/src/daft-writers/src/file.rs
+++ b/src/daft-writers/src/file.rs
@@ -59,8 +59,10 @@ impl TargetFileSizeWriter {
     ) -> DaftResult<usize> {
         self.current_in_memory_bytes_written += size_bytes;
         let written_bytes = self.current_writer.write(input)?;
+        // println!("Written bytes: {}", written_bytes);
         self.total_physical_bytes_written += written_bytes;
         if self.current_in_memory_bytes_written >= self.current_in_memory_size_estimate {
+            println!("Total physical bytes written: {}; rotating writer", self.total_physical_bytes_written);
             self.rotate_writer_and_update_estimates()?;
         }
         Ok(written_bytes)

--- a/src/daft-writers/src/physical.rs
+++ b/src/daft-writers/src/physical.rs
@@ -2,10 +2,13 @@ use std::{
     io::BufWriter,
     path::{Path, PathBuf},
     sync::Arc,
+    future::Future,
+    pin::Pin,
 };
 
 use common_error::{DaftError, DaftResult};
 use common_file_formats::FileFormat;
+use common_runtime::{get_compute_runtime, get_io_runtime, Runtime, RuntimeTask};
 use daft_core::{prelude::*, series::Series};
 use daft_io::{parse_url, IOStatsContext, SourceType};
 use daft_logical_plan::OutputFileInfo;
@@ -13,7 +16,7 @@ use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use parquet::{
     arrow::{
-        arrow_writer::{compute_leaves, get_column_writers, ArrowLeafColumn},
+        arrow_writer::{compute_leaves, get_column_writers, ArrowColumnChunk, ArrowLeafColumn},
         ArrowSchemaConverter,
     },
     basic::Compression,
@@ -23,11 +26,12 @@ use parquet::{
     },
     schema::types::SchemaDescriptor,
 };
+use tokio::sync::Mutex;
 
 use crate::{FileWriter, WriterFactory};
 
-/// Default buffer size for writing to files. We choose 132MiB since row groups are best-effort kept to ~128MiB.
-const DEFAULT_WRITE_BUFFER_SIZE: usize = 132 * 1024 * 1024;
+/// Default buffer size for writing to files. We choose 128MiB since row groups are best-effort kept to ~128MiB.
+const DEFAULT_WRITE_BUFFER_SIZE: usize = 128 * 1024 * 1024;
 
 /// PhysicalWriterFactory is a factory for creating physical writers, i.e. parquet, csv writers.
 pub struct PhysicalWriterFactory {
@@ -70,7 +74,7 @@ impl WriterFactory for PhysicalWriterFactory {
                 std::fs::create_dir_all(&dir)?;
                 let filename = dir.join(format!("{}-{}.parquet", uuid::Uuid::new_v4(), file_idx));
                 // TODO(desmond): Explore configurations such data page size limit, writer version, etc. Parquet format v2
-                // could be interesting but has much less support in the ecosystem (including ourselves).
+                // could be interesting but has much less support in the ecosystem (including by ourselves).
                 let writer_properties = Arc::new(
                     WriterProperties::builder()
                         .set_writer_version(WriterVersion::PARQUET_1_0)
@@ -83,16 +87,15 @@ impl WriterFactory for PhysicalWriterFactory {
                 let parquet_schema = ArrowSchemaConverter::new()
                     .with_coerce_types(writer_properties.coerce_types())
                     .convert(&arrow_schema)
-                    .unwrap();
+                    .map_err(|e| DaftError::ParquetError(e.to_string()))?;
 
-                Ok(Box::new(ArrowParquetWriter {
+                Ok(Box::new(ArrowParquetWriter::new(
                     filename,
                     writer_properties,
                     arrow_schema,
                     parquet_schema,
-                    file_writer: None,
-                    partition_values: partition_values.cloned(),
-                }))
+                    partition_values.cloned(),
+                )))
             }
             _ => {
                 let writer = create_pyarrow_file_writer(
@@ -114,21 +117,52 @@ struct ArrowParquetWriter {
     writer_properties: Arc<WriterProperties>,
     arrow_schema: Arc<arrow_schema::Schema>,
     parquet_schema: SchemaDescriptor,
-    file_writer: Option<SerializedFileWriter<BufWriter<std::fs::File>>>,
+    file_writer: Option<Arc<Mutex<SerializedFileWriter<BufWriter<std::fs::File>>>>>,
+    io_runtime: Option<Arc<Runtime>>,
+    flusher_task: Option<RuntimeTask<DaftResult<()>>>,
     partition_values: Option<RecordBatch>,
+    row_group_sender: Option<tokio::sync::mpsc::UnboundedSender<Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = DaftResult<()>> + Send>> + Send + 'static>>>,
 }
 
 impl ArrowParquetWriter {
+    fn new(filename: PathBuf, writer_properties: Arc<WriterProperties>, arrow_schema: Arc<arrow_schema::Schema>, parquet_schema: SchemaDescriptor, partition_values: Option<RecordBatch>) -> Self {
+        Self {
+            filename,
+            writer_properties,
+            arrow_schema,
+            parquet_schema,
+            file_writer: None,
+            io_runtime: None,
+            flusher_task: None,
+            partition_values,
+            row_group_sender: None,
+        }
+    }
+
     fn create_writer(&mut self) -> DaftResult<()> {
         let file = std::fs::File::create(&self.filename)?;
-        let bufwriter = BufWriter::with_capacity(DEFAULT_WRITE_BUFFER_SIZE, file);
+        let bufwriter = BufWriter::new(file);
         let writer = SerializedFileWriter::new(
             bufwriter,
             self.parquet_schema.root_schema_ptr(),
             self.writer_properties.clone(),
         )
         .map_err(|e| DaftError::ParquetError(e.to_string()))?;
-        self.file_writer = Some(writer);
+        self.file_writer = Some(Arc::new(Mutex::new(writer)));
+        let io_runtime = get_io_runtime(true);
+        let (row_group_sender, mut row_group_receiver) = tokio::sync::mpsc::unbounded_channel::<Box<dyn FnOnce() -> Pin<Box<dyn Future<Output = DaftResult<()>> + Send>> + Send + 'static>>();
+        let flusher_task = io_runtime.spawn(async move {
+            while let Some(row_group_writer) = row_group_receiver.recv().await {
+                println!("Received row group writer");
+                row_group_writer().await?;
+                println!("Flushed row group writer");
+            }
+            Ok::<(), DaftError>(())
+        });
+        self.io_runtime = Some(io_runtime);
+        self.flusher_task = Some(flusher_task);
+        self.row_group_sender = Some(row_group_sender);
+        
         Ok(())
     }
 }
@@ -138,88 +172,120 @@ impl FileWriter for ArrowParquetWriter {
     type Result = Option<RecordBatch>;
 
     fn write(&mut self, data: Self::Input) -> DaftResult<usize> {
+        println!("Write row group");
         if self.file_writer.is_none() {
             self.create_writer()?;
         }
-        let file_writer = self
-            .file_writer
-            .as_mut()
-            .expect("File writer should be created by now");
-        let current_bytes_written = file_writer.bytes_written();
+        // let file_writer = self
+        //     .file_writer
+        //     .expect("File writer should be created by now")
+        //     .lock()
+        // let current_bytes_written = file_writer.bytes_written();
+
+        let size_estimate = data.size_bytes()?.unwrap_or(0);
+
+        // Get column writers for each leaf column. We'll encode and compress these in parallel
+        // and then flush them to the row group writer when they're done.
         let column_writers = get_column_writers(
             &self.parquet_schema,
             &self.writer_properties,
             &self.arrow_schema,
         )
         .map_err(|e| DaftError::ParquetError(e.to_string()))?;
-        let mut workers: Vec<_> = column_writers
+
+
+        // Process all record batches in the micropartition.
+        // TODO(desmond): We should be able to pipeline each record batch with upstream nodes rather than processes all
+        // record batches at once.
+        let fields = self.arrow_schema.fields.clone();
+        let record_batches =
+            data.tables_or_read(IOStatsContext::new("ArrowParquetWriter::write"))?;
+
+        let mut column_writer_worker_threads: Vec<_> = column_writers
             .into_iter()
             .map(|mut col_writer| {
-                let (send, recv) = std::sync::mpsc::channel::<ArrowLeafColumn>();
-                let handle = std::thread::spawn(move || {
-                    // receive Arrays to encode via the channel
-                    for col in recv {
+                let (send, mut recv) = tokio::sync::mpsc::unbounded_channel::<ArrowLeafColumn>();
+                let handle = self.io_runtime.as_ref().expect("IO runtime should be created by now").spawn( async move {
+                    // Receive Arrays to encode via the channel.
+                    while let Some(col) = recv.recv().await {
                         col_writer.write(&col)?;
                     }
-                    // once the input is complete, close the writer
-                    // to return the newly created ArrowColumnChunk
+                    // Once the input is complete, close the writer to return the newly created ArrowColumnChunk.
                     col_writer.close()
                 });
                 (handle, send)
             })
-            .collect();
-        let mut row_group_writer = file_writer
-            .next_row_group()
-            .map_err(|e| DaftError::ParquetError(e.to_string()))?;
-
-        let record_batches =
-            data.tables_or_read(IOStatsContext::new("ArrowParquetWriter::write"))?;
-        // compute_leaves(field, array)
+            .collect(); 
+        
         for record_batch in record_batches.iter() {
-            let mut worker_iter = workers.iter_mut();
+            let mut worker_iter = column_writer_worker_threads.iter_mut();
             let arrays = record_batch.get_inner_arrow_arrays();
-            for (arr, field) in arrays.zip(&self.arrow_schema.fields) {
-                for leaves in compute_leaves(field, &arr.into())
+            for (arr, field) in arrays.zip(&fields) {
+                for leaf in compute_leaves(field, &arr.into())
                     .map_err(|e| DaftError::ParquetError(e.to_string()))?
                 {
-                    worker_iter.next().unwrap().1.send(leaves).unwrap();
+                    worker_iter.next().unwrap().1.send(leaf);
                 }
             }
         }
+        let handles: Vec<_> = column_writer_worker_threads.into_iter().map(|(handle, send)| {
+            // Drop send side to signal termination.
+            drop(send);
+            handle
+        }).collect();
 
-        // Wait for the workers to complete encoding, and append
-        // the resulting column chunks to the row group (and the file)
-        for (handle, send) in workers {
-            drop(send); // Drop send side to signal termination
-                        // wait for the worker to send the completed chunk
-            let chunk = handle
-                .join()
-                .unwrap()
+        let file_writer = self.file_writer.clone();
+        let row_group_writer = || Box::pin(async move {
+            let mut file_writer = file_writer
+                .as_ref()
+                .expect("File writer should be created by now")
+                .lock()
+                .await;
+            let mut row_group_writer = file_writer
+                .next_row_group()
                 .map_err(|e| DaftError::ParquetError(e.to_string()))?;
-            chunk
-                .append_to_row_group(&mut row_group_writer)
+            // Append the column chunks to the row group and the file.
+            for handle in handles {
+                let chunk = handle
+                    .await?
+                    .map_err(|e| DaftError::ParquetError(e.to_string()))?;
+                chunk
+                    .append_to_row_group(&mut row_group_writer)
+                    .map_err(|e| DaftError::ParquetError(e.to_string()))?;
+            }
+            // Close the row group which writes to the underlying file
+            row_group_writer
+                .close()
                 .map_err(|e| DaftError::ParquetError(e.to_string()))?;
-        }
-        // Close the row group which writes to the underlying file
-        row_group_writer
-            .close()
-            .map_err(|e| DaftError::ParquetError(e.to_string()))?;
 
-        let bytes_written = file_writer.bytes_written() - current_bytes_written;
-        Ok(bytes_written)
+            Ok::<(), DaftError>(())
+        }) as Pin<Box<dyn Future<Output = DaftResult<()>> + Send>>;
+        println!("Sending row group");
+        self.row_group_sender.as_ref().expect("Row group sender should be created by now").send(Box::new(row_group_writer));
+
+        // TODO(desmond): maybe we can do better.
+        Ok(size_estimate)
     }
 
     fn close(&mut self) -> DaftResult<Self::Result> {
         // TODO(desmond): We can shove some pretty useful metadata before closing the file.
-        let file_writer = self.file_writer.as_mut().ok_or_else(|| {
-            DaftError::InternalError(
-                "File writer should be created if close() is called".to_string(),
-            )
-        })?;
+        let file_writer = self.file_writer.clone();
+        let row_group_sender = self.row_group_sender.take();
+        drop(row_group_sender);
+        let flusher_task = self.flusher_task.take();
+        self.io_runtime.as_ref().expect("IO runtime should be created by now").block_on(async move {
+            flusher_task.unwrap().await?;
+            let mut file_writer = file_writer
+                .as_ref()
+                .expect("File writer should be created by now")
+                .lock()
+                .await;
 
-        let _metadata = file_writer
-            .finish()
-            .map_err(|e| DaftError::ParquetError(e.to_string()))?;
+            let _metadata = file_writer
+                .finish()
+                .map_err(|e| DaftError::ParquetError(e.to_string()))?;
+            Ok::<(), DaftError>(())
+        })?;
         let field = Field::new("path", DataType::Utf8);
         let filename_series = Series::from_arrow(
             Arc::new(field.clone()),
@@ -239,17 +305,31 @@ impl FileWriter for ArrowParquetWriter {
     }
 
     fn bytes_written(&self) -> usize {
-        self.file_writer
-            .as_ref()
-            .map(|w| w.bytes_written())
-            .unwrap_or(0)
+        let file_writer = self.file_writer.clone();
+        let bytes_written = self.io_runtime.as_ref().expect("IO runtime should be created by now").block_on(async move {
+            let file_writer = file_writer
+                .as_ref()
+                .expect("File writer should be created by now")
+                .lock()
+                .await;
+
+            file_writer.bytes_written()
+        }).unwrap_or(0);
+        bytes_written
     }
 
     fn bytes_per_file(&self) -> Vec<usize> {
-        self.file_writer
-            .as_ref()
-            .map(|w| vec![w.bytes_written()])
-            .unwrap_or_else(|| vec![0])
+        let file_writer = self.file_writer.clone();
+        let bytes_written = self.io_runtime.as_ref().expect("IO runtime should be created by now").block_on(async move {
+            let file_writer = file_writer
+                .as_ref()
+                .expect("File writer should be created by now")
+                .lock()
+                .await;
+
+            file_writer.bytes_written()
+        }).unwrap_or(0);
+        vec![bytes_written]
     }
 }
 

--- a/src/daft-writers/src/physical.rs
+++ b/src/daft-writers/src/physical.rs
@@ -125,7 +125,7 @@ impl FileWriter for ArrowParquetWriter {
             )),
         )?;
         Ok(Some(RecordBatch::new_with_size(
-            Schema::new(vec![field])?,
+            Schema::new(vec![field]),
             vec![filename_series],
             1,
         )?))

--- a/src/daft-writers/src/physical.rs
+++ b/src/daft-writers/src/physical.rs
@@ -1,24 +1,39 @@
-use std::sync::Arc;
+use std::{
+    io::BufWriter,
+    sync::{Arc, Mutex},
+};
 
 use common_error::{DaftError, DaftResult};
 use common_file_formats::FileFormat;
+use daft_core::{
+    prelude::{DataType, Field, Schema, SchemaRef},
+    series::Series,
+};
+use daft_io::{parse_url, IOStatsContext, SourceType};
 use daft_logical_plan::OutputFileInfo;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
+use parquet::{
+    arrow::ArrowWriter,
+    basic::Compression,
+    file::properties::{WriterProperties, WriterVersion},
+};
 
 use crate::{FileWriter, WriterFactory};
 
 /// PhysicalWriterFactory is a factory for creating physical writers, i.e. parquet, csv writers.
 pub struct PhysicalWriterFactory {
     output_file_info: OutputFileInfo,
+    schema: SchemaRef,
     native: bool, // TODO: Implement native writer
 }
 
 impl PhysicalWriterFactory {
-    pub fn new(output_file_info: OutputFileInfo) -> Self {
+    pub fn new(output_file_info: OutputFileInfo, file_schema: &SchemaRef, native: bool) -> Self {
         Self {
             output_file_info,
-            native: false,
+            schema: file_schema.clone(),
+            native,
         }
     }
 }
@@ -32,9 +47,38 @@ impl WriterFactory for PhysicalWriterFactory {
         file_idx: usize,
         partition_values: Option<&RecordBatch>,
     ) -> DaftResult<Box<dyn FileWriter<Input = Self::Input, Result = Self::Result>>> {
+        let (source_type, _) = parse_url(&self.output_file_info.root_dir)?;
         match self.native {
-            true => unimplemented!(),
-            false => {
+            // TODO(desmond): Remote writes.
+            // TODO(desmond): Handle partitioned values.
+            // TODO(desmond): Proper error handling.
+            true if partition_values.is_none() && matches!(source_type, SourceType::File) => {
+                // TODO(desmond): Explore configurations such data page size limit, writer version, etc. Parquet format v2
+                // could be interesting but has much less support in the ecosystem (including ourselves).
+                let writer_properties = WriterProperties::builder()
+                    .set_writer_version(WriterVersion::PARQUET_1_0)
+                    .set_compression(Compression::SNAPPY)
+                    .build();
+                let filename = format!(
+                    "{}/{}-{}.parquet",
+                    self.output_file_info.root_dir,
+                    uuid::Uuid::new_v4(),
+                    file_idx
+                );
+                // Create the root directory if it doesn't exist.
+                std::fs::create_dir_all(&self.output_file_info.root_dir)?;
+                let file = std::fs::File::create(&filename)?;
+                let bufwriter = BufWriter::new(file);
+                let arrow_rs_schema = Arc::new(self.schema.to_arrow()?.to_arrow_rs_schema());
+                let writer =
+                    ArrowWriter::try_new(bufwriter, arrow_rs_schema, Some(writer_properties))
+                        .expect("Failed to create ArrowWriter");
+                Ok(Box::new(ArrowParquetWriter {
+                    filename,
+                    file_writer: Mutex::new(writer),
+                }))
+            }
+            _ => {
                 let writer = create_pyarrow_file_writer(
                     &self.output_file_info.root_dir,
                     file_idx,
@@ -46,6 +90,61 @@ impl WriterFactory for PhysicalWriterFactory {
                 Ok(writer)
             }
         }
+    }
+}
+
+struct ArrowParquetWriter {
+    filename: String,
+    file_writer: Mutex<ArrowWriter<BufWriter<std::fs::File>>>,
+}
+
+impl FileWriter for ArrowParquetWriter {
+    type Input = Arc<MicroPartition>;
+    type Result = Option<RecordBatch>;
+
+    fn write(&mut self, data: Self::Input) -> DaftResult<usize> {
+        let mut file_writer = self.file_writer.lock().expect("Failed to lock file writer");
+        let current_bytes_written = file_writer.bytes_written();
+        let tables = data.tables_or_read(IOStatsContext::new("ArrowParquetWriter::write"))?;
+        tables.iter().for_each(|daft_record_batch| {
+            let _ = file_writer.write(
+                &daft_record_batch
+                    .to_arrow_rs_record_batch()
+                    .expect("Failed to convert record batch to arrow rs record batch"),
+            );
+        });
+        // Flush the current row group.
+        file_writer.flush().unwrap();
+        let bytes_written = file_writer.bytes_written() - current_bytes_written;
+        Ok(bytes_written)
+    }
+
+    fn close(&mut self) -> DaftResult<Self::Result> {
+        // TODO(desmond): We can shove some pretty useful metadata before closing the file.
+        let mut file_writer = self.file_writer.lock().unwrap();
+        let _metadata = file_writer.finish().unwrap();
+        let field = Field::new("path", DataType::Utf8);
+        let filename_series = Series::from_arrow(
+            Arc::new(field.clone()),
+            Box::new(arrow2::array::Utf8Array::<i64>::from_slice(
+                [&self.filename],
+            )),
+        )?;
+        Ok(Some(RecordBatch::new_with_size(
+            Schema::new(vec![field])?,
+            vec![filename_series],
+            1,
+        )?))
+    }
+
+    fn bytes_written(&self) -> usize {
+        let file_writer = self.file_writer.lock().unwrap();
+        file_writer.bytes_written()
+    }
+
+    fn bytes_per_file(&self) -> Vec<usize> {
+        let file_writer = self.file_writer.lock().unwrap();
+        vec![file_writer.bytes_written()]
     }
 }
 

--- a/src/daft-writers/src/physical.rs
+++ b/src/daft-writers/src/physical.rs
@@ -5,10 +5,7 @@ use std::{
 
 use common_error::{DaftError, DaftResult};
 use common_file_formats::FileFormat;
-use daft_core::{
-    prelude::{DataType, Field, Schema, SchemaRef},
-    series::Series,
-};
+use daft_core::{prelude::*, series::Series};
 use daft_io::{parse_url, IOStatsContext, SourceType};
 use daft_logical_plan::OutputFileInfo;
 use daft_micropartition::MicroPartition;


### PR DESCRIPTION
The current pyarrow-based writer writes parquet files with a single thread:
![image](https://github.com/user-attachments/assets/2a9c07be-3af1-4fed-8783-4f7125678798)
_Note: for this and the following examples, the first part of the trace is a `df.collect()`, it's the `df.write_parquet()` chunk later on that we're interested in._

In a discussion with @colin-ho and @samster25, we realized that most of the time went into column encoding (and mainly during compression), not writing. So we could encode columns in parallel then flush the row group once all columns are ready:
![image](https://github.com/user-attachments/assets/7e1f7905-4f07-4109-b6b5-74cfe8c139b7)

This is nice, but we notice that some columns take longer to encode than others. If we go one row group at a time we'll still have a bunch of threads sitting idly if the columns are skewed.

But what if... we encode _row groups_ in parallel (and still write them in the sequence they came in):
![image](https://github.com/user-attachments/assets/4d58fc80-58f2-4377-b0ed-177d6855aba2)

