### PR TITLE
chore(flotilla): Refactor task naming for clarity

### DIFF
--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use common_error::DaftResult;
 
 use super::{
-    scheduler::{SchedulableTask, ScheduledTask},
+    scheduler::{PendingTask, ScheduledTask},
     task::{Task, TaskResultAwaiter, TaskStatus},
     worker::{Worker, WorkerManager},
 };
@@ -73,7 +73,7 @@ impl<W: Worker> Dispatcher<W> {
         &mut self,
         worker_manager: &Arc<dyn WorkerManager<Worker = W>>,
         statistics_manager: &StatisticsManagerRef,
-    ) -> DaftResult<Vec<SchedulableTask<W::Task>>> {
+    ) -> DaftResult<Vec<PendingTask<W::Task>>> {
         let mut failed_tasks = Vec::new();
         let mut task_results = Vec::new();
 
@@ -125,12 +125,12 @@ impl<W: Worker> Dispatcher<W> {
                         // Task worker died, add the task to the failed tasks, and mark the worker as dead
                         TaskStatus::WorkerDied => {
                             worker_manager.mark_worker_died(worker_id);
-                            let schedulable_task = SchedulableTask::new(task, result_tx, canc);
+                            let schedulable_task = PendingTask::new(task, result_tx, canc);
                             failed_tasks.push(schedulable_task);
                         }
                         // Task worker unavailable, add the task to the failed tasks
                         TaskStatus::WorkerUnavailable => {
-                            let schedulable_task = SchedulableTask::new(task, result_tx, canc);
+                            let schedulable_task = PendingTask::new(task, result_tx, canc);
                             failed_tasks.push(schedulable_task);
                         }
                     },

--- a/src/daft-distributed/src/scheduling/scheduler/linear.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/linear.rs
@@ -1,12 +1,12 @@
 use std::collections::{BinaryHeap, HashMap};
 
-use super::{SchedulableTask, ScheduledTask, Scheduler, WorkerSnapshot};
+use super::{PendingTask, ScheduledTask, Scheduler, WorkerSnapshot};
 use crate::scheduling::{task::Task, worker::WorkerId};
 
 #[allow(dead_code)]
 pub(super) struct LinearScheduler<T: Task> {
     worker_snapshots: HashMap<WorkerId, WorkerSnapshot>,
-    pending_tasks: BinaryHeap<SchedulableTask<T>>,
+    pending_tasks: BinaryHeap<PendingTask<T>>,
 }
 
 impl<T: Task> Default for LinearScheduler<T> {
@@ -39,11 +39,11 @@ impl<T: Task> Scheduler<T> for LinearScheduler<T> {
         }
     }
 
-    fn enqueue_tasks(&mut self, _tasks: Vec<SchedulableTask<T>>) {
+    fn enqueue_tasks(&mut self, _tasks: Vec<PendingTask<T>>) {
         todo!("FLOTILLA_MS1: Implement enqueue_tasks for linear scheduler")
     }
 
-    fn get_schedulable_tasks(&mut self) -> Vec<ScheduledTask<T>> {
+    fn schedule_tasks(&mut self) -> Vec<ScheduledTask<T>> {
         todo!("FLOTILLA_MS1: Implement get_schedulable_tasks for linear scheduler")
     }
 

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -20,19 +20,19 @@ use tokio_util::sync::CancellationToken;
 
 pub(super) trait Scheduler<T: Task>: Send + Sync {
     fn update_worker_state(&mut self, worker_snapshots: &[WorkerSnapshot]);
-    fn enqueue_tasks(&mut self, tasks: Vec<SchedulableTask<T>>);
-    fn get_schedulable_tasks(&mut self) -> Vec<ScheduledTask<T>>;
+    fn enqueue_tasks(&mut self, tasks: Vec<PendingTask<T>>);
+    fn schedule_tasks(&mut self) -> Vec<ScheduledTask<T>>;
     fn get_autoscaling_request(&mut self) -> Option<usize>;
     fn num_pending_tasks(&self) -> usize;
 }
 
-pub(crate) struct SchedulableTask<T: Task> {
+pub(crate) struct PendingTask<T: Task> {
     task: T,
     result_tx: OneshotSender<DaftResult<Option<MaterializedOutput>>>,
     cancel_token: CancellationToken,
 }
 
-impl<T: Task> SchedulableTask<T> {
+impl<T: Task> PendingTask<T> {
     pub fn new(
         task: T,
         result_tx: OneshotSender<DaftResult<Option<MaterializedOutput>>>,
@@ -64,7 +64,7 @@ impl<T: Task> SchedulableTask<T> {
     }
 }
 
-impl<T: Task> std::fmt::Debug for SchedulableTask<T> {
+impl<T: Task> std::fmt::Debug for PendingTask<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -75,21 +75,21 @@ impl<T: Task> std::fmt::Debug for SchedulableTask<T> {
     }
 }
 
-impl<T: Task> PartialEq for SchedulableTask<T> {
+impl<T: Task> PartialEq for PendingTask<T> {
     fn eq(&self, other: &Self) -> bool {
         self.task.task_id() == other.task.task_id()
     }
 }
 
-impl<T: Task> Eq for SchedulableTask<T> {}
+impl<T: Task> Eq for PendingTask<T> {}
 
-impl<T: Task> PartialOrd for SchedulableTask<T> {
+impl<T: Task> PartialOrd for PendingTask<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T: Task> Ord for SchedulableTask<T> {
+impl<T: Task> Ord for PendingTask<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.task.priority().cmp(&other.task.priority())
     }
@@ -103,7 +103,7 @@ pub(super) struct ScheduledTask<T: Task> {
 }
 
 impl<T: Task> ScheduledTask<T> {
-    pub fn new(task: SchedulableTask<T>, worker_id: WorkerId) -> Self {
+    pub fn new(task: PendingTask<T>, worker_id: WorkerId) -> Self {
         let (task, result_tx, cancel_token) = task.into_inner();
         Self {
             task,
@@ -270,15 +270,15 @@ pub(super) mod test_utils {
         scheduler
     }
 
-    pub fn create_schedulable_task(mock_task: MockTask) -> SchedulableTask<MockTask> {
-        SchedulableTask::new(
+    pub fn create_schedulable_task(mock_task: MockTask) -> PendingTask<MockTask> {
+        PendingTask::new(
             mock_task,
             tokio::sync::oneshot::channel().0,
             tokio_util::sync::CancellationToken::new(),
         )
     }
 
-    pub fn create_spread_task(id: Option<TaskID>) -> SchedulableTask<MockTask> {
+    pub fn create_spread_task(id: Option<TaskID>) -> PendingTask<MockTask> {
         let task = MockTaskBuilder::default()
             .with_scheduling_strategy(SchedulingStrategy::Spread)
             .with_task_id(id.unwrap_or_default())
@@ -290,7 +290,7 @@ pub(super) mod test_utils {
         worker_id: &WorkerId,
         soft: bool,
         id: Option<TaskID>,
-    ) -> SchedulableTask<MockTask> {
+    ) -> PendingTask<MockTask> {
         let task = MockTaskBuilder::default()
             .with_scheduling_strategy(SchedulingStrategy::WorkerAffinity {
                 worker_id: worker_id.clone(),

--- a/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/scheduler_actor.rs
@@ -11,7 +11,7 @@ use futures::FutureExt;
 use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 
-use super::{default::DefaultScheduler, linear::LinearScheduler, SchedulableTask, Scheduler};
+use super::{default::DefaultScheduler, linear::LinearScheduler, PendingTask, Scheduler};
 use crate::{
     pipeline_node::MaterializedOutput,
     scheduling::{
@@ -29,8 +29,8 @@ use crate::{
     },
 };
 
-pub(crate) type SchedulerSender<T> = UnboundedSender<SchedulableTask<T>>;
-pub(crate) type SchedulerReceiver<T> = UnboundedReceiver<SchedulableTask<T>>;
+pub(crate) type SchedulerSender<T> = UnboundedSender<PendingTask<T>>;
+pub(crate) type SchedulerReceiver<T> = UnboundedReceiver<PendingTask<T>>;
 
 const SCHEDULER_LOG_TARGET: &str = "DaftFlotillaScheduler";
 const SCHEDULER_TICK_INTERVAL: Duration = Duration::from_secs(1);
@@ -90,7 +90,7 @@ where
     }
 
     fn handle_new_tasks(
-        maybe_new_task: Option<SchedulableTask<W::Task>>,
+        maybe_new_task: Option<PendingTask<W::Task>>,
         task_rx: &mut SchedulerReceiver<W::Task>,
         statistics_manager: &StatisticsManagerRef,
         scheduler: &mut S,
@@ -148,7 +148,7 @@ where
             scheduler.update_worker_state(&worker_snapshots);
 
             // 1: Get all tasks that are ready to be scheduled
-            let scheduled_tasks = scheduler.get_schedulable_tasks();
+            let scheduled_tasks = scheduler.schedule_tasks();
             // 2: Dispatch tasks directly to the dispatcher
             if !scheduled_tasks.is_empty() {
                 tracing::info!(target: SCHEDULER_LOG_TARGET, num_tasks = scheduled_tasks.len(), "Scheduling tasks for dispatch");
@@ -238,10 +238,10 @@ impl<T: Task> SchedulerHandle<T> {
 
     pub fn prepare_task_for_submission(
         submittable_task: SubmittableTask<T>,
-    ) -> (SchedulableTask<T>, SubmittedTask) {
+    ) -> (PendingTask<T>, SubmittedTask) {
         let task_id = submittable_task.task.task_id();
 
-        let schedulable_task = SchedulableTask::new(
+        let schedulable_task = PendingTask::new(
             submittable_task.task,
             submittable_task.result_tx,
             submittable_task.cancel_token.clone(),


### PR DESCRIPTION
This PR renames two key components in the scheduling code to improve semantic clarity and alignment with actual behavior:
1. SchedulableTask -> PendingTask - Think "Schedulable" and "Scheduled" are quite a mouthful for verbal conversations. Besides, we already have a method called 'num_pending_tasks'. So I just chose 'PendingTask'.
2. get_schedulable_tasks -> schedule_tasks - This was a mutating method that actually performs the scheduling (i.e. assigns tasks to workers).

No functional behavior has changed—this is a naming/clarity refactor only.