### PR TITLE
chore: Split `.str.split` into `.str.split` and `.str.regexp_split`

### DIFF
--- a/daft/series.py
+++ b/daft/series.py
@@ -837,8 +837,36 @@ class SeriesStringNamespace(SeriesNamespace):
         return self._eval_expressions("regexp_match", pattern)
 
     def split(self, pattern: Series, regex: bool = False) -> Series:
-        f_name = "regexp_split" if regex else "split"
-        return self._eval_expressions(f_name, pattern)
+        """Splits each string on the given literal pattern, into a list of strings.
+
+        Args:
+            pattern: The literal pattern on which each string should be split.
+            regex: DEPRECATED. Use regexp_split() instead for regex patterns.
+
+        Returns:
+            Series: A List[Utf8] series containing the string splits for each string.
+        """
+        if regex:
+            import warnings
+
+            warnings.warn(
+                "The 'regex' parameter in str.split() is deprecated and will be removed in v0.7.0. Use str.regexp_split() instead for regex patterns.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return self.regexp_split(pattern)
+        return self._eval_expressions("split", pattern)
+
+    def regexp_split(self, pattern: Series) -> Series:
+        """Splits each string on the given regex pattern, into a list of strings.
+
+        Args:
+            pattern: The regex pattern on which each string should be split.
+
+        Returns:
+            Series: A List[Utf8] series containing the string splits for each string.
+        """
+        return self._eval_expressions("regexp_split", pattern)
 
     def concat(self, other: Series) -> Series:
         if not isinstance(other, Series):

--- a/tests/recordbatch/utf8/test_split.py
+++ b/tests/recordbatch/utf8/test_split.py
@@ -21,17 +21,17 @@ from daft.recordbatch import MicroPartition
             [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]],
         ),
         (
-            col("col").str.split(r",+", True),
+            col("col").str.regexp_split(r",+"),
             ["a,,,,b,,,,c", "d,,,e", "f", "g,h"],
             [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]],
         ),
         (
-            col("col").str.split(lit(r",+"), True),
+            col("col").str.regexp_split(lit(r",+")),
             ["a,,,,b,,,,c", "d,,,e", "f", "g,h"],
             [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]],
         ),
         (
-            col("col").str.split(col("emptystrings") + lit(r",+"), True),
+            col("col").str.regexp_split(col("emptystrings") + lit(r",+")),
             ["a,,,,b,,,,c", "d,,,e", "f", "g,h"],
             [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]],
         ),

--- a/tests/series/test_utf8_ops.py
+++ b/tests/series/test_utf8_ops.py
@@ -129,7 +129,10 @@ def test_series_utf8_compare_invalid_inputs(funcname, bad_series) -> None:
 def test_series_utf8_split_broadcast_pattern(data, patterns, expected, regex) -> None:
     s = Series.from_arrow(pa.array(data))
     patterns = Series.from_arrow(pa.array(patterns))
-    result = s.str.split(patterns, regex=regex)
+    if regex:
+        result = s.str.regexp_split(patterns)
+    else:
+        result = s.str.split(patterns)
     assert result.to_pylist() == expected
 
 
@@ -155,7 +158,10 @@ def test_series_utf8_split_broadcast_pattern(data, patterns, expected, regex) ->
 def test_series_utf8_split_multi_pattern(data, patterns, expected, regex) -> None:
     s = Series.from_arrow(pa.array(data))
     patterns = Series.from_arrow(pa.array(patterns))
-    result = s.str.split(patterns, regex=regex)
+    if regex:
+        result = s.str.regexp_split(patterns)
+    else:
+        result = s.str.split(patterns)
     assert result.to_pylist() == expected
 
 
@@ -179,7 +185,10 @@ def test_series_utf8_split_multi_pattern(data, patterns, expected, regex) -> Non
 def test_series_utf8_split_broadcast_arr(data, patterns, expected, regex) -> None:
     s = Series.from_arrow(pa.array(data))
     patterns = Series.from_arrow(pa.array(patterns))
-    result = s.str.split(patterns, regex=regex)
+    if regex:
+        result = s.str.regexp_split(patterns)
+    else:
+        result = s.str.split(patterns)
     assert result.to_pylist() == expected
 
 
@@ -202,7 +211,10 @@ def test_series_utf8_split_broadcast_arr(data, patterns, expected, regex) -> Non
 def test_series_utf8_split_nulls(data, patterns, expected, regex) -> None:
     s = Series.from_arrow(pa.array(data, type=pa.string()))
     patterns = Series.from_arrow(pa.array(patterns, type=pa.string()))
-    result = s.str.split(patterns, regex=regex)
+    if regex:
+        result = s.str.regexp_split(patterns)
+    else:
+        result = s.str.split(patterns)
     assert result.to_pylist() == expected
 
 
@@ -218,7 +230,10 @@ def test_series_utf8_split_empty_arrs(data, patterns, regex) -> None:
     s = Series.from_arrow(pa.array(data, type=pa.string()))
     patterns = Series.from_arrow(pa.array(patterns, type=pa.string()))
     with pytest.raises(ValueError):
-        s.str.split(patterns, regex=regex)
+        if regex:
+            s.str.regexp_split(patterns)
+        else:
+            s.str.split(patterns)
 
 
 def test_series_utf8_split_empty_input() -> None:
@@ -240,7 +255,10 @@ def test_series_utf8_split_empty_input() -> None:
 def test_series_utf8_split_invalid_inputs(patterns, regex) -> None:
     s = Series.from_arrow(pa.array(["a,b,c", "d, e", "f"]))
     with pytest.raises(ValueError):
-        s.str.split(patterns, regex=regex)
+        if regex:
+            s.str.regexp_split(patterns)
+        else:
+            s.str.split(patterns)
 
 
 def test_series_utf8_length() -> None:

--- a/tests/sql/test_utf8_exprs.py
+++ b/tests/sql/test_utf8_exprs.py
@@ -79,7 +79,7 @@ def test_utf8_exprs():
             col("a").str.match("ba.").alias("match_a"),
             col("a").str.extract("ba.").alias("extract_a"),
             col("a").str.extract_all("ba.").alias("extract_all_a"),
-            col("a").str.split(r"\s+", regex=True).alias("regexp_split_a"),
+            col("a").str.regexp_split(r"\s+").alias("regexp_split_a"),
             col("a").str.replace("ba.", "foo", regex=True).alias("replace_a"),
             col("a").str.length().alias("length_a"),
             col("a").str.length_bytes().alias("length_bytes_a"),


### PR DESCRIPTION
## Changes Made

Based on the discussion in https://github.com/Eventual-Inc/Daft/pull/5191#issuecomment-3293354079, split the function into 2 forms and deprecate the `regex` kwarg. 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
