### PR TITLE
fix: use associate type for swordfish into_batches operator state

### DIFF
--- a/src/daft-local-execution/src/intermediate_ops/into_batches.rs
+++ b/src/daft-local-execution/src/intermediate_ops/into_batches.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
+use common_error::DaftResult;
 use daft_io::IOStatsContext;
 use daft_micropartition::MicroPartition;
 use tracing::Span;
 
 use super::intermediate_op::{
-    IntermediateOpExecuteResult, IntermediateOpState, IntermediateOperator,
-    IntermediateOperatorResult,
+    IntermediateOpExecuteResult, IntermediateOperator, IntermediateOperatorResult,
 };
 use crate::{ops::NodeType, pipeline::NodeName, ExecutionRuntimeContext, ExecutionTaskSpawner};
 
@@ -21,12 +21,14 @@ impl IntoBatchesOperator {
 }
 
 impl IntermediateOperator for IntoBatchesOperator {
+    type State = ();
+
     fn execute(
         &self,
         input: Arc<MicroPartition>,
-        state: Box<dyn IntermediateOpState>,
+        state: Self::State,
         task_spawner: &ExecutionTaskSpawner,
-    ) -> IntermediateOpExecuteResult {
+    ) -> IntermediateOpExecuteResult<Self> {
         task_spawner
             .spawn(
                 async move {
@@ -55,5 +57,8 @@ impl IntermediateOperator for IntoBatchesOperator {
     }
     fn morsel_size_range(&self, _runtime_handle: &ExecutionRuntimeContext) -> (usize, usize) {
         (self.batch_size, self.batch_size)
+    }
+    fn make_state(&self) -> DaftResult<Self::State> {
+        Ok(())
     }
 }


### PR DESCRIPTION
## Changes Made

Fixes issue here https://github.com/Eventual-Inc/Daft/actions/runs/16889682307/job/47846055281

merge conflict between https://github.com/Eventual-Inc/Daft/pull/4935 and https://github.com/Eventual-Inc/Daft/pull/4921

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
