### PR TITLE
fix: Swap arg order for list_fill

### DIFF
--- a/src/daft-logical-plan/src/ops/set_operations.rs
+++ b/src/daft-logical-plan/src/ops/set_operations.rs
@@ -233,7 +233,7 @@ impl Intersect {
             let fill_and_explodes = left_cols
                 .iter()
                 .map(|column| {
-                    explode(list_fill(resolved_col(V_MIN_COUNT), column.clone()))
+                    explode(list_fill(column.clone(), resolved_col(V_MIN_COUNT)))
                         .alias(column.name())
                 })
                 .collect::<Vec<_>>();
@@ -514,7 +514,7 @@ impl Except {
             let fill_and_explodes = left_cols
                 .iter()
                 .map(|column| {
-                    explode(list_fill(resolved_col(virtual_sum), column.clone()))
+                    explode(list_fill(column.clone(), resolved_col(virtual_sum)))
                         .alias(column.name())
                 })
                 .collect::<Vec<_>>();


### PR DESCRIPTION
## Changes Made

Swap arg order for list fill so that we can use the first arg for the name.


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
