### PR TITLE
fix(spark-connect): withColumnRenamed now preserves non-renamed columns

### DIFF
--- a/src/daft-connect/src/spark_analyzer.rs
+++ b/src/daft-connect/src/spark_analyzer.rs
@@ -642,30 +642,37 @@ impl SparkAnalyzer<'_> {
 
         let plan = Box::pin(self.to_logical_plan(*input)).await?;
 
-        // todo: let's implement this directly into daft
-
-        // Convert the rename mappings into expressions
-        let rename_exprs = if !rename_columns_map.is_empty() {
+        // Create rename mappings from either format
+        let rename_map: HashMap<String, String> = if !rename_columns_map.is_empty() {
             // Use rename_columns_map if provided (legacy format)
             rename_columns_map
-                .into_iter()
-                .map(|(old_name, new_name)| {
-                    unresolved_col(old_name.as_str()).alias(new_name.as_str())
-                })
-                .collect()
         } else {
             // Use renames if provided (new format)
             renames
                 .into_iter()
-                .map(|rename| {
-                    unresolved_col(rename.col_name.as_str()).alias(rename.new_col_name.as_str())
-                })
+                .map(|rename| (rename.col_name, rename.new_col_name))
                 .collect()
         };
 
-        // Apply the rename expressions to the plan
+        // Get all column names from the schema and create expressions for each
+        let all_exprs: Vec<_> = plan
+            .schema()
+            .names()
+            .into_iter()
+            .map(|col_name| {
+                if let Some(new_name) = rename_map.get(&col_name) {
+                    // This column should be renamed
+                    unresolved_col(col_name.as_str()).alias(new_name.as_str())
+                } else {
+                    // This column should remain unchanged
+                    unresolved_col(col_name.as_str())
+                }
+            })
+            .collect();
+
+        // Apply the expressions to select all columns (with renames applied)
         let plan = plan
-            .select(rename_exprs)
+            .select(all_exprs)
             .wrap_err("Failed to apply rename expressions to logical plan")?;
 
         Ok(plan)

--- a/tests/connect/test_basics.py
+++ b/tests/connect/test_basics.py
@@ -349,6 +349,57 @@ def test_with_columns_renamed(spark_session):
     # assert [(row["number"], row["character"]) for row in collected] == [(0, 0), (1, 1)]
 
 
+def test_with_column_renamed_preserves_other_columns(spark_session):
+    """Test that withColumnRenamed preserves non-renamed columns."""
+    # Create a DataFrame with multiple columns
+    data = [(1, "alice", 25), (2, "bob", 30), (3, "charlie", 35)]
+    df = spark_session.createDataFrame(data, ["id", "name", "age"])
+    
+    # Rename only the 'name' column to 'full_name'
+    renamed_df = df.withColumnRenamed("name", "full_name")
+    
+    # Verify the schema has all columns
+    assert "id" in renamed_df.columns, "Original 'id' column should be preserved"
+    assert "age" in renamed_df.columns, "Original 'age' column should be preserved" 
+    assert "full_name" in renamed_df.columns, "Renamed column should exist"
+    assert "name" not in renamed_df.columns, "Original 'name' column should be gone"
+    assert len(renamed_df.columns) == 3, "Should have same number of columns"
+    
+    # Verify the data is correct
+    collected = renamed_df.collect()
+    assert len(collected) == 3
+    assert collected[0]["id"] == 1
+    assert collected[0]["full_name"] == "alice"
+    assert collected[0]["age"] == 25
+
+
+def test_with_column_renamed_chained(spark_session):
+    """Test that multiple withColumnRenamed calls work correctly."""
+    # Create a DataFrame with multiple columns
+    data = [(1, "alice", 25), (2, "bob", 30), (3, "charlie", 35)]
+    df = spark_session.createDataFrame(data, ["id", "name", "age"])
+    
+    # Chain multiple renames
+    renamed_df = (df
+                  .withColumnRenamed("name", "full_name")
+                  .withColumnRenamed("age", "years"))
+    
+    # Verify the schema has all columns with correct names
+    assert "id" in renamed_df.columns, "Original 'id' column should be preserved"
+    assert "full_name" in renamed_df.columns, "First renamed column should exist"
+    assert "years" in renamed_df.columns, "Second renamed column should exist"
+    assert "name" not in renamed_df.columns, "Original 'name' column should be gone"
+    assert "age" not in renamed_df.columns, "Original 'age' column should be gone"
+    assert len(renamed_df.columns) == 3, "Should have same number of columns"
+    
+    # Verify the data is correct
+    collected = renamed_df.collect()
+    assert len(collected) == 3
+    assert collected[0]["id"] == 1
+    assert collected[0]["full_name"] == "alice"
+    assert collected[0]["years"] == 25
+
+
 def test_explain(spark_session, capsys):
     df = spark_session.createDataFrame([(1, 2), (2, 2)], ["a", "b"])
     df.explain()

--- a/tests/connect/test_basics.py
+++ b/tests/connect/test_basics.py
@@ -354,17 +354,17 @@ def test_with_column_renamed_preserves_other_columns(spark_session):
     # Create a DataFrame with multiple columns
     data = [(1, "alice", 25), (2, "bob", 30), (3, "charlie", 35)]
     df = spark_session.createDataFrame(data, ["id", "name", "age"])
-    
+
     # Rename only the 'name' column to 'full_name'
     renamed_df = df.withColumnRenamed("name", "full_name")
-    
+
     # Verify the schema has all columns
     assert "id" in renamed_df.columns, "Original 'id' column should be preserved"
-    assert "age" in renamed_df.columns, "Original 'age' column should be preserved" 
+    assert "age" in renamed_df.columns, "Original 'age' column should be preserved"
     assert "full_name" in renamed_df.columns, "Renamed column should exist"
     assert "name" not in renamed_df.columns, "Original 'name' column should be gone"
     assert len(renamed_df.columns) == 3, "Should have same number of columns"
-    
+
     # Verify the data is correct
     collected = renamed_df.collect()
     assert len(collected) == 3
@@ -378,12 +378,10 @@ def test_with_column_renamed_chained(spark_session):
     # Create a DataFrame with multiple columns
     data = [(1, "alice", 25), (2, "bob", 30), (3, "charlie", 35)]
     df = spark_session.createDataFrame(data, ["id", "name", "age"])
-    
+
     # Chain multiple renames
-    renamed_df = (df
-                  .withColumnRenamed("name", "full_name")
-                  .withColumnRenamed("age", "years"))
-    
+    renamed_df = df.withColumnRenamed("name", "full_name").withColumnRenamed("age", "years")
+
     # Verify the schema has all columns with correct names
     assert "id" in renamed_df.columns, "Original 'id' column should be preserved"
     assert "full_name" in renamed_df.columns, "First renamed column should exist"
@@ -391,7 +389,7 @@ def test_with_column_renamed_chained(spark_session):
     assert "name" not in renamed_df.columns, "Original 'name' column should be gone"
     assert "age" not in renamed_df.columns, "Original 'age' column should be gone"
     assert len(renamed_df.columns) == 3, "Should have same number of columns"
-    
+
     # Verify the data is correct
     collected = renamed_df.collect()
     assert len(collected) == 3


### PR DESCRIPTION
## Summary
Fixes a critical bug in Spark Connect's `withColumnRenamed` implementation where calling this method was dropping all non-renamed columns from the DataFrame.

## Problem
Previously, `withColumnRenamed` was using `plan.select(rename_exprs)` which only selected the columns being renamed, causing all other columns to be lost. This was a significant deviation from expected Spark behavior and caused data loss.

## Solution
Modified the `with_columns_renamed` method in `spark_analyzer.rs` to:
- Create expressions for ALL columns in the schema
- Apply aliases only to columns that need renaming
- Keep other columns unchanged
- Use `plan.select(all_exprs)` to preserve the complete DataFrame structure

## Test Plan
- [x] Added `test_with_column_renamed_preserves_other_columns` to verify non-renamed columns are preserved
- [x] Added `test_with_column_renamed_chained` to test multiple renames
- [x] All existing Spark Connect tests pass
- [x] Manual verification with multi-column DataFrames

## Example
Before this fix:
```python
df = spark.createDataFrame([(1, "alice", 25)], ["id", "name", "age"])
renamed = df.withColumnRenamed("name", "full_name")
print(renamed.columns)  # Output: ['full_name'] ❌ Lost 'id' and 'age'
```

After this fix:
```python
df = spark.createDataFrame([(1, "alice", 25)], ["id", "name", "age"])  
renamed = df.withColumnRenamed("name", "full_name")
print(renamed.columns)  # Output: ['id', 'full_name', 'age'] ✅ All preserved
```

🤖 Generated with [Claude Code](https://claude.ai/code)