### PR TITLE
feat: automatic into batches for single partitions

### DIFF
--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -1,4 +1,6 @@
 #![feature(let_chains)]
+use std::num::{IntErrorKind, ParseIntError};
+
 pub use common_io_config::IOConfig;
 use serde::{Deserialize, Serialize};
 
@@ -74,6 +76,7 @@ pub struct DaftExecutionConfig {
     pub native_parquet_writer: bool,
     pub use_experimental_distributed_engine: bool,
     pub min_cpu_per_task: f64,
+    pub suggested_batch_size: u64,
 }
 
 impl Default for DaftExecutionConfig {
@@ -109,6 +112,7 @@ impl Default for DaftExecutionConfig {
             native_parquet_writer: true,
             use_experimental_distributed_engine: true,
             min_cpu_per_task: 0.5,
+            suggested_batch_size: 1000,
         }
     }
 }
@@ -155,6 +159,25 @@ impl DaftExecutionConfig {
                 Err(_) => eprintln!(
                     "Invalid {} value: {}, using default {}",
                     min_cpu_var, val, cfg.min_cpu_per_task
+                ),
+            }
+        }
+        let suggested_batch_size_var = "DAFT_SUGGESTED_BATCH_SIZE";
+        if let Ok(val) = std::env::var(suggested_batch_size_var) {
+            match val
+                .parse::<u64>()
+                .map_err(|e| format!("{e}"))
+                .and_then(|bs| {
+                    if bs == 0 {
+                        Err("Batch size must be greater than 0".to_string())
+                    } else {
+                        Ok(bs)
+                    }
+                }) {
+                Ok(parsed) => cfg.suggested_batch_size = parsed,
+                Err(e) => eprintln!(
+                    "Invalid {} value: {} ({e}), using default {}",
+                    suggested_batch_size_var, val, cfg.suggested_batch_size
                 ),
             }
         }

--- a/src/daft-distributed/src/pipeline_node/scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/scan_source.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use common_display::{tree::TreeDisplay, DisplayAs, DisplayLevel};
-use common_error::DaftResult;
+use common_error::{DaftError, DaftResult};
 use common_file_formats::FileFormatConfig;
 use common_scan_info::{Pushdowns, ScanTaskLikeRef};
 use daft_local_plan::LocalPhysicalPlan;
