### PR TITLE
chore: support pass virtual host style to pyarrow s3 fs

### DIFF
--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -219,6 +219,7 @@ def _infer_filesystem(
             _set_if_not_none(translated_kwargs, "session_token", s3_config.session_token)
             _set_if_not_none(translated_kwargs, "region", s3_config.region_name)
             _set_if_not_none(translated_kwargs, "anonymous", s3_config.anonymous)
+            _set_if_not_none(translated_kwargs, "force_virtual_addressing", s3_config.force_virtual_addressing)
             if s3_config.num_tries is not None:
                 try:
                     from pyarrow.fs import AwsStandardS3RetryStrategy


### PR DESCRIPTION
## Changes Made

passing the virtual host style parameter to pyarrow s3 fs, becuase some s3-like object store only support virtual host style

## Related Issues



## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
