### PR TITLE
fix: Add handle for swordfish runtime stats manager

### DIFF
--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -237,7 +237,7 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
                 child_result_receiver,
                 self.node_id(),
                 self.runtime_stats.clone(),
-                runtime_handle.stats_manager().clone(),
+                runtime_handle.stats_manager(),
             ));
         }
         let op = self.intermediate_op.clone();

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -23,10 +23,9 @@ use std::{
 
 use common_error::{DaftError, DaftResult};
 use common_runtime::{RuntimeRef, RuntimeTask};
-use runtime_stats::RuntimeStatsManagerHandle;
 use resource_manager::MemoryManager;
 pub use run::{ExecutionEngineResult, NativeExecutor};
-use runtime_stats::{RuntimeStats, TimedFuture};
+use runtime_stats::{RuntimeStats, RuntimeStatsManagerHandle, TimedFuture};
 use snafu::{futures::TryFutureExt, ResultExt, Snafu};
 use tracing::Instrument;
 

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -23,9 +23,10 @@ use std::{
 
 use common_error::{DaftError, DaftResult};
 use common_runtime::{RuntimeRef, RuntimeTask};
+use runtime_stats::RuntimeStatsManagerHandle;
 use resource_manager::MemoryManager;
 pub use run::{ExecutionEngineResult, NativeExecutor};
-use runtime_stats::{RuntimeStats, RuntimeStatsManager, TimedFuture};
+use runtime_stats::{RuntimeStats, TimedFuture};
 use snafu::{futures::TryFutureExt, ResultExt, Snafu};
 use tracing::Instrument;
 
@@ -129,7 +130,7 @@ pub(crate) struct ExecutionRuntimeContext {
     worker_set: TaskSet<crate::Result<()>>,
     default_morsel_size: usize,
     memory_manager: Arc<MemoryManager>,
-    stats_manager: Arc<RuntimeStatsManager>,
+    stats_manager: RuntimeStatsManagerHandle,
 }
 
 impl ExecutionRuntimeContext {
@@ -137,7 +138,7 @@ impl ExecutionRuntimeContext {
     pub fn new(
         default_morsel_size: usize,
         memory_manager: Arc<MemoryManager>,
-        stats_manager: Arc<RuntimeStatsManager>,
+        stats_manager: RuntimeStatsManagerHandle,
     ) -> Self {
         Self {
             worker_set: TaskSet::new(),
@@ -180,7 +181,7 @@ impl ExecutionRuntimeContext {
     }
 
     #[must_use]
-    pub(crate) fn stats_manager(&self) -> Arc<RuntimeStatsManager> {
+    pub(crate) fn stats_manager(&self) -> RuntimeStatsManagerHandle {
         self.stats_manager.clone()
     }
 }

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -301,13 +301,14 @@ impl NativeExecutor {
                 )
             });
 
-            let stats_manager = Arc::new(RuntimeStatsManager::new(runtime.handle(), &pipeline));
+            let stats_manager = RuntimeStatsManager::new(runtime.handle(), &pipeline);
+            let stats_manager_handle = stats_manager.handle();
             let execution_task = async {
                 let memory_manager = get_or_init_memory_manager();
                 let mut runtime_handle = ExecutionRuntimeContext::new(
                     cfg.default_morsel_size,
                     memory_manager.clone(),
-                    stats_manager.clone(),
+                    stats_manager_handle,
                 );
                 let receiver = pipeline.start(true, &mut runtime_handle)?;
 
@@ -348,8 +349,6 @@ impl NativeExecutor {
             })?;
 
             // Finish the stats manager
-            let stats_manager = Arc::into_inner(stats_manager)
-                .expect("There should only be 1 stats manager instance by the end");
             stats_manager.finish(&runtime);
 
             if enable_explain_analyze {

--- a/src/daft-local-execution/src/streaming_sink/base.rs
+++ b/src/daft-local-execution/src/streaming_sink/base.rs
@@ -242,7 +242,7 @@ impl<Op: StreamingSink + 'static> PipelineNode for StreamingSinkNode<Op> {
                 child_result_receiver,
                 self.node_id(),
                 self.runtime_stats.clone(),
-                runtime_handle.stats_manager().clone(),
+                runtime_handle.stats_manager(),
             ));
         }
 


### PR DESCRIPTION
## Changes Made

Fixes the 
```
thread '<unnamed>' panicked at src/daft-local-execution/src/run.rs:368:18:
There should only be 1 stats manager instance by the end
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread '<unnamed>' panicked at src/daft-local-execution/src/run.rs:500:26:
Execution engine thread panicked: Any { .. }
Error in sys.excepthook:
Traceback (most recent call last):
  File "/Users/colinho/Desktop/Daft/.venv/lib/python3.12/site-packages/ray/_private/worker.py", line 1887, in custom_excepthook
    def custom_excepthook(type, value, tb):
    
```
issues

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
