### PR TITLE
fix: read/write embeddings for Parquet and Lance

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -82,12 +82,16 @@ jobs:
     - name: Override deltalake for pyarrow
       if: ${{ (matrix.pyarrow-version == '8.0.0') }}
       run: uv pip install deltalake==0.10.0
-
-    - name: debug build (Linux)
+    
+      # Rust code coverage does not work on ubuntu-latest, so we only run it on macOS
+      # For more info: https://github.com/Eventual-Inc/Daft/issues/3801
+    - name: Debug Build library and Test with pytest (Linux)
       if: ${{ (runner.os == 'Linux') }}
       run: |
         maturin develop
-        pytest -v --cov=daft 'tests/io/test_roundtrip_embeddings.py::test_roundtrip_embedding[uint32-256-parquet]'
+        python -c 'import pyarrow; print(f"pyarrow=={pyarrow.__version__}"); pyarrow.show_versions()'
+        pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
+        pytest -v --cov=daft 'tests/io/test_roundtrip_embeddings.py::test_roundtrip_embedding[uint32-256-parquet]' || true
       env:
         CARGO_TARGET_DIR: ./target
 

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -83,6 +83,17 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '8.0.0') }}
       run: uv pip install deltalake==0.10.0
 
+    - name: debug build (Linux)
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        maturin develop
+        pytest -v --cov=daft 'tests/io/test_roundtrip_embeddings.py::test_roundtrip_embedding[uint32-256-parquet]'
+      env:
+        CARGO_TARGET_DIR: ./target
+
+        DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_FLOTILLA: ${{ matrix.flotilla }}
+
     - name: Setup upterm session
       uses: lhotari/action-upterm@v1
 

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -89,6 +89,7 @@ jobs:
       if: ${{ (runner.os == 'Linux') }}
       run: |
         maturin develop
+        python -c 'import pyarrow; print(f"pyarrow=={pyarrow.__version__}"); pyarrow.show_versions()'
         pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
         pytest --cov=daft --ignore tests/integration --durations=50
         coverage combine -a --data-file='.coverage' || true

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -89,7 +89,6 @@ jobs:
       if: ${{ (runner.os == 'Linux') }}
       run: |
         maturin develop
-        python -c 'import pyarrow; print(f"pyarrow=={pyarrow.__version__}"); pyarrow.show_versions()'
         pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
         pytest --cov=daft --ignore tests/integration --durations=50
         coverage combine -a --data-file='.coverage' || true

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -83,6 +83,9 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '8.0.0') }}
       run: uv pip install deltalake==0.10.0
 
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
+
     # Rust code coverage does not work on ubuntu-latest, so we only run it on macOS
     # For more info: https://github.com/Eventual-Inc/Daft/issues/3801
     - name: Build library and Test with pytest (Linux)

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -83,25 +83,6 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '8.0.0') }}
       run: uv pip install deltalake==0.10.0
 
-      # Rust code coverage does not work on ubuntu-latest, so we only run it on macOS
-      # For more info: https://github.com/Eventual-Inc/Daft/issues/3801
-    - name: DEBUG Build library and Test with pytest (Linux)
-      if: ${{ (runner.os == 'Linux') }}
-      run: |
-        maturin develop
-        python -c 'import pyarrow; print(f"pyarrow=={pyarrow.__version__}"); pyarrow.show_versions()'
-        pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
-        pytest -v --cov=daft 'tests/io/test_roundtrip_embeddings.py::test_roundtrip_embedding[uint32-256-parquet]' || true
-        
-      env:
-        CARGO_TARGET_DIR: ./target
-
-        DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_FLOTILLA: ${{ matrix.flotilla }}
-
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
-
     # Rust code coverage does not work on ubuntu-latest, so we only run it on macOS
     # For more info: https://github.com/Eventual-Inc/Daft/issues/3801
     - name: Build library and Test with pytest (Linux)

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -82,7 +82,23 @@ jobs:
     - name: Override deltalake for pyarrow
       if: ${{ (matrix.pyarrow-version == '8.0.0') }}
       run: uv pip install deltalake==0.10.0
