### PR TITLE
docs: Clean up AGENTS.md structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,10 @@
-# AGENTS.md
-
-## Resources
+# Resources
 
 - https://docs.daft.ai for the user-facing API docs
 - CONTRIBUTING.md for detailed development process
 - https://github.com/Eventual-Inc/Daft for issues, discussions, and PRs
 
-## Dev Workflow
+# Dev Workflow
 
 1) [Once] Set up Python environment and install dependencies: `make .venv`
 2) [Optional] Activate .venv: `source .venv/bin/activate`. Not necessary with Makefile commands.
@@ -14,7 +12,7 @@
 4) If `.proto` files are modified, rebuild protocol buffers code: `make daft-proto`
 5) Run tests. See [Testing Details](#testing-details).
 
-## Testing Details
+# Testing Details
 
 - `make test` runs tests in `tests/` directory. Uses `pytest` under the hood.
   - Must set `DAFT_RUNNER` environment variable to `ray` or `native` to run the tests with the corresponding runner.
@@ -25,7 +23,7 @@
   -  Default `integration`, `benchmark`, and `hypothesis` tests are disabled. Best to run on CI.
 - `make doctests` runs doctests in `daft/` directory. Tests docstrings in Daft APIs.
 
-## PR Conventions
+# PR Conventions
 
-- Titles: Conventional Commits (e.g., `feat: ...`); enforced by `.github/workflows/pr-labeller.yml`.
+- Titles: Conventional Commits format; enforced by `.github/workflows/pr-labeller.yml`.
 - Descriptions: follow `.github/pull_request_template.md`.


### PR DESCRIPTION
## Changes Made

Cleaned up AGENTS.md structure for better readability:
- Removed redundant file name header (`# AGENTS.md`)
- Promoted all section headers from `##` to `#` for cleaner structure
- Simplified PR conventions line by removing example text (`e.g., feat: ...`)

## Related Issues

N/A

## Checklist

- [x] Documented in API Docs (if applicable) - N/A, this is a docs file cleanup
- [x] Documented in User Guide (if applicable) - N/A, this is a docs file cleanup
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation - N/A
- [x] Documentation builds and is formatted properly - Markdown-only changes