### PR TITLE
fix: Use patched azure_identity@0.21.0 for AKS Workload Identity credentials to continue working > 24 hours

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,8 +1165,7 @@ dependencies = [
 [[package]]
 name = "azure_core"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b552ad43a45a746461ec3d3a51dfb6466b4759209414b439c165eb6a6b7729e"
+source = "git+https://github.com/Eventual-Inc/azure-sdk-for-rust?branch=desmond%2Fpatch-azure-identity#25ebe5a599a88f311e28a0b63102ce318998f8b6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1195,8 +1194,7 @@ dependencies = [
 [[package]]
 name = "azure_identity"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ddd80344317c40c04b603807b63a5cefa532f1b43522e72f480a988141f744"
+source = "git+https://github.com/Eventual-Inc/azure-sdk-for-rust?branch=desmond%2Fpatch-azure-identity#25ebe5a599a88f311e28a0b63102ce318998f8b6"
 dependencies = [
  "async-lock",
  "async-process",
@@ -1215,8 +1213,7 @@ dependencies = [
 [[package]]
 name = "azure_storage"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f838159f4d29cb400a14d9d757578ba495ae64feb07a7516bf9e4415127126"
+source = "git+https://github.com/Eventual-Inc/azure-sdk-for-rust?branch=desmond%2Fpatch-azure-identity#25ebe5a599a88f311e28a0b63102ce318998f8b6"
 dependencies = [
  "RustyXML",
  "async-lock",
@@ -1234,8 +1231,7 @@ dependencies = [
 [[package]]
 name = "azure_storage_blobs"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e83c3636ae86d9a6a7962b2112e3b19eb3903915c50ce06ff54ff0a2e6a7e4"
+source = "git+https://github.com/Eventual-Inc/azure-sdk-for-rust?branch=desmond%2Fpatch-azure-identity#25ebe5a599a88f311e28a0b63102ce318998f8b6"
 dependencies = [
  "RustyXML",
  "azure_core",
@@ -1255,8 +1251,7 @@ dependencies = [
 [[package]]
 name = "azure_svc_blobstorage"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6c6f20c5611b885ba94c7bae5e02849a267381aecb8aee577e8c35ff4064c6"
+source = "git+https://github.com/Eventual-Inc/azure-sdk-for-rust?branch=desmond%2Fpatch-azure-identity#25ebe5a599a88f311e28a0b63102ce318998f8b6"
 dependencies = [
  "azure_core",
  "bytes",

--- a/src/daft-io/Cargo.toml
+++ b/src/daft-io/Cargo.toml
@@ -7,10 +7,10 @@ aws-credential-types = {version = "1.2.6", features = ["hardcoded-credentials"]}
 aws-sdk-s3 = {version = "1.96.0", features = ["default-https-client", "rt-tokio", "sigv4a"], default-features = false}
 aws-smithy-http-client = "1.1.1"
 aws-smithy-runtime-api = "1.8.0"
-azure_core = {version = "0.21.0", features = ["enable_reqwest_rustls", "hmac_rust"], default-features = false}
-azure_identity = {version = "0.21.0", features = ["enable_reqwest_rustls"], default-features = false}
-azure_storage = {version = "0.21.0", features = ["enable_reqwest_rustls"], default-features = false}
-azure_storage_blobs = {version = "0.21.0", features = ["enable_reqwest_rustls"], default-features = false}
+azure_core = {git = "https://github.com/Eventual-Inc/azure-sdk-for-rust", branch = "desmond/patch-azure-identity", features = ["enable_reqwest_rustls", "hmac_rust"], default-features = false}
+azure_identity = {git = "https://github.com/Eventual-Inc/azure-sdk-for-rust", branch = "desmond/patch-azure-identity", features = ["enable_reqwest_rustls"], default-features = false}
+azure_storage = {git = "https://github.com/Eventual-Inc/azure-sdk-for-rust", branch = "desmond/patch-azure-identity", features = ["enable_reqwest_rustls"], default-features = false}
+azure_storage_blobs = {git = "https://github.com/Eventual-Inc/azure-sdk-for-rust", branch = "desmond/patch-azure-identity", features = ["enable_reqwest_rustls"], default-features = false}
 bytes = {workspace = true}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}


### PR DESCRIPTION
## Changes Made

From https://github.com/Eventual-Inc/Daft/issues/5269, we know that the azure_identity crate has a bug where AKS Workload Identity credentials stop working ~24 hours after pod start (https://github.com/Azure/azure-sdk-for-rust/issues/1739) that's only fixed in v0.22.0. However, from https://github.com/Azure/azure-sdk-for-rust/issues/2504 and https://github.com/Azure/azure-sdk-for-rust/issues/2635, we see that there is no path to upgrading azure_identity because the latest azure_storage and azure_storage_blobs crates require azure_identity and azure_core <= 0.21.0.

The temporary escape hatch is to fork  v0.21.0 ourselves (https://github.com/Eventual-Inc/azure-sdk-for-rust), and pull in the patch that fixes the bug (https://github.com/Azure/azure-sdk-for-rust/pull/1997). This patch lives on branch [`desmond/patch-azure-identity`](https://github.com/Eventual-Inc/azure-sdk-for-rust/tree/desmond/patch-azure-identity).