### PR TITLE
feat: Add distributed Lance FTS index creation

### DIFF
--- a/daft/io/lance/__init__.py
+++ b/daft/io/lance/__init__.py
@@ -1,5 +1,6 @@
-from ._lance import merge_columns
+from ._lance import merge_columns, create_fts_index
 
 __all__ = [
+    "create_fts_index",
     "merge_columns",
 ]

--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -221,3 +221,121 @@ def merge_columns(
         daft_remote_args=daft_remote_args,
         concurrency=concurrency,
     )
+
+
+@PublicAPI
+def create_fts_index(
+    url: str,
+    io_config: Optional[IOConfig] = None,
+    *,
+    column: str,
+    index_type: str = "INVERTED",
+    name: Optional[str] = None,
+    replace: bool = True,
+    train: bool = True,
+    fragment_ids: Optional[list[int]] = None,
+    fragment_uuid: Optional[str] = None,
+    storage_options: Optional[dict[str, Any]] = None,
+    daft_remote_args: Optional[dict[str, Any]] = None,
+    concurrency: Optional[int] = None,
+    version: Optional[Union[int, str]] = None,
+    asof: Optional[str] = None,
+    block_size: Optional[int] = None,
+    commit_lock: Optional[Any] = None,
+    index_cache_size: Optional[int] = None,
+    default_scan_options: Optional[dict[str, Any]] = None,
+    metadata_cache_size_bytes: Optional[int] = None,
+    **kwargs: Any,
+) -> None:
+    """Build a distributed full-text search index using Daft's distributed computing.
+
+    This function distributes the index building process across multiple Daft workers,
+    with each worker building indices for a subset of fragments. The indices are then
+    merged and committed as a single index.
+
+    Args:
+        dataset: Lance dataset or URI to build index on
+        column: Column name to index
+        index_type: Type of index to build ("INVERTED" or "FTS")
+        name: Name of the index (generated if None)
+        concurrency: Number of Daft workers to use
+        io_config: A custom IOConfig to use when accessing Lance data. Defaults to None.
+        storage_options: Storage options for the dataset
+        daft_remote_args: Options for Daft remote execution (e.g., num_cpus, num_gpus, memory_bytes)
+        **kwargs: Additional arguments to pass to create_scalar_index
+
+    Returns:
+        Updated Lance dataset with the index created
+
+    Raises:
+        ValueError: If input parameters are invalid
+        TypeError: If column type is not string
+        RuntimeError: If index building fails
+        ImportError: If lance package is not available
+
+    Note:
+        This function requires the use of [LanceDB](https://lancedb.github.io/lancedb/), which is the Python library for the LanceDB project.
+
+    Examples:
+        Create a distributed inverted index:
+        >>> import daft
+        >>> dataset = daft.io.lance.create_fts_index(
+        ...     "s3://my-bucket/dataset/", column="text_content", index_type="INVERTED", concurrency=8
+        ... )
+
+        Create an index with custom Daft remote arguments:
+        >>> dataset = daft.io.lance.create_fts_index(
+        ...     "s3://my-bucket/dataset/",
+        ...     column="description",
+        ...     daft_remote_args={"num_cpus": 2, "memory_bytes": 4 * 1024**3},
+        ... )
+    """
+    try:
+        import lance
+        from packaging import version as packaging_version
+
+        from daft.io.lance.lance_fts_index import create_fts_index_internal
+
+        lance_version = packaging_version.parse(lance.__version__)
+        min_required_version = packaging_version.parse("0.36.0")
+        if lance_version < min_required_version:
+            raise RuntimeError(
+                f"Distributed indexing requires pylance >= 0.36.0, but found {lance.__version__}. "
+                "The distribute-related interfaces are not available in older versions. "
+                "Please upgrade pylance by running: pip install --upgrade pylance"
+            )
+    except ImportError as e:
+        raise ImportError(
+            "Unable to import the `lance` package, please ensure that Daft is installed with the lance extra dependency: `pip install daft[lance]`"
+        ) from e
+
+    io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
+    storage_options = storage_options or io_config_to_storage_options(io_config, url)
+
+    lance_ds = lance.dataset(
+        url,
+        storage_options=storage_options,
+        version=version,
+        asof=asof,
+        block_size=block_size,
+        commit_lock=commit_lock,
+        index_cache_size=index_cache_size,
+        default_scan_options=default_scan_options,
+        metadata_cache_size_bytes=metadata_cache_size_bytes,
+    )
+
+    create_fts_index_internal(
+        lance_ds=lance_ds,
+        uri=url,
+        column=column,
+        index_type=index_type,
+        name=name,
+        replace=replace,
+        train=train,
+        fragment_ids=fragment_ids,
+        fragment_uuid=fragment_uuid,
+        storage_options=storage_options,
+        daft_remote_args=daft_remote_args,
+        concurrency=concurrency,
+        **kwargs,
+    )

