### PR TITLE
fix: support serialize and deserialize LazyImport

### DIFF
--- a/daft/lazy_import.py
+++ b/daft/lazy_import.py
@@ -66,11 +66,11 @@ class LazyImport:
                 return lazy_submodule
             raise e
 
-    def __getstate__(self) -> dict:
+    def __getstate__(self) -> dict[str, Any]:
         # Only serialize the module name, don't serialize the loaded module to avoid pickling issues
-        return {'_module_name': self._module_name}
+        return {"_module_name": self._module_name}
 
-    def __setstate__(self, state: dict) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         # Restore the module name and initialize module as None
-        self._module_name = state['_module_name']
+        self._module_name = state["_module_name"]
         self._module = None


### PR DESCRIPTION
## Changes Made

Support serialize and deserialize LazyImport

## Related Issues

If the daft job include some library like pyarrow by LazyImport, it will deserialize failed.

The root reason is LazyImport didn't implement `__getattr__`  and `__setattr__` , during deserialize LazyImport, since `__setattr__` is not found, pickle will calling `__getattr__` to access `__setattr__`, but `_module` is not set, will continue to access `_module` via `__getattr__` and loop in calling `__getattr__`, and then exceeded maximun recursion depth (edited) 

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
