### PR TITLE
feat: Add experimental turbopuffer sink

### DIFF
--- a/daft/io/turbopuffer/__init__.py
+++ b/daft/io/turbopuffer/__init__.py
@@ -1,0 +1,3 @@
+from .turbopuffer_data_sink import TurbopufferDataSink
+
+__all__ = ["TurbopufferDataSink"]

--- a/daft/io/turbopuffer/turbopuffer_data_sink.py
+++ b/daft/io/turbopuffer/turbopuffer_data_sink.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any, Literal
+
+import turbopuffer
+
+from daft.datatype import DataType
+from daft.io import DataSink
+from daft.io.sink import WriteResult
+from daft.recordbatch import MicroPartition
+from daft.schema import Schema
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import ModuleType
+
+
+class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
+    """WriteSink for writing data to a Turbopuffer namespace."""
+
+    def _import_turbopuffer(self) -> ModuleType:
+        try:
+            import turbopuffer
+
+            return turbopuffer
+        except ImportError:
+            raise ImportError(
+                "turbopuffer is not installed. Please install turbopuffer using `pip install turbopuffer`"
+            )
+
+    def __init__(
+        self,
+        namespace: str,
+        api_key: str | None = None,
+        region: str = "aws-us-west-2",
+        distance_metric: Literal["cosine_distance", "euclidean_squared"] | None = None,
+        schema: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the Turbopuffer data sink.
+
+        For more details on parameters, please see the turbopuffer documentation: https://turbopuffer.com/docs/write
+
+        Args:
+            namespace: The namespace to write to.
+            api_key: Turbopuffer API key (defaults to TURBOPUFFER_API_KEY env var).
+            region: Turbopuffer region (defaults to "aws-us-west-2").
+            distance_metric: Distance metric for vector similarity ("cosine_distance", "euclidean_distance").
+            schema: Optional manual schema specification.
+            io_config: IO configuration
+        """
+        self._namespace_name = namespace
+        self._api_key = api_key or os.getenv("TURBOPUFFER_API_KEY")
+        if not self._api_key:
+            raise ValueError("Turbopuffer API key must be provided or set in TURBOPUFFER_API_KEY environment variable")
+
+        self._region = region
+        self._distance_metric = distance_metric
+        self._schema = schema or {}
+
+        self._result_schema = Schema._from_field_name_and_types([("write_responses", DataType.python())])
+
+    def schema(self) -> Schema:
+        return self._result_schema
+
+    def write(
+        self, micropartitions: Iterator[MicroPartition]
+    ) -> Iterator[WriteResult[turbopuffer.types.NamespaceWriteResponse]]:
+        """Writes micropartitions to Turbopuffer namespace."""
+        turbopuffer = self._import_turbopuffer()
+        tpuf = turbopuffer.Turbopuffer(
+            api_key=self._api_key,
+            region=self._region,
+        )
+
+        namespace = tpuf.namespace(self._namespace_name)
+
+        for micropartition in micropartitions:
+            arrow_table = micropartition.to_arrow()
+            bytes_written = arrow_table.nbytes
+            rows_written = arrow_table.num_rows
+
+            write_response = namespace.write(
+                upsert_rows=arrow_table.to_pylist(),
+                distance_metric=self._distance_metric,
+                schema=self._schema,
+            )
+
+            yield WriteResult(
+                result=write_response,
+                bytes_written=bytes_written,
+                rows_written=rows_written,
+            )
+
+    def finalize(self, write_results: list[WriteResult[turbopuffer.types.NamespaceWriteResponse]]) -> MicroPartition:
+        """Finalizes the write process and returns summary statistics."""
+        result_table = MicroPartition.from_pydict(
+            {
+                "write_responses": write_results,
+            }
+        )
+
+        return result_table


### PR DESCRIPTION
## Changes Made

Adds an experimental turbopuffer data sink. Currently it transforms each row of the dataframe into a document. This means that an `id` column is always required, and a `vector` column is required if the namespace has a vector index. All other columns become attributes.

For more details, see the turbopuffer documentation: https://turbopuffer.com/docs/write

### Non-vector index write

```
import daft
from daft.io.turbopuffer import TurbopufferDataSink
df = daft.from_pydict({
    "id": [1, 2, 3, 4, 5],
    "val": ["a", "b", "c", "d", "e"]
})
tpuf_sink = TurbopufferDataSink(namespace="desmond_test_sink")
df.write_sink(tpuf_sink).show()
```

### Vector index write

```
from __future__ import annotations

import os

import daft
from daft.io.turbopuffer import TurbopufferDataSink


def openai_or_rand_vector(text: str) -> list[float]:
    if not os.getenv("OPENAI_API_KEY"):
        print("OPENAI_API_KEY not set, using random vectors")
        return [__import__('random').random()]*2
    try:
        return __import__('openai').embeddings.create(model="text-embedding-3-small",input=text).data[0].embedding
    except ImportError:
        return [__import__('random').random()]*2


animal_names = [
    "Elephant", "Tiger", "Kangaroo", "Penguin", "Giraffe", "Panda", "Zebra", "Koala", "Dolphin", "Sloth",
    "Otter", "Leopard", "Flamingo", "Hedgehog", "Raccoon", "Lemur", "Moose", "Orangutan", "Walrus", "Cheetah"
]

vectors = [openai_or_rand_vector(name) for name in animal_names]

df = daft.from_pydict({
    "id": list(range(len(animal_names))),
    "name": animal_names,
    "vector": vectors,
})

tpuf_sink = TurbopufferDataSink(
    namespace="desmond_test_vector_sink",
    distance_metric="cosine_distance" # Distance metric must be defined for vector index writes.
)

df.write_sink(tpuf_sink).show()
```


Will add docs when we've stabilized the API.
