### PR TITLE
docs: fix typo "Github" --> "GitHub"

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,5 +2,5 @@
 
 ## Reporting a Vulnerability
 
-Please do not make a Github issue when reporting security issues but email daft-security@eventualcomputing.com.
+Please do not make a GitHub issue when reporting security issues but email daft-security@eventualcomputing.com.
 Thank you!

--- a/docs/connectors/delta_lake.md
+++ b/docs/connectors/delta_lake.md
@@ -10,7 +10,7 @@ Daft currently supports:
 
 3. **Multi-cloud Support:** Daft supports reading Delta Lake tables from AWS S3, Azure Blob Store, and GCS, as well as local files.
 
-A detailed Delta Lake roadmap for Daft can be found on [our Github issues](https://github.com/Eventual-Inc/Daft/issues/2457). For the overall Daft development plan, see [Daft Roadmap](../roadmap.md).
+A detailed Delta Lake roadmap for Daft can be found on [our GitHub issues](https://github.com/Eventual-Inc/Daft/issues/2457). For the overall Daft development plan, see [Daft Roadmap](../roadmap.md).
 
 ## Installing Daft with Delta Lake Support
 

--- a/docs/connectors/hudi.md
+++ b/docs/connectors/hudi.md
@@ -11,7 +11,7 @@ Daft currently supports:
 3. **Multi-cloud Support:** Daft supports reading Hudi tables from AWS S3, Azure Blob Store, and GCS, as well as local files.
 
 
-A detailed Apache Hudi roadmap for Daft can be found on [our Github Issues page](https://github.com/Eventual-Inc/Daft/issues/4389). For the overall Daft development plan, see [Daft Roadmap](../roadmap.md).
+A detailed Apache Hudi roadmap for Daft can be found on [our GitHub Issues page](https://github.com/Eventual-Inc/Daft/issues/4389). For the overall Daft development plan, see [Daft Roadmap](../roadmap.md).
 
 ## Installing Daft with Apache Hudi Support
 

--- a/docs/connectors/iceberg.md
+++ b/docs/connectors/iceberg.md
@@ -8,7 +8,7 @@ Daft currently natively supports:
 2. **Skipping Filtered Data:** Daft uses [`df.where()`][daft.DataFrame.where] filter calls to only read data that matches your predicates
 3. **All Catalogs From PyIceberg:** Daft is natively integrated with PyIceberg, and supports all the catalogs that PyIceberg does
 
-A detailed Iceberg roadmap for Daft can be found on [our Github issues](https://github.com/Eventual-Inc/Daft/issues/2458). For the overall Daft development plan, see [Daft Roadmap](../roadmap.md).
+A detailed Iceberg roadmap for Daft can be found on [our GitHub issues](https://github.com/Eventual-Inc/Daft/issues/2458). For the overall Daft development plan, see [Daft Roadmap](../roadmap.md).
 
 ## Tutorial
 

--- a/docs/core_concepts.md
+++ b/docs/core_concepts.md
@@ -1708,7 +1708,7 @@ Daft abstracts away the in-memory representation of your data and provides kerne
 
 <!-- todo(docs - cc): add relative path to expressions image page after figure out image namespace-->
 
-Please add suggestions for new DataTypes to our Github Discussions page!
+Please add suggestions for new DataTypes to our GitHub Discussions page!
 
 ## SQL
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Start local, scale global—without changing a line of code. Daft's Rust-powered
 
 ## Contribute to Daft
 
-If you're interested in hands-on learning about Daft internals and would like to contribute to our project, join us [on Github](https://github.com/Eventual-Inc/Daft) 🚀
+If you're interested in hands-on learning about Daft internals and would like to contribute to our project, join us [on GitHub](https://github.com/Eventual-Inc/Daft) 🚀
 
 Take a look at the many issues tagged with `good first issue` in our repo. If there are any that interest you, feel free to chime in on the issue itself or join us in our [Distributed Data Slack Community](https://join.slack.com/t/dist-data/shared_invite/zt-2e77olvxw-uyZcPPV1SRchhi8ah6ZCtg) and send us a message in #daft-dev. Daft team members will be happy to assign any issue to you and provide any guidance if needed!
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,6 +1,6 @@
 # Integrations
 
-Here are all the integrations that Daft currently supports. If there are integrations missing from this list, feel free to [open an issue on Github](https://github.com/Eventual-Inc/Daft/issues) or contribute your own with our [User-Defined Data Sources & Sinks](https://docs.daft.ai/en/stable/connectors/#user-defined)!
+Here are all the integrations that Daft currently supports. If there are integrations missing from this list, feel free to [open an issue on GitHub](https://github.com/Eventual-Inc/Daft/issues) or contribute your own with our [User-Defined Data Sources & Sinks](https://docs.daft.ai/en/stable/connectors/#user-defined)!
 
 ## Catalogs
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,7 +4,7 @@ _Last updated: May 2025_
 
 What is in store for Daft in 2025? This roadmap outlines the big picture of what the Daft team plans to work on in the coming year, as well as some of the features to expect from these.
 
-Please note that items on this roadmap are subject to change any time. If there are features you would like to implement, we highly welcome and encourage open source contributions! Our team is happy to provide guidance, help scope the work, and review PRs. Feel free to open an issue or PR on [Github](https://github.com/Eventual-Inc/Daft) or join our [Daft Slack Community](https://join.slack.com/t/dist-data/shared_invite/zt-2e77olvxw-uyZcPPV1SRchhi8ah6ZCtg).
+Please note that items on this roadmap are subject to change any time. If there are features you would like to implement, we highly welcome and encourage open source contributions! Our team is happy to provide guidance, help scope the work, and review PRs. Feel free to open an issue or PR on [GitHub](https://github.com/Eventual-Inc/Daft) or join our [Daft Slack Community](https://join.slack.com/t/dist-data/shared_invite/zt-2e77olvxw-uyZcPPV1SRchhi8ah6ZCtg).
 
 <!-- See also [Contribute to Daft](contributing.md) for information. -->
 
@@ -58,6 +58,6 @@ The following features would be valuable additions to Daft, but are not currentl
 - Improved Apache Hudi support (see [roadmap for Apache Hudi](https://github.com/Eventual-Inc/Daft/issues/4389))
 - Expressions parity with PySpark: Temporal ([issue #3798](https://github.com/Eventual-Inc/Daft/issues/3798)), Math ([issue #3793](https://github.com/Eventual-Inc/Daft/issues/3793)), String ([issue #3792](https://github.com/Eventual-Inc/Daft/issues/3792))
 
-If you are interested in working on any of these features, feel free to open an issue or start a discussion on [Github](https://github.com/Eventual-Inc/Daft) or join our [Daft Slack Community](https://join.slack.com/t/dist-data/shared_invite/zt-2e77olvxw-uyZcPPV1SRchhi8ah6ZCtg). Our team can provide technical direction and help scope the work appropriately. Thank you in advance 💜
+If you are interested in working on any of these features, feel free to open an issue or start a discussion on [GitHub](https://github.com/Eventual-Inc/Daft) or join our [Daft Slack Community](https://join.slack.com/t/dist-data/shared_invite/zt-2e77olvxw-uyZcPPV1SRchhi8ah6ZCtg). Our team can provide technical direction and help scope the work appropriately. Thank you in advance 💜
 
 <!-- See also [Contribute to Daft](contributing.md) for information. -->

--- a/docs/sql/datatypes.md
+++ b/docs/sql/datatypes.md
@@ -65,7 +65,7 @@ These tables define how Daft's [DataType](../api/datatypes.md) maps to the commo
 
 !!! warning "Warning"
 
-    Daft does not currently support `TIME WITH TIMEZONE` and `TIMESTAMP WITH TIMEZONE`, please see [Github #3957](https://github.com/Eventual-Inc/Daft/issues/3957) and feel free to bump this issue if you need it prioritized.
+    Daft does not currently support `TIME WITH TIMEZONE` and `TIMESTAMP WITH TIMEZONE`, please see [GitHub #3957](https://github.com/Eventual-Inc/Daft/issues/3957) and feel free to bump this issue if you need it prioritized.
 
 
 ## Array Types

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -571,11 +571,11 @@ async fn build_s3_conf(config: &S3Config) -> super::Result<s3::Config> {
         }
 
         fn no_verify_hostname_client() -> SharedHttpClient {
-            unimplemented!("Setting `S3Config.check_hostname_ssl` is no longer supported. See this Github Issue for more info: https://github.com/Eventual-Inc/Daft/issues/4530");
+            unimplemented!("Setting `S3Config.check_hostname_ssl` is no longer supported. See this GitHub Issue for more info: https://github.com/Eventual-Inc/Daft/issues/4530");
         }
 
         fn no_verify_client() -> SharedHttpClient {
-            unimplemented!("Setting `S3Config.verify_ssl` is no longer supported. See this Github Issue for more info: https://github.com/Eventual-Inc/Daft/issues/4530");
+            unimplemented!("Setting `S3Config.verify_ssl` is no longer supported. See this GitHub Issue for more info: https://github.com/Eventual-Inc/Daft/issues/4530");
         }
 
         match (config.verify_ssl, config.check_hostname_ssl) {

--- a/tests/integration/io/conftest.py
+++ b/tests/integration/io/conftest.py
@@ -59,7 +59,7 @@ def anonymous_minio_io_config() -> daft.io.IOConfig:
 
 @pytest.fixture(scope="session")
 def aws_public_s3_config(request) -> daft.io.IOConfig:
-    # Use anonymous mode to avoid having to search for credentials in the Github Runner
+    # Use anonymous mode to avoid having to search for credentials in the GitHub Runner
     # If pytest is run with `--credentials` then we set anonymous=None to go down the credentials chain
     anonymous = None if request.config.getoption("--credentials") else True
 
@@ -74,7 +74,7 @@ def aws_public_s3_config(request) -> daft.io.IOConfig:
 
 @pytest.fixture(scope="session")
 def gcs_public_config(request) -> daft.io.IOConfig:
-    # Use anonymous mode to avoid having to search for credentials in the Github Runner
+    # Use anonymous mode to avoid having to search for credentials in the GitHub Runner
     # If pytest is run with `--credentials` then we set anonymous=None to go down the credentials chain
     anonymous = None if request.config.getoption("--credentials") else True
     return daft.io.IOConfig(gcs=daft.io.GCSConfig(project_id=None, anonymous=anonymous))


### PR DESCRIPTION
## Changes Made

Fixes GitHub capitalization across the docs.

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
