### PR TITLE
ci: add 3.11 to matrix and always include typing_extensions

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
         daft-runner: [ray, native]
         pyarrow-version: [8.0.0, 19.0.1]
         flotilla: [1, 0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
   "pyarrow >= 8.0.0",
   "fsspec",
   "tqdm",
-  "typing-extensions >= 4.0.0; python_version < '3.10'"
+  "typing-extensions >= 4.0.0"
 ]
 description = "Distributed Dataframes for Multimodal Data"
 dynamic = ["version"]


### PR DESCRIPTION
## Changes Made

* Adds 3.11 to testing matrix
* Always include typing_extensions to avoid missing imports

Not including typing_extensions in later python versions has caused us to cut two bad releases. I don't believe there's a reason not to include typing_extensions, so this should eliminate the possibility of missing imports again.

## Related Issues

* #4878 
* Closes #4913 

## Checklist

- [n/a] Documented in API Docs (if applicable)
- [n/a] Documented in User Guide (if applicable)
- [n/a] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [n/a] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
