### PR TITLE
feat: adds .serialize('json') to expressions

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -1659,8 +1659,19 @@ class Expression:
             dtype = DataType._infer_type(dtype)
         return self._eval_expressions("try_deserialize", format, dtype._dtype)
 
+    def serialize(self, format: Literal["json"]) -> Expression:
+        """Serializes the expression as a string using the specified format.
+
+        Args:
+            format (Literal["json"]): The serialization format.
+
+        Returns:
+            Expression: A new expression with the serialized string.
+        """
+        return self._eval_expressions("serialize", format)
+
     def jq(self, filter: builtins.str) -> Expression:
-        """Applies a [https://jqlang.github.io/jq/manual/](jq) to the expression (string), returning the results as a string.
+        """Applies a [https://jqlang.github.io/jq/manual/](jq) filter to the expression (string), returning the results as a string.
 
         Args:
             file (str): The jq filter.

--- a/src/arrow2/src/io/json/write/mod.rs
+++ b/src/arrow2/src/io/json/write/mod.rs
@@ -3,8 +3,8 @@ mod serialize;
 mod utf8;
 
 pub use fallible_streaming_iterator::*;
-pub(crate) use serialize::new_serializer;
-use serialize::serialize;
+pub use serialize::new_serializer;
+use serialize::serialize_array;
 use std::io::Write;
 
 use crate::{
@@ -48,7 +48,7 @@ where
         self.buffer.clear();
         self.arrays
             .next()
-            .map(|maybe_array| maybe_array.map(|array| serialize(array.as_ref(), &mut self.buffer)))
+            .map(|maybe_array| maybe_array.map(|array| serialize_array(array.as_ref(), &mut self.buffer)))
             .transpose()?;
         Ok(())
     }

--- a/src/arrow2/src/io/json/write/serialize.rs
+++ b/src/arrow2/src/io/json/write/serialize.rs
@@ -357,7 +357,8 @@ fn timestamp_tz_serializer<'a>(
     }
 }
 
-pub(crate) fn new_serializer<'a>(
+/// Creates a new serializer
+pub fn new_serializer<'a>(
     array: &'a dyn Array,
     offset: usize,
     take: usize,
@@ -499,7 +500,7 @@ fn serialize_item(buffer: &mut Vec<u8>, record: &[(&str, &[u8])], is_first_row: 
 /// Serializes `array` to a valid JSON to `buffer`
 /// # Implementation
 /// This operation is CPU-bounded
-pub(crate) fn serialize(array: &dyn Array, buffer: &mut Vec<u8>) {
+pub(crate) fn serialize_array(array: &dyn Array, buffer: &mut Vec<u8>) {
     let mut serializer = new_serializer(array, 0, usize::MAX);
 
     (0..array.len()).for_each(|i| {

--- a/src/daft-functions-serde/Cargo.toml
+++ b/src/daft-functions-serde/Cargo.toml
@@ -1,5 +1,5 @@
 [dependencies]
-arrow2 = {workspace = true, features = ["io_json_read"]}
+arrow2 = {workspace = true, features = ["io_json_read", "io_json_write"]}
 common-error = {path = "../common/error", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}

--- a/src/daft-functions-serde/src/format/mod.rs
+++ b/src/daft-functions-serde/src/format/mod.rs
@@ -10,8 +10,11 @@ use serde::{Deserialize, Serialize};
 
 mod json;
 
-//
+/// Signature of a deserialization implementation e.g. strings to arbitrary series.
 pub type Deserializer = fn(input: &Utf8Array, dtype: &DataType) -> DaftResult<Series>;
+
+/// Signature of a serialization implementation e.g. arbitrary series to string.
+pub type Serializer = fn(input: Series) -> DaftResult<Utf8Array>;
 
 /// Supported formsts for the serialize and deserialize functions.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -67,6 +70,18 @@ impl Format {
     pub(crate) fn try_deserializer(&self) -> Deserializer {
         match self {
             Self::Json => json::try_deserialize,
+        }
+    }
+
+    pub(crate) fn serializer(&self) -> Serializer {
+        match self {
+            Self::Json => json::serialize,
+        }
+    }
+
+    pub(crate) fn try_serializer(&self) -> Serializer {
+        match self {
+            Self::Json => json::try_serialize,
         }
     }
 }

--- a/src/daft-functions-serde/src/lib.rs
+++ b/src/daft-functions-serde/src/lib.rs
@@ -2,6 +2,7 @@ use daft_dsl::functions::{FunctionModule, FunctionRegistry};
 
 mod deserialize;
 mod format;
+mod serialize;
 
 /// SerdeFunctions module.
 pub struct SerdeFunctions;
@@ -11,6 +12,6 @@ impl FunctionModule for SerdeFunctions {
     fn register(parent: &mut FunctionRegistry) {
         parent.add_fn(crate::deserialize::Deserialize);
         parent.add_fn(crate::deserialize::TryDeserialize);
-        // parent.add_fn(crate::serialize::Serialize);
+        parent.add_fn(crate::serialize::Serialize);
     }
 }

--- a/src/daft-functions-serde/src/serialize.rs
+++ b/src/daft-functions-serde/src/serialize.rs
@@ -1,0 +1,73 @@
+use daft_core::series::IntoSeries;
+use daft_dsl::functions::prelude::*;
+
+use crate::format::Format;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct Serialize;
+
+#[derive(FunctionArgs)]
+pub struct SerializeArgs<T> {
+    input: T,
+    format: Format,
+}
+
+#[typetag::serde]
+impl ScalarUDF for Serialize {
+    fn name(&self) -> &'static str {
+        "serialize"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Serializes the expression as a string using the specified format."
+    }
+
+    fn function_args_to_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        get_field(inputs, schema)
+    }
+
+    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+        let SerializeArgs { input, format } = inputs.try_into()?;
+        format.serializer()(input).map(|array| array.into_series())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct TrySerialize;
+
+#[typetag::serde]
+impl ScalarUDF for TrySerialize {
+    fn name(&self) -> &'static str {
+        "try_serialize"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Serializes the expression as a string using the specified format, insert null on failures."
+    }
+
+    fn function_args_to_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        get_field(inputs, schema)
+    }
+
+    fn evaluate(&self, inputs: FunctionArgs<Series>) -> DaftResult<Series> {
+        let SerializeArgs { input, format } = inputs.try_into()?;
+        format.try_serializer()(input).map(|array| array.into_series())
+    }
+}
+
+fn get_field(inputs: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+    // validate argument arity
+    let SerializeArgs { input, format: _ } = inputs.try_into()?;
+    // [try_]serialize supports any arbitrary value
+    let input = input.to_field(schema)?;
+    // use name of the single argument as the output field name
+    Ok(Field::new(input.name, DataType::Utf8))
+}

--- a/tests/functions/serde/test_serde_json.py
+++ b/tests/functions/serde/test_serde_json.py
@@ -116,3 +116,65 @@ def test_deserialize_json_with_missing_fields(deserialize):
         {"name": None, "age": 25},
         {"name": "Charlie", "age": None},
     ]
