### PR TITLE
refactor: make DaftExtension class definition static

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -1175,6 +1175,29 @@ _EXT_TYPE_REGISTERED = False
 _STATIC_DAFT_EXTENSION: pa.ExtensionType | None = None
 
 
+class DaftExtension(pa.ExtensionType):  # type: ignore[misc]
+    def __init__(self, dtype: pa.DataType, metadata: bytes = b"") -> None:
+        # attributes need to be set first before calling
+        # super init (as that calls serialize)
+        self._metadata = metadata
+        super().__init__(dtype, "daft.super_extension")
+
+    def __reduce__(
+        self,
+    ) -> tuple[Callable[[pa.DataType, bytes], DaftExtension], tuple[pa.DataType, bytes]]:
+        return type(self).__arrow_ext_deserialize__, (self.storage_type, self.__arrow_ext_serialize__())
+
+    def __arrow_ext_serialize__(self) -> bytes:
+        return self._metadata
+
+    @classmethod
+    def __arrow_ext_deserialize__(cls, storage_type: pa.DataType, serialized: bytes) -> DaftExtension:
+        return cls(storage_type, serialized)
+
+    def __arrow_ext_equals__(self, other: pa.ExtensionType) -> bool:
+        return self.storage_type == other.storage_type and self._metadata == other._metadata
+
+
 def _ensure_registered_super_ext_type() -> None:
     global _EXT_TYPE_REGISTERED
     global _STATIC_DAFT_EXTENSION
@@ -1184,26 +1207,6 @@ def _ensure_registered_super_ext_type() -> None:
     if not _EXT_TYPE_REGISTERED:
         with _EXT_TYPE_REGISTRATION_LOCK:
             if not _EXT_TYPE_REGISTERED:
-
-                class DaftExtension(pa.ExtensionType):  # type: ignore[misc]
-                    def __init__(self, dtype: pa.DataType, metadata: bytes = b"") -> None:
-                        # attributes need to be set first before calling
-                        # super init (as that calls serialize)
-                        self._metadata = metadata
-                        super().__init__(dtype, "daft.super_extension")
-
-                    def __reduce__(
-                        self,
-                    ) -> tuple[Callable[[pa.DataType, bytes], DaftExtension], tuple[pa.DataType, bytes]]:
-                        return type(self).__arrow_ext_deserialize__, (self.storage_type, self.__arrow_ext_serialize__())
-
-                    def __arrow_ext_serialize__(self) -> bytes:
-                        return self._metadata
-
-                    @classmethod
-                    def __arrow_ext_deserialize__(cls, storage_type: pa.DataType, serialized: bytes) -> DaftExtension:
-                        return cls(storage_type, serialized)
-
                 _STATIC_DAFT_EXTENSION = DaftExtension
                 pa.register_extension_type(DaftExtension(pa.null()))
                 import atexit


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
`daft.datatype._ensure_registered_super_ext_type.<locals>.DaftExtension`   vs  `<class 'daft.datatype.DaftExtension'>`
 
Moves the DaftExtension class definition to the module level. Previously, this class was defined at runtime from within the _ensure_registered_super_ext_type function. This meant that the class definition itself was dynamic, which causes problems for some specific cases of schema handling while writing out to some data formats.


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
