### PR TITLE
fix

### DIFF
--- a/src/daft-logical-plan/src/optimization/rules/push_down_limit.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_limit.rs
@@ -2,12 +2,14 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_treenode::{DynTreeNode, Transformed, TreeNode};
+use daft_dsl::{Expr, ExprRef, functions::scalar::ScalarFn};
 
 use super::OptimizerRule;
 use crate::{
     LogicalPlan,
     ops::{
-        Limit as LogicalLimit, Sort as LogicalSort, Source as LogicalSource, TopN as LogicalTopN,
+        Limit as LogicalLimit, Project as LogicalProject, Sort as LogicalSort,
+        Source as LogicalSource, TopN as LogicalTopN,
     },
     source_info::SourceInfo,
 };
@@ -19,6 +21,16 @@ pub struct PushDownLimit {}
 impl PushDownLimit {
     pub fn new() -> Self {
         Self {}
+    }
+
+    fn contains_explode(expr: &ExprRef) -> bool {
+        expr.exists(|e| {
+            if let Expr::ScalarFn(ScalarFn::Builtin(sf)) = e.as_ref() {
+                sf.is_function_type::<daft_functions_list::Explode>()
+            } else {
+                false
+            }
+        })
     }
 }
 
@@ -47,15 +59,27 @@ impl PushDownLimit {
                     // Naive commuting with unary ops.
                     //
                     // Limit-UnaryOp -> UnaryOp-Limit
-                    LogicalPlan::Repartition(_)
-                    | LogicalPlan::Project(_)
-                    | LogicalPlan::IntoBatches(_) => {
+                    LogicalPlan::Repartition(_) | LogicalPlan::IntoBatches(_) => {
                         let new_limit = plan
                             .with_new_children(&[input.arc_children()[0].clone()])
                             .into();
                         Ok(Transformed::yes(
                             input.with_new_children(&[new_limit]).into(),
                         ))
+                    }
+                    LogicalPlan::Project(LogicalProject { projection, .. }) => {
+                        let has_explode = projection.iter().any(Self::contains_explode);
+
+                        if has_explode {
+                            Ok(Transformed::no(plan))
+                        } else {
+                            let new_limit = plan
+                                .with_new_children(&[input.arc_children()[0].clone()])
+                                .into();
+                            Ok(Transformed::yes(
+                                input.with_new_children(&[new_limit]).into(),
+                            ))
+                        }
                     }
                     // Push limit into source as a "local" limit.
                     //

--- a/tests/expressions/test_explode.py
+++ b/tests/expressions/test_explode.py
@@ -4,6 +4,7 @@ import pytest
 
 import daft
 from daft import col
+from daft.functions import abs, explode
 
 
 def test_explode_basic():
@@ -42,3 +43,14 @@ def test_explode_mismatched_column():
 
     with pytest.raises(Exception, match="DaftError::ValueError In multicolumn explode, list length did not match"):
         exploded.collect()
+
+
+def test_explode_with_another_projection_and_limit():
+    """Test combining explode with another projection and limit operations."""
+    df = daft.from_pydict({"list": [[1, 2], [3, 4]]})
+    result = df.select(abs(explode(col("list")))).limit(2)
+
+    result_dict = result.to_pydict()
+
+    assert len(result_dict["list"]) == 2
+    assert result_dict["list"] == [1, 2]


### PR DESCRIPTION
## Changes Made

Currently, limits are being pushed past explodes in projections in the edge case where the explode is not a top-level projection. That's not correct.

e.g.

```
import daft
from daft.functions import abs, explode
daft.from_pydict({"list": [[1, 2], [3, 4]]}).select(abs(explode(daft.col("list")))).limit(2).show()
```
currently returns
```
╭───────╮
│ list  │
│ ---   │
│ Int64 │
╞═══════╡
│ 1     │
├╌╌╌╌╌╌╌┤
│ 2     │
├╌╌╌╌╌╌╌┤
│ 3     │
├╌╌╌╌╌╌╌┤
│ 4     │
╰───────╯
```
when it should only return
```
╭───────╮
│ list  │
│ ---   │
│ Int64 │
╞═══════╡
│ 1     │
├╌╌╌╌╌╌╌┤
│ 2     │
╰───────╯
```

This PR fixes this issue.

## Related Issues

Closes #5291 