### PR TITLE
perf: Perform Local Distinct list_agg in count_distinct aggregations

### DIFF
--- a/src/daft-physical-plan/src/physical_planner/translate.rs
+++ b/src/daft-physical-plan/src/physical_planner/translate.rs
@@ -660,7 +660,7 @@ pub fn populate_aggregation_stages(
             AggExpr::CountDistinct(sub_expr) => {
                 // First stage
                 let list_agg_id = add_to_stage(
-                    AggExpr::List,
+                    AggExpr::Set,
                     sub_expr.clone(),
                     schema,
                     &mut first_stage_aggs,


### PR DESCRIPTION
## Changes Made

Currently, most of the actual work for count_distinct is done at the finalization step, which only runs on 1 task / thread. Thus, very little parallelism is possible. With this change, Daft will perform a local distinct operation on micro-partitions during the sink phase, which can be done in parallel.

Performance results of running ClickBench Queries 4 & 5 (6 runs each, skipping first) on a M4 Max MacBook Pro w/ 14 cores & 32 GB memory:

| Query |	Before | After | Improvement |
| ------ | ------- | ----- | ------------- |
| Q4 | 2.95s | 1.89s| 1.56x |
| Q5 | 2.82s | 1.30s | 2.16x |

## Related Issues

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
