### PR TITLE
fix: populate query graph nodes even if they lack task progress

### DIFF
--- a/src/daft-distributed/src/statistics/http_subscriber.rs
+++ b/src/daft-distributed/src/statistics/http_subscriber.rs
@@ -378,12 +378,64 @@ impl HttpSubscriber {
         // Mapping from logical node ID to QueryGraphNode
         let mut nodes_map: HashMap<NodeID, QueryGraphNode> = HashMap::new();
 
+        // Build a mapping from node_id to logical plan node information
+        let mut node_info_map: HashMap<NodeID, (&'static str, String)> = HashMap::new();
+        let _ = plan_data.plan_state.logical_plan.apply(|node| {
+            if let Some(node_id) = node.node_id() {
+                let name = node.name();
+                let description = node.multiline_display().join(", ");
+                node_info_map.insert(*node_id as NodeID, (name, description));
+            }
+            Ok(common_treenode::TreeNodeRecursion::Continue)
+        });
+
+        // First, create nodes for all logical plan nodes in the adjacency list
+        // This ensures we have all nodes, even if they don't have tasks yet
+        for node_id in plan_data.adjacency_list.keys() {
+            let (label, description) = node_info_map
+                .get(node_id)
+                .map(|(name, desc)| ((*name).to_string(), desc.clone()))
+                .unwrap_or_else(|| {
+                    (
+                        format!("Node_{}", node_id),
+                        format!("Logical node {}", node_id),
+                    )
+                });
+
+            let node = QueryGraphNode {
+                id: *node_id,
+                label,
+                description,
+                metadata: HashMap::from([(
+                    "plan_id".to_string(),
+                    plan_data.plan_state.plan_id.to_string(),
+                )]),
+                status: NodeStatus::Created, // Default status
+                pending: 0,
+                completed: 0,
+                canceled: 0,
+                failed: 0,
+                total: 0,
+                metrics: None,
+            };
+            nodes_map.insert(*node_id, node);
+        }
+
         for (context, task_state) in &plan_data.tasks {
             let node_id = context
                 .logical_node_id
                 .expect("Logical node ID must be set for optimized logical plan");
 
             if let Some(existing_node) = nodes_map.get_mut(&node_id) {
+                // Update node with task information
+                existing_node.label = Self::extract_operation_name(&task_state.name);
+                existing_node.description.clone_from(&task_state.name);
+                existing_node.metadata = HashMap::from([
+                    ("plan_id".to_string(), context.plan_id.to_string()),
+                    ("stage_id".to_string(), context.stage_id.to_string()),
+                    ("node_id".to_string(), context.node_id.to_string()),
+                ]);
+
                 // Collect task progress per node
                 existing_node.pending += task_state.pending;
                 existing_node.completed += task_state.completed;
@@ -394,25 +446,6 @@ impl HttpSubscriber {
                 // Update status - prioritize Failed > Running > Completed > Canceled > Created
                 let new_status = Self::convert_task_status(&task_state.status);
                 existing_node.status = Self::merge_node_status(&existing_node.status, &new_status);
-            } else {
-                let node = QueryGraphNode {
-                    id: node_id,
-                    label: Self::extract_operation_name(&task_state.name),
-                    description: task_state.name.clone(),
-                    metadata: HashMap::from([
-                        ("plan_id".to_string(), context.plan_id.to_string()),
-                        ("stage_id".to_string(), context.stage_id.to_string()),
-                        ("node_id".to_string(), context.node_id.to_string()),
-                    ]),
-                    status: Self::convert_task_status(&task_state.status),
-                    pending: task_state.pending,
-                    completed: task_state.completed,
-                    canceled: task_state.canceled,
-                    failed: task_state.failed,
-                    total: task_state.total,
-                    metrics: None,
-                };
-                nodes_map.insert(node_id, node);
             }
         }
 


### PR DESCRIPTION
## Changes Made

Query nodes may not receive task progress, in which case they don't appear as part of the nodes list in the query graph. Make sure we initialize the query graph to contain all logical nodes.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

N/A

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
