### PR TITLE
docs: fix readthedocs version dropdown 

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Welcome to **Daft**!
 
-Daft is a simple, reliable, and performant data engine that can seamlessly scale from local to petabyte-scale distributed workloads without compromising on capability. The core engine is written in Rust and exposes both SQL and Python DataFrame interfaces as first-class citizens.
+Daft is a simple, reliable, and performant data engine for any modality or scale, from local to petabyte-scale distributed workloads without compromising on capability. The core engine is written in Rust and exposes both SQL and Python DataFrame interfaces as first-class citizens.
 
 ## Why Daft?
 

--- a/docs/js/readthedocs.js
+++ b/docs/js/readthedocs.js
@@ -1,29 +1,4 @@
-// Use CustomEvent to generate the version selector and inject CSS to hide readthedocs-flyout
-// document.addEventListener(
-//   "readthedocs-addons-data-ready",
-//   function (event) {
-//     const config = event.detail.data();
-//     const versioning = `
-//             <div class="md-version">
-//               <button class="md-version__current" aria-label="Select version">
-//                 ${config.versions.current.slug}
-//               </button>
-
-//               <ul class="md-version__list">
-//               ${config.versions.active.map(
-//       (version) => `
-//                 <li class="md-version__item">
-//                   <a href="${version.urls.documentation}" class="md-version__link">
-//                     ${version.slug}
-//                   </a>
-//                 </li>`).join("\n")}
-//               </ul>
-//             </div>`;
-
-//     document.querySelector(".md-header__topic").insertAdjacentHTML("beforeend", versioning);
-//   });
-
-// Use CustomEvent to generate the version selector and inject CSS to hide readthedocs-flyout
+// Use CustomEvent to generate the version selector and show on click, not hover
 document.addEventListener(
   "readthedocs-addons-data-ready",
   function (event) {

--- a/docs/js/readthedocs.js
+++ b/docs/js/readthedocs.js
@@ -27,6 +27,11 @@
 document.addEventListener(
   "readthedocs-addons-data-ready",
   function (event) {
+    // Check if version selector already exists
+    if (document.querySelector('.md-version')) {
+      return;
+    }
+
     const config = event.detail.data();
     const versioning = `
             <div class="md-version">

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,6 +56,7 @@ The following features would be valuable additions to Daft, but are not currentl
     - Support for reading tables with deletion vectors ([issue #1954](https://github.com/Eventual-Inc/Daft/issues/1954))
     - Support for reading tables with column mappings ([issue #1955](https://github.com/Eventual-Inc/Daft/issues/1955))
 - Improved Apache Hudi support (see [roadmap for Apache Hudi](https://github.com/Eventual-Inc/Daft/issues/4389))
+- Expressions parity with PySpark: Temporal ([issue #3798](https://github.com/Eventual-Inc/Daft/issues/3798)), Math ([issue #3793](https://github.com/Eventual-Inc/Daft/issues/3793)), String ([issue #3792](https://github.com/Eventual-Inc/Daft/issues/3792))
 
 If you are interested in working on any of these features, feel free to open an issue or start a discussion on [Github](https://github.com/Eventual-Inc/Daft) or join our [Daft Slack Community](https://join.slack.com/t/dist-data/shared_invite/zt-2e77olvxw-uyZcPPV1SRchhi8ah6ZCtg). Our team can provide technical direction and help scope the work appropriately. Thank you in advance 💜
 


### PR DESCRIPTION
## Changes Made

Adds new selector every time a new page is clicked.

![image](https://github.com/user-attachments/assets/74b578da-5b37-4463-a4de-10329fc280e1)

Also made a small fix to Daft overview page and added an item to Daft Roadmap

See build here: https://www.getdaft.io/projects/docs/en/chanchan-readthedocs/
