### PR TITLE
fix: Handle unserializable exceptions from data sinks

### DIFF
--- a/daft/io/sink.py
+++ b/daft/io/sink.py
@@ -94,7 +94,7 @@ class DataSink(ABC, Generic[WriteResultType]):
         try:
             yield from self.write(micropartitions)
         except Exception as e:
-            raise RuntimeError(f"Exception occurred while writing to {self.name()}: {type(e).__name__}: {e!s}")
+            raise RuntimeError(f"Exception occurred while writing to {self.name()}: {type(e).__name__}: {e!s}") from e
 
     @abstractmethod
     def finalize(self, write_results: list[WriteResult[WriteResultType]]) -> MicroPartition:

--- a/daft/io/sink.py
+++ b/daft/io/sink.py
@@ -79,6 +79,23 @@ class DataSink(ABC, Generic[WriteResultType]):
         """
         raise NotImplementedError
 
+    def safe_write(self, micropartitions: Iterator[MicroPartition]) -> Iterator[WriteResult[WriteResultType]]:
+        """This method wraps the abstract `write()` method with a try block to reraise potentially unserializable exceptions.
+
+        Args:
+            micropartitions (Iterator[MicroPartition]): An iterator of micropartitions to be written.
+
+        Returns:
+            Iterator[WriteResult[WriteResultType]]: An iterator of write results wrapped in a WriteOutput.
+
+        Raises:
+            Exception: Any exception that occurs during the write operation.
+        """
+        try:
+            yield from self.write(micropartitions)
+        except Exception as e:
+            raise RuntimeError(f"Exception occurred while writing to {self.name()}: {type(e).__name__}: {e!s}")
+
     @abstractmethod
     def finalize(self, write_results: list[WriteResult[WriteResultType]]) -> MicroPartition:
         """Finalizes the write process and returns a resulting micropartition.

--- a/src/daft-writers/src/sink.rs
+++ b/src/daft-writers/src/sink.rs
@@ -44,10 +44,10 @@ impl AsyncFileWriter for DataSinkWriter {
             let py_list = pyo3::types::PyList::new(py, &[py_micropartition])?;
             let py_iter = py_list.try_iter()?;
 
-            let result = self
-                .data_sink_info
-                .sink
-                .call_method(py, "write", (py_iter,), None)?;
+            let result =
+                self.data_sink_info
+                    .sink
+                    .call_method(py, "safe_write", (py_iter,), None)?;
             let result_list = py
                 .import(pyo3::intern!(py, "builtins"))?
                 .call_method1("list", (result,))?;

--- a/tests/io/test_sink.py
+++ b/tests/io/test_sink.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+import daft
+from daft.io.sink import DataSink, WriteResult
+from daft.recordbatch import MicroPartition
+
+
+class UnserializableException(Exception):
+    def __init__(self, message="Recovered the message in the exception"):
+        super().__init__(message)
+        self.unsafe_lambda = lambda x: x * 2
+
+
+class SampleSink(DataSink[None]):
+    def name(self) -> str:
+        return "sample_sink"
+
+    def schema(self) -> daft.Schema:
+        return daft.Schema.from_pydict({"id": daft.DataType.int64()})
+
+    def write(self, df: daft.DataFrame) -> Iterator[WriteResult[None]]:
+        raise UnserializableException()
+
+    def finalize(self, write_results: list[WriteResult[None]]) -> MicroPartition:
+        result_table = MicroPartition.from_pydict(
+            {
+                "write_responses": write_results,
+            }
+        )
+
+        return result_table
+
+
+def test_sink_raises_unserializable_exception():
+    df = daft.from_pydict({"id": [1, 2, 3]})
+    sink = SampleSink()
+    with pytest.raises(RuntimeError, match=".*UnserializableException: Recovered the message in the exception.*"):
+        df.write_sink(sink)


### PR DESCRIPTION
## Changes Made

If an exception is thrown in the data sink and is unserializable, we may get errors like
```
File ~/anaconda3/lib/python3.12/site-packages/daft/dataframe/dataframe.py:1304, in DataFrame.write_sink(self, sink)
   1302 builder = self._builder.write_datasink(sink.name(), sink)
   1303 write_df = DataFrame(builder)
-> 1304 write_df.collect()
   1306 results = write_df.to_pydict()
   1307 assert "write_results" in results
...
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ray/anaconda3/lib/python3.12/site-packages/ray/exceptions.py", line 54, in from_ray_exception
    raise RuntimeError(msg) from e
RuntimeError: Failed to unpickle serialized exception
```

Catching and reraising their string representations allow us to report the actual exception to the user.
