### PR TITLE
feat!: Catch transient errors on turbopuffer writes

### DIFF
--- a/daft/io/turbopuffer/turbopuffer_data_sink.py
+++ b/daft/io/turbopuffer/turbopuffer_data_sink.py
@@ -151,7 +151,10 @@ class TurbopufferDataSink(DataSink[dict[str, Any]]):
                 )
             arrow_table = arrow_table.rename_columns({self._vector_column: "vector"})
 
-        return arrow_table.filter(~pc.field("id").is_null())
+        # Use compute function approach for pyarrow 8.0.0 compatibility
+        id_column = arrow_table.column("id")
+        mask = pc.invert(pc.is_null(id_column))
+        return arrow_table.filter(mask)
 
     def _write_with_error_handling(
         self, namespace: turbopuffer.Namespace, arrow_table: pa.Table

--- a/tests/io/test_turbopuffer_write.py
+++ b/tests/io/test_turbopuffer_write.py
@@ -2,15 +2,11 @@ from __future__ import annotations
 
 from unittest.mock import Mock, patch
 
-import pyarrow as pa
 import pytest
 import turbopuffer
 
 import daft
 from tests.conftest import get_tests_daft_runner_name
-
-# Skip tests for pyarrow 8.0.0
-PYARROW_8_0_0_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) == (8, 0, 0)
 
 
 @pytest.fixture
@@ -92,8 +88,8 @@ def test_resilience_to_transient_errors(sample_df, error_class, status_code, err
 
 
 @pytest.mark.skipif(
-    get_tests_daft_runner_name() == "ray" or PYARROW_8_0_0_SKIP,
-    reason="Mocking the data sink's dependencies doesn't work in Ray execution environment or pyarrow 8.0.0",
+    get_tests_daft_runner_name() == "ray",
+    reason="Mocking the data sink's dependencies doesn't work in Ray execution environment",
 )
 @pytest.mark.parametrize(
     "error_class,status_code,error_message",


### PR DESCRIPTION
## Changes Made

The turbopuffer client library [retries transient errors 4 times with appropriate back-offs and jitters](https://github.com/turbopuffer/turbopuffer-python?tab=readme-ov-file#retries). In the event that we receive a transient error from the client library, instead of causing the entire script to fail, we should simply track these transient errors and report the number of failed rows later on. Non-transient errors should cause a script to fail fast, as it did before. 

In the future, this should ideally extend to the proposal of splitting results so that we keep track of what rows resulted in errors so that we can retry them later. For now we simply track the number of failed rows.
