### PR TITLE
feat: Commit write sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,6 +2497,7 @@ dependencies = [
  "common-display",
  "common-error",
  "common-file-formats",
+ "common-io-config",
  "common-partitioning",
  "common-py-serde",
  "common-resource-request",
@@ -2857,6 +2858,7 @@ name = "daft-local-plan"
 version = "0.3.0-dev0"
 dependencies = [
  "common-error",
+ "common-file-formats",
  "common-py-serde",
  "common-resource-request",
  "common-scan-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2497,7 +2497,6 @@ dependencies = [
  "common-display",
  "common-error",
  "common-file-formats",
- "common-io-config",
  "common-partitioning",
  "common-py-serde",
  "common-resource-request",

--- a/src/daft-distributed/Cargo.toml
+++ b/src/daft-distributed/Cargo.toml
@@ -3,7 +3,6 @@ common-daft-config = {path = "../common/daft-config", default-features = false}
 common-display = {path = "../common/display", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}
-common-io-config = {path = "../common/io-config", default-features = false}
 common-partitioning = {path = "../common/partitioning", default-features = false}
 common-py-serde = {path = "../common/py-serde", default-features = false}
 common-resource-request = {path = "../common/resource-request", default-features = false}
@@ -33,7 +32,6 @@ python = [
   "common-daft-config/python",
   "common-error/python",
   "common-treenode/python",
-  "common-io-config/python",
   "daft-logical-plan/python",
   "daft-local-plan/python"
 ]

--- a/src/daft-distributed/Cargo.toml
+++ b/src/daft-distributed/Cargo.toml
@@ -3,6 +3,7 @@ common-daft-config = {path = "../common/daft-config", default-features = false}
 common-display = {path = "../common/display", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}
+common-io-config = {path = "../common/io-config", default-features = false}
 common-partitioning = {path = "../common/partitioning", default-features = false}
 common-py-serde = {path = "../common/py-serde", default-features = false}
 common-resource-request = {path = "../common/resource-request", default-features = false}
@@ -32,6 +33,7 @@ python = [
   "common-daft-config/python",
   "common-error/python",
   "common-treenode/python",
+  "common-io-config/python",
   "daft-logical-plan/python",
   "daft-local-plan/python"
 ]

--- a/src/daft-distributed/src/lib.rs
+++ b/src/daft-distributed/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 mod pipeline_node;
 mod plan;
 #[cfg(feature = "python")]

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -8,7 +8,7 @@ use daft_schema::schema::SchemaRef;
 use futures::StreamExt;
 
 use super::{
-    make_new_task_from_materialized_output, DistributedPipelineNode, PipelineOutput,
+    make_new_task_from_materialized_outputs, DistributedPipelineNode, PipelineOutput,
     RunningPipelineNode,
 };
 use crate::{
@@ -71,8 +71,8 @@ impl LimitNode {
                 }
                 Ordering::Equal => (PipelineOutput::Materialized(materialized_output), true),
                 Ordering::Greater => {
-                    let task = make_new_task_from_materialized_output(
-                        materialized_output,
+                    let task = make_new_task_from_materialized_outputs(
+                        vec![materialized_output],
                         &(self.clone() as Arc<dyn DistributedPipelineNode>),
                         &move |input| {
                             Ok(LocalPhysicalPlan::limit(

--- a/src/daft-distributed/src/pipeline_node/sink.rs
+++ b/src/daft-distributed/src/pipeline_node/sink.rs
@@ -3,20 +3,28 @@ use std::sync::Arc;
 use common_display::{tree::TreeDisplay, DisplayLevel};
 use common_error::DaftResult;
 use common_file_formats::WriteMode;
+use daft_dsl::ExprRef;
 use daft_local_plan::{LocalPhysicalPlan, LocalPhysicalPlanRef};
-use daft_logical_plan::{stats::StatsState, SinkInfo};
+use daft_logical_plan::{stats::StatsState, OutputFileInfo, SinkInfo};
 use daft_schema::schema::SchemaRef;
+use futures::TryStreamExt;
 
-use super::{DistributedPipelineNode, RunningPipelineNode};
+use super::{
+    make_new_task_from_materialized_outputs, DistributedPipelineNode, PipelineOutput,
+    RunningPipelineNode,
+};
 use crate::{
     pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
+    scheduling::{scheduler::SchedulerHandle, task::SwordfishTask},
     stage::{StageConfig, StageExecutionContext},
+    utils::channel::{create_channel, Sender},
 };
 
 pub(crate) struct SinkNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     sink_info: Arc<SinkInfo>,
+    data_schema: SchemaRef,
     child: Arc<dyn DistributedPipelineNode>,
 }
 
@@ -27,7 +35,8 @@ impl SinkNode {
         stage_config: &StageConfig,
         node_id: NodeID,
         sink_info: Arc<SinkInfo>,
-        schema: SchemaRef,
+        file_schema: SchemaRef,
+        data_schema: SchemaRef,
         child: Arc<dyn DistributedPipelineNode>,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -37,11 +46,12 @@ impl SinkNode {
             vec![*child.node_id()],
             vec![child.name()],
         );
-        let config = PipelineNodeConfig::new(schema, stage_config.config.clone());
+        let config = PipelineNodeConfig::new(file_schema, stage_config.config.clone());
         Self {
             config,
             context,
             sink_info,
+            data_schema,
             child,
         }
     }
@@ -50,8 +60,11 @@ impl SinkNode {
         Arc::new(self)
     }
 
-    fn create_sink_plan(&self, input: LocalPhysicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> {
-        let data_schema = input.schema().clone();
+    fn create_sink_plan(
+        &self,
+        input: LocalPhysicalPlanRef,
+        data_schema: SchemaRef,
+    ) -> DaftResult<LocalPhysicalPlanRef> {
         let file_schema = self.config.schema.clone();
         match self.sink_info.as_ref() {
             SinkInfo::OutputFileInfo(info) => {
@@ -93,6 +106,33 @@ impl SinkNode {
                 StatsState::NotMaterialized,
             )),
         }
+    }
+
+    async fn finish_writes_and_commit(
+        self: Arc<Self>,
+        info: OutputFileInfo<ExprRef>,
+        input: RunningPipelineNode,
+        scheduler: SchedulerHandle<SwordfishTask>,
+        sender: Sender<PipelineOutput<SwordfishTask>>,
+    ) -> DaftResult<()> {
+        let file_schema = self.config.schema.clone();
+        let data_schema = self.data_schema.clone();
+        let materialized_stream = input.materialize(scheduler);
+        let materialized = materialized_stream.try_collect::<Vec<_>>().await?;
+        let task = make_new_task_from_materialized_outputs(
+            materialized,
+            &(self as Arc<dyn DistributedPipelineNode>),
+            &move |input| {
+                Ok(LocalPhysicalPlan::commit_write(
+                    input,
+                    file_schema.clone(),
+                    info.clone().bind(&data_schema)?,
+                    StatsState::NotMaterialized,
+                ))
+            },
+        )?;
+        let _ = sender.send(PipelineOutput::Task(task)).await;
+        Ok(())
     }
 
     fn multiline_display(&self) -> Vec<String> {
@@ -174,7 +214,7 @@ impl DistributedPipelineNode for SinkNode {
 
         let sink_node = self.clone();
         let plan_builder = move |input: LocalPhysicalPlanRef| -> DaftResult<LocalPhysicalPlanRef> {
-            sink_node.create_sink_plan(input)
+            sink_node.create_sink_plan(input, sink_node.data_schema.clone())
         };
 
         let pipelined_node_with_writes =
@@ -185,16 +225,17 @@ impl DistributedPipelineNode for SinkNode {
                 WriteMode::Overwrite | WriteMode::OverwritePartitions
             )
         {
-            pipelined_node_with_writes.pipeline_instruction(
-                stage_context,
-                self,
-                move |input: LocalPhysicalPlanRef| -> DaftResult<LocalPhysicalPlanRef> {
-                    Ok(LocalPhysicalPlan::commit_write(
-                        input,
-                        StatsState::NotMaterialized,
-                    ))
-                },
-            )
+            let sink_node = self.clone();
+            let scheduler = stage_context.scheduler_handle.clone();
+            let (sender, receiver) = create_channel(1);
+            stage_context.joinset.spawn(Self::finish_writes_and_commit(
+                sink_node,
+                info.clone(),
+                pipelined_node_with_writes,
+                scheduler,
+                sender,
+            ));
+            RunningPipelineNode::new(receiver)
         } else {
             pipelined_node_with_writes
         }

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -187,6 +187,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 node_id,
                 sink.sink_info.clone(),
                 sink.schema.clone(),
+                sink.input.schema(),
                 self.curr_node.pop().unwrap(),
             )
             .arced(),

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -945,11 +945,7 @@ pub fn physical_plan_to_pipeline(
             ..
         }) => {
             let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
-            let write_sink = CommitWriteSink::new(
-                file_info.partition_cols.clone(),
-                file_schema.clone(),
-                file_info.clone(),
-            );
+            let write_sink = CommitWriteSink::new(file_schema.clone(), file_info.clone());
             BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
                 .boxed()
         }

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -12,10 +12,11 @@ use common_file_formats::FileFormat;
 use daft_core::{join::JoinSide, prelude::Schema};
 use daft_dsl::join::get_common_join_cols;
 use daft_local_plan::{
-    ActorPoolProject, Concat, CrossJoin, Dedup, EmptyScan, Explode, Filter, HashAggregate,
-    HashJoin, InMemoryScan, Limit, LocalPhysicalPlan, MonotonicallyIncreasingId, PhysicalWrite,
-    Pivot, Project, Sample, Sort, TopN, UnGroupedAggregate, Unpivot, WindowOrderByOnly,
-    WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy, WindowPartitionOnly,
+    ActorPoolProject, CommitWrite, Concat, CrossJoin, Dedup, EmptyScan, Explode, Filter,
+    HashAggregate, HashJoin, InMemoryScan, Limit, LocalPhysicalPlan, MonotonicallyIncreasingId,
+    PhysicalWrite, Pivot, Project, Sample, Sort, TopN, UnGroupedAggregate, Unpivot,
+    WindowOrderByOnly, WindowPartitionAndDynamicFrame, WindowPartitionAndOrderBy,
+    WindowPartitionOnly,
 };
 use daft_logical_plan::{stats::StatsState, JoinType};
 use daft_micropartition::{
@@ -40,6 +41,7 @@ use crate::{
         aggregate::AggregateSink,
         anti_semi_hash_join_probe::AntiSemiProbeSink,
         blocking_sink::BlockingSinkNode,
+        commit_write::CommitWriteSink,
         concat::ConcatSink,
         cross_join_collect::CrossJoinCollectSink,
         dedup::DedupSink,
@@ -931,7 +933,22 @@ pub fn physical_plan_to_pipeline(
                 writer_factory,
                 file_info.partition_cols.clone(),
                 file_schema.clone(),
-                Some(file_info.clone()),
+            );
+            BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
+                .boxed()
+        }
+        LocalPhysicalPlan::CommitWrite(CommitWrite {
+            input,
+            file_schema,
+            file_info,
+            stats_state,
+            ..
+        }) => {
+            let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
+            let write_sink = CommitWriteSink::new(
+                file_info.partition_cols.clone(),
+                file_schema.clone(),
+                file_info.clone(),
             );
             BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
                 .boxed()
@@ -979,7 +996,6 @@ pub fn physical_plan_to_pipeline(
                 writer_factory,
                 partition_by,
                 file_schema.clone(),
-                None,
             );
             BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
                 .boxed()
@@ -999,7 +1015,6 @@ pub fn physical_plan_to_pipeline(
                 writer_factory,
                 None,
                 file_schema.clone(),
-                None,
             );
             BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
                 .boxed()
@@ -1019,7 +1034,6 @@ pub fn physical_plan_to_pipeline(
                 writer_factory,
                 None,
                 file_schema.clone(),
-                None,
             );
             BlockingSinkNode::new(Arc::new(write_sink), child_node, stats_state.clone(), ctx)
                 .boxed()

--- a/src/daft-local-execution/src/sinks/commit_write.rs
+++ b/src/daft-local-execution/src/sinks/commit_write.rs
@@ -1,0 +1,188 @@
+use std::sync::Arc;
+
+use common_error::{DaftError, DaftResult};
+use common_file_formats::WriteMode;
+use daft_core::prelude::SchemaRef;
+use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_logical_plan::OutputFileInfo;
+use daft_micropartition::MicroPartition;
+use daft_recordbatch::RecordBatch;
+use tracing::{instrument, Span};
+
+use super::blocking_sink::{
+    BlockingSink, BlockingSinkFinalizeResult, BlockingSinkSinkResult, BlockingSinkState,
+    BlockingSinkStatus,
+};
+use crate::ExecutionTaskSpawner;
+
+struct CommitWriteState {
+    written_file_path_record_batches: Vec<RecordBatch>,
+}
+
+impl CommitWriteState {
+    pub fn new() -> Self {
+        Self {
+            written_file_path_record_batches: vec![],
+        }
+    }
+
+    pub fn append(&mut self, input: impl IntoIterator<Item = RecordBatch>) {
+        self.written_file_path_record_batches.extend(input);
+    }
+}
+
+impl BlockingSinkState for CommitWriteState {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+pub(crate) struct CommitWriteSink {
+    partition_by: Option<Vec<BoundExpr>>,
+    file_schema: SchemaRef,
+    file_info: OutputFileInfo<BoundExpr>,
+}
+
+impl CommitWriteSink {
+    pub(crate) fn new(
+        partition_by: Option<Vec<BoundExpr>>,
+        file_schema: SchemaRef,
+        file_info: OutputFileInfo<BoundExpr>,
+    ) -> Self {
+        Self {
+            partition_by,
+            file_schema,
+            file_info,
+        }
+    }
+}
+
+impl BlockingSink for CommitWriteSink {
+    #[instrument(skip_all, name = "CommitWriteSink::sink")]
+    fn sink(
+        &self,
+        input: Arc<MicroPartition>,
+        mut state: Box<dyn BlockingSinkState>,
+        _spawner: &ExecutionTaskSpawner,
+    ) -> BlockingSinkSinkResult {
+        let tables = match input.get_tables() {
+            Ok(tables) => tables,
+            Err(e) => {
+                return Err(e.into()).into();
+            }
+        };
+        state
+            .as_any_mut()
+            .downcast_mut::<CommitWriteState>()
+            .expect("CommitWriteSink should have CommitWriteState")
+            .append(tables.iter().cloned());
+        Ok(BlockingSinkStatus::NeedMoreInput(state)).into()
+    }
+
+    #[instrument(skip_all, name = "WriteSink::finalize")]
+    fn finalize(
+        &self,
+        states: Vec<Box<dyn BlockingSinkState>>,
+        spawner: &ExecutionTaskSpawner,
+    ) -> BlockingSinkFinalizeResult {
+        let file_schema = self.file_schema.clone();
+        let file_info = self.file_info.clone();
+        spawner
+            .spawn(
+                async move {
+                    let written_file_path_record_batches = states
+                        .into_iter()
+                        .flat_map(|mut state| {
+                            let state = state
+                                .as_any_mut()
+                                .downcast_mut::<CommitWriteState>()
+                                .expect("State type mismatch");
+                            std::mem::take(&mut state.written_file_path_record_batches)
+                        })
+                        .collect::<Vec<_>>();
+
+                    if matches!(
+                        file_info.write_mode,
+                        WriteMode::Overwrite | WriteMode::OverwritePartitions
+                    ) {
+                        #[cfg(feature = "python")]
+                        {
+                            use pyo3::{prelude::*, types::PyList};
+
+                            Python::with_gil(|py| {
+                                let fs = py.import(pyo3::intern!(py, "daft.filesystem"))?;
+                                let overwrite_files = fs.getattr("overwrite_files")?;
+                                let file_paths = written_file_path_record_batches
+                                    .iter()
+                                    .flat_map(|res| {
+                                        let path_index = res
+                                            .schema
+                                            .get_index("path")
+                                            .expect("path to be a column");
+
+                                        let s = res.get_column(path_index);
+                                        s.utf8()
+                                            .expect("path to be utf8")
+                                            .into_iter()
+                                            .filter_map(|s| s.map(|s| s.to_string()))
+                                    })
+                                    .collect::<Vec<_>>();
+                                let file_paths = PyList::new(py, file_paths).expect("file_paths");
+                                let root_dir = file_info.root_dir.clone();
+                                let py_io_config = file_info
+                                    .io_config
+                                    .clone()
+                                    .map(|io_conf| daft_io::python::IOConfig { config: io_conf });
+                                let overwrite_partitions =
+                                    matches!(file_info.write_mode, WriteMode::OverwritePartitions);
+                                overwrite_files.call1((
+                                    file_paths,
+                                    root_dir,
+                                    py_io_config,
+                                    overwrite_partitions,
+                                ))?;
+
+                                PyResult::Ok(())
+                            })
+                            .map_err(DaftError::PyO3Error)?;
+                        }
+                        #[cfg(not(feature = "python"))]
+                        {
+                            unimplemented!(
+                                "Overwrite mode is not supported without the Python feature."
+                            )
+                        }
+                    }
+                    let written_file_paths_mp = MicroPartition::new_loaded(
+                        file_schema,
+                        written_file_path_record_batches.into(),
+                        None,
+                    );
+                    Ok(Some(written_file_paths_mp.into()))
+                },
+                Span::current(),
+            )
+            .into()
+    }
+
+    fn name(&self) -> &'static str {
+        "CommitWriteSink"
+    }
+
+    fn make_state(&self) -> DaftResult<Box<dyn BlockingSinkState>> {
+        Ok(Box::new(CommitWriteState::new()) as Box<dyn BlockingSinkState>)
+    }
+
+    fn multiline_display(&self) -> Vec<String> {
+        let mut lines = vec![];
+        lines.push("CommitWriteSink".to_string());
+        if let Some(partition_by) = &self.partition_by {
+            lines.push(format!("Partition by: {:?}", partition_by));
+        }
+        lines
+    }
+
+    fn max_concurrency(&self) -> usize {
+        1
+    }
+}

--- a/src/daft-local-execution/src/sinks/mod.rs
+++ b/src/daft-local-execution/src/sinks/mod.rs
@@ -1,6 +1,7 @@
 pub mod aggregate;
 pub mod anti_semi_hash_join_probe;
 pub mod blocking_sink;
+pub mod commit_write;
 pub mod concat;
 pub mod cross_join_collect;
 pub mod dedup;

--- a/src/daft-local-execution/src/sinks/write.rs
+++ b/src/daft-local-execution/src/sinks/write.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
-use common_error::{DaftError, DaftResult};
-use common_file_formats::WriteMode;
+use common_error::DaftResult;
 use common_runtime::get_compute_pool_num_threads;
 use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::bound_expr::BoundExpr;
-use daft_logical_plan::OutputFileInfo;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use daft_writers::{AsyncFileWriter, WriterFactory};
@@ -57,8 +55,6 @@ pub(crate) struct WriteSink {
     writer_factory: Arc<dyn WriterFactory<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
     partition_by: Option<Vec<BoundExpr>>,
     file_schema: SchemaRef,
-    /// File information is needed for overwriting files.
-    file_info: Option<OutputFileInfo<BoundExpr>>,
 }
 
 impl WriteSink {
@@ -69,14 +65,12 @@ impl WriteSink {
         >,
         partition_by: Option<Vec<BoundExpr>>,
         file_schema: SchemaRef,
-        file_info: Option<OutputFileInfo<BoundExpr>>,
     ) -> Self {
         Self {
             write_format,
             writer_factory,
             partition_by,
             file_schema,
-            file_info,
         }
     }
 }
@@ -113,7 +107,6 @@ impl BlockingSink for WriteSink {
         spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkFinalizeResult {
         let file_schema = self.file_schema.clone();
-        let file_info = self.file_info.clone();
         spawner
             .spawn(
                 async move {
@@ -124,64 +117,6 @@ impl BlockingSink for WriteSink {
                             .downcast_mut::<WriteState>()
                             .expect("State type mismatch");
                         results.extend(state.writer.close().await?);
-                    }
-
-                    if let Some(file_info) = &file_info {
-                        if matches!(
-                            file_info.write_mode,
-                            WriteMode::Overwrite | WriteMode::OverwritePartitions
-                        ) {
-                            #[cfg(feature = "python")]
-                            {
-                                use pyo3::{prelude::*, types::PyList};
-
-                                Python::with_gil(|py| {
-                                    let fs = py.import(pyo3::intern!(py, "daft.filesystem"))?;
-                                    let overwrite_files = fs.getattr("overwrite_files")?;
-                                    let file_paths = results
-                                        .iter()
-                                        .flat_map(|res| {
-                                            let path_index = res
-                                                .schema
-                                                .get_index("path")
-                                                .expect("path to be a column");
-
-                                            let s = res.get_column(path_index);
-                                            s.utf8()
-                                                .expect("path to be utf8")
-                                                .into_iter()
-                                                .filter_map(|s| s.map(|s| s.to_string()))
-                                                .collect::<Vec<_>>()
-                                        })
-                                        .collect::<Vec<_>>();
-                                    let file_paths =
-                                        PyList::new(py, file_paths).expect("file_paths");
-                                    let root_dir = file_info.root_dir.clone();
-                                    let py_io_config = file_info.io_config.clone().map(|io_conf| {
-                                        daft_io::python::IOConfig { config: io_conf }
-                                    });
-                                    let overwrite_partitions = matches!(
-                                        file_info.write_mode,
-                                        WriteMode::OverwritePartitions
-                                    );
-                                    overwrite_files.call1((
-                                        file_paths,
-                                        root_dir,
-                                        py_io_config,
-                                        overwrite_partitions,
-                                    ))?;
-
-                                    PyResult::Ok(())
-                                })
-                                .map_err(DaftError::PyO3Error)?;
-                            }
-                            #[cfg(not(feature = "python"))]
-                            {
-                                unimplemented!(
-                                    "Overwrite mode is not supported without the Python feature."
-                                )
-                            }
-                        }
                     }
                     let mp = Arc::new(MicroPartition::new_loaded(
                         file_schema,

--- a/src/daft-local-plan/Cargo.toml
+++ b/src/daft-local-plan/Cargo.toml
@@ -1,5 +1,6 @@
 [dependencies]
 common-error = {path = "../common/error", default-features = false}
+common-file-formats = {path = "../common/file-formats", default-features = false}
 common-py-serde = {path = "../common/py-serde", default-features = false}
 common-resource-request = {path = "../common/resource-request", default-features = false}
 common-scan-info = {path = "../common/scan-info", default-features = false}

--- a/src/daft-local-plan/src/lib.rs
+++ b/src/daft-local-plan/src/lib.rs
@@ -12,8 +12,8 @@ pub use plan::DistributedActorPoolProject;
 #[cfg(feature = "python")]
 pub use plan::LanceWrite;
 pub use plan::{
-    ActorPoolProject, Concat, CrossJoin, Dedup, EmptyScan, Explode, Filter, HashAggregate,
-    HashJoin, InMemoryScan, Limit, LocalPhysicalPlan, LocalPhysicalPlanRef,
+    ActorPoolProject, CommitWrite, Concat, CrossJoin, Dedup, EmptyScan, Explode, Filter,
+    HashAggregate, HashJoin, InMemoryScan, Limit, LocalPhysicalPlan, LocalPhysicalPlanRef,
     MonotonicallyIncreasingId, PhysicalScan, PhysicalWrite, Pivot, Project, Sample, Sort, TopN,
     UnGroupedAggregate, Unpivot, WindowOrderByOnly, WindowPartitionAndDynamicFrame,
     WindowPartitionAndOrderBy, WindowPartitionOnly,

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -593,16 +593,10 @@ impl LocalPhysicalPlan {
 
     pub fn commit_write(
         input: LocalPhysicalPlanRef,
+        file_schema: SchemaRef,
+        file_info: OutputFileInfo<BoundExpr>,
         stats_state: StatsState,
     ) -> LocalPhysicalPlanRef {
-        let (file_schema, file_info) = match input.as_ref() {
-            Self::PhysicalWrite(PhysicalWrite {
-                file_schema,
-                file_info,
-                ..
-            }) => (file_schema.clone(), file_info.clone()),
-            _ => panic!("CommitWrite must be the followed by a PhysicalWrite"),
-        };
         Self::CommitWrite(CommitWrite {
             input,
             file_schema,
@@ -809,7 +803,7 @@ impl LocalPhysicalPlan {
                 Self::WindowOrderByOnly(WindowOrderByOnly {  order_by, descending, schema, functions, aliases, .. }) => Self::window_order_by_only(new_child.clone(), order_by.clone(), descending.clone(), schema.clone(), StatsState::NotMaterialized, functions.clone(), aliases.clone()),
                 Self::TopN(TopN {  sort_by, descending, nulls_first, limit, schema, .. }) => Self::top_n(new_child.clone(), sort_by.clone(), descending.clone(), nulls_first.clone(), *limit, StatsState::NotMaterialized),
                 Self::PhysicalWrite(PhysicalWrite {  data_schema, file_schema, file_info, stats_state, .. }) => Self::physical_write(new_child.clone(), data_schema.clone(), file_schema.clone(), file_info.clone(), stats_state.clone()),
-                Self::CommitWrite(CommitWrite {  input, stats_state, .. }) => Self::commit_write(new_child.clone(), stats_state.clone()),
+                Self::CommitWrite(CommitWrite {  input, stats_state, file_schema, file_info, .. }) => Self::commit_write(new_child.clone(), file_schema.clone(), file_info.clone(), stats_state.clone()),
                 #[cfg(feature = "python")]
                 Self::DataSink(DataSink {  input, data_sink_info, file_schema, stats_state, .. }) => Self::data_sink(new_child.clone(), data_sink_info.clone(), file_schema.clone(), stats_state.clone()),
                 #[cfg(feature = "python")]

--- a/src/daft-local-plan/src/translate.rs
+++ b/src/daft-local-plan/src/translate.rs
@@ -374,7 +374,7 @@ pub fn translate(plan: &LogicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> {
                         input,
                         data_schema,
                         sink.schema.clone(),
-                        bound_info,
+                        bound_info.clone(),
                         sink.stats_state.clone(),
                     );
                     if matches!(
@@ -383,6 +383,8 @@ pub fn translate(plan: &LogicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> {
                     ) {
                         Ok(LocalPhysicalPlan::commit_write(
                             physical_write,
+                            sink.schema.clone(),
+                            bound_info,
                             sink.stats_state.clone(),
                         ))
                     } else {

--- a/src/daft-local-plan/src/translate.rs
+++ b/src/daft-local-plan/src/translate.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};
+use common_file_formats::WriteMode;
 use common_scan_info::ScanState;
 use daft_core::join::JoinStrategy;
 use daft_dsl::{
@@ -368,14 +369,25 @@ pub fn translate(plan: &LogicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> {
             let data_schema = input.schema().clone();
             match sink.sink_info.as_ref() {
                 SinkInfo::OutputFileInfo(info) => {
-                    let info = info.clone().bind(&data_schema)?;
-                    Ok(LocalPhysicalPlan::physical_write(
+                    let bound_info = info.clone().bind(&data_schema)?;
+                    let physical_write = LocalPhysicalPlan::physical_write(
                         input,
                         data_schema,
                         sink.schema.clone(),
-                        info,
+                        bound_info,
                         sink.stats_state.clone(),
-                    ))
+                    );
+                    if matches!(
+                        info.write_mode,
+                        WriteMode::Overwrite | WriteMode::OverwritePartitions
+                    ) {
+                        Ok(LocalPhysicalPlan::commit_write(
+                            physical_write,
+                            sink.stats_state.clone(),
+                        ))
+                    } else {
+                        Ok(physical_write)
+                    }
                 }
                 #[cfg(feature = "python")]
                 SinkInfo::CatalogInfo(info) => match &info.catalog {

--- a/tests/io/test_write_modes.py
+++ b/tests/io/test_write_modes.py
@@ -249,66 +249,31 @@ def test_write_modes_s3_minio_empty_data(
 
 OVERWRITE_PARTITION_TEST_CASES = [
     pytest.param(
-        daft.range(0, 4).with_columns(
-            {
-                "a": daft.col("id").map_elements(lambda x: "a" if x < 2 else "b"),
-                "b": daft.col("id") + 1,
-            }
-        ),
-        daft.range(0, 4).with_columns(
-            {
-                "a": daft.col("id").map_elements(lambda x: "a" if x < 2 else "b"),
-                "b": daft.col("id") + 5,
-            }
-        ),
+        daft.range(0, 4, partitions=4).with_column("a", daft.lit("a")),
+        daft.range(0, 4, partitions=4).with_column("a", daft.lit("b")),
         {
-            "a": ["a", "a", "b", "b"],
-            "b": [5, 6, 7, 8],
+            "id": [0, 1, 2, 3],
+            "a": ["b", "b", "b", "b"],
         },
         id="overwrite-all",
     ),
     pytest.param(
-        daft.range(0, 4).with_columns(
-            {
-                "a": daft.col("id").map_elements(lambda x: "a" if x < 2 else "b"),
-                "b": daft.col("id") + 1,
-            }
-        ),
-        daft.range(0, 2).with_columns({"a": daft.col("id").map_elements(lambda x: "a"), "b": daft.col("id") + 5}),
+        daft.range(0, 4, partitions=4).with_column("a", daft.lit("a")),
+        daft.range(0, 2, partitions=4).with_column("a", daft.lit("b")),
         {
-            "a": ["a", "a", "b", "b"],
-            "b": [5, 6, 3, 4],
+            "id": [0, 1, 2, 3],
+            "a": ["b", "b", "a", "a"],
         },
         id="overwrite-some",
     ),
     pytest.param(
-        daft.range(0, 4).with_columns(
-            {
-                "a": daft.col("id").map_elements(lambda x: "a" if x < 2 else "b"),
-                "b": daft.col("id") + 1,
-            }
-        ),
-        daft.range(2, 6).with_columns(
-            {
-                "a": daft.col("id").map_elements(lambda x: "b" if x < 4 else "c"),
-                "b": daft.col("id") + 7,
-            }
-        ),
+        daft.range(0, 4, partitions=4).with_column("a", daft.lit("a")),
+        daft.range(2, 6, partitions=4).with_column("a", daft.lit("b")),
         {
-            "a": ["a", "a", "b", "b", "c", "c"],
-            "b": [1, 2, 9, 10, 11, 12],
+            "id": [0, 1, 2, 3, 4, 5],
+            "a": ["a", "a", "b", "b", "b", "b"],
         },
         id="overwrite-and-append",
-    ),
-    pytest.param(
-        daft.range(0, 10).with_columns({"a": daft.col("id").alias("a"), "b": daft.col("id") + 1}),
-        daft.range(5, 15, partitions=10).with_columns({"a": daft.col("id").alias("a"), "b": daft.col("id") + 2}),
-        {
-            # Up to 4 is not overwritten and b is = a + 1, but 5-14 is overwritten and b is = a + 2
-            "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-            "b": [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        },
-        id="overwrite-and-append-multiple-partitions",
     ),
 ]
 
@@ -327,9 +292,9 @@ def _run_overwrite_partitions_test(
         path,
         format,
         "overwrite-partitions",
-        ["a"],
+        ["id"],
         io_config,
-        sort_cols=["a", "b"],
+        sort_cols=["id"],
     )
 
     # Check the data

--- a/tests/io/test_write_modes.py
+++ b/tests/io/test_write_modes.py
@@ -86,13 +86,17 @@ def arrange_write_mode_test(
 ):
     # Write some existing_data
     write(existing_data, path, format, "append", partition_cols, io_config)
-
+    print(f"Wrote existing data to {path}")
     # Write some new data
     write(new_data, path, format, write_mode, partition_cols, io_config)
+    print(f"Wrote new data to {path}")
 
     # Read back the data
     read_path = path + "/**" if partition_cols is not None else path
-    read_back = read(read_path, format, io_config).collect().sort(sort_cols).to_pydict()
+    read_back = read(read_path, format, io_config).collect()
+    print(f"Read back data from {read_path}")
+    read_back = read_back.sort(sort_cols).to_pydict()
+    print(f"Read back sorted data: {read_back}")
 
     return read_back
 


### PR DESCRIPTION
## Changes Made

Adds a `CommitWrite` sink to swordfish, which performs overwrite / overwrite partitions. In the future it will allow us to add other functionality needed to do `commits`.

Mainly this PR is to allow flotilla to properly perform overwrites, as previously it was doing it at a per-task level, which was incorrect.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
