### PR TITLE
fix: Fix setting `min_cpu_per_task` when using `daft.context.set_execution_config`

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -235,6 +235,7 @@ def set_execution_config(
         native_parquet_writer: Whether to use the native parquet writer vs the pyarrow parquet writer. Defaults to `True`.
         use_experimental_distributed_engine: Whether to use the experimental distributed engine on the ray runner. Defaults to `True`.
             Note: Not all operations are currently supported, and daft will fallback to the current engine if necessary.
+        min_cpu_per_task: Minimum CPU used for each task. Defaults to 1.
     """
     # Replace values in the DaftExecutionConfig with user-specified overrides
     ctx = get_context()
@@ -269,6 +270,7 @@ def set_execution_config(
             scantask_splitting_level=scantask_splitting_level,
             native_parquet_writer=native_parquet_writer,
             use_experimental_distributed_engine=use_experimental_distributed_engine,
+            min_cpu_per_task=min_cpu_per_task,
         )
 
         ctx._ctx._daft_execution_config = new_daft_execution_config


### PR DESCRIPTION
## Changes Made

The `min_cpu_per_task` config cannot update now because it is not set into the new config when using `daft.context.set_execution_config`.

## Related Issues

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
