### PR TITLE
fix: fix ray connection issues with ray:// protocol

### DIFF
--- a/daft/pyspark/__init__.py
+++ b/daft/pyspark/__init__.py
@@ -16,7 +16,7 @@ spark = SparkSession.builder.local().getOrCreate()
 
 # alternatively, connect to a ray cluster
 
-spark = SparkSession.builder.remote("ray://<HEAD_IP>:6379").getOrCreate()
+spark = SparkSession.builder.remote("ray://<HEAD_IP>:10001").getOrCreate()
 # you can use `ray get-head-ip <cluster_config.yaml>` to get the head ip!
 # use spark as you would with the native spark library, but with a daft backend!
 

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -1229,11 +1229,6 @@ class RayRunner(Runner[ray.ObjectRef]):
     ) -> None:
         super().__init__()
 
-        # ray.init does not accept "ray://" prefix for some reason.
-        # We remove it here to avoid issues.
-        if address is not None and address.startswith("ray://"):
-            address = address.replace("ray://", "")
-
         self.ray_address = address
 
         if ray.is_initialized():

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -7,6 +7,7 @@ import os
 import threading
 import time
 import uuid
+import warnings
 from collections.abc import Generator, Iterable, Iterator
 from datetime import datetime
 from queue import Full, Queue
@@ -1239,6 +1240,16 @@ class RayRunner(Runner[ray.ObjectRef]):
                     address,
                 )
         else:
+            if address is not None:
+                if not address.endswith("10001"):
+                    warnings.warn(
+                        f"The address to a Ray client server is typically at port :10001, but instead we found: {address}"
+                    )
+                elif address.startswith("ray://"):
+                    warnings.warn(
+                        f"Expected Ray address to start with 'ray://' protocol but found: {address}. Automatically prefixing your address with the protocol to make a Ray connection: ray://{address}"
+                    )
+                    address = "ray://" + address
             ray.init(address=address)
 
         # Check if Ray is running in "client mode" (connected to a Ray cluster via a Ray client)

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -1245,7 +1245,7 @@ class RayRunner(Runner[ray.ObjectRef]):
                     warnings.warn(
                         f"The address to a Ray client server is typically at port :10001, but instead we found: {address}"
                     )
-                elif address.startswith("ray://"):
+                if not address.startswith("ray://"):
                     warnings.warn(
                         f"Expected Ray address to start with 'ray://' protocol but found: {address}. Automatically prefixing your address with the protocol to make a Ray connection: ray://{address}"
                     )

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -12,7 +12,7 @@ If you want to start a single node ray cluster on your local machine, you can do
 
 ```bash
 pip install ray[default]
-ray start --head --port=6379
+ray start --head
 ```
 
 This should output something like:
@@ -33,13 +33,13 @@ You can take the IP address and port and pass it to Daft with [`set_runner_ray`]
 
 ```python
 >>> import daft
->>> daft.context.set_runner_ray("127.0.0.1:6379")
-DaftContext(_daft_execution_config=<daft.daft.PyDaftExecutionConfig object at 0x100fbd1f0>, _daft_planning_config=<daft.daft.PyDaftPlanningConfig object at 0x100fbd270>, _runner_config=_RayRunnerConfig(address='127.0.0.1:6379', max_task_backlog=None), _disallow_set_runner=True, _runner=None)
+>>> daft.context.set_runner_ray("ray://127.0.0.1:10001")
+DaftContext(_daft_execution_config=<daft.daft.PyDaftExecutionConfig object at 0x100fbd1f0>, _daft_planning_config=<daft.daft.PyDaftPlanningConfig object at 0x100fbd270>, _runner_config=_RayRunnerConfig(address='127.0.0.1:10001', max_task_backlog=None), _disallow_set_runner=True, _runner=None)
 
 >>> df = daft.from_pydict({
 ...   'text': ['hello', 'world']
 ... })
-2024-07-29 15:49:26,610 INFO worker.py:1567 -- Connecting to existing Ray cluster at address: 127.0.0.1:6379...
+2024-07-29 15:49:26,610 INFO worker.py:1567 -- Connecting to existing Ray cluster at address: 127.0.0.1:10001...
 2024-07-29 15:49:26,622 INFO worker.py:1752 -- Connected to Ray cluster.
 
 >>> print(df)

--- a/docs/spark_connect.md
+++ b/docs/spark_connect.md
@@ -25,7 +25,7 @@ spark = SparkSession.builder.local().getOrCreate()
 
 # Alternatively, connect to a Ray cluster
 # You can use `ray get-head-ip <cluster_config.yaml>` to get the head ip!
-spark = SparkSession.builder.remote("ray://<HEAD_IP>:6379").getOrCreate()
+spark = SparkSession.builder.remote("ray://<HEAD_IP>:10001").getOrCreate()
 
 # Use spark as you would with the native spark library, but with a daft backend!
 spark.createDataFrame([{"hello": "world"}]).select(col("hello")).show()


### PR DESCRIPTION
## Changes Made

Testing against the most recent version of Ray (2.47.0):

When Daft connects to Ray, #3899 strips the `ray://` protocol. However this seems to be broken against new versions of Ray (I only tested from 2.44 onwards)

```
ray.init("ray://localhost:10001")  # ok

ray.init("localhost:10001")  # not ok -- gcs_client.cc:178: Failed to get cluster ID from GCS server: RpcError: RPC Error message: Method not found!; RPC Error details:
ray.init("localhost:6379")  # not ok -- 2025-06-19 11:30:45,578	INFO node.py:1047 -- Can't find a `node_ip_address.json` file from /tmp/ray/session_2025-06-19_10-54-08_399102_1. Have you started Ray instance using `ray start` or `ray.init`?
ray.init("ray://localhost:6379")  # not ok -- it just hangs
```

This PR fixes these issues, and standardizes across our documentation to have people connect Ray client mode via `:10001` instead of to redis directly.

The following was executed with Ray version `2.47.0`

Before:
<img width="1200" alt="image" src="https://github.com/user-attachments/assets/3b273075-b51a-4a99-9a2e-f070b13c5667" />

After:
<img width="922" alt="image" src="https://github.com/user-attachments/assets/7fc86005-5901-4414-87e0-f71afa47de8c" />

Connecting with 6379 throws weird errors and we should just throw an error to folks when they attempt to do so.

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/a922d2b8-1b7a-49fa-b22e-ff5311ca4b94" />


## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
