### PR TITLE
fix(ci): import matplotlib for window function tutorial

### DIFF
--- a/.github/workflows/notebook-checker.yml
+++ b/.github/workflows/notebook-checker.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install -U jupyter papermill
+        pip install -U jupyter papermill matplotlib
     - name: Run notebooks in docs
       run: find docs -name "*.ipynb" -print0 | xargs -0 -I {} papermill {} /tmp/out.ipynb -p CI True --kernel python3 --no-progress-bar --cwd /tmp/
     - name: Run notebooks in tutorials


### PR DESCRIPTION
## Changes Made

Add matplotlib as an import to our notebook checker so that it succeeds.

## Related Issues

none

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
