### PR TITLE
feat(flotilla): Flotilla autoscaling

### DIFF
--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -28,7 +28,7 @@ from daft.runners.partitioning import (
 from daft.runners.profiler import profile
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator
+    from collections.abc import AsyncGenerator, AsyncIterator, Generator
 
     from daft.runners.ray_runner import RayMaterializedResult
 
@@ -178,11 +178,7 @@ def try_autoscale(num_cpus: int) -> None:
 
 
 class FlotillaPlanRunner:
-    """Core functionality for running distributed physical plans with Flotilla.
-
-    This class contains the business logic for managing plans and their execution,
-    separate from the Ray actor wrapper.
-    """
+    """Core functionality for running distributed physical plans with Flotilla."""
 
     def __init__(self) -> None:
         self.curr_plans: dict[str, DistributedPhysicalPlan] = {}
@@ -194,6 +190,7 @@ class FlotillaPlanRunner:
         plan: DistributedPhysicalPlan,
         partition_sets: dict[str, PartitionSet[ray.ObjectRef]],
     ) -> None:
+        """Start a plan on Flotilla."""
         psets = {
             k: [RayPartitionRef(v.partition(), v.metadata().num_rows, v.metadata().size_bytes or 0) for v in v.values()]
             for k, v in partition_sets.items()
@@ -201,7 +198,8 @@ class FlotillaPlanRunner:
         self.curr_plans[plan.id()] = plan
         self.curr_result_gens[plan.id()] = self.plan_runner.run_plan(plan, psets)
 
-    async def get_next_partition(self, plan_id: str) -> RayMaterializedResult | None:
+    async def _get_next_partition(self, plan_id: str) -> RayMaterializedResult | None:
+        """Get the next partition from a given plan."""
         from daft.runners.ray_runner import (
             PartitionMetadataAccessor,
             RayMaterializedResult,
@@ -226,52 +224,104 @@ class FlotillaPlanRunner:
         return materialized_result
 
 
-class LocalFlotillaPlanRunner:
-    """Local wrapper around FlotillaPlanRunnerCore.
+class LocalFlotillaPlanRunner(FlotillaPlanRunner):
+    """Local wrapper around FlotillaPlanRunner that uses asyncio to run the plan.
 
-    This wrapper provides the same interface as FlotillaPlanRunner but without
-    Ray actor overhead, useful for local testing or when distributed execution
-    is not needed.
+    For use in local testing or Ray job mode.
     """
 
     def __init__(self) -> None:
         self.loop = asyncio.new_event_loop()
-        self.core = self.loop.run_until_complete(self._make_runner())
-
-    async def _make_runner(self) -> FlotillaPlanRunner:
-        return FlotillaPlanRunner()
+        super().__init__()
 
     def run_plan(
         self,
         plan: DistributedPhysicalPlan,
         partition_sets: dict[str, PartitionSet[ray.ObjectRef]],
     ) -> None:
-        self.core.run_plan(plan, partition_sets)
+        super().run_plan(plan, partition_sets)
 
     def get_next_partition(self, plan_id: str) -> RayMaterializedResult | None:
         """Synchronous version of get_next_partition that internally uses asyncio."""
-        return self.loop.run_until_complete(self.core.get_next_partition(plan_id))
+        return self.loop.run_until_complete(self._get_next_partition(plan_id))
 
 
 @ray.remote(
     num_cpus=0,
 )
-class RemoteFlotillaPlanRunner:
-    """Ray actor wrapper around FlotillaPlanRunnerCore.
+class RemoteFlotillaPlanRunner(FlotillaPlanRunner):
+    """Ray actor wrapper around FlotillaPlanRunner.
 
-    This actor provides the distributed interface for running plans,
-    while delegating the actual work to the core class.
+    Used in Ray client mode.
     """
 
     def __init__(self) -> None:
-        self.core = FlotillaPlanRunner()
+        super().__init__()
 
-    def run_plan(
+    def start_plan(
         self,
         plan: DistributedPhysicalPlan,
         partition_sets: dict[str, PartitionSet[ray.ObjectRef]],
     ) -> None:
-        self.core.run_plan(plan, partition_sets)
+        super().run_plan(plan, partition_sets)
 
     async def get_next_partition(self, plan_id: str) -> RayMaterializedResult | None:
-        return await self.core.get_next_partition(plan_id)
+        return await self._get_next_partition(plan_id)
+
+
+def get_head_node_id() -> str | None:
+    for node in ray.nodes():
+        if (
+            "Resources" in node
+            and "node:__internal_head__" in node["Resources"]
+            and node["Resources"]["node:__internal_head__"] == 1
+        ):
+            return node["NodeID"]
+    return None
+
+
+FLOTILLA_PLAN_RUNNER_NAME = "flotilla-plan-runner"
+FLOTILLA_PLAN_RUNNER_NAMESPACE = "flotilla"
+
+
+class FlotillaRunnerHandle:
+    def __init__(self, use_remote_actor: bool) -> None:
+        if use_remote_actor:
+            head_node_id = get_head_node_id()
+            self.runner = RemoteFlotillaPlanRunner.options(  # type: ignore
+                name=FLOTILLA_PLAN_RUNNER_NAME,
+                namespace=FLOTILLA_PLAN_RUNNER_NAMESPACE,
+                get_if_exists=True,
+                scheduling_strategy=(
+                    ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
+                        node_id=head_node_id,
+                        soft=False,
+                    )
+                    if head_node_id is not None
+                    else "DEFAULT"
+                ),
+            ).remote()
+        else:
+            self.runner = LocalFlotillaPlanRunner()
+
+    def stream_plan(
+        self,
+        plan: DistributedPhysicalPlan,
+        partition_sets: dict[str, PartitionSet[ray.ObjectRef]],
+    ) -> Generator[RayMaterializedResult, None, None]:
+        # Start the plan
+        if isinstance(self.runner, RemoteFlotillaPlanRunner):
+            ray.get(self.runner.run_plan.remote(plan, partition_sets))  # type: ignore
+        else:
+            self.runner.run_plan(plan, partition_sets)
+
+        # Stream results
+        while True:
+            if isinstance(self.runner, RemoteFlotillaPlanRunner):
+                materialized_result = ray.get(self.runner.get_next_partition.remote(plan.id()))  # type: ignore
+            else:
+                materialized_result = self.runner.get_next_partition(plan.id())
+
+            if materialized_result is None:
+                break
+            yield materialized_result

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -26,7 +26,7 @@ from daft.daft import PyRecordBatch as _PyRecordBatch
 from daft.dependencies import np
 from daft.recordbatch import RecordBatch
 from daft.runners import ray_tracing
-from daft.runners.flotilla import LocalFlotillaPlanRunner, RemoteFlotillaPlanRunner
+from daft.runners.flotilla import FlotillaRunnerHandle
 from daft.runners.progress_bar import ProgressBar
 from daft.scarf_telemetry import track_runner_on_scarf
 from daft.series import Series, item_to_series
@@ -1021,18 +1021,6 @@ class Scheduler(ActorPoolManager):
 
 SCHEDULER_ACTOR_NAME = "scheduler"
 SCHEDULER_ACTOR_NAMESPACE = "daft"
-FLOTILLA_PLAN_RUNNER_NAME = "flotilla-plan-runner"
-
-
-def get_head_node_id() -> str | None:
-    for node in ray.nodes():
-        if (
-            "Resources" in node
-            and "node:__internal_head__" in node["Resources"]
-            and node["Resources"]["node:__internal_head__"] == 1
-        ):
-            return node["NodeID"]
-    return None
 
 
 @ray.remote(num_cpus=1)
@@ -1253,7 +1241,6 @@ class RayRunner(Runner[ray.ObjectRef]):
                     address = "ray://" + address
             ray.init(address=address)
 
-        self.flotilla_enabled = os.getenv("DAFT_FLOTILLA") == "1"
         # Check if Ray is running in "client mode" (connected to a Ray cluster via a Ray client)
         self.ray_client_mode: bool = force_client_mode or ray.util.client.ray.get_context().is_connected()
 
@@ -1267,28 +1254,12 @@ class RayRunner(Runner[ray.ObjectRef]):
                 max_task_backlog=max_task_backlog,
                 use_ray_tqdm=True,
             )
-            head_node_id = get_head_node_id()
-            self.flotilla_plan_runner = (
-                RemoteFlotillaPlanRunner.options(  # type: ignore
-                    name=FLOTILLA_PLAN_RUNNER_NAME,
-                    namespace=SCHEDULER_ACTOR_NAMESPACE,
-                    get_if_exists=True,
-                    scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
-                        node_id=head_node_id,
-                        soft=False,
-                    )
-                    if head_node_id is not None
-                    else "DEFAULT",
-                ).remote()
-                if self.flotilla_enabled
-                else None
-            )
         else:
             self.scheduler = Scheduler(
                 max_task_backlog=max_task_backlog,
                 use_ray_tqdm=False,
             )
