### PR TITLE
chore: Remove deprecated APIs for 0.6

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -148,8 +148,6 @@ from daft.file import File
 import daft.context as context
 import daft.io as io
 
-to_struct = Expression.to_struct
-
 __all__ = [
     "Catalog",
     "DataCatalogTable",
@@ -243,7 +241,6 @@ __all__ = [
     "sql",
     "sql_expr",
     "struct",
-    "to_struct",
     "udf",
     "write_table",
 ]

--- a/daft/catalog/__glue.py
+++ b/daft/catalog/__glue.py
@@ -408,7 +408,6 @@ class GlueParquetTable(GlueTable):
             file_path_column=None,
             hive_partitioning=self._hive_partitioning,
             coerce_int96_timestamp_unit=None,
-            schema_hints=None,
         )
 
     def append(self, df: DataFrame, **options: Any) -> None:

--- a/daft/catalog/__iceberg.py
+++ b/daft/catalog/__iceberg.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any
 
 from pyiceberg.catalog import Catalog as InnerCatalog
@@ -35,13 +34,8 @@ if TYPE_CHECKING:
 class IcebergCatalog(Catalog):
     _inner: InnerCatalog
 
-    def __init__(self, pyiceberg_catalog: InnerCatalog):
-        """DEPRECATED: Please use `Catalog.from_iceberg`; version 0.5.0!"""
-        warnings.warn(
-            "This is deprecated and will be removed in daft >= 0.5.0, please use `Catalog.from_iceberg` instead.",
-            category=DeprecationWarning,
-        )
-        self._inner = pyiceberg_catalog
+    def __init__(self) -> None:
+        raise RuntimeError("IcebergCatalog.__init__ is not supported, please use `Catalog.from_iceberg` instead.")
 
     @staticmethod
     def _from_obj(obj: object) -> IcebergCatalog:
@@ -206,13 +200,8 @@ class IcebergTable(Table):
     _read_options = {"snapshot_id"}
     _write_options: set[str] = set()
 
-    def __init__(self, inner: InnerTable):
-        """DEPRECATED: Please use `Table.from_iceberg`; version 0.5.0!"""
-        warnings.warn(
-            "This is deprecated and will be removed in daft >= 0.5.0, please prefer using `Table.from_iceberg` instead; version 0.5.0!",
-            category=DeprecationWarning,
-        )
-        self._inner = inner
+    def __init__(self) -> None:
+        raise RuntimeError("IcebergTable.__init__ is not supported, please use `Table.from_iceberg` instead.")
 
     @property
     def name(self) -> str:

--- a/daft/catalog/__unity.py
+++ b/daft/catalog/__unity.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any
 
 from unitycatalog import NotFoundError as UnityNotFoundError
@@ -20,13 +19,8 @@ if TYPE_CHECKING:
 class UnityCatalog(Catalog):
     _inner: InnerCatalog
 
-    def __init__(self, unity_catalog: InnerCatalog):
-        """DEPRECATED: Please use `Catalog.from_unity`; version 0.5.0!"""
-        warnings.warn(
-            "This is deprecated and will be removed in daft >= 0.5.0, please prefer using `Catalog.from_unity` instead; version 0.5.0!",
-            category=DeprecationWarning,
-        )
-        self._inner = unity_catalog
+    def __init__(self) -> None:
+        raise RuntimeError("UnityCatalog.__init__ is not supported, please use `Catalog.from_unity` instead.")
 
     @property
     def name(self) -> str:
@@ -37,7 +31,7 @@ class UnityCatalog(Catalog):
     def _from_obj(obj: object) -> UnityCatalog:
         """Returns an UnityCatalog instance if the given object can be adapted so."""
         if isinstance(obj, InnerCatalog):
-            return UnityCatalog(obj)
+            return UnityCatalog.__new__(UnityCatalog)
         raise ValueError(f"Unsupported unity catalog type: {type(obj)}")
 
     ###
