### PR TITLE
fix(flotilla): Disambiguate StatisticsEvent variant names to reflect events

### DIFF
--- a/src/daft-distributed/src/python/progress_bar.rs
+++ b/src/daft-distributed/src/python/progress_bar.rs
@@ -80,7 +80,7 @@ impl StatisticsSubscriber for FlotillaProgressBar {
                 Ok(())
             }
             // For progress bar we don't care if it is scheduled, for now.
-            StatisticsEvent::ScheduledTask { .. } => Ok(()),
+            StatisticsEvent::TaskScheduled { .. } => Ok(()),
             StatisticsEvent::TaskStarted { .. } => Ok(()), // Progress bar doesn't need to handle task start separately
             StatisticsEvent::TaskCompleted { context } => {
                 self.update_bar(BarId::from(context))?;

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -157,7 +157,7 @@ where
                 // Report to statistics manager
                 for task in &scheduled_tasks {
                     let task_context = task.task().task_context();
-                    statistics_manager.handle_event(StatisticsEvent::ScheduledTask {
+                    statistics_manager.handle_event(StatisticsEvent::TaskScheduled {
                         context: task_context,
                     })?;
                 }

--- a/src/daft-distributed/src/statistics/http_subscriber.rs
+++ b/src/daft-distributed/src/statistics/http_subscriber.rs
@@ -223,7 +223,7 @@ impl HttpSubscriber {
                 }
                 // If plan doesn't exist yet, ignore the task - it will be processed when PlanSubmitted arrives
             }
-            StatisticsEvent::ScheduledTask { context } => {
+            StatisticsEvent::TaskScheduled { context } => {
                 let plan_id = context.plan_id;
                 if let Some(plan_data) = self.plan_data.get_mut(&plan_id) {
                     if let Some(task_state) = plan_data.tasks.get_mut(context) {

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -53,7 +53,7 @@ pub(crate) enum StatisticsEvent {
         name: TaskName,
     },
     #[allow(dead_code)]
-    ScheduledTask {
+    TaskScheduled {
         context: TaskContext,
     },
     TaskCompleted {
@@ -89,7 +89,7 @@ impl StatisticsEvent {
             Self::PlanStarted { plan_id } => *plan_id,
             Self::PlanFinished { plan_id } => *plan_id,
             Self::TaskSubmitted { context, .. } => context.plan_id,
-            Self::ScheduledTask { context } => context.plan_id,
+            Self::TaskScheduled { context } => context.plan_id,
             Self::TaskCompleted { context } => context.plan_id,
             Self::TaskStarted { context } => context.plan_id,
             Self::TaskFailed { context, .. } => context.plan_id,


### PR DESCRIPTION
## Changes Made

Renames the StatisticsEvent enum variants to better reflect that these are events occurring to tasks, not tasks themselves.

For example:
	•	SubmittedTask → TaskSubmitted
	•	FinishedTask → TaskFinished
	•	etc.

This improves clarity for future readers, especially when trying to build a mental model of system behavior based on event traces. The change is purely cosmetic: no behavioral or structural changes involved.

Happy to discuss if there’s a preferred naming pattern.