### PR TITLE
fix: Fix daft.range partitioning logic

### DIFF
--- a/daft/io/_range.py
+++ b/daft/io/_range.py
@@ -159,13 +159,17 @@ class RangeSource(DataSource):
             partitions (int, optional): The number of partitions to split the range into. Defaults to 1.
         """
         if step == 0:
-            raise ValueError("step cannot be zero")
+            raise ValueError("daft.range() step parameter cannot be zero - use a positive or negative integer")
 
         if step > 0 and start >= end:
-            raise ValueError(f"for positive step {step}, start ({start}) must be less than end ({end})")
+            raise ValueError(
+                f"daft.range() with positive step {step} requires start ({start}) to be less than end ({end})"
+            )
 
         if step < 0 and start <= end:
-            raise ValueError(f"for negative step {step}, start ({start}) must be greater than end ({end})")
+            raise ValueError(
+                f"daft.range() with negative step {step} requires start ({start}) to be greater than end ({end})"
+            )
 
         self._start = start
         self._end = end

--- a/daft/io/_range.py
+++ b/daft/io/_range.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, overload
@@ -182,17 +183,11 @@ class RangeSource(DataSource):
     def get_tasks(self, pushdowns: Pushdowns) -> Iterator[RangeSourceTask]:
         step = self._step
 
-        # Calculate the total number of elements in the range
-        # For negative steps, we need to handle the calculation differently
+        # Calculate the total number of elements in the range using ceiling division
         if step > 0:
-            total_elements = (self._end - self._start) // step
-            if (self._end - self._start) % step != 0:
-                total_elements += 1
+            total_elements = math.ceil((self._end - self._start) / step)
         else:
-            # For negative steps, end < start
-            total_elements = (self._start - self._end) // abs(step)
-            if (self._start - self._end) % abs(step) != 0:
-                total_elements += 1
+            total_elements = math.ceil((self._start - self._end) / abs(step))
 
         # Calculate elements per partition
         elements_per_partition = total_elements // self._partitions

--- a/daft/io/_range.py
+++ b/daft/io/_range.py
@@ -157,6 +157,15 @@ class RangeSource(DataSource):
             step (int, optional): The step size of the range. Defaults to 1.
             partitions (int, optional): The number of partitions to split the range into. Defaults to 1.
         """
+        if step == 0:
+            raise ValueError("step cannot be zero")
+
+        if step > 0 and start >= end:
+            raise ValueError(f"for positive step {step}, start ({start}) must be less than end ({end})")
+
+        if step < 0 and start <= end:
+            raise ValueError(f"for negative step {step}, start ({start}) must be greater than end ({end})")
+
         self._start = start
         self._end = end
         self._step = step
@@ -172,14 +181,39 @@ class RangeSource(DataSource):
 
     def get_tasks(self, pushdowns: Pushdowns) -> Iterator[RangeSourceTask]:
         step = self._step
-        size = (self._end - self._start) // self._partitions
+
+        # Calculate the total number of elements in the range
+        # For negative steps, we need to handle the calculation differently
+        if step > 0:
+            total_elements = (self._end - self._start) // step
+            if (self._end - self._start) % step != 0:
+                total_elements += 1
+        else:
+            # For negative steps, end < start
+            total_elements = (self._start - self._end) // abs(step)
+            if (self._start - self._end) % abs(step) != 0:
+                total_elements += 1
+
+        # Calculate elements per partition
+        elements_per_partition = total_elements // self._partitions
+        remainder = total_elements % self._partitions
+
         curr_s = self._start
-        curr_e = self._start + size
-        while curr_e <= self._end:
+        for i in range(self._partitions):
+            # Add one extra element to early partitions if there's a remainder
+            partition_elements = elements_per_partition + (1 if i < remainder else 0)
+            curr_e = curr_s + (partition_elements * step)
+
+            # Ensure we don't exceed the end boundary
+            if step > 0:
+                if curr_e > self._end:
+                    curr_e = self._end
+            else:
+                if curr_e < self._end:
+                    curr_e = self._end
+
             yield RangeSourceTask(curr_s, curr_e, step)
-            # update to the next chunk
-            curr_s = curr_e + step
-            curr_e = curr_s + size
+            curr_s = curr_e
 
 
 @dataclass

--- a/tests/io/test_range.py
+++ b/tests/io/test_range.py
@@ -20,12 +20,6 @@ def test_range_with_step():
     assert df.to_pydict() == {"id": [2, 4, 6, 8]}
 
 
