### PR TITLE
Feature/issue 4914

### DIFF
--- a/src/daft-functions-list/src/max.rs
+++ b/src/daft-functions-list/src/max.rs
@@ -33,7 +33,7 @@ impl ScalarUDF for ListMax {
         ensure!(inputs.len() == 1, SchemaMismatch: "Expected 1 input arg, got {}", inputs.len());
         let input = inputs.required((0, "input"))?;
         let field = input.to_field(schema)?.to_exploded_field()?;
-        ensure!(field.dtype.is_numeric(), TypeError: "Expected input to be numeric, got {}", field.dtype);
+        ensure!(field.dtype.is_numeric() || field.dtype.is_boolean(), TypeError: "Expected input to be numeric, got {}", field.dtype);
         Ok(field)
     }
 }

--- a/src/daft-functions-list/src/min.rs
+++ b/src/daft-functions-list/src/min.rs
@@ -30,7 +30,7 @@ impl ScalarUDF for ListMin {
         ensure!(inputs.len() == 1, SchemaMismatch: "Expected 1 input arg, got {}", inputs.len());
         let input = inputs.required((0, "input"))?;
         let field = input.to_field(schema)?.to_exploded_field()?;
-        ensure!(field.dtype.is_numeric(), TypeError: "Expected input to be numeric, got {}", field.dtype);
+        ensure!(field.dtype.is_numeric() || field.dtype.is_boolean(), TypeError: "Expected input to be numeric, got {}", field.dtype);
         Ok(field)
     }
 }

--- a/tests/recordbatch/list/test_list_bool_aggs.py
+++ b/tests/recordbatch/list/test_list_bool_aggs.py
@@ -35,3 +35,15 @@ def test_list_bool_and(table):
 def test_list_bool_or(table):
     result = table.eval_expression_list([col("a").list.bool_or()])
     assert result.to_pydict() == {"a": [True, True, False, True, False, None, None]}
+
+
+@pytest.mark.parametrize("table", [table, fixed_table])
+def test_list_bool_max(table):
+    result = table.eval_expression_list([col("a").list.max()])
+    assert result.to_pydict() == {"a": [True, True, False, True, False, None, None]}
+
+
+@pytest.mark.parametrize("table", [table, fixed_table])
+def test_list_bool_min(table):
+    result = table.eval_expression_list([col("a").list.min()])
+    assert result.to_pydict() == {"a": [True, False, False, True, False, None, None]}


### PR DESCRIPTION
## Changes Made

Support for using max() and min() on list of boolean values.
Earlier we were type checking to ensure the dtypes are numeric, added changes to consider boolean dtype as acceptable. Created new tests for the same.

## Related Issues

https://github.com/Eventual-Inc/Daft/issues/4914

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
