### PR TITLE
fix: Handle Unserializable Errors in Process UDFs

### DIFF
--- a/tests/expressions/test_legacy_udf.py
+++ b/tests/expressions/test_legacy_udf.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import os
 
+import httpx
 import numpy as np
 import pyarrow as pa
 import pytest
+from openai import APIStatusError
 
 import daft
 from daft import col
@@ -681,3 +683,41 @@ def test_run_udf_on_separate_process(batch_size):
     current_pid = os.getpid()
     for pid in result.to_pydict()["udf_1"]:
         assert pid != current_pid
+
+
+def test_udf_error_serialize_err():
+    """Test that UDF errors that can't be serialized are handled."""
+
+    @udf(return_dtype=DataType.string(), use_process=True)
+    def throw_value_err(x):
+        raise ValueError(lambda x: x * 2)
+
+    expr = throw_value_err(col("a"))
+
+    table = MicroPartition.from_pydict({"a": ["foo", "bar", "baz"]})
+    with pytest.raises(UDFException) as exc_info:
+        table.eval_expression_list([expr])
+
+    assert str(exc_info.value).startswith("User-defined function")
+    assert str(exc_info.value).endswith("failed when executing on inputs:\n  - a (Utf8, length=3)")
+    assert isinstance(exc_info.value.__cause__, ValueError)
+
+
+def test_udf_error_deserialize_err():
+    """Test that UDF errors that can't be deserialized are handled."""
+
+    @udf(return_dtype=DataType.int64(), use_process=True)
+    def throw_api_status_err(x: int) -> int:
+        fake_request = httpx.Request("GET", "http://google.com")
+        fake_response = httpx.Response(status_code=400, request=fake_request, headers={})
+        raise APIStatusError("test", response=fake_response, body=None)
+
+    expr = throw_api_status_err(col("a"))
+
+    table = MicroPartition.from_pydict({"a": [1, 2, 3]})
+    with pytest.raises(UDFException) as exc_info:
+        table.eval_expression_list([expr])
+
+    assert str(exc_info.value).startswith("User-defined function")
+    assert str(exc_info.value).endswith("failed when executing on inputs:\n  - a (Int64, length=3)")
+    assert isinstance(exc_info.value.__cause__, APIStatusError)


### PR DESCRIPTION
## Changes Made

In process-based UDFs, if the UDF throws an exception and it is not picklable, then we should still send the traceback through. The error message is formatted slightly differently though, unfortunately.

Normal
```
Error when running pipeline node UDF udf
ValueError: test
Traceback (most recent call last):

  File "/Users/slade/daft/main/mor.py", line 7, in udf
    raise ValueError("test")

ValueError: test

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/slade/daft/main/mor.py", line 15, in <module>
    print(df.collect())
          ^^^^^^^^^^^^
daft.errors.UDFException: User-defined function `<function udf at 0x16662db20>` failed when executing on inputs:
  - city (Utf8, length=3)

```

Can't serialize or de-serialize.
```
Error when running pipeline node UDF udf
Traceback (most recent call last):
  File "/Users/slade/daft/main/ser.py", line 15, in <module>
    print(df.collect())
          ^^^^^^^^^^^^
daft.errors.UDFException: Traceback (most recent call last):

  File "/Users/slade/daft/main/ser.py", line 7, in udf
    raise ValueError("test", lambda x: x * 2)

ValueError: ('test', <function udf.<locals>.<lambda> at 0x14b2d9bc0>)

The above exception was the direct cause of the following exception:

User-defined function `<function udf at 0x14b2d9b20>` failed when executing on inputs:
  - city (Utf8, length=3)
```

## Related Issues

Closes #4881.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
