### PR TITLE
fix: Allow anonymous mode to be used for S3 uploads

### DIFF
--- a/tests/integration/io/conftest.py
+++ b/tests/integration/io/conftest.py
@@ -44,6 +44,17 @@ def minio_io_config() -> daft.io.IOConfig:
 
 
 @pytest.fixture(scope="session")
+def anonymous_minio_io_config() -> daft.io.IOConfig:
+    return daft.io.IOConfig(
+        s3=daft.io.S3Config(
+            endpoint_url="http://127.0.0.1:9000",
+            use_ssl=False,
+            anonymous=True,
+        )
+    )
+
+
+@pytest.fixture(scope="session")
 def aws_public_s3_config(request) -> daft.io.IOConfig:
     # Use anonymous mode to avoid having to search for credentials in the Github Runner
     # If pytest is run with `--credentials` then we set anonymous=None to go down the credentials chain

--- a/tests/integration/io/conftest.py
+++ b/tests/integration/io/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import os
 import pathlib
 import shutil
@@ -14,9 +15,11 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeAlias
 
+import boto3
 import numpy as np
 import pytest
 import s3fs
+from botocore.config import Config
 from PIL import Image
 
 import daft
@@ -138,6 +141,59 @@ def minio_create_bucket(
         yield fs
     finally:
         fs.rm(bucket_name, recursive=True)
+
+
+@contextlib.contextmanager
+def minio_create_public_bucket(
+    minio_io_config: daft.io.IOConfig, bucket_name: str = "my-minio-public-bucket"
+) -> YieldFixture[list[str]]:
+    """Creates a public bucket in MinIO.
+
+    Yields the bucket name.
+    """
+    # Create authenticated S3 client to set up the bucket.
+    s3_client = boto3.client(
+        "s3",
+        endpoint_url=minio_io_config.s3.endpoint_url,
+        aws_access_key_id=minio_io_config.s3.key_id,
+        aws_secret_access_key=minio_io_config.s3.access_key,
+        config=Config(signature_version="s3v4"),
+        region_name="us-east-1",
+    )
+
+    # Create bucket if it doesn't exist.
+    try:
+        s3_client.create_bucket(Bucket=bucket_name)
+    except s3_client.exceptions.BucketAlreadyOwnedByYou:
+        pass
+
+    # Set bucket policy for anonymous access.
+    bucket_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+                "Resource": [f"arn:aws:s3:::{bucket_name}", f"arn:aws:s3:::{bucket_name}/*"],
+            }
+        ],
+    }
+    s3_client.put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(bucket_policy))
+
+    try:
+        yield bucket_name
+    finally:
+        paginator = s3_client.get_paginator("list_objects_v2")
+        pages = paginator.paginate(Bucket=bucket_name)
+
+        for page in pages:
+            if "Contents" in page:
+                objects_to_delete = [{"Key": obj["Key"]} for obj in page["Contents"]]
+                if objects_to_delete:
+                    s3_client.delete_objects(Bucket=bucket_name, Delete={"Objects": objects_to_delete})
+
+        s3_client.delete_bucket(Bucket=bucket_name)
 
 
 @contextlib.contextmanager

--- a/tests/integration/io/test_files_roundtrip_s3_minio.py
+++ b/tests/integration/io/test_files_roundtrip_s3_minio.py
@@ -7,23 +7,28 @@ import daft
 from .conftest import minio_create_bucket, minio_create_public_bucket
 
 
+def run_url_upload_roundtrip_test(folder: str, io_config, bytes_data: list[bytes]):
+    """Helper function to run URL upload/download roundtrip test."""
+    data = {"data": bytes_data}
+    df = daft.from_pydict(data)
+    df = df.with_column("file_paths", df["data"].url.upload(folder, io_config=io_config))
+    df.collect()
+
+    df = df.with_column("roundtrip_data", df["file_paths"].url.download(io_config=io_config))
+    results = df.to_pydict()
+
+    assert results["data"] == results["roundtrip_data"] == bytes_data
+    for path in results["file_paths"]:
+        assert path.startswith(folder)
+
+
 @pytest.mark.integration()
 def test_files_roundtrip_minio_native_downloader(minio_io_config):
     bucket_name = "my-bucket"
     folder = f"s3://{bucket_name}/my-folder"
     with minio_create_bucket(minio_io_config=minio_io_config, bucket_name=bucket_name):
         bytes_data = [b"a", b"b", b"c"]
