### PR TITLE
feat: better dtype type inference

### DIFF
--- a/tests/test_datatype_inference.py
+++ b/tests/test_datatype_inference.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+from PIL import Image
+
+from daft import DataType as dt
+
+
+@pytest.mark.parametrize(
+    "user_provided_type, expected_datatype",
+    [
+        (int, dt.int64()),
+        (float, dt.float64()),
+        (bytes, dt.binary()),
+        (None, dt.null()),
+        (bool, dt.bool()),
+        (object, dt.python()),
+        (dict[str, str], dt.map(dt.string(), dt.string())),
+        ({"foo": str}, dt.struct({"foo": dt.string()})),
+        ({"_1": str, "_2": str}, dt.struct({"_1": dt.string(), "_2": dt.string()})),
+        (Image, dt.image()),
+        (Image.Image, dt.image()),
+    ],
+)
+def test_dtype_inference(user_provided_type, expected_datatype):
+    actual = dt._infer_type(user_provided_type)
+    assert actual == expected_datatype


### PR DESCRIPTION
## Changes Made

Small PR to improve inference of `DataType._infer_type`

It now supports converting: 
- `PIL.Image -> dt.image()`
- `PIL.Image.Image  -> dt.image()`
- `bool -> dt.bool()` -- how did we miss this one? 🤠 
- `None -> dt.null()`

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
