### PR TITLE
chore: Add AGENTS.md

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -32,7 +32,8 @@ jobs:
     - name: Detect non-trivial changes
       id: filter
       run: |
-        set -exo pipefail
+        set +e
+        set -xo pipefail
 
         # On main branch, we want to run all tests (no skipping)
         if [ "${{ github.ref }}" = "refs/heads/main" ]; then

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -67,7 +67,7 @@ jobs:
         echo "diff: $diff"
         echo "exit_code: $exit_code"
 
-        if [ $exit_code -ne 0 ] || [ -n "$diff" ]; then
+        if [ $exit_code -ne 0 ] || [ -z "$diff" ]; then
           echo "skip=true" >> $GITHUB_OUTPUT
         else
           echo "skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -58,7 +58,7 @@ jobs:
           ':!SECURITY.md' \
           ':!codecov.yml' \
           ':!mkdocs.yml' \
-          ':!AGENTS.md' \
+          ':!AGENTS.md'
         then
           echo "skip=true" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -42,7 +42,7 @@ jobs:
         BASE=${{ github.base_ref || 'origin/main' }}
         git fetch origin $BASE --depth=1
 
-        if git diff --quiet origin/$BASE -- \
+        diff=$(git diff --quiet origin/$BASE -- \
           . \
           ':!.vscode/**' \
           ':!ci/**' \
@@ -58,8 +58,13 @@ jobs:
           ':!SECURITY.md' \
           ':!codecov.yml' \
           ':!mkdocs.yml' \
-          ':!AGENTS.md'
-        then
+          ':!AGENTS.md')
+        exit_code=$?
+
+        echo "diff: $diff"
+        echo "exit_code: $exit_code"
+
+        if [ $exit_code -ne 0 ] || [ -n "$diff" ]; then
           echo "skip=true" >> $GITHUB_OUTPUT
         else
           echo "skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -57,7 +57,8 @@ jobs:
           ':!README.rst' \
           ':!SECURITY.md' \
           ':!codecov.yml' \
-          ':!mkdocs.yml'
+          ':!mkdocs.yml' \
+          ':!AGENTS.md' \
         then
           echo "skip=true" >> $GITHUB_OUTPUT
         else

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -32,6 +32,8 @@ jobs:
     - name: Detect non-trivial changes
       id: filter
       run: |
+        set -exo pipefail
+
         # On main branch, we want to run all tests (no skipping)
         if [ "${{ github.ref }}" = "refs/heads/main" ]; then
           echo "skip=false" >> $GITHUB_OUTPUT

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ site
 # added by vim
 *.swp
 *.swo