+
+
+@pytest.mark.parametrize("series", ["Expression", "SQL"], indirect=True)
+def test_serialize_json(series):
+    items = [
+        {"a": None, "b": 1, "c": 1.1, "d": "ABC"},
+        {"a": None, "b": 2, "c": 2.2, "d": "DEF"},
+        {"a": None, "b": 3, "c": 3.3, "d": "GHI"},
+        {"a": None, "b": 4, "c": 4.4, "d": "JKL"},
+    ]
+    assert series(items).serialize("json") == [
+        '{"a":null,"b":1,"c":1.1,"d":"ABC"}',
+        '{"a":null,"b":2,"c":2.2,"d":"DEF"}',
+        '{"a":null,"b":3,"c":3.3,"d":"GHI"}',
+        '{"a":null,"b":4,"c":4.4,"d":"JKL"}',
+    ]
+
+
+@pytest.mark.parametrize("series", ["Expression", "SQL"], indirect=True)
+def test_serialize_json_with_nulls(series):
+    items = [
+        None,
+        {"a": 1, "b": None, "c": "valid"},
+        {"a": None, "b": 2, "c": None},
+        {"a": 3, "b": 3, "c": "valid"},
+        None,
+    ]
+    assert series(items).serialize("json") == [
+        None,
+        '{"a":1,"b":null,"c":"valid"}',
+        '{"a":null,"b":2,"c":null}',
+        '{"a":3,"b":3,"c":"valid"}',
+        None,
+    ]
+
+
+@pytest.mark.parametrize("series", ["Expression", "SQL"], indirect=True)
+def test_serialize_json_with_collections(series):
+    items = [
+        {"arr": [1, 2, 3], "map": {"a": None, "b": 2}, "struct": {"x": 1, "y": "z"}},
+        {"arr": [4, 5, 6], "map": {"a": 3, "b": None}, "struct": {"x": 2, "y": "w"}},
+        {"arr": None, "map": None, "struct": None},
+    ]
+    assert series(items).serialize("json") == [
+        '{"arr":[1,2,3],"map":{"a":null,"b":2},"struct":{"x":1,"y":"z"}}',
+        '{"arr":[4,5,6],"map":{"a":3,"b":null},"struct":{"x":2,"y":"w"}}',
+        '{"arr":null,"map":null,"struct":null}',
+    ]
+
+
+@pytest.mark.parametrize("series", ["Expression", "SQL"], indirect=True)
+def test_serialize_json_with_nested_collections(series):
+    items = [
+        {"arr": [{"x": 1}, {"x": 2}], "map": {"a": [1, 2], "b": {"c": 3}}},
+        {"arr": [{"x": 3}, {"x": 4}], "map": {"a": [3, 4], "b": {"c": 5}}},
+        {"arr": None, "map": None},
+    ]
+    assert series(items).serialize("json") == [
+        '{"arr":[{"x":1},{"x":2}],"map":{"a":[1,2],"b":{"c":3}}}',
+        '{"arr":[{"x":3},{"x":4}],"map":{"a":[3,4],"b":{"c":5}}}',
+        '{"arr":null,"map":null}',
+    ]


### PR DESCRIPTION
## Changes Made

* Adds `Expression.serialize(input, "json")` to write values as json encoded strings.

## Related Issues

n/a

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
