### PR TITLE
fix: Add s3n to parse_url

### DIFF
--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -418,7 +418,7 @@ pub fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
     match scheme.as_ref() {
         "file" => Ok((SourceType::File, fixed_input)),
         "http" | "https" => Ok((SourceType::Http, fixed_input)),
-        "s3" | "s3a" => Ok((SourceType::S3, fixed_input)),
+        "s3" | "s3a" | "s3n" => Ok((SourceType::S3, fixed_input)),
         "az" | "abfs" | "abfss" => Ok((SourceType::AzureBlob, fixed_input)),
         "gcs" | "gs" => Ok((SourceType::GCS, fixed_input)),
         "hf" => Ok((SourceType::HF, fixed_input)),

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -42,10 +42,7 @@ pub(crate) fn native_parquet_writer_supported(
     // TODO(desmond): Currently we only support local writes.
     // TODO(desmond): We return false on an error because S3n is incorrectly reported to be unsupported
     // in parse_url. I'll fix this in another PR.
-    let source_type = match parse_url(root_dir) {
-        Ok((st, _)) => st,
-        _ => return Ok(false),
-    };
+    let (source_type, _) = parse_url(root_dir)?;
     if !matches!(source_type, SourceType::File) {
         return Ok(false);
     }


### PR DESCRIPTION
## Changes Made

The `parse_url` utility function didn't map `s3n` to the S3 source type, leading us to throw a `NotImplementedSource` error when parsing s3n urls. This PR fixes this.