### PR TITLE
feat: adds support for classify_text 

### DIFF
--- a/daft/ai/_expressions.py
+++ b/daft/ai/_expressions.py
@@ -4,8 +4,15 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from daft import Series
-    from daft.ai.protocols import ImageEmbedder, ImageEmbedderDescriptor, TextEmbedder, TextEmbedderDescriptor
-    from daft.ai.typing import Embedding
+    from daft.ai.protocols import (
+        ImageEmbedder,
+        ImageEmbedderDescriptor,
+        TextClassifier,
+        TextClassifierDescriptor,
+        TextEmbedder,
+        TextEmbedderDescriptor,
+    )
+    from daft.ai.typing import Embedding, Label
 
 
 class _TextEmbedderExpression:
@@ -32,3 +39,18 @@ class _ImageEmbedderExpression:
     def __call__(self, image_series: Series) -> list[Embedding]:
         image = image_series.to_pylist()
         return self.image_embedder.embed_image(image) if image else []
+
+
+class _TextClassificationExpression:
+    """Function expression implementation for a TextClassifier protocol."""
+
+    text_classifier: TextClassifier
+    labels: list[Label]
+
+    def __init__(self, text_classifier: TextClassifierDescriptor, labels: list[Label]):
+        self.text_classifier = text_classifier.instantiate()
+        self.labels = labels
+
+    def __call__(self, text_series: Series) -> list[Label]:
+        text = text_series.to_pylist()
+        return self.text_classifier.classify_text(text, labels=self.labels) if text else []

--- a/daft/ai/protocols.py
+++ b/daft/ai/protocols.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from daft.ai.typing import Descriptor
 
 if TYPE_CHECKING:
-    from daft.ai.typing import Embedding, EmbeddingDimensions, Image
+    from daft.ai.typing import Embedding, EmbeddingDimensions, Image, Label
 
 
 @runtime_checkable
@@ -41,3 +41,15 @@ class ImageEmbedderDescriptor(Descriptor[ImageEmbedder]):
     @abstractmethod
     def get_dimensions(self) -> EmbeddingDimensions:
         """Returns the dimensions of the embeddings produced by the described ImageEmbedder."""
+
+
+class TextClassifier(Protocol):
+    """Protocol for text classification implementations."""
+
+    def classify_text(self, text: list[str], labels: Label | list[Label]) -> list[Label]:
+        """Classifies a batch of text strings using the given label(s)."""
+        ...
+
+
+class TextClassifierDescriptor(Descriptor[TextClassifier]):
+    """Descriptor for a TextClassifier implementation."""

--- a/daft/ai/protocols.py
+++ b/daft/ai/protocols.py
@@ -43,6 +43,7 @@ class ImageEmbedderDescriptor(Descriptor[ImageEmbedder]):
         """Returns the dimensions of the embeddings produced by the described ImageEmbedder."""
 
 
+@runtime_checkable
 class TextClassifier(Protocol):
     """Protocol for text classification implementations."""
 

--- a/daft/ai/provider.py
+++ b/daft/ai/provider.py
@@ -7,7 +7,7 @@ from typing_extensions import Unpack
 
 if TYPE_CHECKING:
     from daft.ai.openai.typing import OpenAIProviderOptions
-    from daft.ai.protocols import ImageEmbedderDescriptor, TextEmbedderDescriptor
+    from daft.ai.protocols import ImageEmbedderDescriptor, TextClassifierDescriptor, TextEmbedderDescriptor
 
 
 class ProviderImportError(ImportError):
@@ -92,3 +92,7 @@ class Provider(ABC):
     def get_image_embedder(self, model: str | None = None, **options: Any) -> ImageEmbedderDescriptor:
         """Returns an ImageEmbedderDescriptor for this provider."""
         raise not_implemented_err(self, method="embed_image")
+
+    def get_text_classifier(self, model: str | None = None, **options: Any) -> TextClassifierDescriptor:
+        """Returns a TextClassifierDescriptor for this provider."""
+        raise not_implemented_err(self, method="classify_text")

