### PR TITLE
fix: Fix iceberg docker compose entrypoint command

### DIFF
--- a/tests/integration/iceberg/docker-compose/docker-compose.yml
+++ b/tests/integration/iceberg/docker-compose/docker-compose.yml
@@ -81,7 +81,7 @@ services:
     - AWS_REGION=us-east-1
     entrypoint: >
       /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
+      until (/usr/bin/mc alias set minio http://minio:9000 admin password) do echo '...waiting...' && sleep 1; done;
       /usr/bin/mc mb minio/warehouse;
       /usr/bin/mc policy set public minio/warehouse;
       tail -f /dev/null


### PR DESCRIPTION
## Changes Made

https://github.com/minio/mc/issues/5206

```mc: <ERROR> `config` is not a recognized command. Get help using `--help` flag.```

replaced with `mc alias set`

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
