### PR TITLE
chore: Only test MacOS on Python 3.11 in CI

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -74,6 +74,8 @@ jobs:
           pyarrow-version: 8.0.0
         - python-version: '3.9'
           os: macos-latest
+        - python-version: '3.10'
+          os: macos-latest
         - pyarrow-version: 8.0.0
           os: macos-latest
         - python-version: '3.11'


### PR DESCRIPTION
## Changes Made

Right now every PR runs 6 jobs on MacOS runners, which causes a lot of contention in our repo (since we only can run 3 concurrently). Since we already check 3 Python versions in Linux, we don't need to test in MacOS most likely.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
