### PR TITLE
feat: Make file writers async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2841,6 +2841,7 @@ name = "daft-writers"
 version = "0.3.0-dev0"
 dependencies = [
  "arrow2",
+ "async-trait",
  "common-daft-config",
  "common-error",
  "common-file-formats",
@@ -2851,6 +2852,7 @@ dependencies = [
  "daft-micropartition",
  "daft-recordbatch",
  "pyo3",
+ "tokio",
 ]
 
 [[package]]

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -1,7 +1,7 @@
 [dependencies]
 async-recursion = "1.0.4"
 async-stream = "0.3.6"
-async-trait = "0.1.79"
+async-trait = {workspace = true}
 aws-config = {version = "0.55.3", features = ["native-tls", "rt-tokio", "client-hyper", "credentials-sso"], default-features = false}
 aws-credential-types = {version = "0.55.3", features = ["hardcoded-credentials"]}
 aws-sdk-s3 = {version = "0.28.0", features = ["native-tls", "rt-tokio"], default-features = false}

--- a/src/daft-local-execution/src/sinks/write.rs
+++ b/src/daft-local-execution/src/sinks/write.rs
@@ -8,7 +8,7 @@ use daft_dsl::ExprRef;
 use daft_logical_plan::OutputFileInfo;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
-use daft_writers::{FileWriter, WriterFactory};
+use daft_writers::{AsyncFileWriter, WriterFactory};
 use tracing::{instrument, Span};
 
 use super::blocking_sink::{
@@ -34,12 +34,12 @@ pub enum WriteFormat {
 }
 
 struct WriteState {
-    writer: Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
+    writer: Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
 }
 
 impl WriteState {
     pub fn new(
-        writer: Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
+        writer: Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
     ) -> Self {
         Self { writer }
     }
@@ -96,7 +96,8 @@ impl BlockingSink for WriteSink {
                         .downcast_mut::<WriteState>()
                         .expect("WriteSink should have WriteState")
                         .writer
-                        .write(input)?;
+                        .write(input)
+                        .await?;
                     Ok(BlockingSinkStatus::NeedMoreInput(state))
                 },
                 Span::current(),
@@ -121,7 +122,7 @@ impl BlockingSink for WriteSink {
                             .as_any_mut()
                             .downcast_mut::<WriteState>()
                             .expect("State type mismatch");
-                        results.extend(state.writer.close()?);
+                        results.extend(state.writer.close().await?);
                     }
 
                     if let Some(file_info) = &file_info {

--- a/src/daft-shuffles/src/shuffle_cache.rs
+++ b/src/daft-shuffles/src/shuffle_cache.rs
@@ -7,7 +7,7 @@ use daft_io::{parse_url, SourceType};
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use daft_schema::schema::SchemaRef;
-use daft_writers::{make_ipc_writer, FileWriter, RETURN_PATHS_COLUMN_NAME};
+use daft_writers::{make_ipc_writer, AsyncFileWriter, RETURN_PATHS_COLUMN_NAME};
 use itertools::Itertools;
 use tokio::sync::Mutex;
 
@@ -117,7 +117,9 @@ impl InProgressShuffleCache {
     }
 
     fn try_new_with_writers(
-        writers: Vec<Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>>,
+        writers: Vec<
+            Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
+        >,
         num_partitions: usize,
         partition_by: Option<Vec<ExprRef>>,
         shuffle_dirs: Vec<String>,
@@ -311,7 +313,7 @@ async fn partitioner_task(
 // Writer task that takes partitions from the partitioner sender, writes them to a file, and returns the schema and file paths
 async fn writer_task(
     rx: async_channel::Receiver<Arc<MicroPartition>>,
-    mut writer: Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
+    mut writer: Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
 ) -> DaftResult<WriterTaskResult> {
     let compute_runtime = get_compute_runtime();
     let mut schema = None;
@@ -325,12 +327,12 @@ async fn writer_task(
         total_bytes_written += partition.size_bytes()?.expect("size_bytes should be Some");
         writer = compute_runtime
             .spawn(async move {
-                writer.write(partition)?;
+                writer.write(partition).await?;
                 DaftResult::Ok(writer)
             })
             .await??;
     }
-    let file_path_tables = writer.close()?;
+    let file_path_tables = writer.close().await?;
 
     let file_paths = file_path_tables
         .into_iter()

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -2,7 +2,7 @@
 arrow2 = {workspace = true, features = [
   "io_ipc_compression"
 ]}
-async-trait = "0.1.79"
+async-trait = {workspace = true}
 common-daft-config = {path = "../common/daft-config", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -2,6 +2,7 @@
 arrow2 = {workspace = true, features = [
   "io_ipc_compression"
 ]}
+async-trait = "0.1.79"
 common-daft-config = {path = "../common/daft-config", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}
@@ -12,6 +13,7 @@ daft-logical-plan = {path = "../daft-logical-plan", default-features = false}
 daft-micropartition = {path = "../daft-micropartition", default-features = false}
 daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
 pyo3 = {workspace = true, optional = true}
+tokio = {workspace = true}
 
 [features]
 python = ["dep:pyo3", "common-file-formats/python", "common-error/python", "daft-dsl/python", "daft-io/python", "daft-logical-plan/python", "daft-micropartition/python"]

--- a/src/daft-writers/src/batch.rs
+++ b/src/daft-writers/src/batch.rs
@@ -4,11 +4,12 @@ use std::{
     sync::Arc,
 };
 
+use async_trait::async_trait;
 use common_error::DaftResult;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 
-use crate::{FileWriter, TargetInMemorySizeBytesCalculator, WriterFactory};
+use crate::{AsyncFileWriter, TargetInMemorySizeBytesCalculator, WriterFactory};
 
 // SizeBasedBuffer is a buffer that stores tables and their sizes in bytes.
 // It produces Micropartitions that are within a certain size range.
@@ -121,7 +122,7 @@ impl SizeBasedBuffer {
 // a row group at a time.
 pub struct TargetBatchWriter {
     size_calculator: Arc<TargetInMemorySizeBytesCalculator>,
-    writer: Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>,
+    writer: Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>,
     buffer: SizeBasedBuffer,
     is_closed: bool,
 }
@@ -133,7 +134,7 @@ impl TargetBatchWriter {
 
     pub fn new(
         size_calculator: Arc<TargetInMemorySizeBytesCalculator>,
-        writer: Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>,
+        writer: Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>,
     ) -> Self {
         Self {
             size_calculator,
@@ -143,23 +144,24 @@ impl TargetBatchWriter {
         }
     }
 
-    fn write_and_update_inflation_factor(
+    async fn write_and_update_inflation_factor(
         &mut self,
         input: Arc<MicroPartition>,
         in_memory_size_bytes: usize,
     ) -> DaftResult<usize> {
-        let bytes_written = self.writer.write(input)?;
+        let bytes_written = self.writer.write(input).await?;
         self.size_calculator
             .record_and_update_inflation_factor(bytes_written, in_memory_size_bytes);
         Ok(bytes_written)
     }
 }
 
-impl FileWriter for TargetBatchWriter {
+#[async_trait]
+impl AsyncFileWriter for TargetBatchWriter {
     type Input = Arc<MicroPartition>;
     type Result = Option<RecordBatch>;
 
-    fn write(&mut self, input: Arc<MicroPartition>) -> DaftResult<usize> {
+    async fn write(&mut self, input: Arc<MicroPartition>) -> DaftResult<usize> {
         assert!(
             !self.is_closed,
             "Cannot write to a closed TargetBatchWriter"
@@ -177,7 +179,9 @@ impl FileWriter for TargetBatchWriter {
             (target_size_bytes as f64 * (1.0 + Self::SIZE_BYTE_LENIENCY)) as usize;
         let mut bytes_written = 0;
         while let Some(mp) = self.buffer.pop(min_size_bytes, max_size_bytes)? {
-            bytes_written += self.write_and_update_inflation_factor(mp, target_size_bytes)?;
+            bytes_written += self
+                .write_and_update_inflation_factor(mp, target_size_bytes)
+                .await?;
             target_size_bytes = self.size_calculator.calculate_target_in_memory_size_bytes();
             min_size_bytes = (target_size_bytes as f64 * (1.0 - Self::SIZE_BYTE_LENIENCY)) as usize;
             max_size_bytes = (target_size_bytes as f64 * (1.0 + Self::SIZE_BYTE_LENIENCY)) as usize;
@@ -194,12 +198,12 @@ impl FileWriter for TargetBatchWriter {
         self.writer.bytes_per_file()
     }
 
-    fn close(&mut self) -> DaftResult<Self::Result> {
+    async fn close(&mut self) -> DaftResult<Self::Result> {
         if let Some(leftovers) = self.buffer.pop_all()? {
-            self.writer.write(leftovers)?;
+            self.writer.write(leftovers).await?;
         }
         self.is_closed = true;
-        self.writer.close()
+        self.writer.close().await
     }
 }
 
@@ -231,7 +235,7 @@ impl WriterFactory for TargetBatchWriterFactory {
         &self,
         file_idx: usize,
         partition_values: Option<&RecordBatch>,
-    ) -> DaftResult<Box<dyn FileWriter<Input = Self::Input, Result = Self::Result>>> {
+    ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>> {
         let writer = self
             .writer_factory
             .create_writer(file_idx, partition_values)?;
@@ -248,8 +252,8 @@ mod tests {
     use super::*;
     use crate::test::{make_dummy_mp, DummyWriterFactory};
 
-    #[test]
-    fn test_target_batch_writer_exact_batch() {
+    #[tokio::test]
+    async fn test_target_batch_writer_exact_batch() {
         let dummy_writer_factory = DummyWriterFactory;
         let size_calculator = Arc::new(TargetInMemorySizeBytesCalculator::new(1, 1.0));
         let mut writer = TargetBatchWriter::new(
@@ -258,8 +262,8 @@ mod tests {
         );
 
         let mp = make_dummy_mp(1);
-        writer.write(mp).unwrap();
-        let res = writer.close().unwrap();
+        writer.write(mp).await.unwrap();
+        let res = writer.close().await.unwrap();
 
         assert!(res.is_some());
         let write_count = res
@@ -273,8 +277,8 @@ mod tests {
         assert_eq!(write_count, 1);
     }
 
-    #[test]
-    fn test_target_batch_writer_small_batches() {
+    #[tokio::test]
+    async fn test_target_batch_writer_small_batches() {
         let dummy_writer_factory = DummyWriterFactory;
         let size_calculator = Arc::new(TargetInMemorySizeBytesCalculator::new(3, 1.0));
         let mut writer = TargetBatchWriter::new(
@@ -284,9 +288,9 @@ mod tests {
 
         for _ in 0..8 {
             let mp = make_dummy_mp(1);
-            writer.write(mp).unwrap();
+            writer.write(mp).await.unwrap();
         }
-        let res = writer.close().unwrap();
+        let res = writer.close().await.unwrap();
 
         assert!(res.is_some());
         let write_count = res
@@ -300,8 +304,8 @@ mod tests {
         assert_eq!(write_count, 3);
     }
 
-    #[test]
-    fn test_target_batch_writer_big_batch() {
+    #[tokio::test]
+    async fn test_target_batch_writer_big_batch() {
         let dummy_writer_factory = DummyWriterFactory;
         let size_calculator = Arc::new(TargetInMemorySizeBytesCalculator::new(3, 1.0));
         let mut writer = TargetBatchWriter::new(
@@ -310,8 +314,8 @@ mod tests {
         );
 
         let mp = make_dummy_mp(10);
-        writer.write(mp).unwrap();
-        let res = writer.close().unwrap();
+        writer.write(mp).await.unwrap();
+        let res = writer.close().await.unwrap();
 
         assert!(res.is_some());
         let write_count = res

--- a/src/daft-writers/src/catalog.rs
+++ b/src/daft-writers/src/catalog.rs
@@ -5,7 +5,7 @@ use daft_logical_plan::{CatalogType, DeltaLakeCatalogInfo, IcebergCatalogInfo};
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 
-use crate::{pyarrow::PyArrowWriter, FileWriter, WriterFactory};
+use crate::{pyarrow::PyArrowWriter, AsyncFileWriter, WriterFactory};
 
 /// CatalogWriterFactory is a factory for creating Catalog writers, i.e. iceberg, delta writers.
 pub struct CatalogWriterFactory {
@@ -30,7 +30,7 @@ impl WriterFactory for CatalogWriterFactory {
         &self,
         file_idx: usize,
         partition_values: Option<&RecordBatch>,
-    ) -> DaftResult<Box<dyn FileWriter<Input = Self::Input, Result = Self::Result>>> {
+    ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>> {
         match self.native {
             true => unimplemented!(),
             false => {
@@ -46,7 +46,8 @@ pub fn create_pyarrow_catalog_writer(
     file_idx: usize,
     partition_values: Option<&RecordBatch>,
     catalog_info: &CatalogType,
-) -> DaftResult<Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>> {
+) -> DaftResult<Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>>
+{
     match catalog_info {
         CatalogType::DeltaLake(DeltaLakeCatalogInfo {
             path,

--- a/src/daft-writers/src/lance.rs
+++ b/src/daft-writers/src/lance.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use common_error::DaftResult;
 use daft_logical_plan::LanceCatalogInfo;
 use daft_micropartition::{python::PyMicroPartition, MicroPartition};
 use daft_recordbatch::{python::PyRecordBatch, RecordBatch};
 use pyo3::{types::PyAnyMethods, Python};
 
-use crate::{FileWriter, WriterFactory};
+use crate::{AsyncFileWriter, WriterFactory};
 
 pub struct LanceWriter {
     is_closed: bool,
@@ -26,11 +27,12 @@ impl LanceWriter {
     }
 }
 
-impl FileWriter for LanceWriter {
+#[async_trait]
+impl AsyncFileWriter for LanceWriter {
     type Input = Arc<MicroPartition>;
     type Result = Vec<RecordBatch>;
 
-    fn write(&mut self, data: Self::Input) -> DaftResult<usize> {
+    async fn write(&mut self, data: Self::Input) -> DaftResult<usize> {
         assert!(!self.is_closed, "Cannot write to a closed LanceWriter");
         self.bytes_written += data
             .size_bytes()?
@@ -73,7 +75,7 @@ impl FileWriter for LanceWriter {
         vec![self.bytes_written]
     }
 
-    fn close(&mut self) -> DaftResult<Self::Result> {
+    async fn close(&mut self) -> DaftResult<Self::Result> {
         self.is_closed = true;
         Ok(std::mem::take(&mut self.results))
     }
@@ -98,7 +100,7 @@ impl WriterFactory for LanceWriterFactory {
         &self,
         _file_idx: usize,
         _partition_values: Option<&RecordBatch>,
-    ) -> DaftResult<Box<dyn FileWriter<Input = Self::Input, Result = Self::Result>>> {
+    ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>> {
         let writer = LanceWriter::new(self.lance_info.clone());
         Ok(Box::new(writer))
     }

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -24,6 +24,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use async_trait::async_trait;
 use batch::TargetBatchWriterFactory;
 use common_daft_config::DaftExecutionConfig;
 use common_error::{DaftError, DaftResult};
@@ -45,15 +46,16 @@ pub const RETURN_PATHS_COLUMN_NAME: &str = "path";
 ///
 /// The `Input` type is the type of data that will be written to the file.
 /// The `Result` type is the type of the result that will be returned when the file is closed.
-pub trait FileWriter: Send + Sync {
+#[async_trait]
+pub trait AsyncFileWriter: Send + Sync {
     type Input;
     type Result;
 
     /// Write data to the file, returning the number of bytes written.
-    fn write(&mut self, data: Self::Input) -> DaftResult<usize>;
+    async fn write(&mut self, data: Self::Input) -> DaftResult<usize>;
 
     /// Close the file and return the result. The caller should NOT write to the file after calling this method.
-    fn close(&mut self) -> DaftResult<Self::Result>;
+    async fn close(&mut self) -> DaftResult<Self::Result>;
 
     /// Return the total number of bytes written by this writer.
     fn bytes_written(&self) -> usize;
@@ -74,7 +76,7 @@ pub trait WriterFactory: Send + Sync {
         &self,
         file_idx: usize,
         partition_values: Option<&RecordBatch>,
-    ) -> DaftResult<Box<dyn FileWriter<Input = Self::Input, Result = Self::Result>>>;
+    ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>>;
 }
 
 pub fn make_physical_writer_factory(
@@ -144,7 +146,7 @@ pub fn make_ipc_writer(
     dir: &str,
     target_filesize: usize,
     compression: Option<&str>,
-) -> DaftResult<Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>> {
+) -> DaftResult<Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>> {
     let compression = match compression {
         Some("lz4") => Some(arrow2::io::ipc::write::Compression::LZ4),
         Some("zstd") => Some(arrow2::io::ipc::write::Compression::ZSTD),

--- a/src/daft-writers/src/partition.rs
+++ b/src/daft-writers/src/partition.rs
@@ -3,6 +3,7 @@ use std::{
     sync::Arc,
 };
 
+use async_trait::async_trait;
 use common_error::DaftResult;
 use daft_core::{array::ops::as_arrow::AsArrow, utils::identity_hash_set::IndexHash};
 use daft_dsl::ExprRef;
@@ -10,7 +11,7 @@ use daft_io::IOStatsContext;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 
-use crate::{FileWriter, WriterFactory};
+use crate::{AsyncFileWriter, WriterFactory};
 
 /// PartitionedWriter is a writer that partitions the input data by a set of columns, and writes each partition
 /// to a separate file. It uses a map to keep track of the writers for each partition.
@@ -18,7 +19,7 @@ struct PartitionedWriter {
     // TODO: Figure out a way to NOT use the IndexHash + RawEntryMut pattern here. Ideally we want to store ScalarValues, aka. single Rows of the partition values as keys for the hashmap.
     per_partition_writers: HashMap<
         IndexHash,
-        Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
+        Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
     >,
     saved_partition_values: Vec<RecordBatch>,
     writer_factory: Arc<dyn WriterFactory<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
@@ -53,11 +54,12 @@ impl PartitionedWriter {
     }
 }
 
-impl FileWriter for PartitionedWriter {
+#[async_trait]
+impl AsyncFileWriter for PartitionedWriter {
     type Input = Arc<MicroPartition>;
     type Result = Vec<RecordBatch>;
 
-    fn write(&mut self, input: Arc<MicroPartition>) -> DaftResult<usize> {
+    async fn write(&mut self, input: Arc<MicroPartition>) -> DaftResult<usize> {
         assert!(
             !self.is_closed,
             "Cannot write to a closed PartitionedWriter"
@@ -88,11 +90,13 @@ impl FileWriter for PartitionedWriter {
                     let mut writer = self
                         .writer_factory
                         .create_writer(0, Some(partition_value_row.as_ref()))?;
-                    bytes_written += writer.write(Arc::new(MicroPartition::new_loaded(
-                        table.schema.clone(),
-                        vec![table].into(),
-                        None,
-                    )))?;
+                    bytes_written += writer
+                        .write(Arc::new(MicroPartition::new_loaded(
+                            table.schema.clone(),
+                            vec![table].into(),
+                            None,
+                        )))
+                        .await?;
                     entry.insert_hashed_nocheck(
                         *partition_value_hash,
                         IndexHash {
@@ -105,11 +109,13 @@ impl FileWriter for PartitionedWriter {
                 }
                 RawEntryMut::Occupied(mut entry) => {
                     let writer = entry.get_mut();
-                    bytes_written += writer.write(Arc::new(MicroPartition::new_loaded(
-                        table.schema.clone(),
-                        vec![table].into(),
-                        None,
-                    )))?;
+                    bytes_written += writer
+                        .write(Arc::new(MicroPartition::new_loaded(
+                            table.schema.clone(),
+                            vec![table].into(),
+                            None,
+                        )))
+                        .await?;
                 }
             }
         }
@@ -130,10 +136,10 @@ impl FileWriter for PartitionedWriter {
             .collect()
     }
 
-    fn close(&mut self) -> DaftResult<Self::Result> {
+    async fn close(&mut self) -> DaftResult<Self::Result> {
         let mut results = vec![];
         for (_, mut writer) in self.per_partition_writers.drain() {
-            results.extend(writer.close()?);
+            results.extend(writer.close().await?);
         }
         self.is_closed = true;
         Ok(results)
@@ -166,13 +172,13 @@ impl WriterFactory for PartitionedWriterFactory {
         &self,
         _file_idx: usize,
         _partition_values: Option<&RecordBatch>,
-    ) -> DaftResult<Box<dyn FileWriter<Input = Self::Input, Result = Self::Result>>> {
+    ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>> {
         Ok(Box::new(PartitionedWriter::new(
             self.writer_factory.clone(),
             self.partition_cols.clone(),
         ))
             as Box<
-                dyn FileWriter<Input = Self::Input, Result = Self::Result>,
+                dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>,
             >)
     }
 }

--- a/src/daft-writers/src/physical.rs
+++ b/src/daft-writers/src/physical.rs
@@ -6,7 +6,7 @@ use daft_logical_plan::OutputFileInfo;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 
-use crate::{FileWriter, WriterFactory};
+use crate::{AsyncFileWriter, WriterFactory};
 
 /// PhysicalWriterFactory is a factory for creating physical writers, i.e. parquet, csv writers.
 pub struct PhysicalWriterFactory {
@@ -31,7 +31,7 @@ impl WriterFactory for PhysicalWriterFactory {
         &self,
         file_idx: usize,
         partition_values: Option<&RecordBatch>,
-    ) -> DaftResult<Box<dyn FileWriter<Input = Self::Input, Result = Self::Result>>> {
+    ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>> {
         match self.native {
             true => unimplemented!(),
             false => {
@@ -56,7 +56,8 @@ pub fn create_pyarrow_file_writer(
     io_config: Option<&daft_io::IOConfig>,
     format: FileFormat,
     partition: Option<&RecordBatch>,
-) -> DaftResult<Box<dyn FileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>> {
+) -> DaftResult<Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>>
+{
     match format {
         #[cfg(feature = "python")]
         FileFormat::Parquet => Ok(Box::new(crate::pyarrow::PyArrowWriter::new_parquet_writer(


### PR DESCRIPTION
## Changes Made

The native file writers (e.g. https://github.com/Eventual-Inc/Daft/pull/4260) that we intend to implement are asynchronous. As prep, we move our file writer traits from synchronous to asynchronous.