@@ -13,13 +13,13 @@ use super::{
     SubmittableTaskStream,
 };
 use crate::{
-    pipeline_node::NodeID,
+    pipeline_node::{make_new_task_from_materialized_outputs, NodeID},
     scheduling::{
-        scheduler::SubmittableTask,
+        scheduler::{SchedulerHandle, SubmittableTask},
         task::{SchedulingStrategy, SwordfishTask, TaskContext},
     },
-    stage::{StageConfig, StageExecutionContext, TaskIDCounter},
-    utils::channel::{create_channel, Sender},
+    stage::{self, StageConfig, StageExecutionContext, TaskIDCounter},
+    utils::channel::{create_channel, create_oneshot_channel, Sender},
 };
 
 pub(crate) struct ScanSourceNode {
@@ -92,6 +92,75 @@ impl ScanSourceNode {
         Ok(())
     }
 
+    async fn execute_optimized_scan(
+        self: Arc<Self>,
+        single_scan_task: ScanTaskLikeRef,
+        task_id_counter: TaskIDCounter,
+        result_tx: Sender<SubmittableTask<SwordfishTask>>,
+        scheduler_handle: SchedulerHandle<SwordfishTask>,
+        batch_size: usize,
+    ) -> DaftResult<()> {
+        if batch_size == 0 {
+            return Err(
+                DaftError::InternalError("Batch size must be greater than 0".to_string()).into(),
+            );
+        }
+
+        // Step 1: Materialize the scan task to get ray data pointers
+        // let scan_task = SubmittableTask::new(SwordfishTask::new(
+        //     TaskContext::from((&self.context, task_id_counter.next())),
+        //     // self.scan_tasks[0].clone(), // Use the single scan task
+        //     single_scan_task.clone(),
+        //     self.config.execution_config.clone(),
+        //     HashMap::from([(self.node_id().to_string(), vec![single_scan_task])]),
+        //     SchedulingStrategy::Spread,
+        //     self.context.to_hashmap(),
+        // ));
+
+        let submit_single_scan_task = SubmittableTask::new(self.make_source_tasks(
+            vec![single_scan_task].into(),
+            TaskContext::from((&self.context, task_id_counter.next())),
+        )?);
+
+        let maybe_materialized_output = submit_single_scan_task.submit(&scheduler_handle)?.await?;
+
+        if let Some(materialized_output) = maybe_materialized_output {
+            // Step 2: Split the materialized output into batches of size 'k'
+            let materialized_outputs = materialized_output.split_into_materialized_outputs();
+
+            // Step 3: Create into_batches tasks for each batch
+            for batch in materialized_outputs.chunks(batch_size) {
+                let batch_materialized_outputs = batch.to_vec();
+
+                let task = make_new_task_from_materialized_outputs(
+                    TaskContext::from((&self.context, task_id_counter.next())),
+                    batch_materialized_outputs,
+                    &(self.clone() as Arc<dyn DistributedPipelineNode>),
+                    move |input| {
+                        LocalPhysicalPlan::into_batches(
+                            input,
+                            batch_size,
+                            true, // Strict batch sizes
+                            StatsState::NotMaterialized,
+                        )
+                    },
+                )?;
+
+                match result_tx.send(task).await {
+                    Ok(_) => (),
+                    Err(e) => {
+                        return Err(DaftError::InternalError(format!(
+                            "Failed to send internal batch to result channel: {e:?}"
+                        ))
+                        .into());
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn make_source_tasks(
         &self,
         scan_tasks: Arc<Vec<ScanTaskLikeRef>>,
@@ -143,13 +212,82 @@ impl DistributedPipelineNode for ScanSourceNode {
         vec![]
     }
 
+    // fn produce_tasks(
+    //     self: Arc<Self>,
+    //     stage_context: &mut StageExecutionContext,
+    // ) -> SubmittableTaskStream {
+    //     let (result_tx, result_rx) = create_channel(1);
+
+    //     if self.scan_tasks.len() == 1 {
+    //         // materialize the read -> send to scheduler
+    //         let task_read = SubmittableTask::new(SwordfishTask::new(...));
+    //         // task_read.submit(&stage_context.scheduler_handle());
+    //         let read_result = stage_context.scheduler_handle().submit_task(task_read);
+    //         match read_result {
+    //             Ok(o) => match o {
+    //                 Some(materialized_output) => {}
+    //                 None => {
+    //                     let (err_result_tx, err_result_rx) = create_oneshot_channel();
+    //                     // err_result_tx.send()
+    //                     // TODO [mg] can we send the error task?
+    //                     // what do we do here???
+    //                     return SubmittableTaskStream::from(err_result_rx);
+    //                 }
+    //             },
+    //             Err(_) => {
+    //                 panic!("TODO [mg] what do we do here? *HOW* do we send the error?");
+    //             }
+    //         }
+
+    //         // get the result --> generate N batches of size K each
+    //         stage_context.spawn(task_in_batches);
+    //         // TODO [mg] this needs to be another scheduler send
+
+    //         // we now have lots of these data pointers, each is to one of these InBatches
+    //         // --> we can now send down the line a ton of In-memory read Tasks
+
+    //         stage_context.spawn(tasks_from_in_batches);
+    //         // TODO [mg] THIS ONE IS OK TO .spawn()
+    //         // TODO [mg] but, how do we create the right tasks? there should be an absolute
+    //         // ton of tasks from the in-batches thing
+    //     }
+
+    //     let execution_loop = self.execution_loop(result_tx, stage_context.task_id_counter());
+    //     stage_context.spawn(execution_loop);
+
+    //     SubmittableTaskStream::from(result_rx)
+    // }
+
     fn produce_tasks(
         self: Arc<Self>,
         stage_context: &mut StageExecutionContext,
     ) -> SubmittableTaskStream {
         let (result_tx, result_rx) = create_channel(1);
-        let execution_loop = self.execution_loop(result_tx, stage_context.task_id_counter());
-        stage_context.spawn(execution_loop);
+
+        // Check if this is a map-only pipeline by examining the stage type
+        // And make sure that we only have 1 scan task
+        if self.scan_tasks.len() == 1 {
+            let batch_size = 1000;
+            let self_clone = self.clone();
+            let task_id_counter = stage_context.task_id_counter().clone();
+            let scheduler_handle = stage_context.scheduler_handle().clone();
+            let execution_future = async move {
+                self_clone
+                    .execute_optimized_scan(
+                        self.scan_tasks[0].clone(),
+                        task_id_counter,
+                        result_tx,
+                        scheduler_handle,
+                        batch_size,
+                    )
+                    .await
+            };
+            stage_context.spawn(execution_future);
+        } else {
+            // Fall back to normal execution
+            let execution_loop = self.execution_loop(result_tx, stage_context.task_id_counter());
+            stage_context.spawn(execution_loop);
+        }
 
         SubmittableTaskStream::from(result_rx)
     }

--- a/src/daft-distributed/src/pipeline_node/scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/scan_source.rs
@@ -211,52 +211,6 @@ impl DistributedPipelineNode for ScanSourceNode {
         vec![]
     }
 
-    // fn produce_tasks(
-    //     self: Arc<Self>,
-    //     stage_context: &mut StageExecutionContext,
-    // ) -> SubmittableTaskStream {
-    //     let (result_tx, result_rx) = create_channel(1);
-
-    //     if self.scan_tasks.len() == 1 {
-    //         // materialize the read -> send to scheduler
-    //         let task_read = SubmittableTask::new(SwordfishTask::new(...));
-    //         // task_read.submit(&stage_context.scheduler_handle());
-    //         let read_result = stage_context.scheduler_handle().submit_task(task_read);
-    //         match read_result {
-    //             Ok(o) => match o {
-    //                 Some(materialized_output) => {}
-    //                 None => {
-    //                     let (err_result_tx, err_result_rx) = create_oneshot_channel();
-    //                     // err_result_tx.send()
-    //                     // TODO [mg] can we send the error task?
-    //                     // what do we do here???
-    //                     return SubmittableTaskStream::from(err_result_rx);
-    //                 }
-    //             },
-    //             Err(_) => {
-    //                 panic!("TODO [mg] what do we do here? *HOW* do we send the error?");
-    //             }
-    //         }
-
-    //         // get the result --> generate N batches of size K each
-    //         stage_context.spawn(task_in_batches);
-    //         // TODO [mg] this needs to be another scheduler send
-
-    //         // we now have lots of these data pointers, each is to one of these InBatches
-    //         // --> we can now send down the line a ton of In-memory read Tasks
-
-    //         stage_context.spawn(tasks_from_in_batches);
-    //         // TODO [mg] THIS ONE IS OK TO .spawn()
-    //         // TODO [mg] but, how do we create the right tasks? there should be an absolute
-    //         // ton of tasks from the in-batches thing
-    //     }
-
-    //     let execution_loop = self.execution_loop(result_tx, stage_context.task_id_counter());
-    //     stage_context.spawn(execution_loop);
-
-    //     SubmittableTaskStream::from(result_rx)
-    // }
-
     fn produce_tasks(
         self: Arc<Self>,
         stage_context: &mut StageExecutionContext,


### PR DESCRIPTION
## Changes Made

Updates `daft-distributed`'s `scan_source` to insert into-batches when running on a single partition in a map-only pipeline. The into batches are of a fixed size, which is configurable by a new `DAFT_SUGGESTED_BATCH_SIZE` environment variable.

## Related Issues

Closes DF-1003

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
