### PR TITLE
feat: Url parse function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
  "serde",
  "tokio",
  "typetag",
+ "url",
  "uuid 1.17.0",
 ]
 

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -2068,7 +2068,7 @@ class ExpressionUrlNamespace(ExpressionNamespace):
 
         Note:
             Invalid URLs will result in null values for all components.
-            The parsed result is automatically aliased to 'url' to enable easy struct field expansion.
+            The parsed result is automatically aliased to 'urls' to enable easy struct field expansion.
         """
         f = native.get_function_from_registry("url_parse")
         return Expression._from_pyexpr(f(self._expr)).alias("urls")

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -2044,6 +2044,33 @@ class ExpressionUrlNamespace(ExpressionNamespace):
             )
         )
 
+    def parse(self) -> Expression:
+        """Parses URLs in a string column and extracts URL components.
+
+        Returns:
+            Expression: a Struct expression containing the parsed URL components:
+                - scheme (str): The URL scheme (e.g., "https", "http")
+                - username (str): The username, if present
+                - password (str): The password, if present
+                - host (str): The hostname or IP address
+                - port (int): The port number, if specified
+                - path (str): The path component
+                - query (str): The query string, if present
+                - fragment (str): The fragment/anchor, if present
+
+        Examples:
+            >>> import daft
+            >>> df = daft.from_pydict(
+            ...     {"urls": ["https://user:pass@example.com:8080/path?query=value#fragment", "http://localhost/api"]}
+            ... )
+            >>> df.select(daft.col("urls").url.parse()).collect()  # doctest: +SKIP
+
+        Note:
+            Invalid URLs will result in null values for all components.
+        """
+        f = native.get_function_from_registry("url_parse")
+        return Expression._from_pyexpr(f(self._expr))
+
 
 class ExpressionFloatNamespace(ExpressionNamespace):
     """The following methods are available under the `expr.float` attribute."""

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -2063,13 +2063,15 @@ class ExpressionUrlNamespace(ExpressionNamespace):
             >>> df = daft.from_pydict(
             ...     {"urls": ["https://user:pass@example.com:8080/path?query=value#fragment", "http://localhost/api"]}
             ... )
-            >>> df.select(daft.col("urls").url.parse()).collect()  # doctest: +SKIP
+            >>> # Parse URLs and expand all components
+            >>> df.select(daft.col("urls").url.parse()).select(daft.col("urls").struct.get("*")).collect()  # doctest: +SKIP
 
         Note:
             Invalid URLs will result in null values for all components.
+            The parsed result is automatically aliased to 'url' to enable easy struct field expansion.
         """
         f = native.get_function_from_registry("url_parse")
-        return Expression._from_pyexpr(f(self._expr))
+        return Expression._from_pyexpr(f(self._expr)).alias("urls")
 
 
 class ExpressionFloatNamespace(ExpressionNamespace):

--- a/src/daft-functions-uri/Cargo.toml
+++ b/src/daft-functions-uri/Cargo.toml
@@ -9,6 +9,7 @@ futures = {workspace = true}
 serde = {workspace = true}
 tokio = {workspace = true}
 typetag = {workspace = true}
+url = {workspace = true}
 uuid = {workspace = true}
 
 [lints]

--- a/src/daft-functions-uri/src/lib.rs
+++ b/src/daft-functions-uri/src/lib.rs
@@ -1,8 +1,10 @@
 pub mod download;
+pub mod parse;
 pub mod upload;
 
 use daft_dsl::functions::FunctionModule;
 use download::UrlDownload;
+use parse::UrlParse;
 use upload::UrlUpload;
 
 pub struct UriFunctions;
@@ -10,6 +12,7 @@ pub struct UriFunctions;
 impl FunctionModule for UriFunctions {
     fn register(parent: &mut daft_dsl::functions::FunctionRegistry) {
         parent.add_fn(UrlDownload);
+        parent.add_fn(UrlParse);
         parent.add_fn(UrlUpload);
     }
 }

