### PR TITLE
fix: decimal format for handling scientific notation

### DIFF
--- a/src/daft-core/src/lit/python.rs
+++ b/src/daft-core/src/lit/python.rs
@@ -570,7 +570,10 @@ fn pytuple_to_struct_lit(ob: &Bound<PyAny>, dtype: Option<&DataType>) -> PyResul
 }
 
 fn pydecimal_to_decimal_lit(ob: &Bound<PyAny>) -> PyResult<Literal> {
-    let pystring = ob.str()?;
+    // call `format(ob, 'f')` to force decimal notation, this handles scientific notation.
+    let py = ob.py();
+    let format_func = py.import("builtins")?.getattr("format")?;
+    let pystring = format_func.call1((ob, "f"))?.str()?;
     let decimal_str = pystring.to_cow()?;
 
     // just always use max precision. we will cast if user specifies a different precision


### PR DESCRIPTION
## Changes Made

* Uses `format` instead of `str` when handling decimal conversions — this normalizes the decimals from either scientific or decimal notation into decimal notation.
* Adds tests for various scientific notation forms.
* Adds tests for all failure cases listed by the customer 

## Related Issues

* Closes #5302 

## Checklist

- [n/a] Documented in API Docs (if applicable)
- [n/a] Documented in User Guide (if applicable)
- [n/a] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [n/a] Documentation builds and is formatted properly
