### PR TITLE
revert: "fix: remove io_config from global scan operator"

### DIFF
--- a/src/common/io-config/src/config.rs
+++ b/src/common/io-config/src/config.rs
@@ -8,54 +8,42 @@ use crate::{
 };
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct IOConfig {
-    pub s3: Option<S3Config>,
-    pub azure: Option<AzureConfig>,
-    pub gcs: Option<GCSConfig>,
-    pub http: Option<HTTPConfig>,
-    pub unity: Option<UnityConfig>,
-    pub hf: Option<HuggingFaceConfig>,
+    pub s3: S3Config,
+    pub azure: AzureConfig,
+    pub gcs: GCSConfig,
+    pub http: HTTPConfig,
+    pub unity: UnityConfig,
+    pub hf: HuggingFaceConfig,
 }
 
 impl IOConfig {
     #[must_use]
     pub fn multiline_display(&self) -> Vec<String> {
         let mut res = vec![];
-        if let Some(s3) = &self.s3 {
-            res.push(format!(
-                "S3 config = {{ {} }}",
-                s3.multiline_display().join(", ")
-            ));
-        }
-        if let Some(azure) = &self.azure {
-            res.push(format!(
-                "Azure config = {{ {} }}",
-                azure.multiline_display().join(", ")
-            ));
-        }
-        if let Some(gcs) = &self.gcs {
-            res.push(format!(
-                "GCS config = {{ {} }}",
-                gcs.multiline_display().join(", ")
-            ));
-        }
-        if let Some(http) = &self.http {
-            res.push(format!(
-                "HTTP config = {{ {} }}",
-                http.multiline_display().join(", ")
-            ));
-        }
-        if let Some(unity) = &self.unity {
-            res.push(format!(
-                "Unity config = {{ {} }}",
-                unity.multiline_display().join(", ")
-            ));
-        }
-        if let Some(hf) = &self.hf {
-            res.push(format!(
-                "Hugging Face config = {{ {} }}",
-                hf.multiline_display().join(", ")
-            ));
-        }
+        res.push(format!(
+            "S3 config = {{ {} }}",
+            self.s3.multiline_display().join(", ")
+        ));
+        res.push(format!(
+            "Azure config = {{ {} }}",
+            self.azure.multiline_display().join(", ")
+        ));
+        res.push(format!(
+            "GCS config = {{ {} }}",
+            self.gcs.multiline_display().join(", ")
+        ));
+        res.push(format!(
+            "HTTP config = {{ {} }}",
+            self.http.multiline_display().join(", ")
+        ));
+        res.push(format!(
+            "Unity config = {{ {} }}",
+            self.unity.multiline_display().join(", ")
+        ));
+        res.push(format!(
+            "Hugging Face config = {{ {} }}",
+            self.hf.multiline_display().join(", ")
+        ));
         res
     }
 }
@@ -68,15 +56,8 @@ impl Display for IOConfig {
 {}
 {}
 {}
-{}
-{}
 {}",
-            self.s3.clone().unwrap_or_default(),
-            self.azure.clone().unwrap_or_default(),
-            self.gcs.clone().unwrap_or_default(),
-            self.http.clone().unwrap_or_default(),
-            self.unity.clone().unwrap_or_default(),
-            self.hf.clone().unwrap_or_default(),
+            self.s3, self.azure, self.gcs, self.http,
         )
     }
 }

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -194,12 +194,12 @@ impl IOConfig {
     ) -> Self {
         Self {
             config: config::IOConfig {
-                s3: s3.map(|s| s.config),
-                azure: azure.map(|a| a.config),
-                gcs: gcs.map(|g| g.config),
-                http: http.map(|h| h.config),
-                unity: unity.map(|u| u.config),
-                hf: hf.map(|h| h.config),
+                s3: s3.unwrap_or_default().config,
+                azure: azure.unwrap_or_default().config,
+                gcs: gcs.unwrap_or_default().config,
+                http: http.unwrap_or_default().config,
+                unity: unity.unwrap_or_default().config,
+                hf: hf.unwrap_or_default().config,
             },
         }
     }
