### PR TITLE
feat: Allow flotilla to autoscale with existing workers

### DIFF
--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -9,6 +9,7 @@ use crate::scheduling::{
 pub(super) struct DefaultScheduler<T: Task> {
     pending_tasks: BinaryHeap<PendingTask<T>>,
     worker_snapshots: HashMap<WorkerId, WorkerSnapshot>,
+    autoscaling_threshold: f64,
 }
 
 impl<T: Task> Default for DefaultScheduler<T> {
@@ -19,10 +20,27 @@ impl<T: Task> Default for DefaultScheduler<T> {
 
 impl<T: Task> DefaultScheduler<T> {
     pub fn new() -> Self {
+        let threshold = Self::get_threshold_from_env().unwrap_or(1.25);
+        Self::with_autoscaling_threshold(threshold)
+    }
+
+    pub fn with_autoscaling_threshold(autoscaling_threshold: f64) -> Self {
+        assert!(
+            autoscaling_threshold >= 1.0,
+            "Autoscaling threshold must be >= 1.0, got: {}",
+            autoscaling_threshold
+        );
         Self {
             pending_tasks: BinaryHeap::new(),
             worker_snapshots: HashMap::new(),
+            autoscaling_threshold,
         }
+    }
+
+    fn get_threshold_from_env() -> Option<f64> {
+        std::env::var("DAFT_AUTOSCALING_THRESHOLD")
+            .ok()
+            .and_then(|val| val.parse::<f64>().ok())
     }
 
     // Spread scheduling: Schedule tasks to the worker with the most available slots, to
@@ -118,6 +136,19 @@ impl<T: Task> Scheduler<T> for DefaultScheduler<T> {
         if self.worker_snapshots.is_empty() {
             return Some(self.pending_tasks.len());
         }
+
+        let total_capacity: usize = self
+            .worker_snapshots
+            .values()
+            .map(|worker| worker.total_num_cpus() as usize)
+            .sum();
+
+        let ratio = self.pending_tasks.len() as f64 / total_capacity as f64;
+
+        if ratio > self.autoscaling_threshold {
+            return Some(self.pending_tasks.len());
+        }
+
         None
     }
 }
@@ -582,5 +613,67 @@ mod tests {
         assert_eq!(result.len(), 0);
         assert_eq!(scheduler.num_pending_tasks(), 1);
         assert_eq!(scheduler.get_autoscaling_request(), Some(1));
+    }
+
+    #[test]
+    fn test_default_scheduler_with_insufficient_worker_capacity_can_autoscale() {
+        let worker_1: WorkerId = Arc::from("worker1");
+
+        // Create a worker with only 1 slot available
+        let workers = setup_workers(&[
+            (worker_1.clone(), 1), // 1 slot available
+        ]);
+
+        let mut scheduler: DefaultScheduler<MockTask> = setup_scheduler(&workers);
+
+        // Create 5 tasks - more than the single worker can handle
+        let tasks = vec![
+            create_spread_task(Some(1)),
+            create_spread_task(Some(2)),
+            create_spread_task(Some(3)),
+            create_spread_task(Some(4)),
+            create_spread_task(Some(5)),
+        ];
+
+        scheduler.enqueue_tasks(tasks);
+        let result = scheduler.schedule_tasks();
+
+        // Only 1 task should be scheduled (worker capacity is 1)
+        assert_eq!(result.len(), 1);
+        assert_eq!(scheduler.num_pending_tasks(), 4);
+
+        // Should request 4 workers (ratio 5 total demand / 1 capacity = 5.0 > default threshold 1.25)
+        assert_eq!(scheduler.get_autoscaling_request(), Some(4));
+    }
+
+    #[test]
+    fn test_default_scheduler_with_sufficient_worker_capacity_no_autoscale() {
+        let worker_1: WorkerId = Arc::from("worker1");
+        let worker_2: WorkerId = Arc::from("worker2");
+
+        // Create workers with sufficient capacity
+        let workers = setup_workers(&[
+            (worker_1.clone(), 2), // 2 slots available
+            (worker_2.clone(), 3), // 3 slots available
+        ]);
+
+        let mut scheduler: DefaultScheduler<MockTask> = setup_scheduler(&workers);
+
+        // Create 3 tasks - less than total worker capacity (5)
+        let tasks = vec![
+            create_spread_task(Some(1)),
+            create_spread_task(Some(2)),
+            create_spread_task(Some(3)),
+        ];
+
+        scheduler.enqueue_tasks(tasks);
+        let result = scheduler.schedule_tasks();
+
+        // All tasks should be scheduled
+        assert_eq!(result.len(), 3);
+        assert_eq!(scheduler.num_pending_tasks(), 0);
+
+        // Should not request autoscaling
+        assert_eq!(scheduler.get_autoscaling_request(), None);
     }
 }


### PR DESCRIPTION
## Changes Made

Previously can only autoscale if no workers. Now we set a ratio of `pending_task` to `cluster capacity` to decide autoscaling

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
