### PR TITLE
fix(flotilla): Change MaterializedOutput to return a Vec<Partitions>

### DIFF
--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -219,7 +219,7 @@ impl ActorUDF {
                     };
 
                     let task = self.make_actor_udf_task_for_materialized_outputs(
-                        vec![materialized_output],
+                        materialized_output,
                         worker_id,
                         actors,
                         TaskContext::from((&self.context, task_id_counter.next())),
@@ -275,17 +275,13 @@ impl ActorUDF {
 
     fn make_actor_udf_task_for_materialized_outputs(
         &self,
-        materialized_outputs: Vec<MaterializedOutput>,
+        materialized_output: MaterializedOutput,
         worker_id: WorkerId,
         actors: Vec<PyObjectWrapper>,
         task_context: TaskContext,
     ) -> DaftResult<SubmittableTask<SwordfishTask>> {
         // Extract all partitions from materialized outputs
-        let mut partitions = Vec::new();
-        for materialized_output in materialized_outputs {
-            let (partition, _) = materialized_output.into_inner();
-            partitions.push(partition);
-        }
+        let partitions = materialized_output.partitions().to_vec();
 
         let in_memory_info = InMemoryInfo::new(
             self.config.schema.clone(),

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -66,6 +66,7 @@ impl LimitNode {
 
         while let Some(materialized_output) = materialized_result_stream.next().await {
             let materialized_output = materialized_output?;
+
             for next_input in materialized_output.split_by_partitions() {
                 let num_rows = next_input.num_rows()?;
 
@@ -92,13 +93,14 @@ impl LimitNode {
                     }
                 };
                 if result_tx.send(to_send).await.is_err() {
-                    break;
+                    return Ok(());
                 }
                 if should_break {
-                    break;
+                    return Ok(());
                 }
             }
         }
+
         Ok(())
     }
 

--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -51,19 +51,19 @@ pub(crate) type NodeName = &'static str;
 /// to schedule follow-up pipeline nodes on the same worker.
 #[derive(Clone, Debug)]
 pub(crate) struct MaterializedOutput {
-    partition: PartitionRef,
+    partition: Vec<PartitionRef>,
     worker_id: WorkerId,
 }
 
 impl MaterializedOutput {
-    pub fn new(partition: PartitionRef, worker_id: WorkerId) -> Self {
+    pub fn new(partition: Vec<PartitionRef>, worker_id: WorkerId) -> Self {
         Self {
             partition,
             worker_id,
         }
     }
 
-    pub fn partition(&self) -> &PartitionRef {
+    pub fn partitions(&self) -> &[PartitionRef] {
         &self.partition
     }
 
@@ -72,8 +72,29 @@ impl MaterializedOutput {
         &self.worker_id
     }
 
-    pub fn into_inner(self) -> (PartitionRef, WorkerId) {
+    pub fn into_inner(self) -> (Vec<PartitionRef>, WorkerId) {
         (self.partition, self.worker_id)
+    }
+
+    pub fn split_by_partitions(&self) -> Vec<Self> {
+        self.partition
+            .iter()
+            .map(|partition| Self::new(vec![partition.clone()], self.worker_id.clone()))
+            .collect()
+    }
+
+    pub fn num_rows(&self) -> DaftResult<usize> {
+        self.partition
+            .iter()
+            .map(|partition| partition.num_rows())
+            .sum()
+    }
+
+    pub fn size_bytes(&self) -> DaftResult<usize> {
+        self.partition
+            .iter()
+            .map(|partition| partition.size_bytes().map(|size| size.unwrap_or(0)))
+            .sum()
     }
 }
 
@@ -296,10 +317,10 @@ where
     let mut worker_id_counts: HashMap<WorkerId, usize> = HashMap::new();
 
     for materialized_output in materialized_outputs {
-        let (partition_ref, worker_id) = materialized_output.into_inner();
-        total_size_bytes += partition_ref.size_bytes()?.unwrap_or(0);
-        total_num_rows += partition_ref.num_rows().unwrap_or(0);
-        partition_refs.push(partition_ref);
+        total_size_bytes += materialized_output.size_bytes()?;
+        total_num_rows += materialized_output.num_rows()?;
+        let (output_refs, worker_id) = materialized_output.into_inner();
+        partition_refs.extend(output_refs);
         let count = worker_id_counts.entry(worker_id.clone()).or_insert(0);
         *count += 1;
     }

--- a/src/daft-distributed/src/plan/mod.rs
+++ b/src/daft-distributed/src/plan/mod.rs
@@ -5,7 +5,9 @@ use std::sync::{
 
 use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
+use common_partitioning::PartitionRef;
 use daft_logical_plan::LogicalPlanBuilder;
+use futures::{stream, Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -53,7 +55,8 @@ impl DistributedPhysicalPlan {
     }
 }
 
-pub(crate) type PlanResultStream = JoinableForwardingStream<ReceiverStream<MaterializedOutput>>;
+pub(crate) type PlanResultStream =
+    JoinableForwardingStream<Box<dyn Stream<Item = PartitionRef> + Send + Unpin + 'static>>;
 
 pub(crate) struct PlanResult {
     joinset: JoinSet<DaftResult<()>>,
@@ -66,6 +69,9 @@ impl PlanResult {
     }
 
     pub fn into_stream(self) -> PlanResultStream {
-        JoinableForwardingStream::new(ReceiverStream::new(self.rx), self.joinset)
+        JoinableForwardingStream::new(
+            Box::new(ReceiverStream::new(self.rx).flat_map(|mat| stream::iter(mat.into_inner().0))),
+            self.joinset,
+        )
     }
 }

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -40,12 +40,12 @@ impl PythonPartitionRefStream {
             let next = match next {
                 Some(result) => {
                     let result = result?;
-                    let ray_part_refs = result
+                    let ray_part_ref = result
                         .as_any()
                         .downcast_ref::<RayPartitionRef>()
                         .expect("Failed to downcast to RayPartitionRef")
                         .clone();
-                    Some(ray_part_refs)
+                    Some(ray_part_ref)
                 }
                 None => None,
             };

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -41,16 +41,10 @@ impl PythonPartitionRefStream {
                 Some(result) => {
                     let result = result?;
                     let ray_part_refs = result
-                        .partitions()
-                        .iter()
-                        .map(|partition| {
-                            partition
-                                .as_any()
-                                .downcast_ref::<RayPartitionRef>()
-                                .expect("Failed to downcast to RayPartitionRef")
-                                .clone()
-                        })
-                        .collect::<Vec<_>>();
+                        .as_any()
+                        .downcast_ref::<RayPartitionRef>()
+                        .expect("Failed to downcast to RayPartitionRef")
+                        .clone();
                     Some(ray_part_refs)
                 }
                 None => None,

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -40,13 +40,18 @@ impl PythonPartitionRefStream {
             let next = match next {
                 Some(result) => {
                     let result = result?;
-                    let ray_part_ref = result
-                        .partition()
-                        .as_any()
-                        .downcast_ref::<RayPartitionRef>()
-                        .expect("Failed to downcast to RayPartitionRef")
-                        .clone();
-                    Some(ray_part_ref)
+                    let ray_part_refs = result
+                        .partitions()
+                        .iter()
+                        .map(|partition| {
+                            partition
+                                .as_any()
+                                .downcast_ref::<RayPartitionRef>()
+                                .expect("Failed to downcast to RayPartitionRef")
+                                .clone()
+                        })
+                        .collect::<Vec<_>>();
+                    Some(ray_part_refs)
                 }
                 None => None,
             };

--- a/src/daft-distributed/src/python/ray/task.rs
+++ b/src/daft-distributed/src/python/ray/task.rs
@@ -101,17 +101,16 @@ impl TaskResultHandle for RayTaskResultHandle {
 
             match ray_task_result {
                 Ok(RayTaskResult::Success(ray_part_refs)) => {
-                    let materialized_outputs = ray_part_refs
-                        .into_iter()
-                        .map(|ray_part_ref| {
-                            MaterializedOutput::new(
-                                Arc::new(ray_part_ref) as PartitionRef,
-                                worker_id.clone(),
-                            )
-                        })
-                        .collect();
+                    let materialized_output = MaterializedOutput::new(
+                        ray_part_refs
+                            .into_iter()
+                            .map(|ray_part_ref| Arc::new(ray_part_ref) as PartitionRef)
+                            .collect(),
+                        worker_id.clone(),
+                    );
+
                     TaskStatus::Success {
-                        result: materialized_outputs,
+                        result: materialized_output,
                     }
                 }
                 Ok(RayTaskResult::WorkerDied()) => TaskStatus::WorkerDied,

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -110,7 +110,7 @@ impl<W: Worker> Dispatcher<W> {
                     Ok(task_status) => match task_status {
                         // Task completed successfully, send the result to the result_tx
                         TaskStatus::Success { result } => {
-                            if result_tx.send(Ok(result)).is_err() {
+                            if result_tx.send(Ok(Some(result))).is_err() {
                                 tracing::error!(target: DISPATCHER_LOG_TARGET, error = "Failed to send result of task to result_tx", task_context = ?task.task_context());
                             }
                         }
@@ -228,7 +228,7 @@ mod tests {
         assert!(failed_tasks.is_empty());
 
         let result = submitted_task.await?;
-        let partition = result[0].partition();
+        let partition = result.unwrap().partitions()[0].clone();
         assert!(Arc::ptr_eq(&partition, &partition_ref));
 
         Ok(())
@@ -271,7 +271,7 @@ mod tests {
         // Verify results
         for (i, submitted_task) in submitted_tasks.into_iter().enumerate() {
             let result = submitted_task.await?;
-            let partition = result[0].partition();
+            let partition = result.unwrap().partitions()[0].clone();
             assert_eq!(partition.num_rows().unwrap(), 100 + i);
             assert_eq!(partition.size_bytes().unwrap(), Some(1024 * (i + 1)));
         }

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -28,14 +28,14 @@ pub(super) trait Scheduler<T: Task>: Send + Sync {
 
 pub(crate) struct SchedulableTask<T: Task> {
     task: T,
-    result_tx: OneshotSender<DaftResult<Vec<MaterializedOutput>>>,
+    result_tx: OneshotSender<DaftResult<Option<MaterializedOutput>>>,
     cancel_token: CancellationToken,
 }
 
 impl<T: Task> SchedulableTask<T> {
     pub fn new(
         task: T,
-        result_tx: OneshotSender<DaftResult<Vec<MaterializedOutput>>>,
+        result_tx: OneshotSender<DaftResult<Option<MaterializedOutput>>>,
         cancel_token: CancellationToken,
     ) -> Self {
         Self {
@@ -57,7 +57,7 @@ impl<T: Task> SchedulableTask<T> {
         self,
     ) -> (
         T,
-        OneshotSender<DaftResult<Vec<MaterializedOutput>>>,
+        OneshotSender<DaftResult<Option<MaterializedOutput>>>,
         CancellationToken,
     ) {
         (self.task, self.result_tx, self.cancel_token)
@@ -97,7 +97,7 @@ impl<T: Task> Ord for SchedulableTask<T> {
 
 pub(super) struct ScheduledTask<T: Task> {
     task: T,
-    result_tx: OneshotSender<DaftResult<Vec<MaterializedOutput>>>,
+    result_tx: OneshotSender<DaftResult<Option<MaterializedOutput>>>,
     cancel_token: CancellationToken,
     worker_id: WorkerId,
 }
@@ -130,7 +130,7 @@ impl<T: Task> ScheduledTask<T> {
     ) -> (
         WorkerId,
         T,
-        OneshotSender<DaftResult<Vec<MaterializedOutput>>>,
+        OneshotSender<DaftResult<Option<MaterializedOutput>>>,
         CancellationToken,
     ) {
         (self.worker_id, self.task, self.result_tx, self.cancel_token)

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -351,7 +351,7 @@ impl Future for SubmittedTask {
                 }
                 Poll::Ready(result)
             }
-            // If the receiver is dropped, return no results
+            // If the sender is dropped (i.e. the task is cancelled), return no results
             Poll::Ready(Err(_)) => {
                 self.finished = true;
                 if let Some(notify_token) = self.notify_token.take() {

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -283,7 +283,7 @@ impl Task for SwordfishTask {
 
 #[derive(Debug)]
 pub(crate) enum TaskStatus {
-    Success { result: Vec<MaterializedOutput> },
+    Success { result: MaterializedOutput },
     Failed { error: DaftError },
     Cancelled,
     WorkerDied,
@@ -380,7 +380,7 @@ pub(super) mod tests {
         priority: MockTaskPriority,
         scheduling_strategy: SchedulingStrategy,
         resource_request: TaskResourceRequest,
-        task_result: Vec<MaterializedOutput>,
+        task_result: MaterializedOutput,
         cancel_notifier: Arc<Mutex<Option<OneshotSender<()>>>>,
         sleep_duration: Option<std::time::Duration>,
         failure: Option<MockTaskFailure>,
@@ -400,7 +400,7 @@ pub(super) mod tests {
         task_name: TaskName,
         priority: MockTaskPriority,
         scheduling_strategy: SchedulingStrategy,
-        task_result: Vec<MaterializedOutput>,
+        task_result: MaterializedOutput,
         resource_request: TaskResourceRequest,
         cancel_notifier: Arc<Mutex<Option<OneshotSender<()>>>>,
         sleep_duration: Option<Duration>,
@@ -422,7 +422,7 @@ pub(super) mod tests {
                 priority: MockTaskPriority { priority: 0 },
                 scheduling_strategy: SchedulingStrategy::Spread,
                 resource_request: TaskResourceRequest::new(ResourceRequest::default()),
-                task_result: vec![MaterializedOutput::new(partition_ref, "".into())],
+                task_result: MaterializedOutput::new(vec![partition_ref], "".into()),
                 cancel_notifier: Arc::new(Mutex::new(None)),
                 sleep_duration: None,
                 failure: None,

--- a/src/daft-distributed/src/utils/stream.rs
+++ b/src/daft-distributed/src/utils/stream.rs
@@ -9,7 +9,7 @@ use futures::{Stream, StreamExt};
 use crate::utils::joinset::JoinSet;
 
 #[derive(Debug)]
-enum ForwardingStreamState<S> {
+enum ForwardingStreamState<S: Stream + Send + Unpin + 'static> {
     // Active: Forwarding results from input stream and tracking background tasks
     Active {
         input_stream: S,
@@ -21,11 +21,14 @@ enum ForwardingStreamState<S> {
     Complete,
 }
 
-pub(crate) struct JoinableForwardingStream<S> {
+pub(crate) struct JoinableForwardingStream<S: Stream + Send + Unpin + 'static> {
     state: ForwardingStreamState<S>,
 }
 
-impl<S> JoinableForwardingStream<S> {
+impl<S> JoinableForwardingStream<S>
+where
+    S: Stream + Send + Unpin + 'static,
+{
     pub fn new(input_stream: S, joinset: JoinSet<DaftResult<()>>) -> Self {
         Self {
             state: ForwardingStreamState::Active {
@@ -36,19 +39,19 @@ impl<S> JoinableForwardingStream<S> {
     }
 }
 
-impl<S, T> Stream for JoinableForwardingStream<S>
+impl<S> Stream for JoinableForwardingStream<S>
 where
-    S: Stream<Item = T> + Send + Unpin + 'static,
+    S: Stream + Send + Unpin + 'static,
 {
-    type Item = DaftResult<T>;
+    type Item = DaftResult<S::Item>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        fn poll_inner<S, T>(
+        fn poll_inner<S>(
             state: &mut ForwardingStreamState<S>,
             cx: &mut Context<'_>,
-        ) -> Option<Poll<Option<DaftResult<T>>>>
+        ) -> Option<Poll<Option<DaftResult<S::Item>>>>
         where
-            S: Stream<Item = T> + Send + Unpin + 'static,
+            S: Stream + Send + Unpin + 'static,
         {
             match state {
                 // Active: Forwarding results from input stream and tracking background tasks

--- a/tests/integration/iceberg/docker-compose/docker-compose.yml
+++ b/tests/integration/iceberg/docker-compose/docker-compose.yml
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-version: '3'
 
 services:
   spark-iceberg:


### PR DESCRIPTION
## Changes Made

To make repartition easier to implement and less flaky, it would be better if all returned partitions from a task are packaged together into one MaterializedOutput instead of multiple. This makes other sections that work better on individual partitions a bit more complicated, so reworked other operators.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
