### PR TITLE
fix: Can translate sort in flotilla

### DIFF
--- a/src/daft-distributed/src/stage/stage_builder.rs
+++ b/src/daft-distributed/src/stage/stage_builder.rs
@@ -47,6 +47,7 @@ impl StagePlanBuilder {
             | LogicalPlan::Window(_)
             | LogicalPlan::Concat(_)
             | LogicalPlan::Limit(_)
+            | LogicalPlan::Sort(_)
             | LogicalPlan::Repartition(_)
             | LogicalPlan::TopN(_) => Ok(TreeNodeRecursion::Continue),
             LogicalPlan::Join(join) => {
@@ -64,17 +65,6 @@ impl StagePlanBuilder {
                     } else {
                         Ok(TreeNodeRecursion::Continue)
                     }
-                }
-            }
-            LogicalPlan::Sort(_) => {
-                if plan.materialized_stats().approx_stats.num_rows <= 1_000 {
-                    // Max 1GB with 1KB per row and off by 3 orders of magnitude
-                    Ok(TreeNodeRecursion::Continue)
-                } else {
-                    // TODO: Implement a distributed sort algorithm that can handle
-                    // a large number of rows without OOMing.
-                    can_translate = false;
-                    Ok(TreeNodeRecursion::Stop)
                 }
             }
             LogicalPlan::Pivot(_) => {


### PR DESCRIPTION
## Changes Made

Remove the `can_translate` blocker for sorts.

I totally forgot about this

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
