### PR TITLE
docs: fixed typo on s3 section of docs

### DIFF
--- a/docs/connectors/aws.md
+++ b/docs/connectors/aws.md
@@ -30,7 +30,7 @@ You may also choose to pass these values into your Daft I/O function calls using
     ```python
     from daft.io import IOConfig, S3Config
 
-    # Supply actual values for the se
+    # Supply actual values for the secret key to the s3
     io_config = IOConfig(s3=S3Config(key_id="key_id", session_token="session_token", secret_key="secret_key"))
 
     # Globally set the default IOConfig for any subsequent I/O calls


### PR DESCRIPTION
## Changes Made

https://docs.daft.ai/en/stable/connectors/aws/#rely-on-environment
old: `# Supply actual values for the se`
new: `# Supply actual values for the secret key to the s3`

## Related Issues

N/A

## Checklist

- [ ] Documented in API Docs (if applicable) (N\A)
- [x] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation (N/A)
- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