-    
+
+      # Rust code coverage does not work on ubuntu-latest, so we only run it on macOS
+      # For more info: https://github.com/Eventual-Inc/Daft/issues/3801
+    - name: DEBUG Build library and Test with pytest (Linux)
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        maturin develop
+        python -c 'import pyarrow; print(f"pyarrow=={pyarrow.__version__}"); pyarrow.show_versions()'
+        pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
+        pytest -v --cov=daft 'tests/io/test_roundtrip_embeddings.py::test_roundtrip_embedding[uint32-256-parquet]' || true
+        
+      env:
+        CARGO_TARGET_DIR: ./target
+
+        DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_FLOTILLA: ${{ matrix.flotilla }}
+
     - name: Setup upterm session
       uses: lhotari/action-upterm@v1
 

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -83,21 +83,6 @@ jobs:
       if: ${{ (matrix.pyarrow-version == '8.0.0') }}
       run: uv pip install deltalake==0.10.0
     
-      # Rust code coverage does not work on ubuntu-latest, so we only run it on macOS
-      # For more info: https://github.com/Eventual-Inc/Daft/issues/3801
-    - name: Debug Build library and Test with pytest (Linux)
-      if: ${{ (runner.os == 'Linux') }}
-      run: |
-        maturin develop
-        python -c 'import pyarrow; print(f"pyarrow=={pyarrow.__version__}"); pyarrow.show_versions()'
-        pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
-        pytest -v --cov=daft 'tests/io/test_roundtrip_embeddings.py::test_roundtrip_embedding[uint32-256-parquet]' || true
-      env:
-        CARGO_TARGET_DIR: ./target
-
-        DAFT_RUNNER: ${{ matrix.daft-runner }}
-        DAFT_FLOTILLA: ${{ matrix.flotilla }}
-
     - name: Setup upterm session
       uses: lhotari/action-upterm@v1
 

--- a/daft/io/writer.py
+++ b/daft/io/writer.py
@@ -145,6 +145,10 @@ class ParquetFileWriter(FileWriterBase):
             compression=self.compression,
             use_compliant_nested_type=False,
             filesystem=self.fs,
+            # When using Arrow 8, it defaults to parquet version 1.
+            # This hits a known bug where Arrow cannot correctly write u32 values in Parquet files:
+            # https://issues.apache.org/jira/browse/ARROW-12201
+            # The fix is to always use at least Parquet version 2.
             version="2.6",
             **opts,
         )

--- a/daft/io/writer.py
+++ b/daft/io/writer.py
@@ -145,6 +145,7 @@ class ParquetFileWriter(FileWriterBase):
             compression=self.compression,
             use_compliant_nested_type=False,
             filesystem=self.fs,
+            version="2.6",
             **opts,
         )
 

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -2264,6 +2264,14 @@ impl FixedSizeListArray {
                         dtype
                     )));
                 }
