### PR TITLE
fix: Ignore partition refs if they are empty

### DIFF
--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -371,7 +371,7 @@ where
         psets,
         SchedulingStrategy::WorkerAffinity {
             worker_id,
-            soft: false,
+            soft: true,
         },
         node.context().to_hashmap(),
     );

--- a/src/daft-distributed/src/pipeline_node/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/repartition.rs
@@ -116,7 +116,10 @@ impl RepartitionNode {
         for idx in 0..num_partitions {
             let mut partition_group = vec![];
             for materialized_partition in &materialized_partitions {
-                partition_group.push(materialized_partition[idx].clone());
+                let part = &materialized_partition[idx];
+                if part.num_rows()? > 0 {
+                    partition_group.push(part.clone());
+                }
             }
             transposed_outputs.push(partition_group);
         }


### PR DESCRIPTION
## Changes Made

This PR prevents propagation of empty partition refs for subsequent tasks

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
