### PR TITLE
chore: Refactor DistributedPipelineNode to implement TreeDisplay

### DIFF
--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -10,11 +10,11 @@ use futures::StreamExt;
 use pyo3::{PyObject, Python, types::PyAnyMethods};
 
 use super::{
-    DisplayLevel, DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig,
-    PipelineNodeContext, SubmittableTaskStream, TreeDisplay,
+    DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+    SubmittableTaskStream,
 };
 use crate::{
-    pipeline_node::append_plan_to_existing_task,
+    pipeline_node::{DistributedPipelineNodeWrapper, append_plan_to_existing_task},
     plan::{PlanConfig, PlanExecutionContext},
     scheduling::{scheduler::SubmittableTask, task::SwordfishTask},
     utils::{
@@ -129,7 +129,7 @@ impl UDFActors {
 pub(crate) struct ActorUDF {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
     projection: Vec<BoundExpr>,
     udf_properties: UDFProperties,
     actor_ready_timeout: usize,
@@ -146,7 +146,7 @@ impl ActorUDF {
         projection: Vec<BoundExpr>,
         udf_properties: UDFProperties,
         schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> DaftResult<Self> {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -171,8 +171,8 @@ impl ActorUDF {
         })
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
     }
 
     async fn execution_loop_fused(
@@ -235,8 +235,22 @@ impl ActorUDF {
             },
         )
     }
+}
 
-    fn multiline_display(&self) -> Vec<String> {
+impl DistributedPipelineNode for ActorUDF {
+    fn context(&self) -> &PipelineNodeContext {
+        &self.context
+    }
+
+    fn config(&self) -> &PipelineNodeConfig {
+        &self.config
+    }
+
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+        vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
         let mut res = vec![];
         res.push("ActorUDF:".to_string());
@@ -262,20 +276,6 @@ impl ActorUDF {
         }
         res
     }
-}
-
-impl DistributedPipelineNode for ActorUDF {
-    fn context(&self) -> &PipelineNodeContext {
-        &self.context
-    }
-
-    fn config(&self) -> &PipelineNodeConfig {
-        &self.config
-    }
-
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
-        vec![self.child.clone()]
-    }
 
     fn produce_tasks(
         self: Arc<Self>,
@@ -288,34 +288,5 @@ impl DistributedPipelineNode for ActorUDF {
         plan_context.spawn(execution_loop);
 
         SubmittableTaskStream::from(result_rx)
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
-    }
-}
-
-impl TreeDisplay for ActorUDF {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.name()).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.name().to_string()
     }
 }

