### PR TITLE
fix: Remove flotilla fallback

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -202,7 +202,7 @@ def set_execution_config(
     scantask_splitting_level: int | None = None,
     scantask_max_parallel: int | None = None,
     native_parquet_writer: bool | None = None,
-    use_experimental_distributed_engine: bool | None = None,
+    use_legacy_ray_runner: bool | None = None,
     min_cpu_per_task: float | None = None,
 ) -> DaftContext:
     """Globally sets various configuration parameters which control various aspects of Daft execution.
@@ -251,8 +251,7 @@ def set_execution_config(
         scantask_splitting_level: How aggressively to split scan tasks. Setting this to `2` will use a more aggressive ScanTask splitting algorithm which might be more expensive to run but results in more even splits of partitions. Defaults to 1.
         scantask_max_parallel: Set the max parallelism for running scan tasks simultaneously. Currently, this only works for Native Runner. If set to 0, all available CPUs will be used. Defaults to 8.
         native_parquet_writer: Whether to use the native parquet writer vs the pyarrow parquet writer. Defaults to `True`.
-        use_experimental_distributed_engine: Whether to use the experimental distributed engine on the ray runner. Defaults to `True`.
-            Note: Not all operations are currently supported, and daft will fallback to the current engine if necessary.
+        use_legacy_ray_runner: Whether to use the legacy ray runner. Defaults to `False`.
         min_cpu_per_task: Minimum CPU per task in the Ray runner. Defaults to 0.5.
     """
     # Replace values in the DaftExecutionConfig with user-specified overrides
@@ -288,7 +287,7 @@ def set_execution_config(
             scantask_splitting_level=scantask_splitting_level,
             scantask_max_parallel=scantask_max_parallel,
             native_parquet_writer=native_parquet_writer,
-            use_experimental_distributed_engine=use_experimental_distributed_engine,
+            use_legacy_ray_runner=use_legacy_ray_runner,
             min_cpu_per_task=min_cpu_per_task,
         )
 

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1958,7 +1958,7 @@ class PyDaftExecutionConfig:
         scantask_splitting_level: int | None = None,
         scantask_max_parallel: int | None = None,
         native_parquet_writer: bool | None = None,
-        use_experimental_distributed_engine: bool | None = None,
+        use_legacy_ray_runner: bool | None = None,
         min_cpu_per_task: float | None = None,
     ) -> PyDaftExecutionConfig: ...
     @property
@@ -2008,7 +2008,7 @@ class PyDaftExecutionConfig:
     @property
     def enable_ray_tracing(self) -> bool: ...
     @property
-    def use_experimental_distributed_engine(self) -> bool: ...
+    def use_legacy_ray_runner(self) -> bool: ...
     @property
     def min_cpu_per_task(self) -> float: ...
     @property

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -302,9 +302,11 @@ class DataFrame:
             print_to_file(builder.pretty_print(simple))
             print_to_file("\n== Physical Plan ==\n")
             if get_context().get_or_create_runner().name != "native":
-                # Check if flotilla is enabled for distributed execution
                 daft_execution_config = get_context().daft_execution_config
                 if daft_execution_config.use_legacy_ray_runner:
