### PR TITLE
ci: Don't run pr test suite on non-code changes

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths-ignore:
     - '.vscode/**'
-    - 'benchmarking/**'
     - 'ci/**'
     - 'docs/**'
     - '.git-blame-ignore-revs'
@@ -24,7 +23,6 @@ on:
     branches: [main]
     paths-ignore:
     - '.vscode/**'
-    - 'benchmarking/**'
     - 'ci/**'
     - 'docs/**'
     - '.git-blame-ignore-revs'


### PR DESCRIPTION
## Changes Made

Trivial non-code changes are clogging our CI. This needs to stop.