### PR TITLE
ci: re-add mac os unit tests on main

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -97,8 +97,8 @@ jobs:
         - os: macos-latest
           flotilla: 0
         # don't run mac unit tests in PRs
-        # - os: macos-latest
-        #   on-main: false
+        - os: macos-latest
+          on-main: false
 
     steps:
     - name: Free Disk Space (Ubuntu) # only run on ubuntu


### PR DESCRIPTION
## Changes Made

Follow-up to #5142 to add the mac tests back for commits on the main branch.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
