### PR TITLE
chore: add docstring template to contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,6 +347,36 @@ def extract_all(self, pattern: Series, index: int = 0) -> Series:
   return self._eval_expressions("extract_all", pattern, index=index)
 ```
 
+##### Docstring Format
+
+``` py
+def method(args) -> return:
+    """Summary of method
+
+    Args:
+        arg1: description
+
+    Returns:
+        return1: description
+
+    Raises: title (optional)
+         description
+
+    Warning: title (optional)
+         description
+
+    Note: title (optional)
+         description
+
+    Examples: (make sure this is plural!)
+        >>> code example (this needs to be a runnable `doctest` example)
+        output
+
+    Tip: title (optional)
+         description
+    """
+```
+
 #### Step 4: Write tests
 
 For testing, you can add a new file, or update an existing one in `tests/expressions/`


### PR DESCRIPTION
## Changes Made

add docstring template to `CONTRIBUTING.MD`

## Related Issues

n/a

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