+                    physical_plan_scheduler = builder.to_physical_plan_scheduler(get_context().daft_execution_config)
+                    print_to_file(physical_plan_scheduler.pretty_print(simple, format=format))
+                else:
                     from daft.daft import DistributedPhysicalPlan
 
                     distributed_plan = DistributedPhysicalPlan.from_logical_plan_builder(
@@ -314,9 +316,6 @@ class DataFrame:
                         print_to_file(distributed_plan.repr_ascii(simple))
                     elif format == "mermaid":
                         print_to_file(distributed_plan.repr_mermaid(MermaidOptions(simple)))
-                else:
-                    physical_plan_scheduler = builder.to_physical_plan_scheduler(get_context().daft_execution_config)
-                    print_to_file(physical_plan_scheduler.pretty_print(simple, format=format))
             else:
                 native_executor = NativeExecutor()
                 print_to_file(

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -304,22 +304,16 @@ class DataFrame:
             if get_context().get_or_create_runner().name != "native":
                 # Check if flotilla is enabled for distributed execution
                 daft_execution_config = get_context().daft_execution_config
-                if daft_execution_config.use_experimental_distributed_engine:
-                    try:
-                        from daft.daft import DistributedPhysicalPlan
+                if daft_execution_config.use_legacy_ray_runner:
+                    from daft.daft import DistributedPhysicalPlan
 
-                        distributed_plan = DistributedPhysicalPlan.from_logical_plan_builder(
-                            builder._builder, daft_execution_config
-                        )
-                        if format == "ascii":
-                            print_to_file(distributed_plan.repr_ascii(simple))
-                        elif format == "mermaid":
-                            print_to_file(distributed_plan.repr_mermaid(MermaidOptions(simple)))
-                    except Exception:
-                        physical_plan_scheduler = builder.to_physical_plan_scheduler(
-                            get_context().daft_execution_config
-                        )
-                        print_to_file(physical_plan_scheduler.pretty_print(simple, format=format))
+                    distributed_plan = DistributedPhysicalPlan.from_logical_plan_builder(
+                        builder._builder, daft_execution_config
+                    )
+                    if format == "ascii":
+                        print_to_file(distributed_plan.repr_ascii(simple))
+                    elif format == "mermaid":
+                        print_to_file(distributed_plan.repr_mermaid(MermaidOptions(simple)))
                 else:
                     physical_plan_scheduler = builder.to_physical_plan_scheduler(get_context().daft_execution_config)
                     print_to_file(physical_plan_scheduler.pretty_print(simple, format=format))

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -1335,77 +1335,66 @@ class RayRunner(Runner[ray.ObjectRef]):
         # Optimize the logical plan.
         builder = builder.optimize()
 
-        if daft_execution_config.enable_aqe:
-            adaptive_planner = builder.to_adaptive_physical_plan_scheduler(daft_execution_config)
-            while not adaptive_planner.is_done():
-                stage_id, plan_scheduler = adaptive_planner.next()
-                start_time = time.time()
-                # don't store partition sets in variable to avoid reference
+        if daft_execution_config.use_legacy_ray_runner:
+            if daft_execution_config.enable_aqe:
+                adaptive_planner = builder.to_adaptive_physical_plan_scheduler(daft_execution_config)
+                while not adaptive_planner.is_done():
+                    stage_id, plan_scheduler = adaptive_planner.next()
+                    start_time = time.time()
+                    # don't store partition sets in variable to avoid reference
+                    result_uuid = self._start_plan(
+                        plan_scheduler, daft_execution_config, results_buffer_size=results_buffer_size
+                    )
+                    del plan_scheduler
+                    results_iter = self._stream_plan(result_uuid)
+                    # if stage_id is None that means this is the final stage
+                    if stage_id is None:
+                        num_rows_processed = 0
+                        bytes_processed = 0
+
+                        for result in results_iter:
+                            num_rows_processed += result.metadata().num_rows
+                            size_bytes = result.metadata().size_bytes
+                            if size_bytes is not None:
+                                bytes_processed += size_bytes
+                            yield result
+                        adaptive_planner.update_stats(
+                            time.time() - start_time, bytes_processed, num_rows_processed, stage_id
+                        )
+                    else:
+                        cache_entry = self._collect_into_cache(results_iter)
+                        adaptive_planner.update_stats(
+                            time.time() - start_time, cache_entry.size_bytes(), cache_entry.num_rows(), stage_id
+                        )
+                        adaptive_planner.update(stage_id, cache_entry)
+                        del cache_entry
+
+                enable_explain_analyze = os.getenv("DAFT_DEV_ENABLE_EXPLAIN_ANALYZE")
+                ray_logs_location = ray_tracing.get_log_location()
+                should_explain_analyze = (
+                    ray_logs_location.exists()
+                    and enable_explain_analyze is not None
+                    and enable_explain_analyze in ["1", "true"]
+                )
+                if should_explain_analyze:
+                    explain_analyze_dir = ray_tracing.get_daft_trace_location(ray_logs_location)
+                    explain_analyze_dir.mkdir(exist_ok=True, parents=True)
+                    adaptive_planner.explain_analyze(str(explain_analyze_dir))
+            else:
+                plan_scheduler = builder.to_physical_plan_scheduler(daft_execution_config)
                 result_uuid = self._start_plan(
                     plan_scheduler, daft_execution_config, results_buffer_size=results_buffer_size
                 )
-                del plan_scheduler
-                results_iter = self._stream_plan(result_uuid)
-                # if stage_id is None that means this is the final stage
-                if stage_id is None:
-                    num_rows_processed = 0
-                    bytes_processed = 0
-
-                    for result in results_iter:
-                        num_rows_processed += result.metadata().num_rows
-                        size_bytes = result.metadata().size_bytes
-                        if size_bytes is not None:
-                            bytes_processed += size_bytes
-                        yield result
-                    adaptive_planner.update_stats(
-                        time.time() - start_time, bytes_processed, num_rows_processed, stage_id
-                    )
-                else:
-                    cache_entry = self._collect_into_cache(results_iter)
-                    adaptive_planner.update_stats(
-                        time.time() - start_time, cache_entry.size_bytes(), cache_entry.num_rows(), stage_id
-                    )
-                    adaptive_planner.update(stage_id, cache_entry)
-                    del cache_entry
-
-            enable_explain_analyze = os.getenv("DAFT_DEV_ENABLE_EXPLAIN_ANALYZE")
-            ray_logs_location = ray_tracing.get_log_location()
-            should_explain_analyze = (
-                ray_logs_location.exists()
-                and enable_explain_analyze is not None
-                and enable_explain_analyze in ["1", "true"]
-            )
-            if should_explain_analyze:
-                explain_analyze_dir = ray_tracing.get_daft_trace_location(ray_logs_location)
-                explain_analyze_dir.mkdir(exist_ok=True, parents=True)
-                adaptive_planner.explain_analyze(str(explain_analyze_dir))
-        elif daft_execution_config.use_experimental_distributed_engine:
-            try:
-                distributed_plan = DistributedPhysicalPlan.from_logical_plan_builder(
-                    builder._builder, daft_execution_config
-                )
-            except Exception as e:
-                logger.error("Failed to build distributed plan, falling back to regular execution. Error: %s", str(e))
-                # Fallback to regular execution
-                yield from self._execute_plan(builder, daft_execution_config, results_buffer_size)
-            else:
-                if self.flotilla_plan_runner is None:
-                    self.flotilla_plan_runner = FlotillaRunner()
-                yield from self.flotilla_plan_runner.stream_plan(
-                    distributed_plan, self._part_set_cache.get_all_partition_sets()
-                )
-
+                yield from self._stream_plan(result_uuid)
         else:
-            yield from self._execute_plan(builder, daft_execution_config, results_buffer_size)
-
-    def _execute_plan(
-        self, builder: LogicalPlanBuilder, daft_execution_config: PyDaftExecutionConfig, results_buffer_size: int | None
-    ) -> Iterator[RayMaterializedResult]:
-        # Finalize the logical plan and get a physical plan scheduler for translating the
-        # physical plan to executable tasks.
-        plan_scheduler = builder.to_physical_plan_scheduler(daft_execution_config)
-        result_uuid = self._start_plan(plan_scheduler, daft_execution_config, results_buffer_size=results_buffer_size)
-        yield from self._stream_plan(result_uuid)
+            distributed_plan = DistributedPhysicalPlan.from_logical_plan_builder(
+                builder._builder, daft_execution_config
+            )
+            if self.flotilla_plan_runner is None:
+                self.flotilla_plan_runner = FlotillaRunner()
+            yield from self.flotilla_plan_runner.stream_plan(
+                distributed_plan, self._part_set_cache.get_all_partition_sets()
+            )
 
     def run_iter_tables(
         self, builder: LogicalPlanBuilder, results_buffer_size: int | None = None

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -73,7 +73,7 @@ pub struct DaftExecutionConfig {
     pub scantask_splitting_level: i32,
     pub scantask_max_parallel: usize,
     pub native_parquet_writer: bool,
-    pub use_experimental_distributed_engine: bool,
+    pub use_legacy_ray_runner: bool,
     pub min_cpu_per_task: f64,
 }
 
@@ -109,7 +109,7 @@ impl Default for DaftExecutionConfig {
             scantask_splitting_level: 1,
             scantask_max_parallel: 8,
             native_parquet_writer: true,
-            use_experimental_distributed_engine: true,
+            use_legacy_ray_runner: false,
             min_cpu_per_task: 0.5,
         }
     }
@@ -161,8 +161,7 @@ impl DaftExecutionConfig {
         }
         let flotilla_env_var_name = "DAFT_FLOTILLA";
         if let Ok(val) = std::env::var(flotilla_env_var_name) {
-            cfg.use_experimental_distributed_engine =
-                !matches!(val.trim().to_lowercase().as_str(), "0" | "false");
+            cfg.use_legacy_ray_runner = matches!(val.trim().to_lowercase().as_str(), "0" | "false");
         }
         let min_cpu_var = "DAFT_MIN_CPU_PER_TASK";
         if let Ok(val) = std::env::var(min_cpu_var) {

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -116,7 +116,7 @@ impl PyDaftExecutionConfig {
         scantask_splitting_level=None,
         scantask_max_parallel=None,
         native_parquet_writer=None,
-        use_experimental_distributed_engine=None,
+        use_legacy_ray_runner=None,
         min_cpu_per_task=None,
     ))]
     fn with_config_values(
@@ -148,7 +148,7 @@ impl PyDaftExecutionConfig {
         scantask_splitting_level: Option<i32>,
         scantask_max_parallel: Option<usize>,
         native_parquet_writer: Option<bool>,
-        use_experimental_distributed_engine: Option<bool>,
+        use_legacy_ray_runner: Option<bool>,
         min_cpu_per_task: Option<f64>,
     ) -> PyResult<Self> {
         let mut config = self.config.as_ref().clone();
@@ -258,8 +258,8 @@ impl PyDaftExecutionConfig {
             config.native_parquet_writer = native_parquet_writer;
         }
 
-        if let Some(use_experimental_distributed_engine) = use_experimental_distributed_engine {
-            config.use_experimental_distributed_engine = use_experimental_distributed_engine;
+        if let Some(use_legacy_ray_runner) = use_legacy_ray_runner {
+            config.use_legacy_ray_runner = use_legacy_ray_runner;
         }
 
         if let Some(min_cpu_per_task) = min_cpu_per_task {
@@ -388,8 +388,8 @@ impl PyDaftExecutionConfig {
     }
 
     #[getter]
-    fn use_experimental_distributed_engine(&self) -> PyResult<bool> {
-        Ok(self.config.use_experimental_distributed_engine)
+    fn use_legacy_ray_runner(&self) -> PyResult<bool> {
+        Ok(self.config.use_legacy_ray_runner)
     }
 
     #[getter]

--- a/src/daft-distributed/src/pipeline_node/join/translate_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/translate_join.rs
@@ -210,7 +210,8 @@ impl LogicalPlanToPipelineNodeTranslator {
         let right_on = BoundExpr::bind_all(&right_on, &right_node.config().schema)?;
 
         match join_strategy {
-            JoinStrategy::Hash => self.gen_hash_join_nodes(
+            // TODO(Flotilla MS3): Implement sort-merge join
+            JoinStrategy::Hash | JoinStrategy::SortMerge => self.gen_hash_join_nodes(
                 logical_node_id,
                 left_node,
                 right_node,
@@ -232,10 +233,6 @@ impl LogicalPlanToPipelineNodeTranslator {
                 &right_stats,
                 join.output_schema.clone(),
             ),
-            JoinStrategy::SortMerge => {
-                // TODO: Implement sort-merge join
-                todo!("FLOTILLA_MS?: Implement sort-merge join")
-            }
             JoinStrategy::Cross => {
                 // TODO: Implement cross join
                 todo!("FLOTILLA_MS?: Implement cross join")

--- a/src/daft-distributed/src/stage/stage_builder.rs
+++ b/src/daft-distributed/src/stage/stage_builder.rs
@@ -29,9 +29,8 @@ impl StagePlanBuilder {
         curr
     }
 
-    fn can_translate_logical_plan(plan: &LogicalPlanRef) -> bool {
-        let mut can_translate = true;
-        let _ = plan.apply(|node| match node.as_ref() {
+    fn can_translate_logical_plan(plan: &LogicalPlanRef) -> DaftResult<()> {
+        plan.apply(|node| match node.as_ref() {
             LogicalPlan::Source(_)
             | LogicalPlan::Project(_)
             | LogicalPlan::Filter(_)
@@ -55,21 +54,24 @@ impl StagePlanBuilder {
                     .join_strategy
                     .is_some_and(|x| !matches!(x, JoinStrategy::Hash | JoinStrategy::Broadcast))
                 {
-                    can_translate = false;
-                    Ok(TreeNodeRecursion::Stop)
+                    Err(DaftError::ValueError(
+                        "Sort merge joins are currently not supported on the new ray runner. Please set `daft.set_execution_config(use_legacy_ray_runner=True)` to use the legacy ray runner for sort merge joins.".to_string(),
+                    ))
                 } else {
                     let (remaining_on, left_on, right_on, _) = join.on.split_eq_preds();
                     if !remaining_on.is_empty() || left_on.is_empty() || right_on.is_empty() {
-                        can_translate = false;
-                        Ok(TreeNodeRecursion::Stop)
+                        Err(DaftError::ValueError(
+                            "Cross joins are currently not supported on the new ray runner. Please set `daft.set_execution_config(use_legacy_ray_runner=True)` to use the legacy ray runner for cross joins.".to_string(),
+                        ))
                     } else {
                         Ok(TreeNodeRecursion::Continue)
                     }
                 }
             }
             LogicalPlan::Pivot(_) => {
-                can_translate = false;
-                Ok(TreeNodeRecursion::Stop)
+                Err(DaftError::ValueError(
+                    "Pivot operations are currently not supported on the new ray runner. Please set `daft.set_execution_config(use_legacy_ray_runner=True)` to use the legacy ray runner for pivot operations.".to_string(),
+                ))
             }
             LogicalPlan::Intersect(_)
             | LogicalPlan::Union(_)
@@ -79,17 +81,12 @@ impl StagePlanBuilder {
                 "Logical plan operator {} should be optimized away before planning stages",
                 node.name()
             ),
-        });
-        can_translate
+        })?;
+        Ok(())
     }
 
     fn build_stages_from_plan(&mut self, plan: LogicalPlanRef) -> DaftResult<StageID> {
-        if !Self::can_translate_logical_plan(&plan) {
-            return Err(DaftError::ValueError(format!(
-                "Cannot translate logical plan: {} into stages",
-                plan
-            )));
-        }
+        Self::can_translate_logical_plan(&plan)?;
 
         let schema = plan.schema();
         // Create a MapPipeline stage

--- a/src/daft-local-plan/src/translate.rs
+++ b/src/daft-local-plan/src/translate.rs
@@ -283,11 +283,11 @@ pub fn translate(plan: &LogicalPlanRef) -> DaftResult<LocalPhysicalPlanRef> {
         LogicalPlan::Join(join) => {
             if join
                 .join_strategy
-                .is_some_and(|x| !matches!(x, JoinStrategy::Hash | JoinStrategy::Broadcast))
+                .is_some_and(|x| !matches!(x, JoinStrategy::Hash))
             {
-                return Err(DaftError::not_implemented(
-                    "Only hash and broadcast join strategies are supported for now",
-                ));
+                log::warn!(
+                    "Only hash join strategy is supported on the native runner, falling back to hash join. Broadcast and sort merge joins are not implemented on the native runner as it is single node only."
+                );
             }
             let left = translate(&join.left)?;
             let right = translate(&join.right)?;

--- a/tests/actor_pool/test_actor_cuda_devices.py
+++ b/tests/actor_pool/test_actor_cuda_devices.py
@@ -14,7 +14,7 @@ from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
     get_tests_daft_runner_name() == "native"
-    or daft.context.get_context().daft_execution_config.use_experimental_distributed_engine,
+    or daft.context.get_context().daft_execution_config.use_legacy_ray_runner is False,
     reason="Native runner does not support GPU tests yet",
 )
 

--- a/tests/cookbook/test_joins.py
+++ b/tests/cookbook/test_joins.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from daft.context import get_context
 from daft.expressions import col
 from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 
@@ -10,6 +11,8 @@ def skip_invalid_join_strategies(join_strategy):
     if get_tests_daft_runner_name() == "native":
         if join_strategy not in [None, "hash"]:
             pytest.skip("Native executor fails for these tests")
+    elif not get_context().daft_execution_config.use_legacy_ray_runner and join_strategy == "sort_merge":
+        pytest.skip("Sort merge joins are not supported on Flotilla")
 
 
 @pytest.mark.parametrize(

--- a/tests/dataframe/test_aggregations.py
+++ b/tests/dataframe/test_aggregations.py
@@ -1014,7 +1014,7 @@ def test_join_followed_by_groupby(make_df, repartition_nparts, with_morsel_size)
 
 
 @pytest.mark.skipif(
-    get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="Legacy ray runner does not support skipping shuffles on already partitioned data",
 )
 def test_join_on_hash_partitioned_df_does_not_shuffle(capsys):

--- a/tests/dataframe/test_decimals.py
+++ b/tests/dataframe/test_decimals.py
@@ -90,7 +90,7 @@ def test_decimal_stddev(prec, partitions) -> None:
 
 @pytest.mark.parametrize("prec, partitions", itertools.product([5, 30], [1, 2]))
 @pytest.mark.skipif(
-    get_context().daft_execution_config.use_experimental_distributed_engine is True,
+    get_context().daft_execution_config.use_legacy_ray_runner is False,
     reason="resource requests are not fully supported in Flotilla",
 )
 def test_decimal_grouped_sum(prec, partitions) -> None:
@@ -108,7 +108,7 @@ def test_decimal_grouped_sum(prec, partitions) -> None:
 
 @pytest.mark.parametrize("prec, partitions", itertools.product([5, 30], [1, 2]))
 @pytest.mark.skipif(
-    get_context().daft_execution_config.use_experimental_distributed_engine is True,
+    get_context().daft_execution_config.use_legacy_ray_runner is False,
     reason="resource requests are not fully supported in Flotilla",
 )
 def test_decimal_grouped_mean(prec, partitions) -> None:

--- a/tests/dataframe/test_into_batches.py
+++ b/tests/dataframe/test_into_batches.py
@@ -7,8 +7,7 @@ from daft.context import get_context
 from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
-    get_tests_daft_runner_name() == "ray"
-    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_tests_daft_runner_name() == "ray" and get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="requires Native Runner or Flotilla to be in use",
 )
 

--- a/tests/dataframe/test_pivot.py
+++ b/tests/dataframe/test_pivot.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import pytest
 
+from daft.context import get_context
+
+pytestmark = pytest.mark.skipif(
+    get_context().daft_execution_config.use_legacy_ray_runner,
+    reason="Pivot operations are not supported on the legacy ray runner",
+)
+
 
 @pytest.mark.parametrize("repartition_nparts", [1, 2, 5])
 def test_pivot(make_df, repartition_nparts, with_morsel_size):

--- a/tests/dataframe/test_pivot.py
+++ b/tests/dataframe/test_pivot.py
@@ -5,7 +5,7 @@ import pytest
 from daft.context import get_context
 
 pytestmark = pytest.mark.skipif(
-    get_context().daft_execution_config.use_legacy_ray_runner,
+    not get_context().daft_execution_config.use_legacy_ray_runner,
     reason="Pivot operations are not supported on the legacy ray runner",
 )
 

--- a/tests/dataframe/test_shuffles.py
+++ b/tests/dataframe/test_shuffles.py
@@ -174,8 +174,7 @@ def test_pre_shuffle_merge_randomly_sized_partitions(pre_shuffle_merge_ctx, inpu
 
 
 @pytest.mark.skipif(
-    get_tests_daft_runner_name() != "ray"
-    or get_context().daft_execution_config.use_experimental_distributed_engine is True,
+    get_tests_daft_runner_name() != "ray" or get_context().daft_execution_config.use_legacy_ray_runner is False,
     reason="shuffle tests are meant for the ray runner and flight shuffle is not yet supported for flotilla",
 )
 @pytest.mark.parametrize(

--- a/tests/expressions/test_legacy_udf.py
+++ b/tests/expressions/test_legacy_udf.py
@@ -510,8 +510,7 @@ def test_udf_with_error(use_actor_pool):
 
 
 @pytest.mark.skipif(
-    get_tests_daft_runner_name() != "ray"
-    or get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_tests_daft_runner_name() != "ray" or get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="requires Flotilla to be in use",
 )
 @pytest.mark.parametrize("use_actor_pool", [True, False])
@@ -550,8 +549,7 @@ def test_udf_retry_with_process_killed_ray(use_actor_pool):
 @pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
 @pytest.mark.parametrize("use_actor_pool", [False, True])
 @pytest.mark.skipif(
-    get_tests_daft_runner_name() == "ray"
-    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_tests_daft_runner_name() == "ray" and get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="Multiple UDFs on different columns fails on legacy ray runner",
 )
 def test_multiple_udfs_different_columns(batch_size, use_actor_pool):
@@ -600,8 +598,7 @@ def test_multiple_udfs_different_columns(batch_size, use_actor_pool):
 @pytest.mark.parametrize("batch_size", [None, 1, 2, 3, 10])
 @pytest.mark.parametrize("use_actor_pool", [False, True])
 @pytest.mark.skipif(
-    get_tests_daft_runner_name() == "ray"
-    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_tests_daft_runner_name() == "ray" and get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="Multiple UDFs on same column fails on legacy ray runner",
 )
 def test_multiple_udfs_same_column(batch_size, use_actor_pool):

--- a/tests/sql/test_joins.py
+++ b/tests/sql/test_joins.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import daft
+from daft.context import get_context
 from tests.utils import sort_pydict
 
 
@@ -172,6 +173,10 @@ def test_join_qualifiers_with_alias(join_condition, selection):
     assert df_sql == expected
 
 
+@pytest.mark.skipif(
+    not get_context().daft_execution_config.use_legacy_ray_runner,
+    reason="Cross joins are not supported on Flotilla",
+)
 def test_cross_join():
     x = daft.from_pydict(
         {

--- a/tests/sql/test_window.py
+++ b/tests/sql/test_window.py
@@ -14,7 +14,6 @@ from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
     get_tests_daft_runner_name() == "ray",
-    # and get_context().daft_execution_config.use_experimental_distributed_engine is False,
     reason="requires Native Runner to be in use",
 )
 
@@ -488,7 +487,12 @@ def test_range_window_sql():
         .collect()
     )
 
-    assert_df_equals(sql_result.to_pandas(), daft_result.to_pandas(), sort_key=["category", "ts"], check_dtype=False)
+    assert_df_equals(
+        sql_result.to_pandas(),
+        daft_result.to_pandas(),
+        sort_key=["category", "ts"],
+        check_dtype=False,
+    )
 
 
 def test_range_window_desc_sql():
@@ -555,7 +559,12 @@ def test_range_window_desc_sql():
         .collect()
     )
 
-    assert_df_equals(sql_result.to_pandas(), daft_result.to_pandas(), sort_key=["category", "ts"], check_dtype=False)
+    assert_df_equals(
+        sql_result.to_pandas(),
+        daft_result.to_pandas(),
+        sort_key=["category", "ts"],
+        check_dtype=False,
+    )
 
 
 def test_range_window_with_dates():
@@ -612,7 +621,10 @@ def test_range_window_with_dates():
     )
 
     assert_df_equals(
-        sql_result.to_pandas(), daft_result.to_pandas(), sort_key=["category", "date", "value"], check_dtype=False
+        sql_result.to_pandas(),
+        daft_result.to_pandas(),
+        sort_key=["category", "date", "value"],
+        check_dtype=False,
     )
 
 

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -143,7 +143,7 @@ RAY_VERSION_LT_2 = int(ray.__version__.split(".")[0]) < 2
 )
 @pytest.mark.skipif(get_tests_daft_runner_name() not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(
-    get_context().daft_execution_config.use_experimental_distributed_engine is True,
+    get_context().daft_execution_config.use_legacy_ray_runner is False,
     reason="resource requests are not fully supported in Flotilla",
 )
 def test_with_column_rayrunner():
@@ -163,7 +163,7 @@ def test_with_column_rayrunner():
 )
 @pytest.mark.skipif(get_tests_daft_runner_name() not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(
-    get_context().daft_execution_config.use_experimental_distributed_engine is True,
+    get_context().daft_execution_config.use_legacy_ray_runner is False,
     reason="resource requests are not fully supported in Flotilla",
 )
 def test_with_column_folded_rayrunner():
@@ -212,7 +212,7 @@ def test_with_column_rayrunner_class():
 )
 @pytest.mark.skipif(get_tests_daft_runner_name() not in {"ray"}, reason="requires RayRunner to be in use")
 @pytest.mark.skipif(
-    get_context().daft_execution_config.use_experimental_distributed_engine is True,
+    get_context().daft_execution_config.use_legacy_ray_runner is False,
     reason="resource requests are not fully supported in Flotilla",
 )
 def test_with_column_folded_rayrunner_class():

--- a/tests/window/test_order_by_only.py
+++ b/tests/window/test_order_by_only.py
@@ -11,8 +11,7 @@ from daft.functions import dense_rank, rank, row_number
 from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
-    get_tests_daft_runner_name() == "ray"
-    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_tests_daft_runner_name() == "ray" and get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="requires Native Runner or Flotilla to be in use",
 )
 

--- a/tests/window/test_partition_only.py
+++ b/tests/window/test_partition_only.py
@@ -10,8 +10,7 @@ from daft.context import get_context
 from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
-    get_tests_daft_runner_name() == "ray"
-    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_tests_daft_runner_name() == "ray" and get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="requires Native Runner or Flotilla to be in use",
 )
 

--- a/tests/window/test_partition_order_by_lag_lead.py
+++ b/tests/window/test_partition_order_by_lag_lead.py
@@ -11,8 +11,7 @@ from daft.functions import dense_rank, rank
 from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
-    get_tests_daft_runner_name() == "ray"
-    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_tests_daft_runner_name() == "ray" and get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="requires Native Runner or Flotilla to be in use",
 )
 

--- a/tests/window/test_partition_order_by_rank.py
+++ b/tests/window/test_partition_order_by_rank.py
@@ -11,8 +11,7 @@ from daft.functions import dense_rank, rank, row_number
 from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
-    get_tests_daft_runner_name() == "ray"
-    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_tests_daft_runner_name() == "ray" and get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="requires Native Runner or Flotilla to be in use",
 )
 

--- a/tests/window/test_running_agg.py
+++ b/tests/window/test_running_agg.py
@@ -13,8 +13,7 @@ from daft.context import get_context
 from tests.conftest import assert_df_equals, get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
-    get_tests_daft_runner_name() == "ray"
-    and get_context().daft_execution_config.use_experimental_distributed_engine is False,
+    get_tests_daft_runner_name() == "ray" and get_context().daft_execution_config.use_legacy_ray_runner is True,
     reason="requires Native Runner or Flotilla to be in use",
 )
 


### PR DESCRIPTION
## Changes Made

Removes the flotilla fallback. If the plan is not translatable raise a helpful error message.

Additionally changes the flotilla execution config to be `use_legacy_ray_runner` instead of `use_experimental_distributed_engine`.


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