--- a/daft/io/lance/lance_fts_index.py
+++ b/daft/io/lance/lance_fts_index.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+import lance
+from lance.dataset import IndexConfig
+
+from daft import DataType, from_pylist
+from daft.dependencies import pa
+from daft.udf import udf
+
+logger = logging.getLogger(__name__)
+
+
+@udf(
+    return_dtype=DataType.struct(
+        {
+            "status": DataType.string(),
+            "fragment_ids": DataType.list(DataType.int32()),
+            "fields": DataType.list(DataType.int32()),
+            "uuid": DataType.string(),
+            "error": DataType.string(),
+        }
+    ),
+    concurrency=1,
+)
+class FragmentIndexHandler:
+    def __init__(
+        self,
+        lance_ds: lance.LanceDataset,
+        column: str,
+        index_type: str,
+        name: str,
+        fragment_uuid: str,
+        replace: bool,
+        train: bool,
+        **kwargs: Any,
+    ):
+        self.lance_ds = lance_ds
+        self.column = column
+        self.index_type = index_type
+        self.name = name
+        self.fragment_uuid = fragment_uuid
+        self.replace = replace
+        self.train = train
+        self.kwargs = kwargs
+
+    def __call__(self, fragment_ids_batch: list[list[int]]) -> list[dict[str, Any]]:
+        try:
+            res = []
+            for fragment_ids in fragment_ids_batch:
+                res.append(self._handle_fragment_index(fragment_ids))
+            return res
+        except Exception as e:
+            logger.error("Error creating fragment index for fragment_ids %s: %s", fragment_ids, e)
+            return [{"status": "error", "fragment_ids": fragment_ids, "error": str(e)}]
+
+    def _handle_fragment_index(self, fragment_ids: list[int]) -> dict[str, Any]:
+        try:
+            # Basic input validation
+            if not fragment_ids:
+                raise ValueError("fragment_ids cannot be empty")
+
+            # Validate fragment_id ranges
+            for fragment_id in fragment_ids:
+                if fragment_id < 0 or fragment_id > 0xFFFFFFFF:
+                    raise ValueError(f"Invalid fragment_id: {fragment_id}")
+
+            # Validate fragments exist
+            available_fragments = {f.fragment_id for f in self.lance_ds.get_fragments()}
+            invalid_fragments = set(fragment_ids) - available_fragments
+            if invalid_fragments:
+                raise ValueError(f"Fragment IDs {invalid_fragments} do not exist")
+
+            # Use the distributed index building API - Phase 1: Fragment index creation
+            logger.info("Building distributed index for fragments %s using create_scalar_index", fragment_ids)
+
+            # Call create_scalar_index directly - no return value expected
+            # After execution, fragment-level indices are automatically built
+            self.lance_ds.create_scalar_index(
+                column=self.column,
+                index_type=self.index_type,
+                name=self.name,
+                replace=self.replace,
+                train=self.train,
+                fragment_uuid=self.fragment_uuid,
+                fragment_ids=fragment_ids,
+                **self.kwargs,
+            )
+
+            # Get field ID for the indexed column
+            field_id = self.lance_ds.schema.get_field_index(self.column)
+            logger.info("Fragment index created successfully for fragments %s", fragment_ids)
+            return {
+                "status": "success",
+                "fragment_ids": fragment_ids,
+                "fields": [field_id],
+                "uuid": self.fragment_uuid,
+            }
+        except Exception as e:
+            logger.error("Fragment index task failed for fragments %s: %s", fragment_ids, str(e))
+            return {
+                "status": "error",
+                "fragment_ids": fragment_ids,
+                "error": str(e),
+            }
+
+
+def _distribute_fragments_balanced(fragments: list[Any], concurrency: int) -> list[dict[str, list[Any]]]:
+    """Distribute fragments across workers using a balanced algorithm that considers fragment sizes.
+
+    This function implements a greedy algorithm that assigns fragments to the worker
+    with the currently smallest total workload, helping to balance the processing
+    time across workers.
+
+    Args:
+        fragments: List of Lance fragment objects
+        concurrency: Number of workers to distribute fragments across
+        logger: Logger instance for debugging information
+
+    Returns:
+        List of lists, where each inner list contains fragment IDs for one worker
+    """
+    if not fragments:
+        return [{"fragment_ids": []} for _ in range(concurrency)]
+
+    # Get fragment information (ID and size)
+    fragment_info = []
+    for fragment in fragments:
+        try:
+            # Try to get fragment size information
+            # fragment.count_rows() gives us the number of rows in the fragment
+            row_count = fragment.count_rows()
+            fragment_info.append(
+                {
+                    "id": fragment.fragment_id,
+                    "size": row_count,
+                }
+            )
+        except Exception as e:
+            # If we can't get size info, use fragment_id as a fallback
+            logger.warning(
+                "Could not get size for fragment %s: %s. " "Using fragment_id as size estimate.",
+                fragment.fragment_id,
+                e,
+            )
+            fragment_info.append(
+                {
+                    "id": fragment.fragment_id,
+                    "size": fragment.fragment_id,  # Fallback to fragment_id
+                }
+            )
+
+    # Sort fragments by size in descending order (largest first)
+    # This helps with better load balancing using the greedy algorithm
+    fragment_info.sort(key=lambda x: x["size"], reverse=True)
+
+    # Initialize worker batches and their current workloads
+    worker_batches: list[list[int]] = [[] for _ in range(concurrency)]
+    worker_workloads = [0] * concurrency
+
+    # Greedy assignment: assign each fragment to the worker with minimum workload
+    for frag_info in fragment_info:
+        # Find the worker with the minimum current workload
+        min_workload_idx = min(range(concurrency), key=lambda i: worker_workloads[i])
+
+        # Assign fragment to this worker
+        worker_batches[min_workload_idx].append(frag_info["id"])
+        worker_workloads[min_workload_idx] += frag_info["size"]
+
+    # Log distribution statistics for debugging
+    total_size = sum(frag_info["size"] for frag_info in fragment_info)
+    logger.info("Fragment distribution statistics:")
+    logger.info("  Total fragments: %d", len(fragment_info))
+    logger.info("  Total size: %d", total_size)
+    logger.info("  Workers: %d", concurrency)
+
+    for i, (batch, workload) in enumerate(zip(worker_batches, worker_workloads)):
+        percentage = (workload / total_size * 100) if total_size > 0 else 0
+        logger.info("  Worker %d: %d fragments, " "workload: %d (%d%%)", i, len(batch), workload, percentage)
+
+    # Filter out empty batches (shouldn't happen with proper input validation)
+    non_empty_batches = [
+        {
+            "fragment_ids": batch,
+        }
+        for batch in worker_batches
+        if batch
+    ]
+
+    return non_empty_batches
+
+
+def create_fts_index_internal(
+    lance_ds: lance.LanceDataset,
+    uri: str,
+    *,
+    column: str,
+    index_type: str | IndexConfig = "INVERTED",
+    name: str | None = None,
+    replace: bool = True,
+    train: bool = True,
+    fragment_ids: list[int] | None = None,
+    fragment_uuid: str | None = None,
+    storage_options: dict[str, str] | None = None,
+    daft_remote_args: dict[str, Any] | None = None,
+    concurrency: int | None = None,
+    **kwargs: Any,
+) -> None:
+    """Internal implementation of distributed FTS index creation using Daft UDFs.
+
+    This function implements the 3-phase distributed indexing workflow:
+    Phase 1: Fragment parallel processing using Daft UDFs
+    Phase 2: Index metadata merging
+    Phase 3: Atomic index creation and commit
+    """
+    if not column:
+        raise ValueError("Column name cannot be empty")
+
+    # Handle index_type validation
+    if isinstance(index_type, str):
+        valid_index_types = ["BTREE", "BITMAP", "LABEL_LIST", "INVERTED", "FTS", "NGRAM", "ZONEMAP"]
+        if index_type not in valid_index_types:
+            raise ValueError(f"Index type must be one of {valid_index_types}, not '{index_type}'")
+        # For distributed indexing, currently only support text-based indexes
+        if index_type not in ["INVERTED", "FTS"]:
+            raise ValueError(
+                f"Distributed indexing currently only supports 'INVERTED' and 'FTS' index types, not '{index_type}'"
+            )
+    elif not isinstance(index_type, IndexConfig):
+        raise ValueError(f"index_type must be a string literal or IndexConfig object, got {type(index_type)}")
+
+    # Validate column exists and has correct type
+    try:
+        field = lance_ds.schema.field(column)
+    except KeyError as e:
+        available_columns = [field.name for field in lance_ds.schema]
+        raise ValueError(f"Column '{column}' not found. Available: {available_columns}") from e
+
+    # Check column type
+    value_type = field.type
+    if pa.types.is_list(field.type) or pa.types.is_large_list(field.type):
+        value_type = field.type.value_type
+
+    if not pa.types.is_string(value_type) and not pa.types.is_large_string(value_type):
+        raise TypeError(f"Column {column} must be string type, got {value_type}")
+
+    # Generate index name if not provided
+    if name is None:
+        name = f"{column}_idx"
+
+    # Handle replace parameter - check for existing index with same name
+    if not replace:
+        try:
+            existing_indices = lance_ds.list_indices()
+            existing_names = {idx["name"] for idx in existing_indices}
+            if name in existing_names:
+                raise ValueError(f"Index with name '{name}' already exists. Set replace=True to replace it.")
+        except Exception:
+            # If we can't check existing indices, continue
+            pass
+
+    # Get fragments and validate fragment IDs
+    fragments = lance_ds.get_fragments()
+    if not fragments:
+        raise ValueError("Dataset contains no fragments")
+
+    # Handle fragment_ids parameter - if provided, filter fragments
+    if fragment_ids is not None:
+        available_fragment_ids = {f.fragment_id for f in fragments}
+        invalid_fragments = set(fragment_ids) - available_fragment_ids
+        if invalid_fragments:
+            raise ValueError(f"Fragment IDs {invalid_fragments} do not exist in dataset")
+        # Filter fragments to only include requested ones
+        fragments = [f for f in fragments if f.fragment_id in fragment_ids]
+        fragment_ids_to_use = fragment_ids
+    else:
+        fragment_ids_to_use = [fragment.fragment_id for fragment in fragments]
+
+    # Adjust concurrency based on fragment count
+    if concurrency is None:
+        concurrency = 4
+
+    if concurrency <= 0:
+        raise ValueError(f"concurrency must be positive, got {concurrency}")
+
+    if concurrency > len(fragment_ids_to_use):
+        concurrency = len(fragment_ids_to_use)
+        logger.info("Adjusted concurrency to %d to match fragment count", concurrency)
+
+    # Generate unique index ID
+    index_id = fragment_uuid or str(uuid.uuid4())
+
+    logger.info(
+        "Starting distributed FTS index creation: column=%s, type=%s, name=%s, workers=%s",
+        column,
+        index_type,
+        name,
+        concurrency,
+    )
+
+    # Phase 1: Fragment parallel processing using Daft UDFs
+    logger.info("Phase 1: Starting fragment parallel processing")
+
+    # Create DataFrame with fragment batches
+    fragment_data = _distribute_fragments_balanced(fragments, concurrency)
+    df = from_pylist(fragment_data)
+
+    # Configure Daft remote args
+    from daft.udf.legacy import _UnsetMarker
+
+    daft_remote_args = daft_remote_args or {}
+    num_cpus = daft_remote_args.get("num_cpus", _UnsetMarker)
+    num_gpus = daft_remote_args.get("num_gpus", _UnsetMarker)
+    memory_bytes = daft_remote_args.get("memory_bytes", _UnsetMarker)
+    batch_size = daft_remote_args.get("batch_size", _UnsetMarker)
+
+    handler_fragment_udf = (
+        FragmentIndexHandler.with_init_args(  # type: ignore[attr-defined]
+            lance_ds=lance_ds,
+            column=column,
+            index_type=index_type,
+            name=name,
+            fragment_uuid=index_id,
+            replace=replace,
+            train=train,
+            **kwargs,
+        )
+        .override_options(num_cpus=num_cpus, num_gpus=num_gpus, memory_bytes=memory_bytes, batch_size=batch_size)
+        .with_concurrency(concurrency)
+    )
+    df = df.with_column("index_result", handler_fragment_udf(df["fragment_ids"]))
+
+    results = df.to_pandas()["index_result"]
+
+    # Check for failures
+    failed_results = [r for r in results if r["status"] == "error"]
+    if failed_results:
+        error_messages = [r["error"] for r in failed_results]
+        raise RuntimeError(
+            f"Index building failed on {len(failed_results)} fragment batches: {'; '.join(error_messages)}"
+        )
+
+    successful_results = [r for r in results if r["status"] == "success"]
+    if not successful_results:
+        raise RuntimeError("No successful index building results")
+
+    logger.info("Phase 1 completed successfully: %d fragment batches processed", len(successful_results))
+
+    # Phase 2: Index metadata merging
+    logger.info("Phase 2: Starting index metadata merging")
+
+    # Reload dataset to get latest state
+    lance_ds = lance.LanceDataset(uri, storage_options=storage_options)
+    try:
+        lance_ds.merge_index_metadata(index_id, index_type)
+    except TypeError:
+        lance_ds.merge_index_metadata(index_id)
+
+    logger.info("Phase 2 completed: Index metadata merged")
+
+    # Phase 3: Atomic index creation and commit
+    logger.info("Phase 3: Starting atomic index creation and commit")
+
+    # Get field information from successful results
+    fields = successful_results[0]["fields"]
+
+    # Create index object
+    index = lance.Index(
+        uuid=index_id,
+        name=name,
+        fields=fields,
+        dataset_version=lance_ds.version,
+        fragment_ids=set(fragment_ids_to_use),
+        index_version=0,
+    )
+
+    # Create and commit the index operation
+    create_index_op = lance.LanceOperation.CreateIndex(
+        new_indices=[index],
+        removed_indices=[],
+    )
+
+    # Commit the index operation atomically
+    lance.LanceDataset.commit(
+        uri,
+        create_index_op,
+        read_version=lance_ds.version,
+        storage_options=storage_options,
+    )
+
+    logger.info("Phase 3 completed: Index '%s' created successfully with ID %s", name, index_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ dev = [
   # Ray
   "ray[data, client]==2.34.0",
   # Lance
-  "pylance>=0.20.0",
+  "pylance>=0.36.0",
   # Iceberg
   "pyiceberg==0.7.0",
   "pydantic==2.10.6",

--- a/tests/io/lancedb/test_lancedb_fts_index.py
+++ b/tests/io/lancedb/test_lancedb_fts_index.py
@@ -1,0 +1,449 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import lance
+import pandas as pd
+import pytest
+
+import daft
+from daft.io.lance import create_fts_index
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for testing."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield temp_dir
+
+
+@pytest.fixture
+def multi_fragment_lance_dataset(temp_dir):
+    """Create a Lance dataset with multiple fragments for testing."""
+    path = Path(temp_dir) / "multi_fragment_text.lance"
+    # Create dataset with multiple fragments (2 rows per fragment)
+    text_data = {
+        "id": [1, 2, 3, 4, 5, 6, 7, 8],
+        "text": [
+            "The quick brown fox jumps over the lazy dog",
+            "Python is a powerful programming language",
+            "Machine learning algorithms are fascinating",
+            "Data science requires statistical knowledge",
+            "Natural language processing uses text analysis",
+            "Distributed computing scales horizontally",
+            "Daft framework enables parallel processing",
+            "Lance format provides efficient storage",
+        ],
+        "category": [
+            "animals",
+            "tech",
+            "ml",
+            "data",
+            "nlp",
+            "distributed",
+            "daft",
+            "storage",
+        ],
+    }
+    text_dataset = daft.from_pydict(text_data)
+    text_dataset.write_lance(str(path), max_rows_per_file=2)
+    return str(path)
+
+
+def generate_multi_fragment_dataset(tmp_path, num_fragments=4, rows_per_fragment=250):
+    """Generate a test dataset with multiple fragments."""
+    all_data = []
+    for frag_idx in range(num_fragments):
+        for row_idx in range(rows_per_fragment):
+            row_id = frag_idx * rows_per_fragment + row_idx
+            all_data.append(
+                {
+                    "id": row_id,
+                    "text": f"This is test document {row_id} with some sample text content for fragment {frag_idx}",
+                    "fragment_id": frag_idx,
+                }
+            )
+
+    df = pd.DataFrame(all_data)
+    dataset = daft.from_pandas(df)
+
+    path = Path(tmp_path) / "large_multi_fragment.lance"
+    dataset.write_lance(str(path), max_rows_per_file=rows_per_fragment)
+    return str(path)
+
+
+class TestDistributedIndexing:
+    """Test cases for distributed indexing functionality."""
+
+    def test_build_distributed_fts_index_basic(self, multi_fragment_lance_dataset):
+        """Test basic distributed FTS index building."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            concurrency=2,
+        )
+        updated_dataset = lance.dataset(dataset_uri)
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+        # Find our index
+        text_index = None
+        for idx in indices:
+            if "text" in idx["name"]:
+                text_index = idx
+                break
+
+        assert text_index is not None, "Text index not found"
+        assert text_index["type"] == "Inverted", f"Expected Inverted index, got {text_index['type']}"
+
+    def test_build_distributed_fts_index_with_name(self, multi_fragment_lance_dataset):
+        """Test building distributed index with custom name."""
+        dataset_uri = multi_fragment_lance_dataset
+        custom_name = "custom_text_index"
+
+        # Build distributed index with custom name
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            name=custom_name,
+            concurrency=2,
+        )
+        updated_dataset = lance.dataset(dataset_uri)
+
+        # Verify the index was created with correct name
+        indices = updated_dataset.list_indices()
+        index_names = [idx["name"] for idx in indices]
+        assert custom_name in index_names, f"Custom index name '{custom_name}' not found in {index_names}"
+
+    def test_build_distributed_fts_index_search_functionality(self, multi_fragment_lance_dataset):
+        """Test that the built index actually works for searching."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            concurrency=2,
+        )
+        updated_dataset = lance.dataset(dataset_uri)
+
+        # Test full-text search functionality
+        search_term = "Python"
+        results = updated_dataset.scanner(
+            full_text_query=search_term,
+            columns=["id", "text"],
+        ).to_table()
+
+        # Should find at least one result containing "Python"
+        assert results.num_rows > 0, f"No results found for search term '{search_term}'"
+
+        # Verify results contain the search term
+        text_results = results.column("text").to_pylist()
+        assert any(search_term in text for text in text_results), "Search results don't contain the search term"
+
+    def test_build_distributed_fts_index_fts_type(self, multi_fragment_lance_dataset):
+        """Test building distributed FTS index."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed FTS index
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            concurrency=2,
+        )
+        updated_dataset = lance.dataset(dataset_uri)
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_large_dataset(self, temp_dir):
+        """Test distributed indexing on a larger dataset with multiple fragments."""
+        # Generate larger dataset
+        dataset_uri = generate_multi_fragment_dataset(temp_dir, num_fragments=4, rows_per_fragment=50)
+
+        # Build distributed index
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            concurrency=4,
+        )
+        updated_dataset = lance.dataset(dataset_uri)
+
+        # Verify the index was created
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+        # Test search functionality
+        search_term = "test"
+        results = updated_dataset.scanner(
+            full_text_query=search_term,
+            columns=["id", "text"],
+        ).to_table()
+
+        assert results.num_rows > 0, f"No results found for search term '{search_term}'"
+
+    def test_build_distributed_index_invalid_column(self, multi_fragment_lance_dataset):
+        """Test error handling for invalid column."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        with pytest.raises(ValueError, match="Column 'nonexistent' not found"):
+            create_fts_index(
+                url=dataset_uri,
+                column="nonexistent",
+                index_type="INVERTED",
+                concurrency=2,
+            )
+
+    def test_build_distributed_index_invalid_index_type(self, multi_fragment_lance_dataset):
+        """Test error handling for invalid index type."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        with pytest.raises(
+            ValueError,
+            match=r"Index type must be one of \['BTREE', 'BITMAP', 'LABEL_LIST', 'INVERTED', 'FTS', 'NGRAM', 'ZONEMAP'\], not 'INVALID'",
+        ):
+            create_fts_index(
+                url=dataset_uri,
+                column="text",
+                index_type="INVALID",
+                concurrency=2,
+            )
+
+    def test_build_distributed_index_invalid_num_workers(self, multi_fragment_lance_dataset):
+        """Test error handling for invalid concurrency."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        with pytest.raises(ValueError, match="concurrency must be positive"):
+            create_fts_index(
+                url=dataset_uri,
+                column="text",
+                index_type="INVERTED",
+                concurrency=0,
+            )
+
+    def test_build_distributed_index_empty_column(self, multi_fragment_lance_dataset):
+        """Test error handling for empty column name."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        with pytest.raises(ValueError, match="Column name cannot be empty"):
+            create_fts_index(
+                url=dataset_uri,
+                column="",
+                index_type="INVERTED",
+                concurrency=2,
+            )
+
+    def test_build_distributed_index_non_string_column(self, temp_dir):
+        """Test error handling for non-string column."""
+        # Create dataset with non-string column
+        data = pd.DataFrame(
+            {
+                "id": [1, 2, 3, 4],
+                "numeric_col": [10, 20, 30, 40],
+                "text": ["text1", "text2", "text3", "text4"],
+            }
+        )
+        dataset = daft.from_pandas(data)
+        path = Path(temp_dir) / "non_string_test.lance"
+        dataset.write_lance(str(path), max_rows_per_file=2)
+
+        with pytest.raises(TypeError, match="must be string type"):
+            create_fts_index(
+                url=str(path),
+                column="numeric_col",
+                index_type="INVERTED",
+                concurrency=2,
+            )
+
+    def test_build_distributed_index_with_ray_remote_args(self, multi_fragment_lance_dataset):
+        """Test building distributed index with Ray options."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index with Ray options
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            concurrency=2,
+            ray_remote_args={"num_cpus": 1},
+        )
+
+        updated_dataset = lance.dataset(dataset_uri)
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_with_storage_options(self, multi_fragment_lance_dataset):
+        """Test building distributed index with storage options."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index with storage options
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            concurrency=2,
+            storage_options={},  # Empty storage options should work
+        )
+
+        updated_dataset = lance.dataset(dataset_uri)
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_with_kwargs(self, multi_fragment_lance_dataset):
+        """Test building distributed index with additional kwargs."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index with additional kwargs
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            concurrency=2,
+            remove_stop_words=False,  # Additional kwarg for create_scalar_index
+        )
+
+        updated_dataset = lance.dataset(dataset_uri)
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_dataset_object(self, multi_fragment_lance_dataset):
+        """Test building distributed index with Lance dataset object instead of URI."""
+        dataset_uri = multi_fragment_lance_dataset
+
+        # Build distributed index using dataset object
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            concurrency=2,
+        )
+
+        updated_dataset = lance.dataset(dataset_uri)
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"
+
+    def test_build_distributed_index_replace_false_existing_index(self, multi_fragment_lance_dataset):
+        """Test that replace=False raises error when trying to create index with existing name."""
+        dataset_uri = multi_fragment_lance_dataset
+        index_name = "test_replace_false_index"
+
+        # First, create an index
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            name=index_name,
+            concurrency=2,
+        )
+
+        updated_dataset = lance.dataset(dataset_uri)
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "Initial index creation failed"
+
+        # Now try to create another index with the same name but replace=False
+        # The error might be raised as RuntimeError during distributed processing
+        with pytest.raises((ValueError, RuntimeError)) as exc_info:
+            create_fts_index(
+                url=dataset_uri,
+                column="text",
+                index_type="INVERTED",
+                name=index_name,
+                replace=False,
+                concurrency=2,
+            )
+
+        # Verify the error message contains information about existing index
+        error_msg = str(exc_info.value)
+        assert "already exists" in error_msg and index_name in error_msg
+
+    def test_build_distributed_index_replace_true_overwrite_existing(self, multi_fragment_lance_dataset):
+        """Test that replace=True successfully overwrites existing index."""
+        dataset_uri = multi_fragment_lance_dataset
+        index_name = "test_replace_true_index"
+
+        # First, create an index
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            name=index_name,
+            concurrency=2,
+        )
+
+        updated_dataset = lance.dataset(dataset_uri)
+        initial_indices = updated_dataset.list_indices()
+        assert len(initial_indices) > 0, "Initial index creation failed"
+
+        # Find our initial index
+        initial_index = None
+        for idx in initial_indices:
+            if idx["name"] == index_name:
+                initial_index = idx
+                break
+        assert initial_index is not None, "Initial index not found"
+
+        # Now create another index with the same name but replace=True
+        create_fts_index(
+            url=dataset_uri,
+            column="text",
+            index_type="INVERTED",
+            name=index_name,
+            replace=True,
+            concurrency=2,
+        )
+
+        updated_dataset = lance.dataset(dataset_uri)
+        final_indices = updated_dataset.list_indices()
+        final_index = None
+        for idx in final_indices:
+            if idx["name"] == index_name:
+                final_index = idx
+                break
+
+        assert final_index is not None, "Index should still exist after replacement"
+        assert final_index["type"] == "Inverted", "Index type should remain Inverted"
+
+        # Test that the replaced index still works for searching
+        search_term = "Python"
+        results = updated_dataset.scanner(
+            full_text_query=search_term,
+            columns=["id", "text"],
+        ).to_table()
+
+        assert results.num_rows > 0, f"No results found for search term '{search_term}' after index replacement"
+
+    def test_build_distributed_index_auto_adjust_workers(self, temp_dir):
+        """Test that concurrency is automatically adjusted if it exceeds fragment count."""
+        # Create dataset with only 2 fragments
+        data = {
+            "id": [1, 2, 3, 4],
+            "text": ["text1", "text2", "text3", "text4"],
+        }
+        dataset = daft.from_pydict(data)
+        path = Path(temp_dir) / "small_dataset.lance"
+        dataset.write_lance(str(path), max_rows_per_file=2)
+
+        # Request more workers than fragments
+        create_fts_index(
+            url=str(path),
+            column="text",
+            index_type="INVERTED",
+            concurrency=10,  # More than the 2 fragments
+        )
+
+        # Should still work and create the index
+        updated_dataset = lance.dataset(str(path))
+        indices = updated_dataset.list_indices()
+        assert len(indices) > 0, "No indices found after building"

