### PR TITLE
feat: adds daft expr to pyarrow compute translator

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1171,6 +1171,12 @@ class PyExpr:
     def _hash(self) -> int: ...
 
     ###
+    # Conversion methods
+    ###
+
+    def as_py(self) -> Any: ...
+
+    ###
     # Helper methods required by optimizer:
     # These should be removed from the Python API for Expressions when logical plans and optimizer are migrated to Rust
     ###

--- a/daft/dependencies.py
+++ b/daft/dependencies.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     import pandas as pd
     import PIL.Image as pil_image
     import pyarrow as pa
+    import pyarrow.compute as pc
     import pyarrow.csv as pacsv
     import pyarrow.dataset as pads
     import pyarrow.flight as flight
@@ -26,6 +27,7 @@ else:
     pads = LazyImport("pyarrow.dataset")
     pafs = LazyImport("pyarrow.fs")
     pajson = LazyImport("pyarrow.json")
+    pc = LazyImport("pyarrow.compute")
     pq = LazyImport("pyarrow.parquet")
     flight = LazyImport("pyarrow.flight")
 
@@ -40,6 +42,7 @@ __all__ = [
     "pads",
     "pafs",
     "pajson",
+    "pc",
     "pd",
     "pil_image",
     "pq",

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -37,7 +37,7 @@ from daft.daft import time_lit as _time_lit
 from daft.daft import timestamp_lit as _timestamp_lit
 from daft.daft import udf as _udf
 from daft.datatype import DataType, DataTypeLike, TimeUnit
-from daft.dependencies import pa
+from daft.dependencies import pa, pc
 from daft.expressions.testing import expr_structurally_equal
 from daft.logical.schema import Field, Schema
 from daft.series import Series, item_to_series
@@ -366,6 +366,12 @@ class Expression:
             return obj
         else:
             return lit(obj)
+
+    def to_arrow_expr(self) -> pc.Expression:
+        """Returns this expression as a pyarrow.compute.Expression for integrations with other systems."""
+        from daft.expressions.visitor import _PyArrowExpressionVisitor
+
+        return _PyArrowExpressionVisitor().visit(self)
 
     @staticmethod
     def udf(

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -373,6 +373,10 @@ class Expression:
 
         return _PyArrowExpressionVisitor().visit(self)
 
+    def as_py(self) -> Any:
+        """Returns this literal expression as a python value, raises a ValueError if this is not a literal expression."""
+        return self._expr.as_py()
+
     @staticmethod
     def udf(
         name: builtins.str,

--- a/daft/expressions/visitor.py
+++ b/daft/expressions/visitor.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
+from daft.dependencies import pc
+
 R = TypeVar("R")
 
 
@@ -151,3 +153,123 @@ class PredicateVisitor(ExpressionVisitor[R]):
     def visit_not_null(self, expr: Expression) -> R:
         """Visit an not_null predicate."""
         ...
+
+
+class _PyArrowExpressionVisitor(PredicateVisitor[pc.Expression]):
+    """This visitor does a tree fold into the pyarrow.compute.Expression domain."""
+
+    # FUNCTION OVERRIDES
+    #
+    #   This maps daft functions to pyarrow.compute expression functions.
+    #   https://arrow.apache.org/docs/python/api/compute.html
+    #
+    _FUNCTION_OVERRIDES: dict[str, str] = {}
+
+    def visit_col(self, name: str) -> pc.Expression:
+        """Convert the daft column to pc field reference by name."""
+        return pc.field(name)
+
+    def visit_lit(self, value: Any) -> pc.Expression:
+        """Convert the Literal to a pyarrow.compute.Scalar without check the type.
+
+        From the pyarrow scalar docs:
+        > value : bool, int, float or string
+        > Python value of the scalar. Note that only a subset of types are currently supported.
+
+        Coincidentally, this is what term is currently limited to.
+        """
+        return pc.scalar(value)
+
+    def visit_alias(self, expr: Expression, alias: str) -> pc.Expression:
+        """Convert an alias 'expression' by ... ignoring it .. as these aren't supposed to be expressions."""
+        return self.visit(expr)
+
+    def visit_cast(self, expr: Expression, dtype: DataType) -> pc.Expression:
+        """Converts the cast with default safety and cast options because daft does not have these options."""
+        pc_expr = self.visit(expr)
+        pc_type = dtype.to_arrow_dtype()
+        return pc_expr.cast(pc_type)
+
+    def visit_list(self, items: list[Expression]) -> pc.Expression:
+        raise ValueError("pyarrow.compute does not have a make_list function.")
+
+    def visit_and(self, left: Expression, right: Expression) -> pc.Expression:
+        pc_lhs = self.visit(left)
+        pc_rhs = self.visit(right)
+        return pc_lhs & pc_rhs
+
+    def visit_or(self, left: Expression, right: Expression) -> pc.Expression:
+        pc_lhs = self.visit(left)
+        pc_rhs = self.visit(right)
+        return pc_lhs | pc_rhs
+
+    def visit_not(self, expr: Expression) -> pc.Expression:
+        pc_expr = self.visit(expr)
+        return ~pc_expr
+
+    def visit_equal(self, left: Expression, right: Expression) -> pc.Expression:
+        pc_lhs = self.visit(left)
+        pc_rhs = self.visit(right)
+        return pc_lhs == pc_rhs
+
+    def visit_not_equal(self, left: Expression, right: Expression) -> pc.Expression:
+        pc_lhs = self.visit(left)
+        pc_rhs = self.visit(right)
+        return pc_lhs != pc_rhs
+
+    def visit_less_than(self, left: Expression, right: Expression) -> pc.Expression:
+        pc_lhs = self.visit(left)
+        pc_rhs = self.visit(right)
+        return pc_lhs < pc_rhs
+
+    def visit_less_than_or_equal(self, left: Expression, right: Expression) -> pc.Expression:
+        pc_lhs = self.visit(left)
+        pc_rhs = self.visit(right)
+        return pc_lhs <= pc_rhs
+
+    def visit_greater_than(self, left: Expression, right: Expression) -> pc.Expression:
+        pc_lhs = self.visit(left)
+        pc_rhs = self.visit(right)
+        return pc_lhs > pc_rhs
+
+    def visit_greater_than_or_equal(self, left: Expression, right: Expression) -> pc.Expression:
+        pc_lhs = self.visit(left)
+        pc_rhs = self.visit(right)
+        return pc_lhs >= pc_rhs
+
+    def visit_between(self, expr: Expression, lower: Expression, upper: Expression) -> pc.Expression:
+        """Convert between using le and ge since the bounds are inclusive."""
+        pc_expr = self.visit(expr)
+        pc_lower = self.visit(lower)
+        pc_upper = self.visit(upper)
+        return (pc_lower <= pc_expr) and (pc_expr <= pc_upper)
+
+    def visit_is_in(self, expr: Expression, items: list[Expression]) -> pc.Expression:
+        pc_expr = self.visit(expr)
+        pc_items = [self.visit(item) for item in items]
+        return pc_expr.isin(pc_items)
+
+    def visit_is_null(self, expr: Expression) -> pc.Expression:
+        pc_expr = self.visit(expr)
+        return pc_expr.is_null()
+
+    def visit_not_null(self, expr: Expression) -> pc.Expression:
+        pc_expr = self.visit(expr)
+        return ~pc_expr.is_null()
+
+    def visit_function(self, name: str, args: list[Expression]) -> pc.Expression:
+        """Converting using either the EXACT function name or an override, otherwise error."""
+        pc_func = self._get_pc_func(name)
+        pc_args = [self.visit(arg) for arg in args]
+        return pc_func(pc_args)
+
+    def _get_pc_func(self, name: str) -> Any:
+        """Resolve the pyarrow.compute function from the module, otherwise error."""
+        try:
+            pc_name = self._FUNCTION_OVERRIDES.get(name, name)
+            pc_func = getattr(pc, pc_name)
+            return pc_func
+        except AttributeError:
+            raise ValueError(
+                f"pyarrow.compute has not function '{pc_name}', please see: https://arrow.apache.org/docs/python/api/compute.html."
+            )

--- a/daft/io/_lance.py
+++ b/daft/io/_lance.py
@@ -8,7 +8,9 @@ from daft import context
 from daft.api_annotations import PublicAPI
 from daft.daft import IOConfig, PyPartitionField, PyPushdowns, PyRecordBatch, ScanOperatorHandle, ScanTask
 from daft.dataframe import DataFrame
+from daft.dependencies import pc
 from daft.io.object_store_options import io_config_to_storage_options
+from daft.io.pushdowns import Pushdowns
 from daft.io.scan import ScanOperator
 from daft.logical.builder import LogicalPlanBuilder
 from daft.logical.schema import Schema
@@ -120,9 +122,13 @@ class LanceDBScanOperator(ScanOperator):
                 else pushdowns.columns + filter_required_column_names
             )
 
-        # TODO: figure out how to translate Pushdowns into LanceDB filters
-        filters = None
-        fragments = self._ds.get_fragments(filter=filters)
+        # convert to the python pushdowns
+        pds = Pushdowns._from_pypushdowns(pushdowns)
+
+        # convert the filter pushdown to pyarrow expression.
+        filter_ = self._get_filter_pushdown(pds)
+
+        fragments = self._ds.get_fragments(filter=filter_)
         for i, fragment in enumerate(fragments):
             # TODO: figure out how if we can get this metadata from LanceDB fragments cheaply
             size_bytes = None
@@ -146,3 +152,13 @@ class LanceDBScanOperator(ScanOperator):
                 pushdowns=pushdowns,
                 stats=stats,
             )
+
+    def _get_filter_pushdown(self, pushdowns: Pushdowns) -> pc.Expression:
+        if not pushdowns.filters:
+            return None
+        try:
+            # best attempt convert to pyarrow.compute.Expression
+            return pushdowns.filters.to_arrow_expr()
+        except ValueError:
+            # don't error, just accept that we couldn't push this down.
+            return None

--- a/src/daft-dsl/src/python.rs
+++ b/src/daft-dsl/src/python.rs
@@ -604,6 +604,17 @@ impl PyExpr {
         self.expr.hash(&mut hasher);
         hasher.finish()
     }
+
+    pub fn as_py<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        if let Expr::Literal(lit) = self.expr.as_ref() {
+            lit.clone().into_pyobject(py)
+        } else {
+            Err(PyValueError::new_err(format!(
+                "The method .py_any() was called on a non literal value! Got: {}",
+                &self.expr
+            )))
+        }
+    }
 }
 
 impl_bincode_py_state_serialization!(PyExpr);

