### PR TITLE
fix: import error for unitycatalog

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -2093,8 +2093,7 @@ class ExpressionUrlNamespace(ExpressionNamespace):
         """
         multi_thread = ExpressionUrlNamespace._should_use_multithreading_tokio_runtime()
         io_config = ExpressionUrlNamespace._override_io_config_max_connections(max_connections, io_config)
-
-        if io_config.unity.endpoint is None:
+        if getattr(io_config, "unity", None) is not None and getattr(io_config.unity, "endpoint", None) is None:
             try:
                 from daft.catalog.__unity import UnityCatalog
             except ImportError:


### PR DESCRIPTION
fix: https://github.com/Eventual-Inc/Daft/issues/4553

This issue seems to have been modified in the main branch, but the modification doesn't seem to be thorough enough.
```
class IOConfig:
    unity = None  #

io_config = IOConfig()

io_config.unity.endpoint  # throw AttributeError: 'NoneType' have not 'endpoint'
```

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
