### PR TITLE
fix: Progress bar no longer panics

### DIFF
--- a/daft/runners/progress_bar.py
+++ b/daft/runners/progress_bar.py
@@ -26,7 +26,7 @@ def get_tqdm(use_ray_tqdm: bool) -> Any:
             # source: https://github.com/tqdm/tqdm/blob/74722959a8626fd2057be03e14dcf899c25a3fd5/tqdm/autonotebook.py#L14
             if ipython is not None and "IPKernelApp" in ipython.config:
 
-                class tqdm(_tqdm[Any]):  # type: ignore[no-redef]
+                class tqdm(_tqdm):  # type: ignore[no-redef]
                     def __init__(self, *args: Any, **kwargs: Any) -> None:
                         kwargs = kwargs.copy()
                         if "file" not in kwargs:


### PR DESCRIPTION
## Changes Made

Daft runs into panics in a notebook when trying to render a progress bar:

![4AB2AB7F-FC3C-44B4-B082-C9B164425EF4](https://github.com/user-attachments/assets/b28e5158-a250-470c-9a7e-b5558e3edc57)

This is because `type 'tqdm' is not subscriptable`. So we remove the subscript.
