### PR TITLE
Add Kubernetes quickstart to Daft docs

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -35,7 +35,9 @@
         * [SQL Databases](connectors/sql.md)
         * [Turbopuffer](connectors/turbopuffer.md)
         * [Unity Catalog (Databricks)](connectors/unity_catalog.md)
-    * [Scaling Out and Deployment](distributed.md)
+    * Scaling Out and Deployment
+        * [Distributed Computing](distributed.md)
+        * [Running on Kubernetes](kubernetes.md)
     * Optimization and Debugging
         * [Optimization](optimization/index.md)
         * [Architecture](optimization/architecture.md)

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -58,6 +58,10 @@ DaftContext(_daft_execution_config=<daft.daft.PyDaftExecutionConfig object at 0x
 
 By default, if no address is specified, Daft will spin up a Ray cluster locally on your machine. If you are running Daft on a powerful machine (such as an AWS P3 machine which is equipped with multiple GPUs) this is already very useful because Daft can parallelize its execution of computation across your CPUs and GPUs.
 
+!!! tip "Deploy on Kubernetes"
+
+    Looking to try out Daft with Ray on Kubernetes? Check out our [Kubernetes quickstart](kubernetes.md).
+
 ### Connecting to Remote Ray Clusters
 
 If you already have your own Ray cluster running remotely, you can connect Daft to it by supplying an address with [`set_runner_ray`][daft.context.set_runner_ray]:

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,101 @@
+# Running on Kubernetes
+
+Daft can run on Kubernetes using the Daft quickstart Helm chart. This allows you to test drive both simple single-node jobs and distributed Ray-based workloads on your Kubernetes cluster without any additional dependencies.
+
+!!! warning "Not for Production"
+
+    The Daft quickstart is designed for development and experimentation. For running production Daft workloads on Ray clusters on Kubernetes, use [KubeRay](https://ray-project.github.io/kuberay/), the official Ray operator for Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.x
+- kubectl configured to access your cluster
+
+## Simple Mode
+
+Run a quick Daft job on Kubernetes using the native runner:
+
+=== "🐍 Python"
+
+    ```python
+    # Create a script file: my_script.py
+    # /// script
+    # dependencies = ["daft"]
+    # ///
+    import daft
+
+    # Set IO config for anonymous S3 access
+    daft.set_planning_config(
+        default_io_config=daft.io.IOConfig(s3=daft.io.S3Config(anonymous=True))
+    )
+
+    df = daft.read_parquet(
+        "s3://daft-public-data/tutorials/10-min/sample-data-dog-owners-partitioned.pq/**"
+    )
+
+    df.where(daft.col("age") >= 40).show()
+    ```
+
+Deploy to Kubernetes:
+
+```bash
+# Install the job with your script
+helm install my-job oci://ghcr.io/eventual-inc/daft/quickstart \
+  --set-file job.script=my_script.py
+
+# View logs
+kubectl logs -f job/my-job-quickstart-job
+
+# Cleanup
+helm uninstall my-job
+```
+
+## Distributed Mode
+
+Run a Daft job on a Ray cluster with multiple workers:
+
+=== "🐍 Python"
+
+    ```python
+    # Create a script file: distributed_script.py
+    # /// script
+    # dependencies = ["daft", "ray[client]==2.46.0"]
+    # ///
+    import daft
+    import ray
+
+    ray.init(runtime_env={"pip": ["daft"]})
+
+    df = daft.from_pydict({
+        "a": [3, 2, 5, 6, 1, 4],
+        "b": [True, False, False, True, True, False]
+    })
+
+    df = df.where(df["b"]).sort(df["a"])
+    print(df.collect())
+    ```
+
+Deploy with Ray cluster:
+
+```bash
+# Install with Ray cluster (3 workers)
+helm install distributed-job oci://ghcr.io/eventual-inc/daft/quickstart \
+  --set distributed=true \
+  --set worker.replicas=3 \
+  --set-file job.script=distributed_script.py
+
+# Access Ray Dashboard
+kubectl port-forward service/distributed-job-quickstart-head 8265:8265
+# Open http://localhost:8265 in your browser
+
+# View job logs
+kubectl logs -f job/distributed-job-quickstart-job
+
+# Cleanup
+helm uninstall distributed-job
+```
+
+## What's Next?
+
+Visit the [Helm chart documentation](https://github.com/Eventual-Inc/Daft/tree/main/k8s/charts/quickstart) to try out your own Daft workloads on Kubernetes.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -509,8 +509,11 @@ You can **group** and **aggregate** your data using the [`df.groupby()`][daft.Da
 
 ### What's Next?
 
-Now that you have a basic sense of Daft’s functionality and features, here are some more resources to help you get the most out of Daft:
+Now that you have a basic sense of Daft's functionality and features, here are some more resources to help you get the most out of Daft:
 
+!!! tip "Try this on Kubernetes"
+
+    Want to run this example on Kubernetes? Check out our [Kubernetes quickstart](kubernetes.md).
 
 **Work with your favorite table and catalog formats**:
 


### PR DESCRIPTION
## Changes Made

Adds Kubernetes quickstart to Daft docs: https://www.loom.com/share/c70bb43bf9bc4974a42a79c0cf8ead9d?sid=302cf4cf-b9df-4eea-a4d5-97e067f8a0b3

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
