### PR TITLE
docs: Fix docs generation for `Expression.embedding.cosine_distance`

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -5049,7 +5049,13 @@ class ExpressionEmbeddingNamespace(ExpressionNamespace):
     def cosine_distance(self, other: Expression) -> Expression:
         """Compute the cosine distance between two embeddings.
 
-        Example:
+        Args:
+            other (Expression): The other embedding to compute the cosine distance against.
+
+        Returns:
+            Expression: a Float64 Expression with the cosine distance between the two embeddings.
+
+        Examples:
             >>> import daft
             >>> df = daft.from_pydict({"e1": [[1, 2, 3], [1, 2, 3]], "e2": [[1, 2, 3], [-1, -2, -3]]})
             >>> dtype = daft.DataType.fixed_size_list(daft.DataType.float32(), 3)
@@ -5067,8 +5073,6 @@ class ExpressionEmbeddingNamespace(ExpressionNamespace):
             <BLANKLINE>
             (Showing first 2 of 2 rows)
 
-        Returns:
-            Expression: a Float64 Expression with the cosine distance between the two embeddings.
         """
         return Expression._from_pyexpr(native.cosine_distance(self._expr, other._expr))
 


### PR DESCRIPTION
## Changes Made

Noticed that the API docs for `Expression.embedding.cosine_distance` were not rendering correctly, so fixed it. 

Current:
<img width="639" alt="Screenshot 2025-05-23 at 2 12 11 PM" src="https://github.com/user-attachments/assets/31c43507-776c-46b4-8716-df95cc3d1515" />

Rendered on PR:
<img width="639" alt="Screenshot 2025-05-23 at 2 11 45 PM" src="https://github.com/user-attachments/assets/c5d82df8-a883-4a3c-a9fe-e86ed68ed5b1" />

## Checklist

- [x] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
