### PR TITLE
ci: Pipe unit test failures through duration aggregator

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1273,7 +1273,7 @@ jobs:
     - name: Python And Rust Style Check
       run: |
         source .venv/bin/activate
-        pre-commit run --all-files
+        pre-commit run --all-files -v
 
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v2.0.0


### PR DESCRIPTION
## Changes Made

Currently test failures are not captured properly because the pytest output is piped to the aggregator script.

This PR adds `set -o pipefail` to the test step so that exit code is properly captured.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
