### PR TITLE
ci: Deflake series iter memory test

### DIFF
--- a/tests/series/test_series.py
+++ b/tests/series/test_series.py
@@ -14,6 +14,8 @@ import pytest
 from daft import DataType, Series
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES, ARROW_STRING_TYPES
 
+IS_CI = True if os.getenv("CI") else False
+
 
 class CustomTestObject:
     def __init__(self, a):
@@ -269,6 +271,7 @@ def get_memory_usage() -> float:
     return process.memory_info().rss / (1024 * 1024)
 
 
+@pytest.mark.skipif(IS_CI, reason="Memory usage test is flaky in CI environments")
 def test_series_iter_memory_efficiency() -> None:
     # Create a Series with 1 million elements.
     n = 1000_000


### PR DESCRIPTION
## Changes Made

We have a test assertion that a Series iterator takes less peak memory than converting the Series to pylist. This test is flaky in CI, but it's still useful for sanity checks. We can disable this test in CI environments.

Closes #4580 