### PR TITLE
docs: Improve installation instructions

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,8 +1,8 @@
 * Guide
     * [Overview](index.md)
-    * [Installation](install.md)
     * [Quickstart](quickstart.md)
-    * Modalities
+    * [Installation](install.md)
+    * Working with Modalities
         * [Overview](modalities/index.md)
         * [Custom Modalities](modalities/custom.md)
         * [URLs and Files](modalities/urls.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,58 +1,258 @@
-# Installation
+# How to Install Daft
 
-To install Daft, run this from your terminal:
+This guide helps you install Daft based on your specific needs and environment.
+
+For most users, install Daft with a single command:
 
 ```bash
 pip install -U daft
 ```
 
-## Extra Dependencies
+This includes most essential features for using Daft.
 
-Some Daft functionality may also require other dependencies, which are specified as "extras":
+## Optional Dependencies
 
-To install Daft with the extra dependencies required for interacting with AWS services, such as AWS S3, run:
+Depending on your use case, you may need to install Daft with additional dependencies.
+
+<div id="daft-install-tool" class="daft-install-tool">
+  <div class="use-cases">
+    <h4>Use Cases:</h4>
+
+    <div class="checkbox-group">
+      <label class="checkbox-item">
+        <input type="checkbox" id="huggingface" data-extra="huggingface">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Hugging Face</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="openai" data-extra="openai">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>OpenAI</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="sentence-transformers" data-extra="sentence-transformers">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Sentence Transformers</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="ray" data-extra="ray">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Distributed Computing on Ray</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="turbopuffer" data-extra="turbopuffer">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Turbopuffer</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="aws" data-extra="aws">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>AWS Glue or AWS S3 Tables</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="iceberg" data-extra="iceberg">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Apache Iceberg</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="deltalake" data-extra="deltalake">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Delta Lake</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="hudi" data-extra="hudi">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Apache Hudi</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="unity" data-extra="unity">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>Unity Catalog (Databricks)</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="lance" data-extra="lance">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>LanceDB</strong>
+        </div>
+      </label>
+
+      <label class="checkbox-item">
+        <input type="checkbox" id="clickhouse" data-extra="clickhouse">
+        <span class="checkmark"></span>
+        <div class="checkbox-content">
+          <strong>ClickHouse</strong>
+        </div>
+      </label>
+    </div>
+  </div>
+
+  <div class="command-output">
+    <h4>Installation Command:</h4>
+    <div class="highlight">
+      <table class="highlighttable">
+        <tbody>
+          <tr>
+            <td class="linenos">
+              <div class="linenodiv">
+                <pre><span></span><span class="normal">1</span></pre>
+              </div>
+            </td>
+            <td class="code">
+              <div>
+                <pre><button class="md-clipboard md-icon" title="Copy to clipboard" data-clipboard-target="#install-command > code"></button><code id="install-command" class="language-bash">pip install -U daft</code></pre>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+You can also install Daft with all extra dependencies:
 
 ```bash
-pip install -U daft[aws]
+pip install -U "daft[all]"
 ```
 
-To install Daft with the extra dependencies required for running distributed Daft on top of a [Ray cluster](https://docs.ray.io/en/latest/index.html), run:
+## Troubleshooting Legacy CPU Support
 
-```bash
-pip install -U daft[ray]
-```
-
-To install Daft with all extras, run:
-
-```bash
-pip install -U daft[all]
-```
-
-## Legacy CPUs
-
-If you see the text `Illegal instruction` when trying to run Daft, it may be because your CPU lacks support for certain instruction sets such as [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions). For those CPUs, use the `daft-lts` package instead:
+If you encounter `Illegal instruction` errors, your CPU may lack support for advanced instruction sets like [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions). Use the LTS version instead:
 
 ```bash
 pip install -U daft-lts
 ```
 
-!!! tip "Note"
-    Because `daft-lts` is compiled to use a limited CPU instruction set, the package is unable to take advantage of more performant vectorized operations. Only install this package if your CPU does not support running the `daft` package.
+!!! warning "Performance Impact"
+    The LTS version uses limited CPU instructions and cannot leverage vectorized operations, resulting in slower performance. Only use this if the standard package fails to run.
 
-## Advanced Installation
+<style>
+.daft-install-tool {
+  margin: 20px 0;
+}
 
-### Installing Nightlies
+.use-cases h4 {
+  margin-top: 0;
+  margin-bottom: 16px;
+  color: var(--md-default-fg-color);
+}
 
-If you wish to use Daft at the bleeding edge of development, you may also install the nightly build of Daft which is built every night against the `main` branch:
+.checkbox-group {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 12px;
+  margin-bottom: 24px;
+}
 
-```bash
-pip install -U daft --pre --extra-index-url https://d1p3klp2t5517h.cloudfront.net/builds/nightly
-```
+.checkbox-item {
+  display: flex;
+  align-items: flex-start;
+  cursor: pointer;
+  padding: 12px;
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 6px;
+  transition: all 0.2s ease;
+}
 
-### Installing Daft from source
+.checkbox-item:hover {
+  background: var(--md-default-fg-color--lightest);
+  border-color: var(--md-accent-fg-color);
+}
 
-```bash
-pip install -U https://github.com/Eventual-Inc/Daft/archive/refs/heads/main.zip
-```
+.checkbox-item input[type="checkbox"] {
+  display: none;
+}
 
-Please note that Daft requires the Rust toolchain in order to build from source.
+.checkmark {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--md-default-fg-color--light);
+  border-radius: 4px;
+  margin-right: 12px;
+  margin-top: 2px;
+  position: relative;
+  transition: all 0.2s ease;
+}
+
+.checkbox-item input[type="checkbox"]:checked + .checkmark {
+  background: var(--md-accent-fg-color);
+  border-color: var(--md-accent-fg-color);
+}
+
+.checkbox-item input[type="checkbox"]:checked + .checkmark::after {
+  content: '✓';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.checkbox-content {
+  flex: 1;
+}
+
+.checkbox-content strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--md-default-fg-color);
+  font-size: 14px;
+  font-weight: normal;
+}
+
+.checkbox-content .description {
+  font-size: 14px;
+  color: var(--md-default-fg-color--light);
+}
+
+.command-output h4 {
+  margin-top: 0;
+  margin-bottom: 12px;
+  color: var(--md-default-fg-color);
+}
+
+.highlight {
+  margin-bottom: 12px;
+}
+
+.explanation {
+  font-size: 14px;
+  color: var(--md-default-fg-color--light);
+  line-height: 1.5;
+}
+
+
+</style>