@@ -224,16 +224,24 @@ impl IOConfig {
     ) -> Self {
         Self {
             config: config::IOConfig {
-                s3: s3.map(|s| s.config).or_else(|| self.config.s3.clone()),
+                s3: s3
+                    .map(|s3| s3.config)
+                    .unwrap_or_else(|| self.config.s3.clone()),
                 azure: azure
-                    .map(|a| a.config)
-                    .or_else(|| self.config.azure.clone()),
-                gcs: gcs.map(|g| g.config).or_else(|| self.config.gcs.clone()),
-                http: http.map(|h| h.config).or_else(|| self.config.http.clone()),
+                    .map(|azure| azure.config)
+                    .unwrap_or_else(|| self.config.azure.clone()),
+                gcs: gcs
+                    .map(|gcs| gcs.config)
+                    .unwrap_or_else(|| self.config.gcs.clone()),
+                http: http
+                    .map(|http| http.config)
+                    .unwrap_or_else(|| self.config.http.clone()),
                 unity: unity
-                    .map(|u| u.config)
-                    .or_else(|| self.config.unity.clone()),
-                hf: hf.map(|hf| hf.config).or_else(|| self.config.hf.clone()),
+                    .map(|unity| unity.config)
+                    .unwrap_or_else(|| self.config.unity.clone()),
+                hf: hf
+                    .map(|hf| hf.config)
+                    .unwrap_or_else(|| self.config.hf.clone()),
             },
         }
     }
