### PR TITLE
fix: ignore NotFound error of the non-first list during iter dir

### DIFF
--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -235,10 +235,23 @@ pub trait ObjectSource: Sync + Send {
 
             let mut continuation_token = lsr.continuation_token.clone();
             while continuation_token.is_some() {
-                let lsr = self.ls(&uri, posix, continuation_token.as_deref(), page_size, io_stats.clone()).await?;
-                continuation_token.clone_from(&lsr.continuation_token);
-                for fm in lsr.files {
-                    yield Ok(fm);
+                // Note: There might some race conditions here that the list response is empty
+                // even through the continuation token of previous response is not empty, so skip NotFound error here.
+                let lsr_result = self.ls(&uri, posix, continuation_token.as_deref(), page_size, io_stats.clone()).await;
+                match lsr_result {
+                    Ok(lsr) => {
+                        continuation_token.clone_from(&lsr.continuation_token);
+                        for fm in lsr.files {
+                            yield Ok(fm);
+                        }
+                    },
+                    Err(err) => {
+                        if matches!(err, super::Error::NotFound { .. }) {
+                            continuation_token = None;
+                        } else {
+                            yield Err(err);
+                        }
+                    }
                 }
             }
         };


### PR DESCRIPTION
## Changes Made

Ignore the NotFound error during iter dir if got empty response after the first list operation.

## Related Issues

<img width="1345" height="234" alt="image" src="https://github.com/user-attachments/assets/ae5a8b0d-885c-453d-b1c9-208c0023cc97" />
As the above picture show, glob the parent folder got a Not found error, but glob the sub folder succeed. 

The Not Found error was thrown during the second list request with next contine token, but got empty response, and then throw Not Found error, and then pop up the error to downstream, cause the glob process failed.

The reason why got empty response for the second list request with a continue token from prev response is that the listV2 of S3-like object store is trying to solve the timeout problem of list compare to listv1. If we are trying to list 1000 keys among abundant objects, especially if did much delete operations before listing which might lead to delete holes problem via delete tombstone, which will impact the list performance. The listV1 might be hanged in this situation and cause the http timeout, the listV2 will try to retrieve objects matched the request condition as much as possible within timeout, which means the response objects might less than required, the response contains the continue token indicate the client continue to list the remaining objects, but not ensure the existence of remaining objects, so the later list request might get empty response.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
