### PR TITLE
fix(runtime): Reduce thread name length for compute and I/O threadpools

### DIFF
--- a/src/common/runtime/src/lib.rs
+++ b/src/common/runtime/src/lib.rs
@@ -183,7 +183,7 @@ fn init_compute_runtime(num_worker_threads: usize) -> RuntimeRef {
             .thread_name_fn(move || {
                 static COMPUTE_THREAD_ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
                 let id = COMPUTE_THREAD_ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                format!("Compute-Thread-{}", id)
+                format!("DAFTCPU-{}", id)
             })
             .max_blocking_threads(1);
         Runtime::new(builder.build().unwrap(), PoolType::Compute)
@@ -205,7 +205,7 @@ fn init_io_runtime(multi_thread: bool) -> RuntimeRef {
             .thread_name_fn(move || {
                 static COMPUTE_THREAD_ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
                 let id = COMPUTE_THREAD_ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                format!("IO-Thread-{}", id)
+                format!("DAFTIO-{}", id)
             });
         Runtime::new(builder.build().unwrap(), PoolType::IO)
     })

--- a/src/common/runtime/src/lib.rs
+++ b/src/common/runtime/src/lib.rs
@@ -204,7 +204,7 @@ fn init_io_runtime(multi_thread: bool) -> RuntimeRef {
             .enable_all()
             .thread_name_fn(move || {
                 static IO_THREAD_ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                let id = COMPUTE_THREAD_ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+                let id = IO_THREAD_ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
                 format!("DAFTIO-{}", id)
             });
         Runtime::new(builder.build().unwrap(), PoolType::IO)

--- a/src/common/runtime/src/lib.rs
+++ b/src/common/runtime/src/lib.rs
@@ -203,7 +203,7 @@ fn init_io_runtime(multi_thread: bool) -> RuntimeRef {
             })
             .enable_all()
             .thread_name_fn(move || {
-                static COMPUTE_THREAD_ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+                static IO_THREAD_ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
                 let id = COMPUTE_THREAD_ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
                 format!("DAFTIO-{}", id)
             });


### PR DESCRIPTION
## Changes Made

POSIX thread names are limited to 16 characters. The thread names for CPU and IO threadpools appear truncated in dumps and stack traces.

Source: https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html