### PR TITLE
fix: Use {} for dashboard dynamic route

### DIFF
--- a/src/daft-dashboard/src/lib.rs
+++ b/src/daft-dashboard/src/lib.rs
@@ -373,7 +373,7 @@ pub async fn launch_server(
         .route("/api/queries", get(get_queries))
         .route("/api/queries", post(add_query))
         .route(
-            "/api/dataframes/:dataframe_id/cell",
+            "/api/dataframes/{dataframe_id}/cell",
             get(get_dataframe_cell),
         )
         .nest_service("/", ServeDir::new(ASSETS_DIR.path()))

--- a/src/daft-dashboard/src/lib.rs
+++ b/src/daft-dashboard/src/lib.rs
@@ -376,7 +376,7 @@ pub async fn launch_server(
             "/api/dataframes/{dataframe_id}/cell",
             get(get_dataframe_cell),
         )
-        .nest_service("/", ServeDir::new(ASSETS_DIR.path()))
+        .fallback_service(ServeDir::new(ASSETS_DIR.path()))
         .layer(
             ServiceBuilder::new()
                 .layer(

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -375,6 +375,8 @@ def test_repr_empty_struct():
 
 def test_interactive_html_with_record_batch():
     """Test interactive HTML generation with a RecordBatch directly."""
+    import requests
+
     from daft.dataframe.preview import PreviewFormatter
 
     # Create a DataFrame and get its RecordBatch
@@ -386,6 +388,10 @@ def test_interactive_html_with_record_batch():
     schema = df.schema()
     formatter = PreviewFormatter(preview, schema)
     html = formatter._generate_interactive_html()
+
+    # Extract the dataframe table id, which is a random uuid
+    table_id = html.find('id="dataframe-')
+    table_id = html[table_id + 14 : table_id + 14 + 36]
 
     # Extract the dataframe table part for exact testing
     table_start = html.find('<table class="dataframe"')
@@ -409,3 +415,8 @@ def test_interactive_html_with_record_batch():
     assert "side-pane" in html
     assert "showSidePane" in html
     assert "serverUrl" in html
+
+    # make the request for the dataframe cell
+    response = requests.get(f"http://localhost:3238/api/dataframes/{table_id}/cell?row=0&col=0")
+    assert response.status_code == 200
+    assert response.json()["value"] == "1"

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -375,8 +375,6 @@ def test_repr_empty_struct():
 
 def test_interactive_html_with_record_batch():
     """Test interactive HTML generation with a RecordBatch directly."""
-    import requests
-
     from daft.dataframe.preview import PreviewFormatter
 
     # Create a DataFrame and get its RecordBatch
@@ -388,10 +386,6 @@ def test_interactive_html_with_record_batch():
     schema = df.schema()
     formatter = PreviewFormatter(preview, schema)
     html = formatter._generate_interactive_html()
-
-    # Extract the dataframe table id, which is a random uuid
-    table_id = html.find('id="dataframe-')
-    table_id = html[table_id + 14 : table_id + 14 + 36]
 
     # Extract the dataframe table part for exact testing
     table_start = html.find('<table class="dataframe"')
@@ -415,8 +409,3 @@ def test_interactive_html_with_record_batch():
     assert "side-pane" in html
     assert "showSidePane" in html
     assert "serverUrl" in html
-
-    # make the request for the dataframe cell
-    response = requests.get(f"http://localhost:3238/api/dataframes/{table_id}/cell?row=0&col=0")
-    assert response.status_code == 200
-    assert response.json()["value"] == "1"


### PR DESCRIPTION
## Changes Made

Use {} for the dataframe cell route. Also add a test that makes the cell request

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
