### PR TITLE
feat: adds functions prelude and clean up contributing notes.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,21 +147,26 @@ Add your function to the appropriate crate (`daft-functions-json`, `daft-functio
 For more advanced use cases, see existing implementations in [daft-functions-utf8](src/daft-functions-utf8/src/lib.rs)
 
 ```rs
-// we need these for the trait.
+// This prelude defines all required ScalarUDF dependencies.
+use daft_dsl::functions::prelude::*;
+
+// We need these for the trait.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 struct MyToUpperCase;
 
 #[typetag::serde]
 impl ScalarUDF for MyToUpperCase {
-    // start by giving the function a name.
-    // this will be the name used in SQL when calling the function
+
+    // Start by giving the function a name.
+    // This will be the name used in SQL when calling the function.
     fn name(&self) -> &'static str {
         "to_uppercase"
     }
-    // then we add an implementation for it
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series>
+
+    // Then we add an implementation for it.
+    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let s = inputs.required(0)?;
-        // Note: using into_iter is not the most performant way of implementing this, but for this example, we don't care about performance
+        // Note: using into_iter is not the most performant way of implementing this, but for this example, we don't care about performance.
         let arr = s
             .utf8()
             .expect("type should have been validated already during `function_args_to_field`")
@@ -170,7 +175,8 @@ impl ScalarUDF for MyToUpperCase {
             .collect::<Utf8Array>();
         Ok(arr.into_series())
     }
-    // We also need a `function_args_to_field` which is used during planning to ensure that the args and datatypes are compatible
+
+    // We also need a `function_args_to_field` which is used during planning to ensure that the args and datatypes are compatible.
     fn function_args_to_field(
         &self,
         inputs: FunctionArgs<ExprRef>,
@@ -184,7 +190,7 @@ impl ScalarUDF for MyToUpperCase {
         Ok(input)
     }
 
-    // finally we want a brief docstring for the function. This is used when generating the sql documentation.
+    // Finally, we want a brief docstring for the function. This is used when generating the sql documentation.
     fn docstring(&self) -> &'static str {
         "Converts a string to uppercase."
     }

--- a/src/daft-dsl/src/functions/mod.rs
+++ b/src/daft-dsl/src/functions/mod.rs
@@ -4,6 +4,7 @@ pub mod function_args;
 mod macro_tests;
 pub mod map;
 pub mod partitioning;
+pub mod prelude;
 pub mod python;
 pub mod scalar;
 pub mod sketch;

--- a/src/daft-dsl/src/functions/prelude.rs
+++ b/src/daft-dsl/src/functions/prelude.rs
@@ -4,7 +4,7 @@
 
 pub use common_error::{ensure, DaftResult};
 pub use daft_core::{
-    prelude::{Field, Schema, SchemaRef, Utf8Array},
+    prelude::{DataType, Field, Schema, SchemaRef},
     series::Series,
 };
 pub use serde::{Deserialize, Serialize};

--- a/src/daft-dsl/src/functions/prelude.rs
+++ b/src/daft-dsl/src/functions/prelude.rs
@@ -1,0 +1,15 @@
+//! Exports for ScalarUDF trait.
+//!
+//! This is so we don't have to manually import all each time we implement a function.
+
+pub use common_error::{ensure, DaftResult};
+pub use daft_core::{
+    prelude::{Field, Schema, SchemaRef, Utf8Array},
+    series::Series,
+};
+pub use serde::{Deserialize, Serialize};
+
+pub use crate::{
+    functions::{FunctionArgs, ScalarUDF},
+    ExprRef,
+};


### PR DESCRIPTION
## Changes Made

Adds the required deps for implementing a ScalarUDF to the common interface package. We could also `pub use` in the ScalarUDF module. Reduces loc in each function impl from 15 to 1, since you have to import these anyways. Minor docs edits for consistent spacing, casing and punctuation,.

## Related Issues

n/a

## Checklist

- [n/a] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [n/a] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [n/a] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
