### PR TITLE
feat: HTTPConfig settings for timeouts and retries

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -448,8 +448,19 @@ class HTTPConfig:
     """I/O configuration for accessing HTTP systems."""
 
     bearer_token: str | None
+    retry_initial_backoff_ms: int
+    connect_timeout_ms: int
+    read_timeout_ms: int
+    num_tries: int
 
-    def __init__(self, bearer_token: str | None = None): ...
+    def __init__(
+        self,
+        bearer_token: str | None = None,
+        retry_initial_backoff_ms: int | None = None,
+        connect_timeout_ms: int | None = None,
+        read_timeout_ms: int | None = None,
+        num_tries: int | None = None,
+    ): ...
 
 class S3Config:
     """I/O configuration for accessing an S3-compatible system."""

--- a/src/common/io-config/src/http.rs
+++ b/src/common/io-config/src/http.rs
@@ -28,15 +28,6 @@ impl Default for HTTPConfig {
 }
 
 impl HTTPConfig {
-    pub fn new<S: Into<ObfuscatedString>>(bearer_token: Option<S>) -> Self {
-        Self {
-            bearer_token: bearer_token.map(std::convert::Into::into),
-            ..Default::default()
-        }
-    }
-}
-
-impl HTTPConfig {
     #[must_use]
     pub fn multiline_display(&self) -> Vec<String> {
         let mut res = vec![];

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -1074,10 +1074,25 @@ impl From<IOConfig> for config::IOConfig {
 impl HTTPConfig {
     #[new]
     #[must_use]
-    #[pyo3(signature = (bearer_token=None))]
-    pub fn new(bearer_token: Option<String>) -> Self {
+    #[pyo3(signature = (bearer_token=None, retry_initial_backoff_ms=None, connect_timeout_ms=None, read_timeout_ms=None, num_tries=None))]
+    pub fn new(
+        bearer_token: Option<String>,
+        retry_initial_backoff_ms: Option<u64>,
+        connect_timeout_ms: Option<u64>,
+        read_timeout_ms: Option<u64>,
+        num_tries: Option<u32>,
+    ) -> Self {
+        let def = crate::HTTPConfig::default();
         Self {
-            config: crate::HTTPConfig::new(bearer_token),
+            config: crate::HTTPConfig {
+                bearer_token: bearer_token.map(Into::into).or(def.bearer_token),
+                retry_initial_backoff_ms: retry_initial_backoff_ms
+                    .unwrap_or(def.retry_initial_backoff_ms),
+                connect_timeout_ms: connect_timeout_ms.unwrap_or(def.connect_timeout_ms),
+                read_timeout_ms: read_timeout_ms.unwrap_or(def.read_timeout_ms),
+                num_tries: num_tries.unwrap_or(def.num_tries),
+                ..def
+            },
         }
     }
 

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -146,6 +146,10 @@ pub struct IOConfig {
 /// Args:
 ///     user_agent (str, optional): The value for the user-agent header, defaults to "daft/{__version__}" if not provided
 ///     bearer_token (str, optional): Bearer token to use for authentication. This will be used as the value for the `Authorization` header. such as "Authorization: Bearer xxx"
+///     retry_initial_backoff_ms (int, optional): Initial backoff duration in milliseconds for an HTTP retry, defaults to 1000ms
+///     connect_timeout_ms (int, optional): Timeout duration to wait to make a connection to HTTP in milliseconds, defaults to 30 seconds
+///     read_timeout_ms (int, optional): Timeout duration to wait to read the first byte from HTTP in milliseconds, defaults to 30 seconds
+///     num_tries (int, optional): Number of attempts to make a connection, defaults to 5
 ///
 /// Examples:
 ///     >>> io_config = IOConfig(http=HTTPConfig(user_agent="my_application/0.0.1", bearer_token="xxx"))

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -204,6 +204,8 @@ impl HttpSource {
         let base_client = reqwest_middleware::reqwest::ClientBuilder::default()
             .pool_idle_timeout(Duration::from_secs(60))
             .pool_max_idle_per_host(70)
+            .connect_timeout(Duration::from_millis(config.connect_timeout_ms))
+            .read_timeout(Duration::from_millis(config.read_timeout_ms))
             .default_headers(default_headers)
             .build()
             .context(UnableToCreateClientSnafu)?;


### PR DESCRIPTION
## Changes Made

Expose the HTTPConfig settings for timeout and retry handling to Python

## Related Issues

Closes #4518.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