+                // TODO [mg]: I recall in testing that this shape is wrong. It flattens everything.
+                //            It needs to preserve the shape! Otherwise it is *strictly wrong*.
+                //            Why is this occurring when it deserializes??
+                //            Need to figure out how to trace the data flow / debug so I can
+                //            see where this incorrect decision occurs. Maybe because Parquet
+                //            saves it as a big ol' fixed list? We need to recognize this
+                //            by saving the type + shape in the Arrow schema, recognizing this, and
+                //            deserializing into a real n-dimensional tensor!
                 Ok(FixedShapeTensorArray::new(
                     Field::new(self.name().to_string(), dtype.clone()),
                     self.clone(),
@@ -2279,6 +2287,31 @@ impl FixedSizeListArray {
                     )));
                 }
                 Ok(FixedShapeImageArray::new(
+                    Field::new(self.name().to_string(), dtype.clone()),
+                    self.clone(),
+                )
+                .into_series())
+            }
+            DataType::Embedding(child_dtype, dimensionality) => {
+                if **child_dtype != *self.child_data_type() {
+                    return Err(DaftError::TypeError(format!(
+                        "Cannot cast {} to {}: mismatched child type. Found {} but expected {}",
+                        self.data_type(),
+                        dtype,
+                        child_dtype.as_ref(),
+                        self.child_data_type(),
+                    )));
+                }
+                if *dimensionality != self.fixed_element_len() {
+                    return Err(DaftError::TypeError(format!(
+                        "Cannot cast {} to {}: mismatched sizes. Found {} but expected {}",
+                        self.data_type(),
+                        dtype,
+                        dimensionality,
+                        self.fixed_element_len(),
+                    )));
+                }
+                Ok(EmbeddingArray::new(
                     Field::new(self.name().to_string(), dtype.clone()),
                     self.clone(),
                 )
@@ -2500,7 +2533,7 @@ where
 #[cfg(test)]
 mod tests {
     use arrow2::array::PrimitiveArray;
-    use rand::{thread_rng, Rng};
+    use rand::{rng, Rng};
 
     use super::*;
     use crate::{
@@ -2547,12 +2580,15 @@ mod tests {
     const MIN_DIFF_FOR_PRECISION: usize = 12;
     #[test]
     fn test_decimal_to_decimal_cast() {
-        let mut rng = thread_rng();
-        let mut values: Vec<f64> = (0..100).map(|_| rng.gen_range(-MAX_VAL..MAX_VAL)).collect();
+        let mut rng = rng();
+        let mut values: Vec<f64> = (0..100)
+            .map(|_| rng.random_range(-MAX_VAL..MAX_VAL))
+            .collect();
         values.extend_from_slice(&[0.0, -0.0]);
 
-        let initial_scale: usize = rng.gen_range(0..=MAX_SCALE);
-        let initial_precision: usize = rng.gen_range(initial_scale + MIN_DIFF_FOR_PRECISION..=32);
+        let initial_scale: usize = rng.random_range(0..=MAX_SCALE);
+        let initial_precision: usize =
+            rng.random_range(initial_scale + MIN_DIFF_FOR_PRECISION..=32);
         let min_integral_comp = initial_precision - initial_scale;
         let i128_values: Vec<i128> = values
             .iter()
@@ -2561,9 +2597,9 @@ mod tests {
         let original = create_test_decimal_array(i128_values, initial_precision, initial_scale);
 
         // We always widen the Decimal, otherwise we lose information and can no longer compare with the original Decimal values.
-        let intermediate_scale: usize = rng.gen_range(initial_scale..=32 - min_integral_comp);
+        let intermediate_scale: usize = rng.random_range(initial_scale..=32 - min_integral_comp);
         let intermediate_precision: usize =
-            rng.gen_range(intermediate_scale + min_integral_comp..=32);
+            rng.random_range(intermediate_scale + min_integral_comp..=32);
 
         let result = original
             .cast(&DataType::Decimal128(
@@ -2587,13 +2623,15 @@ mod tests {
     // of floats during casting, while avoiding flakiness due small differences in floats.
     #[test]
     fn test_decimal_to_float() {
-        let mut rng = thread_rng();
-        let mut values: Vec<f64> = (0..100).map(|_| rng.gen_range(-MAX_VAL..MAX_VAL)).collect();
+        let mut rng = rng();
+        let mut values: Vec<f64> = (0..100)
+            .map(|_| rng.random_range(-MAX_VAL..MAX_VAL))
+            .collect();
         values.extend_from_slice(&[0.0, -0.0]);
         let num_values = values.len();
 
-        let scale: usize = rng.gen_range(0..=MAX_SCALE);
-        let precision: usize = rng.gen_range(scale + MIN_DIFF_FOR_PRECISION..=32);
+        let scale: usize = rng.random_range(0..=MAX_SCALE);
+        let precision: usize = rng.random_range(scale + MIN_DIFF_FOR_PRECISION..=32);
         // when the scale is 0, the created decimal values are integers, the epsilon should be 1
         let epsilon = if scale == 0 { 1f64 } else { 0.1f64 };
 
@@ -2622,13 +2660,15 @@ mod tests {
     const MAX_DIFF_FOR_PRECISION: usize = 18;
     #[test]
     fn test_decimal_to_int() {
-        let mut rng = thread_rng();
-        let mut values: Vec<f64> = (0..100).map(|_| rng.gen_range(-MAX_VAL..MAX_VAL)).collect();
+        let mut rng = rng();
+        let mut values: Vec<f64> = (0..100)
+            .map(|_| rng.random_range(-MAX_VAL..MAX_VAL))
+            .collect();
         values.extend_from_slice(&[0.0, -0.0]);
 
-        let scale: usize = rng.gen_range(0..=MAX_SCALE);
+        let scale: usize = rng.random_range(0..=MAX_SCALE);
         let precision: usize =
-            rng.gen_range(scale + MIN_DIFF_FOR_PRECISION..=scale + MAX_DIFF_FOR_PRECISION);
+            rng.random_range(scale + MIN_DIFF_FOR_PRECISION..=scale + MAX_DIFF_FOR_PRECISION);
         let i128_values: Vec<i128> = values
             .iter()
             .map(|&x| (x * 10_f64.powi(scale as i32) as f64) as i128)

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -2690,4 +2690,32 @@ mod tests {
             scale,
         );
     }
+
+    #[test]
+    fn cast_fsl_into_embedding() {
+        let fsl = FixedSizeListArray::new(
+            Arc::new(Field::new(
+                "item",
+                DataType::FixedSizeList(Box::new(DataType::Int64), 0),
+            )),
+            Series::empty("item", &DataType::Int64),
+            None,
+        );
+
+        assert!(
+            fsl.cast(&DataType::Embedding(Box::new(DataType::Int64), 0))
+                .is_ok(),
+            "Expected to be able to cast FixedSizeList into Embedding of same datatype & size."
+        );
+        assert!(
+            fsl.cast(&DataType::Embedding(Box::new(DataType::Int64), 1))
+                .is_err(),
+            "Not expected to be able to cast FixedSizeList into Embedding with different size."
+        );
+
+        assert!(
+            fsl.cast(&DataType::Embedding(Box::new(DataType::Float32), 0)).is_err(),
+            "Not expected to be able to cast FixedSizeList into Embedding with different element type."
+        );
+    }
 }

--- a/tests/io/test_roundtrip_embeddings.py
+++ b/tests/io/test_roundtrip_embeddings.py
@@ -77,6 +77,11 @@ def test_roundtrip_embedding(tmp_path: Path, fmt: FMT, dtype: np.dtype, size: in
     # make a checking function for the loaded dataframe & verify our original dataframe
     check = _make_check_embeddings(test_df, dtype)
 
+    if fmt == 'parquet':
+        new_temp_path = f"./roundtrip_{dtype}_{size}.parquet"
+        getattr(test_df, f"write_{fmt}")(new_temp_path)
+        print(f"WROTE TO: {new_temp_path}")
+
     # write the embeddings-containing dataframe to disk using the specified format
     getattr(test_df, f"write_{fmt}")(str(tmp_path))
 

--- a/tests/io/test_roundtrip_embeddings.py
+++ b/tests/io/test_roundtrip_embeddings.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from functools import partial
+from pathlib import Path
+from typing import Callable, Literal
+
+import numpy as np
+import pytest
+
+import daft
+from daft import DataType
+from tests.utils import random_numerical_embedding
+
+FMT = Literal["parquet", "lance"]
+
+
+def _make_check_embeddings(
+    test_df: daft.DataFrame, dtype, *, embeddings_col: str = "e"
+) -> Callable[[daft.DataFrame], None]:
+    """Verify validity of the test dataframe & produce a function that checks another dataframe for equality."""
+    test_df = test_df.collect()
+    if test_df.count_rows() == 0:
+        raise ValueError("Test DataFrame cannot be empty!")
+
+    if embeddings_col not in test_df:
+        raise ValueError(f"Test DataFrame doesn't have an embeddings column={embeddings_col}")
+
+    test_rows = test_df.to_pydict()[embeddings_col]
+    for i, t in enumerate(test_rows):
+        assert isinstance(t, np.ndarray), f"Row {i} is not a numpy array, it is: {type(t)}: {t}"
+        assert t.dtype == dtype, f"Row {i} array doesn't have {dtype=}, instead={t.dtype}"
+
+    def _check_embeddings(loaded_df: daft.DataFrame) -> None:
+        loaded_df = loaded_df.collect()
+        if loaded_df.count_rows() != test_df.count_rows():
+            raise ValueError(
+                f"Expecting {test_df.count_rows()} rows but got a " f"DataFrame with {loaded_df.count_rows()}"
+            )
+
+        l_rows = loaded_df.to_pydict()[embeddings_col]
+        for i, (t, l) in enumerate(zip(test_rows, l_rows)):  # noqa: E741
+            assert isinstance(l, np.ndarray), f"Row {i} expected a numpy array when loading, got a {type(l)}: {l}"
+            assert l.dtype == t.dtype, f"Row {i} has wrong dtype. Expected={t.dtype} vs. found={l.dtype}"
+            assert (t == l).all(), f"Row {i} failed equality check: test_df={t} vs. loaded={l}"
+
+    return _check_embeddings
+
+
+@pytest.mark.parametrize("fmt", ["parquet", "lance"])
+@pytest.mark.parametrize(
+    ["dtype", "size"],
+    [
+        # (np.float16, 64), -- Arrow doesn't support f16
+        (np.float32, 1024),
+        (np.float64, 512),
+        (np.int8, 2048),
+        (np.int16, 512),
+        (np.int32, 256),
+        (np.int64, 128),
+        (np.uint8, 2048),
+        (np.uint16, 512),
+        (np.uint32, 256),
+        (np.uint64, 128),
+        # (np.bool_, 512), -- Arrow only accepts numeric types
+        # (np.complex64, 32), (np.complex128, 16), - Arrow doesn't support complex numbers
+    ],
+)
+def test_roundtrip_embedding(tmp_path: Path, fmt: FMT, dtype: np.dtype, size: int) -> None:
+    # make some embeddings of the specified data type and dimensionality
+    # with uniformly at random distributed values
+    make_array = partial(random_numerical_embedding, np.random.default_rng(), dtype, size)
+    test_df = (
+        daft.from_pydict({"e": [make_array() for _ in range(50)]})
+        .with_column("e", daft.col("e").cast(DataType.embedding(DataType.from_numpy_dtype(dtype), size)))
+    )
+
+    # make a checking function for the loaded dataframe & verify our original dataframe
+    check = _make_check_embeddings(test_df, dtype)
+
+    # write the embeddings-containing dataframe to disk using the specified format
+    getattr(test_df, f"write_{fmt}")(str(tmp_path))
+
+    # read that same dataframe
+    loaded_df = getattr(daft, f"read_{fmt}")(str(tmp_path))
+
+    # check that the values in the embedding column exactly equal each other
+    check(loaded_df)

--- a/tests/io/test_roundtrip_embeddings.py
+++ b/tests/io/test_roundtrip_embeddings.py
@@ -69,18 +69,12 @@ def test_roundtrip_embedding(tmp_path: Path, fmt: FMT, dtype: np.dtype, size: in
     # make some embeddings of the specified data type and dimensionality
     # with uniformly at random distributed values
     make_array = partial(random_numerical_embedding, np.random.default_rng(), dtype, size)
-    test_df = (
-        daft.from_pydict({"e": [make_array() for _ in range(50)]})
-        .with_column("e", daft.col("e").cast(DataType.embedding(DataType.from_numpy_dtype(dtype), size)))
+    test_df = daft.from_pydict({"e": [make_array() for _ in range(50)]}).with_column(
+        "e", daft.col("e").cast(DataType.embedding(DataType.from_numpy_dtype(dtype), size))
     )
 
     # make a checking function for the loaded dataframe & verify our original dataframe
     check = _make_check_embeddings(test_df, dtype)
-
-    if fmt == 'parquet':
-        new_temp_path = f"./roundtrip_{dtype}_{size}.parquet"
-        getattr(test_df, f"write_{fmt}")(new_temp_path)
-        print(f"WROTE TO: {new_temp_path}")
 
     # write the embeddings-containing dataframe to disk using the specified format
     getattr(test_df, f"write_{fmt}")(str(tmp_path))

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 from datetime import date, datetime, time, timedelta, timezone
+from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -12,6 +13,7 @@ from daft.datatype import DataType, ImageMode, TimeUnit
 from daft.exceptions import DaftCoreException
 from daft.series import Series
 from tests.series import ARROW_FLOAT_TYPES, ARROW_INT_TYPES
+from tests.utils import random_numerical_embedding
 
 daft_int_types = [
     DataType.int8(),
@@ -783,6 +785,76 @@ def test_series_cast_fixed_shape_tensor_to_tensor() -> None:
 
 
 ### Embedding ###
+
+
+@pytest.mark.parametrize(
+    ["dtype", "size"],
+    [
+        (np.float32, 1024),
+        (np.float64, 512),
+        (np.int8, 2048),
+        (np.int16, 512),
+        (np.int32, 256),
+        (np.int64, 128),
+        (np.uint8, 2048),
+        (np.uint16, 512),
+        (np.uint32, 256),
+        (np.uint64, 128),
+    ],
+)
+def test_series_cast_fixed_shape_list_to_embedding(dtype: np.dtype, size: int):
+    daft_dtype = DataType.from_numpy_dtype(dtype)
+    make_array = partial(random_numerical_embedding, np.random.default_rng(), dtype, size)
+
+    data = [make_array() for _ in range(5)]
+    s = Series.from_pylist(data, dtype=DataType.fixed_size_list(daft_dtype, size))
+
+    target_dtype = DataType.embedding(daft_dtype, size)
+    t = s.cast(target_dtype)
+    assert len(t) == len(s)
+    assert t.datatype() == target_dtype, f"Expecting {target_dtype} but cast resulted in {t.datatype()}"
+    for i, (s_lst, t_arr) in enumerate(zip(s, t)):
+        assert len(s_lst) == len(t_arr)
+        assert len(s_lst) == size
+        assert isinstance(s_lst, list)
+        assert isinstance(t_arr, np.ndarray)
+        assert t_arr.shape == (size,)
+        assert (np.array(s_lst) == t_arr).all()
+
+
+@pytest.mark.parametrize(
+    ["dtype", "size"],
+    [
+        (np.float32, 1024),
+        (np.float64, 512),
+        (np.int8, 2048),
+        (np.int16, 512),
+        (np.int32, 256),
+        (np.int64, 128),
+        (np.uint8, 2048),
+        (np.uint16, 512),
+        (np.uint32, 256),
+        (np.uint64, 128),
+    ],
+)
+def test_series_cast_embedding_to_fixed_shape_list(dtype: np.dtype, size: int):
+    daft_dtype = DataType.from_numpy_dtype(dtype)
+    make_array = partial(random_numerical_embedding, np.random.default_rng(), dtype, size)
+
+    data = [make_array() for _ in range(5)]
+    s = Series.from_pylist(data, dtype=DataType.embedding(daft_dtype, size))
+
+    target_dtype = DataType.fixed_size_list(daft_dtype, size)
+    t = s.cast(target_dtype)
+    assert len(t) == len(s)
+    assert t.datatype() == target_dtype, f"Expecting {target_dtype} but cast resulted in {t.datatype()}"
+    for i, (s_arr, t_lst) in enumerate(zip(s, t)):
+        assert len(s_arr) == len(t_lst)
+        assert len(t_lst) == size
+        assert isinstance(s_arr, np.ndarray)
+        assert isinstance(t_lst, list)
+        assert s_arr.shape == (size,)
+        assert (np.array(t_lst) == s_arr).all()
 
 
 def test_series_cast_embedding_to_fixed_shape_tensor() -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
+import numpy as np
 import pyarrow as pa
 
 from daft.recordbatch import RecordBatch
@@ -13,15 +14,39 @@ TD_STYLE = 'style="text-align:left; max-width:192px; max-height:64px; overflow:a
 TH_STYLE = 'style="text-wrap: nowrap; max-width:192px; overflow:auto; text-align:left"'
 
 
-def sort_arrow_table(tbl: pa.Table, *sort_by: str, ascending: bool = False):
+def sort_arrow_table(tbl: pa.Table, *sort_by: str, ascending: bool = False) -> pa.Table:
     return tbl.sort_by([(name, "ascending" if ascending else "descending") for name in sort_by])
 
 
-def assert_pyarrow_tables_equal(from_daft: pa.Table, expected: pa.Table):
+def assert_pyarrow_tables_equal(from_daft: pa.Table, expected: pa.Table) -> None:
     # Do a round-trip with Daft in order to cast pyarrow dtypes to Daft's supported Arrow dtypes (e.g. string -> large_string).
     expected = RecordBatch.from_arrow_table(expected).to_arrow_table()
     assert from_daft == expected, f"from_daft = {from_daft}\n\nexpected = {expected}"
 
 
-def sort_pydict(pydict: dict[str, list[Any]], *sort_by: str, ascending: bool = False):
+def sort_pydict(pydict: dict[str, list[Any]], *sort_by: str, ascending: bool = False) -> pa.Table:
     return sort_arrow_table(RecordBatch.from_pydict(pydict).to_arrow_table(), *sort_by, ascending=ascending).to_pydict()
+
+
+def random_numerical_embedding(
+    rng: np.random.Generator, dtype: np.dtype, size: int, *, mult_for_int_like: int = 100
+) -> np.ndarray:
+    """Generate a uniformly distributed 1-D array of the specified datatype & dimensionality.
+
+    The :param:`mult_for_int_like` parameter controls how much to multiply the randomly generated
+    floating point values before rounding them to make integer vectors. Only applicable when
+    :param:`dtype` is a signed or unsigned integer. Must be nonzero.
+
+    :raises:`ValueError` if :param:`mult_for_int_like` is nonzero and :param:`dtype` is integer.
+    """
+    if dtype in (np.float32, np.float64):
+        return rng.random(size=(size,), dtype=dtype)
+    else:
+        if mult_for_int_like <= 0:
+            raise ValueError(
+                "Multiplier for converting random float vectors into integer "
+                f"vectors must be nonzero: {mult_for_int_like=}"
+            )
+        v = rng.random(size=(size,), dtype=np.float32)
+        c = np.rint(v * mult_for_int_like)
+        return c.astype(dtype)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,7 +37,7 @@ def random_numerical_embedding(
     floating point values before rounding them to make integer vectors. Only applicable when
     :param:`dtype` is a signed or unsigned integer. Must be nonzero.
 
-    :raises:`ValueError` if :param:`mult_for_int_like` is nonzero and :param:`dtype` is integer.
+    :raises:`ValueError` if :param:`mult_for_int_like` is non-positive and :param:`dtype` is integer.
     """
     if dtype in (np.float32, np.float64):
         return rng.random(size=(size,), dtype=dtype)


### PR DESCRIPTION
## Changes Made

Fixes reading embedding-typed columns from DataFrames saved to both Parquet and Lance data formats.

Primary fix is to in `daft-core`'s `array/ops/cast.rs`. Specifically the `FixedSizeListArray`'s `cast` implementation.
There is now a match arm for `DataType::Embedding`. Upon encountering this, Daft will now properly cast the 
data into an `EmbeddingArray` struct (from `datatypes::logical`). Before, this case was unrecognized and thus 
led an `unimplemented!` error.

Secondary fix is related to this Arrow 8 bug: https://issues.apache.org/jira/browse/ARROW-12201 . When writing to Parquet in Arrow 8, the logical datatype information for u32 values are incorrectly written. They will instead be written as signed 64 bit integers! The fix is to always use Parquet version >= 2.0. In later versions of Arrow, the default switches from parquet version 1.0 to >= 2.0. Here, the fix is to always set `version=2.6` in the `ParquetWriter` object used in `daft.io.writer`.

Added a new Python based test to cover the fix `tests/io/test_roundtrip_embeddings.py`. The new
`test_roundtrip_embedding` covers a roundtrip serialization to and from both Parquet and Lance.

Also added new tests in `tests/series/test_cast.py`: `test_series_cast_fixed_shape_list_to_embedding` 
explicitly casts fixed size list arrays into and embeddings and `test_series_cast_embedding_to_fixed_shape_list` 
does the reverse.

Supporting these tests is a new `random_numerical_embedding` helper function in `tests/utils.py`.

One drive-by change: updated to use non-deprecated `rand` functions & types in `src/daft-core/src/array/ops/cast.rs`.

**Fixes**: https://github.com/Eventual-Inc/Daft/issues/4732

## Related Issues

https://github.com/Eventual-Inc/Daft/issues/4732

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
