### PR TITLE
docs: add Examples link to getting started sections

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,7 @@ More Resources
 ^^^^^^^^^^^^^^
 
 * `Daft Quickstart <https://docs.daft.ai/en/stable/quickstart/>`_ - learn more about Daft's full range of capabilities including dataloading from URLs, joins, user-defined functions (UDF), groupby, aggregations and more.
+* `Examples <https://docs.daft.ai/en/stable/examples/>`_ - see Daft in action with use cases across text, images, audio, and more
 * `User Guide <https://docs.daft.ai/en/stable/>`_ - take a deep-dive into each topic within Daft
 * `API Reference <https://docs.daft.ai/en/stable/api/>`_ - API reference for public classes/functions of Daft
 * `SQL Reference <https://docs.daft.ai/en/stable/sql/>`_ - Daft SQL reference

--- a/docs/index.md
+++ b/docs/index.md
@@ -504,7 +504,9 @@ Start local, scale global—without changing a line of code. Daft's Rust-powered
 
     1. [Quickstart](quickstart.md): Itching to run some Daft code? Hit the ground running with our 10 minute quickstart notebook.
 
-    2. [API Documentation](api/index.md): Searchable documentation and reference material to Daft’s public API.
+    2. [Examples](examples/index.md): See Daft in action with use cases across text, images, audio, and more.
+
+    3. [API Documentation](api/index.md): Searchable documentation and reference material to Daft's public API.
 
 ## Contribute to Daft
 


### PR DESCRIPTION
- Added Examples link between Quickstart and API Documentation in docs/index.md
- Added Examples link to More Resources section in README.rst
- Maintains consistency across documentation entry points