### PR TITLE
feat: adds python partition fields to the DataSource API

### DIFF
--- a/daft/io/__shim.py
+++ b/daft/io/__shim.py
@@ -37,7 +37,7 @@ class _DataSourceShim(ScanOperator):
         return f"DataSource({self.name()})"
 
     def partitioning_keys(self) -> list[PyPartitionField]:
-        return []
+        return [pf._partition_field for pf in self._source.get_partition_fields()]
 
     def can_absorb_filter(self) -> bool:
         return False

--- a/daft/io/source.py
+++ b/daft/io/source.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from daft.dataframe import DataFrame
+    from daft.io.partitioning import PartitionField
     from daft.io.pushdowns import Pushdowns
     from daft.recordbatch import MicroPartition
     from daft.schema import Schema
@@ -42,6 +43,10 @@ class DataSource(ABC):
     def schema(self) -> Schema:
         """Returns the schema shared by each task's record batches."""
         ...
+
+    def get_partition_fields(self) -> list[PartitionField]:
+        """Returns the partitioning fields for this data source."""
+        return []
 
     @abstractmethod
     def get_tasks(self, pushdowns: Pushdowns) -> Iterator[DataSourceTask]:


### PR DESCRIPTION
## Changes Made

Now that we have python classes for PartitionField and PartitionSpec, they can be hooked up to the DataSource API, and the __shim does the PyPartitionField unwrapping.

## Related Issues

- #4228 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
