### PR TITLE
fix: subprocess UDF inherits current process env

### DIFF
--- a/daft/ai/openai/text_embedder.py
+++ b/daft/ai/openai/text_embedder.py
@@ -164,7 +164,7 @@ class OpenAITextEmbedder(TextEmbedder):
         """Embeds a single text input and possibly returns a zero vector."""
         try:
             response: CreateEmbeddingResponse = self._client.embeddings.create(
-                input=[input_text],
+                input=input_text,
                 model=self._model,
                 encoding_format="float",
             )

--- a/daft/execution/udf.py
+++ b/daft/execution/udf.py
@@ -60,6 +60,12 @@ class UdfHandle:
         secret = secrets.token_bytes(32)
         self.listener = Listener(self.socket_path, authkey=secret)
 
+        # Copy the current process environment
+        env = dict(os.environ)
+
+        # Python auto-buffers stdout by default, so disable
+        env["PYTHONBUFFERED"] = "1"
+
         # Start the worker process
         self.process = subprocess.Popen(
             [
@@ -71,8 +77,7 @@ class UdfHandle:
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            # Python auto-buffers stdout by default, so disable
-            env={"PYTHONUNBUFFERED": "1"},
+            env=env,
         )
 
         # Initialize communication

--- a/daft/execution/udf.py
+++ b/daft/execution/udf.py
@@ -64,7 +64,7 @@ class UdfHandle:
         env = dict(os.environ)
 
         # Python auto-buffers stdout by default, so disable
-        env["PYTHONBUFFERED"] = "1"
+        env["PYTHONUNBUFFERED"] = "1"
 
         # Start the worker process
         self.process = subprocess.Popen(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -118,7 +118,7 @@ grpcio-status==1.67.0
 
 # ai
 vllm; platform_system == "Linux" and platform_machine == "x86_64" # for other systems, see install instructions: https://docs.vllm.ai/en/latest/getting_started/installation.html
-openai
+openai==1.100
 
 #clickhouse
 clickhouse-connect


### PR DESCRIPTION
## Changes Made

While debugging some OpenAI text_embed failures, I couldn't figure out why my OPENAI_API_KEY wasn't being picked up. 

## Related Issues

n/a

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
