### PR TITLE
feat: Flotilla scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,6 +2248,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "uuid 1.16.0",
 ]
 
 [[package]]

--- a/src/daft-distributed/Cargo.toml
+++ b/src/daft-distributed/Cargo.toml
@@ -16,6 +16,7 @@ rand = {workspace = true}
 tokio = {workspace = true}
 tokio-stream = {workspace = true}
 tokio-util = {workspace = true}
+uuid = {version = "1.10.0", features = ["v4"]}
 
 [features]
 python = [

--- a/src/daft-distributed/src/pipeline_node/collect.rs
+++ b/src/daft-distributed/src/pipeline_node/collect.rs
@@ -6,7 +6,7 @@ use daft_local_plan::LocalPhysicalPlanRef;
 
 use super::{DistributedPipelineNode, PipelineOutput, RunningPipelineNode};
 use crate::{
-    scheduling::dispatcher::TaskDispatcherHandle,
+    scheduling::{dispatcher::TaskDispatcherHandle, task::Task},
     stage::StageContext,
     utils::channel::{create_channel, Sender},
 };
@@ -40,8 +40,8 @@ impl CollectNode {
     }
 
     #[allow(dead_code)]
-    async fn execution_loop(
-        _task_dispatcher_handle: TaskDispatcherHandle,
+    async fn execution_loop<T: Task>(
+        _task_dispatcher_handle: TaskDispatcherHandle<T>,
         _local_physical_plans: Vec<LocalPhysicalPlanRef>,
         _psets: HashMap<String, Vec<PartitionRef>>,
         _input_node: Option<RunningPipelineNode>,

--- a/src/daft-distributed/src/pipeline_node/collect.rs
+++ b/src/daft-distributed/src/pipeline_node/collect.rs
@@ -6,7 +6,7 @@ use daft_local_plan::LocalPhysicalPlanRef;
 
 use super::{DistributedPipelineNode, PipelineOutput, RunningPipelineNode};
 use crate::{
-    scheduling::{dispatcher::TaskDispatcherHandle, task::Task},
+    scheduling::{dispatcher::TaskDispatcherHandle, task::SwordfishTask},
     stage::StageContext,
     utils::channel::{create_channel, Sender},
 };
@@ -40,8 +40,8 @@ impl CollectNode {
     }
 
     #[allow(dead_code)]
-    async fn execution_loop<T: Task>(
-        _task_dispatcher_handle: TaskDispatcherHandle<T>,
+    async fn execution_loop(
+        _task_dispatcher_handle: TaskDispatcherHandle<SwordfishTask>,
         _local_physical_plans: Vec<LocalPhysicalPlanRef>,
         _psets: HashMap<String, Vec<PartitionRef>>,
         _input_node: Option<RunningPipelineNode>,

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -6,7 +6,7 @@ use daft_local_plan::LocalPhysicalPlanRef;
 
 use super::{DistributedPipelineNode, PipelineOutput, RunningPipelineNode};
 use crate::{
-    scheduling::dispatcher::TaskDispatcherHandle,
+    scheduling::{dispatcher::TaskDispatcherHandle, task::Task},
     stage::StageContext,
     utils::channel::{create_channel, Sender},
 };
@@ -43,8 +43,8 @@ impl LimitNode {
     }
 
     #[allow(dead_code)]
-    async fn execution_loop(
-        _task_dispatcher_handle: TaskDispatcherHandle,
+    async fn execution_loop<T: Task>(
+        _task_dispatcher_handle: TaskDispatcherHandle<T>,
         _local_physical_plans: Vec<LocalPhysicalPlanRef>,
         _input_node: Option<RunningPipelineNode>,
         _input_psets: HashMap<String, Vec<PartitionRef>>,

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -6,7 +6,7 @@ use daft_local_plan::LocalPhysicalPlanRef;
 
 use super::{DistributedPipelineNode, PipelineOutput, RunningPipelineNode};
 use crate::{
-    scheduling::{dispatcher::TaskDispatcherHandle, task::Task},
+    scheduling::{dispatcher::TaskDispatcherHandle, task::SwordfishTask},
     stage::StageContext,
     utils::channel::{create_channel, Sender},
 };
@@ -43,8 +43,8 @@ impl LimitNode {
     }
 
     #[allow(dead_code)]
-    async fn execution_loop<T: Task>(
-        _task_dispatcher_handle: TaskDispatcherHandle<T>,
+    async fn execution_loop(
+        _task_dispatcher_handle: TaskDispatcherHandle<SwordfishTask>,
         _local_physical_plans: Vec<LocalPhysicalPlanRef>,
         _input_node: Option<RunningPipelineNode>,
         _input_psets: HashMap<String, Vec<PartitionRef>>,

--- a/src/daft-distributed/src/pipeline_node/materialize.rs
+++ b/src/daft-distributed/src/pipeline_node/materialize.rs
@@ -1,12 +1,15 @@
 use common_error::DaftResult;
 use futures::Stream;
 
-use crate::{pipeline_node::PipelineOutput, scheduling::dispatcher::TaskDispatcherHandle};
+use crate::{
+    pipeline_node::PipelineOutput,
+    scheduling::{dispatcher::TaskDispatcherHandle, task::Task},
+};
 
 #[allow(dead_code)]
-pub(crate) fn materialize_all_pipeline_outputs(
+pub(crate) fn materialize_all_pipeline_outputs<T: Task>(
     _input: impl Stream<Item = DaftResult<PipelineOutput>> + Send + Unpin + 'static,
-    _task_dispatcher_handle: TaskDispatcherHandle,
+    _task_dispatcher_handle: TaskDispatcherHandle<T>,
 ) {
     todo!("FLOTILLA_MS1: Implement materialize_all_pipeline_outputs")
 }

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -41,10 +41,6 @@ impl PythonPartitionRefStream {
                         let objref = ray_part_ref.object_ref.clone_ref(py);
                         let size_bytes = ray_part_ref.size_bytes;
                         let num_rows = ray_part_ref.num_rows;
-                        println!(
-                            "objref: {:?}, num_rows: {:?}, size_bytes: {:?}",
-                            objref, num_rows, size_bytes
-                        );
                         let ret = (objref, num_rows, size_bytes);
                         Some(ret)
                     }

--- a/src/daft-distributed/src/python/ray/mod.rs
+++ b/src/daft-distributed/src/python/ray/mod.rs
@@ -1,5 +1,7 @@
 mod task;
+mod worker;
 mod worker_manager;
 
 pub(crate) use task::{RayPartitionRef, RaySwordfishTask};
-pub(crate) use worker_manager::RayWorkerManagerFactory;
+pub(crate) use worker::RaySwordfishWorker;
+pub(crate) use worker_manager::PyRayWorkerManager;

--- a/src/daft-distributed/src/python/ray/task.rs
+++ b/src/daft-distributed/src/python/ray/task.rs
@@ -6,7 +6,7 @@ use common_partitioning::{Partition, PartitionRef};
 use daft_local_plan::PyLocalPhysicalPlan;
 use pyo3::{pyclass, pymethods, FromPyObject, PyObject, PyResult, Python};
 
-use crate::scheduling::task::{SwordfishTask, SwordfishTaskResultHandle, Task};
+use crate::scheduling::task::{SwordfishTask, SwordfishTaskResultHandle, Task, TaskId};
 
 /// TaskHandle that wraps a Python RaySwordfishTaskHandle
 #[allow(dead_code)]
@@ -131,8 +131,8 @@ impl RaySwordfishTask {
 
 #[pymethods]
 impl RaySwordfishTask {
-    fn task_id(&self) -> String {
-        self.task.task_id().to_string()
+    fn task_id(&self) -> &TaskId {
+        self.task.task_id()
     }
 
     fn plan(&self) -> PyResult<PyLocalPhysicalPlan> {

--- a/src/daft-distributed/src/python/ray/task.rs
+++ b/src/daft-distributed/src/python/ray/task.rs
@@ -1,17 +1,18 @@
 use std::{any::Any, collections::HashMap, sync::Arc};
 
+use common_daft_config::PyDaftExecutionConfig;
 use common_error::DaftResult;
 use common_partitioning::{Partition, PartitionRef};
 use daft_local_plan::PyLocalPhysicalPlan;
 use pyo3::{pyclass, pymethods, FromPyObject, PyObject, PyResult, Python};
 
-use crate::scheduling::task::{SwordfishTask, SwordfishTaskResultHandle};
+use crate::scheduling::task::{SwordfishTask, SwordfishTaskResultHandle, Task};
 
 /// TaskHandle that wraps a Python RaySwordfishTaskHandle
 #[allow(dead_code)]
 pub(crate) struct RayTaskResultHandle {
     /// The handle to the task
-    handle: Option<PyObject>,
+    handle: PyObject,
     /// The task locals, i.e. the asyncio event loop
     task_locals: Option<pyo3_async_runtimes::TaskLocals>,
 }
@@ -21,7 +22,7 @@ impl RayTaskResultHandle {
     #[allow(dead_code)]
     pub fn new(handle: PyObject, task_locals: pyo3_async_runtimes::TaskLocals) -> Self {
         Self {
-            handle: Some(handle),
+            handle,
             task_locals: Some(task_locals),
         }
     }
@@ -30,34 +31,42 @@ impl RayTaskResultHandle {
 #[async_trait::async_trait]
 impl SwordfishTaskResultHandle for RayTaskResultHandle {
     /// Get the result of the task, awaiting if necessary
-    async fn get_result(&mut self) -> DaftResult<PartitionRef> {
-        let handle = self.handle.take().unwrap();
+    async fn get_result(&mut self) -> DaftResult<Vec<PartitionRef>> {
+        // Create a coroutine that will await the result of the task
         let coroutine = Python::with_gil(|py| {
-            let coroutine = handle
-                .call_method0(py, pyo3::intern!(py, "get_result"))?
-                .into_bound(py);
-            pyo3_async_runtimes::tokio::into_future(coroutine)
-        })?;
+            self.handle
+                .call_method0(py, pyo3::intern!(py, "get_result"))
+                .expect("Failed to get result from RayTaskResultHandle")
+        });
+
+        // Create a rust future that will await the coroutine
+        let await_coroutine = async move {
+            let result = Python::with_gil(|py| {
+                pyo3_async_runtimes::tokio::into_future(coroutine.into_bound(py))
+            })?;
+            DaftResult::Ok(result.await)
+        };
 
         // await the rust future in the scope of the asyncio event loop
         let task_locals = self.task_locals.take().unwrap();
-        let materialized_result = pyo3_async_runtimes::tokio::scope(task_locals, coroutine).await?;
-
-        let ray_part_ref =
-            Python::with_gil(|py| materialized_result.extract::<RayPartitionRef>(py))?;
-        Ok(Arc::new(ray_part_ref))
+        let materialized_result =
+            pyo3_async_runtimes::tokio::scope(task_locals, await_coroutine).await??;
+        let ray_part_refs =
+            Python::with_gil(|py| materialized_result.extract::<Vec<RayPartitionRef>>(py))?;
+        Ok(ray_part_refs
+            .into_iter()
+            .map(|r| Arc::new(r) as PartitionRef)
+            .collect::<Vec<PartitionRef>>())
     }
 }
 
 impl Drop for RayTaskResultHandle {
     fn drop(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            Python::with_gil(|py| {
-                handle
-                    .call_method0(py, "cancel")
-                    .expect("Failed to cancel ray task")
-            });
-        }
+        Python::with_gil(|py| {
+            self.handle
+                .call_method0(py, "cancel")
+                .expect("Failed to cancel ray task")
+        });
     }
 }
 
@@ -67,6 +76,33 @@ pub(crate) struct RayPartitionRef {
     pub object_ref: PyObject,
     pub num_rows: usize,
     pub size_bytes: usize,
+}
+
+#[pymethods]
+impl RayPartitionRef {
+    #[new]
+    pub fn new(object_ref: PyObject, num_rows: usize, size_bytes: usize) -> Self {
+        Self {
+            object_ref,
+            num_rows,
+            size_bytes,
+        }
+    }
+
+    #[getter]
+    pub fn get_object_ref(&self, py: Python) -> PyObject {
+        self.object_ref.clone_ref(py)
+    }
+
+    #[getter]
+    pub fn get_num_rows(&self) -> usize {
+        self.num_rows
+    }
+
+    #[getter]
+    pub fn get_size_bytes(&self) -> usize {
+        self.size_bytes
+    }
 }
 
 impl Partition for RayPartitionRef {
@@ -83,25 +119,32 @@ impl Partition for RayPartitionRef {
 
 #[pyclass(module = "daft.daft", name = "RaySwordfishTask")]
 pub(crate) struct RaySwordfishTask {
-    task: SwordfishTask,
+    task: Box<SwordfishTask>,
 }
 
 impl RaySwordfishTask {
     #[allow(dead_code)]
-    pub fn new(task: SwordfishTask) -> Self {
+    pub fn new(task: Box<SwordfishTask>) -> Self {
         Self { task }
     }
 }
 
 #[pymethods]
 impl RaySwordfishTask {
-    fn estimated_memory_cost(&self) -> usize {
-        self.task.estimated_memory_cost()
+    fn task_id(&self) -> String {
+        self.task.task_id().to_string()
     }
 
     fn plan(&self) -> PyResult<PyLocalPhysicalPlan> {
         let plan = self.task.plan();
         Ok(PyLocalPhysicalPlan { plan })
+    }
+
+    fn config(&self) -> PyResult<PyDaftExecutionConfig> {
+        let config = self.task.config();
+        Ok(PyDaftExecutionConfig {
+            config: config.clone(),
+        })
     }
 
     fn psets(&self, py: Python) -> PyResult<HashMap<String, Vec<RayPartitionRef>>> {

--- a/src/daft-distributed/src/python/ray/worker.rs
+++ b/src/daft-distributed/src/python/ray/worker.rs
@@ -1,0 +1,92 @@
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+use common_error::DaftResult;
+use pyo3::prelude::*;
+
+use super::{task::RayTaskResultHandle, RaySwordfishTask};
+use crate::scheduling::{
+    task::{SwordfishTask, SwordfishTaskResultHandle, Task, TaskId},
+    worker::{Worker, WorkerId},
+};
+
+#[pyclass(module = "daft.daft", name = "RaySwordfishWorker")]
+#[derive(Debug, Clone)]
+pub(crate) struct RaySwordfishWorker {
+    worker_id: WorkerId,
+    actor_handle: Arc<PyObject>,
+    num_cpus: usize,
+    #[allow(dead_code)]
+    total_memory_bytes: usize,
+    active_task_ids: Arc<Mutex<HashSet<String>>>,
+}
+
+#[pymethods]
+impl RaySwordfishWorker {
+    #[new]
+    pub fn new(
+        worker_id: WorkerId,
+        actor_handle: PyObject,
+        num_cpus: usize,
+        total_memory_bytes: usize,
+    ) -> Self {
+        Self {
+            worker_id,
+            actor_handle: Arc::new(actor_handle),
+            num_cpus,
+            total_memory_bytes,
+            active_task_ids: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl RaySwordfishWorker {
+    pub fn mark_task_finished(&self, task_id: String) {
+        self.active_task_ids.lock().unwrap().remove(&task_id);
+    }
+
+    pub fn submit_task(
+        &self,
+        task: Box<dyn Task>,
+        task_locals: &pyo3_async_runtimes::TaskLocals,
+    ) -> DaftResult<Box<dyn SwordfishTaskResultHandle>> {
+        let task = task.into_any().downcast::<SwordfishTask>().unwrap();
+        let task_id = task.task_id().to_string();
+        let py_task = RaySwordfishTask::new(task);
+        let py_task_handle = Python::with_gil(|py| {
+            let py_task_handle = self
+                .actor_handle
+                .call_method1(py, pyo3::intern!(py, "submit_task"), (py_task,))
+                .expect("Failed to submit task to RayWorker");
+            let task_locals = task_locals.clone_ref(py);
+            Box::new(RayTaskResultHandle::new(py_task_handle, task_locals))
+        });
+        self.active_task_ids.lock().unwrap().insert(task_id);
+        Ok(py_task_handle)
+    }
+
+    pub fn shutdown(&self) {
+        Python::with_gil(|py| {
+            self.actor_handle
+                .call_method0(py, pyo3::intern!(py, "shutdown"))
+                .unwrap();
+        });
+    }
+}
+
+impl Worker for RaySwordfishWorker {
+    fn id(&self) -> &WorkerId {
+        &self.worker_id
+    }
+
+    fn num_cpus(&self) -> usize {
+        self.num_cpus
+    }
+
+    fn active_task_ids(&self) -> HashSet<TaskId> {
+        self.active_task_ids.lock().unwrap().clone()
+    }
+}

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -1,120 +1,109 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use common_daft_config::{DaftExecutionConfig, PyDaftExecutionConfig};
 use common_error::DaftResult;
 use pyo3::prelude::*;
 
-use super::task::*;
+use super::worker::RaySwordfishWorker;
 use crate::scheduling::{
-    task::{SwordfishTask, SwordfishTaskResultHandle},
-    worker::{WorkerManager, WorkerManagerFactory},
+    task::{SwordfishTaskResultHandle, Task, TaskId},
+    worker::{Worker, WorkerId, WorkerManager},
 };
 
 // Wrapper around the RaySwordfishWorkerManager class in the distributed_swordfish module.
 #[allow(dead_code)]
 pub(crate) struct RayWorkerManager {
-    ray_worker_manager: PyObject,
+    ray_workers: HashMap<WorkerId, RaySwordfishWorker>,
     task_locals: pyo3_async_runtimes::TaskLocals,
 }
 
-// TODO(FLOTILLA_MS1): Make Ray worker manager live for the duration of the program
-// so that we don't have to recreate it on every stage.
 impl RayWorkerManager {
-    pub fn try_new(
-        daft_execution_config: Arc<DaftExecutionConfig>,
-        task_locals: &pyo3_async_runtimes::TaskLocals,
-    ) -> DaftResult<Self> {
-        let py_daft_execution_config = PyDaftExecutionConfig {
-            config: daft_execution_config,
-        };
-        let (ray_worker_manager, task_locals) = Python::with_gil(|py| {
+    pub fn try_new() -> DaftResult<Self> {
+        let (ray_workers, task_locals) = Python::with_gil(|py| {
             let distributed_swordfish_module = py.import("daft.runners.distributed_swordfish")?;
-            let ray_worker_manager_class =
-                distributed_swordfish_module.getattr("RaySwordfishWorkerManager")?;
-            let instance = ray_worker_manager_class.call1((py_daft_execution_config,))?;
-            let task_locals = task_locals.clone_ref(py);
-            DaftResult::Ok((instance.unbind(), task_locals))
+            let ray_workers = distributed_swordfish_module
+                .call_method0("start_ray_workers")?
+                .extract::<Vec<RaySwordfishWorker>>()?;
+            let ray_worker_hashmap = ray_workers
+                .into_iter()
+                .map(|w| (w.id().clone(), w))
+                .collect();
+            let task_locals = pyo3_async_runtimes::tokio::get_current_locals(py)
+                .expect("Failed to get current task locals");
+            DaftResult::Ok((ray_worker_hashmap, task_locals))
         })?;
         Ok(Self {
-            ray_worker_manager,
+            ray_workers,
             task_locals,
         })
     }
 }
 
 impl WorkerManager for RayWorkerManager {
+    type Worker = RaySwordfishWorker;
+
     fn submit_task_to_worker(
         &self,
-        task: SwordfishTask,
+        task: Box<dyn Task>,
         worker_id: String,
     ) -> Box<dyn SwordfishTaskResultHandle> {
-        Python::with_gil(|py| {
-            let py_task = RaySwordfishTask::new(task);
-            let py_task_handle = self
-                .ray_worker_manager
-                .call_method1(
-                    py,
-                    pyo3::intern!(py, "submit_task_to_worker"),
-                    (py_task, worker_id),
-                )
-                .expect("Failed to submit task to RayWorkerManager");
-            let task_locals = self.task_locals.clone_ref(py);
-            Box::new(RayTaskResultHandle::new(py_task_handle, task_locals))
-        })
+        self.ray_workers
+            .get(&worker_id)
+            .unwrap()
+            .submit_task(task, &self.task_locals)
+            .expect("Failed to submit task to RayWorkerManager")
     }
 
-    fn get_worker_resources(&self) -> Vec<(String, usize, usize)> {
-        Python::with_gil(|py| {
-            let py_worker_resources = self
-                .ray_worker_manager
-                .call_method0(py, pyo3::intern!(py, "get_worker_resources"))
-                .expect("Failed to get worker resources from RayWorkerManager");
-            py_worker_resources
-                .extract::<Vec<(String, usize, usize)>>(py)
-                .expect("Failed to extract worker resources from RayWorkerManager")
-        })
+    fn workers(&self) -> &HashMap<WorkerId, Self::Worker> {
+        &self.ray_workers
     }
 
-    fn try_autoscale(&self, num_workers: usize) -> DaftResult<()> {
-        Python::with_gil(|py| {
-            self.ray_worker_manager.call_method1(
-                py,
-                pyo3::intern!(py, "try_autoscale"),
-                (num_workers,),
-            )
-        })?;
-        Ok(())
+    fn mark_task_finished(&self, task_id: TaskId, worker_id: WorkerId) {
+        self.ray_workers
+            .get(&worker_id)
+            .unwrap()
+            .mark_task_finished(task_id);
+    }
+
+    fn total_available_cpus(&self) -> usize {
+        self.ray_workers
+            .values()
+            .map(|w| w.num_cpus() - w.active_task_ids().len())
+            .sum()
     }
 
     fn shutdown(&self) -> DaftResult<()> {
-        Python::with_gil(|py| {
-            self.ray_worker_manager
-                .call_method0(py, pyo3::intern!(py, "shutdown"))
-        })?;
+        for worker in self.ray_workers.values() {
+            worker.shutdown();
+        }
         Ok(())
     }
 }
 
-pub(crate) struct RayWorkerManagerFactory {
-    daft_execution_config: Arc<DaftExecutionConfig>,
-    task_locals: pyo3_async_runtimes::TaskLocals,
-}
-
-impl RayWorkerManagerFactory {
-    pub fn new(
-        daft_execution_config: Arc<DaftExecutionConfig>,
-        task_locals: pyo3_async_runtimes::TaskLocals,
-    ) -> Self {
-        Self {
-            daft_execution_config,
-            task_locals,
-        }
+impl Drop for RayWorkerManager {
+    fn drop(&mut self) {
+        self.shutdown().unwrap();
     }
 }
 
-impl WorkerManagerFactory for RayWorkerManagerFactory {
-    fn create_worker_manager(&self) -> DaftResult<Box<dyn WorkerManager>> {
-        RayWorkerManager::try_new(self.daft_execution_config.clone(), &self.task_locals)
-            .map(|ray_worker_manager| Box::new(ray_worker_manager) as Box<dyn WorkerManager>)
+#[pyclass(module = "daft.daft", name = "RayWorkerManager")]
+#[derive(Clone)]
+pub(crate) struct PyRayWorkerManager {
+    pub inner: Arc<RayWorkerManager>,
+}
+
+#[pymethods]
+impl PyRayWorkerManager {
+    #[new]
+    pub fn new() -> DaftResult<Self> {
+        let inner = RayWorkerManager::try_new()?;
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
+    }
+}
+
+impl PyRayWorkerManager {
+    pub fn inner(&self) -> Arc<dyn WorkerManager<Worker = RaySwordfishWorker>> {
+        self.inner.clone()
     }
 }

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -159,7 +159,7 @@ impl SubmittedTask {
     }
 
     #[allow(dead_code)]
-    pub fn id(&self) -> &str {
+    pub fn id(&self) -> &TaskId {
         &self._task_id
     }
 }

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -1,16 +1,22 @@
 use std::{
     future::Future,
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
-use common_error::{DaftError, DaftResult};
+use common_error::DaftResult;
 use common_partitioning::PartitionRef;
 use futures::FutureExt;
 use tokio_util::sync::CancellationToken;
 
+use super::{
+    scheduler::{DefaultScheduler, Scheduler},
+    task::{SchedulingStrategy, Task, TaskId},
+    worker::Worker,
+};
 use crate::{
-    scheduling::{task::SwordfishTask, worker::WorkerManager},
+    scheduling::worker::WorkerManager,
     utils::{
         channel::{
             create_channel, create_oneshot_channel, OneshotReceiver, OneshotSender, Receiver,
@@ -21,20 +27,39 @@ use crate::{
 };
 // The task dispatcher is responsible for dispatching tasks to workers.
 #[allow(dead_code)]
-pub(crate) struct TaskDispatcher {
-    worker_manager: Box<dyn WorkerManager>,
+pub(crate) struct TaskDispatcher<T: Task, W: Worker> {
+    worker_manager: Arc<dyn WorkerManager<Worker = W>>,
+    scheduler: Box<dyn Scheduler<T, W>>,
 }
 
-impl TaskDispatcher {
-    pub fn new(worker_manager: Box<dyn WorkerManager>) -> Self {
-        Self { worker_manager }
+impl<T: Task, W: Worker> TaskDispatcher<T, W> {
+    const MAX_TASKS_IN_CHANNEL: usize = 512;
+
+    pub fn new(worker_manager: Arc<dyn WorkerManager<Worker = W>>) -> Self {
+        let scheduler = Box::new(DefaultScheduler::new());
+        Self {
+            worker_manager,
+            scheduler,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn new_with_scheduler(
+        worker_manager: Arc<dyn WorkerManager<Worker = W>>,
+        scheduler: Box<dyn Scheduler<T, W>>,
+    ) -> Self {
+        Self {
+            worker_manager,
+            scheduler,
+        }
     }
 
     pub fn spawn_task_dispatcher(
         task_dispatcher: Self,
         joinset: &mut JoinSet<DaftResult<()>>,
-    ) -> TaskDispatcherHandle {
-        let (task_dispatcher_sender, task_dispatcher_receiver) = create_channel(1);
+    ) -> TaskDispatcherHandle<T> {
+        let (task_dispatcher_sender, task_dispatcher_receiver) =
+            create_channel(Self::MAX_TASKS_IN_CHANNEL);
         joinset.spawn(Self::run_dispatch_loop(
             task_dispatcher,
             task_dispatcher_receiver,
@@ -44,103 +69,114 @@ impl TaskDispatcher {
 
     async fn run_dispatch_loop(
         _dispatcher: Self,
-        _task_rx: Receiver<DispatchedTask>,
+        _task_rx: Receiver<SchedulableTask<T>>,
     ) -> DaftResult<()> {
         todo!("FLOTILLA_MS1: Implement run dispatch loop");
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct TaskDispatcherHandle {
-    task_dispatcher_sender: Sender<DispatchedTask>,
+#[allow(dead_code)]
+pub(crate) struct SchedulableTask<T: Task> {
+    task: T,
+    result_tx: OneshotSender<DaftResult<Vec<PartitionRef>>>,
+    cancel_token: CancellationToken,
 }
 
-impl TaskDispatcherHandle {
-    fn new(task_dispatcher_sender: Sender<DispatchedTask>) -> Self {
+impl<T: Task> SchedulableTask<T> {
+    pub fn new(
+        task: T,
+        result_tx: OneshotSender<DaftResult<Vec<PartitionRef>>>,
+        cancel_token: CancellationToken,
+    ) -> Self {
+        Self {
+            task,
+            result_tx,
+            cancel_token,
+        }
+    }
+
+    pub fn strategy(&self) -> &SchedulingStrategy {
+        self.task.strategy()
+    }
+
+    #[allow(dead_code)]
+    pub fn task_id(&self) -> &str {
+        self.task.task_id()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TaskDispatcherHandle<T: Task> {
+    task_dispatcher_sender: Sender<SchedulableTask<T>>,
+}
+
+impl<T: Task> TaskDispatcherHandle<T> {
+    fn new(task_dispatcher_sender: Sender<SchedulableTask<T>>) -> Self {
         Self {
             task_dispatcher_sender,
         }
     }
 
+    fn prepare_task_for_submission(&self, task: T) -> (SchedulableTask<T>, SubmittedTask) {
+        let (result_tx, result_rx) = create_oneshot_channel();
+        let cancel_token = CancellationToken::new();
+
+        let task_id = task.task_id().to_string();
+        let schedulable_task = SchedulableTask::new(task, result_tx, cancel_token.clone());
+        let submitted_task = SubmittedTask::new(task_id, result_rx, Some(cancel_token));
+
+        (schedulable_task, submitted_task)
+    }
+
     #[allow(dead_code)]
-    pub async fn submit_task(&self, task: SwordfishTask) -> DaftResult<SubmittedTask> {
-        let dispatchable_task = DispatchableTask::new(task);
-        let submitted_task = dispatchable_task
-            .dispatch(&self.task_dispatcher_sender)
-            .await?;
+    pub async fn submit_task(&self, task: T) -> DaftResult<SubmittedTask> {
+        let (schedulable_task, submitted_task) = self.prepare_task_for_submission(task);
+        let _ = self.task_dispatcher_sender.send(schedulable_task).await;
         Ok(submitted_task)
     }
 }
 
-#[allow(dead_code)]
-struct DispatchableTask {
-    task: SwordfishTask,
-}
-
-impl DispatchableTask {
-    fn new(task: SwordfishTask) -> Self {
-        Self { task }
-    }
-
-    async fn dispatch(
-        self,
-        task_dispatcher_sender: &Sender<DispatchedTask>,
-    ) -> DaftResult<SubmittedTask> {
-        let (result_tx, result_rx) = create_oneshot_channel();
-        let cancel_token = CancellationToken::new();
-        let task = DispatchedTask::new(self.task, result_tx, cancel_token.clone());
-        task_dispatcher_sender
-            .send(task)
-            .await
-            .map_err(|e| DaftError::InternalError(e.to_string()))?;
-        Ok(SubmittedTask::new(result_rx, Some(cancel_token)))
-    }
-}
-
-#[allow(dead_code)]
-struct DispatchedTask {
-    swordfish_task: SwordfishTask,
-    result_tx: OneshotSender<DaftResult<PartitionRef>>,
-    cancel_token: CancellationToken,
-}
-
-impl DispatchedTask {
-    fn new(
-        swordfish_task: SwordfishTask,
-        result_tx: OneshotSender<DaftResult<PartitionRef>>,
-        cancel_token: CancellationToken,
-    ) -> Self {
-        Self {
-            swordfish_task,
-            result_tx,
-            cancel_token,
-        }
-    }
-}
+#[derive(Debug)]
 pub(crate) struct SubmittedTask {
-    result_rx: OneshotReceiver<DaftResult<PartitionRef>>,
+    _task_id: TaskId,
+    result_rx: OneshotReceiver<DaftResult<Vec<PartitionRef>>>,
     cancel_token: Option<CancellationToken>,
+    finished: bool,
 }
 
 impl SubmittedTask {
     fn new(
-        result_rx: OneshotReceiver<DaftResult<PartitionRef>>,
+        task_id: TaskId,
+        result_rx: OneshotReceiver<DaftResult<Vec<PartitionRef>>>,
         cancel_token: Option<CancellationToken>,
     ) -> Self {
         Self {
+            _task_id: task_id,
             result_rx,
             cancel_token,
+            finished: false,
         }
+    }
+
+    #[allow(dead_code)]
+    pub fn id(&self) -> &str {
+        &self._task_id
     }
 }
 
 impl Future for SubmittedTask {
-    type Output = Option<DaftResult<PartitionRef>>;
+    type Output = Option<DaftResult<Vec<PartitionRef>>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.result_rx.poll_unpin(cx) {
-            Poll::Ready(Ok(result)) => Poll::Ready(Some(result)),
-            Poll::Ready(Err(_)) => Poll::Ready(None),
+            Poll::Ready(Ok(result)) => {
+                self.finished = true;
+                Poll::Ready(Some(result))
+            }
+            Poll::Ready(Err(_)) => {
+                self.finished = true;
+                Poll::Ready(None)
+            }
             Poll::Pending => Poll::Pending,
         }
     }
@@ -148,6 +184,9 @@ impl Future for SubmittedTask {
 
 impl Drop for SubmittedTask {
     fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
         if let Some(cancel_token) = self.cancel_token.take() {
             cancel_token.cancel();
         }

--- a/src/daft-distributed/src/scheduling/mod.rs
+++ b/src/daft-distributed/src/scheduling/mod.rs
@@ -1,3 +1,4 @@
-pub mod dispatcher;
-pub mod task;
-pub mod worker;
+pub(crate) mod dispatcher;
+mod scheduler;
+pub(crate) mod task;
+pub(crate) mod worker;

--- a/src/daft-distributed/src/scheduling/scheduler.rs
+++ b/src/daft-distributed/src/scheduling/scheduler.rs
@@ -49,15 +49,15 @@ impl DefaultScheduler {
         }
     }
     fn try_schedule_spread_task(&self) -> Option<WorkerId> {
-        todo!()
+        todo!("FLOTILLA_MS1: Implement scheduling spread task for default scheduler")
     }
 
     fn try_schedule_soft_node_affinity_task(&self, _node_id: &str) -> Option<WorkerId> {
-        todo!()
+        todo!("FLOTILLA_MS1: Implement scheduling soft node affinity task for default scheduler")
     }
 
     fn try_schedule_hard_node_affinity_task(&self, _node_id: &str) -> Option<WorkerId> {
-        todo!()
+        todo!("FLOTILLA_MS1: Implement scheduling hard node affinity task for default scheduler")
     }
 
     fn try_schedule_task<T: Task>(&self, task: &SchedulableTask<T>) -> Option<WorkerId> {
@@ -121,10 +121,10 @@ impl LinearScheduler {
 
 impl<T: Task, W: Worker> Scheduler<T, W> for LinearScheduler {
     fn update_state(&mut self, _workers: &HashMap<WorkerId, W>) {
-        todo!()
+        todo!("FLOTILLA_MS1: Implement updating state for linear scheduler")
     }
 
     fn schedule_tasks(&mut self, _tasks: Vec<SchedulableTask<T>>) -> ScheduleResult<T> {
-        todo!()
+        todo!("FLOTILLA_MS1: Implement scheduling tasks for linear scheduler")
     }
 }

--- a/src/daft-distributed/src/scheduling/scheduler.rs
+++ b/src/daft-distributed/src/scheduling/scheduler.rs
@@ -1,0 +1,130 @@
+use std::collections::{HashMap, HashSet};
+
+use super::{
+    dispatcher::SchedulableTask,
+    task::{SchedulingStrategy, Task, TaskId},
+    worker::{Worker, WorkerId},
+};
+
+#[allow(dead_code)]
+pub(crate) struct ScheduleResult<T: Task> {
+    pub scheduled_tasks: Vec<(WorkerId, SchedulableTask<T>)>,
+    pub unscheduled_tasks: Vec<SchedulableTask<T>>,
+}
+
+#[allow(dead_code)]
+pub(crate) trait Scheduler<T: Task, W: Worker>: Send + Sync {
+    fn update_state(&mut self, workers: &HashMap<WorkerId, W>);
+    fn schedule_tasks(&mut self, tasks: Vec<SchedulableTask<T>>) -> ScheduleResult<T>;
+}
+
+#[allow(dead_code)]
+struct WorkerSnapshot {
+    worker_id: WorkerId,
+    num_cpus: usize,
+    active_task_ids: HashSet<TaskId>,
+}
+
+#[allow(dead_code)]
+impl WorkerSnapshot {
+    fn new(worker: &impl Worker) -> Self {
+        Self {
+            worker_id: worker.id().clone(),
+            active_task_ids: worker.active_task_ids(),
+            num_cpus: worker.num_cpus(),
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct DefaultScheduler {
+    worker_snapshots: HashMap<WorkerId, WorkerSnapshot>,
+}
+
+#[allow(dead_code)]
+impl DefaultScheduler {
+    pub fn new() -> Self {
+        Self {
+            worker_snapshots: HashMap::new(),
+        }
+    }
+    fn try_schedule_spread_task(&self) -> Option<WorkerId> {
+        todo!()
+    }
+
+    fn try_schedule_soft_node_affinity_task(&self, _node_id: &str) -> Option<WorkerId> {
+        todo!()
+    }
+
+    fn try_schedule_hard_node_affinity_task(&self, _node_id: &str) -> Option<WorkerId> {
+        todo!()
+    }
+
+    fn try_schedule_task<T: Task>(&self, task: &SchedulableTask<T>) -> Option<WorkerId> {
+        match task.strategy() {
+            SchedulingStrategy::Spread => self.try_schedule_spread_task(),
+            SchedulingStrategy::NodeAffinity { node_id, soft } => match soft {
+                true => self.try_schedule_soft_node_affinity_task(node_id),
+                false => self.try_schedule_hard_node_affinity_task(node_id),
+            },
+        }
+    }
+}
+
+impl<T: Task, W: Worker> Scheduler<T, W> for DefaultScheduler {
+    fn update_state(&mut self, workers: &HashMap<WorkerId, W>) {
+        self.worker_snapshots = workers
+            .iter()
+            .map(|(id, worker)| (id.clone(), WorkerSnapshot::new(worker)))
+            .collect();
+    }
+
+    fn schedule_tasks(&mut self, tasks: Vec<SchedulableTask<T>>) -> ScheduleResult<T> {
+        let mut scheduled_tasks: Vec<(WorkerId, SchedulableTask<T>)> = Vec::new();
+        let mut unscheduled_tasks: Vec<SchedulableTask<T>> = Vec::new();
+
+        for task in tasks {
+            let worker_id = self.try_schedule_task(&task);
+            if let Some(worker_id) = worker_id {
+                let task_id = task.task_id().to_string();
+                scheduled_tasks.push((worker_id.clone(), task));
+                self.worker_snapshots
+                    .get_mut(&worker_id)
+                    .unwrap()
+                    .active_task_ids
+                    .insert(task_id);
+            } else {
+                unscheduled_tasks.push(task);
+            }
+        }
+
+        ScheduleResult {
+            scheduled_tasks,
+            unscheduled_tasks,
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct LinearScheduler {
+    worker_snapshots: HashMap<WorkerId, WorkerSnapshot>,
+}
+
+#[allow(dead_code)]
+impl LinearScheduler {
+    pub fn new() -> Self {
+        Self {
+            worker_snapshots: HashMap::new(),
+        }
+    }
+}
+
+impl<T: Task, W: Worker> Scheduler<T, W> for LinearScheduler {
+    fn update_state(&mut self, _workers: &HashMap<WorkerId, W>) {
+        todo!()
+    }
+
+    fn schedule_tasks(&mut self, _tasks: Vec<SchedulableTask<T>>) -> ScheduleResult<T> {
+        todo!()
+    }
+}

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -24,7 +24,7 @@ pub(crate) enum SchedulingStrategy {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SwordfishTask {
-    id: String,
+    id: TaskId,
     plan: LocalPhysicalPlanRef,
     config: Arc<DaftExecutionConfig>,
     psets: HashMap<String, Vec<PartitionRef>>,
@@ -49,7 +49,7 @@ impl SwordfishTask {
         }
     }
 
-    pub fn id(&self) -> &str {
+    pub fn id(&self) -> &TaskId {
         &self.id
     }
 

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -1,26 +1,68 @@
-use std::collections::HashMap;
+use std::{any::Any, collections::HashMap, sync::Arc};
 
+use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
 use common_partitioning::PartitionRef;
 use daft_local_plan::LocalPhysicalPlanRef;
+use uuid::Uuid;
 
-#[derive(Debug)]
-pub struct SwordfishTask {
-    plan: LocalPhysicalPlanRef,
-    psets: HashMap<String, Vec<PartitionRef>>,
+pub(crate) type TaskId = String;
+
+#[allow(dead_code)]
+pub(crate) trait Task: Send + Sync + 'static {
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    fn task_id(&self) -> &TaskId;
+    fn strategy(&self) -> &SchedulingStrategy;
 }
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub(crate) enum SchedulingStrategy {
+    Spread,
+    NodeAffinity { node_id: String, soft: bool },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SwordfishTask {
+    id: String,
+    plan: LocalPhysicalPlanRef,
+    config: Arc<DaftExecutionConfig>,
+    psets: HashMap<String, Vec<PartitionRef>>,
+    strategy: SchedulingStrategy,
+}
+
+#[allow(dead_code)]
 impl SwordfishTask {
-    #[allow(dead_code)]
-    pub fn new(plan: LocalPhysicalPlanRef, psets: HashMap<String, Vec<PartitionRef>>) -> Self {
-        Self { plan, psets }
+    pub fn new(
+        plan: LocalPhysicalPlanRef,
+        config: Arc<DaftExecutionConfig>,
+        psets: HashMap<String, Vec<PartitionRef>>,
+        strategy: SchedulingStrategy,
+    ) -> Self {
+        let task_id = Uuid::new_v4().to_string();
+        Self {
+            id: task_id,
+            plan,
+            config,
+            psets,
+            strategy,
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn strategy(&self) -> &SchedulingStrategy {
+        &self.strategy
     }
 
     pub fn plan(&self) -> LocalPhysicalPlanRef {
         self.plan.clone()
     }
 
-    pub fn estimated_memory_cost(&self) -> usize {
-        self.plan.estimated_memory_cost()
+    pub fn config(&self) -> &Arc<DaftExecutionConfig> {
+        &self.config
     }
 
     pub fn psets(&self) -> HashMap<String, Vec<PartitionRef>> {
@@ -28,8 +70,22 @@ impl SwordfishTask {
     }
 }
 
+impl Task for SwordfishTask {
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn task_id(&self) -> &TaskId {
+        &self.id
+    }
+
+    fn strategy(&self) -> &SchedulingStrategy {
+        &self.strategy
+    }
+}
+
 #[async_trait::async_trait]
 pub trait SwordfishTaskResultHandle: Send + Sync {
     #[allow(dead_code)]
-    async fn get_result(&mut self) -> DaftResult<PartitionRef>;
+    async fn get_result(&mut self) -> DaftResult<Vec<PartitionRef>>;
 }

--- a/src/daft-distributed/src/scheduling/worker.rs
+++ b/src/daft-distributed/src/scheduling/worker.rs
@@ -1,21 +1,33 @@
+use std::collections::{HashMap, HashSet};
+
 use common_error::DaftResult;
 
-use super::task::{SwordfishTask, SwordfishTaskResultHandle};
+use super::task::{SwordfishTaskResultHandle, Task, TaskId};
+
+pub(crate) type WorkerId = String;
+
+#[allow(dead_code)]
+pub(crate) trait Worker: Send + Sync + 'static {
+    fn id(&self) -> &WorkerId;
+    fn num_cpus(&self) -> usize;
+    fn active_task_ids(&self) -> HashSet<TaskId>;
+}
 
 #[allow(dead_code)]
 pub(crate) trait WorkerManager: Send + Sync {
+    type Worker: Worker;
+
     fn submit_task_to_worker(
         &self,
-        task: SwordfishTask,
-        worker_id: String,
+        task: Box<dyn Task>,
+        worker_id: WorkerId,
     ) -> Box<dyn SwordfishTaskResultHandle>;
-    // (worker id, num_cpus, memory)
-    fn get_worker_resources(&self) -> Vec<(String, usize, usize)>;
+    fn mark_task_finished(&self, task_id: TaskId, worker_id: WorkerId);
+    fn workers(&self) -> &HashMap<WorkerId, Self::Worker>;
+    fn total_available_cpus(&self) -> usize;
     #[allow(dead_code)]
-    fn try_autoscale(&self, num_workers: usize) -> DaftResult<()>;
+    fn try_autoscale(&self, _num_workers: usize) -> DaftResult<()> {
+        Ok(())
+    }
     fn shutdown(&self) -> DaftResult<()>;
-}
-
-pub(crate) trait WorkerManagerFactory: Send + Sync {
-    fn create_worker_manager(&self) -> DaftResult<Box<dyn WorkerManager>>;
 }


### PR DESCRIPTION
## Changes Made

This PR implements the `scheduler` trait, as well as stubbed implementations for the `Default` scheduler and `Linear` Scheduler.

This PR also refactors several components into generics, namely task and worker. This will allow us to create different implementations of tasks and workers, for example mock tasks and mock workers for testing.

I will implement the logic as well as unit tests for scheduler in a separate PR.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
