### PR TITLE
chore: improve the stability of unit test

### DIFF
--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import io
+import os
+from collections.abc import Iterator
+
+import pytest
+import requests
+
+from tests.io.mock_aws_server import start_service, stop_process
+
+############################
+### AWS-specific fixtures ###
+############################
+
+
+@pytest.fixture(scope="session")
+def aws_credentials() -> dict[str, str]:
+    return {
+        "AWS_ACCESS_KEY_ID": "testing",
+        "AWS_SECRET_ACCESS_KEY": "testing",
+        "AWS_SESSION_TOKEN": "testing",
+    }
+
+
+@pytest.fixture(scope="session")
+def aws_server_ip() -> str:
+    return "127.0.0.1"
+
+
+@pytest.fixture(scope="session")
+def aws_server_port() -> int:
+    return 5000
+
+
+@pytest.fixture(scope="session")
+def aws_log_file(tmp_path_factory: pytest.TempPathFactory) -> Iterator[io.IOBase]:
+    # NOTE(Clark): We have to use a log file for the mock AWS server's stdout/sterr.
+    # - If we use None, then the server output will spam stdout.
+    # - If we use PIPE, then the server will deadlock if the (relatively small) buffer fills, and the server is pretty
+    #   noisy.
+    # - If we use DEVNULL, all log output is lost.
+    # With a tmp_path log file, we can prevent spam and deadlocks while also providing an avenue for debuggability, via
+    # changing this fixture to something persistent, or dumping the file to stdout before closing the file, etc.
+    tmp_path = tmp_path_factory.mktemp("aws_logging")
+    with open(tmp_path / "aws_log.txt", "w") as f:
+        yield f
+
+
+@pytest.fixture(scope="session")
+def aws_server(aws_server_ip: str, aws_server_port: int, aws_log_file: io.IOBase) -> Iterator[str]:
+    # NOTE(Clark): The background-threaded moto server tends to lock up under concurrent access, so we run a background
+    # moto_server process.
+    aws_server_url = f"http://{aws_server_ip}:{aws_server_port}"
+    old_env = os.environ.copy()
+    # Set required AWS environment variables before starting server.
+    # Required to opt out of concurrent writing, since we don't provide a LockClient.
+    os.environ["AWS_S3_ALLOW_UNSAFE_RENAME"] = "true"
+    try:
+        # Start moto server.
+        process = start_service(aws_server_ip, aws_server_port, aws_log_file)
+        yield aws_server_url
+    finally:
+        # Shutdown moto server.
+        stop_process(process)
+        # Restore old set of environment variables.
+        os.environ = old_env
+
+
+@pytest.fixture(scope="function")
+def reset_aws(aws_server) -> Iterator[None]:
+    # Clears local AWS server of all state (e.g. S3 buckets and objects).
+    yield
+    requests.post(f"{aws_server}/moto-api/reset")

--- a/tests/io/delta_lake/conftest.py
+++ b/tests/io/delta_lake/conftest.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import decimal
-import io
 import os
 import pathlib
 import posixpath
@@ -13,14 +12,12 @@ from collections.abc import Iterator
 import boto3
 import pyarrow as pa
 import pytest
-import requests
 from azure.storage.blob import BlobServiceClient
 from pytest_lazyfixture import lazy_fixture
 
 import daft
 from daft import DataCatalogTable, DataCatalogType
 from daft.io.object_store_options import io_config_to_storage_options
-from tests.io.mock_aws_server import start_service, stop_process
 
 
 @pytest.fixture(params=[1, 2, 8])
