### PR TITLE
feat: Support multiple namespaces in the turbopuffer writer

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1388,9 +1388,9 @@ class DataFrame:
     @DataframePublicAPI
     def write_turbopuffer(
         self,
-        namespace: str,
-        api_key: str,
-        region: str = "aws-us-west-2",
+        namespace: Union[str, Expression],
+        api_key: Optional[str] = None,
+        region: Optional[str] = None,
         distance_metric: Optional[Literal["cosine_distance", "euclidean_squared"]] = None,
         schema: Optional[dict[str, Any]] = None,
         id_column: Optional[str] = None,
@@ -1409,13 +1409,16 @@ class DataFrame:
 
         All other columns become attributes.
 
+        The namespace parameter can be either a string (for a single namespace) or an expression (for multiple namespaces).
+        When using an expression, the data will be partitioned by the computed namespace values and written to each namespace separately.
+
         For more details on parameters, please see the turbopuffer documentation: https://turbopuffer.com/docs/write
 
         Args:
-            namespace: The namespace to write to.
+            namespace: The namespace to write to. Can be a string for a single namespace or an expression for multiple namespaces.
             api_key: Turbopuffer API key.
             region: Turbopuffer region.
-            distance_metric: Optional distance metric for vector similarity ("cosine_distance", "euclidean_squared").
+            distance_metric: Distance metric for vector similarity ("cosine_distance", "euclidean_squared").
             schema: Optional manual schema specification.
             id_column: Optional column name for the id column. The data sink will automatically rename the column to "id" for the id column.
             vector_column: Optional column name for the vector index column. The data sink will automatically rename the column to "vector" for the vector index.

--- a/daft/io/turbopuffer/turbopuffer_data_sink.py
+++ b/daft/io/turbopuffer/turbopuffer_data_sink.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import warnings
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -98,11 +99,9 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
         else:
             self._namespace = ExpressionsProjection([namespace])
 
-        self._api_key = api_key
+        self._api_key = api_key or os.getenv("TURBOPUFFER_API_KEY")
         if not self._api_key:
-            warnings.warn(
-                "Turbopuffer API key is not set. Turbopuffer will use the value set in the TURBOPUFFER_API_KEY environment variable"
-            )
+            warnings.warn("Turbopuffer API key is not set and TURBOPUFFER_API_KEY environment variable is not found")
 
         self._region = region
         self._distance_metric = distance_metric

--- a/daft/io/turbopuffer/turbopuffer_data_sink.py
+++ b/daft/io/turbopuffer/turbopuffer_data_sink.py
@@ -183,6 +183,7 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
 
                     arrow_table = self._prepare_arrow_table(data.to_arrow())
 
+                    TurbopufferDataSink._check_namespace_name(namespace_name)
                     namespace = tpuf.namespace(namespace_name)
                     write_response = namespace.write(
                         upsert_rows=arrow_table.to_pylist(),

--- a/daft/io/turbopuffer/turbopuffer_data_sink.py
+++ b/daft/io/turbopuffer/turbopuffer_data_sink.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Any, Literal
 
 import turbopuffer
 
 from daft.datatype import DataType
 from daft.dependencies import pc
+from daft.expressions import ExpressionsProjection
 from daft.io import DataSink
 from daft.io.sink import WriteResult
 from daft.recordbatch import MicroPartition
@@ -15,11 +17,17 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from types import ModuleType
 
+    from daft.dependencies import pa
+    from daft.expressions import Expression
+
 
 class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
     """WriteSink for writing data to a Turbopuffer namespace."""
 
-    def _import_turbopuffer(self) -> ModuleType:
+    _namespace: str | ExpressionsProjection
+
+    @staticmethod
+    def _import_turbopuffer() -> ModuleType:
         try:
             import turbopuffer
 
@@ -29,10 +37,24 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
                 "turbopuffer is not installed. Please install turbopuffer using `pip install turbopuffer`"
             )
 
+    @staticmethod
+    def _check_namespace_name(namespace_name: str) -> None:
+        if not isinstance(namespace_name, str):
+            raise ValueError(f"Namespace name must be a string, got {namespace_name} with type {type(namespace_name)}")
+        if not (1 <= len(namespace_name) <= 128):
+            raise ValueError(
+                f"Namespace name must be between 1 and 128 characters, got length {len(namespace_name)}. For more details, see: https://turbopuffer.com/docs/write"
+            )
+        if not all(c.isalnum() or c in "-_." for c in namespace_name):
+            raise ValueError(
+                f"Namespace name can only contain alphanumeric characters, hyphens, underscores and periods. Got: {namespace_name}. For more details, see: https://turbopuffer.com/docs/write"
+            )
+        return
+
     def __init__(
         self,
-        namespace: str,
-        api_key: str,
+        namespace: str | Expression,
+        api_key: str | None = None,
         region: str | None = None,
         distance_metric: Literal["cosine_distance", "euclidean_squared"] | None = None,
         schema: dict[str, Any] | None = None,
@@ -52,13 +74,16 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
 
         All other columns become attributes.
 
+        The namespace parameter can be either a string (for a single namespace) or an expression (for multiple namespaces).
+        When using an expression, the data will be partitioned by the computed namespace values and written to each namespace separately.
+
         For more details on parameters, please see the turbopuffer documentation: https://turbopuffer.com/docs/write
 
         Args:
-            namespace: The namespace to write to.
+            namespace: The namespace to write to. Can be a string for a single namespace or an expression for multiple namespaces.
             api_key: Turbopuffer API key.
             region: Turbopuffer region.
-            distance_metric: Optional distance metric for vector similarity ("cosine_distance", "euclidean_squared").
+            distance_metric: Distance metric for vector similarity ("cosine_distance", "euclidean_squared").
             schema: Optional manual schema specification.
             id_column: Optional column name for the id column. The data sink will automatically rename the column to "id" for the id column.
             vector_column: Optional column name for the vector index column. The data sink will automatically rename the column to "vector" for the vector index.
@@ -67,10 +92,17 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
             write_kwargs: Optional dictionary of arguments to pass to the namespace.write() method.
                 Explicit arguments (distance_metric, schema) will be merged into write_kwargs.
         """
-        self._namespace_name = namespace
+        if isinstance(namespace, str):
+            TurbopufferDataSink._check_namespace_name(namespace)
+            self._namespace = namespace
+        else:
+            self._namespace = ExpressionsProjection([namespace])
+
         self._api_key = api_key
         if not self._api_key:
-            raise ValueError("Turbopuffer API key must be provided or set in TURBOPUFFER_API_KEY environment variable")
+            warnings.warn(
+                "Turbopuffer API key is not set. Turbopuffer will use the value set in the TURBOPUFFER_API_KEY environment variable"
+            )
 
         self._region = region
         self._distance_metric = distance_metric
@@ -104,43 +136,65 @@ class TurbopufferDataSink(DataSink[turbopuffer.types.NamespaceWriteResponse]):
     def schema(self) -> Schema:
         return self._result_schema
 
+    def _prepare_arrow_table(self, arrow_table: pa.Table) -> pa.Table:
+        if self._id_column:
+            if self._id_column not in arrow_table.column_names:
+                raise ValueError(f"ID column {self._id_column} not found in schema, cannot use as column for id")
+            arrow_table = arrow_table.rename_columns({self._id_column: "id"})
+
+        if self._vector_column:
+            if self._vector_column not in arrow_table.column_names:
+                raise ValueError(
+                    f"Vector column {self._vector_column} not found in schema, cannot use as column for vector index"
+                )
+            arrow_table = arrow_table.rename_columns({self._vector_column: "vector"})
+
+        return arrow_table.filter(~pc.field("id").is_null())
+
     def write(
         self, micropartitions: Iterator[MicroPartition]
     ) -> Iterator[WriteResult[turbopuffer.types.NamespaceWriteResponse]]:
-        """Writes micropartitions to Turbopuffer namespace."""
-        turbopuffer = self._import_turbopuffer()
+        """Writes micropartitions to Turbopuffer namespace(s)."""
+        turbopuffer = TurbopufferDataSink._import_turbopuffer()
         tpuf = turbopuffer.Turbopuffer(**self._client_kwargs)
 
-        namespace = tpuf.namespace(self._namespace_name)
-
         for micropartition in micropartitions:
-            arrow_table = micropartition.to_arrow()
-            if self._id_column:
-                if self._id_column not in arrow_table.column_names:
-                    raise ValueError(f"ID column {self._id_column} not found in schema, cannot use as column for id")
-                arrow_table = arrow_table.rename_columns({self._id_column: "id"})
-            if self._vector_column:
-                if self._vector_column not in arrow_table.column_names:
-                    raise ValueError(
-                        f"Vector column {self._vector_column} not found in schema, cannot use as column for vector index"
+            if isinstance(self._namespace, str):
+                # Namespace is a string. Write all data to this namespace.
+                arrow_table = self._prepare_arrow_table(micropartition.to_arrow())
+
+                namespace = tpuf.namespace(self._namespace)
+                write_response = namespace.write(
+                    upsert_rows=arrow_table.to_pylist(),
+                    **self._write_kwargs,
+                )
+
+                yield WriteResult(
+                    result=write_response,
+                    bytes_written=arrow_table.nbytes,
+                    rows_written=arrow_table.num_rows,
+                )
+            else:
+                # Namespace is an expression. Partition the data by namespace then write to each namespace.
+                (partitioned_data, partition_keys) = micropartition.partition_by_value(self._namespace)
+                for data, namespace_name in zip(partitioned_data, partition_keys.get_column(0)):
+                    if len(data) == 0:
+                        continue
+
+                    arrow_table = self._prepare_arrow_table(data.to_arrow())
+
+                    namespace = tpuf.namespace(namespace_name)
+                    write_response = namespace.write(
+                        upsert_rows=arrow_table.to_pylist(),
+                        distance_metric=self._distance_metric,
+                        schema=self._schema,
                     )
-                arrow_table = arrow_table.rename_columns({self._vector_column: "vector"})
 
-            arrow_table = arrow_table.filter(~pc.field("id").is_null())
-
-            bytes_written = arrow_table.nbytes
-            rows_written = arrow_table.num_rows
-
-            write_response = namespace.write(
-                upsert_rows=arrow_table.to_pylist(),
-                **self._write_kwargs,
-            )
-
-            yield WriteResult(
-                result=write_response,
-                bytes_written=bytes_written,
-                rows_written=rows_written,
-            )
+                    yield WriteResult(
+                        result=write_response,
+                        bytes_written=arrow_table.nbytes,
+                        rows_written=arrow_table.num_rows,
+                    )
 
     def finalize(self, write_results: list[WriteResult[turbopuffer.types.NamespaceWriteResponse]]) -> MicroPartition:
         """Finalizes the write process and returns summary statistics."""


### PR DESCRIPTION
## Changes Made

When writing to turbopuffer, it's common to write data to multiple namespaces. We extend the turbopuffer data sink so that the `namespace` parameter can take either a string or an expression. If we're given a string, all data gets written to the given namespace. Otherwise, we evaluate the expression and partition the data by namespace value before writing to their respective namespaces.