### PR TITLE
fix: Increase actor udf readiness timeout

### DIFF
--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -111,7 +111,7 @@ impl Default for DaftExecutionConfig {
             native_parquet_writer: true,
             use_legacy_ray_runner: false,
             min_cpu_per_task: 0.5,
-            actor_udf_ready_timeout: 60,
+            actor_udf_ready_timeout: 120,
         }
     }
 }


### PR DESCRIPTION
## Changes Made

For udfs that have expensive initialization like model weights download 60s is not enough

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
