### PR TITLE
ci: Pin pydantic version in `provision.py` for iceberg tests

### DIFF
--- a/tests/integration/iceberg/docker-compose/Dockerfile
+++ b/tests/integration/iceberg/docker-compose/Dockerfile
@@ -62,7 +62,8 @@ RUN chmod u+x /opt/spark/sbin/* && \
 
 RUN pip3 install -q ipython
 
-RUN pip3 install "pyiceberg[s3fs]==${PYICEBERG_VERSION} pydantic==2.11.0"
+RUN pip3 install "pyiceberg[s3fs]==${PYICEBERG_VERSION}"
+RUN pip3 install "pydantic==2.11.0"
 
 RUN pip3 install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cpu
 


### PR DESCRIPTION
## Changes Made

https://github.com/apache/iceberg-python/issues/2590

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