-@pytest.mark.skip("determine usage of 'num_partitions' in sources.")
-def test_range_with_partitions():
-    df = daft.range(2, 10, 2, 2)
-    assert df.num_partitions() == 2
-
-
 def test_range_with_step_kwargs():
     df = daft.range(2, 10, step=2)
     assert df.to_pydict() == {"id": [2, 4, 6, 8]}
@@ -54,3 +48,110 @@ def test_range_called_multiple_times():
     assert df_with_filter.count_rows() == 5
     assert len(df_with_filter.collect()) == 5
     assert len(df_with_filter.collect()) == 5
+
+
+def test_range_partitioning_even():
+    df = daft.range(0, 10, 1, 2)
+    assert df.num_partitions() == 2
+
+    partitions = list(df.iter_partitions())
+    assert len(partitions) == 2
+
+    assert partitions[0].to_pydict() == {"id": [0, 1, 2, 3, 4]}
+    assert partitions[1].to_pydict() == {"id": [5, 6, 7, 8, 9]}
+
+
+def test_range_partitioning_uneven():
+    df = daft.range(0, 10, 1, 3)
+    assert df.num_partitions() == 3
+
+    partitions = list(df.iter_partitions())
+    assert len(partitions) == 3
+
+    assert partitions[0].to_pydict() == {"id": [0, 1, 2, 3]}
+    assert partitions[1].to_pydict() == {"id": [4, 5, 6]}
+    assert partitions[2].to_pydict() == {"id": [7, 8, 9]}
+
+
+def test_range_partitioning_with_step_even():
+    df = daft.range(0, 24, 2, 4)
+    assert df.num_partitions() == 4
+
+    partitions = list(df.iter_partitions())
+    assert len(partitions) == 4
+
+    assert partitions[0].to_pydict() == {"id": [0, 2, 4]}
+    assert partitions[1].to_pydict() == {"id": [6, 8, 10]}
+    assert partitions[2].to_pydict() == {"id": [12, 14, 16]}
+    assert partitions[3].to_pydict() == {"id": [18, 20, 22]}
+
+
+def test_range_partitioning_with_step_uneven():
+    df = daft.range(0, 15, 2, 3)
+    assert df.num_partitions() == 3
+
+    partitions = list(df.iter_partitions())
+    assert len(partitions) == 3
+
+    assert partitions[0].to_pydict() == {"id": [0, 2, 4]}
+    assert partitions[1].to_pydict() == {"id": [6, 8, 10]}
+    assert partitions[2].to_pydict() == {"id": [12, 14]}
+
+
+def test_range_partitioning_with_negative_step_even():
+    df = daft.range(10, -2, -2, 2)
+    assert df.num_partitions() == 2
+
+    partitions = list(df.iter_partitions())
+    assert len(partitions) == 2
+
+    assert partitions[0].to_pydict() == {"id": [10, 8, 6]}
+    assert partitions[1].to_pydict() == {"id": [4, 2, 0]}
+
+
+def test_range_partitioning_with_negative_step_uneven():
+    df = daft.range(15, 0, -2, 3)
+    assert df.num_partitions() == 3
+
+    partitions = list(df.iter_partitions())
+    assert len(partitions) == 3
+
+    assert partitions[0].to_pydict() == {"id": [15, 13, 11]}
+    assert partitions[1].to_pydict() == {"id": [9, 7, 5]}
+    assert partitions[2].to_pydict() == {"id": [3, 1]}
+
+
+def test_range_negative_step_validation():
+    with pytest.raises(
+        ValueError,
+        match="for negative step -2, start \\(5\\) must be greater than end \\(10\\)",
+    ):
+        daft.range(5, 10, -2)
+
+    # Should raise error when start == end for negative step
+    with pytest.raises(
+        ValueError,
+        match="for negative step -1, start \\(5\\) must be greater than end \\(5\\)",
+    ):
+        daft.range(5, 5, -1)
+
+
+def test_range_positive_step_validation():
+    # Should raise error when start >= end for positive step
+    with pytest.raises(
+        ValueError,
+        match="for positive step 2, start \\(10\\) must be less than end \\(5\\)",
+    ):
+        daft.range(10, 5, 2)
+
+    # Should raise error when start == end for positive step
+    with pytest.raises(
+        ValueError,
+        match="for positive step 1, start \\(5\\) must be less than end \\(5\\)",
+    ):
+        daft.range(5, 5, 1)
+
+
+def test_range_zero_step_validation():
+    with pytest.raises(ValueError, match="step cannot be zero"):
+        daft.range(0, 10, 0)

