### PR TITLE
fix: Remove botocore dependency when working with deltalake

### DIFF
--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -49,7 +49,7 @@ def get_s3_bucket_region(bucket_name):
         return bucket_region
     except Exception as e:
         logger.warning(
-            "ailed to get the S3 bucket region using the given S3 uri. Error: %s",
+            "Failed to get the S3 bucket region using the given S3 uri. Error: %s",
             e,
         )
         return None

--- a/daft/delta_lake/delta_lake_scan.py
+++ b/daft/delta_lake/delta_lake_scan.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 import os
 from typing import TYPE_CHECKING
+from urllib.error import HTTPError
 from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 from deltalake.table import DeltaTable
 
@@ -17,7 +19,6 @@ from daft.daft import (
     ScanTask,
     StorageConfig,
 )
-from daft.io.aws_config import boto3_client_from_s3_config
 from daft.io.object_store_options import io_config_to_storage_options
 from daft.io.scan import PartitionField, ScanOperator
 from daft.logical.schema import Schema
@@ -27,6 +28,31 @@ if TYPE_CHECKING:
     from datetime import datetime
 
 logger = logging.getLogger(__name__)
+
+
+def get_s3_bucket_region(bucket_name):
+    # When making a https request to https://{bucket_name}.s3.amazonaws.com/, aws returns either a 200 response, 403 response, or 404 response.
+    # In the header of the 200 and 403 responses, there is an `x-amz-bucket-region` field from which we can extract the bucket's region.
+    url = f"https://{bucket_name}.s3.amazonaws.com"
+
+    try:
+        req = Request(url, method="HEAD")
+        with urlopen(req) as response:
+            return response.headers.get("x-amz-bucket-region")
+    except HTTPError as e:
+        bucket_region = e.headers.get("x-amz-bucket-region")
+        if bucket_region is None:
+            logger.warning(
+                "Failed to get the S3 bucket region using the given S3 uri. HTTPError error: %s",
+                e,
+            )
+        return bucket_region
+    except Exception as e:
+        logger.warning(
+            "ailed to get the S3 bucket region using the given S3 uri. Error: %s",
+            e,
+        )
+        return None
 
 
 class DeltaLakeScanOperator(ScanOperator):
@@ -44,21 +70,13 @@ class DeltaLakeScanOperator(ScanOperator):
         deltalake_sdk_io_config = storage_config.io_config
         scheme = urlparse(table_uri).scheme
         if scheme == "s3" or scheme == "s3a":
-            # Try to get region from boto3
+            # Try to get the bucket's region.
             if deltalake_sdk_io_config.s3.region_name is None:
-                from botocore.exceptions import BotoCoreError
-
-                try:
-                    client = boto3_client_from_s3_config("s3", deltalake_sdk_io_config.s3)
-                    response = client.get_bucket_location(Bucket=urlparse(table_uri).netloc)
-                except BotoCoreError as e:
-                    logger.warning(
-                        "Failed to get the S3 bucket region using existing storage config, will attempt to get it from the environment instead. Error from boto3: %s",
-                        e,
-                    )
-                else:
+                bucket_name = urlparse(table_uri).netloc
+                region = get_s3_bucket_region(bucket_name)
+                if region is not None:
                     deltalake_sdk_io_config = deltalake_sdk_io_config.replace(
-                        s3=deltalake_sdk_io_config.s3.replace(region_name=response["LocationConstraint"])
+                        s3=deltalake_sdk_io_config.s3.replace(region_name=region)
                     )
 
             # Try to get config from the environment


### PR DESCRIPTION
## Changes Made

In our current deltalake scanner, we use botocore to grab the region name of a given S3 bucket. This adds a botocore dependency to using deltalake. We can remove this dependency by instead making a HTTP request to the S3 url which returns a region name in the header.

## Related Issues

Closes #4189 
