### PR TITLE
WIP: feat: implement Lance filter+count pushdown optimization

### DIFF
--- a/src/common/scan-info/src/scan_operator.rs
+++ b/src/common/scan-info/src/scan_operator.rs
@@ -36,7 +36,7 @@ pub trait ScanOperator: Send + Sync + Debug {
     fn supports_count_pushdown(&self) -> bool {
         false
     }
-
+    
     fn supported_count_modes(&self) -> Vec<daft_core::count_mode::CountMode> {
         Vec::new()
     }


### PR DESCRIPTION
This commit implements filter+count joint pushdown optimization for Lance tables, significantly improving query performance for count queries with filter conditions.

Key changes:
- Enhanced push_down_aggregation.rs to support filter+count joint pushdown
- Improved lance_scan.py to handle filter+count operations natively
- Updated _lancedb_count_result_function to process filters correctly
- Enhanced test coverage for filter+count pushdown scenarios


The optimization maintains backward compatibility and includes graceful fallback mechanisms for unsupported filter expressions.

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
