### PR TITLE
chore: add additional context to the runtime stats events

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1755,6 +1755,7 @@ class NativeExecutor:
         psets: dict[str, list[PyMicroPartition]],
         daft_execution_config: PyDaftExecutionConfig,
         results_buffer_size: int | None,
+        context: dict[str, str] | None
     ) -> AsyncIterator[PyMicroPartition]: ...
     def repr_ascii(
         self, builder: LogicalPlanBuilder, daft_execution_config: PyDaftExecutionConfig, simple: bool

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1730,6 +1730,7 @@ class RaySwordfishTask:
     def plan(self) -> LocalPhysicalPlan: ...
     def psets(self) -> dict[str, list[RayPartitionRef]]: ...
     def config(self) -> PyDaftExecutionConfig: ...
+    def context(self) -> dict[str, str]: ...
 
 class RaySwordfishWorker:
     def __init__(
@@ -1755,7 +1756,7 @@ class NativeExecutor:
         psets: dict[str, list[PyMicroPartition]],
         daft_execution_config: PyDaftExecutionConfig,
         results_buffer_size: int | None,
-        context: dict[str, str] | None
+        context: dict[str, str] | None,
     ) -> AsyncIterator[PyMicroPartition]: ...
     def repr_ascii(
         self, builder: LogicalPlanBuilder, daft_execution_config: PyDaftExecutionConfig, simple: bool

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -56,10 +56,9 @@ class RaySwordfishActor:
         plan: LocalPhysicalPlan,
         config: PyDaftExecutionConfig,
         psets: dict[str, list[ray.ObjectRef]],
-        context: dict[str, str] | None
+        context: dict[str, str] | None,
     ) -> AsyncGenerator[MicroPartition | list[PartitionMetadata], None]:
         """Run a plan on swordfish and yield partitions."""
-        print("run_plan")
         psets = {k: await asyncio.gather(*v) for k, v in psets.items()}
         psets_mp = {k: [v._micropartition for v in v] for k, v in psets.items()}
 
@@ -123,14 +122,8 @@ class RaySwordfishActorHandle:
 
     def submit_task(self, task: RaySwordfishTask) -> RaySwordfishTaskHandle:
         psets = {k: [v.object_ref for v in v] for k, v in task.psets().items()}
-        print(task)
         return RaySwordfishTaskHandle(
-            self.actor_handle.run_plan.remote(
-                task.plan(),
-                task.config(),
-                psets,
-                task.task_context()
-            ),
+            self.actor_handle.run_plan.remote(task.plan(), task.config(), psets, task.context()),
             self.actor_handle,
         )
 
@@ -181,7 +174,6 @@ class FlotillaPlanRunner:
         plan: DistributedPhysicalPlan,
         partition_sets: dict[str, PartitionSet[ray.ObjectRef]],
     ) -> None:
