### PR TITLE
fix: add cachebusting parameter to huggingface urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,6 +2785,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "uuid 1.17.0",
 ]
 
 [[package]]

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -37,6 +37,7 @@ tokio = {workspace = true}
 tokio-stream = {workspace = true}
 tracing = {workspace = true}
 url = {workspace = true}
+uuid = {workspace = true}
 
 [dependencies.reqwest]
 default-features = false

--- a/tests/integration/test_huggingface.py
+++ b/tests/integration/test_huggingface.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import daft
+
+
+def test_read_huggingface_datasets_doesnt_flae():
+    from daft import DataType as dt
+
+    # run it multiple times to ensure it doesn't fail
+    for _ in range(10):
+        df = daft.read_parquet("hf://datasets/huggingface/documentation-images")
+        schema = df.schema()
+        expected = daft.Schema.from_pydict({"image": dt.struct({"bytes": dt.binary(), "path": dt.string()})})
+        assert schema == expected


### PR DESCRIPTION
## Changes Made

Adds a unique parameter to huggingface urls to prevent getting cache hits. 

## Related Issues

Closes https://github.com/Eventual-Inc/Daft/issues/4780

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