-            self.flotilla_plan_runner = LocalFlotillaPlanRunner() if self.flotilla_enabled else None
+        self.flotilla_runner_handle: FlotillaRunnerHandle | None = None
 
     def initialize_partition_set_cache(self) -> PartitionSetCache:
         return PartitionSetCache()
@@ -1413,26 +1384,11 @@ class RayRunner(Runner[ray.ObjectRef]):
                 # Fallback to regular execution
                 yield from self._execute_plan(builder, daft_execution_config, results_buffer_size)
             else:
-                assert self.flotilla_plan_runner is not None
-                plan_id = distributed_plan.id()
-                if self.ray_client_mode:
-                    ray.get(
-                        self.flotilla_plan_runner.run_plan.remote(
-                            distributed_plan, self._part_set_cache.get_all_partition_sets()
-                        )
-                    )
-                    while True:
-                        materialized_result = ray.get(self.flotilla_plan_runner.get_next_partition.remote(plan_id))
-                        if materialized_result is None:
-                            break
-                        yield materialized_result
-                else:
-                    self.flotilla_plan_runner.run_plan(distributed_plan, self._part_set_cache.get_all_partition_sets())
-                    while True:
-                        materialized_result = self.flotilla_plan_runner.get_next_partition(plan_id)
-                        if materialized_result is None:
-                            break
-                        yield materialized_result
+                if self.flotilla_runner_handle is None:
+                    self.flotilla_runner_handle = FlotillaRunnerHandle(use_remote_actor=self.ray_client_mode)
+                yield from self.flotilla_runner_handle.stream_plan(
+                    distributed_plan, self._part_set_cache.get_all_partition_sets()
+                )
 
         else:
             yield from self._execute_plan(builder, daft_execution_config, results_buffer_size)

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -26,7 +26,7 @@ from daft.daft import PyRecordBatch as _PyRecordBatch
 from daft.dependencies import np
 from daft.recordbatch import RecordBatch
 from daft.runners import ray_tracing
