### PR TITLE
refactor!: use struct datatype as daft representation of tuples

### DIFF
--- a/daft/datatype.py
+++ b/daft/datatype.py
@@ -134,7 +134,20 @@ class DataType:
                     return None
                 else:
                     pass
+            elif isinstance(item, tuple):
+                fields = {}
 
+                for i, value in enumerate(item):
+                    if isinstance(value, list):
+                        dtype = DataType._infer_dtype_from_pylist(value)
+                        dtype = dtype if dtype else DataType.python()
+
+                        fields[f"_{i}"] = DataType.list(DataType._infer_type(type(value[0])))
+                    else:
+                        dtype = DataType._infer_type(value)
+
+                    fields[f"_{i}"] = dtype
+                curr_dtype = DataType.struct(fields)
             else:
                 return None
 
@@ -178,10 +191,30 @@ class DataType:
                 return DataType.binary()
             elif user_provided_type is bool:
                 return DataType.bool()
+            elif user_provided_type is list:
+                inner_type = get_args(user_provided_type)
+                return DataType.list(DataType._infer_type(inner_type))
             elif user_provided_type is object:
                 return DataType.python()
             else:
                 raise ValueError(f"Unrecognized Python type, cannot convert to Daft type: {user_provided_type}")
+        elif isinstance(user_provided_type, bool):
+            return DataType.bool()
+        elif isinstance(user_provided_type, int):
+            return DataType.int64()
+        elif isinstance(user_provided_type, float):
+            return DataType.float64()
+        elif isinstance(user_provided_type, str):
+            return DataType.string()
+        elif isinstance(user_provided_type, bytes):
+            return DataType.binary()
+
+        elif isinstance(user_provided_type, list):
+            return DataType.list(DataType._infer_type(user_provided_type[0]))
+        elif isinstance(user_provided_type, tuple):
+            return DataType.struct({f"_{i}": DataType._infer_type(value) for i, value in enumerate(user_provided_type)})
+        elif user_provided_type is object:
+            return DataType.python()
         else:
             raise ValueError(f"Unable to infer Daft DataType for provided value: {user_provided_type}")
 
@@ -1193,7 +1226,7 @@ class DataType:
 
 
 # Type alias for a union of types that can be inferred into a DataType
-DataTypeLike = Union[DataType, type, str]
+DataTypeLike = Union[DataType, type, str, tuple[Any]]
 
 
 _EXT_TYPE_REGISTRATION_LOCK = threading.Lock()

--- a/daft/series.py
+++ b/daft/series.py
@@ -112,6 +112,9 @@ class Series:
             if data and np.module_available() and isinstance(data[0], np.datetime64):  # type: ignore[attr-defined]
                 np_arr = np.array(data)
                 arrow_array = pa.array(np_arr)
+            elif isinstance(data[0], tuple):
+                dtype = DataType._infer_dtype_from_pylist(data)
+                arrow_array = pa.array(data, type=dtype.to_arrow_dtype() if dtype else None)
             else:
                 arrow_array = pa.array(data, type=dtype.to_arrow_dtype() if dtype else None)
             return Series.from_arrow(arrow_array, name=name, dtype=dtype)