-        data = {"data": bytes_data}
-        df = daft.from_pydict(data)
-        df = df.with_column("file_paths", df["data"].url.upload(folder, io_config=minio_io_config))
-        df.collect()
-
-        df = df.with_column("roundtrip_data", df["file_paths"].url.download(io_config=minio_io_config))
-        results = df.to_pydict()
-
-        assert results["data"] == results["roundtrip_data"] == bytes_data
-        for path, expected in zip(results["file_paths"], bytes_data):
-            assert path.startswith(folder)
+        run_url_upload_roundtrip_test(folder, minio_io_config, bytes_data)
 
 
 @pytest.mark.integration()
@@ -31,16 +36,7 @@ def test_files_roundtrip_minio_anonymous_upload(anonymous_minio_io_config, minio
     """Test anonymous URL upload and download roundtrip."""
     bucket_name = "my-public-bucket"
     folder = f"s3://{bucket_name}/my-folder"
+    # Use the authenticated config to create the public bucket, but use the anonymous config to upload/download.
     with minio_create_public_bucket(minio_io_config=minio_io_config, bucket_name=bucket_name):
         bytes_data = [b"a", b"b", b"c"]
-        data = {"data": bytes_data}
-        df = daft.from_pydict(data)
-        df = df.with_column("file_paths", df["data"].url.upload(folder, io_config=anonymous_minio_io_config))
-        df.collect()
-
-        df = df.with_column("roundtrip_data", df["file_paths"].url.download(io_config=anonymous_minio_io_config))
-        results = df.to_pydict()
-
-        assert results["data"] == results["roundtrip_data"] == bytes_data
-        for path, expected in zip(results["file_paths"], bytes_data):
-            assert path.startswith(folder)
+        run_url_upload_roundtrip_test(folder, anonymous_minio_io_config, bytes_data)

--- a/tests/integration/io/test_files_roundtrip_s3_minio.py
+++ b/tests/integration/io/test_files_roundtrip_s3_minio.py
@@ -4,7 +4,7 @@ import pytest
 
 import daft
 
-from .conftest import minio_create_bucket
+from .conftest import minio_create_bucket, minio_create_public_bucket
 
 
 @pytest.mark.integration()
@@ -19,6 +19,26 @@ def test_files_roundtrip_minio_native_downloader(minio_io_config):
         df.collect()
 
         df = df.with_column("roundtrip_data", df["file_paths"].url.download(io_config=minio_io_config))
+        results = df.to_pydict()
+
+        assert results["data"] == results["roundtrip_data"] == bytes_data
+        for path, expected in zip(results["file_paths"], bytes_data):
+            assert path.startswith(folder)
+
+
+@pytest.mark.integration()
+def test_files_roundtrip_minio_anonymous_upload(anonymous_minio_io_config, minio_io_config):
+    """Test anonymous URL upload and download roundtrip."""
+    bucket_name = "my-public-bucket"
+    folder = f"s3://{bucket_name}/my-folder"
+    with minio_create_public_bucket(minio_io_config=minio_io_config, bucket_name=bucket_name):
+        bytes_data = [b"a", b"b", b"c"]
+        data = {"data": bytes_data}
+        df = daft.from_pydict(data)
+        df = df.with_column("file_paths", df["data"].url.upload(folder, io_config=anonymous_minio_io_config))
+        df.collect()
+
+        df = df.with_column("roundtrip_data", df["file_paths"].url.download(io_config=anonymous_minio_io_config))
         results = df.to_pydict()
 
         assert results["data"] == results["roundtrip_data"] == bytes_data

--- a/tests/integration/io/test_write_files_s3_minio.py
+++ b/tests/integration/io/test_write_files_s3_minio.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
-import json
 import uuid
 
-import boto3
 import pytest
 import s3fs
-from botocore.config import Config
 
 import daft
-from tests.conftest import get_tests_daft_runner_name
+from tests.conftest import get_tests_daft_runner_name, minio_create_public_bucket
 
 
 @pytest.fixture(scope="function")
@@ -26,46 +23,6 @@ def bucket(minio_io_config):
     )
     if not fs.exists(BUCKET):
         fs.mkdir(BUCKET)
