### PR TITLE
fix: ignores tests/integration for make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ build-release: check-toolchain frontend .venv  ## Compile and install a faster D
 
 .PHONY: test
 test: .venv build  ## Run tests
-	HYPOTHESIS_MAX_EXAMPLES=$(HYPOTHESIS_MAX_EXAMPLES) $(VENV_BIN)/pytest --hypothesis-seed=$(HYPOTHESIS_SEED)
+	HYPOTHESIS_MAX_EXAMPLES=$(HYPOTHESIS_MAX_EXAMPLES) $(VENV_BIN)/pytest --hypothesis-seed=$(HYPOTHESIS_SEED) --ignore tests/integration
 
 .PHONY: doctests
 doctests:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,6 +35,8 @@ Pillow==10.4.0
 opencv-python==4.10.0.84
 tiktoken==0.7.0
 duckdb==1.1.2
+torch==2.7.0
+torchvision==0.22.0
 
 # TQDM
 tqdm

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,8 +35,6 @@ Pillow==10.4.0
 opencv-python==4.10.0.84
 tiktoken==0.7.0
 duckdb==1.1.2
-torch==2.7.0
-torchvision==0.22.0
 
 # TQDM
 tqdm

--- a/tests/sql/test_uri_exprs.py
+++ b/tests/sql/test_uri_exprs.py
@@ -7,7 +7,7 @@ from daft import col, lit
 
 def test_url_download():
     df = daft.from_pydict({"one": [1]})  # just have a single row, doesn't matter what it is
-    url = "https://raw.githubusercontent.com/Eventual-Inc/Daft/refs/heads/main/LICENSE"
+    url = "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/small_images/rickroll0.jpg"
 
     # download one
     df_actual = daft.sql(f"SELECT url_download('{url}') as downloaded FROM df").collect().to_pydict()
@@ -20,8 +20,8 @@ def test_url_download_multi():
     df = daft.from_pydict(
         {
             "urls": [
-                "https://raw.githubusercontent.com/Eventual-Inc/Daft/refs/heads/main/README.rst",
-                "https://raw.githubusercontent.com/Eventual-Inc/Daft/refs/heads/main/LICENSE",
+                "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/small_images/rickroll0.jpg",
+                "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/small_images/rickroll1.jpg",
             ]
         }
     )


### PR DESCRIPTION
## Changes Made

Integ tests using torch were added, but the dep was not included in reqs. This meant I could not `make test` a fresh repo since you'd get a missing dep error. This has not failed in CI because we scope pytest to `tests/` in CI, but not in `make test`. Possible solutions are lazy-dep, scope `make test` down, or add this dep.

## Related Issues

n/a


## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
