### PR TITLE
ci: enable building wheels without LTO

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,5 +1,5 @@
 name: Build Daft wheel
-run-name: 'Build Daft wheel for ${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}'
+run-name: 'Build Daft wheel for ${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}-lto=${{ inputs.use_lto }}'
 
 on:
   workflow_call:
@@ -16,6 +16,10 @@ on:
       build_type:
         description: Value to set RUST_DAFT_PKG_BUILD_TYPE to (release, dev, nightly, etc.)
         type: string
+      use_lto:
+        description: Whether to use link-time optimization (release-lto profile)
+        type: boolean
+        default: true
 
 env:
   PYTHON_VERSION: 3.11
@@ -77,7 +81,7 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         target: x86_64
-        args: --profile release-lto --out dist
+        args: --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist
       env:
         GITHUB_ACTIONS: true
 
@@ -88,7 +92,7 @@ jobs:
         target: x86_64
         manylinux: 2_24
         # only produce sdist for linux x86 to avoid multiple copies
-        args: --profile release-lto --out dist --sdist
+        args: --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist --sdist
       env:
         GITHUB_ACTIONS: true
 
@@ -99,7 +103,7 @@ jobs:
         target: aarch64-unknown-linux-gnu
         manylinux: 2_24
         # only produce sdist for linux x86 to avoid multiple copies
-        args: --profile release-lto --out dist --sdist
+        args: --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist --sdist
         before-script-linux: export JEMALLOC_SYS_WITH_LG_PAGE=16
       env:
         GITHUB_ACTIONS: true
@@ -109,7 +113,7 @@ jobs:
       uses: PyO3/maturin-action@v1
       with:
         target: aarch64
-        args: --profile release-lto --out dist
+        args: --profile ${{ inputs.use_lto && 'release-lto' || 'release' }} --out dist
       env:
         RUSTFLAGS: -Ctarget-cpu=apple-m1
         CFLAGS: -mtune=apple-m1
@@ -118,5 +122,5 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}
+        name: wheels-${{ inputs.os }}-${{ inputs.arch }}-lts=${{ inputs.lts }}-lto=${{ inputs.use_lto }}
         path: dist

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -3,6 +3,12 @@ name: Build dev package and publish to S3
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      use_lto:
+        description: Whether to enable link-time optimization
+        type: boolean
+        default: true
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -40,7 +46,7 @@ jobs:
         echo "build_exists=$OBJECT_EXISTS" >> "$GITHUB_OUTPUT"
 
   build:
-    name: 'Build Daft wheel for ${{ matrix.os }}-${{ matrix.arch }}-lts=${{ matrix.lts }}'
+    name: 'Build Daft wheel for ${{ matrix.os }}-${{ matrix.arch }}-lts=${{ matrix.lts }}-lto=${{ inputs.use_lto }}'
     needs: check-exists
     if: ${{ needs.check-exists.outputs.build_exists == 'false' }}
     uses: ./.github/workflows/build-wheel.yml
@@ -48,6 +54,7 @@ jobs:
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
       lts: ${{ matrix.lts }}
+      use_lto: ${{ inputs.use_lto }}
       build_type: release
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       use_lto:
-        description: nable link-time optimization
+        description: Enable link-time optimization
         type: boolean
         default: true
         required: false

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       use_lto:
         description: Whether to enable link-time optimization
+        type: boolean
         default: true
         required: false
   workflow_call:

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -2,6 +2,11 @@ name: Build dev package and publish to S3
 
 on:
   workflow_dispatch:
+    inputs:
+      use_lto:
+        description: Whether to enable link-time optimization
+        default: true
+        required: false
   workflow_call:
     inputs:
       use_lto:

--- a/.github/workflows/publish-dev-s3.yml
+++ b/.github/workflows/publish-dev-s3.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       use_lto:
-        description: Whether to enable link-time optimization
+        description: nable link-time optimization
         type: boolean
         default: true
         required: false
   workflow_call:
     inputs:
       use_lto:
-        description: Whether to enable link-time optimization
+        description: Enable link-time optimization
         type: boolean
         default: true
         required: false


### PR DESCRIPTION
## Changes Made

Make LTO optional so we can build Daft wheels more quickly for platform testing.

<img width="345" height="187" alt="Screenshot 2025-07-16 at 2 52 31 PM" src="https://github.com/user-attachments/assets/0d987242-e2e8-49a3-a4d9-ec51c464a93c" />


fyi @kevinzwang @ohbh @rchowell 


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
N/A

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
