### PR TITLE
chore: Refactor storage backends for native writers

### DIFF
--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -6,6 +6,7 @@ mod ipc;
 mod parquet_writer;
 mod partition;
 mod physical;
+mod storage_backend;
 #[cfg(test)]
 mod test;
 mod utils;

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -1,8 +1,6 @@
 use std::{
     collections::VecDeque,
     future::Future,
-    io::{BufWriter, Write},
-    num::NonZeroUsize,
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
@@ -11,16 +9,11 @@ use std::{
 use async_trait::async_trait;
 use common_error::{DaftError, DaftResult};
 use common_file_formats::FileFormat;
-use common_runtime::{
-    get_compute_pool_num_threads, get_compute_runtime, get_io_runtime, RuntimeTask,
-};
+use common_runtime::{get_compute_pool_num_threads, get_compute_runtime, get_io_runtime};
 use daft_core::prelude::*;
-use daft_io::{
-    get_io_client, parse_url, IOConfig, S3LikeSource, S3MultipartWriter, S3PartBuffer, SourceType,
-};
+use daft_io::{parse_url, IOConfig, SourceType};
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
-use parking_lot::Mutex;
 use parquet::{
     arrow::{
         arrow_writer::{compute_leaves, get_column_writers, ArrowColumnChunk, ArrowLeafColumn},
@@ -34,180 +27,13 @@ use parquet::{
     schema::types::SchemaDescriptor,
 };
 
-use crate::{utils::record_batch_to_partition_path, AsyncFileWriter};
+use crate::{
+    storage_backend::{FileStorageBackend, S3StorageBackend, StorageBackend},
+    utils::record_batch_to_partition_path,
+    AsyncFileWriter,
+};
 
 type ColumnWriterFuture = dyn Future<Output = DaftResult<ArrowColumnChunk>> + Send;
-
-/// We currently support two kinds of storage backends: FileStorageBackend for local file writes,
-/// and S3StorageBackend for writes to S3.
-#[async_trait]
-trait StorageBackend: Send + Sync + 'static {
-    type Writer: Write + Send + Sync;
-
-    /// Create the output buffer (buffered file writer, S3 buffer, etc).
-    async fn create_writer(&mut self, filename: &Path) -> DaftResult<Self::Writer>;
-
-    /// Finalize the write operation (close file, await upload to S3, etc).
-    async fn finalize(&mut self) -> DaftResult<()>;
-}
-
-struct FileStorageBackend {}
-
-impl FileStorageBackend {
-    // Buffer potentially small writes for highly compressed columns.
-    const DEFAULT_WRITE_BUFFER_SIZE: usize = 4 * 1024;
-}
-
-#[async_trait]
-impl StorageBackend for FileStorageBackend {
-    type Writer = BufWriter<std::fs::File>;
-
-    async fn create_writer(&mut self, filename: &Path) -> DaftResult<Self::Writer> {
-        // Create directories if they don't exist.
-        if let Some(parent) = filename.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let file = std::fs::File::create(filename)?;
-        Ok(BufWriter::with_capacity(
-            Self::DEFAULT_WRITE_BUFFER_SIZE,
-            file,
-        ))
-    }
-    async fn finalize(&mut self) -> DaftResult<()> {
-        // Nothing needed for finalizing file storage.
-        Ok(())
-    }
-}
-
-struct S3StorageBackend {
-    scheme: String,
-    io_config: IOConfig,
-    s3_client: Option<Arc<S3LikeSource>>,
-    s3part_buffer: Option<Arc<Mutex<S3PartBuffer>>>,
-    upload_task: Option<RuntimeTask<DaftResult<()>>>,
-}
-
-impl S3StorageBackend {
-    const S3_MULTIPART_PART_SIZE: usize = 8 * 1024 * 1024; // 8 MB
-    const S3_MULTIPART_MAX_CONCURRENT_UPLOADS_PER_OBJECT: usize = 100; // 100 uploads per S3 object
-
-    fn new(scheme: String, io_config: IOConfig) -> Self {
-        Self {
-            scheme,
-            io_config,
-            s3_client: None,
-            s3part_buffer: None,
-            upload_task: None,
-        }
-    }
-}
-
-/// A Send and Sync wrapper around S3PartBuffer.
-pub struct SharedS3PartBuffer {
-    inner: Arc<Mutex<S3PartBuffer>>,
-}
-
-impl Write for SharedS3PartBuffer {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.inner.lock().write(buf)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.inner.lock().flush()
-    }
-}
-
-#[async_trait]
-impl StorageBackend for S3StorageBackend {
-    type Writer = SharedS3PartBuffer;
-
-    async fn create_writer(&mut self, filename: &Path) -> DaftResult<Self::Writer> {
-        let filename = filename.to_string_lossy().to_string();
-        let part_size = NonZeroUsize::new(Self::S3_MULTIPART_PART_SIZE)
-            .expect("S3 multipart part size must be non-zero");
-        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
-
-        // Create the S3 part buffer that interfaces with parquet-rs.
-        let s3part_buffer = Arc::new(Mutex::new(S3PartBuffer::new(part_size, tx)));
-        self.s3part_buffer = Some(s3part_buffer.clone());
-
-        if self.s3_client.is_none() {
-            // Initialize S3 client if needed.
-            let io_config = Arc::new(self.io_config.clone());
-
-            let io_client = get_io_client(true, io_config)?;
-            let s3_client = io_client
-                .get_source(&format!("s3://{}", filename))
-                .await?
-                .as_any_arc()
-                .downcast()
-                .unwrap();
-            self.s3_client = Some(s3_client);
-        }
-
-        // Spawn background upload thread.
-        let s3_client = self
-            .s3_client
-            .clone()
-            .expect("S3 client must be initialized");
-        let uri = format!("{}://{}", self.scheme, filename);
-
-        let io_runtime = get_io_runtime(true);
-
-        let mut s3_multipart_writer = S3MultipartWriter::create(
-            uri,
-            part_size,
-            NonZeroUsize::new(Self::S3_MULTIPART_MAX_CONCURRENT_UPLOADS_PER_OBJECT)
-                .expect("S3 multipart concurrent uploads per object must be non-zero"),
-            s3_client,
-        )
-        .await
-        .expect("Failed to create S3 multipart writer");
-
-        let background_task = io_runtime.spawn(async move {
-            while let Some(part) = rx.recv().await {
-                s3_multipart_writer.write_part(part).await?;
-            }
-            s3_multipart_writer.shutdown().await?;
-            Ok(())
-        });
-
-        self.upload_task = Some(background_task);
-
-        Ok(SharedS3PartBuffer {
-            inner: s3part_buffer,
-        })
-    }
-
-    async fn finalize(&mut self) -> DaftResult<()> {
-        let part_buffer = self
-            .s3part_buffer
-            .take()
-            .expect("S3 part buffer must be initialized for multipart upload");
-        let upload_task = self
-            .upload_task
-            .take()
-            .expect("Upload thread must be initialized for multipart upload");
-
-        let io_runtime = get_io_runtime(true);
-
-        io_runtime
-            .spawn_blocking(move || -> DaftResult<()> {
-                // Close the S3PartBuffer, this flushes any remaining data to S3 as the final part.
-                part_buffer.lock().shutdown()?;
-                Ok(())
-            })
-            .await
-            .map_err(|e| DaftError::ParquetError(e.to_string()))??;
-
-        // Wait for the upload task to complete.
-        upload_task
-            .await
-            .map_err(|e| DaftError::ParquetError(e.to_string()))??;
-
-        Ok(())
-    }
-}
 
 /// Helper function that checks if we support native writes given the file format, root directory, and schema.
 pub(crate) fn native_parquet_writer_supported(

--- a/src/daft-writers/src/storage_backend.rs
+++ b/src/daft-writers/src/storage_backend.rs
@@ -1,0 +1,182 @@
+use std::{
+    io::{BufWriter, Write},
+    num::NonZeroUsize,
+    path::Path,
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use common_error::{DaftError, DaftResult};
+use common_runtime::{get_io_runtime, RuntimeTask};
+use daft_io::{get_io_client, IOConfig, S3LikeSource, S3MultipartWriter, S3PartBuffer};
+use parking_lot::Mutex;
+
+/// A trait for storage backends. Currently only supports files and S3 as backends.
+#[async_trait]
+pub(crate) trait StorageBackend: Send + Sync + 'static {
+    type Writer: Write + Send + Sync;
+
+    /// Create the output buffer (buffered file writer, S3 buffer, etc).
+    async fn create_writer(&mut self, filename: &Path) -> DaftResult<Self::Writer>;
+
+    /// Finalize the write operation (close file, await upload to S3, etc).
+    async fn finalize(&mut self) -> DaftResult<()>;
+}
+
+pub(crate) struct FileStorageBackend {}
+
+impl FileStorageBackend {
+    // Buffer potentially small writes for highly compressed columns.
+    const DEFAULT_WRITE_BUFFER_SIZE: usize = 4 * 1024;
+}
+
+#[async_trait]
+impl StorageBackend for FileStorageBackend {
+    type Writer = BufWriter<std::fs::File>;
+
+    async fn create_writer(&mut self, filename: &Path) -> DaftResult<Self::Writer> {
+        // Create directories if they don't exist.
+        if let Some(parent) = filename.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = std::fs::File::create(filename)?;
+        Ok(BufWriter::with_capacity(
+            Self::DEFAULT_WRITE_BUFFER_SIZE,
+            file,
+        ))
+    }
+    async fn finalize(&mut self) -> DaftResult<()> {
+        // Nothing needed for finalizing file storage.
+        Ok(())
+    }
+}
+
+pub(crate) struct S3StorageBackend {
+    scheme: String,
+    io_config: IOConfig,
+    s3_client: Option<Arc<S3LikeSource>>,
+    s3part_buffer: Option<Arc<Mutex<S3PartBuffer>>>,
+    upload_task: Option<RuntimeTask<DaftResult<()>>>,
+}
+
+impl S3StorageBackend {
+    const S3_MULTIPART_PART_SIZE: usize = 8 * 1024 * 1024; // 8 MB
+    const S3_MULTIPART_MAX_CONCURRENT_UPLOADS_PER_OBJECT: usize = 100; // 100 uploads per S3 object
+
+    pub(crate) fn new(scheme: String, io_config: IOConfig) -> Self {
+        Self {
+            scheme,
+            io_config,
+            s3_client: None,
+            s3part_buffer: None,
+            upload_task: None,
+        }
+    }
+}
+
+/// A Send and Sync wrapper around S3PartBuffer.
+pub(crate) struct SharedS3PartBuffer {
+    inner: Arc<Mutex<S3PartBuffer>>,
+}
+
+impl Write for SharedS3PartBuffer {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.inner.lock().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.lock().flush()
+    }
+}
+
+#[async_trait]
+impl StorageBackend for S3StorageBackend {
+    type Writer = SharedS3PartBuffer;
+
+    async fn create_writer(&mut self, filename: &Path) -> DaftResult<Self::Writer> {
+        let filename = filename.to_string_lossy().to_string();
+        let part_size = NonZeroUsize::new(Self::S3_MULTIPART_PART_SIZE)
+            .expect("S3 multipart part size must be non-zero");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        // Create the S3 part buffer that interfaces with parquet-rs.
+        let s3part_buffer = Arc::new(Mutex::new(S3PartBuffer::new(part_size, tx)));
+        self.s3part_buffer = Some(s3part_buffer.clone());
+
+        if self.s3_client.is_none() {
+            // Initialize S3 client if needed.
+            let io_config = Arc::new(self.io_config.clone());
+
+            let io_client = get_io_client(true, io_config)?;
+            let s3_client = io_client
+                .get_source(&format!("s3://{}", filename))
+                .await?
+                .as_any_arc()
+                .downcast()
+                .unwrap();
+            self.s3_client = Some(s3_client);
+        }
+
+        // Spawn background upload thread.
+        let s3_client = self
+            .s3_client
+            .clone()
+            .expect("S3 client must be initialized");
+        let uri = format!("{}://{}", self.scheme, filename);
+
+        let io_runtime = get_io_runtime(true);
+
+        let mut s3_multipart_writer = S3MultipartWriter::create(
+            uri,
+            part_size,
+            NonZeroUsize::new(Self::S3_MULTIPART_MAX_CONCURRENT_UPLOADS_PER_OBJECT)
+                .expect("S3 multipart concurrent uploads per object must be non-zero"),
+            s3_client,
+        )
+        .await
+        .expect("Failed to create S3 multipart writer");
+
+        let background_task = io_runtime.spawn(async move {
+            while let Some(part) = rx.recv().await {
+                s3_multipart_writer.write_part(part).await?;
+            }
+            s3_multipart_writer.shutdown().await?;
+            Ok(())
+        });
+
+        self.upload_task = Some(background_task);
+
+        Ok(SharedS3PartBuffer {
+            inner: s3part_buffer,
+        })
+    }
+
+    async fn finalize(&mut self) -> DaftResult<()> {
+        let part_buffer = self
+            .s3part_buffer
+            .take()
+            .expect("S3 part buffer must be initialized for multipart upload");
+        let upload_task = self
+            .upload_task
+            .take()
+            .expect("Upload thread must be initialized for multipart upload");
+
+        let io_runtime = get_io_runtime(true);
+
+        io_runtime
+            .spawn_blocking(move || -> DaftResult<()> {
+                // Close the S3PartBuffer, this flushes any remaining data to S3 as the final part.
+                part_buffer.lock().shutdown()?;
+                Ok(())
+            })
+            .await
+            .map_err(|e| DaftError::ParquetError(e.to_string()))??;
+
+        // Wait for the upload task to complete.
+        upload_task
+            .await
+            .map_err(|e| DaftError::ParquetError(e.to_string()))??;
+
+        Ok(())
+    }
+}

--- a/src/daft-writers/src/utils.rs
+++ b/src/daft-writers/src/utils.rs
@@ -7,7 +7,7 @@ use daft_recordbatch::RecordBatch;
 /// The default value used by Hive for null partition values.
 const DEFAULT_PARTITION_VALUE: &str = "__HIVE_DEFAULT_PARTITION__";
 
-/// Helper function to build the filename for the parquet file.
+/// Helper function to build the filename for the output file.
 pub(crate) fn build_filename(
     source_type: SourceType,
     root_dir: &str,

--- a/src/daft-writers/src/utils.rs
+++ b/src/daft-writers/src/utils.rs
@@ -81,7 +81,7 @@ fn record_batch_to_partition_path(
     Ok(partition_path)
 }
 
-// Helper function to generate the parquet filename.
+// Helper function to generate a filename.
 fn generate_filename(file_idx: usize, suffix: &str) -> String {
     format!("{}-{}.{}", uuid::Uuid::new_v4(), file_idx, suffix)
 }

--- a/src/daft-writers/src/utils.rs
+++ b/src/daft-writers/src/utils.rs
@@ -1,10 +1,40 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use common_error::{DaftError, DaftResult};
+use daft_io::SourceType;
 use daft_recordbatch::RecordBatch;
 
 /// The default value used by Hive for null partition values.
-pub const DEFAULT_PARTITION_VALUE: &str = "__HIVE_DEFAULT_PARTITION__";
+const DEFAULT_PARTITION_VALUE: &str = "__HIVE_DEFAULT_PARTITION__";
+
+/// Helper function to build the filename for the parquet file.
+pub(crate) fn build_filename(
+    source_type: SourceType,
+    root_dir: &str,
+    partition_values: Option<&RecordBatch>,
+    file_idx: usize,
+    suffix: &str,
+) -> DaftResult<PathBuf> {
+    let partition_path = get_partition_path(partition_values)?;
+    let filename = generate_filename(file_idx, suffix);
+
+    match source_type {
+        SourceType::File => build_local_file_path(root_dir, partition_path, filename),
+        SourceType::S3 => build_s3_path(root_dir, partition_path, filename),
+        _ => Err(DaftError::ValueError(format!(
+            "Unsupported source type: {:?}",
+            source_type
+        ))),
+    }
+}
+
+/// Helper function to get the partition path from the record batch.
+fn get_partition_path(partition_values: Option<&RecordBatch>) -> DaftResult<PathBuf> {
+    match partition_values {
+        Some(partition_values) => Ok(record_batch_to_partition_path(partition_values, None)?),
+        None => Ok(PathBuf::new()),
+    }
+}
 
 /// Converts a single-row RecordBatch to a Hive-style partition path.
 ///
@@ -21,7 +51,7 @@ pub const DEFAULT_PARTITION_VALUE: &str = "__HIVE_DEFAULT_PARTITION__";
 ///
 /// * `Ok(PathBuf)` - The partition path if successful
 /// * `Err(DaftError)` - If the RecordBatch has more than one row, or if we fail to downcast the partition values to UTF-8 strings.
-pub(crate) fn record_batch_to_partition_path(
+fn record_batch_to_partition_path(
     record_batch: &RecordBatch,
     partition_null_fallback: Option<&str>,
 ) -> DaftResult<PathBuf> {
@@ -49,6 +79,29 @@ pub(crate) fn record_batch_to_partition_path(
         })
         .collect::<DaftResult<PathBuf>>()?;
     Ok(partition_path)
+}
+
+// Helper function to generate the parquet filename.
+fn generate_filename(file_idx: usize, suffix: &str) -> String {
+    format!("{}-{}.{}", uuid::Uuid::new_v4(), file_idx, suffix)
+}
+
+/// Helper function to build the path to a local file.
+fn build_local_file_path(
+    root_dir: &str,
+    partition_path: PathBuf,
+    filename: String,
+) -> DaftResult<PathBuf> {
+    let root_dir = Path::new(root_dir.trim_start_matches("file://"));
+    let dir = root_dir.join(partition_path);
+    Ok(dir.join(filename))
+}
+
+/// Helper function to build the path to an S3 url.
+fn build_s3_path(root_dir: &str, partition_path: PathBuf, filename: String) -> DaftResult<PathBuf> {
+    let (_scheme, bucket, key) = daft_io::s3_like::parse_s3_url(root_dir)?;
+    let key = Path::new(&key).join(partition_path).join(filename);
+    Ok(PathBuf::from(format!("{}/{}", bucket, key.display())))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Changes Made

Pull out the storage backends and utility functions currently used for the parquet writer. This sets us up for reusing this when writing to other file formats like JSON.