### PR TITLE
docs: Fix broken link in Common Crawl dataset docs

### DIFF
--- a/docs/datasets/common-crawl.md
+++ b/docs/datasets/common-crawl.md
@@ -219,4 +219,4 @@ from daft.functions import try_decode
 
 - When using datasets like Common Crawl for pre-training, content deduplication is essential for model performance.
 Check out our [MinHash deduplication example](../examples/minhash-dedupe.md) to see how this can be done in Daft.
-- See the [Common Crawl Dataset API reference](../../api/datasets.md#common-crawl) for complete parameter documentation
+- See the [Common Crawl Dataset API reference](../api/datasets.md#common-crawl) for complete parameter documentation


### PR DESCRIPTION
## Changes Made

Made a mistake in the previous PR introducing docs for the Common Crawl dataset. Fixing this.
