### PR TITLE
ci: Always run the `unit-tests` required check

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -210,8 +210,8 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
-    needs: [skipcheck, unit-test]
-    if: ${{ needs.skipcheck.outputs.skip == 'false' }}
+    needs: unit-test
+    if: always()
     steps:
     - name: All tests ok
       if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}


### PR DESCRIPTION
## Changes Made

`unit-tests` is the check to encompass all the unit tests, and it is a 'required' job. It should fail if any unit test failed or cancelled (i.e. timeout), and pass otherwise (skipped or success). 

Previously, it had a dependency on `unit-test`, which meant that as long as one unit test cancelled due to timeout, it will be skipped. This overrides the `if` condition, as the `if` condition is not an `always()`. https://github.com/orgs/community/discussions/25286 


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
