### PR TITLE
chore: add DAFT_LOG env indicates log level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ We run test suites across Python and Rust. Python tests focus on high-level Data
 
 Our python tests are located in the `tests` directory, you can run all the tests at once with `make tests`.
 
-To run specific tests, set the runner for the tests in the environment and then run the tests directly using [pytest]("https://doc.rust-lang.org/cargo/commands/cargo-test.html").
+To run specific tests, set the runner for the tests in the environment and then run the tests directly using [pytest](https://docs.pytest.org/en/stable/how-to/usage.html).
 
 ```
 DAFT_RUNNER=native pytest -s tests/dataframe --log-cli-level=DEBUG

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ Our python tests are located in the `tests` directory, you can run all the tests
 To run specific tests, set the runner for the tests in the environment and then run the tests directly using [pytest]("https://doc.rust-lang.org/cargo/commands/cargo-test.html").
 
 ```
-DAFT_RUNNER=native pytest tests/dataframe
+DAFT_RUNNER=native pytest -s tests/dataframe --log-cli-level=DEBUG
 ```
 
 #### Rust tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,8 +163,15 @@ Our python tests are located in the `tests` directory, you can run all the tests
 To run specific tests, set the runner for the tests in the environment and then run the tests directly using [pytest](https://docs.pytest.org/en/stable/how-to/usage.html).
 
 ```
-DAFT_RUNNER=native pytest -s tests/dataframe --log-cli-level=DEBUG
+DAFT_RUNNER=native pytest tests/dataframe/test_limit.py::test_limit
 ```
+
+To enable debug logs from tests, set the `--log-cli-level` option, as well as disable capturing.
+
+```
+DAFT_RUNNER=native pytest tests/dataframe/test_limit.py::test_limit -s --log-cli-level=DEBUG
+```
+
 
 #### Rust tests
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,21 +72,30 @@ pub mod pylib {
     #[pyfunction]
     pub fn refresh_logger(py: Python) -> PyResult<()> {
         use log::LevelFilter;
-        let logging = py.import(pyo3::intern!(py, "logging"))?;
-        let python_log_level = logging
-            .getattr(pyo3::intern!(py, "getLogger"))?
-            .call0()?
-            .getattr(pyo3::intern!(py, "level"))?
-            .extract::<usize>()
-            .unwrap_or(0);
+        // If the `DAFT_LOG` environment variable is set, it will be used to set the log level.
+        // Otherwise, the log level will be set to the level of the Python logger.
+        let env_level = std::env::var("DAFT_LOG")
+            .ok()
+            .and_then(|v| v.parse::<LevelFilter>().ok());
 
-        // https://docs.python.org/3/library/logging.html#logging-levels
-        let level_filter = match python_log_level {
-            0 => LevelFilter::Off,
-            1..=10 => LevelFilter::Debug,
-            11..=20 => LevelFilter::Info,
-            21..=30 => LevelFilter::Warn,
-            _ => LevelFilter::Error,
+        let level_filter = if let Some(level) = env_level {
+            level
+        } else {
+            let logging = py.import(pyo3::intern!(py, "logging"))?;
+            let python_log_level = logging
+                .getattr(pyo3::intern!(py, "getLogger"))?
+                .call0()?
+                .getattr(pyo3::intern!(py, "level"))?
+                .extract::<usize>()
+                .unwrap_or(0);
+
+            match python_log_level {
+                0 => LevelFilter::Off,
+                1..=10 => LevelFilter::Debug,
+                11..=20 => LevelFilter::Info,
+                21..=30 => LevelFilter::Warn,
+                _ => LevelFilter::Error,
+            }
         };
 
         LOG_RESET_HANDLE.reset();


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Currently, if you want to set the log level, you need to follow the following method, which is rather cumbersome. Therefore, an environment variable is introduced here as the top - priority identifier for the log level of Rust.
```
logging.basicConfig(
    level=logging.DEBUG,
    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
    stream=sys.stdout
)
daft.refresh_logger()
```

In addition, some instructions on how to view debug logs in pytest were added to CONTRIBUTE.md.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