--- a/tests/expressions/test_to_arrow_expr.py
+++ b/tests/expressions/test_to_arrow_expr.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from daft import col, lit
+from daft.dependencies import pa, pc
+
+
+def assert_eq(lhs: pc.Expression, rhs: str):
+    """I don't know of a better way, but this can be switched a later time."""
+    assert str(lhs) == rhs
+
+
+def test_col():
+    expr = col("a").to_arrow_expr()
+
+    assert_eq(expr, "a")
+
+
+def test_and():
+    expr = lit(True) & lit(False)
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "(true and false)")
+
+
+def test_or():
+    expr = lit(True) | lit(False)
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "(true or false)")
+
+
+def test_not():
+    expr = ~lit(True)
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "invert(true)")
+
+
+def test_equal():
+    expr = col("a") == col("b")
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "(a == b)")
+
+
+def test_not_equal():
+    expr = col("a") != col("b")
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "(a != b)")
+
+
+def test_less_than():
+    expr = col("a") < col("b")
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "(a < b)")
+
+
+def test_less_than_or_equal():
+    expr = col("a") <= col("b")
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "(a <= b)")
+
+
+def test_greater_than():
+    expr = col("a") > col("b")
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "(a > b)")
+
+
+def test_greater_than_or_equal():
+    expr = col("a") >= col("b")
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "(a >= b)")
+
+
+def test_between():
+    expr = col("a").between(col("b"), col("c"))
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "((b <= a) and (a <= c))")
+
+
+def test_is_in():
+    expr = col("a").is_in([1, 2, 3])
+    expr = expr.to_arrow_expr()
+
+    expected = pc.field("a").isin([1, 2, 3])
+    assert_eq(expr, str(expected))
+
+
+def test_is_null():
+    expr = col("a").is_null()
+    expr = expr.to_arrow_expr()
+
+    expected = pc.field("a").is_null()
+    assert_eq(expr, str(expected))
+
+
+def test_not_null():
+    expr = col("a").not_null()
+    expr = expr.to_arrow_expr()
+
+    expected = ~pc.field("a").is_null()
+    assert_eq(expr, str(expected))
+
+
+def test_alias():
+    expr = col("a").alias("b")
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "a")
+
+
+def test_cast():
+    expr = col("a").cast("int64")
+    expr = expr.to_arrow_expr()
+
+    expected = pc.field("a").cast(pa.int64())
+    assert_eq(expr, str(expected))
+
+
+def test_lit():
+    expr = lit(42)
+    expr = expr.to_arrow_expr()
+
+    assert_eq(expr, "42")

