### PR TITLE
fix: casting from list(list(T)) to list(tensor(T))

### DIFF
--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -2372,6 +2372,11 @@ impl ListArray {
                 );
                 Ok(embedding_array.into_series())
             }
+            DataType::FixedShapeTensor(_, _) => {
+                let result = self.cast(&dtype.to_physical())?;
+                let result = result.fixed_size_list()?;
+                result.cast(dtype)
+            }
             _ => unimplemented!("List casting not implemented for dtype: {}", dtype),
         }
     }

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -1302,3 +1302,16 @@ def test_series_cast_fixed_shape_sparse_without_indices_offset_to_regular(sparse
 
     regular_fixed_shape_series = regular_fixed_shape_series.to_pylist()
     np.testing.assert_equal(regular_fixed_shape_series, sparse_tensor_data)
+
+
+# see: https://github.com/Eventual-Inc/Daft/issues/4426
+def test_cast_list_list_to_list_tensor():
+    boxes = [
+        [[100, 100, 200, 200], [300, 300, 400, 400], [500, 500, 600, 600], [700, 700, 800, 800], [900, 900, 1000, 1000]]
+        for _ in range(5)
+    ]
+
+    s = Series.from_pylist(boxes)
+    cast_to = DataType.list(DataType.tensor(DataType.int64(), shape=(4,)))
+    s = s.cast(cast_to)
+    assert s.datatype() == cast_to


### PR DESCRIPTION
## Changes Made

We supported this indirectly by first casting to a fixed size list:
```py
i64 = DataType.int64()
s.cast(DataType.fixed_size_list(i64, 4)).cast(DataType.tensor(i64, shape=(4,)))
```

So I just routed the list(list(T)) implementation to use the same path as above..



## Related Issues

partially closes https://github.com/Eventual-Inc/Daft/issues/4426, 

Note: `list(python)` is not implemented in this PR, so the issue should remain open. 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
