### PR TITLE
fix: Filter out null ids for turbopuffer sink

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1310,8 +1310,7 @@ class DataFrame:
         # TODO(desmond): Connect the old and new logical plan builders so that a .explain() shows the
         # plan from the source all the way to the sink to the sink's results. In theory we can do this
         # for all other sinks too.
-        write_plan_builder = to_logical_plan_builder(micropartition)
-        return DataFrame(write_plan_builder)
+        return DataFrame._from_micropartitions(micropartition)
 
     @DataframePublicAPI
     def write_lance(

--- a/daft/io/turbopuffer/turbopuffer_data_sink.py
+++ b/daft/io/turbopuffer/turbopuffer_data_sink.py
@@ -102,6 +102,8 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
                     )
                 arrow_table = arrow_table.rename_columns({self._vector_column: "vector"})
 
+            arrow_table = arrow_table.filter(~arrow_table.field("id").is_null())
+
             bytes_written = arrow_table.nbytes
             rows_written = arrow_table.num_rows
 


### PR DESCRIPTION
## Changes Made

The client will error if ids are null

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
