### PR TITLE
chore: Support specify extra arguments when running `make test`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ To set up your development environment:
 ### Developing
 
 1. `make build`: recompile your code after modifying any Rust code in `src/`
-2. `DAFT_RUNNER=native make test`: run tests
+2. `DAFT_RUNNER=native make test`: run tests, you can set additional run parameters through `EXTRA_ARGS`
 3. `DAFT_RUNNER=ray make test`: set the runner to the Ray runner and run tests
 4. `make docs`: build docs
 5. `make docs-serve`: build docs in development server

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,10 @@ build-whl: check-toolchain .venv  ## Compile Daft for development, only generate
 
 .PHONY: test
 test: .venv build  ## Run tests
-	HYPOTHESIS_MAX_EXAMPLES=$(HYPOTHESIS_MAX_EXAMPLES) $(VENV_BIN)/pytest --hypothesis-seed=$(HYPOTHESIS_SEED) --ignore tests/integration
+	# You can set additional run parameters through EXTRA_ARGS, such as running a specific test case file or method:
+	# make test EXTRA_ARGS="-v tests/dataframe/test_select.py" # Run a single test file
+	# make test EXTRA_ARGS="-v tests/dataframe/test_select.py::test_select_dataframe" # Run a single test method
+	HYPOTHESIS_MAX_EXAMPLES=$(HYPOTHESIS_MAX_EXAMPLES) $(VENV_BIN)/pytest --hypothesis-seed=$(HYPOTHESIS_SEED) --ignore tests/integration $(EXTRA_ARGS)
 
 .PHONY: doctests
 doctests:


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Currently, `make test` will trigger run all test cases, but during development or when writing test cases, we usually need to run specific test case files or methods separately, so i add the `EXTRA_ARGS` parameter to `make test` in this PR. While being compatible with the original functionality of `make test`, you can also:

- Run a single test file: `make test EXTRA_ARGS="-v tests/dataframe/test_select.py"`

- Run a single test method: `make test EXTRA_ARGS="-v tests/dataframe/test_select.py::test_select_dataframe"`

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

No issue

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
