### PR TITLE
docs: update slack link in runllm widget

### DIFF
--- a/docs/js/runllm.js
+++ b/docs/js/runllm.js
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", function () {
   script.setAttribute("runllm-preset", "mkdocs");
   script.setAttribute("runllm-theme-color", "#ff00ff");
   script.setAttribute("runllm-join-community-text", "Join Daft Slack!");
-  script.setAttribute("runllm-community-url", "https://www.getdaft.io/slack.html?utm_source=docs&utm_medium=button&utm_campaign=docs_ask_ai");
+  script.setAttribute("runllm-community-url", "https://dist-data.slack.com/join/shared_invite/zt-2e77olvxw-uyZcPPV1SRchhi8ah6ZCtg#/shared-invite/email");
   script.setAttribute("runllm-community-type", "slack");
   script.setAttribute("runllm-brand-logo", "https://raw.githubusercontent.com/Eventual-Inc/Daft/refs/heads/main/docs/img/favicon.png");
 


### PR DESCRIPTION
## Changes Made

Fix link for "Join Daft Slack!" button

<img width="1640" height="472" alt="image" src="https://github.com/user-attachments/assets/d4e0281a-9e0b-4d64-a5cb-03a3596416e9" />

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
