### PR TITLE
docs: fix flickering typewriter animation on overview page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,6 @@ Daft is a high-performance data engine providing simple and reliable data proces
   }
 
   .daft-pipeline-component .cursor-fade {
-    color: #ff00ff;
     animation: daft-cursor-fade 400ms ease-out forwards;
     transform-origin: bottom right;
     display: inline-block;

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,18 +132,25 @@ Daft is a high-performance data engine providing simple and reliable data proces
     animation: daft-caret .9s steps(1,end) infinite;
   }
 
+  .daft-pipeline-component .cursor-fade {
+    color: #ff00ff;
+    animation: daft-cursor-fade 400ms ease-out forwards;
+  }
+
+  @keyframes daft-cursor-fade {
+    0% {
+      opacity: 1;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+
   @keyframes daft-caret {
     50% { opacity: 0; }
   }
 
-  .daft-pipeline-component .fade-in {
-    animation: daft-enter .45s ease both;
-  }
 
-  @keyframes daft-enter {
-    from { opacity: 0; transform: translateY(6px); }
-    to { opacity: 1; transform: translateY(0); }
-  }
 
   @media (max-width: 720px) {
     .daft-pipeline-component .stage-box {
@@ -396,7 +403,6 @@ async function typeTo(el, text) {
     if (!el) return; // Safety check for null elements
 
     const speed = 12 + Math.random() * 10;
-    el.classList.remove("fade-in");
     el.innerHTML = "";
     const span = document.createElement("span");
     span.className = "type";
@@ -414,7 +420,15 @@ async function typeTo(el, text) {
         span.innerHTML = formattedLines.join('\n') + '<span class="cursor">█</span>';
         await new Promise(r => setTimeout(r, speed));
     }
-    el.classList.add("fade-in");
+
+    // Let cursor blink for a moment, then fade away
+    const cursor = span.querySelector('.cursor');
+    if (cursor) {
+        setTimeout(() => {
+            cursor.classList.remove('cursor');
+            cursor.classList.add('cursor-fade');
+        }, 2200); // Keep blinking for N seconds before fading
+    }
 }
 
 // Cycle logic

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,6 +137,7 @@ Daft is a high-performance data engine providing simple and reliable data proces
   }
 
   .daft-pipeline-component .cursor-fade {
+    color: #ff00ff;
     animation: daft-cursor-fade 400ms ease-out forwards;
     transform-origin: bottom right;
     display: inline-block;

--- a/docs/index.md
+++ b/docs/index.md
@@ -154,8 +154,6 @@ Daft is a high-performance data engine providing simple and reliable data proces
     50% { opacity: 0; }
   }
 
-
-
   @media (max-width: 720px) {
     .daft-pipeline-component .stage-box {
       padding: 8px;

--- a/docs/index.md
+++ b/docs/index.md
@@ -132,6 +132,10 @@ Daft is a high-performance data engine providing simple and reliable data proces
     animation: daft-caret .9s steps(1,end) infinite;
   }
 
+  @keyframes daft-caret {
+    50% { opacity: 0; }
+  }
+
   .daft-pipeline-component .cursor-fade {
     color: #ff00ff;
     animation: daft-cursor-fade 400ms ease-out forwards;
@@ -148,10 +152,6 @@ Daft is a high-performance data engine providing simple and reliable data proces
       opacity: 0;
       transform: rotate(10deg);
     }
-  }
-
-  @keyframes daft-caret {
-    50% { opacity: 0; }
   }
 
   @media (max-width: 720px) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,14 +135,18 @@ Daft is a high-performance data engine providing simple and reliable data proces
   .daft-pipeline-component .cursor-fade {
     color: #ff00ff;
     animation: daft-cursor-fade 400ms ease-out forwards;
+    transform-origin: bottom right;
+    display: inline-block;
   }
 
   @keyframes daft-cursor-fade {
     0% {
       opacity: 1;
+      transform: rotate(0deg);
     }
     100% {
       opacity: 0;
+      transform: rotate(10deg);
     }
   }
 


### PR DESCRIPTION
## Changes Made

On the overview page, when the typewriter animation finished rendering the text, it flickered, which didn't feel good on your eye. Fixed by removing the abrupt fade-in effect and replacing with a subtle cursor fade that falls gently.

## Before

https://github.com/user-attachments/assets/00dc1aff-c70d-4e07-8490-7f9b13698ecf

## After

https://github.com/user-attachments/assets/c4efc583-7e14-438e-a38b-e22d37ff0a72

## Checklist

- [x] Documentation builds and is formatted properly

## Internal

Closes https://linear.app/eventual/issue/EVE-839/on-the-overview-page-when-the-animation-finishes-rendering-the-text-it