### PR TITLE
Fix typo in docs: remove extra 'with' in scaling description

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Built for modern AI/ML workflows with Python at its core and Rust under the hood
 
 **:fontawesome-solid-laptop: Seamless scaling, from laptop to cluster**
 
-Start local, scale global—without changing a line of code. Daft's Rust-powered engine delivers blazing performance on a single machine and effortlessly extends to distributed clusters with when you need more horsepower.
+Start local, scale global—without changing a line of code. Daft's Rust-powered engine delivers blazing performance on a single machine and effortlessly extends to distributed clusters when you need more horsepower.
 
 ## Key Features
 


### PR DESCRIPTION
## Summary
- Fixed grammatical error in the seamless scaling section of the documentation
- Changed "extends to distributed clusters with when you need" to "extends to distributed clusters when you need"

## Test plan
This is a documentation-only change that fixes a typo. No functional changes or tests required.