--- a/src/daft-functions-uri/src/parse.rs
+++ b/src/daft-functions-uri/src/parse.rs
@@ -1,0 +1,161 @@
+use common_error::{DaftError, DaftResult};
+use daft_core::prelude::*;
+use daft_dsl::{
+    functions::{FunctionArgs, ScalarUDF},
+    ExprRef,
+};
+use serde::Serialize;
+use url::Url;
+
+#[derive(Debug, Clone, Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
+pub struct UrlParse;
+
+#[derive(FunctionArgs)]
+pub struct UrlParseArgs<T> {
+    pub input: T,
+}
+
+#[typetag::serde]
+impl ScalarUDF for UrlParse {
+    fn name(&self) -> &'static str {
+        "url_parse"
+    }
+
+    fn evaluate(&self, inputs: daft_dsl::functions::FunctionArgs<Series>) -> DaftResult<Series> {
+        let UrlParseArgs { input } = inputs.try_into()?;
+        let array = input.utf8()?;
+        let result = url_parse(array)?;
+        Ok(result.into_series())
+    }
+
+    fn function_args_to_field(
+        &self,
+        inputs: FunctionArgs<ExprRef>,
+        schema: &Schema,
+    ) -> DaftResult<Field> {
+        let UrlParseArgs { input } = inputs.try_into()?;
+        let field = input.to_field(schema)?;
+
+        if !field.dtype.is_string() {
+            return Err(DaftError::TypeError(format!(
+                "Expected input to be a string, got {}",
+                field.dtype
+            )));
+        }
+
+        // Define the struct fields for parsed URL components
+        let struct_fields = vec![
+            Field::new("scheme", DataType::Utf8),
+            Field::new("username", DataType::Utf8),
+            Field::new("password", DataType::Utf8),
+            Field::new("host", DataType::Utf8),
+            Field::new("port", DataType::UInt16),
+            Field::new("path", DataType::Utf8),
+            Field::new("query", DataType::Utf8),
+            Field::new("fragment", DataType::Utf8),
+        ];
+
+        Ok(Field::new(field.name, DataType::Struct(struct_fields)))
+    }
+}
+
+fn url_parse(array: &Utf8Array) -> DaftResult<StructArray> {
+    let name = array.name();
+    let len = array.len();
+
+    // Initialize vectors for each component
+    let mut schemes = Vec::with_capacity(len);
+    let mut usernames = Vec::with_capacity(len);
+    let mut passwords = Vec::with_capacity(len);
+    let mut hosts = Vec::with_capacity(len);
+    let mut ports = Vec::with_capacity(len);
+    let mut paths = Vec::with_capacity(len);
+    let mut queries = Vec::with_capacity(len);
+    let mut fragments = Vec::with_capacity(len);
+
+    for i in 0..len {
+        match array.get(i) {
+            None => {
+                // Handle null input
+                schemes.push(None);
+                usernames.push(None);
+                passwords.push(None);
+                hosts.push(None);
+                ports.push(None);
+                paths.push(None);
+                queries.push(None);
+                fragments.push(None);
+            }
+            Some(url_str) => {
+                match Url::parse(url_str) {
+                    Ok(url) => {
+                        schemes.push(Some(url.scheme().to_string()));
+                        usernames.push(if url.username().is_empty() {
+                            None
+                        } else {
+                            Some(url.username().to_string())
+                        });
+                        passwords.push(url.password().map(|s| s.to_string()));
+                        hosts.push(url.host_str().map(|s| s.to_string()));
+                        ports.push(url.port());
+                        paths.push(Some(url.path().to_string()));
+                        queries.push(url.query().map(|s| s.to_string()));
+                        fragments.push(url.fragment().map(|s| s.to_string()));
+                    }
+                    Err(_) => {
+                        // Handle parse error by setting all fields to null
+                        schemes.push(None);
+                        usernames.push(None);
+                        passwords.push(None);
+                        hosts.push(None);
+                        ports.push(None);
+                        paths.push(None);
+                        queries.push(None);
+                        fragments.push(None);
+                    }
+                }
+            }
+        }
+    }
+
+    // Create arrays for each field
+    let scheme_array = Utf8Array::from_iter("scheme", schemes.into_iter());
+    let username_array = Utf8Array::from_iter("username", usernames.into_iter());
+    let password_array = Utf8Array::from_iter("password", passwords.into_iter());
+    let host_array = Utf8Array::from_iter("host", hosts.into_iter());
+    let port_array =
+        UInt16Array::from_iter(Field::new("port", DataType::UInt16), ports.into_iter());
+    let path_array = Utf8Array::from_iter("path", paths.into_iter());
+    let query_array = Utf8Array::from_iter("query", queries.into_iter());
+    let fragment_array = Utf8Array::from_iter("fragment", fragments.into_iter());
+
+    // Create the struct array
+    let struct_array = StructArray::new(
+        Field::new(
+            name,
+            DataType::Struct(vec![
+                Field::new("scheme", DataType::Utf8),
+                Field::new("username", DataType::Utf8),
+                Field::new("password", DataType::Utf8),
+                Field::new("host", DataType::Utf8),
+                Field::new("port", DataType::UInt16),
+                Field::new("path", DataType::Utf8),
+                Field::new("query", DataType::Utf8),
+                Field::new("fragment", DataType::Utf8),
+            ]),
+        ),
+        vec![
+            scheme_array.into_series(),
+            username_array.into_series(),
+            password_array.into_series(),
+            host_array.into_series(),
+            port_array.into_series(),
+            path_array.into_series(),
+            query_array.into_series(),
+            fragment_array.into_series(),
+        ],
+        None,
+    );
+
+    Ok(struct_array)
+}

--- a/src/daft-functions-uri/src/parse.rs
+++ b/src/daft-functions-uri/src/parse.rs
@@ -43,7 +43,6 @@ impl ScalarUDF for UrlParse {
             )));
         }
 
