### PR TITLE
fix: Fix chrome trace

### DIFF
--- a/src/common/tracing/src/lib.rs
+++ b/src/common/tracing/src/lib.rs
@@ -145,6 +145,9 @@ pub fn init_tracing(enable_chrome_trace: bool) {
     );
 
     let (chrome_layer, guard) = ChromeLayerBuilder::new()
+        // The initial writer to the chrome trace is a no-op sink, so we don't write anything
+        // only on calls to start_chrome_trace() do we write traces.
+        .writer(std::io::sink())
         .trace_style(tracing_chrome::TraceStyle::Threaded)
         .name_fn(Box::new(|event_or_span| {
             match event_or_span {
@@ -163,10 +166,24 @@ pub fn init_tracing(enable_chrome_trace: bool) {
     *mg = Some(guard);
 }
 
-pub fn refresh_chrome_trace() -> bool {
+pub fn start_chrome_trace() -> bool {
     let mut mg = CHROME_GUARD_HANDLE.lock().unwrap();
     if let Some(fg) = mg.as_mut() {
+        // start_new(None) will let tracing-chrome choose the file and file name.
         fg.start_new(None);
+        true
+    } else {
+        false
+    }
+}
+
+pub fn finish_chrome_trace() -> bool {
+    let mut mg = CHROME_GUARD_HANDLE.lock().unwrap();
+    if let Some(fg) = mg.as_mut() {
+        // start_new(Some(Box::new(std::io::sink()))) will flush the current trace, and start a new one with a dummy writer.
+        // The flush method doesn't actually close the file. The only way to do it is to drop the guard or call 'start_new'.
+        // But we can't drop the guard because it's a static and we may have multiple traces per process, so we need to call start_new.
+        fg.start_new(Some(Box::new(std::io::sink())));
         true
     } else {
         false

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -9,7 +9,7 @@ use std::{
 use common_daft_config::DaftExecutionConfig;
 use common_display::{mermaid::MermaidDisplayOptions, DisplayLevel};
 use common_error::DaftResult;
-use common_tracing::{flush_opentelemetry_providers, refresh_chrome_trace};
+use common_tracing::{finish_chrome_trace, flush_opentelemetry_providers, start_chrome_trace};
 use daft_local_plan::{translate, LocalPhysicalPlanRef};
 use daft_logical_plan::LogicalPlanBuilder;
 use daft_micropartition::{
@@ -282,7 +282,7 @@ impl NativeExecutor {
         results_buffer_size: Option<usize>,
         additional_context: Option<HashMap<String, String>>,
     ) -> DaftResult<ExecutionEngineResult> {
-        refresh_chrome_trace();
+        start_chrome_trace();
         let cancel = self.cancel.clone();
         let ctx = RuntimeContext::new_with_context(additional_context.unwrap_or_default());
         let pipeline = physical_plan_to_pipeline(local_physical_plan, psets, &cfg, &ctx)?;
@@ -345,6 +345,7 @@ impl NativeExecutor {
                     )?;
                 }
                 flush_opentelemetry_providers();
+                finish_chrome_trace();
                 Ok(())
             };
 


### PR DESCRIPTION
## Changes Made

Previously the chrome trace would emit an empty file followed by a malformed file. This is because we always start a new trace on query run but don't close the trace.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
