### PR TITLE
feat(connect): add support for spark when/otherwise

### DIFF
--- a/src/daft-connect/src/functions/core.rs
+++ b/src/daft-connect/src/functions/core.rs
@@ -1,4 +1,6 @@
-use daft_dsl::{binary_op, Operator};
+use std::sync::Arc;
+
+use daft_dsl::{binary_op, null_lit, Operator};
 use daft_functions::{coalesce::Coalesce, float::IsNan};
 use daft_sql::sql_expr;
 use spark_connect::Expression;
@@ -46,7 +48,7 @@ impl FunctionModule for CoreFunctions {
         parent.add_todo_fn("rand");
         parent.add_todo_fn("randn");
         parent.add_todo_fn("spark_partition_id");
-        parent.add_todo_fn("when");
+        parent.add_fn("when", WhenFunction);
         parent.add_todo_fn("bitwise_not");
         parent.add_todo_fn("bitwiseNOT");
         parent.add_fn("expr", SqlExpr);
@@ -59,6 +61,26 @@ impl FunctionModule for CoreFunctions {
         parent.add_fn("isnull", UnaryFunction(|arg| arg.is_null()));
         parent.add_fn("not", UnaryFunction(|arg| arg.not()));
         parent.add_fn("and", BinaryFunction(|arg1, arg2| arg1.and(arg2)));
+    }
+}
+
+pub struct WhenFunction;
+impl SparkFunction for WhenFunction {
+    fn to_expr(&self, args: &[Expression]) -> ConnectResult<daft_dsl::ExprRef> {
+        let args = args
+            .iter()
+            .map(analyze_expr)
+            .collect::<ConnectResult<Vec<_>>>()?;
+
+        let predicate = args[0].clone();
+        let if_false = args[1].clone();
+        let if_true = args.get(2).cloned().unwrap_or_else(null_lit);
+
+        Ok(Arc::new(daft_dsl::Expr::IfElse {
+            if_true,
+            if_false,
+            predicate,
+        }))
     }
 }
 

--- a/tests/connect/test_basics.py
+++ b/tests/connect/test_basics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from pyspark.sql import Row
 from pyspark.sql import functions as F
 from pyspark.sql.functions import col
 from pyspark.sql.types import LongType, StringType, StructField, StructType
@@ -411,3 +412,11 @@ def test_explain(spark_session, capsys):
 
 """
     assert actual.out == expected
+
+
+def test_when_otherwise(spark_session):
+    df = spark_session.createDataFrame([(1), (None), (10)], ["a"])
+
+    result = df.select(F.when(col("a").isNull(), True).otherwise(False)).collect()
+
+    assert result == [Row(a=True), Row(a=False), Row(a=True)]

--- a/tests/connect/test_basics.py
+++ b/tests/connect/test_basics.py
@@ -414,6 +414,12 @@ def test_explain(spark_session, capsys):
     assert actual.out == expected
 
 
+def test_when(spark_session):
+    df = spark_session.createDataFrame([(1), (None), (10)], ["a"])
+    result = df.select(F.when(col("a").isNull(), True)).collect()
+    assert result == [Row(a=None), Row(a=True), Row(a=None)]
+
+
 def test_when_otherwise(spark_session):
     df = spark_session.createDataFrame([(1), (None), (10)], ["a"])
 


### PR DESCRIPTION
## Changes Made

adds support for spark's control flow expression `when().otherwise()`

## Related Issues

related: https://github.com/Eventual-Inc/Daft/issues/4514

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
