### PR TITLE
feat: struct Expression.unnest()

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
     from daft.udf import BoundUDFArgs, InitArgsType, UninitializedUdf
     from daft.window import Window
 
-    EncodingCodec = Literal["deflate", "gzip", "gz", "utf-8", "utf8zlib"]
+    EncodingCodec = Literal["deflate", "gzip", "gz", "utf-8", "utf8" "zlib"]
 
 
 def lit(value: object) -> Expression:


### PR DESCRIPTION
## Changes Made

Add the `Expression.unnest` method. Since we already have the mechanism for unnesting with `Expression.struct.get("*")`, I'm just reusing that for now. We will need to change it once we introduce selectors anyway.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
