### PR TITLE
ci: Cancel ongoing PR tests on push

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -14,7 +14,7 @@ env:
   RUST_BACKTRACE: 1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -13,6 +13,10 @@ env:
   DAFT_ANALYTICS_ENABLED: '0'
   RUST_BACKTRACE: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -14,7 +14,7 @@ env:
   RUST_BACKTRACE: 1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event.pull_request.number != '' }}
 
 jobs:

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -14,8 +14,8 @@ env:
   RUST_BACKTRACE: 1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event.pull_request.number != '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   unit-test:

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -14,8 +14,8 @@ env:
   RUST_BACKTRACE: 1
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event.pull_request.number != '' }}
 
 jobs:
   unit-test:

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -13,9 +13,12 @@ env:
   DAFT_ANALYTICS_ENABLED: '0'
   RUST_BACKTRACE: 1
 
+# Cancel in-progress CI runs for outdated PR pushes to save resources.
+# For pull requests, use the PR number to group runs.
+# For pushes to main, i.e. not PRs, use the unique commit SHA to avoid canceling other CI runs.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   unit-test:

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,6 @@
+|Banner|
 
+|CI| |PyPI| |Latest Tag| |Coverage| |Slack|
 
 `Website <https://www.getdaft.io>`_ • `Docs <https://www.getdaft.io/projects/docs/>`_ • `Installation`_ • `Daft Quickstart <https://www.getdaft.io/projects/docs/en/stable/quickstart/>`_ • `Community and Support <https://github.com/Eventual-Inc/Daft/discussions>`_
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,3 @@
-|Banner|
 
 |CI| |PyPI| |Latest Tag| |Coverage| |Slack|
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-
+|Banner|
 
 |CI| |PyPI| |Latest Tag| |Coverage| |Slack|
 

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Banner|
+
 
 |CI| |PyPI| |Latest Tag| |Coverage| |Slack|
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,4 @@
-|Banner|
 
-|CI| |PyPI| |Latest Tag| |Coverage| |Slack|
 
 `Website <https://www.getdaft.io>`_ • `Docs <https://www.getdaft.io/projects/docs/>`_ • `Installation`_ • `Daft Quickstart <https://www.getdaft.io/projects/docs/en/stable/quickstart/>`_ • `Community and Support <https://github.com/Eventual-Inc/Daft/discussions>`_
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,4 @@
+|Banner|
 
 |CI| |PyPI| |Latest Tag| |Coverage| |Slack|
 


### PR DESCRIPTION
## Changes Made

Cancel old PR test suite runs when there is a new push to a PR. This allows us to hammer github actions less, but also lets us start testing the latest push faster since it won't have to wait as long for runners to become available.