-from daft.runners.flotilla import FlotillaRunnerHandle
+from daft.runners.flotilla import LocalFlotillaPlanRunner, RemoteFlotillaPlanRunner
 from daft.runners.progress_bar import ProgressBar
 from daft.scarf_telemetry import track_runner_on_scarf
 from daft.series import Series, item_to_series
@@ -1021,6 +1021,18 @@ class Scheduler(ActorPoolManager):
 
 SCHEDULER_ACTOR_NAME = "scheduler"
 SCHEDULER_ACTOR_NAMESPACE = "daft"
+FLOTILLA_PLAN_RUNNER_NAME = "flotilla-plan-runner"
+
+
+def get_head_node_id() -> str | None:
+    for node in ray.nodes():
+        if (
+            "Resources" in node
+            and "node:__internal_head__" in node["Resources"]
+            and node["Resources"]["node:__internal_head__"] == 1
+        ):
+            return node["NodeID"]
+    return None
 
 
 @ray.remote(num_cpus=1)
@@ -1241,6 +1253,7 @@ class RayRunner(Runner[ray.ObjectRef]):
                     address = "ray://" + address
             ray.init(address=address)
 
+        self.flotilla_enabled = os.getenv("DAFT_FLOTILLA") == "1"
         # Check if Ray is running in "client mode" (connected to a Ray cluster via a Ray client)
         self.ray_client_mode: bool = force_client_mode or ray.util.client.ray.get_context().is_connected()
 
@@ -1254,12 +1267,28 @@ class RayRunner(Runner[ray.ObjectRef]):
                 max_task_backlog=max_task_backlog,
                 use_ray_tqdm=True,
             )
+            head_node_id = get_head_node_id()
+            self.flotilla_plan_runner = (
+                RemoteFlotillaPlanRunner.options(  # type: ignore
+                    name=FLOTILLA_PLAN_RUNNER_NAME,
+                    namespace=SCHEDULER_ACTOR_NAMESPACE,
+                    get_if_exists=True,
+                    scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
+                        node_id=head_node_id,
+                        soft=False,
+                    )
+                    if head_node_id is not None
+                    else "DEFAULT",
+                ).remote()
+                if self.flotilla_enabled
+                else None
+            )
         else:
             self.scheduler = Scheduler(
                 max_task_backlog=max_task_backlog,
                 use_ray_tqdm=False,
             )
-        self.flotilla_runner_handle: FlotillaRunnerHandle | None = None
+            self.flotilla_plan_runner = LocalFlotillaPlanRunner() if self.flotilla_enabled else None
 
     def initialize_partition_set_cache(self) -> PartitionSetCache:
         return PartitionSetCache()
@@ -1384,11 +1413,26 @@ class RayRunner(Runner[ray.ObjectRef]):
                 # Fallback to regular execution
                 yield from self._execute_plan(builder, daft_execution_config, results_buffer_size)
             else:
