### PR TITLE
feat: Automatically grab embedding dimensions for sentence transformers

### DIFF
--- a/daft/ai/sentence_transformers/__init__.py
+++ b/daft/ai/sentence_transformers/__init__.py
@@ -6,7 +6,7 @@ from daft.ai.sentence_transformers.text_embedder import SentenceTransformersText
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from daft.ai.protocols import TextEmbedder, TextEmbedderDescriptor
+    from daft.ai.protocols import TextEmbedderDescriptor
     from daft.ai.typing import Options
 
 __all__ = [
@@ -27,5 +27,4 @@ class SentenceTransformersProvider(Provider):
         return self._name
 
     def get_text_embedder(self, model: str | None = None, **options: Any) -> TextEmbedderDescriptor:
-        # TODO: ASAP plumbing embedding dimensions, can also create a large default table for common models
-        return SentenceTransformersTextEmbedderDescriptor(model or "all-MiniLM-L6-v2", options)
+        return SentenceTransformersTextEmbedderDescriptor(model or "sentence-transformers/all-MiniLM-L6-v2", options)

--- a/daft/ai/sentence_transformers/text_embedder.py
+++ b/daft/ai/sentence_transformers/text_embedder.py
@@ -29,8 +29,10 @@ class SentenceTransformersTextEmbedderDescriptor(TextEmbedderDescriptor):
         return self.options
 
     def get_dimensions(self) -> EmbeddingDimensions:
-        # hardcoding all-MiniLM-L6-v2 for now
-        return EmbeddingDimensions(size=384, dtype=DataType.float32())
+        from transformers import AutoConfig
+
+        dimensions = AutoConfig.from_pretrained(self.model).hidden_size
+        return EmbeddingDimensions(size=dimensions, dtype=DataType.float32())
 
     def instantiate(self) -> TextEmbedder:
         return SentenceTransformersTextEmbedder(self.model, **self.options)

--- a/tests/ai/test_sentence_transformers.py
+++ b/tests/ai/test_sentence_transformers.py
@@ -16,18 +16,28 @@ def test_sentence_transformers_text_embedder_default():
     descriptor = provider.get_text_embedder()
     assert isinstance(descriptor, TextEmbedderDescriptor)
     assert descriptor.get_provider() == "sentence_transformers"
-    assert descriptor.get_model() == "all-MiniLM-L6-v2"
+    assert descriptor.get_model() == "sentence-transformers/all-MiniLM-L6-v2"
     assert descriptor.get_dimensions() == EmbeddingDimensions(384, dtype=DataType.float32())
 
 
-def test_sentence_transformers_text_embedder_other():
-    mock_name = "other"
+@pytest.mark.parametrize(
+    "model_name, dimensions",
+    [
+        ("sentence-transformers/all-MiniLM-L6-v2", 384),
+        ("sentence-transformers/all-mpnet-base-v2", 768),
+        ("Qwen/Qwen3-Embedding-8B", 4096),
+        ("Qwen/Qwen3-Embedding-4B", 2560),
+        ("Qwen/Qwen3-Embedding-0.6B", 1024),
+        ("BAAI/bge-base-en-v1.5", 768),
+    ],
+)
+def test_sentence_transformers_text_embedder_other(model_name, dimensions):
     mock_options = {"arg1": "val1", "arg2": "val2"}
 
     provider = SentenceTransformersProvider()
-    descriptor = provider.get_text_embedder(mock_name, **mock_options)
+    descriptor = provider.get_text_embedder(model_name, **mock_options)
     assert isinstance(descriptor, TextEmbedderDescriptor)
     assert descriptor.get_provider() == "sentence_transformers"
-    assert descriptor.get_model() == mock_name  # currently no validation on the names/identifiers
+    assert descriptor.get_model() == model_name
     assert descriptor.get_options() == mock_options
-    assert descriptor.get_dimensions() == EmbeddingDimensions(384, dtype=DataType.float32())
+    assert descriptor.get_dimensions() == EmbeddingDimensions(dimensions, dtype=DataType.float32())


### PR DESCRIPTION
## Changes Made

Automatically grab embedding dimensions for sentence transformers using `AutoConfi` (from `transformers` which is a dependency of `sentence_transformers`).

`hidden_size` alone might not always equal the final embedding dimension it seems. Will need to experiment and test more but this gets us most of the way.