-        print("FlotillaPlanRunner")
         psets = {
             k: [RayPartitionRef(v.partition(), v.metadata().num_rows, v.metadata().size_bytes or 0) for v in v.values()]
             for k, v in partition_sets.items()

--- a/src/daft-distributed/src/pipeline_node/in_memory_source.rs
+++ b/src/daft-distributed/src/pipeline_node/in_memory_source.rs
@@ -9,14 +9,14 @@ use daft_logical_plan::{stats::StatsState, InMemoryInfo};
 
 use super::{DistributedPipelineNode, PipelineOutput, RunningPipelineNode};
 use crate::{
-    scheduling::task::{SchedulingStrategy, SwordfishTask},
-    stage::StageContext,
-    utils::channel::{create_channel, Sender},
+    plan::PlanID, scheduling::task::{SchedulingStrategy, SwordfishTask}, stage::{StageContext, StageID}, utils::channel::{create_channel, Sender}
 };
 
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct InMemorySourceNode {
+    plan_id: PlanID,
+    stage_id: StageID,
     node_id: usize,
     config: Arc<DaftExecutionConfig>,
     info: InMemoryInfo,
@@ -27,6 +27,8 @@ pub(crate) struct InMemorySourceNode {
 impl InMemorySourceNode {
     #[allow(dead_code)]
     pub fn new(
+        plan_id: PlanID,
+        stage_id: StageID,
         node_id: usize,
         config: Arc<DaftExecutionConfig>,
         info: InMemoryInfo,
@@ -34,6 +36,8 @@ impl InMemorySourceNode {
         input_psets: Arc<HashMap<String, Vec<PartitionRef>>>,
     ) -> Self {
         Self {
+            plan_id,
+            stage_id,
             node_id,
             config,
             info,

--- a/src/daft-distributed/src/pipeline_node/in_memory_source.rs
+++ b/src/daft-distributed/src/pipeline_node/in_memory_source.rs
@@ -9,15 +9,19 @@ use daft_logical_plan::{stats::StatsState, InMemoryInfo};
 
 use super::{DistributedPipelineNode, PipelineOutput, RunningPipelineNode};
 use crate::{
-    plan::PlanID, scheduling::task::{SchedulingStrategy, SwordfishTask}, stage::{StageContext, StageID}, utils::channel::{create_channel, Sender}
+    pipeline_node::NodeID,
+    plan::PlanID,
+    scheduling::task::{SchedulingStrategy, SwordfishTask},
+    stage::{StageContext, StageID},
+    utils::channel::{create_channel, Sender},
 };
 
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct InMemorySourceNode {
     plan_id: PlanID,
     stage_id: StageID,
-    node_id: usize,
+    node_id: NodeID,
     config: Arc<DaftExecutionConfig>,
     info: InMemoryInfo,
     plan: LocalPhysicalPlanRef,
@@ -47,25 +51,59 @@ impl InMemorySourceNode {
     }
 
     async fn execution_loop(
-        plan: LocalPhysicalPlanRef,
-        config: Arc<DaftExecutionConfig>,
-        in_memory_info: InMemoryInfo,
-        psets: Arc<HashMap<String, Vec<PartitionRef>>>,
+        self,
         result_tx: Sender<PipelineOutput<SwordfishTask>>,
     ) -> DaftResult<()> {
-        let partition_refs = psets.get(&in_memory_info.cache_key).expect("InMemorySourceNode::execution_loop: Expected in-memory input is not available in partition set").clone();
+        let partition_refs = self.input_psets.get(&self.info.cache_key).expect("InMemorySourceNode::execution_loop: Expected in-memory input is not available in partition set").clone();
+
         for partition_ref in partition_refs {
-            let task = make_task_for_partition_ref(
-                plan.clone(),
-                partition_ref,
-                in_memory_info.cache_key.clone(),
-                config.clone(),
-            )?;
+            let task = self.make_task_for_partition_ref(partition_ref)?;
             if result_tx.send(PipelineOutput::Task(task)).await.is_err() {
                 break;
             }
         }
         Ok(())
+    }
+
+    fn make_task_for_partition_ref(
+        &self,
+        partition_ref: PartitionRef,
+    ) -> DaftResult<SwordfishTask> {
+        let info = InMemoryInfo::new(
+            self.plan.schema().clone(),
+            self.info.cache_key.clone(),
+            None,
+            1,
+            partition_ref.size_bytes()?.expect("make_task_for_partition_ref: Expect that the input partition ref for a in-memory source node has a known size"),
+            partition_ref.num_rows()?,
+            None,
+            None,
+        );
+        let in_memory_source = LocalPhysicalPlan::in_memory_scan(info, StatsState::NotMaterialized);
+        // the first operator of physical_plan has to be a scan
+        let transformed_plan = self
+            .plan
+            .clone()
+            .transform_up(|p| match p.as_ref() {
+                LocalPhysicalPlan::PlaceholderScan(_) => {
+                    Ok(Transformed::yes(in_memory_source.clone()))
+                }
+                _ => Ok(Transformed::no(p)),
+            })?
+            .data;
+        let psets = HashMap::from([(self.info.cache_key.clone(), vec![partition_ref])]);
+        let task = SwordfishTask::new(
+            self.plan_id.clone(),
+            self.stage_id.clone(),
+            self.node_id,
+            transformed_plan,
+            self.config.clone(),
+            psets,
+            // TODO: Replace with WorkerAffinity based on the psets location
+            // Need to get that from `ray.experimental.get_object_locations(object_refs)`
+            SchedulingStrategy::Spread,
+        );
+        Ok(task)
     }
 }
 
@@ -80,51 +118,9 @@ impl DistributedPipelineNode for InMemorySourceNode {
 
     fn start(&mut self, stage_context: &mut StageContext) -> RunningPipelineNode {
         let (result_tx, result_rx) = create_channel(1);
-        let execution_loop = Self::execution_loop(
-            self.plan.clone(),
-            self.config.clone(),
-            self.info.clone(),
-            self.input_psets.clone(),
-            result_tx,
-        );
+        let execution_loop = self.clone().execution_loop(result_tx);
         stage_context.joinset.spawn(execution_loop);
 
         RunningPipelineNode::new(result_rx)
     }
-}
-
-fn make_task_for_partition_ref(
-    plan: LocalPhysicalPlanRef,
-    partition_ref: PartitionRef,
-    cache_key: String,
-    config: Arc<DaftExecutionConfig>,
-) -> DaftResult<SwordfishTask> {
-    let info = InMemoryInfo::new(
-        plan.schema().clone(),
-        cache_key.clone(),
-        None,
-        1,
-        partition_ref.size_bytes()?.expect("make_task_for_partition_ref: Expect that the input partition ref for a in-memory source node has a known size"),
-        partition_ref.num_rows()?,
-        None,
-        None,
-    );
-    let in_memory_source = LocalPhysicalPlan::in_memory_scan(info, StatsState::NotMaterialized);
-    // the first operator of physical_plan has to be a scan
-    let transformed_plan = plan
-        .transform_up(|p| match p.as_ref() {
-            LocalPhysicalPlan::PlaceholderScan(_) => Ok(Transformed::yes(in_memory_source.clone())),
-            _ => Ok(Transformed::no(p)),
-        })?
-        .data;
-    let psets = HashMap::from([(cache_key, vec![partition_ref])]);
-    let task = SwordfishTask::new(
-        transformed_plan,
-        config,
-        psets,
-        // TODO: Replace with WorkerAffinity based on the psets location
-        // Need to get that from `ray.experimental.get_object_locations(object_refs)`
-        SchedulingStrategy::Spread,
-    );
-    Ok(task)
 }

--- a/src/daft-distributed/src/pipeline_node/in_memory_source.rs
+++ b/src/daft-distributed/src/pipeline_node/in_memory_source.rs
@@ -92,16 +92,19 @@ impl InMemorySourceNode {
             })?
             .data;
         let psets = HashMap::from([(self.info.cache_key.clone(), vec![partition_ref])]);
+        let context = HashMap::from([
+            ("plan_id".to_string(), self.plan_id.to_string()),
+            ("stage_id".to_string(), format!("{}", self.stage_id)),
+            ("node_id".to_string(), format!("{}", self.node_id)),
+        ]);
         let task = SwordfishTask::new(
-            self.plan_id.clone(),
-            self.stage_id.clone(),
-            self.node_id,
             transformed_plan,
             self.config.clone(),
             psets,
             // TODO: Replace with WorkerAffinity based on the psets location
             // Need to get that from `ray.experimental.get_object_locations(object_refs)`
             SchedulingStrategy::Spread,
+            context,
         );
         Ok(task)
     }

--- a/src/daft-distributed/src/pipeline_node/intermediate.rs
+++ b/src/daft-distributed/src/pipeline_node/intermediate.rs
@@ -161,10 +161,12 @@ fn make_task_for_materialized_output(
         })?
         .data;
     let psets = HashMap::from([(cache_key, vec![partition_ref])]);
+    let context = HashMap::from([
+        ("plan_id".to_string(), plan_id.to_string()),
+        ("stage_id".to_string(), format!("{}", stage_id)),
+        ("node_id".to_string(), format!("{}", node_id)),
+    ]);
     let task = SwordfishTask::new(
-        plan_id,
-        stage_id,
-        node_id,
         transformed_plan,
         config,
         psets,
@@ -172,6 +174,7 @@ fn make_task_for_materialized_output(
             worker_id,
             soft: true,
         },
+        context,
     );
     Ok(task)
 }
@@ -190,14 +193,17 @@ fn append_plan_to_task(
             _ => Ok(Transformed::no(p)),
         })?
         .data;
+    let context = HashMap::from([
+        ("plan_id".to_string(), plan_id.to_string()),
+        ("stage_id".to_string(), format!("{stage_id}")),
+        ("node_id".to_string(), format!("{node_id}")),
+    ]);
     let task = SwordfishTask::new(
-        plan_id,
-        stage_id,
-        node_id,
         transformed_plan,
         config,
         Default::default(),
         SchedulingStrategy::Spread,
+        context,
     );
     Ok(task)
 }

--- a/src/daft-distributed/src/pipeline_node/intermediate.rs
+++ b/src/daft-distributed/src/pipeline_node/intermediate.rs
@@ -28,6 +28,7 @@ pub(crate) struct IntermediateNode {
 
 impl IntermediateNode {
     #[allow(dead_code)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         plan_id: PlanID,
         stage_id: StageID,
@@ -190,9 +191,9 @@ fn append_plan_to_task(
         })?
         .data;
     let task = SwordfishTask::new(
-        plan_id.clone(),
-        stage_id.clone(),
-        node_id.clone(),
+        plan_id,
+        stage_id,
+        node_id,
         transformed_plan,
         config,
         Default::default(),

--- a/src/daft-distributed/src/pipeline_node/intermediate.rs
+++ b/src/daft-distributed/src/pipeline_node/intermediate.rs
@@ -9,13 +9,16 @@ use futures::StreamExt;
 
 use super::{DistributedPipelineNode, MaterializedOutput, PipelineOutput, RunningPipelineNode};
 use crate::{
+    plan::PlanID,
     scheduling::task::{SchedulingStrategy, SwordfishTask},
-    stage::StageContext,
+    stage::{StageContext, StageID},
     utils::channel::{create_channel, Sender},
 };
 
 #[allow(dead_code)]
 pub(crate) struct IntermediateNode {
+    plan_id: PlanID,
+    stage_id: StageID,
     node_id: usize,
     config: Arc<DaftExecutionConfig>,
     plan: LocalPhysicalPlanRef,
@@ -25,12 +28,16 @@ pub(crate) struct IntermediateNode {
 impl IntermediateNode {
     #[allow(dead_code)]
     pub fn new(
+        plan_id: PlanID,
+        stage_id: StageID,
         node_id: usize,
         config: Arc<DaftExecutionConfig>,
         plan: LocalPhysicalPlanRef,
         children: Vec<Box<dyn DistributedPipelineNode>>,
     ) -> Self {
         Self {
+            plan_id,
+            stage_id,
             node_id,
             config,
             plan,

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -151,11 +151,12 @@ fn make_task_with_limit(
         LocalPhysicalPlan::limit(in_memory_source, limit as i64, StatsState::NotMaterialized);
 
     let mpset = HashMap::from([(node_id.to_string(), vec![partition])]);
-
+    let context = HashMap::from([
+        ("plan_id".to_string(), plan_id.to_string()),
+        ("stage_id".to_string(), format!("{stage_id}")),
+        ("node_id".to_string(), format!("{node_id}")),
+    ]);
     let task = SwordfishTask::new(
-        plan_id,
-        stage_id,
-        node_id,
         limit_plan,
         config,
         mpset,
@@ -163,6 +164,7 @@ fn make_task_with_limit(
             worker_id,
             soft: true,
         },
+        context,
     );
     Ok(task)
 }

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -32,6 +32,7 @@ pub(crate) struct LimitNode {
 
 impl LimitNode {
     #[allow(dead_code)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         plan_id: PlanID,
         stage_id: StageID,
@@ -52,6 +53,7 @@ impl LimitNode {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn execution_loop(
         plan_id: PlanID,
         stage_id: StageID,
@@ -60,7 +62,6 @@ impl LimitNode {
         result_tx: Sender<PipelineOutput<SwordfishTask>>,
         mut remaining_limit: usize,
         scheduler_handle: SchedulerHandle<SwordfishTask>,
-
         schema: SchemaRef,
         config: Arc<DaftExecutionConfig>,
     ) -> DaftResult<()> {

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -9,16 +9,16 @@ use futures::StreamExt;
 
 use super::{DistributedPipelineNode, MaterializedOutput, PipelineOutput, RunningPipelineNode};
 use crate::{
-    scheduling::{
+    plan::PlanID, scheduling::{
         scheduler::SchedulerHandle,
         task::{SchedulingStrategy, SwordfishTask},
-    },
-    stage::StageContext,
-    utils::channel::{create_channel, Sender},
+    }, stage::{StageContext, StageID}, utils::channel::{create_channel, Sender}
 };
 
 #[allow(dead_code)]
 pub(crate) struct LimitNode {
+    plan_id: PlanID,
+    stage_id: StageID,
     node_id: usize,
     limit: usize,
     schema: SchemaRef,
@@ -29,6 +29,8 @@ pub(crate) struct LimitNode {
 impl LimitNode {
     #[allow(dead_code)]
     pub fn new(
+        plan_id: PlanID,
+        stage_id: StageID,
         node_id: usize,
         limit: usize,
         schema: SchemaRef,
@@ -36,6 +38,8 @@ impl LimitNode {
         child: Box<dyn DistributedPipelineNode>,
     ) -> Self {
         Self {
+            plan_id,
+            stage_id,
             node_id,
             limit,
             schema,

--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -23,7 +23,6 @@ mod translate;
 pub(crate) use translate::logical_plan_to_pipeline_node;
 pub(crate) type NodeID = usize;
 
-
 /// The materialized output of a completed pipeline node.
 /// Contains both the partition data as well as metadata about the partition.
 /// Right now, the only metadata is the worker id that has it so we can try

--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -21,6 +21,8 @@ mod scan_source;
 mod translate;
 
 pub(crate) use translate::logical_plan_to_pipeline_node;
+pub(crate) type NodeID = usize;
+
 
 /// The materialized output of a completed pipeline node.
 /// Contains both the partition data as well as metadata about the partition.

--- a/src/daft-distributed/src/pipeline_node/scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/scan_source.rs
@@ -89,14 +89,17 @@ impl ScanSourceNode {
             .data;
 
         let psets = HashMap::new();
+        let context = HashMap::from([
+            ("plan_id".to_string(), self.plan_id.to_string()),
+            ("stage_id".to_string(), format!("{}", self.stage_id)),
+            ("node_id".to_string(), format!("{}", self.node_id)),
+        ]);
         let task = SwordfishTask::new(
-            self.plan_id.clone(),
-            self.stage_id.clone(),
-            self.node_id,
             transformed_plan,
             self.config.clone(),
             psets,
             SchedulingStrategy::Spread,
+            context,
         );
         Ok(task)
     }
@@ -112,16 +115,19 @@ impl ScanSourceNode {
                 _ => Ok(Transformed::no(p)),
             })?
             .data;
+        let context = HashMap::from([
+            ("plan_id".to_string(), self.plan_id.to_string()),
+            ("stage_id".to_string(), format!("{}", self.stage_id)),
+            ("node_id".to_string(), format!("{}", self.node_id)),
+        ]);
 
         let psets = HashMap::new();
         let task = SwordfishTask::new(
-            self.plan_id.clone(),
-            self.stage_id.clone(),
-            self.node_id,
             transformed_plan,
             self.config.clone(),
             psets,
             SchedulingStrategy::Spread,
+            context,
         );
         Ok(task)
     }

--- a/src/daft-distributed/src/pipeline_node/scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/scan_source.rs
@@ -9,14 +9,14 @@ use daft_logical_plan::stats::StatsState;
 
 use super::{DistributedPipelineNode, PipelineOutput, RunningPipelineNode};
 use crate::{
-    scheduling::task::{SchedulingStrategy, SwordfishTask},
-    stage::StageContext,
-    utils::channel::{create_channel, Sender},
+    plan::PlanID, scheduling::task::{SchedulingStrategy, SwordfishTask}, stage::{StageContext, StageID}, utils::channel::{create_channel, Sender}
 };
 
 #[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct ScanSourceNode {
+    plan_id: PlanID,
+    stage_id: StageID,
     node_id: usize,
     config: Arc<DaftExecutionConfig>,
     plan: LocalPhysicalPlanRef,
@@ -27,6 +27,8 @@ pub(crate) struct ScanSourceNode {
 impl ScanSourceNode {
     #[allow(dead_code)]
     pub fn new(
+        plan_id: PlanID,
+        stage_id: StageID,
         node_id: usize,
         config: Arc<DaftExecutionConfig>,
         plan: LocalPhysicalPlanRef,
@@ -34,6 +36,8 @@ impl ScanSourceNode {
         scan_tasks: Arc<Vec<ScanTaskLikeRef>>,
     ) -> Self {
         Self {
+            plan_id,
+            stage_id,
             node_id,
             config,
             plan,

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -11,18 +11,26 @@ use daft_logical_plan::{
     LogicalPlanRef, SourceInfo,
 };
 
-use crate::pipeline_node::{
-    in_memory_source::InMemorySourceNode, intermediate::IntermediateNode, limit::LimitNode,
-    scan_source::ScanSourceNode, DistributedPipelineNode,
+use crate::{
+    pipeline_node::{
+        in_memory_source::InMemorySourceNode, intermediate::IntermediateNode, limit::LimitNode,
+        scan_source::ScanSourceNode, DistributedPipelineNode,
+    },
+    plan::PlanID,
+    stage::StageID,
 };
 
 pub(crate) fn logical_plan_to_pipeline_node(
+    plan_id: PlanID,
+    stage_id: StageID,
     plan: LogicalPlanRef,
     config: Arc<DaftExecutionConfig>,
     psets: Arc<HashMap<String, Vec<PartitionRef>>>,
 ) -> DaftResult<Box<dyn DistributedPipelineNode>> {
     #[allow(dead_code)]
     struct PipelineNodeBoundarySplitter {
+        plan_id: PlanID,
+        stage_id: StageID,
         root: LogicalPlanRef,
         current_nodes: Vec<Box<dyn DistributedPipelineNode>>,
         config: Arc<DaftExecutionConfig>,
@@ -39,6 +47,7 @@ pub(crate) fn logical_plan_to_pipeline_node(
 
         fn create_node(
             &mut self,
+
             logical_plan: LogicalPlanRef,
             current_nodes: Vec<Box<dyn DistributedPipelineNode>>,
         ) -> DaftResult<Box<dyn DistributedPipelineNode>> {
@@ -46,6 +55,8 @@ pub(crate) fn logical_plan_to_pipeline_node(
             if !current_nodes.is_empty() {
                 let translated = translate(&logical_plan)?;
                 return Ok(Box::new(IntermediateNode::new(
+                    self.plan_id.clone(),
+                    self.stage_id.clone(),
                     self.get_next_node_id(),
                     self.config.clone(),
                     translated,
@@ -58,6 +69,8 @@ pub(crate) fn logical_plan_to_pipeline_node(
             let translated = translate(&logical_plan)?;
             let node = match inputs {
                 PipelineInput::InMemorySource { info } => Box::new(InMemorySourceNode::new(
+                    self.plan_id.clone(),
+                    self.stage_id.clone(),
                     self.get_next_node_id(),
                     self.config.clone(),
                     info,
@@ -69,6 +82,8 @@ pub(crate) fn logical_plan_to_pipeline_node(
                     pushdowns,
                     scan_tasks,
                 } => Box::new(ScanSourceNode::new(
+                    self.plan_id.clone(),
+                    self.stage_id.clone(),
                     self.get_next_node_id(),
                     self.config.clone(),
                     translated,
@@ -93,6 +108,8 @@ pub(crate) fn logical_plan_to_pipeline_node(
                     let current_nodes = std::mem::take(&mut self.current_nodes);
                     let input_node = self.create_node(node.clone(), current_nodes)?;
                     let limit_node = Box::new(LimitNode::new(
+                        self.plan_id.clone(),
+                        self.stage_id.clone(),
                         self.get_next_node_id(),
                         limit.limit as usize,
                         node.schema(),
@@ -118,6 +135,8 @@ pub(crate) fn logical_plan_to_pipeline_node(
     }
 
     let mut splitter = PipelineNodeBoundarySplitter {
+        plan_id,
+        stage_id,
         root: plan.clone(),
         current_nodes: vec![],
         config,
@@ -261,8 +280,11 @@ mod tests {
             Field::new("value", DataType::Int64),
         ];
         let plan = dummy_in_memory_scan(fields).unwrap().build();
-
+        let plan_id = Arc::from("foo");
+        let stage_id = StageID::new(0);
         let pipeline_node = logical_plan_to_pipeline_node(
+            plan_id,
+            stage_id,
             plan,
             Arc::new(DaftExecutionConfig::default()),
             Arc::new(HashMap::new()),
@@ -285,8 +307,11 @@ mod tests {
             .unwrap() // To fill scan node with tasks
             .build();
         eprintln!("{}", plan.repr_ascii(false));
-
+        let plan_id = Arc::from("foo");
+        let stage_id = StageID::new(0);
         let pipeline_node = logical_plan_to_pipeline_node(
+            plan_id,
+            stage_id,
             plan,
             Arc::new(DaftExecutionConfig::default()),
             Arc::new(HashMap::new()),
@@ -308,8 +333,11 @@ mod tests {
             .limit(20, false)?
             .optimize()? // To fill scan node with tasks
             .build();
-
+        let plan_id = Arc::from("foo");
+        let stage_id = StageID::new(0);
         let pipeline_node = logical_plan_to_pipeline_node(
+            plan_id,
+            stage_id,
             plan,
             Arc::new(DaftExecutionConfig::default()),
             Arc::new(HashMap::new()),
@@ -339,8 +367,11 @@ mod tests {
                 .alias("group_value")])?
             .optimize()? // To fill scan node with tasks
             .build();
-
+        let plan_id = Arc::from("foo");
+        let stage_id = StageID::new(0);
         let pipeline_node = logical_plan_to_pipeline_node(
+            plan_id,
+            stage_id,
             plan,
             Arc::new(DaftExecutionConfig::default()),
             Arc::new(HashMap::new()),
@@ -369,8 +400,11 @@ mod tests {
             .limit(20, false)?
             .select(vec![resolved_col("group_value")])?
             .build();
-
+        let plan_id = Arc::from("foo");
+        let stage_id = StageID::new(0);
         let pipeline_node = logical_plan_to_pipeline_node(
+            plan_id,
+            stage_id,
             plan,
             Arc::new(DaftExecutionConfig::default()),
             Arc::new(HashMap::new()),

--- a/src/daft-distributed/src/plan/mod.rs
+++ b/src/daft-distributed/src/plan/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 mod runner;
-pub(crate) use runner::PlanRunner;
+pub(crate) use runner::{PlanID, PlanRunner};
 
 static PLAN_ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 

--- a/src/daft-distributed/src/plan/runner.rs
+++ b/src/daft-distributed/src/plan/runner.rs
@@ -20,17 +20,25 @@ use crate::{
         runtime::get_or_init_runtime,
     },
 };
+pub type PlanID = Arc<str>;
 
+#[derive(Clone)]
 pub(crate) struct PlanRunner<W: Worker<Task = SwordfishTask>> {
     worker_manager: Arc<dyn WorkerManager<Worker = W>>,
+    plan_id: PlanID,
 }
 
 impl<W: Worker<Task = SwordfishTask>> PlanRunner<W> {
     pub fn new(worker_manager: Arc<dyn WorkerManager<Worker = W>>) -> Self {
-        Self { worker_manager }
+        let plan_id = uuid::Uuid::new_v4().to_string();
+        Self {
+            worker_manager,
+            plan_id: Arc::from(plan_id),
+        }
     }
 
     async fn execute_stages(
+        &self,
         stage_plan: StagePlan,
         psets: HashMap<String, Vec<PartitionRef>>,
         config: Arc<DaftExecutionConfig>,
@@ -45,7 +53,12 @@ impl<W: Worker<Task = SwordfishTask>> PlanRunner<W> {
         }
 
         let stage = stage_plan.get_root_stage();
-        let running_stage = stage.run_stage(psets, config, scheduler_handle.clone())?;
+        let running_stage = stage.run_stage(
+            self.plan_id.clone(),
+            psets,
+            config,
+            scheduler_handle.clone(),
+        )?;
         let mut materialized_result_stream = running_stage.materialize(scheduler_handle);
         while let Some(result) = materialized_result_stream.next().await {
             if sender.send(result?).await.is_err() {
@@ -56,7 +69,7 @@ impl<W: Worker<Task = SwordfishTask>> PlanRunner<W> {
     }
 
     pub fn run_plan(
-        &self,
+        self: &Arc<Self>,
         plan: &DistributedPhysicalPlan,
         psets: HashMap<String, Vec<PartitionRef>>,
     ) -> DaftResult<PlanResult> {
@@ -66,13 +79,15 @@ impl<W: Worker<Task = SwordfishTask>> PlanRunner<W> {
         let runtime = get_or_init_runtime();
         let (result_sender, result_receiver) = create_channel(1);
 
+        let this = self.clone();
+
         let joinset = runtime.block_on_current_thread(async move {
             let mut joinset = create_join_set();
             let scheduler_handle =
                 spawn_default_scheduler_actor(self.worker_manager.clone(), &mut joinset);
 
             joinset.spawn(async move {
-                Self::execute_stages(stage_plan, psets, config, scheduler_handle, result_sender)
+                this.execute_stages(stage_plan, psets, config, scheduler_handle, result_sender)
                     .await
             });
             joinset

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -83,7 +83,7 @@ impl_bincode_py_state_serialization!(PyDistributedPhysicalPlan);
 
 #[pyclass(module = "daft.daft", name = "DistributedPhysicalPlanRunner", frozen)]
 struct PyDistributedPhysicalPlanRunner {
-    runner: PlanRunner<RaySwordfishWorker>,
+    runner: Arc<PlanRunner<RaySwordfishWorker>>,
 }
 
 #[pymethods]
@@ -92,7 +92,7 @@ impl PyDistributedPhysicalPlanRunner {
     fn new() -> PyResult<Self> {
         let worker_manager = RayWorkerManager::try_new()?;
         Ok(Self {
-            runner: PlanRunner::new(Arc::new(worker_manager)),
+            runner: Arc::new(PlanRunner::new(Arc::new(worker_manager))),
         })
     }
 

--- a/src/daft-distributed/src/python/ray/task.rs
+++ b/src/daft-distributed/src/python/ray/task.rs
@@ -150,6 +150,11 @@ impl RaySwordfishTask {
 
 #[pymethods]
 impl RaySwordfishTask {
+    
+    fn task_context(&self) -> HashMap<String, String> {
+        self.task.task_context().clone().into()
+    }
+    
     fn plan(&self) -> PyResult<PyLocalPhysicalPlan> {
         let plan = self.task.plan();
         Ok(PyLocalPhysicalPlan { plan })

--- a/src/daft-distributed/src/python/ray/task.rs
+++ b/src/daft-distributed/src/python/ray/task.rs
@@ -150,8 +150,8 @@ impl RaySwordfishTask {
 
 #[pymethods]
 impl RaySwordfishTask {
-    fn task_context(&self) -> HashMap<String, String> {
-        self.task.task_context().clone().into()
+    fn context(&self) -> HashMap<String, String> {
+        self.task.context().clone()
     }
 
     fn plan(&self) -> PyResult<PyLocalPhysicalPlan> {

--- a/src/daft-distributed/src/python/ray/task.rs
+++ b/src/daft-distributed/src/python/ray/task.rs
@@ -150,11 +150,10 @@ impl RaySwordfishTask {
 
 #[pymethods]
 impl RaySwordfishTask {
-    
     fn task_context(&self) -> HashMap<String, String> {
         self.task.task_context().clone().into()
     }
-    
+
     fn plan(&self) -> PyResult<PyLocalPhysicalPlan> {
         let plan = self.task.plan();
         Ok(PyLocalPhysicalPlan { plan })

--- a/src/daft-distributed/src/python/ray/worker.rs
+++ b/src/daft-distributed/src/python/ray/worker.rs
@@ -9,7 +9,7 @@ use pyo3::prelude::*;
 use super::{task::RayTaskResultHandle, RaySwordfishTask};
 use crate::scheduling::{
     scheduler::SchedulableTask,
-    task::{SwordfishTask, Task, TaskDetails, TaskId, TaskResultHandleAwaiter},
+    task::{SwordfishTask, Task, TaskDetails, TaskID, TaskResultHandleAwaiter},
     worker::{Worker, WorkerId},
 };
 
@@ -21,7 +21,7 @@ pub(crate) struct RaySwordfishWorker {
     num_cpus: usize,
     #[allow(dead_code)]
     total_memory_bytes: usize,
-    active_task_details: Arc<Mutex<HashMap<TaskId, TaskDetails>>>,
+    active_task_details: Arc<Mutex<HashMap<TaskID, TaskDetails>>>,
 }
 
 #[pymethods]
@@ -45,7 +45,7 @@ impl RaySwordfishWorker {
 
 #[allow(dead_code)]
 impl RaySwordfishWorker {
-    pub fn mark_task_finished(&self, task_id: &TaskId) {
+    pub fn mark_task_finished(&self, task_id: &TaskID) {
         self.active_task_details
             .lock()
             .expect("Active task ids should be present")
@@ -129,7 +129,7 @@ impl Worker for RaySwordfishWorker {
         self.total_num_cpus() - self.active_num_cpus()
     }
 
-    fn active_task_details(&self) -> HashMap<TaskId, TaskDetails> {
+    fn active_task_details(&self) -> HashMap<TaskID, TaskDetails> {
         self.active_task_details
             .lock()
             .expect("Active task details should be present")

--- a/src/daft-distributed/src/python/ray/worker.rs
+++ b/src/daft-distributed/src/python/ray/worker.rs
@@ -61,7 +61,7 @@ impl RaySwordfishWorker {
         let mut task_handles = Vec::with_capacity(tasks.len());
         for task in tasks {
             let (task, result_tx, cancel_token) = task.into_inner();
-            let task_id = task.task_id().clone();
+            let task_id: Arc<str> = Arc::from(task.task_id().to_string());
             let task_details = TaskDetails::from(&task);
 
             let ray_swordfish_task = RaySwordfishTask::new(task);
@@ -75,7 +75,7 @@ impl RaySwordfishWorker {
             self.active_task_details
                 .lock()
                 .expect("Active task details should be present")
-                .insert(task_id.clone(), task_details);
+                .insert(Arc::from(task_id.to_string()), task_details);
 
             let task_locals = task_locals.clone_ref(py);
             let ray_task_result_handle = RayTaskResultHandle::new(

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -6,7 +6,7 @@ use pyo3::prelude::*;
 use super::{task::RayTaskResultHandle, worker::RaySwordfishWorker};
 use crate::scheduling::{
     scheduler::SchedulableTask,
-    task::{SwordfishTask, TaskId, TaskResultHandleAwaiter},
+    task::{SwordfishTask, TaskID, TaskResultHandleAwaiter},
     worker::{Worker, WorkerId, WorkerManager},
 };
 
@@ -65,7 +65,7 @@ impl WorkerManager for RayWorkerManager {
         &self.ray_workers
     }
 
-    fn mark_task_finished(&self, task_id: &TaskId, worker_id: &WorkerId) {
+    fn mark_task_finished(&self, task_id: &TaskID, worker_id: &WorkerId) {
         self.ray_workers
             .get(worker_id)
             .expect("Worker should be present in RayWorkerManager")

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -4,7 +4,7 @@ use common_error::{DaftError, DaftResult};
 
 use super::{
     scheduler::{ScheduledTask, WorkerSnapshot},
-    task::{Task, TaskId},
+    task::{Task, TaskID},
     worker::{Worker, WorkerId, WorkerManager},
 };
 use crate::utils::{
@@ -40,7 +40,7 @@ impl<W: Worker> DispatcherActor<W> {
         scheduled_tasks: Vec<ScheduledTask<W::Task>>,
         worker_manager: &Arc<dyn WorkerManager<Worker = W>>,
         running_tasks: &mut JoinSet<()>,
-        running_tasks_by_id: &mut HashMap<JoinSetId, (TaskId, WorkerId)>,
+        running_tasks_by_id: &mut HashMap<JoinSetId, (TaskID, WorkerId)>,
     ) -> DaftResult<()> {
         let mut worker_to_tasks = HashMap::new();
 
@@ -67,7 +67,7 @@ impl<W: Worker> DispatcherActor<W> {
     async fn handle_finished_task(
         finished_joinset_id: JoinSetId,
         finished_task_result: DaftResult<()>,
-        running_tasks_by_id: &mut HashMap<JoinSetId, (TaskId, WorkerId)>,
+        running_tasks_by_id: &mut HashMap<JoinSetId, (TaskID, WorkerId)>,
         running_tasks: &mut JoinSet<()>,
         worker_manager: &Arc<dyn WorkerManager<Worker = W>>,
         worker_update_sender: &Sender<Vec<WorkerSnapshot>>,

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -1,4 +1,7 @@
-use std::collections::{BinaryHeap, HashMap};
+use std::{
+    collections::{BinaryHeap, HashMap},
+    sync::Arc,
+};
 
 use super::{SchedulableTask, ScheduledTask, Scheduler, WorkerSnapshot};
 use crate::scheduling::{
@@ -86,7 +89,10 @@ impl<T: Task> Scheduler<T> for DefaultScheduler<T> {
                     .get_mut(&worker_id)
                     .expect("Worker should be present in DefaultScheduler")
                     .active_task_details
-                    .insert(task.task_id().clone(), TaskDetails::from(&task.task));
+                    .insert(
+                        Arc::from(task.task_id().to_string()),
+                        TaskDetails::from(&task.task),
+                    );
                 scheduled.push(ScheduledTask { task, worker_id });
             } else {
                 unscheduled.push(task);

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -54,7 +54,7 @@ impl<T: Task> SchedulableTask<T> {
     }
 
     #[allow(dead_code)]
-    pub fn task_id(&self) -> &TaskID {
+    pub fn task_id(&self) -> &str {
         self.task.task_id()
     }
 

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, collections::HashMap};
 
 use super::{
-    task::{SchedulingStrategy, Task, TaskDetails, TaskId},
+    task::{SchedulingStrategy, Task, TaskDetails, TaskID},
     worker::{Worker, WorkerId},
 };
 use crate::{pipeline_node::MaterializedOutput, utils::channel::OneshotSender};
@@ -54,7 +54,7 @@ impl<T: Task> SchedulableTask<T> {
     }
 
     #[allow(dead_code)]
-    pub fn task_id(&self) -> &TaskId {
+    pub fn task_id(&self) -> &TaskID {
         self.task.task_id()
     }
 
@@ -112,7 +112,7 @@ impl<T: Task> ScheduledTask<T> {
 pub(super) struct WorkerSnapshot {
     worker_id: WorkerId,
     total_num_cpus: usize,
-    active_task_details: HashMap<TaskId, TaskDetails>,
+    active_task_details: HashMap<TaskID, TaskDetails>,
 }
 
 #[allow(dead_code)]
@@ -120,7 +120,7 @@ impl WorkerSnapshot {
     pub fn new(
         worker_id: WorkerId,
         total_num_cpus: usize,
-        active_task_details: HashMap<TaskId, TaskDetails>,
+        active_task_details: HashMap<TaskID, TaskDetails>,
     ) -> Self {
         Self {
             worker_id,

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -170,7 +170,7 @@ impl<T: Task> SchedulerHandle<T> {
         let (result_tx, result_rx) = create_oneshot_channel();
         let cancel_token = CancellationToken::new();
 
-        let task_id = task.task_id().clone();
+        let task_id = Arc::from(task.task_id().to_string());
         let schedulable_task = SchedulableTask::new(task, result_tx, cancel_token.clone());
         let submitted_task = SubmittedTask::new(task_id, result_rx, Some(cancel_token));
 

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -17,7 +17,7 @@ use crate::{
     pipeline_node::MaterializedOutput,
     scheduling::{
         dispatcher::{DispatcherActor, DispatcherHandle},
-        task::{Task, TaskId},
+        task::{Task, TaskID},
         worker::{Worker, WorkerManager},
     },
     utils::{
@@ -192,7 +192,7 @@ impl<T: Task> SchedulerHandle<T> {
 
 #[derive(Debug)]
 pub(crate) struct SubmittedTask {
-    _task_id: TaskId,
+    _task_id: TaskID,
     result_rx: OneshotReceiver<DaftResult<Vec<MaterializedOutput>>>,
     cancel_token: Option<CancellationToken>,
     finished: bool,
@@ -200,7 +200,7 @@ pub(crate) struct SubmittedTask {
 
 impl SubmittedTask {
     fn new(
-        task_id: TaskId,
+        task_id: TaskID,
         result_rx: OneshotReceiver<DaftResult<Vec<MaterializedOutput>>>,
         cancel_token: Option<CancellationToken>,
     ) -> Self {
@@ -213,7 +213,7 @@ impl SubmittedTask {
     }
 
     #[allow(dead_code)]
-    pub fn id(&self) -> &TaskId {
+    pub fn id(&self) -> &TaskID {
         &self._task_id
     }
 }

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -52,6 +52,7 @@ pub(crate) trait Task: Send + Sync + Debug + 'static {
 }
 
 #[derive(Debug, Clone)]
+#[allow(clippy::struct_field_names)]
 pub(crate) struct TaskContext {
     plan_id: PlanID,
     stage_id: StageID,
@@ -61,7 +62,7 @@ pub(crate) struct TaskContext {
 
 impl From<TaskContext> for HashMap<String, String> {
     fn from(value: TaskContext) -> Self {
-        let mut hmap = HashMap::with_capacity(4);
+        let mut hmap = Self::with_capacity(4);
         hmap.insert("plan_id".to_string(), value.plan_id.to_string());
         hmap.insert("stage_id".to_string(), value.stage_id.to_string());
         hmap.insert("node_id".to_string(), value.node_id.to_string());
@@ -159,7 +160,7 @@ impl SwordfishTask {
     pub fn psets(&self) -> &HashMap<String, Vec<PartitionRef>> {
         &self.psets
     }
-    
+
     pub fn task_context(&self) -> &TaskContext {
         &self.task_context
     }

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -59,6 +59,17 @@ pub(crate) struct TaskContext {
     task_id: TaskID,
 }
 
+impl From<TaskContext> for HashMap<String, String> {
+    fn from(value: TaskContext) -> Self {
+        let mut hmap = HashMap::with_capacity(4);
+        hmap.insert("plan_id".to_string(), value.plan_id.to_string());
+        hmap.insert("stage_id".to_string(), value.stage_id.to_string());
+        hmap.insert("node_id".to_string(), value.node_id.to_string());
+        hmap.insert("task_id".to_string(), value.task_id.to_string());
+        hmap
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct TaskDetails {
     #[allow(dead_code)]
@@ -147,6 +158,10 @@ impl SwordfishTask {
 
     pub fn psets(&self) -> &HashMap<String, Vec<PartitionRef>> {
         &self.psets
+    }
+    
+    pub fn task_context(&self) -> &TaskContext {
+        &self.task_context
     }
 }
 

--- a/src/daft-distributed/src/scheduling/worker.rs
+++ b/src/daft-distributed/src/scheduling/worker.rs
@@ -90,7 +90,7 @@ pub(super) mod tests {
                     }
 
                     result.push(TaskResultHandleAwaiter::new(
-                        task.task_id().clone(),
+                        Arc::from(task.task_id().to_string()),
                         worker_id.clone(),
                         MockTaskResultHandle::new(task),
                         result_tx,
@@ -153,10 +153,10 @@ pub(super) mod tests {
         }
 
         pub fn add_active_task(&self, task: &impl Task) {
-            self.active_task_details
-                .lock()
-                .unwrap()
-                .insert(task.task_id().clone(), TaskDetails::from(task));
+            self.active_task_details.lock().unwrap().insert(
+                Arc::from(task.task_id().to_string()),
+                TaskDetails::from(task),
+            );
         }
 
         pub fn shutdown(&self) {

--- a/src/daft-distributed/src/scheduling/worker.rs
+++ b/src/daft-distributed/src/scheduling/worker.rs
@@ -4,7 +4,7 @@ use common_error::DaftResult;
 
 use super::{
     scheduler::SchedulableTask,
-    task::{Task, TaskDetails, TaskId, TaskResultHandle, TaskResultHandleAwaiter},
+    task::{Task, TaskDetails, TaskID, TaskResultHandle, TaskResultHandleAwaiter},
 };
 
 pub(crate) type WorkerId = Arc<str>;
@@ -15,7 +15,7 @@ pub(crate) trait Worker: Send + Sync + Debug + 'static {
     type TaskResultHandle: TaskResultHandle;
 
     fn id(&self) -> &WorkerId;
-    fn active_task_details(&self) -> HashMap<TaskId, TaskDetails>;
+    fn active_task_details(&self) -> HashMap<TaskID, TaskDetails>;
     fn total_num_cpus(&self) -> usize;
     fn active_num_cpus(&self) -> usize;
     fn available_num_cpus(&self) -> usize;
@@ -34,7 +34,7 @@ pub(crate) trait WorkerManager: Send + Sync {
     ) -> DaftResult<
         Vec<TaskResultHandleAwaiter<<<Self as WorkerManager>::Worker as Worker>::TaskResultHandle>>,
     >;
-    fn mark_task_finished(&self, task_id: &TaskId, worker_id: &WorkerId);
+    fn mark_task_finished(&self, task_id: &TaskID, worker_id: &WorkerId);
     fn workers(&self) -> &HashMap<WorkerId, Self::Worker>;
     fn total_available_cpus(&self) -> usize;
     #[allow(dead_code)]
@@ -102,7 +102,7 @@ pub(super) mod tests {
             Ok(result)
         }
 
-        fn mark_task_finished(&self, task_id: &TaskId, worker_id: &WorkerId) {
+        fn mark_task_finished(&self, task_id: &TaskID, worker_id: &WorkerId) {
             if let Some(worker) = self.workers.get(worker_id) {
                 worker.mark_task_finished(task_id);
             }
@@ -134,7 +134,7 @@ pub(super) mod tests {
     pub struct MockWorker {
         worker_id: WorkerId,
         total_num_cpus: usize,
-        active_task_details: Arc<Mutex<HashMap<TaskId, TaskDetails>>>,
+        active_task_details: Arc<Mutex<HashMap<TaskID, TaskDetails>>>,
         is_shutdown: Arc<AtomicBool>,
     }
 
@@ -148,7 +148,7 @@ pub(super) mod tests {
             }
         }
 
-        pub fn mark_task_finished(&self, task_id: &TaskId) {
+        pub fn mark_task_finished(&self, task_id: &TaskID) {
             self.active_task_details.lock().unwrap().remove(task_id);
         }
 
@@ -190,7 +190,7 @@ pub(super) mod tests {
             self.total_num_cpus() - self.active_num_cpus()
         }
 
-        fn active_task_details(&self) -> HashMap<TaskId, TaskDetails> {
+        fn active_task_details(&self) -> HashMap<TaskID, TaskDetails> {
             self.active_task_details
                 .lock()
                 .expect("Active task ids should be present")

--- a/src/daft-distributed/src/stage/mod.rs
+++ b/src/daft-distributed/src/stage/mod.rs
@@ -33,9 +33,10 @@ impl std::fmt::Display for StageID {
     }
 }
 
+#[allow(dead_code)]
 impl StageID {
     pub fn new(id: usize) -> Self {
-        StageID(id)
+        Self(id)
     }
 }
 

--- a/src/daft-distributed/src/stage/mod.rs
+++ b/src/daft-distributed/src/stage/mod.rs
@@ -27,6 +27,12 @@ mod stage_builder;
 #[derive(Eq, Hash, PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct StageID(usize);
 
+impl std::fmt::Display for StageID {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl StageID {
     pub fn new(id: usize) -> Self {
         StageID(id)

--- a/src/daft-distributed/src/utils/joinset.rs
+++ b/src/daft-distributed/src/utils/joinset.rs
@@ -19,7 +19,14 @@ impl<T: Send + 'static> JoinSet<T> {
         }
     }
 
-    pub fn spawn(&mut self, task: impl Future<Output = T> + Send + 'static) -> JoinSetId {
+    pub fn spawn<F>(&mut self, task: F) -> JoinSetId
+    where
+        F: Future<Output = T>,
+        F: Send + 'static,
+        T: Send,
+        // Bounds from impl:
+        T: 'static,
+    {
         let handle = self.inner.spawn(task);
         handle.id()
     }

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -14,7 +14,7 @@ use crate::{
         Sender,
     },
     dispatcher::{DispatchSpawner, RoundRobinDispatcher, UnorderedDispatcher},
-    pipeline::{NodeInfo, PipelineNode, TranslationContext},
+    pipeline::{NodeInfo, PipelineNode, RuntimeContext},
     progress_bar::ProgressBarColor,
     resource_manager::MemoryManager,
     runtime_stats::{CountingReceiver, CountingSender, RuntimeStatsContext},
@@ -90,7 +90,7 @@ impl IntermediateNode {
         intermediate_op: Arc<dyn IntermediateOperator>,
         children: Vec<Box<dyn PipelineNode>>,
         plan_stats: StatsState,
-        ctx: &TranslationContext,
+        ctx: &RuntimeContext,
     ) -> Self {
         let info = ctx.next_node_info(intermediate_op.name());
 
@@ -293,6 +293,6 @@ impl PipelineNode for IntermediateNode {
     }
 
     fn plan_id(&self) -> Arc<str> {
-        self.node_info.plan_id.clone()
+        Arc::from(self.node_info.context.get("plan_id").unwrap().clone())
     }
 }

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use common_daft_config::DaftExecutionConfig;
 use common_display::{
@@ -80,9 +80,9 @@ pub(crate) trait PipelineNode: Sync + Send + TreeDisplay {
 
 /// Single use context for translating a physical plan to a Pipeline.
 /// It generates a plan_id, and node ids for each plan.
-pub struct TranslationContext {
+pub struct RuntimeContext {
     index_counter: std::cell::RefCell<usize>,
-    plan_id: String,
+    context: HashMap<String, String>,
 }
 
 /// Contains information about the node such as name, id, and the plan_id
@@ -90,14 +90,23 @@ pub struct TranslationContext {
 pub struct NodeInfo {
     pub name: Arc<str>,
     pub id: usize,
-    pub plan_id: Arc<str>,
+    pub context: HashMap<String, String>,
 }
 
-impl TranslationContext {
+impl RuntimeContext {
     pub fn new() -> Self {
+        Self::new_with_context(HashMap::new())
+    }
+
+    pub fn new_with_context(mut context: HashMap<String, String>) -> Self {
+        if !context.contains_key("plan_id") {
+            let plan_id = uuid::Uuid::new_v4().to_string();
+            context.insert("plan_id".to_string(), plan_id);
+        }
+
         Self {
             index_counter: std::cell::RefCell::new(0),
-            plan_id: uuid::Uuid::new_v4().to_string(),
+            context,
         }
     }
 
@@ -108,15 +117,11 @@ impl TranslationContext {
         index
     }
 
-    pub fn plan_id(&self) -> &str {
-        &self.plan_id
-    }
-
     pub fn next_node_info(&self, name: &str) -> NodeInfo {
         NodeInfo {
             name: Arc::from(name.to_string()),
             id: self.next_id(),
-            plan_id: Arc::from(self.plan_id().to_string()),
+            context: self.context.clone(),
         }
     }
 }
@@ -202,7 +207,7 @@ pub fn physical_plan_to_pipeline(
     physical_plan: &LocalPhysicalPlan,
     psets: &(impl PartitionSetCache<MicroPartitionRef, Arc<MicroPartitionSet>> + ?Sized),
     cfg: &Arc<DaftExecutionConfig>,
-    ctx: &TranslationContext,
+    ctx: &RuntimeContext,
 ) -> crate::Result<Box<dyn PipelineNode>> {
     use daft_local_plan::PhysicalScan;
 

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -33,7 +33,7 @@ use crate::{
     channel::{create_channel, Receiver},
     pipeline::{
         get_pipeline_relationship_mapping, physical_plan_to_pipeline, viz_pipeline_ascii,
-        viz_pipeline_mermaid, RelationshipInformation, TranslationContext,
+        viz_pipeline_mermaid, RelationshipInformation, RuntimeContext,
     },
     progress_bar::{make_progress_bar_manager, ProgressBarManager},
     resource_manager::get_or_init_memory_manager,
@@ -163,7 +163,6 @@ impl PyNativeExecutor {
         results_buffer_size: Option<usize>,
         context: Option<HashMap<String, String>>,
     ) -> PyResult<Bound<'a, PyAny>> {
-        dbg!(&context);
         let native_psets: HashMap<String, Arc<MicroPartitionSet>> = psets
             .into_iter()
             .map(|(part_id, parts)| {
@@ -281,11 +280,11 @@ impl NativeExecutor {
         psets: &(impl PartitionSetCache<MicroPartitionRef, Arc<MicroPartitionSet>> + ?Sized),
         cfg: Arc<DaftExecutionConfig>,
         results_buffer_size: Option<usize>,
-        run_context: Option<HashMap<String, String>>,
+        additional_context: Option<HashMap<String, String>>,
     ) -> DaftResult<ExecutionEngineResult> {
         refresh_chrome_trace();
         let cancel = self.cancel.clone();
-        let ctx = TranslationContext::new();
+        let ctx = RuntimeContext::new_with_context(additional_context.unwrap_or_default());
         let pipeline = physical_plan_to_pipeline(local_physical_plan, psets, &cfg, &ctx)?;
         let (tx, rx) = create_channel(results_buffer_size.unwrap_or(0));
 
@@ -380,7 +379,7 @@ impl NativeExecutor {
     ) -> String {
         let logical_plan = logical_plan_builder.build();
         let physical_plan = translate(&logical_plan).unwrap();
-        let ctx = TranslationContext::new();
+        let ctx = RuntimeContext::new();
         let pipeline_node = physical_plan_to_pipeline(
             &physical_plan,
             &InMemoryPartitionSetCache::empty(),
@@ -400,7 +399,7 @@ impl NativeExecutor {
     ) -> String {
         let logical_plan = logical_plan_builder.build();
         let physical_plan = translate(&logical_plan).unwrap();
-        let ctx = TranslationContext::new();
+        let ctx = RuntimeContext::new();
         let pipeline_node = physical_plan_to_pipeline(
             &physical_plan,
             &InMemoryPartitionSetCache::empty(),
@@ -428,7 +427,7 @@ impl NativeExecutor {
     ) -> RelationshipInformation {
         let logical_plan = logical_plan_builder.build();
         let physical_plan = translate(&logical_plan).unwrap();
-        let ctx = TranslationContext::new();
+        let ctx = RuntimeContext::new();
         let pipeline_node = physical_plan_to_pipeline(
             &physical_plan,
             &InMemoryPartitionSetCache::empty(),

--- a/src/daft-local-execution/src/runtime_stats.rs
+++ b/src/daft-local-execution/src/runtime_stats.rs
@@ -85,6 +85,7 @@ impl RuntimeStatsSubscriber for OpenTelemetrySubscriber {
         }
         self.rows_emitted.add(count, &attributes);
     }
+
     fn on_cpu_time_elapsed(&self, context: &NodeInfo, microseconds: u64) {
         let mut attributes = vec![
             KeyValue::new("name", context.name.to_string()),

--- a/src/daft-local-execution/src/runtime_stats.rs
+++ b/src/daft-local-execution/src/runtime_stats.rs
@@ -55,34 +55,38 @@ impl OpenTelemetrySubscriber {
 
 impl RuntimeStatsSubscriber for OpenTelemetrySubscriber {
     fn on_rows_received(&self, context: &NodeInfo, count: u64) {
-        self.rows_received.add(
-            count,
-            &[
-                KeyValue::new("name", context.name.to_string()),
-                KeyValue::new("id", context.id.to_string()),
-                KeyValue::new("plan_id", context.plan_id.to_string()),
-            ],
-        );
+        let mut attributes = vec![
+            KeyValue::new("name", context.name.to_string()),
+            KeyValue::new("id", context.id.to_string()),
+        ];
+
+        for (k, v) in &context.context {
+            attributes.push(KeyValue::new(k.clone(), v.clone()));
+        }
+
+        self.rows_received.add(count, &attributes);
     }
     fn on_rows_emitted(&self, context: &NodeInfo, count: u64) {
-        self.rows_emitted.add(
-            count,
-            &[
-                KeyValue::new("name", context.name.to_string()),
-                KeyValue::new("id", context.id.to_string()),
-                KeyValue::new("plan_id", context.plan_id.to_string()),
-            ],
-        );
+        let mut attributes = vec![
+            KeyValue::new("name", context.name.to_string()),
+            KeyValue::new("id", context.id.to_string()),
+        ];
+
+        for (k, v) in &context.context {
+            attributes.push(KeyValue::new(k.clone(), v.clone()));
+        }
+        self.rows_emitted.add(count, &attributes);
     }
     fn on_cpu_time_elapsed(&self, context: &NodeInfo, microseconds: u64) {
-        self.cpu_us.add(
-            microseconds,
-            &[
-                KeyValue::new("name", context.name.to_string()),
-                KeyValue::new("id", context.id.to_string()),
-                KeyValue::new("plan_id", context.plan_id.to_string()),
-            ],
-        );
+        let mut attributes = vec![
+            KeyValue::new("name", context.name.to_string()),
+            KeyValue::new("id", context.id.to_string()),
+        ];
+
+        for (k, v) in &context.context {
+            attributes.push(KeyValue::new(k.clone(), v.clone()));
+        }
+        self.cpu_us.add(microseconds, &attributes);
     }
 }
 

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -10,7 +10,7 @@ use tracing::{info_span, instrument};
 use crate::{
     channel::{create_channel, Receiver},
     dispatcher::{DispatchSpawner, UnorderedDispatcher},
-    pipeline::{NodeInfo, PipelineNode, TranslationContext},
+    pipeline::{NodeInfo, PipelineNode, RuntimeContext},
     progress_bar::ProgressBarColor,
     resource_manager::MemoryManager,
     runtime_stats::{CountingReceiver, CountingSender, RuntimeStatsContext},
@@ -71,7 +71,7 @@ impl BlockingSinkNode {
         op: Arc<dyn BlockingSink>,
         child: Box<dyn PipelineNode>,
         plan_stats: StatsState,
-        ctx: &TranslationContext,
+        ctx: &RuntimeContext,
     ) -> Self {
         let name = op.name();
         let node_info = ctx.next_node_info(name);
@@ -251,6 +251,6 @@ impl PipelineNode for BlockingSinkNode {
         self.node_info.id
     }
     fn plan_id(&self) -> Arc<str> {
-        self.node_info.plan_id.clone()
+        Arc::from(self.node_info.context.get("plan_id").unwrap().clone())
     }
 }

--- a/src/daft-local-execution/src/sinks/streaming_sink.rs
+++ b/src/daft-local-execution/src/sinks/streaming_sink.rs
@@ -13,7 +13,7 @@ use crate::{
         Sender,
     },
     dispatcher::DispatchSpawner,
-    pipeline::{NodeInfo, PipelineNode, TranslationContext},
+    pipeline::{NodeInfo, PipelineNode, RuntimeContext},
     progress_bar::ProgressBarColor,
     resource_manager::MemoryManager,
     runtime_stats::{CountingReceiver, CountingSender, RuntimeStatsContext},
@@ -88,7 +88,7 @@ impl StreamingSinkNode {
         op: Arc<dyn StreamingSink>,
         children: Vec<Box<dyn PipelineNode>>,
         plan_stats: StatsState,
-        ctx: &TranslationContext,
+        ctx: &RuntimeContext,
     ) -> Self {
         let name = op.name();
         let node_info = ctx.next_node_info(name);
@@ -305,6 +305,6 @@ impl PipelineNode for StreamingSinkNode {
         self.node_info.id
     }
     fn plan_id(&self) -> Arc<str> {
-        self.node_info.plan_id.clone()
+        Arc::from(self.node_info.context.get("plan_id").unwrap().clone())
     }
 }

--- a/src/daft-local-execution/src/sources/source.rs
+++ b/src/daft-local-execution/src/sources/source.rs
@@ -11,7 +11,7 @@ use futures::{stream::BoxStream, StreamExt};
 
 use crate::{
     channel::{create_channel, Receiver},
-    pipeline::{NodeInfo, PipelineNode, TranslationContext},
+    pipeline::{NodeInfo, PipelineNode, RuntimeContext},
     progress_bar::ProgressBarColor,
     runtime_stats::{CountingSender, RuntimeStatsContext},
     ExecutionRuntimeContext,
@@ -40,7 +40,7 @@ pub(crate) struct SourceNode {
 }
 
 impl SourceNode {
-    pub fn new(source: Arc<dyn Source>, plan_stats: StatsState, ctx: &TranslationContext) -> Self {
+    pub fn new(source: Arc<dyn Source>, plan_stats: StatsState, ctx: &RuntimeContext) -> Self {
         let info = ctx.next_node_info(source.name());
         let runtime_stats = RuntimeStatsContext::new(info.clone());
         let io_stats = IOStatsContext::new(source.name());
@@ -152,6 +152,6 @@ impl PipelineNode for SourceNode {
     }
 
     fn plan_id(&self) -> Arc<str> {
-        self.node_info.plan_id.clone()
+        Arc::from(self.node_info.context.get("plan_id").unwrap().clone())
     }
 }


### PR DESCRIPTION
## Changes Made

adds an opaque `context` object that we can use to pass in additional context when emitting the runtimestats events. 

When using the new flotilla engine, this adds the following additional properties: [plan_id, stage_id, node_id, task_id]

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
