### PR TITLE
ci: Only fail broken link checker on 404s

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -34,8 +34,8 @@ jobs:
             -ro \
             | tee "$LOG"
 
-          # Only fail on 404s; print other broken links too.
-          BROKEN_LINES="$(grep 'BROKEN' "$LOG" || true)"
+          # Only fail on 404s; print other broken links too (deduplicated).
+          BROKEN_LINES="$(grep 'BROKEN' "$LOG" | sort -u || true)"
           if [ -n "$BROKEN_LINES" ]; then
             NON_404="$(printf "%s\n" "$BROKEN_LINES" | grep -v 'HTTP_404' || true)"
             ONLY_404="$(printf "%s\n" "$BROKEN_LINES" | grep 'HTTP_404' || true)"

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -32,25 +32,27 @@ jobs:
           LOG="$(mktemp)"
           blc ${{ matrix.site.url }} \
             -ro \
-            --exclude www.pytorch.org/ \
-            --exclude https://github.com/Eventual-Inc/Daft/ \
-            --exclude https://twitter.com/daftengine \
-            --exclude https://www.linkedin.com/company/eventualai/ \
-            --exclude https://x.com/daftengine \
-            --exclude https://www.linkedin.com/showcase/daftengine/ \
-            --exclude https://scarf.sh/ \
-            --exclude https://static.scarf.sh/* \
-            --exclude https://huggingface.co/docs/dataset-viewer/en/parquet \
             | tee "$LOG"
 
-          # Treat HTTP_308 as noise, fail if any BROKEN lines remain.
-          if grep -v 'HTTP_308' "$LOG" | grep -q 'BROKEN'; then
-            echo "Broken links found:"
-            grep -v 'HTTP_308' "$LOG" | grep 'BROKEN' || true
-            exit 1
-          fi
+          # Only fail on 404s; print other broken links too.
+          BROKEN_LINES="$(grep 'BROKEN' "$LOG" || true)"
+          if [ -n "$BROKEN_LINES" ]; then
+            NON_404="$(printf "%s\n" "$BROKEN_LINES" | grep -v 'HTTP_404' || true)"
+            ONLY_404="$(printf "%s\n" "$BROKEN_LINES" | grep 'HTTP_404' || true)"
 
-          echo "No broken links detected."
+            if [ -n "$NON_404" ]; then
+              echo "Broken links (non-404, non-fatal):"
+              printf "%s\n" "$NON_404"
+            fi
+
+            if [ -n "$ONLY_404" ]; then
+              echo "Broken links (404 - failing):"
+              printf "%s\n" "$ONLY_404"
+              exit 1
+            fi
+          else
+            echo "No broken links detected."
+          fi
   notify_on_failure:
     runs-on: self-hosted
     if: failure()

--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -32,6 +32,9 @@ jobs:
           LOG="$(mktemp)"
           blc ${{ matrix.site.url }} \
             -ro \
+            --exclude https://scarf.sh/ \
+            --exclude https://static.scarf.sh/* \
+            --exclude http://www.allaboutcookies.org/ \
             | tee "$LOG"
 
           # Only fail on 404s; print other broken links too (deduplicated).


### PR DESCRIPTION
## Changes Made

Broken link checker by default fails on anything non 200, but we don't care about pages that are redirects or ones that denies bots. We don't want to exclude the domain because they might eventually become 404s though, like https://platform.openai.com/docs/guides/embeddings could totally change.

This PR we only fail if there are 404s, but still print out any link that was 'broken'.

```
   Broken links (non-404, non-fatal):
  ├─BROKEN─ http://www.daft.ai/ (HTTP_308)
  ├─BROKEN─ http://www.daft.ai/slack (HTTP_308)
  ├─BROKEN─ https://code.visualstudio.com/docs/editor/debugging#_launch-configurations (HTTP_500)
  ├─BROKEN─ https://dl.acm.org/doi/abs/10.1145/2670979.2670997 (HTTP_403)
  ├─BROKEN─ https://dl.acm.org/doi/pdf/10.1145/2670979.2670997 (HTTP_403)
  ├─BROKEN─ https://ieeexplore.ieee.org/document/666900 (HTTP_418)
  ├─BROKEN─ https://linux-audit.com/protect-ptrace-processes-kernel-yama-ptrace_scope (HTTP_406)
  ├─BROKEN─ https://platform.openai.com/docs/guides/embeddings (HTTP_403)
  ├─BROKEN─ https://platform.openai.com/docs/models (HTTP_403)
  ├─BROKEN─ https://platform.openai.com/docs/models/text-embedding-3-small (HTTP_403)
  ├─BROKEN─ https://platform.openai.com/settings/organization/api-keys (HTTP_403)
  ├─BROKEN─ https://www.daft.ai/slack (HTTP_308)
  ├─BROKEN─ https://www.daft.ai/slack?utm_source=docs&utm_medium=header&utm_campaign=docs_slack (HTTP_308)
  ├─BROKEN─ https://x.com/daftengine (HTTP_403)
  Broken links (404 - failing):
  ├─BROKEN─ https://docs.daft.ai/en/stable/examples/api/dataframe#daft.DataFrame.write_turbopuffer (HTTP_404)
  ├─BROKEN─ https://docs.daft.ai/en/stable/examples/api/expressions/#daft.expressions.Expression.minhash (HTTP_404)
  ├─BROKEN─ https://docs.daft.ai/en/stable/examples/api/expressions/#daft.expressions.expressions.ExpressionStringNamespace.normalize (HTTP_404)
  ├─BROKEN─ https://docs.daft.ai/en/stable/examples/api/io/#daft.read_warc (HTTP_404)
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