@@ -72,7 +66,7 @@ class UnityCatalog(Catalog):
 
     def _get_table(self, ident: Identifier) -> UnityTable:
         try:
-            return UnityTable(self._inner.load_table(str(ident)))
+            return UnityTable._from_obj(self._inner.load_table(str(ident)))
         except UnityNotFoundError:
             raise NotFoundError(f"Table {ident} not found!")
 
@@ -135,13 +129,8 @@ class UnityTable(Table):
         "allow_unsafe_rename",
     }
 
-    def __init__(self, unity_table: InnerTable):
-        """DEPRECATED: Please use `Table.from_unity`; version 0.5.0!"""
-        warnings.warn(
-            "This is deprecated and will be removed in daft >= 0.5.0, please prefer using `Table.from_unity` instead; version 0.5.0!",
-            category=DeprecationWarning,
-        )
-        self._inner = unity_table
+    def __init__(self) -> None:
+        raise RuntimeError("UnityTable.__init__ is not supported, please use `Table.from_unity` instead.")
 
     @property
     def name(self) -> str:

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import builtins
 import math
-import warnings
 from collections.abc import Collection, Iterable, Iterator
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
@@ -353,11 +352,6 @@ class Expression:
         return ExpressionPartitioningNamespace.from_expression(self)
 
     @property
-    def json(self) -> ExpressionJsonNamespace:
-        """Access methods that work on columns of json."""
-        return ExpressionJsonNamespace.from_expression(self)
-
-    @property
     def binary(self) -> ExpressionBinaryNamespace:
         """Access binary string operations for this expression.
 
@@ -428,18 +422,6 @@ class Expression:
         return Expression._from_pyexpr(
             _row_wise_udf(name, inner, return_dtype._dtype, original_args, [e._expr for e in expr_args])
         )
-
-    @staticmethod
-    def to_struct(*fields: Expression | builtins.str) -> Expression:
-        """Constructs a struct from the input field expressions.
-
-        Renamed to 'struct' in https://github.com/Eventual-Inc/Daft/pull/3755.
-        """
-        warnings.warn(
-            "This function will be deprecated from Daft version >= 0.4.4!  Instead, please use 'struct'",
-            category=DeprecationWarning,
-        )
-        return struct(*fields)
 
     def unnest(self) -> Expression:
         """Flatten the fields of a struct expression into columns in a DataFrame.
@@ -4688,21 +4670,6 @@ class ExpressionListNamespace(ExpressionNamespace):
         """
         return self._eval_expressions("list_count", mode)
 
-    def lengths(self) -> Expression:
-        """Gets the length of each list.
-
-        (DEPRECATED) Please use Expression.list.length instead
-
-        Returns:
-            Expression: a UInt64 expression which is the length of each list
-        """
-        warnings.warn(
-            "This function will be deprecated from Daft version >= 0.3.5!  Instead, please use 'Expression.list.length'",
-            category=DeprecationWarning,
-        )
-
-        return self._eval_expressions("list_count", CountMode.All)
-
     def length(self) -> Expression:
         """Gets the length of each list.
 
