### PR TITLE
docs: fix daft.File usage examples

### DIFF
--- a/docs/examples/audio-transcription.md
+++ b/docs/examples/audio-transcription.md
@@ -66,7 +66,8 @@ def transcribe(file: daft.File) -> str:
     """
     Transcribes an audio file using openai whisper.
     """
-    audio, _ = sf.read(file, dtype = 'float32')
+    with file.open() as f:
+        audio, _ = sf.read(f, dtype = 'float32')
     result = model.transcribe(audio, verbose=True)
 
 
@@ -145,7 +146,8 @@ model = whisper.load_model("tiny")
 @daft.func
 def transcribe(file: daft.File) -> str:
     """Transcribes an audio file using OpenAI Whisper"""
-    audio, _ = sf.read(file, dtype='float32')
+    with file.open() as f:
+        audio, _ = sf.read(f, dtype='float32')
     result = model.transcribe(audio)
     return result['text']
 

--- a/docs/modalities/urls.md
+++ b/docs/modalities/urls.md
@@ -91,7 +91,8 @@ The `File` datatype is preferable when dealing with large files that don't fit i
     @daft.func
     def detect_file_type(file: daft.File) -> str:
         # Read just the first 12 bytes to identify file type
-        header = file.read(12)
+        with file.open() as f:
+            header = f.read(12)
 
         # Common file signatures (magic numbers)
         if header.startswith(b"\xff\xd8\xff"):


### PR DESCRIPTION
## Changes Made

We changed `daft.File` to be immutable and require the use of a context manager to read files in #5288, but we missed changing a few examples. This PR fixes them.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [x] Documented in API Docs (if applicable)
- [x] Documented in User Guide (if applicable)
- [x] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly
