### PR TITLE
fix: Fix `get_or_create_runner` deadlock

### DIFF
--- a/daft/utils.py
+++ b/daft/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from collections.abc import AsyncIterator, Iterable
 from typing import TYPE_CHECKING, Any, Callable, Union
 
@@ -126,6 +127,28 @@ def column_inputs_to_expressions(columns: ManyColumnsInputType) -> list[Expressi
 
     column_iter: Iterable[ColumnInputType] = [columns] if is_column_input(columns) else columns  # type: ignore
     return [col(c) if isinstance(c, str) else c for c in column_iter]
+
+
+def detect_ray_state() -> bool:
+    ray_is_initialized = False
+    ray_is_in_job = False
+    in_ray_worker = False
+    try:
+        import ray
+
+        if ray.is_initialized():
+            ray_is_initialized = True
+            # Check if running inside a Ray worker
+            if ray._private.worker.global_worker.mode == ray.WORKER_MODE:
+                in_ray_worker = True
+        # In a Ray job, Ray might not be initialized yet but we can pick up an environment variable as a heuristic here
+        elif os.getenv("RAY_JOB_ID") is not None:
+            ray_is_in_job = True
+
+    except ImportError:
+        pass
+
+    return not in_ray_worker and (ray_is_initialized or ray_is_in_job)
 
 
 class SyncFromAsyncIterator:

--- a/src/daft-catalog/src/impls/memory.rs
+++ b/src/daft-catalog/src/impls/memory.rs
@@ -310,10 +310,9 @@ impl Table for MemoryTable {
             return Err(DaftError::SchemaMismatch(format!("Expected overwritten table to preserve the schema, found:\nTable schema:\n{}\nNew schema:\n{}", schema, plan.schema())).into());
         }
 
-        let runner = get_context().get_or_create_runner()?;
-
         let pset = MicroPartitionSet::empty();
         pyo3::Python::with_gil(|py| {
+            let runner = get_context().get_or_create_runner(py)?;
             for (i, res) in runner.run_iter_tables(py, plan, None)?.enumerate() {
                 let mp = res?;
                 pset.set_partition(i, &mp)?;

--- a/src/daft-catalog/src/impls/memory.rs
+++ b/src/daft-catalog/src/impls/memory.rs
@@ -311,8 +311,8 @@ impl Table for MemoryTable {
         }
 
         let pset = MicroPartitionSet::empty();
+        let runner = get_context().get_or_create_runner()?;
         pyo3::Python::with_gil(|py| {
-            let runner = get_context().get_or_create_runner(py)?;
             for (i, res) in runner.run_iter_tables(py, plan, None)?.enumerate() {
                 let mp = res?;
                 pset.set_partition(i, &mp)?;

--- a/src/daft-connect/src/execute.rs
+++ b/src/daft-connect/src/execute.rs
@@ -37,9 +37,9 @@ impl ConnectSession {
         &self,
         lp: LogicalPlanBuilder,
     ) -> ConnectResult<BoxStream<DaftResult<Arc<MicroPartition>>>> {
+        let runner = get_context().get_or_create_runner()?;
         let result_set = tokio::task::spawn_blocking(move || {
             Python::with_gil(|py| {
-                let runner = get_context().get_or_create_runner(py)?;
                 Ok::<_, DaftError>(runner.run_iter_tables(py, lp, None)?.collect::<Vec<_>>())
             })
         })

--- a/src/daft-connect/src/execute.rs
+++ b/src/daft-connect/src/execute.rs
@@ -37,10 +37,9 @@ impl ConnectSession {
         &self,
         lp: LogicalPlanBuilder,
     ) -> ConnectResult<BoxStream<DaftResult<Arc<MicroPartition>>>> {
-        let runner = get_context().get_or_create_runner()?;
-
         let result_set = tokio::task::spawn_blocking(move || {
             Python::with_gil(|py| {
+                let runner = get_context().get_or_create_runner(py)?;
                 Ok::<_, DaftError>(runner.run_iter_tables(py, lp, None)?.collect::<Vec<_>>())
             })
         })

--- a/src/daft-context/src/lib.rs
+++ b/src/daft-context/src/lib.rs
@@ -88,14 +88,8 @@ impl DaftContext {
     /// Retrieves the runner.
     ///
     /// WARNING: This will set the runner if it has not yet been set.
-    ///
-    /// This method requires the GIL to be held, as it will need to call into python to create the runner.
-    pub fn get_or_create_runner(&self, py: Python) -> DaftResult<Arc<Runner>> {
-        // DO NOT REMOVE THIS ALLOW_THREADS CALL.
-        // Internally, get_or_create_runner will make a call intpy python that subsequently releases the GIL.
-        // Allowing other threads to acquire this lock, and will cause a deadlock.
-        // See: https://pyo3.rs/main/doc/pyo3/marker/struct.python#deadlocks for a simple example.
-        py.allow_threads(|| self.with_state_mut(|state| state.get_or_create_runner()))
+    pub fn get_or_create_runner(&self) -> DaftResult<Arc<Runner>> {
+        self.with_state_mut(|state| state.get_or_create_runner())
     }
 
     /// Get the current runner, if one has been set.

--- a/src/daft-context/src/partition_cache.rs
+++ b/src/daft-context/src/partition_cache.rs
@@ -68,9 +68,9 @@ pub fn put_partition_set_into_cache(
     use daft_micropartition::python::PyMicroPartitionSet;
     use pyo3::{types::PyAnyMethods, Python};
 
-    let runner = get_context().get_or_create_runner()?;
     Python::with_gil(|py| {
         // get runner as python object so we can add a partition to the cache
+        let runner = get_context().get_or_create_runner(py)?;
         let py_runner = runner.to_pyobj(py);
         let py_runner = py_runner.bind(py);
         // TODO chore: replace LocalPartitionSet with MicroPartitionSet

--- a/src/daft-context/src/partition_cache.rs
+++ b/src/daft-context/src/partition_cache.rs
@@ -68,9 +68,10 @@ pub fn put_partition_set_into_cache(
     use daft_micropartition::python::PyMicroPartitionSet;
     use pyo3::{types::PyAnyMethods, Python};
 
+    let runner = get_context().get_or_create_runner()?;
     Python::with_gil(|py| {
         // get runner as python object so we can add a partition to the cache
-        let py_runner = get_context().get_or_create_runner()?.to_pyobj(py);
+        let py_runner = runner.to_pyobj(py);
         let py_runner = py_runner.bind(py);
         // TODO chore: replace LocalPartitionSet with MicroPartitionSet
         //   We cannot use PyMicroPartition as a PartitionSet implementation

--- a/src/daft-context/src/partition_cache.rs
+++ b/src/daft-context/src/partition_cache.rs
@@ -68,9 +68,9 @@ pub fn put_partition_set_into_cache(
     use daft_micropartition::python::PyMicroPartitionSet;
     use pyo3::{types::PyAnyMethods, Python};
 
+    let runner = get_context().get_or_create_runner()?;
     Python::with_gil(|py| {
         // get runner as python object so we can add a partition to the cache
-        let runner = get_context().get_or_create_runner(py)?;
         let py_runner = runner.to_pyobj(py);
         let py_runner = py_runner.bind(py);
         // TODO chore: replace LocalPartitionSet with MicroPartitionSet

--- a/src/daft-context/src/python.rs
+++ b/src/daft-context/src/python.rs
@@ -32,7 +32,7 @@ impl PyDaftContext {
     }
 
     pub fn get_or_create_runner(&self, py: Python) -> PyResult<PyObject> {
-        let runner = self.inner.get_or_create_runner(py)?;
+        let runner = py.allow_threads(|| self.inner.get_or_create_runner())?;
 
         match runner.as_ref() {
             Runner::Ray(ray) => {
@@ -46,40 +46,40 @@ impl PyDaftContext {
         }
     }
     #[getter(_daft_execution_config)]
-    pub fn get_daft_execution_config(&self) -> PyResult<PyDaftExecutionConfig> {
-        let config = self.inner.execution_config();
+    pub fn get_daft_execution_config(&self, py: Python) -> PyResult<PyDaftExecutionConfig> {
+        let config = py.allow_threads(|| self.inner.execution_config());
         let config = PyDaftExecutionConfig { config };
         Ok(config)
     }
 
     #[getter(_daft_planning_config)]
-    pub fn get_daft_planning_config(&self) -> PyResult<PyDaftPlanningConfig> {
-        let config = self.inner.planning_config();
+    pub fn get_daft_planning_config(&self, py: Python) -> PyResult<PyDaftPlanningConfig> {
+        let config = py.allow_threads(|| self.inner.planning_config());
         let config = PyDaftPlanningConfig { config };
         Ok(config)
     }
 
     #[setter(_daft_execution_config)]
-    pub fn set_daft_execution_config(&self, config: PyDaftExecutionConfig) {
-        self.inner.set_execution_config(config.config);
+    pub fn set_daft_execution_config(&self, py: Python, config: PyDaftExecutionConfig) {
+        py.allow_threads(|| self.inner.set_execution_config(config.config));
     }
 
     #[setter(_daft_planning_config)]
-    pub fn set_daft_planning_config(&self, config: PyDaftPlanningConfig) {
-        self.inner.set_planning_config(config.config);
+    pub fn set_daft_planning_config(&self, py: Python, config: PyDaftPlanningConfig) {
+        py.allow_threads(|| self.inner.set_planning_config(config.config));
     }
 
     #[getter(_runner)]
     pub fn get_runner(&self, py: Python) -> Option<PyObject> {
-        let runner = self.inner.runner();
+        let runner = py.allow_threads(|| self.inner.runner());
         runner.map(|r| r.to_pyobj(py))
     }
 
     #[setter(_runner)]
-    pub fn set_runner(&self, runner: PyObject) -> PyResult<()> {
+    pub fn set_runner(&self, py: Python, runner: PyObject) -> PyResult<()> {
         let runner = Runner::from_pyobj(runner)?;
         let runner = Arc::new(runner);
-        self.inner.set_runner(runner)?;
+        py.allow_threads(|| self.inner.set_runner(runner))?;
         Ok(())
     }
 }

--- a/src/daft-context/src/python.rs
+++ b/src/daft-context/src/python.rs
@@ -32,15 +32,7 @@ impl PyDaftContext {
     }
 
     pub fn get_or_create_runner(&self, py: Python) -> PyResult<PyObject> {
-        let runner = py.allow_threads(|| {
-            let mut lock =
-                self.inner.state.write().map_err(|e| {
-                    PyErr::new::<pyo3::exceptions::PyException, _>(format!("{:?}", e))
-                })?;
-
-            let runner = lock.get_or_create_runner()?;
-            PyResult::Ok(runner)
-        })?;
+        let runner = self.inner.get_or_create_runner(py)?;
 
         match runner.as_ref() {
             Runner::Ray(ray) => {
@@ -55,49 +47,40 @@ impl PyDaftContext {
     }
     #[getter(_daft_execution_config)]
     pub fn get_daft_execution_config(&self) -> PyResult<PyDaftExecutionConfig> {
-        let state = self.inner.state.read().unwrap();
-        let config = state.config.execution.clone();
+        let config = self.inner.execution_config();
         let config = PyDaftExecutionConfig { config };
         Ok(config)
     }
 
     #[getter(_daft_planning_config)]
     pub fn get_daft_planning_config(&self) -> PyResult<PyDaftPlanningConfig> {
-        let state = self.inner.state.read().unwrap();
-        let config = state.config.planning.clone();
+        let config = self.inner.planning_config();
         let config = PyDaftPlanningConfig { config };
         Ok(config)
     }
 
     #[setter(_daft_execution_config)]
     pub fn set_daft_execution_config(&self, config: PyDaftExecutionConfig) {
-        let mut state = self.inner.state.write().unwrap();
-        state.config.execution = config.config;
+        self.inner.set_execution_config(config.config);
     }
 
     #[setter(_daft_planning_config)]
     pub fn set_daft_planning_config(&self, config: PyDaftPlanningConfig) {
-        let mut state = self.inner.state.write().unwrap();
-        state.config.planning = config.config;
+        self.inner.set_planning_config(config.config);
     }
 
     #[getter(_runner)]
     pub fn get_runner(&self, py: Python) -> Option<PyObject> {
-        let state = self.inner.state.read().unwrap();
-        state.runner.clone().map(|r| r.to_pyobj(py))
+        let runner = self.inner.runner();
+        runner.map(|r| r.to_pyobj(py))
     }
 
     #[setter(_runner)]
-    pub fn set_runner(&self, runner: Option<PyObject>) -> PyResult<()> {
-        if let Some(runner) = runner {
-            let runner = Runner::from_pyobj(runner)?;
-            let runner = Arc::new(runner);
-            self.inner.set_runner(runner)?;
-            Ok(())
-        } else {
-            self.inner.state.write().unwrap().runner = None;
-            Ok(())
-        }
+    pub fn set_runner(&self, runner: PyObject) -> PyResult<()> {
+        let runner = Runner::from_pyobj(runner)?;
+        let runner = Arc::new(runner);
+        self.inner.set_runner(runner)?;
+        Ok(())
     }
 }
 impl From<DaftContext> for PyDaftContext {


### PR DESCRIPTION
## Changes Made

Consider the following:
```
import concurrent.futures
from daft.context import get_context

with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
    futures = [
        executor.submit(lambda: get_context().get_or_create_runner()) for _ in range(10)
    ]

    results = [future.result() for future in concurrent.futures.as_completed(futures)]
```

where we just call `get_or_create_runner()` across multiple threads.

Thread 1: Acquires `DaftContext` rwlock
Thread 1: Checks if runner is set. Runner is not set
Thread 1: Checks if should use ray. Tries to import ray, releases GIL.
Thread 2: Acquires GIL, and tries to acquire `DaftContext` rwlock. Deadlock because Thread 1 is holding it.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
