### PR TITLE
docs: clarify data catalog vs table format in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Daft: Unified Engine for Data Analytics, Engineering & ML/AI
 
 * **Familiar interactive API:** Lazy Python Dataframe for rapid and interactive iteration, or SQL for analytical queries
 * **Focus on the what:** Powerful Query Optimizer that rewrites queries to be as efficient as possible
-* **Data Catalog integrations:** Full integration with data catalogs such as Apache Iceberg
+* **Data Catalog integrations:** Integration with data catalogs (AWS Glue, Unity Catalog) and table formats like Apache Iceberg
 * **Rich multimodal type-system:** Supports multimodal types such as Images, URLs, Tensors and more
 * **Seamless Interchange**: Built on the `Apache Arrow <https://arrow.apache.org/docs/index.html>`_ In-Memory Format
 * **Built for the cloud:** `Record-setting <https://www.daft.ai/blog/announcing-daft-02>`_ I/O performance for integrations with S3 cloud storage


### PR DESCRIPTION
## Changes Made

Updated README to accurately distinguish between data catalogs (AWS Glue, Unity Catalog) and table formats (Apache Iceberg). The previous wording incorrectly implied Iceberg was a data catalog rather than a table format.

## Related Issues

N/A - Documentation clarity improvement

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)

## Internal

Closes https://linear.app/eventual/issue/EVE-888/docs-clarify-data-catalog-vs-table-format-in-readme