### PR TITLE
chore: optimize operator naming

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -856,6 +856,7 @@ class ScanTask:
         size_bytes: int | None,
         pushdowns: PyPushdowns | None,
         stats: PyRecordBatch | None,
+        source_type: str | None = None,
     ) -> ScanTask:
         """Create a Python factory function Scan Task."""
         ...

--- a/daft/io/__shim.py
+++ b/daft/io/__shim.py
@@ -34,7 +34,7 @@ class _DataSourceShim(ScanOperator):
         return self._source.name
 
     def display_name(self) -> str:
-        return f"DataSource({self.name()})"
+        return f"{self.name()}(Python)"
 
     def partitioning_keys(self) -> list[PyPartitionField]:
         return [pf._partition_field for pf in self._source.get_partition_fields()]
@@ -66,6 +66,7 @@ class _DataSourceShim(ScanOperator):
                 size_bytes=None,
                 pushdowns=pushdowns,
                 stats=None,
+                source_type=self.name(),
             )
 
     def as_pushdown_filter(self) -> SupportsPushdownFilters | None:

--- a/daft/io/_generator.py
+++ b/daft/io/_generator.py
@@ -119,4 +119,5 @@ class GeneratorScanOperator(ScanOperator):
                 size_bytes=None,
                 pushdowns=pushdowns,
                 stats=None,
+                source_type=self.name(),
             )

--- a/daft/io/lance/lance_scan.py
+++ b/daft/io/lance/lance_scan.py
@@ -156,6 +156,7 @@ class LanceDBScanOperator(ScanOperator, SupportsPushdownFilters):
                 size_bytes=None,
                 pushdowns=pushdowns,
                 stats=None,
+                source_type=self.name(),
             )
         # Check if there is a limit pushdown and no filters
         elif pushdowns.limit is not None and self._pushed_filters is None:
@@ -197,6 +198,7 @@ class LanceDBScanOperator(ScanOperator, SupportsPushdownFilters):
                     size_bytes=None,
                     pushdowns=pushdowns,
                     stats=None,
+                    source_type=self.name(),
                 )
 
     def _create_regular_scan_tasks(
@@ -224,6 +226,7 @@ class LanceDBScanOperator(ScanOperator, SupportsPushdownFilters):
                     size_bytes=size_bytes,
                     pushdowns=pushdowns,
                     stats=stats,
+                    source_type=self.name(),
                 )
         else:
             # Group fragments
@@ -258,6 +261,7 @@ class LanceDBScanOperator(ScanOperator, SupportsPushdownFilters):
                     size_bytes=size_bytes,
                     pushdowns=pushdowns,
                     stats=stats,
+                    source_type=self.name(),
                 )
 
     def _combine_filters_to_arrow(self) -> Optional["pa.compute.Expression"]:

--- a/src/common/file-formats/src/file_format_config.rs
+++ b/src/common/file-formats/src/file_format_config.rs
@@ -22,7 +22,11 @@ pub enum FileFormatConfig {
     #[cfg(feature = "python")]
     Database(DatabaseSourceConfig),
     #[cfg(feature = "python")]
-    PythonFunction,
+    PythonFunction {
+        source_type: Option<String>,
+        module_name: Option<String>,
+        function_name: Option<String>,
+    },
 }
 
 impl FileFormatConfig {
@@ -32,16 +36,29 @@ impl FileFormatConfig {
     }
 
     #[must_use]
-    pub fn var_name(&self) -> &'static str {
+    pub fn var_name(&self) -> String {
         match self {
-            Self::Parquet(_) => "Parquet",
-            Self::Csv(_) => "Csv",
-            Self::Json(_) => "Json",
-            Self::Warc(_) => "Warc",
+            Self::Parquet(_) => "Parquet".to_string(),
+            Self::Csv(_) => "Csv".to_string(),
+            Self::Json(_) => "Json".to_string(),
+            Self::Warc(_) => "Warc".to_string(),
             #[cfg(feature = "python")]
-            Self::Database(_) => "Database",
+            Self::Database(_) => "Database".to_string(),
             #[cfg(feature = "python")]
-            Self::PythonFunction => "PythonFunction",
+            Self::PythonFunction {
+                source_type,
+                module_name,
+                function_name: _,
+            } => {
+                if let Some(source_type) = source_type {
+                    format!("{}(Python)", source_type)
+                } else if let Some(module_name) = module_name {
+                    // Infer type from module name
+                    format!("{}(Python)", module_name)
+                } else {
+                    "PythonFunction".to_string()
+                }
+            }
         }
     }
 
@@ -55,7 +72,7 @@ impl FileFormatConfig {
             #[cfg(feature = "python")]
             Self::Database(source) => source.multiline_display(),
             #[cfg(feature = "python")]
-            Self::PythonFunction => vec![],
+            Self::PythonFunction { .. } => vec![],
         }
     }
 }

