### PR TITLE
docs: improve copy and consistency on index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -474,7 +474,7 @@ setInterval(runCycle, 4600);
 
 **:octicons-image-24: Unified multimodal data processing**
 
-Break down data silos with a single framework that handles structured tables, unstructured text, and rich media like images—all with the same intuitive API. Why juggle multiple tools when one can do it all?
+Process structured and unstructured data with one framework. While traditional dataframes struggle with anything beyond tables, Daft natively handles tables, images, text, and embeddings through a single Python API. No more stitching together specialized tools for different data types.
 
 **:material-language-python: Python-native, no JVM required**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -180,7 +180,7 @@ Daft is a high-performance data engine providing simple and reliable data proces
         <div class="description">
           <div class="stage-header">READ ANYTHING</div>
           <p>Daft reads raw unstructured and multimodal data collected from application systems</p>
-          <p>Object Store (AWS S3, GCS, R2)<br>Event Bus (Kafka)<br>Data Lake (Iceberg, Deltalake)</p>
+          <p>Object storage (AWS S3, GCS, R2)<br>Event bus (Kafka)<br>Data lake (Iceberg, Deltalake)</p>
         </div>
         <div class="pipeline-item">
           <span id="read" class="swap"></span>
@@ -206,7 +206,7 @@ Daft is a high-performance data engine providing simple and reliable data proces
         <div class="description">
           <div class="stage-header">WRITE</div>
           <p>Daft lands data into specialized data systems for downstream use cases</p>
-          <p>Search (full-text search and vector DBs)<br>Applications (SQL/NoSQL databases)<br>Analytics (data warehouses)<br>Model Training (S3 object storage)</p>
+          <p>Search (full-text search and vector DBs)<br>Applications (SQL/NoSQL databases)<br>Analytics (data warehouses)<br>Model training (S3 object storage)</p>
         </div>
         <div class="pipeline-item">
           <span id="write" class="swap"></span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -474,7 +474,7 @@ setInterval(runCycle, 4600);
 
 **:octicons-image-24: Unified multimodal data processing**
 
-Process structured and unstructured data with one framework. While traditional dataframes struggle with anything beyond tables, Daft natively handles tables, images, text, and embeddings through a single Python API. No more stitching together specialized tools for different data types.
+While traditional dataframes struggle with anything beyond tables, Daft natively handles tables, images, text, and embeddings through a single Python API. No more stitching together specialized tools for different data types.
 
 **:material-language-python: Python-native, no JVM required**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -205,7 +205,7 @@ Daft is a high-performance data engine providing simple and reliable data proces
       <div class="row">
         <div class="description">
           <div class="stage-header">WRITE</div>
-          <p>Daft lands data into specialized data systems for downstream use-cases</p>
+          <p>Daft lands data into specialized data systems for downstream use cases</p>
           <p>Search (full-text search and vector DBs)<br>Applications (SQL/NoSQL databases)<br>Analytics (data warehouses)<br>Model Training (S3 object storage)</p>
         </div>
         <div class="pipeline-item">


### PR DESCRIPTION
## Changes Made

Fixed inconsistent capitalization and improved clarity of copy on the documentation index page:
- Updated all sections to use sentence case for descriptive phrases (e.g., "Object Store" → "Object storage") 
- Changed "use-cases" to "use cases" for standard usage
- Replaced vague "data silos" phrasing with specific description of Daft's multimodal capabilities vs traditional dataframes

## Checklist
- [x] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)