--- a/daft/ai/transformers/protocols/image_embedder.py
+++ b/daft/ai/transformers/protocols/image_embedder.py
@@ -9,7 +9,7 @@ from transformers import AutoConfig, AutoModel, AutoProcessor
 from daft import DataType
 from daft.ai.protocols import ImageEmbedder, ImageEmbedderDescriptor
 from daft.ai.typing import EmbeddingDimensions, Options
-from daft.ai.utils import get_device
+from daft.ai.utils import get_torch_device
 from daft.dependencies import pil_image
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ class TransformersImageEmbedder(ImageEmbedder):
     options: Options
 
     def __init__(self, model_name_or_path: str, **options: Any):
-        self.device = get_device()
+        self.device = get_torch_device()
         self.model = AutoModel.from_pretrained(
             model_name_or_path,
             trust_remote_code=True,

--- a/daft/ai/transformers/protocols/text_classifier.py
+++ b/daft/ai/transformers/protocols/text_classifier.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import transformers
 from transformers import pipeline
+from typing_extensions import Unpack
 
 from daft.ai.protocols import TextClassifier, TextClassifierDescriptor
 from daft.ai.utils import get_torch_device
@@ -13,17 +14,21 @@ if TYPE_CHECKING:
     from daft.ai.typing import Label, Options
 
 
-class ZeroShotClassificationResult(TypedDict):
+class TransformersTextClassiferResult(TypedDict):
     sequence: str
     labels: list[str]  # labels sorted by likelihood
     scores: list[float]  # probability of each label
+
+
+class TransformersTextClassifierOptions(TypedDict, total=False):
+    batch_size: int | None
 
 
 @dataclass
 class TransformersTextClassifierDescriptor(TextClassifierDescriptor):
     provider_name: str
     model_name: str
-    model_options: Options
+    model_options: TransformersTextClassifierOptions
 
     def get_provider(self) -> str:
         return self.provider_name
@@ -32,7 +37,7 @@ class TransformersTextClassifierDescriptor(TextClassifierDescriptor):
         return self.model_name
 
     def get_options(self) -> Options:
-        return self.model_options
+        return self.model_options  # type: ignore
 
     def instantiate(self) -> TextClassifier:
         return TransformersTextClassifier(self.model_name, **self.model_options)
@@ -46,16 +51,24 @@ class TransformersTextClassifier(TextClassifier):
         template and other pipeline-related options. This is sufficient for now.
     """
 
-    pipe: transformers.ZeroShotClassificationPipeline
+    _model: str
+    _options: TransformersTextClassifierOptions
+    _pipeline: transformers.ZeroShotClassificationPipeline
 
-    def __init__(self, model_name_or_path: str, **options: Any):
-        self.device = get_torch_device()
-        self.pipe = pipeline(
+    def __init__(self, model_name_or_path: str, **options: Unpack[TransformersTextClassifierOptions]):
+        self._model = model_name_or_path
+        self._options = options
+        self._pipeline = pipeline(
             task="zero-shot-classification",
             model=model_name_or_path,
             device=get_torch_device(),
         )
 
     def classify_text(self, text: list[str], labels: Label | list[Label]) -> list[Label]:
-        results: list[ZeroShotClassificationResult] = self.pipe(text, candidate_labels=labels)
+        batch_size = self._options.get("batch_size", None)
+        results: list[TransformersTextClassiferResult] = self._pipeline(
+            text,
+            batch_size=batch_size,
+            candidate_labels=labels,
+        )
         return [result["labels"][0] for result in results]

--- a/daft/ai/transformers/protocols/text_classifier.py
+++ b/daft/ai/transformers/protocols/text_classifier.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypedDict
+
+import transformers
+from transformers import pipeline
+
+from daft.ai.protocols import TextClassifier, TextClassifierDescriptor
+from daft.ai.utils import get_torch_device
+
+if TYPE_CHECKING:
+    from daft.ai.typing import Label, Options
+
+
+class ZeroShotClassificationResult(TypedDict):
+    sequence: str
+    labels: list[str]  # labels sorted by likelihood
+    scores: list[float]  # probability of each label
+
+
+@dataclass
+class TransformersTextClassifierDescriptor(TextClassifierDescriptor):
+    provider_name: str
+    model_name: str
+    model_options: Options
+
+    def get_provider(self) -> str:
+        return self.provider_name
+
+    def get_model(self) -> str:
+        return self.model_name
+
+    def get_options(self) -> Options:
+        return self.model_options
+
+    def instantiate(self) -> TextClassifier:
+        return TransformersTextClassifier(self.model_name, **self.model_options)
+
+
+class TransformersTextClassifier(TextClassifier):
+    """Pipeline based zero-shot text classification.
+
+    Note:
+        This could be improved or configurable with allowing a custom hypothesis
+        template and other pipeline-related options. This is sufficient for now.
+    """
+
+    pipe: transformers.ZeroShotClassificationPipeline
+
+    def __init__(self, model_name_or_path: str, **options: Any):
+        self.device = get_torch_device()
+        self.pipe = pipeline(
+            task="zero-shot-classification",
+            model=model_name_or_path,
+            device=get_torch_device(),
+        )
+
+    def classify_text(self, text: list[str], labels: Label | list[Label]) -> list[Label]:
+        results: list[ZeroShotClassificationResult] = self.pipe(text, candidate_labels=labels)
+        return [result["labels"][0] for result in results]

--- a/daft/ai/transformers/provider.py
+++ b/daft/ai/transformers/provider.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from daft.ai.provider import Provider
 
 if TYPE_CHECKING:
-    from daft.ai.protocols import ImageEmbedderDescriptor
+    from daft.ai.protocols import ImageEmbedderDescriptor, TextClassifierDescriptor
     from daft.ai.typing import Options
 
 
@@ -25,3 +25,12 @@ class TransformersProvider(Provider):
         from daft.ai.transformers.protocols.image_embedder import TransformersImageEmbedderDescriptor
 
         return TransformersImageEmbedderDescriptor(model or "openai/clip-vit-base-patch32", options)
+
+    def get_text_classifier(self, model: str | None = None, **options: Any) -> TextClassifierDescriptor:
+        from daft.ai.transformers.protocols.text_classifier import TransformersTextClassifierDescriptor
+
+        return TransformersTextClassifierDescriptor(
+            provider_name=self._name,
+            model_name=(model or "facebook/bart-large-mnli"),
+            model_options=options,
+        )

--- a/daft/ai/transformers/provider.py
+++ b/daft/ai/transformers/provider.py
@@ -27,10 +27,18 @@ class TransformersProvider(Provider):
         return TransformersImageEmbedderDescriptor(model or "openai/clip-vit-base-patch32", options)
 
     def get_text_classifier(self, model: str | None = None, **options: Any) -> TextClassifierDescriptor:
-        from daft.ai.transformers.protocols.text_classifier import TransformersTextClassifierDescriptor
+        from daft.ai.transformers.protocols.text_classifier import (
+            TransformersTextClassifierDescriptor,
+            TransformersTextClassifierOptions,
+        )
+
+        # Extract known options from TransformersTextClassifierOptions
+        transformers_options = {
+            k: v for k, v in options.items() if k in TransformersTextClassifierOptions.__annotations__
+        }
 
         return TransformersTextClassifierDescriptor(
             provider_name=self._name,
             model_name=(model or "facebook/bart-large-mnli"),
-            model_options=options,
+            model_options=transformers_options,  # type: ignore
         )

--- a/daft/ai/transformers/provider.py
+++ b/daft/ai/transformers/provider.py
@@ -32,13 +32,10 @@ class TransformersProvider(Provider):
             TransformersTextClassifierOptions,
         )
 
-        # Extract known options from TransformersTextClassifierOptions
-        transformers_options = {
-            k: v for k, v in options.items() if k in TransformersTextClassifierOptions.__annotations__
-        }
+        model_options = {k: v for k, v in options.items() if k in TransformersTextClassifierOptions.__annotations__}
 
         return TransformersTextClassifierDescriptor(
             provider_name=self._name,
             model_name=(model or "facebook/bart-large-mnli"),
-            model_options=transformers_options,  # type: ignore
+            model_options=model_options,  # type: ignore
         )

--- a/daft/ai/typing.py
+++ b/daft/ai/typing.py
@@ -17,6 +17,7 @@ __all__ = [
     "Embedding",
     "EmbeddingDimensions",
     "Image",
+    "Label",
 ]
 
 
@@ -61,3 +62,6 @@ class EmbeddingDimensions:
 
     def as_dtype(self) -> DataType:
         return DataType.embedding(dtype=self.dtype, size=self.size)
+
+
+Label = str

--- a/daft/ai/utils.py
+++ b/daft/ai/utils.py
@@ -6,21 +6,17 @@ if TYPE_CHECKING:
     import torch
 
 
-def get_device() -> torch.device:
-    """Get the best available PyTorch device for computation.
-
-    This function automatically selects the optimal device in order of preference:
-    1. CUDA GPU (if available) - for NVIDIA GPUs with CUDA support
-    2. MPS (Metal Performance Shaders) - for Apple Silicon Macs
-    3. CPU - as fallback when no GPU acceleration is available
-    """
+def get_torch_device() -> torch.device:
+    """Get the best available PyTorch device for computation."""
     import torch
 
-    device = (
-        torch.device("cuda")
-        if torch.cuda.is_available()
-        else torch.device("mps")
-        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
-        else torch.device("cpu")
-    )
-    return device
+    # 1. CUDA GPU (if available) - for NVIDIA GPUs with CUDA support
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+
+    # 2. MPS (Metal Performance Shaders) - for Apple Silicon Macs
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return torch.device("mps")
+
+    # 3. CPU - as fallback when no GPU acceleration is available
+    return torch.device("cpu")

--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -4,7 +4,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from daft.expressions import Expression
 
-from daft.functions.ai import embed_text
+from daft.functions.ai import (
+    classify_text,
+    embed_text,
+    embed_image,
+)
 from daft.functions.columnar import (
     columns_sum,
     columns_mean,
@@ -22,12 +26,14 @@ from daft.functions.window import (
 
 
 __all__ = [
+    "classify_text",
     "columns_avg",
     "columns_max",
     "columns_mean",
     "columns_min",
     "columns_sum",
     "dense_rank",
+    "embed_image",
     "embed_text",
     "file",
     "format",

--- a/daft/functions/ai/__init__.py
+++ b/daft/functions/ai/__init__.py
@@ -145,10 +145,11 @@ def classify_text(
     model: str | None = None,
     **options: str,
 ) -> Expression:
-    """Returns an expression that embeds text using the specified embedding model and provider.
+    """Returns an expression that classifies text using the specified model and provider.
 
     Args:
         text (Expression): The input text column expression.
+        labels (str | list[str]): Label(s) for classification.
         provider (str | Provider | None): The provider to use for the embedding model. If None, the default provider is used.
         model (str | None): The embedding model to use. Can be a model instance or a model name. If None, the default model is used.
         **options: Any additional options to pass for the model.
@@ -157,12 +158,11 @@ def classify_text(
         Make sure the required provider packages are installed (e.g. vllm, transformers, openai).
 
     Returns:
-        Expression: An expression representing the embedded text vectors.
+        Expression: An expression representing the most-probable label string.
     """
     from daft.ai._expressions import _TextClassificationExpression
     from daft.ai.protocols import TextClassifier
 
-    # load a TextEmbedderDescriptor from the resolved provider
     text_classifier = _resolve_provider(provider, "transformers").get_text_classifier(model, **options)
 
     # TODO(rchowell): classification with structured outputs will be more interesting

--- a/daft/functions/ai/__init__.py
+++ b/daft/functions/ai/__init__.py
@@ -16,8 +16,11 @@ from daft.ai.provider import Provider
 if TYPE_CHECKING:
     from daft.ai.protocols import TextEmbedderDescriptor
     from daft.utils import ColumnInputType
+    from daft.ai.typing import Label
 
 __all__ = [
+    "classify_text",
+    "embed_image",
     "embed_text",
 ]
 
@@ -127,3 +130,51 @@ def embed_image(
     expr = expr_udf(_ImageEmbedderExpression)
     expr = expr.with_init_args(image_embedder)
     return expr(image)
+
+
+##
+# CLASSIFY FUNCTIONS
+##
+
+
+def classify_text(
+    text: Expression,
+    labels: Label | list[Label],
+    *,
+    provider: str | Provider | None = None,
+    model: str | None = None,
+    **options: str,
+) -> Expression:
+    """Returns an expression that embeds text using the specified embedding model and provider.
+
+    Args:
+        text (Expression): The input text column expression.
+        provider (str | Provider | None): The provider to use for the embedding model. If None, the default provider is used.
+        model (str | None): The embedding model to use. Can be a model instance or a model name. If None, the default model is used.
+        **options: Any additional options to pass for the model.
+
+    Note:
+        Make sure the required provider packages are installed (e.g. vllm, transformers, openai).
+
+    Returns:
+        Expression: An expression representing the embedded text vectors.
+    """
+    from daft.ai._expressions import _TextClassificationExpression
+    from daft.ai.protocols import TextClassifier
+
+    # load a TextEmbedderDescriptor from the resolved provider
+    text_classifier = _resolve_provider(provider, "transformers").get_text_classifier(model, **options)
+
+    # TODO(rchowell): classification with structured outputs will be more interesting
+    label_list = [labels] if isinstance(labels, str) else labels
+
+    # implemented as a class-based udf for now
+    expr_callable = udf(
+        return_dtype=DataType.string(),
+        concurrency=1,
+        use_process=False,
+    )
+
+    expr = expr_callable(_TextClassificationExpression)
+    expr = expr.with_init_args(text_classifier, label_list)
+    return expr(text)

--- a/docs/api/ai.md
+++ b/docs/api/ai.md
@@ -43,3 +43,11 @@ Daft has a Provider interface and model protocols for various inference APIs.
 ::: daft.ai.protocols.ImageEmbedderDescriptor
     options:
         heading_level: 3
+
+::: daft.ai.protocols.TextClassifier
+    options:
+        heading_level: 3
+
+::: daft.ai.protocols.TextClassifierDescriptor
+    options:
+        heading_level: 3

--- a/tests/ai/openai/test_openai_text_embedder.py
+++ b/tests/ai/openai/test_openai_text_embedder.py
@@ -64,7 +64,7 @@ def test_invalid_model_name():
 
 
 def test_instantiate():
-    """Test that instantiate creates a proper OpenAITextEmbedder."""
+    """Test to instantiate a proper OpenAITextEmbedder with no mocks."""
     descriptor = OpenAITextEmbedderDescriptor(
         provider_name="openai",
         provider_options={"api_key": "test-key"},

--- a/tests/ai/transformers/test_transformers.py
+++ b/tests/ai/transformers/test_transformers.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("transformers")
+pytest.importorskip("torch")
+
+
+import torch
+
+from daft.ai.transformers.provider import TransformersProvider
+
+
+def test_transformers_device_selection():
+    """Test that the embedder uses the correct device selection."""
+    provider = TransformersProvider()
+    descriptor = provider.get_image_embedder("openai/clip-vit-base-patch32")
+    embedder = descriptor.instantiate()
+
+    if torch.cuda.is_available():
+        expected_device = "cuda"
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        expected_device = "mps"
+    else:
+        expected_device = "cpu"
+
+    embedder_device = next(embedder.model.parameters()).device
+    assert expected_device in str(embedder_device)

--- a/tests/ai/transformers/test_transformers_image_embedder.py
+++ b/tests/ai/transformers/test_transformers_image_embedder.py
@@ -10,7 +10,6 @@ pytest.importorskip("PIL")
 import time
 
 import numpy as np
-import torch
 
 from daft.ai.protocols import ImageEmbedderDescriptor
 from daft.ai.transformers.provider import TransformersProvider
@@ -76,20 +75,3 @@ def test_transformers_image_embedder_other(model_name, dimensions, run_model_in_
         assert len(embeddings[0]) == dimensions
     else:
         assert descriptor.get_dimensions() == EmbeddingDimensions(dimensions, dtype=DataType.float32())
-
-
-def test_transformers_device_selection():
-    """Test that the embedder uses the correct device selection."""
-    provider = TransformersProvider()
-    descriptor = provider.get_image_embedder("openai/clip-vit-base-patch32")
-    embedder = descriptor.instantiate()
-
-    if torch.cuda.is_available():
-        expected_device = "cuda"
-    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-        expected_device = "mps"
-    else:
-        expected_device = "cpu"
-
-    embedder_device = next(embedder.model.parameters()).device
-    assert expected_device in str(embedder_device)

--- a/tests/ai/transformers/test_transformers_text_classifier.py
+++ b/tests/ai/transformers/test_transformers_text_classifier.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("transformers")
+
+from unittest.mock import MagicMock, Mock, patch
+
+from daft.ai.provider import Provider
+from daft.ai.transformers.protocols.text_classifier import (
+    TransformersTextClassifier,
+    TransformersTextClassifierDescriptor,
+)
+
+
+class MockProvider(Provider):
+    @property
+    def name(self) -> str:
+        return "mock"
+
+
+@pytest.fixture
+def mock_pipeline():
+    yield Mock()
+
+
+@pytest.fixture
+def mock_text_classifier(mock_pipeline):
+    with patch("daft.ai.transformers.protocols.text_classifier.pipeline", return_value=mock_pipeline):
+        yield TransformersTextClassifier("mock")
+
+
+@pytest.fixture
+def mock_provider(mock_text_classifier):
+    provider = MockProvider()
+    # Create a mock descriptor that returns our mock classifier
+    mock_descriptor = MagicMock()
+    mock_descriptor.instantiate.return_value = mock_text_classifier
+    provider.get_text_classifier = MagicMock(return_value=mock_descriptor)
+
+    # Mock the classify_text method to return expected results
+    def mock_classify_text(texts, labels):
+        return ["mock!"] * len(texts)
+
+    mock_text_classifier.classify_text = mock_classify_text
+    yield provider
+
+
+def test_instantiate():
+    """Test to instantiate a TransformersTextClassifier, this instantiates a pipeline."""
+    descriptor = TransformersTextClassifierDescriptor(
+        provider_name="transformers",
+        model_name="facebook/bart-large-mnli",
+        model_options={},
+    )
+
+    classifier = descriptor.instantiate()
+    assert isinstance(classifier, TransformersTextClassifier)
+    assert classifier._model == "facebook/bart-large-mnli"
+    assert classifier._pipeline, "Current implementation should have a pipeline."
+
+
+def test_mock_text_classifier(mock_pipeline, mock_text_classifier):
+    """Sanity check that our mocks are properly plumbed."""
+    assert mock_text_classifier._model == "mock"
+    assert mock_text_classifier._pipeline is mock_pipeline
+
+
+def test_text_classifier(mock_text_classifier):
+    """Test text classification using the model."""
+    # Test the classify_text method directly
+    texts = ["This is a statement.", "Is this a question?"]
+    labels = ["statement", "question"]
+
+    # Mock the pipeline's return value
+    mock_text_classifier._pipeline.return_value = [
+        {"labels": ["statement", "question"], "scores": [0.8, 0.2]},
+        {"labels": ["question", "statement"], "scores": [0.9, 0.1]},
+    ]
+
+    results = mock_text_classifier.classify_text(texts, labels)
+    assert results == ["statement", "question"]
+
+
+def test_classify_test_with_mock(mock_provider):
+    """Test text classification using the expression."""
+    # Test that the provider returns the expected descriptor
+    descriptor = mock_provider.get_text_classifier()
+    assert descriptor is not None
+
+    # Test that the descriptor can be instantiated
+    classifier = descriptor.instantiate()
+    assert classifier is not None
+
+    # Test that the classifier returns the expected results
+    results = classifier.classify_text(["test"], ["statement", "question"])
+    assert results == ["mock!"]
+
+
+def test_classify_test_with_default(mock_provider):
+    """Test text classification using the expression."""
+    import daft
+    from daft.functions import classify_text
+
+    df = daft.from_pydict(
+        {"comment": ["These snozzberries taste like snozzberries.", "Snozzberries? Who ever heard of a snozzberry?"]}
+    )
+
+    df = df.with_column("label", classify_text(df["comment"], labels=["statement", "question"]))
+
+    assert df.select("label").to_pylist() == [
+        {"label": "statement"},
+        {"label": "question"},
+    ]


### PR DESCRIPTION
## Changes Made

- Creates a TextClassifier protocol and supporting operations.
- Implements `classify_text` with string labels for transformers.

## TODO

- [ ] Testing
- [ ] Documentation
- [ ] Examples

## Related Issues

n/a

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
