### PR TITLE
ci: disable running tpch profiling on push

### DIFF
--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -1,8 +1,10 @@
 name: Run Profiling on the TPCH Benchmark
 
 on:
-  push:
-    branches: [main]
+  # disabling because it is failing and we don't seem to use the results anyway
+  # can still be run manually with the workflow_dispatch trigger
+  # push:
+  #   branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Changes Made

This job has been failing for a while, but I don't think we check the profiling results anymore anyway, so I'm disabling it. Additionally:
- TPC-H is still tested with other tests
- this workflow can still be run manually if someone wants to.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly
