### PR TITLE
fix: concat chunked array safety

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -100,7 +100,7 @@ class Series:
                 combined_array = arr_type.wrap_array(combined_storage_array)
             else:
                 combined_array = array.combine_chunks()
-            return Series.from_arrow(combined_array, dtype=dtype)
+            return Series.from_arrow(combined_array, name=name, dtype=dtype)
         else:
             raise TypeError(f"expected either PyArrow Array or Chunked Array, got {type(array)}")
 

--- a/daft/udf.py
+++ b/daft/udf.py
@@ -193,18 +193,26 @@ def run_udf(
 
 
 def _safe_concat_arrays(pa_arrays: list[pa.Array | pa.ChunkedArray]) -> pa.ChunkedArray:
-    chunks = []
+    if len(pa_arrays) == 0:
+        return pa.concat_arrays([])
+
     data_type = pa_arrays[0].type
+    chunks = []
+    is_chunked = False
 
     for arr in pa_arrays:
         if isinstance(arr, pa.Array):
             chunks.append(arr)
         elif isinstance(arr, pa.ChunkedArray):
+            is_chunked = True
             chunks.extend(arr.chunks)
         else:
             raise TypeError(f"Unsupported type: {type(arr)}")
 
-    return pa.chunked_array(chunks, type=data_type)
+    if is_chunked:
+        return pa.chunked_array(chunks, type=data_type)
+    else:
+        return pa.concat_arrays(chunks)
 
 
 # Marker that helps us differentiate whether a user provided the argument or not

--- a/tests/expressions/test_udf.py
+++ b/tests/expressions/test_udf.py
@@ -192,7 +192,7 @@ def test_udf_tuples(batch_size):
     assert result.to_pydict() == {"a": ["foofoo", "barbar", "bazbaz"]}
 
 
-@pytest.mark.parametrize("container", [Series, list, np.ndarray])
+@pytest.mark.parametrize("container", [Series, list, np.ndarray, pa.Array, pa.ChunkedArray])
 @pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
 def test_udf_return_containers(container, batch_size):
     table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
@@ -205,6 +205,10 @@ def test_udf_return_containers(container, batch_size):
             return data.to_pylist()
         elif container is np.ndarray:
             return np.array(data.to_arrow())
+        elif container is pa.Array:
+            return data.to_arrow()
+        elif container is pa.ChunkedArray:
+            return pa.chunked_array([data.to_arrow()])
         else:
             raise NotImplementedError(f"Test not implemented for container type: {container}")
 


### PR DESCRIPTION
## Changes Made

As mentioned in https://github.com/Eventual-Inc/Daft/issues/4851, the `pyarrow.concat_arrays()` doesn't support concat chunked arrays, so need to loop each chunks at first and then concat them together

## Related Issues

https://github.com/Eventual-Inc/Daft/issues/4851

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
