### PR TITLE
fix: mirror raw.githubusercontent via S3 to avoid CI throttling

### DIFF
--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -25,141 +25,141 @@ def get_filesystem_from_path(path: str, **kwargs) -> fsspec.AbstractFileSystem:
 DAFT_CAN_READ_FILES = [
     (
         "parquet-testing/data/alltypes_dictionary.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/alltypes_dictionary.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/alltypes_dictionary.parquet",
     ),
     (
         "parquet-testing/data/alltypes_plain.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/alltypes_plain.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/alltypes_plain.parquet",
     ),
     (
         "parquet-testing/data/alltypes_plain.snappy.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/alltypes_plain.snappy.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/alltypes_plain.snappy.parquet",
     ),
     (
         "parquet-testing/data/alltypes_tiny_pages.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/alltypes_tiny_pages.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/alltypes_tiny_pages.parquet",
     ),
     (
         "parquet-testing/data/alltypes_tiny_pages_plain.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/alltypes_tiny_pages_plain.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/alltypes_tiny_pages_plain.parquet",
     ),
     (
         "parquet-testing/data/binary.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/binary.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/binary.parquet",
     ),
     # Needs Decimals decoding from byte arrays
     (
         "parquet-testing/data/byte_array_decimal.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/byte_array_decimal.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/byte_array_decimal.parquet",
     ),
     (
         "parquet-testing/data/data_index_bloom_encoding_stats.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/data_index_bloom_encoding_stats.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/data_index_bloom_encoding_stats.parquet",
     ),
     (
         "parquet-testing/data/datapage_v1-snappy-compressed-checksum.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/datapage_v1-snappy-compressed-checksum.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/datapage_v1-snappy-compressed-checksum.parquet",
     ),
     (
         "parquet-testing/data/datapage_v1-uncompressed-checksum.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/datapage_v1-uncompressed-checksum.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/datapage_v1-uncompressed-checksum.parquet",
     ),
     # Thrift Error?
     # (
     #     "parquet-testing/data/dict-page-offset-zero.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/dict-page-offset-zero.parquet",
+    #     "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/dict-page-offset-zero.parquet",
     # ),
     # Need Fixed Length Binary in Daft or convert to Variable Sized Binary
     # (
     #     "parquet-testing/data/fixed_length_byte_array.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/fixed_length_byte_array.parquet",
+    #     "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/fixed_length_byte_array.parquet",
     # ),
     (
         "parquet-testing/data/fixed_length_decimal.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/fixed_length_decimal.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/fixed_length_decimal.parquet",
     ),
     (
         "parquet-testing/data/fixed_length_decimal_legacy.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/fixed_length_decimal_legacy.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/fixed_length_decimal_legacy.parquet",
     ),
     (
         "parquet-testing/data/int32_decimal.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/int32_decimal.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/int32_decimal.parquet",
     ),
     (
         "parquet-testing/data/int32_with_null_pages.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/int32_with_null_pages.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/int32_with_null_pages.parquet",
     ),
     (
         "parquet-testing/data/int64_decimal.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/int64_decimal.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/int64_decimal.parquet",
     ),
     (
         "parquet-testing/data/list_columns.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/list_columns.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/list_columns.parquet",
     ),
     (
         "parquet-testing/data/nan_in_stats.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/nan_in_stats.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/nan_in_stats.parquet",
     ),
     # Page Header Wrong Size?
     # (
     #     "parquet-testing/data/nation.dict-malformed.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/nation.dict-malformed.parquet",
+    #     "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/nation.dict-malformed.parquet",
     # ),
     (
         "parquet-testing/data/nested_lists.snappy.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/nested_lists.snappy.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/nested_lists.snappy.parquet",
     ),
     # We have problems decoding struct objects in our arrow2 decoder
     # (
     #     "parquet-testing/data/nested_structs.rust.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/nested_structs.rust.parquet",
+    #     "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/nested_structs.rust.parquet",
     # ),
     # We currently don't support Map Dtypes
     # (
     #     "parquet-testing/data/nonnullable.impala.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/nonnullable.impala.parquet",
+    #     "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/nonnullable.impala.parquet",
     # ),
     (
         "parquet-testing/data/null_list.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/null_list.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/null_list.parquet",
     ),
     # We currently don't support Map Dtypes
     # (
     #     "parquet-testing/data/nullable.impala.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/nullable.impala.parquet",
+    #     "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/nullable.impala.parquet",
     # ),
     (
         "parquet-testing/data/nulls.snappy.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/nulls.snappy.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/nulls.snappy.parquet",
     ),
     # For some reason the program segfaults with this file unless we make the chunk size > 2024
     # (
     #     "parquet-testing/data/overflow_i16_page_cnt.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/overflow_i16_page_cnt.parquet",
+    #     "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/overflow_i16_page_cnt.parquet",
     # ),
     (
         "parquet-testing/data/plain-dict-uncompressed-checksum.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/plain-dict-uncompressed-checksum.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/plain-dict-uncompressed-checksum.parquet",
     ),
     # We have problems decoding struct objects in our arrow2 decoder
     # (
     #     "parquet-testing/data/repeated_no_annotation.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/repeated_no_annotation.parquet",
+    #     "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/repeated_no_annotation.parquet",
     # ),
     (
         "parquet-testing/data/rle-dict-snappy-checksum.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/rle-dict-snappy-checksum.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/rle-dict-snappy-checksum.parquet",
     ),
     # We currently don't support RLE Boolean encodings
     # (
     #     "parquet-testing/data/rle_boolean_encoding.parquet",
-    #     "https://raw.githubusercontent.com/apache/parquet-testing/master/data/rle_boolean_encoding.parquet",
+    #     "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/rle_boolean_encoding.parquet",
     # ),
     (
         "parquet-testing/data/single_nan.parquet",
-        "https://raw.githubusercontent.com/apache/parquet-testing/master/data/single_nan.parquet",
+        "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github/apache/parquet-testing/data/single_nan.parquet",
     ),
     # This is currently is in a private s3 bucket
     # (
@@ -208,16 +208,8 @@ def public_storage_io_config() -> daft.io.IOConfig:
 
 @pytest.fixture(scope="session", params=DAFT_CAN_READ_FILES, ids=[name for name, _ in DAFT_CAN_READ_FILES])
 def parquet_file(request) -> tuple[str, str]:
-    """Returns a tuple of (`name`, `path`) of files that Daft should be able to handle. Path URLs may be HTTPs or S3.
-
-    Note:
-        We replace raw.githubusercontent.com with our public S3 bucket to avoid Github throttling.
-    """
-    name: str = request[0]
-    path: str = request[1].replace(
-        "https://raw.githubusercontent.com", "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github"
-    )
-    return (name, path)
+    """Returns a tuple of (`name`, `url`) of files that Daft should be able to handle. URLs may be HTTPs or S3."""
+    return request.param
 
 
 @pytest.fixture(params=[(True, True), (True, False), (False, False)], ids=["split", "merge", "ignore"])

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -208,8 +208,16 @@ def public_storage_io_config() -> daft.io.IOConfig:
 
 @pytest.fixture(scope="session", params=DAFT_CAN_READ_FILES, ids=[name for name, _ in DAFT_CAN_READ_FILES])
 def parquet_file(request) -> tuple[str, str]:
-    """Returns a tuple of (`name`, `url`) of files that Daft should be able to handle. URLs may be HTTPs or S3."""
-    return request.param
+    """Returns a tuple of (`name`, `path`) of files that Daft should be able to handle. Path URLs may be HTTPs or S3.
+
+    Note:
+        We replace raw.githubusercontent.com with our public S3 bucket to avoid Github throttling.
+    """
+    name: str = request[0]
+    path: str = request[1].replace(
+        "https://raw.githubusercontent.com", "https://daft-public-data.s3.us-west-2.amazonaws.com/test_fixtures/github"
+    )
+    return (name, path)
 
 
 @pytest.fixture(params=[(True, True), (True, False), (False, False)], ids=["split", "merge", "ignore"])


### PR DESCRIPTION
## Changes Made

This PR changes `raw.githubusercontent.com` requests to go to our public S3 bucket to avoid throttling from Github which has recently been breaking GH actions / CI.

Ran locally,

```shell
tests/integration/io/parquet/test_reads_public_data.py ........................................................................................................................................................................................... [ 54%]
..............................................................................................................................................................                                                                                     [100%]

============================================================================================================ 345 passed in 207.14s (0:03:27)
```

## Related Issues

n/a

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