-                if self.flotilla_runner_handle is None:
-                    self.flotilla_runner_handle = FlotillaRunnerHandle(use_remote_actor=self.ray_client_mode)
-                yield from self.flotilla_runner_handle.stream_plan(
-                    distributed_plan, self._part_set_cache.get_all_partition_sets()
-                )
+                assert self.flotilla_plan_runner is not None
+                plan_id = distributed_plan.id()
+                if self.ray_client_mode:
+                    ray.get(
+                        self.flotilla_plan_runner.run_plan.remote(
+                            distributed_plan, self._part_set_cache.get_all_partition_sets()
+                        )
+                    )
+                    while True:
+                        materialized_result = ray.get(self.flotilla_plan_runner.get_next_partition.remote(plan_id))
+                        if materialized_result is None:
+                            break
+                        yield materialized_result
+                else:
+                    self.flotilla_plan_runner.run_plan(distributed_plan, self._part_set_cache.get_all_partition_sets())
+                    while True:
+                        materialized_result = self.flotilla_plan_runner.get_next_partition(plan_id)
+                        if materialized_result is None:
+                            break
+                        yield materialized_result
 
         else:
             yield from self._execute_plan(builder, daft_execution_config, results_buffer_size)

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -16,12 +16,19 @@ use crate::scheduling::{
 // Wrapper around the RaySwordfishWorkerManager class in the distributed_swordfish module.
 pub(crate) struct RayWorkerManager {
     ray_workers: Arc<Mutex<HashMap<WorkerId, RaySwordfishWorker>>>,
+    task_locals: pyo3_async_runtimes::TaskLocals,
 }
 
 impl RayWorkerManager {
     pub fn try_new() -> DaftResult<Self> {
+        let task_locals = Python::with_gil(|py| {
+            pyo3_async_runtimes::tokio::get_current_locals(py)
+                .expect("Failed to get current task locals")
+        });
+
         Ok(Self {
             ray_workers: Arc::new(Mutex::new(HashMap::new())),
+            task_locals,
         })
     }
 
@@ -62,8 +69,6 @@ impl WorkerManager for RayWorkerManager {
         self.refresh_workers()?;
 
         Python::with_gil(|py| {
-            let task_locals = pyo3_async_runtimes::tokio::get_current_locals(py)?;
-
             let mut task_result_handles =
                 Vec::with_capacity(tasks_per_worker.values().map(|v| v.len()).sum());
 
@@ -72,7 +77,7 @@ impl WorkerManager for RayWorkerManager {
                 let handles = workers_guard
                     .get_mut(&worker_id)
                     .expect("Worker should be present in RayWorkerManager")
-                    .submit_tasks(tasks, py, &task_locals)?;
+                    .submit_tasks(tasks, py, &self.task_locals)?;
                 task_result_handles.extend(handles);
             }
             DaftResult::Ok(task_result_handles)

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -1,39 +1,59 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
 use common_error::DaftResult;
 use pyo3::prelude::*;
 
 use super::{task::RayTaskResultHandle, worker::RaySwordfishWorker};
 use crate::scheduling::{
-    scheduler::SchedulableTask,
+    scheduler::{SchedulableTask, WorkerSnapshot},
     task::{SwordfishTask, TaskID, TaskResultHandleAwaiter},
     worker::{Worker, WorkerId, WorkerManager},
 };
 
 // Wrapper around the RaySwordfishWorkerManager class in the distributed_swordfish module.
 pub(crate) struct RayWorkerManager {
-    ray_workers: HashMap<WorkerId, RaySwordfishWorker>,
+    ray_workers: Arc<Mutex<HashMap<WorkerId, RaySwordfishWorker>>>,
     task_locals: pyo3_async_runtimes::TaskLocals,
 }
 
 impl RayWorkerManager {
     pub fn try_new() -> DaftResult<Self> {
-        let (ray_workers, task_locals) = Python::with_gil(|py| {
-            let flotilla_module = py.import("daft.runners.flotilla")?;
-            let ray_workers = flotilla_module
-                .call_method0("start_ray_workers")?
-                .extract::<Vec<RaySwordfishWorker>>()?;
-            let ray_worker_hashmap = ray_workers
-                .into_iter()
-                .map(|w| (w.id().clone(), w))
-                .collect();
-            let task_locals = pyo3_async_runtimes::tokio::get_current_locals(py)
-                .expect("Failed to get current task locals");
-            DaftResult::Ok((ray_worker_hashmap, task_locals))
-        })?;
+        let task_locals = Python::with_gil(|py| {
+            pyo3_async_runtimes::tokio::get_current_locals(py)
+                .expect("Failed to get current task locals")
+        });
+
         Ok(Self {
-            ray_workers,
+            ray_workers: Arc::new(Mutex::new(HashMap::new())),
             task_locals,
+        })
+    }
+
+    fn refresh_workers(&self) -> DaftResult<()> {
+        Python::with_gil(|py| {
+            let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
+
+            // Get existing worker IDs to avoid duplicates
+            let mut workers_guard = self.ray_workers.lock().expect("Failed to lock ray_workers");
+
+            let ray_workers = flotilla_module
+                .call_method1(
+                    pyo3::intern!(py, "start_ray_workers"),
+                    (workers_guard
+                        .keys()
+                        .map(|id| id.as_ref())
+                        .collect::<Vec<_>>(),),
+                )?
+                .extract::<Vec<RaySwordfishWorker>>()?;
+
+            for worker in ray_workers {
+                workers_guard.insert(worker.id().clone(), worker);
+            }
+
+            DaftResult::Ok(())
         })
     }
 }
@@ -45,13 +65,17 @@ impl WorkerManager for RayWorkerManager {
         &self,
         tasks_per_worker: HashMap<WorkerId, Vec<SchedulableTask<SwordfishTask>>>,
     ) -> DaftResult<Vec<TaskResultHandleAwaiter<RayTaskResultHandle>>> {
+        // Refresh workers before submitting tasks to ensure we have the latest workers
+        self.refresh_workers()?;
+
         Python::with_gil(|py| {
             let mut task_result_handles =
                 Vec::with_capacity(tasks_per_worker.values().map(|v| v.len()).sum());
+
+            let mut workers_guard = self.ray_workers.lock().expect("Failed to lock ray_workers");
             for (worker_id, tasks) in tasks_per_worker {
-                let handles = self
-                    .ray_workers
-                    .get(&worker_id)
+                let handles = workers_guard
+                    .get_mut(&worker_id)
                     .expect("Worker should be present in RayWorkerManager")
                     .submit_tasks(tasks, py, &self.task_locals)?;
                 task_result_handles.extend(handles);
@@ -60,24 +84,39 @@ impl WorkerManager for RayWorkerManager {
         })
     }
 
-    fn workers(&self) -> &HashMap<WorkerId, Self::Worker> {
-        &self.ray_workers
+    fn worker_snapshots(&self) -> DaftResult<Vec<WorkerSnapshot>> {
+        self.refresh_workers()?;
+        let workers_guard = self.ray_workers.lock().expect("Failed to lock ray_workers");
+        Ok(workers_guard
+            .values()
+            .map(WorkerSnapshot::from)
+            .collect::<Vec<_>>())
     }
 
     fn mark_task_finished(&self, task_id: &TaskID, worker_id: &WorkerId) {
-        self.ray_workers
-            .get(worker_id)
+        let mut workers_guard = self.ray_workers.lock().expect("Failed to lock ray_workers");
+        workers_guard
+            .get_mut(worker_id)
             .expect("Worker should be present in RayWorkerManager")
             .mark_task_finished(task_id);
     }
 
     fn shutdown(&self) -> DaftResult<()> {
         Python::with_gil(|py| {
-            for worker in self.ray_workers.values() {
+            let workers_guard = self.ray_workers.lock().expect("Failed to lock ray_workers");
+            for worker in workers_guard.values() {
                 worker.shutdown(py);
             }
         });
         Ok(())
+    }
+
+    fn try_autoscale(&self, num_cpus: usize) -> DaftResult<()> {
+        Python::with_gil(|py| {
+            let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
+            flotilla_module.call_method1(pyo3::intern!(py, "try_autoscale"), (num_cpus,))?;
+            Ok(())
+        })
     }
 }
 

--- a/src/daft-distributed/src/scheduling/autoscaler.rs
+++ b/src/daft-distributed/src/scheduling/autoscaler.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use common_error::{DaftError, DaftResult};
+
+use crate::{
+    scheduling::worker::{Worker, WorkerManager},
+    utils::{
+        channel::{create_channel, Receiver, Sender},
+        joinset::JoinSet,
+    },
+};
+
+#[derive(Debug)]
+pub(super) enum AutoscalerRequest {
+    ScaleUp {
+        workers: usize,
+    },
+    #[allow(dead_code)]
+    ScaleDown {
+        workers: usize,
+    },
+}
+
+pub(super) struct AutoscalerActor<W: Worker> {
+    worker_manager: Arc<dyn WorkerManager<Worker = W>>,
+}
+
+impl<W: Worker> AutoscalerActor<W> {
+    pub fn new(worker_manager: Arc<dyn WorkerManager<Worker = W>>) -> Self {
+        Self { worker_manager }
+    }
+
+    pub fn spawn_autoscaler_actor(
+        autoscaler: Self,
+        joinset: &mut JoinSet<DaftResult<()>>,
+    ) -> AutoscalerHandle {
+        let (autoscaler_sender, autoscaler_receiver) = create_channel(1);
+        joinset.spawn(Self::run_autoscaler_loop(autoscaler, autoscaler_receiver));
+        AutoscalerHandle::new(autoscaler_sender)
+    }
+
+    async fn run_autoscaler_loop(
+        autoscaler: Self,
+        mut autoscaler_receiver: Receiver<AutoscalerRequest>,
+    ) -> DaftResult<()> {
+        while let Some(request) = autoscaler_receiver.recv().await {
+            match request {
+                AutoscalerRequest::ScaleUp { workers } => {
+                    autoscaler.worker_manager.try_autoscale(workers)?;
+                }
+                AutoscalerRequest::ScaleDown { workers } => {
+                    autoscaler.worker_manager.try_autoscale(workers)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(super) struct AutoscalerHandle {
+    autoscaler_sender: Sender<AutoscalerRequest>,
+}
+
+impl AutoscalerHandle {
+    pub fn new(autoscaler_sender: Sender<AutoscalerRequest>) -> Self {
+        Self { autoscaler_sender }
+    }
+
+    pub async fn send_autoscaling_request(&self, request: AutoscalerRequest) -> DaftResult<()> {
+        self.autoscaler_sender.send(request).await.map_err(|_| {
+            DaftError::InternalError("Failed to send autoscaler request".to_string())
+        })?;
+        Ok(())
+    }
+}

--- a/src/daft-distributed/src/scheduling/autoscaler.rs
+++ b/src/daft-distributed/src/scheduling/autoscaler.rs
@@ -10,7 +10,7 @@ use crate::{
     },
 };
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(super) enum AutoscalerRequest {
     ScaleUp {
         workers: usize,

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -127,6 +127,9 @@ impl<W: Worker> DispatcherActor<W> {
     where
         <W as Worker>::TaskResultHandle: std::marker::Send,
     {
+        // send worker updates at the start of the loop
+        Self::handle_worker_updates(&worker_manager, &worker_update_sender).await?;
+
         let mut input_exhausted = false;
         let mut running_tasks = JoinSet::new();
         let mut running_tasks_by_context = HashMap::new();

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use common_error::{DaftError, DaftResult};
 
@@ -21,6 +21,8 @@ pub(super) struct DispatcherActor<W: Worker> {
 }
 
 impl<W: Worker> DispatcherActor<W> {
+    const DISPATCHER_TICK_INTERVAL: Duration = Duration::from_secs(1);
+
     pub fn new(worker_manager: Arc<dyn WorkerManager<Worker = W>>) -> Self {
         Self { worker_manager }
     }
@@ -31,14 +33,7 @@ impl<W: Worker> DispatcherActor<W> {
         statistics_manager: StatisticsManagerRef,
     ) -> DispatcherHandle<W::Task> {
         let (dispatcher_sender, dispatcher_receiver) = create_channel(1);
-        let initial_worker_snapshots = dispatcher
-            .worker_manager
-            .workers()
-            .values()
-            .map(WorkerSnapshot::from)
-            .collect::<Vec<_>>();
-        let (worker_update_sender, worker_update_receiver) =
-            tokio::sync::watch::channel(initial_worker_snapshots);
+        let (worker_update_sender, worker_update_receiver) = tokio::sync::watch::channel(vec![]);
         joinset.spawn(Self::run_dispatcher_loop(
             dispatcher.worker_manager,
             dispatcher_receiver,
@@ -107,15 +102,18 @@ impl<W: Worker> DispatcherActor<W> {
             })?;
         }
 
-        let workers = worker_manager.workers();
-        let worker_snapshots = workers
-            .values()
-            .map(WorkerSnapshot::from)
-            .collect::<Vec<_>>();
-        if worker_update_sender.send(worker_snapshots).is_err() {
-            tracing::debug!("Unable to send worker update, dispatcher handle dropped");
-        }
+        Self::handle_worker_updates(worker_manager, worker_update_sender).await?;
+        Ok(())
+    }
 
+    async fn handle_worker_updates(
+        worker_manager: &Arc<dyn WorkerManager<Worker = W>>,
+        worker_update_sender: &tokio::sync::watch::Sender<Vec<WorkerSnapshot>>,
+    ) -> DaftResult<()> {
+        let worker_snapshots = worker_manager.worker_snapshots()?;
+        if worker_update_sender.send(worker_snapshots).is_err() {
+            tracing::debug!("Unable to send worker update while handling worker updates, dispatcher handle dropped");
+        }
         Ok(())
     }
 
@@ -132,7 +130,7 @@ impl<W: Worker> DispatcherActor<W> {
         let mut input_exhausted = false;
         let mut running_tasks = JoinSet::new();
         let mut running_tasks_by_context = HashMap::new();
-
+        let mut tick_interval = tokio::time::interval(Self::DISPATCHER_TICK_INTERVAL);
         while !input_exhausted || !running_tasks.is_empty() {
             tokio::select! {
                 maybe_tasks = task_rx.recv() => {
@@ -157,6 +155,9 @@ impl<W: Worker> DispatcherActor<W> {
                         &worker_update_sender,
                         &statistics_manager,
                     ).await?;
+                }
+                _ = tick_interval.tick() => {
+                    Self::handle_worker_updates(&worker_manager, &worker_update_sender).await?;
                 }
             }
         }

--- a/src/daft-distributed/src/scheduling/mod.rs
+++ b/src/daft-distributed/src/scheduling/mod.rs
@@ -1,3 +1,4 @@
+pub(super) mod autoscaler;
 pub(super) mod dispatcher;
 pub(super) mod scheduler;
 pub(crate) mod task;

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -542,4 +542,21 @@ mod tests {
         assert_eq!(*worker_task_counts.get(&worker_1).unwrap(), 1);
         assert_eq!(*worker_task_counts.get(&worker_2).unwrap(), 1);
     }
+
+    #[test]
+    fn test_default_scheduler_with_no_workers_can_autoscale() {
+        let mut scheduler: DefaultScheduler<MockTask> = setup_scheduler(&HashMap::new());
+
+        let tasks = vec![create_spread_task()];
+
+        scheduler.enqueue_tasks(tasks);
+        let result = scheduler.get_schedulable_tasks();
+
+        assert_eq!(result.len(), 0);
+        assert_eq!(scheduler.num_pending_tasks(), 1);
+        assert_eq!(
+            scheduler.get_autoscaling_request(),
+            Some(AutoscalerRequest::ScaleUp { workers: 1 })
+        );
+    }
 }

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -2,6 +2,7 @@ use std::collections::{BinaryHeap, HashMap};
 
 use super::{SchedulableTask, ScheduledTask, Scheduler, WorkerSnapshot};
 use crate::scheduling::{
+    autoscaler::AutoscalerRequest,
     task::{SchedulingStrategy, Task, TaskDetails},
     worker::WorkerId,
 };
@@ -111,6 +112,16 @@ impl<T: Task> Scheduler<T> for DefaultScheduler<T> {
 
     fn num_pending_tasks(&self) -> usize {
         self.pending_tasks.len()
+    }
+
+    fn get_autoscaling_request(&mut self) -> Option<AutoscalerRequest> {
+        // if there's no workers, we need to scale up by the number of pending tasks
+        if self.worker_snapshots.is_empty() {
+            return Some(AutoscalerRequest::ScaleUp {
+                workers: self.pending_tasks.len(),
+            });
+        }
+        None
     }
 }
 

--- a/src/daft-distributed/src/scheduling/scheduler/linear.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/linear.rs
@@ -1,7 +1,7 @@
 use std::collections::{BinaryHeap, HashMap};
 
 use super::{SchedulableTask, ScheduledTask, Scheduler, WorkerSnapshot};
-use crate::scheduling::{task::Task, worker::WorkerId};
+use crate::scheduling::{autoscaler::AutoscalerRequest, task::Task, worker::WorkerId};
 
 #[allow(dead_code)]
 pub(super) struct LinearScheduler<T: Task> {
@@ -49,6 +49,10 @@ impl<T: Task> Scheduler<T> for LinearScheduler<T> {
 
     fn num_pending_tasks(&self) -> usize {
         self.pending_tasks.len()
+    }
+
+    fn get_autoscaling_request(&mut self) -> Option<AutoscalerRequest> {
+        todo!("FLOTILLA_MS1: Implement get_autoscaling_request for linear scheduler")
     }
 }
 

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -5,7 +5,9 @@ use super::{
     worker::{Worker, WorkerId},
 };
 use crate::{
-    pipeline_node::MaterializedOutput, scheduling::task::TaskContext, utils::channel::OneshotSender,
+    pipeline_node::MaterializedOutput,
+    scheduling::{autoscaler::AutoscalerRequest, task::TaskContext},
+    utils::channel::OneshotSender,
 };
 
 mod default;
@@ -22,6 +24,7 @@ pub(super) trait Scheduler<T: Task>: Send + Sync {
     fn update_worker_state(&mut self, worker_snapshots: &[WorkerSnapshot]);
     fn enqueue_tasks(&mut self, tasks: Vec<SchedulableTask<T>>);
     fn get_schedulable_tasks(&mut self) -> Vec<ScheduledTask<T>>;
+    fn get_autoscaling_request(&mut self) -> Option<AutoscalerRequest>;
     fn num_pending_tasks(&self) -> usize;
 }
 
@@ -113,7 +116,7 @@ impl<T: Task> ScheduledTask<T> {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct WorkerSnapshot {
+pub(crate) struct WorkerSnapshot {
     worker_id: WorkerId,
     total_num_cpus: f64,
     total_num_gpus: f64,

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -10,12 +10,11 @@ use futures::FutureExt;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
-use super::{
-    default::DefaultScheduler, linear::LinearScheduler, SchedulableTask, Scheduler, WorkerSnapshot,
-};
+use super::{default::DefaultScheduler, linear::LinearScheduler, SchedulableTask, Scheduler};
 use crate::{
     pipeline_node::MaterializedOutput,
     scheduling::{
+        autoscaler::{AutoscalerActor, AutoscalerHandle},
         dispatcher::{DispatcherActor, DispatcherHandle},
         task::{Task, TaskID},
         worker::{Worker, WorkerManager},
@@ -60,26 +59,20 @@ where
     S: Scheduler<W::Task> + Send + 'static,
 {
     fn spawn_scheduler_actor(
-        mut scheduler: Self,
+        scheduler: Self,
         joinset: &mut JoinSet<DaftResult<()>>,
         statistics_manager: StatisticsManagerRef,
     ) -> SchedulerHandle<W::Task> {
         // Spawn a dispatcher actor to handle task dispatch and await task results
-        let initial_worker_snapshots = scheduler
-            .worker_manager
-            .workers()
-            .values()
-            .map(WorkerSnapshot::from)
-            .collect::<Vec<_>>();
-        scheduler
-            .scheduler
-            .update_worker_state(&initial_worker_snapshots);
-        let dispatcher_actor = DispatcherActor::new(scheduler.worker_manager);
+        let dispatcher_actor = DispatcherActor::new(scheduler.worker_manager.clone());
         let dispatcher_handle = DispatcherActor::spawn_dispatcher_actor(
             dispatcher_actor,
             joinset,
             statistics_manager.clone(),
         );
+
+        let autoscaler_actor = AutoscalerActor::new(scheduler.worker_manager);
+        let autoscaler_handle = AutoscalerActor::spawn_autoscaler_actor(autoscaler_actor, joinset);
 
         // Spawn the scheduler actor to schedule tasks and dispatch them to the dispatcher
         let (scheduler_sender, scheduler_receiver) = create_channel(10000);
@@ -87,6 +80,7 @@ where
             scheduler.scheduler,
             scheduler_receiver,
             dispatcher_handle,
+            autoscaler_handle,
             statistics_manager,
         ));
         SchedulerHandle::new(scheduler_sender)
@@ -127,6 +121,7 @@ where
         mut scheduler: S,
         mut task_rx: Receiver<SchedulableTask<W::Task>>,
         mut dispatcher_handle: DispatcherHandle<W::Task>,
+        autoscaler_handle: AutoscalerHandle,
         statistics_manager: StatisticsManagerRef,
     ) -> DaftResult<()> {
         let mut input_exhausted = false;
@@ -146,7 +141,15 @@ where
                 dispatcher_handle.dispatch_tasks(scheduled_tasks).await?;
             }
 
-            // 3: Concurrently wait for new tasks or worker updates
+            // 3: Send autoscaling request if needed
+            let autoscaling_request = scheduler.get_autoscaling_request();
+            if let Some(request) = autoscaling_request {
+                tracing::debug!("Sending autoscaling request: {:?}", request);
+
+                autoscaler_handle.send_autoscaling_request(request).await?;
+            }
+
+            // 4: Concurrently wait for new tasks or worker updates
             tokio::select! {
                 maybe_new_task = task_rx.recv() => {
                     Self::handle_new_tasks(maybe_new_task, &mut task_rx, &statistics_manager, &mut scheduler, &mut input_exhausted)?;


### PR DESCRIPTION
## Changes Made

Enable autoscaling functionality in the flotilla scheduler. 

For now it's quite basic, if there's no workers then request `num_cpus=num_pending_tasks`. In the future we should consider implementing autoscaling strategies. 

The ray worker manager autoscales via https://docs.ray.io/en/latest/cluster/running-applications/autoscaling/reference.html.

To check for new workers, the dispatcher now has a tick interval that queries the worker manager for updates. Upon receiving request for worker snapshots, the worker manager will now always check for new nodes to run workers on if available.

Tested this on a simple `read_parquet("TPCH_1000_LINEITEM").collect()` in a ray cluster with 0 workers and it autoscaled properly.



## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
