### PR TITLE
chore: remove expr.str.regexp_split since we will immediately deprecate it

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -3036,14 +3036,6 @@ class ExpressionStringNamespace(ExpressionNamespace):
         else:
             return self._to_expression().split(pattern)
 
-    def regexp_split(self, pattern: str | Expression) -> Expression:
-        """(DEPRECATED) Please use `daft.functions.regexp_split` or `daft.functions.regexp_split` instead."""
-        warnings.warn(
-            "`Expression.str.regexp_split` is deprecated since Daft version >= 0.6.2 and will be removed in >= 0.7.0. Please use `daft.functions.regexp_split` instead.",
-            category=DeprecationWarning,
-        )
-        return self._to_expression().regexp_split(pattern)
-
     def concat(self, other: str | Expression) -> Expression:
         """(DEPRECATED) Please use `daft.functions.concat` instead."""
         warnings.warn(

--- a/tests/recordbatch/utf8/test_split.py
+++ b/tests/recordbatch/utf8/test_split.py
@@ -9,29 +9,29 @@ from daft.recordbatch import MicroPartition
 @pytest.mark.parametrize(
     ["expr", "data", "expected"],
     [
-        (col("col").str.split(","), ["a,b,c", "d,e", "f", "g,h"], [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]]),
+        (col("col").split(","), ["a,b,c", "d,e", "f", "g,h"], [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]]),
         (
-            col("col").str.split(lit(",")),
+            col("col").split(lit(",")),
             ["a,b,c", "d,e", "f", "g,h"],
             [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]],
         ),
         (
-            col("col").str.split(col("emptystrings") + lit(",")),
+            col("col").split(col("emptystrings") + lit(",")),
             ["a,b,c", "d,e", "f", "g,h"],
             [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]],
         ),
         (
-            col("col").str.regexp_split(r",+"),
+            col("col").regexp_split(r",+"),
             ["a,,,,b,,,,c", "d,,,e", "f", "g,h"],
             [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]],
         ),
         (
-            col("col").str.regexp_split(lit(r",+")),
+            col("col").regexp_split(lit(r",+")),
             ["a,,,,b,,,,c", "d,,,e", "f", "g,h"],
             [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]],
         ),
         (
-            col("col").str.regexp_split(col("emptystrings") + lit(r",+")),
+            col("col").regexp_split(col("emptystrings") + lit(r",+")),
             ["a,,,,b,,,,c", "d,,,e", "f", "g,h"],
             [["a", "b", "c"], ["d", "e"], ["f"], ["g", "h"]],
         ),

--- a/tests/sql/test_utf8_exprs.py
+++ b/tests/sql/test_utf8_exprs.py
@@ -79,7 +79,7 @@ def test_utf8_exprs():
             col("a").str.match("ba.").alias("match_a"),
             col("a").str.extract("ba.").alias("extract_a"),
             col("a").str.extract_all("ba.").alias("extract_all_a"),
-            col("a").str.regexp_split(r"\s+").alias("regexp_split_a"),
+            col("a").str.split(r"\s+", regex=True).alias("regexp_split_a"),
             col("a").str.replace("ba.", "foo", regex=True).alias("replace_a"),
             col("a").str.length().alias("length_a"),
             col("a").str.length_bytes().alias("length_bytes_a"),


### PR DESCRIPTION
## Changes Made

Removes `ExpressionStringNamespace.regexp_split` which was added in #5211 but then deprecated in #5086. Since we haven't cut a release between thowe PRs, the addition is not necessary.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