--- a/tests/expressions/test_to_arrow_expr.py
+++ b/tests/expressions/test_to_arrow_expr.py
@@ -149,8 +149,9 @@ def test_bitwise_functions(daft_expr: Expression, arrow_expr: str):
         (lit(1).log(5), "logb(1, 5)"),
         (lit(1).ln(), "ln(1)"),
         (lit(1).log1p(), "log1p(1)"),
-        (lit(1).exp(), "exp(1)"),
-        (lit(1).expm1(), "expm1(1)"),
+        # not available in older versions
+        # (lit(1).exp(), "exp(1)"),
+        # (lit(1).expm1(), "expm1(1)"),
         # not supported
         # (lit(1).cbrt(), "cbrt(1)"),
         # (lit(1).csc(), "csc(1)"),

--- a/tests/expressions/test_to_arrow_expr.py
+++ b/tests/expressions/test_to_arrow_expr.py
@@ -1,131 +1,211 @@
 from __future__ import annotations
 
-from daft import col, lit
+import pytest
+
+from daft import Expression, col, lit
 from daft.dependencies import pa, pc
 
 
-def assert_eq(lhs: pc.Expression, rhs: str):
-    """I don't know of a better way, but this can be switched a later time."""
-    assert str(lhs) == rhs
+def assert_eq(actual: Expression, expect):
+    """I don't know of a better way, but this can be switched out at a later time."""
+    assert str(actual.to_arrow_expr()) == str(expect)
 
 
 def test_col():
