### PR TITLE
chore: add default execution environment

### DIFF
--- a/benchmarking/tpch/__main__.py
+++ b/benchmarking/tpch/__main__.py
@@ -195,7 +195,11 @@ def get_daft_version() -> str:
 def get_daft_benchmark_runner_name() -> Literal["ray"] | Literal["native"]:
     """Test utility that checks the environment variable for the runner that is being used for the benchmarking."""
     name = os.getenv("DAFT_RUNNER")
-    assert name is not None, "Tests must be run with $DAFT_RUNNER env var"
+    if name is None:
+        import warnings
+
+        warnings.warn("DAFT_RUNNER environment variable is not set, using default value 'native'")
+        name = "native"
     name = name.lower()
 
     assert name in {"ray", "native"}, f"Runner name not recognized: {name}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,11 @@ def pytest_configure(config):
 def get_tests_daft_runner_name() -> Literal["ray"] | Literal["native"]:
     """Test utility that checks the environment variable for the runner that is being used for the test."""
     name = os.getenv("DAFT_RUNNER")
-    assert name is not None, "Tests must be run with $DAFT_RUNNER env var"
+    if name is None:
+        import warnings
+
+        warnings.warn("DAFT_RUNNER environment variable is not set, using default value 'native'")
+        name = "native"
     name = name.lower()
 
     assert name in {"ray", "native"}, f"Runner name not recognized: {name}"


### PR DESCRIPTION
## Changes Made
Every time I execute Python's ut, I forget to set the default execution environment. I feel that only a warning needs to be added here. What do you think?
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
