### PR TITLE
chore: remove ChanChan from PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,4 @@
 - [ ] Documented in API Docs (if applicable)
 - [ ] Documented in User Guide (if applicable)
 - [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
-- [ ] Documentation builds and is formatted properly (tag @/ccmao1130 for docs review)
+- [ ] Documentation builds and is formatted properly


### PR DESCRIPTION
## Changes Made

ChanChan is no longer the docs maintainer, so removing her from the checklist

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