+
+# AGENT Prompting Templates
+AGENTS.md
+CLAUDE.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# AGENTS.md - Building and Testing Daft
+
+This document provides guidance for AI agents and developers on how to build and test the Daft project. While the project includes a comprehensive Makefile, this guide focuses on the direct commands and processes that agents can use to understand and work with the codebase.
+
+## Project Overview
+
+Daft is a distributed query engine for large-scale multimodal data processing using Python or SQL, implemented in Rust with Python bindings. The project uses:
+- **Rust** for the core engine implementation
+- **Python** for the user-facing API
+- **Maturin** for building Python extensions from Rust code
+- **uv** for Python dependency management
+- **pytest** for testing
+
+## Prerequisites
+
+Before building or testing, ensure you have the following installed:
+
+1. **Rust toolchain**: Install via [rustup](https://rustup.rs/)
+2. **Python 3.9+**: The project supports Python 3.9 and above
+3. **uv**: Python package manager (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
+4. **Additional tools** (for full functionality):
+   - `bun` for dashboard functionality
+   - `cmake` for certain dependencies
+   - `protoc` for protocol buffer compilation
+
+## Building the Project
+
+### Setting Up the Environment
+
+The project uses `uv` for dependency management, which is handled through the Makefile:
+
+```bash
+# Create virtual environment and install dependencies
+make .venv
+
+# Activate the virtual environment
+# Not necessary if you use the Makefile commands
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+```
+
+### Building Rust Extensions
+
+The core of Daft is written in Rust and compiled to Python extensions using Maturin:
+
+```bash
+# Development build (faster compilation, slower runtime)
+make build
+
+# Release build (slower compilation, faster runtime)
+make build-release
+
+# Build wheel without installation
+make build-whl
+```
+
+### Building Protocol Buffers
+
+If any .proto files are modified, you will need to rebuild the protocol buffers:
+
+```bash
+# Build proto sources (requires protoc to be installed)
+make daft-proto
+```
+
+## Testing the Project
+
+### Test Configuration
+
+The project uses pytest with specific configuration in `pyproject.toml`:
+
+```toml
+[tool.pytest.ini_options]
+addopts = "-m 'not (integration or benchmark or hypothesis)'"
+minversion = "6.0"
+testpaths = ["tests"]
+```
+
+### Running Tests
+
+Tests can be run using the Makefile commands:
+
+```bash
+# Basic test run
+make test
+
+# Run with specific runner (required environment variable)
+DAFT_RUNNER=native make test
+DAFT_RUNNER=ray make test
+
+# Run specific test files or methods
+make test EXTRA_ARGS="-v tests/dataframe/test_select.py"
+make test EXTRA_ARGS="-v tests/dataframe/test_select.py::test_select_dataframe"
+
+# Run with additional options
+make test EXTRA_ARGS="-v --tb=short"
+```
+
+## Performance Considerations
+
+- **Development builds** are faster to compile but slower at runtime
+- **Release builds** take longer to compile but provide optimal performance
+- **Integration tests** may require significant time and resources
+- **Benchmark tests** should be run separately from regular test suites
+
+## Resources
+
+- [Project Documentation](https://docs.daft.ai)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Rust Documentation](https://doc.rust-lang.org/)
+- [Maturin Documentation](https://maturin.rs/)
+- [uv Documentation](https://docs.astral.sh/uv/)
+
+---
+
+This guide provides the essential information for AI agents to understand and work with the Daft project's build and testing processes. For more detailed information, refer to the project's documentation and contributing guidelines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,97 +1,26 @@
-# AGENTS.md - Building and Testing Daft
-
-## Project Overview
-
-Daft is a distributed query engine for large-scale multimodal data processing using Python or SQL, implemented in Rust with Python bindings. The project uses:
-- **Rust** for the core engine implementation
-- **Python** for the user-facing API
-- **Maturin** for building Python extensions from Rust code
-- **uv** for Python dependency management
-- **pytest** for testing
-
-## Prerequisites
-
-Before building or testing, ensure you have the following installed:
-
-1. **Rust toolchain**: Install via [rustup](https://rustup.rs/)
-2. **Python 3.9+**: The project supports Python 3.9 and above
-3. **uv**: Python package manager (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
-4. **Additional tools** (for full functionality):
-   - `bun` for dashboard functionality
-   - `cmake` for certain dependencies
-   - `protoc` for protocol buffer compilation
-
-## Building the Project
-
-### Setting Up the Environment
-
-The project uses `uv` for dependency management, which is handled through the Makefile:
-
-```bash
-# Create virtual environment and install dependencies
-make .venv
-
-# Activate the virtual environment
-# Not necessary if you use the Makefile commands
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-```
-
-### Building Rust Extensions
-
-The core of Daft is written in Rust and compiled to Python extensions using Maturin:
-
-```bash
-# Development build (faster compilation, slower runtime)
-make build
-
-# Release build (slower compilation, faster runtime)
-make build-release
-```
-
-### Building Protocol Buffers
-
-If any .proto files are modified, you will need to rebuild the protocol buffers:
-
-```bash
-# Build proto sources (requires protoc to be installed)
-make daft-proto
-```
-
-## Testing the Project
-
-### Test Configuration
-
-The project uses pytest with specific configuration in `pyproject.toml`:
-
-```toml
-[tool.pytest.ini_options]
-addopts = "-m 'not (integration or benchmark or hypothesis)'"
-minversion = "6.0"
-testpaths = ["tests"]
-```
-
-### Running Tests
-
-Tests can be run using the Makefile commands:
-
-```bash
-# Basic test run
-make test
-
-# Run with specific runner (required environment variable)
-DAFT_RUNNER=native make test
-DAFT_RUNNER=ray make test
-
-# Run specific test files or methods
-make test EXTRA_ARGS="-v tests/dataframe/test_select.py"
-make test EXTRA_ARGS="-v tests/dataframe/test_select.py::test_select_dataframe"
-
-# Run with additional options
-make test EXTRA_ARGS="-v --tb=short"
-```
+# AGENTS.md
 
 ## Resources
 
-- [Library Documentation](https://docs.daft.ai)
-- [Contributing Guide](CONTRIBUTING.md)
-- [GitHub Repo](https://github.com/Eventual-Inc/Daft)
+- [Library Documentation](https://docs.daft.ai) for the user-facing API
+- [Contributing Guide](CONTRIBUTING.md) for detailed development process
+- [GitHub Repo](https://github.com/Eventual-Inc/Daft) for issues, discussions, and PRs
+
+## Dev Workflow
+
+1) [Once] Set up Python environment and install dependencies: `make .venv`
+2) [Optional] Activate .venv: `source .venv/bin/activate`. Not necessary with Makefile commands.
+3) If Rust code is modified, rebuild: `make build`
+4) If `.proto` files are modified, rebuild protocol buffers code: `make daft-proto`
+5) Run tests. See [Testing Details](#testing-details).
+
+## Testing Details
+
+- `make test` runs tests in `tests/` directory. Uses `pytest` under the hood.
+  - Must set `DAFT_RUNNER` environment variable to `ray` or `native` to run the tests with the corresponding runner.
+    - Start with `DAFT_RUNNER=native` unless testing Ray or distributed code.
+  - `make test EXTRA_ARGS="..."` passes additional arguments to `pytest`.
+    - `make test EXTRA_ARGS="-v tests/dataframe/test_select.py"` runs the test in the given file.
+    - `make test EXTRA_ARGS="-v tests/dataframe/test_select.py::test_select_dataframe"` runs the given test method.
+  -  Default `integration`, `benchmark`, and `hypothesis` tests are disabled. Best to run on CI.
+- `make doctests` runs doctests in `daft/` directory. Tests docstrings in Daft APIs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Resources
 
-- [Library Documentation](https://docs.daft.ai) for the user-facing API
-- [Contributing Guide](CONTRIBUTING.md) for detailed development process
-- [GitHub Repo](https://github.com/Eventual-Inc/Daft) for issues, discussions, and PRs
+- https://docs.daft.ai for the user-facing API docs
+- CONTRIBUTING.md for detailed development process
+- https://github.com/Eventual-Inc/Daft for issues, discussions, and PRs
 
 ## Dev Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,9 +46,6 @@ make build
 
 # Release build (slower compilation, faster runtime)
 make build-release
-
-# Build wheel without installation
-make build-whl
 ```
 
 ### Building Protocol Buffers
@@ -92,13 +89,6 @@ make test EXTRA_ARGS="-v tests/dataframe/test_select.py::test_select_dataframe"
 # Run with additional options
 make test EXTRA_ARGS="-v --tb=short"
 ```
-
-## Performance Considerations
-
-- **Development builds** are faster to compile but slower at runtime
-- **Release builds** take longer to compile but provide optimal performance
-- **Integration tests** may require significant time and resources
-- **Benchmark tests** should be run separately from regular test suites
 
 ## Resources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md - Building and Testing Daft
 
-This document provides guidance for AI agents and developers on how to build and test the Daft project. While the project includes a comprehensive Makefile, this guide focuses on the direct commands and processes that agents can use to understand and work with the codebase.
-
 ## Project Overview
 
 Daft is a distributed query engine for large-scale multimodal data processing using Python or SQL, implemented in Rust with Python bindings. The project uses:
@@ -104,12 +102,6 @@ make test EXTRA_ARGS="-v --tb=short"
 
 ## Resources
 
-- [Project Documentation](https://docs.daft.ai)
+- [Library Documentation](https://docs.daft.ai)
 - [Contributing Guide](CONTRIBUTING.md)
-- [Rust Documentation](https://doc.rust-lang.org/)
-- [Maturin Documentation](https://maturin.rs/)
-- [uv Documentation](https://docs.astral.sh/uv/)
-
----
-
-This guide provides the essential information for AI agents to understand and work with the Daft project's build and testing processes. For more detailed information, refer to the project's documentation and contributing guidelines.
+- [GitHub Repo](https://github.com/Eventual-Inc/Daft)

--- a/tests/actor_pool/test_actor_cuda_devices.py
+++ b/tests/actor_pool/test_actor_cuda_devices.py
@@ -22,6 +22,8 @@ pytestmark = pytest.mark.skipif(
 @contextmanager
 def reset_runner_with_gpus(num_gpus, monkeypatch):
     """If current runner does not have enough GPUs, create a new runner with mocked GPU resources."""
+    print("testing CI detection")
+
     if len(cuda_visible_devices()) < num_gpus:
         if get_tests_daft_runner_name() == "ray":
             try:

--- a/tests/actor_pool/test_actor_cuda_devices.py
+++ b/tests/actor_pool/test_actor_cuda_devices.py
@@ -22,8 +22,6 @@ pytestmark = pytest.mark.skipif(
 @contextmanager
 def reset_runner_with_gpus(num_gpus, monkeypatch):
     """If current runner does not have enough GPUs, create a new runner with mocked GPU resources."""
-    print("testing CI detection")
-
     if len(cuda_visible_devices()) < num_gpus:
         if get_tests_daft_runner_name() == "ray":
             try:


### PR DESCRIPTION
## Changes Made

I noticed that AI agents like Cursor seem to default to using our underlying tools (`uv`, `maturin`, `pytest`) rather than the nicer Makefile commands that do other setup. That might be a documentation issue, but after talking to the agent, it seems to prefer using the underlying tools. So I added an `AGENTS.md` to mitigate it.

`AGENTS.md` is supposed to be the emerging standard (https://agents.md/), but Claude Code doesn't support it yet. We can symlink this file to `CLAUDE.md` if others prefer.

Feel free to also add more details about development patterns, opening PRs, or anything else. But from my understanding, the shorter the better.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
