### PR TITLE
chore: Add `build-whl` make command for building wheel package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,6 @@ Daft is an open-source project and we welcome contributions from the community. 
 - **Have a feature idea?** 💡 [Start a discussion](#proposing-features)
 - **Want to make your first PR?** 🚀 [Contribute new code](#contributing-code)
 
-
 ## Reporting Issues
 
 To report bugs and issues with Daft, please file an issue on our [issues](https://github.com/Eventual-Inc/Daft/issues) page.
@@ -61,6 +60,8 @@ To set up your development environment:
 8. `make check-format`: check that all Python and Rust code is formatted, alias `make format-check`
 9. `make precommit`: run all pre-commit hooks, must install pre-commit first(pip install pre-commit)
 10. `make build-release`: perform a full release build of Daft
+11. `make build-whl`: recompile your code after modifying any Rust code in `src/` for development, only generate `whl` file without installation
+12. `make daft-proto`: build Daft proto sources in `src/daft-proto`
 
 #### Note about Developing `daft-dashboard`
 
@@ -156,6 +157,7 @@ At this point, your debugger should stop on breakpoints in any .rs file located 
 We run test suites across Python and Rust. Python tests focus on high-level DataFrame and Expression functionality, while Rust tests validate individual kernel implementations at a lower level.
 
 #### Python tests
+
 Our python tests are located in the `tests` directory, you can run all the tests at once with `make tests`.
 
 To run specific tests, set the runner for the tests in the environment and then run the tests directly using [pytest]("https://doc.rust-lang.org/cargo/commands/cargo-test.html").
@@ -165,6 +167,7 @@ DAFT_RUNNER=native pytest tests/dataframe
 ```
 
 #### Rust tests
+
 Our rust tests are distributed across crates, you can run all tests with `cargo test --no-default-features --workspace`.
 
 To run rust tests that call into Python, the `--features python` flag and libpython3.*.so dynamic libraries are required. Please ensure that these are installed, here's a table of common locations on different os:
@@ -180,12 +183,12 @@ To run rust tests that call into Python, the `--features python` flag and libpyt
 
 Set environment variables to locate the Python library:
 
-
 ```sh
 export PYO3_PYTHON=".venv/bin/python"
 export PYO3_PYTHON_PYLIB="/usr/lib/x86_64-linux-gnu/libpython3.11.so.1"
 export RUSTFLAGS="-C link-arg=-Wl,-rpath,${PYO3_PYTHON_PYLIB%/*} -C link-arg=-L${PYO3_PYTHON_PYLIB%/*} -C link-arg=-lpython3.11"
 ```
+
 Execute the test after configuration:
 
 ```sh
@@ -354,7 +357,7 @@ here's an example of testing the `extract` function using the `test_expression` 
 
 ```py
 def test_extract(test_expression):
-    test_data =["123-456", "789-012", "345-678"]
+    test_data = ["123-456", "789-012", "345-678"]
     regex = r"(\d)(\d*)"
     expected = ["123", "789", "345"]
     test_expression(

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,11 @@ build: check-toolchain .venv  ## Compile and install Daft for development
 build-release: check-toolchain .venv  ## Compile and install a faster Daft binary
 	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin develop --release --uv
 
+.PHONY: build-whl
+build-whl: check-toolchain .venv  ## Compile Daft for development, only generate whl file without installation
+	cargo clean --target-dir target
+	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin build
+
 .PHONY: test
 test: .venv build  ## Run tests
 	HYPOTHESIS_MAX_EXAMPLES=$(HYPOTHESIS_MAX_EXAMPLES) $(VENV_BIN)/pytest --hypothesis-seed=$(HYPOTHESIS_SEED) --ignore tests/integration


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

In some scenarios, we need to install the development version of Daft through the `whl` package in the application for testing. However, the current `make build` and `make build-release` instructions will install the compiled `whl` into the local virtualenv and delete it after completion. 

Therefore, I added a `make build-whl` make command, which will compile the project and generate a `whl` package under target for subsequent `pip install` usage.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

No issue.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
