### PR TITLE
fix: better error messaging for pickle problems

### DIFF
--- a/daft/ai/openai/text_embedder.py
+++ b/daft/ai/openai/text_embedder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from openai import OpenAI, RateLimitError
+from openai import OpenAI, OpenAIError, RateLimitError
 
 from daft import DataType
 from daft.ai.protocols import TextEmbedder, TextEmbedderDescriptor
@@ -159,6 +159,8 @@ class OpenAITextEmbedder(TextEmbedder):
             # fall back to individual calls when rate limited
             # consider sleeping or other backoff mechanisms
             return [self._embed_text(text) for text in input_batch]
+        except OpenAIError as ex:
+            raise ValueError("The `embed_text` method encountered an OpenAI error.") from ex
 
     def _embed_text(self, input_text: str) -> Embedding:
         """Embeds a single text input and possibly returns a zero vector."""

--- a/daft/functions/ai/__init__.py
+++ b/daft/functions/ai/__init__.py
@@ -80,6 +80,8 @@ def embed_text(
     text_embedder = _resolve_provider(provider, "sentence_transformers").get_text_embedder(model, **options)
 
     # implemented as class-based UDF for now
-    expr = udf(return_dtype=text_embedder.get_dimensions().as_dtype(), concurrency=1)(_TextEmbedderExpression)
+    expr = udf(return_dtype=text_embedder.get_dimensions().as_dtype(), concurrency=1, use_process=False)(
+        _TextEmbedderExpression
+    )
     expr = expr.with_init_args(text_embedder)
     return expr(text)


### PR DESCRIPTION
## Changes Made

The OpenAI errors have issues when being serialized, this PR uses a `raise .. from` which enables showing the full error.

## Related Issues

n/a

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
