### PR TITLE
ci: move transformers tests to integration tests

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -829,6 +829,84 @@ jobs:
         webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
         webhook-type: incoming-webhook
 
+
+  integration-test-ai:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [skipcheck, integration-test-build]
+    if: ${{ needs.skipcheck.outputs.skip == 'false' && github.ref == 'refs/heads/main' }}
+    env:
+      package-name: daft
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.9']
+        daft-runner: [ray, native]
+        enable-aqe: [1, 0]
+        exclude:
+        - daft-runner: native
+          enable-aqe: 1
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+        fetch-depth: 0
+    - name: Download built wheels
+      uses: actions/download-artifact@v4
+      with:
+        pattern: wheels-*
+        merge-multiple: true
+        path: dist
+    - name: Setup Python and uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        python-version: ${{ matrix.python-version }}
+        enable-cache: true
+        cache-dependency-glob: "**/pyproject.toml"
+    - name: Setup Virtual Env
+      run: |
+        uv venv --seed .venv
+        echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
+    - name: Install Daft and dev dependencies
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        retry_wait_seconds: 10
+        command: |
+          source .venv/bin/activate
+          uv sync --no-install-project --all-extras --all-groups
+          uv pip install dist/${{ env.package-name }}-*x86_64*.whl --force-reinstall
+          rm -rf daft
+    - name: Run AI provider integration tests
+      run: |
+        set -o pipefail
+        source .venv/bin/activate
+        pytest -m integration tests/ai --durations=0 | ./tools/capture-durations.sh "ai_pytest_output.txt"
+        python tools/aggregate_test_durations.py ai_pytest_output.txt
+      env:
+        DAFT_RUNNER: ${{ matrix.daft-runner }}
+        DAFT_ENABLE_AQE: ${{ matrix.enable-aqe }}
+    - name: Send Slack notification on failure
+      uses: slackapi/slack-github-action@v2.0.0
+      if: ${{ failure() && (github.event_name == 'push') }}
+      with:
+        payload: |
+          {
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: [CI] AI Provider Integration Test <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
+                }
+              }
+            ]
+          }
+        webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+
+
   integration-test-ai-credentialed:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -881,8 +959,8 @@ jobs:
       run: |
         set -o pipefail
         source .venv/bin/activate
-        pytest -m integration tests/integration/ai --credentials --durations=0 | ./tools/capture-durations.sh "ai_pytest_output.txt"
-        python tools/aggregate_test_durations.py ai_pytest_output.txt
+        pytest -m integration tests/integration/ai --credentials --durations=0 | ./tools/capture-durations.sh "ai_credentialed_pytest_output.txt"
+        python tools/aggregate_test_durations.py ai_credentialed_pytest_output.txt
       env:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
         DAFT_ENABLE_AQE: ${{ matrix.enable-aqe }}
@@ -898,7 +976,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": ":rotating_light: [CI] AI Provider Integration Tests <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
+                  "text": ":rotating_light: [CI] AI Provider Integration Test Credentialed <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow> *FAILED on main* :rotating_light:"
                 }
               }
             ]
@@ -915,6 +993,7 @@ jobs:
     - integration-test-io-credentialed
     - integration-test-sql
     - integration-test-catalogs
+    - integration-test-ai
     - integration-test-ai-credentialed
     if: always()
     steps:

--- a/tests/ai/transformers/test_transformers_text_classifier.py
+++ b/tests/ai/transformers/test_transformers_text_classifier.py
@@ -46,20 +46,6 @@ def mock_provider(mock_text_classifier):
     yield provider
 
 
-def test_instantiate():
-    """Test to instantiate a TransformersTextClassifier, this instantiates a pipeline."""
-    descriptor = TransformersTextClassifierDescriptor(
-        provider_name="transformers",
-        model_name="facebook/bart-large-mnli",
-        model_options={},
-    )
-
-    classifier = descriptor.instantiate()
-    assert isinstance(classifier, TransformersTextClassifier)
-    assert classifier._model == "facebook/bart-large-mnli"
-    assert classifier._pipeline, "Current implementation should have a pipeline."
-
-
 def test_mock_text_classifier(mock_pipeline, mock_text_classifier):
     """Sanity check that our mocks are properly plumbed."""
     assert mock_text_classifier._model == "mock"
@@ -97,6 +83,22 @@ def test_classify_test_with_mock(mock_provider):
     assert results == ["mock!"]
 
 
+@pytest.mark.integration()
+def test_instantiate():
+    """Test to instantiate a TransformersTextClassifier, this instantiates a pipeline."""
+    descriptor = TransformersTextClassifierDescriptor(
+        provider_name="transformers",
+        model_name="facebook/bart-large-mnli",
+        model_options={},
+    )
+
+    classifier = descriptor.instantiate()
+    assert isinstance(classifier, TransformersTextClassifier)
+    assert classifier._model == "facebook/bart-large-mnli"
+    assert classifier._pipeline, "Current implementation should have a pipeline."
+
+
+@pytest.mark.integration()
 def test_classify_test_with_default(mock_provider):
     """Test text classification using the expression."""
     import daft


### PR DESCRIPTION
## Changes Made

These tests take a long time because they actually use the model. This results in slow and bad unit tests, so these have been marked as integ tests which are run in a non-credentialed way.

## Related Issues

n/a

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
