### PR TITLE
fix: Allow file:/ schemes in read_iceberg

### DIFF
--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -443,7 +443,15 @@ pub fn parse_url(input: &str) -> Result<(SourceType, Cow<'_, str>)> {
 
     let scheme = url.scheme().to_lowercase();
     match scheme.as_ref() {
-        "file" => Ok((SourceType::File, fixed_input)),
+        "file" => {
+            // Normalize file:/ to file:/// format for consistency
+            if input.starts_with("file:/") && !input.starts_with("file://") {
+                let normalized = input.replacen("file:/", "file:///", 1);
+                Ok((SourceType::File, Cow::Owned(normalized)))
+            } else {
+                Ok((SourceType::File, fixed_input))
+            }
+        }
         "http" | "https" => Ok((SourceType::Http, fixed_input)),
         "s3" | "s3a" | "s3n" => Ok((SourceType::S3, fixed_input)),
         "az" | "abfs" | "abfss" => Ok((SourceType::AzureBlob, fixed_input)),


### PR DESCRIPTION
## Changes Made

Allow `file:/` schemes in read_iceberg by normalizing `file:/` schemes to `file:///` in the `parse_url` function. More generally this should allow `file:/` schemes in all our read paths.

## Related Issues

Closes https://github.com/Eventual-Inc/Daft/issues/4822

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