--- a/docs/install.md
+++ b/docs/install.md
@@ -8,8 +8,6 @@ For most users, install Daft with a single command:
 pip install -U daft
 ```
 
-This includes most essential features for using Daft.
-
 ## Optional Dependencies
 
 Depending on your use case, you may need to install Daft with additional dependencies.
@@ -23,7 +21,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="huggingface" data-extra="huggingface">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>Hugging Face</strong>
+          <strong>Hugging Face</strong> <code>huggingface</code>
         </div>
       </label>
 
@@ -31,7 +29,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="openai" data-extra="openai">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>OpenAI</strong>
+          <strong>OpenAI</strong> <code>openai</code>
         </div>
       </label>
 
@@ -39,7 +37,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="sentence-transformers" data-extra="sentence-transformers">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>Sentence Transformers</strong>
+          <strong>Sentence Transformers</strong> <code>sentence-transformers</code>
         </div>
       </label>
 
@@ -47,7 +45,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="ray" data-extra="ray">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>Distributed Computing on Ray</strong>
+          <strong>Distributed Computing on Ray</strong> <code>ray</code>
         </div>
       </label>
 
@@ -55,7 +53,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="turbopuffer" data-extra="turbopuffer">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>Turbopuffer</strong>
+          <strong>Turbopuffer</strong> <code>turbopuffer</code>
         </div>
       </label>
 
@@ -63,7 +61,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="aws" data-extra="aws">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>AWS Glue or AWS S3 Tables</strong>
+          <strong>AWS Glue or AWS S3 Tables</strong> <code>aws</code>
         </div>
       </label>
 
@@ -71,7 +69,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="iceberg" data-extra="iceberg">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>Apache Iceberg</strong>
+          <strong>Apache Iceberg</strong> <code>iceberg</code>
         </div>
       </label>
 
@@ -79,7 +77,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="deltalake" data-extra="deltalake">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>Delta Lake</strong>
+          <strong>Delta Lake</strong> <code>deltalake</code>
         </div>
       </label>
 
@@ -87,7 +85,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="hudi" data-extra="hudi">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>Apache Hudi</strong>
+          <strong>Apache Hudi</strong> <code>hudi</code>
         </div>
       </label>
 
@@ -95,7 +93,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="unity" data-extra="unity">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>Unity Catalog (Databricks)</strong>
+          <strong>Unity Catalog (Databricks)</strong> <code>unity</code>
         </div>
       </label>
 
@@ -103,7 +101,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="lance" data-extra="lance">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>LanceDB</strong>
+          <strong>LanceDB</strong> <code>lance</code>
         </div>
       </label>
 
@@ -111,7 +109,7 @@ Depending on your use case, you may need to install Daft with additional depende
         <input type="checkbox" id="clickhouse" data-extra="clickhouse">
         <span class="checkmark"></span>
         <div class="checkbox-content">
-          <strong>ClickHouse</strong>
+          <strong>ClickHouse</strong> <code>clickhouse</code>
         </div>
       </label>
     </div>
@@ -146,6 +144,8 @@ You can also install Daft with all extra dependencies:
 pip install -U "daft[all]"
 ```
 
