### PR TITLE
chore: rename block_on method to convey intent

### DIFF
--- a/src/common/runtime/src/lib.rs
+++ b/src/common/runtime/src/lib.rs
@@ -118,8 +118,14 @@ impl Runtime {
     /// For example, URL download is an async function, but it is called from a synchronous function in a tokio runtime,
     /// i.e. calling the Expression Evaluator from the Native Executor.
     ///
+    /// Caution:
+    /// If the tokio runtimes of the synchronous function and the asynchronous function are same, that can potentially cause
+    /// a deadlock, so the caller needs to be careful to avoid nested calls that can cause this situation.
+    ///
+    /// Also, the calling runtime thread will not do any other work until this call returns, since it is blocked.
+    ///
     /// In the future, we should refactor the code to be fully async, but for now, this is a workaround.
-    pub fn block_on<F>(&self, future: F) -> DaftResult<F::Output>
+    pub fn block_within_async_context<F>(&self, future: F) -> DaftResult<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,

--- a/src/daft-functions-tokenize/src/bpe.rs
+++ b/src/daft-functions-tokenize/src/bpe.rs
@@ -162,8 +162,9 @@ fn get_file_bpe(
     let runtime = get_io_runtime(false);
 
     let path = path.to_string();
-    let file_bytes = runtime
-        .block_on(async move { client.single_url_get(path, None, None).await?.bytes().await })??;
+    let file_bytes = runtime.block_within_async_context(async move {
+        client.single_url_get(path, None, None).await?.bytes().await
+    })??;
     let file_str = std::str::from_utf8(&file_bytes).with_context(|_| InvalidUtf8SequenceSnafu)?;
 
     let tokens_res = parse_tokens(file_str)?;

--- a/src/daft-functions-uri/src/download.rs
+++ b/src/daft-functions-uri/src/download.rs
@@ -146,7 +146,7 @@ fn url_download(
         stream.try_collect::<Vec<_>>().await
     };
 
-    let mut results = runtime_handle.block_on(fetches)??;
+    let mut results = runtime_handle.block_within_async_context(fetches)??;
 
     results.sort_by_key(|k| k.0);
     let mut offsets: Vec<i64> = Vec::with_capacity(results.len() + 1);

--- a/src/daft-functions-uri/src/upload.rs
+++ b/src/daft-functions-uri/src/upload.rs
@@ -259,7 +259,7 @@ pub fn url_upload(
             .await
         };
 
-        let mut results = runtime_handle.block_on(uploads)??;
+        let mut results = runtime_handle.block_within_async_context(uploads)??;
         results.sort_by_key(|k| k.0);
 
         Ok(results.into_iter().map(|(_, path)| path).collect())

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -1203,7 +1203,7 @@ mod tests {
         let io_client = Arc::new(IOClient::new(io_config.into())?);
         let runtime_handle = get_io_runtime(true);
 
-        runtime_handle.block_on(async move {
+        runtime_handle.block_within_async_context(async move {
             let metadata = read_parquet_metadata(&file, io_client, None, None).await?;
             let serialized = bincode::serialize(&metadata).unwrap();
             let deserialized = bincode::deserialize::<FileMetaData>(&serialized).unwrap();
@@ -1230,7 +1230,7 @@ mod tests {
         let io_client = Arc::new(IOClient::new(io_config.into()).unwrap());
         let runtime_handle = get_io_runtime(true);
         let file_metadata = runtime_handle
-            .block_on({
+            .block_within_async_context({
                 let parquet = parquet.clone();
                 let io_client = io_client.clone();
                 async move { read_parquet_metadata(&parquet, io_client, None, None).await }

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -157,7 +157,7 @@ pub mod pylib {
                     hive_partitioning,
                 );
 
-                let operator = executor.block_on(task)??;
+                let operator = executor.block_within_async_context(task)??;
                 let operator = Arc::new(operator);
 
                 Ok(Self {

--- a/src/daft-sql/src/table_provider/read_csv.rs
+++ b/src/daft-sql/src/table_provider/read_csv.rs
@@ -105,7 +105,7 @@ impl SQLTableFunction for ReadCsvFunction {
         )?;
 
         let runtime = common_runtime::get_io_runtime(true);
-        let result = runtime.block_on(builder.finish())??;
+        let result = runtime.block_within_async_context(builder.finish())??;
         Ok(result)
     }
 }

--- a/src/daft-sql/src/table_provider/read_json.rs
+++ b/src/daft-sql/src/table_provider/read_json.rs
@@ -32,7 +32,7 @@ impl SQLTableFunction for ReadJsonFunction {
             1, // (path)
         )?;
         let runtime = common_runtime::get_io_runtime(true);
-        let result = runtime.block_on(builder.finish())??;
+        let result = runtime.block_within_async_context(builder.finish())??;
         Ok(result)
     }
 }

--- a/src/daft-sql/src/table_provider/read_parquet.rs
+++ b/src/daft-sql/src/table_provider/read_parquet.rs
@@ -92,7 +92,7 @@ impl SQLTableFunction for ReadParquetFunction {
 
         let runtime = common_runtime::get_io_runtime(true);
 
-        let result = runtime.block_on(builder.finish())??;
+        let result = runtime.block_within_async_context(builder.finish())??;
         Ok(result)
     }
 }


### PR DESCRIPTION
## Changes Made

For `Runtime::block_on()`:

- Updated comments to reflect 
  - The method can deadlock if the calling and receiving runtimes are the same.
  - Repercussions of blocking a runtime thread.
- Update method name to convey this intent.