### PR TITLE
docs: improve text readability on examples page

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -220,7 +220,7 @@
 }
 
 .example-overlay-dark {
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.9) 15%, rgba(0, 0, 0, 0.6) 45%, rgba(0, 0, 0, 0.2) 75%);
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.9) 12%, rgba(0, 0, 0, 0.6) 35%, rgba(0, 0, 0, 0) 65%);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Add darker overlay for image generation and document processing cards to improve text readability on light-colored cover images
- Maintain same gradient positioning as base overlay while increasing opacity values

## Before/After Screenshots
<img width="1070" height="945" alt="image" src="https://github.com/user-attachments/assets/7ef48940-fa07-4c14-a4a9-092d1e9bb274" />

<img width="1066" height="947" alt="image" src="https://github.com/user-attachments/assets/643bfbba-2b78-48ae-94ae-ae2039820cf8" />

## Test plan
- [x] Verify text is readable on all example cards
- [x] Check overlay doesn't obscure image details unnecessarily
- [x] Test responsive behavior on mobile

## Internal
Closes https://linear.app/eventual/issue/EVE-875/darken-the-background-overlay-for-the-text-for-examples