### PR TITLE
fix(flotilla): Add multiple notify tokens to task

### DIFF
--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -230,7 +230,7 @@ impl ActorUDF {
                         actors,
                         TaskContext::from((&self.context, task_id_counter.next())),
                     )?;
-                    let (submittable_task, notify_token) = task.with_notify_token();
+                    let (submittable_task, notify_token) = task.add_notify_token();
                     running_tasks.spawn(notify_token);
                     if result_tx
                         .send(PipelineOutput::Task(submittable_task))
@@ -256,7 +256,7 @@ impl ActorUDF {
                         actors,
                         TaskContext::from((&self.context, task_id_counter.next())),
                     )?;
-                    let (submittable_task, notify_token) = modified_task.with_notify_token();
+                    let (submittable_task, notify_token) = modified_task.add_notify_token();
                     running_tasks.spawn(notify_token);
                     if result_tx
                         .send(PipelineOutput::Task(submittable_task))

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -81,6 +81,9 @@ impl<T: Task> Scheduler<T> for DefaultScheduler<T> {
         let mut scheduled = Vec::new();
         let mut unscheduled = Vec::new();
         while let Some(task) = self.pending_tasks.pop() {
+            if task.cancel_token.is_cancelled() {
+                continue;
+            }
             if let Some(worker_id) = self.try_schedule_task(&task) {
                 self.worker_snapshots
                     .get_mut(&worker_id)

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -81,9 +81,6 @@ impl<T: Task> Scheduler<T> for DefaultScheduler<T> {
         let mut scheduled = Vec::new();
         let mut unscheduled = Vec::new();
         while let Some(task) = self.pending_tasks.pop() {
-            if task.cancel_token.is_cancelled() {
-                continue;
-            }
             if let Some(worker_id) = self.try_schedule_task(&task) {
                 self.worker_snapshots
                     .get_mut(&worker_id)

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -626,9 +626,9 @@ def test_multiple_udfs_different_columns(batch_size, use_actor_pool):
         return [f**2 for f in data]
 
     if use_actor_pool:
-        uppercase_strings = uppercase_strings.with_concurrency(2)
-        multiply_numbers = multiply_numbers.with_concurrency(2)
-        square_floats = square_floats.with_concurrency(2)
+        uppercase_strings = uppercase_strings.with_concurrency(1)
+        multiply_numbers = multiply_numbers.with_concurrency(1)
+        square_floats = square_floats.with_concurrency(1)
 
     # Apply all UDFs simultaneously on different columns
     result = df.select(
@@ -673,10 +673,10 @@ def test_multiple_udfs_same_column(batch_size, use_actor_pool):
         return [f"num_{n}" for n in data]
 
     if use_actor_pool:
-        multiply_by_2 = multiply_by_2.with_concurrency(2)
-        add_10 = add_10.with_concurrency(2)
-        square_and_divide = square_and_divide.with_concurrency(2)
-        number_to_string = number_to_string.with_concurrency(2)
+        multiply_by_2 = multiply_by_2.with_concurrency(1)
+        add_10 = add_10.with_concurrency(1)
+        square_and_divide = square_and_divide.with_concurrency(1)
+        number_to_string = number_to_string.with_concurrency(1)
 
     # Apply all UDFs to the same column simultaneously
     result = df.select(

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -603,6 +603,11 @@ def test_func_batch_same_as_udf():
 
 @pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
 @pytest.mark.parametrize("use_actor_pool", [False, True])
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() == "ray"
+    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    reason="Multiple UDFs on different columns fails on legacy ray runner",
+)
 def test_multiple_udfs_different_columns(batch_size, use_actor_pool):
     """Test running multiple UDFs on different columns simultaneously."""
     df = daft.from_pydict(
@@ -648,6 +653,11 @@ def test_multiple_udfs_different_columns(batch_size, use_actor_pool):
 
 @pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
 @pytest.mark.parametrize("use_actor_pool", [False, True])
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() == "ray"
+    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    reason="Multiple UDFs on same column fails on legacy ray runner",
+)
 def test_multiple_udfs_same_column(batch_size, use_actor_pool):
     """Test running multiple UDFs on the same column simultaneously."""
     df = daft.from_pydict(

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -599,3 +599,98 @@ def test_func_batch_same_as_udf():
     using_udf = df.select(my_udf(col("x"), col("y"))).to_pydict()
 
     assert using_batch == using_udf
+
+
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+@pytest.mark.parametrize("use_actor_pool", [False, True])
+def test_multiple_udfs_different_columns(batch_size, use_actor_pool):
+    """Test running multiple UDFs on different columns simultaneously."""
+    df = daft.from_pydict(
+        {
+            "strings": ["foo", "bar", "baz", "qux", "hello", "world", "test", "data", "more", "items"],
+            "numbers": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "floats": [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5, 9.5, 10.5],
+        }
+    )
+
+    @udf(return_dtype=DataType.string(), batch_size=batch_size)
+    def uppercase_strings(data):
+        return [s.upper() for s in data]
+
+    @udf(return_dtype=DataType.int64(), batch_size=batch_size)
+    def multiply_numbers(data):
+        return [n * 10 for n in data]
+
+    @udf(return_dtype=DataType.float64(), batch_size=batch_size)
+    def square_floats(data):
+        return [f**2 for f in data]
+
+    if use_actor_pool:
+        uppercase_strings = uppercase_strings.with_concurrency(2)
+        multiply_numbers = multiply_numbers.with_concurrency(2)
+        square_floats = square_floats.with_concurrency(2)
+
+    # Apply all UDFs simultaneously on different columns
+    result = df.select(
+        uppercase_strings(col("strings")).alias("upper_strings"),
+        multiply_numbers(col("numbers")).alias("mult_numbers"),
+        square_floats(col("floats")).alias("squared_floats"),
+    )
+
+    expected = {
+        "upper_strings": ["FOO", "BAR", "BAZ", "QUX", "HELLO", "WORLD", "TEST", "DATA", "MORE", "ITEMS"],
+        "mult_numbers": [10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+        "squared_floats": [2.25, 6.25, 12.25, 20.25, 30.25, 42.25, 56.25, 72.25, 90.25, 110.25],
+    }
+
+    assert result.to_pydict() == expected
+
+
+@pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
+@pytest.mark.parametrize("use_actor_pool", [False, True])
+def test_multiple_udfs_same_column(batch_size, use_actor_pool):
+    """Test running multiple UDFs on the same column simultaneously."""
+    df = daft.from_pydict(
+        {
+            "numbers": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        }
+    )
+
+    @udf(return_dtype=DataType.int64(), batch_size=batch_size)
+    def multiply_by_2(data):
+        return [n * 2 for n in data]
+
+    @udf(return_dtype=DataType.int64(), batch_size=batch_size)
+    def add_10(data):
+        return [n + 10 for n in data]
+
+    @udf(return_dtype=DataType.float64(), batch_size=batch_size)
+    def square_and_divide(data):
+        return [n**2 / 2.0 for n in data]
+
+    @udf(return_dtype=DataType.string(), batch_size=batch_size)
+    def number_to_string(data):
+        return [f"num_{n}" for n in data]
+
+    if use_actor_pool:
+        multiply_by_2 = multiply_by_2.with_concurrency(2)
+        add_10 = add_10.with_concurrency(2)
+        square_and_divide = square_and_divide.with_concurrency(2)
+        number_to_string = number_to_string.with_concurrency(2)
+
+    # Apply all UDFs to the same column simultaneously
+    result = df.select(
+        multiply_by_2(col("numbers")).alias("doubled"),
+        add_10(col("numbers")).alias("plus_ten"),
+        square_and_divide(col("numbers")).alias("squared_halved"),
+        number_to_string(col("numbers")).alias("stringified"),
+    )
+
+    expected = {
+        "doubled": [2, 4, 6, 8, 10, 12, 14, 16, 18, 20],
+        "plus_ten": [11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+        "squared_halved": [0.5, 2.0, 4.5, 8.0, 12.5, 18.0, 24.5, 32.0, 40.5, 50.0],
+        "stringified": ["num_1", "num_2", "num_3", "num_4", "num_5", "num_6", "num_7", "num_8", "num_9", "num_10"],
+    }
+
+    assert result.to_pydict() == expected


### PR DESCRIPTION
## Changes Made

If there are multiple actor pool projects in a row, the notify tokens get overridden.

This PR makes it such that a task can have multiple notify tokens, so multiple pipeline nodes can subscribe to the task finished notification.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
