### PR TITLE
Fixing Link to Resource Requests from Managing Memory Usage Page

### DIFF
--- a/docs/optimization/memory.md
+++ b/docs/optimization/memory.md
@@ -59,7 +59,7 @@ There are some options available to you.
 
 3. Aggressively filter your data so that Daft can avoid reading data that it does not have to (e.g. `df.where(...)`)
 
-4. Request more memory for your UDFs (see [Resource Requests](../core_concepts.md#resource-requests)) if your UDFs are memory intensive (e.g. decompression of data, running large matrix computations etc)
+4. Request more memory for your UDFs (see [Resource Requests](../custom-code/udfs.md#resource-requests)) if your UDFs are memory intensive (e.g. decompression of data, running large matrix computations etc)
 
 5. Increase the number of partitions in your dataframe (hence making each partition smaller) using something like: `df.into_partitions(df.num_partitions() * 2)`
 


### PR DESCRIPTION
## Changes Made

On the "[Managing Memory Usage](https://docs.getdaft.io/en/stable/optimization/memory/)" page, in the "Dealing with out-of-memory (OOM) errors" section, the link to "[Resource Requests] (https://docs.getdaft.io/en/stable/core_concepts/#resource-requests)" is broken. Change it to point to "https://docs.getdaft.io/en/stable/custom-code/udfs/#resource-requests".

## Related Issues

None

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [X] Documentation builds and is formatted properly (tag @ccmao1130  for docs review)
