### PR TITLE
docs: Update sessions.md to reflect correct import behavior as described in session class docstring

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -14,7 +14,7 @@ import daft
 
 # `import daft` defines an implicit session `daft.current_session()`
 
-from daft import Session
+from daft.session import Session
 
 # create a new session
 sess = Session()
@@ -89,7 +89,7 @@ Let's get started by creating an empty session and checking the state.
 ```python
 import daft
 
-from daft import Session
+from daft.session import Session
 
 # create a new empty session
 sess = Session()


### PR DESCRIPTION
Looks like the import behavior is actually from daft.session import session

## Changes Made

Update Sessions docs to use correct import behavior

## Related Issues

No Issue

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
