### PR TITLE
fix(flotilla): Set flotilla actor cpu requests to 1

### DIFF
--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -189,7 +189,6 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
                     node_id=node["NodeID"],
                     soft=False,
                 ),
-                num_cpus=1,
             ).remote(
                 num_cpus=int(node["Resources"]["CPU"]),
                 num_gpus=int(node["Resources"].get("GPU", 0)),


### PR DESCRIPTION
## Changes Made

Set the default cpu request for UDF actors to 1, so they don't get scheduled on the head node. Users can always override this.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
