### PR TITLE
feat: Casting from Python into struct or list types

### DIFF
--- a/daft/udf/row_wise.py
+++ b/daft/udf/row_wise.py
@@ -104,7 +104,8 @@ def __call_func(
     fn: Callable[..., Any],
     original_args: tuple[tuple[Any, ...], dict[str, Any]],
     evaluated_args: list[Any],
-) -> PySeries:
+) -> list[Any]:
+    """Called from Rust to evaluate a Python scalar UDF. Returns a list of Python objects."""
     args, kwargs = original_args
 
     new_args = [evaluated_args.pop(0) if isinstance(arg, Expression) else arg for arg in args]

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -697,6 +697,11 @@ type ArrayPayload<Tgt> = (
     Option<Vec<i64>>,
 );
 
+/// Extract a PythonArray of elements list[T] into set of vectors:
+/// 1) A values Vec<T>
+/// 2) An optional offsets Vec<i64>
+/// 3) An optional shapes Vec<u64>
+/// 4) An optional shape_offsets Vec<i64>
 #[cfg(feature = "python")]
 fn extract_python_to_vec<
     Tgt: numpy::Element + NumCast + ToPrimitive + arrow2::types::NativeType,
@@ -1166,36 +1171,48 @@ impl PythonArray {
                 pycast_then_arrowcast!(self, dt, "float")
             }
             DataType::List(child_dtype) => {
-                if !child_dtype.is_numeric() {
-                    return Err(DaftError::ValueError(format!(
+                if child_dtype.is_numeric() {
+                    with_match_numeric_daft_types!(child_dtype.as_ref(), |$T| {
+                        type Tgt = <$T as DaftNumericType>::Native;
+                        pyo3::Python::with_gil(|py| {
+                            let result = extract_python_like_to_list::<Tgt>(py, self, child_dtype.as_ref())?;
+                            Ok(result.into_series())
+                        })
+                    })
+                } else if child_dtype.is_physical() {
+                    // TODO: This is not fully operational since we can't guarantee that our Series.from_pylist
+                    // implementation (using PyArrow) will cast the values arrays correctly.
+                    pycast_then_arrowcast!(self, dtype, "list")
+                } else {
+                    Err(DaftError::ValueError(format!(
                         "We can only convert numeric python types to List, got {}",
                         child_dtype
-                    )));
+                    )))
                 }
-                with_match_numeric_daft_types!(child_dtype.as_ref(), |$T| {
-                    type Tgt = <$T as DaftNumericType>::Native;
-                    pyo3::Python::with_gil(|py| {
-                        let result = extract_python_like_to_list::<Tgt>(py, self, child_dtype.as_ref())?;
-                        Ok(result.into_series())
-                    })
-                })
             }
             DataType::FixedSizeList(child_dtype, size) => {
-                if !child_dtype.is_numeric() {
-                    return Err(DaftError::ValueError(format!(
+                if child_dtype.is_numeric() {
+                    with_match_numeric_daft_types!(child_dtype.as_ref(), |$T| {
+                        type Tgt = <$T as DaftNumericType>::Native;
+                        pyo3::Python::with_gil(|py| {
+                            let result = extract_python_like_to_fixed_size_list::<Tgt>(py, self, child_dtype.as_ref(), *size)?;
+                            Ok(result.into_series())
+                        })
+                    })
+                } else if child_dtype.is_physical() {
+                    pycast_then_arrowcast!(self, dtype, "list")
+                } else {
+                    Err(DaftError::ValueError(format!(
                         "We can only convert numeric python types to FixedSizeList, got {}",
                         child_dtype,
-                    )));
+                    )))
                 }
-                with_match_numeric_daft_types!(child_dtype.as_ref(), |$T| {
-                    type Tgt = <$T as DaftNumericType>::Native;
-                    pyo3::Python::with_gil(|py| {
-                        let result = extract_python_like_to_fixed_size_list::<Tgt>(py, self, child_dtype.as_ref(), *size)?;
-                        Ok(result.into_series())
-                    })
-                })
             }
-            DataType::Struct(_) => unimplemented!(),
+            DataType::Struct(_) => {
+                // TODO: This is not fully operational since we can't guarantee that our Series.from_pylist
+                // implementation (using PyArrow) will cast the struct field arrays correctly.
+                pycast_then_arrowcast!(self, dtype, "dict")
+            }
             DataType::Embedding(..) => {
                 let result = self.cast(&dtype.to_physical())?;
                 let embedding_array = EmbeddingArray::new(

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -1387,3 +1387,23 @@ def test_cast_list_list_to_list_tensor():
     cast_to = DataType.list(DataType.tensor(DataType.int64(), shape=(4,)))
     s = s.cast(cast_to)
     assert s.datatype() == cast_to
+
+
+def test_cast_python_to_struct():
+    data = [{"a": 1, "b": True}, {"a": 3, "b": False}]
+    dtype = DataType.struct({"a": DataType.int64(), "b": DataType.bool()})
+
+    s = Series.from_pylist(data, pyobj="force")
+    s = s.cast(dtype)
+    assert s.datatype() == dtype
+    assert s.to_pylist() == data
+
+
+def test_cast_python_to_list_of_structs():
+    data = [[{"a": 1, "b": True}, {"a": 3, "b": False}]]
+    dtype = DataType.list(DataType.struct({"a": DataType.int64(), "b": DataType.bool()}))
+
+    s = Series.from_pylist(data, pyobj="force")
+    s = s.cast(dtype)
+    assert s.datatype() == dtype
+    assert s.to_pylist() == data


### PR DESCRIPTION
## Changes Made

I think the `@daft.func` code goes through a different code path than `@daft.udf` for output conversion, using PythonArray.cast instead. Thus, to support more datatypes, I added casting support from Python to ListArray, FixedSizedListArray, and StructArray. It uses PyArrow for the casting under the hood.

I didn't support all List internal types just yet to be safe though; in particular, our logical types may not translate well. Will do that as a followup. Also didn't modify our code for Numpy based conversion.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
