### PR TITLE
chore: Add daft-dashboard frontend build step to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build: check-toolchain .venv  ## Compile and install Daft for development
 	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin develop --extras=all --uv
 
 .PHONY: build-release
-build-release: check-toolchain .venv  ## Compile and install a faster Daft binary
+build-release: check-toolchain frontend .venv  ## Compile and install a faster Daft binary
 	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin develop --release --uv
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ docs: .venv ## Build Daft documentation
 docs-serve: .venv ## Build Daft documentation in development server
 	JUPYTER_PLATFORM_DIRS=1 uv run mkdocs serve -f mkdocs.yml
 
+.PHONY: frontend
+frontend: .venv ## Build daft-dashboard frontend assets
+	cd src/daft-dashboard/frontend && \
+		bun run build
+
 .PHONY: clean
 clean:
 	rm -rf $(VENV)


### PR DESCRIPTION
## Changes Made

Added a rule to the Makefile to build the daft-dashboard frontend because I had to keep doing it manually every time I pull from main.

## Related Issues

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