@@ -218,71 +215,6 @@ def _unity_table(
         finally:
             # Restore old set of environment variables.
             os.environ = old_env
-
-
-############################
-### AWS-specific fixtures ###
-############################
-
-
-@pytest.fixture(scope="session")
-def aws_credentials() -> dict[str, str]:
-    return {
-        "AWS_ACCESS_KEY_ID": "testing",
-        "AWS_SECRET_ACCESS_KEY": "testing",
-        "AWS_SESSION_TOKEN": "testing",
-    }
-
-
-@pytest.fixture(scope="session")
-def aws_server_ip() -> str:
-    return "127.0.0.1"
-
-
-@pytest.fixture(scope="session")
-def aws_server_port() -> int:
-    return 5000
-
-
-@pytest.fixture(scope="session")
-def aws_log_file(tmp_path_factory: pytest.TempPathFactory) -> Iterator[io.IOBase]:
-    # NOTE(Clark): We have to use a log file for the mock AWS server's stdout/sterr.
-    # - If we use None, then the server output will spam stdout.
-    # - If we use PIPE, then the server will deadlock if the (relatively small) buffer fills, and the server is pretty
-    #   noisy.
-    # - If we use DEVNULL, all log output is lost.
-    # With a tmp_path log file, we can prevent spam and deadlocks while also providing an avenue for debuggability, via
-    # changing this fixture to something persistent, or dumping the file to stdout before closing the file, etc.
-    tmp_path = tmp_path_factory.mktemp("aws_logging")
-    with open(tmp_path / "aws_log.txt", "w") as f:
-        yield f
-
-
-@pytest.fixture(scope="session")
-def aws_server(aws_server_ip: str, aws_server_port: int, aws_log_file: io.IOBase) -> Iterator[str]:
-    # NOTE(Clark): The background-threaded moto server tends to lock up under concurrent access, so we run a background
-    # moto_server process.
-    aws_server_url = f"http://{aws_server_ip}:{aws_server_port}"
-    old_env = os.environ.copy()
-    # Set required AWS environment variables before starting server.
-    # Required to opt out of concurrent writing, since we don't provide a LockClient.
-    os.environ["AWS_S3_ALLOW_UNSAFE_RENAME"] = "true"
-    try:
-        # Start moto server.
-        process = start_service(aws_server_ip, aws_server_port, aws_log_file)
-        yield aws_server_url
-    finally:
-        # Shutdown moto server.
-        stop_process(process)
-        # Restore old set of environment variables.
-        os.environ = old_env
-
-
-@pytest.fixture(scope="function")
-def reset_aws(aws_server) -> Iterator[None]:
-    # Clears local AWS server of all state (e.g. S3 buckets and objects).
-    yield
-    requests.post(f"{aws_server}/moto-api/reset")
 
 
 @pytest.fixture(scope="function")

--- a/tests/io/test_url_upload_local.py
+++ b/tests/io/test_url_upload_local.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
 import daft
@@ -67,6 +69,7 @@ def test_upload_local_row_specifc_urls(tmpdir):
         assert path == "file://" + expected
 
 
+@pytest.mark.skipif(os.geteuid() == 0, reason="Skipping test when run as root user")
 def test_upload_local_no_write_permissions(tmpdir):
     bytes_data = [b"a", b"b", b"c"]
     # We have no write permissions to the first and third paths.

--- a/tests/recordbatch/numeric/test_numeric.py
+++ b/tests/recordbatch/numeric/test_numeric.py
@@ -257,7 +257,7 @@ def test_table_numeric_trigonometry(fun: str, is_arc: bool, is_co: bool) -> None
     trigonometry_table = table.eval_expression_list([getattr(col("a"), fun)()])
     assert (
         all(
-            x == y or (math.isnan(x) and math.isnan(y))
+            x == pytest.approx(y, rel=1e-9) or (math.isnan(x) and math.isnan(y))
             for x, y in zip(trigonometry_table.get_column_by_name("a").to_pylist(), np_result.to_list())
         )
         is True

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -90,23 +90,6 @@ def test_subscripted_datatype_parsing(source, expected):
     assert DataType._infer_type(source) == expected
 
 
-@pytest.mark.parametrize(
-    ["source", "expected"],
-    [
-        # These tests must be run in later version of Python that allow for subscripting of types
-        (list[str], DataType.list(DataType.string())),
-        (dict[str, int], DataType.map(DataType.string(), DataType.int64())),
-        (
-            {"foo": list[str], "bar": int},
-            DataType.struct({"foo": DataType.list(DataType.string()), "bar": DataType.int64()}),
-        ),
-        (list[list[str]], DataType.list(DataType.list(DataType.string()))),
-    ],
-)
-def test_legacy_subscripted_datatype_parsing(source, expected):
-    assert DataType._infer_type(source) == expected
-
-
 @pytest.mark.parametrize("test_type", all_daft_types)
 def test_is_null(test_type):
     assert test_type.is_null() == (test_type == DataType.null())


### PR DESCRIPTION
## Changes Made


## Related Issues

improve some test cases describe in https://github.com/Eventual-Inc/Daft/discussions/4564

```
FAILED tests/io/test_s3_credentials_refresh.py::test_s3_credentials_refresh - botocore.errorfactory.BucketAlreadyOwnedByYou: An error occurred (BucketAlreadyOwnedByYou) when calling the CreateBucket operati...

FAILED tests/io/test_url_upload_local.py::test_upload_local_no_write_permissions - Failed: DID NOT RAISE <class 'daft.exceptions.DaftCoreException'>

FAILED tests/recordbatch/numeric/test_numeric.py::test_table_numeric_trigonometry[sinh-False-False] - assert False is True

FAILED tests/recordbatch/numeric/test_numeric.py::test_table_numeric_trigonometry[cosh-False-False] - assert False is True

FAILED tests/recordbatch/numeric/test_numeric.py::test_table_numeric_trigonometry[arccos-True-False] - assert False is True
```

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
