### PR TITLE
chore: Don't log failures in url download if `on_error="null"`

### DIFF
--- a/src/daft-functions-uri/src/download.rs
+++ b/src/daft-functions-uri/src/download.rs
@@ -132,7 +132,7 @@ fn url_download(
                 (
                     i,
                     owned_client
-                        .single_url_download(i, url, raise_error_on_failure, owned_io_stats)
+                        .single_url_download(url, raise_error_on_failure, owned_io_stats)
                         .await,
                 )
             })

--- a/src/daft-functions-uri/src/upload.rs
+++ b/src/daft-functions-uri/src/upload.rs
@@ -237,7 +237,6 @@ pub fn url_upload(
                             i,
                             owned_client
                                 .single_url_upload(
-                                    i,
                                     path,
                                     data,
                                     raise_error_on_failure,

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -337,7 +337,6 @@ impl IOClient {
 
     pub async fn single_url_download(
         &self,
-        index: usize,
         input: Option<String>,
         raise_error_on_failure: bool,
         io_stats: Option<IOStatsRef>,
@@ -359,10 +358,6 @@ impl IOClient {
                 if raise_error_on_failure {
                     Err(err)
                 } else {
-                    log::warn!(
-                        "Error occurred during url_download at index: {index} {} (falling back to Null)",
-                        err
-                    );
                     Ok(None)
                 }
             }
@@ -372,7 +367,6 @@ impl IOClient {
 
     pub async fn single_url_upload(
         &self,
-        index: usize,
         dest: String,
         data: Option<bytes::Bytes>,
         raise_error_on_failure: bool,
@@ -391,10 +385,6 @@ impl IOClient {
                 if raise_error_on_failure {
                     Err(err)
                 } else {
-                    log::warn!(
-                        "Error occurred during file upload at index: {index} {} (falling back to Null)",
-                        err
-                    );
                     Ok(None)
                 }
             }


### PR DESCRIPTION
## Changes Made

It's kinda annoying especially if theres a lot of invalid urls. Also, the on_error method doesn't say anything about logging or warning, it just says the row will be set to null. Don't see why we need to log it actually.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
