### PR TITLE
build: make dashboard self contained again, except when running in ci

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -23,7 +23,7 @@ on:
 env:
   PYTHON_VERSION: 3.11
   DAFT_ANALYTICS_ENABLED: '0'
-  UV_SYSTEM_PYTHON: l
+  UV_SYSTEM_PYTHON: 1
   RUST_DAFT_PKG_BUILD_TYPE: ${{ inputs.build_type }}
 
 defaults:

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -23,7 +23,7 @@ on:
 env:
   PYTHON_VERSION: 3.11
   DAFT_ANALYTICS_ENABLED: '0'
-  UV_SYSTEM_PYTHON: 1
+  UV_SYSTEM_PYTHON: l
   RUST_DAFT_PKG_BUILD_TYPE: ${{ inputs.build_type }}
 
 defaults:
@@ -85,6 +85,8 @@ jobs:
       with:
         target: x86_64
         args: --profile release-lto --out dist
+      env:
+        GITHUB_ACTIONS: true
 
     - name: Build wheels - Linux x86
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'x86_64') }}
@@ -94,6 +96,8 @@ jobs:
         manylinux: 2_24
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
+      env:
+        GITHUB_ACTIONS: true
 
     - name: Build wheels - Linux aarch64
       if: ${{ (inputs.os == 'ubuntu') && (inputs.arch == 'aarch64') }}
@@ -104,6 +108,8 @@ jobs:
         # only produce sdist for linux x86 to avoid multiple copies
         args: --profile release-lto --out dist --sdist
         before-script-linux: export JEMALLOC_SYS_WITH_LG_PAGE=16
+      env:
+        GITHUB_ACTIONS: true
 
     - name: Build wheels - Mac aarch64
       if: ${{ (inputs.os == 'macos') && (inputs.arch == 'aarch64')  }}
@@ -114,6 +120,7 @@ jobs:
       env:
         RUSTFLAGS: -Ctarget-cpu=apple-m1
         CFLAGS: -mtune=apple-m1
+        GITHUB_ACTIONS: true
 
     - name: Upload wheels
       uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build: check-toolchain .venv  ## Compile and install Daft for development
 	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin develop --extras=all --uv
 
 .PHONY: build-release
-build-release: check-toolchain frontend .venv  ## Compile and install a faster Daft binary
+build-release: check-toolchain .venv  ## Compile and install a faster Daft binary
 	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin develop --release --uv
 
 .PHONY: test
@@ -82,10 +82,6 @@ docs: .venv ## Build Daft documentation
 docs-serve: .venv ## Build Daft documentation in development server
 	JUPYTER_PLATFORM_DIRS=1 uv run mkdocs serve -f mkdocs.yml
 
-.PHONY: frontend
-frontend: .venv ## Build daft-dashboard frontend assets
-	cd src/daft-dashboard/frontend && \
-		bun run build
 
 .PHONY: clean
 clean:

--- a/src/daft-dashboard/build.rs
+++ b/src/daft-dashboard/build.rs
@@ -1,9 +1,6 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let out_dir = std::env::var("OUT_DIR")?;
+use std::process::Command;
 
-    // always set the env var so that the include_dir! macro doesn't panic
-    println!("cargo:rustc-env=DASHBOARD_ASSETS_DIR={}", out_dir);
-
+fn ci_main(out_dir: &str) -> Result<(), Box<dyn std::error::Error>> {
     let frontend_dir = std::env::var("CARGO_MANIFEST_DIR")? + "/frontend/out";
 
     if !std::path::Path::new(&frontend_dir).is_dir() {
@@ -17,11 +14,82 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // if there's anything in the output directory, remove it
-    if std::fs::exists(&out_dir)? {
-        std::fs::remove_dir_all(&out_dir)?;
+    if std::fs::exists(out_dir)? {
+        std::fs::remove_dir_all(out_dir)?;
     }
 
     // move the frontend assets to the output directory
     std::fs::rename(frontend_dir, out_dir)?;
     Ok(())
+}
+
+fn default_main(out_dir: &str) -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo:rerun-if-changed=frontend/src/");
+    println!("cargo:rerun-if-changed=frontend/bun.lockb");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // Check if bun is installed
+    let bun_available = Command::new("bun")
+        .arg("--version")
+        .output()
+        .map(|_| true)
+        .unwrap_or(false);
+
+    // if bun is not available, we can't build the frontend assets
+    // so we just print a warning and return
+    // but if we're in release mode, we panic
+    if !bun_available {
+        if cfg!(debug_assertions) {
+            println!("cargo:warning=Bun not found, skipping dashboard frontend assets");
+            return Ok(());
+        } else {
+            panic!("Bun is required for release builds");
+        }
+    }
+
+    // Install dependencies
+    let install_status = Command::new("bun")
+        .current_dir("./frontend")
+        .args(["install"])
+        .status()?;
+
+    assert!(install_status.success(), "Failed to install dependencies");
+
+    // Run `bun run build`
+    let mut cmd = Command::new("bun");
+    let status = cmd.current_dir("./frontend");
+
+    let status = if cfg!(debug_assertions) {
+        status.args(["run", "build", "--no-lint", "--no-mangling"])
+    } else {
+        status.args(["run", "build"])
+    };
+    let status = status.status()?;
+
+    assert!(status.success(), "Failed to build frontend assets");
+
+    let frontend_dir = std::env::var("CARGO_MANIFEST_DIR")? + "/frontend/out";
+
+    // if there's anything in the output directory, remove it
+    if std::fs::metadata(out_dir).is_ok() {
+        std::fs::remove_dir_all(out_dir)?;
+    }
+
+    // move the frontend assets to the output directory
+    std::fs::rename(frontend_dir, out_dir)?;
+    assert!(status.success(), "Failed to build frontend assets");
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir = std::env::var("OUT_DIR")?;
+    // always set the env var so that the include_dir! macro doesn't panic
+    println!("cargo:rustc-env=DASHBOARD_ASSETS_DIR={}", out_dir);
+
+    let is_ci = std::env::var("CI").is_ok() || std::env::var("GITHUB_ACTIONS").is_ok();
+    if is_ci {
+        ci_main(&out_dir)
+    } else {
+        default_main(&out_dir)
+    }
 }


### PR DESCRIPTION
## Changes Made

splits the `dashboard/build.rs` into 2 separate mains. one for ci, and one for normal.

Prior to the build.rs changes in https://github.com/Eventual-Inc/Daft/pull/4272, you could manually install daft via

```sh
uv pip install daft@file:///path/to/repo/Daft
```

but after these changes, this no longer works. 

So this PR essentially reverts those for everywhere except CI. 

Notes regarding ci. 

Maturin passes the `GITHUB_` env vars through to the image, so by detecting the `GITHUB_ACTIONS` flag, the build should use the existing code path. 


- https://github.com/PyO3/maturin-action/blob/main/src/index.ts#L866
- https://github.com/PyO3/maturin-action/blob/main/src/index.ts#L250

so it should run as expected inside the CI.



⚠️ before merging, we must validate a manual run of the build CI. 



## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
