### PR TITLE
chore: add warning on repartition in native runner

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2636,6 +2636,10 @@ class DataFrame:
             3
 
         """
+        if get_context().get_or_create_runner().name == "native":
+            warnings.warn(
+                "DataFrame.repartition not supported on the NativeRunner. This will be a no-op. Please use the RayRunner instead if you need to repartition."
+            )
         if len(partition_by) == 0:
             warnings.warn(
                 "No columns specified for repartition, so doing a random shuffle. If you do not require rebalancing of "
@@ -2667,6 +2671,11 @@ class DataFrame:
             >>> df_with_5_partitions.num_partitions()
             5
         """
+        if get_context().get_or_create_runner().name == "native":
+            warnings.warn(
+                "DataFrame.into_partitions not supported on the NativeRunner. This will be a no-op. Please use the RayRunner instead if you need to repartition."
+            )
+
         builder = self._builder.into_partitions(num)
         return DataFrame(builder)
 

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2638,7 +2638,7 @@ class DataFrame:
         """
         if get_context().get_or_create_runner().name == "native":
             warnings.warn(
-                "DataFrame.repartition not supported on the NativeRunner. This will be a no-op. Please use the RayRunner instead if you need to repartition."
+                "DataFrame.repartition not supported on the NativeRunner. This will be a no-op. Please use the RayRunner via `daft.context.set_runner_ray()` instead if you need to repartition."
             )
         if len(partition_by) == 0:
             warnings.warn(
@@ -2673,7 +2673,7 @@ class DataFrame:
         """
         if get_context().get_or_create_runner().name == "native":
             warnings.warn(
-                "DataFrame.into_partitions not supported on the NativeRunner. This will be a no-op. Please use the RayRunner instead if you need to repartition."
+                "DataFrame.into_partitions not supported on the NativeRunner. This will be a no-op. Please use the RayRunner via `daft.context.set_runner_ray()` instead if you need to repartition."
             )
 
         builder = self._builder.into_partitions(num)


### PR DESCRIPTION
## Changes Made

Adds warnings to `into_partitions` and `repartition`.

## Related Issues

Closes #3652

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
