### PR TITLE
chore: scalarudf post refactor cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ impl ScalarUDF for MyToUpperCase {
     }
 
     // Then we add an implementation for it.
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let s = inputs.required(0)?;
         // Note: using into_iter is not the most performant way of implementing this, but for this example, we don't care about performance.
         let arr = s
@@ -176,8 +176,8 @@ impl ScalarUDF for MyToUpperCase {
         Ok(arr.into_series())
     }
 
-    // We also need a `function_args_to_field` which is used during planning to ensure that the args and datatypes are compatible.
-    fn function_args_to_field(
+    // We also need a `get_return_type_from_args` which is used during planning to ensure that the args and datatypes are compatible.
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-dsl/src/functions/agg/mod.rs
+++ b/src/daft-dsl/src/functions/agg/mod.rs
@@ -3,7 +3,7 @@ use daft_core::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    functions::{ScalarFunction, ScalarUDF},
+    functions::{FunctionArgs, ScalarFunction, ScalarUDF},
     ExprRef,
 };
 
@@ -13,6 +13,11 @@ pub(super) struct MergeMeanFunction;
 impl MergeMeanFunction {
     const EXTRA_SCALE: usize = 4;
 }
+#[derive(FunctionArgs)]
+struct Args<T> {
+    input: T,
+    counts: T,
+}
 
 #[typetag::serde]
 impl ScalarUDF for MergeMeanFunction {
@@ -20,86 +25,56 @@ impl ScalarUDF for MergeMeanFunction {
         "merge_mean"
     }
 
-    #[allow(deprecated)]
-    fn evaluate(&self, inputs: super::function_args::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: super::function_args::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let inputs = inputs.into_inner();
 
-        self.evaluate_from_series(&inputs)
+        self.call(&inputs)
     }
 
-    fn evaluate_from_series(&self, inputs: &[Series]) -> DaftResult<Series> {
-        match inputs {
-            [sum, counts] => {
-                if !matches!(counts.data_type(), DataType::UInt64) {
-                    return Err(DaftError::SchemaMismatch(format!(
-                        "Expected Counts to be type UInt64, got {}",
-                        counts.data_type()
-                    )));
-                }
-                match sum.data_type() {
-                    DataType::Decimal128(p, s) => {
-                        let new_type =
-                            DataType::Decimal128(*p, std::cmp::min(*p, s + Self::EXTRA_SCALE));
-                        let sum_array = sum.cast(&new_type)?;
-                        let sum_array = sum_array.decimal128()?;
-                        let count_array = counts.u64()?;
-                        Ok(sum_array.merge_mean(count_array)?.into_series())
-                    }
-                    _ => sum / counts,
-                }
-            }
-            _ => Err(DaftError::SchemaMismatch(format!(
-                "Expected 2 input arg, got {}",
-                inputs.len()
-            ))),
+    fn get_return_type_from_args(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let Args { input: sum, counts } = inputs.try_into()?;
+        let count_field = counts.to_field(schema)?;
+        if !matches!(count_field.dtype, DataType::UInt64) {
+            return Err(DaftError::SchemaMismatch(format!(
+                "Expected Counts to be type UInt64, got {}",
+                count_field.dtype
+            )));
         }
-    }
 
-    fn to_field(&self, inputs: &[ExprRef], schema: &Schema) -> DaftResult<Field> {
-        match inputs {
-            [sum, counts] => {
-                let count_field = counts.to_field(schema)?;
+        let sum_field = sum.to_field(schema)?;
+        match sum_field.dtype {
+            DataType::Decimal128(p, s) => {
+                let p_prime = p;
 
-                if !matches!(count_field.dtype, DataType::UInt64) {
-                    return Err(DaftError::SchemaMismatch(format!(
-                        "Expected Counts to be type UInt64, got {}",
-                        count_field.dtype
-                    )));
-                }
+                let s_max = std::cmp::min(p_prime, s + Self::EXTRA_SCALE);
 
-                let sum_field = sum.to_field(schema)?;
-                match sum_field.dtype {
-                    DataType::Decimal128(p, s) => {
-                        let p_prime = p;
-
-                        let s_max = std::cmp::min(p_prime, s + Self::EXTRA_SCALE);
-
-                        if !(1..=38).contains(&p_prime) {
-                            Err(DaftError::TypeError(
-                                format!("Cannot infer supertypes for mean on type: {} result precision: {p_prime} exceed bounds of [1, 38]", sum_field.dtype)
-                            ))
-                        } else if s_max > 38 {
-                            Err(DaftError::TypeError(
-                                format!("Cannot infer supertypes for mean on type: {} result scale: {s_max} exceed bounds of [0, 38]", sum_field.dtype)
-                            ))
-                        } else if s_max > p_prime {
-                            Err(DaftError::TypeError(
-                                format!("Cannot infer supertypes for mean on type: {} result scale: {s_max} exceed precision {p_prime}", sum_field.dtype)
-                            ))
-                        } else {
-                            Ok(Field::new(
-                                sum_field.name,
-                                DataType::Decimal128(p_prime, s_max),
-                            ))
-                        }
-                    }
-                    _ => sum.clone().div(counts.clone()).to_field(schema),
+                if !(1..=38).contains(&p_prime) {
+                    Err(DaftError::TypeError(
+                        format!("Cannot infer supertypes for mean on type: {} result precision: {p_prime} exceed bounds of [1, 38]", sum_field.dtype)
+                    ))
+                } else if s_max > 38 {
+                    Err(DaftError::TypeError(
+                        format!("Cannot infer supertypes for mean on type: {} result scale: {s_max} exceed bounds of [0, 38]", sum_field.dtype)
+                    ))
+                } else if s_max > p_prime {
+                    Err(DaftError::TypeError(
+                        format!("Cannot infer supertypes for mean on type: {} result scale: {s_max} exceed precision {p_prime}", sum_field.dtype)
+                    ))
+                } else {
+                    Ok(Field::new(
+                        sum_field.name,
+                        DataType::Decimal128(p_prime, s_max),
+                    ))
                 }
             }
-            _ => Err(DaftError::SchemaMismatch(format!(
-                "Expected 2 input arg, got {}",
-                inputs.len()
-            ))),
+            _ => sum.div(counts).to_field(schema),
         }
     }
 }

--- a/src/daft-dsl/src/functions/function_args.rs
+++ b/src/daft-dsl/src/functions/function_args.rs
@@ -362,6 +362,10 @@ impl<T> FunctionArgs<T> {
         Self(inner)
     }
 
+    pub fn new_unnamed(inner: Vec<T>) -> Self {
+        Self(inner.into_iter().map(FunctionArg::Unnamed).collect())
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/src/daft-functions-binary/src/concat.rs
+++ b/src/daft-functions-binary/src/concat.rs
@@ -26,7 +26,10 @@ impl ScalarUDF for BinaryConcat {
     fn name(&self) -> &'static str {
         "binary_concat"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let BinaryConcatArgs { input, other } = inputs.try_into()?;
         let name = input.name();
         use DataType::{Binary, FixedSizeBinary, Null};
@@ -68,7 +71,7 @@ impl ScalarUDF for BinaryConcat {
         }
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-binary/src/decode.rs
+++ b/src/daft-functions-binary/src/decode.rs
@@ -34,7 +34,7 @@ impl ScalarUDF for BinaryDecode {
         "decode"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -55,7 +55,10 @@ impl ScalarUDF for BinaryDecode {
         Ok(Field::new(input.name, codec.returns()))
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args { input, codec } = inputs.try_into()?;
         if codec == Codec::Utf8 {
             // special-case for decode('utf-8')
@@ -93,7 +96,7 @@ impl ScalarUDF for BinaryTryDecode {
         "try_decode"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -110,7 +113,10 @@ impl ScalarUDF for BinaryTryDecode {
         Ok(Field::new(input.name, codec.returns()))
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args { input, codec } = inputs.try_into()?;
 
         match input.data_type() {

--- a/src/daft-functions-binary/src/encode.rs
+++ b/src/daft-functions-binary/src/encode.rs
@@ -27,7 +27,7 @@ impl ScalarUDF for BinaryEncode {
     fn name(&self) -> &'static str {
         "encode"
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -47,7 +47,10 @@ impl ScalarUDF for BinaryEncode {
         Ok(Field::new(input.name, DataType::Binary))
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args { input, codec } = inputs.try_into()?;
 
         match input.data_type() {
@@ -78,7 +81,7 @@ impl ScalarUDF for BinaryTryEncode {
         "try_encode"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -97,7 +100,10 @@ impl ScalarUDF for BinaryTryEncode {
         Ok(Field::new(input.name, DataType::Binary))
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args { input, codec } = inputs.try_into()?;
 
         match input.data_type() {

--- a/src/daft-functions-binary/src/length.rs
+++ b/src/daft-functions-binary/src/length.rs
@@ -20,7 +20,7 @@ impl ScalarUDF for BinaryLength {
     fn name(&self) -> &'static str {
         "binary_length"
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -35,7 +35,10 @@ impl ScalarUDF for BinaryLength {
         Ok(Field::new(input.name, DataType::UInt64))
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
         match input.data_type() {
             DataType::Binary => {

--- a/src/daft-functions-binary/src/slice.rs
+++ b/src/daft-functions-binary/src/slice.rs
@@ -29,7 +29,7 @@ impl ScalarUDF for BinarySlice {
     fn name(&self) -> &'static str {
         "binary_slice"
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -64,7 +64,10 @@ impl ScalarUDF for BinarySlice {
         }
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let BinarySliceArgs {
             input,
             start,

--- a/src/daft-functions-json/src/json_query.rs
+++ b/src/daft-functions-json/src/json_query.rs
@@ -29,7 +29,7 @@ impl ScalarUDF for JsonQuery {
         "Extracts a JSON object from a JSON string using a JSONPath expression."
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -43,7 +43,7 @@ impl ScalarUDF for JsonQuery {
         Ok(Field::new(input.name, DataType::Utf8))
     }
 
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let JsonQueryArgs { input, query } = inputs.try_into()?;
         jq::query_series(&input, &query)
     }

--- a/src/daft-functions-list/src/bool_and.rs
+++ b/src/daft-functions-list/src/bool_and.rs
@@ -19,12 +19,15 @@ impl ScalarUDF for ListBoolAnd {
     fn name(&self) -> &'static str {
         "list_bool_and"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         input.list_bool_and()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/bool_or.rs
+++ b/src/daft-functions-list/src/bool_or.rs
@@ -20,12 +20,15 @@ impl ScalarUDF for ListBoolOr {
         "list_bool_or"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         input.list_bool_or()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/chunk.rs
+++ b/src/daft-functions-list/src/chunk.rs
@@ -19,7 +19,10 @@ impl ScalarUDF for ListChunk {
     fn name(&self) -> &'static str {
         "list_chunk"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 2, SchemaMismatch: "Expected 2 input args, got {}", inputs.len());
 
         let input = inputs.required((0, "input"))?;
@@ -30,7 +33,7 @@ impl ScalarUDF for ListChunk {
 
         input.list_chunk(size as _)
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/count.rs
+++ b/src/daft-functions-list/src/count.rs
@@ -26,14 +26,17 @@ impl ScalarUDF for ListCount {
     fn name(&self) -> &'static str {
         "list_count"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let ListCountArgs { input, mode } = inputs.try_into()?;
         let mode = mode.unwrap_or(CountMode::Valid);
 
         Ok(input.list_count(mode)?.into_series())
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/count_distinct.rs
+++ b/src/daft-functions-list/src/count_distinct.rs
@@ -19,12 +19,15 @@ impl ScalarUDF for ListCountDistinct {
     fn name(&self) -> &'static str {
         "list_count_distinct"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         input.list_count_distinct()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/distinct.rs
+++ b/src/daft-functions-list/src/distinct.rs
@@ -20,12 +20,15 @@ impl ScalarUDF for ListDistinct {
         "list_distinct"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         input.list_distinct()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/explode.rs
+++ b/src/daft-functions-list/src/explode.rs
@@ -22,12 +22,15 @@ impl ScalarUDF for Explode {
     fn aliases(&self) -> &'static [&'static str] {
         &["unnest"]
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         input.explode()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/get.rs
+++ b/src/daft-functions-list/src/get.rs
@@ -20,14 +20,17 @@ impl ScalarUDF for ListGet {
         "list_get"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         let idx = inputs.required((1, "index"))?;
         let _default = inputs.required((2, "default"))?;
         input.list_get(idx, _default)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/join.rs
+++ b/src/daft-functions-list/src/join.rs
@@ -22,7 +22,10 @@ impl ScalarUDF for ListJoin {
     fn aliases(&self) -> &'static [&'static str] {
         &["array_to_string"]
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         let delimiter = inputs.required((1, "delimiter"))?;
         ensure!(
@@ -32,7 +35,7 @@ impl ScalarUDF for ListJoin {
 
         Ok(input.join(delimiter.utf8()?)?.into_series())
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/list_fill.rs
+++ b/src/daft-functions-list/src/list_fill.rs
@@ -20,7 +20,10 @@ impl ScalarUDF for ListFill {
         "list_fill"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let inputs = inputs.into_inner();
         match inputs.as_slice() {
             [num, elem] => {
@@ -35,7 +38,7 @@ impl ScalarUDF for ListFill {
         }
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -92,14 +95,15 @@ mod tests {
         ]);
 
         let fill = ListFill {};
-        let DaftError::SchemaMismatch(e) =
-            fill.to_field(&[col0_null.clone()], &schema).unwrap_err()
+        let DaftError::SchemaMismatch(e) = fill
+            .get_return_type(&[col0_null.clone()], &schema)
+            .unwrap_err()
         else {
             panic!("Expected SchemaMismatch error");
         };
         assert_eq!(e, "Expected 2 input args, got 1");
         let DaftError::TypeError(e) = fill
-            .to_field(&[col0_null.clone(), col1_str.clone()], &schema)
+            .get_return_type(&[col0_null.clone(), col1_str.clone()], &schema)
             .unwrap_err()
         else {
             panic!("Expected TypeError error");
@@ -110,12 +114,12 @@ mod tests {
         );
 
         let list_of_null = fill
-            .to_field(&[col0_num.clone(), col1_null.clone()], &schema)
+            .get_return_type(&[col0_num.clone(), col1_null.clone()], &schema)
             .unwrap();
         let expected = Field::new("c1", DataType::List(Box::new(DataType::Null)));
         assert_eq!(list_of_null, expected);
         let list_of_str = fill
-            .to_field(&[col0_num.clone(), col1_str.clone()], &schema)
+            .get_return_type(&[col0_num.clone(), col1_str.clone()], &schema)
             .unwrap();
         let expected = Field::new("c1", DataType::List(Box::new(DataType::Utf8)));
         assert_eq!(list_of_str, expected);
@@ -130,7 +134,7 @@ mod tests {
         )
         .into_series();
 
-        let error = fill.evaluate_from_series(&[num.clone()]).unwrap_err();
+        let error = fill.call(&[num.clone()]).unwrap_err();
         assert_eq!(
             error.to_string(),
             "DaftError::ValueError Expected 2 input args, got 1"
@@ -148,8 +152,7 @@ mod tests {
         let str = Utf8Array::from_iter("s2", vec![None, Some("hello"), Some("world")].into_iter())
             .into_series();
         let error = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            fill.evaluate_from_series(&[num.clone(), str.clone()])
-                .unwrap()
+            fill.call(&[num.clone(), str.clone()]).unwrap()
         }));
         assert!(error.is_err());
     }
@@ -164,7 +167,7 @@ mod tests {
         .into_series();
         let str = Utf8Array::from_iter("s2", vec![None, Some("hello"), Some("world")].into_iter())
             .into_series();
-        let result = fill.evaluate_from_series(&[num.clone(), str.clone()])?;
+        let result = fill.call(&[num.clone(), str.clone()])?;
         // the expected result should be a list of strings: [[None], [], ["world", "world", "world"]]
         let flat_child = Utf8Array::from_iter(
             "s2",

--- a/src/daft-functions-list/src/max.rs
+++ b/src/daft-functions-list/src/max.rs
@@ -19,13 +19,16 @@ impl ScalarUDF for ListMax {
     fn name(&self) -> &'static str {
         "list_max"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 1, ValueError: "Expected 1 input arg, got {}", inputs.len());
         let input = inputs.required((0, "input"))?;
         input.list_max()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/mean.rs
+++ b/src/daft-functions-list/src/mean.rs
@@ -20,13 +20,16 @@ impl ScalarUDF for ListMean {
     fn name(&self) -> &'static str {
         "list_mean"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 1, ValueError: "Expected 1 input arg, got {}", inputs.len());
         let input = inputs.required((0, "input"))?;
         input.list_mean()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/min.rs
+++ b/src/daft-functions-list/src/min.rs
@@ -16,13 +16,16 @@ impl ScalarUDF for ListMin {
     fn name(&self) -> &'static str {
         "list_min"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 1, ValueError: "Expected 1 input arg, got {}", inputs.len());
         let input = inputs.required((0, "input"))?;
         input.list_min()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/slice.rs
+++ b/src/daft-functions-list/src/slice.rs
@@ -19,13 +19,16 @@ impl ScalarUDF for ListSlice {
     fn name(&self) -> &'static str {
         "list_slice"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         let start = inputs.required((1, "start"))?;
         let end = inputs.required((2, "end"))?;
         input.list_slice(start, end)
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/sort.rs
+++ b/src/daft-functions-list/src/sort.rs
@@ -17,7 +17,10 @@ impl ScalarUDF for ListSort {
         "list_sort"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let data = inputs.required((0, "input"))?;
 
         let desc = inputs
@@ -33,7 +36,7 @@ impl ScalarUDF for ListSort {
         data.list_sort(&desc, &nulls_first)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/sum.rs
+++ b/src/daft-functions-list/src/sum.rs
@@ -19,13 +19,16 @@ impl ScalarUDF for ListSum {
     fn name(&self) -> &'static str {
         "list_sum"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 1, ValueError: "Expected 1 input arg, got {}", inputs.len());
         let input = inputs.required((0, "input"))?;
         input.list_sum()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-list/src/value_counts.rs
+++ b/src/daft-functions-list/src/value_counts.rs
@@ -17,13 +17,16 @@ impl ScalarUDF for ListValueCounts {
         "list_value_counts"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 1, ValueError: "Expected 1 input arg, got {}", inputs.len());
         let input = inputs.required((0, "input"))?;
         input.list_value_counts()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-serde/src/deserialize.rs
+++ b/src/daft-functions-serde/src/deserialize.rs
@@ -22,7 +22,7 @@ impl ScalarUDF for Deserialize {
         "Deserializes the expression (string) using the specified format and data type."
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -30,7 +30,7 @@ impl ScalarUDF for Deserialize {
         get_field(inputs, schema)
     }
 
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let DeserializeArgs {
             input,
             format,
@@ -53,7 +53,7 @@ impl ScalarUDF for TryDeserialize {
         "Deserializes the expression (string) using the specified format and data type, insert null on parsing failures."
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -61,7 +61,7 @@ impl ScalarUDF for TryDeserialize {
         get_field(inputs, schema)
     }
 
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let DeserializeArgs {
             input,
             format,

--- a/src/daft-functions-temporal/src/lib.rs
+++ b/src/daft-functions-temporal/src/lib.rs
@@ -38,12 +38,12 @@ macro_rules! impl_temporal {
                     stringify!([ < $name:snake:lower > ])
                 }
 
-                fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+                fn call_with_args(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
                     let UnaryArg {input} = inputs.try_into()?;
                     input.$dt()
 
                 }
-                fn function_args_to_field(
+                fn get_return_type_from_args(
                     &self,
                     inputs: FunctionArgs<ExprRef>,
                     schema: &Schema,

--- a/src/daft-functions-temporal/src/time.rs
+++ b/src/daft-functions-temporal/src/time.rs
@@ -11,12 +11,15 @@ impl ScalarUDF for Time {
         "time"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
         input.dt_time()
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-temporal/src/to_string.rs
+++ b/src/daft-functions-temporal/src/to_string.rs
@@ -20,12 +20,15 @@ impl ScalarUDF for ToString {
         &["to_string"]
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args { input, format } = inputs.try_into()?;
         input.dt_strftime(format.as_deref())
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-temporal/src/total.rs
+++ b/src/daft-functions-temporal/src/total.rs
@@ -22,7 +22,7 @@ macro_rules! impl_total {
                 stringify!([ < $name:snake:lower > ])
             }
 
-            fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+            fn call_with_args(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
                 ensure!(inputs.len() == 1, SchemaMismatch: "Expected 1 input, but received {}", inputs.len());
                 let s = inputs.required((0, "input"))?;
                 match s.data_type() {
@@ -33,7 +33,7 @@ macro_rules! impl_total {
                 }
             }
 
-            fn function_args_to_field(&self, inputs: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+            fn get_return_type_from_args(&self, inputs: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
                 ensure!(inputs.len() == 1, SchemaMismatch: "Expected 1 input, but received {}", inputs.len());
                 let input = inputs.required((0, "input"))?.to_field(schema)?;
                 ensure!(input.dtype.is_duration(), "expected duration");

--- a/src/daft-functions-temporal/src/truncate.rs
+++ b/src/daft-functions-temporal/src/truncate.rs
@@ -20,7 +20,10 @@ impl ScalarUDF for Truncate {
         "truncate"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args {
             input,
             relative_to,
@@ -31,7 +34,7 @@ impl ScalarUDF for Truncate {
         input.dt_truncate(&interval, &relative_to)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-temporal/src/unix_timestamp.rs
+++ b/src/daft-functions-temporal/src/unix_timestamp.rs
@@ -34,7 +34,10 @@ impl ScalarUDF for UnixTimestamp {
         "to_unix_epoch"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args { input, time_unit } = inputs.try_into()?;
         let tu = time_unit.map(|tu| tu.0).unwrap_or(TimeUnit::Seconds);
         input
@@ -42,7 +45,7 @@ impl ScalarUDF for UnixTimestamp {
             .and_then(|s| s.cast(&DataType::Int64))
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-tokenize/src/decode.rs
+++ b/src/daft-functions-tokenize/src/decode.rs
@@ -30,7 +30,10 @@ struct DecodeArgs<T> {
 
 #[typetag::serde]
 impl ScalarUDF for TokenizeDecodeFunction {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let DecodeArgs {
             input,
             _varargs,
@@ -53,7 +56,7 @@ impl ScalarUDF for TokenizeDecodeFunction {
         "tokenize_decode"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-tokenize/src/encode.rs
+++ b/src/daft-functions-tokenize/src/encode.rs
@@ -40,7 +40,10 @@ impl ScalarUDF for TokenizeEncodeFunction {
     fn name(&self) -> &'static str {
         "tokenize_encode"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let EncodeArgs {
             input,
             _varargs: _,
@@ -62,7 +65,7 @@ impl ScalarUDF for TokenizeEncodeFunction {
             use_special_tokens,
         )
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-uri/src/download.rs
+++ b/src/daft-functions-uri/src/download.rs
@@ -41,7 +41,10 @@ impl ScalarUDF for UrlDownload {
     fn name(&self) -> &'static str {
         "url_download"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let UrlDownloadArgs {
             input,
             multi_thread,
@@ -79,7 +82,7 @@ impl ScalarUDF for UrlDownload {
         Ok(result.into_series())
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-uri/src/upload.rs
+++ b/src/daft-functions-uri/src/upload.rs
@@ -32,7 +32,10 @@ struct UrlUploadArgs<T> {
 
 #[typetag::serde]
 impl ScalarUDF for UrlUpload {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let UrlUploadArgs {
             input,
             location,
@@ -76,7 +79,7 @@ impl ScalarUDF for UrlUpload {
         "url_upload"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/capitalize.rs
+++ b/src/daft-functions-utf8/src/capitalize.rs
@@ -19,11 +19,14 @@ impl ScalarUDF for Capitalize {
     fn name(&self) -> &'static str {
         "capitalize"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         unary_utf8_evaluate(inputs, capitalize_impl)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/contains.rs
+++ b/src/daft-functions-utf8/src/contains.rs
@@ -16,11 +16,14 @@ pub struct Contains;
 
 #[typetag::serde]
 impl ScalarUDF for Contains {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "pattern", contains_impl)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/count_matches.rs
+++ b/src/daft-functions-utf8/src/count_matches.rs
@@ -19,7 +19,10 @@ impl ScalarUDF for CountMatches {
     fn name(&self) -> &'static str {
         "count_matches"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         let patterns = inputs.required((1, "patterns"))?;
 
@@ -42,7 +45,7 @@ impl ScalarUDF for CountMatches {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/endswith.rs
+++ b/src/daft-functions-utf8/src/endswith.rs
@@ -20,10 +20,13 @@ impl ScalarUDF for EndsWith {
         "ends_with"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "pattern", endswith_impl)
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/find.rs
+++ b/src/daft-functions-utf8/src/find.rs
@@ -22,7 +22,10 @@ impl ScalarUDF for Find {
         "find"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "substr", |s, substr| {
             s.with_utf8_array(|arr| {
                 substr.with_utf8_array(|substr_arr| {
@@ -32,7 +35,7 @@ impl ScalarUDF for Find {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/ilike.rs
+++ b/src/daft-functions-utf8/src/ilike.rs
@@ -21,7 +21,10 @@ impl ScalarUDF for ILike {
     fn name(&self) -> &'static str {
         "ilike"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "pattern", |s, pattern| {
             s.with_utf8_array(|arr| {
                 pattern
@@ -30,7 +33,7 @@ impl ScalarUDF for ILike {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/left.rs
+++ b/src/daft-functions-utf8/src/left.rs
@@ -27,7 +27,10 @@ impl ScalarUDF for Left {
         "left"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "n", |s, nchars| {
             s.with_utf8_array(|arr| {
             if nchars.data_type().is_integer() {
@@ -46,7 +49,7 @@ impl ScalarUDF for Left {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/length.rs
+++ b/src/daft-functions-utf8/src/length.rs
@@ -19,13 +19,16 @@ impl ScalarUDF for Length {
     fn name(&self) -> &'static str {
         "length"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         unary_utf8_evaluate(inputs, |s| {
             s.with_utf8_array(|arr| Ok(length_impl(arr)?.into_series()))
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/length_bytes.rs
+++ b/src/daft-functions-utf8/src/length_bytes.rs
@@ -19,13 +19,16 @@ impl ScalarUDF for LengthBytes {
     fn name(&self) -> &'static str {
         "length_bytes"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         unary_utf8_evaluate(inputs, |s| {
             s.with_utf8_array(|arr| Ok(length_bytes_impl(arr)?.into_series()))
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/like.rs
+++ b/src/daft-functions-utf8/src/like.rs
@@ -22,7 +22,10 @@ impl ScalarUDF for Like {
         "like"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "pattern", |s, pattern| {
             s.with_utf8_array(|arr| {
                 pattern
@@ -31,7 +34,7 @@ impl ScalarUDF for Like {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/lower.rs
+++ b/src/daft-functions-utf8/src/lower.rs
@@ -20,7 +20,10 @@ impl ScalarUDF for Lower {
         "lower"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         unary_utf8_evaluate(inputs, |s| {
             s.with_utf8_array(|arr| {
                 Ok(arr
@@ -30,7 +33,7 @@ impl ScalarUDF for Lower {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/lpad.rs
+++ b/src/daft-functions-utf8/src/lpad.rs
@@ -19,7 +19,10 @@ impl ScalarUDF for LPad {
     fn name(&self) -> &'static str {
         "lpad"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 3, SchemaMismatch: "Expected 3 inputs, but received {}", inputs.len());
         let data = inputs.required((0, "input"))?;
         let length = inputs.required((1, "length"))?;
@@ -28,7 +31,7 @@ impl ScalarUDF for LPad {
         series_pad(data, length, pad, PadPlacement::Left)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/lstrip.rs
+++ b/src/daft-functions-utf8/src/lstrip.rs
@@ -20,7 +20,10 @@ impl ScalarUDF for LStrip {
         "lstrip"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         unary_utf8_evaluate(inputs, |s| {
             s.with_utf8_array(|arr| {
                 arr.unary_broadcasted_op(|val| val.trim_start().into())
@@ -29,7 +32,7 @@ impl ScalarUDF for LStrip {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/normalize.rs
+++ b/src/daft-functions-utf8/src/normalize.rs
@@ -1,6 +1,6 @@
-use common_error::{ensure, DaftError, DaftResult};
+use common_error::{ensure, DaftResult};
 use daft_core::{
-    prelude::{AsArrow, DataType, Field, Schema, Utf8Array},
+    prelude::{AsArrow, Field, Schema, Utf8Array},
     series::{IntoSeries, Series},
 };
 use daft_dsl::{
@@ -13,141 +13,105 @@ use unicode_normalization::{is_nfd_quick, IsNormalized, UnicodeNormalization};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Normalize;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
-pub struct NormalizeOptions {
-    pub remove_punct: bool,
-    pub lowercase: bool,
-    pub nfd_unicode: bool,
-    pub white_space: bool,
+#[derive(FunctionArgs)]
+struct NormalizeArgs<T> {
+    input: T,
+    #[arg(optional)]
+    remove_punct: Option<bool>,
+    #[arg(optional)]
+    lowercase: Option<bool>,
+    #[arg(optional)]
+    nfd_unicode: Option<bool>,
+    #[arg(optional)]
+    white_space: Option<bool>,
 }
 
 #[typetag::serde]
 impl ScalarUDF for Normalize {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
-        let s = inputs.required((0, "input"))?;
-        let remove_punct = evaluate_helper(&inputs, "remove_punct")?;
-        let lowercase = evaluate_helper(&inputs, "lowercase")?;
-        let nfd_unicode = evaluate_helper(&inputs, "nfd_unicode")?;
-        let white_space = evaluate_helper(&inputs, "white_space")?;
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
+        let args: NormalizeArgs<Series> = inputs.try_into()?;
 
-        let options = NormalizeOptions {
-            remove_punct,
-            lowercase,
-            nfd_unicode,
-            white_space,
-        };
-
-        s.with_utf8_array(|arr| Ok(normalize_impl(arr, options)?.into_series()))
+        normalize_impl(args)
     }
 
     fn name(&self) -> &'static str {
         "normalize"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
     ) -> DaftResult<Field> {
-        ensure!(
-            !inputs.is_empty() && inputs.len() <=5,
-            SchemaMismatch: "valid arguments for normalize are [input, remove_punct, lowercase, nfd_unicode, white_space]"
-        );
-        let input = inputs.required((0, "input"))?.to_field(schema)?;
+        let NormalizeArgs { input, .. } = inputs.try_into()?;
+
+        let input = input.to_field(schema)?;
+
         ensure!(input.dtype.is_string(), TypeError: "Expected string type for input argument");
-        to_field_helper(&inputs, "remove_punct", schema)?;
-        to_field_helper(&inputs, "lowercase", schema)?;
-        to_field_helper(&inputs, "nfd_unicode", schema)?;
-        to_field_helper(&inputs, "white_space", schema)?;
 
         Ok(input)
     }
-
-    fn to_field(&self, inputs: &[ExprRef], schema: &Schema) -> DaftResult<Field> {
-        match inputs {
-            [data] => match data.to_field(schema) {
-                Ok(data_field) => match &data_field.dtype {
-                    DataType::Utf8 => Ok(Field::new(data_field.name, DataType::Utf8)),
-                    _ => Err(DaftError::TypeError(format!(
-                        "Expects input to normalize to be utf8, but received {data_field}",
-                    ))),
-                },
-                Err(e) => Err(e),
-            },
-            _ => Err(DaftError::SchemaMismatch(format!(
-                "Expected 1 input args, got {}",
-                inputs.len()
-            ))),
-        }
-    }
 }
 
-fn to_field_helper(
-    args: &FunctionArgs<ExprRef>,
-    flag_name: &'static str,
-    schema: &Schema,
-) -> DaftResult<()> {
-    if let Some(flag) = args
-        .optional(flag_name)?
-        .map(|f| f.to_field(schema))
-        .transpose()?
-    {
-        ensure!(flag.dtype.is_boolean(), TypeError: "Expected boolean type for {flag_name} argument");
-    };
-    Ok(())
-}
-fn evaluate_helper(args: &FunctionArgs<Series>, arg_name: &'static str) -> DaftResult<bool> {
-    args.optional(arg_name)?
-        .map(|s| {
-            ensure!(s.data_type().is_boolean(), ValueError: "{arg_name} must be a boolean");
-            ensure!(s.len() == 1, ValueError: "{arg_name} must be a single value");
+fn normalize_impl(
+    NormalizeArgs {
+        input,
+        remove_punct,
+        lowercase,
+        nfd_unicode,
+        white_space,
+    }: NormalizeArgs<Series>,
+) -> DaftResult<Series> {
+    let white_space = white_space.unwrap_or(false);
+    let lowercase = lowercase.unwrap_or(false);
+    let nfd_unicode = nfd_unicode.unwrap_or(false);
+    let remove_punct = remove_punct.unwrap_or(false);
 
-            Ok(s.bool().unwrap().get(0).unwrap())
-        })
-        .transpose()
-        .map(|v| v.unwrap_or(false))
-}
+    input.with_utf8_array(|arr| {
+        Ok(Utf8Array::from_iter(
+            arr.name(),
+            arr.as_arrow().iter().map(|maybe_s| {
+                if let Some(s) = maybe_s {
+                    let mut s = if white_space {
+                        s.trim().to_string()
+                    } else {
+                        s.to_string()
+                    };
 
-fn normalize_impl(arr: &Utf8Array, opts: NormalizeOptions) -> DaftResult<Utf8Array> {
-    Ok(Utf8Array::from_iter(
-        arr.name(),
-        arr.as_arrow().iter().map(|maybe_s| {
-            if let Some(s) = maybe_s {
-                let mut s = if opts.white_space {
-                    s.trim().to_string()
+                    let mut prev_white = true;
+                    s = s
+                        .chars()
+                        .filter_map(|c| {
+                            if !(remove_punct && c.is_ascii_punctuation()
+                                || white_space && c.is_whitespace())
+                            {
+                                prev_white = false;
+                                Some(c)
+                            } else if prev_white || (remove_punct && c.is_ascii_punctuation()) {
+                                None
+                            } else {
+                                prev_white = true;
+                                Some(' ')
+                            }
+                        })
+                        .collect();
+
+                    if lowercase {
+                        s = s.to_lowercase();
+                    }
+
+                    if nfd_unicode && is_nfd_quick(s.chars()) != IsNormalized::Yes {
+                        s = s.nfd().collect();
+                    }
+                    Some(s)
                 } else {
-                    s.to_string()
-                };
-
-                let mut prev_white = true;
-                s = s
-                    .chars()
-                    .filter_map(|c| {
-                        if !(opts.remove_punct && c.is_ascii_punctuation()
-                            || opts.white_space && c.is_whitespace())
-                        {
-                            prev_white = false;
-                            Some(c)
-                        } else if prev_white || (opts.remove_punct && c.is_ascii_punctuation()) {
-                            None
-                        } else {
-                            prev_white = true;
-                            Some(' ')
-                        }
-                    })
-                    .collect();
-
-                if opts.lowercase {
-                    s = s.to_lowercase();
+                    None
                 }
-
-                if opts.nfd_unicode && is_nfd_quick(s.chars()) != IsNormalized::Yes {
-                    s = s.nfd().collect();
-                }
-                Some(s)
-            } else {
-                None
-            }
-        }),
-    ))
+            }),
+        )
+        .into_series())
+    })
 }

--- a/src/daft-functions-utf8/src/regexp_extract.rs
+++ b/src/daft-functions-utf8/src/regexp_extract.rs
@@ -22,7 +22,10 @@ impl ScalarUDF for RegexpExtract {
     fn aliases(&self) -> &'static [&'static str] {
         &["regexp_extract"]
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(
             inputs.len() == 2 || inputs.len() == 3,
             ComputeError: "Expected 2 or 3 input args, got {}",
@@ -46,7 +49,7 @@ impl ScalarUDF for RegexpExtract {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/regexp_extract_all.rs
+++ b/src/daft-functions-utf8/src/regexp_extract_all.rs
@@ -22,7 +22,10 @@ impl ScalarUDF for RegexpExtractAll {
     fn aliases(&self) -> &'static [&'static str] {
         &["regexp_extract_all"]
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(
             inputs.len() == 2 || inputs.len() == 3,
             ComputeError: "Expected 2 or 3 input args, got {}",
@@ -46,7 +49,7 @@ impl ScalarUDF for RegexpExtractAll {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/regexp_match.rs
+++ b/src/daft-functions-utf8/src/regexp_match.rs
@@ -20,7 +20,10 @@ impl ScalarUDF for RegexpMatch {
         "regexp_match"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "pattern", |s, pattern| {
             s.with_utf8_array(|arr| {
                 pattern
@@ -29,7 +32,7 @@ impl ScalarUDF for RegexpMatch {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/repeat.rs
+++ b/src/daft-functions-utf8/src/repeat.rs
@@ -25,7 +25,10 @@ impl ScalarUDF for Repeat {
         "repeat"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let s = inputs.required((0, "input"))?;
         let n = inputs.required((1, "n"))?;
 
@@ -45,7 +48,7 @@ impl ScalarUDF for Repeat {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/replace.rs
+++ b/src/daft-functions-utf8/src/replace.rs
@@ -21,14 +21,17 @@ impl ScalarUDF for RegexpReplace {
     fn name(&self) -> &'static str {
         "regexp_replace"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         let pattern = inputs.required((1, "pattern"))?;
         let replacement = inputs.required((2, "replacement"))?;
         series_replace(input, pattern, replacement, true)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -49,14 +52,17 @@ impl ScalarUDF for Replace {
     fn name(&self) -> &'static str {
         "replace"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         let pattern = inputs.required((1, "pattern"))?;
         let replacement = inputs.required((2, "replacement"))?;
         series_replace(input, pattern, replacement, false)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/reverse.rs
+++ b/src/daft-functions-utf8/src/reverse.rs
@@ -19,7 +19,10 @@ impl ScalarUDF for Reverse {
     fn name(&self) -> &'static str {
         "reverse"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         unary_utf8_evaluate(inputs, |s| {
             s.with_utf8_array(|arr| {
                 Ok(arr
@@ -29,7 +32,7 @@ impl ScalarUDF for Reverse {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/right.rs
+++ b/src/daft-functions-utf8/src/right.rs
@@ -27,7 +27,10 @@ impl ScalarUDF for Right {
         "right"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "n", |s, nchars| {
             s.with_utf8_array(|arr| {
             if nchars.data_type().is_integer() {
@@ -46,7 +49,7 @@ impl ScalarUDF for Right {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/rpad.rs
+++ b/src/daft-functions-utf8/src/rpad.rs
@@ -19,7 +19,10 @@ impl ScalarUDF for RPad {
     fn name(&self) -> &'static str {
         "rpad"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 3, SchemaMismatch: "Expected 3 inputs, but received {}", inputs.len());
         let data = inputs.required((0, "input"))?;
         let length = inputs.required((1, "length"))?;
@@ -28,7 +31,7 @@ impl ScalarUDF for RPad {
         series_pad(data, length, pad, PadPlacement::Right)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/rstrip.rs
+++ b/src/daft-functions-utf8/src/rstrip.rs
@@ -20,7 +20,10 @@ impl ScalarUDF for RStrip {
         "rstrip"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         unary_utf8_evaluate(inputs, |s| {
             s.with_utf8_array(|arr| {
                 arr.unary_broadcasted_op(|val| val.trim_end().into())
@@ -29,7 +32,7 @@ impl ScalarUDF for RStrip {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/split.rs
+++ b/src/daft-functions-utf8/src/split.rs
@@ -28,11 +28,14 @@ impl ScalarUDF for Split {
     fn name(&self) -> &'static str {
         "split"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "delimiter", |s, pat| series_split(s, pat, false))
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -56,11 +59,14 @@ impl ScalarUDF for RegexpSplit {
     fn name(&self) -> &'static str {
         "regexp_split"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "delimiter", |s, pat| series_split(s, pat, true))
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/startswith.rs
+++ b/src/daft-functions-utf8/src/startswith.rs
@@ -20,7 +20,10 @@ impl ScalarUDF for StartsWith {
         "starts_with"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "pattern", |s, pattern| {
             s.with_utf8_array(|arr| {
                 pattern.with_utf8_array(|pattern_arr| {
@@ -34,7 +37,7 @@ impl ScalarUDF for StartsWith {
             })
         })
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/substr.rs
+++ b/src/daft-functions-utf8/src/substr.rs
@@ -35,7 +35,10 @@ impl ScalarUDF for Substr {
         "substr"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let SubstrArgs {
             input: data,
             start,
@@ -71,7 +74,7 @@ impl ScalarUDF for Substr {
             })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/to_date.rs
+++ b/src/daft-functions-utf8/src/to_date.rs
@@ -21,7 +21,10 @@ impl ScalarUDF for ToDate {
     fn name(&self) -> &'static str {
         "to_date"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 2, ValueError: "Expected 2 input args, got {}", inputs.len());
         let input = inputs.required((0, "input"))?;
         let pattern = inputs.required((1, "format"))?;
@@ -30,7 +33,7 @@ impl ScalarUDF for ToDate {
         input.with_utf8_array(|arr| Ok(to_date_impl(arr, pattern)?.into_series()))
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -18,7 +18,10 @@ impl ScalarUDF for ToDatetime {
     fn name(&self) -> &'static str {
         "to_datetime"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let data = inputs.required((0, "input"))?;
         let format = inputs.required((1, "format"))?;
         ensure!(format.data_type().is_string() && format.len() == 1, ValueError: "format must be a string literal");
@@ -39,7 +42,7 @@ impl ScalarUDF for ToDatetime {
         data.with_utf8_array(|arr| Ok(to_datetime_impl(arr, format, tz)?.into_series()))
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions-utf8/src/upper.rs
+++ b/src/daft-functions-utf8/src/upper.rs
@@ -20,7 +20,10 @@ impl ScalarUDF for Upper {
         "upper"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         unary_utf8_evaluate(inputs, |s| {
             s.with_utf8_array(|arr| {
                 Ok(arr
@@ -30,7 +33,7 @@ impl ScalarUDF for Upper {
         })
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/coalesce.rs
+++ b/src/daft-functions/src/coalesce.rs
@@ -26,7 +26,10 @@ impl ScalarUDF for Coalesce {
     ///  > the <result> of the first (leftmost) <searched when clause> whose <search
     ///  > condition> evaluates to True, cast as the declared type of the <case
     ///  > specification>.
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let inputs = inputs.into_inner();
         let inputs = inputs.as_slice();
         match inputs.len() {
@@ -66,7 +69,7 @@ impl ScalarUDF for Coalesce {
             }
         }
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -112,7 +115,10 @@ mod tests {
         prelude::{DataType, Field, FullNull, Int8Array, Schema, Utf8Array},
         series::{IntoSeries, Series},
     };
-    use daft_dsl::{functions::ScalarUDF, lit, null_lit, resolved_col};
+    use daft_dsl::{
+        functions::{FunctionArgs, ScalarUDF},
+        lit, null_lit, resolved_col,
+    };
 
     #[test]
     fn test_coalesce_0() {
@@ -133,7 +139,7 @@ mod tests {
         .into_series();
 
         let coalesce = super::Coalesce {};
-        let output = coalesce.evaluate_from_series(&[s0, s1, s2]).unwrap();
+        let output = coalesce.call(&[s0, s1, s2]).unwrap();
         let actual = output.i8().unwrap();
         let expected = Int8Array::from_iter(
             Field::new("s0", DataType::Int8),
@@ -158,7 +164,7 @@ mod tests {
         .into_series();
 
         let coalesce = super::Coalesce {};
-        let output = coalesce.evaluate_from_series(&[s0, s1]).unwrap();
+        let output = coalesce.call(&[s0, s1]).unwrap();
         let actual = output.i8().unwrap();
         let expected = Int8Array::from_iter(
             Field::new("s0", DataType::Int8),
@@ -171,7 +177,7 @@ mod tests {
     #[test]
     fn test_coalesce_no_args() {
         let coalesce = super::Coalesce {};
-        let output = coalesce.evaluate_from_series(&[]);
+        let output = coalesce.call(&[]);
 
         assert!(output.is_err());
     }
@@ -185,7 +191,7 @@ mod tests {
         .into_series();
 
         let coalesce = super::Coalesce {};
-        let output = coalesce.evaluate_from_series(&[s0.clone()]).unwrap();
+        let output = coalesce.call(&[s0.clone()]).unwrap();
         // can't directly compare as null != null
         let output = output.i8().unwrap();
         let s0 = s0.i8().unwrap();
@@ -199,7 +205,7 @@ mod tests {
         let s2 = Series::full_null("s2", &DataType::Utf8, 100);
 
         let coalesce = super::Coalesce {};
-        let output = coalesce.evaluate_from_series(&[s0, s1, s2]).unwrap();
+        let output = coalesce.call(&[s0, s1, s2]).unwrap();
         let actual = output.utf8().unwrap();
         let expected = Utf8Array::full_null("s0", &DataType::Utf8, 100);
 
@@ -232,7 +238,7 @@ mod tests {
         .into_series();
 
         let coalesce = super::Coalesce {};
-        let output = coalesce.evaluate_from_series(&[s0, s1, s2]);
+        let output = coalesce.call(&[s0, s1, s2]);
 
         let expected = Utf8Array::from_iter(
             "s2",
@@ -253,7 +259,9 @@ mod tests {
         let expected = Field::new("s0", DataType::Int32);
 
         let coalesce = super::Coalesce {};
-        let output = coalesce.to_field(&[col_0, fallback], &schema).unwrap();
+        let output = coalesce
+            .get_return_type_from_args(FunctionArgs::new_unnamed(vec![col_0, fallback]), &schema)
+            .unwrap();
         assert_eq!(output, expected);
     }
 
@@ -272,7 +280,10 @@ mod tests {
 
         let coalesce = super::Coalesce {};
         let output = coalesce
-            .to_field(&[col_0, col_1, fallback], &schema)
+            .get_return_type_from_args(
+                FunctionArgs::new_unnamed(vec![col_0, col_1, fallback]),
+                &schema,
+            )
             .unwrap();
         assert_eq!(output, expected);
     }
@@ -291,7 +302,10 @@ mod tests {
         let expected = "could not determine supertype of Date and Boolean".to_string();
         let coalesce = super::Coalesce {};
         let DaftError::TypeError(e) = coalesce
-            .to_field(&[col_0, col_1, col_2], &schema)
+            .get_return_type_from_args(
+                FunctionArgs::new_unnamed(vec![col_0, col_1, col_2]),
+                &schema,
+            )
             .unwrap_err()
         else {
             panic!("Expected error")

--- a/src/daft-functions/src/distance/cosine.rs
+++ b/src/daft-functions/src/distance/cosine.rs
@@ -13,7 +13,10 @@ impl ScalarUDF for CosineDistanceFunction {
     fn name(&self) -> &'static str {
         "cosine_distance"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args {
             input: source,
             query,
@@ -46,7 +49,7 @@ impl ScalarUDF for CosineDistanceFunction {
         Ok(output.into_series())
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/float/fill_nan.rs
+++ b/src/daft-functions/src/float/fill_nan.rs
@@ -1,11 +1,11 @@
-use common_error::{ensure, DaftError, DaftResult};
+use common_error::{DaftError, DaftResult};
 use daft_core::{
     prelude::{DataType, Field, Schema},
     series::Series,
     utils::supertype::try_get_supertype,
 };
 use daft_dsl::{
-    functions::{ScalarFunction, ScalarUDF},
+    functions::{prelude::*, ScalarFunction},
     ExprRef,
 };
 use serde::{Deserialize, Serialize};
@@ -15,33 +15,44 @@ use super::NotNan;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct FillNan;
 
+#[derive(FunctionArgs)]
+struct Args<T> {
+    input: T,
+    fill_value: T,
+}
+
 #[typetag::serde]
 impl ScalarUDF for FillNan {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
-        ensure!(inputs.len() == 2, ComputeError: "Expected 2 input args, got {}", inputs.len());
-        let data = inputs.required((0, "input"))?;
-        let fill_value = inputs.required((1, "fill_value"))?;
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
+        let Args { input, fill_value } = inputs.try_into()?;
 
-        if data.data_type() == &DataType::Null {
-            return Ok(Series::full_null(data.name(), data.data_type(), data.len()));
+        if input.data_type() == &DataType::Null {
+            return Ok(Series::full_null(
+                input.name(),
+                input.data_type(),
+                input.len(),
+            ));
         }
 
         // TODO(perf): we can likely do this without fully evaluating the not_nan predicate first
         // The original implementation also did this, but was hidden behind the series methods.
-        let predicate = NotNan {}.evaluate_from_series(&[data.clone()])?;
+        let predicate = NotNan {}.call(&[input.clone()])?;
         match fill_value.len() {
             1 => {
-                let fill_value = fill_value.broadcast(data.len())?;
-                data.if_else(&fill_value, &predicate)
+                let fill_value = fill_value.broadcast(input.len())?;
+                input.if_else(&fill_value, &predicate)
 
             }
-            len if len == data.len() => {
-                data.if_else(fill_value, &predicate)
+            len if len == input.len() => {
+                input.if_else(&fill_value, &predicate)
 
             }
             len => Err(DaftError::ValueError(format!(
-                "Expected fill_value to be a scalar or a vector of the same length as data, but received {len} and {}",
-                data.len()
+                "Expected fill_value to be a scalar or a vector of the same length as input, but received {len} and {}",
+                input.len()
             )))
         }
     }
@@ -49,28 +60,23 @@ impl ScalarUDF for FillNan {
     fn name(&self) -> &'static str {
         "fill_nan"
     }
-
-    fn to_field(&self, inputs: &[ExprRef], schema: &Schema) -> DaftResult<Field> {
-        match inputs {
-            [data, fill_value] => match (data.to_field(schema), fill_value.to_field(schema)) {
-                (Ok(data_field), Ok(fill_value_field)) => {
-                    if data_field.dtype == DataType::Null {
-                        Ok(Field::new(data_field.name, DataType::Null))
-                    } else {
-                        match (&data_field.dtype.is_floating(), &fill_value_field.dtype.is_floating(), try_get_supertype(&data_field.dtype, &fill_value_field.dtype)) {
-                        (true, true, Ok(dtype)) => Ok(Field::new(data_field.name, dtype)),
-                        _ => Err(DaftError::TypeError(format!(
-                            "Expects input for fill_nan to be float, but received {data_field} and {fill_value_field}",
-                        ))),
-                    }
-                    }
-                }
-                (Err(e), _) | (_, Err(e)) => Err(e),
-            },
-            _ => Err(DaftError::SchemaMismatch(format!(
-                "Expected 2 input args, got {}",
-                inputs.len()
+    fn get_return_type_from_args(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let Args { input, fill_value } = inputs.try_into()?;
+        let data_field = input.to_field(schema)?;
+        let fill_value_field = fill_value.to_field(schema)?;
+        if data_field.dtype == DataType::Null {
+            Ok(Field::new(data_field.name, DataType::Null))
+        } else {
+            match (&data_field.dtype.is_floating(), &fill_value_field.dtype.is_floating(), try_get_supertype(&data_field.dtype, &fill_value_field.dtype)) {
+            (true, true, Ok(dtype)) => Ok(Field::new(data_field.name, dtype)),
+            _ => Err(DaftError::TypeError(format!(
+                "Expects input for fill_nan to be float, but received {data_field} and {fill_value_field}",
             ))),
+        }
         }
     }
 

--- a/src/daft-functions/src/float/is_inf.rs
+++ b/src/daft-functions/src/float/is_inf.rs
@@ -1,11 +1,11 @@
-use common_error::{ensure, DaftError, DaftResult};
+use common_error::{DaftError, DaftResult};
 use daft_core::{
     prelude::{DataType, Field, Schema},
     series::Series,
     with_match_float_and_null_daft_types,
 };
 use daft_dsl::{
-    functions::{ScalarFunction, ScalarUDF},
+    functions::{FunctionArgs, ScalarFunction, ScalarUDF, UnaryArg},
     ExprRef,
 };
 use serde::{Deserialize, Serialize};
@@ -15,11 +15,12 @@ pub struct IsInf;
 
 #[typetag::serde]
 impl ScalarUDF for IsInf {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         use daft_core::{array::ops::DaftIsInf, series::IntoSeries};
-
-        ensure!(inputs.len() == 1, ComputeError: "Expected 1 input, got {}", inputs.len());
-        let data = inputs.required(("input", 0))?;
+        let UnaryArg { input: data } = inputs.try_into()?;
 
         with_match_float_and_null_daft_types!(data.data_type(), |$T| {
             Ok(DaftIsInf::is_inf(data.downcast::<<$T as DaftDataType>::ArrayType>()?)?.into_series())
@@ -29,23 +30,19 @@ impl ScalarUDF for IsInf {
     fn name(&self) -> &'static str {
         "is_inf"
     }
-
-    fn to_field(&self, inputs: &[ExprRef], schema: &Schema) -> DaftResult<Field> {
-        match inputs {
-            [data] => match data.to_field(schema) {
-                Ok(data_field) => match &data_field.dtype {
-                    DataType::Null | DataType::Float32 | DataType::Float64 => {
-                        Ok(Field::new(data_field.name, DataType::Boolean))
-                    }
-                    _ => Err(DaftError::TypeError(format!(
-                        "Expects input to is_inf to be float, but received {data_field}",
-                    ))),
-                },
-                Err(e) => Err(e),
-            },
-            _ => Err(DaftError::SchemaMismatch(format!(
-                "Expected 1 input args, got {}",
-                inputs.len()
+    fn get_return_type_from_args(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let UnaryArg { input: data } = inputs.try_into()?;
+        let data = data.to_field(schema)?;
+        match &data.dtype {
+            DataType::Null | DataType::Float32 | DataType::Float64 => {
+                Ok(Field::new(data.name, DataType::Boolean))
+            }
+            _ => Err(DaftError::TypeError(format!(
+                "Expects input to is_inf to be float, but received {data}",
             ))),
         }
     }

--- a/src/daft-functions/src/float/not_nan.rs
+++ b/src/daft-functions/src/float/not_nan.rs
@@ -1,4 +1,4 @@
-use common_error::{ensure, DaftError, DaftResult};
+use common_error::{DaftError, DaftResult};
 use daft_core::{
     array::ops::DaftNotNan,
     prelude::{DataType, Field, Schema},
@@ -6,7 +6,7 @@ use daft_core::{
     with_match_float_and_null_daft_types,
 };
 use daft_dsl::{
-    functions::{ScalarFunction, ScalarUDF},
+    functions::{FunctionArgs, ScalarFunction, ScalarUDF, UnaryArg},
     ExprRef,
 };
 use serde::{Deserialize, Serialize};
@@ -15,37 +15,34 @@ pub struct NotNan;
 
 #[typetag::serde]
 impl ScalarUDF for NotNan {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
-        ensure!(inputs.len() == 1, ComputeError: "Expected 1 input, got {}", inputs.len());
-
-        let data = inputs.required((0, "input"))?;
+    fn name(&self) -> &'static str {
+        "not_nan"
+    }
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
+        let UnaryArg { input: data } = inputs.try_into()?;
 
         with_match_float_and_null_daft_types!(data.data_type(), |$T| {
             Ok(DaftNotNan::not_nan(data.downcast::<<$T as DaftDataType>::ArrayType>()?)?.into_series())
         })
     }
 
-    fn name(&self) -> &'static str {
-        "not_nan"
-    }
-
-    fn to_field(&self, inputs: &[ExprRef], schema: &Schema) -> DaftResult<Field> {
-        match inputs {
-            [data] => match data.to_field(schema) {
-                Ok(data_field) => match &data_field.dtype {
-                    // DataType::Float16 |
-                    DataType::Null | DataType::Float32 | DataType::Float64 => {
-                        Ok(Field::new(data_field.name, DataType::Boolean))
-                    }
-                    _ => Err(DaftError::TypeError(format!(
-                        "Expects input to not_nan to be float, but received {data_field}",
-                    ))),
-                },
-                Err(e) => Err(e),
-            },
-            _ => Err(DaftError::SchemaMismatch(format!(
-                "Expected 1 input args, got {}",
-                inputs.len()
+    fn get_return_type_from_args(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let UnaryArg { input } = inputs.try_into()?;
+        let data_field = input.to_field(schema)?;
+        match &data_field.dtype {
+            // DataType::Float16 |
+            DataType::Null | DataType::Float32 | DataType::Float64 => {
+                Ok(Field::new(data_field.name, DataType::Boolean))
+            }
+            _ => Err(DaftError::TypeError(format!(
+                "Expects input to not_nan to be float, but received {data_field}",
             ))),
         }
     }

--- a/src/daft-functions/src/hash.rs
+++ b/src/daft-functions/src/hash.rs
@@ -20,7 +20,10 @@ impl ScalarUDF for HashFunction {
         "hash"
     }
 
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args { input, seed } = inputs.try_into()?;
         if let Some(seed) = seed {
             match seed.len() {
@@ -64,7 +67,7 @@ impl ScalarUDF for HashFunction {
         }
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/minhash.rs
+++ b/src/daft-functions/src/minhash.rs
@@ -25,7 +25,10 @@ impl ScalarUDF for MinHashFunction {
     fn name(&self) -> &'static str {
         "minhash"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let Args {
             input,
             num_hashes,
@@ -56,7 +59,7 @@ impl ScalarUDF for MinHashFunction {
             }
         }
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/monotonically_increasing_id.rs
+++ b/src/daft-functions/src/monotonically_increasing_id.rs
@@ -14,13 +14,13 @@ impl ScalarUDF for MonotonicallyIncreasingId {
     fn name(&self) -> &'static str {
         "monotonically_increasing_id"
     }
-    fn evaluate(&self, _: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, _: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         Err(DaftError::NotImplemented(
             "monotonically_increasing_id should be rewritten into a separate plan step by the optimizer. If you're seeing this error, the DetectMonotonicId optimization rule may not have been applied.".to_string(),
         ))
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         _: &Schema,

--- a/src/daft-functions/src/numeric/abs.rs
+++ b/src/daft-functions/src/numeric/abs.rs
@@ -16,7 +16,7 @@ pub struct Abs;
 
 #[typetag::serde]
 impl ScalarUDF for Abs {
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
         input.abs()
     }
@@ -25,7 +25,7 @@ impl ScalarUDF for Abs {
         "abs"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/numeric/cbrt.rs
+++ b/src/daft-functions/src/numeric/cbrt.rs
@@ -13,7 +13,7 @@ pub struct Cbrt;
 
 #[typetag::serde]
 impl ScalarUDF for Cbrt {
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
         let casted_dtype = input.to_floating_data_type()?;
         let casted_self = input
@@ -30,7 +30,7 @@ impl ScalarUDF for Cbrt {
         "cbrt"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/numeric/ceil.rs
+++ b/src/daft-functions/src/numeric/ceil.rs
@@ -16,7 +16,7 @@ pub struct Ceil;
 
 #[typetag::serde]
 impl ScalarUDF for Ceil {
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
         match input.data_type() {
             DataType::Int8
@@ -40,7 +40,7 @@ impl ScalarUDF for Ceil {
         "ceil"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/numeric/clip.rs
+++ b/src/daft-functions/src/numeric/clip.rs
@@ -25,7 +25,7 @@ struct ClipArgs<T> {
 
 #[typetag::serde]
 impl ScalarUDF for Clip {
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let ClipArgs { input, min, max } = inputs.try_into()?;
 
         let input_dtype = input.data_type();
@@ -63,7 +63,7 @@ impl ScalarUDF for Clip {
         "clip"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/numeric/exp.rs
+++ b/src/daft-functions/src/numeric/exp.rs
@@ -16,7 +16,7 @@ macro_rules! exp {
 
         #[typetag::serde]
         impl ScalarUDF for $variant {
-            fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+            fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
                 let UnaryArg { input } = inputs.try_into()?;
                 $impl(input)
             }
@@ -25,7 +25,7 @@ macro_rules! exp {
                 stringify!($name)
             }
 
-            fn function_args_to_field(
+            fn get_return_type_from_args(
                 &self,
                 inputs: FunctionArgs<ExprRef>,
                 schema: &Schema,

--- a/src/daft-functions/src/numeric/floor.rs
+++ b/src/daft-functions/src/numeric/floor.rs
@@ -16,7 +16,7 @@ pub struct Floor;
 
 #[typetag::serde]
 impl ScalarUDF for Floor {
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
         input.floor()
     }
@@ -25,7 +25,7 @@ impl ScalarUDF for Floor {
         "floor"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/numeric/round.rs
+++ b/src/daft-functions/src/numeric/round.rs
@@ -22,7 +22,10 @@ struct RoundArgs<T> {
 
 #[typetag::serde]
 impl ScalarUDF for Round {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let RoundArgs { input, decimals } = inputs.try_into()?;
 
         let decimals = decimals.unwrap_or(0);
@@ -34,7 +37,7 @@ impl ScalarUDF for Round {
         "round"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/numeric/sign.rs
+++ b/src/daft-functions/src/numeric/sign.rs
@@ -16,7 +16,7 @@ pub struct Sign;
 
 #[typetag::serde]
 impl ScalarUDF for Sign {
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
 
         match input.data_type() {
@@ -40,7 +40,7 @@ impl ScalarUDF for Sign {
         stringify!(sign)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
@@ -63,7 +63,7 @@ pub struct Negative;
 
 #[typetag::serde]
 impl ScalarUDF for Negative {
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
 
         match input.data_type() {
@@ -108,7 +108,7 @@ impl ScalarUDF for Negative {
         stringify!(negative)
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/numeric/sqrt.rs
+++ b/src/daft-functions/src/numeric/sqrt.rs
@@ -16,7 +16,7 @@ pub struct Sqrt;
 
 #[typetag::serde]
 impl ScalarUDF for Sqrt {
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
 
         let casted_dtype = input.to_floating_data_type()?;
@@ -34,7 +34,7 @@ impl ScalarUDF for Sqrt {
         "sqrt"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/numeric/trigonometry.rs
+++ b/src/daft-functions/src/numeric/trigonometry.rs
@@ -18,7 +18,7 @@ macro_rules! trigonometry {
 
         #[typetag::serde]
         impl ScalarUDF for $variant {
-            fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+            fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
                 let UnaryArg { input } = inputs.try_into()?;
 
                 trigonometry(input, &TrigonometricFunction::$variant)
@@ -28,7 +28,7 @@ macro_rules! trigonometry {
                 TrigonometricFunction::$variant.fn_name()
             }
 
-            fn function_args_to_field(
+            fn get_return_type_from_args(
                 &self,
                 inputs: FunctionArgs<ExprRef>,
                 schema: &Schema,
@@ -134,7 +134,7 @@ struct Atan2Args<T> {
 
 #[typetag::serde]
 impl ScalarUDF for Atan2 {
-    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let Atan2Args { x, y } = inputs.try_into()?;
 
         atan2_impl(x, y)
@@ -148,7 +148,7 @@ impl ScalarUDF for Atan2 {
         &["arctan2"]
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-functions/src/to_struct.rs
+++ b/src/daft-functions/src/to_struct.rs
@@ -11,7 +11,10 @@ impl ScalarUDF for ToStructFunction {
     fn name(&self) -> &'static str {
         "struct"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let inputs = inputs.into_inner();
         if inputs.is_empty() {
             return Err(DaftError::ValueError(
@@ -23,7 +26,7 @@ impl ScalarUDF for ToStructFunction {
 
         Ok(StructArray::new(field, inputs, None).into_series())
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-image/src/functions/crop.rs
+++ b/src/daft-image/src/functions/crop.rs
@@ -14,14 +14,17 @@ impl ScalarUDF for ImageCrop {
     fn name(&self) -> &'static str {
         "image_crop"
     }
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         ensure!(inputs.len() == 2, "expected 2 inputs");
 
         let input = inputs.required((0, "input"))?;
         let bbox = inputs.required((1, "bbox"))?;
         crate::series::crop(input, bbox)
     }
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-image/src/functions/decode.rs
+++ b/src/daft-image/src/functions/decode.rs
@@ -28,7 +28,10 @@ struct ImageDecodeArgs<T> {
 
 #[typetag::serde]
 impl ScalarUDF for ImageDecode {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let ImageDecodeArgs {
             input,
             mode,
@@ -64,7 +67,7 @@ impl ScalarUDF for ImageDecode {
         "image_decode"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-image/src/functions/encode.rs
+++ b/src/daft-image/src/functions/encode.rs
@@ -21,7 +21,10 @@ struct ImageEncodeArgs<T> {
 
 #[typetag::serde]
 impl ScalarUDF for ImageEncode {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let ImageEncodeArgs {
             input,
             image_format,
@@ -34,7 +37,7 @@ impl ScalarUDF for ImageEncode {
         "image_encode"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-image/src/functions/resize.rs
+++ b/src/daft-image/src/functions/resize.rs
@@ -11,7 +11,10 @@ pub struct ImageResize;
 
 #[typetag::serde]
 impl ScalarUDF for ImageResize {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;
         let height = inputs.required(("h", "height")).and_then(|s| {
             ensure!(s.len() == 1, "height must be a scalar");
@@ -40,7 +43,7 @@ impl ScalarUDF for ImageResize {
         "image_resize"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-image/src/functions/to_mode.rs
+++ b/src/daft-image/src/functions/to_mode.rs
@@ -17,7 +17,10 @@ struct ImageToModeArgs<T> {
 
 #[typetag::serde]
 impl ScalarUDF for ImageToMode {
-    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+    fn call_with_args(
+        &self,
+        inputs: daft_dsl::functions::FunctionArgs<Series>,
+    ) -> DaftResult<Series> {
         let ImageToModeArgs { input, mode } = inputs.try_into()?;
 
         crate::series::to_mode(&input, mode)
@@ -27,7 +30,7 @@ impl ScalarUDF for ImageToMode {
         "to_mode"
     }
 
-    fn function_args_to_field(
+    fn get_return_type_from_args(
         &self,
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -698,7 +698,7 @@ impl RecordBatch {
                     .collect::<DaftResult<FunctionArgs<Series>>>()?;
 
 
-                func.udf.evaluate(args)
+                func.udf.call_with_args(args)
             }
             Expr::Literal(lit_value) => Ok(lit_value.to_series()),
             Expr::IfElse {


### PR DESCRIPTION
## Changes Made

small pr to do some post refactor cleanup

some renaming of the `ScalarUDF` methods:
- `evaluate` -> `call_with_args`
- `evaluate_from_series` -> `call`
- `function_args_to_field` -> `get_return_type_with_args`
- `to_field` -> `get_return_type` 

a few dangling impls were not fully moved over such as `MergeMean` and the float functions (isnan, isinf, ...)




## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
