### PR TITLE
docs: Add docs to broken link checker

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -31,7 +31,7 @@ jobs:
         command: |
           LOG="$(mktemp)"
           blc ${{ matrix.site.url }} \
-            -ro --verbose \
+            -ro \
             --exclude www.pytorch.org/ \
             --exclude https://github.com/Eventual-Inc/Daft/ \
             --exclude https://twitter.com/daftengine \

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -12,10 +12,20 @@ jobs:
   check-links:
     timeout-minutes: 45
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        site:
+        - url: https://www.daft.ai
+          name: daft.ai
+        - url: https://docs.daft.ai
+          name: docs.daft.ai
+        - url: https://www.eventual.ai
+          name: eventual.ai
     steps:
     - name: setup broken link checker
       run: npm install -g broken-link-checker
-    - name: Check daft.ai
+    - name: Check ${{ matrix.site.name }}
       uses: nick-fields/retry@v3
       with:
         timeout_minutes: 10
@@ -23,7 +33,7 @@ jobs:
         max_attempts: 3
         command: |
           LOG="$(mktemp)"
-          blc https://www.daft.ai \
+          blc ${{ matrix.site.url }} \
             -ro --verbose \
             --exclude www.pytorch.org/ \
             --exclude https://github.com/Eventual-Inc/Daft/ \

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -17,15 +17,12 @@ jobs:
       matrix:
         site:
         - url: https://www.daft.ai
-          name: daft.ai
         - url: https://docs.daft.ai
-          name: docs.daft.ai
         - url: https://www.eventual.ai
-          name: eventual.ai
     steps:
     - name: setup broken link checker
       run: npm install -g broken-link-checker
-    - name: Check ${{ matrix.site.name }}
+    - name: Check ${{ matrix.site.url }}
       uses: nick-fields/retry@v3
       with:
         timeout_minutes: 10


### PR DESCRIPTION
## Changes Made

Found a couple broken links in docs, and turns out the broken link checker doesn't check it.

The broken link checker currently checks `daft.ai`, and doesn't check `docs.daft.ai` because its a subdomain. This adds docs.daft.ai (as well as eventual.ai) to the broken link checker. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
