### PR TITLE
feat: `f""` string style string concatenation

### DIFF
--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -10,6 +10,7 @@ from .functions import (
     row_number,
     rank,
     dense_rank,
+    format,
 )
 from .llm_generate import llm_generate
 
@@ -20,6 +21,7 @@ __all__ = [
     "columns_min",
     "columns_sum",
     "dense_rank",
+    "format",
     "llm_generate",
     "monotonically_increasing_id",
     "rank",

--- a/daft/functions/functions.py
+++ b/daft/functions/functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import daft.daft as native
-from daft.expressions import Expression, list_
+from daft.expressions import Expression, col, list_, lit
 
 
 def monotonically_increasing_id() -> Expression:
@@ -327,3 +327,62 @@ def dense_rank() -> Expression:
         Expression: An expression that returns the dense rank of the current row.
     """
     return Expression._from_pyexpr(native.dense_rank())
+
+
+def format(f_string: str, *args: Expression | str) -> Expression:
+    """Format a string using the given arguments.
+
+    Args:
+        f_string: The format string.
+        *args: The arguments to format the string with.
+
+    Returns:
+        Expression: A string expression with the formatted result.
+
+    Examples:
+        >>> import daft
+        >>> from daft.functions import format
+        >>> from daft import col
+        >>> df = daft.from_pydict({"first_name": ["Alice", "Bob"], "last_name": ["Smith", "Jones"]})
+        >>> df = df.with_column("greeting", format("Hello {} {}", col("first_name"), "last_name"))
+        >>> df.show()
+        ╭────────────┬───────────┬───────────────────╮
+        │ first_name ┆ last_name ┆ greeting          │
+        │ ---        ┆ ---       ┆ ---               │
+        │ Utf8       ┆ Utf8      ┆ Utf8              │
+        ╞════════════╪═══════════╪═══════════════════╡
+        │ Alice      ┆ Smith     ┆ Hello Alice Smith │
+        ├╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        │ Bob        ┆ Jones     ┆ Hello Bob Jones   │
+        ╰────────────┴───────────┴───────────────────╯
+        <BLANKLINE>
+        (Showing first 2 of 2 rows)
+    """
+    if f_string.count("{}") != len(args):
+        raise ValueError(
+            f"Format string {f_string} has {f_string.count('{}')} placeholders but {len(args)} arguments were provided"
+        )
+
+    parts = f_string.split("{}")
+    exprs = []
+
+    for part, arg in zip(parts, args):
+        if part:
+            exprs.append(lit(part))
+
+        if isinstance(arg, str):
+            exprs.append(col(arg))
+        else:
+            exprs.append(arg)
+
+    if parts[-1]:
+        exprs.append(lit(parts[-1]))
+
+    if not exprs:
+        return lit("")
+
+    result = exprs[0]
+    for expr in exprs[1:]:
+        result = result + expr
+
+    return result

--- a/tests/dataframe/test_format_function.py
+++ b/tests/dataframe/test_format_function.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+
+from daft.expressions import col
+from daft.functions import format
+
+
+def test_format_basic(make_df) -> None:
+    """Test basic format functionality."""
+    data = {"first": ["Alice", "Bob"], "last": ["Smith", "Jones"]}
+    df = make_df(data).with_column("greeting", format("Hello {} {}", "first", "last"))
+
+    expected = ["Hello Alice Smith", "Hello Bob Jones"]
+    assert df.to_pydict()["greeting"] == expected
+
+
+def test_format_string_vs_expression_args(make_df) -> None:
+    """Test that string column names and col() expressions work the same."""
+    data = {"name": ["Alice", "Bob"]}
+    df = make_df(data).with_column("greeting", format("Hello {}", "name"))
+
+    expected = ["Hello Alice", "Hello Bob"]
+    assert df.to_pydict()["greeting"] == expected
+
+
+def test_format_no_placeholders(make_df) -> None:
+    """Test format with no placeholders returns just the literal string."""
+    data = {"name": ["Alice", "Bob"]}
+    df = make_df(data).with_column("static", format("Hello World"))
+
+    expected = ["Hello World", "Hello World"]
+    assert df.to_pydict()["static"] == expected
+
+
+def test_format_only_placeholders(make_df) -> None:
+    """Test format with only placeholders (no static text)."""
+    data = {"first": ["Alice", "Bob"], "last": ["Smith", "Jones"]}
+    df = make_df(data).with_column("full", format("{}{}", "first", "last"))
+
+    expected = ["AliceSmith", "BobJones"]
+    assert df.to_pydict()["full"] == expected
+
+
+def test_format_ends_with_placeholder(make_df) -> None:
+    """Test that parts[-1] is handled correctly when format string ends with {}."""
+    data = {"name": ["Alice", "Bob"]}
+    df = make_df(data).with_column("greeting", format("Hello {}", "name"))
+
+    expected = ["Hello Alice", "Hello Bob"]
+    assert df.to_pydict()["greeting"] == expected
+
+
+def test_format_starts_with_placeholder(make_df) -> None:
+    """Test format string that starts with a placeholder."""
+    data = {"name": ["Alice", "Bob"]}
+    df = make_df(data).with_column("greeting", format("{}, welcome!", "name"))
+
+    expected = ["Alice, welcome!", "Bob, welcome!"]
+    assert df.to_pydict()["greeting"] == expected
+
+
+def test_format_multiple_static_parts(make_df) -> None:
+    """Test format with multiple static text parts between placeholders."""
+    data = {"first": ["Alice", "Bob"], "last": ["Smith", "Jones"]}
+    df = make_df(data).with_column("message", format("Dear {} from {}, welcome!", "first", "last"))
+
+    expected = ["Dear Alice from Smith, welcome!", "Dear Bob from Jones, welcome!"]
+    assert df.to_pydict()["message"] == expected
+
+
+def test_format_with_expressions(make_df) -> None:
+    """Test format with computed expressions as arguments."""
+    data = {"a": [1, 2], "b": [3, 4]}
+    df = make_df(data).with_column("result", format("Sum: {}", col("a") + col("b")))
+
+    expected = ["Sum: 4", "Sum: 6"]
+    assert df.to_pydict()["result"] == expected
+
+
+def test_format_placeholder_count_mismatch_too_few_args() -> None:
+    """Test error when number of placeholders does not match number of arguments."""
+    with pytest.raises(ValueError, match="Format string .* has 2 placeholders but 1 arguments were provided"):
+        format("Hello {} {}", "name")
+
+
+def test_format_empty_string_no_args(make_df) -> None:
+    """Test format with empty string and no arguments returns empty string literal."""
+    data = {"name": ["Alice", "Bob"]}
+    df = make_df(data).with_column("empty", format(""))
+
+    expected = ["", ""]
+    assert df.to_pydict()["empty"] == expected


### PR DESCRIPTION
## Changes Made

Implemented `f""` string style string concatenation (see linked issue for more detail) and added some tests. Probs want to also add this to the docs at some point?

## Related Issues

https://github.com/Eventual-Inc/Daft/issues/4001


## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
