### PR TITLE
perf: Improve efficiency of `to_arrow` for struct / fixed size lists

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -260,7 +260,6 @@ class Series:
         _ensure_registered_super_ext_type()
 
         dtype = self.datatype()
-        arrow_arr = self._series.to_arrow()
 
         # Special-case for PyArrow FixedShapeTensor if it is supported by the version of PyArrow
         # TODO: Push this down into self._series.to_arrow()?
@@ -268,8 +267,8 @@ class Series:
             pyarrow_dtype = dtype.to_arrow_dtype()
             arrow_series = self._series.to_arrow()
             return pa.ExtensionArray.from_storage(pyarrow_dtype, arrow_series.storage)
-
-        return arrow_arr
+        else:
+            return self._series.to_arrow()
 
     def to_pylist(self) -> list[Any]:
         """Convert this Series to a Python list."""

--- a/daft/utils.py
+++ b/daft/utils.py
@@ -53,7 +53,9 @@ def pydict_to_rows(pydict: dict[str, list[Any]]) -> list[frozenset[tuple[str, An
     ]
 
 
-def freeze(input: dict[Any, Any] | list[Any] | Any) -> frozenset[Any] | tuple[Any, ...] | Any:
+def freeze(
+    input: dict[Any, Any] | list[Any] | Any,
+) -> frozenset[Any] | tuple[Any, ...] | Any:
     """Freezes mutable containers for equality comparison."""
     if isinstance(input, dict):
         return frozenset((key, freeze(value)) for key, value in input.items())
@@ -101,11 +103,8 @@ def map_operator_arrow_semantics(
 
 
 def pyarrow_supports_fixed_shape_tensor() -> bool:
-    """Whether pyarrow supports the fixed_shape_tensor canonical extension type.
-
-    We also check if the version is >= 13.0.0 because there is a bug when using the canonical extension type on < 13.0.0 with ray.
-    """
-    return hasattr(pa, "fixed_shape_tensor") and get_arrow_version() >= (13, 0, 0)
+    """Whether pyarrow supports the fixed_shape_tensor canonical extension type."""
+    return hasattr(pa, "fixed_shape_tensor")
 
 
 # Column utility functions

--- a/daft/utils.py
+++ b/daft/utils.py
@@ -101,12 +101,11 @@ def map_operator_arrow_semantics(
 
 
 def pyarrow_supports_fixed_shape_tensor() -> bool:
-    """Whether pyarrow supports the fixed_shape_tensor canonical extension type."""
-    from daft.context import get_context
+    """Whether pyarrow supports the fixed_shape_tensor canonical extension type.
 
-    return hasattr(pa, "fixed_shape_tensor") and (
-        (get_context().get_or_create_runner().name != "ray") or get_arrow_version() >= (13, 0, 0)
-    )
+    We also check if the version is >= 13.0.0 because there is a bug when using the canonical extension type on < 13.0.0 with ray.
+    """
+    return hasattr(pa, "fixed_shape_tensor") and get_arrow_version() >= (13, 0, 0)
 
 
 # Column utility functions

--- a/src/daft-core/src/python/series.rs
+++ b/src/daft-core/src/python/series.rs
@@ -81,13 +81,11 @@ impl PySeries {
         PyList::new(py, pyobj_vec_cloned)
     }
 
-    pub fn to_arrow(&self) -> PyResult<PyObject> {
+    pub fn to_arrow<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyAny>> {
         let arrow_array = self.series.to_arrow();
         let arrow_array = cast_array_from_daft_if_needed(arrow_array);
-        Python::with_gil(|py| {
-            let pyarrow = py.import(pyo3::intern!(py, "pyarrow"))?;
-            Ok(ffi::to_py_array(py, arrow_array, &pyarrow)?.unbind())
-        })
+        let pyarrow = py.import(pyo3::intern!(py, "pyarrow"))?;
+        ffi::to_py_array(py, arrow_array, &pyarrow)
     }
 
     pub fn __abs__(&self) -> PyResult<Self> {


### PR DESCRIPTION
## Changes Made

This PR improves the efficiency of `to_arrow` for structs and fixed size lists, namely getting rid of a redundant `to_arrow` and enabling parallelization for the array ipc ser/de.

When testing on the imagenet inference workload, the speedup was 6:15s -> 4:50s, roughly 30%

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