+
+
 ## Troubleshooting Legacy CPU Support
 
 If you encounter `Illegal instruction` errors, your CPU may lack support for advanced instruction sets like [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions). Use the LTS version instead:
@@ -173,13 +173,14 @@ pip install -U daft-lts
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 12px;
   margin-bottom: 24px;
+  align-items: center;
 }
 
 .checkbox-item {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   cursor: pointer;
-  padding: 12px;
+  padding: 8px 8px 8px 16px;
   border: 1px solid var(--md-default-fg-color--lightest);
   border-radius: 6px;
   transition: all 0.2s ease;
@@ -227,15 +228,10 @@ pip install -U daft-lts
 
 .checkbox-content strong {
   display: block;
-  margin-bottom: 4px;
+  margin-bottom: -2px;
   color: var(--md-default-fg-color);
   font-size: 14px;
   font-weight: normal;
-}
-
-.checkbox-content .description {
-  font-size: 14px;
-  color: var(--md-default-fg-color--light);
 }
 
 .command-output h4 {
@@ -247,12 +243,4 @@ pip install -U daft-lts
 .highlight {
   margin-bottom: 12px;
 }
-
-.explanation {
-  font-size: 14px;
-  color: var(--md-default-fg-color--light);
-  line-height: 1.5;
-}
-
-
 </style>

--- a/docs/js/install-tool.js
+++ b/docs/js/install-tool.js
@@ -1,6 +1,6 @@
-// Daft Installation Tool JavaScript
+// Daft Installation Tool JavaScript.
 document.addEventListener('DOMContentLoaded', function() {
-  // Wait a bit to ensure the DOM is fully loaded
+  // Wait a bit to ensure the DOM is fully loaded.
   setTimeout(function() {
     initializeInstallTool();
   }, 100);
@@ -37,17 +37,21 @@ function updateInstallCommand() {
     }
   });
 
-  let command = 'pip install -U ';
-  command += 'daft';
+  const prefix = 'pip install -U ';
+  let packageName = 'daft';
+
   if (extras.length > 0) {
-    // If all checkboxes are selected, use "all" instead of listing them all
+    // If all checkboxes are selected, use "all" instead of listing them all.
     if (extras.length === checkboxes.length) {
-      command += '[all]';
+      packageName += '[all]';
     } else {
-      command += '[' + extras.join(',') + ']';
+      packageName += '[' + extras.join(',') + ']';
     }
-    command = 'pip install -U "' + command.substring(15) + '"';
+    // Quote the package name when it has extras.
+    packageName = '"' + packageName + '"';
   }
+
+  let command = prefix + packageName;
 
   commandElement.textContent = command;
 }

--- a/docs/js/install-tool.js
+++ b/docs/js/install-tool.js
@@ -49,15 +49,5 @@ function updateInstallCommand() {
     command = 'pip install -U "' + command.substring(15) + '"';
   }
 
-  // Add syntax highlighting - only highlight quoted strings
-  let highlightedCommand = command;
-  if (command.includes('"daft[')) {
-    // Highlight only the quoted package name
-    highlightedCommand = command.replace(
-      /(pip install -U )(")(daft\[[^\]]+\])(")/,
-      '$1<span class="s2">$2$3$4</span>'
-    );
-  }
-
-  commandElement.innerHTML = highlightedCommand;
+  commandElement.textContent = command;
 }

