### PR TITLE
fix(tests): add retry to pyarrow parquet read

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -794,7 +794,7 @@ class Expression:
         assert isinstance(decimals, int)
         f = native.get_function_from_registry("round")
         decimals_expr = Expression._to_expression(decimals)._expr
-        return Expression._from_pyexpr(f(self._expr, decimals=decimals_expr))
+        return Expression._from_pyexpr(f(self._expr, decimal=decimals_expr))
 
     def sqrt(self) -> Expression:
         """The square root of a numeric expression."""

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -794,7 +794,7 @@ class Expression:
         assert isinstance(decimals, int)
         f = native.get_function_from_registry("round")
         decimals_expr = Expression._to_expression(decimals)._expr
-        return Expression._from_pyexpr(f(self._expr, decimal=decimals_expr))
+        return Expression._from_pyexpr(f(self._expr, decimals=decimals_expr))
 
     def sqrt(self) -> Expression:
         """The square root of a numeric expression."""

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import time
+
 import fsspec
 import pandas as pd
 import pyarrow as pa
 import pytest
+from aiohttp.client_exceptions import ClientPayloadError
 from pyarrow import parquet as pq
 
 import daft
@@ -239,10 +242,11 @@ def read_parquet_with_pyarrow(path) -> pa.Table:
     while not table:
         try:
             table = pq.read_table(path, filesystem=fs)
-        except Exception as e:
-            retries += 1
+        except ClientPayloadError as e:
             if retries > 5:
                 raise e
+            time.sleep(0.1 * (2**retries))
+            retries += 1
     return table
 
 

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -233,7 +233,8 @@ def read_parquet_with_pyarrow(path) -> pa.Table:
         kwargs["anon"] = True
 
     fs = get_filesystem_from_path(path, **kwargs)
-    table = pq.read_table(path, filesystem=fs)
+
+    table = pq.read_table(path, filesystem=fs, use_threads=False)
     return table
 
 

--- a/tests/integration/io/parquet/test_reads_public_data.py
+++ b/tests/integration/io/parquet/test_reads_public_data.py
@@ -234,7 +234,15 @@ def read_parquet_with_pyarrow(path) -> pa.Table:
 
     fs = get_filesystem_from_path(path, **kwargs)
 
-    table = pq.read_table(path, filesystem=fs, use_threads=False)
+    table = None
+    retries = 0
+    while not table:
+        try:
+            table = pq.read_table(path, filesystem=fs)
+        except Exception as e:
+            retries += 1
+            if retries > 5:
+                raise e
     return table
 
 


### PR DESCRIPTION
## Changes Made

Not 100% sure if this will fix it, but the errors in CI are coming from this `pyarrow.parquet.read_table` call.

## Related Issues

none

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
