### PR TITLE
fix(docs): Updated docs to correct calculate max rows per partition

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1432,7 +1432,7 @@ class DataFrame:
         """Generates a column of monotonically increasing unique ids for the DataFrame.
 
         The implementation of this method puts the partition number in the upper 28 bits, and the row number in each partition
-        in the lower 36 bits. This allows for 2^28 ≈ 268 million partitions and 2^40 ≈ 68 billion rows per partition.
+        in the lower 36 bits. This allows for 2^28 ≈ 268 million partitions and 2^36 ≈ 68 billion rows per partition.
 
         Args:
             column_name (Optional[str], optional): name of the new column. Defaults to "id".

--- a/daft/functions/functions.py
+++ b/daft/functions/functions.py
@@ -8,7 +8,7 @@ def monotonically_increasing_id() -> Expression:
     """Generates a column of monotonically increasing unique ids.
 
     The implementation puts the partition number in the upper 28 bits, and the row number in each partition
-    in the lower 36 bits. This allows for 2^28 ≈ 268 million partitions and 2^40 ≈ 68 billion rows per partition.
+    in the lower 36 bits. This allows for 2^28 ≈ 268 million partitions and 2^36 ≈ 68 billion rows per partition.
 
     Returns:
         Expression: An expression that generates monotonically increasing IDs


### PR DESCRIPTION
## Changes Made

The monotonically increasing ID document has a small error in maximum rows per partition calculation. It should say `2^36` instead of `2^40`.