### PR TITLE
feat: Implement embed_image()

### DIFF
--- a/daft/ai/_expressions.py
+++ b/daft/ai/_expressions.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from daft import Series
-    from daft.ai.protocols import TextEmbedder, TextEmbedderDescriptor
+    from daft.ai.protocols import ImageEmbedder, ImageEmbedderDescriptor, TextEmbedder, TextEmbedderDescriptor
     from daft.ai.typing import Embedding
 
 
@@ -19,3 +19,16 @@ class _TextEmbedderExpression:
     def __call__(self, text_series: Series) -> list[Embedding]:
         text = text_series.to_pylist()
         return self.text_embedder.embed_text(text) if text else []
+
+
+class _ImageEmbedderExpression:
+    """Function expression implementation for a ImageEmbedder protocol."""
+
+    image_embedder: ImageEmbedder
+
+    def __init__(self, image_embedder: ImageEmbedderDescriptor):
+        self.image_embedder = image_embedder.instantiate()
+
+    def __call__(self, image_series: Series) -> list[Embedding]:
+        image = image_series.to_pylist()
+        return self.image_embedder.embed_image(image) if image else []

--- a/daft/ai/openai/__init__.py
+++ b/daft/ai/openai/__init__.py
@@ -9,7 +9,7 @@ from typing_extensions import Unpack
 
 if TYPE_CHECKING:
     from daft.ai.openai.typing import OpenAIProviderOptions
-    from daft.ai.protocols import TextEmbedder, TextEmbedderDescriptor
+    from daft.ai.protocols import ImageEmbedderDescriptor, TextEmbedderDescriptor
     from daft.ai.typing import Options
 
 __all__ = [
@@ -36,3 +36,6 @@ class OpenAIProvider(Provider):
             model_name=(model or "text-embedding-3-small"),
             model_options=options,
         )
+
+    def get_image_embedder(self, model: str | None = None, **options: Any) -> ImageEmbedderDescriptor:
+        raise NotImplementedError("embed_image is not currently implemented for the OpenAI provider")

--- a/daft/ai/protocols.py
+++ b/daft/ai/protocols.py
@@ -7,6 +7,7 @@ from daft.ai.typing import Descriptor
 
 if TYPE_CHECKING:
     from daft.ai.typing import Embedding, EmbeddingDimensions
+    from daft.dependencies import np
 
 
 @runtime_checkable
@@ -24,3 +25,20 @@ class TextEmbedderDescriptor(Descriptor[TextEmbedder]):
     @abstractmethod
     def get_dimensions(self) -> EmbeddingDimensions:
         """Returns the dimensions of the embeddings produced by the described TextEmbedder."""
+
+
+@runtime_checkable
+class ImageEmbedder(Protocol):
+    """Protocol for image embedding implementations."""
+
+    def embed_image(self, image: list[np.ndarray]) -> list[Embedding]:
+        """Embeds a batch of images into an embedding vector."""
+        ...
+
+
+class ImageEmbedderDescriptor(Descriptor[ImageEmbedder]):
+    """Descriptor for a ImageEmbedder implementation."""
+
+    @abstractmethod
+    def get_dimensions(self) -> EmbeddingDimensions:
+        """Returns the dimensions of the embeddings produced by the described ImageEmbedder."""

--- a/daft/ai/provider.py
+++ b/daft/ai/provider.py
@@ -7,7 +7,7 @@ from typing_extensions import Unpack
 
 if TYPE_CHECKING:
     from daft.ai.openai.typing import OpenAIProviderOptions
-    from daft.ai.protocols import TextEmbedderDescriptor
+    from daft.ai.protocols import ImageEmbedderDescriptor, TextEmbedderDescriptor
 
 
 class ProviderImportError(ImportError):
@@ -34,9 +34,19 @@ def load_sentence_transformers(name: str | None = None, **options: Any) -> Provi
         raise ProviderImportError(["sentence_transformers", "torch"]) from e
 
 
+def load_transformers(name: str | None = None, **options: Any) -> Provider:
+    try:
+        from daft.ai.transformers import TransformersProvider
+
+        return TransformersProvider(name, **options)
+    except ImportError as e:
+        raise ProviderImportError(["transformers", "torch", "torchvision"]) from e
+
+
 PROVIDERS: dict[str, Callable[..., Provider]] = {
     "openai": load_openai,
     "sentence_transformers": load_sentence_transformers,
+    "transformers": load_transformers,
 }
 
 
