### PR TITLE
chore: Cleanup MicroPartition::concat_or_get 

### DIFF
--- a/src/daft-csv/src/local.rs
+++ b/src/daft-csv/src/local.rs
@@ -176,7 +176,7 @@ pub async fn read_csv_local(
             io_stats,
         )
         .await?;
-        return RecordBatch::empty(Some(Arc::new(schema.into())));
+        return Ok(RecordBatch::empty(Some(Arc::new(schema.into()))));
     }
     let concated_table = tables_concat(collected_tables)?;
 

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -362,7 +362,7 @@ async fn read_csv_single_into_table(
         .collect::<DaftResult<Vec<_>>>()?;
     // Handle empty table case.
     if collected_tables.is_empty() {
-        return RecordBatch::empty(Some(schema));
+        return Ok(RecordBatch::empty(Some(schema)));
     }
 
     // // TODO(Clark): Don't concatenate all chunks from a file into a single table, since MicroPartition is natively chunked.

--- a/src/daft-json/src/read.rs
+++ b/src/daft-json/src/read.rs
@@ -289,7 +289,7 @@ async fn read_json_single_into_table(
         .collect::<DaftResult<Vec<_>>>()?;
     // Handle empty table case.
     if collected_tables.is_empty() {
-        return RecordBatch::empty(Some(daft_schema));
+        return Ok(RecordBatch::empty(Some(daft_schema)));
     }
     // // TODO(Clark): Don't concatenate all chunks from a file into a single table, since MicroPartition is natively chunked.
     let concated_table = tables_concat(collected_tables)?;

--- a/src/daft-local-execution/src/sinks/hash_join_build.rs
+++ b/src/daft-local-execution/src/sinks/hash_join_build.rs
@@ -51,7 +51,7 @@ impl ProbeTableState {
             let probe_table_builder = probe_table_builder.as_mut().unwrap();
             let input_tables = input.get_tables()?;
             if input_tables.is_empty() {
-                tables.push(RecordBatch::empty(Some(input.schema()))?);
+                tables.push(RecordBatch::empty(Some(input.schema())));
                 return Ok(());
             }
             for table in input_tables.iter() {

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -116,7 +116,15 @@ impl BlockingSink for RepartitionSink {
                             let together = MicroPartition::concat(&data)?;
                             let concated =
                                 together.concat_or_get(IOStatsContext::new("get tables"))?;
-                            let mp = MicroPartition::new_loaded(schema, concated, None);
+                            let mp = MicroPartition::new_loaded(
+                                schema,
+                                Arc::new(if let Some(t) = concated {
+                                    vec![t]
+                                } else {
+                                    vec![]
+                                }),
+                                None,
+                            );
                             Ok(Arc::new(mp))
                         });
                         outputs.push(fut);

--- a/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
@@ -157,7 +157,7 @@ impl BlockingSink for WindowPartitionAndDynamicFrameSink {
                             let input_data = RecordBatch::concat(&all_partitions)?;
 
                             if input_data.is_empty() {
-                                return RecordBatch::empty(Some(params.original_schema.clone()));
+                                return Ok(RecordBatch::empty(Some(params.original_schema.clone())));
                             }
 
                             let partitionby_table = input_data.eval_expression_list(&params.partition_by)?;

--- a/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
@@ -146,7 +146,9 @@ impl BlockingSink for WindowPartitionAndOrderBySink {
                             let input_data = RecordBatch::concat(&all_partitions)?;
 
                             if input_data.is_empty() {
-                                return RecordBatch::empty(Some(params.original_schema.clone()));
+                                return Ok(RecordBatch::empty(Some(
+                                    params.original_schema.clone(),
+                                )));
                             }
 
                             let groupby_table =

--- a/src/daft-micropartition/src/ops/agg.rs
+++ b/src/daft-micropartition/src/ops/agg.rs
@@ -11,9 +11,9 @@ impl MicroPartition {
 
         let tables = self.concat_or_get(io_stats)?;
 
-        match tables.as_slice() {
-            [] => {
-                let empty_table = RecordBatch::empty(Some(self.schema.clone()))?;
+        match tables {
+            None => {
+                let empty_table = RecordBatch::empty(Some(self.schema.clone()));
                 let agged = empty_table.agg(to_agg, group_by)?;
                 Ok(Self::new_loaded(
                     agged.schema.clone(),
@@ -21,7 +21,7 @@ impl MicroPartition {
                     None,
                 ))
             }
-            [t] => {
+            Some(t) => {
                 let agged = t.agg(to_agg, group_by)?;
                 Ok(Self::new_loaded(
                     agged.schema.clone(),
@@ -29,7 +29,6 @@ impl MicroPartition {
                     None,
                 ))
             }
-            _ => unreachable!(),
         }
     }
 
@@ -43,16 +42,16 @@ impl MicroPartition {
         let io_stats = IOStatsContext::new("MicroPartition::dedup");
         let tables = self.concat_or_get(io_stats)?;
 
-        match tables.as_slice() {
-            [] => {
-                let empty_table = RecordBatch::empty(Some(self.schema.clone()))?;
+        match tables {
+            None => {
+                let empty_table = RecordBatch::empty(Some(self.schema.clone()));
                 Ok(Self::new_loaded(
                     empty_table.schema.clone(),
                     vec![empty_table].into(),
                     None,
                 ))
             }
-            [t] => {
+            Some(t) => {
                 let deduped = t.dedup(columns)?;
                 Ok(Self::new_loaded(
                     deduped.schema.clone(),
@@ -60,7 +59,6 @@ impl MicroPartition {
                     None,
                 ))
             }
-            _ => unreachable!(),
         }
     }
 }

--- a/src/daft-micropartition/src/ops/join.rs
+++ b/src/daft-micropartition/src/ops/join.rs
@@ -65,20 +65,19 @@ impl MicroPartition {
         }
 
         // TODO(Clark): Elide concatenations where possible by doing a chunk-aware local table join.
-        let lt = self.concat_or_get(io_stats.clone())?;
-        let rt = right.concat_or_get(io_stats)?;
+        let lt = self.concat_or_get_update(io_stats.clone())?;
+        let rt = right.concat_or_get_update(io_stats)?;
 
-        match (lt.as_slice(), rt.as_slice()) {
-            ([], _) | (_, []) => Ok(Self::empty(Some(join_schema))),
-            ([lt], [rt]) => {
-                let joined_table = table_join(lt, rt, left_on, right_on, how)?;
+        match (lt, rt) {
+            (None, _) | (_, None) => Ok(Self::empty(Some(join_schema))),
+            (Some(lt), Some(rt)) => {
+                let joined_table = table_join(&lt, &rt, left_on, right_on, how)?;
                 Ok(Self::new_loaded(
                     join_schema,
                     vec![joined_table].into(),
                     None,
                 ))
             }
-            _ => unreachable!(),
         }
     }
 

--- a/src/daft-micropartition/src/ops/partition.rs
+++ b/src/daft-micropartition/src/ops/partition.rs
@@ -114,12 +114,12 @@ impl MicroPartition {
 
         let tables = self.concat_or_get(io_stats)?;
 
-        if tables.is_empty() {
+        if tables.is_none() {
             let empty = Self::empty(Some(self.schema.clone()));
             let pkeys = empty.eval_expression_list(partition_keys)?;
             return Ok((vec![], pkeys));
         }
-        let table = tables.first().unwrap();
+        let table = tables.unwrap();
 
         let (tables, values) = table.partition_by_value(partition_keys)?;
 

--- a/src/daft-micropartition/src/ops/sort.rs
+++ b/src/daft-micropartition/src/ops/sort.rs
@@ -19,9 +19,9 @@ impl MicroPartition {
 
         let tables = self.concat_or_get(io_stats)?;
 
-        match tables.as_slice() {
-            [] => Ok(Self::empty(Some(self.schema.clone()))),
-            [single] => {
+        match tables {
+            None => Ok(Self::empty(Some(self.schema.clone()))),
+            Some(single) => {
                 let sorted = single.sort(sort_keys, descending, nulls_first)?;
                 Ok(Self::new_loaded(
                     self.schema.clone(),
@@ -29,7 +29,6 @@ impl MicroPartition {
                     self.statistics.clone(),
                 ))
             }
-            _ => unreachable!(),
         }
     }
 
@@ -43,13 +42,12 @@ impl MicroPartition {
 
         let tables = self.concat_or_get(io_stats)?;
 
-        match tables.as_slice() {
-            [] => {
-                let empty_table = RecordBatch::empty(Some(self.schema.clone()))?;
+        match tables {
+            None => {
+                let empty_table = RecordBatch::empty(Some(self.schema.clone()));
                 empty_table.argsort(sort_keys, descending, nulls_first)
             }
-            [single] => single.argsort(sort_keys, descending, nulls_first),
-            _ => unreachable!(),
+            Some(single) => single.argsort(sort_keys, descending, nulls_first),
         }
     }
 
@@ -64,9 +62,9 @@ impl MicroPartition {
 
         let tables = self.concat_or_get(io_stats)?;
 
-        match tables.as_slice() {
-            [] => Ok(Self::empty(Some(self.schema.clone()))),
-            [single] => {
+        match tables {
+            None => Ok(Self::empty(Some(self.schema.clone()))),
+            Some(single) => {
                 let sorted = single.top_n(sort_keys, descending, nulls_first, limit)?;
                 Ok(Self::new_loaded(
                     self.schema.clone(),
@@ -74,7 +72,6 @@ impl MicroPartition {
                     self.statistics.clone(),
                 ))
             }
-            _ => unreachable!(),
         }
     }
 }

--- a/src/daft-micropartition/src/ops/unpivot.rs
+++ b/src/daft-micropartition/src/ops/unpivot.rs
@@ -19,8 +19,8 @@ impl MicroPartition {
 
         let tables = self.concat_or_get(io_stats)?;
 
-        match tables.as_slice() {
-            [] => {
+        match tables {
+            None => {
                 if values.is_empty() {
                     return Err(DaftError::ValueError(
                         "Unpivot requires at least one value column".to_string(),
@@ -44,7 +44,7 @@ impl MicroPartition {
 
                 Ok(Self::empty(Some(Arc::new(Schema::new(fields)))))
             }
-            [t] => {
+            Some(t) => {
                 let unpivoted = t.unpivot(ids, values, variable_name, value_name)?;
                 Ok(Self::new_loaded(
                     unpivoted.schema.clone(),
@@ -52,7 +52,6 @@ impl MicroPartition {
                     None,
                 ))
             }
-            _ => unreachable!(),
         }
     }
 }

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -55,52 +55,48 @@ impl PyMicroPartition {
         let tables = py.allow_threads(|| {
             let io_stats =
                 IOStatsContext::new(format!("PyMicroPartition::get_column_by_name: {name}"));
-            self.inner.concat_or_get(io_stats)
+            self.inner.concat_or_get_update(io_stats)
         })?;
-        let columns = tables
-            .iter()
-            .map(|t| t.get_column(index))
-            .collect::<Vec<_>>();
-        match columns.as_slice() {
-            [] => Ok(Series::empty(name, &self.inner.schema.get_field(name)?.dtype).into()),
-            columns => Ok(Series::concat(columns)?.into()),
+        match tables {
+            None => Ok(Series::empty(name, &self.inner.schema.get_field(name)?.dtype).into()),
+            Some(t) => Ok(t.get_column(index).clone().into()),
         }
     }
 
     pub fn get_column(&self, idx: usize, py: Python) -> PyResult<PySeries> {
         let tables = py.allow_threads(|| {
             let io_stats = IOStatsContext::new(format!("PyMicroPartition::get_column: {idx}"));
-            self.inner.concat_or_get(io_stats)
+            self.inner.concat_or_get_update(io_stats)
         })?;
 
-        if tables.is_empty() {
-            let field = &self.inner.schema()[idx];
-            Ok(Series::empty(&field.name, &field.dtype).into())
-        } else {
-            let columns = tables.iter().map(|t| t.get_column(idx)).collect::<Vec<_>>();
-
-            Ok(Series::concat(&columns)?.into())
+        match tables {
+            None => {
+                let field = &self.inner.schema()[idx];
+                Ok(Series::empty(&field.name, &field.dtype).into())
+            }
+            Some(t) => Ok(t.get_column(idx).clone().into()),
         }
     }
 
     pub fn columns(&self, py: Python) -> PyResult<Vec<PySeries>> {
         let tables = py.allow_threads(|| {
             let io_stats = IOStatsContext::new("PyMicroPartition::columns");
-            self.inner.concat_or_get(io_stats)
+            self.inner.concat_or_get_update(io_stats)
         })?;
 
-        (0..self.inner.schema().len())
-            .map(|idx| {
-                if tables.is_empty() {
-                    let field = &self.inner.schema()[idx];
-                    Ok(Series::empty(&field.name, &field.dtype).into())
-                } else {
-                    let columns = tables.iter().map(|t| t.get_column(idx)).collect::<Vec<_>>();
-
-                    Ok(Series::concat(&columns)?.into())
-                }
-            })
-            .collect()
+        match tables {
+            None => {
+                let series = self
+                    .inner
+                    .schema()
+                    .fields()
+                    .iter()
+                    .map(|f| Series::empty(&f.name, &f.dtype).into())
+                    .collect::<Vec<_>>();
+                Ok(series)
+            }
+            Some(t) => Ok(t.columns().iter().map(|s| s.clone().into()).collect()),
+        }
     }
 
     pub fn get_record_batches(&self, py: Python) -> PyResult<Vec<PyRecordBatch>> {
@@ -196,14 +192,11 @@ impl PyMicroPartition {
     pub fn to_record_batch(&self, py: Python) -> PyResult<PyRecordBatch> {
         let concatted = py.allow_threads(|| {
             let io_stats = IOStatsContext::new("PyMicroPartition::to_record_batch");
-            self.inner.concat_or_get(io_stats)
+            self.inner.concat_or_get_update(io_stats)
         })?;
-        match &concatted.as_ref()[..] {
-            [] => PyRecordBatch::empty(Some(self.schema()?)),
-            [batch] => Ok(PyRecordBatch {
-                record_batch: batch.clone(),
-            }),
-            [..] => unreachable!("concat_or_get should return one or none"),
+        match concatted {
+            None => Ok(PyRecordBatch::empty(Some(self.schema()?))),
+            Some(record_batch) => Ok(PyRecordBatch { record_batch }),
         }
     }
 
@@ -241,7 +234,15 @@ impl PyMicroPartition {
     }
 
     pub fn take(&self, py: Python, idx: &PySeries) -> PyResult<Self> {
-        py.allow_threads(|| Ok(self.inner.take(&idx.series)?.into()))
+        py.allow_threads(|| {
+            let taken = self.inner.take(&idx.series)?;
+            let mp = MicroPartition::new_loaded(
+                taken.schema.clone(),
+                Arc::new(vec![taken]),
+                self.inner.statistics.clone(),
+            );
+            Ok(mp.into())
+        })
     }
 
     pub fn filter(&self, py: Python, exprs: Vec<PyExpr>) -> PyResult<Self> {

--- a/src/daft-recordbatch/src/ffi.rs
+++ b/src/daft-recordbatch/src/ffi.rs
@@ -15,7 +15,7 @@ pub fn record_batch_from_arrow(
     schema: SchemaRef,
 ) -> PyResult<RecordBatch> {
     if batches.is_empty() {
-        return Ok(RecordBatch::empty(Some(schema))?);
+        return Ok(RecordBatch::empty(Some(schema)));
     }
 
     let names = schema.field_names().collect::<Vec<_>>();

--- a/src/daft-recordbatch/src/growable/mod.rs
+++ b/src/daft-recordbatch/src/growable/mod.rs
@@ -71,7 +71,7 @@ impl<'a> GrowableRecordBatch<'a> {
     /// Builds an array from the [`Growable`]
     pub fn build(&mut self) -> DaftResult<RecordBatch> {
         if self.growables.is_empty() {
-            RecordBatch::empty(None)
+            Ok(RecordBatch::empty(None))
         } else {
             let columns = self
                 .growables

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -182,14 +182,14 @@ impl RecordBatch {
         }
     }
 
-    pub fn empty(schema: Option<SchemaRef>) -> DaftResult<Self> {
+    pub fn empty(schema: Option<SchemaRef>) -> Self {
         let schema = schema.unwrap_or_else(|| Schema::empty().into());
         let mut columns: Vec<Series> = Vec::with_capacity(schema.len());
         for field in schema.as_ref() {
             let series = Series::empty(&field.name, &field.dtype);
             columns.push(series);
         }
-        Ok(Self::new_unchecked(schema, columns, 0))
+        Self::new_unchecked(schema, columns, 0)
     }
 
     /// Create a RecordBatch from a set of columns.
@@ -443,7 +443,7 @@ impl RecordBatch {
         schema: Option<SchemaRef>,
     ) -> DaftResult<Self> {
         if tables.is_empty() {
-            return Self::empty(schema);
+            return Ok(Self::empty(schema));
         }
         Self::concat(tables)
     }

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -119,7 +119,7 @@ impl RecordBatch {
 
         // Take fast path short circuit if there is only 1 group
         let (groupkeys_table, grouped_col) = if groupvals_indices.is_empty() {
-            let empty_groupkeys_table = Self::empty(Some(groupby_table.schema))?;
+            let empty_groupkeys_table = Self::empty(Some(groupby_table.schema));
             let empty_udf_output_col = Series::empty(
                 evaluated_inputs
                     .first()

--- a/src/daft-recordbatch/src/python.rs
+++ b/src/daft-recordbatch/src/python.rs
@@ -486,7 +486,7 @@ impl PyRecordBatch {
     pub fn from_pyseries_list(pycolumns: Vec<PySeries>) -> PyResult<Self> {
         if pycolumns.is_empty() {
             return Ok(Self {
-                record_batch: RecordBatch::empty(None)?,
+                record_batch: RecordBatch::empty(None),
             });
         }
 
@@ -501,7 +501,7 @@ impl PyRecordBatch {
 
         if first == 0 {
             return Ok(Self {
-                record_batch: RecordBatch::empty(Some(Arc::new(Schema::new(fields)))).unwrap(),
+                record_batch: RecordBatch::empty(Some(Arc::new(Schema::new(fields)))),
             });
         }
 
@@ -519,12 +519,12 @@ impl PyRecordBatch {
 
     #[staticmethod]
     #[pyo3(signature = (schema=None))]
-    pub fn empty(schema: Option<PySchema>) -> PyResult<Self> {
-        Ok(RecordBatch::empty(match schema {
+    pub fn empty(schema: Option<PySchema>) -> Self {
+        RecordBatch::empty(match schema {
             Some(s) => Some(s.schema),
             None => None,
-        })?
-        .into())
+        })
+        .into()
     }
 
     pub fn to_file_infos(&self) -> PyResult<FileInfos> {

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -398,8 +398,7 @@ pub mod pylib {
             // TODO(Clark): Filter out scan tasks with pushed down filters + table stats?
 
             let pspec = PartitionSpec {
-                keys: partition_values
-                    .map_or_else(|| RecordBatch::empty(None).unwrap(), |p| p.record_batch),
+                keys: partition_values.map_or_else(|| RecordBatch::empty(None), |p| p.record_batch),
             };
             let statistics = stats
                 .map(|s| TableStatistics::from_stats_table(&s.record_batch))

--- a/src/daft-writers/src/partition.rs
+++ b/src/daft-writers/src/partition.rs
@@ -48,7 +48,7 @@ impl PartitionedWriter {
         data: Arc<MicroPartition>,
     ) -> DaftResult<(Vec<RecordBatch>, RecordBatch)> {
         let data = data.concat_or_get(IOStatsContext::new("MicroPartition::partition_by_value"))?;
-        let table = data.first().unwrap();
+        let table = data.unwrap();
 
         let (split_tables, partition_values) = table.partition_by_value(partition_cols)?;
         Ok((split_tables, partition_values))


### PR DESCRIPTION
## Changes Made

In the URL nodes PR (that I hope to open up next), I made some of these refactors. The ended up being pretty large and bloating that PR, so split it into here. I made 4 refactors / changes:
- (Potentially controversial) Refactored `MicroPartition::concat_or_get` to return a `Option<RecordBatch>` instead of a `Arc<Vec<MicroPartition>>`
- Added an explicit `MicroPartition::concat_or_get_update` to update the base MicroPartition in specific situations only
- Update `RecordBatch::empty` to never return an error
- Update `MicroPartition::take` to return a RecordBatch

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
