### PR TITLE
Use PYTHON_VERSION instead of python3 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 
 .venv:  ## Set up virtual environment
 ifeq (, $(shell which uv))
-	python3 -m venv $(VENV)
+	$(PYTHON_VERSION) -m venv $(VENV)
 	$(VENV_BIN)/python -m pip install --upgrade uv
 else
 	uv venv $(VENV) -p $(PYTHON_VERSION)


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
In the `make .venv` command, if uv isn't installed, this PR makes it so `PYTHON_VERSION` (currently set to python3.11)is used instead of `python3`.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
Closes #4498

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