-    yield BUCKET
-
-
-@pytest.fixture(scope="function")
-def anonymous_bucket(minio_io_config):
-    # For some reason s3fs is having trouble cleaning up MinIO
-    # folders created by pyarrow write_parquet. We just write to
-    # paths with random UUIDs to work around this.
-    BUCKET = "my-bucket-anonymous"
-
-    # Create authenticated S3 client to set up the bucket.
-    s3_client = boto3.client(
-        "s3",
-        endpoint_url=minio_io_config.s3.endpoint_url,
-        aws_access_key_id=minio_io_config.s3.key_id,
-        aws_secret_access_key=minio_io_config.s3.access_key,
-        config=Config(signature_version="s3v4"),
-        region_name="us-east-1",
-    )
-
-    # Create bucket if it doesn't exist.
-    try:
-        s3_client.create_bucket(Bucket=BUCKET)
-    except s3_client.exceptions.BucketAlreadyOwnedByYou:
-        pass
-
-    # Set bucket policy for anonymous access.
-    bucket_policy = {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Principal": "*",
-                "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
-                "Resource": [f"arn:aws:s3:::{BUCKET}", f"arn:aws:s3:::{BUCKET}/*"],
-            }
-        ],
-    }
-    s3_client.put_bucket_policy(Bucket=BUCKET, Policy=json.dumps(bucket_policy))
-
     yield BUCKET
 
 
@@ -89,20 +46,22 @@ def test_writing_parquet(minio_io_config, bucket, protocol):
 
 @pytest.mark.integration()
 @pytest.mark.parametrize("protocol", ["s3://", "s3a://", "s3n://"])
-def test_writing_parquet_anonymous_mode(anonymous_minio_io_config, anonymous_bucket, protocol):
-    data = {
-        "foo": [1, 2, 3],
-        "bar": ["a", "b", "c"],
-    }
-    df = daft.from_pydict(data)
-    df = df.repartition(2)
-    results = df.write_parquet(
-        f"{protocol}{anonymous_bucket}/parquet-writes-{uuid.uuid4()}",
-        partition_cols=["bar"],
-        io_config=anonymous_minio_io_config,
-    )
-    results.collect()
-    assert len(results) == 3
+def test_writing_parquet_anonymous_mode(anonymous_minio_io_config, minio_io_config, protocol):
+    bucket_name = "my-public-bucket"
+    with minio_create_public_bucket(minio_io_config=minio_io_config, bucket_name=bucket_name):
+        data = {
+            "foo": [1, 2, 3],
+            "bar": ["a", "b", "c"],
+        }
+        df = daft.from_pydict(data)
+        df = df.repartition(2)
+        results = df.write_parquet(
+            f"{protocol}{bucket_name}/parquet-writes-{uuid.uuid4()}",
+            partition_cols=["bar"],
+            io_config=anonymous_minio_io_config,
+        )
+        results.collect()
+        assert len(results) == 3
 
 
 @pytest.mark.integration()

--- a/tests/integration/io/test_write_files_s3_minio.py
+++ b/tests/integration/io/test_write_files_s3_minio.py
@@ -36,7 +36,7 @@ def anonymous_bucket(minio_io_config):
     # paths with random UUIDs to work around this.
     BUCKET = "my-bucket-anonymous"
 
-    # Create authenticated S3 client to set up the bucket
+    # Create authenticated S3 client to set up the bucket.
     s3_client = boto3.client(
         "s3",
         endpoint_url=minio_io_config.s3.endpoint_url,
@@ -46,16 +46,13 @@ def anonymous_bucket(minio_io_config):
         region_name="us-east-1",
     )
 
-    # Create bucket if it doesn't exist
+    # Create bucket if it doesn't exist.
     try:
         s3_client.create_bucket(Bucket=BUCKET)
-        print(f"Created bucket: {BUCKET}")
-    except s3_client.exceptions.BucketAlreadyExists:
-        print(f"Bucket already exists: {BUCKET}")
-    except Exception as e:
-        print(f"Error creating bucket: {e}")
+    except s3_client.exceptions.BucketAlreadyOwnedByYou:
+        pass
 
