### PR TITLE
fix: Add pip installs to window demo

### DIFF
--- a/tutorials/window_functions/demo.ipynb
+++ b/tutorials/window_functions/demo.ipynb
@@ -16,7 +16,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install matplotlib pandas daft"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1411,7 +1420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Changes Made

Add pip installs for the dependencies in window function demo notebook.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
