### PR TITLE
feat: support label_selector specification in ray actor/task creation

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1440,6 +1440,7 @@ def udf(
     batch_size: int | None,
     concurrency: int | None,
     use_process: bool | None,
+    ray_options: dict[str, Any] | None = None,
 ) -> PyExpr: ...
 def row_wise_udf(
     name: str,

--- a/daft/execution/ray_actor_pool_udf.py
+++ b/daft/execution/ray_actor_pool_udf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from daft.expressions.expressions import Expression, ExpressionsProjection
 from daft.recordbatch.micropartition import MicroPartition
@@ -78,19 +78,30 @@ async def start_udf_actors(
     num_gpus_per_actor: float,
     num_cpus_per_actor: float,
     memory_per_actor: float,
+    ray_options: dict[str, Any] | None,
     timeout: int,
     actor_name: str | None = None,
 ) -> list[UDFActorHandle]:
     expr_projection = ExpressionsProjection([Expression._from_pyexpr(expr) for expr in projection])
 
     random_suffix = str(uuid.uuid4())[:8]
+    base_opts: dict[str, Any] = {
+        "scheduling_strategy": "SPREAD",
+        "num_gpus": num_gpus_per_actor,
+        "num_cpus": num_cpus_per_actor,
+        "memory": memory_per_actor,
+    }
+    if ray_options and isinstance(ray_options.get("label_selector"), dict):
+        base_opts["label_selector"] = ray_options["label_selector"]
+
+    # Normalize label_selector for older Ray versions
+    from daft.runners.ray_compat import normalize_ray_options_with_label_selector
+
+    normalized_opts = normalize_ray_options_with_label_selector(base_opts.copy())
     actors: list[RayActorHandle] = [
         UDFActor.options(  # type: ignore
-            scheduling_strategy="SPREAD",
-            num_gpus=num_gpus_per_actor,
-            num_cpus=num_cpus_per_actor,
-            memory=memory_per_actor,
             name=None if actor_name is None else f"{actor_name}:{random_suffix}-{rank}",
+            **normalized_opts,
         ).remote(expr_projection)
         for rank in range(num_actors)
     ]

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -177,6 +177,7 @@ class Expression:
         batch_size: int | None,
         concurrency: int | None,
         use_process: bool | None,
+        ray_options: dict[builtins.str, builtins.str] | None = None,
     ) -> Expression:
         return Expression._from_pyexpr(
             _udf(
@@ -190,6 +191,7 @@ class Expression:
                 batch_size,
                 concurrency,
                 use_process,
+                ray_options,
             )
         )
 

