### PR TITLE
fix: correct GitHub capitalization and add missing period in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ More Resources
 Contributing
 ------------
 
-We <3 developers! To start contributing to Daft, please read `CONTRIBUTING.md <https://github.com/Eventual-Inc/Daft/blob/main/CONTRIBUTING.md>`_ This document describes the development lifecycle and toolchain for working on Daft. It also details how to add new functionality to the core engine and expose it through a Python API.
+We <3 developers! To start contributing to Daft, please read `CONTRIBUTING.md <https://github.com/Eventual-Inc/Daft/blob/main/CONTRIBUTING.md>`_. This document describes the development lifecycle and toolchain for working on Daft. It also details how to add new functionality to the core engine and expose it through a Python API.
 
 Here's a list of `good first issues <https://github.com/Eventual-Inc/Daft/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22>`_ to get yourself warmed up with Daft. Comment in the issue to pick it up, and feel free to ask any questions!
 
@@ -151,7 +151,7 @@ Daft has an Apache 2.0 license - please see the LICENSE file.
 
 .. |CI| image:: https://github.com/Eventual-Inc/Daft/actions/workflows/pr-test-suite.yml/badge.svg
    :target: https://github.com/Eventual-Inc/Daft/actions/workflows/pr-test-suite.yml?query=branch:main
-   :alt: Github Actions tests
+   :alt: GitHub Actions tests
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/daft.svg?label=pip&logo=PyPI&logoColor=white
    :target: https://pypi.org/project/daft


### PR DESCRIPTION
## Summary
- Fixed "Github" to "GitHub" in alt text (line 154)
- Added missing period after CONTRIBUTING.md link (line 94)

## Context
Two small grammar/punctuation fixes in the README.rst file.