-    expr = col("a").to_arrow_expr()
-
-    assert_eq(expr, "a")
+    assert_eq(col("a"), pc.field("a"))
 
 
 def test_and():
     expr = lit(True) & lit(False)
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "(true and false)")
 
 
 def test_or():
     expr = lit(True) | lit(False)
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "(true or false)")
 
 
 def test_not():
     expr = ~lit(True)
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "invert(true)")
 
 
 def test_equal():
     expr = col("a") == col("b")
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "(a == b)")
 
 
 def test_not_equal():
     expr = col("a") != col("b")
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "(a != b)")
 
 
 def test_less_than():
     expr = col("a") < col("b")
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "(a < b)")
 
 
 def test_less_than_or_equal():
     expr = col("a") <= col("b")
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "(a <= b)")
 
 
 def test_greater_than():
     expr = col("a") > col("b")
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "(a > b)")
 
 
 def test_greater_than_or_equal():
     expr = col("a") >= col("b")
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "(a >= b)")
 
 
 def test_between():
     expr = col("a").between(col("b"), col("c"))
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "((b <= a) and (a <= c))")
 
 
 def test_is_in():
     expr = col("a").is_in([1, 2, 3])
-    expr = expr.to_arrow_expr()
 
-    expected = pc.field("a").isin([1, 2, 3])
-    assert_eq(expr, str(expected))
+    assert_eq(expr, pc.field("a").isin([1, 2, 3]))
 
 
 def test_is_null():
     expr = col("a").is_null()