-    # Set bucket policy for anonymous access
+    # Set bucket policy for anonymous access.
     bucket_policy = {
         "Version": "2012-10-17",
         "Statement": [
@@ -67,13 +64,7 @@ def anonymous_bucket(minio_io_config):
             }
         ],
     }
-
-    try:
-        s3_client.put_bucket_policy(Bucket=BUCKET, Policy=json.dumps(bucket_policy))
-        print(f"Successfully set public policy for bucket: {BUCKET}")
-    except Exception as e:
-        print(f"Warning: Could not set bucket policy: {e}")
-        print("Anonymous uploads may not work without the bucket policy")
+    s3_client.put_bucket_policy(Bucket=BUCKET, Policy=json.dumps(bucket_policy))
 
     yield BUCKET
 

--- a/tests/integration/io/test_write_files_s3_minio.py
+++ b/tests/integration/io/test_write_files_s3_minio.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
 import uuid
 
+import boto3
 import pytest
 import s3fs
+from botocore.config import Config
 
 import daft
 from tests.conftest import get_tests_daft_runner_name
@@ -26,6 +29,55 @@ def bucket(minio_io_config):
     yield BUCKET
 
 
+@pytest.fixture(scope="function")
+def anonymous_bucket(minio_io_config):
+    # For some reason s3fs is having trouble cleaning up MinIO
+    # folders created by pyarrow write_parquet. We just write to
+    # paths with random UUIDs to work around this.
+    BUCKET = "my-bucket-anonymous"
+
+    # Create authenticated S3 client to set up the bucket
+    s3_client = boto3.client(
+        "s3",
+        endpoint_url=minio_io_config.s3.endpoint_url,
+        aws_access_key_id=minio_io_config.s3.key_id,
+        aws_secret_access_key=minio_io_config.s3.access_key,
+        config=Config(signature_version="s3v4"),
+        region_name="us-east-1",
+    )
+
+    # Create bucket if it doesn't exist
+    try:
+        s3_client.create_bucket(Bucket=BUCKET)
+        print(f"Created bucket: {BUCKET}")
+    except s3_client.exceptions.BucketAlreadyExists:
+        print(f"Bucket already exists: {BUCKET}")
+    except Exception as e:
+        print(f"Error creating bucket: {e}")
+
+    # Set bucket policy for anonymous access
+    bucket_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+                "Resource": [f"arn:aws:s3:::{BUCKET}", f"arn:aws:s3:::{BUCKET}/*"],
+            }
+        ],
+    }
+
+    try:
+        s3_client.put_bucket_policy(Bucket=BUCKET, Policy=json.dumps(bucket_policy))
+        print(f"Successfully set public policy for bucket: {BUCKET}")
+    except Exception as e:
+        print(f"Warning: Could not set bucket policy: {e}")
+        print("Anonymous uploads may not work without the bucket policy")
+
+    yield BUCKET
+
+
 @pytest.mark.integration()
 @pytest.mark.parametrize("protocol", ["s3://", "s3a://", "s3n://"])
 def test_writing_parquet(minio_io_config, bucket, protocol):
@@ -39,6 +91,24 @@ def test_writing_parquet(minio_io_config, bucket, protocol):
         f"{protocol}{bucket}/parquet-writes-{uuid.uuid4()}",
         partition_cols=["bar"],
         io_config=minio_io_config,
+    )
+    results.collect()
+    assert len(results) == 3
+
+
+@pytest.mark.integration()
+@pytest.mark.parametrize("protocol", ["s3://", "s3a://", "s3n://"])
+def test_writing_parquet_anonymous_mode(anonymous_minio_io_config, anonymous_bucket, protocol):
+    data = {
+        "foo": [1, 2, 3],
+        "bar": ["a", "b", "c"],
+    }
+    df = daft.from_pydict(data)
+    df = df.repartition(2)
+    results = df.write_parquet(
+        f"{protocol}{anonymous_bucket}/parquet-writes-{uuid.uuid4()}",
+        partition_cols=["bar"],
+        io_config=anonymous_minio_io_config,
     )
     results.collect()
     assert len(results) == 3


### PR DESCRIPTION
## Changes Made

We previously assumed that uploads could not be anonymous, but have since learnt that there are setups that allow this.