--- a/docs/js/install-tool.js
+++ b/docs/js/install-tool.js
@@ -1,0 +1,63 @@
+// Daft Installation Tool JavaScript
+document.addEventListener('DOMContentLoaded', function() {
+  // Wait a bit to ensure the DOM is fully loaded
+  setTimeout(function() {
+    initializeInstallTool();
+  }, 100);
+});
+
+function initializeInstallTool() {
+  const checkboxes = document.querySelectorAll('#daft-install-tool input[type="checkbox"]');
+
+  if (checkboxes.length === 0) {
+    return;
+  }
+
+  checkboxes.forEach(checkbox => {
+    checkbox.addEventListener('change', updateInstallCommand);
+  });
+
+  updateInstallCommand();
+}
+
+function updateInstallCommand() {
+  const checkboxes = document.querySelectorAll('#daft-install-tool input[type="checkbox"]');
+  const commandElement = document.getElementById('install-command');
+
+  if (!commandElement) {
+    return;
+  }
+
+  let extras = [];
+
+  checkboxes.forEach(checkbox => {
+    if (checkbox.checked) {
+      const extra = checkbox.getAttribute('data-extra');
+      extras.push(extra);
+    }
+  });
+
+  let command = 'pip install -U ';
+  command += 'daft';
+  if (extras.length > 0) {
+    // If all checkboxes are selected, use "all" instead of listing them all
+    if (extras.length === checkboxes.length) {
+      command += '[all]';
+    } else {
+      command += '[' + extras.join(',') + ']';
+    }
+    command = 'pip install -U "' + command.substring(15) + '"';
+  }
+
+  // Add syntax highlighting - only highlight quoted strings
+  let highlightedCommand = command;
+  if (command.includes('"daft[')) {
+    // Highlight only the quoted package name
+    highlightedCommand = command.replace(
+      /(pip install -U )(")(daft\[[^\]]+\])(")/,
+      '$1<span class="s2">$2$3$4</span>'
+    );
+  }
+
+  commandElement.innerHTML = highlightedCommand;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ extra_javascript:
 - js/reo.js
 - js/custom.js
 - js/docsearch.js
+- js/install-tool.js
 - https://cdn.jsdelivr.net/npm/@docsearch/js@3
 - js/readthedocs.js
 # Extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ homepage = "https://www.daft.ai"
 repository = "https://github.com/Eventual-Inc/Daft"
 
 [project.optional-dependencies]
-all = ["daft[aws, azure, gcp, ray, pandas, numpy, iceberg, deltalake, spark, sql, unity, clickhouse, huggingface]"]
+all = ["daft[aws, azure, clickhouse, deltalake, gcp, hudi, huggingface, iceberg, lance, numpy, openai, pandas, ray, sentence-transformers, spark, sql, turbopuffer, unity]"]
 aws = ["boto3"]
 azure = []
 clickhouse = ["clickhouse_connect"]
@@ -37,12 +37,13 @@ deltalake = ["deltalake", "packaging"]
 gcp = []
 hudi = ["pyarrow >= 8.0.0"]
 huggingface = ["huggingface-hub"]
-# TDOO: pyiceberg 0.9.1 has a bug https://github.com/apache/iceberg-python/issues/1979. It was not
+# TODO: pyiceberg 0.9.1 has a bug https://github.com/apache/iceberg-python/issues/1979. It was not
 # triggered because we specify pyiceberg == 0.7.0 in requrements-dev.txt which hide this problem.
 # See https://github.com/Eventual-Inc/Daft/issues/4868.
 iceberg = ["pyiceberg >= 0.7.0, < 0.9.1", "packaging"]
 lance = ["pylance"]
 numpy = ["numpy"]
+openai = ["openai"]
 pandas = ["pandas"]
 ray = [
   # Inherit existing Ray version. Get the "default" extra for the Ray dashboard.
@@ -52,8 +53,10 @@ ray = [
   # Explicitly install packaging. See issue: https://github.com/ray-project/ray/issues/34806
   "packaging"
 ]
+sentence-transformers = ["sentence-transformers"]
 spark = ["googleapis-common-protos >= 1.56.4", "grpcio >= 1.48", "grpcio-status >= 1.48", "numpy >= 1.15", "pandas >= 1.0.5", "py4j >= 0.10.9.7", "pyspark == 3.5.5"]
 sql = ["connectorx", "sqlalchemy", "sqlglot"]
+turbopuffer = ["turbopuffer"]
 unity = ["httpx <= 0.27.2", "unitycatalog"]
 viz = []
 


### PR DESCRIPTION
## Changes Made

Some improvements:
- Focus on making this a How To guide based on https://diataxis.fr/
- Installation comes after the quickstart. The quickstart gets you going and contains a self-contained installation instruction. There's no need to boggle down the user with installation before a quickstart.
- List most important optional dependencies (if a user wants pandas or numpy they can figure it out themselves).
- Remove info on installing nightlies or building from source. Fastest path to success.
- Emphasize that they should only look at the legacy cpu support section for troubleshooting only.