### PR TITLE
ci: Do not skip postmerge tests

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -31,9 +31,15 @@ jobs:
 
     - name: Detect non-trivial changes
       id: filter
-      if: ${{ github.ref != 'refs/heads/main' }}
       run: |
-        BASE=${{ github.base_ref || 'main' }}
+        # On main branch, we want to run all tests (no skipping)
+        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          echo "skip=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # For PRs, check if there are non-trivial changes
+        BASE=${{ github.base_ref || 'origin/main' }}
         git fetch origin $BASE --depth=1
 
         if git diff --quiet origin/$BASE -- \

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -31,15 +31,9 @@ jobs:
 
     - name: Detect non-trivial changes
       id: filter
+      if: ${{ github.ref != 'refs/heads/main' }}
       run: |
-        # On main branch, we want to run all tests (no skipping)
-        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-          echo "skip=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        # For PRs, check if there are non-trivial changes
-        BASE=${{ github.base_ref || 'origin/main' }}
+        BASE=${{ github.base_ref || 'main' }}
         git fetch origin $BASE --depth=1
 
         if git diff --quiet origin/$BASE -- \

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -32,6 +32,13 @@ jobs:
     - name: Detect non-trivial changes
       id: filter
       run: |
+        # On main branch, we want to run all tests (no skipping)
+        if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          echo "skip=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # For PRs, check if there are non-trivial changes
         BASE=${{ github.base_ref || 'origin/main' }}
         git fetch origin $BASE --depth=1
 


### PR DESCRIPTION
## Changes Made

We skipped premerge tests for non-code changes in https://github.com/Eventual-Inc/Daft/pull/5057

But we shouldn't do this for postmerge