### PR TITLE
fix: Pass io config when grabbing Common Crawl manifest

### DIFF
--- a/daft/datasets/common_crawl.py
+++ b/daft/datasets/common_crawl.py
@@ -26,7 +26,6 @@ def _get_common_crawl_paths(
 ) -> list[str]:
     """Get the paths to the Common Crawl files for a given crawl, segment, file type. Limited by `num_files`."""
     paths_url = _get_manifest_path(crawl, file_type)
-    print(f"io config: {io_config}")
 
     # The manifest file is a gzipped plaintext file with one path per line.
     # Technically, this is equivalent to a CSV file with one column, "url", with no headers, and we could use read_csv.

--- a/tests/datasets/test_common_crawl_mocked.py
+++ b/tests/datasets/test_common_crawl_mocked.py
@@ -194,7 +194,7 @@ def test_io_config_passed_through(mock_read_warc, mock_get_manifest_path, mock_m
     mock_read_warc.return_value = Mock()
     mock_get_manifest_path.side_effect = mock_manifest_path
 
-    mock_io_config = {"some": "config"}
+    mock_io_config = daft.IOConfig()
 
     daft.datasets.common_crawl("CC-MAIN-2025-33", io_config=mock_io_config)
 

--- a/tests/integration/io/test_common_crawl_integration.py
+++ b/tests/integration/io/test_common_crawl_integration.py
@@ -21,7 +21,10 @@ def test_read_common_crawl(pytestconfig):
 
     io_config = daft.IOConfig(
         s3=daft.io.S3Config(
-            key_id=creds.access_key, access_key=creds.secret_key, session_token=creds.token, region_name="us-west-2"
+            key_id=creds.access_key,
+            access_key=creds.secret_key,
+            session_token=creds.token,
+            region_name="us-east-1",  # Common Crawl is hosted in us-east-1.
         )
     )
 


### PR DESCRIPTION
## Changes Made

In #5244 I missed passing the io config into the url download. This PR fixes that.

Good on the credentialed integration test for catching it.