### PR TITLE
chore: add sort key to make the group-by-related ut more stable

### DIFF
--- a/tests/window/test_running_agg.py
+++ b/tests/window/test_running_agg.py
@@ -1778,7 +1778,7 @@ def test_range_window_with_timestamp(make_df):
     df = make_df(data)
 
     three_days = datetime.timedelta(days=3)
-    window_spec = Window().partition_by("category").order_by("date").range_between(-three_days, three_days)
+    window_spec = Window().partition_by("category").order_by("date", "value").range_between(-three_days, three_days)
 
     result = df.select(
         col("category"),
@@ -1788,7 +1788,9 @@ def test_range_window_with_timestamp(make_df):
         col("value").mean().over(window_spec).alias("window_avg"),
     ).collect()
 
-    assert_df_equals(result.to_pandas(), pd.DataFrame(expected_data), sort_key=["category", "date"], check_dtype=False)
+    assert_df_equals(
+        result.to_pandas(), pd.DataFrame(expected_data), sort_key=["category", "date", "value"], check_dtype=False
+    )
 
 
 def test_timestamp_mixed_resolution(make_df):


### PR DESCRIPTION
## Changes Made
In this use case, if the sorting keys are only category and date, there will be situations where when the category and date are the same but the values are different, the processing results of the two may be different. Therefore, some additional sorting keys are added here.

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