-    expr = expr.to_arrow_expr()
 
-    expected = pc.field("a").is_null()
-    assert_eq(expr, str(expected))
+    assert_eq(expr, pc.field("a").is_null())
 
 
 def test_not_null():
     expr = col("a").not_null()
-    expr = expr.to_arrow_expr()
 
-    expected = ~pc.field("a").is_null()
-    assert_eq(expr, str(expected))
+    assert_eq(expr, ~pc.field("a").is_null())
 
 
 def test_alias():
     expr = col("a").alias("b")
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "a")
 
 
 def test_cast():
     expr = col("a").cast("int64")
-    expr = expr.to_arrow_expr()
 
-    expected = pc.field("a").cast(pa.int64())
-    assert_eq(expr, str(expected))
+    assert_eq(expr, pc.field("a").cast(pa.int64()))
 
 
 def test_lit():
     expr = lit(42)
-    expr = expr.to_arrow_expr()
 
     assert_eq(expr, "42")
+
+
+@pytest.mark.parametrize(
+    ["daft_expr", "arrow_expr"],
+    [
+        (lit(1).bitwise_and(lit(2)), "(1 and 2)"),
+        (lit(1).bitwise_or(lit(2)), "(1 or 2)"),
+        (lit(1) << lit(2), "shift_left(1, 2)"),
+        (lit(1) >> lit(2), "shift_right(1, 2)"),
+    ],
+)
+def test_bitwise_functions(daft_expr: Expression, arrow_expr: str):
+    assert_eq(daft_expr, arrow_expr)
+
+
+@pytest.mark.parametrize(
+    ["daft_expr", "arrow_expr"],
+    [
+        (lit(1) + lit(2), "add(1, 2)"),
+        (lit(1) - lit(2), "subtract(1, 2)"),
+        (lit(1) * lit(2), "multiply(1, 2)"),
+        (lit(1).ceil(), "ceil(1)"),
+        (lit(1).floor(), "floor(1)"),
+        (lit(1).sign(), "sign(1)"),
+        (lit(1).signum(), "sign(1)"),
+        (lit(1).negative(), "negate(1)"),
+        (lit(1).round(2), pc.round(pc.scalar(1), 2)),
+        (lit(1).sqrt(), "sqrt(1)"),
+        (lit(1).sin(), "sin(1)"),
+        (lit(1).cos(), "cos(1)"),
+        (lit(1).tan(), "tan(1)"),
+        (lit(1).arcsin(), "asin(1)"),
+        (lit(1).arccos(), "acos(1)"),
+        (lit(1).arctan(), "atan(1)"),
+        (lit(1).arctan2(lit(2)), "atan2(1, 2)"),
+        (lit(1).log2(), "log2(1)"),
+        (lit(1).log10(), "log10(1)"),
+        (lit(1).log(5), "logb(1, 5)"),
+        (lit(1).ln(), "ln(1)"),
+        (lit(1).log1p(), "log1p(1)"),
+        (lit(1).exp(), "exp(1)"),
+        (lit(1).expm1(), "expm1(1)"),
+        # not supported
+        # (lit(1).cbrt(), "cbrt(1)"),
+        # (lit(1).csc(), "csc(1)"),
+        # (lit(1).sec(), "sec(1)"),
+        # (lit(1).cot(), "cot(1)"),
+        # (lit(1).sinh(), "sinh(1)"),
+        # (lit(1).tanh(), "tanh(1)"),
+        # (lit(1).arctanh(), "atanh(1)"),
+        # (lit(1).arccosh(), "acosh(1)"),
+        # (lit(1).arcsinh(), "asinh(1)"),
+        # (lit(1).radians(), "radians(1)"),
+        # (lit(1).degrees(), "degrees(1)"),
+    ],
+)
+def test_math_functions(daft_expr: Expression, arrow_expr: str):
+    assert_eq(daft_expr, arrow_expr)
+
+
+@pytest.mark.parametrize(
+    ["daft_expr", "arrow_expr"],
+    [
+        (lit("hello").str.capitalize(), 'utf8_capitalize("hello")'),
+        (lit("hello").str.concat(lit("world")), 'add("hello", "world")'),
+        # containment tests
+        (lit("hello").str.count_matches(lit("l")), pc.count_substring(pc.scalar("hello"), "l")),
+        (lit("hello").str.contains(lit("ll")), pc.match_substring(pc.scalar("hello"), "ll")),
+        (lit("hello").str.endswith(lit("o")), pc.ends_with(pc.scalar("hello"), "o")),
+        (lit("hello").str.startswith(lit("h")), pc.starts_with(pc.scalar("hello"), "h")),
+        # TODO
+        # (lit("hello").str.extract(lit("h(.*)o")), "extract('hello', 'h(.*)o')"),
+        # (lit("hello").str.extract_all(lit("l")), "extract_all('hello', 'l')"),
+        # (lit("hello").str.find(lit("l")), "find('hello', 'l')"),
+        # (lit("hello").str.ilike(lit("HELLO")), "ilike('hello', 'HELLO')"),
+        # (lit("hello").str.left(lit(3)), "left('hello', 3)"),
+        # (lit("hello").str.length(), "utf8_length('hello')"),
+        # (lit("hello").str.length_bytes(), "length_bytes('hello')"),
+        # (lit("hello").str.like(lit("h%")), "like('hello', 'h%')"),
+        # (lit("hello").str.lower(), "lower('hello')"),
+        # (lit("hello").str.lpad(lit(10), lit(" ")), "lpad('hello', 10, ' ')"),
+        # (lit("hello").str.lstrip(), "lstrip('hello')"),
+        # (lit("hello").str.match(lit("h.*o")), "match('hello', 'h.*o')"),
+        # (lit("hello").str.repeat(lit(3)), "repeat('hello', 3)"),
+        # (lit("hello").str.replace(lit("l"), lit("L")), "replace('hello', 'l', 'L')"),
+        # (lit("hello").str.reverse(), "reverse('hello')"),
+        # (lit("hello").str.right(lit(3)), "right('hello', 3)"),
+        # (lit("hello").str.rpad(lit(10), lit(" ")), "rpad('hello', 10, ' ')"),
+        # (lit("hello").str.rstrip(), "rstrip('hello')"),
+        # (lit("hello").str.split(lit("l")), "split('hello', 'l')"),
+        # (lit("hello").str.substr(lit(1), lit(3)), "substr('hello', 1, 3)"),
+        # (lit("hello").str.to_date(format="xxx"), "strftime('hello', 'xxx')"),
+        # (lit("hello").str.to_datetime(format="xxx"), "strftime('hello', 'xxx')"),
+        # (lit("hello").str.upper(), "utf8_upper('hello')"),
+        # not supported
+        # (lit("hello").str.normalize(lit("NFC")), "normalize('hello', 'NFC')"),
+    ],
+)
+def test_string_functions(daft_expr: Expression, arrow_expr: str):
+    assert_eq(daft_expr, arrow_expr)


### PR DESCRIPTION
## Changes Made

This PR adds a daft expression to pyarrow compute translator so that we can leverage pushdowns in other sources such as lance. There has been ongoing discussion, and the pieces are ready.

I need to add some tests, but this get's us quite far.

https://github.com/Eventual-Inc/Daft/discussions/4615

## Related Issues

* #4278 
* #4203 
* #4239 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
