### PR TITLE
chore: Fix dependabot h11 security warning

### DIFF
--- a/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
+++ b/tests/integration/io/docker-compose/retry_server/retry-server-requirements.txt
@@ -3,7 +3,7 @@ anyio==3.7.1
 click==8.1.6
 exceptiongroup==1.1.2
 fastapi==0.100.1
-h11==0.14.0
+h11>=0.16.0
 httptools==0.6.0
 idna==3.4
 pydantic==2.1.1


### PR DESCRIPTION
## Changes Made

Noticed that Dependabot was giving us some security warnings. The "critical" ones are mostly tests or with libraries we're using for frontend assets for the dashboard. Not sure why the dependabot version bumps haven't been working, but we can make small bumps so that they go through.

https://github.com/Eventual-Inc/Daft/security/dependabot/65