### PR TITLE
docs: update the example to access S3-compatible services

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -519,7 +519,7 @@ class S3Config:
         >>> # For S3-compatible services (e.g. Volcengine TOS)
         >>> io_config = IOConfig(
         ...     s3=S3Config(
-        ...         endpoint_url=https://tos-s3-{region}.ivolces.com",
+        ...         endpoint_url="https://tos-s3-{region}.ivolces.com",
         ...         region_name="{region}",
         ...         force_virtual_addressing=True,
         ...         verify_ssl=True,


### PR DESCRIPTION
## Changes Made
Updates the S3-compatible services example in S3Config docstring to add HTTPS protocol and make region placeholder more generic.
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
