### PR TITLE
feat(turbopuffer): Add client and write kwargs

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1389,16 +1389,18 @@ class DataFrame:
     def write_turbopuffer(
         self,
         namespace: str,
-        api_key: Optional[str] = None,
+        api_key: str,
         region: str = "aws-us-west-2",
         distance_metric: Optional[Literal["cosine_distance", "euclidean_squared"]] = None,
         schema: Optional[dict[str, Any]] = None,
         id_column: Optional[str] = None,
         vector_column: Optional[str] = None,
+        client_kwargs: Optional[dict[str, Any]] = None,
+        write_kwargs: Optional[dict[str, Any]] = None,
     ) -> "DataFrame":
         """Writes the DataFrame to a Turbopuffer namespace.
 
-        This method transforms each row of the dataframe into a turbopuffer document and writes it to the given namespace.
+        This method transforms each row of the dataframe into a turbopuffer document.
         This means that an `id` column is always required. Optionally, the `id_column` parameter can be used to specify the column name to used for the id column.
         Note that the column with the name specified by `id_column` will be renamed to "id" when written to turbopuffer.
 
@@ -1411,16 +1413,22 @@ class DataFrame:
 
         Args:
             namespace: The namespace to write to.
-            api_key: Turbopuffer API key (defaults to TURBOPUFFER_API_KEY env var).
-            region: Turbopuffer region (defaults to "aws-us-west-2").
-            distance_metric: Distance metric for vector similarity ("cosine_distance", "euclidean_squared").
+            api_key: Turbopuffer API key.
+            region: Turbopuffer region.
+            distance_metric: Optional distance metric for vector similarity ("cosine_distance", "euclidean_squared").
             schema: Optional manual schema specification.
             id_column: Optional column name for the id column. The data sink will automatically rename the column to "id" for the id column.
             vector_column: Optional column name for the vector index column. The data sink will automatically rename the column to "vector" for the vector index.
+            client_kwargs: Optional dictionary of arguments to pass to the Turbopuffer client constructor.
+                Explicit arguments (api_key, region) will be merged into client_kwargs.
+            write_kwargs: Optional dictionary of arguments to pass to the namespace.write() method.
+                Explicit arguments (distance_metric, schema) will be merged into write_kwargs.
         """
         from daft.io.turbopuffer.turbopuffer_data_sink import TurbopufferDataSink
 
-        sink = TurbopufferDataSink(namespace, api_key, region, distance_metric, schema, id_column, vector_column)
+        sink = TurbopufferDataSink(
+            namespace, api_key, region, distance_metric, schema, id_column, vector_column, client_kwargs, write_kwargs
+        )
         return self.write_sink(sink)
 
     ###

--- a/daft/io/turbopuffer/turbopuffer_data_sink.py
+++ b/daft/io/turbopuffer/turbopuffer_data_sink.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING, Any, Literal
 
 import turbopuffer
@@ -33,12 +32,14 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
     def __init__(
         self,
         namespace: str,
-        api_key: str | None = None,
-        region: str = "aws-us-west-2",
+        api_key: str,
+        region: str | None = None,
         distance_metric: Literal["cosine_distance", "euclidean_squared"] | None = None,
         schema: dict[str, Any] | None = None,
         id_column: str | None = None,
         vector_column: str | None = None,
+        client_kwargs: dict[str, Any] | None = None,
+        write_kwargs: dict[str, Any] | None = None,
     ) -> None:
         """Initialize the Turbopuffer data sink.
 
@@ -55,15 +56,19 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
 
         Args:
             namespace: The namespace to write to.
-            api_key: Turbopuffer API key (defaults to TURBOPUFFER_API_KEY env var).
-            region: Turbopuffer region (defaults to "aws-us-west-2").
-            distance_metric: Distance metric for vector similarity ("cosine_distance", "euclidean_squared").
+            api_key: Turbopuffer API key.
+            region: Turbopuffer region.
+            distance_metric: Optional distance metric for vector similarity ("cosine_distance", "euclidean_squared").
             schema: Optional manual schema specification.
             id_column: Optional column name for the id column. The data sink will automatically rename the column to "id" for the id column.
             vector_column: Optional column name for the vector index column. The data sink will automatically rename the column to "vector" for the vector index.
+            client_kwargs: Optional dictionary of arguments to pass to the Turbopuffer client constructor.
+                Explicit arguments (api_key, region) will be merged into client_kwargs.
+            write_kwargs: Optional dictionary of arguments to pass to the namespace.write() method.
+                Explicit arguments (distance_metric, schema) will be merged into write_kwargs.
         """
         self._namespace_name = namespace
-        self._api_key = api_key or os.getenv("TURBOPUFFER_API_KEY")
+        self._api_key = api_key
         if not self._api_key:
             raise ValueError("Turbopuffer API key must be provided or set in TURBOPUFFER_API_KEY environment variable")
 
@@ -72,6 +77,27 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
         self._schema = schema or {}
         self._id_column = id_column
         self._vector_column = vector_column
+
+        # Merge explicit arguments into kwargs.
+        self._client_kwargs = client_kwargs or {}
+        if api_key is not None:
+            if "api_key" in self._client_kwargs:
+                raise ValueError("api_key is already set in client_kwargs")
+            self._client_kwargs["api_key"] = api_key
+        if region is not None:
+            if "region" in self._client_kwargs:
+                raise ValueError("region is already set in client_kwargs")
+            self._client_kwargs["region"] = region
+
+        self._write_kwargs = write_kwargs or {}
+        if distance_metric is not None:
+            if "distance_metric" in self._write_kwargs:
+                raise ValueError("distance_metric is already set in write_kwargs")
+            self._write_kwargs["distance_metric"] = distance_metric
+        if schema is not None:
+            if "schema" in self._write_kwargs:
+                raise ValueError("schema is already set in write_kwargs")
+            self._write_kwargs["schema"] = schema
 
         self._result_schema = Schema._from_field_name_and_types([("write_responses", DataType.python())])
 
@@ -83,10 +109,7 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
     ) -> Iterator[WriteResult[turbopuffer.types.NamespaceWriteResponse]]:
         """Writes micropartitions to Turbopuffer namespace."""
         turbopuffer = self._import_turbopuffer()
-        tpuf = turbopuffer.Turbopuffer(
-            api_key=self._api_key,
-            region=self._region,
-        )
+        tpuf = turbopuffer.Turbopuffer(**self._client_kwargs)
 
         namespace = tpuf.namespace(self._namespace_name)
 
@@ -110,8 +133,7 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
 
             write_response = namespace.write(
                 upsert_rows=arrow_table.to_pylist(),
-                distance_metric=self._distance_metric,
-                schema=self._schema,
+                **self._write_kwargs,
             )
 
             yield WriteResult(


### PR DESCRIPTION
## Changes Made

Turbopuffer client construction and writes accept many possible arguments. Instead of enumerating them and always trying to stay in sync, lets add support for kwargs.