### PR TITLE
docs: fix grammar in CONTRIBUTING.md setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ To set up your development environment:
 4. Install [cmake](https://cmake.org/). If you use [homebrew](https://brew.sh), you can run `brew install cmake`.
 5. Install [protoc](https://protobuf.dev/installation/). You will need this for release builds -- `make build-release`. With homebrew, installation is `brew install protobuf`.
 6. Clone the Daft repo: `git clone git@github.com:Eventual-Inc/Daft.git`
-7. Run `make .venv` from your new cloned Daft repository to create a new virtual environment with all of Daft's development dependencies installed
+7. Run `make .venv` from your newly cloned Daft repository to create a new virtual environment with all of Daft's development dependencies installed
 8. Run `make hooks` to install pre-commit hooks: these will run tooling on every commit to ensure that your code meets Daft development standards
 
 ### Developing


### PR DESCRIPTION
## Summary
- Fixed grammatical error in CONTRIBUTING.md: changed "your new cloned Daft repository" to "your newly cloned Daft repository"

## Context
Minor documentation fix to improve grammar in the setup instructions.