### PR TITLE
fix: adds HTTP and HF retry logic based upon exist GCS retry logic

### DIFF
--- a/src/common/io-config/src/http.rs
+++ b/src/common/io-config/src/http.rs
@@ -8,6 +8,10 @@ use crate::ObfuscatedString;
 pub struct HTTPConfig {
     pub user_agent: String,
     pub bearer_token: Option<ObfuscatedString>,
+    pub retry_initial_backoff_ms: u64,
+    pub connect_timeout_ms: u64,
+    pub read_timeout_ms: u64,
+    pub num_tries: u32,
 }
 
 impl Default for HTTPConfig {
@@ -15,6 +19,10 @@ impl Default for HTTPConfig {
         Self {
             user_agent: "daft/0.0.1".to_string(), // NOTE: Ideally we grab the version of Daft, but that requires a dependency on daft-core
             bearer_token: None,
+            retry_initial_backoff_ms: 1000,
+            connect_timeout_ms: 30_000,
+            read_timeout_ms: 30_000,
+            num_tries: 5,
         }
     }
 }
@@ -31,32 +39,24 @@ impl HTTPConfig {
 impl HTTPConfig {
     #[must_use]
     pub fn multiline_display(&self) -> Vec<String> {
-        let mut v = vec![format!("user_agent = {}", self.user_agent)];
+        let mut res = vec![];
         if let Some(bearer_token) = &self.bearer_token {
-            v.push(format!("bearer_token = {bearer_token}"));
+            res.push(format!("Bearer token = {bearer_token}"));
         }
-
-        v
+        res.push(format!("User agent = {}", self.user_agent));
+        res.push(format!(
+            "Retry initial backoff ms = {}",
+            self.retry_initial_backoff_ms
+        ));
+        res.push(format!("Connect timeout ms = {}", self.connect_timeout_ms));
+        res.push(format!("Read timeout ms = {}", self.read_timeout_ms));
+        res.push(format!("Max retries = {}", self.num_tries));
+        res
     }
 }
 
 impl Display for HTTPConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        write!(
-            f,
-            "HTTPConfig
-    user_agent: {}",
-            self.user_agent,
-        )?;
-
-        if let Some(bearer_token) = &self.bearer_token {
-            write!(
-                f,
-                "
-    bearer_token: {bearer_token}"
-            )
-        } else {
-            Ok(())
-        }
+        write!(f, "HTTPConfig\n{}", self.multiline_display().join("\n"))
     }
 }

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -3,6 +3,7 @@ use std::{
     ops::Range,
     string::FromUtf8Error,
     sync::{Arc, LazyLock},
+    time::Duration,
 };
 
 use async_trait::async_trait;
@@ -178,7 +179,8 @@ impl HttpSource {
 
         Ok(Self {
             client: reqwest::ClientBuilder::default()
-                .pool_max_idle_per_host(70)
+                .pool_idle_timeout(Duration::from_secs(90))
+                .pool_max_idle_per_host(10)
                 .default_headers(default_headers)
                 .build()
                 .context(UnableToCreateClientSnafu)?,

--- a/src/daft-sql/src/modules/config.rs
+++ b/src/daft-sql/src/modules/config.rs
@@ -394,6 +394,7 @@ pub(crate) fn expr_to_iocfg(expr: &ExprRef) -> SQLPlannerResult<IOConfig> {
                 http: HTTPConfig {
                     user_agent,
                     bearer_token,
+                    ..Default::default()
                 },
                 ..Default::default()
             })


### PR DESCRIPTION
## Changes Made

Adds reqwest retry logic to `https://` and `hf://` based upon the existing GCS retry logic. https://github.com/Eventual-Inc/Daft/pull/3253

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
