### PR TITLE
feat(dashboard): Add verbose flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,7 +1978,6 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "tracing",
- "tracing-chrome",
  "tracing-opentelemetry",
  "tracing-subscriber",
 ]
@@ -2448,6 +2447,8 @@ dependencies = [
  "daft-dashboard",
  "pyo3",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2595,6 +2596,7 @@ dependencies = [
  "tokio",
  "tower 0.5.2",
  "tower-http",
+ "tracing",
  "uuid 1.17.0",
 ]
 
@@ -8299,17 +8301,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-chrome"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
-dependencies = [
- "serde_json",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-core"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8343,7 +8334,6 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -8359,7 +8349,6 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,6 +334,7 @@ tokio-util = "0.7.11"
 tonic = "0.12.3"
 tonic-build = "0.12.3"
 tracing = {version = "0.1", features = ["log"]}
+tracing-subscriber = {version = "0.3.20", default-features = false, features = ["std", "fmt", "ansi", "env-filter"]}
 typed-builder = "0.20.0"
 typetag = "0.2.18"
 url = "2.4.0"

--- a/src/common/tracing/Cargo.toml
+++ b/src/common/tracing/Cargo.toml
@@ -4,9 +4,8 @@ opentelemetry = {workspace = true}
 opentelemetry-otlp = {workspace = true}
 opentelemetry_sdk = {workspace = true}
 tracing = {workspace = true}
-tracing-chrome = "0.7.2"
-tracing-opentelemetry = {version = "0.30", features = ["default"]}
-tracing-subscriber = "0.3.20"
+tracing-opentelemetry = {version = "0.30", default-features = false, features = ["metrics"]}
+tracing-subscriber = {workspace = true}
 
 [lints]
 workspace = true

--- a/src/common/tracing/src/lib.rs
+++ b/src/common/tracing/src/lib.rs
@@ -1,9 +1,7 @@
-use std::sync::{Mutex, atomic::AtomicBool};
-
-use tracing_chrome::ChromeLayerBuilder;
-use tracing_subscriber::{layer::SubscriberExt, prelude::*};
-static TRACING_INIT: AtomicBool = AtomicBool::new(false);
-use std::{sync::LazyLock, time::Duration};
+use std::{
+    sync::{LazyLock, Mutex},
+    time::Duration,
+};
 
 use common_runtime::get_io_runtime;
 use opentelemetry::{KeyValue, global, trace::TracerProvider};
@@ -12,9 +10,7 @@ use opentelemetry_sdk::{
     Resource,
     trace::{Sampler, SdkTracerProvider},
 };
-
-static CHROME_GUARD_HANDLE: LazyLock<Mutex<Option<tracing_chrome::FlushGuard>>> =
-    LazyLock::new(|| Mutex::new(None));
+use tracing_subscriber::{layer::SubscriberExt, prelude::*};
 
 static GLOBAL_TRACER_PROVIDER: LazyLock<
     Mutex<Option<opentelemetry_sdk::trace::SdkTracerProvider>>,
@@ -111,6 +107,7 @@ async fn init_otlp_tracer_provider(otlp_endpoint: &str) {
         .with_tracer(tracer)
         .with_filter(tracing::level_filters::LevelFilter::INFO);
 
+    eprintln!("Setting global default for otel layer");
     tracing::subscriber::set_global_default(tracing_subscriber::registry().with(telemetry_layer))
         .unwrap();
 
@@ -123,68 +120,5 @@ fn flush_oltp_tracer_provider() {
         && let Err(e) = tracer_provider.force_flush()
     {
         println!("Failed to flush OTLP tracer provider: {}", e);
-    }
-}
-pub fn init_tracing(enable_chrome_trace: bool) {
-    use std::sync::atomic::Ordering;
-
-    assert!(
-        !TRACING_INIT.swap(true, Ordering::Relaxed),
-        "Cannot init tracing, already initialized!"
-    );
-
-    if !enable_chrome_trace {
-        return; // Do nothing for now
-    }
-
-    let mut mg = CHROME_GUARD_HANDLE.lock().unwrap();
-    assert!(
-        mg.is_none(),
-        "Expected chrome flush guard to be None on init"
-    );
-
-    let (chrome_layer, guard) = ChromeLayerBuilder::new()
-        // The initial writer to the chrome trace is a no-op sink, so we don't write anything
-        // only on calls to start_chrome_trace() do we write traces.
-        .writer(std::io::sink())
-        .trace_style(tracing_chrome::TraceStyle::Threaded)
-        .name_fn(Box::new(|event_or_span| {
-            match event_or_span {
-                tracing_chrome::EventOrSpan::Event(ev) => ev.metadata().name().into(),
-                tracing_chrome::EventOrSpan::Span(s) => {
-                    // TODO: this is where we should extract out fields (such as node id to show the different pipelines)
-                    s.name().into()
-                }
-            }
-        }))
-        .build();
-
-    tracing::subscriber::set_global_default(tracing_subscriber::registry().with(chrome_layer))
-        .unwrap();
-
-    *mg = Some(guard);
-}
-
-pub fn start_chrome_trace() -> bool {
-    let mut mg = CHROME_GUARD_HANDLE.lock().unwrap();
-    if let Some(fg) = mg.as_mut() {
-        // start_new(None) will let tracing-chrome choose the file and file name.
-        fg.start_new(None);
-        true
-    } else {
-        false
-    }
-}
-
-pub fn finish_chrome_trace() -> bool {
-    let mut mg = CHROME_GUARD_HANDLE.lock().unwrap();
-    if let Some(fg) = mg.as_mut() {
-        // start_new(Some(Box::new(std::io::sink()))) will flush the current trace, and start a new one with a dummy writer.
-        // The flush method doesn't actually close the file. The only way to do it is to drop the guard or call 'start_new'.
-        // But we can't drop the guard because it's a static and we may have multiple traces per process, so we need to call start_new.
-        fg.start_new(Some(Box::new(std::io::sink())));
-        true
-    } else {
-        false
     }
 }

--- a/src/daft-cli/Cargo.toml
+++ b/src/daft-cli/Cargo.toml
@@ -3,6 +3,8 @@ clap = {version = "4.5", features = ["derive"], optional = true}
 daft-dashboard = {path = "../daft-dashboard", optional = true}
 pyo3 = {workspace = true, optional = true}
 tokio = {workspace = true, optional = true}
+tracing-subscriber = {workspace = true}
+tracing = {workspace = true}
 
 [features]
 python = ["dep:pyo3", "dep:clap", "dep:tokio", "dep:daft-dashboard"]

--- a/src/daft-dashboard/Cargo.toml
+++ b/src/daft-dashboard/Cargo.toml
@@ -6,6 +6,7 @@ tower-http = {version = "0.6", features = ["fs", "trace", "cors"]}
 include_dir = "0.7.4"
 parking_lot = {workspace = true}
 pyo3 = {workspace = true, optional = true}
+tracing = {workspace = true}
 serde.workspace = true
 tokio.workspace = true
 uuid.workspace = true

--- a/src/daft-dashboard/src/lib.rs
+++ b/src/daft-dashboard/src/lib.rs
@@ -17,7 +17,13 @@ use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tower::ServiceBuilder;
-use tower_http::{cors::CorsLayer, services::ServeDir};
+use tower_http::{
+    LatencyUnit,
+    cors::CorsLayer,
+    services::ServeDir,
+    trace::{DefaultOnResponse, TraceLayer},
+};
+use tracing::Level;
 use uuid::Uuid;
 
 type StrRef = Arc<str>;
@@ -362,8 +368,6 @@ pub async fn launch_server(
     port: u16,
     shutdown_fn: impl Future<Output = ()> + Send + 'static,
 ) -> std::io::Result<()> {
-    let listener = TcpListener::bind((DEFAULT_SERVER_ADDR, port)).await?;
-
     let app = Router::new()
         .route("/api/ping", get(ping))
         .route("/api/queries", get(get_queries))
@@ -375,11 +379,18 @@ pub async fn launch_server(
         .nest_service("/", ServeDir::new(ASSETS_DIR.path()))
         .layer(
             ServiceBuilder::new()
-                // TODO: Add tracing layer
+                .layer(
+                    TraceLayer::new_for_http().on_request(()).on_response(
+                        DefaultOnResponse::new()
+                            .level(Level::INFO)
+                            .latency_unit(LatencyUnit::Micros),
+                    ),
+                )
                 .layer(CorsLayer::very_permissive()),
         );
 
     // Start the server
+    let listener = TcpListener::bind((DEFAULT_SERVER_ADDR, port)).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_fn)
         .await

--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -9,7 +9,7 @@ use std::{
 use common_daft_config::DaftExecutionConfig;
 use common_display::{DisplayLevel, mermaid::MermaidDisplayOptions};
 use common_error::DaftResult;
-use common_tracing::{finish_chrome_trace, flush_opentelemetry_providers, start_chrome_trace};
+use common_tracing::flush_opentelemetry_providers;
 use daft_local_plan::{LocalPhysicalPlanRef, translate};
 use daft_logical_plan::LogicalPlanBuilder;
 use daft_micropartition::{
@@ -280,7 +280,6 @@ impl NativeExecutor {
         results_buffer_size: Option<usize>,
         additional_context: Option<HashMap<String, String>>,
     ) -> DaftResult<ExecutionEngineResult> {
-        start_chrome_trace();
         let cancel = self.cancel.clone();
         let ctx = RuntimeContext::new_with_context(additional_context.unwrap_or_default());
         let pipeline = translate_physical_plan_to_pipeline(local_physical_plan, psets, &cfg, &ctx)?;
@@ -367,7 +366,6 @@ impl NativeExecutor {
                 )?;
             }
             flush_opentelemetry_providers();
-            finish_chrome_trace();
             Ok(())
         });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,23 +33,12 @@ pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
     .y
 });
 
-fn should_enable_chrome_trace() -> bool {
-    let chrome_trace_var_name = "DAFT_DEV_ENABLE_CHROME_TRACE";
-    if let Ok(val) = std::env::var(chrome_trace_var_name)
-        && matches!(val.trim().to_lowercase().as_str(), "1" | "true")
-    {
-        true
-    } else {
-        false
-    }
-}
-
 #[cfg(feature = "python")]
 pub mod pylib {
     use std::sync::LazyLock;
 
     use common_logging::GLOBAL_LOGGER;
-    use common_tracing::{init_opentelemetry_providers, init_tracing};
+    use common_tracing::init_opentelemetry_providers;
     use pyo3::prelude::*;
 
     static LOG_RESET_HANDLE: LazyLock<pyo3_log::ResetHandle> = LazyLock::new(|| {
@@ -119,7 +108,6 @@ pub mod pylib {
     #[pymodule]
     fn daft(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
         refresh_logger(py)?;
-        init_tracing(crate::should_enable_chrome_trace());
         init_opentelemetry_providers();
 
         common_daft_config::register_modules(m)?;


### PR DESCRIPTION
## Changes Made

Useful when testing to see when requests and responses are going through.

In the process, I had to remove `tracing-chrome` because it was forcefully importing `tracing-log` which causes our logging stuff to break. Talked to Colin and since we don't really use it much and we may want the dashboard to supercede it, its ok. If we still want it, we just need to vendor and modify it to not import `tracing-log` (since its a mistake on their part, and the repo is unmaintained).

Alternatively if we can move entirely to tracing it would work, but that breaks the progress bar right now and need to look further into fixing it.

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
