### PR TITLE
perf: batch up series instead of always series of 1 in rowwise udf

### DIFF
--- a/daft/udf/row_wise.py
+++ b/daft/udf/row_wise.py
@@ -10,10 +10,9 @@ else:
 
 from daft.datatype import DataType
 from daft.expressions import Expression
-from daft.series import Series
 
 if TYPE_CHECKING:
-    from daft.daft import PyDataType, PySeries
+    from daft.daft import PySeries
 
 
 P = ParamSpec("P")
@@ -63,7 +62,6 @@ class RowWiseUdf(Generic[P, T]):
 
 def call_func_with_evaluated_exprs(
     fn: Callable[..., Any],
-    return_dtype: PyDataType,
     original_args: tuple[tuple[Any, ...], dict[str, Any]],
     evaluted_args: list[Any],
 ) -> PySeries:
@@ -73,5 +71,4 @@ def call_func_with_evaluated_exprs(
     new_kwargs = {key: (evaluted_args.pop(0) if isinstance(arg, Expression) else arg) for key, arg in kwargs.items()}
 
     output = fn(*new_args, **new_kwargs)
-    dtype = DataType._from_pydatatype(return_dtype)
-    return Series.from_pylist([output], dtype=dtype)._series
+    return output

--- a/src/daft-core/src/python/series.rs
+++ b/src/daft-core/src/python/series.rs
@@ -31,6 +31,23 @@ use crate::{
 pub struct PySeries {
     pub series: series::Series,
 }
+impl PySeries {
+    pub fn from_pylist_impl(
+        name: &str,
+        vec_pyobj: Vec<Py<PyAny>>,
+        dtype: DataType,
+    ) -> PyResult<Self> {
+        let vec_pyobj_arced = vec_pyobj.into_iter().map(Arc::new).collect();
+        let arrow_array: Box<dyn arrow2::array::Array> =
+            Box::new(PseudoArrowArray::from_pyobj_vec(vec_pyobj_arced));
+
+        let field = Field::new(name, DataType::Python);
+        let data_array = DataArray::<PythonType>::new(field.into(), arrow_array)?;
+        let series = data_array.cast(&dtype)?;
+
+        Ok(series.into())
+    }
+}
 
 #[pymethods]
 impl PySeries {
@@ -60,15 +77,7 @@ impl PySeries {
     pub fn from_pylist(name: &str, pylist: Bound<PyAny>, dtype: PyDataType) -> PyResult<Self> {
         let vec_pyobj: Vec<PyObject> = pylist.extract()?;
 
-        let vec_pyobj_arced = vec_pyobj.into_iter().map(Arc::new).collect();
-        let arrow_array: Box<dyn arrow2::array::Array> =
-            Box::new(PseudoArrowArray::from_pyobj_vec(vec_pyobj_arced));
-
-        let field = Field::new(name, DataType::Python);
-        let data_array = DataArray::<PythonType>::new(field.into(), arrow_array)?;
-        let series = data_array.cast(&dtype.into())?;
-
-        Ok(series.into())
+        Self::from_pylist_impl(name, vec_pyobj, dtype.dtype)
     }
 
     // This is for PythonArrays only,


### PR DESCRIPTION
## Changes Made

previously, `call_func_with_evaluated_exprs` was returning a PySeries with a single value. This was problematic because we were doing `Series::concat` on `N` series with a single value, and Series::concat is quite expensive. 

Instead, I refactored it so that the `call_func_with_evaluated_exprs` returns the python value, then we use the same `PySeries::from_pylist` method to create a series of many values. We're still performing a `Series::concat` at the end, but of much less values. 

here's a small test I ran that tokenizes the yelp_review_full dataset. 


```py
# %%
import daft
import time
import pyarrow as pa
from transformers import AutoTokenizer
from datasets import load_dataset

tokenizer = AutoTokenizer.from_pretrained("sentence-transformers/all-MiniLM-L6-v2")

@daft.func
def tokenize(s: str) -> list[int]:
    return tokenizer.encode(s)

# using datasets api because of hf caching bug
ds = load_dataset("Yelp/yelp_review_full")
tbl = pa.Table.from_batches(ds.data['train']._batches)
df = daft.from_arrow(tbl).collect()

start = time.perf_counter()

df = df.select(tokenize(df["text"])).collect()

end = time.perf_counter()
print(f"Execution time: {end - start:.4f} seconds")
```

### Results
```
# HEAD Execution time: 35.9118 seconds
# HEAD Execution time: 35.6711 seconds
# HEAD Execution time: 36.0107 seconds

# main Execution time: 49.6138 seconds
# main Execution time: 48.4861 seconds
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