--- a/src/daft-core/src/python/series.rs
+++ b/src/daft-core/src/python/series.rs
@@ -37,7 +37,6 @@ impl PySeries {
         let vec_pyobj_arced = vec_pyobj.into_iter().map(Arc::new).collect();
         let arrow_array: Box<dyn arrow2::array::Array> =
             Box::new(PseudoArrowArray::from_pyobj_vec(vec_pyobj_arced));
-
         let field = Field::new(name, DataType::Python);
         let data_array = DataArray::<PythonType>::new(field.into(), arrow_array)?;
         let series = data_array.cast(&dtype)?;

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -1259,3 +1259,16 @@ def test_create_dataframe_parquet_read_mismatched_schemas_with_pushdown_no_rows_
         df = df.select("x")  # Applies column selection pushdown on each read
         assert df.schema().column_names() == ["x"]
         assert df.to_pydict() == {"x": [1, 2, 3, 4, None, None, None, None]}
+
+
+def test_create_dataframe_of_tuples():
+    df = daft.from_pydict({"tuples": [(1, "a"), (2, "b")]})
+    expected = {"tuples": [{"_0": 1, "_1": "a"}, {"_0": 2, "_1": "b"}]}
+    assert df.to_pydict() == expected
+
+
+def test_create_dataframe_of_deeply_nested_tuples():
+    df = daft.from_pydict({"tuples": [(1, {"foo": 1, "more_nesting": [1, 2, 3], "bar": (1, "a")})]})
+    expected = {"tuples": [{"_0": 1, "_1": {"foo": 1, "more_nesting": [1, 2, 3], "bar": {"_0": 1, "_1": "a"}}}]}
+
+    assert df.to_pydict() == expected

--- a/tests/test_datatype_inference.py
+++ b/tests/test_datatype_inference.py
@@ -20,6 +20,50 @@ from daft import DataType as dt
         ({"_1": str, "_2": str}, dt.struct({"_1": dt.string(), "_2": dt.string()})),
         (Image, dt.image()),
         (Image.Image, dt.image()),
+        ((1, "a"), dt.struct({"_0": dt.int64(), "_1": dt.string()})),
+        (
+            [(1, "a", True, {"foo": [1.0]})],
+            dt.list(
+                dt.struct(
+                    {
+                        "_0": dt.int64(),
+                        "_1": dt.string(),
+                        "_2": dt.bool(),
+                        "_3": dt.struct({"foo": dt.list(dt.float64())}),
+                    }
+                )
+            ),
+        ),
+        ((True, False, False), dt.struct({"_0": dt.bool(), "_1": dt.bool(), "_2": dt.bool()})),
+        (
+            {
+                "string": "s",
+                "int": 1,
+                "float": 1.0,
+                "list": [1.0, 2.0, 3.0],
+                "struct": {"foo": "bar"},
+                "tuple": (1, "a"),
+                "nested_tuples": ((1, "a"), ("2", "b")),
+                "nested_list": [[1.0, 2.0], [3.0, 4.0]],
+            },
+            dt.struct(
+                {
+                    "string": dt.string(),
+                    "int": dt.int64(),
+                    "float": dt.float64(),
+                    "list": dt.list(dt.float64()),
+                    "struct": dt.struct({"foo": dt.string()}),
+                    "tuple": dt.struct({"_0": dt.int64(), "_1": dt.string()}),
+                    "nested_tuples": dt.struct(
+                        {
+                            "_0": dt.struct({"_0": dt.int64(), "_1": dt.string()}),
+                            "_1": dt.struct({"_0": dt.string(), "_1": dt.string()}),
+                        }
+                    ),
+                    "nested_list": dt.list(dt.list(dt.float64())),
+                }
+            ),
+        ),
     ],
 )
 def test_dtype_inference(user_provided_type, expected_datatype):


### PR DESCRIPTION
## Changes Made

refactors the type conversion and dtype inference for `from_pydict`/`from_pylist` to treat tuples as daft structs with the following format
`Struct[f"_{idx}": dtype, ...]` 

Such as:
```py
(1, 'a') # -> Struct[_0: int64, _1: string]
(True, True, [1,2,3]) # -> Struct[_0: bool, _1: bool, _2: list[int64]]
```


Some important things to note is that unlike many other nested datatypes (list, dict), we do not guarantee round trips for 

example:
```py
    original = {"tuples": [(1, "a"), (2, "b")]}
    df = daft.from_pydict(original)
    assert df.to_pydict() != original 
    
    # it's converted to a dict with the indices as the keys
    expected = {"tuples": [{"_0": 1, "_1": "a"}, {"_0": 2, "_1": "b"}]}
    assert df.to_pydict() == expected
```


## Related Issues

Closes https://github.com/Eventual-Inc/Daft/issues/4974

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
