### PR TITLE
feat: support reading from AWS Athena

### DIFF
--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -80,6 +80,9 @@ class SQLConnection:
         # sqlglot does not recognize "mssql" as a dialect, it instead recognizes "tsql", which is the SQL dialect for Microsoft SQL Server
         elif target_dialect == "mssql":
             target_dialect = "tsql"
+        # sqlglot does not recognize "awsathena", the dialect registered by PyAthena, SQLAlchemy driver for reading from AWS Athena. It only support "athena"
+        elif target_dialect == "awsathena":
+            target_dialect = "athena"
 
         if not any(target_dialect == supported_dialect.value for supported_dialect in sqlglot.Dialects):
             raise ValueError(


### PR DESCRIPTION
## Changes Made
- Change the target_dialect from "awsathena" to "athena", which is supported by sqlglot
## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
