### PR TITLE
ci: enable AI integration tests in PR

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -836,7 +836,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [skipcheck, integration-test-build]
-    if: ${{ needs.skipcheck.outputs.skip == 'false' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     env:
       package-name: daft
     strategy:


### PR DESCRIPTION
## Changes Made

Noticed `integration-test-ai` does not run in pull requests. This fixes that

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