--- a/src/common/file-formats/src/lib.rs
+++ b/src/common/file-formats/src/lib.rs
@@ -21,7 +21,11 @@ impl From<&FileFormatConfig> for FileFormat {
             #[cfg(feature = "python")]
             FileFormatConfig::Database(_) => Self::Database,
             #[cfg(feature = "python")]
-            FileFormatConfig::PythonFunction => Self::Python,
+            FileFormatConfig::PythonFunction {
+                source_type: _,
+                module_name: _,
+                function_name: _,
+            } => Self::Python,
         }
     }
 }

--- a/src/common/file-formats/src/python.rs
+++ b/src/common/file-formats/src/python.rs
@@ -74,7 +74,11 @@ impl PyFileFormatConfig {
                 .clone()
                 .into_pyobject(py)
                 .map(|c| c.unbind().into_any()),
-            FileFormatConfig::PythonFunction => Ok(py.None()),
+            FileFormatConfig::PythonFunction {
+                source_type: _,
+                module_name: _,
+                function_name: _,
+            } => Ok(py.None()),
         }
     }
 

--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -622,7 +622,7 @@ async fn stream_scan_task(
             Box::pin(futures::stream::once(async { Ok(table) }))
         }
         #[cfg(feature = "python")]
-        FileFormatConfig::PythonFunction => {
+        FileFormatConfig::PythonFunction { .. } => {
             let iter = daft_micropartition::python::read_pyfunc_into_table_iter(scan_task.clone())?;
             let stream = futures::stream::iter(iter.map(|r| r.map_err(|e| e.into())));
             Box::pin(stream)

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -320,7 +320,11 @@ fn materialize_scan_task(
             })?
         }
         #[cfg(feature = "python")]
-        FileFormatConfig::PythonFunction => {
+        FileFormatConfig::PythonFunction {
+            source_type: _,
+            module_name: _,
+            function_name: _,
+        } => {
             let tables = crate::python::read_pyfunc_into_table_iter(scan_task.clone())?;
             tables.collect::<crate::Result<Vec<_>>>()?
         }

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -284,7 +284,11 @@ impl GlobScanOperator {
                         ));
                     }
                     #[cfg(feature = "python")]
-                    FileFormatConfig::PythonFunction => {
+                    FileFormatConfig::PythonFunction {
+                        source_type: _,
+                        module_name: _,
+                        function_name: _,
+                    } => {
                         return Err(DaftError::ValueError(
                             "Cannot glob a PythonFunction source".to_string(),
                         ));

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -741,7 +741,11 @@ impl ScanTask {
                         #[cfg(feature = "python")]
                         FileFormatConfig::Database(_) => 1.0,
                         #[cfg(feature = "python")]
-                        FileFormatConfig::PythonFunction => 1.0,
+                        FileFormatConfig::PythonFunction {
+                            source_type: _,
+                            module_name: _,
+                            function_name: _,
+                        } => 1.0,
                     };
                     let in_mem_size: f64 = (file_size as f64) * inflation_factor;
                     let read_row_size = if self.is_warc() {


### PR DESCRIPTION
In the current progress, if the scan is of the Python version, its display is not user-friendly. 
Therefore, this PR attempts to fix this issue.
The main approach is to convert PythonFunction into a specific Datasource Scan, for example
Before PR
```
tests/io/lancedb/test_lancedb_reads.py 🗡️ 🐟[1/1] ⠁    PythonFunction Scan | [00:00:00] 
🗡️ 🐟[1/1] ⠁    PythonFunction Scan | [00:00:00] 2 rows out, 0 B bytes read
🗡️ 🐟[1/1] ✓    PythonFunction Scan | [00:00:00] 2 rows out, 0 B bytes read  

```


After PR

```
tests/io/lancedb/test_lancedb_reads.py 🗡️ 🐟[1/1] ⠁             Lance(Python) Scan | [00:00:00] 
🗡️ 🐟[1/1] ⠁             Lance(Python) Scan | [00:00:00] 2 rows out, 0 B bytes read 
🗡️ 🐟[1/1] ✓             Lance(Python) Scan | [00:00:00] 2 rows out, 0 B bytes read        

```

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
