### PR TITLE
refactor(exprs): move func registry from daft-functions -> daft-dsl

### DIFF
--- a/src/daft-dsl/src/functions/mod.rs
+++ b/src/daft-dsl/src/functions/mod.rs
@@ -8,8 +8,10 @@ pub mod sketch;
 pub mod struct_;
 
 use std::{
+    collections::HashMap,
     fmt::{Display, Formatter, Result, Write},
     hash::Hash,
+    sync::{Arc, LazyLock, RwLock},
 };
 
 use common_error::DaftResult;
@@ -117,3 +119,44 @@ pub fn function_semantic_id(func: &FunctionExpr, inputs: &[ExprRef], schema: &Sc
     // TODO: check for function idempotency here.
     FieldID::new(format!("Function_{func:?}({inputs})"))
 }
+
+#[derive(Default)]
+pub struct FunctionRegistry {
+    // Todo: Use the Bindings object instead, so we can get aliases and case handling.
+    map: HashMap<String, Arc<dyn ScalarUDF>>,
+}
+pub trait FunctionModule {
+    /// Register this module to the given [SQLFunctions] table.
+    fn register(_parent: &mut FunctionRegistry);
+}
+
+impl FunctionRegistry {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+    pub fn register<Mod: FunctionModule>(&mut self) {
+        Mod::register(self);
+    }
+
+    pub fn add_fn<UDF: ScalarUDF + 'static>(&mut self, func: UDF) {
+        let func = Arc::new(func);
+        // todo: use bindings instead of hashmap so we don't need duplicate entries.
+        for alias in func.aliases() {
+            self.map.insert((*alias).to_string(), func.clone());
+        }
+        self.map.insert(func.name().to_string(), func);
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<dyn ScalarUDF>> {
+        self.map.get(name).cloned()
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = (&String, &Arc<dyn ScalarUDF>)> {
+        self.map.iter()
+    }
+}
+
+pub static FUNCTION_REGISTRY: LazyLock<RwLock<FunctionRegistry>> =
+    LazyLock::new(|| RwLock::new(FunctionRegistry::new()));

--- a/src/daft-functions/src/float/mod.rs
+++ b/src/daft-functions/src/float/mod.rs
@@ -3,18 +3,17 @@ mod is_inf;
 mod is_nan;
 mod not_nan;
 
+use daft_dsl::functions::FunctionModule;
 pub use fill_nan::fill_nan;
 use fill_nan::FillNan;
 pub use is_inf::{is_inf, IsInf};
 pub use is_nan::{is_nan, IsNan};
 pub use not_nan::{not_nan, NotNan};
 
-use crate::FunctionModule;
-
 pub struct FloatFunctions;
 
 impl FunctionModule for FloatFunctions {
-    fn register(parent: &mut crate::FunctionRegistry) {
+    fn register(parent: &mut daft_dsl::functions::FunctionRegistry) {
         parent.add_fn(FillNan);
         parent.add_fn(IsInf);
         parent.add_fn(IsNan);

--- a/src/daft-functions/src/lib.rs
+++ b/src/daft-functions/src/lib.rs
@@ -16,13 +16,7 @@ pub mod tokenize;
 pub mod uri;
 pub mod utf8;
 
-use std::{
-    collections::HashMap,
-    sync::{Arc, LazyLock, RwLock},
-};
-
 use common_error::DaftError;
-use daft_dsl::functions::ScalarUDF;
 #[cfg(feature = "python")]
 pub use python::register as register_modules;
 use snafu::Snafu;
@@ -53,47 +47,3 @@ macro_rules! invalid_argument_err {
         return Err(common_error::DaftError::TypeError(msg).into());
     }};
 }
-#[derive(Default)]
-pub struct FunctionRegistry {
-    // Todo: Use the Bindings object instead, so we can get aliases and case handling.
-    map: HashMap<String, Arc<dyn ScalarUDF>>,
-}
-pub trait FunctionModule {
-    /// Register this module to the given [SQLFunctions] table.
-    fn register(_parent: &mut FunctionRegistry);
-}
-
-impl FunctionRegistry {
-    pub fn new() -> Self {
-        Self {
-            map: HashMap::new(),
-        }
-    }
-    pub fn register<Mod: FunctionModule>(&mut self) {
-        Mod::register(self);
-    }
-
-    pub fn add_fn<UDF: ScalarUDF + 'static>(&mut self, func: UDF) {
-        let func = Arc::new(func);
-        // todo: use bindings instead of hashmap so we don't need duplicate entries.
-        for alias in func.aliases() {
-            self.map.insert((*alias).to_string(), func.clone());
-        }
-        self.map.insert(func.name().to_string(), func);
-    }
-
-    pub fn get(&self, name: &str) -> Option<Arc<dyn ScalarUDF>> {
-        self.map.get(name).cloned()
-    }
-
-    pub fn entries(&self) -> impl Iterator<Item = (&String, &Arc<dyn ScalarUDF>)> {
-        self.map.iter()
-    }
-}
-
-pub static FUNCTION_REGISTRY: LazyLock<RwLock<FunctionRegistry>> = LazyLock::new(|| {
-    let mut registry = FunctionRegistry::new();
-    registry.register::<numeric::NumericFunctions>();
-    registry.register::<float::FloatFunctions>();
-    RwLock::new(registry)
-});

--- a/src/daft-functions/src/numeric/mod.rs
+++ b/src/daft-functions/src/numeric/mod.rs
@@ -19,15 +19,16 @@ use daft_core::{
     prelude::{Field, Schema},
     series::Series,
 };
-use daft_dsl::{functions::ScalarUDF, ExprRef};
+use daft_dsl::{
+    functions::{FunctionModule, FunctionRegistry, ScalarUDF},
+    ExprRef,
+};
 use exp::{Exp, Expm1};
 use floor::Floor;
 use log::{Ln, Log, Log10, Log1p, Log2};
 use round::Round;
 use sign::{Negative, Sign};
 use sqrt::Sqrt;
-
-use crate::FunctionModule;
 
 fn to_field_single_numeric(
     f: &dyn ScalarUDF,
@@ -84,8 +85,9 @@ fn evaluate_single_numeric<F: Fn(&Series) -> DaftResult<Series>>(
 }
 
 pub struct NumericFunctions;
+
 impl FunctionModule for NumericFunctions {
-    fn register(parent: &mut crate::FunctionRegistry) {
+    fn register(parent: &mut FunctionRegistry) {
         parent.add_fn(Abs);
         parent.add_fn(Cbrt);
         parent.add_fn(Ceil);

--- a/src/daft-functions/src/python/mod.rs
+++ b/src/daft-functions/src/python/mod.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 
 use daft_dsl::{
     expr::named_expr,
-    functions::{ScalarFunction, ScalarUDF},
+    functions::{ScalarFunction, ScalarUDF, FUNCTION_REGISTRY},
     python::PyExpr,
     ExprRef,
 };
@@ -35,8 +35,6 @@ use pyo3::{
     types::{PyDict, PyModule, PyModuleMethods, PyTuple},
     wrap_pyfunction, Bound, PyResult,
 };
-
-use crate::FUNCTION_REGISTRY;
 
 #[pyo3::pyclass]
 pub struct PyScalarFunction {

--- a/src/daft-image/src/functions/mod.rs
+++ b/src/daft-image/src/functions/mod.rs
@@ -1,4 +1,4 @@
-use daft_functions::FunctionModule;
+use daft_dsl::functions::FunctionModule;
 
 pub mod crop;
 pub mod decode;
@@ -9,7 +9,7 @@ pub mod to_mode;
 pub struct ImageFunctions;
 
 impl FunctionModule for ImageFunctions {
-    fn register(parent: &mut daft_functions::FunctionRegistry) {
+    fn register(parent: &mut daft_dsl::functions::FunctionRegistry) {
         parent.add_fn(crop::ImageCrop);
         parent.add_fn(decode::ImageDecode);
         parent.add_fn(encode::ImageEncode);

--- a/src/daft-sql/src/functions.rs
+++ b/src/daft-sql/src/functions.rs
@@ -8,10 +8,9 @@ use daft_dsl::{
         named_expr,
         window::{WindowBoundary, WindowFrame, WindowFrameType},
     },
-    functions::{ScalarFunction, ScalarUDF},
+    functions::{ScalarFunction, ScalarUDF, FUNCTION_REGISTRY},
     Expr, ExprRef, WindowExpr, WindowSpec,
 };
-use daft_functions::FUNCTION_REGISTRY;
 use daft_session::Session;
 use sqlparser::ast::{
     DuplicateTreatment, Function, FunctionArg, FunctionArgExpr, FunctionArgOperator,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub mod pylib {
         daft_cli::register_modules(m)?;
 
         // We need to do this here because it's the only point in the rust codebase that we have access to all crates.
-        let mut functions_registry = daft_functions::FUNCTION_REGISTRY
+        let mut functions_registry = daft_dsl::functions::FUNCTION_REGISTRY
             .write()
             .expect("Failed to acquire write lock on function registry");
 


### PR DESCRIPTION
## Changes Made

small PR to move the FUNCTION_REGISTRY from daft-functions to daft-dsl. This improves compilation by making other modules such as `daft-image` and `daft-functions-json` not need to depend on `daft-functions` and only need to depend on `daft-dsl`. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
