### PR TITLE
docs: fix additional incorrect references to Iceberg as a catalog

### DIFF
--- a/daft/catalog/__init__.py
+++ b/daft/catalog/__init__.py
@@ -4,7 +4,7 @@ A Catalog can be understood as a system/service for users to discover, access an
 Most commonly, users' data is represented as a "table". Some more modern Catalogs such as Unity Catalog
 also expose other types of data including files, ML models, registered functions and more.
 
-Examples of Catalogs include AWS Glue, Hive Metastore, Apache Iceberg REST and Unity Catalog.
+Examples of Catalogs include AWS Glue, Hive Metastore, Unity Catalog and S3 Tables.
 
 **Catalog**
 

--- a/docs/optimization/architecture.md
+++ b/docs/optimization/architecture.md
@@ -79,7 +79,7 @@ This is useful for a few reasons:
 4. **Memory pressure:** by processing one partition at a time, Daft can limit the amount of memory it needs to execute and possibly spill result partitions to disk if necessary, freeing up memory that it needs for execution.
 5. **Optimizations:** by understanding the PartitionSpec (invariants around the data inside each partition), Daft can make intelligent decisions to avoid unnecessary data movement for certain operations that may otherwise require a global shuffle of data.
 
-Partitioning is most often inherited from the data source that Daft is reading from. For example, if read from a directory of files, each file naturally is read as a single partition. If reading from a data catalog service such as Apache Iceberg or Delta Lake, Daft will inherit the partitioning scheme as informed by these services.
+Partitioning is most often inherited from the data source that Daft is reading from. For example, if read from a directory of files, each file naturally is read as a single partition. If reading from a table format such as Apache Iceberg or Delta Lake, Daft will inherit the partitioning scheme as informed by these formats.
 
 When querying a DataFrame, global operations will also require a repartitioning of the data, depending on the operation. For instance, sorting a DataFrame on [`daft.col(x)`][daft.col]will require repartitioning by range on [`daft.col(x)`][daft.col], so that a local sort on each partition will provide a globally sorted DataFrame.
 


### PR DESCRIPTION
## Changes Made

Fixed additional instances where Apache Iceberg was incorrectly referenced as a catalog rather than a table format:

1. **`daft/catalog/__init__.py`**: Replaced "Apache Iceberg REST" with "S3 Tables" in the examples of catalogs. Apache Iceberg REST is a catalog API specification, not an actual catalog service.

2. **`docs/optimization/architecture.md`**: Changed "data catalog service such as Apache Iceberg or Delta Lake" to "table format such as Apache Iceberg or Delta Lake" to correctly identify them as table formats.

This ensures consistent and accurate distinction throughout the codebase between:
- **Data Catalogs**: Services for metadata management (AWS Glue, Unity Catalog, S3 Tables, Hive Metastore)
- **Table Formats**: Specifications for data organization (Apache Iceberg, Delta Lake, Apache Hudi)

## Related Issues

Builds on #5197 - should be merged after that PR

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)

## Internal

Closes https://linear.app/eventual/issue/EVE-889/docs-fix-additional-incorrect-references-to-iceberg-as-a-catalog