--- a/src/daft-distributed/src/pipeline_node/aggregate.rs
+++ b/src/daft-distributed/src/pipeline_node/aggregate.rs
@@ -1,6 +1,5 @@
 use std::{cmp::min, sync::Arc};
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use common_error::DaftResult;
 use daft_dsl::{
     AggExpr,
@@ -24,8 +23,9 @@ use daft_schema::{
 use super::DistributedPipelineNode;
 use crate::{
     pipeline_node::{
-        NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext, SubmittableTaskStream,
-        project::ProjectNode, translate::LogicalPlanToPipelineNodeTranslator,
+        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        SubmittableTaskStream, project::ProjectNode,
+        translate::LogicalPlanToPipelineNodeTranslator,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -35,7 +35,7 @@ pub(crate) struct AggregateNode {
     context: PipelineNodeContext,
     group_by: Vec<BoundExpr>,
     aggs: Vec<BoundAggExpr>,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl AggregateNode {
@@ -57,7 +57,7 @@ impl AggregateNode {
         group_by: Vec<BoundExpr>,
         aggs: Vec<BoundAggExpr>,
         output_schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -83,11 +83,25 @@ impl AggregateNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    }
+}
+
+impl DistributedPipelineNode for AggregateNode {
+    fn context(&self) -> &PipelineNodeContext {
+        &self.context
     }
 
-    fn multiline_display(&self) -> Vec<String> {
+    fn config(&self) -> &PipelineNodeConfig {
+        &self.config
+    }
+
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+        vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
         let agg_str = self.aggs.iter().map(|e| e.to_string()).join(", ");
         if self.group_by.is_empty() {
@@ -106,45 +120,6 @@ impl AggregateNode {
             ]
         }
     }
-}
-
-impl TreeDisplay for AggregateNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.context.node_name).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.context.node_name.to_string()
-    }
-}
-
-impl DistributedPipelineNode for AggregateNode {
-    fn context(&self) -> &PipelineNodeContext {
-        &self.context
-    }
-
-    fn config(&self) -> &PipelineNodeConfig {
-        &self.config
-    }
-
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
-        vec![self.child.clone()]
-    }
 
     fn produce_tasks(
         self: Arc<Self>,
@@ -155,7 +130,7 @@ impl DistributedPipelineNode for AggregateNode {
         // Pipeline the aggregation
         let self_clone = self.clone();
 
-        input_node.pipeline_instruction(self.clone(), move |input| {
+        input_node.pipeline_instruction(self, move |input| {
             if self_clone.group_by.is_empty() {
                 LocalPhysicalPlan::ungrouped_aggregate(
                     input,
@@ -173,10 +148,6 @@ impl DistributedPipelineNode for AggregateNode {
                 )
             }
         })
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }
 
@@ -262,13 +233,13 @@ impl LogicalPlanToPipelineNodeTranslator {
     /// That is currently only applicable for MapGroup aggregations
     fn gen_without_pre_agg(
         &mut self,
-        input_node: Arc<dyn DistributedPipelineNode>,
+        input_node: DistributedPipelineNodeWrapper,
         logical_node_id: Option<NodeID>,
         group_by: Vec<BoundExpr>,
         aggregations: Vec<BoundAggExpr>,
         output_schema: SchemaRef,
         partition_by: Vec<BoundExpr>,
-    ) -> DaftResult<Arc<dyn DistributedPipelineNode>> {
+    ) -> DaftResult<DistributedPipelineNodeWrapper> {
         let shuffle = if partition_by.is_empty() {
             self.gen_gather_node(logical_node_id, input_node)
         } else {
@@ -292,18 +263,18 @@ impl LogicalPlanToPipelineNodeTranslator {
             output_schema,
             shuffle,
         )
-        .arced())
+        .into_node())
     }
 
     /// Generate PipelineNodes for aggregates with some pre-aggregation.
     /// This is used by most other aggregations
     fn gen_with_pre_agg(
         &mut self,
-        input_node: Arc<dyn DistributedPipelineNode>,
+        input_node: DistributedPipelineNodeWrapper,
         logical_node_id: Option<NodeID>,
         split_details: GroupByAggSplit,
         output_schema: SchemaRef,
-    ) -> DaftResult<Arc<dyn DistributedPipelineNode>> {
+    ) -> DaftResult<DistributedPipelineNodeWrapper> {
         let num_partitions = input_node.config().clustering_spec.num_partitions();
         let initial_agg = AggregateNode::new(
             self.get_next_pipeline_node_id(),
@@ -314,7 +285,7 @@ impl LogicalPlanToPipelineNodeTranslator {
             split_details.first_stage_schema.clone(),
             input_node,
         )
-        .arced();
+        .into_node();
 
         // Second stage: Shuffle to distribute the dataset
         let num_partitions = min(
@@ -351,7 +322,7 @@ impl LogicalPlanToPipelineNodeTranslator {
             split_details.second_stage_schema.clone(),
             shuffle,
         )
-        .arced();
+        .into_node();
 
         // Last stage project to get the final result
         Ok(ProjectNode::new(
@@ -362,7 +333,7 @@ impl LogicalPlanToPipelineNodeTranslator {
             output_schema,
             final_aggregation,
         )
-        .arced())
+        .into_node())
     }
 
     /// Generate PipelineNodes for aggregates
@@ -377,13 +348,13 @@ impl LogicalPlanToPipelineNodeTranslator {
     /// * `partition_by` The columns to partition by. Most of the time, this will be the same as the group_by columns.
     pub fn gen_agg_nodes(
         &mut self,
-        input_node: Arc<dyn DistributedPipelineNode>,
+        input_node: DistributedPipelineNodeWrapper,
         logical_node_id: Option<NodeID>,
         group_by: Vec<BoundExpr>,
         aggregations: Vec<BoundAggExpr>,
         output_schema: SchemaRef,
         partition_by: Vec<BoundExpr>,
-    ) -> DaftResult<Arc<dyn DistributedPipelineNode>> {
+    ) -> DaftResult<DistributedPipelineNodeWrapper> {
         let input_clustering_spec = &input_node.config().clustering_spec;
         // If there is only one partition, or the input is already partitioned by the group_by columns,
         // then we can just do a single stage aggregation and skip the shuffle.
@@ -409,7 +380,7 @@ impl LogicalPlanToPipelineNodeTranslator {
                 output_schema,
                 input_node,
             )
-            .arced());
+            .into_node());
         }
 
         let split_details = split_groupby_aggs(

--- a/src/daft-distributed/src/pipeline_node/concat.rs
+++ b/src/daft-distributed/src/pipeline_node/concat.rs
@@ -9,8 +9,8 @@ use futures::StreamExt;
 
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, DistributedPipelineNodeWrapper, NodeID, NodeName,
-        PipelineNodeConfig, PipelineNodeContext, SubmittableTaskStream,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        PipelineNodeImpl, SubmittableTaskStream,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -18,8 +18,8 @@ use crate::{
 pub(crate) struct ConcatNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
-    child: DistributedPipelineNodeWrapper,
-    other: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
+    other: DistributedPipelineNode,
 }
 
 impl ConcatNode {
@@ -30,8 +30,8 @@ impl ConcatNode {
         logical_node_id: Option<NodeID>,
         plan_config: &PlanConfig,
         schema: SchemaRef,
-        other: DistributedPipelineNodeWrapper,
-        child: DistributedPipelineNodeWrapper,
+        other: DistributedPipelineNode,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -59,12 +59,12 @@ impl ConcatNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for ConcatNode {
+impl PipelineNodeImpl for ConcatNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -73,7 +73,7 @@ impl DistributedPipelineNode for ConcatNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone(), self.other.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/distinct.rs
+++ b/src/daft-distributed/src/pipeline_node/distinct.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::{partitioning::HashClusteringConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, SubmittableTaskStream};
+use super::{DistributedPipelineNode, DistributedPipelineNodeWrapper, SubmittableTaskStream};
 use crate::{
     pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
     plan::{PlanConfig, PlanExecutionContext},
@@ -16,7 +15,7 @@ pub(crate) struct DistinctNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     columns: Vec<BoundExpr>,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl DistinctNode {
@@ -29,7 +28,7 @@ impl DistinctNode {
         plan_config: &PlanConfig,
         columns: Vec<BoundExpr>,
         schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -58,43 +57,8 @@ impl DistinctNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
-    }
-
-    fn multiline_display(&self) -> Vec<String> {
-        use itertools::Itertools;
-        let mut res = vec![];
-        res.push(format!(
-            "Distinct: By {}",
-            self.columns.iter().map(|e| e.to_string()).join(", ")
-        ));
-        res
-    }
-}
-
-impl TreeDisplay for DistinctNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.context.node_name).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.context.node_name.to_string()
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
     }
 }
 
@@ -107,8 +71,18 @@ impl DistributedPipelineNode for DistinctNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
         vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
+        use itertools::Itertools;
+        let mut res = vec![];
+        res.push(format!(
+            "Distinct: By {}",
+            self.columns.iter().map(|e| e.to_string()).join(", ")
+        ));
+        res
     }
 
     fn produce_tasks(
@@ -119,7 +93,7 @@ impl DistributedPipelineNode for DistinctNode {
 
         // Pipeline the distinct op
         let self_clone = self.clone();
-        input_node.pipeline_instruction(self.clone(), move |input| {
+        input_node.pipeline_instruction(self, move |input| {
             LocalPhysicalPlan::dedup(
                 input,
                 self_clone.columns.clone(),
@@ -127,9 +101,5 @@ impl DistributedPipelineNode for DistinctNode {
                 StatsState::NotMaterialized,
             )
         })
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }

--- a/src/daft-distributed/src/pipeline_node/distinct.rs
+++ b/src/daft-distributed/src/pipeline_node/distinct.rs
@@ -5,7 +5,7 @@ use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::{partitioning::HashClusteringConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, DistributedPipelineNodeWrapper, SubmittableTaskStream};
+use super::{DistributedPipelineNode, PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
     pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
     plan::{PlanConfig, PlanExecutionContext},
@@ -15,7 +15,7 @@ pub(crate) struct DistinctNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     columns: Vec<BoundExpr>,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl DistinctNode {
@@ -28,7 +28,7 @@ impl DistinctNode {
         plan_config: &PlanConfig,
         columns: Vec<BoundExpr>,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -57,12 +57,12 @@ impl DistinctNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for DistinctNode {
+impl PipelineNodeImpl for DistinctNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -71,7 +71,7 @@ impl DistributedPipelineNode for DistinctNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/explode.rs
+++ b/src/daft-distributed/src/pipeline_node/explode.rs
@@ -5,7 +5,7 @@ use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, DistributedPipelineNodeWrapper, SubmittableTaskStream};
+use super::{DistributedPipelineNode, PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
     pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
     plan::{PlanConfig, PlanExecutionContext},
@@ -15,7 +15,7 @@ pub(crate) struct ExplodeNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     to_explode: Vec<BoundExpr>,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl ExplodeNode {
@@ -27,7 +27,7 @@ impl ExplodeNode {
         plan_config: &PlanConfig,
         to_explode: Vec<BoundExpr>,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -50,12 +50,12 @@ impl ExplodeNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for ExplodeNode {
+impl PipelineNodeImpl for ExplodeNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -64,7 +64,7 @@ impl DistributedPipelineNode for ExplodeNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/explode.rs
+++ b/src/daft-distributed/src/pipeline_node/explode.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, SubmittableTaskStream};
+use super::{DistributedPipelineNode, DistributedPipelineNodeWrapper, SubmittableTaskStream};
 use crate::{
     pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
     plan::{PlanConfig, PlanExecutionContext},
@@ -16,7 +15,7 @@ pub(crate) struct ExplodeNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     to_explode: Vec<BoundExpr>,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl ExplodeNode {
@@ -28,7 +27,7 @@ impl ExplodeNode {
         plan_config: &PlanConfig,
         to_explode: Vec<BoundExpr>,
         schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -51,41 +50,8 @@ impl ExplodeNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
-    }
-
-    fn multiline_display(&self) -> Vec<String> {
-        use itertools::Itertools;
-        vec![format!(
-            "Explode: {}",
-            self.to_explode.iter().map(|e| e.to_string()).join(", ")
-        )]
-    }
-}
-
-impl TreeDisplay for ExplodeNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.name()).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.name().to_string()
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
     }
 }
 
@@ -98,8 +64,16 @@ impl DistributedPipelineNode for ExplodeNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
         vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
+        use itertools::Itertools;
+        vec![format!(
+            "Explode: {}",
+            self.to_explode.iter().map(|e| e.to_string()).join(", ")
+        )]
     }
 
     fn produce_tasks(
@@ -109,7 +83,7 @@ impl DistributedPipelineNode for ExplodeNode {
         let input_node = self.child.clone().produce_tasks(plan_context);
         let to_explode = self.to_explode.clone();
         let schema = self.config.schema.clone();
-        input_node.pipeline_instruction(self.clone(), move |input| {
+        input_node.pipeline_instruction(self, move |input| {
             LocalPhysicalPlan::explode(
                 input,
                 to_explode.clone(),
@@ -117,9 +91,5 @@ impl DistributedPipelineNode for ExplodeNode {
                 StatsState::NotMaterialized,
             )
         })
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }

--- a/src/daft-distributed/src/pipeline_node/filter.rs
+++ b/src/daft-distributed/src/pipeline_node/filter.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, SubmittableTaskStream};
+use super::{DistributedPipelineNode, DistributedPipelineNodeWrapper, SubmittableTaskStream};
 use crate::{
     pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
     plan::{PlanConfig, PlanExecutionContext},
@@ -16,7 +15,7 @@ pub(crate) struct FilterNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     predicate: BoundExpr,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl FilterNode {
@@ -28,7 +27,7 @@ impl FilterNode {
         plan_config: &PlanConfig,
         predicate: BoundExpr,
         schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -51,37 +50,8 @@ impl FilterNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
-    }
-
-    fn multiline_display(&self) -> Vec<String> {
-        vec![format!("Filter: {}", self.predicate)]
-    }
-}
-
-impl TreeDisplay for FilterNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.name()).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.name().to_string()
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
     }
 }
 
@@ -94,8 +64,12 @@ impl DistributedPipelineNode for FilterNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
         vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
+        vec![format!("Filter: {}", self.predicate)]
     }
 
     fn produce_tasks(
@@ -105,12 +79,8 @@ impl DistributedPipelineNode for FilterNode {
         let input_node = self.child.clone().produce_tasks(plan_context);
 
         let predicate = self.predicate.clone();
-        input_node.pipeline_instruction(self.clone(), move |input| {
+        input_node.pipeline_instruction(self, move |input| {
             LocalPhysicalPlan::filter(input, predicate.clone(), StatsState::NotMaterialized)
         })
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }

--- a/src/daft-distributed/src/pipeline_node/filter.rs
+++ b/src/daft-distributed/src/pipeline_node/filter.rs
@@ -5,7 +5,7 @@ use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, DistributedPipelineNodeWrapper, SubmittableTaskStream};
+use super::{DistributedPipelineNode, PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
     pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
     plan::{PlanConfig, PlanExecutionContext},
@@ -15,7 +15,7 @@ pub(crate) struct FilterNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     predicate: BoundExpr,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl FilterNode {
@@ -27,7 +27,7 @@ impl FilterNode {
         plan_config: &PlanConfig,
         predicate: BoundExpr,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -50,12 +50,12 @@ impl FilterNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for FilterNode {
+impl PipelineNodeImpl for FilterNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -64,7 +64,7 @@ impl DistributedPipelineNode for FilterNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/in_memory_source.rs
+++ b/src/daft-distributed/src/pipeline_node/in_memory_source.rs
@@ -5,9 +5,9 @@ use common_partitioning::PartitionRef;
 use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::{ClusteringSpec, InMemoryInfo, stats::StatsState};
 
-use super::{DistributedPipelineNode, PipelineNodeContext, SubmittableTaskStream};
+use super::{PipelineNodeContext, PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
-    pipeline_node::{DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig},
+    pipeline_node::{DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig},
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
         scheduler::SubmittableTask,
@@ -57,8 +57,8 @@ impl InMemorySourceNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 
     async fn execution_loop(
@@ -118,7 +118,7 @@ impl InMemorySourceNode {
     }
 }
 
-impl DistributedPipelineNode for InMemorySourceNode {
+impl PipelineNodeImpl for InMemorySourceNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -127,7 +127,7 @@ impl DistributedPipelineNode for InMemorySourceNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![]
     }
 

--- a/src/daft-distributed/src/pipeline_node/join/broadcast_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/broadcast_join.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, sync::Arc};
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use common_error::DaftResult;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_local_plan::LocalPhysicalPlan;
@@ -10,8 +9,9 @@ use futures::{StreamExt, TryStreamExt};
 
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
-        SubmittableTaskStream, make_in_memory_scan_from_materialized_outputs,
+        DistributedPipelineNode, DistributedPipelineNodeWrapper, NodeID, NodeName,
+        PipelineNodeConfig, PipelineNodeContext, SubmittableTaskStream,
+        make_in_memory_scan_from_materialized_outputs,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -32,9 +32,9 @@ pub(crate) struct BroadcastJoinNode {
     join_type: JoinType,
     is_swapped: bool,
 
-    broadcaster: Arc<dyn DistributedPipelineNode>,
+    broadcaster: DistributedPipelineNodeWrapper,
     broadcaster_schema: SchemaRef,
-    receiver: Arc<dyn DistributedPipelineNode>,
+    receiver: DistributedPipelineNodeWrapper,
 }
 
 impl BroadcastJoinNode {
@@ -50,8 +50,8 @@ impl BroadcastJoinNode {
         null_equals_nulls: Option<Vec<bool>>,
         join_type: JoinType,
         is_swapped: bool,
-        broadcaster: Arc<dyn DistributedPipelineNode>,
-        receiver: Arc<dyn DistributedPipelineNode>,
+        broadcaster: DistributedPipelineNodeWrapper,
+        receiver: DistributedPipelineNodeWrapper,
         output_schema: SchemaRef,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -86,30 +86,8 @@ impl BroadcastJoinNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
-    }
-
-    fn multiline_display(&self) -> Vec<String> {
-        use itertools::Itertools;
-        let mut res = vec!["Broadcast Join".to_string()];
-        res.push(format!(
-            "Left on: {}",
-            self.left_on.iter().map(|e| e.to_string()).join(", ")
-        ));
-        res.push(format!(
-            "Right on: {}",
-            self.right_on.iter().map(|e| e.to_string()).join(", ")
-        ));
-        res.push(format!("Join type: {}", self.join_type));
-        res.push(format!("Is swapped: {}", self.is_swapped));
-        if let Some(null_equals_nulls) = &self.null_equals_nulls {
-            res.push(format!(
-                "Null equals nulls: [{}]",
-                null_equals_nulls.iter().map(|b| b.to_string()).join(", ")
-            ));
-        }
-        res
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
     }
 
     async fn execution_loop(
@@ -179,26 +157,6 @@ impl BroadcastJoinNode {
     }
 }
 
-impl TreeDisplay for BroadcastJoinNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        match level {
-            DisplayLevel::Compact => self.get_name(),
-            _ => self.multiline_display().join("\n"),
-        }
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![
-            self.broadcaster.as_tree_display(),
-            self.receiver.as_tree_display(),
-        ]
-    }
-
-    fn get_name(&self) -> String {
-        Self::NODE_NAME.to_string()
-    }
-}
-
 impl DistributedPipelineNode for BroadcastJoinNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
@@ -208,8 +166,30 @@ impl DistributedPipelineNode for BroadcastJoinNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
         vec![self.broadcaster.clone(), self.receiver.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
+        use itertools::Itertools;
+        let mut res = vec!["Broadcast Join".to_string()];
+        res.push(format!(
+            "Left on: {}",
+            self.left_on.iter().map(|e| e.to_string()).join(", ")
+        ));
+        res.push(format!(
+            "Right on: {}",
+            self.right_on.iter().map(|e| e.to_string()).join(", ")
+        ));
+        res.push(format!("Join type: {}", self.join_type));
+        res.push(format!("Is swapped: {}", self.is_swapped));
+        if let Some(null_equals_nulls) = &self.null_equals_nulls {
+            res.push(format!(
+                "Null equals nulls: [{}]",
+                null_equals_nulls.iter().map(|b| b.to_string()).join(", ")
+            ));
+        }
+        res
     }
 
     fn produce_tasks(
@@ -230,9 +210,5 @@ impl DistributedPipelineNode for BroadcastJoinNode {
         plan_context.spawn(execution_loop);
 
         SubmittableTaskStream::from(result_rx)
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }

--- a/src/daft-distributed/src/pipeline_node/join/cross_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/cross_join.rs
@@ -8,8 +8,8 @@ use futures::{StreamExt, stream::select};
 
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, DistributedPipelineNodeWrapper, NodeID, NodeName,
-        PipelineNodeConfig, PipelineNodeContext, SubmittableTaskStream,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        PipelineNodeImpl, SubmittableTaskStream,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -22,8 +22,8 @@ use crate::{
 pub(crate) struct CrossJoinNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
-    left_node: DistributedPipelineNodeWrapper,
-    right_node: DistributedPipelineNodeWrapper,
+    left_node: DistributedPipelineNode,
+    right_node: DistributedPipelineNode,
 }
 
 impl CrossJoinNode {
@@ -34,8 +34,8 @@ impl CrossJoinNode {
         logical_node_id: Option<NodeID>,
         plan_config: &PlanConfig,
         num_partitions: usize,
-        left_node: DistributedPipelineNodeWrapper,
-        right_node: DistributedPipelineNodeWrapper,
+        left_node: DistributedPipelineNode,
+        right_node: DistributedPipelineNode,
         output_schema: SchemaRef,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -61,8 +61,8 @@ impl CrossJoinNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 
     async fn execution_loop(
@@ -146,7 +146,7 @@ impl CrossJoinNode {
     }
 }
 
-impl DistributedPipelineNode for CrossJoinNode {
+impl PipelineNodeImpl for CrossJoinNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -155,7 +155,7 @@ impl DistributedPipelineNode for CrossJoinNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.left_node.clone(), self.right_node.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/join/hash_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/hash_join.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::{JoinType, partitioning::HashClusteringConfig, stats::StatsState};
@@ -9,8 +8,8 @@ use futures::StreamExt;
 
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
-        SubmittableTaskStream,
+        DistributedPipelineNode, DistributedPipelineNodeWrapper, NodeID, NodeName,
+        PipelineNodeConfig, PipelineNodeContext, SubmittableTaskStream,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -29,8 +28,8 @@ pub(crate) struct HashJoinNode {
     null_equals_nulls: Option<Vec<bool>>,
     join_type: JoinType,
 
-    left: Arc<dyn DistributedPipelineNode>,
-    right: Arc<dyn DistributedPipelineNode>,
+    left: DistributedPipelineNodeWrapper,
+    right: DistributedPipelineNodeWrapper,
 }
 
 impl HashJoinNode {
@@ -46,8 +45,8 @@ impl HashJoinNode {
         null_equals_nulls: Option<Vec<bool>>,
         join_type: JoinType,
         num_partitions: usize,
-        left: Arc<dyn DistributedPipelineNode>,
-        right: Arc<dyn DistributedPipelineNode>,
+        left: DistributedPipelineNodeWrapper,
+        right: DistributedPipelineNodeWrapper,
         output_schema: SchemaRef,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -81,22 +80,8 @@ impl HashJoinNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
-    }
-
-    fn multiline_display(&self) -> Vec<String> {
-        use itertools::Itertools;
-        let mut res = vec!["Hash Join".to_string()];
-        res.push(format!(
-            "Left on: {}",
-            self.left_on.iter().map(|e| e.to_string()).join(", ")
-        ));
-        res.push(format!(
-            "Right on: {}",
-            self.right_on.iter().map(|e| e.to_string()).join(", ")
-        ));
-        res
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
     }
 
     fn build_hash_join_task(
@@ -135,31 +120,6 @@ impl HashJoinNode {
     }
 }
 
-impl TreeDisplay for HashJoinNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.context.node_name).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.left.as_tree_display(), self.right.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.context.node_name.to_string()
-    }
-}
-
 impl DistributedPipelineNode for HashJoinNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
@@ -169,8 +129,22 @@ impl DistributedPipelineNode for HashJoinNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
         vec![self.left.clone(), self.right.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
+        use itertools::Itertools;
+        let mut res = vec!["Hash Join".to_string()];
+        res.push(format!(
+            "Left on: {}",
+            self.left_on.iter().map(|e| e.to_string()).join(", ")
+        ));
+        res.push(format!(
+            "Right on: {}",
+            self.right_on.iter().map(|e| e.to_string()).join(", ")
+        ));
+        res
     }
 
     fn produce_tasks(
@@ -189,9 +163,5 @@ impl DistributedPipelineNode for HashJoinNode {
                 })
                 .boxed(),
         )
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }

--- a/src/daft-distributed/src/pipeline_node/join/hash_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/hash_join.rs
@@ -8,8 +8,8 @@ use futures::StreamExt;
 
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, DistributedPipelineNodeWrapper, NodeID, NodeName,
-        PipelineNodeConfig, PipelineNodeContext, SubmittableTaskStream,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        PipelineNodeImpl, SubmittableTaskStream,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -28,8 +28,8 @@ pub(crate) struct HashJoinNode {
     null_equals_nulls: Option<Vec<bool>>,
     join_type: JoinType,
 
-    left: DistributedPipelineNodeWrapper,
-    right: DistributedPipelineNodeWrapper,
+    left: DistributedPipelineNode,
+    right: DistributedPipelineNode,
 }
 
 impl HashJoinNode {
@@ -45,8 +45,8 @@ impl HashJoinNode {
         null_equals_nulls: Option<Vec<bool>>,
         join_type: JoinType,
         num_partitions: usize,
-        left: DistributedPipelineNodeWrapper,
-        right: DistributedPipelineNodeWrapper,
+        left: DistributedPipelineNode,
+        right: DistributedPipelineNode,
         output_schema: SchemaRef,
     ) -> Self {
         let context = PipelineNodeContext::new(
@@ -80,8 +80,8 @@ impl HashJoinNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 
     fn build_hash_join_task(
@@ -120,7 +120,7 @@ impl HashJoinNode {
     }
 }
 
-impl DistributedPipelineNode for HashJoinNode {
+impl PipelineNodeImpl for HashJoinNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -129,7 +129,7 @@ impl DistributedPipelineNode for HashJoinNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.left.clone(), self.right.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/monotonically_increasing_id.rs
+++ b/src/daft-distributed/src/pipeline_node/monotonically_increasing_id.rs
@@ -1,14 +1,13 @@
 use std::sync::{Arc, atomic::AtomicU64};
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
-        SubmittableTaskStream,
+        DistributedPipelineNode, DistributedPipelineNodeWrapper, NodeID, NodeName,
+        PipelineNodeConfig, PipelineNodeContext, SubmittableTaskStream,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -17,7 +16,7 @@ pub(crate) struct MonotonicallyIncreasingIdNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     column_name: String,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl MonotonicallyIncreasingIdNode {
@@ -29,7 +28,7 @@ impl MonotonicallyIncreasingIdNode {
         plan_config: &PlanConfig,
         column_name: String,
         schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -52,37 +51,8 @@ impl MonotonicallyIncreasingIdNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
-    }
-
-    fn multiline_display(&self) -> Vec<String> {
-        vec![format!("MonotonicallyIncreasingId: {}", self.column_name)]
-    }
-}
-
-impl TreeDisplay for MonotonicallyIncreasingIdNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.context.node_name).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_name(&self) -> String {
-        self.context.node_name.to_string()
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
     }
 }
 
@@ -103,8 +73,12 @@ impl DistributedPipelineNode for MonotonicallyIncreasingIdNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
         vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
+        vec![format!("MonotonicallyIncreasingId: {}", self.column_name)]
     }
 
     fn produce_tasks(
@@ -117,7 +91,7 @@ impl DistributedPipelineNode for MonotonicallyIncreasingIdNode {
 
         let next_starting_offset = AtomicU64::new(0);
 
-        input_node.pipeline_instruction(self.clone(), move |input| {
+        input_node.pipeline_instruction(self, move |input| {
             LocalPhysicalPlan::monotonically_increasing_id(
                 input,
                 column_name.clone(),
@@ -129,9 +103,5 @@ impl DistributedPipelineNode for MonotonicallyIncreasingIdNode {
                 StatsState::NotMaterialized,
             )
         })
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }

--- a/src/daft-distributed/src/pipeline_node/monotonically_increasing_id.rs
+++ b/src/daft-distributed/src/pipeline_node/monotonically_increasing_id.rs
@@ -6,8 +6,8 @@ use daft_schema::schema::SchemaRef;
 
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, DistributedPipelineNodeWrapper, NodeID, NodeName,
-        PipelineNodeConfig, PipelineNodeContext, SubmittableTaskStream,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        PipelineNodeImpl, SubmittableTaskStream,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -16,7 +16,7 @@ pub(crate) struct MonotonicallyIncreasingIdNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     column_name: String,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl MonotonicallyIncreasingIdNode {
@@ -28,7 +28,7 @@ impl MonotonicallyIncreasingIdNode {
         plan_config: &PlanConfig,
         column_name: String,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -51,8 +51,8 @@ impl MonotonicallyIncreasingIdNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
@@ -64,7 +64,7 @@ impl MonotonicallyIncreasingIdNode {
 /// 2^36 ≈ 68 billion rows per partition.
 const MAX_ROWS_PER_PARTITION: u64 = 1u64 << 36;
 
-impl DistributedPipelineNode for MonotonicallyIncreasingIdNode {
+impl PipelineNodeImpl for MonotonicallyIncreasingIdNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -73,7 +73,7 @@ impl DistributedPipelineNode for MonotonicallyIncreasingIdNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/pivot.rs
+++ b/src/daft-distributed/src/pipeline_node/pivot.rs
@@ -5,10 +5,10 @@ use daft_local_plan::{LocalPhysicalPlan, LocalPhysicalPlanRef};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, SubmittableTaskStream};
+use super::{PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
     pipeline_node::{
-        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -21,7 +21,7 @@ pub(crate) struct PivotNode {
     value_column: BoundExpr,
     aggregation: BoundAggExpr,
     names: Vec<String>,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl PivotNode {
@@ -38,7 +38,7 @@ impl PivotNode {
         aggregation: BoundAggExpr,
         names: Vec<String>,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -65,12 +65,12 @@ impl PivotNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for PivotNode {
+impl PipelineNodeImpl for PivotNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -79,7 +79,7 @@ impl DistributedPipelineNode for PivotNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/pivot.rs
+++ b/src/daft-distributed/src/pipeline_node/pivot.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_dsl::expr::bound_expr::{BoundAggExpr, BoundExpr};
 use daft_local_plan::{LocalPhysicalPlan, LocalPhysicalPlanRef};
 use daft_logical_plan::stats::StatsState;
@@ -8,7 +7,9 @@ use daft_schema::schema::SchemaRef;
 
 use super::{DistributedPipelineNode, SubmittableTaskStream};
 use crate::{
-    pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
+    pipeline_node::{
+        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+    },
     plan::{PlanConfig, PlanExecutionContext},
 };
 
@@ -20,7 +21,7 @@ pub(crate) struct PivotNode {
     value_column: BoundExpr,
     aggregation: BoundAggExpr,
     names: Vec<String>,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl PivotNode {
@@ -37,7 +38,7 @@ impl PivotNode {
         aggregation: BoundAggExpr,
         names: Vec<String>,
         schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -64,11 +65,25 @@ impl PivotNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    }
+}
+
+impl DistributedPipelineNode for PivotNode {
+    fn context(&self) -> &PipelineNodeContext {
+        &self.context
     }
 
-    fn multiline_display(&self) -> Vec<String> {
+    fn config(&self) -> &PipelineNodeConfig {
+        &self.config
+    }
+
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+        vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
         vec![
             "Pivot:".to_string(),
@@ -82,45 +97,6 @@ impl PivotNode {
             format!("Pivoted Columns = {}", self.names.iter().join(", ")),
             format!("Output Schema = {}", self.config.schema.short_string()),
         ]
-    }
-}
-
-impl TreeDisplay for PivotNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.context.node_name).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.context.node_name.to_string()
-    }
-}
-
-impl DistributedPipelineNode for PivotNode {
-    fn context(&self) -> &PipelineNodeContext {
-        &self.context
-    }
-
-    fn config(&self) -> &PipelineNodeConfig {
-        &self.config
-    }
-
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
-        vec![self.child.clone()]
     }
 
     fn produce_tasks(
@@ -144,10 +120,6 @@ impl DistributedPipelineNode for PivotNode {
             )
         };
 
-        input_node.pipeline_instruction(self.clone(), plan_builder)
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
+        input_node.pipeline_instruction(self, plan_builder)
     }
 }

--- a/src/daft-distributed/src/pipeline_node/project.rs
+++ b/src/daft-distributed/src/pipeline_node/project.rs
@@ -5,10 +5,10 @@ use daft_local_plan::{LocalPhysicalPlan, LocalPhysicalPlanRef};
 use daft_logical_plan::{partitioning::translate_clustering_spec, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, SubmittableTaskStream};
+use super::{PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
     pipeline_node::{
-        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -17,7 +17,7 @@ pub(crate) struct ProjectNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     projection: Vec<BoundExpr>,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl ProjectNode {
@@ -29,7 +29,7 @@ impl ProjectNode {
         plan_config: &PlanConfig,
         projection: Vec<BoundExpr>,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -58,12 +58,12 @@ impl ProjectNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for ProjectNode {
+impl PipelineNodeImpl for ProjectNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -72,7 +72,7 @@ impl DistributedPipelineNode for ProjectNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/project.rs
+++ b/src/daft-distributed/src/pipeline_node/project.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_local_plan::{LocalPhysicalPlan, LocalPhysicalPlanRef};
 use daft_logical_plan::{partitioning::translate_clustering_spec, stats::StatsState};
@@ -8,7 +7,9 @@ use daft_schema::schema::SchemaRef;
 
 use super::{DistributedPipelineNode, SubmittableTaskStream};
 use crate::{
-    pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
+    pipeline_node::{
+        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+    },
     plan::{PlanConfig, PlanExecutionContext},
 };
 
@@ -16,7 +17,7 @@ pub(crate) struct ProjectNode {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     projection: Vec<BoundExpr>,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl ProjectNode {
@@ -28,7 +29,7 @@ impl ProjectNode {
         plan_config: &PlanConfig,
         projection: Vec<BoundExpr>,
         schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -57,11 +58,25 @@ impl ProjectNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    }
+}
+
+impl DistributedPipelineNode for ProjectNode {
+    fn context(&self) -> &PipelineNodeContext {
+        &self.context
     }
 
-    fn multiline_display(&self) -> Vec<String> {
+    fn config(&self) -> &PipelineNodeConfig {
+        &self.config
+    }
+
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+        vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use daft_dsl::functions::python::get_resource_request;
         use itertools::Itertools;
         let mut res = vec![];
@@ -79,45 +94,6 @@ impl ProjectNode {
             res.push("Resource request = None".to_string());
         }
         res
-    }
-}
-
-impl TreeDisplay for ProjectNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.name()).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.name().to_string()
-    }
-}
-
-impl DistributedPipelineNode for ProjectNode {
-    fn context(&self) -> &PipelineNodeContext {
-        &self.context
-    }
-
-    fn config(&self) -> &PipelineNodeConfig {
-        &self.config
-    }
-
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
-        vec![self.child.clone()]
     }
 
     fn produce_tasks(
@@ -137,10 +113,6 @@ impl DistributedPipelineNode for ProjectNode {
             )
         };
 
-        input_node.pipeline_instruction(self.clone(), plan_builder)
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
+        input_node.pipeline_instruction(self, plan_builder)
     }
 }

--- a/src/daft-distributed/src/pipeline_node/sample.rs
+++ b/src/daft-distributed/src/pipeline_node/sample.rs
@@ -4,10 +4,10 @@ use daft_local_plan::{LocalPhysicalPlan, LocalPhysicalPlanRef, SamplingMethod};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, SubmittableTaskStream};
+use super::{PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
     pipeline_node::{
-        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -18,7 +18,7 @@ pub(crate) struct SampleNode {
     fraction: f64,
     with_replacement: bool,
     seed: Option<u64>,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl SampleNode {
@@ -33,7 +33,7 @@ impl SampleNode {
         with_replacement: bool,
         seed: Option<u64>,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -58,12 +58,12 @@ impl SampleNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for SampleNode {
+impl PipelineNodeImpl for SampleNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -72,7 +72,7 @@ impl DistributedPipelineNode for SampleNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/scan_source.rs
@@ -9,11 +9,10 @@ use daft_logical_plan::{ClusteringSpec, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 
 use super::{
-    DistributedPipelineNode, NodeName, PipelineNodeConfig, PipelineNodeContext,
-    SubmittableTaskStream,
+    NodeName, PipelineNodeConfig, PipelineNodeContext, PipelineNodeImpl, SubmittableTaskStream,
 };
 use crate::{
-    pipeline_node::{DistributedPipelineNodeWrapper, NodeID},
+    pipeline_node::{DistributedPipelineNode, NodeID},
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
         scheduler::SubmittableTask,
@@ -63,8 +62,8 @@ impl ScanSourceNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 
     async fn execution_loop(
@@ -130,7 +129,7 @@ impl ScanSourceNode {
     }
 }
 
-impl DistributedPipelineNode for ScanSourceNode {
+impl PipelineNodeImpl for ScanSourceNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -139,7 +138,7 @@ impl DistributedPipelineNode for ScanSourceNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![]
     }
 

--- a/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
@@ -3,7 +3,7 @@ use daft_logical_plan::partitioning::RepartitionSpec;
 use daft_schema::schema::SchemaRef;
 
 use crate::pipeline_node::{
-    DistributedPipelineNodeWrapper, NodeID,
+    DistributedPipelineNode, NodeID,
     shuffles::{
         gather::GatherNode, pre_shuffle_merge::PreShuffleMergeNode, repartition::RepartitionNode,
     },
@@ -16,8 +16,8 @@ impl LogicalPlanToPipelineNodeTranslator {
         logical_node_id: Option<NodeID>,
         repartition_spec: RepartitionSpec,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
-    ) -> DaftResult<DistributedPipelineNodeWrapper> {
+        child: DistributedPipelineNode,
+    ) -> DaftResult<DistributedPipelineNode> {
         let num_partitions = match &repartition_spec {
             RepartitionSpec::Hash(config) => config
                 .num_partitions
@@ -72,7 +72,7 @@ impl LogicalPlanToPipelineNodeTranslator {
     /// Determine if we should use pre-shuffle merge strategy
     fn should_use_pre_shuffle_merge(
         &self,
-        child: &DistributedPipelineNodeWrapper,
+        child: &DistributedPipelineNode,
         target_num_partitions: usize,
     ) -> DaftResult<bool> {
         let input_num_partitions = child.config().clustering_spec.num_partitions();
@@ -96,8 +96,8 @@ impl LogicalPlanToPipelineNodeTranslator {
     pub fn gen_gather_node(
         &mut self,
         logical_node_id: Option<NodeID>,
-        input_node: DistributedPipelineNodeWrapper,
-    ) -> DistributedPipelineNodeWrapper {
+        input_node: DistributedPipelineNode,
+    ) -> DistributedPipelineNode {
         if input_node.config().clustering_spec.num_partitions() == 1 {
             return input_node;
         }

--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -1,6 +1,5 @@
 use std::{future, sync::Arc};
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use common_error::{DaftError, DaftResult};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_io::IOStatsContext;
@@ -20,7 +19,8 @@ use super::{
 };
 use crate::{
     pipeline_node::{
-        MaterializedOutput, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        DistributedPipelineNodeWrapper, MaterializedOutput, NodeID, NodeName, PipelineNodeConfig,
+        PipelineNodeContext,
     },
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
@@ -40,7 +40,7 @@ pub(crate) struct SortNode {
     sort_by: Vec<BoundExpr>,
     descending: Vec<bool>,
     nulls_first: Vec<bool>,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl SortNode {
@@ -55,7 +55,7 @@ impl SortNode {
         descending: Vec<bool>,
         nulls_first: Vec<bool>,
         output_schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -81,8 +81,8 @@ impl SortNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
     }
 
     #[cfg(feature = "python")]
@@ -321,8 +321,22 @@ impl SortNode {
         }
         Ok(())
     }
+}
 
-    fn multiline_display(&self) -> Vec<String> {
+impl DistributedPipelineNode for SortNode {
+    fn context(&self) -> &PipelineNodeContext {
+        &self.context
+    }
+
+    fn config(&self) -> &PipelineNodeConfig {
+        &self.config
+    }
+
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+        vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
         let mut res = vec!["Sort".to_string()];
         res.push(format!(
@@ -339,45 +353,6 @@ impl SortNode {
         ));
         res
     }
-}
-
-impl TreeDisplay for SortNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.context.node_name).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.context.node_name.to_string()
-    }
-}
-
-impl DistributedPipelineNode for SortNode {
-    fn context(&self) -> &PipelineNodeContext {
-        &self.context
-    }
-
-    fn config(&self) -> &PipelineNodeConfig {
-        &self.config
-    }
-
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
-        vec![self.child.clone()]
-    }
 
     fn produce_tasks(
         self: Arc<Self>,
@@ -392,9 +367,5 @@ impl DistributedPipelineNode for SortNode {
             plan_context.scheduler_handle(),
         ));
         SubmittableTaskStream::from(result_rx)
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }

--- a/src/daft-distributed/src/pipeline_node/top_n.rs
+++ b/src/daft-distributed/src/pipeline_node/top_n.rs
@@ -5,10 +5,10 @@ use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, SubmittableTaskStream};
+use super::{PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
     pipeline_node::{
-        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -22,7 +22,7 @@ pub(crate) struct TopNNode {
     nulls_first: Vec<bool>,
     limit: u64,
     offset: Option<u64>,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl TopNNode {
@@ -39,7 +39,7 @@ impl TopNNode {
         limit: u64,
         offset: Option<u64>,
         output_schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -66,12 +66,12 @@ impl TopNNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for TopNNode {
+impl PipelineNodeImpl for TopNNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -80,7 +80,7 @@ impl DistributedPipelineNode for TopNNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/top_n.rs
+++ b/src/daft-distributed/src/pipeline_node/top_n.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::stats::StatsState;
@@ -8,7 +7,9 @@ use daft_schema::schema::SchemaRef;
 
 use super::{DistributedPipelineNode, SubmittableTaskStream};
 use crate::{
-    pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
+    pipeline_node::{
+        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+    },
     plan::{PlanConfig, PlanExecutionContext},
 };
 
@@ -21,7 +22,7 @@ pub(crate) struct TopNNode {
     nulls_first: Vec<bool>,
     limit: u64,
     offset: Option<u64>,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl TopNNode {
@@ -38,7 +39,7 @@ impl TopNNode {
         limit: u64,
         offset: Option<u64>,
         output_schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -65,11 +66,25 @@ impl TopNNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    }
+}
+
+impl DistributedPipelineNode for TopNNode {
+    fn context(&self) -> &PipelineNodeContext {
+        &self.context
     }
 
-    fn multiline_display(&self) -> Vec<String> {
+    fn config(&self) -> &PipelineNodeConfig {
+        &self.config
+    }
+
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+        vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
 
         let mut res = vec!["TopN".to_string()];
@@ -93,45 +108,6 @@ impl TopNNode {
 
         res
     }
-}
-
-impl TreeDisplay for TopNNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.context.node_name).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.context.node_name.to_string()
-    }
-}
-
-impl DistributedPipelineNode for TopNNode {
-    fn context(&self) -> &PipelineNodeContext {
-        &self.context
-    }
-
-    fn config(&self) -> &PipelineNodeConfig {
-        &self.config
-    }
-
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
-        vec![self.child.clone()]
-    }
 
     fn produce_tasks(
         self: Arc<Self>,
@@ -141,7 +117,7 @@ impl DistributedPipelineNode for TopNNode {
 
         // Pipeline the top-n
         let self_clone = self.clone();
-        input_node.pipeline_instruction(self.clone(), move |input| {
+        input_node.pipeline_instruction(self, move |input| {
             LocalPhysicalPlan::top_n(
                 input,
                 self_clone.sort_by.clone(),
@@ -152,9 +128,5 @@ impl DistributedPipelineNode for TopNNode {
                 StatsState::NotMaterialized,
             )
         })
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -18,7 +18,7 @@ use daft_schema::schema::Schema;
 
 use crate::{
     pipeline_node::{
-        DistributedPipelineNode, NodeID, concat::ConcatNode, distinct::DistinctNode,
+        DistributedPipelineNodeWrapper, NodeID, concat::ConcatNode, distinct::DistinctNode,
         explode::ExplodeNode, filter::FilterNode, in_memory_source::InMemorySourceNode,
         into_batches::IntoBatchesNode, into_partitions::IntoPartitionsNode, limit::LimitNode,
         monotonically_increasing_id::MonotonicallyIncreasingIdNode, pivot::PivotNode,
@@ -32,7 +32,7 @@ pub(crate) fn logical_plan_to_pipeline_node(
     plan_config: PlanConfig,
     plan: LogicalPlanRef,
     psets: Arc<HashMap<String, Vec<PartitionRef>>>,
-) -> DaftResult<Arc<dyn DistributedPipelineNode>> {
+) -> DaftResult<DistributedPipelineNodeWrapper> {
     let mut translator = LogicalPlanToPipelineNodeTranslator::new(plan_config, psets);
     let _ = plan.visit(&mut translator)?;
     Ok(translator.curr_node.pop().unwrap())
@@ -42,7 +42,7 @@ pub(crate) struct LogicalPlanToPipelineNodeTranslator {
     pub plan_config: PlanConfig,
     pipeline_node_id_counter: NodeID,
     psets: Arc<HashMap<String, Vec<PartitionRef>>>,
-    curr_node: Vec<Arc<dyn DistributedPipelineNode>>,
+    curr_node: Vec<DistributedPipelineNodeWrapper>,
 }
 
 impl LogicalPlanToPipelineNodeTranslator {
@@ -80,7 +80,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                         self.psets.clone(),
                         logical_node_id,
                     )
-                    .arced(),
+                    .into_node(),
                     SourceInfo::Physical(info) => {
                         // We should be able to pass the ScanOperator into the physical plan directly but we need to figure out the serialization story
                         let scan_tasks = match &info.scan_state {
@@ -97,7 +97,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                             source.output_schema.clone(),
                             logical_node_id,
                         )
-                        .arced()
+                        .into_node()
                     }
                     SourceInfo::PlaceHolder(_) => unreachable!(
                         "PlaceHolder should not be present in the logical plan for pipeline node translation"
@@ -124,7 +124,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                         udf.projected_schema.clone(),
                         self.curr_node.pop().unwrap(),
                     )?
-                    .arced()
+                    .into_node()
                 }
                 #[cfg(not(feature = "python"))]
                 {
@@ -146,7 +146,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     node.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::Filter(filter) => {
                 let predicate =
@@ -159,7 +159,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     node.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::IntoBatches(into_batches) => IntoBatchesNode::new(
                 self.get_next_pipeline_node_id(),
@@ -169,8 +169,8 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 node.schema(),
                 self.curr_node.pop().unwrap(),
             )
-            .arced(),
-            LogicalPlan::Limit(limit) => Arc::new(LimitNode::new(
+            .into_node(),
+            LogicalPlan::Limit(limit) => LimitNode::new(
                 self.get_next_pipeline_node_id(),
                 logical_node_id,
                 &self.plan_config,
@@ -178,7 +178,8 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 limit.offset.map(|x| x as usize),
                 node.schema(),
                 self.curr_node.pop().unwrap(),
-            )),
+            )
+            .into_node(),
             LogicalPlan::Project(project) => {
                 let projection = BoundExpr::bind_all(&project.projection, &project.input.schema())?;
                 ProjectNode::new(
@@ -189,7 +190,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     node.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::Explode(explode) => {
                 let to_explode = BoundExpr::bind_all(&explode.to_explode, &explode.input.schema())?;
@@ -201,7 +202,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     node.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::Unpivot(unpivot) => {
                 let ids = BoundExpr::bind_all(&unpivot.ids, &unpivot.input.schema())?;
@@ -217,7 +218,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     node.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::Sample(sample) => SampleNode::new(
                 self.get_next_pipeline_node_id(),
@@ -229,7 +230,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 node.schema(),
                 self.curr_node.pop().unwrap(),
             )
-            .arced(),
+            .into_node(),
             LogicalPlan::Sink(sink) => {
                 let sink_info = sink.sink_info.bind(&sink.input.schema())?;
                 SinkNode::new(
@@ -241,7 +242,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     sink.input.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::MonotonicallyIncreasingId(monotonically_increasing_id) => {
                 MonotonicallyIncreasingIdNode::new(
@@ -252,7 +253,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     node.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::Concat(_) => ConcatNode::new(
                 self.get_next_pipeline_node_id(),
@@ -262,7 +263,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                 self.curr_node.pop().unwrap(), // Other
                 self.curr_node.pop().unwrap(), // Child
             )
-            .arced(),
+            .into_node(),
             LogicalPlan::Repartition(repartition) => match &repartition.repartition_spec {
                 RepartitionSpec::Hash(_)
                 | RepartitionSpec::Random(_)
@@ -283,7 +284,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     node.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced(),
+                .into_node(),
             },
             LogicalPlan::Aggregate(aggregate) => {
                 let input_schema = aggregate.input.schema();
@@ -327,7 +328,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     distinct.input.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced();
+                .into_node();
 
                 // Second stage: Repartition to distribute the dataset
                 let repartition = self.gen_shuffle_node(
@@ -349,7 +350,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     distinct.input.schema(),
                     repartition,
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::Window(window) => {
                 let partition_by =
@@ -391,7 +392,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     window.schema.clone(),
                     repartition,
                 )?
-                .arced()
+                .into_node()
             }
             LogicalPlan::Join(join) => {
                 // Visitor appends in in-order
@@ -414,7 +415,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     sort.input.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::TopN(top_n) => {
                 let sort_by = BoundExpr::bind_all(&top_n.sort_by, &top_n.input.schema())?;
@@ -432,7 +433,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     top_n.input.schema(),
                     self.curr_node.pop().unwrap(),
                 )
-                .arced();
+                .into_node();
 
                 // Second stage: Gather all data to a single node
                 let gather = self.gen_gather_node(logical_node_id, local_topn);
@@ -450,7 +451,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     top_n.input.schema(),
                     gather,
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::Pivot(pivot) => {
                 let input_schema = pivot.input.schema();
@@ -499,7 +500,7 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
                     pivot.output_schema.clone(),
                     agg,
                 )
-                .arced()
+                .into_node()
             }
             LogicalPlan::SubqueryAlias(_)
             | LogicalPlan::Union(_)

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -18,7 +18,7 @@ use daft_schema::schema::Schema;
 
 use crate::{
     pipeline_node::{
-        DistributedPipelineNodeWrapper, NodeID, concat::ConcatNode, distinct::DistinctNode,
+        DistributedPipelineNode, NodeID, concat::ConcatNode, distinct::DistinctNode,
         explode::ExplodeNode, filter::FilterNode, in_memory_source::InMemorySourceNode,
         into_batches::IntoBatchesNode, into_partitions::IntoPartitionsNode, limit::LimitNode,
         monotonically_increasing_id::MonotonicallyIncreasingIdNode, pivot::PivotNode,
@@ -32,7 +32,7 @@ pub(crate) fn logical_plan_to_pipeline_node(
     plan_config: PlanConfig,
     plan: LogicalPlanRef,
     psets: Arc<HashMap<String, Vec<PartitionRef>>>,
-) -> DaftResult<DistributedPipelineNodeWrapper> {
+) -> DaftResult<DistributedPipelineNode> {
     let mut translator = LogicalPlanToPipelineNodeTranslator::new(plan_config, psets);
     let _ = plan.visit(&mut translator)?;
     Ok(translator.curr_node.pop().unwrap())
@@ -42,7 +42,7 @@ pub(crate) struct LogicalPlanToPipelineNodeTranslator {
     pub plan_config: PlanConfig,
     pipeline_node_id_counter: NodeID,
     psets: Arc<HashMap<String, Vec<PartitionRef>>>,
-    curr_node: Vec<DistributedPipelineNodeWrapper>,
+    curr_node: Vec<DistributedPipelineNode>,
 }
 
 impl LogicalPlanToPipelineNodeTranslator {

--- a/src/daft-distributed/src/pipeline_node/udf.rs
+++ b/src/daft-distributed/src/pipeline_node/udf.rs
@@ -6,10 +6,10 @@ use daft_logical_plan::{partitioning::translate_clustering_spec, stats::StatsSta
 use daft_schema::schema::SchemaRef;
 use itertools::Itertools;
 
-use super::DistributedPipelineNode;
+use super::PipelineNodeImpl;
 use crate::{
     pipeline_node::{
-        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
         SubmittableTaskStream,
     },
     plan::{PlanConfig, PlanExecutionContext},
@@ -21,7 +21,7 @@ pub(crate) struct UDFNode {
     project: BoundExpr,
     passthrough_columns: Vec<BoundExpr>,
     udf_properties: UDFProperties,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl UDFNode {
@@ -36,7 +36,7 @@ impl UDFNode {
         passthrough_columns: Vec<BoundExpr>,
         udf_properties: UDFProperties,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -67,12 +67,12 @@ impl UDFNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for UDFNode {
+impl PipelineNodeImpl for UDFNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -81,7 +81,7 @@ impl DistributedPipelineNode for UDFNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/udf.rs
+++ b/src/daft-distributed/src/pipeline_node/udf.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_dsl::{expr::bound_expr::BoundExpr, functions::python::UDFProperties};
 use daft_local_plan::{LocalPhysicalPlan, LocalPhysicalPlanRef};
 use daft_logical_plan::{partitioning::translate_clustering_spec, stats::StatsState};
@@ -10,7 +9,8 @@ use itertools::Itertools;
 use super::DistributedPipelineNode;
 use crate::{
     pipeline_node::{
-        NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext, SubmittableTaskStream,
+        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        SubmittableTaskStream,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -21,7 +21,7 @@ pub(crate) struct UDFNode {
     project: BoundExpr,
     passthrough_columns: Vec<BoundExpr>,
     udf_properties: UDFProperties,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl UDFNode {
@@ -36,7 +36,7 @@ impl UDFNode {
         passthrough_columns: Vec<BoundExpr>,
         udf_properties: UDFProperties,
         schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -67,11 +67,25 @@ impl UDFNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    }
+}
+
+impl DistributedPipelineNode for UDFNode {
+    fn context(&self) -> &PipelineNodeContext {
+        &self.context
     }
 
-    fn multiline_display(&self) -> Vec<String> {
+    fn config(&self) -> &PipelineNodeConfig {
+        &self.config
+    }
+
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+        vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         let mut res = vec![];
         res.push("UDF Executor:".to_string());
         res.push(format!(
@@ -92,37 +106,6 @@ impl UDFNode {
             res.push("Resource request = None".to_string());
         }
         res
-    }
-}
-
-impl TreeDisplay for UDFNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        match level {
-            DisplayLevel::Compact => self.name().to_string(),
-            _ => self.multiline_display().join("\n"),
-        }
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.name().to_string()
-    }
-}
-
-impl DistributedPipelineNode for UDFNode {
-    fn context(&self) -> &PipelineNodeContext {
-        &self.context
-    }
-
-    fn config(&self) -> &PipelineNodeConfig {
-        &self.config
-    }
-
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
-        vec![self.child.clone()]
     }
 
     fn produce_tasks(
@@ -145,9 +128,5 @@ impl DistributedPipelineNode for UDFNode {
         };
 
         input_node.pipeline_instruction(self, plan_builder)
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
     }
 }

--- a/src/daft-distributed/src/pipeline_node/unpivot.rs
+++ b/src/daft-distributed/src/pipeline_node/unpivot.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use common_display::{DisplayLevel, tree::TreeDisplay};
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_local_plan::{LocalPhysicalPlan, LocalPhysicalPlanRef};
 use daft_logical_plan::stats::StatsState;
@@ -8,7 +7,9 @@ use daft_schema::schema::SchemaRef;
 
 use super::{DistributedPipelineNode, SubmittableTaskStream};
 use crate::{
-    pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
+    pipeline_node::{
+        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+    },
     plan::{PlanConfig, PlanExecutionContext},
 };
 
@@ -19,7 +20,7 @@ pub(crate) struct UnpivotNode {
     values: Vec<BoundExpr>,
     variable_name: String,
     value_name: String,
-    child: Arc<dyn DistributedPipelineNode>,
+    child: DistributedPipelineNodeWrapper,
 }
 
 impl UnpivotNode {
@@ -35,7 +36,7 @@ impl UnpivotNode {
         variable_name: String,
         value_name: String,
         schema: SchemaRef,
-        child: Arc<dyn DistributedPipelineNode>,
+        child: DistributedPipelineNodeWrapper,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -61,11 +62,25 @@ impl UnpivotNode {
         }
     }
 
-    pub fn arced(self) -> Arc<dyn DistributedPipelineNode> {
-        Arc::new(self)
+    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
+        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    }
+}
+
+impl DistributedPipelineNode for UnpivotNode {
+    fn context(&self) -> &PipelineNodeContext {
+        &self.context
     }
 
-    fn multiline_display(&self) -> Vec<String> {
+    fn config(&self) -> &PipelineNodeConfig {
+        &self.config
+    }
+
+    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+        vec![self.child.clone()]
+    }
+
+    fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
         let mut res = vec![];
         res.push(format!(
@@ -79,45 +94,6 @@ impl UnpivotNode {
         res.push(format!("Variable name = {}", self.variable_name));
         res.push(format!("Value name = {}", self.value_name));
         res
-    }
-}
-
-impl TreeDisplay for UnpivotNode {
-    fn display_as(&self, level: DisplayLevel) -> String {
-        use std::fmt::Write;
-        let mut display = String::new();
-        match level {
-            DisplayLevel::Compact => {
-                writeln!(display, "{}", self.context.node_name).unwrap();
-            }
-            _ => {
-                let multiline_display = self.multiline_display().join("\n");
-                writeln!(display, "{}", multiline_display).unwrap();
-            }
-        }
-        display
-    }
-
-    fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        vec![self.child.as_tree_display()]
-    }
-
-    fn get_name(&self) -> String {
-        self.context.node_name.to_string()
-    }
-}
-
-impl DistributedPipelineNode for UnpivotNode {
-    fn context(&self) -> &PipelineNodeContext {
-        &self.context
-    }
-
-    fn config(&self) -> &PipelineNodeConfig {
-        &self.config
-    }
-
-    fn children(&self) -> Vec<Arc<dyn DistributedPipelineNode>> {
-        vec![self.child.clone()]
     }
 
     fn produce_tasks(
@@ -139,10 +115,6 @@ impl DistributedPipelineNode for UnpivotNode {
             )
         };
 
-        input_node.pipeline_instruction(self.clone(), plan_builder)
-    }
-
-    fn as_tree_display(&self) -> &dyn TreeDisplay {
-        self
+        input_node.pipeline_instruction(self, plan_builder)
     }
 }

--- a/src/daft-distributed/src/pipeline_node/unpivot.rs
+++ b/src/daft-distributed/src/pipeline_node/unpivot.rs
@@ -5,10 +5,10 @@ use daft_local_plan::{LocalPhysicalPlan, LocalPhysicalPlanRef};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 
-use super::{DistributedPipelineNode, SubmittableTaskStream};
+use super::{PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
     pipeline_node::{
-        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -20,7 +20,7 @@ pub(crate) struct UnpivotNode {
     values: Vec<BoundExpr>,
     variable_name: String,
     value_name: String,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl UnpivotNode {
@@ -36,7 +36,7 @@ impl UnpivotNode {
         variable_name: String,
         value_name: String,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -62,12 +62,12 @@ impl UnpivotNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 }
 
-impl DistributedPipelineNode for UnpivotNode {
+impl PipelineNodeImpl for UnpivotNode {
     fn context(&self) -> &PipelineNodeContext {
         &self.context
     }
@@ -76,7 +76,7 @@ impl DistributedPipelineNode for UnpivotNode {
         &self.config
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
     }
 

--- a/src/daft-distributed/src/pipeline_node/window.rs
+++ b/src/daft-distributed/src/pipeline_node/window.rs
@@ -11,10 +11,10 @@ use daft_logical_plan::{partitioning::HashClusteringConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 use itertools::Itertools;
 
-use super::{DistributedPipelineNode, SubmittableTaskStream};
+use super::{PipelineNodeImpl, SubmittableTaskStream};
 use crate::{
     pipeline_node::{
-        DistributedPipelineNodeWrapper, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
+        DistributedPipelineNode, NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext,
     },
     plan::{PlanConfig, PlanExecutionContext},
 };
@@ -23,7 +23,7 @@ pub(crate) struct WindowNodeBase {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     aliases: Vec<String>,
-    child: DistributedPipelineNodeWrapper,
+    child: DistributedPipelineNode,
 }
 
 impl WindowNodeBase {
@@ -31,7 +31,7 @@ impl WindowNodeBase {
         config: PipelineNodeConfig,
         context: PipelineNodeContext,
         aliases: Vec<String>,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> Self {
         Self {
             config,
@@ -244,7 +244,7 @@ impl WindowNode {
         window_exprs: Vec<BoundWindowExpr>,
         aliases: Vec<String>,
         schema: SchemaRef,
-        child: DistributedPipelineNodeWrapper,
+        child: DistributedPipelineNode,
     ) -> DaftResult<Self> {
         let context = PipelineNodeContext::new(
             plan_config.plan_id,
@@ -320,8 +320,8 @@ impl WindowNode {
         }
     }
 
-    pub fn into_node(self) -> DistributedPipelineNodeWrapper {
-        DistributedPipelineNodeWrapper::new(Arc::new(self))
+    pub fn into_node(self) -> DistributedPipelineNode {
+        DistributedPipelineNode::new(Arc::new(self))
     }
 
     fn base(&self) -> &WindowNodeBase {
@@ -341,12 +341,12 @@ impl WindowNode {
         &self.base().context
     }
 
-    fn child(&self) -> &DistributedPipelineNodeWrapper {
+    fn child(&self) -> &DistributedPipelineNode {
         &self.base().child
     }
 }
 
-impl DistributedPipelineNode for WindowNode {
+impl PipelineNodeImpl for WindowNode {
     fn context(&self) -> &PipelineNodeContext {
         self.context()
     }
@@ -355,7 +355,7 @@ impl DistributedPipelineNode for WindowNode {
         self.config()
     }
 
-    fn children(&self) -> Vec<DistributedPipelineNodeWrapper> {
+    fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child().clone()]
     }
 

--- a/src/daft-distributed/src/python/mod.rs
+++ b/src/daft-distributed/src/python/mod.rs
@@ -94,10 +94,7 @@ impl PyDistributedPhysicalPlan {
             Default::default(),
         )?;
 
-        Ok(viz_distributed_pipeline_ascii(
-            pipeline_node.as_ref(),
-            simple,
-        ))
+        Ok(viz_distributed_pipeline_ascii(&pipeline_node, simple))
     }
 
     /// Visualize the distributed pipeline as Mermaid markdown
@@ -116,7 +113,7 @@ impl PyDistributedPhysicalPlan {
             DisplayLevel::Default
         };
         Ok(viz_distributed_pipeline_mermaid(
-            pipeline_node.as_ref(),
+            &pipeline_node,
             display_level,
             bottom_up,
             None,


### PR DESCRIPTION
## Changes Made

Rather than having each node implementation implement TreeDisplay itself, leading to a lot of repeated code, just lift it up and have a wrapper struct that implements it. Similar to what we do in Swordfish actually. I did this in preparation of a `repr_json` method on TreeDisplay, since all DistributedPipelineNodes will return similar stuff anyways

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
