### PR TITLE
docs: add dark mode support for Algolia DocSearch

### DIFF
--- a/docs/css/docsearch.css
+++ b/docs/css/docsearch.css
@@ -67,3 +67,21 @@
 .DocSearch-Help {
     font-size: 1em !important
 }
+
+/* DARK MODE OVERRIDES */
+[data-md-color-scheme="slate"] {
+    --docsearch-text-color: var(--md-default-fg-color);
+    --docsearch-container-background: rgba(0, 0, 0, 0.6);
+    --docsearch-modal-background: var(--md-default-bg-color);
+    --docsearch-modal-shadow: 0 8px 32px rgba(0, 0, 0, 0.8);
+    --docsearch-searchbox-background: var(--md-code-bg-color);
+    --docsearch-searchbox-focus-background: var(--md-code-bg-color);
+    --docsearch-hit-color: var(--md-default-fg-color);
+    --docsearch-hit-active-color: var(--md-default-bg-color);
+    --docsearch-hit-background: transparent;
+    --docsearch-hit-shadow: none;
+    --docsearch-footer-background: var(--md-default-bg-color);
+    --docsearch-footer-shadow: inset 0 1px 0 0 rgba(73, 76, 106, 0.2);
+    --docsearch-spacing: 12px;
+    --docsearch-muted-color: var(--md-default-fg-color--light);
+}

--- a/docs/css/docsearch.css
+++ b/docs/css/docsearch.css
@@ -69,7 +69,7 @@
 }
 
 /* DARK MODE OVERRIDES */
-[data-md-color-scheme="slate"] {
+[data-md-color-scheme="slate"][data-md-color-primary="black"] {
     --docsearch-text-color: var(--md-default-fg-color);
     --docsearch-container-background: rgba(0, 0, 0, 0.6);
     --docsearch-modal-background: var(--md-default-bg-color);


### PR DESCRIPTION
## Summary
- Adds dark mode CSS variables for Algolia DocSearch modal
- Uses Material Design variables for consistent theming with existing dark mode
- Implements subtle shadow and background colors appropriate for dark theme
- Uses consistent dark mode selector pattern matching existing codebase

## Test plan
- [x] Test search modal in light mode (unchanged)  
- [x] Test search modal in dark mode (now properly styled)
- [x] Verify colors match overall Material Design dark theme