### PR TITLE
fix: use pc.field in turbopuffer sink

### DIFF
--- a/daft/io/turbopuffer/turbopuffer_data_sink.py
+++ b/daft/io/turbopuffer/turbopuffer_data_sink.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import turbopuffer
 
 from daft.datatype import DataType
+from daft.dependencies import pc
 from daft.io import DataSink
 from daft.io.sink import WriteResult
 from daft.recordbatch import MicroPartition
@@ -102,7 +103,7 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
                     )
                 arrow_table = arrow_table.rename_columns({self._vector_column: "vector"})
 
-            arrow_table = arrow_table.filter(~arrow_table.field("id").is_null())
+            arrow_table = arrow_table.filter(~pc.field("id").is_null())
 
             bytes_written = arrow_table.nbytes
             rows_written = arrow_table.num_rows


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