--- a/daft/runners/ray_compat.py
+++ b/daft/runners/ray_compat.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any
+
+# Ray is required for this module but imported locally in functions that use it
+
+
+def _supports_label_selector_option() -> bool:
+    try:
+        from ray._private import ray_option_utils as _rou
+    except Exception:
+        return False
+    # Ray recognizes option keys via these dictionaries
+    return (
+        "label_selector" in getattr(_rou, "task_options", {})
+        or "label_selector" in getattr(_rou, "actor_options", {})
+        or "label_selector" in getattr(_rou, "valid_options", {})
+    )
+
+
+def _parse_label_selector_to_strategy(label_selector: dict[str, str]) -> Any:
+    """Convert Daft's string-based label selector into Ray's NodeLabelSchedulingStrategy.
+
+    Supported syntaxes per Ray tests/docs:
+    - Equals: {"key": "value"}
+    - Not equals: {"key": "!value"}
+    - In: {"key": "in(v1, v2)"}
+    - Not in: {"key": "!in(v1, v2)"}
+    """
+    from ray.util.scheduling_strategies import In, NodeLabelSchedulingStrategy, NotIn
+
+    hard_map: dict[str, Any] = {}
+    for k, v in label_selector.items():
+        s = v.strip()
+        if s.startswith("!in(") and s.endswith(")"):
+            values = [x.strip() for x in s[len("!in(") : -1].split(",") if x.strip()]
+            hard_map[k] = NotIn(*values)  # codespell: ignore
+        elif s.startswith("in(") and s.endswith(")"):
+            values = [x.strip() for x in s[len("in(") : -1].split(",") if x.strip()]
+            hard_map[k] = In(*values)  # codespell: ignore
+        elif s.startswith("!"):
+            hard_map[k] = NotIn(s[1:])  # codespell: ignore
+        else:
+            hard_map[k] = In(s)  # codespell: ignore
+
+    return NodeLabelSchedulingStrategy(hard=hard_map)
+
+
+def normalize_ray_options_with_label_selector(options: dict[str, Any]) -> dict[str, Any]:
+    """Normalize Ray .options(**kwargs) for cross-version compatibility.
+
+    - If current Ray supports "label_selector" option, return as-is.
+    - Otherwise, convert {label_selector: {...}} to scheduling_strategy=NodeLabelSchedulingStrategy
+      and drop the unsupported "label_selector" key.
+    """
+    if not options:
+        return options
+
+    if "label_selector" not in options:
+        return options
+
+    if _supports_label_selector_option():
+        # Newer Ray versions accept label_selector directly.
+        return options
+
+    # Older Ray: convert to NodeLabelSchedulingStrategy and remove label_selector.
+    label_selector = options.get("label_selector") or {}
+    if not isinstance(label_selector, dict):
+        # Invalid format; leave options untouched to let Ray raise errors
+        return options
+
+    strategy = _parse_label_selector_to_strategy(label_selector)
+    # Avoid conflicting strategies: override existing scheduling_strategy if any
+    options = {k: v for k, v in options.items() if k != "label_selector"}
+    options["scheduling_strategy"] = strategy
+    return options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ lint = [
 [tool.codespell]
 check-filenames = true
 check-hidden = true
-ignore-words-list = "crate,arithmetics,ser,acter,MOR"
+ignore-words-list = "crate,arithmetics,ser,acter,MOR,NotIn"
 # Feel free to un-skip examples, and experimental, you will just need to
 # work through many typos (--write-changes and --interactive will help)
 skip = "tests/series/*,target,.git,.venv,venv,data,*.csv,*.csv.*,*.html,*.json,*.jsonl,*.pdf,*.txt,*.ipynb,*.tiktoken,*.sql,tests/table/utf8/*,tests/table/binary/*,*.warc,tests/ai/*"

--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -56,10 +56,16 @@ impl UDFActors {
         };
 
         let actor_name = udf_properties.name.clone();
+        let ray_options = udf_properties.ray_options.clone();
         let result =
             common_runtime::python::execute_python_coroutine::<_, Vec<Py<PyAny>>>(move |py| {
                 let ray_actor_pool_udf_module =
                     py.import(pyo3::intern!(py, "daft.execution.ray_actor_pool_udf"))?;
+                // Convert RuntimePyObject option to a Python object (dict) or None
+                let py_ray_options = match &ray_options {
+                    Some(ro) => ro.as_ref().clone_ref(py),
+                    None => py.None(),
+                };
                 ray_actor_pool_udf_module.call_method1(
                     pyo3::intern!(py, "start_udf_actors"),
                     (
@@ -68,6 +74,7 @@ impl UDFActors {
                         gpu_request,
                         cpu_request,
                         memory_request,
+                        py_ray_options,
                         actor_ready_timeout,
                         actor_name,
                     ),

--- a/src/daft-dsl/src/functions/python/mod.rs
+++ b/src/daft-dsl/src/functions/python/mod.rs
@@ -1,7 +1,7 @@
 mod runtime_py_object;
 mod udf;
 
-use std::{num::NonZeroUsize, str::FromStr, sync::Arc};
+use std::{hash::Hash, num::NonZeroUsize, str::FromStr, sync::Arc};
 
 use common_error::{DaftError, DaftResult};
 use common_resource_request::ResourceRequest;
@@ -62,7 +62,7 @@ use crate::python::PyExpr;
 use crate::{
     Expr, ExprRef,
     functions::scalar::ScalarFn,
-    python_udf::{BatchPyFn, PyScalarFn, RowWisePyFn},
+    python_udf::{BatchPyFn, PyScalarFn},
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
@@ -122,6 +122,7 @@ pub struct LegacyPythonUDF {
     pub batch_size: Option<usize>,
     pub concurrency: Option<NonZeroUsize>,
     pub use_process: Option<bool>,
+    pub ray_options: Option<RuntimePyObject>,
 }
 
 impl LegacyPythonUDF {
@@ -140,6 +141,7 @@ impl LegacyPythonUDF {
             batch_size: None,
             concurrency: Some(NonZeroUsize::new(4).unwrap()),
             use_process: None,
+            ray_options: None,
         }
     }
 }
@@ -156,6 +158,7 @@ pub fn udf(
     batch_size: Option<usize>,
     concurrency: Option<NonZeroUsize>,
     use_process: Option<bool>,
+    ray_options: Option<RuntimePyObject>,
 ) -> DaftResult<Expr> {
     Ok(Expr::Function {
         func: super::FunctionExpr::Python(LegacyPythonUDF {
@@ -168,6 +171,7 @@ pub fn udf(
             batch_size,
             concurrency,
             use_process,
+            ray_options,
         }),
         inputs: expressions.into(),
     })
@@ -275,6 +279,7 @@ pub struct UDFProperties {
     pub is_async: bool,
     pub is_scalar: bool,
     pub on_error: Option<OnError>,
+    pub ray_options: Option<RuntimePyObject>,
 }
 
 impl UDFProperties {
@@ -292,6 +297,7 @@ impl UDFProperties {
                             batch_size,
                             concurrency,
                             use_process,
+                            ray_options,
                             ..
                         }),
                     ..
@@ -307,33 +313,26 @@ impl UDFProperties {
                         is_async: false,
                         on_error: None,
                         is_scalar: false,
+                        ray_options: ray_options.clone(),
                     });
                 }
-                Expr::ScalarFn(ScalarFn::Python(PyScalarFn::RowWise(RowWisePyFn {
-                    function_name,
-                    gpus,
-                    max_concurrency,
-                    use_process,
-                    max_retries,
-                    on_error,
-                    is_async,
-                    ..
-                }))) => {
+                Expr::ScalarFn(ScalarFn::Python(PyScalarFn::RowWise(row_wise_fn))) => {
                     num_udfs += 1;
                     udf_properties = Some(Self {
-                        name: function_name.to_string(),
+                        name: row_wise_fn.function_name.to_string(),
                         resource_request: Some(ResourceRequest::try_new_internal(
                             None,
-                            Some(*gpus as f64),
+                            Some(row_wise_fn.gpus as f64),
                             None,
                         )?),
-                        batch_size: None,
-                        concurrency: *max_concurrency,
-                        use_process: *use_process,
-                        max_retries: *max_retries,
-                        is_async: *is_async,
-                        on_error: Some(*on_error),
-                        is_scalar: true,
+                        batch_size: None, // Row-wise functions don't have batch_size
+                        concurrency: row_wise_fn.max_concurrency,
+                        use_process: row_wise_fn.use_process,
+                        max_retries: row_wise_fn.max_retries,
+                        is_async: row_wise_fn.is_async,
+                        on_error: Some(row_wise_fn.on_error),
+                        is_scalar: false,
+                        ray_options: None,
                     });
                 }
                 Expr::ScalarFn(ScalarFn::Python(PyScalarFn::Batch(BatchPyFn {
@@ -362,6 +361,7 @@ impl UDFProperties {
                         is_async: *is_async,
                         on_error: Some(*on_error),
                         is_scalar: false,
+                        ray_options: None,
                     });
                 }
                 _ => {}

--- a/src/daft-dsl/src/python.rs
+++ b/src/daft-dsl/src/python.rs
@@ -195,6 +195,7 @@ pub fn list_(items: Vec<PyExpr>) -> PyExpr {
     batch_size=None,
     concurrency=None,
     use_process=None,
+    ray_options=None,
 ))]
 pub fn udf(
     name: &str,
@@ -207,6 +208,7 @@ pub fn udf(
     batch_size: Option<usize>,
     concurrency: Option<usize>,
     use_process: Option<bool>,
+    ray_options: Option<Py<PyAny>>,
 ) -> PyResult<PyExpr> {
     use crate::functions::python::udf;
 
@@ -238,6 +240,7 @@ pub fn udf(
             batch_size,
             concurrency,
             use_process,
+            ray_options.map(|r| r.into()),
         )?
         .into(),
     })

--- a/src/daft-dsl/src/python_udf/batch.rs
+++ b/src/daft-dsl/src/python_udf/batch.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, num::NonZeroUsize, sync::Arc};
 
 use common_error::DaftResult;
-use daft_core::{prelude::DataType, series::Series};
+use daft_core::{prelude::*, series::Series};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 

--- a/src/daft-dsl/src/python_udf/row_wise.rs
+++ b/src/daft-dsl/src/python_udf/row_wise.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, num::NonZeroUsize, sync::Arc};
 
 use common_error::DaftResult;
-use daft_core::prelude::*;
+use daft_core::{prelude::*, series::Series};
 use itertools::Itertools;
 use opentelemetry::logs::{AnyValue, LogRecord, Logger, LoggerProvider};
 #[cfg(feature = "python")]

--- a/src/daft-logical-plan/src/optimization/rules/split_udfs.rs
+++ b/src/daft-logical-plan/src/optimization/rules/split_udfs.rs
@@ -682,6 +682,7 @@ mod tests {
                 batch_size: None,
                 concurrency: Some(NonZeroUsize::new(8).unwrap()),
                 use_process: None,
+                ray_options: None,
             }),
             inputs,
         }
@@ -703,6 +704,7 @@ mod tests {
                 batch_size: Some(32),
                 concurrency: None,
                 use_process: None,
+                ray_options: None,
             }),
             inputs,
         }