-        // Define the struct fields for parsed URL components
         let struct_fields = vec![
             Field::new("scheme", DataType::Utf8),
             Field::new("username", DataType::Utf8),
@@ -63,7 +62,6 @@ fn url_parse(array: &Utf8Array) -> DaftResult<StructArray> {
     let name = array.name();
     let len = array.len();
 
-    // Initialize vectors for each component
     let mut schemes = Vec::with_capacity(len);
     let mut usernames = Vec::with_capacity(len);
     let mut passwords = Vec::with_capacity(len);
@@ -76,7 +74,6 @@ fn url_parse(array: &Utf8Array) -> DaftResult<StructArray> {
     for i in 0..len {
         match array.get(i) {
             None => {
-                // Handle null input
                 schemes.push(None);
                 usernames.push(None);
                 passwords.push(None);
@@ -86,39 +83,35 @@ fn url_parse(array: &Utf8Array) -> DaftResult<StructArray> {
                 queries.push(None);
                 fragments.push(None);
             }
-            Some(url_str) => {
-                match Url::parse(url_str) {
-                    Ok(url) => {
-                        schemes.push(Some(url.scheme().to_string()));
-                        usernames.push(if url.username().is_empty() {
-                            None
-                        } else {
-                            Some(url.username().to_string())
-                        });
-                        passwords.push(url.password().map(|s| s.to_string()));
-                        hosts.push(url.host_str().map(|s| s.to_string()));
-                        ports.push(url.port());
-                        paths.push(Some(url.path().to_string()));
-                        queries.push(url.query().map(|s| s.to_string()));
-                        fragments.push(url.fragment().map(|s| s.to_string()));
-                    }
-                    Err(_) => {
-                        // Handle parse error by setting all fields to null
-                        schemes.push(None);
-                        usernames.push(None);
-                        passwords.push(None);
-                        hosts.push(None);
-                        ports.push(None);
-                        paths.push(None);
-                        queries.push(None);
-                        fragments.push(None);
-                    }
+            Some(url_str) => match Url::parse(url_str) {
+                Ok(url) => {
+                    schemes.push(Some(url.scheme().to_string()));
+                    usernames.push(if url.username().is_empty() {
+                        None
+                    } else {
+                        Some(url.username().to_string())
+                    });
+                    passwords.push(url.password().map(|s| s.to_string()));
+                    hosts.push(url.host_str().map(|s| s.to_string()));
+                    ports.push(url.port());
+                    paths.push(Some(url.path().to_string()));
+                    queries.push(url.query().map(|s| s.to_string()));
+                    fragments.push(url.fragment().map(|s| s.to_string()));
                 }
-            }
+                Err(_) => {
+                    schemes.push(None);
+                    usernames.push(None);
+                    passwords.push(None);
+                    hosts.push(None);
+                    ports.push(None);
+                    paths.push(None);
+                    queries.push(None);
+                    fragments.push(None);
+                }
+            },
         }
     }
 
-    // Create arrays for each field
     let scheme_array = Utf8Array::from_iter("scheme", schemes.into_iter());
     let username_array = Utf8Array::from_iter("username", usernames.into_iter());
     let password_array = Utf8Array::from_iter("password", passwords.into_iter());
@@ -129,7 +122,6 @@ fn url_parse(array: &Utf8Array) -> DaftResult<StructArray> {
     let query_array = Utf8Array::from_iter("query", queries.into_iter());
     let fragment_array = Utf8Array::from_iter("fragment", fragments.into_iter());
 
-    // Create the struct array
     let struct_array = StructArray::new(
         Field::new(
             name,

--- a/tests/expressions/test_url_parse.py
+++ b/tests/expressions/test_url_parse.py
@@ -4,249 +4,233 @@ import daft
 from daft import col
 
 
-class TestUrlParse:
-    def test_url_parse_basic(self):
-        urls = [
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00004-of-00007.parquet",
-            "https://user:pass@example.com:8080/path?query=value#fragment",
-            "http://localhost/api",
-            "ftp://files.example.com/file.txt",
-        ]
+def test_url_parse_basic():
+    urls = [
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00004-of-00007.parquet",
+        "https://user:pass@example.com:8080/path?query=value#fragment",
+        "http://localhost/api",
+        "ftp://files.example.com/file.txt",
+    ]
 
-        df = daft.from_pydict({"urls": urls})
+    df = daft.from_pydict({"urls": urls})
 
-        # Test the parse functionality
-        result = df.select(col("urls").url.parse()).collect()
+    result = df.select(col("urls").url.parse()).collect()
 
-        # Verify the result has the correct structure
-        assert len(result) == 4  # 4 URLs in the test data
-        schema = result.schema()
-        assert len(schema) == 1
-        field = schema["urls"]  # Column is auto-aliased to 'url'
-        assert field.name == "urls"
-        assert field.dtype.is_struct()
+    assert len(result) == 4
+    schema = result.schema()
+    assert len(schema) == 1
+    field = schema["urls"]
+    assert field.name == "urls"
+    assert field.dtype.is_struct()
 
-        # Verify that parsing creates a struct (detailed field verification is done in other tests)
-        result_data = result.to_pydict()
-        assert len(result_data["urls"]) == 4
-        assert all(isinstance(url_struct, dict) for url_struct in result_data["urls"] if url_struct is not None)
+    result_data = result.to_pydict()
+    assert len(result_data["urls"]) == 4
+    assert all(isinstance(url_struct, dict) for url_struct in result_data["urls"] if url_struct is not None)
 
-    def test_url_parse_component_extraction(self):
-        urls = [
-            "https://user:pass@example.com:8080/path?query=value#fragment",
-            "http://localhost/api",
-        ]
 
-        df = daft.from_pydict({"urls": urls})
+def test_url_parse_component_extraction():
+    urls = [
+        "https://user:pass@example.com:8080/path?query=value#fragment",
+        "http://localhost/api",
+    ]
 
-        # Extract all components using wildcard
-        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+    df = daft.from_pydict({"urls": urls})
 
-        data = result.to_pydict()
+    result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
 
-        # Verify first URL components
-        assert data["scheme"][0] == "https"
-        assert data["username"][0] == "user"
-        assert data["password"][0] == "pass"
-        assert data["host"][0] == "example.com"
-        assert data["port"][0] == 8080
-        assert data["path"][0] == "/path"
-        assert data["query"][0] == "query=value"
-        assert data["fragment"][0] == "fragment"
+    data = result.to_pydict()
 
-        # Verify second URL components
-        assert data["scheme"][1] == "http"
-        assert data["username"][1] is None
-        assert data["password"][1] is None
-        assert data["host"][1] == "localhost"
-        assert data["port"][1] is None
-        assert data["path"][1] == "/api"
-        assert data["query"][1] is None
-        assert data["fragment"][1] is None
+    assert data["scheme"][0] == "https"
+    assert data["username"][0] == "user"
+    assert data["password"][0] == "pass"
+    assert data["host"][0] == "example.com"
+    assert data["port"][0] == 8080
+    assert data["path"][0] == "/path"
+    assert data["query"][0] == "query=value"
+    assert data["fragment"][0] == "fragment"
 
-    def test_url_parse_individual_fields(self):
-        urls = ["https://example.com:443/path?query=value#fragment"]
+    assert data["scheme"][1] == "http"
+    assert data["username"][1] is None
+    assert data["password"][1] is None
+    assert data["host"][1] == "localhost"
+    assert data["port"][1] is None
+    assert data["path"][1] == "/api"
+    assert data["query"][1] is None
+    assert data["fragment"][1] is None
 
-        df = daft.from_pydict({"urls": urls})
 
-        result = (
-            df.select(col("urls").url.parse().alias("parsed"))
-            .select(
-                col("parsed").struct.get("scheme").alias("scheme"),
-                col("parsed").struct.get("host").alias("host"),
-                col("parsed").struct.get("port").alias("port"),
-                col("parsed").struct.get("path").alias("path"),
-                col("parsed").struct.get("query").alias("query"),
-                col("parsed").struct.get("fragment").alias("fragment"),
-                col("parsed").struct.get("username").alias("username"),
-                col("parsed").struct.get("password").alias("password"),
-            )
-            .collect()
+def test_url_parse_individual_fields():
+    urls = ["https://example.com:443/path?query=value#fragment"]
+
+    df = daft.from_pydict({"urls": urls})
+
+    result = (
+        df.select(col("urls").url.parse().alias("parsed"))
+        .select(
+            col("parsed").struct.get("scheme").alias("scheme"),
+            col("parsed").struct.get("host").alias("host"),
+            col("parsed").struct.get("port").alias("port"),
+            col("parsed").struct.get("path").alias("path"),
+            col("parsed").struct.get("query").alias("query"),
+            col("parsed").struct.get("fragment").alias("fragment"),
+            col("parsed").struct.get("username").alias("username"),
+            col("parsed").struct.get("password").alias("password"),
         )
+        .collect()
+    )
 
-        data = result.to_pydict()
+    data = result.to_pydict()
 
-        assert data["scheme"][0] == "https"
-        assert data["host"][0] == "example.com"
-        assert data["port"][0] is None  # Default HTTPS port is not returned by url crate
-        assert data["path"][0] == "/path"
-        assert data["query"][0] == "query=value"
-        assert data["fragment"][0] == "fragment"
-        assert data["username"][0] is None
-        assert data["password"][0] is None
+    assert data["scheme"][0] == "https"
+    assert data["host"][0] == "example.com"
+    assert data["port"][0] is None
+    assert data["path"][0] == "/path"
+    assert data["query"][0] == "query=value"
+    assert data["fragment"][0] == "fragment"
+    assert data["username"][0] is None
+    assert data["password"][0] is None
 
-    def test_url_parse_null_handling(self):
-        urls = [
-            "https://example.com",
-            None,
-            "http://localhost",
-        ]
 
-        df = daft.from_pydict({"urls": urls})
+def test_url_parse_null_handling():
+    urls = [
+        "https://example.com",
+        None,
+        "http://localhost",
+    ]
 
-        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+    df = daft.from_pydict({"urls": urls})
 
-        data = result.to_pydict()
+    result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
 
-        # First URL should be parsed correctly
-        assert data["scheme"][0] == "https"
-        assert data["host"][0] == "example.com"
+    data = result.to_pydict()
 
-        # Second URL (null) should have all null components
-        assert data["scheme"][1] is None
-        assert data["host"][1] is None
-        assert data["path"][1] is None
+    assert data["scheme"][0] == "https"
+    assert data["host"][0] == "example.com"
 
-        # Third URL should be parsed correctly
-        assert data["scheme"][2] == "http"
-        assert data["host"][2] == "localhost"
+    assert data["scheme"][1] is None
+    assert data["host"][1] is None
+    assert data["path"][1] is None
 
-    def test_url_parse_invalid_urls(self):
-        urls = [
-            "https://example.com",  # Valid
-            "invalid-url",  # Invalid
-            "",  # Empty string
-            "not a url at all",  # Invalid
-        ]
+    assert data["scheme"][2] == "http"
+    assert data["host"][2] == "localhost"
 
-        df = daft.from_pydict({"urls": urls})
 
-        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+def test_url_parse_invalid_urls():
+    urls = [
+        "https://example.com",
+        "invalid-url",
+        "",
+        "not a url at all",
+    ]
 
-        data = result.to_pydict()
+    df = daft.from_pydict({"urls": urls})
 
-        # First URL should be parsed correctly
-        assert data["scheme"][0] == "https"
-        assert data["host"][0] == "example.com"
+    result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
 
-        # Invalid URLs should have all null components
-        for i in [1, 2, 3]:
-            assert data["scheme"][i] is None
-            assert data["host"][i] is None
-            assert data["path"][i] is None
-            assert data["query"][i] is None
-            assert data["fragment"][i] is None
+    data = result.to_pydict()
 
-    def test_url_parse_edge_cases(self):
-        urls = [
-            "https://example.com",  # No path
-            "https://example.com/",  # Root path
-            "https://example.com:443",  # Standard HTTPS port
-            "http://example.com:80",  # Standard HTTP port
-            "https://example.com?query=value",  # Query without explicit path
-            "https://example.com#fragment",  # Fragment without explicit path
-            "mailto:user@example.com",  # Different scheme
-            "file:///path/to/file",  # File scheme
-        ]
+    assert data["scheme"][0] == "https"
+    assert data["host"][0] == "example.com"
 
-        df = daft.from_pydict({"urls": urls})
+    for i in [1, 2, 3]:
+        assert data["scheme"][i] is None
+        assert data["host"][i] is None
+        assert data["path"][i] is None
+        assert data["query"][i] is None
+        assert data["fragment"][i] is None
 
-        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
 
-        data = result.to_pydict()
+def test_url_parse_edge_cases():
+    urls = [
+        "https://example.com",
+        "https://example.com/",
+        "https://example.com:443",
+        "http://example.com:80",
+        "https://example.com?query=value",
+        "https://example.com#fragment",
+        "mailto:user@example.com",
+        "file:///path/to/file",
+    ]
 
-        # Verify schemes are parsed correctly
-        expected_schemes = ["https", "https", "https", "http", "https", "https", "mailto", "file"]
-        assert data["scheme"] == expected_schemes
+    df = daft.from_pydict({"urls": urls})
 
-        # Verify hosts are parsed correctly
-        expected_hosts = [
-            "example.com",
-            "example.com",
-            "example.com",
-            "example.com",
-            "example.com",
-            "example.com",
-            None,
-            None,
-        ]
-        assert data["host"] == expected_hosts
+    result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
 
-        # Verify ports are parsed correctly (only non-default ports are returned)
-        expected_ports = [None, None, None, None, None, None, None, None]
-        assert data["port"] == expected_ports
+    data = result.to_pydict()
 
-    def test_url_parse_github_issue_example(self):
-        urls = [
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00004-of-00007.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00005-of-00007.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00006-of-00007.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.arc/train-00000-of-00001.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ary/train-00000-of-00001.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00013-of-00020.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00014-of-00020.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00015-of-00020.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00016-of-00020.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00017-of-00020.parquet",
-            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00018-of-00020.parquet",
-        ]
+    expected_schemes = ["https", "https", "https", "http", "https", "https", "mailto", "file"]
+    assert data["scheme"] == expected_schemes
 
-        df = daft.from_pydict({"urls": urls})
+    expected_hosts = [
+        "example.com",
+        "example.com",
+        "example.com",
+        "example.com",
+        "example.com",
+        "example.com",
+        None,
+        None,
+    ]
+    assert data["host"] == expected_hosts
 
-        # Parse URLs and expand all fields (column is auto-aliased to 'url')
-        result = df.select(col("urls").url.parse()).select(col("urls").struct.get("*")).collect()
+    expected_ports = [None, None, None, None, None, None, None, None]
+    assert data["port"] == expected_ports
 
-        data = result.to_pydict()
 
-        # All URLs should have https scheme and huggingface.co host
-        assert all(scheme == "https" for scheme in data["scheme"])
-        assert all(host == "huggingface.co" for host in data["host"])
+def test_url_parse_github_issue_example():
+    urls = [
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00004-of-00007.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00005-of-00007.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00006-of-00007.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.arc/train-00000-of-00001.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ary/train-00000-of-00001.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00013-of-00020.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00014-of-00020.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00015-of-00020.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00016-of-00020.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00017-of-00020.parquet",
+        "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00018-of-00020.parquet",
+    ]
 
-        # All should have the expected path structure
-        for path in data["path"]:
-            assert path.startswith("/datasets/wikimedia/wikipedia/resolve/main/")
-            assert path.endswith(".parquet")
+    df = daft.from_pydict({"urls": urls})
 
-        # No query, fragment, username, or password
-        assert all(query is None for query in data["query"])
-        assert all(fragment is None for fragment in data["fragment"])
-        assert all(username is None for username in data["username"])
-        assert all(password is None for password in data["password"])
+    result = df.select(col("urls").url.parse()).select(col("urls").struct.get("*")).collect()
 
-        # No explicit ports (should be None for default HTTPS)
-        assert all(port is None for port in data["port"])
+    data = result.to_pydict()
 
-    def test_url_parse_with_authentication(self):
-        urls = [
-            "https://user@example.com/path",  # Username only
-            "https://user:pass@example.com/path",  # Username and password
-            "ftp://anonymous:email@ftp.example.com/file",  # FTP with credentials
-        ]
+    assert all(scheme == "https" for scheme in data["scheme"])
+    assert all(host == "huggingface.co" for host in data["host"])
 
-        df = daft.from_pydict({"urls": urls})
+    for path in data["path"]:
+        assert path.startswith("/datasets/wikimedia/wikipedia/resolve/main/")
+        assert path.endswith(".parquet")
 
-        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+    assert all(query is None for query in data["query"])
+    assert all(fragment is None for fragment in data["fragment"])
+    assert all(username is None for username in data["username"])
+    assert all(password is None for password in data["password"])
 
-        data = result.to_pydict()
+    assert all(port is None for port in data["port"])
 
-        # First URL: username only
-        assert data["username"][0] == "user"
-        assert data["password"][0] is None
 
-        # Second URL: username and password
-        assert data["username"][1] == "user"
-        assert data["password"][1] == "pass"
+def test_url_parse_with_authentication():
+    urls = [
+        "https://user@example.com/path",
+        "https://user:pass@example.com/path",
+        "ftp://anonymous:email@ftp.example.com/file",
+    ]
 
-        # Third URL: FTP credentials
-        assert data["username"][2] == "anonymous"
-        assert data["password"][2] == "email"
+    df = daft.from_pydict({"urls": urls})
+
+    result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+
+    data = result.to_pydict()
+
+    assert data["username"][0] == "user"
+    assert data["password"][0] is None
+
+    assert data["username"][1] == "user"
+    assert data["password"][1] == "pass"
+
+    assert data["username"][2] == "anonymous"
+    assert data["password"][2] == "email"

--- a/tests/expressions/test_url_parse.py
+++ b/tests/expressions/test_url_parse.py
@@ -22,7 +22,7 @@ class TestUrlParse:
         assert len(result) == 4  # 4 URLs in the test data
         schema = result.schema()
         assert len(schema) == 1
-        field = schema["urls"]
+        field = schema["urls"]  # Column is auto-aliased to 'url'
         assert field.name == "urls"
         assert field.dtype.is_struct()
 
@@ -203,8 +203,8 @@ class TestUrlParse:
 
         df = daft.from_pydict({"urls": urls})
 
-        # Parse URLs and expand all fields
-        result = df.select(col("urls").url.parse().alias("url")).select(col("url").struct.get("*")).collect()
+        # Parse URLs and expand all fields (column is auto-aliased to 'url')
+        result = df.select(col("urls").url.parse()).select(col("urls").struct.get("*")).collect()
 
         data = result.to_pydict()
 

--- a/tests/expressions/test_url_parse.py
+++ b/tests/expressions/test_url_parse.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import daft
+from daft import col
+
+
+class TestUrlParse:
+    def test_url_parse_basic(self):
+        urls = [
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00004-of-00007.parquet",
+            "https://user:pass@example.com:8080/path?query=value#fragment",
+            "http://localhost/api",
+            "ftp://files.example.com/file.txt",
+        ]
+
+        df = daft.from_pydict({"urls": urls})
+
+        # Test the parse functionality
+        result = df.select(col("urls").url.parse()).collect()
+
+        # Verify the result has the correct structure
+        assert len(result) == 4  # 4 URLs in the test data
+        schema = result.schema()
+        assert len(schema) == 1
+        field = schema["urls"]
+        assert field.name == "urls"
+        assert field.dtype.is_struct()
+
+        # Verify that parsing creates a struct (detailed field verification is done in other tests)
+        result_data = result.to_pydict()
+        assert len(result_data["urls"]) == 4
+        assert all(isinstance(url_struct, dict) for url_struct in result_data["urls"] if url_struct is not None)
+
+    def test_url_parse_component_extraction(self):
+        urls = [
+            "https://user:pass@example.com:8080/path?query=value#fragment",
+            "http://localhost/api",
+        ]
+
+        df = daft.from_pydict({"urls": urls})
+
+        # Extract all components using wildcard
+        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+
+        data = result.to_pydict()
+
+        # Verify first URL components
+        assert data["scheme"][0] == "https"
+        assert data["username"][0] == "user"
+        assert data["password"][0] == "pass"
+        assert data["host"][0] == "example.com"
+        assert data["port"][0] == 8080
+        assert data["path"][0] == "/path"
+        assert data["query"][0] == "query=value"
+        assert data["fragment"][0] == "fragment"
+
+        # Verify second URL components
+        assert data["scheme"][1] == "http"
+        assert data["username"][1] is None
+        assert data["password"][1] is None
+        assert data["host"][1] == "localhost"
+        assert data["port"][1] is None
+        assert data["path"][1] == "/api"
+        assert data["query"][1] is None
+        assert data["fragment"][1] is None
+
+    def test_url_parse_individual_fields(self):
+        urls = ["https://example.com:443/path?query=value#fragment"]
+
+        df = daft.from_pydict({"urls": urls})
+
+        result = (
+            df.select(col("urls").url.parse().alias("parsed"))
+            .select(
+                col("parsed").struct.get("scheme").alias("scheme"),
+                col("parsed").struct.get("host").alias("host"),
+                col("parsed").struct.get("port").alias("port"),
+                col("parsed").struct.get("path").alias("path"),
+                col("parsed").struct.get("query").alias("query"),
+                col("parsed").struct.get("fragment").alias("fragment"),
+                col("parsed").struct.get("username").alias("username"),
+                col("parsed").struct.get("password").alias("password"),
+            )
+            .collect()
+        )
+
+        data = result.to_pydict()
+
+        assert data["scheme"][0] == "https"
+        assert data["host"][0] == "example.com"
+        assert data["port"][0] is None  # Default HTTPS port is not returned by url crate
+        assert data["path"][0] == "/path"
+        assert data["query"][0] == "query=value"
+        assert data["fragment"][0] == "fragment"
+        assert data["username"][0] is None
+        assert data["password"][0] is None
+
+    def test_url_parse_null_handling(self):
+        urls = [
+            "https://example.com",
+            None,
+            "http://localhost",
+        ]
+
+        df = daft.from_pydict({"urls": urls})
+
+        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+
+        data = result.to_pydict()
+
+        # First URL should be parsed correctly
+        assert data["scheme"][0] == "https"
+        assert data["host"][0] == "example.com"
+
+        # Second URL (null) should have all null components
+        assert data["scheme"][1] is None
+        assert data["host"][1] is None
+        assert data["path"][1] is None
+
+        # Third URL should be parsed correctly
+        assert data["scheme"][2] == "http"
+        assert data["host"][2] == "localhost"
+
+    def test_url_parse_invalid_urls(self):
+        urls = [
+            "https://example.com",  # Valid
+            "invalid-url",  # Invalid
+            "",  # Empty string
+            "not a url at all",  # Invalid
+        ]
+
+        df = daft.from_pydict({"urls": urls})
+
+        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+
+        data = result.to_pydict()
+
+        # First URL should be parsed correctly
+        assert data["scheme"][0] == "https"
+        assert data["host"][0] == "example.com"
+
+        # Invalid URLs should have all null components
+        for i in [1, 2, 3]:
+            assert data["scheme"][i] is None
+            assert data["host"][i] is None
+            assert data["path"][i] is None
+            assert data["query"][i] is None
+            assert data["fragment"][i] is None
+
+    def test_url_parse_edge_cases(self):
+        urls = [
+            "https://example.com",  # No path
+            "https://example.com/",  # Root path
+            "https://example.com:443",  # Standard HTTPS port
+            "http://example.com:80",  # Standard HTTP port
+            "https://example.com?query=value",  # Query without explicit path
+            "https://example.com#fragment",  # Fragment without explicit path
+            "mailto:user@example.com",  # Different scheme
+            "file:///path/to/file",  # File scheme
+        ]
+
+        df = daft.from_pydict({"urls": urls})
+
+        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+
+        data = result.to_pydict()
+
+        # Verify schemes are parsed correctly
+        expected_schemes = ["https", "https", "https", "http", "https", "https", "mailto", "file"]
+        assert data["scheme"] == expected_schemes
+
+        # Verify hosts are parsed correctly
+        expected_hosts = [
+            "example.com",
+            "example.com",
+            "example.com",
+            "example.com",
+            "example.com",
+            "example.com",
+            None,
+            None,
+        ]
+        assert data["host"] == expected_hosts
+
+        # Verify ports are parsed correctly (only non-default ports are returned)
+        expected_ports = [None, None, None, None, None, None, None, None]
+        assert data["port"] == expected_ports
+
+    def test_url_parse_github_issue_example(self):
+        urls = [
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00004-of-00007.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00005-of-00007.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ar/train-00006-of-00007.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.arc/train-00000-of-00001.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.ary/train-00000-of-00001.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00013-of-00020.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00014-of-00020.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00015-of-00020.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00016-of-00020.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00017-of-00020.parquet",
+            "https://huggingface.co/datasets/wikimedia/wikipedia/resolve/main/20231101.de/train-00018-of-00020.parquet",
+        ]
+
+        df = daft.from_pydict({"urls": urls})
+
+        # Parse URLs and expand all fields
+        result = df.select(col("urls").url.parse().alias("url")).select(col("url").struct.get("*")).collect()
+
+        data = result.to_pydict()
+
+        # All URLs should have https scheme and huggingface.co host
+        assert all(scheme == "https" for scheme in data["scheme"])
+        assert all(host == "huggingface.co" for host in data["host"])
+
+        # All should have the expected path structure
+        for path in data["path"]:
+            assert path.startswith("/datasets/wikimedia/wikipedia/resolve/main/")
+            assert path.endswith(".parquet")
+
+        # No query, fragment, username, or password
+        assert all(query is None for query in data["query"])
+        assert all(fragment is None for fragment in data["fragment"])
+        assert all(username is None for username in data["username"])
+        assert all(password is None for password in data["password"])
+
+        # No explicit ports (should be None for default HTTPS)
+        assert all(port is None for port in data["port"])
+
+    def test_url_parse_with_authentication(self):
+        urls = [
+            "https://user@example.com/path",  # Username only
+            "https://user:pass@example.com/path",  # Username and password
+            "ftp://anonymous:email@ftp.example.com/file",  # FTP with credentials
+        ]
+
+        df = daft.from_pydict({"urls": urls})
+
+        result = df.select(col("urls").url.parse().alias("parsed")).select(col("parsed").struct.get("*")).collect()
+
+        data = result.to_pydict()
+
+        # First URL: username only
+        assert data["username"][0] == "user"
+        assert data["password"][0] is None
+
+        # Second URL: username and password
+        assert data["username"][1] == "user"
+        assert data["password"][1] == "pass"
+
+        # Third URL: FTP credentials
+        assert data["username"][2] == "anonymous"
+        assert data["password"][2] == "email"

--- a/tests/sql/test_uri_exprs.py
+++ b/tests/sql/test_uri_exprs.py
@@ -109,36 +109,34 @@ def test_url_parse():
         }
     )
 
-    # Test SQL url_parse function
     actual = (
         daft.sql(
             """
-        SELECT url_parse(urls) as parsed FROM df
+        SELECT url_parse(urls) FROM df
         """
         )
         .collect()
         .to_pydict()
     )
 
-    expected = df.select(col("urls").url.parse().alias("parsed")).collect().to_pydict()
+    expected = df.select(col("urls").url.parse()).collect().to_pydict()
 
     assert actual == expected
 
-    # Test extracting individual components from parsed URL
     actual_components = (
         daft.sql(
             """
         SELECT
-            parsed.scheme as scheme,
-            parsed.host as host,
-            parsed.port as port,
-            parsed.path as path,
-            parsed.query as query,
-            parsed.fragment as fragment,
-            parsed.username as username,
-            parsed.password as password
+            urls.scheme as scheme,
+            urls.host as host,
+            urls.port as port,
+            urls.path as path,
+            urls.query as query,
+            urls.fragment as fragment,
+            urls.username as username,
+            urls.password as password
         FROM (
-            SELECT url_parse(urls) as parsed FROM df
+            SELECT url_parse(urls) FROM df
         )
         """
         )
@@ -147,16 +145,16 @@ def test_url_parse():
     )
 
     expected_components = (
-        df.select(col("urls").url.parse().alias("parsed"))
+        df.select(col("urls").url.parse())
         .select(
-            col("parsed").struct.get("scheme").alias("scheme"),
-            col("parsed").struct.get("host").alias("host"),
-            col("parsed").struct.get("port").alias("port"),
-            col("parsed").struct.get("path").alias("path"),
-            col("parsed").struct.get("query").alias("query"),
-            col("parsed").struct.get("fragment").alias("fragment"),
-            col("parsed").struct.get("username").alias("username"),
-            col("parsed").struct.get("password").alias("password"),
+            col("urls").struct.get("scheme").alias("scheme"),
+            col("urls").struct.get("host").alias("host"),
+            col("urls").struct.get("port").alias("port"),
+            col("urls").struct.get("path").alias("path"),
+            col("urls").struct.get("query").alias("query"),
+            col("urls").struct.get("fragment").alias("fragment"),
+            col("urls").struct.get("username").alias("username"),
+            col("urls").struct.get("password").alias("password"),
         )
         .collect()
         .to_pydict()


### PR DESCRIPTION
## Changes Made

This PR implements a url parse expression. Note that I could not find a way to implement the exact example given in #2951 with `col('url.*')` but I used a struct field on which `.get("*")` can be called. Not sure this is exactly what you had in mind @universalmind303?

## Related Issues

Closes #2951

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
