### PR TITLE
perf(expression): remove serde constraint on `ScalarUDF`, and add caching for `ScalarFunction::to_field`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ use daft_dsl::functions::prelude::*;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 struct MyToUpperCase;
 
-#[typetag::serde]
+
 impl ScalarUDF for MyToUpperCase {
 
     // Start by giving the function a name.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2289,6 +2289,7 @@ dependencies = [
  "indexmap 2.9.0",
  "itertools 0.11.0",
  "num-traits",
+ "parking_lot 0.12.4",
  "pyo3",
  "rstest",
  "serde",

--- a/src/daft-algebra/src/boolean.rs
+++ b/src/daft-algebra/src/boolean.rs
@@ -140,6 +140,10 @@ fn apply_de_morgans(expr: ExprRef) -> Transformed<ExprRef> {
 /// Examples:
 /// - (x > 0) AND (y > 0) would filter out nulls if either x or y are null, since if one side of an AND is null, the whole expression is null.
 /// - (x > 0) OR (y > 0) would filter out nulls if both x and y are null, but not necessarily if only one is null, since (null OR true) is true and not null.
+#[allow(
+    clippy::mutable_key_type,
+    reason = "ScalarFunction has inner mutability that is not included in the hashing"
+)]
 pub fn predicate_removes_nulls(
     expr: ExprRef,
     schema: &SchemaRef,

--- a/src/daft-dsl/Cargo.toml
+++ b/src/daft-dsl/Cargo.toml
@@ -16,6 +16,7 @@ num-traits = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 serde = {workspace = true}
 typetag = {workspace = true}
+parking_lot.workspace = true
 
 [dev-dependencies]
 rstest = {workspace = true}

--- a/src/daft-dsl/src/functions/agg/mod.rs
+++ b/src/daft-dsl/src/functions/agg/mod.rs
@@ -19,7 +19,6 @@ struct Args<T> {
     counts: T,
 }
 
-#[typetag::serde]
 impl ScalarUDF for MergeMeanFunction {
     fn name(&self) -> &'static str {
         "merge_mean"

--- a/src/daft-dsl/src/functions/mod.rs
+++ b/src/daft-dsl/src/functions/mod.rs
@@ -14,12 +14,13 @@ use std::{
     collections::HashMap,
     fmt::{Display, Formatter, Result, Write},
     hash::Hash,
-    sync::{Arc, LazyLock, RwLock},
+    sync::{Arc, LazyLock},
 };
 
 use common_error::DaftResult;
 use daft_core::prelude::*;
 pub use function_args::{FunctionArg, FunctionArgs, UnaryArg};
+use parking_lot::RwLock;
 use python::PythonUDF;
 use scalar::DynamicScalarFunction;
 pub use scalar::{ScalarFunction, ScalarFunctionFactory, ScalarUDF};

--- a/src/daft-functions-binary/src/concat.rs
+++ b/src/daft-functions-binary/src/concat.rs
@@ -21,7 +21,6 @@ pub struct BinaryConcatArgs<T> {
     other: T,
 }
 
-#[typetag::serde]
 impl ScalarUDF for BinaryConcat {
     fn name(&self) -> &'static str {
         "binary_concat"

--- a/src/daft-functions-binary/src/decode.rs
+++ b/src/daft-functions-binary/src/decode.rs
@@ -28,7 +28,6 @@ struct Args<T> {
     codec: Codec,
 }
 
-#[typetag::serde]
 impl ScalarUDF for BinaryDecode {
     fn name(&self) -> &'static str {
         "decode"
@@ -83,7 +82,6 @@ impl ScalarUDF for BinaryDecode {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct BinaryTryDecode;
 
-#[typetag::serde]
 impl ScalarUDF for BinaryTryDecode {
     fn name(&self) -> &'static str {
         "try_decode"

--- a/src/daft-functions-binary/src/encode.rs
+++ b/src/daft-functions-binary/src/encode.rs
@@ -22,7 +22,6 @@ struct Args<T> {
     codec: Codec,
 }
 
-#[typetag::serde]
 impl ScalarUDF for BinaryEncode {
     fn name(&self) -> &'static str {
         "encode"
@@ -68,7 +67,6 @@ impl ScalarUDF for BinaryEncode {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct BinaryTryEncode;
 
-#[typetag::serde]
 impl ScalarUDF for BinaryTryEncode {
     fn name(&self) -> &'static str {
         "try_encode"

--- a/src/daft-functions-binary/src/length.rs
+++ b/src/daft-functions-binary/src/length.rs
@@ -15,7 +15,6 @@ use crate::kernels::BinaryArrayExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct BinaryLength;
 
-#[typetag::serde]
 impl ScalarUDF for BinaryLength {
     fn name(&self) -> &'static str {
         "binary_length"

--- a/src/daft-functions-binary/src/slice.rs
+++ b/src/daft-functions-binary/src/slice.rs
@@ -24,7 +24,6 @@ struct BinarySliceArgs<T> {
     length: Option<T>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for BinarySlice {
     fn name(&self) -> &'static str {
         "binary_slice"

--- a/src/daft-functions-json/src/jq.rs
+++ b/src/daft-functions-json/src/jq.rs
@@ -19,7 +19,6 @@ struct JqArgs<T> {
     filter: String,
 }
 
-#[typetag::serde]
 impl ScalarUDF for Jq {
     fn name(&self) -> &'static str {
         "jq"

--- a/src/daft-functions-list/src/bool_and.rs
+++ b/src/daft-functions-list/src/bool_and.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListBoolAnd;
 
-#[typetag::serde]
 impl ScalarUDF for ListBoolAnd {
     fn name(&self) -> &'static str {
         "list_bool_and"

--- a/src/daft-functions-list/src/bool_or.rs
+++ b/src/daft-functions-list/src/bool_or.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListBoolOr;
 
-#[typetag::serde]
 impl ScalarUDF for ListBoolOr {
     fn name(&self) -> &'static str {
         "list_bool_or"

--- a/src/daft-functions-list/src/chunk.rs
+++ b/src/daft-functions-list/src/chunk.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListChunk;
 
-#[typetag::serde]
 impl ScalarUDF for ListChunk {
     fn name(&self) -> &'static str {
         "list_chunk"

--- a/src/daft-functions-list/src/count.rs
+++ b/src/daft-functions-list/src/count.rs
@@ -21,7 +21,6 @@ struct ListCountArgs<T> {
     mode: Option<CountMode>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for ListCount {
     fn name(&self) -> &'static str {
         "list_count"

--- a/src/daft-functions-list/src/count_distinct.rs
+++ b/src/daft-functions-list/src/count_distinct.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListCountDistinct;
 
-#[typetag::serde]
 impl ScalarUDF for ListCountDistinct {
     fn name(&self) -> &'static str {
         "list_count_distinct"

--- a/src/daft-functions-list/src/distinct.rs
+++ b/src/daft-functions-list/src/distinct.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListDistinct;
 
-#[typetag::serde]
 impl ScalarUDF for ListDistinct {
     fn name(&self) -> &'static str {
         "list_distinct"

--- a/src/daft-functions-list/src/explode.rs
+++ b/src/daft-functions-list/src/explode.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Explode;
 
-#[typetag::serde]
 impl ScalarUDF for Explode {
     fn name(&self) -> &'static str {
         "explode"

--- a/src/daft-functions-list/src/get.rs
+++ b/src/daft-functions-list/src/get.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListGet;
 
-#[typetag::serde]
 impl ScalarUDF for ListGet {
     fn name(&self) -> &'static str {
         "list_get"

--- a/src/daft-functions-list/src/join.rs
+++ b/src/daft-functions-list/src/join.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListJoin;
 
-#[typetag::serde]
 impl ScalarUDF for ListJoin {
     fn name(&self) -> &'static str {
         "list_join"

--- a/src/daft-functions-list/src/list_fill.rs
+++ b/src/daft-functions-list/src/list_fill.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListFill;
 
-#[typetag::serde]
 impl ScalarUDF for ListFill {
     fn name(&self) -> &'static str {
         "list_fill"

--- a/src/daft-functions-list/src/max.rs
+++ b/src/daft-functions-list/src/max.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListMax;
 
-#[typetag::serde]
 impl ScalarUDF for ListMax {
     fn name(&self) -> &'static str {
         "list_max"

--- a/src/daft-functions-list/src/mean.rs
+++ b/src/daft-functions-list/src/mean.rs
@@ -15,7 +15,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListMean;
 
-#[typetag::serde]
 impl ScalarUDF for ListMean {
     fn name(&self) -> &'static str {
         "list_mean"

--- a/src/daft-functions-list/src/min.rs
+++ b/src/daft-functions-list/src/min.rs
@@ -11,7 +11,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListMin;
 
-#[typetag::serde]
 impl ScalarUDF for ListMin {
     fn name(&self) -> &'static str {
         "list_min"

--- a/src/daft-functions-list/src/slice.rs
+++ b/src/daft-functions-list/src/slice.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListSlice;
 
-#[typetag::serde]
 impl ScalarUDF for ListSlice {
     fn name(&self) -> &'static str {
         "list_slice"

--- a/src/daft-functions-list/src/sort.rs
+++ b/src/daft-functions-list/src/sort.rs
@@ -11,7 +11,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListSort;
 
-#[typetag::serde]
 impl ScalarUDF for ListSort {
     fn name(&self) -> &'static str {
         "list_sort"

--- a/src/daft-functions-list/src/sum.rs
+++ b/src/daft-functions-list/src/sum.rs
@@ -14,7 +14,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListSum;
 
-#[typetag::serde]
 impl ScalarUDF for ListSum {
     fn name(&self) -> &'static str {
         "list_sum"

--- a/src/daft-functions-list/src/value_counts.rs
+++ b/src/daft-functions-list/src/value_counts.rs
@@ -11,7 +11,6 @@ use crate::series::SeriesListExtension;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ListValueCounts;
 
-#[typetag::serde]
 impl ScalarUDF for ListValueCounts {
     fn name(&self) -> &'static str {
         "list_value_counts"

--- a/src/daft-functions-serde/src/deserialize.rs
+++ b/src/daft-functions-serde/src/deserialize.rs
@@ -12,7 +12,6 @@ pub struct DeserializeArgs<T> {
     dtype: DataType,
 }
 
-#[typetag::serde]
 impl ScalarUDF for Deserialize {
     fn name(&self) -> &'static str {
         "deserialize"
@@ -39,7 +38,6 @@ impl ScalarUDF for Deserialize {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct TryDeserialize;
 
-#[typetag::serde]
 impl ScalarUDF for TryDeserialize {
     fn name(&self) -> &'static str {
         "try_deserialize"

--- a/src/daft-functions-serde/src/format/mod.rs
+++ b/src/daft-functions-serde/src/format/mod.rs
@@ -13,7 +13,7 @@ mod json;
 //
 pub type Deserializer = fn(input: &Utf8Array, dtype: &DataType) -> DaftResult<Series>;
 
-/// Supported formsts for the serialize and deserialize functions.
+/// Supported formats for the serialize and deserialize functions.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Format {
     Json,

--- a/src/daft-functions-temporal/src/lib.rs
+++ b/src/daft-functions-temporal/src/lib.rs
@@ -31,7 +31,7 @@ macro_rules! impl_temporal {
             #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
             pub struct $name;
 
-            #[typetag::serde]
+
             impl ScalarUDF for $name {
 
                 fn name(&self) -> &'static str {

--- a/src/daft-functions-temporal/src/time.rs
+++ b/src/daft-functions-temporal/src/time.rs
@@ -5,7 +5,6 @@ use daft_dsl::functions::{prelude::*, UnaryArg};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Time;
 
-#[typetag::serde]
 impl ScalarUDF for Time {
     fn name(&self) -> &'static str {
         "time"

--- a/src/daft-functions-temporal/src/to_string.rs
+++ b/src/daft-functions-temporal/src/to_string.rs
@@ -10,7 +10,6 @@ struct Args<T> {
     format: Option<String>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for ToString {
     fn name(&self) -> &'static str {
         "strftime"

--- a/src/daft-functions-temporal/src/total.rs
+++ b/src/daft-functions-temporal/src/total.rs
@@ -16,7 +16,7 @@ macro_rules! impl_total {
         #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
         pub struct $name;
 
-        #[typetag::serde]
+
         impl ScalarUDF for $name {
             fn name(&self) -> &'static str {
                 stringify!([ < $name:snake:lower > ])

--- a/src/daft-functions-temporal/src/truncate.rs
+++ b/src/daft-functions-temporal/src/truncate.rs
@@ -14,7 +14,6 @@ struct Args<T> {
     interval: String,
 }
 
-#[typetag::serde]
 impl ScalarUDF for Truncate {
     fn name(&self) -> &'static str {
         "truncate"

--- a/src/daft-functions-temporal/src/unix_timestamp.rs
+++ b/src/daft-functions-temporal/src/unix_timestamp.rs
@@ -28,7 +28,6 @@ struct Args<T> {
     time_unit: Option<WrappedTimeUnit>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for UnixTimestamp {
     fn name(&self) -> &'static str {
         "to_unix_epoch"

--- a/src/daft-functions-tokenize/src/decode.rs
+++ b/src/daft-functions-tokenize/src/decode.rs
@@ -28,7 +28,6 @@ struct DecodeArgs<T> {
     pub special_tokens: Option<String>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for TokenizeDecodeFunction {
     fn call(&self, args: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         let DecodeArgs {

--- a/src/daft-functions-tokenize/src/encode.rs
+++ b/src/daft-functions-tokenize/src/encode.rs
@@ -35,7 +35,6 @@ struct EncodeArgs<T> {
     pub use_special_tokens: Option<bool>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for TokenizeEncodeFunction {
     fn name(&self) -> &'static str {
         "tokenize_encode"

--- a/src/daft-functions-uri/src/download.rs
+++ b/src/daft-functions-uri/src/download.rs
@@ -36,7 +36,6 @@ pub struct UrlDownloadArgs<T> {
     pub on_error: Option<String>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for UrlDownload {
     fn name(&self) -> &'static str {
         "url_download"

--- a/src/daft-functions-uri/src/upload.rs
+++ b/src/daft-functions-uri/src/upload.rs
@@ -30,7 +30,6 @@ struct UrlUploadArgs<T> {
     io_config: Option<IOConfig>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for UrlUpload {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         let UrlUploadArgs {

--- a/src/daft-functions-utf8/src/capitalize.rs
+++ b/src/daft-functions-utf8/src/capitalize.rs
@@ -14,7 +14,6 @@ use crate::utils::{unary_utf8_evaluate, unary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Capitalize;
 
-#[typetag::serde]
 impl ScalarUDF for Capitalize {
     fn name(&self) -> &'static str {
         "capitalize"

--- a/src/daft-functions-utf8/src/contains.rs
+++ b/src/daft-functions-utf8/src/contains.rs
@@ -14,7 +14,6 @@ use crate::utils::{binary_utf8_evaluate, binary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Contains;
 
-#[typetag::serde]
 impl ScalarUDF for Contains {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         binary_utf8_evaluate(inputs, "pattern", contains_impl)

--- a/src/daft-functions-utf8/src/count_matches.rs
+++ b/src/daft-functions-utf8/src/count_matches.rs
@@ -14,7 +14,6 @@ pub struct CountMatches;
 const WHOLE_WORDS_DEFAULT_VALUE: bool = false;
 const CASE_SENSITIVE_DEFAULT_VALUE: bool = true;
 
-#[typetag::serde]
 impl ScalarUDF for CountMatches {
     fn name(&self) -> &'static str {
         "count_matches"

--- a/src/daft-functions-utf8/src/endswith.rs
+++ b/src/daft-functions-utf8/src/endswith.rs
@@ -14,7 +14,6 @@ use crate::utils::{binary_utf8_evaluate, binary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct EndsWith;
 
-#[typetag::serde]
 impl ScalarUDF for EndsWith {
     fn name(&self) -> &'static str {
         "ends_with"

--- a/src/daft-functions-utf8/src/find.rs
+++ b/src/daft-functions-utf8/src/find.rs
@@ -16,7 +16,6 @@ use crate::utils::{
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Find;
 
-#[typetag::serde]
 impl ScalarUDF for Find {
     fn name(&self) -> &'static str {
         "find"

--- a/src/daft-functions-utf8/src/ilike.rs
+++ b/src/daft-functions-utf8/src/ilike.rs
@@ -16,7 +16,6 @@ use crate::utils::{
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ILike;
 
-#[typetag::serde]
 impl ScalarUDF for ILike {
     fn name(&self) -> &'static str {
         "ilike"

--- a/src/daft-functions-utf8/src/left.rs
+++ b/src/daft-functions-utf8/src/left.rs
@@ -21,7 +21,6 @@ use crate::utils::{
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Left;
 
-#[typetag::serde]
 impl ScalarUDF for Left {
     fn name(&self) -> &'static str {
         "left"

--- a/src/daft-functions-utf8/src/length.rs
+++ b/src/daft-functions-utf8/src/length.rs
@@ -14,7 +14,6 @@ use crate::utils::{unary_utf8_evaluate, unary_utf8_to_field};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Length;
 
-#[typetag::serde]
 impl ScalarUDF for Length {
     fn name(&self) -> &'static str {
         "length"

--- a/src/daft-functions-utf8/src/length_bytes.rs
+++ b/src/daft-functions-utf8/src/length_bytes.rs
@@ -14,7 +14,6 @@ use crate::utils::{unary_utf8_evaluate, unary_utf8_to_field};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct LengthBytes;
 
-#[typetag::serde]
 impl ScalarUDF for LengthBytes {
     fn name(&self) -> &'static str {
         "length_bytes"

--- a/src/daft-functions-utf8/src/like.rs
+++ b/src/daft-functions-utf8/src/like.rs
@@ -16,7 +16,6 @@ use crate::utils::{
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Like;
 
-#[typetag::serde]
 impl ScalarUDF for Like {
     fn name(&self) -> &'static str {
         "like"

--- a/src/daft-functions-utf8/src/lower.rs
+++ b/src/daft-functions-utf8/src/lower.rs
@@ -14,7 +14,6 @@ use crate::utils::{unary_utf8_evaluate, unary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Lower;
 
-#[typetag::serde]
 impl ScalarUDF for Lower {
     fn name(&self) -> &'static str {
         "lower"

--- a/src/daft-functions-utf8/src/lpad.rs
+++ b/src/daft-functions-utf8/src/lpad.rs
@@ -14,7 +14,6 @@ use crate::pad::{series_pad, PadPlacement};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct LPad;
 
-#[typetag::serde]
 impl ScalarUDF for LPad {
     fn name(&self) -> &'static str {
         "lpad"

--- a/src/daft-functions-utf8/src/lstrip.rs
+++ b/src/daft-functions-utf8/src/lstrip.rs
@@ -14,7 +14,6 @@ use crate::utils::{unary_utf8_evaluate, unary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct LStrip;
 
-#[typetag::serde]
 impl ScalarUDF for LStrip {
     fn name(&self) -> &'static str {
         "lstrip"

--- a/src/daft-functions-utf8/src/normalize.rs
+++ b/src/daft-functions-utf8/src/normalize.rs
@@ -26,7 +26,6 @@ struct NormalizeArgs<T> {
     white_space: Option<bool>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for Normalize {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         let args: NormalizeArgs<Series> = inputs.try_into()?;

--- a/src/daft-functions-utf8/src/regexp_extract.rs
+++ b/src/daft-functions-utf8/src/regexp_extract.rs
@@ -14,7 +14,6 @@ use crate::utils::{create_broadcasted_str_iter, parse_inputs};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct RegexpExtract;
 
-#[typetag::serde]
 impl ScalarUDF for RegexpExtract {
     fn name(&self) -> &'static str {
         "extract"

--- a/src/daft-functions-utf8/src/regexp_extract_all.rs
+++ b/src/daft-functions-utf8/src/regexp_extract_all.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct RegexpExtractAll;
 
-#[typetag::serde]
 impl ScalarUDF for RegexpExtractAll {
     fn name(&self) -> &'static str {
         "extract_all"

--- a/src/daft-functions-utf8/src/regexp_match.rs
+++ b/src/daft-functions-utf8/src/regexp_match.rs
@@ -14,7 +14,6 @@ use crate::utils::{binary_utf8_evaluate, binary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct RegexpMatch;
 
-#[typetag::serde]
 impl ScalarUDF for RegexpMatch {
     fn name(&self) -> &'static str {
         "regexp_match"

--- a/src/daft-functions-utf8/src/repeat.rs
+++ b/src/daft-functions-utf8/src/repeat.rs
@@ -19,7 +19,6 @@ use crate::utils::{create_broadcasted_str_iter, parse_inputs};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Repeat;
 
-#[typetag::serde]
 impl ScalarUDF for Repeat {
     fn name(&self) -> &'static str {
         "repeat"

--- a/src/daft-functions-utf8/src/replace.rs
+++ b/src/daft-functions-utf8/src/replace.rs
@@ -1,12 +1,10 @@
-use std::sync::Arc;
-
 use common_error::{ensure, DaftError, DaftResult};
 use daft_core::{
     prelude::{AsArrow, DataType, Field, FullNull, Schema, Utf8Array},
     series::{IntoSeries, Series},
 };
 use daft_dsl::{
-    functions::{FunctionArg, FunctionArgs, ScalarFunction, ScalarUDF},
+    functions::{FunctionArgs, ScalarFunction, ScalarUDF},
     ExprRef,
 };
 use serde::{Deserialize, Serialize};
@@ -16,7 +14,6 @@ use crate::utils::{create_broadcasted_str_iter, parse_inputs};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct RegexpReplace;
 
-#[typetag::serde]
 impl ScalarUDF for RegexpReplace {
     fn name(&self) -> &'static str {
         "regexp_replace"
@@ -40,7 +37,6 @@ impl ScalarUDF for RegexpReplace {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Replace;
 
-#[typetag::serde]
 impl ScalarUDF for Replace {
     fn name(&self) -> &'static str {
         "replace"
@@ -63,17 +59,10 @@ impl ScalarUDF for Replace {
 
 #[must_use]
 pub fn replace(input: ExprRef, pattern: ExprRef, replacement: ExprRef, regex: bool) -> ExprRef {
-    ScalarFunction {
-        udf: if regex {
-            Arc::new(RegexpReplace) as _
-        } else {
-            Arc::new(Replace) as _
-        },
-        inputs: FunctionArgs::new_unchecked(vec![
-            FunctionArg::unnamed(input),
-            FunctionArg::unnamed(pattern),
-            FunctionArg::unnamed(replacement),
-        ]),
+    if regex {
+        ScalarFunction::new(RegexpReplace, vec![input, pattern, replacement])
+    } else {
+        ScalarFunction::new(Replace, vec![input, pattern, replacement])
     }
     .into()
 }

--- a/src/daft-functions-utf8/src/reverse.rs
+++ b/src/daft-functions-utf8/src/reverse.rs
@@ -14,7 +14,6 @@ use crate::utils::{unary_utf8_evaluate, unary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Reverse;
 
-#[typetag::serde]
 impl ScalarUDF for Reverse {
     fn name(&self) -> &'static str {
         "reverse"

--- a/src/daft-functions-utf8/src/right.rs
+++ b/src/daft-functions-utf8/src/right.rs
@@ -21,7 +21,6 @@ use crate::utils::{
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Right;
 
-#[typetag::serde]
 impl ScalarUDF for Right {
     fn name(&self) -> &'static str {
         "right"

--- a/src/daft-functions-utf8/src/rpad.rs
+++ b/src/daft-functions-utf8/src/rpad.rs
@@ -14,7 +14,6 @@ use crate::pad::{series_pad, PadPlacement};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct RPad;
 
-#[typetag::serde]
 impl ScalarUDF for RPad {
     fn name(&self) -> &'static str {
         "rpad"

--- a/src/daft-functions-utf8/src/rstrip.rs
+++ b/src/daft-functions-utf8/src/rstrip.rs
@@ -14,7 +14,6 @@ use crate::utils::{unary_utf8_evaluate, unary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct RStrip;
 
-#[typetag::serde]
 impl ScalarUDF for RStrip {
     fn name(&self) -> &'static str {
         "rstrip"

--- a/src/daft-functions-utf8/src/split.rs
+++ b/src/daft-functions-utf8/src/split.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::array::Array;
 use common_error::{DaftError, DaftResult};
 use daft_core::{
@@ -8,7 +6,7 @@ use daft_core::{
     series::{IntoSeries, Series},
 };
 use daft_dsl::{
-    functions::{FunctionArg, FunctionArgs, ScalarFunction, ScalarUDF},
+    functions::{FunctionArgs, ScalarFunction, ScalarUDF},
     ExprRef,
 };
 use serde::{Deserialize, Serialize};
@@ -23,7 +21,6 @@ pub struct Split;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct RegexpSplit;
 
-#[typetag::serde]
 impl ScalarUDF for Split {
     fn name(&self) -> &'static str {
         "split"
@@ -47,7 +44,7 @@ impl ScalarUDF for Split {
         "Splits a string into substrings based on a delimiter."
     }
 }
-#[typetag::serde]
+
 impl ScalarUDF for RegexpSplit {
     fn name(&self) -> &'static str {
         "regexp_split"
@@ -74,16 +71,10 @@ impl ScalarUDF for RegexpSplit {
 
 #[must_use]
 pub fn split(input: ExprRef, pattern: ExprRef, regex: bool) -> ExprRef {
-    ScalarFunction {
-        udf: if regex {
-            Arc::new(RegexpSplit) as _
-        } else {
-            Arc::new(Split)
-        },
-        inputs: FunctionArgs::new_unchecked(vec![
-            FunctionArg::unnamed(input),
-            FunctionArg::unnamed(pattern),
-        ]),
+    if regex {
+        ScalarFunction::new(RegexpSplit, vec![input, pattern])
+    } else {
+        ScalarFunction::new(Split, vec![input, pattern])
     }
     .into()
 }

--- a/src/daft-functions-utf8/src/startswith.rs
+++ b/src/daft-functions-utf8/src/startswith.rs
@@ -14,7 +14,6 @@ use crate::utils::{binary_utf8_evaluate, binary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct StartsWith;
 
-#[typetag::serde]
 impl ScalarUDF for StartsWith {
     fn name(&self) -> &'static str {
         "starts_with"

--- a/src/daft-functions-utf8/src/substr.rs
+++ b/src/daft-functions-utf8/src/substr.rs
@@ -29,7 +29,6 @@ struct SubstrArgs<T> {
     length: Option<T>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for Substr {
     fn name(&self) -> &'static str {
         "substr"

--- a/src/daft-functions-utf8/src/to_date.rs
+++ b/src/daft-functions-utf8/src/to_date.rs
@@ -16,7 +16,6 @@ use crate::utils::binary_utf8_to_field;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ToDate;
 
-#[typetag::serde]
 impl ScalarUDF for ToDate {
     fn name(&self) -> &'static str {
         "to_date"

--- a/src/daft-functions-utf8/src/to_datetime.rs
+++ b/src/daft-functions-utf8/src/to_datetime.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ToDatetime;
 
-#[typetag::serde]
 impl ScalarUDF for ToDatetime {
     fn name(&self) -> &'static str {
         "to_datetime"

--- a/src/daft-functions-utf8/src/upper.rs
+++ b/src/daft-functions-utf8/src/upper.rs
@@ -14,7 +14,6 @@ use crate::utils::{unary_utf8_evaluate, unary_utf8_to_field, Utf8ArrayUtils};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Upper;
 
-#[typetag::serde]
 impl ScalarUDF for Upper {
     fn name(&self) -> &'static str {
         "upper"

--- a/src/daft-functions/src/coalesce.rs
+++ b/src/daft-functions/src/coalesce.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Coalesce;
 
-#[typetag::serde]
 impl ScalarUDF for Coalesce {
     fn name(&self) -> &'static str {
         "coalesce"

--- a/src/daft-functions/src/distance/cosine.rs
+++ b/src/daft-functions/src/distance/cosine.rs
@@ -8,7 +8,7 @@ struct Args<T> {
     input: T,
     query: T,
 }
-#[typetag::serde]
+
 impl ScalarUDF for CosineDistanceFunction {
     fn name(&self) -> &'static str {
         "cosine_distance"

--- a/src/daft-functions/src/float/fill_nan.rs
+++ b/src/daft-functions/src/float/fill_nan.rs
@@ -21,7 +21,6 @@ struct Args<T> {
     fill_value: T,
 }
 
-#[typetag::serde]
 impl ScalarUDF for FillNan {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         let Args { input, fill_value } = inputs.try_into()?;

--- a/src/daft-functions/src/float/is_inf.rs
+++ b/src/daft-functions/src/float/is_inf.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct IsInf;
 
-#[typetag::serde]
 impl ScalarUDF for IsInf {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         use daft_core::{array::ops::DaftIsInf, series::IntoSeries};

--- a/src/daft-functions/src/float/is_nan.rs
+++ b/src/daft-functions/src/float/is_nan.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct IsNan;
 
-#[typetag::serde]
 impl ScalarUDF for IsNan {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         ensure!(inputs.len() == 1, ComputeError: "Expected 1 input, got {}", inputs.len());
@@ -29,6 +28,7 @@ impl ScalarUDF for IsNan {
     fn name(&self) -> &'static str {
         "is_nan"
     }
+
     fn get_return_type(&self, inputs: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
         let UnaryArg { input } = inputs.try_into()?;
         let data_field = input.to_field(schema)?;

--- a/src/daft-functions/src/float/not_nan.rs
+++ b/src/daft-functions/src/float/not_nan.rs
@@ -13,7 +13,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct NotNan;
 
-#[typetag::serde]
 impl ScalarUDF for NotNan {
     fn name(&self) -> &'static str {
         "not_nan"

--- a/src/daft-functions/src/hash.rs
+++ b/src/daft-functions/src/hash.rs
@@ -14,7 +14,6 @@ struct Args<T> {
     seed: Option<T>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for HashFunction {
     fn name(&self) -> &'static str {
         "hash"

--- a/src/daft-functions/src/minhash.rs
+++ b/src/daft-functions/src/minhash.rs
@@ -20,7 +20,6 @@ struct Args<T> {
     hash_function: Option<String>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for MinHashFunction {
     fn name(&self) -> &'static str {
         "minhash"

--- a/src/daft-functions/src/monotonically_increasing_id.rs
+++ b/src/daft-functions/src/monotonically_increasing_id.rs
@@ -9,7 +9,6 @@ pub struct MonotonicallyIncreasingId;
 #[derive(FunctionArgs)]
 struct Args {}
 
-#[typetag::serde]
 impl ScalarUDF for MonotonicallyIncreasingId {
     fn name(&self) -> &'static str {
         "monotonically_increasing_id"

--- a/src/daft-functions/src/numeric/abs.rs
+++ b/src/daft-functions/src/numeric/abs.rs
@@ -14,7 +14,6 @@ use super::to_field_numeric;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Abs;
 
-#[typetag::serde]
 impl ScalarUDF for Abs {
     fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;

--- a/src/daft-functions/src/numeric/cbrt.rs
+++ b/src/daft-functions/src/numeric/cbrt.rs
@@ -11,7 +11,6 @@ use super::to_field_floating;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Cbrt;
 
-#[typetag::serde]
 impl ScalarUDF for Cbrt {
     fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;

--- a/src/daft-functions/src/numeric/ceil.rs
+++ b/src/daft-functions/src/numeric/ceil.rs
@@ -14,7 +14,6 @@ use super::to_field_numeric;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Ceil;
 
-#[typetag::serde]
 impl ScalarUDF for Ceil {
     fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;

--- a/src/daft-functions/src/numeric/clip.rs
+++ b/src/daft-functions/src/numeric/clip.rs
@@ -23,7 +23,6 @@ struct ClipArgs<T> {
     max: Option<T>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for Clip {
     fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let ClipArgs { input, min, max } = inputs.try_into()?;

--- a/src/daft-functions/src/numeric/exp.rs
+++ b/src/daft-functions/src/numeric/exp.rs
@@ -14,7 +14,6 @@ macro_rules! exp {
         #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
         pub struct $variant;
 
-        #[typetag::serde]
         impl ScalarUDF for $variant {
             fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
                 let UnaryArg { input } = inputs.try_into()?;

--- a/src/daft-functions/src/numeric/floor.rs
+++ b/src/daft-functions/src/numeric/floor.rs
@@ -14,7 +14,6 @@ use super::to_field_numeric;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Floor;
 
-#[typetag::serde]
 impl ScalarUDF for Floor {
     fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;

--- a/src/daft-functions/src/numeric/log.rs
+++ b/src/daft-functions/src/numeric/log.rs
@@ -15,7 +15,6 @@ macro_rules! log {
         #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
         pub struct $variant;
 
-        #[typetag::serde]
         impl ScalarUDF for $variant {
             fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
                 let UnaryArg { input } = inputs.try_into()?;
@@ -80,7 +79,6 @@ struct LogArgs<T> {
     base: f64,
 }
 
-#[typetag::serde]
 impl ScalarUDF for Log {
     fn name(&self) -> &'static str {
         "log"

--- a/src/daft-functions/src/numeric/round.rs
+++ b/src/daft-functions/src/numeric/round.rs
@@ -20,7 +20,6 @@ struct RoundArgs<T> {
     decimals: Option<u32>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for Round {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         let RoundArgs { input, decimals } = inputs.try_into()?;

--- a/src/daft-functions/src/numeric/sign.rs
+++ b/src/daft-functions/src/numeric/sign.rs
@@ -14,7 +14,6 @@ use super::to_field_numeric;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Sign;
 
-#[typetag::serde]
 impl ScalarUDF for Sign {
     fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;
@@ -57,7 +56,6 @@ pub fn sign(input: ExprRef) -> ExprRef {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Negative;
 
-#[typetag::serde]
 impl ScalarUDF for Negative {
     fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;

--- a/src/daft-functions/src/numeric/sqrt.rs
+++ b/src/daft-functions/src/numeric/sqrt.rs
@@ -14,7 +14,6 @@ use super::to_field_floating;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Sqrt;
 
-#[typetag::serde]
 impl ScalarUDF for Sqrt {
     fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let UnaryArg { input } = inputs.try_into()?;

--- a/src/daft-functions/src/numeric/trigonometry.rs
+++ b/src/daft-functions/src/numeric/trigonometry.rs
@@ -16,7 +16,6 @@ macro_rules! trigonometry {
         #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
         pub struct $variant;
 
-        #[typetag::serde]
         impl ScalarUDF for $variant {
             fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
                 let UnaryArg { input } = inputs.try_into()?;
@@ -132,7 +131,6 @@ struct Atan2Args<T> {
     y: T,
 }
 
-#[typetag::serde]
 impl ScalarUDF for Atan2 {
     fn call(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
         let Atan2Args { x, y } = inputs.try_into()?;

--- a/src/daft-functions/src/to_struct.rs
+++ b/src/daft-functions/src/to_struct.rs
@@ -6,7 +6,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub(super) struct ToStructFunction;
 
-#[typetag::serde]
 impl ScalarUDF for ToStructFunction {
     fn name(&self) -> &'static str {
         "struct"

--- a/src/daft-image/src/functions/crop.rs
+++ b/src/daft-image/src/functions/crop.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ImageCrop;
 
-#[typetag::serde]
 impl ScalarUDF for ImageCrop {
     fn name(&self) -> &'static str {
         "image_crop"

--- a/src/daft-image/src/functions/decode.rs
+++ b/src/daft-image/src/functions/decode.rs
@@ -26,7 +26,6 @@ struct ImageDecodeArgs<T> {
     on_error: Option<T>,
 }
 
-#[typetag::serde]
 impl ScalarUDF for ImageDecode {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         let ImageDecodeArgs {

--- a/src/daft-image/src/functions/encode.rs
+++ b/src/daft-image/src/functions/encode.rs
@@ -19,7 +19,6 @@ struct ImageEncodeArgs<T> {
     image_format: ImageFormat,
 }
 
-#[typetag::serde]
 impl ScalarUDF for ImageEncode {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         let ImageEncodeArgs {

--- a/src/daft-image/src/functions/resize.rs
+++ b/src/daft-image/src/functions/resize.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct ImageResize;
 
-#[typetag::serde]
 impl ScalarUDF for ImageResize {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         let input = inputs.required((0, "input"))?;

--- a/src/daft-image/src/functions/to_mode.rs
+++ b/src/daft-image/src/functions/to_mode.rs
@@ -15,7 +15,6 @@ struct ImageToModeArgs<T> {
     mode: ImageMode,
 }
 
-#[typetag::serde]
 impl ScalarUDF for ImageToMode {
     fn call(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
         let ImageToModeArgs { input, mode } = inputs.try_into()?;

--- a/src/daft-local-execution/src/intermediate_ops/project.rs
+++ b/src/daft-local-execution/src/intermediate_ops/project.rs
@@ -55,9 +55,11 @@ pub fn try_get_batch_size(exprs: &[BoundExpr]) -> Option<usize> {
                         func: FunctionExpr::Python(PythonUDF { batch_size, .. }),
                         ..
                     } => *batch_size,
-                    Expr::ScalarFunction(ScalarFunction { udf, inputs, .. })
-                        if udf.name() == "url_download" =>
-                    {
+                    Expr::ScalarFunction(ScalarFunction {
+                        function_name,
+                        inputs,
+                        ..
+                    }) if function_name.as_ref() == "url_download" => {
                         let UrlDownloadArgs {
                             max_connections, ..
                         } = inputs.clone().try_into()?;
@@ -240,14 +242,10 @@ mod tests {
             BoundExpr::new_unchecked(bound_col(0, Field::new("a", DataType::Utf8))),
             BoundExpr::new_unchecked(bound_col(1, Field::new("b", DataType::Utf8))),
             BoundExpr::new_unchecked(
-                Expr::ScalarFunction(ScalarFunction {
-                    udf: Arc::new(UrlDownload),
-                    inputs: FunctionArgs::try_new(vec![FunctionArg::unnamed(bound_col(
-                        0,
-                        Field::new("a", DataType::Utf8),
-                    ))])
-                    .unwrap(),
-                })
+                Expr::ScalarFunction(ScalarFunction::new(
+                    UrlDownload,
+                    vec![bound_col(0, Field::new("a", DataType::Utf8))],
+                ))
                 .arced(),
             ),
         ];
@@ -264,14 +262,14 @@ mod tests {
         let projection = vec![
             BoundExpr::new_unchecked(bound_col(0, Field::new("a", DataType::Utf8))),
             BoundExpr::new_unchecked(
-                Expr::ScalarFunction(ScalarFunction {
-                    udf: Arc::new(UrlDownload),
-                    inputs: FunctionArgs::try_new(vec![
+                Expr::ScalarFunction(ScalarFunction::new_with_args(
+                    UrlDownload,
+                    FunctionArgs::try_new(vec![
                         FunctionArg::unnamed(bound_col(0, Field::new("a", DataType::Utf8))),
                         FunctionArg::named("max_connections", lit(10)),
                     ])
                     .unwrap(),
-                })
+                ))
                 .arced(),
             ),
         ];
@@ -286,25 +284,25 @@ mod tests {
             BoundExpr::new_unchecked(bound_col(0, Field::new("a", DataType::Utf8))),
             BoundExpr::new_unchecked(bound_col(1, Field::new("b", DataType::Utf8))),
             BoundExpr::new_unchecked(
-                Expr::ScalarFunction(ScalarFunction {
-                    udf: Arc::new(UrlDownload),
-                    inputs: FunctionArgs::try_new(vec![
+                Expr::ScalarFunction(ScalarFunction::new_with_args(
+                    UrlDownload,
+                    FunctionArgs::try_new(vec![
                         FunctionArg::unnamed(bound_col(0, Field::new("a", DataType::Utf8))),
                         FunctionArg::named("max_connections", lit(4)),
                     ])
                     .unwrap(),
-                })
+                ))
                 .arced(),
             ),
             BoundExpr::new_unchecked(
-                Expr::ScalarFunction(ScalarFunction {
-                    udf: Arc::new(UrlDownload),
-                    inputs: FunctionArgs::try_new(vec![FunctionArg::unnamed(bound_col(
+                Expr::ScalarFunction(ScalarFunction::new_with_args(
+                    UrlDownload,
+                    FunctionArgs::try_new(vec![FunctionArg::unnamed(bound_col(
                         1,
                         Field::new("b", DataType::Utf8),
                     ))])
                     .unwrap(),
-                })
+                ))
                 .arced(),
             ),
         ];

--- a/src/daft-logical-plan/src/builder/resolve_expr.rs
+++ b/src/daft-logical-plan/src/builder/resolve_expr.rs
@@ -1,3 +1,7 @@
+#![allow(
+    clippy::mutable_key_type,
+    reason = "ScalarFunction has inner mutability that is not included in the hashing"
+)]
 use std::{collections::HashSet, sync::Arc};
 
 use common_error::{DaftError, DaftResult};
@@ -191,6 +195,7 @@ fn convert_udfs_to_map_groups(expr: &ExprRef) -> ExprRef {
 /// Used for resolving and validating expressions.
 /// Specifically, makes sure the expression does not contain aggregations or actor pool UDFs
 /// where they are not allowed, and resolves struct accessors and wildcards.
+
 #[derive(Default, TypedBuilder)]
 pub struct ExprResolver<'a> {
     #[builder(default)]

--- a/src/daft-logical-plan/src/optimization/rules/granular_projections.rs
+++ b/src/daft-logical-plan/src/optimization/rules/granular_projections.rs
@@ -1,8 +1,11 @@
-use std::{any::TypeId, collections::HashSet, sync::Arc};
+use std::{collections::HashSet, sync::Arc};
 
 use common_error::DaftResult;
 use common_treenode::{Transformed, TreeNode};
-use daft_dsl::{functions::ScalarFunction, resolved_col, Expr};
+use daft_dsl::{
+    functions::{ScalarFunction, ScalarUDF},
+    resolved_col, Expr,
+};
 use daft_functions_uri::download::UrlDownload;
 use itertools::Itertools;
 
@@ -43,7 +46,7 @@ impl SplitGranularProjection {
         // As well as good testing
         matches!(
             expr,
-            Expr::ScalarFunction(ScalarFunction { udf, .. }) if udf.as_ref().type_id() == TypeId::of::<UrlDownload>()
+            Expr::ScalarFunction(ScalarFunction { function_name, .. }) if function_name.as_ref() == UrlDownload{}.name()
         )
     }
 
@@ -318,7 +321,7 @@ mod tests {
         };
         assert!(matches!(
             func.as_ref(),
-            Expr::ScalarFunction(ScalarFunction { udf, .. }) if udf.as_ref().type_id() == TypeId::of::<BinaryDecode>()
+            Expr::ScalarFunction(ScalarFunction { function_name, .. }) if function_name.as_ref() == BinaryDecode{}.name()
         ));
 
         // Check that the top level project has a single child, which is a project
@@ -339,7 +342,7 @@ mod tests {
         };
         assert!(matches!(
             func.as_ref(),
-            Expr::ScalarFunction(ScalarFunction { udf, .. }) if udf.as_ref().type_id() == TypeId::of::<UrlDownload>()
+            Expr::ScalarFunction(ScalarFunction { function_name, .. }) if function_name.as_ref() == UrlDownload{}.name()
         ));
 
         // Check that the bottom level project has a single child, which is a source node
@@ -406,7 +409,7 @@ mod tests {
         };
         assert!(matches!(
             func.as_ref(),
-            Expr::ScalarFunction(ScalarFunction { udf, .. }) if udf.as_ref().type_id() == TypeId::of::<BinaryConcat>()
+            Expr::ScalarFunction(ScalarFunction { function_name, .. }) if function_name.as_ref() == BinaryConcat{}.name()
         ));
 
         // Check that the top level project has a single child, which is a project
@@ -427,7 +430,7 @@ mod tests {
         };
         assert!(matches!(
             func.as_ref(),
-            Expr::ScalarFunction(ScalarFunction { udf, .. }) if udf.as_ref().type_id() == TypeId::of::<UrlDownload>()
+            Expr::ScalarFunction(ScalarFunction { function_name, .. }) if function_name.as_ref() == UrlDownload{}.name()
         ));
 
         // Check that the middle level project has a single child, which is a project
@@ -448,7 +451,7 @@ mod tests {
         };
         assert!(matches!(
             func.as_ref(),
-            Expr::ScalarFunction(ScalarFunction { udf, .. }) if udf.as_ref().type_id() == TypeId::of::<Capitalize>()
+            Expr::ScalarFunction(ScalarFunction { function_name, .. }) if function_name.as_ref() == Capitalize{}.name()
         ));
 
         // Check that the bottom level project has a single child, which is a source node

--- a/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
@@ -34,7 +34,10 @@ impl OptimizerRule for PushDownFilter {
         plan.transform_down(|node| self.try_optimize_node(node))
     }
 }
-
+#[allow(
+    clippy::mutable_key_type,
+    reason = "ScalarFunction has inner mutability that is not included in the hashing"
+)]
 impl PushDownFilter {
     #[allow(clippy::only_used_in_recursion)]
     fn try_optimize_node(

--- a/src/daft-logical-plan/src/optimization/rules/simplify_null_filtered_join.rs
+++ b/src/daft-logical-plan/src/optimization/rules/simplify_null_filtered_join.rs
@@ -28,7 +28,10 @@ impl SimplifyNullFilteredJoin {
         Self {}
     }
 }
-
+#[allow(
+    clippy::mutable_key_type,
+    reason = "ScalarFunction has inner mutability that is not included in the hashing"
+)]
 impl OptimizerRule for SimplifyNullFilteredJoin {
     fn try_optimize(&self, plan: LogicalPlanRef) -> DaftResult<Transformed<LogicalPlanRef>> {
         plan.transform(|node| {

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -698,7 +698,7 @@ impl RecordBatch {
                     .collect::<DaftResult<FunctionArgs<Series>>>()?;
 
 
-                func.udf.call(args)
+                func.call(args)
             }
             Expr::Literal(lit_value) => Ok(lit_value.to_series()),
             Expr::IfElse {

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -485,6 +485,10 @@ impl SQLPlanner<'_> {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(
+        clippy::mutable_key_type,
+        reason = "ScalarFunction has inner mutability that is not included in the hashing"
+    )]
     fn plan_aggregate_query(
         &mut self,
         projections: Vec<Arc<Expr>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,9 +148,7 @@ pub mod pylib {
         daft_cli::register_modules(m)?;
 
         // We need to do this here because it's the only point in the rust codebase that we have access to all crates.
-        let mut functions_registry = daft_dsl::functions::FUNCTION_REGISTRY
-            .write()
-            .expect("Failed to acquire write lock on function registry");
+        let mut functions_registry = daft_dsl::functions::FUNCTION_REGISTRY.write();
         functions_registry.register::<daft_functions::numeric::NumericFunctions>();
         functions_registry.register::<daft_functions::float::FloatFunctions>();
         functions_registry.register::<daft_functions_uri::UriFunctions>();


### PR DESCRIPTION
## Changes Made

Some general post refactor cleanup to scalarudf/scalarfunction

### - removes the `typetag` constraint from `ScalarUDF`

As we move more logic to the `ScalarFunctionFactory` for resolving the concrete implementation, all we need to know to serialize a udf is it's name and its args. The registry/factories will take care of resolving it to a concrete implementation from there.  

### Replaces the `FunctionRegistry`'s RwLock with parking_lot::RwLock
Easier to work with as you don't need to unwrap results, and is generally known to have slightly better performance


### Adds some caching to `ScalarFunction`
during optimization and planning, `to_field` can get called many times per function. Since we do some potentially expensive type checking via the `FunctionArgs` macros, we want to ensure we're not performing the same computation unnecessarily.

So this adds a `field_cache` to `ScalarFunction` that is cached during planning. 

It also caches the concrete function implementation during planning _(via the factories & registry)_


### 👀 **Note for reviewers**: 

AFAIK, there's no practical case for calling `to_field(schema)` with different schemas for a single instance of a `ScalarFunction`?

Conceptually, a single instance of a `ScalarFunction` should always be bound to a single plan right? I did some experiments to validate this, and it seems that there's never a case where we'd want to call to_field on a single instance with multiple schemas? 

I also suspect that there's a way to do this caching outside of `ScalarFunction` and inside the optimizers/planner instead, but this seemed like a sensible approach to me. **Happy to discuss alternatives!**



### Note about the allow(clippy) 
I guess there's a clippy rule that forbids inner mutability when using something like a `HashSet<T>`, but it's not actually smart enough to detect what is being used in the `impl Hash` for that hash key. Since `ScalarFunction` now has inner mutability, it's complaining, but it doesn't see that the `impl Hash for ScalarFunction` doesn't even hash on those fields. 


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
