### PR TITLE
feat: async @daft.func

### DIFF
--- a/src/daft-dsl/src/python_udf.rs
+++ b/src/daft-dsl/src/python_udf.rs
@@ -137,7 +137,7 @@ impl RowWisePyFn {
         let py_return_type = PyDataType::from(self.return_dtype.clone());
 
         if is_async {
-            return Ok(pyo3::Python::with_gil(|py| {
+            Ok(pyo3::Python::with_gil(|py| {
                 let f = py
                     .import(pyo3::intern!(py, "daft.udf.row_wise"))?
                     .getattr(pyo3::intern!(py, "call_async_batch_with_evaluated_exprs"))?;
@@ -169,73 +169,72 @@ impl RowWisePyFn {
                 let result_series = res.extract::<PySeries>()?.series;
 
                 Ok::<_, PyErr>(result_series.rename(name))
-            })?);
-            // todo!()
-        }
+            })?)
+        } else {
+            let call_func_with_evaluated_exprs = pyo3::Python::with_gil(|py| {
+                Ok::<_, PyErr>(
+                    py.import(pyo3::intern!(py, "daft.udf.row_wise"))?
+                        .getattr(pyo3::intern!(py, "call_func_with_evaluated_exprs"))?
+                        .unbind(),
+                )
+            })?;
 
-        let call_func_with_evaluated_exprs = pyo3::Python::with_gil(|py| {
-            Ok::<_, PyErr>(
-                py.import(pyo3::intern!(py, "daft.udf.row_wise"))?
-                    .getattr(pyo3::intern!(py, "call_func_with_evaluated_exprs"))?
-                    .unbind(),
-            )
-        })?;
+            // To minimize gil contention, while also allowing parallelism, we chunk up the rows
+            // for now,its just based on the max of (512) and (num rows / (number of CPUs * 4))
+            // This may need additional tuning based on usage patterns
+            //
+            // Instead of running sequentially and acquiring the gil for each row, we instead parallelize based off the chunk size.
+            // Each chunk then acquires the gil.
+            // Since we're processing data in chunks, there's less thrashing of the gil than if we were to use `.par_iter().map(|row| {Python::with_gil(..)})`
+            let n_cpus =
+                std::thread::available_parallelism().expect("Failed to get available parallelism");
 
-        // To minimize gil contention, while also allowing parallelism, we chunk up the rows
-        // for now,its just based on the max of (512) and (num rows / (number of CPUs * 4))
-        // This may need additional tuning based on usage patterns
-        //
-        // Instead of running sequentially and acquiring the gil for each row, we instead parallelize based off the chunk size.
-        // Each chunk then acquires the gil.
-        // Since we're processing data in chunks, there's less thrashing of the gil than if we were to use `.par_iter().map(|row| {Python::with_gil(..)})`
-        let n_cpus =
-            std::thread::available_parallelism().expect("Failed to get available parallelism");
+            let chunk_size = (num_rows / (n_cpus.get() * 4)).clamp(1, 512);
 
-        let chunk_size = (num_rows / (n_cpus.get() * 4)).clamp(1, 512);
+            let indices: Vec<usize> = (0..num_rows).collect();
+            let outputs = indices
+                .par_chunks(chunk_size)
+                .map(|chunk| {
+                    Python::with_gil(|py| {
+                        chunk
+                            .iter()
+                            .map(|&i| {
+                                let args_for_row = args
+                                    .iter()
+                                    .map(|a| {
+                                        let idx = if a.len() == 1 { 0 } else { i };
+                                        LiteralValue::get_from_series(a, idx)
+                                    })
+                                    .collect::<DaftResult<Vec<_>>>()?;
 
-        let indices: Vec<usize> = (0..num_rows).collect();
-        let outputs = indices
-            .par_chunks(chunk_size)
-            .map(|chunk| {
-                Python::with_gil(|py| {
-                    chunk
-                        .iter()
-                        .map(|&i| {
-                            let args_for_row = args
-                                .iter()
-                                .map(|a| {
-                                    let idx = if a.len() == 1 { 0 } else { i };
-                                    LiteralValue::get_from_series(a, idx)
-                                })
-                                .collect::<DaftResult<Vec<_>>>()?;
+                                let py_args = args_for_row
+                                    .into_iter()
+                                    .map(|a| a.into_pyobject(py))
+                                    .collect::<PyResult<Vec<_>>>()?;
 
-                            let py_args = args_for_row
-                                .into_iter()
-                                .map(|a| a.into_pyobject(py))
-                                .collect::<PyResult<Vec<_>>>()?;
+                                let result = call_func_with_evaluated_exprs.bind(py).call1((
+                                    self.inner.clone().unwrap().as_ref(),
+                                    py_return_type.clone(),
+                                    self.original_args.clone().unwrap().as_ref(),
+                                    py_args,
+                                ))?;
 
-                            let result = call_func_with_evaluated_exprs.bind(py).call1((
-                                self.inner.clone().unwrap().as_ref(),
-                                py_return_type.clone(),
-                                self.original_args.clone().unwrap().as_ref(),
-                                py_args,
-                            ))?;
-
-                            let result_series = result.extract::<PySeries>()?.series;
-                            Ok(result_series)
-                        })
-                        .collect::<DaftResult<Vec<Series>>>()
+                                let result_series = result.extract::<PySeries>()?.series;
+                                Ok(result_series)
+                            })
+                            .collect::<DaftResult<Vec<Series>>>()
+                    })
                 })
-            })
-            .collect::<DaftResult<Vec<Vec<Series>>>>()?
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
+                .collect::<DaftResult<Vec<Vec<Series>>>>()?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
 
-        let outputs_ref = outputs.iter().collect::<Vec<_>>();
+            let outputs_ref = outputs.iter().collect::<Vec<_>>();
 
-        let name = args[0].name();
+            let name = args[0].name();
 
-        Ok(Series::concat(&outputs_ref)?.rename(name))
+            Ok(Series::concat(&outputs_ref)?.rename(name))
+        }
     }
 }

--- a/tests/udf/test_row_wise_udf.py
+++ b/tests/udf/test_row_wise_udf.py
@@ -107,3 +107,16 @@ def test_row_wise_udf_kwargs():
 
     dynamic_repeat_df = df.select(my_stringify_and_sum_repeat(col("x"), col("y"), repeat=col("x")))
     assert dynamic_repeat_df.to_pydict() == {"x": ["5", "77", "999"]}
+
+
+def test_row_wise_async_udf():
+    import asyncio
+
+    @daft.func
+    async def my_async_stringify_and_sum(a: int, b: int) -> str:
+        await asyncio.sleep(0.1)
+        return f"{a + b}"
+
+    df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
+    async_df = df.select(my_async_stringify_and_sum(col("x"), col("y")))
+    assert async_df.to_pydict() == {"x": ["5", "7", "9"]}


### PR DESCRIPTION
## Changes Made

adds basic support & tests for async `@daft.func`


```py
@daft.func
async def my_udf(text)->str:
    return text.upper()

df = daft.from_pydict({
    "text":["hello", "world"]
})

print(df.select(my_udf(df["text"])).collect())
```


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
