### PR TITLE
chore: random the counter during creating DistributedActorPoolProject…

### DIFF
--- a/src/daft-local-execution/src/intermediate_ops/distributed_actor_pool_project.rs
+++ b/src/daft-local-execution/src/intermediate_ops/distributed_actor_pool_project.rs
@@ -13,6 +13,7 @@ use daft_micropartition::MicroPartition;
 use itertools::Itertools;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
+use rand::Rng;
 use tracing::{instrument, Span};
 
 use super::intermediate_op::{
@@ -111,11 +112,16 @@ impl DistributedActorPoolProjectOperator {
             local_actor_handles
         };
 
+        let init_counter = if actor_handles.is_empty() {
+            0
+        } else {
+            rand::thread_rng().gen_range(0..actor_handles.len())
+        };
         Ok(Self {
             actor_handles,
             batch_size,
             memory_request,
-            counter: AtomicUsize::new(0),
+            counter: AtomicUsize::new(init_counter),
         })
     }
 }


### PR DESCRIPTION

## Changes Made

In case if there are multiple swordfish tasks dispatched to a worker, the swordfish worker/actor always chose the first N actor_handles/UDFActors to run morsel once receive upstream morsel for each task according the robin strategy, it might lead to the head actor_handles are hot actors and the tail actor_handles alway idled because no data been passed to these actor_handles.

So it's better to random the initial counter of DistributedActorPoolProjectOperator。 

## Related Issues



## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
