### PR TITLE
refactor: add fragment_group_size to reduce lance scan task

### DIFF
--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -36,6 +36,7 @@ def read_lance(
     index_cache_size: Optional[int] = None,
     default_scan_options: Optional[dict[str, str]] = None,
     metadata_cache_size_bytes: Optional[int] = None,
+    fragment_group_size: Optional[int] = None,
 ) -> DataFrame:
     """Create a DataFrame from a LanceDB table.
 
@@ -60,7 +61,6 @@ def read_lance(
 
             Roughly, for an ``IVF_PQ`` partition with ``n`` rows, the size of each index
             page equals the combination of the pq code (``np.array([n,pq], dtype=uint8))``
-            and the row ids (``np.array([n], dtype=uint64)``).
             Approximately, ``n = Total Rows / number of IVF partitions``.
             ``pq = number of PQ sub-vectors``.
         storage_options : optional, dict
@@ -82,11 +82,13 @@ def read_lance(
             Size of the metadata cache in bytes. This cache is used to store metadata
             information about the dataset, such as schema and statistics. If not specified,
             a default size will be used.
+        fragment_group_size : optional, int
+            Number of fragments to group together in a single scan task. If None or <= 1,
+            each fragment will be processed individually (default behavior).
 
     Returns:
         DataFrame: a DataFrame with the schema converted from the specified LanceDB table
 
-    Note:
         This function requires the use of [LanceDB](https://lancedb.github.io/lancedb/), which is the Python library for the LanceDB project.
         To ensure that this is installed with Daft, you may install: `pip install daft[lance]`
 
@@ -103,6 +105,10 @@ def read_lance(
 
         Read a local LanceDB table and specify a version:
         >>> df = daft.read_lance("s3://my-lancedb-bucket/data/", version=1)
+        >>> df.show()
+
+        Read a local LanceDB table with fragment grouping:
+        >>> df = daft.read_lance("s3://my-lancedb-bucket/data/", fragment_group_size=5)
         >>> df.show()
     """
     try:
@@ -126,7 +132,7 @@ def read_lance(
         default_scan_options=default_scan_options,
         metadata_cache_size_bytes=metadata_cache_size_bytes,
     )
-    lance_operator = LanceDBScanOperator(ds)
+    lance_operator = LanceDBScanOperator(ds, fragment_group_size=fragment_group_size)
 
     handle = ScanOperatorHandle.from_python_scan_operator(lance_operator)
     builder = LogicalPlanBuilder.from_tabular_scan(scan_operator=handle)


### PR DESCRIPTION
## Changes Made
When the number of fragments is large, the current implementation method assigns one task to each fragment, which results in a long planning time. Therefore, some fragment filtering and fragment grouping implementations have been added here to reduce the number of tasks.
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
