### PR TITLE
fix: Clarify `json.query` deprecation

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -5253,7 +5253,7 @@ class ExpressionJsonNamespace(ExpressionNamespace):
 
         """
         warnings.warn(
-            "This API is deprecated in daft >=0.5.1 and will be removed in >=0.6.0. Users should use `Expression.jq` instead.",
+            "`.json.query` is deprecated in daft >=0.5.1 and will be removed in >=0.6.0. Users should use `.jq` instead. Example: `col('x').jq('query')`",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
## Changes Made

While using `json.query` i found that the deprecation warning can be more clear.

It was not clear to me which api is referred to by `This API is deprecated`. Additionally, the deprecation warning can benefit from an example for the user on what the new syntax is.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