--- a/tests/ray/conftest.py
+++ b/tests/ray/conftest.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""conftest.py for Ray tests.
+
+This file provides pytest fixtures for testing Ray functionality,
+including local cluster with placement groups and multi-worker groups.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import tempfile
+import time
+from uuid import uuid4
+
+import pytest
+
+# Setup logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Try to import ray, with fallback to local source
+try:
+    import ray
+    from ray import exceptions as ray_exceptions  # Import for GetTimeoutError
+except ImportError:
+    repo_python = os.path.join(os.path.dirname(__file__), "..", "..", "ray", "python")
+    if os.path.isdir(repo_python):
+        sys.path.insert(0, repo_python)
+        import ray
+        from ray import exceptions as ray_exceptions  # Import for GetTimeoutError
+    else:
+        ray = None
+        ray_exceptions = None
+
+if ray:
+    from ray.cluster_utils import Cluster
+    from ray.util.placement_group import placement_group, remove_placement_group
+
+
+@pytest.fixture
+def multi_group_cluster():
+    """Create a multi-group cluster setup for testing.
+
+    This fixture provides a complete setup with:
+    - A Ray cluster with nodes labeled for different groups
+    - Placement groups for each group
+
+    The fixture yields the cluster resources and handles cleanup after the test.
+    Note: This fixture only creates the placement groups and cluster resources,
+    but does not pre-allocate any actors, leaving resources available for tests.
+    """
+    if not ray:
+        pytest.skip("Ray not available")
+
+    logger.info("Initializing multi-group cluster")
+    # Use a per-fixture tmpdir and unique namespace to avoid cross-test interference
+    tmpdir = tempfile.mkdtemp()
+    os.environ["RAY_TMPDIR"] = tmpdir
+    namespace = f"label_selector_fixture_{uuid4().hex[:8]}"
+
+    # Initialize head node with better port configuration to avoid conflicts
+    # Use separate port ranges for different components
+    cluster = Cluster(
+        initialize_head=True,
+        connect=False,  # avoid implicit ray.init; we'll connect explicitly with a unique namespace
+        head_node_args={
+            "num_cpus": 1,
+            # Let Ray automatically handle ports to avoid conflicts
+            # We disable dashboard to reduce potential port conflicts
+            "dashboard_port": None,
+        },
+    )
+
+    # Number of groups and workers per group
+    num_groups = 2
+    workers_per_group = 2
+
+    # Add worker nodes with custom resources for different groups
+    for g in range(num_groups):
+        for k in range(workers_per_group):
+            cluster.add_node(
+                num_cpus=num_groups,
+                resources={f"group_{g}": num_groups},
+                labels={"group": str(g), "index": str(k)},
+            )
+
+    cluster.wait_for_nodes()
+
+    # Connect to the cluster with improved initialization and cleanup
+    ctx = None
+    try:
+        # Initialize new Ray cluster with stronger parameters
+        logger.info("Initializing new Ray cluster, address: %s, namespace: %s", cluster.address, namespace)
+        ray_context = ray.init(
+            cluster.address,
+            namespace=namespace,
+            ignore_reinit_error=True,
+        )
+        ctx = ray_context
+        logger.info("Successfully initialized new Ray cluster")
+
+        # Verify cluster is actually initialized and healthy
+        logger.info("Verifying Ray cluster health")
+        ray.cluster_resources()  # This will throw if cluster is not healthy
+        logger.info("Ray cluster health verified")
+
+    except Exception as e:
+        logger.error("Error initializing Ray cluster: %s", e)
+        # Try to clean up on failure
+        try:
+            if ray.is_initialized():
+                ray.shutdown()
+        except Exception:
+            pass
+        raise
+
+    # Use the Ray Client context to ensure fixture-scoped Ray API calls target the new cluster
+    with ctx:
+        logger.info("Using Ray cluster via context, address: %s", cluster.address)
+
+        # Create placement groups for each group
+        placement_groups = []
+
+        # Create placement groups (without pre-allocating actors) with timeout
+        for g in range(num_groups):
+            # Create placement group for this group
+            bundles = [{"CPU": workers_per_group, f"group_{g}": workers_per_group}]
+            bundle_label_selector = [{"group": str(g)}]
+            pg = placement_group(
+                bundles=bundles,
+                strategy="STRICT_SPREAD",
+                name=f"pg-group-{g}",
+                bundle_label_selector=bundle_label_selector,
+            )
+            # Add timeout to placement group ready call to prevent hanging
+            try:
+                ray.get(pg.ready(), timeout=30)
+            except ray_exceptions.GetTimeoutError:
+                logger.warning("Placement group %s not ready within 30 seconds, continuing anyway", pg.id)
+            placement_groups.append(pg)
+            logger.info(
+                "Created placement group %s for group %s, bundles: %s, label_selector: %s",
+                pg.id,
+                g,
+                bundles,
+                bundle_label_selector,
+            )
+
+        logger.info("All placement groups created successfully")
+
+        # Return cluster info and placement groups (no pre-allocated workers)
+        cluster_info = {
+            "cluster": cluster,
+            "placement_groups": placement_groups,
+            "num_groups": num_groups,
+            "workers_per_group": workers_per_group,
+        }
+
+        try:
+            yield cluster_info
+        finally:
+            # Add timeout protection for the entire fixture cleanup
+            cleanup_start_time = time.time()
+            cleanup_timeout = 60  # 60 seconds max for entire cleanup
+
+            # Cleanup placement groups with better error handling and timeout
+            logger.info("Cleaning up %d placement groups", len(placement_groups))
+            for pg in placement_groups:
+                if time.time() - cleanup_start_time > cleanup_timeout:
+                    logger.warning("Cleanup timeout reached, forcing immediate cleanup")
+                    break
+
+                try:
+                    logger.info("Removing placement group %s", pg.id.hex())
+                    remove_placement_group(pg)
+                    # Wait for placement group to be removed with shorter timeout
+                    timeout = 10  # Reduced from 100 to 10 seconds
+                    start_time = time.time()
+                    removed = False
+                    while time.time() - start_time < timeout:
+                        if time.time() - cleanup_start_time > cleanup_timeout:
+                            logger.warning("Overall cleanup timeout reached, breaking")
+                            break
+
+                        try:
+                            pg_state = ray.util.placement_group_table(pg)["state"]
+                            if pg_state == "REMOVED":
+                                logger.info("Placement group %s successfully removed", pg.id.hex())
+                                removed = True
+                                break
+                        except Exception as e:
+                            # If placement group is already gone, consider it removed
+                            logger.info("Placement group %s may already be removed: %s", pg.id, e)
+                            removed = True
+                            break
+                        time.sleep(0.2)  # Check more frequently
+
+                    if not removed:
+                        logger.warning(
+                            "Timeout waiting for placement group %s to be removed, skipping cleanup", pg.id.hex()
+                        )
+                except Exception as e:
+                    logger.error("Error removing placement group %s: %s", pg.id.hex(), e)
+                    # Continue with cleanup of other placement groups

