### PR TITLE
feat: Add a DataFrame.write_turbopuffer method

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1385,6 +1385,44 @@ class DataFrame:
         sink = LanceDataSink(uri, schema, mode, io_config, **kwargs)
         return self.write_sink(sink)
 
+    @DataframePublicAPI
+    def write_turbopuffer(
+        self,
+        namespace: str,
+        api_key: Optional[str] = None,
+        region: str = "aws-us-west-2",
+        distance_metric: Optional[Literal["cosine_distance", "euclidean_squared"]] = None,
+        schema: Optional[dict[str, Any]] = None,
+        id_column: Optional[str] = None,
+        vector_column: Optional[str] = None,
+    ) -> "DataFrame":
+        """Writes the DataFrame to a Turbopuffer namespace.
+
+        This method transforms each row of the dataframe into a turbopuffer document and writes it to the given namespace.
+        This means that an `id` column is always required. Optionally, the `id_column` parameter can be used to specify the column name to used for the id column.
+        Note that the column with the name specified by `id_column` will be renamed to "id" when written to turbopuffer.
+
+        A `vector` column is required if the namespace has a vector index. Optionally, the `vector_column` parameter can be used to specify the column name to used for the vector index.
+        Note that the column with the name specified by `vector_column` will be renamed to "vector" when written to turbopuffer.
+
+        All other columns become attributes.
+
+        For more details on parameters, please see the turbopuffer documentation: https://turbopuffer.com/docs/write
+
+        Args:
+            namespace: The namespace to write to.
+            api_key: Turbopuffer API key (defaults to TURBOPUFFER_API_KEY env var).
+            region: Turbopuffer region (defaults to "aws-us-west-2").
+            distance_metric: Distance metric for vector similarity ("cosine_distance", "euclidean_squared").
+            schema: Optional manual schema specification.
+            id_column: Optional column name for the id column. The data sink will automatically rename the column to "id" for the id column.
+            vector_column: Optional column name for the vector index column. The data sink will automatically rename the column to "vector" for the vector index.
+        """
+        from daft.io.turbopuffer.turbopuffer_data_sink import TurbopufferDataSink
+
+        sink = TurbopufferDataSink(namespace, api_key, region, distance_metric, schema, id_column, vector_column)
+        return self.write_sink(sink)
+
     ###
     # DataFrame operations
     ###


### PR DESCRIPTION
## Changes Made

Adds a DataFrame.write_turbopuffer convenience method. Under the hood it simply passes all arguments to a turbopuffer data sink then calls DataFrame.write_sink on it.
