### PR TITLE
fix: Improve UDF Error Messaging

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -77,6 +77,7 @@ from daft.expressions import Expression, col, element, list_, lit, interval, str
 from daft.io import (
     DataCatalogTable,
     DataCatalogType,
+    IOConfig,
     from_glob_path,
     _range as range,
     read_csv,

--- a/daft/api_annotations.py
+++ b/daft/api_annotations.py
@@ -54,6 +54,9 @@ def PublicAPI(func: Callable[P, T]) -> Callable[P, T]:
         type_check_function(func, *args, **kwargs)
         try:
             return func(*args, **kwargs)
+        except UDFException as e:
+            e = e.with_traceback(None)
+            raise
         except Exception as e:
             e = e.with_traceback(e.__traceback__.tb_next if e.__traceback__ else None)
             raise  # If we `raise e`, it will add a new frame right here

--- a/daft/api_annotations.py
+++ b/daft/api_annotations.py
@@ -14,6 +14,8 @@ from typing import (
     get_origin,
 )
 
+from daft.errors import UDFException
+
 if sys.version_info < (3, 10):
     from typing_extensions import ParamSpec
 else:
@@ -31,7 +33,14 @@ def DataframePublicAPI(func: Callable[P, T]) -> Callable[P, T]:
     def _wrap(*args: P.args, **kwargs: P.kwargs) -> T:
         __tracebackhide__ = True
         type_check_function(func, *args, **kwargs)
-        return func(*args, **kwargs)
+        try:
+            return func(*args, **kwargs)
+        except UDFException as e:
+            e = e.with_traceback(None)
+            raise
+        except Exception as e:
+            e = e.with_traceback(e.__traceback__.tb_next if e.__traceback__ else None)
+            raise  # If we `raise e`, it will add a new frame right here
 
     return _wrap
 
@@ -43,7 +52,11 @@ def PublicAPI(func: Callable[P, T]) -> Callable[P, T]:
     def _wrap(*args: P.args, **kwargs: P.kwargs) -> T:
         __tracebackhide__ = True
         type_check_function(func, *args, **kwargs)
-        return func(*args, **kwargs)
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            e = e.with_traceback(e.__traceback__.tb_next if e.__traceback__ else None)
+            raise  # If we `raise e`, it will add a new frame right here
 
     return _wrap
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1293,6 +1293,9 @@ class DataFrame:
 
         Returns:
             DataFrame: A dataframe from the micropartition returned by the DataSink's `.finalize()` method.
+
+        Note:
+            This call is **blocking** and will execute the DataFrame when called
         """
         sink.start()
 
@@ -1330,7 +1333,8 @@ class DataFrame:
           **kwargs: Additional keyword arguments to pass to the Lance writer.
 
         Note:
-            write_lance` requires python 3.9 or higher
+            `write_lance` requires python 3.9 or higher
+            This call is **blocking** and will execute the DataFrame when called
 
         Examples:
             >>> import daft

--- a/daft/errors.py
+++ b/daft/errors.py
@@ -3,3 +3,12 @@ from __future__ import annotations
 
 class ExpressionTypeError(Exception):
     pass
+
+
+class UDFException(Exception):
+    """An Daft exception raised when a UDF raises an exception.
+
+    Also provides additional context about the error.
+    """
+
+    pass

--- a/daft/errors.py
+++ b/daft/errors.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from traceback import TracebackException
+
 
 class ExpressionTypeError(Exception):
     pass
@@ -8,7 +13,29 @@ class ExpressionTypeError(Exception):
 class UDFException(Exception):
     """An Daft exception raised when a UDF raises an exception.
 
-    Also provides additional context about the error.
+    Also provides additional context about the error. The original exception is either available as:
+    - The original exception via `__cause__` if running in the same process
+    - A replica & rendered traceback via `tb_info` if running in a different process
+    Both are accessible via `original_exception`
     """
 
-    pass
+    def __init__(self, message: str, tb_info: TracebackException | None = None):
+        super().__init__(message)
+        self.message = message
+        self.tb_info = tb_info
+
+    @property
+    def original_exception(self) -> BaseException | None:
+        """The original exception that was raised by the UDF."""
+        # We except every creation of UDFException to be `raise UDFException(...) from ...`
+        return self.__cause__
+
+    def __str__(self) -> str:
+        if self.tb_info:
+            return (
+                "\n".join(self.tb_info.format())
+                + "\nThe above exception was the direct cause of the following exception:\n\n"
+                + f"\n{self.message}"
+            )
+        else:
+            return self.message

--- a/daft/errors.py
+++ b/daft/errors.py
@@ -34,7 +34,7 @@ class UDFException(Exception):
         if self.tb_info:
             return (
                 "\n".join(self.tb_info.format())
-                + "\nThe above exception was the direct cause of the following exception:\n\n"
+                + "\nThe above exception was the direct cause of the following exception:\n"
                 + f"\n{self.message}"
             )
         else:

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -184,11 +184,12 @@ def test_iter_exception(make_df):
         with pytest.raises(UDFException) as exc_info:
             list(it)
 
-        assert isinstance(exc_info.value.__cause__, MockException)
-
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
         if get_tests_daft_runner_name() == "ray":
             assert "MockException" in str(exc_info.value)
+        else:
+            assert isinstance(exc_info.value.__cause__, MockException)
+
         assert str(exc_info.value).endswith("failed when executing on inputs:\n  - a (Int64, length=2)")
 
 
@@ -223,9 +224,9 @@ def test_iter_partitions_exception(make_df):
             if get_tests_daft_runner_name() == "ray":
                 ray.get(res)
 
-        assert isinstance(exc_info.value.__cause__, MockException)
-
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
         if get_tests_daft_runner_name() == "ray":
             assert "MockException" in str(exc_info.value)
+        else:
+            assert isinstance(exc_info.value.__cause__, MockException)
         assert str(exc_info.value).endswith("failed when executing on inputs:\n  - a (Int64, length=2)")

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -5,6 +5,7 @@ import pyarrow as pa
 import pytest
 
 import daft
+from daft.errors import UDFException
 from tests.conftest import get_tests_daft_runner_name
 
 
@@ -180,8 +181,10 @@ def test_iter_exception(make_df):
         assert next(it) == {"a": 0, "b": 0}
 
         # Ensure the exception does trigger if execution continues.
-        with pytest.raises(MockException) as exc_info:
+        with pytest.raises(UDFException) as exc_info:
             list(it)
+
+        assert isinstance(exc_info.value.__cause__, MockException)
 
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
         if get_tests_daft_runner_name() == "ray":
@@ -215,10 +218,12 @@ def test_iter_partitions_exception(make_df):
         assert part == {"a": [0, 1], "b": [0, 1]}
 
         # Ensure the exception does trigger if execution continues.
-        with pytest.raises(MockException) as exc_info:
+        with pytest.raises(UDFException) as exc_info:
             res = list(it)
             if get_tests_daft_runner_name() == "ray":
                 ray.get(res)
+
+        assert isinstance(exc_info.value.__cause__, MockException)
 
         # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
         if get_tests_daft_runner_name() == "ray":


### PR DESCRIPTION
## Changes Made

Improves the traceback printed by Python for errors raised from UDFs by suppressing some of our internals. 

With the following example:
```py
import daft

def g(x):
    raise RuntimeError("This is a custom exception")

@daft.udf(return_dtype=daft.DataType.string())
def f(x):
    return g(x)

df = daft.from_pydict({"x": ["a", "b", "c"]})
df.with_column("transformed", f(daft.col("x"))).show()
```

Before:
```
Traceback (most recent call last):
  File "/Users/slade/daft/main/tracing.py", line 11, in <module>
    df.with_column("transformed", f(daft.col("x"))).show()
  File "/Users/slade/daft/main/daft/api_annotations.py", line 34, in _wrap
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/slade/daft/main/daft/dataframe/dataframe.py", line 3377, in show
    preview = self._construct_show_preview(n)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/slade/daft/main/daft/dataframe/dataframe.py", line 3298, in _construct_show_preview
    for table in get_context().get_or_create_runner().run_iter_tables(builder, results_buffer_size=1):
  File "/Users/slade/daft/main/daft/runners/native_runner.py", line 102, in run_iter_tables
    for result in self.run_iter(builder, results_buffer_size=results_buffer_size):
  File "/Users/slade/daft/main/daft/runners/native_runner.py", line 97, in run_iter
    yield from results_gen
  File "/Users/slade/daft/main/daft/execution/native_executor.py", line 42, in <genexpr>
    return (
           ^
  File "/Users/slade/daft/main/daft/udf.py", line 157, in run_udf
    results.append(func(*args, **kwargs))
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/slade/daft/main/tracing.py", line 8, in f
    return g(x)
           ^^^^
  File "/Users/slade/daft/main/tracing.py", line 4, in g
    raise RuntimeError("This is a custom exception")
RuntimeError: This is a custom exception
User-defined function `<function f at 0x10541d4e0>` failed when executing on inputs:
  - x (Utf8, length=3)
```

After:
```
Traceback (most recent call last):
  File "/Users/slade/daft/main/tracing.py", line 8, in f
    return g(x)
           ^^^^
  File "/Users/slade/daft/main/tracing.py", line 4, in g
    raise RuntimeError("This is a custom exception")
RuntimeError: This is a custom exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/slade/daft/main/tracing.py", line 11, in <module>
    df.with_column("transformed", f(daft.col("x"))).show()
daft.errors.UDFException: User-defined function `<function f at 0x10121d4e0>` failed when executing on inputs:
  - x (Utf8, length=3)
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
