### PR TITLE
experiment: ipc udfs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ dependencies = [
  "daft-distributed",
  "daft-dsl",
  "daft-functions",
+ "daft-functions-ipc",
  "daft-functions-json",
  "daft-functions-list",
  "daft-functions-temporal",
@@ -2313,6 +2314,25 @@ dependencies = [
  "typetag",
  "uuid 1.16.0",
  "xxhash-rust",
+]
+
+[[package]]
+name = "daft-functions-ipc"
+version = "0.3.0-dev0"
+dependencies = [
+ "arrow2",
+ "common-error",
+ "daft-core",
+ "daft-dsl",
+ "daft-recordbatch",
+ "itertools 0.11.0",
+ "jaq-core",
+ "jaq-interpret",
+ "jaq-parse",
+ "jaq-std",
+ "serde",
+ "serde_json",
+ "typetag",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ daft-distributed = {path = "src/daft-distributed", default-features = false}
 daft-dsl = {path = "src/daft-dsl", default-features = false}
 daft-functions = {path = "src/daft-functions"}
 daft-functions-json = {path = "src/daft-functions-json", default-features = false}
+daft-functions-ipc = {path = "src/daft-functions-ipc", default-features = false}
 daft-functions-list = {path = "src/daft-functions-list", default-features = false}
 daft-functions-temporal = {path = "src/daft-functions-temporal", default-features = false}
 daft-functions-utf8 = {path = "src/daft-functions-utf8", default-features = false}
@@ -75,6 +76,7 @@ python = [
   "daft-distributed/python",
   "daft-dsl/python",
   "daft-functions-json/python",
+  "daft-functions-ipc/python",
   "daft-functions-list/python",
   "daft-functions-utf8/python",
   "daft-functions/python",
@@ -170,6 +172,7 @@ members = [
   "src/daft-dsl",
   "src/daft-functions",
   "src/daft-functions-json",
+  "src/daft-functions-ipc",
   "src/daft-functions-list",
   "src/daft-functions-utf8",
   "src/daft-hash",
@@ -224,6 +227,7 @@ daft-core = {path = "src/daft-core"}
 daft-dsl = {path = "src/daft-dsl"}
 daft-functions = {path = "src/daft-functions"}
 daft-functions-json = {path = "src/daft-functions-json"}
+daft-functions-ipc = {path = "src/daft-functions-ipc"}
 daft-functions-list = {path = "src/daft-functions-list"}
 daft-functions-utf8 = {path = "src/daft-functions-utf8"}
 daft-hash = {path = "src/daft-hash"}

--- a/src/daft-dsl/src/lit/mod.rs
+++ b/src/daft-dsl/src/lit/mod.rs
@@ -569,8 +569,9 @@ impl LiteralValue {
                 Ok(lst.literal_value())
             }
             DataType::List(_) => {
-                let lst = s.list()?.get(idx).ok_or_else(err)?;
-                Ok(lst.literal_value())
+                let lst = s.list()?.slice(idx, idx + 1)?;
+
+                Ok(lst.into_series().literal_value())
             }
             DataType::Struct(fields) => {
                 let children = &s.struct_()?.children;

--- a/src/daft-functions-ipc/Cargo.toml
+++ b/src/daft-functions-ipc/Cargo.toml
@@ -1,0 +1,29 @@
+[dependencies]
+common-error = {path = "../common/error", default-features = false}
+daft-core = {path = "../daft-core", default-features = false}
+daft-dsl = {path = "../daft-dsl", default-features = false}
+daft-recordbatch = {path = "../daft-recordbatch", default-features = false}
+arrow2 = {workspace = true, features = ["io_ipc"]}
+jaq-core = {workspace = true}
+jaq-interpret = {workspace = true}
+jaq-parse = {workspace = true}
+jaq-std = {workspace = true}
+serde = {workspace = true}
+serde_json = {workspace = true}
+typetag = {workspace = true}
+itertools.workspace = true
+
+[features]
+python = [
+  "common-error/python",
+  "daft-core/python",
+  "daft-dsl/python"
+]
+
+[lints]
+workspace = true
+
+[package]
+name = "daft-functions-ipc"
+edition.workspace = true
+version.workspace = true

--- a/src/daft-functions-ipc/src/lib.rs
+++ b/src/daft-functions-ipc/src/lib.rs
@@ -1,0 +1,128 @@
+use std::{
+    io::Cursor,
+    process::{Command, Stdio},
+};
+
+use common_error::DaftResult;
+use daft_core::{
+    prelude::{DataType, Field, Schema},
+    series::Series,
+};
+use daft_dsl::{
+    functions::{FunctionArgs, ScalarUDF},
+    ExprRef,
+};
+use daft_recordbatch::{GrowableRecordBatch, RecordBatch};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct IPCUDF;
+
+#[derive(FunctionArgs, Debug)]
+pub struct Args<T> {
+    // args
+    #[arg(variadic)]
+    pub args: Vec<T>,
+
+    // kwargs
+    pub name: String,
+    pub num_expressions: usize,
+    pub return_dtype: DataType,
+    pub command: String,
+    pub command_args: Vec<String>,
+}
+
+use arrow2::{
+    datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
+    io::ipc::{
+        read::{read_stream_metadata, StreamReader},
+        write::{StreamWriter, WriteOptions},
+    },
+};
+
+#[typetag::serde]
+impl ScalarUDF for IPCUDF {
+    fn name(&self) -> &'static str {
+        "ipc_udf"
+    }
+
+    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+        let args: Args<_> = inputs.try_into()?;
+
+        let rb = RecordBatch::from_nonempty_columns(args.args)?;
+
+        let schema = rb.schema.to_arrow()?;
+        let chunk = rb.to_chunk();
+
+        // // Spawn the parameterized process
+        let mut child = Command::new(args.command.clone())
+            .args(args.command_args.clone())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        // Write Arrow data to process stdin
+        {
+            let stdin = child.stdin.take().unwrap();
+            let options = WriteOptions { compression: None };
+            let mut writer = StreamWriter::new(stdin, options);
+            writer.start(&schema, None)?;
+            writer.write(&chunk, None)?;
+            writer.finish()?;
+        }
+        // Wait for process to complete and read all output
+        let output = child.wait_with_output()?;
+
+        if !output.status.success() {
+            eprintln!("Process failed with status: {}", output.status);
+            eprintln!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+            panic!("Process failed");
+        }
+
+        // Show process debug output
+        if !output.stderr.is_empty() {
+            eprintln!(
+                "Process stderr: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+
+        // Parse Arrow data from the complete output
+        let mut cursor = Cursor::new(output.stdout);
+        let stream_metadata = read_stream_metadata(&mut cursor)?;
+        let output_schema = &stream_metadata.schema;
+        let schema: Schema = output_schema.clone().into();
+        let reader = StreamReader::new(&mut cursor, stream_metadata, None);
+        let mut batches = Vec::new();
+
+        for batch_result in reader {
+            match batch_result {
+                Ok(batch) => {
+                    let batch = batch.unwrap();
+                    let rb = RecordBatch::from_arrow(schema.clone(), batch.into_arrays())?;
+                    batches.push(rb);
+                }
+                Err(e) => {
+                    eprintln!("Error: {}", e);
+                    break;
+                }
+            }
+        }
+        let rb = RecordBatch::concat(&batches)?;
+        let s = rb.get_column(0);
+        Ok(s.clone())
+    }
+
+    fn function_args_to_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &daft_core::prelude::Schema,
+    ) -> common_error::DaftResult<daft_core::prelude::Field> {
+        let args: Args<_> = inputs.try_into()?;
+        let fld = args.args[0].to_field(schema)?;
+
+        Ok(Field::new(fld.name, args.return_dtype.clone()))
+    }
+}

--- a/src/daft-functions-ipc/src/lib.rs
+++ b/src/daft-functions-ipc/src/lib.rs
@@ -54,7 +54,6 @@ impl ScalarUDF for IPCUDF {
         let schema = rb.schema.to_arrow()?;
         let chunk = rb.to_chunk();
 
-        // // Spawn the parameterized process
         let mut child = Command::new(args.command.clone())
             .args(args.command_args.clone())
             .stdin(Stdio::piped())
@@ -62,7 +61,6 @@ impl ScalarUDF for IPCUDF {
             .stderr(Stdio::piped())
             .spawn()?;
 
-        // Write Arrow data to process stdin
         {
             let stdin = child.stdin.take().unwrap();
             let options = WriteOptions { compression: None };
@@ -71,7 +69,6 @@ impl ScalarUDF for IPCUDF {
             writer.write(&chunk, None)?;
             writer.finish()?;
         }
-        // Wait for process to complete and read all output
         let output = child.wait_with_output()?;
 
         if !output.status.success() {
@@ -80,7 +77,6 @@ impl ScalarUDF for IPCUDF {
             panic!("Process failed");
         }
 
-        // Show process debug output
         if !output.stderr.is_empty() {
             eprintln!(
                 "Process stderr: {}",
@@ -88,8 +84,6 @@ impl ScalarUDF for IPCUDF {
             );
         }
 
-
-        // Parse Arrow data from the complete output
         let mut cursor = Cursor::new(output.stdout);
         let stream_metadata = read_stream_metadata(&mut cursor)?;
         let output_schema = &stream_metadata.schema;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ pub mod pylib {
     use std::sync::LazyLock;
 
     use common_tracing::{init_opentelemetry_providers, init_tracing};
+    use daft_functions_ipc::IPCUDF;
     use pyo3::prelude::*;
 
     static LOG_RESET_HANDLE: LazyLock<pyo3_log::ResetHandle> = LazyLock::new(pyo3_log::init);
@@ -151,6 +152,7 @@ pub mod pylib {
         let mut functions_registry = daft_dsl::functions::FUNCTION_REGISTRY
             .write()
             .expect("Failed to acquire write lock on function registry");
+        functions_registry.add_fn(IPCUDF);
         functions_registry.register::<daft_functions::numeric::NumericFunctions>();
         functions_registry.register::<daft_functions::float::FloatFunctions>();
         functions_registry.register::<daft_functions::uri::UriFunctions>();


### PR DESCRIPTION
## Changes Made

call arbitrary code over ipc via stdin/stdout. Idea is that it opens up new kinds of udfs such as the ability to write udfs in javascript or other languages.

example:
```py

import daft

df = daft.from_pydict({
    "nums": [1,2,3,4]
})

daft.sql("""select ipc_udf(
    nums,
    name := 'test',
    num_expressions := 1,
    return_dtype := 'Int32',
    command := '/Users/corygrinstead/Development/Daft/.venv/bin/python',
    command_args := [
        '-c',
        '
import sys
import pyarrow as pa
reader = pa.ipc.open_stream(sys.stdin.buffer)
table = reader.read_all()
numbers = table.column("nums").to_pylist()
doubled = [x * 2 for x in numbers]
new_array = pa.array(doubled, type=pa.int32())
new_table = pa.table([new_array], names=["nums"])
writer = pa.ipc.new_stream(sys.stdout.buffer, new_table.schema)
writer.write_table(new_table)
writer.close()
'
    ]
) from df""").collect()
```



## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