@@ -5292,50 +5259,6 @@ class ExpressionPartitioningNamespace(ExpressionNamespace):
             Expression: Expression of the Same Type of the input
         """
         return Expression._from_pyexpr(self._expr.partitioning_iceberg_truncate(w))
-
-
-class ExpressionJsonNamespace(ExpressionNamespace):
-    """The following methods are available under the `expr.json` attribute."""
-
-    def query(self, jq_query: str) -> Expression:
-        """Query JSON data in a column using a JQ-style filter <https://jqlang.github.io/jq/manual/>.
-
-        This expression uses jaq as the underlying executor, see <https://github.com/01mf02/jaq> for the full list of supported filters.
-
-        Args:
-            jq_query (str): JQ query string
-
-        Returns:
-            Expression: Expression representing the result of the JQ query as a column of JSON-compatible strings
-
-        Examples:
-            >>> import daft
-            >>> df = daft.from_pydict({"col": ['{"a": 1}', '{"a": 2}', '{"a": 3}']})
-            >>> df.with_column("res", df["col"].json.query(".a")).collect()
-            ╭──────────┬──────╮
-            │ col      ┆ res  │
-            │ ---      ┆ ---  │
-            │ Utf8     ┆ Utf8 │
-            ╞══════════╪══════╡
-            │ {"a": 1} ┆ 1    │
-            ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
-            │ {"a": 2} ┆ 2    │
-            ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌┤
-            │ {"a": 3} ┆ 3    │
-            ╰──────────┴──────╯
-            <BLANKLINE>
-            (Showing first 3 of 3 rows)
-
-        """
-        warnings.warn(
-            "`.json.query` is deprecated in daft >=0.5.1 and will be removed in >=0.6.0. Users should use `.jq` instead. Example: `col('x').jq('query')`",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        f = native.get_function_from_registry("jq")
-        filter = Expression._to_expression(jq_query)._expr
-
-        return Expression._from_pyexpr(f(self._expr, filter))
 
 
 class ExpressionEmbeddingNamespace(ExpressionNamespace):

--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -31,7 +31,6 @@ def read_csv(
     io_config: Optional[IOConfig] = None,
     file_path_column: Optional[str] = None,
     hive_partitioning: bool = False,
-    schema_hints: Optional[dict[str, DataType]] = None,
     _buffer_size: Optional[int] = None,
     _chunk_size: Optional[int] = None,
 ) -> DataFrame:
@@ -63,11 +62,6 @@ def read_csv(
     """
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of CSV filepaths")
-
-    if schema_hints is not None:
-        raise ValueError(
-            "Specifying schema_hints is deprecated from Daft version >= 0.3.0! Instead, please use the 'schema' and 'infer_schema' arguments."
-        )
 
     if not infer_schema and schema is None:
         raise ValueError(

--- a/daft/io/_json.py
+++ b/daft/io/_json.py
@@ -24,7 +24,6 @@ def read_json(
     io_config: Optional[IOConfig] = None,
     file_path_column: Optional[str] = None,
     hive_partitioning: bool = False,
-    schema_hints: Optional[dict[str, DataType]] = None,
     _buffer_size: Optional[int] = None,
     _chunk_size: Optional[int] = None,
 ) -> DataFrame:
@@ -50,11 +49,6 @@ def read_json(
     """
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of JSON filepaths")
-
-    if schema_hints is not None:
-        raise ValueError(
-            "Specifying schema_hints is deprecated from Daft version >= 0.3.0! Instead, please use the 'schema' and 'infer_schema' arguments."
-        )
 
     if not infer_schema and schema is None:
         raise ValueError(

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -26,7 +26,6 @@ def read_parquet(
     file_path_column: Optional[str] = None,
     hive_partitioning: bool = False,
     coerce_int96_timestamp_unit: Optional[Union[str, TimeUnit]] = None,
-    schema_hints: Optional[dict[str, DataType]] = None,
     _multithreaded_io: Optional[bool] = None,
     _chunk_size: Optional[int] = None,  # A hidden parameter for testing purposes.
 ) -> DataFrame:
@@ -60,11 +59,6 @@ def read_parquet(
 
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of Parquet filepaths")
-
-    if schema_hints is not None:
-        raise ValueError(
-            "Specifying schema_hints is deprecated from Daft version >= 0.3.0! Instead, please use the 'schema' and 'infer_schema' arguments."
-        )
 
     # If running on Ray, we want to limit the amount of concurrency and requests being made.
     # This is because each Ray worker process receives its own pool of thread workers and connections

--- a/daft/io/catalog.py
+++ b/daft/io/catalog.py
@@ -34,15 +34,6 @@ class DataCatalogTable:
     table_name: str
     catalog_id: Optional[str] = None
 
-    def __post_init__(self) -> None:
-        import warnings
-
-        warnings.warn(
-            "This API is deprecated in daft >=0.5.0 and will be removed in >=0.6.0. Users should use the new functionality in daft.catalog.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
     def table_uri(self, io_config: IOConfig) -> str:
         """Get the URI of the table in the data catalog.
 

--- a/daft/recordbatch/micropartition.py
+++ b/daft/recordbatch/micropartition.py
@@ -154,10 +154,6 @@ class MicroPartition:
     # Exporting methods
     ###
 
-    def to_table(self) -> RecordBatch:
-        """DEPRECATED: Please use `to_record_batch`."""
-        return self.to_record_batch()
-
     def to_record_batch(self) -> RecordBatch:
         """Returns the MicroPartition as a single (concatenated) RecordBatch."""
         return RecordBatch._from_pyrecordbatch(self._micropartition.to_record_batch())

--- a/daft/series.py
+++ b/daft/series.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Any, Callable, Literal, TypeVar
 
 import daft.daft as native
@@ -1049,14 +1048,6 @@ class SeriesPartitioningNamespace(SeriesNamespace):
 
 
 class SeriesListNamespace(SeriesNamespace):
-    def lengths(self) -> Series:
-        warnings.warn(
-            "This function will be deprecated from Daft version >= 0.3.5!  Instead, please use 'length'",
-            category=DeprecationWarning,
-        )
-
-        return self._eval_expressions("list_count", mode=CountMode.All)
-
     def length(self) -> Series:
         return self._eval_expressions("list_count", mode=CountMode.All)
 

--- a/daft/sql/sql.py
+++ b/daft/sql/sql.py
@@ -2,8 +2,6 @@
 # isort: dont-add-import: from __future__ import annotations
 
 import inspect
-import warnings
-from typing import Optional
 
 import daft
 from daft.api_annotations import PublicAPI
@@ -25,13 +23,6 @@ class SQLCatalog:
     """
 
     _catalog: _PySqlCatalog = None  # type: ignore
-
-    def __post_init__(self) -> None:
-        warnings.warn(
-            "This is deprecated and will be removed in daft >= 0.6.0; please use `Catalog.from_pydict()`.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     def __init__(self, tables: dict[str, DataFrame]) -> None:
         """Create a new SQLCatalog from a dictionary of table names to dataframes."""
@@ -110,7 +101,6 @@ def sql_expr(sql: str) -> Expression:
 @PublicAPI
 def sql(
     sql: str,
-    catalog: Optional[SQLCatalog] = None,
     register_globals: bool = True,
     **bindings: DataFrame,
 ) -> DataFrame:
@@ -201,15 +191,6 @@ def sql(
         for alias, variable in caller_vars.items():
             if isinstance(variable, DataFrame):
                 py_ctes[alias] = variable._builder._builder
-
-    # 2. Add all SQLCatalog names for backwards compatibility.
-    if catalog:
-        warnings.warn(
-            "The `catalog` argument is deprecated and will be removed in daft >= 0.6.0. Please use `ctes` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        py_ctes.update(catalog._catalog.to_pydict())
 
     # 3. Add explicit CTEs last so these can't be shadowed.
     for alias, df in bindings.items():

--- a/tests/recordbatch/list/test_list_count_length.py
+++ b/tests/recordbatch/list/test_list_count_length.py
@@ -50,12 +50,3 @@ def test_fixed_list_count(fixed_table):
 
     result = fixed_table.eval_expression_list([col("col").list.count(CountMode.Null)])
     assert result.to_pydict() == {"col": [0, 0, 1, 2, None]}
-
-
-def test_list_length(fixed_table):
-    with pytest.warns(DeprecationWarning):
-        lengths_result = fixed_table.eval_expression_list([col("col").list.lengths()])
-    length_result = fixed_table.eval_expression_list([col("col").list.length()])
-
-    assert lengths_result.to_pydict() == {"col": [2, 2, 2, 2, None]}
-    assert length_result.to_pydict() == {"col": [2, 2, 2, 2, None]}


### PR DESCRIPTION
## Changes Made

Remove any previously deprecated APIs in version 0.5 and below

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
