### PR TITLE
ci: Bump pyarrow version in CI to 20.0.0

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         python-version: ['3.9', '3.10']
         daft-runner: [py, ray, native]
-        pyarrow-version: [8.0.0, 19.0.0]
+        pyarrow-version: [8.0.0, 20.0.0]
         enable-aqe: [1, 0]
         os: [ubuntu-latest, macos-latest]
         exclude:

--- a/benchmarking/parquet/benchmark-requirements.txt
+++ b/benchmarking/parquet/benchmark-requirements.txt
@@ -1,5 +1,5 @@
 pytest==7.4.0
 pytest-benchmark==4.0.0
 pytest-memray==1.4.1
-pyarrow==19.0.0
+pyarrow==20.0.0
 boto3==1.28.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -40,7 +40,7 @@ duckdb==1.1.2
 tqdm
 
 # Pyarrow
-pyarrow==19.0.0
+pyarrow==20.0.0
 # Ray
 ray[data, client]==2.34.0
 

--- a/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
+++ b/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
@@ -17,7 +17,7 @@ uvicorn==0.23.2
 uvloop==0.17.0
 watchfiles==0.19.0
 websockets==11.0.3
-pyarrow==19.0.0
+pyarrow==20.0.0
 slowapi==0.1.8
 
 # Pin numpy version otherwise pyarrow doesn't work


### PR DESCRIPTION
## Changes Made

Arrow 19.0.0 is unable to read parquet files written by newer versions of arrow with statistics.

The issue arises from an optimization where level histograms in statistics (e.g. the level histogram used for repetition levels) is omitted when the max level is 0.

This means we should use either the minor release of arrow 19 (i.e. arrow 19.0.1) or arrow 20.