### PR TITLE
docs: Add debugging udfs docs

### DIFF
--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -2422,6 +2422,33 @@ UDFs can also be parametrized with new resource requests after being initialized
     )
     ```
 
+### Debugging UDFs
+
+UDFs can be debugged using python's built-in debugger, [pdb](https://docs.python.org/3/library/pdb.html), by setting breakpoints in your UDF. The debugger
+will function normally as if you are debugging any other python script.
+
+=== "🐍 Python"
+    ``` python
+    @daft.udf(return_dtype=daft.DataType.python())
+    def my_udf(*cols):
+        breakpoint()
+        ...
+    ```
+
+If you are setting breakpoints via IDEs like VS Code, Cursor, or others that use [debugpy](https://github.com/microsoft/debugpy), you need to set `debugpy.debug_this_thread()` in the UDF. This is because `debugpy` does not automatically detect native threads.
+
+=== "🐍 Python"
+    ``` python
+    import debugpy
+
+    @daft.udf(return_dtype=daft.DataType.python())
+    def my_udf(*cols):
+        debugpy.debug_this_thread()
+        ...
+    ```
+
+
+
 ## Multimodal Data
 
 Daft is built to work comfortably with multimodal data types, including URLs and images.

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -2424,8 +2424,7 @@ UDFs can also be parametrized with new resource requests after being initialized
 
 ### Debugging UDFs
 
-UDFs can be debugged using python's built-in debugger, [pdb](https://docs.python.org/3/library/pdb.html), by setting breakpoints in your UDF. The debugger
-will function normally as if you are debugging any other python script.
+When running Daft locally, UDFs can be debugged using python's built-in debugger, [pdb](https://docs.python.org/3/library/pdb.html), by setting breakpoints in your UDF.
 
 === "🐍 Python"
     ``` python


### PR DESCRIPTION
## Changes Made

Add a section in the UDF docs about how to debug udfs

## Related Issues

Closes https://github.com/Eventual-Inc/Daft/issues/3796

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