--- a/tests/io/test_range.py
+++ b/tests/io/test_range.py
@@ -131,14 +131,14 @@ def test_range_partitioning_with_negative_step_uneven():
 def test_range_negative_step_validation():
     with pytest.raises(
         ValueError,
-        match="for negative step -2, start \\(5\\) must be greater than end \\(10\\)",
+        match="daft.range\\(\\) with negative step -2 requires start \\(5\\) to be greater than end \\(10\\)",
     ):
         daft.range(5, 10, -2)
 
     # Should raise error when start == end for negative step
     with pytest.raises(
         ValueError,
-        match="for negative step -1, start \\(5\\) must be greater than end \\(5\\)",
+        match="daft.range\\(\\) with negative step -1 requires start \\(5\\) to be greater than end \\(5\\)",
     ):
         daft.range(5, 5, -1)
 
@@ -147,18 +147,21 @@ def test_range_positive_step_validation():
     # Should raise error when start >= end for positive step
     with pytest.raises(
         ValueError,
-        match="for positive step 2, start \\(10\\) must be less than end \\(5\\)",
+        match="daft.range\\(\\) with positive step 2 requires start \\(10\\) to be less than end \\(5\\)",
     ):
         daft.range(10, 5, 2)
 
     # Should raise error when start == end for positive step
     with pytest.raises(
         ValueError,
-        match="for positive step 1, start \\(5\\) must be less than end \\(5\\)",
+        match="daft.range\\(\\) with positive step 1 requires start \\(5\\) to be less than end \\(5\\)",
     ):
         daft.range(5, 5, 1)
 
 
 def test_range_zero_step_validation():
-    with pytest.raises(ValueError, match="step cannot be zero"):
+    with pytest.raises(
+        ValueError,
+        match="daft.range\\(\\) step parameter cannot be zero - use a positive or negative integer",
+    ):
         daft.range(0, 10, 0)

--- a/tests/io/test_range.py
+++ b/tests/io/test_range.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import ray
 
 import daft
 
@@ -55,6 +56,7 @@ def test_range_partitioning_even():
     assert df.num_partitions() == 2
 
     partitions = list(df.iter_partitions())
+    partitions = ray.get(partitions) if isinstance(partitions[0], ray.ObjectRef) else partitions
     assert len(partitions) == 2
 
     assert partitions[0].to_pydict() == {"id": [0, 1, 2, 3, 4]}
@@ -66,6 +68,7 @@ def test_range_partitioning_uneven():
     assert df.num_partitions() == 3
 
     partitions = list(df.iter_partitions())
+    partitions = ray.get(partitions) if isinstance(partitions[0], ray.ObjectRef) else partitions
     assert len(partitions) == 3
 
     assert partitions[0].to_pydict() == {"id": [0, 1, 2, 3]}
@@ -78,6 +81,7 @@ def test_range_partitioning_with_step_even():
     assert df.num_partitions() == 4
 
     partitions = list(df.iter_partitions())
+    partitions = ray.get(partitions) if isinstance(partitions[0], ray.ObjectRef) else partitions
     assert len(partitions) == 4
 
     assert partitions[0].to_pydict() == {"id": [0, 2, 4]}
@@ -91,6 +95,7 @@ def test_range_partitioning_with_step_uneven():
     assert df.num_partitions() == 3
 
     partitions = list(df.iter_partitions())
+    partitions = ray.get(partitions) if isinstance(partitions[0], ray.ObjectRef) else partitions
     assert len(partitions) == 3
 
     assert partitions[0].to_pydict() == {"id": [0, 2, 4]}
@@ -103,6 +108,7 @@ def test_range_partitioning_with_negative_step_even():
     assert df.num_partitions() == 2
 
     partitions = list(df.iter_partitions())
+    partitions = ray.get(partitions) if isinstance(partitions[0], ray.ObjectRef) else partitions
     assert len(partitions) == 2
 
     assert partitions[0].to_pydict() == {"id": [10, 8, 6]}
@@ -114,6 +120,7 @@ def test_range_partitioning_with_negative_step_uneven():
     assert df.num_partitions() == 3
 
     partitions = list(df.iter_partitions())
+    partitions = ray.get(partitions) if isinstance(partitions[0], ray.ObjectRef) else partitions
     assert len(partitions) == 3
 
     assert partitions[0].to_pydict() == {"id": [15, 13, 11]}


### PR DESCRIPTION
## Changes Made

`daft.range` with partitions doesn't work properly.

Example:
```
df = daft.range(8, partitions=2)
print(df.to_pydict())
{'id': [0, 1, 2, 3]}
```

I expect the full range from 0-8


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
