### PR TITLE
perf: Add parallel execution for Python UDFs with batched GIL acquisitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,6 +2572,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "pyo3",
+ "rayon",
  "rstest",
  "serde",
  "typetag",

--- a/src/daft-dsl/Cargo.toml
+++ b/src/daft-dsl/Cargo.toml
@@ -16,6 +16,7 @@ num-traits = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 serde = {workspace = true}
 typetag = {workspace = true}
+rayon.workspace = true
 
 [dev-dependencies]
 rstest = {workspace = true}

--- a/src/daft-dsl/src/python_udf.rs
+++ b/src/daft-dsl/src/python_udf.rs
@@ -111,12 +111,14 @@ impl RowWisePyFn {
     pub fn call(&self, args: Vec<Series>) -> DaftResult<Series> {
         use daft_core::python::{PyDataType, PySeries};
         use pyo3::prelude::*;
+        use rayon::{iter::ParallelIterator, slice::ParallelSlice};
 
         let num_rows = args
             .iter()
             .map(Series::len)
             .max()
             .expect("RowWisePyFn should have at least one argument");
+
         for a in &args {
             assert!(
                 a.len() == num_rows || a.len() == 1,
@@ -128,7 +130,7 @@ impl RowWisePyFn {
 
         let py_return_type = PyDataType::from(self.return_dtype.clone());
 
-        let call_func_with_evaluated_exprs = Python::with_gil(|py| {
+        let call_func_with_evaluated_exprs = pyo3::Python::with_gil(|py| {
             Ok::<_, PyErr>(
                 py.import(pyo3::intern!(py, "daft.udf.row_wise"))?
                     .getattr(pyo3::intern!(py, "call_func_with_evaluated_exprs"))?
@@ -136,36 +138,56 @@ impl RowWisePyFn {
             )
         })?;
 
-        let outputs = (0..num_rows)
-            .map(|i| {
-                let args_for_row = args
-                    .iter()
-                    .map(|a| {
-                        let idx = if a.len() == 1 { 0 } else { i };
+        // To minimize gil contention, while also allowing parallelism, we chunk up the rows
+        // for now,its just based on the max of (512) and (num rows / (number of CPUs * 4))
+        // This may need additional tuning based on usage patterns
+        //
+        // Instead of running sequentially and acquiring the gil for each row, we instead parallelize based off the chunk size.
+        // Each chunk then acquires the gil.
+        // Since we're processing data in chunks, there's less thrashing of the gil than if we were to use `.par_iter().map(|row| {Python::with_gil(..)})`
+        let n_cpus =
+            std::thread::available_parallelism().expect("Failed to get available parallelism");
 
-                        LiteralValue::get_from_series(a, idx)
-                    })
-                    .collect::<DaftResult<Vec<_>>>()?;
+        let chunk_size = (num_rows / (n_cpus.get() * 4)).clamp(1, 512);
 
+        let indices: Vec<usize> = (0..num_rows).collect();
+        let outputs = indices
+            .par_chunks(chunk_size)
+            .map(|chunk| {
                 Python::with_gil(|py| {
-                    let py_args = args_for_row
-                        .into_iter()
-                        .map(|a| a.into_pyobject(py))
-                        .collect::<PyResult<Vec<_>>>()?;
+                    chunk
+                        .iter()
+                        .map(|&i| {
+                            let args_for_row = args
+                                .iter()
+                                .map(|a| {
+                                    let idx = if a.len() == 1 { 0 } else { i };
+                                    LiteralValue::get_from_series(a, idx)
+                                })
+                                .collect::<DaftResult<Vec<_>>>()?;
 
-                    let result = call_func_with_evaluated_exprs.bind(py).call1((
-                        self.inner.clone().unwrap().as_ref(),
-                        py_return_type.clone(),
-                        self.original_args.clone().unwrap().as_ref(),
-                        py_args,
-                    ))?;
+                            let py_args = args_for_row
+                                .into_iter()
+                                .map(|a| a.into_pyobject(py))
+                                .collect::<PyResult<Vec<_>>>()?;
 
-                    let result_series = result.extract::<PySeries>()?.series;
+                            let result = call_func_with_evaluated_exprs.bind(py).call1((
+                                self.inner.clone().unwrap().as_ref(),
+                                py_return_type.clone(),
+                                self.original_args.clone().unwrap().as_ref(),
+                                py_args,
+                            ))?;
 
-                    Ok(result_series)
+                            let result_series = result.extract::<PySeries>()?.series;
+                            Ok(result_series)
+                        })
+                        .collect::<DaftResult<Vec<Series>>>()
                 })
             })
-            .collect::<DaftResult<Vec<_>>>()?;
+            .collect::<DaftResult<Vec<Vec<Series>>>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
 
         let outputs_ref = outputs.iter().collect::<Vec<_>>();
 


### PR DESCRIPTION
## Changes Made

Implement parallel execution using batched GIL acquisitions. Process chunks of rows within each thread to avoid GIL contention. Chunk size dynamically calculated as `num_rows / (n_cpus * 4)` with bounds `[1, 512]`.


This enables parallel execution of python udf while avoiding gil contention that would occur with naive per-row parallelization. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
