### PR TITLE
feat: rowwise (scalar) udfs

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -123,7 +123,7 @@ from daft.session import (
     detach_function,
 )
 from daft.sql import sql, sql_expr
-from daft.udf import udf
+from daft.udf import udf, func
 from daft.viz import register_viz_hook
 from daft.window import Window
 
@@ -173,6 +173,7 @@ __all__ = [
     "from_pydict",
     "from_pylist",
     "from_ray_dataset",
+    "func",
     "get_catalog",
     "get_table",
     "has_catalog",

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -569,7 +569,36 @@ def udf(
     return _udf
 
 
-class FuncDecorator:
+@dataclasses.dataclass
+class UDFFunction:
+    """`@daft.func` Decorator to convert a Python function into a `UDF`.
+
+    Unlike `@daft.udf(...)`, `@daft.func` operates on single values instead of batches.
+
+    Examples:
+    >>> @daft.func()
+    ... # or you can specify the return type like our existing daft.udf
+    ... # @daft.func(return_dtype=daft.DataType.int64())
+    ... def my_sum(a: int, b: int) -> int:
+    ...     return a + b
+    >>>
+    >>> df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
+    >>> df.select(my_sum(col("x"), col("y"))).collect()
+    ╭───────╮
+    │ x     │
+    │ ---   │
+    │ Int64 │
+    ╞═══════╡
+    │ 5     │
+    ├╌╌╌╌╌╌╌┤
+    │ 7     │
+    ├╌╌╌╌╌╌╌┤
+    │ 9     │
+    ╰───────╯
+    <BLANKLINE>
+    (Showing first 3 of 3 rows)
+    """
+
     def __init__(self) -> None:
         self.batch = udf
 
@@ -607,4 +636,4 @@ class FuncDecorator:
         return _udf
 
 
-func = FuncDecorator()
+func = UDFFunction()

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -535,3 +535,38 @@ def test_udf_retry_with_process_killed_ray(use_actor_pool):
     expr = random_exit_udf(col("a"), col("b"), HasFailedAlready.remote())
     df = df.select(expr)
     df.collect()
+
+
+def test_non_batched_udf():
+    @daft.func(return_dtype=str)
+    def my_stringify_and_sum(a: int, b: int) -> str:
+        return f"{a + b}"
+
+    df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
+    actual = df.select(my_stringify_and_sum(col("x"), col("y"))).to_pydict()
+
+    expected = {"x": ["5", "7", "9"]}
+
+    assert actual == expected
+
+
+def test_non_batched_udf_should_infer_dtype_from_function():
+    @daft.func()
+    def list_string_return_type(a: int, b: int) -> list[str]:
+        return [f"{a + b}"]
+
+    df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
+    df = df.select(list_string_return_type(col("x"), col("y")))
+
+    schema = df.schema()
+    expected_schema = daft.Schema.from_pydict({"x": daft.DataType.list(daft.DataType.string())})
+
+    assert schema == expected_schema
+
+
+def test_func_requires_return_dtype_when_no_annotation():
+    with pytest.raises(ValueError, match="return_dtype is required when function has no return annotation"):
+
+        @daft.func()
+        def my_func(a: int, b: int):
+            return f"{a + b}"


### PR DESCRIPTION
## Changes Made

adds new `@daft.func` which provides users a way to do rowwise (scalar) udfs

example usage:

```py
# note: it can infer the datatype from the function signature
@daft.func()
# or you can specify the return type like our existing daft.udf
# @daft.func(return_dtype=daft.DataType.int64())
def my_sum(a: int, b: int) -> int:
    return a + b

df = daft.from_pydict({
    "x": [1, 2, 3],
    "y": [4, 5, 6]
})
df.select(my_sum(col("x"), col("y"))).collect()
╭───────╮
│ x     │
│ ---   │
│ Int64 │
╞═══════╡
│ 5     │
├╌╌╌╌╌╌╌┤
│ 7     │
├╌╌╌╌╌╌╌┤
│ 9     │
╰───────╯
(Showing first 3 of 3 rows)
```


Additionally, it adds an alias to the existing `@daft.udf(...)` as `@daft.func.batch(...)`



## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
