### PR TITLE
fix(blc): Attempt to fix the broken link checker.

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -21,7 +21,7 @@ jobs:
         timeout_minutes: 10
         retry_wait_seconds: 120
         max_attempts: 3
-        command: blc https://www.daft.ai -ro --verbose --exclude www.pytorch.org/ --exclude https://github.com/Eventual-Inc/Daft/ --exclude https://twitter.com/daftengine --exclude https://www.linkedin.com/company/eventualai/ --exclude https://x.com/daftengine --exclude https://www.linkedin.com/showcase/daftengine/ --exclude https://scarf.sh/ --exclude https://static.scarf.sh/* --exclude https://huggingface.co/docs/dataset-viewer/en/parquet
+        command: "! (blc https://www.daft.ai -ro --verbose --exclude www.pytorch.org/ --exclude https://github.com/Eventual-Inc/Daft/ --exclude https://twitter.com/daftengine --exclude https://www.linkedin.com/company/eventualai/ --exclude https://x.com/daftengine --exclude https://www.linkedin.com/showcase/daftengine/ --exclude https://scarf.sh/ --exclude https://static.scarf.sh/* --exclude https://huggingface.co/docs/dataset-viewer/en/parquet | grep -v HTTP_308 | grep BROKEN)"
   notify_on_failure:
     runs-on: self-hosted
     if: failure()

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -21,7 +21,32 @@ jobs:
         timeout_minutes: 10
         retry_wait_seconds: 120
         max_attempts: 3
-        command: "! (blc https://www.daft.ai -ro --verbose --exclude www.pytorch.org/ --exclude https://github.com/Eventual-Inc/Daft/ --exclude https://twitter.com/daftengine --exclude https://www.linkedin.com/company/eventualai/ --exclude https://x.com/daftengine --exclude https://www.linkedin.com/showcase/daftengine/ --exclude https://scarf.sh/ --exclude https://static.scarf.sh/* --exclude https://huggingface.co/docs/dataset-viewer/en/parquet | grep -v HTTP_308 | grep BROKEN)"
+        command: |
+          set -euo pipefail
+
+          # Run BLC and capture full output. If blc itself fails, the step fails (pipefail).
+          LOG="$(mktemp)"
+          blc https://www.daft.ai \
+            -ro --verbose \
+            --exclude www.pytorch.org/ \
+            --exclude https://github.com/Eventual-Inc/Daft/ \
+            --exclude https://twitter.com/daftengine \
+            --exclude https://www.linkedin.com/company/eventualai/ \
+            --exclude https://x.com/daftengine \
+            --exclude https://www.linkedin.com/showcase/daftengine/ \
+            --exclude https://scarf.sh/ \
+            --exclude https://static.scarf.sh/* \
+            --exclude https://huggingface.co/docs/dataset-viewer/en/parquet \
+            | tee "$LOG"
+
+          # Treat HTTP_308 as noise, fail if any BROKEN lines remain.
+          if grep -v 'HTTP_308' "$LOG" | grep -q 'BROKEN'; then
+            echo "Broken links found:"
+            grep -v 'HTTP_308' "$LOG" | grep 'BROKEN' || true
+            exit 1
+          fi
+
+          echo "No broken links detected."
   notify_on_failure:
     runs-on: self-hosted
     if: failure()


### PR DESCRIPTION
## Changes Made

Since we couldn't find any broken link checker settings to ignore 308 redirects, just filtering out HTTP_308 and failing if things are still broken.

* `grep` returns 0 if there are any matches. `!` flips that to 1 and the workflow fails.
* `grep` returns 1 if there are no matches. `!` flips that to 0 and the workflow succeeds.