### PR TITLE
docs: Move custom python code higher up in docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,6 +10,11 @@
         * [Images](modalities/images.md)
         * [Videos](modalities/videos.md)
         * [JSON and Nested Data](modalities/json.md)
+    * Running Custom Python Code
+        * [Overview](custom-code/index.md)
+        * [User-Defined Functions (UDFs)](custom-code/udfs.md)
+        * [Working with GPUs](custom-code/gpu.md)
+        * [External APIs](custom-code/apis.md)
     * Data Connectors
         * [Overview](connectors/index.md)
         * [Custom Connectors](connectors/custom.md)
@@ -23,11 +28,6 @@
         * [S3](connectors/aws.md)
         * [SQL Databases](connectors/sql.md)
         * [Unity Catalog (Databricks)](connectors/unity_catalog.md)
-    * Running Custom Python Code
-        * [Overview](custom-code/index.md)
-        * [User-Defined Functions (UDFs)](custom-code/udfs.md)
-        * [Working with GPUs](custom-code/gpu.md)
-        * [External APIs](custom-code/apis.md)
     * [Scaling Out and Deployment](distributed.md)
     * Optimization and Debugging
         * [Overview](optimization/index.md)


### PR DESCRIPTION
## Changes Made

Move custom python code higher up in docs.

Data connectors section is long and hides this section a little.