### PR TITLE
fix: Improve UDF errors

### DIFF
--- a/daft/udf.py
+++ b/daft/udf.py
@@ -178,7 +178,9 @@ def run_udf(
         result_pa = pa.concat_arrays(results)
         return Series.from_arrow(result_pa, name=name).cast(return_dtype)._series
     else:
-        raise NotImplementedError(f"Return type not supported for UDF: {type(results[0])}")
+        raise NotImplementedError(
+            f"Return type {type(results[0])} not supported for UDF {func}, expected daft.Series, list, np.ndarray, or pa.Array containing {return_dtype}"
+        )
 
 
 # Marker that helps us differentiate whether a user provided the argument or not

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -216,7 +216,7 @@ def test_iter_partitions_exception(make_df):
         assert part == {"a": [0, 1], "b": [0, 1]}
 
         # Ensure the exception does trigger if execution continues.
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(MockException) as exc_info:
             res = list(it)
             if get_tests_daft_runner_name() == "ray":
                 ray.get(res)
@@ -224,5 +224,4 @@ def test_iter_partitions_exception(make_df):
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
         if get_tests_daft_runner_name() == "ray":
             assert "MockException" in str(exc_info.value)
-        else:
-            assert isinstance(exc_info.value.__cause__, MockException)
+        assert str(exc_info.value).endswith("failed when executing on inputs:\n  - a (Int64, length=2)")

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -180,14 +180,13 @@ def test_iter_exception(make_df):
         assert next(it) == {"a": 0, "b": 0}
 
         # Ensure the exception does trigger if execution continues.
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(MockException) as exc_info:
             list(it)
 
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
         if get_tests_daft_runner_name() == "ray":
             assert "MockException" in str(exc_info.value)
-        else:
-            assert isinstance(exc_info.value.__cause__, MockException)
+        assert str(exc_info.value).endswith("failed when executing on inputs:\n  - a (Int64, length=2)")
 
 
 def test_iter_partitions_exception(make_df):


### PR DESCRIPTION
## Changes Made

This PR makes the UDF errors more descriptive, easier to understand, and actionable. Additionally, it also improves the readability of the internal code that runs the UDF, `run_udf`.

### Example error:

#### Before:
```
Error when running pipeline node Project
Traceback (most recent call last):
  File "/Users/colinho/Desktop/Daft/daft/udf.py", line 134, in run_udf
    results = [func(*args, **kwargs)]
  File "/Users/colinho/Desktop/Daft/test.py", line 9, in add_one
    raise ValueError("oopsie")
ValueError: oopsie

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/colinho/Desktop/Daft/test.py", line 16, in <module>
    df = df.collect()
  File "/Users/colinho/Desktop/Daft/daft/api_annotations.py", line 26, in _wrap
    return timed_method(*args, **kwargs)
  File "/Users/colinho/Desktop/Daft/daft/analytics.py", line 199, in tracked_method
    result = method(*args, **kwargs)
  File "/Users/colinho/Desktop/Daft/daft/dataframe/dataframe.py", line 3102, in collect
    self._materialize_results()
  File "/Users/colinho/Desktop/Daft/daft/dataframe/dataframe.py", line 3083, in _materialize_results
    self._result_cache = context.get_or_create_runner().run(self._builder)
  File "/Users/colinho/Desktop/Daft/daft/runners/native_runner.py", line 62, in run
    results = list(self.run_iter(builder))
  File "/Users/colinho/Desktop/Daft/daft/runners/native_runner.py", line 91, in run_iter
    yield from results_gen
  File "/Users/colinho/Desktop/Daft/daft/execution/native_executor.py", line 40, in <genexpr>
    return (
  File "/Users/colinho/Desktop/Daft/daft/udf.py", line 136, in run_udf
    raise RuntimeError(
RuntimeError: User-defined function `<function add_one at 0x1027581f0>` failed when executing on inputs with lengths: (5,)
```

The first thing you see is the `RuntimeError...`, but that doesn't actually tell you anything. You have to scroll up past the backtrace to find the actual error. This `RuntimeError` is not an actual error though, it's just trying to add context. 

Instead lets raise the original error and add context to it.

#### After:
```
Error when running pipeline node Project
Traceback (most recent call last):
  File "/Users/colinho/Desktop/Daft/test.py", line 16, in <module>
    df = df.collect()
  File "/Users/colinho/Desktop/Daft/daft/api_annotations.py", line 26, in _wrap
    return timed_method(*args, **kwargs)
  File "/Users/colinho/Desktop/Daft/daft/analytics.py", line 199, in tracked_method
    result = method(*args, **kwargs)
  File "/Users/colinho/Desktop/Daft/daft/dataframe/dataframe.py", line 3102, in collect
    self._materialize_results()
  File "/Users/colinho/Desktop/Daft/daft/dataframe/dataframe.py", line 3083, in _materialize_results
    self._result_cache = context.get_or_create_runner().run(self._builder)
  File "/Users/colinho/Desktop/Daft/daft/runners/native_runner.py", line 62, in run
    results = list(self.run_iter(builder))
  File "/Users/colinho/Desktop/Daft/daft/runners/native_runner.py", line 91, in run_iter
    yield from results_gen
  File "/Users/colinho/Desktop/Daft/daft/execution/native_executor.py", line 40, in <genexpr>
    return (
  File "/Users/colinho/Desktop/Daft/daft/udf.py", line 149, in run_udf
    results.append(func(*args, **kwargs))
  File "/Users/colinho/Desktop/Daft/test.py", line 9, in add_one
    raise ValueError("oopsie")
ValueError: oopsie
User-defined function `<function add_one at 0x1045b01f0>` failed when executing on inputs:
  - id (Int64, length=5)
```

Now the first thing i see is the actual error that happened in the UDF, and i can click on `File "/Users/colinho/Desktop/Daft/test.py", line 9, in add_one` to immediately find the line number in the UDF that caused this exception

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
