### PR TITLE
fix: expand ~ to home directory in deltatable read and write

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1127,7 +1127,7 @@ class DataFrame:
             storage_options.update(new_storage_options or {})
         else:
             if isinstance(table, str):
-                table_uri = table
+                table_uri = os.path.expanduser(table)
             elif isinstance(table, pathlib.Path):
                 table_uri = str(table)
             elif unity_catalog.module_available() and isinstance(table, unity_catalog.UnityCatalogTable):

--- a/daft/io/delta_lake/_deltalake.py
+++ b/daft/io/delta_lake/_deltalake.py
@@ -1,6 +1,6 @@
 # ruff: noqa: I002
 # isort: dont-add-import: from __future__ import annotations
-
+import os
 from typing import TYPE_CHECKING, Optional, Union
 
 from daft import context
@@ -66,7 +66,7 @@ def read_deltalake(
     storage_config = StorageConfig(multithreaded_io, io_config)
 
     if isinstance(table, str):
-        table_uri = table
+        table_uri = os.path.expanduser(table)
     elif isinstance(table, DataCatalogTable):
         table_uri = table.table_uri(io_config)
     elif unity_catalog.module_available() and isinstance(table, unity_catalog.UnityCatalogTable):


### PR DESCRIPTION
## Changes Made
 
Added expanding of `~` to HOME directory in `read_deltalake` and `write_deltalake`. These use different backends (read uses `delta-rs`, write uses `daft`) so implemented the changes in the Python API


## Related Issues

Closes #4786. 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
