### PR TITLE
feat: adds column set visitor and use in pushdowns

### DIFF
--- a/daft/expressions/visitor.py
+++ b/daft/expressions/visitor.py
@@ -321,3 +321,22 @@ class _PyArrowExpressionVisitor(PredicateVisitor[pc.Expression]):
         pc_strings = self.visit(input)
         pc_pattern = prefix.as_py()  # must be literal
         return pc.starts_with(pc_strings, pc_pattern)
+
+
+class _ColumnVisitor(ExpressionVisitor[set[str]]):
+    """Visitor which returns a set of columns in the expression."""
+
+    def visit_col(self, name: str) -> set[str]:
+        return {name}
+
+    def visit_lit(self, value: Any) -> set[str]:
+        return set()
+
+    def visit_alias(self, expr: Expression, alias: str) -> set[str]:
+        return self.visit(expr)
+
+    def visit_cast(self, expr: Expression, dtype: DataType) -> set[str]:
+        return self.visit(expr)
+
+    def visit_function(self, name: str, args: list[Expression]) -> set[str]:
+        return set().union(*(self.visit(arg) for arg in args))

--- a/daft/io/pushdowns.py
+++ b/daft/io/pushdowns.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from daft.expressions import Expression
+from daft.expressions.visitor import _ColumnVisitor
 
 if TYPE_CHECKING:
     from daft.daft import PyExpr, PyPushdowns
@@ -37,17 +38,13 @@ class Pushdowns:
             limit=pushdowns.limit,
         )
 
+    def filter_required_column_names(self) -> set[str]:
+        """Returns a set of field names that are required by the filter predicate."""
+        return set() if self.filters is None else _ColumnVisitor().visit(self.filters)
+
     @classmethod
     def empty(cls) -> Pushdowns:
         return cls()
-
-    # TODO(Check if implementation is needed)
-    def merge(self, other: Pushdowns) -> Pushdowns:
-        return Pushdowns(
-            filters=self.filters or other.filters,
-            limit=min(self.limit, other.limit) if self.limit and other.limit else None,
-            columns=self.columns or other.columns,
-        )
 
 
 class SupportsPushdownFilters(abc.ABC):


### PR DESCRIPTION
## Changes Made

* Adds a visitor which collects a column set
* Uses this in Pushdowns to return the filter column set.

## Related Issues

I considered saving the list from the rust pushdowns object, but a python visitor is more generic and flexible because it can be used outside the context of pushdowns to find all the columns in an arbitrary expression. This also uses a set for unique column names. If/when daft has a notion of bound columns, then the hash will be important for distinctness because for now we rely on unique names within an expression tree.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
