### PR TITLE
feat: allow for functions module to be accessed from daft import

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -148,6 +148,7 @@ from daft.file import File
 
 import daft.context as context
 import daft.io as io
+import daft.functions as functions
 
 __all__ = [
     "Catalog",
@@ -203,6 +204,7 @@ __all__ = [
     "from_pylist",
     "from_ray_dataset",
     "func",
+    "functions",
     "get_catalog",
     "get_provider",
     "get_table",


### PR DESCRIPTION
## Changes Made

Allow for this to work:
```
import daft

df = daft.from_pydict({"path": ["Screenshot 2025-09-16 at 10.47.20 AM.png"]})
df = df.select(daft.functions.file(df["path"]))
df.collect()
```

Previously, it would fail on `daft.functions` because you need to import it separately, but this PR adds it as an export of `daft/__init__.py` so it should work with just `import daft`.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
