### PR TITLE
fix: daft spark-connect server on windows hangs

### DIFF
--- a/daft/pyspark/__init__.py
+++ b/daft/pyspark/__init__.py
@@ -38,7 +38,7 @@ class Builder:
 
     def local(self) -> "Builder":
         self._connection = connect_start()
-        url = f"sc://0.0.0.0:{self._connection.port()}"
+        url = f"sc://localhost:{self._connection.port()}"
         self._builder = PySparkSession.builder.remote(url)
         return self
 
@@ -51,7 +51,7 @@ class Builder:
             else:
                 daft.context.set_runner_ray(address=url, noop_if_initialized=True)
             self._connection = connect_start()
-            url = f"sc://0.0.0.0:{self._connection.port()}"
+            url = f"sc://localhost:{self._connection.port()}"
             self._builder = PySparkSession.builder.remote(url)
             return self
         else:


### PR DESCRIPTION
## Changes Made

Changed local daft spark-connect server address to work both in linux and windows
Now doesn't hang in windows, no changes for linux

## Related Issues

Closes #4559 

Behaviour before the fix:
daft version 0.5.5, pyspark version 3.5.6
this works in linux, but hangs in windows:

```
from daft.pyspark import SparkSession
from pyspark.sql.functions import col

spark = SparkSession.builder.local().getOrCreate()
col("a") + col("b")
```

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