--- a/uv.lock
+++ b/uv.lock
@@ -1584,7 +1584,7 @@ dev = [
     { name = "pyarrow-stubs", specifier = "==19.4" },
     { name = "pydantic", specifier = "==2.10.6" },
     { name = "pyiceberg", specifier = "==0.7.0" },
-    { name = "pylance", specifier = ">=0.20.0" },
+    { name = "pylance", specifier = ">=0.36.0" },
     { name = "pymysql", specifier = "==1.1.0" },
     { name = "pyodbc", specifier = "==5.1.0" },
     { name = "pyspark", specifier = "==3.5.5" },
@@ -6064,20 +6064,20 @@ crypto = [
 
 [[package]]
 name = "pylance"
-version = "0.32.0"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "pyarrow" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/ff/35c1939d0ba4eca22fc718dfc2f1b18772db880adde545fe90a67fba6c51/pylance-0.32.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:476351feca8e398a879f3d8536b0d104dfb261c7bc88eab1273a29d19a3d733d", size = 40886545, upload-time = "2025-07-23T22:23:18.053Z" },
-    { url = "https://files.pythonhosted.org/packages/43/a7/d6b7dfdc78eb29e267d739a2a753460468797dbf4d97a8a657dfdb1deef8/pylance-0.32.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:94f9ab7a37cd941172ee8c75076377193d41afcfee9c51e293fc06b4ee163001", size = 37598534, upload-time = "2025-07-23T22:05:14.931Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e0/ddc4e2708ba1fb3a78ec1020f6491ae919b3bf428882559856226c0c3e3a/pylance-0.32.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50e30e96a9b52f7329d4bd2570d46a83c5ba5fff9dafef21cb7a7c8e6ee800fd", size = 39432383, upload-time = "2025-07-23T22:03:07.266Z" },
-    { url = "https://files.pythonhosted.org/packages/35/ff/c5965f985ba59721f28fa77717de04190a1c9859a6974ac014a560d3215e/pylance-0.32.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2cb52eb178733ececd640075d8b5c057ce8405d05b19d1f41d88cf8625d92a90", size = 42846183, upload-time = "2025-07-23T22:07:13.38Z" },
-    { url = "https://files.pythonhosted.org/packages/51/c9/37f54d3931c9fb66a7b916aa5f7f4cc9d5c51cbe587fac90631d5b8dfd54/pylance-0.32.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b43e667c0543e9d69fdc33023b30f3f506ac6f704e634f9f44779a00cb054e48", size = 39461297, upload-time = "2025-07-23T22:03:31.97Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/7f/d2e87068d02753aece33a08aa815d53798c6f3b89fe47e51469c8260dccf/pylance-0.32.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ed160d10db8bd70455a136252e2030fcda8f1a27baea94430815fa3c9c5cc8af", size = 42839109, upload-time = "2025-07-23T22:07:48.511Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/16/a9b5bb3eff1eb85ef938d91c3aee2c266e33c4891e872fedea21629cc149/pylance-0.32.0-cp39-abi3-win_amd64.whl", hash = "sha256:f752d5d09ae029bdef0068e9cedbbcdb3e326eb23c09e9448fa11cad82597487", size = 43761312, upload-time = "2025-07-23T22:23:49.753Z" },
+    { url = "https://files.pythonhosted.org/packages/09/13/f7f029d12a3dfdc9f3059d77b3999d40f9cc064ba85fef885a08bf65dcb2/pylance-0.36.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:160ed088dc5fb63a71c8c96640d43ea58464f64bca8aa23b0337b1a96fd47b79", size = 43403867, upload-time = "2025-09-12T20:29:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/defad18786260653b33d5ef8223736c0e481861c8d33311756bd471468ad/pylance-0.36.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ce43ad002b4e67ffb1a33925d05d472bbde77c57a5e84aca1728faa9ace0c086", size = 39777498, upload-time = "2025-09-12T20:27:02.906Z" },
+    { url = "https://files.pythonhosted.org/packages/19/33/7080ed4e45648d8c803a49cd5a206eb95176ef9dc06bff26748ec2109c65/pylance-0.36.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ad7b168b0d4b7864be6040bebaf6d9a3959e76a190ff401a84b165b75eade96", size = 41819489, upload-time = "2025-09-12T20:17:06.37Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9a/0c572994d96e03e70481dafb2b062033a9ce24beb5ac6045f00f013ca57c/pylance-0.36.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:353deeb7b19be505db490258b5f2fc897efd4a45255fa0d51455662e01ad59ab", size = 45366480, upload-time = "2025-09-12T20:19:53.924Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/82/a74f0436b6a983c2798d1f44699352cd98c42bc335781ece98a878cf63fb/pylance-0.36.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9cd963fc22257591d1daf281fa2369e05299d78950cb11980aa099d7cbacdf00", size = 41833322, upload-time = "2025-09-12T20:17:40.784Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f2/d28fa3487992c3bd46af6838da13cf9a00be24fcf4cf928f77feec52d8d6/pylance-0.36.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:40117569a87379e08ed12eccac658999158f81df946f2ed02693b77776b57597", size = 45347065, upload-time = "2025-09-12T20:19:26.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ab/e7fc302950f1c6815a6e832d052d0860130374bfe4bd482b075299dc8384/pylance-0.36.0-cp39-abi3-win_amd64.whl", hash = "sha256:a2930738192e5075220bc38c8a58ff4e48a71d53b3ca2a577ffce0318609cac0", size = 46348996, upload-time = "2025-09-12T20:36:04.663Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

Implements distributed full-text search index creation for Lance datasets using Daft's distributed computing framework. Automatically distributes index creation across multiple Daft workers. Currently only support INVERTED type for FTS index

**Three-Phase Workflow:**

Split and Parallel Phase: Distribute dataset fragments to different worker nodes, try to balance the fragments based on the number of rows. Each worker node builds indices for its assigned fragments as a partition.
Merge Phase: Collect and merge partition index metadata from all worker nodes by calling the new method merge_index_metadata by this https://github.com/lancedb/lance/pull/4578
Commit Phase: Atomically commit index information to the dataset

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
