### PR TITLE
fix: Picking MicroPartitions with duplicate column names

### DIFF
--- a/daft/recordbatch/micropartition.py
+++ b/daft/recordbatch/micropartition.py
@@ -446,7 +446,7 @@ class MicroPartition:
         batches = self.get_record_batches()
         if len(batches) == 0:
             return MicroPartition.empty, (self.schema(),)
-        return MicroPartition._from_record_batches, (self.get_record_batches(),)
+        return MicroPartition._from_record_batches, (batches,)
 
     @classmethod
     def read_parquet_statistics(

--- a/daft/recordbatch/micropartition.py
+++ b/daft/recordbatch/micropartition.py
@@ -150,7 +150,7 @@ class MicroPartition:
         return self.to_record_batch()
 
     def to_record_batch(self) -> RecordBatch:
-        """Returns the MicroPartition as a RecordBatch."""
+        """Returns the MicroPartition as a single (concatenated) RecordBatch."""
         return RecordBatch._from_pyrecordbatch(self._micropartition.to_record_batch())
 
     def to_arrow(self, concat_record_batches: bool = False) -> pa.Table:
@@ -442,9 +442,8 @@ class MicroPartition:
             raise TypeError(f"Expected a bool, list[bool] or None for `nulls_first` but got {type(nulls_first)}")
         return Series._from_pyseries(self._micropartition.argsort(pyexprs, descending, nulls_first))
 
-    def __reduce__(self) -> tuple[Callable[[dict[str, Any]], MicroPartition], tuple[dict[str, Series]]]:
-        names = self.column_names()
-        return MicroPartition.from_pydict, ({name: self.get_column_by_name(name) for name in names},)
+    def __reduce__(self) -> tuple[Callable[[list[RecordBatch]], MicroPartition], tuple[list[RecordBatch]]]:
+        return MicroPartition._from_record_batches, (self.get_record_batches(),)
 
     @classmethod
     def read_parquet_statistics(

--- a/daft/recordbatch/micropartition.py
+++ b/daft/recordbatch/micropartition.py
@@ -442,7 +442,10 @@ class MicroPartition:
             raise TypeError(f"Expected a bool, list[bool] or None for `nulls_first` but got {type(nulls_first)}")
         return Series._from_pyseries(self._micropartition.argsort(pyexprs, descending, nulls_first))
 
-    def __reduce__(self) -> tuple[Callable[[list[RecordBatch]], MicroPartition], tuple[list[RecordBatch]]]:
+    def __reduce__(self) -> tuple[Callable, tuple]:  # type: ignore[type-arg]
+        batches = self.get_record_batches()
+        if len(batches) == 0:
+            return MicroPartition.empty, (self.schema(),)
         return MicroPartition._from_record_batches, (self.get_record_batches(),)
 
     @classmethod

--- a/daft/recordbatch/recordbatch.py
+++ b/daft/recordbatch/recordbatch.py
@@ -85,6 +85,10 @@ class RecordBatch:
         return tab
 
     @staticmethod
+    def _from_series(series: list[Series]) -> RecordBatch:
+        return RecordBatch._from_pyrecordbatch(_PyRecordBatch.from_pyseries_list([s._series for s in series]))
+
+    @staticmethod
     def from_arrow_table(arrow_table: pa.Table) -> RecordBatch:
         assert isinstance(arrow_table, pa.Table)
         schema = Schema._from_field_name_and_types(
@@ -462,8 +466,8 @@ class RecordBatch:
 
     def __reduce__(
         self,
-    ) -> tuple[Callable[[dict[str, Any]], RecordBatch], tuple[dict[str, Series]]]:
-        return RecordBatch.from_pydict, ({column.name(): column for column in self.columns()},)
+    ) -> tuple[Callable[[list[Series]], RecordBatch], tuple[list[Series]]]:
+        return RecordBatch._from_series, (self.columns(),)
 
     @classmethod
     def read_parquet(

--- a/tests/recordbatch/test_micropartition.py
+++ b/tests/recordbatch/test_micropartition.py
@@ -5,6 +5,7 @@ import copy
 import pyarrow as pa
 import pytest
 
+from daft import col
 from daft.logical.schema import Schema
 from daft.recordbatch.micropartition import MicroPartition
 
@@ -24,3 +25,19 @@ def test_pickling_loaded(mp) -> None:
 def test_pickling_unloaded() -> None:
     mp = MicroPartition.read_parquet("tests/assets/parquet-data/parquet-with-schema-metadata.parquet")
     assert copy.deepcopy(mp).to_arrow() == mp.to_arrow()
+
+
+@pytest.mark.parametrize(
+    "mp",
+    [
+        MicroPartition.from_pydict(
+            {"a": pa.array([1, 2, 3], type=pa.int64()), "b": pa.array([4.0, 5.0, 6.0], type=pa.float64())}
+        ),
+        MicroPartition.empty(Schema.from_pyarrow_schema(pa.schema({"a": pa.int64(), "b": pa.float64()}))),  # No tables
+    ],
+)
+def test_pickling_duplicate_column_names(mp) -> None:
+    # To force duplicate column names
+    mp = mp.eval_expression_list([col("a"), col("b").alias("a")])
+
+    assert mp.to_arrow() == copy.deepcopy(mp).to_arrow()


### PR DESCRIPTION
## Changes Made

Found a side issue when working on flotilla that affects writing to Ray object store, which uses Ray cloudpickle.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
