### PR TITLE
fix: use `/` for objectstorage instead of os.path.join when reading deltalake

### DIFF
--- a/daft/io/delta_lake/delta_lake_scan.py
+++ b/daft/io/delta_lake/delta_lake_scan.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING
 from urllib.error import HTTPError
 from urllib.parse import urlparse
@@ -20,6 +19,7 @@ from daft.daft import (
     ScanTask,
     StorageConfig,
 )
+from daft.io.delta_lake.utils import construct_delta_file_path
 from daft.io.object_store_options import io_config_to_storage_options
 from daft.io.scan import ScanOperator
 from daft.logical.schema import Schema
@@ -189,18 +189,7 @@ class DeltaLakeScanOperator(ScanOperator):
 
             # NOTE: The paths in the transaction log consist of the post-table-uri suffix.
             scheme = urlparse(self._table.table_uri).scheme
-            if scheme in (
-                "s3",
-                "s3a",
-                "gcs",
-                "gs",
-                "az",
-                "abfs",
-                "abfss",
-            ):  # object storage does not use os path.join, but instead always uses `/`
-                path = self._table.table_uri.rstrip("/") + "/" + add_actions["path"][task_idx].as_py()
-            else:
-                path = os.path.join(self._table.table_uri, add_actions["path"][task_idx].as_py())
+            path = construct_delta_file_path(scheme, self._table.table_uri, add_actions["path"][task_idx].as_py())
 
             try:
                 record_count = add_actions["num_records"][task_idx].as_py()

--- a/daft/io/delta_lake/utils.py
+++ b/daft/io/delta_lake/utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+
+
+def construct_delta_file_path(scheme: str, table_uri: str, relative_path: str) -> str:
+    """Construct full file path for Delta Lake files based on URI scheme.
+
+    Args:
+        scheme: The URI scheme (e.g., 's3', 'file', etc.)
+        table_uri: The base table URI
+        relative_path: The relative path from the Delta log
+
+    Returns:
+        The full file path
+    """
+    if scheme in (
+        "s3",
+        "s3a",
+        "gcs",
+        "gs",
+        "az",
+        "abfs",
+        "abfss",
+    ):  # object storage does not use os path.join, but instead always uses `/`
+        return table_uri.rstrip("/") + "/" + relative_path
+    else:
+        return os.path.join(table_uri, relative_path)

--- a/tests/io/delta_lake/utils.py
+++ b/tests/io/delta_lake/utils.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from daft.io.delta_lake.utils import construct_delta_file_path
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="Unix-specific test")
+@pytest.mark.parametrize(
+    "scheme,table_uri,relative_path,expected",
+    [
+        # Object storage schemes (unaffected by OS)
+        ("s3", "s3://bucket/table", "data/file.parquet", "s3://bucket/table/data/file.parquet"),
+        ("s3a", "s3a://bucket/table/", "data/file.parquet", "s3a://bucket/table/data/file.parquet"),
+        # Local file system - Unix style
+        ("file", "/tmp/table", "data/file.parquet", os.path.join("/tmp/table", "data/file.parquet")),
+        (
+            "hdfs",
+            "hdfs://namenode/table",
+            "data/file.parquet",
+            os.path.join("hdfs://namenode/table", "data/file.parquet"),
+        ),
+    ],
+)
+def test_construct_delta_file_path(scheme, table_uri, relative_path, expected):
+    result = construct_delta_file_path(scheme, table_uri, relative_path)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "scheme,table_uri,relative_path,expected",
+    [
+        # Object storage schemes should always use forward slashes
+        ("s3", "s3://bucket/table", "data/file.parquet", "s3://bucket/table/data/file.parquet"),
+        ("s3a", "s3a://bucket/table/", "data/file.parquet", "s3a://bucket/table/data/file.parquet"),
+        ("gcs", "gs://bucket/table", "_delta_log/00000.json", "gs://bucket/table/_delta_log/00000.json"),
+        ("gs", "gs://bucket/table", "data/file.parquet", "gs://bucket/table/data/file.parquet"),
+        ("az", "az://container/table", "data/file.parquet", "az://container/table/data/file.parquet"),
+        ("abfs", "abfs://container/table", "data/file.parquet", "abfs://container/table/data/file.parquet"),
+        ("abfss", "abfss://container/table", "data/file.parquet", "abfss://container/table/data/file.parquet"),
+    ],
+)
+def test_object_storage_uses_forward_slashes_on_windows(scheme, table_uri, relative_path, expected):
+    # Mock os.path.join to return Windows-style paths with backslashes
+    with patch("os.path.join", return_value="C:\\fake\\windows\\path"):
+        result = construct_delta_file_path(scheme, table_uri, relative_path)
+        assert result == expected
+        assert "\\" not in result  # Ensure no backslashes in object storage paths


### PR DESCRIPTION
## Changes Made
read_deltalake incorrectly used `\` on windows when reading from object storage which use `/` 

## Related Issues

closes https://github.com/Eventual-Inc/Daft/issues/4783

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
