### PR TITLE
perf(embed_text): Let Sentence Transformers select the best available device

### DIFF
--- a/daft/ai/sentence_transformers/text_embedder.py
+++ b/daft/ai/sentence_transformers/text_embedder.py
@@ -42,10 +42,9 @@ class SentenceTransformersTextEmbedder(TextEmbedder):
     options: Options  # not currently used, torch hardcoded
 
     def __init__(self, model_name_or_path: str, **options: Any):
-        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        # Let SentenceTransformer handle device selection automatically.
         self.model = SentenceTransformer(model_name_or_path, trust_remote_code=True, backend="torch")
         self.model.eval()
-        self.model.to(self.device)
         self.options = options
 
     def embed_text(self, text: list[str]) -> list[Embedding]:

--- a/tests/ai/test_sentence_transformers.py
+++ b/tests/ai/test_sentence_transformers.py
@@ -5,6 +5,8 @@ import pytest
 pytest.importorskip("sentence_transformers")
 pytest.importorskip("torch")
 
+import torch
+
 from daft.ai.protocols import TextEmbedderDescriptor
 from daft.ai.sentence_transformers import SentenceTransformersProvider
 from daft.ai.typing import EmbeddingDimensions
@@ -21,17 +23,17 @@ def test_sentence_transformers_text_embedder_default():
 
 
 @pytest.mark.parametrize(
-    "model_name, dimensions",
+    "model_name, dimensions, run_model",
     [
-        ("sentence-transformers/all-MiniLM-L6-v2", 384),
-        ("sentence-transformers/all-mpnet-base-v2", 768),
-        ("Qwen/Qwen3-Embedding-8B", 4096),
-        ("Qwen/Qwen3-Embedding-4B", 2560),
-        ("Qwen/Qwen3-Embedding-0.6B", 1024),
-        ("BAAI/bge-base-en-v1.5", 768),
+        ("sentence-transformers/all-MiniLM-L6-v2", 384, True),
+        ("sentence-transformers/all-mpnet-base-v2", 768, True),
+        ("Qwen/Qwen3-Embedding-8B", 4096, False),  # Too large to run reasonably in CI.
+        ("Qwen/Qwen3-Embedding-4B", 2560, False),  # Too large to run reasonably in CI.
+        ("Qwen/Qwen3-Embedding-0.6B", 1024, True),
+        ("BAAI/bge-base-en-v1.5", 768, True),
     ],
 )
-def test_sentence_transformers_text_embedder_other(model_name, dimensions):
+def test_sentence_transformers_text_embedder_other(model_name, dimensions, run_model):
     mock_options = {"arg1": "val1", "arg2": "val2"}
 
     provider = SentenceTransformersProvider()
@@ -40,4 +42,33 @@ def test_sentence_transformers_text_embedder_other(model_name, dimensions):
     assert descriptor.get_provider() == "sentence_transformers"
     assert descriptor.get_model() == model_name
     assert descriptor.get_options() == mock_options
-    assert descriptor.get_dimensions() == EmbeddingDimensions(dimensions, dtype=DataType.float32())
+
+    if run_model:
+        embedder = descriptor.instantiate()
+
+        true_dimensions = embedder.model.get_sentence_embedding_dimension()
+        assert descriptor.get_dimensions() == EmbeddingDimensions(true_dimensions, dtype=DataType.float32())
+
+        test_texts = ["Hello world", "Bye world"]
+        embeddings = embedder.embed_text(test_texts)
+        assert len(embeddings) == 2
+        assert all(len(emb) == dimensions for emb in embeddings)
+    else:
+        assert descriptor.get_dimensions() == EmbeddingDimensions(dimensions, dtype=DataType.float32())
+
+
+def test_sentence_transformers_device_selection():
+    """Test that the embedder uses SentenceTransformer's automatic device selection."""
+    provider = SentenceTransformersProvider()
+    descriptor = provider.get_text_embedder("sentence-transformers/all-MiniLM-L6-v2")
+    embedder = descriptor.instantiate()
+
+    if torch.cuda.is_available():
+        expected_device = "cuda"
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        expected_device = "mps"
+    else:
+        expected_device = "cpu"
+
+    embedder_device = next(embedder.model.parameters()).device
+    assert expected_device in str(embedder_device)


### PR DESCRIPTION
## Changes Made

From the docs:
> The PyTorch backend is the default backend for Sentence Transformers. If you don’t specify a device, it will use the strongest available option across “cuda”, “mps”, and “cpu”.

Instead of setting cuda or cpu, we should let mps be used too so that we use Metal on MacOS with GPUs.

Planning to explore ONNX and OpenVINO backends next.