### PR TITLE
chore: update dashboard backend and disable query viz temporarily

### DIFF
--- a/src/daft-dashboard/frontend/src/app/queries/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/queries/query/page.tsx
@@ -39,7 +39,6 @@ function SuspendedQueryPage() {
         return (<></>);
     }
 
-    const diagram = queryInfo[id].mermaid_plan.replace("```mermaid", "").replace("```", "");
 
     return (
         <div className="space-y-4">
@@ -73,7 +72,7 @@ function SuspendedQueryPage() {
                     <CardTitle>Query Plan</CardTitle>
                 </CardHeader>
                 <CardContent className="justify-center flex">
-                    <Mermaid chart={diagram} />
+                    <div>Coming Soon</div>
                 </CardContent>
             </Card>
         </div>

--- a/src/daft-dashboard/frontend/src/atoms/queryInfo.ts
+++ b/src/daft-dashboard/frontend/src/atoms/queryInfo.ts
@@ -2,9 +2,12 @@ import { atomWithStorage } from "jotai/utils";
 
 export type QueryInfo = {
     id: string
-    mermaid_plan: string
+    unoptimized_plan: string,
+    optimized_plan: string,
     plan_time_start: string
     plan_time_end: string
+    run_id?: string
+    logs?: string
 };
 
 export type QueryInfoMap = {

--- a/src/daft-dashboard/src/response.rs
+++ b/src/daft-dashboard/src/response.rs
@@ -17,9 +17,9 @@ fn cors() -> String {
         ///
         /// # Note
         /// We only do this for debug builds.
-        const BUN_DEV_PORT: u16 = 3000;
+        const BUN_DEV_PORT: u16 = 3238;
 
-        format!("http://localhost:{}", BUN_DEV_PORT)
+        format!("http://127.0.0.1:{}", BUN_DEV_PORT)
     }
 
     #[cfg(not(debug_assertions))]


### PR DESCRIPTION
## Changes Made

- integrates new changes to broadcast payload
- temporarily disables the query visualization until we can come up with a more useful visualization

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
