### PR TITLE
fix: rename index function to find

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -2486,15 +2486,15 @@ class Expression:
 
         return regexp_replace(self, pattern, replacement)
 
-    def index(self, substr: builtins.str | Expression) -> Expression:
+    def find(self, substr: builtins.str | Expression) -> Expression:
         """Returns the index of the first occurrence of the substring in each string.
 
         Tip: See Also
-            [`daft.functions.index`](https://docs.daft.ai/en/stable/api/functions/index/)
+            [`daft.functions.find`](https://docs.daft.ai/en/stable/api/functions/find/)
         """
-        from daft.functions import index
+        from daft.functions import find
 
-        return index(self, substr)
+        return find(self, substr)
 
     def convert_image(self, mode: builtins.str | ImageMode) -> Expression:
         """Convert an image expression to the specified mode.
@@ -3157,12 +3157,12 @@ class ExpressionStringNamespace(ExpressionNamespace):
         return self._to_expression().right(nchars)
 
     def find(self, substr: str | Expression) -> Expression:
-        """(DEPRECATED) Please use `daft.functions.index` instead."""
+        """(DEPRECATED) Please use `daft.functions.find` instead."""
         warnings.warn(
-            "`Expression.str.find` is deprecated since Daft version >= 0.6.2 and will be removed in >= 0.7.0. Please use `daft.functions.index` instead.",
+            "`Expression.str.find` is deprecated since Daft version >= 0.6.2 and will be removed in >= 0.7.0. Please use `daft.functions.find` instead.",
             category=DeprecationWarning,
         )
-        return self._to_expression().index(substr)
+        return self._to_expression().find(substr)
 
     def rpad(self, length: int | Expression, pad: str | Expression) -> Expression:
         """(DEPRECATED) Please use `daft.functions.rpad` instead."""

--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -170,7 +170,7 @@ from .str import (
     regexp_split,
     replace,
     regexp_replace,
-    index,
+    find,
 )
 from .url import download, upload, parse_url
 from .window import (
@@ -250,12 +250,12 @@ __all__ = [
     "expm1",
     "file",
     "fill_null",
+    "find",
     "floor",
     "format",
     "hash",
     "hour",
     "ilike",
-    "index",
     "is_in",
     "is_null",
     "jq",

--- a/daft/functions/str.py
+++ b/daft/functions/str.py
@@ -1193,7 +1193,7 @@ def regexp_replace(
     return Expression._call_builtin_scalar_fn("regexp_replace", expr, pattern, replacement)
 
 
-def index(expr: Expression, substr: str | Expression) -> Expression:
+def find(expr: Expression, substr: str | Expression) -> Expression:
     """Returns the index of the first occurrence of the substring in each string.
 
     Returns:
@@ -1204,10 +1204,8 @@ def index(expr: Expression, substr: str | Expression) -> Expression:
 
     Examples:
         >>> import daft
-        >>> from daft.functions import index
-        >>>
         >>> df = daft.from_pydict({"x": ["daft", "query daft", "df_daft"]})
-        >>> df = df.select(index(df["x"], "daft"))
+        >>> df = df.select(df["x"].find("daft"))
         >>> df.show()
         ╭───────╮
         │ x     │


### PR DESCRIPTION
## Changes Made

I originally named it `index` because that matched a Python function that did a similar thing, but I just realized Python also has `str.find` which is actually more similar to what we have here, since `str.find` returns -1 when not found, whereas `str.index` raises an exception.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
