### PR TITLE
fix: Add missing source command in Makefile install-docs-deps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ install-docs-deps:
 		curl -fsSL https://bun.sh/install | bash; \
 		export PATH="$$HOME/.bun/bin:$$PATH"; \
 	fi
-	$(VENV_BIN)/activate && uv sync --all-extras --all-groups
-	$(VENV_BIN)/activate && uv pip install -e docs/plugins/nav_hide_children
+	source $(VENV_BIN)/activate && uv sync --all-extras --all-groups
+	source $(VENV_BIN)/activate && uv pip install -e docs/plugins/nav_hide_children
 
 .PHONY: docs
 docs: .venv install-docs-deps ## Build Daft documentation


### PR DESCRIPTION
## Changes Made

Fixed missing `source` command in the `install-docs-deps` target that was causing "Permission denied" errors when running `make docs`.

## Problem

The `install-docs-deps` target was trying to execute the activate script directly instead of sourcing it:
```makefile
$(VENV_BIN)/activate && uv sync --all-extras --all-groups
```

This resulted in permission denied errors because the shell was attempting to execute the script rather than source it into the current environment.

## Solution

Added the missing `source` command to be consistent with other targets in the Makefile:
```makefile
source $(VENV_BIN)/activate && uv sync --all-extras --all-groups
source $(VENV_BIN)/activate && uv pip install -e docs/plugins/nav_hide_children
```

This change makes the `install-docs-deps` target consistent with other targets like `hooks`, `check-format`, `lint`, etc. that correctly use `source $(VENV_BIN)/activate`.