### PR TITLE
fix: azure storage resource url

### DIFF
--- a/src/daft-io/src/azure_blob.rs
+++ b/src/daft-io/src/azure_blob.rs
@@ -26,7 +26,7 @@ use crate::{
 
 const AZURE_DELIMITER: &str = "/";
 const DEFAULT_GLOB_FANOUT_LIMIT: usize = 1024;
-const AZURE_STORAGE_RESOURCE: &str = "https://storage.azure.com";
+const AZURE_STORAGE_RESOURCE: &str = "https://storage.azure.com/.default";
 const AZURE_STORE_SUFFIX: &str = ".dfs.core.windows.net";
 
 #[derive(Debug, Snafu)]


### PR DESCRIPTION
## Changes Made

Update the azure storage resource URL. With our upgrade of the Azure libraries, it no longer adds the `/.default` for us automatically. Confirmed to work by Piqi Chen.

## Related Issues

https://dist-data.slack.com/archives/C041NA2RBFD/p1754006398444219

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
