### PR TITLE
ci: Remove `py` runner tests from PR CI

### DIFF
--- a/.github/workflows/nightly-publish-s3.yml
+++ b/.github/workflows/nightly-publish-s3.yml
@@ -122,7 +122,7 @@ jobs:
       fail-fast: false
       matrix:
         runner-name: [ubuntu-latest, ubuntu-24.04-arm]
-        daft-runner: [py, ray]
+        daft-runner: [py, ray, native]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         runner-name: [ubuntu-latest, ubuntu-24.04-arm]
-        daft-runner: [py, ray]
+        daft-runner: [py, ray, native]
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     # This is used in the step "Assume GitHub Actions AWS Credentials"
     permissions:

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -21,19 +21,14 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10']
-        daft-runner: [py, ray, native]
+        daft-runner: [ray, native]
         pyarrow-version: [8.0.0, 19.0.1]
         enable-aqe: [1, 0]
         os: [ubuntu-latest, macos-latest]
         exclude:
-        - daft-runner: py
-          enable-aqe: 1
         - daft-runner: native
           enable-aqe: 1
         - daft-runner: ray
-          pyarrow-version: 8.0.0
-        - daft-runner: py
-          python-version: '3.10'
           pyarrow-version: 8.0.0
         - daft-runner: native
           python-version: '3.10'
@@ -211,11 +206,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9']
-        daft-runner: [py, ray, native]
+        daft-runner: [ray, native]
         enable-aqe: [1, 0]
         exclude:
-        - daft-runner: py
-          enable-aqe: 1
         - daft-runner: native
           enable-aqe: 1
     steps:
@@ -291,11 +284,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
-        daft-runner: [py, ray, native]
+        daft-runner: [ray, native]
         enable-aqe: [1, 0]
         exclude:
-        - daft-runner: py
-          enable-aqe: 1
         - daft-runner: native
           enable-aqe: 1
     steps:
@@ -375,11 +366,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
-        daft-runner: [py, ray, native]
+        daft-runner: [ray, native]
         enable-aqe: [1, 0]
         exclude:
-        - daft-runner: py
-          enable-aqe: 1
         - daft-runner: native
           enable-aqe: 1
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
@@ -475,11 +464,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
-        daft-runner: [py, ray, native]
+        daft-runner: [ray, native]
         enable-aqe: [1, 0]
         exclude:
-        - daft-runner: py
-          enable-aqe: 1
         - daft-runner: native
           enable-aqe: 1
     steps:
@@ -558,11 +545,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
-        daft-runner: [py, ray, native]
+        daft-runner: [ray, native]
         enable-aqe: [1, 0]
         exclude:
-        - daft-runner: py
-          enable-aqe: 1
         - daft-runner: native
           enable-aqe: 1
     steps:

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -283,7 +283,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
+        python-version: ['3.9']
         daft-runner: [ray, native]
         enable-aqe: [1, 0]
         exclude:
@@ -365,7 +365,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
+        python-version: ['3.9']
         daft-runner: [ray, native]
         enable-aqe: [1, 0]
         exclude:
@@ -463,7 +463,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
+        python-version: ['3.9']
         daft-runner: [ray, native]
         enable-aqe: [1, 0]
         exclude:
@@ -544,7 +544,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9'] # can't use 3.7 due to requiring anon mode for adlfs
+        python-version: ['3.9']
         daft-runner: [ray, native]
         enable-aqe: [1, 0]
         exclude:


### PR DESCRIPTION
## Changes Made

With the latest improvements to projections and URL handling, we should be able to deprecate the `py` runner soon. At a minimum, we won't be making significant changes to the `py` runner. Thus, we don't need to run `py` runner tests on PR CI anymore.

Note that I kept the nightly tests, just removed the PR CI tests. That's because GitHub Actions limits the number of concurrent runners per repo, especially for MacOS. Thus, this should speed up CI times.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
