### PR TITLE
feat: Add optional spark dependency for pyspark connector

### DIFF
--- a/docs/spark_connect.md
+++ b/docs/spark_connect.md
@@ -4,6 +4,14 @@ The `daft.pyspark` module provides a way to create a PySpark session that can be
 
 For the full PySpark SQL API documentation, see the [official PySpark documentation](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/index.html#spark-sql).
 
+## Installing Daft with Spark Connect support
+
+Daft supports Spark Connect through the optional `spark` dependency.
+
+```bash
+pip install -U "daft[spark]"
+```
+
 ## Example
 
 === "🐍 Python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ readme = "README.rst"
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
-all = ["daft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake, sql, unity]"]
+all = ["daft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake, spark, sql, unity]"]
 aws = ["boto3"]
 azure = []
 deltalake = ["deltalake", "packaging"]
@@ -40,6 +40,7 @@ ray = [
   # Explicitly install packaging. See issue: https://github.com/ray-project/ray/issues/34806
   "packaging"
 ]
+spark = ["googleapis-common-protos == 1.56.4", "grpcio >= 1.48, < 1.57", "grpcio-status >= 1.48, < 1.57", "numpy >= 1.15", "pandas >= 1.0.5", "py4j >= 0.10.9.7", "pyspark"]
 sql = ["connectorx", "sqlalchemy", "sqlglot"]
 unity = ["httpx <= 0.27.2", "unitycatalog"]
 viz = []


### PR DESCRIPTION
## Changes Made

Adds the required dependencies for pyspark to work in `pip install daft[spark]`

## Related Issues

Closes #4310 

## Checklist

- [x] Documented in API Docs (if applicable)
