### PR TITLE
feat(flotilla): Use task context for priority

### DIFF
--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -319,7 +319,6 @@ impl ActorUDF {
                 soft: false,
             },
             self.context.to_hashmap(),
-            self.context.node_id,
         ));
 
         Ok(task)
@@ -356,7 +355,6 @@ impl ActorUDF {
             psets,
             scheduling_strategy,
             self.context.to_hashmap(),
-            self.context.node_id,
         ));
         Ok(task)
     }

--- a/src/daft-distributed/src/pipeline_node/in_memory_source.rs
+++ b/src/daft-distributed/src/pipeline_node/in_memory_source.rs
@@ -105,7 +105,6 @@ impl InMemorySourceNode {
             // Need to get that from `ray.experimental.get_object_locations(object_refs)`
             SchedulingStrategy::Spread,
             self.context.to_hashmap(),
-            self.context.node_id,
         );
         Ok(task)
     }

--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -335,7 +335,6 @@ where
             soft: false,
         },
         node.context().to_hashmap(),
-        node.node_id(),
     );
     Ok(SubmittableTask::new(task))
 }
@@ -354,7 +353,6 @@ where
     let scheduling_strategy = submittable_task.task().strategy().clone();
     let psets = submittable_task.task().psets().clone();
     let config = submittable_task.task().config().clone();
-    let task_priority = submittable_task.task().task_priority();
 
     let task = submittable_task.with_new_task(SwordfishTask::new(
         task_context,
@@ -363,7 +361,6 @@ where
         psets,
         scheduling_strategy,
         node.context().to_hashmap(),
-        task_priority,
     ));
     Ok(task)
 }

--- a/src/daft-distributed/src/pipeline_node/scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/scan_source.rs
@@ -105,7 +105,6 @@ impl ScanSourceNode {
             Default::default(),
             SchedulingStrategy::Spread,
             self.context.to_hashmap(),
-            self.context.node_id,
         );
         Ok(task)
     }
