### PR TITLE
docs: add file datatype to urls&files docs page

### DIFF
--- a/docs/modalities/urls.md
+++ b/docs/modalities/urls.md
@@ -12,7 +12,11 @@ Daft supports working with:
 - **Hugging Face datasets**: `hf://dataset/name`
 - **Unity Catalog volumes**: `vol+dbfs:/Volumes/unity/path`
 
-URLs in Daft are simply a special case of String columns. Daft provides the [`.url.*`](../api/expressions.md#daft.expressions.expressions.ExpressionUrlNamespace) method namespace with functionality for working with URL strings. For example, to download data from URLs:
+## Two Ways to Work with Files in Daft
+
+### 1. URL Functions
+
+URL functions are ideal when your data will fit into memory or when you need the entire file content at once. Daft provides the [`.url.*`](../api/expressions.md#daft.expressions.expressions.ExpressionUrlNamespace) method namespace with functionality for working with URL strings. For example, to download data from URLs:
 
 <!-- todo(docs - cc): add relative path to url.download after figure out url namespace-->
 
@@ -61,3 +65,64 @@ URLs in Daft are simply a special case of String columns. Daft provides the [`.u
 ```
 
 This works well for URLs which are HTTP paths to non-HTML files (e.g. jpeg), local filepaths or even paths to a file in an object store such as AWS S3 as well!
+
+
+### 2. File Datatype
+
+The `File` datatype is preferable when dealing with large files that don't fit in memory or when you only need to access specific portions of a file. It provides a file-like interface with random access capabilities:
+
+=== "🐍 Python"
+    ``` python
+    import daft
+    from daft.functions import file
+    from daft.io import IOConfig, S3Config
+
+    io_config = IOConfig(s3=S3Config(anonymous=True))
+
+    df = daft.from_pydict(
+        {
+            "urls": [
+                "https://www.google.com",
+                "s3://daft-public-data/open-images/validation-images/0001eeaf4aed83f9.jpg",
+            ],
+        }
+    )
+
+    @daft.func
+    def detect_file_type(file: daft.File) -> str:
+        # Read just the first 12 bytes to identify file type
+        header = file.read(12)
+
+        # Common file signatures (magic numbers)
+        if header.startswith(b"\xff\xd8\xff"):
+            return "JPEG"
+        elif header.startswith(b"\x89PNG\r\n\x1a\n"):
+            return "PNG"
+        elif header.startswith(b"GIF87a") or header.startswith(b"GIF89a"):
+            return "GIF"
+        elif header.startswith(b"<!") or header.startswith(b"<html"):
+            return "HTML"
+        elif header.startswith(b"HTTP/"):
+            return "HTTP"
+        else:
+            return None
+
+
+
+    df = df.with_column("file_type", detect_file_type(file(df["urls"]))
+    df.collect()
+    ```
+
+``` {title="Output"}
+╭────────────────────────────────┬───────────╮
+│ urls                           ┆ file_type │
+│ ---                            ┆ ---       │
+│ Utf8                           ┆ Utf8      │
+╞════════════════════════════════╪═══════════╡
+│ https://www.google.com         ┆ HTML      │
+├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┤
+│ s3://daft-public-data/open-im… ┆ JPEG      │
+╰────────────────────────────────┴───────────╯
+
+(Showing first 2 of 2 rows)
+```


### PR DESCRIPTION
## Changes Made

small PR to add daft.File to the urls&modalities page

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
