### PR TITLE
feat: add id and plan_id to otel subscribers, and add method for getting tree hierarchy for a pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,6 +2595,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid 1.16.0",
 ]
 
 [[package]]

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1747,8 +1747,12 @@ class NativeExecutor:
     ) -> RelationshipInformation: ...
 
 class RelationshipInformation:
-    ids: list[int]
+    ids: list[RelationshipNode]
     plan_id: str
+
+class RelationshipNode:
+    id: int
+    parent_id: int | None
 
 class PyDaftExecutionConfig:
     @staticmethod

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1740,6 +1740,15 @@ class NativeExecutor:
     def repr_mermaid(
         self, builder: LogicalPlanBuilder, daft_execution_config: PyDaftExecutionConfig, options: MermaidOptions
     ) -> str: ...
+    def get_relationship_info(
+        self,
+        logical_plan_builder: LogicalPlanBuilder,
+        daft_execution_config: PyDaftExecutionConfig,
+    ) -> RelationshipInformation: ...
+
+class RelationshipInformation:
+    ids: list[int]
+    plan_id: str
 
 class PyDaftExecutionConfig:
     @staticmethod

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -40,6 +40,7 @@ snafu = {workspace = true}
 tokio = {workspace = true}
 tokio-util = {workspace = true}
 tracing = {workspace = true}
