### PR TITLE
fix: Propagate worker failures to scheduler

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -106,7 +106,7 @@ jobs:
         cargo llvm-cov clean --workspace
         maturin develop
         pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
-        pytest --cov=daft --ignore tests/integration --durations=50
+        pytest --cov=daft --ignore tests/integration --durations=50 -s -vv
         coverage combine -a --data-file='.coverage' || true
         mkdir -p report-output
         coverage xml -o ./report-output/coverage-${{ join(matrix.*, '-') }}.xml

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -106,7 +106,7 @@ jobs:
         cargo llvm-cov clean --workspace
         maturin develop
         pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
-        pytest --cov=daft --ignore tests/integration --durations=50 -s -vv
+        pytest --cov=daft --ignore tests/integration --durations=50
         coverage combine -a --data-file='.coverage' || true
         mkdir -p report-output
         coverage xml -o ./report-output/coverage-${{ join(matrix.*, '-') }}.xml

--- a/daft/execution/ray_actor_pool_udf.py
+++ b/daft/execution/ray_actor_pool_udf.py
@@ -50,8 +50,8 @@ def start_udf_actors(
     projection: list[PyExpr],
     num_actors: int,
     num_gpus_per_actor: float,
-    memory_per_actor: float,
     num_cpus_per_actor: float,
+    memory_per_actor: float,
 ) -> list[tuple[str, list[UDFActorHandle]]]:
     expr_projection = ExpressionsProjection([Expression._from_pyexpr(expr) for expr in projection])
     handles: dict[str, list[UDFActorHandle]] = {}

--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -49,10 +49,10 @@ impl UDFActors {
         let (gpu_request, cpu_request, memory_request) = match get_resource_request(projection) {
             Some(resource_request) => (
                 resource_request.num_gpus().unwrap_or(0.0),
-                resource_request.num_cpus().unwrap_or(1.0),
+                resource_request.num_cpus().unwrap_or(0.0),
                 resource_request.memory_bytes().unwrap_or(0),
             ),
-            None => (0.0, 1.0, 0),
+            None => (0.0, 0.0, 0),
         };
 
         let actors = Python::with_gil(|py| {

--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -318,7 +318,8 @@ impl ActorUDF {
             HashMap::from([(self.context.node_id.to_string(), partitions)]),
             SchedulingStrategy::WorkerAffinity {
                 worker_id,
-                soft: false,
+                // TODO: We need to cater for cases where the actor has respawned on a different node, and we need to update the node id.
+                soft: true,
             },
             self.context.to_hashmap(),
         ));
@@ -346,7 +347,7 @@ impl ActorUDF {
         // Set scheduling strategy based on whether we have a valid worker ID
         let scheduling_strategy = SchedulingStrategy::WorkerAffinity {
             worker_id,
-            soft: false,
+            soft: true,
         };
         let psets = submittable_task.task().psets().clone();
 

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -102,10 +102,9 @@ impl WorkerManager for RayWorkerManager {
             .ray_workers
             .lock()
             .expect("Failed to lock RayWorkerManager");
-        workers
-            .get_mut(&worker_id)
-            .expect("Worker should be present in RayWorkerManager")
-            .mark_task_finished(&task_context);
+        if let Some(worker) = workers.get_mut(&worker_id) {
+            worker.mark_task_finished(&task_context);
+        }
     }
 
     fn mark_worker_died(&self, worker_id: WorkerId) {

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -107,16 +107,10 @@ impl<T: Task> Scheduler<T> for DefaultScheduler<T> {
     }
 
     fn update_worker_state(&mut self, worker_snapshots: &[WorkerSnapshot]) {
-        for worker_snapshot in worker_snapshots {
-            if let Some(existing_snapshot) =
-                self.worker_snapshots.get_mut(&worker_snapshot.worker_id)
-            {
-                *existing_snapshot = worker_snapshot.clone();
-            } else {
-                self.worker_snapshots
-                    .insert(worker_snapshot.worker_id.clone(), worker_snapshot.clone());
-            }
-        }
+        self.worker_snapshots = worker_snapshots
+            .iter()
+            .map(|snapshot| (snapshot.worker_id.clone(), snapshot.clone()))
+            .collect();
     }
 
     fn num_pending_tasks(&self) -> usize {

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -143,10 +143,11 @@ impl<T: Task> std::fmt::Debug for ScheduledTask<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ScheduledTask(worker_id = {}, {:?}, {:?})",
+            "ScheduledTask(worker_id = {}, {:?}, {:?}, {:?})",
             self.worker_id,
             self.task.task_context(),
-            TaskDetails::from(&self.task)
+            TaskDetails::from(&self.task),
+            self.task.strategy()
         )
     }
 }

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -133,7 +133,7 @@ def test_class_udf_init_args_bad_args(use_actor_pool):
         RepeatN.with_init_args(wrong=5)
 
 
-@pytest.mark.parametrize("concurrency", [1, 2])
+@pytest.mark.parametrize("concurrency", [1, 2, 3])
 def test_actor_pool_udf_concurrency(concurrency):
     df = daft.from_pydict({"a": ["foo", "bar", "baz"]})
 

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -133,7 +133,7 @@ def test_class_udf_init_args_bad_args(use_actor_pool):
         RepeatN.with_init_args(wrong=5)
 
 
-@pytest.mark.parametrize("concurrency", [1, 2, 4])
+@pytest.mark.parametrize("concurrency", [1, 2])
 def test_actor_pool_udf_concurrency(concurrency):
     df = daft.from_pydict({"a": ["foo", "bar", "baz"]})
 


### PR DESCRIPTION
## Changes Made

When scheduler receives worker updates, it should override all worker snapshots.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
