### PR TITLE
ci: remove publish with name 'getdaft'

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,5 +1,5 @@
 name: Build Daft wheel
-run-name: 'Build Daft wheel for ${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}-newname=${{ inputs.use_old_name }}'
+run-name: 'Build Daft wheel for ${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}'
 
 on:
   workflow_call:
@@ -16,9 +16,6 @@ on:
       build_type:
         description: Value to set RUST_DAFT_PKG_BUILD_TYPE to (release, dev, nightly, etc.)
         type: string
-      use_old_name:
-        description: Set to true to build as `getdaft` instead of `daft`
-        type: boolean
 
 env:
   PYTHON_VERSION: 3.11
@@ -53,10 +50,6 @@ jobs:
         echo "Setting package version to: $VERSION"
         tomlq -i -t ".package.version = \"$VERSION\"" Cargo.toml
         tomlq -i -t ".workspace.package.version = \"$VERSION\"" Cargo.toml
-
-    - name: Patch name to daft if using new name
-      if: ${{ inputs.use_old_name }}
-      run: tomlq -i -t ".project.name = \"getdaft\"" pyproject.toml
 
     - name: Patch name to daft-lts if LTS
       if: ${{ inputs.lts }}
@@ -125,5 +118,5 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}-newname=${{ inputs.use_old_name }}
+        name: wheels-${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}
         path: dist

--- a/.github/workflows/nightly-publish-s3.yml
+++ b/.github/workflows/nightly-publish-s3.yml
@@ -30,22 +30,18 @@ jobs:
       arch: ${{ matrix.arch }}
       lts: ${{ matrix.lts }}
       build_type: release
-      use_old_name: ${{ matrix.use_old_name }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
         arch: [x86_64, aarch64]
         lts: [false, true]
-        use_old_name: [false, true]
 
         exclude:
         - os: windows
           arch: aarch64
         - lts: true
           arch: aarch64
-        - lts: true
-          use_old_name: false
 
   publish:
     name: Publish wheels to S3

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -49,14 +49,12 @@ jobs:
       arch: ${{ matrix.arch }}
       lts: ${{ matrix.lts }}
       build_type: release
-      use_old_name: ${{ matrix.use_old_name }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu]
         arch: [x86_64, aarch64]
         lts: [false]
-        use_old_name: [false, true]
 
   publish:
     name: Publish wheels to S3

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,22 +22,18 @@ jobs:
       arch: ${{ matrix.arch }}
       lts: ${{ matrix.lts }}
       build_type: release
-      use_old_name: ${{ matrix.use_old_name }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
         arch: [x86_64, aarch64]
         lts: [false, true]
-        use_old_name: [false, true]
 
         exclude:
         - os: windows
           arch: aarch64
         - lts: true
           arch: aarch64
-        - lts: true
-          use_old_name: false
 
   publish:
     name: Publish wheels to PyPI

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -57,25 +57,6 @@ analytics_client.track_import()
 track_import_on_scarf()
 
 ###
-# Warn if using the old package name
-###
-try:
-    if sys.version_info < (3, 10):
-        from importlib_metadata import packages_distributions
-    else:
-        from importlib.metadata import packages_distributions
-
-    package_map = packages_distributions()
-    if "getdaft" in package_map["daft"]:
-        import warnings
-
-        warnings.warn(
-            "The 'getdaft' PyPI package is migrating to `daft` and will no longer will receive updates v0.5.0 onwards.\nPlease install Daft via\n\t'pip install daft'"
-        )
-except Exception:
-    pass
-
-###
 # Daft top-level imports
 ###
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,7 @@ dependencies = [
   "pyarrow >= 8.0.0",
   "fsspec",
   "tqdm",
-  "typing-extensions >= 4.0.0; python_version < '3.10'",
-  "importlib-metadata; python_version < '3.10'"
+  "typing-extensions >= 4.0.0; python_version < '3.10'"
 ]
 description = "Distributed Dataframes for Multimodal Data"
 dynamic = ["version"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@ ipdb
 maturin
 pre-commit
 docker
-importlib-metadata
 
 # Pinned requests due to docker-py issue: https://github.com/docker/docker-py/issues/3256
 requests<2.32.0


### PR DESCRIPTION
## Changes Made

With our upcoming v0.5 release, we will no longer publish to the PyPI package `getdaft`, and instead only publish to `daft` and `daft-lts`. This PR makes that change.

## Related Issues

#3913

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
