### PR TITLE
fix: import ParamSpec from typing_extensions only for python < 3.10

### DIFF
--- a/daft/udf/__init__.py
+++ b/daft/udf/__init__.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from daft.udf.row_wise import RowWiseUdf
 from typing import overload, Callable, TypeVar, TYPE_CHECKING
-from typing_extensions import ParamSpec
+import sys
+
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
+
 import functools
 from daft.udf.legacy import udf, UDF
 

--- a/daft/udf/row_wise.py
+++ b/daft/udf/row_wise.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, get_type_hints, overload
 
-from typing_extensions import ParamSpec
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
 
 from daft.datatype import DataType
 from daft.expressions import Expression


### PR DESCRIPTION
## Changes Made

We don't require typing-extensions for Python >= 3.10, causing the import to fail

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