@@ -120,7 +119,6 @@ impl ScanSourceNode {
             psets,
             SchedulingStrategy::Spread,
             self.context.to_hashmap(),
-            self.context.node_id,
         );
         Ok(task)
     }

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, collections::HashMap};
 
 use super::{
-    task::{SchedulingStrategy, Task, TaskDetails, TaskID, TaskPriority},
+    task::{SchedulingStrategy, Task, TaskDetails, TaskID},
     worker::{Worker, WorkerId},
 };
 use crate::{
@@ -47,11 +47,6 @@ impl<T: Task> SchedulableTask<T> {
 
     pub fn strategy(&self) -> &SchedulingStrategy {
         self.task.strategy()
-    }
-
-    #[allow(dead_code)]
-    pub fn priority(&self) -> TaskPriority {
-        self.task.priority()
     }
 
     pub fn task_context(&self) -> TaskContext {

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug, future::Future, sync::Arc};
+use std::{cmp::Ordering, collections::HashMap, fmt::Debug, future::Future, sync::Arc};
 
 use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
@@ -41,7 +41,6 @@ impl TaskResourceRequest {
 
 pub(crate) type TaskID = u32;
 pub(crate) type TaskName = String;
-pub(crate) type TaskPriority = u32;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[allow(clippy::struct_field_names)]
@@ -74,8 +73,10 @@ impl From<(&PipelineNodeContext, TaskID)> for TaskContext {
     }
 }
 
+pub(crate) trait TaskPriority: PartialOrd + PartialEq + Ord + Eq + Copy + Clone {}
+
 pub(crate) trait Task: Send + Sync + Debug + 'static {
-    fn priority(&self) -> TaskPriority;
+    fn priority(&self) -> impl TaskPriority;
     fn task_context(&self) -> TaskContext;
     fn resource_request(&self) -> &TaskResourceRequest;
     fn strategy(&self) -> &SchedulingStrategy;
@@ -134,6 +135,42 @@ pub(crate) enum SchedulingStrategy {
     WorkerAffinity { worker_id: WorkerId, soft: bool },
 }
 
+#[derive(Debug, Clone, Copy)]
+struct SwordfishTaskPriority {
+    task_context: TaskContext,
+}
+
+impl PartialEq for SwordfishTaskPriority {
+    fn eq(&self, other: &Self) -> bool {
+        self.task_context.task_id == other.task_context.task_id
+            && self.task_context.plan_id == other.task_context.plan_id
+            && self.task_context.stage_id == other.task_context.stage_id
+            && self.task_context.node_id == other.task_context.node_id
+    }
+}
+
+impl Eq for SwordfishTaskPriority {}
+
+impl PartialOrd for SwordfishTaskPriority {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SwordfishTaskPriority {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .task_context
+            .plan_id
+            .cmp(&self.task_context.plan_id)
+            .then_with(|| self.task_context.stage_id.cmp(&other.task_context.stage_id))
+            .then_with(|| self.task_context.node_id.cmp(&other.task_context.node_id))
+            .then_with(|| other.task_context.task_id.cmp(&self.task_context.task_id))
+    }
+}
+
+impl TaskPriority for SwordfishTaskPriority {}
+
 #[derive(Debug, Clone)]
 pub(crate) struct SwordfishTask {
     task_context: TaskContext,
@@ -143,7 +180,6 @@ pub(crate) struct SwordfishTask {
     psets: HashMap<String, Vec<PartitionRef>>,
     strategy: SchedulingStrategy,
     context: HashMap<String, String>,
-    task_priority: TaskPriority,
 }
 
 impl SwordfishTask {
@@ -154,7 +190,6 @@ impl SwordfishTask {
         psets: HashMap<String, Vec<PartitionRef>>,
         strategy: SchedulingStrategy,
         mut context: HashMap<String, String>,
-        task_priority: TaskPriority,
     ) -> Self {
         let resource_request = TaskResourceRequest::new(plan.resource_request());
         context.insert("task_id".to_string(), task_context.task_id.to_string());
@@ -167,7 +202,6 @@ impl SwordfishTask {
             psets,
             strategy,
             context,
-            task_priority,
         }
     }
 
@@ -194,10 +228,6 @@ impl SwordfishTask {
     pub fn name(&self) -> String {
         self.plan.single_line_display()
     }
-
-    pub fn task_priority(&self) -> TaskPriority {
-        self.task_priority
-    }
 }
 
 impl Task for SwordfishTask {
@@ -217,8 +247,10 @@ impl Task for SwordfishTask {
         &self.strategy
     }
 
-    fn priority(&self) -> TaskPriority {
-        self.task_priority
+    fn priority(&self) -> impl TaskPriority {
+        SwordfishTaskPriority {
+            task_context: self.task_context,
+        }
     }
 }
 
@@ -322,11 +354,18 @@ pub(super) mod tests {
         Arc::new(MockPartition::new(num_rows, size_bytes))
     }
 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct MockTaskPriority {
+        priority: usize,
+    }
+
+    impl TaskPriority for MockTaskPriority {}
+
     #[derive(Debug)]
     pub struct MockTask {
         task_context: TaskContext,
         task_name: TaskName,
-        priority: TaskPriority,
+        priority: MockTaskPriority,
         scheduling_strategy: SchedulingStrategy,
         resource_request: TaskResourceRequest,
         task_result: Vec<MaterializedOutput>,
@@ -345,7 +384,7 @@ pub(super) mod tests {
     pub struct MockTaskBuilder {
         task_context: TaskContext,
         task_name: TaskName,
-        priority: TaskPriority,
+        priority: MockTaskPriority,
         scheduling_strategy: SchedulingStrategy,
         task_result: Vec<MaterializedOutput>,
         resource_request: TaskResourceRequest,
@@ -366,7 +405,7 @@ pub(super) mod tests {
             Self {
                 task_context: TaskContext::default(),
                 task_name: "".into(),
-                priority: 0,
+                priority: MockTaskPriority { priority: 0 },
                 scheduling_strategy: SchedulingStrategy::Spread,
                 resource_request: TaskResourceRequest::new(ResourceRequest::default()),
                 task_result: vec![MaterializedOutput::new(partition_ref, "".into())],
@@ -376,8 +415,8 @@ pub(super) mod tests {
             }
         }
 
-        pub fn with_priority(mut self, priority: TaskPriority) -> Self {
-            self.priority = priority;
+        pub fn with_priority(mut self, priority: usize) -> Self {
+            self.priority = MockTaskPriority { priority };
             self
         }
 
@@ -435,7 +474,7 @@ pub(super) mod tests {
             self.task_context
         }
 
-        fn priority(&self) -> TaskPriority {
+        fn priority(&self) -> impl TaskPriority {
             self.priority
         }
 
@@ -503,5 +542,121 @@ pub(super) mod tests {
             }
             Ok(())
         }
+    }
+
+    #[test]
+    fn test_swordfish_task_priority_ordering() {
+        // Test cases for priority ordering:
+        // Lower plan_id, higher stage_id, higher node_id, lower task_id should have higher priority
+
+        // Test 1: Different plan_ids (lower plan_id should have higher priority)
+        let task1 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 1, 1),
+        };
+        let task2 = SwordfishTaskPriority {
+            task_context: TaskContext::new(2, 1, 1, 1),
+        };
+        assert!(task1 > task2); // plan_id 1 < plan_id 2, so task1 has higher priority (larger in ordering)
+
+        // Test 2: Same plan_id, different stage_ids (higher stage_id should have higher priority)
+        let task1 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 2, 1, 1),
+        };
+        let task2 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 1, 1),
+        };
+        assert!(task1 > task2); // stage_id 2 > stage_id 1, so task1 has higher priority (larger in ordering)
+
+        // Test 3: Same plan_id and stage_id, different node_ids (higher node_id should have higher priority)
+        let task1 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 2, 1),
+        };
+        let task2 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 1, 1),
+        };
+        assert!(task1 > task2); // node_id 2 > node_id 1, so task1 has higher priority (larger in ordering)
+
+        // Test 4: Same plan_id, stage_id, and node_id, different task_ids (lower task_id should have higher priority)
+        let task1 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 1, 1),
+        };
+        let task2 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 1, 2),
+        };
+        assert!(task1 > task2); // task_id 1 < task_id 2, so task1 has higher priority (larger in ordering)
+
+        // Test 5: Complex case with multiple differences
+        let task1 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 2, 2, 1), // plan_id=1, stage_id=2, node_id=2, task_id=1
+        };
+        let task2 = SwordfishTaskPriority {
+            task_context: TaskContext::new(2, 1, 1, 1), // plan_id=2, stage_id=1, node_id=1, task_id=1
+        };
+        assert!(task1 > task2); // task1 has lower plan_id, so it has higher priority (larger in ordering)
+
+        // Test 6: Equality
+        let task1 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 1, 1),
+        };
+        let task2 = SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 1, 1),
+        };
+        assert_eq!(task1, task2);
+    }
+
+    #[test]
+    fn test_swordfish_task_priority_binary_heap() {
+        use std::collections::BinaryHeap;
+
+        // Test that tasks are correctly ordered in a binary heap
+        // Higher priority tasks are now "larger" and come out first
+        let mut heap = BinaryHeap::new();
+
+        // Add tasks in random order - ensuring unique task_ids within each stage
+        heap.push(SwordfishTaskPriority {
+            task_context: TaskContext::new(2, 1, 1, 1), // plan_id=2, stage_id=1, node_id=1, task_id=1
+        });
+        heap.push(SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 2, 1, 1), // plan_id=1, stage_id=2, node_id=1, task_id=1
+        });
+        heap.push(SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 2, 3), // plan_id=1, stage_id=1, node_id=2, task_id=3
+        });
+        heap.push(SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 1, 2), // plan_id=1, stage_id=1, node_id=1, task_id=2
+        });
+        heap.push(SwordfishTaskPriority {
+            task_context: TaskContext::new(1, 1, 1, 1), // plan_id=1, stage_id=1, node_id=1, task_id=1
+        });
+
+        // Pop tasks in order (BinaryHeap is a max heap, so highest priority comes out first)
+        // Expected order (highest priority to lowest priority):
+        // 1. plan_id=1, stage_id=2, node_id=1, task_id=1 (higher stage_id = highest priority = largest in heap)
+        // 2. plan_id=1, stage_id=1, node_id=2, task_id=3 (higher node_id = higher priority = larger in heap)
+        // 3. plan_id=1, stage_id=1, node_id=1, task_id=1 (lower task_id = higher priority = larger in heap)
+        // 4. plan_id=1, stage_id=1, node_id=1, task_id=2 (higher task_id = lower priority = smaller in heap)
+        // 5. plan_id=2, stage_id=1, node_id=1, task_id=1 (higher plan_id = lowest priority = smallest in heap)
+
+        assert_eq!(
+            heap.pop().unwrap().task_context,
+            TaskContext::new(1, 2, 1, 1)
+        );
+        assert_eq!(
+            heap.pop().unwrap().task_context,
+            TaskContext::new(1, 1, 2, 3)
+        );
+        assert_eq!(
+            heap.pop().unwrap().task_context,
+            TaskContext::new(1, 1, 1, 1)
+        );
+        assert_eq!(
+            heap.pop().unwrap().task_context,
+            TaskContext::new(1, 1, 1, 2)
+        );
+        assert_eq!(
+            heap.pop().unwrap().task_context,
+            TaskContext::new(2, 1, 1, 1)
+        );
+        assert!(heap.pop().is_none()); // Heap should be empty
     }
 }

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -159,6 +159,11 @@ impl PartialOrd for SwordfishTaskPriority {
 
 impl Ord for SwordfishTaskPriority {
     fn cmp(&self, other: &Self) -> Ordering {
+        // Rules for swordfish task priority:
+        // 1. Plan ID: Lower plan_id, higher priority
+        // 2. Stage ID: Higher stage_id, higher priority
+        // 3. Node ID: Higher node_id, higher priority
+        // 4. Task ID: Lower task_id, higher priority
         other
             .task_context
             .plan_id


### PR DESCRIPTION
## Changes Made

Establish task priority in flotilla based on `TaskContext`.

Rules for swordfish task priority:
1. Plan ID: Lower plan_id, higher priority
2. Stage ID: Higher stage_id, higher priority
3. Node ID: Higher node_id, higher priority
4. Task ID: Lower task_id, higher priority

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