--- a/tests/ray/test_label_selector.py
+++ b/tests/ray/test_label_selector.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+ray = pytest.importorskip("ray")
+RAY_VERSION = getattr(ray, "__version__", "0.0.0")
+RAY_VERSION_TUPLE = tuple(map(int, RAY_VERSION.split(".")[:3]))
+
+import daft
+
+
+@pytest.mark.skipif(
+    RAY_VERSION_TUPLE < (2, 49, 0), reason="Ray version must be >= 2.49.0 for label selector functionality"
+)
+@pytest.mark.skip(reason="multi group will modify current ray cluster state, so only can run this ut local")
+def test_label_selector_with_multi_group_cluster(multi_group_cluster):
+    """Test label selector functionality with multi-group cluster setup."""
+    # Get cluster information
+    cluster_info = multi_group_cluster
+    num_groups = cluster_info["num_groups"]
+    workers_per_group = cluster_info["workers_per_group"]
+
+    # Verify cluster setup
+    assert num_groups == 2
+    assert workers_per_group == 2
+
+    # Test with label selectors
+    @daft.udf(
+        return_dtype=daft.DataType.string(), ray_options={"label_selector": {"group": "0"}}, concurrency=2, num_cpus=0.5
+    )
+    class Group0UDF:
+        def __init__(self):
+            pass
+
+        def __call__(self, data):
+            return [f"group0_processed_{item}" for item in data.to_pylist()]
+
+    @daft.udf(
+        return_dtype=daft.DataType.string(), ray_options={"label_selector": {"group": "1"}}, concurrency=2, num_cpus=0.5
+    )
+    class Group1UDF:
+        def __init__(self):
+            pass
+
+        def __call__(self, data):
+            return [f"group1_processed_{item}" for item in data.to_pylist()]
+
+    # Connect to the multi-group cluster created by the fixture
+    cluster_address = cluster_info["cluster"].address
+    daft.set_runner_ray(address=cluster_address, noop_if_initialized=True)
+    df = daft.from_pydict({"data": ["a", "b", "c"]})
+
+    df = df.with_column("p_group0", Group0UDF(df["data"]))
+    result_df = df.with_column("p_group1", Group1UDF(df["data"]))
+
+    result = result_df.to_pydict()
+
+    # Verify the results
+    expected_group0 = ["group0_processed_a", "group0_processed_b", "group0_processed_c"]
+    expected_group1 = ["group1_processed_a", "group1_processed_b", "group1_processed_c"]
+
+    assert result["p_group0"] == expected_group0
+    assert result["p_group1"] == expected_group1


### PR DESCRIPTION
## Changes Made
When there are multiple worker groups in a Ray cluster, tasks need to be submitted based on the specific labels of the worker groups. 
Therefore, a `label_selector` parameter has been added to the UDF. For detailed usage, please refer to the Ray documentation at https://docs.ray.io/en/latest/ray-core/scheduling/labels.html#monitor-nodes-using-labels

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
