### PR TITLE
chore: keep same ruff version with pre-commit-config

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -101,7 +101,7 @@ mkdocs-simple-hooks
 pymdown-extensions
 mkdocs-material[imaging]
 mkdocstrings-python
-ruff
+ruff==0.8.2
 mkdocs-minify-plugin
 mkdocs-redirects
 


### PR DESCRIPTION
## Changes Made

I'm using Pycharm with ruff plugin which used the ruff under daft virtual env, `uv pip install requirements-dev.txt` will install the latest `ruff` which is different with the version `0.8.2` in `.pre-commit-config.yaml`, it lead to the auto format from Pycharm is dismatch with the pre-commit hook, e.g. `daft/daft/__init__.py`, so it's better to keep the consistency.

I also tried to upgrade both to the latest version 'v0.12.1', but it will make more changes, so i downgrade the env version.

## Related Issues

None

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
