### PR TITLE
ci: fix property test column name

### DIFF
--- a/tests/property_based_testing/strategies.py
+++ b/tests/property_based_testing/strategies.py
@@ -140,7 +140,7 @@ def columns_dict(
     num_cols = draw(integers(min_value=0, max_value=2), label="Number of additional columns")
     additional_column_names = draw(
         lists(
-            text().filter(lambda name: name not in requested_columns.keys()),
+            text().filter(lambda name: name not in requested_columns.keys() and name != "*"),
             min_size=num_cols,
             max_size=num_cols,
             unique=True,


### PR DESCRIPTION
## Changes Made

Fixes the generation of columns by removing the ability to generate a column named "*", since doing `col("*")` gets all of the columns.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
