### PR TITLE
fix: Batch RuntimeSubscriber updates for all nodes 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1847,7 +1847,7 @@ dependencies = [
 name = "common-metrics"
 version = "0.3.0-dev0"
 dependencies = [
- "indicatif",
+ "indicatif 0.17.11",
  "serde",
  "smallvec",
 ]
@@ -1964,6 +1964,19 @@ dependencies = [
  "once_cell",
  "unicode-width 0.2.1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.1",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2886,7 +2899,7 @@ dependencies = [
  "daft-writers",
  "futures",
  "indexmap 2.9.0",
- "indicatif",
+ "indicatif 0.18.0",
  "itertools 0.14.0",
  "kanal",
  "log",
@@ -4687,10 +4700,23 @@ version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
- "console",
+ "console 0.15.11",
  "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.1",
+ "web-time",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console 0.16.0",
+ "portable-atomic",
+ "unicode-width 0.2.1",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -8390,6 +8416,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8886,6 +8918,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ educe = "0.6.0"
 futures = "0.3.30"
 html-escape = "0.2.13"
 indexmap = "2.9.0"
-indicatif = "0.17"
+indicatif = "0.18"
 itertools = "0.14"
 jaq-core = "2.2.0"
 jaq-json = {version = "1.1.2", features = ["serde_json"]}

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -350,7 +350,7 @@ impl NativeExecutor {
             // Finish the stats manager
             let stats_manager = Arc::into_inner(stats_manager)
                 .expect("There should only be 1 stats manager instance by the end");
-            stats_manager.finish();
+            stats_manager.finish(&runtime);
 
             if enable_explain_analyze {
                 let curr_ms = SystemTime::now()

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -174,6 +174,10 @@ impl RuntimeStatsManager {
                     }
 
                     _ = interval.tick() => {
+                        if active_nodes.is_empty() {
+                            continue;
+                        }
+
                         for node_id in &active_nodes {
                             let (node_info, runtime_stats) = &node_stats[*node_id];
                             let event = runtime_stats.snapshot();
@@ -383,7 +387,9 @@ mod tests {
             self.state
                 .total_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            *self.state.event.lock().unwrap() = Some(events[0].1.clone());
+            for (_, snapshot) in events {
+                *self.state.event.lock().unwrap() = Some(snapshot.clone());
+            }
             Ok(())
         }
 

--- a/src/daft-local-execution/src/runtime_stats/subscribers.rs
+++ b/src/daft-local-execution/src/runtime_stats/subscribers.rs
@@ -18,7 +18,7 @@ pub trait RuntimeStatsSubscriber: Send + Sync + std::fmt::Debug {
     /// Called when a node finishes.
     fn finalize_node(&self, node_info: &NodeInfo) -> DaftResult<()>;
     /// Called each time the manager ticks and when a node finishes.
-    fn handle_event(&self, event: &StatSnapshotSend, node_info: &NodeInfo) -> DaftResult<()>;
+    fn handle_event(&self, events: &[(&NodeInfo, StatSnapshotSend)]) -> DaftResult<()>;
     /// Called when the entire pipeline finishes.
     fn finish(self: Box<Self>) -> DaftResult<()>;
 }

--- a/src/daft-local-execution/src/runtime_stats/subscribers/dashboard.rs
+++ b/src/daft-local-execution/src/runtime_stats/subscribers/dashboard.rs
@@ -145,10 +145,12 @@ impl RuntimeStatsSubscriber for DashboardSubscriber {
         Ok(())
     }
 
-    fn handle_event(&self, event: &StatSnapshotSend, node_info: &NodeInfo) -> DaftResult<()> {
-        self.event_tx
-            .send((event.clone(), node_info.clone()))
-            .map_err(|e| DaftError::MiscTransient(Box::new(e)))?;
+    fn handle_event(&self, events: &[(&NodeInfo, StatSnapshotSend)]) -> DaftResult<()> {
+        for (node_info, event) in events {
+            self.event_tx
+                .send((event.clone(), (*node_info).clone()))
+                .map_err(|e| DaftError::MiscTransient(Box::new(e)))?;
+        }
         Ok(())
     }
 

--- a/src/daft-local-execution/src/runtime_stats/subscribers/debug.rs
+++ b/src/daft-local-execution/src/runtime_stats/subscribers/debug.rs
@@ -22,8 +22,10 @@ impl RuntimeStatsSubscriber for DebugSubscriber {
         Ok(())
     }
 
-    fn handle_event(&self, event: &StatSnapshotSend, node_info: &NodeInfo) -> DaftResult<()> {
-        println!("{:?} {:#?}", node_info, event);
+    fn handle_event(&self, events: &[(&NodeInfo, StatSnapshotSend)]) -> DaftResult<()> {
+        for (node_info, event) in events {
+            println!("{:?} {:#?}", node_info, event);
+        }
         Ok(())
     }
 

--- a/src/daft-local-execution/src/runtime_stats/subscribers/opentelemetry.rs
+++ b/src/daft-local-execution/src/runtime_stats/subscribers/opentelemetry.rs
@@ -44,21 +44,23 @@ impl RuntimeStatsSubscriber for OpenTelemetrySubscriber {
         Ok(())
     }
 
-    fn handle_event(&self, event: &StatSnapshotSend, node_info: &NodeInfo) -> DaftResult<()> {
-        let mut attributes = vec![
-            KeyValue::new("name", node_info.name.to_string()),
-            KeyValue::new("id", node_info.id.to_string()),
-        ];
-        for (k, v) in &node_info.context {
-            attributes.push(KeyValue::new(k.clone(), v.clone()));
-        }
+    fn handle_event(&self, events: &[(&NodeInfo, StatSnapshotSend)]) -> DaftResult<()> {
+        for (node_info, event) in events {
+            let mut attributes = vec![
+                KeyValue::new("name", node_info.name.to_string()),
+                KeyValue::new("id", node_info.id.to_string()),
+            ];
+            for (k, v) in &node_info.context {
+                attributes.push(KeyValue::new(k.clone(), v.clone()));
+            }
 
-        for (k, v) in event.iter() {
-            match (k, v) {
-                (ROWS_RECEIVED_KEY, Stat::Count(v)) => self.rows_received.add(*v, &attributes),
-                (ROWS_EMITTED_KEY, Stat::Count(v)) => self.rows_emitted.add(*v, &attributes),
-                (CPU_US_KEY, Stat::Count(v)) => self.cpu_us.add(*v, &attributes),
-                _ => {}
+            for (k, v) in event.iter() {
+                match (k, v) {
+                    (ROWS_RECEIVED_KEY, Stat::Count(v)) => self.rows_received.add(*v, &attributes),
+                    (ROWS_EMITTED_KEY, Stat::Count(v)) => self.rows_emitted.add(*v, &attributes),
+                    (CPU_US_KEY, Stat::Count(v)) => self.cpu_us.add(*v, &attributes),
+                    _ => {}
+                }
             }
         }
         Ok(())

--- a/src/daft-local-execution/src/sources/source.rs
+++ b/src/daft-local-execution/src/sources/source.rs
@@ -167,6 +167,7 @@ impl PipelineNode for SourceNode {
                     has_data = true;
                     stats_manager.activate_node(node_id);
                     if counting_sender.send(part?).await.is_err() {
+                        stats_manager.finalize_node(node_id);
                         return Ok(());
                     }
                 }


### PR DESCRIPTION
## Changes Made

Rather than sending updates per active node to runtime subscribers, we should just send them all at once and let the subscriber decide what to do (whether to iterate or not). This is useful for the Flotilla subscriber because it allows us to send one packet rather than internal batching.

Also includes changes from the logging PR since they should be fixed ASAP and can help reduce that PR to narrow the segfault.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
