### PR TITLE
feat: Flotilla eager limit

### DIFF
--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -202,7 +202,6 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     logical_node_id,
                     &self.stage_config,
                     limit.limit as usize,
-                    limit.eager,
                     node.schema(),
                     self.curr_node.pop().unwrap(),
                 ))


### PR DESCRIPTION
## Changes Made

If limit is eager, i.e. `.show()`, run one local limit at a time. This is the same behavior as the ray runner.
Otherwise, do slow ramp up. Run one first, get the result, then determine how many concurrent local limits to run next. Rinse and repeat.

The nice thing about this is that it won't spam tasks and cancel a lot of them, which currently show up as failed tasks on the dashboard. Now we don't do any task cancellation because we await for all local limits to finish.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
