### PR TITLE
fix: remove unnecessary field renaming in ListMap scalar UDF

### DIFF
--- a/src/daft-functions-list/src/list_map.rs
+++ b/src/daft-functions-list/src/list_map.rs
@@ -41,9 +41,8 @@ impl ScalarUDF for ListMap {
         inputs: FunctionArgs<ExprRef>,
         schema: &Schema,
     ) -> DaftResult<Field> {
-        let ListMapArgs { input, expr } = inputs.try_into()?;
+        let ListMapArgs { expr, .. } = inputs.try_into()?;
 
-        let _input = input.to_field(schema)?;
         let expr = expr.to_field(schema)?;
 
         Ok(expr.to_list_field())

--- a/src/daft-functions-list/src/list_map.rs
+++ b/src/daft-functions-list/src/list_map.rs
@@ -46,6 +46,6 @@ impl ScalarUDF for ListMap {
         let input = input.to_field(schema)?;
         let expr = expr.to_field(schema)?;
 
-        Ok(expr.to_list_field().rename(input.name))
+        Ok(expr.to_list_field())
     }
 }

--- a/src/daft-functions-list/src/list_map.rs
+++ b/src/daft-functions-list/src/list_map.rs
@@ -43,7 +43,7 @@ impl ScalarUDF for ListMap {
     ) -> DaftResult<Field> {
         let ListMapArgs { input, expr } = inputs.try_into()?;
 
-        let input = input.to_field(schema)?;
+        let _input = input.to_field(schema)?;
         let expr = expr.to_field(schema)?;
 
         Ok(expr.to_list_field())

--- a/tests/functions/test_list_map.py
+++ b/tests/functions/test_list_map.py
@@ -53,3 +53,20 @@ def test_map_nested():
     expected = ["this", "is", "a", "test", "another", "test"]
 
     assert words == expected
+
+
+def test_list_map_struct_field_extraction_without_alias():
+    df = daft.from_pydict(
+        {
+            "structs": [
+                [{"a": "a1", "b": "b1"}, {"a": "a2", "b": "b2"}],
+                [{"a": "a3", "b": "b3"}],
+                [],
+            ]
+        }
+    )
+
+    res = df.select(daft.col("structs").list.map(daft.element().struct.get("a"))).to_pydict()["a"]
+
+    expected = [["a1", "a2"], ["a3"], []]
+    assert res == expected


### PR DESCRIPTION
## Changes Made

Remove input name renaming in get_return_field method to preserve original field names from expressions. This fixes the issue where extracting struct fields from list of structs requires an alias due to name mismatch.

## Related Issues

Fixes #5200

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)