@@ -64,4 +74,9 @@ class Provider(ABC):
     @abstractmethod
     def get_text_embedder(self, model: str | None = None, **options: Any) -> TextEmbedderDescriptor:
         """Returns a TextEmbedderDescriptor for this provider."""
+        ...
+
+    @abstractmethod
+    def get_image_embedder(self, model: str | None = None, **options: Any) -> ImageEmbedderDescriptor:
+        """Returns a ImageEmbedderDescriptor for this provider."""
         ...

--- a/daft/ai/sentence_transformers/__init__.py
+++ b/daft/ai/sentence_transformers/__init__.py
@@ -6,7 +6,7 @@ from daft.ai.sentence_transformers.text_embedder import SentenceTransformersText
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from daft.ai.protocols import TextEmbedderDescriptor
+    from daft.ai.protocols import ImageEmbedderDescriptor, TextEmbedderDescriptor
     from daft.ai.typing import Options
 
 __all__ = [
@@ -28,3 +28,6 @@ class SentenceTransformersProvider(Provider):
 
     def get_text_embedder(self, model: str | None = None, **options: Any) -> TextEmbedderDescriptor:
         return SentenceTransformersTextEmbedderDescriptor(model or "sentence-transformers/all-MiniLM-L6-v2", options)
+
+    def get_image_embedder(self, model: str | None = None, **options: Any) -> ImageEmbedderDescriptor:
+        raise NotImplementedError("embed_image is not currently implemented for the Sentence Transformers provider")

--- a/daft/ai/sentence_transformers/text_embedder.py
+++ b/daft/ai/sentence_transformers/text_embedder.py
@@ -30,7 +30,7 @@ class SentenceTransformersTextEmbedderDescriptor(TextEmbedderDescriptor):
         return self.options
 
     def get_dimensions(self) -> EmbeddingDimensions:
-        dimensions = AutoConfig.from_pretrained(self.model).hidden_size
+        dimensions = AutoConfig.from_pretrained(self.model, trust_remote_code=True).hidden_size
         return EmbeddingDimensions(size=dimensions, dtype=DataType.float32())
 
     def instantiate(self) -> TextEmbedder:

--- a/daft/ai/transformers/__init__.py
+++ b/daft/ai/transformers/__init__.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from daft.ai.provider import Provider
+
+from daft.ai.transformers.image_embedder import TransformersImageEmbedderDescriptor
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from daft.ai.protocols import ImageEmbedderDescriptor, TextEmbedderDescriptor
+    from daft.ai.typing import Options
+
+__all__ = [
+    "TransformersProvider",
+]
+
+
+class TransformersProvider(Provider):
+    _name: str
+    _options: Options
+
+    def __init__(self, name: str | None = None, **options: Any):
+        self._name = name if name else "transformers"
+        self._options = options
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def get_image_embedder(self, model: str | None = None, **options: Any) -> ImageEmbedderDescriptor:
+        return TransformersImageEmbedderDescriptor(model or "openai/clip-vit-base-patch32", options)
+
+    def get_text_embedder(self, model: str | None = None, **options: Any) -> TextEmbedderDescriptor:
+        raise NotImplementedError("embed_text is not currently implemented for the Transformers provider")

--- a/daft/ai/transformers/__init__.py
+++ b/daft/ai/transformers/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from daft.ai.provider import Provider
 
 from daft.ai.transformers.image_embedder import TransformersImageEmbedderDescriptor
+from daft.dependencies import pil_image
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -27,6 +28,10 @@ class TransformersProvider(Provider):
         return self._name
 
     def get_image_embedder(self, model: str | None = None, **options: Any) -> ImageEmbedderDescriptor:
+        # Raise an error early if PIL is not available.
+        if not pil_image.module_available():
+            raise ImportError("Pillow is required for image processing but not available")
+
         return TransformersImageEmbedderDescriptor(model or "openai/clip-vit-base-patch32", options)
 
     def get_text_embedder(self, model: str | None = None, **options: Any) -> TextEmbedderDescriptor:

--- a/daft/ai/transformers/image_embedder.py
+++ b/daft/ai/transformers/image_embedder.py
@@ -47,9 +47,6 @@ class TransformersImageEmbedder(ImageEmbedder):
     options: Options
 
     def __init__(self, model_name_or_path: str, **options: Any):
-        if not pil_image.module_available():
-            raise ImportError("Pillow is required for image processing but not available")
-
         self.device = (
             torch.device("cuda")
             if torch.cuda.is_available()

--- a/daft/ai/transformers/image_embedder.py
+++ b/daft/ai/transformers/image_embedder.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+from transformers import AutoModel, AutoProcessor
+
+from daft import DataType
+from daft.ai.protocols import ImageEmbedder, ImageEmbedderDescriptor
+from daft.ai.typing import EmbeddingDimensions, Options
+from daft.dependencies import pil_image
+
+if TYPE_CHECKING:
+    from daft.ai.typing import Embedding
+    from daft.dependencies import np
+
+
+@dataclass
+class TransformersImageEmbedderDescriptor(ImageEmbedderDescriptor):
+    model: str
+    options: Options
+
+    def get_provider(self) -> str:
+        return "transformers"
+
+    def get_model(self) -> str:
+        return self.model
+
+    def get_options(self) -> Options:
+        return self.options
+
+    def get_dimensions(self) -> EmbeddingDimensions:
+        from transformers import AutoConfig
+
+        config = AutoConfig.from_pretrained(self.model, trust_remote_code=True)
+        # For CLIP models, the image embedding dimension is typically in projection_dim or hidden_size.
+        embedding_size = getattr(config, "projection_dim", getattr(config, "hidden_size", 512))
+        return EmbeddingDimensions(size=embedding_size, dtype=DataType.float32())
+
+    def instantiate(self) -> ImageEmbedder:
+        return TransformersImageEmbedder(self.model, **self.options)
+
+
+class TransformersImageEmbedder(ImageEmbedder):
+    model: Any
+    options: Options
+
+    def __init__(self, model_name_or_path: str, **options: Any):
+        if not pil_image.module_available():
+            raise ImportError("Pillow is required for image processing but not available")
+
+        self.device = (
+            torch.device("cuda")
+            if torch.cuda.is_available()
+            else torch.device("mps")
+            if hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
+            else torch.device("cpu")
+        )
+        self.model = AutoModel.from_pretrained(model_name_or_path, trust_remote_code=True).to(self.device)
+        self.processor = AutoProcessor.from_pretrained(model_name_or_path, trust_remote_code=True, use_fast=True)
+        self.options = options
+
+    def embed_image(self, images: list[np.ndarray]) -> list[Embedding]:
+        # TODO(desmond): There's potential for image decoding and processing on the GPU with greater
+        # performance. Methods differ a little between different models, so let's do it later.
+        pil_images = [pil_image.fromarray(image) for image in images]
+        processed = self.processor(images=pil_images, return_tensors="pt")
+        pixel_values = processed["pixel_values"].to(self.device)
+
+        with torch.inference_mode():
+            embeddings = self.model.get_image_features(pixel_values)
+        return embeddings.cpu().numpy().tolist()

--- a/daft/functions/ai/__init__.py
+++ b/daft/functions/ai/__init__.py
@@ -85,3 +85,21 @@ def embed_text(
     )
     expr = expr.with_init_args(text_embedder)
     return expr(text)
+
+
+def embed_image(
+    image: Expression,
+    *,
+    provider: str | Provider | None = None,
+    model: str | None = None,
+    **options: str,
+) -> Expression:
+    from daft.ai._expressions import _ImageEmbedderExpression
+    from daft.ai.protocols import ImageEmbedder
+
+    image_embedder = _resolve_provider(provider, "transformers").get_image_embedder(model, **options)
+    expr = udf(return_dtype=image_embedder.get_dimensions().as_dtype(), concurrency=1, use_process=False)(
+        _ImageEmbedderExpression
+    )
+    expr = expr.with_init_args(image_embedder)
+    return expr(image)

--- a/daft/functions/ai/__init__.py
+++ b/daft/functions/ai/__init__.py
@@ -94,6 +94,20 @@ def embed_image(
     model: str | None = None,
     **options: str,
 ) -> Expression:
+    """Returns an expression that embeds images using the specified image model and provider.
+
+    Args:
+        image (Expression): The input image column expression.
+        provider (str | Provider | None): The provider to use for the image model. If None, the default provider is used.
+        model (str | None): The image model to use. Can be a model instance or a model name. If None, the default model is used.
+        **options: Any additional options to pass for the model.
+
+    Note:
+        Make sure the required provider packages are installed (e.g. vllm, transformers, openai).
+
+    Returns:
+        Expression: An expression representing the embedded image vectors.
+    """
     from daft.ai._expressions import _ImageEmbedderExpression
     from daft.ai.protocols import ImageEmbedder
 

--- a/tests/ai/test_transformers.py
+++ b/tests/ai/test_transformers.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("transformers")
+pytest.importorskip("torch")
+pytest.importorskip("PIL")
+
+import numpy as np
+import torch
+
+import daft
+from daft.ai.protocols import ImageEmbedderDescriptor
+from daft.ai.transformers import TransformersProvider
+from daft.ai.typing import EmbeddingDimensions
+from daft.datatype import DataType
+from daft.functions.ai import embed_image
+
+
+def test_transformers_image_embedder_default():
+    provider = TransformersProvider()
+    descriptor = provider.get_image_embedder()
+    assert isinstance(descriptor, ImageEmbedderDescriptor)
+    assert descriptor.get_provider() == "transformers"
+    assert descriptor.get_model() == "openai/clip-vit-base-patch32"
+    assert descriptor.get_dimensions() == EmbeddingDimensions(512, dtype=DataType.float32())
+
+
+@pytest.mark.parametrize(
+    "model_name, dimensions, run_model",
+    [
+        ("openai/clip-vit-base-patch32", 512, True),
+        ("openai/clip-vit-large-patch14", 768, True),
+        ("openai/clip-vit-base-patch16", 512, True),
+        ("openai/clip-vit-large-patch14-336", 768, True),
+    ],
+)
+def test_transformers_image_embedder_other(model_name, dimensions, run_model):
+    mock_options = {"arg1": "val1", "arg2": "val2"}
+
+    provider = TransformersProvider()
+    descriptor = provider.get_image_embedder(model_name, **mock_options)
+    assert isinstance(descriptor, ImageEmbedderDescriptor)
+    assert descriptor.get_provider() == "transformers"
+    assert descriptor.get_model() == model_name
+    assert descriptor.get_options() == mock_options
+
+    if run_model:
+        embedder = descriptor.instantiate()
+
+        # Test with a variety of image sizes and shapes that should be preprocessed correctly.
+        # TODO(desmond): This doesn't work with greyscale images. I wonder if we should require users to cast
+        # to RGB or if we want to handle this automagically.
+        test_image1 = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
+        test_image2 = np.random.randint(0, 255, (500, 10, 3), dtype=np.uint8)
+        # test_image3 = np.random.randint(0, 255, (100, 100, 1), dtype=np.uint8)
+        test_images = [test_image1, test_image2] * 8
+
+        embeddings = embedder.embed_image(test_images)
+        assert len(embeddings) == 16
+        assert len(embeddings[0]) == dimensions
+    else:
+        assert descriptor.get_dimensions() == EmbeddingDimensions(dimensions, dtype=DataType.float32())
+
+
+def test_transformers_device_selection():
+    """Test that the embedder uses the correct device selection."""
+    provider = TransformersProvider()
+    descriptor = provider.get_image_embedder("openai/clip-vit-base-patch32")
+    embedder = descriptor.instantiate()
+
+    if torch.cuda.is_available():
+        expected_device = "cuda"
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        expected_device = "mps"
+    else:
+        expected_device = "cpu"
+
+    embedder_device = next(embedder.model.parameters()).device
+    assert expected_device in str(embedder_device)
+
+
+def test_transformers_pil_dependency_check():
+    """Test that the embedder properly checks for PIL availability."""
+    provider = TransformersProvider()
+    descriptor = provider.get_image_embedder("openai/clip-vit-base-patch32")
+
+    # This should work when PIL is available (which it should be due to pytest.importorskip).
+    embedder = descriptor.instantiate()
+    assert embedder is not None
+
+
+def test_transformers_pil_dependency_check_failure():
+    """Test that the embedder fails fast when PIL is not available."""
+    from unittest.mock import patch
+
+    with patch("daft.dependencies.pil_image.module_available", return_value=False):
+        provider = TransformersProvider()
+
+        with pytest.raises(ImportError, match="Pillow is required for image processing but not available"):
+            provider.get_image_embedder("openai/clip-vit-base-patch32")
+
+        with pytest.raises(ImportError, match="Pillow is required for image processing but not available"):
+            test_image = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
+            (
+                daft.from_pydict({"image": [test_image]})
+                .select(daft.col("image").cast(daft.DataType.image()))
+                .select(embed_image(daft.col("image")))
+            )


### PR DESCRIPTION
## Changes Made

Adds support for `embed_image()`, e.g.

```
import daft
from daft.functions.ai import embed_image

import numpy as np

test_image = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)

(
    daft.from_pydict({"image": [test_image] * 16})
    .select(daft.col("image").cast(daft.DataType.image()))
    .select(embed_image(daft.col("image")))
    .show()
)
```