@@ -246,7 +254,7 @@ impl IOConfig {
     #[getter]
     pub fn s3(&self) -> PyResult<S3Config> {
         Ok(S3Config {
-            config: self.config.s3.clone().unwrap_or_default(),
+            config: self.config.s3.clone(),
         })
     }
 
@@ -254,7 +262,7 @@ impl IOConfig {
     #[getter]
     pub fn azure(&self) -> PyResult<AzureConfig> {
         Ok(AzureConfig {
-            config: self.config.azure.clone().unwrap_or_default(),
+            config: self.config.azure.clone(),
         })
     }
 
@@ -262,7 +270,7 @@ impl IOConfig {
     #[getter]
     pub fn gcs(&self) -> PyResult<GCSConfig> {
         Ok(GCSConfig {
-            config: self.config.gcs.clone().unwrap_or_default(),
+            config: self.config.gcs.clone(),
         })
     }
 
@@ -270,21 +278,21 @@ impl IOConfig {
     #[getter]
     pub fn http(&self) -> PyResult<HTTPConfig> {
         Ok(HTTPConfig {
-            config: self.config.http.clone().unwrap_or_default(),
+            config: self.config.http.clone(),
         })
     }
 
     #[getter]
     pub fn unity(&self) -> PyResult<UnityConfig> {
         Ok(UnityConfig {
-            config: self.config.unity.clone().unwrap_or_default(),
+            config: self.config.unity.clone(),
         })
     }
 
     #[getter]
     pub fn hf(&self) -> PyResult<HuggingFaceConfig> {
         Ok(HuggingFaceConfig {
-            config: self.config.hf.clone().unwrap_or_default(),
+            config: self.config.hf.clone(),
         })
     }
 

--- a/src/daft-connect/src/session.rs
+++ b/src/daft-connect/src/session.rs
@@ -75,26 +75,10 @@ impl ConnectSession {
             hf,
         } = get_context().io_config();
 
-        if let Some(s3_config) = s3.take() {
-            let mut s3_config = s3_config;
-            self.s3_config_helper(&mut s3_config)?;
-            s3 = Some(s3_config);
-        }
-        if let Some(azure_config) = azure.take() {
-            let mut azure_config = azure_config;
-            self.azure_config_helper(&mut azure_config)?;
-            azure = Some(azure_config);
-        }
-        if let Some(gcs_config) = gcs.take() {
-            let mut gcs_config = gcs_config;
-            self.gcs_config_helper(&mut gcs_config)?;
-            gcs = Some(gcs_config);
-        }
-        if let Some(http_config) = http.take() {
-            let mut http_config = http_config;
-            self.http_config_helper(&mut http_config)?;
-            http = Some(http_config);
-        }
+        self.s3_config_helper(&mut s3)?;
+        self.azure_config_helper(&mut azure)?;
+        self.gcs_config_helper(&mut gcs)?;
+        self.http_config_helper(&mut http)?;
 
         Ok(IOConfig {
             s3,

--- a/src/daft-csv/src/metadata.rs
+++ b/src/daft-csv/src/metadata.rs
@@ -289,7 +289,7 @@ mod tests {
 
     use common_error::{DaftError, DaftResult};
     use daft_core::prelude::*;
-    use daft_io::{IOClient, IOConfig, init_s3_config};
+    use daft_io::{IOClient, IOConfig};
     use rstest::rstest;
 
     use super::read_csv_schema;
@@ -326,7 +326,8 @@ mod tests {
             compression.map_or(String::new(), |ext| format!(".{ext}"))
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, read_stats) =
@@ -354,7 +355,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, read_stats) = read_csv_schema(
@@ -385,7 +387,8 @@ mod tests {
     async fn test_csv_schema_local_read_stats() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (_, read_stats) = read_csv_schema(file.as_ref(), None, None, io_client, None).await?;
@@ -402,7 +405,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, read_stats) = read_csv_schema(
@@ -436,7 +440,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, read_stats) =
@@ -461,7 +466,8 @@ mod tests {
     async fn test_csv_schema_local_nulls() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny_nulls.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, read_stats) =
@@ -489,7 +495,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, read_stats) =
@@ -515,7 +522,8 @@ mod tests {
     async fn test_csv_schema_local_max_bytes() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, read_stats) =
@@ -552,7 +560,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let err = read_csv_schema(file.as_ref(), None, None, io_client, None).await;
@@ -576,7 +585,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let err = read_csv_schema(
@@ -630,7 +640,8 @@ mod tests {
             compression.map_or(String::new(), |ext| format!(".{ext}"))
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let (schema, _) = read_csv_schema(file.as_ref(), None, None, io_client, None).await?;

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -731,7 +731,7 @@ mod tests {
         prelude::*,
         utils::arrow::{cast_array_for_daft_if_needed, cast_array_from_daft_if_needed},
     };
-    use daft_io::{IOClient, IOConfig, init_s3_config};
+    use daft_io::{IOClient, IOConfig};
     use daft_recordbatch::RecordBatch;
     use rstest::rstest;
 
@@ -828,7 +828,8 @@ mod tests {
             compression.map_or(String::new(), |ext| format!(".{ext}"))
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -871,7 +872,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -930,7 +932,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -980,7 +983,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1029,7 +1033,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1076,7 +1081,8 @@ mod tests {
     fn test_csv_read_local_escape() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny_escape.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1123,7 +1129,8 @@ mod tests {
     fn test_csv_read_local_comment() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny_comment.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1169,7 +1176,8 @@ mod tests {
     fn test_csv_read_local_limit() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1216,7 +1224,8 @@ mod tests {
     fn test_csv_read_local_projection() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1266,7 +1275,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1326,7 +1336,8 @@ mod tests {
     fn test_csv_read_local_larger_than_buffer_size() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1373,7 +1384,8 @@ mod tests {
     fn test_csv_read_local_larger_than_chunk_size() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1420,7 +1432,8 @@ mod tests {
     fn test_csv_read_local_throttled_streaming() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1467,7 +1480,8 @@ mod tests {
     fn test_csv_read_local_nulls() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny_nulls.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1508,7 +1522,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1547,7 +1562,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
         let schema = Schema::new(vec![
@@ -1602,7 +1618,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1640,7 +1657,8 @@ mod tests {
     fn test_csv_read_local_wrong_type_yields_nulls() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.csv", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1680,7 +1698,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1705,7 +1724,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1753,7 +1773,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1787,7 +1808,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1829,7 +1851,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1899,7 +1922,8 @@ mod tests {
             compression.map_or(String::new(), |ext| format!(".{ext}"))
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1921,7 +1945,8 @@ mod tests {
     fn test_csv_read_s3_no_headers() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/csv-dev/mvp_no_header.csv";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1955,7 +1980,8 @@ mod tests {
     fn test_csv_read_s3_no_headers_and_projection() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/csv-dev/mvp_no_header.csv";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1989,7 +2015,8 @@ mod tests {
     fn test_csv_read_s3_limit() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/csv-dev/mvp.csv";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -2020,7 +2047,8 @@ mod tests {
     fn test_csv_read_s3_projection() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/csv-dev/mvp.csv";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -2047,7 +2075,8 @@ mod tests {
     fn test_csv_read_s3_larger_than_buffer_size() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/csv-dev/medium.csv";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -2070,7 +2099,8 @@ mod tests {
     fn test_csv_read_s3_larger_than_chunk_size() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/csv-dev/medium.csv";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -2093,7 +2123,8 @@ mod tests {
     fn test_csv_read_s3_throttled_streaming() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/csv-dev/medium.csv";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -231,43 +231,31 @@ impl IOClient {
                 // Hugging Face requires special logic around cache busting. That logic is encapsulated in the HFSource.
                 match url.domain() {
                     Some("huggingface.co") => {
-                        HFSource::get_client(
-                            &self.config.hf.clone().unwrap_or_default(),
-                            &self.config.http.clone().unwrap_or_default(),
-                        )
-                        .await? as Arc<dyn ObjectSource>
+                        HFSource::get_client(&self.config.hf, &self.config.http).await?
+                            as Arc<dyn ObjectSource>
                     }
-                    _ => {
-                        HttpSource::get_client(&self.config.http.clone().unwrap_or_default())
-                            .await? as Arc<dyn ObjectSource>
-                    }
+                    _ => HttpSource::get_client(&self.config.http).await? as Arc<dyn ObjectSource>,
                 }
             }
             SourceType::S3 => {
-                S3LikeSource::get_client(&self.config.s3.clone().unwrap_or_default()).await?
-                    as Arc<dyn ObjectSource>
+                S3LikeSource::get_client(&self.config.s3).await? as Arc<dyn ObjectSource>
             }
             SourceType::AzureBlob => {
-                AzureBlobSource::get_client(&self.config.azure.clone().unwrap_or_default(), &path)
-                    .await? as Arc<dyn ObjectSource>
+                AzureBlobSource::get_client(&self.config.azure, &path).await?
+                    as Arc<dyn ObjectSource>
             }
 
             SourceType::GCS => {
-                GCSSource::get_client(&self.config.gcs.clone().unwrap_or_default()).await?
-                    as Arc<dyn ObjectSource>
+                GCSSource::get_client(&self.config.gcs).await? as Arc<dyn ObjectSource>
             }
             SourceType::HF => {
-                HFSource::get_client(
-                    &self.config.hf.clone().unwrap_or_default(),
-                    &self.config.http.clone().unwrap_or_default(),
-                )
-                .await? as Arc<dyn ObjectSource>
+                HFSource::get_client(&self.config.hf, &self.config.http).await?
+                    as Arc<dyn ObjectSource>
             }
             SourceType::Unity => {
                 #[cfg(feature = "python")]
                 {
-                    UnitySource::get_client(&self.config.unity.clone().unwrap_or_default()).await?
-                        as Arc<dyn ObjectSource>
+                    UnitySource::get_client(&self.config.unity).await? as Arc<dyn ObjectSource>
                 }
                 #[cfg(not(feature = "python"))]
                 {

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -1733,17 +1733,6 @@ impl Write for S3PartBuffer {
     }
 }
 
-#[macro_export]
-macro_rules! init_s3_config {
-    ($io_config:ident) => {
-        let mut $io_config = IOConfig::default();
-        if $io_config.s3.is_none() {
-            $io_config.s3 = Some(Default::default());
-        }
-        $io_config.s3.as_mut().unwrap().anonymous = true;
-    };
-}
-
 #[cfg(test)]
 mod tests {
 

--- a/src/daft-json/src/read.rs
+++ b/src/daft-json/src/read.rs
@@ -634,7 +634,7 @@ mod tests {
         prelude::*,
         utils::arrow::{cast_array_for_daft_if_needed, cast_array_from_daft_if_needed},
     };
-    use daft_io::{IOClient, IOConfig, init_s3_config};
+    use daft_io::{IOClient, IOConfig};
     use daft_recordbatch::RecordBatch;
     use indexmap::IndexMap;
     use rstest::rstest;
@@ -740,7 +740,8 @@ mod tests {
             compression.map_or(String::new(), |ext| format!(".{}", ext))
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -768,7 +769,8 @@ mod tests {
     fn test_json_read_local_dtypes() -> DaftResult<()> {
         let file = format!("{}/test/dtypes.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -832,7 +834,8 @@ mod tests {
     fn test_json_read_local_limit() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -867,7 +870,8 @@ mod tests {
     fn test_json_read_local_projection() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -909,7 +913,8 @@ mod tests {
     fn test_json_read_local_larger_than_buffer_size() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -944,7 +949,8 @@ mod tests {
     fn test_json_read_local_larger_than_chunk_size() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -979,7 +985,8 @@ mod tests {
     fn test_json_read_local_throttled_streaming() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1014,7 +1021,8 @@ mod tests {
     fn test_json_read_local_nulls() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny_nulls.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1043,7 +1051,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1082,7 +1091,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1138,7 +1148,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
         let schema = Schema::new(vec![
@@ -1185,7 +1196,8 @@ mod tests {
     fn test_json_read_local_wrong_type_yields_nulls() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1248,7 +1260,8 @@ mod tests {
             compression.map_or(String::new(), |ext| format!(".{}", ext))
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1273,7 +1286,8 @@ mod tests {
     fn test_json_read_s3_limit() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/json-dev/iris_tiny.jsonl";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1307,7 +1321,8 @@ mod tests {
     fn test_json_read_s3_projection() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/json-dev/iris_tiny.jsonl";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1343,7 +1358,8 @@ mod tests {
     fn test_json_read_s3_larger_than_buffer_size() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/json-dev/iris_tiny.jsonl";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1377,7 +1393,8 @@ mod tests {
     fn test_json_read_s3_larger_than_chunk_size() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/json-dev/iris_tiny.jsonl";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1411,7 +1428,8 @@ mod tests {
     fn test_json_read_s3_throttled_streaming() -> DaftResult<()> {
         let file = "s3://daft-public-data/test_fixtures/json-dev/iris_tiny.jsonl";
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 

--- a/src/daft-json/src/schema.rs
+++ b/src/daft-json/src/schema.rs
@@ -229,7 +229,7 @@ mod tests {
 
     use common_error::DaftResult;
     use daft_core::prelude::*;
-    use daft_io::{IOClient, IOConfig, init_s3_config};
+    use daft_io::{IOClient, IOConfig};
     use rstest::rstest;
 
     use super::read_json_schema;
@@ -266,7 +266,8 @@ mod tests {
             compression.map_or(String::new(), |ext| format!(".{}", ext))
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let schema = read_json_schema(file.as_ref(), None, None, io_client, None).await?;
@@ -289,7 +290,8 @@ mod tests {
     async fn test_json_schema_local_dtypes() -> DaftResult<()> {
         let file = format!("{}/test/dtypes.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -350,7 +352,8 @@ mod tests {
     async fn test_json_schema_local_nulls() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny_nulls.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let schema = read_json_schema(file.as_ref(), None, None, io_client, None).await?;
@@ -375,7 +378,8 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let schema = read_json_schema(file.as_ref(), None, None, io_client, None).await?;
@@ -399,7 +403,8 @@ mod tests {
     async fn test_json_schema_local_max_bytes() -> DaftResult<()> {
         let file = format!("{}/test/iris_tiny.jsonl", env!("CARGO_MANIFEST_DIR"),);
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let schema = read_json_schema(file.as_ref(), None, Some(100), io_client, None).await?;
@@ -448,7 +453,8 @@ mod tests {
             compression.map_or(String::new(), |ext| format!(".{}", ext))
         );
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         let schema = read_json_schema(file.as_ref(), None, None, io_client, None).await?;

--- a/src/daft-parquet/src/metadata.rs
+++ b/src/daft-parquet/src/metadata.rs
@@ -343,7 +343,7 @@ mod tests {
     use std::sync::Arc;
 
     use common_error::DaftResult;
-    use daft_io::{IOClient, IOConfig, init_s3_config};
+    use daft_io::{IOClient, IOConfig};
 
     use super::read_parquet_metadata;
     use crate::Error;
@@ -353,7 +353,8 @@ mod tests {
         let file = "s3://daft-public-data/test_fixtures/parquet-dev/mvp.parquet";
         let size = 9882;
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
         // Read metadata with actual file size.

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -1143,7 +1143,7 @@ mod tests {
 
     use arrow2::{datatypes::DataType, io::parquet::read::schema::StringEncoding};
     use common_error::DaftResult;
-    use daft_io::{IOClient, IOConfig, init_s3_config};
+    use daft_io::{IOClient, IOConfig};
     use futures::StreamExt;
     use parquet2::{
         metadata::FileMetaData,
@@ -1166,7 +1166,8 @@ mod tests {
     fn test_parquet_read_from_s3() -> DaftResult<()> {
         let file = PARQUET_FILE;
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
 
@@ -1192,7 +1193,8 @@ mod tests {
     fn test_parquet_streaming_read_from_s3() -> DaftResult<()> {
         let file = PARQUET_FILE;
 
-        init_s3_config!(io_config);
+        let mut io_config = IOConfig::default();
+        io_config.s3.anonymous = true;
 
         let io_client = Arc::new(IOClient::new(io_config.into())?);
         let runtime_handle = get_io_runtime(true);

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -381,6 +381,7 @@ impl ScanOperator for GlobScanOperator {
             format!("Glob paths = [{}]", condensed_glob_paths),
         ];
         lines.extend(self.file_format_config.multiline_display());
+        lines.extend(self.storage_config.multiline_display());
 
         lines
     }

--- a/src/daft-scan/src/storage_config.rs
+++ b/src/daft-scan/src/storage_config.rs
@@ -47,22 +47,13 @@ impl StorageConfig {
 
     #[must_use]
     pub fn multiline_display(&self) -> Vec<String> {
-        let mut res = Vec::new();
-
-        match &self.io_config {
-            Some(io_config) => {
-                let display_lines = io_config.multiline_display();
-                if !display_lines.is_empty() {
-                    res.push(format!("IO config = {}", display_lines.join(", ")));
-                } else {
-                    res.push("Local IO config".to_string());
-                }
-            }
-            None => {
-                res.push("Local IO config".to_string());
-            }
+        let mut res = vec![];
+        if let Some(io_config) = &self.io_config {
+            res.push(format!(
+                "IO config = {}",
+                io_config.multiline_display().join(", ")
+            ));
         }
-
         res.push(format!("Use multithreading = {}", self.multithreaded_io));
         res
     }

--- a/src/daft-sql/src/modules/config.rs
+++ b/src/daft-sql/src/modules/config.rs
@@ -404,7 +404,7 @@ pub(crate) fn expr_to_iocfg(expr: &ExprRef) -> SQLPlannerResult<IOConfig> {
             };
 
             Ok(IOConfig {
-                s3: Some(s3_config),
+                s3: s3_config,
                 ..Default::default()
             })
         }
@@ -421,14 +421,14 @@ pub(crate) fn expr_to_iocfg(expr: &ExprRef) -> SQLPlannerResult<IOConfig> {
             let num_tries = get_value!("num_tries", UInt32)?.unwrap_or(default.num_tries);
 
             Ok(IOConfig {
-                http: Some(HTTPConfig {
+                http: HTTPConfig {
                     user_agent,
                     bearer_token,
                     retry_initial_backoff_ms,
                     connect_timeout_ms,
                     read_timeout_ms,
                     num_tries,
-                }),
+                },
                 ..Default::default()
             })
         }
@@ -448,7 +448,7 @@ pub(crate) fn expr_to_iocfg(expr: &ExprRef) -> SQLPlannerResult<IOConfig> {
             let default = AzureConfig::default();
 
             Ok(IOConfig {
-                azure: Some(AzureConfig {
+                azure: AzureConfig {
                     storage_account,
                     access_key: access_key.map(|s| s.into()),
                     sas_token,
@@ -460,7 +460,7 @@ pub(crate) fn expr_to_iocfg(expr: &ExprRef) -> SQLPlannerResult<IOConfig> {
                     anonymous: anonymous.unwrap_or(default.anonymous),
                     endpoint_url,
                     use_ssl: use_ssl.unwrap_or(default.use_ssl),
-                }),
+                },
                 ..Default::default()
             })
         }
@@ -478,7 +478,7 @@ pub(crate) fn expr_to_iocfg(expr: &ExprRef) -> SQLPlannerResult<IOConfig> {
 
             let default = GCSConfig::default();
             Ok(IOConfig {
-                gcs: Some(GCSConfig {
+                gcs: GCSConfig {
                     project_id,
                     credentials: credentials.map(|s| s.into()),
                     token,
@@ -490,7 +490,7 @@ pub(crate) fn expr_to_iocfg(expr: &ExprRef) -> SQLPlannerResult<IOConfig> {
                     connect_timeout_ms: connect_timeout_ms.unwrap_or(default.connect_timeout_ms),
                     read_timeout_ms: read_timeout_ms.unwrap_or(default.read_timeout_ms),
                     num_tries: num_tries.unwrap_or(default.num_tries),
-                }),
+                },
                 ..Default::default()
             })
         }

--- a/tests/dataframe/test_morsels.py
+++ b/tests/dataframe/test_morsels.py
@@ -136,12 +136,7 @@ def test_batch_size_from_udf_propagated_through_ops_to_scan():
 |   Retry initial backoff ms = 1000
 |   Connect timeout ms = 30000
 |   Read timeout ms = 30000
-|   Max retries = 5
-|   UnityConfig
-|       endpoint: None
-|       token: None
-|   HuggingFaceConfig
-|   Anonymous = false))) as {id_placeholder}, col(0: data)
+|   Max retries = 5))) as {id_placeholder}, col(0: data)
 |   Batch Size = Range(0, 10]
 |
 * InMemorySource:
@@ -151,7 +146,6 @@ def test_batch_size_from_udf_propagated_through_ops_to_scan():
 |   Batch Size = Range(0, 10]
 
 """
-    print(f"captured: {captured}")
     assert clean_explain_output(captured) == clean_explain_output(expected)
 
 


### PR DESCRIPTION
Reverts Eventual-Inc/Daft#4676

@Jay-ju this is causing some build & test failures that somehow got through the PR CI. As a result, I'm reverting this to prevent build failures on main. 