+uuid.workspace = true
 
 [features]
 python = [

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -14,7 +14,7 @@ use crate::{
         Sender,
     },
     dispatcher::{DispatchSpawner, RoundRobinDispatcher, UnorderedDispatcher},
-    pipeline::PipelineNode,
+    pipeline::{NodeInfo, PipelineNode, TranslationContext},
     progress_bar::ProgressBarColor,
     resource_manager::MemoryManager,
     runtime_stats::{CountingReceiver, CountingSender, RuntimeStatsContext},
@@ -82,6 +82,7 @@ pub struct IntermediateNode {
     children: Vec<Box<dyn PipelineNode>>,
     runtime_stats: Arc<RuntimeStatsContext>,
     plan_stats: StatsState,
+    node_info: NodeInfo,
 }
 
 impl IntermediateNode {
@@ -89,9 +90,12 @@ impl IntermediateNode {
         intermediate_op: Arc<dyn IntermediateOperator>,
         children: Vec<Box<dyn PipelineNode>>,
         plan_stats: StatsState,
+        ctx: &TranslationContext,
     ) -> Self {
-        let rts = RuntimeStatsContext::new(intermediate_op.name());
-        Self::new_with_runtime_stats(intermediate_op, children, rts, plan_stats)
+        let info = ctx.next_node_info(intermediate_op.name());
+
+        let rts = RuntimeStatsContext::new(info.clone());
+        Self::new_with_runtime_stats(intermediate_op, children, rts, plan_stats, info)
     }
 
     pub(crate) fn new_with_runtime_stats(
@@ -99,12 +103,14 @@ impl IntermediateNode {
         children: Vec<Box<dyn PipelineNode>>,
         runtime_stats: Arc<RuntimeStatsContext>,
         plan_stats: StatsState,
+        node_info: NodeInfo,
     ) -> Self {
         Self {
             intermediate_op,
             children,
             runtime_stats,
             plan_stats,
+            node_info,
         }
     }
 
@@ -281,5 +287,12 @@ impl PipelineNode for IntermediateNode {
 
     fn as_tree_display(&self) -> &dyn TreeDisplay {
         self
+    }
+    fn node_id(&self) -> usize {
+        self.node_info.id
+    }
+
+    fn plan_id(&self) -> Arc<str> {
+        self.node_info.plan_id.clone()
     }
 }

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -71,6 +71,54 @@ pub(crate) trait PipelineNode: Sync + Send + TreeDisplay {
     ) -> crate::Result<Receiver<Arc<MicroPartition>>>;
 
     fn as_tree_display(&self) -> &dyn TreeDisplay;
+
+    /// Unique id to identify which plan all nodes belong to
+    fn plan_id(&self) -> Arc<str>;
+    /// Unique id to identify the node.
+    fn node_id(&self) -> usize;
+}
+
+/// Single use context for translating a physical plan to a Pipeline.
+/// It generates a plan_id, and node ids for each plan.
+pub struct TranslationContext {
+    index_counter: std::cell::RefCell<usize>,
+    plan_id: String,
+}
+
+/// Contains information about the node such as name, id, and the plan_id
+#[derive(Clone)]
+pub struct NodeInfo {
+    pub name: Arc<str>,
+    pub id: usize,
+    pub plan_id: Arc<str>,
+}
+
+impl TranslationContext {
+    pub fn new() -> Self {
+        Self {
+            index_counter: std::cell::RefCell::new(0),
+            plan_id: uuid::Uuid::new_v4().to_string(),
+        }
+    }
+
+    pub fn next_id(&self) -> usize {
+        let mut counter = self.index_counter.borrow_mut();
+        let index = *counter;
+        *counter += 1;
+        index
+    }
+
+    pub fn plan_id(&self) -> &str {
+        &self.plan_id
+    }
+
+    pub fn next_node_info(&self, name: &str) -> NodeInfo {
+        NodeInfo {
+            name: Arc::from(name.to_string()),
+            id: self.next_id(),
+            plan_id: Arc::from(self.plan_id().to_string()),
+        }
+    }
 }
 
 pub fn viz_pipeline_mermaid(
@@ -84,6 +132,44 @@ pub fn viz_pipeline_mermaid(
         MermaidDisplayVisitor::new(&mut output, display_type, bottom_up, subgraph_options);
     visitor.fmt(root.as_tree_display()).unwrap();
     output
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "python", pyo3::pyclass)]
+pub struct RelationshipInformation {
+    pub ids: Vec<usize>,
+    pub plan_id: Arc<str>,
+}
+/// Performs a depth first pre-order traversal of the pipeline tree.
+/// Returning a list of ids for each node traversed
+/// For example, given the following pipeline with ids of:
+/// ```
+///                  1
+///              /   |   \
+///             2    3    4
+///           /  \   |   / \
+///          5    6  7  8   10
+///                    /
+///                   9
+/// ```
+/// The result would be [1, 2, 5, 6, 3, 7, 4, 8, 9, 10]
+/// as we visit each node in pre-order traversal.
+pub fn get_pipeline_relationship_mapping(root: &dyn PipelineNode) -> RelationshipInformation {
+    let mut ids = Vec::new();
+
+    fn get_pipeline_relationship_mapping(root: &dyn PipelineNode, ids: &mut Vec<usize>) {
+        ids.push(root.node_id());
+
+        for child in root.children() {
+            get_pipeline_relationship_mapping(child, ids);
+        }
+    }
+    get_pipeline_relationship_mapping(root, &mut ids);
+
+    RelationshipInformation {
+        ids,
+        plan_id: root.plan_id(),
+    }
 }
 
 pub fn viz_pipeline_ascii(root: &dyn PipelineNode, simple: bool) -> String {
@@ -101,6 +187,7 @@ pub fn physical_plan_to_pipeline(
     physical_plan: &LocalPhysicalPlan,
     psets: &(impl PartitionSetCache<MicroPartitionRef, Arc<MicroPartitionSet>> + ?Sized),
     cfg: &Arc<DaftExecutionConfig>,
+    ctx: &TranslationContext,
 ) -> crate::Result<Box<dyn PipelineNode>> {
     use daft_local_plan::PhysicalScan;
 
@@ -114,7 +201,7 @@ pub fn physical_plan_to_pipeline(
             stats_state,
         }) => {
             let source = EmptyScanSource::new(schema.clone());
-            SourceNode::new(source.arced(), stats_state.clone()).boxed()
+            SourceNode::new(source.arced(), stats_state.clone(), ctx).boxed()
         }
         LocalPhysicalPlan::PhysicalScan(PhysicalScan {
             scan_tasks,
@@ -129,7 +216,7 @@ pub fn physical_plan_to_pipeline(
 
             let scan_task_source =
                 ScanTaskSource::new(scan_tasks, pushdowns.clone(), schema.clone(), cfg);
-            SourceNode::new(scan_task_source.arced(), stats_state.clone()).boxed()
+            SourceNode::new(scan_task_source.arced(), stats_state.clone(), ctx).boxed()
         }
         LocalPhysicalPlan::WindowPartitionOnly(WindowPartitionOnly {
             input,
@@ -139,7 +226,7 @@ pub fn physical_plan_to_pipeline(
             aggregations,
             aliases,
         }) => {
-            let input_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let input_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let window_partition_only_sink =
                 WindowPartitionOnlySink::new(aggregations, aliases, partition_by, schema)
                     .with_context(|_| PipelineCreationSnafu {
@@ -149,6 +236,7 @@ pub fn physical_plan_to_pipeline(
                 Arc::new(window_partition_only_sink),
                 input_node,
                 stats_state.clone(),
+                ctx,
             )
             .boxed()
         }
@@ -162,7 +250,7 @@ pub fn physical_plan_to_pipeline(
             functions,
             aliases,
         }) => {
-            let input_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let input_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let window_partition_and_order_by_sink = WindowPartitionAndOrderBySink::new(
                 functions,
                 aliases,
@@ -178,6 +266,7 @@ pub fn physical_plan_to_pipeline(
                 Arc::new(window_partition_and_order_by_sink),
                 input_node,
                 stats_state.clone(),
+                ctx,
             )
             .boxed()
         }
@@ -193,7 +282,7 @@ pub fn physical_plan_to_pipeline(
             aggregations,
             aliases,
         }) => {
-            let input_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let input_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let window_partition_and_dynamic_frame_sink = WindowPartitionAndDynamicFrameSink::new(
                 aggregations,
                 *min_periods,
@@ -211,6 +300,7 @@ pub fn physical_plan_to_pipeline(
                 Arc::new(window_partition_and_dynamic_frame_sink),
                 input_node,
                 stats_state.clone(),
+                ctx,
             )
             .boxed()
         }
@@ -223,7 +313,7 @@ pub fn physical_plan_to_pipeline(
             functions,
             aliases,
         }) => {
-            let input_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let input_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let window_order_by_only_op =
                 WindowOrderByOnlySink::new(functions, aliases, order_by, descending, schema)
                     .with_context(|_| PipelineCreationSnafu {
@@ -233,6 +323,7 @@ pub fn physical_plan_to_pipeline(
                 Arc::new(window_order_by_only_op),
                 input_node,
                 stats_state.clone(),
+                ctx,
             )
             .boxed()
         }
@@ -246,7 +337,7 @@ pub fn physical_plan_to_pipeline(
                 info.size_bytes,
             )
             .arced();
-            SourceNode::new(in_memory_source, stats_state.clone()).boxed()
+            SourceNode::new(in_memory_source, stats_state.clone(), ctx).boxed()
         }
         LocalPhysicalPlan::Project(Project {
             input,
@@ -259,8 +350,14 @@ pub fn physical_plan_to_pipeline(
                     plan_name: physical_plan.name(),
                 }
             })?;
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
-            IntermediateNode::new(Arc::new(proj_op), vec![child_node], stats_state.clone()).boxed()
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            IntermediateNode::new(
+                Arc::new(proj_op),
+                vec![child_node],
+                stats_state.clone(),
+                ctx,
+            )
+            .boxed()
         }
         LocalPhysicalPlan::ActorPoolProject(ActorPoolProject {
             input,
@@ -274,8 +371,14 @@ pub fn physical_plan_to_pipeline(
                         plan_name: physical_plan.name(),
                     }
                 })?;
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
-            IntermediateNode::new(Arc::new(proj_op), vec![child_node], stats_state.clone()).boxed()
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            IntermediateNode::new(
+                Arc::new(proj_op),
+                vec![child_node],
+                stats_state.clone(),
+                ctx,
+            )
+            .boxed()
         }
         LocalPhysicalPlan::Sample(Sample {
             input,
@@ -286,9 +389,14 @@ pub fn physical_plan_to_pipeline(
             ..
         }) => {
             let sample_op = SampleOperator::new(*fraction, *with_replacement, *seed);
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
-            IntermediateNode::new(Arc::new(sample_op), vec![child_node], stats_state.clone())
-                .boxed()
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            IntermediateNode::new(
+                Arc::new(sample_op),
+                vec![child_node],
+                stats_state.clone(),
+                ctx,
+            )
+            .boxed()
         }
         LocalPhysicalPlan::Filter(Filter {
             input,
@@ -297,9 +405,14 @@ pub fn physical_plan_to_pipeline(
             ..
         }) => {
             let filter_op = FilterOperator::new(predicate.clone());
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
-            IntermediateNode::new(Arc::new(filter_op), vec![child_node], stats_state.clone())
-                .boxed()
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            IntermediateNode::new(
+                Arc::new(filter_op),
+                vec![child_node],
+                stats_state.clone(),
+                ctx,
+            )
+            .boxed()
         }
         LocalPhysicalPlan::Explode(Explode {
             input,
@@ -308,9 +421,14 @@ pub fn physical_plan_to_pipeline(
             ..
         }) => {
             let explode_op = ExplodeOperator::new(to_explode.clone());
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
-            IntermediateNode::new(Arc::new(explode_op), vec![child_node], stats_state.clone())
-                .boxed()
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            IntermediateNode::new(
+                Arc::new(explode_op),
+                vec![child_node],
+                stats_state.clone(),
+                ctx,
+            )
+            .boxed()
         }
         LocalPhysicalPlan::Limit(Limit {
             input,
@@ -319,8 +437,9 @@ pub fn physical_plan_to_pipeline(
             ..
         }) => {
             let sink = LimitSink::new(*num_rows as usize);
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
-            StreamingSinkNode::new(Arc::new(sink), vec![child_node], stats_state.clone()).boxed()
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            StreamingSinkNode::new(Arc::new(sink), vec![child_node], stats_state.clone(), ctx)
+                .boxed()
         }
         LocalPhysicalPlan::Concat(Concat {
             input,
@@ -328,13 +447,14 @@ pub fn physical_plan_to_pipeline(
             stats_state,
             ..
         }) => {
-            let left_child = physical_plan_to_pipeline(input, psets, cfg)?;
-            let right_child = physical_plan_to_pipeline(other, psets, cfg)?;
+            let left_child = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            let right_child = physical_plan_to_pipeline(other, psets, cfg, ctx)?;
             let sink = ConcatSink {};
             StreamingSinkNode::new(
                 Arc::new(sink),
                 vec![left_child, right_child],
                 stats_state.clone(),
+                ctx,
             )
             .boxed()
         }
@@ -344,13 +464,13 @@ pub fn physical_plan_to_pipeline(
             stats_state,
             ..
         }) => {
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let agg_sink = AggregateSink::new(aggregations, input.schema()).with_context(|_| {
                 PipelineCreationSnafu {
                     plan_name: physical_plan.name(),
                 }
             })?;
-            BlockingSinkNode::new(Arc::new(agg_sink), child_node, stats_state.clone()).boxed()
+            BlockingSinkNode::new(Arc::new(agg_sink), child_node, stats_state.clone(), ctx).boxed()
         }
         LocalPhysicalPlan::HashAggregate(HashAggregate {
             input,
@@ -359,12 +479,12 @@ pub fn physical_plan_to_pipeline(
             stats_state,
             ..
         }) => {
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let agg_sink = GroupedAggregateSink::new(aggregations, group_by, input.schema(), cfg)
                 .with_context(|_| PipelineCreationSnafu {
                 plan_name: physical_plan.name(),
             })?;
-            BlockingSinkNode::new(Arc::new(agg_sink), child_node, stats_state.clone()).boxed()
+            BlockingSinkNode::new(Arc::new(agg_sink), child_node, stats_state.clone(), ctx).boxed()
         }
         LocalPhysicalPlan::Unpivot(Unpivot {
             input,
@@ -375,15 +495,20 @@ pub fn physical_plan_to_pipeline(
             stats_state,
             ..
         }) => {
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let unpivot_op = UnpivotOperator::new(
                 ids.clone(),
                 values.clone(),
                 variable_name.clone(),
                 value_name.clone(),
             );
-            IntermediateNode::new(Arc::new(unpivot_op), vec![child_node], stats_state.clone())
-                .boxed()
+            IntermediateNode::new(
+                Arc::new(unpivot_op),
+                vec![child_node],
+                stats_state.clone(),
+                ctx,
+            )
+            .boxed()
         }
         LocalPhysicalPlan::Pivot(Pivot {
             input,
@@ -395,7 +520,7 @@ pub fn physical_plan_to_pipeline(
             stats_state,
             ..
         }) => {
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let pivot_sink = PivotSink::new(
                 group_by.clone(),
                 pivot_column.clone(),
@@ -403,7 +528,8 @@ pub fn physical_plan_to_pipeline(
                 aggregation.clone(),
                 names.clone(),
             );
-            BlockingSinkNode::new(Arc::new(pivot_sink), child_node, stats_state.clone()).boxed()
+            BlockingSinkNode::new(Arc::new(pivot_sink), child_node, stats_state.clone(), ctx)
+                .boxed()
         }
         LocalPhysicalPlan::Sort(Sort {
             input,
@@ -414,8 +540,8 @@ pub fn physical_plan_to_pipeline(
             ..
         }) => {
             let sort_sink = SortSink::new(sort_by.clone(), descending.clone(), nulls_first.clone());
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
-            BlockingSinkNode::new(Arc::new(sort_sink), child_node, stats_state.clone()).boxed()
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            BlockingSinkNode::new(Arc::new(sort_sink), child_node, stats_state.clone(), ctx).boxed()
         }
         LocalPhysicalPlan::TopN(TopN {
             input,
@@ -432,8 +558,8 @@ pub fn physical_plan_to_pipeline(
                 nulls_first.clone(),
                 *limit as usize,
             );
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
-            BlockingSinkNode::new(Arc::new(sink), child_node, stats_state.clone()).boxed()
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            BlockingSinkNode::new(Arc::new(sink), child_node, stats_state.clone(), ctx).boxed()
         }
         LocalPhysicalPlan::MonotonicallyIncreasingId(MonotonicallyIncreasingId {
             input,
@@ -442,13 +568,14 @@ pub fn physical_plan_to_pipeline(
             stats_state,
             ..
         }) => {
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let monotonically_increasing_id_sink =
                 MonotonicallyIncreasingIdSink::new(column_name.clone(), schema.clone());
             StreamingSinkNode::new(
                 Arc::new(monotonically_increasing_id_sink),
                 vec![child_node],
                 stats_state.clone(),
+                ctx,
             )
             .boxed()
         }
@@ -593,15 +720,16 @@ pub fn physical_plan_to_pipeline(
                     track_indices,
                     probe_state_bridge.clone(),
                 )?;
-                let build_child_node = physical_plan_to_pipeline(build_child, psets, cfg)?;
+                let build_child_node = physical_plan_to_pipeline(build_child, psets, cfg, ctx)?;
                 let build_node = BlockingSinkNode::new(
                     Arc::new(build_sink),
                     build_child_node,
                     build_child.get_stats_state().clone(),
+                    ctx
                 )
                 .boxed();
 
-                let probe_child_node = physical_plan_to_pipeline(probe_child, psets, cfg)?;
+                let probe_child_node = physical_plan_to_pipeline(probe_child, psets, cfg, ctx)?;
 
                 match join_type {
                     JoinType::Anti | JoinType::Semi => Ok(StreamingSinkNode::new(
@@ -614,6 +742,7 @@ pub fn physical_plan_to_pipeline(
                         )),
                         vec![build_node, probe_child_node],
                         stats_state.clone(),
+                        ctx
                     )
                     .boxed()),
                     JoinType::Inner => Ok(IntermediateNode::new(
@@ -628,6 +757,7 @@ pub fn physical_plan_to_pipeline(
                         )),
                         vec![build_node, probe_child_node],
                         stats_state.clone(),
+                        ctx
                     )
                     .boxed()),
                     JoinType::Left | JoinType::Right | JoinType::Outer => {
@@ -644,6 +774,7 @@ pub fn physical_plan_to_pipeline(
                             )?),
                             vec![build_node, probe_child_node],
                             stats_state.clone(),
+                            ctx
                         )
                         .boxed())
                     }
@@ -689,14 +820,15 @@ pub fn physical_plan_to_pipeline(
                 JoinSide::Right => (right, left),
             };
 
-            let stream_child_node = physical_plan_to_pipeline(stream_child, psets, cfg)?;
-            let collect_child_node = physical_plan_to_pipeline(collect_child, psets, cfg)?;
+            let stream_child_node = physical_plan_to_pipeline(stream_child, psets, cfg, ctx)?;
+            let collect_child_node = physical_plan_to_pipeline(collect_child, psets, cfg, ctx)?;
 
             let state_bridge = BroadcastStateBridge::new();
             let collect_node = BlockingSinkNode::new(
                 Arc::new(CrossJoinCollectSink::new(state_bridge.clone())),
                 collect_child_node,
                 collect_child.get_stats_state().clone(),
+                ctx,
             )
             .boxed();
 
@@ -708,6 +840,7 @@ pub fn physical_plan_to_pipeline(
                 )),
                 vec![collect_node, stream_child_node],
                 stats_state.clone(),
+                ctx,
             )
             .boxed()
         }
@@ -718,7 +851,7 @@ pub fn physical_plan_to_pipeline(
             stats_state,
             ..
         }) => {
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let writer_factory = make_physical_writer_factory(file_info, input.schema(), cfg)
                 .with_context(|_| PipelineCreationSnafu {
                     plan_name: physical_plan.name(),
@@ -737,7 +870,8 @@ pub fn physical_plan_to_pipeline(
                 file_schema.clone(),
                 Some(file_info.clone()),
             );
-            BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone()).boxed()
+            BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
+                .boxed()
         }
         #[cfg(feature = "python")]
         LocalPhysicalPlan::CatalogWrite(daft_local_plan::CatalogWrite {
@@ -749,7 +883,7 @@ pub fn physical_plan_to_pipeline(
         }) => {
             use daft_logical_plan::CatalogType;
 
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let (partition_by, write_format) = match catalog_type {
                 CatalogType::Iceberg(ic) => {
                     if !ic.partition_cols.is_empty() {
@@ -784,7 +918,8 @@ pub fn physical_plan_to_pipeline(
                 file_schema.clone(),
                 None,
             );
-            BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone()).boxed()
+            BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
+                .boxed()
         }
         #[cfg(feature = "python")]
         LocalPhysicalPlan::LanceWrite(daft_local_plan::LanceWrite {
@@ -794,7 +929,7 @@ pub fn physical_plan_to_pipeline(
             stats_state,
             ..
         }) => {
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let writer_factory = daft_writers::make_lance_writer_factory(lance_info.clone());
             let write_sink = WriteSink::new(
                 WriteFormat::Lance,
@@ -803,7 +938,8 @@ pub fn physical_plan_to_pipeline(
                 file_schema.clone(),
                 None,
             );
-            BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone()).boxed()
+            BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
+                .boxed()
         }
         #[cfg(feature = "python")]
         LocalPhysicalPlan::DataSink(daft_local_plan::DataSink {
@@ -812,7 +948,7 @@ pub fn physical_plan_to_pipeline(
             file_schema,
             stats_state,
         }) => {
-            let child_node = physical_plan_to_pipeline(input, psets, cfg)?;
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let writer_factory =
                 daft_writers::make_data_sink_writer_factory(data_sink_info.clone());
             let write_sink = WriteSink::new(
@@ -822,7 +958,8 @@ pub fn physical_plan_to_pipeline(
                 file_schema.clone(),
                 None,
             );
-            BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone()).boxed()
+            BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
+                .boxed()
         }
     };
 

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -31,7 +31,10 @@ use {
 
 use crate::{
     channel::{create_channel, Receiver},
-    pipeline::{physical_plan_to_pipeline, viz_pipeline_ascii, viz_pipeline_mermaid},
+    pipeline::{
+        get_pipeline_relationship_mapping, physical_plan_to_pipeline, viz_pipeline_ascii,
+        viz_pipeline_mermaid, RelationshipInformation, TranslationContext,
+    },
     progress_bar::{make_progress_bar_manager, ProgressBarManager},
     resource_manager::get_or_init_memory_manager,
     ExecutionRuntimeContext,
@@ -217,6 +220,16 @@ impl PyNativeExecutor {
             .executor
             .repr_mermaid(&logical_plan_builder.builder, cfg.config, options))
     }
+
+    pub fn get_relationship_info(
+        &self,
+        logical_plan_builder: &PyLogicalPlanBuilder,
+        cfg: PyDaftExecutionConfig,
+    ) -> PyResult<RelationshipInformation> {
+        Ok(self
+            .executor
+            .get_relationship_info(&logical_plan_builder.builder, cfg.config))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -267,7 +280,8 @@ impl NativeExecutor {
     ) -> DaftResult<ExecutionEngineResult> {
         refresh_chrome_trace();
         let cancel = self.cancel.clone();
-        let pipeline = physical_plan_to_pipeline(local_physical_plan, psets, &cfg)?;
+        let ctx = TranslationContext::new();
+        let pipeline = physical_plan_to_pipeline(local_physical_plan, psets, &cfg, &ctx)?;
         let (tx, rx) = create_channel(results_buffer_size.unwrap_or(0));
 
         let rt = self.runtime.clone();
@@ -361,9 +375,14 @@ impl NativeExecutor {
     ) -> String {
         let logical_plan = logical_plan_builder.build();
         let physical_plan = translate(&logical_plan).unwrap();
-        let pipeline_node =
-            physical_plan_to_pipeline(&physical_plan, &InMemoryPartitionSetCache::empty(), &cfg)
-                .unwrap();
+        let ctx = TranslationContext::new();
+        let pipeline_node = physical_plan_to_pipeline(
+            &physical_plan,
+            &InMemoryPartitionSetCache::empty(),
+            &cfg,
+            &ctx,
+        )
+        .unwrap();
 
         viz_pipeline_ascii(pipeline_node.as_ref(), simple)
     }
@@ -376,9 +395,14 @@ impl NativeExecutor {
     ) -> String {
         let logical_plan = logical_plan_builder.build();
         let physical_plan = translate(&logical_plan).unwrap();
-        let pipeline_node =
-            physical_plan_to_pipeline(&physical_plan, &InMemoryPartitionSetCache::empty(), &cfg)
-                .unwrap();
+        let ctx = TranslationContext::new();
+        let pipeline_node = physical_plan_to_pipeline(
+            &physical_plan,
+            &InMemoryPartitionSetCache::empty(),
+            &cfg,
+            &ctx,
+        )
+        .unwrap();
 
         let display_type = if options.simple {
             DisplayLevel::Compact
@@ -391,6 +415,23 @@ impl NativeExecutor {
             options.bottom_up,
             options.subgraph_options,
         )
+    }
+    fn get_relationship_info(
+        &self,
+        logical_plan_builder: &LogicalPlanBuilder,
+        cfg: Arc<DaftExecutionConfig>,
+    ) -> RelationshipInformation {
+        let logical_plan = logical_plan_builder.build();
+        let physical_plan = translate(&logical_plan).unwrap();
+        let ctx = TranslationContext::new();
+        let pipeline_node = physical_plan_to_pipeline(
+            &physical_plan,
+            &InMemoryPartitionSetCache::empty(),
+            &cfg,
+            &ctx,
+        )
+        .unwrap();
+        get_pipeline_relationship_mapping(&*pipeline_node)
     }
 }
 

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -10,7 +10,7 @@ use tracing::{info_span, instrument};
 use crate::{
     channel::{create_channel, Receiver},
     dispatcher::{DispatchSpawner, UnorderedDispatcher},
-    pipeline::PipelineNode,
+    pipeline::{NodeInfo, PipelineNode, TranslationContext},
     progress_bar::ProgressBarColor,
     resource_manager::MemoryManager,
     runtime_stats::{CountingReceiver, CountingSender, RuntimeStatsContext},
@@ -63,6 +63,7 @@ pub struct BlockingSinkNode {
     child: Box<dyn PipelineNode>,
     runtime_stats: Arc<RuntimeStatsContext>,
     plan_stats: StatsState,
+    node_info: NodeInfo,
 }
 
 impl BlockingSinkNode {
@@ -70,14 +71,18 @@ impl BlockingSinkNode {
         op: Arc<dyn BlockingSink>,
         child: Box<dyn PipelineNode>,
         plan_stats: StatsState,
+        ctx: &TranslationContext,
     ) -> Self {
         let name = op.name();
+        let node_info = ctx.next_node_info(name);
+
         Self {
             op,
             name,
             child,
-            runtime_stats: RuntimeStatsContext::new(name),
+            runtime_stats: RuntimeStatsContext::new(node_info.clone()),
             plan_stats,
+            node_info,
         }
     }
     pub(crate) fn boxed(self) -> Box<dyn PipelineNode> {
@@ -241,5 +246,11 @@ impl PipelineNode for BlockingSinkNode {
     }
     fn as_tree_display(&self) -> &dyn TreeDisplay {
         self
+    }
+    fn node_id(&self) -> usize {
+        self.node_info.id
+    }
+    fn plan_id(&self) -> Arc<str> {
+        self.node_info.plan_id.clone()
     }
 }

--- a/src/daft-local-execution/src/sinks/streaming_sink.rs
+++ b/src/daft-local-execution/src/sinks/streaming_sink.rs
@@ -13,7 +13,7 @@ use crate::{
         Sender,
     },
     dispatcher::DispatchSpawner,
-    pipeline::PipelineNode,
+    pipeline::{NodeInfo, PipelineNode, TranslationContext},
     progress_bar::ProgressBarColor,
     resource_manager::MemoryManager,
     runtime_stats::{CountingReceiver, CountingSender, RuntimeStatsContext},
@@ -80,6 +80,7 @@ pub struct StreamingSinkNode {
     children: Vec<Box<dyn PipelineNode>>,
     runtime_stats: Arc<RuntimeStatsContext>,
     plan_stats: StatsState,
+    node_info: NodeInfo,
 }
 
 impl StreamingSinkNode {
@@ -87,14 +88,17 @@ impl StreamingSinkNode {
         op: Arc<dyn StreamingSink>,
         children: Vec<Box<dyn PipelineNode>>,
         plan_stats: StatsState,
+        ctx: &TranslationContext,
     ) -> Self {
         let name = op.name();
+        let node_info = ctx.next_node_info(name);
         Self {
             op,
             name,
             children,
-            runtime_stats: RuntimeStatsContext::new(name),
+            runtime_stats: RuntimeStatsContext::new(node_info.clone()),
             plan_stats,
+            node_info,
         }
     }
 
@@ -296,5 +300,11 @@ impl PipelineNode for StreamingSinkNode {
     }
     fn as_tree_display(&self) -> &dyn TreeDisplay {
         self
+    }
+    fn node_id(&self) -> usize {
+        self.node_info.id
+    }
+    fn plan_id(&self) -> Arc<str> {
+        self.node_info.plan_id.clone()
     }
 }

--- a/src/daft-local-execution/src/sources/source.rs
+++ b/src/daft-local-execution/src/sources/source.rs
@@ -11,7 +11,7 @@ use futures::{stream::BoxStream, StreamExt};
 
 use crate::{
     channel::{create_channel, Receiver},
-    pipeline::PipelineNode,
+    pipeline::{NodeInfo, PipelineNode, TranslationContext},
     progress_bar::ProgressBarColor,
     runtime_stats::{CountingSender, RuntimeStatsContext},
     ExecutionRuntimeContext,
@@ -36,17 +36,20 @@ pub(crate) struct SourceNode {
     runtime_stats: Arc<RuntimeStatsContext>,
     plan_stats: StatsState,
     io_stats: IOStatsRef,
+    node_info: NodeInfo,
 }
 
 impl SourceNode {
-    pub fn new(source: Arc<dyn Source>, plan_stats: StatsState) -> Self {
-        let runtime_stats = RuntimeStatsContext::new(source.name());
+    pub fn new(source: Arc<dyn Source>, plan_stats: StatsState, ctx: &TranslationContext) -> Self {
+        let info = ctx.next_node_info(source.name());
+        let runtime_stats = RuntimeStatsContext::new(info.clone());
         let io_stats = IOStatsContext::new(source.name());
         Self {
             source,
             runtime_stats,
             plan_stats,
             io_stats,
+            node_info: info,
         }
     }
 
@@ -142,5 +145,13 @@ impl PipelineNode for SourceNode {
     }
     fn as_tree_display(&self) -> &dyn TreeDisplay {
         self
+    }
+
+    fn node_id(&self) -> usize {
+        self.node_info.id
+    }
+
+    fn plan_id(&self) -> Arc<str> {
+        self.node_info.plan_id.clone()
     }
 }


### PR DESCRIPTION
## Changes Made

### - Creates a new method `get_relationship_info`

This currently isn't being used yet, but the general idea is that for the OSS dashboard visualizations, we need some way to know information about the plan structure (nodes and their children). Which we later fill in with `RuntimeContext` information. `get_relationship_info` is purely just to get the tree hierarchy. 

### - Update the otel subscriber to include `id` as well as `plan_id`. 
As an added bonus, the otel subsciber now has access to some additional fields that'll be useful for generic telemetry purposes (id, and plan_id).

ÏÏ
## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
