### PR TITLE
featrevert daft.func behavior on literal arguments

### DIFF
--- a/daft/udf/__init__.py
+++ b/daft/udf/__init__.py
@@ -48,8 +48,9 @@ class _DaftFuncDecorator:
     - **Async row-wise** (1 row in, 1 row out) - created by decorating a Python async function
     - **Generator** (1 row in, N rows out) - created by decorating a Python generator function
 
-    Decorated functions accept both their original argument types and Daft Expressions, and return an Expression for lazy evaluation.
-    To run the original function, call `<your_function>.eval(<args>)`.
+    Decorated functions accept both their original argument types and Daft Expressions.
+    When any arguments are Expressions, they return a Daft Expression that can be used in DataFrame operations.
+    When called with their original arguments, they execute immediately and the behavior is the same as if the function was not decorated.
 
     Args:
         return_dtype: The data type that this function should return or yield. If not specified, it is derived from the function's return type hint.

--- a/daft/udf/generator.py
+++ b/daft/udf/generator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable, Generator, Iterator
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, get_args, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, get_args, get_origin, get_type_hints, overload
 
 from daft.daft import row_wise_udf
 from daft.datatype import DataType
@@ -56,12 +56,19 @@ class GeneratorUdf(Generic[P, T]):
             return_dtype = args[0]
         self.return_dtype = DataType._infer_type(return_dtype)
 
-    def eval(self, *args: P.args, **kwargs: P.kwargs) -> Iterator[T]:
-        """Run the decorated generator function eagerly and return an iterator."""
-        return self._inner(*args, **kwargs)
+    @overload
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Iterator[T]: ...
+    @overload
+    def __call__(self, *args: Expression, **kwargs: Expression) -> Expression: ...
+    @overload
+    def __call__(self, *args: Any, **kwargs: Any) -> Expression | Iterator[T]: ...
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Expression:
+    def __call__(self, *args: Any, **kwargs: Any) -> Expression | Iterator[T]:
         expr_args = get_expr_args(args, kwargs)
+
+        # evaluate the function eagerly if there are no expression arguments
+        if len(expr_args) == 0:
+            return self._inner(*args, **kwargs)
 
         # temporary workaround before we implement actual generator UDFs: convert it into a list-type row-wise UDF + explode
         def inner_rowwise(*args: P.args, **kwargs: P.kwargs) -> list[T]:

--- a/daft/udf/row_wise.py
+++ b/daft/udf/row_wise.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, get_type_hints
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar, get_type_hints, overload
 
 from daft.daft import row_wise_udf
 
@@ -47,12 +47,19 @@ class RowWiseUdf(Generic[P, T]):
             return_dtype = type_hints["return"]
         self.return_dtype = DataType._infer_type(return_dtype)
 
-    def eval(self, *args: P.args, **kwargs: P.kwargs) -> T:
-        """Run the decorated function eagerly and return the result immediately."""
-        return self._inner(*args, **kwargs)
+    @overload
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T: ...
+    @overload
+    def __call__(self, *args: Expression, **kwargs: Expression) -> Expression: ...
+    @overload
+    def __call__(self, *args: Any, **kwargs: Any) -> Expression | T: ...
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Expression:
+    def __call__(self, *args: Any, **kwargs: Any) -> Expression | T:
         expr_args = get_expr_args(args, kwargs)
+
+        # evaluate the function eagerly if there are no expression arguments
+        if len(expr_args) == 0:
+            return self._inner(*args, **kwargs)
 
         return Expression._from_pyexpr(
             row_wise_udf(self.name, self._inner, self.return_dtype._dtype, (args, kwargs), expr_args)

--- a/tests/udf/test_generator_udf.py
+++ b/tests/udf/test_generator_udf.py
@@ -40,7 +40,7 @@ def test_generator_udf_literal_eval():
         for _ in range(n):
             yield to_repeat
 
-    assert list(my_repeat.eval("foo", 3)) == ["foo", "foo", "foo"]
+    assert list(my_repeat("foo", 3)) == ["foo", "foo", "foo"]
 
 
 def test_generator_udf_typing_iterator():

--- a/tests/udf/test_row_wise_udf.py
+++ b/tests/udf/test_row_wise_udf.py
@@ -90,7 +90,7 @@ def test_row_wise_udf_literal_eval():
     def my_stringify_and_sum(a: int, b: int) -> str:
         return f"{a + b}"
 
-    assert my_stringify_and_sum.eval(1, 2) == "3"
+    assert my_stringify_and_sum(1, 2) == "3"
 
 
 def test_row_wise_udf_kwargs():
@@ -98,8 +98,8 @@ def test_row_wise_udf_kwargs():
     def my_stringify_and_sum_repeat(a: int, b: int, repeat: int = 1) -> str:
         return f"{a + b}" * repeat
 
-    assert my_stringify_and_sum_repeat.eval(1, 2) == "3"
-    assert my_stringify_and_sum_repeat.eval(1, 2, 3) == "333"
+    assert my_stringify_and_sum_repeat(1, 2) == "3"
+    assert my_stringify_and_sum_repeat(1, 2, 3) == "333"
 
     df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
     default_df = df.select(my_stringify_and_sum_repeat(col("x"), col("y")))


### PR DESCRIPTION
## Changes Made

Reverts the changes in #4998 for v0.6 after further discussion.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
