### PR TITLE
fix: Implement Multi-Column Aggregations with List-like columns 

### DIFF
--- a/src/daft-core/src/array/fixed_size_list_array.rs
+++ b/src/daft-core/src/array/fixed_size_list_array.rs
@@ -258,6 +258,19 @@ impl Iterator for FixedSizeListArrayIter<'_> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.array.len() - self.idx,
+            Some(self.array.len() - self.idx),
+        )
+    }
+}
+
+impl ExactSizeIterator for FixedSizeListArrayIter<'_> {
+    fn len(&self) -> usize {
+        self.array.len() - self.idx
+    }
 }
 
 #[cfg(test)]

--- a/src/daft-core/src/array/list_array.rs
+++ b/src/daft-core/src/array/list_array.rs
@@ -235,4 +235,17 @@ impl Iterator for ListArrayIter<'_> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.array.len() - self.idx,
+            Some(self.array.len() - self.idx),
+        )
+    }
+}
+
+impl ExactSizeIterator for ListArrayIter<'_> {
+    fn len(&self) -> usize {
+        self.array.len() - self.idx
+    }
 }

--- a/src/daft-core/src/array/ops/arrow2/comparison.rs
+++ b/src/daft-core/src/array/ops/arrow2/comparison.rs
@@ -1,5 +1,5 @@
 use arrow2::{
-    array::{ord::build_compare, Array, PrimitiveArray},
+    array::{equal, ord::build_compare, Array, FixedSizeListArray, ListArray, PrimitiveArray},
     datatypes::DataType,
     error::Result,
 };
@@ -33,19 +33,66 @@ fn build_is_equal_float<F: Float + arrow2::types::NativeType>(
     }
 }
 
+fn build_is_equal_list(
+    left: &dyn Array,
+    right: &dyn Array,
+) -> Box<dyn Fn(usize, usize) -> bool + Send + Sync> {
+    let left = left
+        .as_any()
+        .downcast_ref::<ListArray<i64>>()
+        .unwrap()
+        .clone();
+    let right = right
+        .as_any()
+        .downcast_ref::<ListArray<i64>>()
+        .unwrap()
+        .clone();
+
+    Box::new(move |i, j| equal(left.value(i).as_ref(), right.value(j).as_ref()))
+}
+
+fn build_is_equal_fixed_size_list(
+    left: &dyn Array,
+    right: &dyn Array,
+) -> Box<dyn Fn(usize, usize) -> bool + Send + Sync> {
+    let left = left
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .unwrap()
+        .clone();
+    let right = right
+        .as_any()
+        .downcast_ref::<FixedSizeListArray>()
+        .unwrap()
+        .clone();
+
+    Box::new(move |i, j| equal(left.value(i).as_ref(), right.value(j).as_ref()))
+}
+
 fn build_is_equal_with_nan(
     left: &dyn Array,
     right: &dyn Array,
-    nulls_equal: bool,
+    nan_equal: bool,
 ) -> Result<Box<dyn Fn(usize, usize) -> bool + Send + Sync>> {
-    if (left.data_type() == &DataType::Float32) && (right.data_type() == &DataType::Float32) {
-        Ok(build_is_equal_float::<f32>(left, right, nulls_equal))
-    } else if (left.data_type() == &DataType::Float64) && (right.data_type() == &DataType::Float64)
-    {
-        Ok(build_is_equal_float::<f64>(left, right, nulls_equal))
-    } else {
-        let comp = build_compare(left, right)?;
-        Ok(Box::new(move |i, j| comp(i, j).is_eq()))
+    match (left.data_type(), right.data_type()) {
+        (DataType::Float32, DataType::Float32) => {
+            Ok(build_is_equal_float::<f32>(left, right, nan_equal))
+        }
+        (DataType::Float64, DataType::Float64) => {
+            Ok(build_is_equal_float::<f64>(left, right, nan_equal))
+        }
+        (DataType::LargeList(f1), DataType::LargeList(f2)) if *f1 == *f2 => {
+            Ok(build_is_equal_list(left, right))
+        }
+        (DataType::FixedSizeList(f1, l1), DataType::FixedSizeList(f2, l2))
+            if *l1 == *l2 && *f1 == *f2 =>
+        {
+            Ok(build_is_equal_fixed_size_list(left, right))
+        }
+        _ => {
+            let comp = build_compare(left, right)?;
+            Ok(Box::new(move |i, j| comp(i, j).is_eq()))
+        }
     }
 }
 

--- a/tests/dataframe/test_aggregations.py
+++ b/tests/dataframe/test_aggregations.py
@@ -13,7 +13,7 @@ from daft.context import get_context
 from daft.datatype import DataType
 from daft.errors import ExpressionTypeError
 from daft.utils import freeze
-from tests.utils import sort_arrow_table
+from tests.utils import sort_arrow_table, sort_pydict
 
 
 def _assert_all_hashable(values, test_name=""):
@@ -934,15 +934,15 @@ def test_groupby_with_list_cols(make_df):
             "key2": pa.array(
                 [["a"], ["a"], ["hello", "world"], ["hello", "world", "and", "beyond"]], type=pa.list_(pa.string())
             ),
-            "values": pa.array([1.0, 2.0, 3.0, 4.0], type=pa.float64()),
+            "values": pa.array([1.0, 10.0, 3.0, 4.0], type=pa.float64()),
         }
     )
 
     res = df.groupby(["key1", "key2"]).agg(col("values").sum())
-    assert res.to_pydict() == {
+    assert sort_pydict(res.to_pydict(), "values") == {
         "key1": [[1, 2], [2, 3], [2, 3]],
-        "key2": [["a"], ["hello", "world"], ["hello", "world", "and", "beyond"]],
-        "values": [3.0, 3.0, 4.0],
+        "key2": [["a"], ["hello", "world", "and", "beyond"], ["hello", "world"]],
+        "values": [11.0, 4.0, 3.0],
     }
 
 

--- a/tests/expressions/test_expressions.py
+++ b/tests/expressions/test_expressions.py
@@ -687,14 +687,17 @@ def test_list_value_counts_nested():
     )
 
     # Apply list_value_counts operation and expect an exception
-    with pytest.raises(daft.exceptions.DaftCoreException) as exc_info:
-        mp.eval_expression_list([col("nested_list_col").list.value_counts().alias("value_counts")])
+    result = mp.eval_expression_list([col("nested_list_col").list.value_counts().alias("value_counts")])
+    result_dict = result.to_pydict()
 
-    # Check the exception message
-    assert (
-        'DaftError::ArrowError Invalid argument error: The data type type LargeList(Field { name: "item", data_type: Int64, is_nullable: true, metadata: {} }) has no natural order'
-        in str(exc_info.value)
-    )
+    assert result_dict["value_counts"] == [
+        [([1, 2], 1), ([3, 4], 1)],
+        [([1, 2], 1), ([5, 6], 1)],
+        [([3, 4], 1), ([1, 2], 1)],
+        [],
+        [],
+        [([1, 2], 2)],
+    ]
 
 
 def test_list_value_counts_fixed_size():


### PR DESCRIPTION
## Changes Made

I'm rewriting minhash deduplication using only Daft expressions, and that requires performing GroupBy on a Int and FixedSizeList column. That doesn't work because Arrow2 doesn't support comparing FixedSizeList values, so I manually override.

In addition, implemented a mini-optimization when calling `series.into_iter` on list columns to allocate once. Helps with functions like `list_min`, `list_max`, etc.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
