### PR TITLE
chore: bump pyo3 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,7 +4851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "serde",
  "serde_core",
 ]
@@ -5692,9 +5692,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "numpy"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f1dee9aa8d3f6f8e8b9af3803006101bb3653866ef056d530d53ae68587191"
+checksum = "9b2dba356160b54f5371b550575b78130a54718b4c6e46b3f33a6da74a27e78b"
 dependencies = [
  "libc",
  "ndarray",
@@ -6454,9 +6454,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -6475,9 +6475,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73cc6b1b7d8b3cef02101d37390dbdfe7e450dfea14921cae80a9534ba59ef2"
+checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
 dependencies = [
  "futures",
  "once_cell",
@@ -6489,9 +6489,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes-macros"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca31e43a0f205f2960208938135e37e579e61e10b36b4e7f49b0e8f60fab5b83"
+checksum = "c29bc5c673e36a8102d0b9179149c1bb59990d8db4f3ae58bd7dceccab90b951"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6500,19 +6500,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -6520,9 +6519,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.12.4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45192e5e4a4d2505587e27806c7b710c231c40c56f3bfc19535d0bb25df52264"
+checksum = "d359e20231345f21a3b5b6aea7e73f4dc97e1712ef3bfe2d88997ac6a308d784"
 dependencies = [
  "arc-swap",
  "log",
@@ -6531,9 +6530,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -6543,9 +6542,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,7 +295,7 @@ ndarray = "0.16.1"
 num-derive = "0.4.2"
 num-format = "0.4.4"
 num-traits = "0.2"
-numpy = "0.25.0"
+numpy = "0.26.0"
 opentelemetry = {version = "0.29", features = ["trace", "metrics"]}
 opentelemetry-otlp = {version = "0.29", features = ["grpc-tonic"]}
 opentelemetry_sdk = "0.29"
@@ -371,14 +371,14 @@ path = "src/parquet2"
 
 [workspace.dependencies.pyo3]
 features = ["extension-module", "multiple-pymethods", "abi3-py39", "indexmap", "chrono", "chrono-tz"]
-version = "0.25.1"
+version = "0.26"
 
 [workspace.dependencies.pyo3-async-runtimes]
 features = ["attributes", "tokio-runtime"]
-version = "0.25"
+version = "0.26"
 
 [workspace.dependencies.pyo3-log]
-version = "0.12.1"
+version = "0.13.1"
 
 [workspace.dependencies.serde]
 features = ["derive", "rc"]

--- a/src/common/arrow-ffi/src/lib.rs
+++ b/src/common/arrow-ffi/src/lib.rs
@@ -45,7 +45,7 @@ pub fn to_py_array<'py>(
 
     // fix_child_array_slice_offsets serializes and deserializes into ipc, and is a parallelizable operation.
     // We allow threads here to avoid blocking the GIL.
-    let arrow_arr = py.allow_threads(|| {
+    let arrow_arr = py.detach(|| {
         let fixed_array = fix_child_array_slice_offsets(array);
         Box::new(ffi::export_array_to_c(fixed_array))
     });
@@ -70,7 +70,7 @@ pub fn field_to_py(
     py: Python,
     field: &arrow2::datatypes::Field,
     pyarrow: &Bound<PyModule>,
-) -> PyResult<PyObject> {
+) -> PyResult<Py<PyAny>> {
     let schema = Box::new(ffi::export_field_to_c(field));
     let schema_ptr: *const ffi::ArrowSchema = &raw const *schema;
 

--- a/src/common/file-formats/src/python.rs
+++ b/src/common/file-formats/src/python.rs
@@ -52,7 +52,7 @@ impl PyFileFormatConfig {
 
     /// Get the underlying data source config.
     #[getter]
-    fn get_config(&self, py: Python) -> PyResult<PyObject> {
+    fn get_config(&self, py: Python) -> PyResult<Py<PyAny>> {
         match self.0.as_ref() {
             FileFormatConfig::Parquet(config) => config
                 .clone()

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -714,7 +714,7 @@ pub struct PyS3CredentialsProvider {
         serialize_with = "serialize_py_object",
         deserialize_with = "deserialize_py_object"
     )]
-    pub provider: Arc<PyObject>,
+    pub provider: Arc<Py<PyAny>>,
     pub hash: isize,
 }
 
@@ -761,7 +761,7 @@ impl S3CredentialsProvider for PyS3CredentialsProvider {
     }
 
     fn provide_credentials(&self) -> DaftResult<crate::S3Credentials> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_creds = self.provider.call0(py)?;
             Ok(py_creds.extract::<S3Credentials>(py)?.credentials)
         })

--- a/src/common/ndarray/src/python.rs
+++ b/src/common/ndarray/src/python.rs
@@ -18,7 +18,7 @@ pub enum NumpyArray<'py> {
     U64(Bound<'py, PyArrayDyn<u64>>),
     F32(Bound<'py, PyArrayDyn<f32>>),
     F64(Bound<'py, PyArrayDyn<f64>>),
-    Py(Bound<'py, PyArrayDyn<PyObject>>),
+    Py(Bound<'py, PyArrayDyn<Py<PyAny>>>),
 }
 
 impl<'py> NumpyArray<'py> {

--- a/src/common/partitioning/src/lib.rs
+++ b/src/common/partitioning/src/lib.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "python")]
 use {
     common_py_serde::{deserialize_py_object, serialize_py_object},
-    pyo3::PyObject,
+    pyo3::{Py, PyAny},
 };
 
 /// Common trait interface for dataset partitioning, defined in this shared crate to avoid circular dependencies.
@@ -152,7 +152,7 @@ pub enum PartitionCacheEntry {
     )]
     #[cfg(feature = "python")]
     /// in python, the partition cache is a weakvalue dictionary, so it will store the entry as long as this reference exists.
-    Python(Arc<PyObject>),
+    Python(Arc<Py<PyAny>>),
 
     Rust {
         key: String,
@@ -177,7 +177,7 @@ impl PartitionCacheEntry {
         use pyo3::Python;
 
         match self {
-            Self::Python(obj) => Python::with_gil(|py| {
+            Self::Python(obj) => Python::attach(|py| {
                 let key = obj.getattr(py, "key").unwrap();
                 key.extract::<String>(py).unwrap()
             }),

--- a/src/common/py-serde/src/python.rs
+++ b/src/common/py-serde/src/python.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 #[cfg(feature = "python")]
-use pyo3::{Bound, PyAny, PyObject, PyResult, Python, types::PyAnyMethods};
+use pyo3::{Bound, Py, PyAny, PyResult, Python, types::PyAnyMethods};
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{Error as DeError, Visitor},
@@ -14,7 +14,7 @@ use serde::{
 };
 
 #[cfg(feature = "python")]
-pub fn pickle_dumps(py: Python, obj: &PyObject) -> PyResult<Vec<u8>> {
+pub fn pickle_dumps(py: Python, obj: &Py<PyAny>) -> PyResult<Vec<u8>> {
     py.import(pyo3::intern!(py, "daft.pickle"))?
         .getattr(pyo3::intern!(py, "dumps"))?
         .call1((obj,))?
@@ -29,12 +29,12 @@ pub fn pickle_loads(py: Python, bytes: impl AsRef<[u8]>) -> PyResult<Bound<PyAny
 }
 
 #[cfg(feature = "python")]
-pub fn serialize_py_object<S>(obj: &PyObject, s: S) -> Result<S::Ok, S::Error>
+pub fn serialize_py_object<S>(obj: &Py<PyAny>, s: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     let bytes =
-        Python::with_gil(|py| pickle_dumps(py, obj).map_err(|e| SerError::custom(e.to_string())))?;
+        Python::attach(|py| pickle_dumps(py, obj).map_err(|e| SerError::custom(e.to_string())))?;
 
     s.serialize_bytes(bytes.as_slice())
 }
@@ -43,7 +43,7 @@ struct PyObjectVisitor;
 
 #[cfg(feature = "python")]
 impl<'de> Visitor<'de> for PyObjectVisitor {
-    type Value = PyObject;
+    type Value = Py<PyAny>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter.write_str("a byte array containing the pickled partition bytes")
@@ -53,7 +53,7 @@ impl<'de> Visitor<'de> for PyObjectVisitor {
     where
         E: DeError,
     {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             py.import(pyo3::intern!(py, "daft.pickle"))
                 .and_then(|m| m.getattr(pyo3::intern!(py, "loads")))
                 .and_then(|f| Ok(f.call1((v,))?.into()))
@@ -82,7 +82,7 @@ impl<'de> Visitor<'de> for PyObjectVisitor {
 }
 
 #[cfg(feature = "python")]
-pub fn deserialize_py_object<'de, D>(d: D) -> Result<Arc<PyObject>, D::Error>
+pub fn deserialize_py_object<'de, D>(d: D) -> Result<Arc<Py<PyAny>>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -98,7 +98,10 @@ macro_rules! impl_bincode_py_state_serialization {
             pub fn __reduce__<'py>(
                 &self,
                 py: Python<'py>,
-            ) -> PyResult<(PyObject, (pyo3::Bound<'py, pyo3::types::PyBytes>,))> {
+            ) -> PyResult<(
+                pyo3::Py<pyo3::PyAny>,
+                (pyo3::Bound<'py, pyo3::types::PyBytes>,),
+            )> {
                 use pyo3::{
                     PyErr, PyTypeInfo,
                     exceptions::PyRuntimeError,
@@ -136,13 +139,13 @@ pub struct PyObjectWrapper(
         serialize_with = "serialize_py_object",
         deserialize_with = "deserialize_py_object"
     )]
-    pub Arc<PyObject>,
+    pub Arc<Py<PyAny>>,
 );
 
 #[cfg(feature = "python")]
 impl PartialEq for PyObjectWrapper {
     fn eq(&self, other: &Self) -> bool {
-        Python::with_gil(|py| self.0.bind(py).eq(other.0.bind(py)).unwrap())
+        Python::attach(|py| self.0.bind(py).eq(other.0.bind(py)).unwrap())
     }
 }
 
@@ -152,7 +155,7 @@ impl Eq for PyObjectWrapper {}
 #[cfg(feature = "python")]
 impl Hash for PyObjectWrapper {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let py_obj_hash = Python::with_gil(|py| self.0.bind(py).hash());
+        let py_obj_hash = Python::attach(|py| self.0.bind(py).hash());
         match py_obj_hash {
             // If Python object is hashable, hash the Python-side hash.
             Ok(py_obj_hash) => py_obj_hash.hash(state),
@@ -167,8 +170,8 @@ impl Hash for PyObjectWrapper {
 }
 
 #[cfg(feature = "python")]
-impl From<Arc<PyObject>> for PyObjectWrapper {
-    fn from(value: Arc<PyObject>) -> Self {
+impl From<Arc<Py<PyAny>>> for PyObjectWrapper {
+    fn from(value: Arc<Py<PyAny>>) -> Self {
         Self(value)
     }
 }

--- a/src/common/resource-request/src/lib.rs
+++ b/src/common/resource-request/src/lib.rs
@@ -8,7 +8,7 @@ use common_hashable_float_wrapper::FloatWrapper;
 use common_py_serde::impl_bincode_py_state_serialization;
 #[cfg(feature = "python")]
 use pyo3::{
-    Bound, PyObject, PyResult, Python, pyclass,
+    Bound, PyResult, Python, pyclass,
     pyclass::CompareOp,
     pymethods,
     types::{PyModule, PyModuleMethods},

--- a/src/daft-ai/src/provider.rs
+++ b/src/daft-ai/src/provider.rs
@@ -10,5 +10,5 @@ pub trait Provider: Sync + Send + std::fmt::Debug {
 
     /// Creates (or extracts) a Python object that subclasses the Provider ABC.
     #[cfg(feature = "python")]
-    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::PyObject>;
+    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>>;
 }

--- a/src/daft-ai/src/python.rs
+++ b/src/daft-ai/src/python.rs
@@ -1,20 +1,20 @@
-use pyo3::{Bound, PyObject, PyResult, Python, intern, prelude::*, types::PyModule};
+use pyo3::{Bound, Py, PyAny, PyResult, Python, intern, prelude::*, types::PyModule};
 
 use crate::provider::Provider;
 
 /// Implement the Provider trait for a python Provider(ABC)
 #[derive(Debug)]
-pub struct PyProviderWrapper(PyObject);
+pub struct PyProviderWrapper(Py<PyAny>);
 
-impl From<PyObject> for PyProviderWrapper {
-    fn from(value: PyObject) -> Self {
+impl From<Py<PyAny>> for PyProviderWrapper {
+    fn from(value: Py<PyAny>) -> Self {
         Self(value)
     }
 }
 
 impl Provider for PyProviderWrapper {
     fn name(&self) -> String {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let provider = self.0.bind(py);
             let name = provider
                 .getattr(intern!(py, "name"))
@@ -24,7 +24,7 @@ impl Provider for PyProviderWrapper {
         })
     }
 
-    fn to_py(&self, py: Python<'_>) -> PyResult<PyObject> {
+    fn to_py(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         Ok(self.0.clone_ref(py))
     }
 }

--- a/src/daft-catalog/src/catalog.rs
+++ b/src/daft-catalog/src/catalog.rs
@@ -33,5 +33,5 @@ pub trait Catalog: Sync + Send + std::fmt::Debug {
 
     /// Create/extract a Python object that subclasses the Catalog ABC
     #[cfg(feature = "python")]
-    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::PyObject>;
+    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>>;
 }

--- a/src/daft-catalog/src/impls/memory.rs
+++ b/src/daft-catalog/src/impls/memory.rs
@@ -250,7 +250,7 @@ impl Catalog for MemoryCatalog {
     }
 
     #[cfg(feature = "python")]
-    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::PyObject> {
+    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
         use pyo3::{intern, types::PyAnyMethods};
 
         use crate::python::PyCatalog;
@@ -310,7 +310,7 @@ impl Table for MemoryTable {
 
         let pset = MicroPartitionSet::empty();
         let runner = daft_runners::get_or_create_runner()?;
-        pyo3::Python::with_gil(|py| {
+        pyo3::Python::attach(|py| {
             for (i, res) in runner.run_iter_tables(py, plan, None)?.enumerate() {
                 let mp = res?;
                 pset.set_partition(i, &mp)?;
@@ -354,7 +354,7 @@ impl Table for MemoryTable {
     }
 
     #[cfg(feature = "python")]
-    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::PyObject> {
+    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
         use pyo3::{intern, types::PyAnyMethods};
 
         use crate::python::PyTable;

--- a/src/daft-catalog/src/python/mod.rs
+++ b/src/daft-catalog/src/python/mod.rs
@@ -34,7 +34,7 @@ impl PyCatalog {
         ident: PyIdentifier,
         schema: PySchema,
         py: Python,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<Py<PyAny>> {
         self.0.create_table(&ident.0, schema.schema)?.to_py(py)
     }
 
@@ -45,7 +45,7 @@ impl PyCatalog {
         Ok(self.0.drop_table(&ident.0)?)
     }
 
-    fn get_table(&self, ident: PyIdentifier, py: Python) -> PyResult<PyObject> {
+    fn get_table(&self, ident: PyIdentifier, py: Python) -> PyResult<Py<PyAny>> {
         self.0.get_table(&ident.0)?.to_py(py)
     }
 
@@ -78,7 +78,7 @@ impl PyCatalog {
     }
 
     #[staticmethod]
-    fn new_memory_catalog(name: String, py: Python) -> PyResult<PyObject> {
+    fn new_memory_catalog(name: String, py: Python) -> PyResult<Py<PyAny>> {
         MemoryCatalog::new(name).to_py(py)
     }
 }
@@ -138,7 +138,7 @@ impl PyTable {
     }
 
     #[staticmethod]
-    fn new_memory_table(name: String, schema: PySchema, py: Python) -> PyResult<PyObject> {
+    fn new_memory_table(name: String, schema: PySchema, py: Python) -> PyResult<Py<PyAny>> {
         MemoryTable::new(name, schema.schema)?.to_py(py)
     }
 }

--- a/src/daft-catalog/src/table.rs
+++ b/src/daft-catalog/src/table.rs
@@ -62,7 +62,7 @@ pub trait Table: Sync + Send + std::fmt::Debug {
 
     /// Create/extract a Python object that subclasses the Table ABC
     #[cfg(feature = "python")]
-    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::PyObject>;
+    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>>;
 }
 
 /// View is an immutable Table backed by a DataFrame.
@@ -126,7 +126,7 @@ impl Table for View {
     }
 
     #[cfg(feature = "python")]
-    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::PyObject> {
+    fn to_py(&self, py: pyo3::Python<'_>) -> pyo3::PyResult<pyo3::Py<pyo3::PyAny>> {
         use pyo3::{intern, types::PyAnyMethods};
 
         use crate::python::PyTable;

--- a/src/daft-cli/src/python.rs
+++ b/src/daft-cli/src/python.rs
@@ -71,7 +71,7 @@ fn run_dashboard(py: Python, args: DashboardArgs) {
         }
         // Necessary to allow other threads to acquire the GIL
         // Such as for Python array deserialization
-        py.allow_threads(|| {
+        py.detach(|| {
             std::thread::sleep(std::time::Duration::from_millis(100));
         });
     }

--- a/src/daft-connect/src/execute.rs
+++ b/src/daft-connect/src/execute.rs
@@ -38,7 +38,7 @@ impl ConnectSession {
     ) -> ConnectResult<BoxStream<'_, DaftResult<Arc<MicroPartition>>>> {
         let runner = daft_runners::get_or_create_runner()?;
         let result_set = tokio::task::spawn_blocking(move || {
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 Ok::<_, DaftError>(runner.run_iter_tables(py, lp, None)?.collect::<Vec<_>>())
             })
         })

--- a/src/daft-connect/src/spark_analyzer.rs
+++ b/src/daft-connect/src/spark_analyzer.rs
@@ -70,7 +70,7 @@ impl SparkAnalyzer<'_> {
         tables: Vec<RecordBatch>,
     ) -> ConnectResult<LogicalPlanBuilder> {
         let mp = MicroPartition::new_loaded(schema, Arc::new(tables), None);
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             // Convert MicroPartition to a logical plan using Python interop.
             let py_micropartition = py
                 .import(intern!(py, "daft.recordbatch"))?
@@ -255,7 +255,7 @@ impl SparkAnalyzer<'_> {
         let step = usize::try_from(step).wrap_err("step must be a positive integer")?;
         ensure!(step > 0, "step must be greater than 0");
 
-        let plan = Python::with_gil(|py| {
+        let plan = Python::attach(|py| {
             let range_module =
                 PyModule::import(py, "daft.io._range").wrap_err("Failed to import range module")?;
 

--- a/src/daft-context/src/partition_cache.rs
+++ b/src/daft-context/src/partition_cache.rs
@@ -67,7 +67,7 @@ pub fn put_partition_set_into_cache(
     use pyo3::{Python, types::PyAnyMethods};
 
     let runner = daft_runners::get_or_create_runner()?;
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // get runner as python object so we can add a partition to the cache
         let py_runner = runner.to_pyobj(py);
         let py_runner = py_runner.bind(py);

--- a/src/daft-context/src/python.rs
+++ b/src/daft-context/src/python.rs
@@ -71,30 +71,30 @@ impl PyDaftContext {
 
     #[getter(_daft_execution_config)]
     pub fn get_daft_execution_config(&self, py: Python) -> PyResult<PyDaftExecutionConfig> {
-        let config = py.allow_threads(|| self.inner.execution_config());
+        let config = py.detach(|| self.inner.execution_config());
         let config = PyDaftExecutionConfig { config };
         Ok(config)
     }
 
     #[getter(_daft_planning_config)]
     pub fn get_daft_planning_config(&self, py: Python) -> PyResult<PyDaftPlanningConfig> {
-        let config = py.allow_threads(|| self.inner.planning_config());
+        let config = py.detach(|| self.inner.planning_config());
         let config = PyDaftPlanningConfig { config };
         Ok(config)
     }
 
     #[setter(_daft_execution_config)]
     pub fn set_daft_execution_config(&self, py: Python, config: PyDaftExecutionConfig) {
-        py.allow_threads(|| self.inner.set_execution_config(config.config));
+        py.detach(|| self.inner.set_execution_config(config.config));
     }
 
     #[setter(_daft_planning_config)]
     pub fn set_daft_planning_config(&self, py: Python, config: PyDaftPlanningConfig) {
-        py.allow_threads(|| self.inner.set_planning_config(config.config));
+        py.detach(|| self.inner.set_planning_config(config.config));
     }
 
-    pub fn attach_subscriber(&self, py: Python, alias: String, subscriber: PyObject) {
-        py.allow_threads(|| {
+    pub fn attach_subscriber(&self, py: Python, alias: String, subscriber: Py<PyAny>) {
+        py.detach(|| {
             self.inner.attach_subscriber(
                 alias,
                 Arc::new(subscribers::python::PySubscriberWrapper(subscriber)),
@@ -103,7 +103,7 @@ impl PyDaftContext {
     }
 
     pub fn detach_subscriber(&self, py: Python, alias: &str) -> PyResult<()> {
-        py.allow_threads(|| self.inner.detach_subscriber(alias))?;
+        py.detach(|| self.inner.detach_subscriber(alias))?;
         Ok(())
     }
 
@@ -113,7 +113,7 @@ impl PyDaftContext {
         query_id: String,
         metadata: PyQueryMetadata,
     ) -> PyResult<()> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .notify_query_start(query_id.into(), metadata.into())
         })?;
@@ -121,7 +121,7 @@ impl PyDaftContext {
     }
 
     pub fn notify_query_end(&self, py: Python, query_id: String) -> PyResult<()> {
-        py.allow_threads(|| self.inner.notify_query_end(query_id.into()))?;
+        py.detach(|| self.inner.notify_query_end(query_id.into()))?;
         Ok(())
     }
 
@@ -131,12 +131,12 @@ impl PyDaftContext {
         query_id: String,
         result: PyMicroPartition,
     ) -> PyResult<()> {
-        py.allow_threads(|| self.inner.notify_result_out(query_id.into(), result.into()))?;
+        py.detach(|| self.inner.notify_result_out(query_id.into(), result.into()))?;
         Ok(())
     }
 
     pub fn notify_optimization_start(&self, py: Python, query_id: String) -> PyResult<()> {
-        py.allow_threads(|| self.inner.notify_optimization_start(query_id.into()))?;
+        py.detach(|| self.inner.notify_optimization_start(query_id.into()))?;
         Ok(())
     }
 
@@ -146,7 +146,7 @@ impl PyDaftContext {
         query_id: String,
         optimized_plan: String,
     ) -> PyResult<()> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.inner
                 .notify_optimization_end(query_id.into(), optimized_plan.into())
         })?;

--- a/src/daft-core/src/array/from_iter.rs
+++ b/src/daft-core/src/array/from_iter.rs
@@ -6,7 +6,7 @@ use arrow2::{
 };
 use common_error::DaftResult;
 #[cfg(feature = "python")]
-use pyo3::PyObject;
+use pyo3::{Py, PyAny};
 
 use super::DataArray;
 use crate::{
@@ -200,7 +200,7 @@ impl PythonArray {
     /// Assumes that all Python objects are not None.
     pub fn from_iter(
         name: &str,
-        iter: impl arrow2::trusted_len::TrustedLen<Item = Option<Arc<PyObject>>>,
+        iter: impl arrow2::trusted_len::TrustedLen<Item = Option<Arc<Py<PyAny>>>>,
     ) -> Self {
         use arrow2::bitmap::MutableBitmap;
         use pyo3::Python;
@@ -211,11 +211,11 @@ impl PythonArray {
         let mut values = Vec::with_capacity(len);
         let mut validity = MutableBitmap::with_capacity(len);
 
-        let pynone = Arc::new(Python::with_gil(|py| py.None()));
+        let pynone = Arc::new(Python::attach(|py| py.None()));
         for v in iter {
             if let Some(obj) = &v {
                 debug_assert!(
-                    Python::with_gil(|py| !obj.is_none(py)),
+                    Python::attach(|py| !obj.is_none(py)),
                     "PythonArray::from_iter requires all Python objects to be not None"
                 );
             }
@@ -259,7 +259,7 @@ impl PythonArray {
         let mut values = Vec::with_capacity(len);
         let mut validity = MutableBitmap::with_capacity(len);
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             use pyo3::PyErr;
 
             let pynone = Arc::new(py.None());

--- a/src/daft-core/src/array/growable/python_growable.rs
+++ b/src/daft-core/src/array/growable/python_growable.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use daft_schema::{dtype::DataType, field::Field};
-use pyo3::PyObject;
+use pyo3::{Py, PyAny};
 
 use crate::{
     array::growable::{Growable, bitmap_growable::ArrowBitmapGrowable},
@@ -14,7 +14,7 @@ pub struct PythonGrowable<'a> {
     name: String,
     dtype: DataType,
     arr_refs: Vec<&'a PythonArray>,
-    buffer: Vec<Arc<PyObject>>,
+    buffer: Vec<Arc<Py<PyAny>>>,
     growable_validity: Option<ArrowBitmapGrowable<'a>>,
 }
 
@@ -57,7 +57,7 @@ impl Growable for PythonGrowable<'_> {
     }
 
     fn add_nulls(&mut self, additional: usize) {
-        let pynone = Arc::new(pyo3::Python::with_gil(|py| py.None()));
+        let pynone = Arc::new(pyo3::Python::attach(|py| py.None()));
         self.buffer.extend(std::iter::repeat_n(pynone, additional));
         if let Some(growable_validity) = &mut self.growable_validity {
             growable_validity.add_nulls(additional);

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -45,7 +45,7 @@ use crate::{
 #[cfg(feature = "python")]
 impl Series {
     fn cast_to_python(&self) -> DaftResult<Self> {
-        let py_values = Python::with_gil(|py| {
+        let py_values = Python::attach(|py| {
             use pyo3::IntoPyObjectExt;
 
             self.to_literals()
@@ -601,7 +601,7 @@ impl PythonArray {
 
         // TODO: optimize this.
         // Currently this does PythonArray -> Vec<Literal> -> Series -> Series::cast
-        let literals = Python::with_gil(|py| {
+        let literals = Python::attach(|py| {
             self.values()
                 .iter()
                 .map(|ob| Literal::from_pyobj(ob.bind(py), Some(dtype)))

--- a/src/daft-core/src/array/ops/full.rs
+++ b/src/daft-core/src/array/ops/full.rs
@@ -174,7 +174,7 @@ impl FullNull for StructArray {
 #[cfg(feature = "python")]
 impl FullNull for PythonArray {
     fn full_null(name: &str, dtype: &DataType, length: usize) -> Self {
-        let pynone = Arc::new(Python::with_gil(|py: Python| py.None()));
+        let pynone = Arc::new(Python::attach(|py: Python| py.None()));
         let values = vec![pynone; length];
 
         let validity = arrow2::bitmap::Bitmap::new_zeroed(length);

--- a/src/daft-core/src/array/ops/get.rs
+++ b/src/daft-core/src/array/ops/get.rs
@@ -123,7 +123,7 @@ impl ExtensionArray {
 #[cfg(feature = "python")]
 impl PythonArray {
     #[inline]
-    pub fn get(&self, idx: usize) -> Option<Arc<pyo3::PyObject>> {
+    pub fn get(&self, idx: usize) -> Option<Arc<pyo3::Py<pyo3::PyAny>>> {
         assert!(
             idx < self.len(),
             "Out of bounds: {} vs len: {}",

--- a/src/daft-core/src/array/ops/len.rs
+++ b/src/daft-core/src/array/ops/len.rs
@@ -43,7 +43,7 @@ impl PythonArray {
 
         let mut sample_size_allowed = MAX_SAMPLE_SIZE;
         let mut sampled_sizes = Vec::with_capacity(sample_candidates.len());
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             for c in sample_candidates {
                 // Just estimate to 0 if pickle_dumps fails.
                 let size = pickle_dumps(py, c).map(|v| v.len()).unwrap_or(0);

--- a/src/daft-core/src/array/ops/repr.rs
+++ b/src/daft-core/src/array/ops/repr.rs
@@ -152,7 +152,7 @@ impl PythonArray {
         let val = self.get(idx);
 
         if let Some(val) = val {
-            Ok(Python::with_gil(|py| {
+            Ok(Python::attach(|py| {
                 val.bind(py)
                     .call_method0(pyo3::intern!(py, "__str__"))?
                     .extract()
@@ -500,7 +500,7 @@ impl PythonArray {
 
         let val = self.get(idx);
 
-        let custom_viz_hook_result: Option<String> = Python::with_gil(|py| {
+        let custom_viz_hook_result: Option<String> = Python::attach(|py| {
             if let Some(val) = val {
                 // Find visualization hooks for this object's class
                 let pyany = val.bind(py);

--- a/src/daft-core/src/join.rs
+++ b/src/daft-core/src/join.rs
@@ -4,7 +4,7 @@ use common_error::{DaftError, DaftResult};
 use common_py_serde::impl_bincode_py_state_serialization;
 use derive_more::Display;
 #[cfg(feature = "python")]
-use pyo3::{PyObject, PyResult, Python, exceptions::PyValueError, pyclass, pymethods};
+use pyo3::{PyResult, Python, exceptions::PyValueError, pyclass, pymethods};
 use serde::{Deserialize, Serialize};
 
 /// Type of a join operation.

--- a/src/daft-core/src/lit/conversions.rs
+++ b/src/daft-core/src/lit/conversions.rs
@@ -2,7 +2,7 @@ use common_error::{DaftError, DaftResult};
 use common_file::FileReference;
 use common_io_config::IOConfig;
 #[cfg(feature = "python")]
-use pyo3::{PyClass, Python};
+use pyo3::{Py, PyAny, PyClass, Python};
 
 use super::{FromLiteral, Literal, deserializer::LiteralDeserializer};
 #[cfg(feature = "python")]
@@ -49,7 +49,7 @@ impl_literal!(FileReference, File);
 impl_literal!(&'_ str, Utf8, |s: &'_ str| s.to_owned());
 impl_literal!(&'_ [u8], Binary, |s: &'_ [u8]| s.to_vec());
 #[cfg(feature = "python")]
-impl_literal!(pyo3::PyObject, Python, |s: pyo3::PyObject| {
+impl_literal!(Py<PyAny>, Python, |s: Py<PyAny>| {
     common_py_serde::PyObjectWrapper(std::sync::Arc::new(s))
 });
 
@@ -169,7 +169,7 @@ where
     T: Clone + PyClass,
 {
     if let Literal::Python(py_value) = value {
-        Python::with_gil(|py| py_value.0.extract::<T>(py).ok())
+        Python::attach(|py| py_value.0.extract::<T>(py).ok())
     } else {
         None
     }

--- a/src/daft-core/src/lit/mod.rs
+++ b/src/daft-core/src/lit/mod.rs
@@ -232,8 +232,7 @@ impl Display for Literal {
             #[cfg(feature = "python")]
             Self::Python(pyobj) => write!(f, "PyObject({})", {
                 use pyo3::prelude::*;
-                Python::with_gil(|py| pyobj.0.call_method0(py, pyo3::intern!(py, "__str__")))
-                    .unwrap()
+                Python::attach(|py| pyobj.0.call_method0(py, pyo3::intern!(py, "__str__"))).unwrap()
             }),
             Self::Struct(entries) => {
                 write!(f, "Struct(")?;

--- a/src/daft-core/src/python/series.rs
+++ b/src/daft-core/src/python/series.rs
@@ -435,7 +435,7 @@ impl PySeries {
         Ok(self.series.fill_null(&fill_value.series)?.into())
     }
 
-    pub fn _debug_bincode_serialize(&self, py: Python) -> PyResult<PyObject> {
+    pub fn _debug_bincode_serialize(&self, py: Python) -> PyResult<Py<PyAny>> {
         let values = bincode::serialize(&self.series).unwrap();
         Ok(PyBytes::new(py, &values).into())
     }

--- a/src/daft-core/src/series/from.rs
+++ b/src/daft-core/src/series/from.rs
@@ -44,7 +44,7 @@ impl Series {
 
                 use crate::python::PySeries;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let pylist = PyList::new(py, arr.iter().map(|obj| obj.0.as_ref())).unwrap();
                     PySeries::from_pylist(&pylist, Some(name), None)
                         .unwrap()

--- a/src/daft-core/src/series/utils/python_fn.rs
+++ b/src/daft-core/src/series/utils/python_fn.rs
@@ -39,7 +39,7 @@ fn python_binary_op_with_utilfn(
         (a, b) => panic!("Cannot apply operation on arrays of different lengths: {a} vs {b}"),
     };
 
-    let result_series: Series = Python::with_gil(|py| -> PyResult<PySeries> {
+    let result_series: Series = Python::attach(|py| -> PyResult<PySeries> {
         let left_pylist = PySeries::from(lhs.clone()).to_pylist(py)?;
         let right_pylist = PySeries::from(rhs).to_pylist(py)?;
 
@@ -74,7 +74,7 @@ pub fn py_membership_op_utilfn(lhs: &Series, rhs: &Series) -> DaftResult<Series>
     let lhs_casted = lhs.cast(&DataType::Python)?;
     let rhs_casted = rhs.cast(&DataType::Python)?;
 
-    let result_series: Series = Python::with_gil(|py| -> PyResult<PySeries> {
+    let result_series: Series = Python::attach(|py| -> PyResult<PySeries> {
         let left_pylist = PySeries::from(lhs_casted.clone()).to_pylist(py)?;
         let right_pylist = PySeries::from(rhs_casted).to_pylist(py)?;
 
@@ -134,7 +134,7 @@ pub fn py_between_op_utilfn(value: &Series, lower: &Series, upper: &Series) -> D
             }
         };
 
-    let result_series: Series = Python::with_gil(|py| -> PyResult<PySeries> {
+    let result_series: Series = Python::attach(|py| -> PyResult<PySeries> {
         let value_pylist = PySeries::from(value_casted.clone()).to_pylist(py)?;
         let lower_pylist = PySeries::from(lower_casted).to_pylist(py)?;
         let upper_pylist = PySeries::from(upper_casted).to_pylist(py)?;

--- a/src/daft-csv/src/options.rs
+++ b/src/daft-csv/src/options.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use {
     daft_core::python::PySchema,
     daft_dsl::python::PyExpr,
-    pyo3::{PyObject, PyResult, Python, pyclass, pyclass::CompareOp, pymethods},
+    pyo3::{PyResult, Python, pyclass, pyclass::CompareOp, pymethods},
 };
 
 /// Options for converting CSV data to Daft data.

--- a/src/daft-csv/src/python.rs
+++ b/src/daft-csv/src/python.rs
@@ -25,7 +25,7 @@ pub mod pylib {
         io_config: Option<IOConfig>,
         multithreaded_io: Option<bool>,
     ) -> PyResult<PyRecordBatch> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_csv: for uri {uri}"));
 
             let io_client = get_io_client(
@@ -61,7 +61,7 @@ pub mod pylib {
         io_config: Option<IOConfig>,
         multithreaded_io: Option<bool>,
     ) -> PyResult<PySchema> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_csv_schema: for uri {uri}"));
 
             let io_client = get_io_client(

--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -7,7 +7,7 @@ use daft_local_plan::LocalPhysicalPlan;
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 use futures::StreamExt;
-use pyo3::{PyObject, Python, types::PyAnyMethods};
+use pyo3::{Py, PyAny, Python, types::PyAnyMethods};
 
 use super::{
     NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext, PipelineNodeImpl,
@@ -37,7 +37,7 @@ impl UDFActors {
         udf_properties: &UDFProperties,
         actor_ready_timeout: usize,
     ) -> DaftResult<Vec<PyObjectWrapper>> {
-        let (task_locals, py_exprs) = Python::with_gil(|py| {
+        let (task_locals, py_exprs) = Python::attach(|py| {
             let task_locals = crate::utils::runtime::PYO3_ASYNC_RUNTIME_LOCALS
                 .get()
                 .expect("Python task locals not initialized")
@@ -64,7 +64,7 @@ impl UDFActors {
 
         // Use async pattern similar to DistributedActorPoolProjectOperator
         let await_coroutine = async move {
-            let result = Python::with_gil(|py| {
+            let result = Python::attach(|py| {
                 let ray_actor_pool_udf_module =
                     py.import(pyo3::intern!(py, "daft.execution.ray_actor_pool_udf"))?;
                 let coroutine = ray_actor_pool_udf_module.call_method1(
@@ -86,8 +86,8 @@ impl UDFActors {
 
         // Execute the coroutine with proper task locals
         let result = pyo3_async_runtimes::tokio::scope(task_locals, await_coroutine).await?;
-        let actors = Python::with_gil(|py| {
-            result.extract::<Vec<PyObject>>(py).map(|py_objects| {
+        let actors = Python::attach(|py| {
+            result.extract::<Vec<Py<PyAny>>>(py).map(|py_objects| {
                 py_objects
                     .into_iter()
                     .map(|py_object| PyObjectWrapper(Arc::new(py_object)))
@@ -113,7 +113,7 @@ impl UDFActors {
     }
 
     fn teardown(&mut self) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             if let Self::Initialized { actors, .. } = self {
                 for actor in actors {
                     if let Err(e) = actor.0.call_method1(py, pyo3::intern!(py, "teardown"), ()) {

--- a/src/daft-distributed/src/python/progress_bar.rs
+++ b/src/daft-distributed/src/python/progress_bar.rs
@@ -1,5 +1,5 @@
 use common_error::DaftResult;
-use pyo3::{PyObject, PyResult, Python, types::PyAnyMethods};
+use pyo3::{Py, PyAny, PyResult, Python, types::PyAnyMethods};
 
 use crate::{
     scheduling::task::TaskContext,
@@ -16,21 +16,21 @@ impl From<&TaskContext> for BarId {
 }
 
 pub(crate) struct FlotillaProgressBar {
-    progress_bar_pyobject: PyObject,
+    progress_bar_pyobject: Py<PyAny>,
 }
 
 impl FlotillaProgressBar {
     pub fn try_new(py: Python) -> PyResult<Self> {
         let progress_bar_module = py.import(pyo3::intern!(py, "daft.runners.progress_bar"))?;
         let progress_bar_class = progress_bar_module.getattr(pyo3::intern!(py, "ProgressBar"))?;
-        let progress_bar = progress_bar_class.call1((true,))?.extract::<PyObject>()?;
+        let progress_bar = progress_bar_class.call1((true,))?.extract::<Py<PyAny>>()?;
         Ok(Self {
             progress_bar_pyobject: progress_bar,
         })
     }
 
     fn make_bar_or_update_total(&self, bar_id: BarId, bar_name: &str) -> PyResult<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let progress_bar = self
                 .progress_bar_pyobject
                 .getattr(py, pyo3::intern!(py, "make_bar_or_update_total"))?;
@@ -40,7 +40,7 @@ impl FlotillaProgressBar {
     }
 
     fn update_bar(&self, bar_id: BarId) -> PyResult<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let progress_bar = self
                 .progress_bar_pyobject
                 .getattr(py, pyo3::intern!(py, "update_bar"))?;
@@ -50,7 +50,7 @@ impl FlotillaProgressBar {
     }
 
     fn close(&self) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let progress_bar = self
                 .progress_bar_pyobject
                 .getattr(py, pyo3::intern!(py, "close"))

--- a/src/daft-distributed/src/python/ray/worker.rs
+++ b/src/daft-distributed/src/python/ray/worker.rs
@@ -15,7 +15,7 @@ type ActiveTaskDetails = HashMap<TaskContext, TaskDetails>;
 #[derive(Debug, Clone)]
 pub(crate) struct RaySwordfishWorker {
     worker_id: WorkerId,
-    ray_worker_handle: Arc<PyObject>,
+    ray_worker_handle: Arc<Py<PyAny>>,
     num_cpus: f64,
     total_memory_bytes: usize,
     num_gpus: f64,
@@ -27,7 +27,7 @@ impl RaySwordfishWorker {
     #[new]
     pub fn new(
         worker_id: String,
-        ray_worker_handle: PyObject,
+        ray_worker_handle: pyo3::Py<pyo3::PyAny>,
         num_cpus: f64,
         num_gpus: f64,
         total_memory_bytes: usize,

--- a/src/daft-distributed/src/python/ray/worker_manager.rs
+++ b/src/daft-distributed/src/python/ray/worker_manager.rs
@@ -34,7 +34,7 @@ impl RayWorkerManagerState {
             return Ok(());
         }
 
-        let ray_workers = Python::with_gil(|py| {
+        let ray_workers = Python::attach(|py| {
             let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
 
             let existing_worker_ids = self
@@ -97,7 +97,7 @@ impl WorkerManager for RayWorkerManager {
         let mut task_result_handles =
             Vec::with_capacity(tasks_per_worker.values().map(|v| v.len()).sum());
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             for (worker_id, tasks) in tasks_per_worker {
                 let handles = state
                     .ray_workers
@@ -154,7 +154,7 @@ impl WorkerManager for RayWorkerManager {
             .state
             .lock()
             .expect("Failed to lock RayWorkerManagerState");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             for worker in state.ray_workers.values() {
                 worker.shutdown(py);
             }
@@ -217,7 +217,7 @@ impl WorkerManager for RayWorkerManager {
                 })
                 .collect::<Vec<_>>();
 
-            Python::with_gil(|py| -> DaftResult<()> {
+            Python::attach(|py| -> DaftResult<()> {
                 let flotilla_module = py.import(pyo3::intern!(py, "daft.runners.flotilla"))?;
                 flotilla_module
                     .call_method1(pyo3::intern!(py, "try_autoscale"), (python_bundles,))?;

--- a/src/daft-distributed/src/utils/runtime.rs
+++ b/src/daft-distributed/src/utils/runtime.rs
@@ -29,7 +29,7 @@ pub fn get_or_init_runtime() -> &'static Runtime {
             PYO3_ASYNC_RUNTIME_LOCALS.get_or_init(|| {
                 use pyo3::Python;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     pyo3_async_runtimes::tokio::get_current_locals(py)
                         .expect("Failed to get current task locals")
                 })

--- a/src/daft-dsl/src/functions/python/mod.rs
+++ b/src/daft-dsl/src/functions/python/mod.rs
@@ -9,10 +9,7 @@ use common_treenode::{TreeNode, TreeNodeRecursion};
 use daft_core::prelude::*;
 use itertools::Itertools;
 #[cfg(feature = "python")]
-use pyo3::{
-    Bound, IntoPyObject, PyObject, PyResult, Python,
-    types::{PyDict, PyTuple},
-};
+use pyo3::{Bound, Py, PyAny, PyResult, Python, call::PyCallArgs, types::PyDict};
 pub use runtime_py_object::RuntimePyObject;
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +35,7 @@ pub enum MaybeInitializedUDF {
 #[derive(Debug, Clone)]
 pub struct WrappedUDFClass {
     #[cfg(feature = "python")]
-    pub inner: Arc<PyObject>,
+    pub inner: Arc<Py<PyAny>>,
 }
 
 #[cfg(feature = "python")]
@@ -50,7 +47,7 @@ impl WrappedUDFClass {
         kwargs: Option<&Bound<'py, PyDict>>,
     ) -> PyResult<PyExpr>
     where
-        A: IntoPyObject<'py, Target = PyTuple>,
+        A: PyCallArgs<'py>,
     {
         let o = self.inner.call(py, args, kwargs)?;
         let inner = o.getattr(py, "_expr")?;
@@ -60,7 +57,7 @@ impl WrappedUDFClass {
     }
 
     pub fn name(&self) -> PyResult<String> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let s: String = self.inner.getattr(py, "name")?.extract(py)?;
             Ok(if s.contains('.') {
                 s.split('.').next_back().unwrap().to_string()
@@ -204,9 +201,9 @@ pub fn try_get_udf_name(expr: &ExprRef) -> Option<String> {
 #[cfg(feature = "python")]
 fn py_udf_initialize(
     py: Python<'_>,
-    func: Arc<pyo3::PyObject>,
-    init_args: Arc<pyo3::PyObject>,
-) -> DaftResult<pyo3::PyObject> {
+    func: Arc<Py<PyAny>>,
+    init_args: Arc<Py<PyAny>>,
+) -> DaftResult<Py<PyAny>> {
     Ok(func.call_method1(
         py,
         pyo3::intern!(py, "initialize"),
@@ -230,7 +227,7 @@ pub fn initialize_udfs(expr: ExprRef) -> DaftResult<ExprRef> {
                 ),
             inputs,
         } => {
-            let initialized_func = Python::with_gil(|py| {
+            let initialized_func = Python::attach(|py| {
                 py_udf_initialize(py, inner.clone().unwrap(), init_args.clone().unwrap())
             })?;
 

--- a/src/daft-dsl/src/functions/python/runtime_py_object.rs
+++ b/src/daft-dsl/src/functions/python/runtime_py_object.rs
@@ -20,7 +20,7 @@ impl RuntimePyObject {
 
         #[cfg(feature = "python")]
         {
-            let none_value = Arc::new(pyo3::Python::with_gil(|py| py.None()));
+            let none_value = Arc::new(pyo3::Python::attach(|py| py.None()));
             Self {
                 obj: PyObjectWrapper(none_value),
             }
@@ -32,29 +32,29 @@ impl RuntimePyObject {
     }
 
     #[cfg(feature = "python")]
-    pub fn new(value: Arc<pyo3::PyObject>) -> Self {
+    pub fn new(value: Arc<pyo3::Py<pyo3::PyAny>>) -> Self {
         Self {
             obj: PyObjectWrapper(value),
         }
     }
 
     #[cfg(feature = "python")]
-    pub fn unwrap(self) -> Arc<pyo3::PyObject> {
+    pub fn unwrap(self) -> Arc<pyo3::Py<pyo3::PyAny>> {
         self.obj.0
     }
 }
 
 #[cfg(feature = "python")]
-impl AsRef<pyo3::PyObject> for RuntimePyObject {
+impl AsRef<pyo3::Py<pyo3::PyAny>> for RuntimePyObject {
     /// Retrieves a reference to the underlying pyo3::PyObject object
-    fn as_ref(&self) -> &pyo3::PyObject {
+    fn as_ref(&self) -> &pyo3::Py<pyo3::PyAny> {
         &self.obj.0
     }
 }
 
 #[cfg(feature = "python")]
-impl From<pyo3::PyObject> for RuntimePyObject {
-    fn from(value: pyo3::PyObject) -> Self {
+impl From<pyo3::Py<pyo3::PyAny>> for RuntimePyObject {
+    fn from(value: pyo3::Py<pyo3::PyAny>) -> Self {
         Self::new(Arc::new(value))
     }
 }

--- a/src/daft-dsl/src/functions/python/udf.rs
+++ b/src/daft-dsl/src/functions/python/udf.rs
@@ -75,7 +75,7 @@ impl LegacyPythonUDF {
             )));
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let func = match &self.func {
                 MaybeInitializedUDF::Initialized(func) => func.clone().unwrap().clone_ref(py),
                 MaybeInitializedUDF::Uninitialized { inner, init_args } => {

--- a/src/daft-dsl/src/python.rs
+++ b/src/daft-dsl/src/python.rs
@@ -195,11 +195,11 @@ pub fn list_(items: Vec<PyExpr>) -> PyExpr {
 ))]
 pub fn udf(
     name: &str,
-    inner: PyObject,
-    bound_args: PyObject,
+    inner: Py<PyAny>,
+    bound_args: Py<PyAny>,
     expressions: Vec<PyExpr>,
     return_dtype: PyDataType,
-    init_args: PyObject,
+    init_args: Py<PyAny>,
     resource_request: Option<ResourceRequest>,
     batch_size: Option<usize>,
     concurrency: Option<usize>,
@@ -237,14 +237,14 @@ pub fn udf(
 #[allow(clippy::too_many_arguments)]
 pub fn row_wise_udf(
     name: &str,
-    cls: PyObject,
-    method: PyObject,
+    cls: Py<PyAny>,
+    method: Py<PyAny>,
     is_async: bool,
     return_dtype: PyDataType,
     gpus: usize,
     use_process: Option<bool>,
     max_concurrency: Option<usize>,
-    original_args: PyObject,
+    original_args: Py<PyAny>,
     expr_args: Vec<PyExpr>,
 ) -> PyExpr {
     let args = expr_args.into_iter().map(|pyexpr| pyexpr.expr).collect();
@@ -270,14 +270,14 @@ pub fn row_wise_udf(
 #[allow(clippy::too_many_arguments)]
 pub fn batch_udf(
     name: &str,
-    cls: PyObject,
-    method: PyObject,
+    cls: Py<PyAny>,
+    method: Py<PyAny>,
     return_dtype: PyDataType,
     gpus: usize,
     use_process: Option<bool>,
     max_concurrency: Option<usize>,
     batch_size: Option<usize>,
-    original_args: PyObject,
+    original_args: Py<PyAny>,
     expr_args: Vec<PyExpr>,
 ) -> PyExpr {
     let args = expr_args.into_iter().map(|pyexpr| pyexpr.expr).collect();
@@ -334,7 +334,7 @@ pub enum ApproxPercentileInput {
 impl PyExpr {
     /// converts the pyexpr into a `daft.Expression` python instance
     /// `daft.Expression._from_pyexpr(self)`
-    pub fn into_expr_cls(self, py: Python) -> PyResult<PyObject> {
+    pub fn into_expr_cls(self, py: Python) -> PyResult<Py<PyAny>> {
         let daft = py.import("daft")?;
         let expr_cls = daft.getattr("Expression")?;
         let expr = expr_cls.call_method1("_from_pyexpr", (self,))?;

--- a/src/daft-dsl/src/python_udf/batch.rs
+++ b/src/daft-dsl/src/python_udf/batch.rs
@@ -92,7 +92,7 @@ impl BatchPyFn {
             .map(|s| PySeries::from(s.clone()))
             .collect::<Vec<_>>();
 
-        let result_series = Python::with_gil(|py| {
+        let result_series = Python::attach(|py| {
             let func = py
                 .import(pyo3::intern!(py, "daft.udf.execution"))?
                 .getattr(pyo3::intern!(py, "call_batch"))?;

--- a/src/daft-dsl/src/python_udf/row_wise.rs
+++ b/src/daft-dsl/src/python_udf/row_wise.rs
@@ -120,7 +120,7 @@ impl RowWisePyFn {
         let method_ref = self.method.as_ref();
         let args_ref = self.original_args.as_ref();
 
-        Ok(pyo3::Python::with_gil(|py| {
+        Ok(pyo3::Python::attach(|py| {
             let f = py
                 .import(pyo3::intern!(py, "daft.udf.execution"))?
                 .getattr(pyo3::intern!(py, "call_async_batch"))?;
@@ -164,7 +164,7 @@ impl RowWisePyFn {
         let args_ref = self.original_args.as_ref();
         let name = args[0].name();
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let func = py
                 .import(pyo3::intern!(py, "daft.udf.execution"))?
                 .getattr(pyo3::intern!(py, "call_func"))?;

--- a/src/daft-file/src/python.rs
+++ b/src/daft-file/src/python.rs
@@ -40,9 +40,9 @@ impl PyFileReference {
 
     fn __exit__(
         &mut self,
-        _exc_type: Option<PyObject>,
-        _exc_value: Option<PyObject>,
-        _traceback: Option<PyObject>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
     ) -> PyResult<()> {
         Ok(())
     }
@@ -198,9 +198,9 @@ impl PyDaftFile {
 
     fn __exit__(
         &mut self,
-        _exc_type: Option<PyObject>,
-        _exc_value: Option<PyObject>,
-        _traceback: Option<PyObject>,
+        _exc_type: Option<Py<PyAny>>,
+        _exc_value: Option<Py<PyAny>>,
+        _traceback: Option<Py<PyAny>>,
     ) -> PyResult<()> {
         self.inside_context.store(false, Ordering::SeqCst);
         self.close()

--- a/src/daft-io/src/python.rs
+++ b/src/daft-io/src/python.rs
@@ -30,7 +30,7 @@ mod py {
         let io_stats = IOStatsContext::new(format!("io_glob for {input}"));
         let io_stats_handle = io_stats;
 
-        let lsr: DaftResult<Vec<_>> = py.allow_threads(|| {
+        let lsr: DaftResult<Vec<_>> = py.detach(|| {
             let io_client = get_io_client(
                 multithreaded_io,
                 io_config.unwrap_or_default().config.into(),
@@ -70,7 +70,7 @@ mod py {
     /// credentials, regions and more.
     #[pyfunction]
     fn s3_config_from_env(py: Python) -> PyResult<common_io_config::python::S3Config> {
-        let s3_config: DaftResult<common_io_config::S3Config> = py.allow_threads(|| {
+        let s3_config: DaftResult<common_io_config::S3Config> = py.detach(|| {
             let runtime = get_io_runtime(false);
             runtime.block_on_current_thread(async { Ok(s3_like::s3_config_from_env().await?) })
         });

--- a/src/daft-io/src/unity.rs
+++ b/src/daft-io/src/unity.rs
@@ -29,7 +29,7 @@ fn invalid_unity_path(path: &str) -> crate::Error {
 
 pub struct UnitySource {
     /// A `daft.unity_catalog.UnityCatalog` instance
-    unity_catalog: PyObject,
+    unity_catalog: pyo3::Py<pyo3::PyAny>,
     /// map of volume name to io client and storage location
     cached_sources: tokio::sync::RwLock<HashMap<String, Arc<ClientAndLocation>>>,
 }
@@ -50,7 +50,7 @@ impl UnitySource {
             });
         };
 
-        let unity_catalog = Python::with_gil(|py| {
+        let unity_catalog = Python::attach(|py| {
             Ok::<_, PyErr>(
                 py.import(intern!(py, "daft.unity_catalog"))?
                     .getattr(intern!(py, "UnityCatalog"))?
@@ -86,7 +86,7 @@ impl UnitySource {
             return Ok(client.clone());
         }
 
-        let (io_config, storage_location) = Python::with_gil(|py| {
+        let (io_config, storage_location) = Python::attach(|py| {
             let volume = self
                 .unity_catalog
                 .bind(py)

--- a/src/daft-json/src/options.rs
+++ b/src/daft-json/src/options.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use {
     daft_core::python::PySchema,
     daft_dsl::python::PyExpr,
-    pyo3::{PyObject, PyResult, Python, pyclass, pyclass::CompareOp, pymethods},
+    pyo3::{PyResult, Python, pyclass, pyclass::CompareOp, pymethods},
 };
 
 /// Options for converting JSON data to Daft data.

--- a/src/daft-json/src/python.rs
+++ b/src/daft-json/src/python.rs
@@ -28,7 +28,7 @@ pub mod pylib {
         multithreaded_io: Option<bool>,
         max_chunks_in_flight: Option<usize>,
     ) -> PyResult<PyRecordBatch> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_json: for uri {uri}"));
 
             let io_client = get_io_client(
@@ -64,7 +64,7 @@ pub mod pylib {
         io_config: Option<IOConfig>,
         multithreaded_io: Option<bool>,
     ) -> PyResult<PySchema> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_json_schema: for uri {uri}"));
 
             let io_client = get_io_client(

--- a/src/daft-local-execution/src/intermediate_ops/udf.rs
+++ b/src/daft-local-execution/src/intermediate_ops/udf.rs
@@ -101,7 +101,7 @@ pub(crate) struct UdfHandle {
     //   - If excessive GIL contention is detected, the UDF will be moved to an external worker
     // Second bool indicates if the UDF was initialized
     #[cfg(feature = "python")]
-    handle: Option<PyObject>,
+    handle: Option<Py<PyAny>>,
 }
 
 impl UdfHandle {
@@ -120,9 +120,9 @@ impl UdfHandle {
         {
             let py_expr = PyExpr::from(self.udf_expr.inner().clone());
 
-            let handle = Python::with_gil(|py| {
+            let handle = Python::attach(|py| {
                 // create python object
-                Ok::<PyObject, PyErr>(
+                Ok::<pyo3::Py<pyo3::PyAny>, PyErr>(
                     py.import(pyo3::intern!(py, "daft.execution.udf"))?
                         .getattr(pyo3::intern!(py, "UdfHandle"))?
                         .call1((py_expr,))?
@@ -142,12 +142,16 @@ impl UdfHandle {
     }
 
     #[cfg(feature = "python")]
-    fn eval_input_with_handle(&self, input: RecordBatch, handle: &PyObject) -> DaftResult<Series> {
+    fn eval_input_with_handle(
+        &self,
+        input: RecordBatch,
+        handle: &pyo3::Py<pyo3::PyAny>,
+    ) -> DaftResult<Series> {
         use daft_recordbatch::python::PyRecordBatch;
 
         use crate::STDOUT;
 
-        let (result, stdout_lines) = Python::with_gil(|py| {
+        let (result, stdout_lines) = Python::attach(|py| {
             handle
                 .bind(py)
                 .call_method1(
@@ -229,7 +233,7 @@ impl UdfHandle {
                 return Ok(());
             };
 
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 handle
                     .bind(py)
                     .call_method0(pyo3::intern!(py, "teardown"))?;

--- a/src/daft-local-execution/src/sinks/commit_write.rs
+++ b/src/daft-local-execution/src/sinks/commit_write.rs
@@ -93,7 +93,7 @@ impl BlockingSink for CommitWriteSink {
                         {
                             use pyo3::{prelude::*, types::PyList};
 
-                            Python::with_gil(|py| {
+                            Python::attach(|py| {
                                 let fs = py.import(pyo3::intern!(py, "daft.filesystem"))?;
                                 let overwrite_files = fs.getattr("overwrite_files")?;
                                 let file_paths = written_file_path_record_batches

--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -602,7 +602,7 @@ async fn stream_scan_task(
                 .filters
                 .as_ref()
                 .map(|p| (*p.as_ref()).clone().into());
-            let table = Python::with_gil(|py| {
+            let table = Python::attach(|py| {
                 daft_micropartition::python::read_sql_into_py_table(
                     py,
                     sql,

--- a/src/daft-logical-plan/src/optimization/rules/push_down_limit.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_limit.rs
@@ -356,7 +356,7 @@ mod tests {
     #[test]
     #[cfg(feature = "python")]
     fn limit_does_not_push_into_in_memory_source() -> DaftResult<()> {
-        let py_obj = Python::with_gil(|py| py.None());
+        let py_obj = Python::attach(|py| py.None());
         let schema: Arc<Schema> = Schema::new(vec![Field::new("a", DataType::Int64)]).into();
         let plan = LogicalPlanBuilder::in_memory_scan(
             "foo",

--- a/src/daft-logical-plan/src/sink_info.rs
+++ b/src/daft-logical-plan/src/sink_info.rs
@@ -9,8 +9,6 @@ use daft_core::prelude::Schema;
 use daft_dsl::{ExprRef, expr::bound_expr::BoundExpr};
 use educe::Educe;
 use itertools::Itertools;
-#[cfg(feature = "python")]
-use pyo3::PyObject;
 use serde::{Deserialize, Serialize};
 
 #[allow(clippy::large_enum_variant)]
@@ -62,14 +60,14 @@ pub struct IcebergCatalogInfo<E = ExprRef> {
     )]
     #[educe(PartialEq(ignore))]
     #[educe(Hash(ignore))]
-    pub iceberg_schema: Arc<PyObject>,
+    pub iceberg_schema: Arc<pyo3::Py<pyo3::PyAny>>,
     #[serde(
         serialize_with = "serialize_py_object",
         deserialize_with = "deserialize_py_object"
     )]
     #[educe(PartialEq(ignore))]
     #[educe(Hash(ignore))]
-    pub iceberg_properties: Arc<PyObject>,
+    pub iceberg_properties: Arc<pyo3::Py<pyo3::PyAny>>,
     pub io_config: Option<IOConfig>,
 }
 
@@ -136,7 +134,7 @@ pub struct LanceCatalogInfo {
     )]
     #[educe(PartialEq(ignore))]
     #[educe(Hash(ignore))]
-    pub kwargs: Arc<PyObject>,
+    pub kwargs: Arc<pyo3::Py<pyo3::PyAny>>,
 }
 
 #[cfg(feature = "python")]
@@ -164,7 +162,7 @@ pub struct DataSinkInfo {
     )]
     #[educe(PartialEq(ignore))]
     #[educe(Hash(ignore))]
-    pub sink: Arc<PyObject>,
+    pub sink: Arc<pyo3::Py<pyo3::PyAny>>,
 }
 
 #[cfg(feature = "python")]

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -300,7 +300,7 @@ fn materialize_scan_task(
                 .filters
                 .as_ref()
                 .map(|p| (*p.as_ref()).clone().into());
-            pyo3::Python::with_gil(|py| {
+            pyo3::Python::attach(|py| {
                 let table = crate::python::read_sql_into_py_table(
                     py,
                     sql,

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -52,7 +52,7 @@ impl PyMicroPartition {
     pub fn get_column_by_name(&self, name: &str, py: Python) -> PyResult<PySeries> {
         let index = self.inner.schema().get_index(name)?;
 
-        let tables = py.allow_threads(|| {
+        let tables = py.detach(|| {
             let io_stats =
                 IOStatsContext::new(format!("PyMicroPartition::get_column_by_name: {name}"));
             self.inner.concat_or_get_update(io_stats)
@@ -64,7 +64,7 @@ impl PyMicroPartition {
     }
 
     pub fn get_column(&self, idx: usize, py: Python) -> PyResult<PySeries> {
-        let tables = py.allow_threads(|| {
+        let tables = py.detach(|| {
             let io_stats = IOStatsContext::new(format!("PyMicroPartition::get_column: {idx}"));
             self.inner.concat_or_get_update(io_stats)
         })?;
@@ -79,7 +79,7 @@ impl PyMicroPartition {
     }
 
     pub fn columns(&self, py: Python) -> PyResult<Vec<PySeries>> {
-        let tables = py.allow_threads(|| {
+        let tables = py.detach(|| {
             let io_stats = IOStatsContext::new("PyMicroPartition::columns");
             self.inner.concat_or_get_update(io_stats)
         })?;
@@ -100,7 +100,7 @@ impl PyMicroPartition {
     }
 
     pub fn get_record_batches(&self, py: Python) -> PyResult<Vec<PyRecordBatch>> {
-        let record_batches = py.allow_threads(|| self.inner.get_tables())?;
+        let record_batches = py.detach(|| self.inner.get_tables())?;
         Ok(record_batches
             .iter()
             .map(|rb| PyRecordBatch {
@@ -129,7 +129,7 @@ impl PyMicroPartition {
     #[staticmethod]
     pub fn from_scan_task(scan_task: PyScanTask, py: Python) -> PyResult<Self> {
         Ok(py
-            .allow_threads(|| {
+            .detach(|| {
                 let io_stats = IOStatsContext::new(format!(
                     "MicroPartition::from_scan_task for {:?}",
                     scan_task.0.sources
@@ -190,7 +190,7 @@ impl PyMicroPartition {
 
     // Export Methods
     pub fn to_record_batch(&self, py: Python) -> PyResult<PyRecordBatch> {
-        let concatted = py.allow_threads(|| {
+        let concatted = py.detach(|| {
             let io_stats = IOStatsContext::new("PyMicroPartition::to_record_batch");
             self.inner.concat_or_get_update(io_stats)
         })?;
@@ -205,27 +205,27 @@ impl PyMicroPartition {
     #[staticmethod]
     pub fn concat(py: Python, to_concat: Vec<Self>) -> PyResult<Self> {
         let mps_iter = to_concat.iter().map(|t| t.inner.as_ref());
-        py.allow_threads(|| Ok(MicroPartition::concat(mps_iter)?.into()))
+        py.detach(|| Ok(MicroPartition::concat(mps_iter)?.into()))
     }
 
     #[staticmethod]
     pub fn concat_or_empty(py: Python, to_concat: Vec<Self>, schema: PySchema) -> PyResult<Self> {
         let mps_iter = to_concat.iter().map(|t| t.inner.as_ref());
-        py.allow_threads(|| Ok(MicroPartition::concat_or_empty(mps_iter, schema.schema)?.into()))
+        py.detach(|| Ok(MicroPartition::concat_or_empty(mps_iter, schema.schema)?.into()))
     }
 
     pub fn slice(&self, py: Python, start: i64, end: i64) -> PyResult<Self> {
-        py.allow_threads(|| Ok(self.inner.slice(start as usize, end as usize)?.into()))
+        py.detach(|| Ok(self.inner.slice(start as usize, end as usize)?.into()))
     }
 
     pub fn cast_to_schema(&self, py: Python, schema: PySchema) -> PyResult<Self> {
         #[allow(deprecated)]
-        py.allow_threads(|| Ok(self.inner.cast_to_schema(schema.schema)?.into()))
+        py.detach(|| Ok(self.inner.cast_to_schema(schema.schema)?.into()))
     }
 
     pub fn eval_expression_list(&self, py: Python, exprs: Vec<PyExpr>) -> PyResult<Self> {
         let converted_exprs = BoundExpr::bind_all(&exprs, &self.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .eval_expression_list(converted_exprs.as_slice())?
@@ -234,7 +234,7 @@ impl PyMicroPartition {
     }
 
     pub fn take(&self, py: Python, idx: &PySeries) -> PyResult<Self> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let taken = self.inner.take(&idx.series)?;
             let mp = MicroPartition::new_loaded(
                 taken.schema.clone(),
@@ -247,7 +247,7 @@ impl PyMicroPartition {
 
     pub fn filter(&self, py: Python, exprs: Vec<PyExpr>) -> PyResult<Self> {
         let converted_exprs = BoundExpr::bind_all(&exprs, &self.inner.schema)?;
-        py.allow_threads(|| Ok(self.inner.filter(converted_exprs.as_slice())?.into()))
+        py.detach(|| Ok(self.inner.filter(converted_exprs.as_slice())?.into()))
     }
 
     pub fn sort(
@@ -258,7 +258,7 @@ impl PyMicroPartition {
         nulls_first: Vec<bool>,
     ) -> PyResult<Self> {
         let converted_exprs = BoundExpr::bind_all(&sort_keys, &self.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .sort(
@@ -278,7 +278,7 @@ impl PyMicroPartition {
         nulls_first: Vec<bool>,
     ) -> PyResult<PySeries> {
         let converted_exprs = BoundExpr::bind_all(&sort_keys, &self.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .argsort(
@@ -304,7 +304,7 @@ impl PyMicroPartition {
             })
             .collect::<DaftResult<Vec<_>>>()?;
         let converted_group_by: Vec<_> = BoundExpr::bind_all(&group_by, &self.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .agg(converted_to_agg.as_slice(), converted_group_by.as_slice())?
@@ -314,7 +314,7 @@ impl PyMicroPartition {
 
     pub fn dedup(&self, py: Python, columns: Vec<PyExpr>) -> PyResult<Self> {
         let converted_columns = BoundExpr::bind_all(&columns, &self.inner.schema)?;
-        py.allow_threads(|| Ok(self.inner.dedup(converted_columns.as_slice())?.into()))
+        py.detach(|| Ok(self.inner.dedup(converted_columns.as_slice())?.into()))
     }
 
     pub fn pivot(
@@ -328,7 +328,7 @@ impl PyMicroPartition {
         let converted_group_by = BoundExpr::bind_all(&group_by, &self.inner.schema)?;
         let converted_pivot_col = BoundExpr::try_new(pivot_col, &self.inner.schema)?;
         let converted_values_col = BoundExpr::try_new(values_col, &self.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .pivot(
@@ -359,7 +359,7 @@ impl PyMicroPartition {
     ) -> PyResult<Self> {
         let left_exprs = BoundExpr::bind_all(&left_on, &self.inner.schema)?;
         let right_exprs = BoundExpr::bind_all(&right_on, &right.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .hash_join(
@@ -383,7 +383,7 @@ impl PyMicroPartition {
     ) -> PyResult<Self> {
         let left_exprs = BoundExpr::bind_all(&left_on, &self.inner.schema)?;
         let right_exprs = BoundExpr::bind_all(&right_on, &right.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .sort_merge_join(
@@ -403,13 +403,13 @@ impl PyMicroPartition {
         right: &Self,
         outer_loop_side: JoinSide,
     ) -> PyResult<Self> {
-        py.allow_threads(|| Ok(self.inner.cross_join(&right.inner, outer_loop_side)?.into()))
+        py.detach(|| Ok(self.inner.cross_join(&right.inner, outer_loop_side)?.into()))
     }
 
     pub fn explode(&self, py: Python, to_explode: Vec<PyExpr>) -> PyResult<Self> {
         let converted_to_explode = BoundExpr::bind_all(&to_explode, &self.inner.schema)?;
 
-        py.allow_threads(|| Ok(self.inner.explode(converted_to_explode.as_slice())?.into()))
+        py.detach(|| Ok(self.inner.explode(converted_to_explode.as_slice())?.into()))
     }
 
     pub fn unpivot(
@@ -422,7 +422,7 @@ impl PyMicroPartition {
     ) -> PyResult<Self> {
         let converted_ids = BoundExpr::bind_all(&ids, &self.inner.schema)?;
         let converted_values = BoundExpr::bind_all(&values, &self.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .unpivot(
@@ -436,7 +436,7 @@ impl PyMicroPartition {
     }
 
     pub fn head(&self, py: Python, num: i64) -> PyResult<Self> {
-        py.allow_threads(|| {
+        py.detach(|| {
             if num < 0 {
                 return Err(PyValueError::new_err(format!(
                     "Can not head MicroPartition with negative number: {num}"
@@ -454,7 +454,7 @@ impl PyMicroPartition {
         with_replacement: bool,
         seed: Option<u64>,
     ) -> PyResult<Self> {
-        py.allow_threads(|| {
+        py.detach(|| {
             if fraction < 0.0 {
                 return Err(PyValueError::new_err(format!(
                     "Can not sample table with negative fraction: {fraction}"
@@ -480,7 +480,7 @@ impl PyMicroPartition {
         with_replacement: bool,
         seed: Option<u64>,
     ) -> PyResult<Self> {
-        py.allow_threads(|| {
+        py.detach(|| {
             if size < 0 {
                 return Err(PyValueError::new_err(format!(
                     "Can not sample table with negative size: {size}"
@@ -494,7 +494,7 @@ impl PyMicroPartition {
     }
 
     pub fn quantiles(&self, py: Python, num: i64) -> PyResult<Self> {
-        py.allow_threads(|| {
+        py.detach(|| {
             if num < 0 {
                 return Err(PyValueError::new_err(format!(
                     "Can not fetch quantile from table with negative number: {num}"
@@ -516,7 +516,7 @@ impl PyMicroPartition {
             )));
         }
         let exprs = BoundExpr::bind_all(&exprs, &self.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .partition_by_hash(exprs.as_slice(), num_partitions as usize)?
@@ -543,7 +543,7 @@ impl PyMicroPartition {
                 "Can not have seed has negative number: {seed}"
             )));
         }
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .partition_by_random(num_partitions as usize, seed as u64)?
@@ -561,7 +561,7 @@ impl PyMicroPartition {
         descending: Vec<bool>,
     ) -> PyResult<Vec<Self>> {
         let exprs = BoundExpr::bind_all(&partition_keys, &self.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .partition_by_range(
@@ -581,7 +581,7 @@ impl PyMicroPartition {
         partition_keys: Vec<PyExpr>,
     ) -> PyResult<(Vec<Self>, Self)> {
         let exprs = BoundExpr::bind_all(&partition_keys, &self.inner.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             let (mps, values) = self.inner.partition_by_value(exprs.as_slice())?;
             let mps = mps
                 .into_iter()
@@ -598,7 +598,7 @@ impl PyMicroPartition {
         partition_num: u64,
         column_name: &str,
     ) -> PyResult<Self> {
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .inner
                 .add_monotonically_increasing_id(partition_num, column_name)?
@@ -656,7 +656,7 @@ impl PyMicroPartition {
         io_config: Option<IOConfig>,
         multithreaded_io: Option<bool>,
     ) -> PyResult<Self> {
-        let mp = py.allow_threads(|| {
+        let mp = py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_json: for uri {uri}"));
             let io_config = io_config.unwrap_or_default().config.into();
 
@@ -691,7 +691,7 @@ impl PyMicroPartition {
         io_config: Option<IOConfig>,
         multithreaded_io: Option<bool>,
     ) -> PyResult<Self> {
-        let mp = py.allow_threads(|| {
+        let mp = py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_csv: for uri {uri}"));
             let io_config = io_config.unwrap_or_default().config.into();
             crate::micropartition::read_csv_into_micropartition(
@@ -732,7 +732,7 @@ impl PyMicroPartition {
         multithreaded_io: Option<bool>,
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<Self> {
-        let mp = py.allow_threads(|| {
+        let mp = py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_parquet: for uri {uri}"));
 
             let io_config = io_config.unwrap_or_default().config.into();
@@ -794,7 +794,7 @@ impl PyMicroPartition {
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
         chunk_size: Option<usize>,
     ) -> PyResult<Self> {
-        let mp = py.allow_threads(|| {
+        let mp = py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_parquet: for uri {uris:?}"));
 
             let io_config = io_config.unwrap_or_default().config.into();
@@ -857,7 +857,7 @@ impl PyMicroPartition {
             Field::new("warc_content", daft_core::prelude::DataType::Binary),
             Field::new("warc_headers", daft_core::prelude::DataType::Utf8),
         ]));
-        let mp = py.allow_threads(|| {
+        let mp = py.detach(|| {
             crate::micropartition::read_warc_into_micropartition(
                 &[uri],
                 schema.into(),
@@ -894,7 +894,7 @@ impl PyMicroPartition {
     pub fn _from_loaded_table_state(
         py: Python,
         schema_bytes: &[u8],
-        table_objs: Vec<PyObject>,
+        table_objs: Vec<pyo3::Py<pyo3::PyAny>>,
         metadata_bytes: &[u8],
         statistics_bytes: &[u8],
     ) -> PyResult<Self> {
@@ -920,7 +920,10 @@ impl PyMicroPartition {
         .into())
     }
 
-    pub fn __reduce__(&self, py: Python) -> PyResult<(PyObject, PyObject)> {
+    pub fn __reduce__(
+        &self,
+        py: Python,
+    ) -> PyResult<(pyo3::Py<pyo3::PyAny>, pyo3::Py<pyo3::PyAny>)> {
         let schema_bytes = PyBytes::new(py, &bincode::serialize(&self.inner.schema).unwrap());
 
         let py_metadata_bytes =
@@ -969,7 +972,7 @@ impl PyMicroPartition {
     }
 
     pub fn write_to_ipc_stream<'a>(&'a self, py: Python<'a>) -> PyResult<Bound<'a, PyBytes>> {
-        let buffer = py.allow_threads(|| self.inner.write_to_ipc_stream())?;
+        let buffer = py.detach(|| self.inner.write_to_ipc_stream())?;
         let bytes = PyBytes::new(py, &buffer);
         Ok(bytes)
     }
@@ -977,7 +980,7 @@ impl PyMicroPartition {
     #[staticmethod]
     pub fn read_from_ipc_stream(bytes: Bound<'_, PyBytes>, py: Python) -> PyResult<Self> {
         let buffer = bytes.as_bytes();
-        let mp = py.allow_threads(|| MicroPartition::read_from_ipc_stream(buffer))?;
+        let mp = py.detach(|| MicroPartition::read_from_ipc_stream(buffer))?;
         Ok(mp.into())
     }
 }
@@ -1082,7 +1085,7 @@ pub fn read_parquet_into_py_table(
 pub fn read_sql_into_py_table(
     py: Python,
     sql: &str,
-    conn: &PyObject,
+    conn: &pyo3::Py<pyo3::PyAny>,
     predicate: Option<PyExpr>,
     schema: PySchema,
     include_columns: Option<Vec<String>>,
@@ -1127,14 +1130,14 @@ pub fn read_pyfunc_into_table_iter(
                 func_args,
                 ..
             } => {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     let func = py.import(module.as_str())
                         .unwrap_or_else(|_| panic!("Cannot import factory function from module {module}"))
                         .getattr(func_name.as_str())
                         .unwrap_or_else(|_| panic!("Cannot find function {func_name} in module {module}"));
                     func.call(func_args.to_pytuple(py).with_context(|_| PyIOSnafu)?, None)
                         .with_context(|_| PyIOSnafu)
-                        .map(Into::<PyObject>::into)
+                        .map(Into::<pyo3::Py<pyo3::PyAny>>::into)
                 })
             },
             _ => unreachable!("PythonFunction file format must be paired with PythonFactoryFunction data file sources"),
@@ -1156,7 +1159,7 @@ pub fn read_pyfunc_into_table_iter(
         .into_iter()
         .flat_map(move |iter| {
             std::iter::from_fn(move || {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     iter.downcast_bound::<pyo3::types::PyIterator>(py)
                         .expect("Function must return an iterator of tables")
                         .clone()

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -37,7 +37,7 @@ pub mod pylib {
         multithreaded_io: Option<bool>,
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<PyRecordBatch> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_parquet: for uri {uri}"));
 
             let io_client = get_io_client(
@@ -65,8 +65,8 @@ pub mod pylib {
             Ok(result)
         })
     }
-    type PyArrowChunks = Vec<Vec<pyo3::PyObject>>;
-    type PyArrowFields = Vec<pyo3::PyObject>;
+    type PyArrowChunks = Vec<Vec<pyo3::Py<pyo3::PyAny>>>;
+    type PyArrowFields = Vec<pyo3::Py<pyo3::PyAny>>;
     type PyArrowParquetType = (
         PyArrowFields,
         BTreeMap<String, String>,
@@ -123,7 +123,7 @@ pub mod pylib {
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
         file_timeout_ms: Option<i64>,
     ) -> PyResult<PyArrowParquetType> {
-        let (schema, all_arrays, num_rows) = py.allow_threads(|| {
+        let (schema, all_arrays, num_rows) = py.detach(|| {
             let io_client = get_io_client(
                 multithreaded_io.unwrap_or(true),
                 io_config.unwrap_or_default().config.into(),
@@ -176,7 +176,7 @@ pub mod pylib {
         multithreaded_io: Option<bool>,
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<Vec<PyRecordBatch>> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let io_stats = IOStatsContext::new("read_parquet_bulk");
 
             let io_client = get_io_client(
@@ -233,7 +233,7 @@ pub mod pylib {
         multithreaded_io: Option<bool>,
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<Vec<PyArrowParquetType>> {
-        let parquet_read_results = py.allow_threads(|| {
+        let parquet_read_results = py.detach(|| {
             let io_client = get_io_client(
                 multithreaded_io.unwrap_or(true),
                 io_config.unwrap_or_default().config.into(),
@@ -277,7 +277,7 @@ pub mod pylib {
         multithreaded_io: Option<bool>,
         coerce_int96_timestamp_unit: Option<PyTimeUnit>,
     ) -> PyResult<PySchema> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let io_stats = IOStatsContext::new(format!("read_parquet_schema: for uri {uri}"));
 
             let schema_infer_options = ParquetSchemaInferenceOptions::new(
@@ -314,7 +314,7 @@ pub mod pylib {
         io_config: Option<IOConfig>,
         multithreaded_io: Option<bool>,
     ) -> PyResult<PyRecordBatch> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let io_stats = IOStatsContext::new("read_parquet_statistics");
 
             let io_client = get_io_client(

--- a/src/daft-recordbatch/src/ffi.rs
+++ b/src/daft-recordbatch/src/ffi.rs
@@ -41,7 +41,7 @@ pub fn record_batch_from_arrow(
         extracted_arrow_arrays.push((columns, rb.len()?));
     }
     // Now do the heavy lifting (casting and concats) without the GIL.
-    py.allow_threads(|| {
+    py.detach(|| {
         let mut tables: Vec<RecordBatch> = Vec::with_capacity(num_batches);
         for (cols, num_rows) in extracted_arrow_arrays {
             let columns = cols
@@ -67,7 +67,7 @@ pub fn record_batch_to_arrow(
     py: Python,
     table: &RecordBatch,
     pyarrow: Bound<PyModule>,
-) -> PyResult<PyObject> {
+) -> PyResult<pyo3::Py<pyo3::PyAny>> {
     let mut arrays = Vec::with_capacity(table.num_columns());
     let mut names: Vec<String> = Vec::with_capacity(table.num_columns());
 

--- a/src/daft-recordbatch/src/file_info.rs
+++ b/src/daft-recordbatch/src/file_info.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use common_py_serde::impl_bincode_py_state_serialization;
 #[cfg(feature = "python")]
-use pyo3::{PyObject, PyResult, Python, exceptions::PyKeyError, pyclass, pymethods};
+use pyo3::{PyResult, Python, exceptions::PyKeyError, pyclass, pymethods};
 use serde::{Deserialize, Serialize};
 
 /// Metadata for a single file.

--- a/src/daft-recordbatch/src/python.rs
+++ b/src/daft-recordbatch/src/python.rs
@@ -36,7 +36,7 @@ impl PyRecordBatch {
 
     pub fn eval_expression_list(&self, py: Python, exprs: Vec<PyExpr>) -> PyResult<Self> {
         let converted_exprs = BoundExpr::bind_all(&exprs, &self.record_batch.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .eval_expression_list(converted_exprs.as_slice())?
@@ -45,12 +45,12 @@ impl PyRecordBatch {
     }
 
     pub fn take(&self, py: Python, idx: &PySeries) -> PyResult<Self> {
-        py.allow_threads(|| Ok(self.record_batch.take(&idx.series)?.into()))
+        py.detach(|| Ok(self.record_batch.take(&idx.series)?.into()))
     }
 
     pub fn filter(&self, py: Python, exprs: Vec<PyExpr>) -> PyResult<Self> {
         let converted_exprs = BoundExpr::bind_all(&exprs, &self.record_batch.schema)?;
-        py.allow_threads(|| Ok(self.record_batch.filter(converted_exprs.as_slice())?.into()))
+        py.detach(|| Ok(self.record_batch.filter(converted_exprs.as_slice())?.into()))
     }
 
     pub fn sort(
@@ -61,7 +61,7 @@ impl PyRecordBatch {
         nulls_first: Vec<bool>,
     ) -> PyResult<Self> {
         let converted_exprs = BoundExpr::bind_all(&sort_keys, &self.record_batch.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .sort(
@@ -81,7 +81,7 @@ impl PyRecordBatch {
         nulls_first: Vec<bool>,
     ) -> PyResult<PySeries> {
         let converted_exprs = BoundExpr::bind_all(&sort_keys, &self.record_batch.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .argsort(
@@ -107,7 +107,7 @@ impl PyRecordBatch {
             })
             .collect::<DaftResult<Vec<_>>>()?;
         let converted_group_by = BoundExpr::bind_all(&group_by, &self.record_batch.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .agg(converted_to_agg.as_slice(), converted_group_by.as_slice())?
@@ -126,7 +126,7 @@ impl PyRecordBatch {
         let converted_group_by = BoundExpr::bind_all(&group_by, &self.record_batch.schema)?;
         let converted_pivot_col = BoundExpr::try_new(pivot_col, &self.record_batch.schema)?;
         let converted_values_col = BoundExpr::try_new(values_col, &self.record_batch.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .pivot(
@@ -150,7 +150,7 @@ impl PyRecordBatch {
         let left_exprs = BoundExpr::bind_all(&left_on, &self.record_batch.schema)?;
         let right_exprs = BoundExpr::bind_all(&right_on, &self.record_batch.schema)?;
         let null_equals_nulls = vec![false; left_exprs.len()];
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .hash_join(
@@ -174,7 +174,7 @@ impl PyRecordBatch {
     ) -> PyResult<Self> {
         let left_exprs = BoundExpr::bind_all(&left_on, &self.record_batch.schema)?;
         let right_exprs = BoundExpr::bind_all(&right_on, &self.record_batch.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .sort_merge_join(
@@ -190,7 +190,7 @@ impl PyRecordBatch {
     pub fn explode(&self, py: Python, to_explode: Vec<PyExpr>) -> PyResult<Self> {
         let converted_to_explode = BoundExpr::bind_all(&to_explode, &self.record_batch.schema)?;
 
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .explode(converted_to_explode.as_slice())?
@@ -227,7 +227,7 @@ impl PyRecordBatch {
             )));
         }
         let num = num as usize;
-        py.allow_threads(|| Ok(self.record_batch.head(num)?.into()))
+        py.detach(|| Ok(self.record_batch.head(num)?.into()))
     }
 
     #[pyo3(signature = (fraction, with_replacement, seed=None))]
@@ -248,7 +248,7 @@ impl PyRecordBatch {
                 "Can not sample table with fraction greater than 1.0: {fraction}"
             )));
         }
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .sample_by_fraction(fraction, with_replacement, seed)?
@@ -269,7 +269,7 @@ impl PyRecordBatch {
                 "Can not sample table with negative size: {size}"
             )));
         }
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .sample(size as usize, with_replacement, seed)?
@@ -284,7 +284,7 @@ impl PyRecordBatch {
             )));
         }
         let num = num as usize;
-        py.allow_threads(|| Ok(self.record_batch.quantiles(num)?.into()))
+        py.detach(|| Ok(self.record_batch.quantiles(num)?.into()))
     }
 
     pub fn partition_by_hash(
@@ -299,7 +299,7 @@ impl PyRecordBatch {
             )));
         }
         let exprs = BoundExpr::bind_all(&exprs, &self.record_batch.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .partition_by_hash(exprs.as_slice(), num_partitions as usize)?
@@ -326,7 +326,7 @@ impl PyRecordBatch {
                 "Can not have seed has negative number: {seed}"
             )));
         }
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .partition_by_random(num_partitions as usize, seed as u64)?
@@ -344,7 +344,7 @@ impl PyRecordBatch {
         descending: Vec<bool>,
     ) -> PyResult<Vec<Self>> {
         let exprs = BoundExpr::bind_all(&partition_keys, &self.record_batch.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .partition_by_range(
@@ -364,7 +364,7 @@ impl PyRecordBatch {
         partition_keys: Vec<PyExpr>,
     ) -> PyResult<(Vec<Self>, Self)> {
         let exprs = BoundExpr::bind_all(&partition_keys, &self.record_batch.schema)?;
-        py.allow_threads(|| {
+        py.detach(|| {
             let (tables, values) = self.record_batch.partition_by_value(exprs.as_slice())?;
             let pyrecordbatches = tables
                 .into_iter()
@@ -381,7 +381,7 @@ impl PyRecordBatch {
         partition_num: u64,
         column_name: &str,
     ) -> PyResult<Self> {
-        py.allow_threads(|| {
+        py.detach(|| {
             Ok(self
                 .record_batch
                 .add_monotonically_increasing_id(partition_num, 0, column_name)?
@@ -413,7 +413,7 @@ impl PyRecordBatch {
     #[staticmethod]
     pub fn concat(py: Python, tables: Vec<Self>) -> PyResult<Self> {
         let record_batches: Vec<_> = tables.iter().map(|t| &t.record_batch).collect();
-        py.allow_threads(|| Ok(RecordBatch::concat(record_batches.as_slice())?.into()))
+        py.detach(|| Ok(RecordBatch::concat(record_batches.as_slice())?.into()))
     }
 
     pub fn slice(&self, start: i64, end: i64) -> PyResult<Self> {
@@ -509,8 +509,8 @@ impl PyRecordBatch {
         })
     }
 
-    pub fn to_arrow_record_batch(&self) -> PyResult<PyObject> {
-        Python::with_gil(|py| {
+    pub fn to_arrow_record_batch(&self) -> PyResult<pyo3::Py<pyo3::PyAny>> {
+        Python::attach(|py| {
             let pyarrow = py.import(pyo3::intern!(py, "pyarrow"))?;
             ffi::record_batch_to_arrow(py, &self.record_batch, pyarrow)
         })
@@ -540,12 +540,12 @@ impl PyRecordBatch {
     #[staticmethod]
     pub fn from_ipc_stream(bytes: Bound<'_, PyBytes>, py: Python) -> PyResult<Self> {
         let buffer = bytes.as_bytes();
-        let record_batch = py.allow_threads(|| RecordBatch::from_ipc_stream(buffer))?;
+        let record_batch = py.detach(|| RecordBatch::from_ipc_stream(buffer))?;
         Ok(record_batch.into())
     }
 
     pub fn to_ipc_stream<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyBytes>> {
-        let buffer = py.allow_threads(|| self.record_batch.to_ipc_stream())?;
+        let buffer = py.detach(|| self.record_batch.to_ipc_stream())?;
         let bytes = PyBytes::new(py, &buffer);
         Ok(bytes)
     }

--- a/src/daft-scan/src/builder.rs
+++ b/src/daft-scan/src/builder.rs
@@ -358,7 +358,7 @@ pub fn delta_scan<T: AsRef<str>>(
 ) -> DaftResult<LogicalPlanBuilder> {
     use crate::storage_config::StorageConfig;
 
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let io_config = io_config.unwrap_or_default();
 
         let storage_config = StorageConfig {
@@ -404,7 +404,7 @@ pub fn iceberg_scan<T: AsRef<str>>(
 ) -> DaftResult<LogicalPlanBuilder> {
     use pyo3::IntoPyObjectExt;
     let storage_config: StorageConfig = io_config.unwrap_or_default().into();
-    let scan_operator = Python::with_gil(|py| -> DaftResult<ScanOperatorHandle> {
+    let scan_operator = Python::attach(|py| -> DaftResult<ScanOperatorHandle> {
         // iceberg_table = pyiceberg.table.StaticTable.from_metadata(metadata_location)
         let iceberg_table_module = PyModule::import(py, "pyiceberg.table")?;
         let iceberg_static_table = iceberg_table_module.getattr("StaticTable")?;

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -15,7 +15,7 @@ struct PyObjectSerializableWrapper(
         serialize_with = "serialize_py_object",
         deserialize_with = "deserialize_py_object"
     )]
-    pub Arc<PyObject>,
+    pub Arc<pyo3::Py<pyo3::PyAny>>,
 );
 
 /// Python arguments to a Python function that produces Tables
@@ -32,9 +32,9 @@ impl Hash for PythonTablesFactoryArgs {
 }
 
 impl PythonTablesFactoryArgs {
-    pub fn new(args: Vec<Arc<PyObject>>) -> Self {
+    pub fn new(args: Vec<Arc<pyo3::Py<pyo3::PyAny>>>) -> Self {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             for obj in &args {
                 // Only hash hashable PyObjects.
                 if let Ok(hash) = obj.bind(py).hash() {
@@ -111,7 +111,7 @@ pub mod pylib {
             file_format_config: PyFileFormatConfig,
             storage_config: StorageConfig,
         ) -> PyResult<Self> {
-            py.allow_threads(|| {
+            py.detach(|| {
                 let schema = schema.schema;
                 let operator = Arc::new(AnonymousScanOperator::new(
                     files,
@@ -149,7 +149,7 @@ pub mod pylib {
             file_path_column: Option<String>,
             skip_glob: bool,
         ) -> PyResult<Self> {
-            py.allow_threads(|| {
+            py.detach(|| {
                 let executor = common_runtime::get_io_runtime(true);
 
                 let task = GlobScanOperator::try_new(
@@ -173,7 +173,10 @@ pub mod pylib {
         }
 
         #[staticmethod]
-        pub fn from_python_scan_operator(py_scan: PyObject, py: Python) -> PyResult<Self> {
+        pub fn from_python_scan_operator(
+            py_scan: pyo3::Py<pyo3::PyAny>,
+            py: Python,
+        ) -> PyResult<Self> {
             let scan_op = ScanOperatorRef(Arc::new(PythonScanOperatorBridge::from_python_abc(
                 py_scan, py,
             )?));
@@ -185,7 +188,7 @@ pub mod pylib {
     #[derive(Debug)]
     pub struct PythonScanOperatorBridge {
         name: String,
-        operator: PyObject,
+        operator: pyo3::Py<pyo3::PyAny>,
         schema: SchemaRef,
         partitioning_keys: Vec<PartitionField>,
         can_absorb_filter: bool,
@@ -196,11 +199,14 @@ pub mod pylib {
     }
 
     impl PythonScanOperatorBridge {
-        fn _name(abc: &PyObject, py: Python) -> PyResult<String> {
+        fn _name(abc: &pyo3::Py<pyo3::PyAny>, py: Python) -> PyResult<String> {
             let result = abc.call_method0(py, pyo3::intern!(py, "name"))?;
             result.extract::<String>(py)
         }
-        fn _partitioning_keys(abc: &PyObject, py: Python) -> PyResult<Vec<PartitionField>> {
+        fn _partitioning_keys(
+            abc: &pyo3::Py<pyo3::PyAny>,
+            py: Python,
+        ) -> PyResult<Vec<PartitionField>> {
             let result = abc.call_method0(py, pyo3::intern!(py, "partitioning_keys"))?;
             result
                 .bind(py)
@@ -209,7 +215,7 @@ pub mod pylib {
                 .collect()
         }
 
-        fn _schema(abc: &PyObject, py: Python) -> PyResult<SchemaRef> {
+        fn _schema(abc: &pyo3::Py<pyo3::PyAny>, py: Python) -> PyResult<SchemaRef> {
             let python_schema = abc.call_method0(py, pyo3::intern!(py, "schema"))?;
             let pyschema = python_schema
                 .getattr(py, pyo3::intern!(py, "_schema"))?
@@ -217,27 +223,27 @@ pub mod pylib {
             Ok(pyschema.schema)
         }
 
-        fn _can_absorb_filter(abc: &PyObject, py: Python) -> PyResult<bool> {
+        fn _can_absorb_filter(abc: &pyo3::Py<pyo3::PyAny>, py: Python) -> PyResult<bool> {
             abc.call_method0(py, pyo3::intern!(py, "can_absorb_filter"))?
                 .extract::<bool>(py)
         }
 
-        fn _can_absorb_limit(abc: &PyObject, py: Python) -> PyResult<bool> {
+        fn _can_absorb_limit(abc: &pyo3::Py<pyo3::PyAny>, py: Python) -> PyResult<bool> {
             abc.call_method0(py, pyo3::intern!(py, "can_absorb_limit"))?
                 .extract::<bool>(py)
         }
 
-        fn _can_absorb_select(abc: &PyObject, py: Python) -> PyResult<bool> {
+        fn _can_absorb_select(abc: &pyo3::Py<pyo3::PyAny>, py: Python) -> PyResult<bool> {
             abc.call_method0(py, pyo3::intern!(py, "can_absorb_select"))?
                 .extract::<bool>(py)
         }
 
-        fn _display_name(abc: &PyObject, py: Python) -> PyResult<String> {
+        fn _display_name(abc: &pyo3::Py<pyo3::PyAny>, py: Python) -> PyResult<String> {
             abc.call_method0(py, pyo3::intern!(py, "display_name"))?
                 .extract::<String>(py)
         }
 
-        fn _supports_count_pushdown(abc: &PyObject, py: Python) -> PyResult<bool> {
+        fn _supports_count_pushdown(abc: &pyo3::Py<pyo3::PyAny>, py: Python) -> PyResult<bool> {
             abc.call_method0(py, pyo3::intern!(py, "supports_count_pushdown"))?
                 .extract::<bool>(py)
         }
@@ -246,7 +252,7 @@ pub mod pylib {
     #[pymethods]
     impl PythonScanOperatorBridge {
         #[staticmethod]
-        pub fn from_python_abc(abc: PyObject, py: Python) -> PyResult<Self> {
+        pub fn from_python_abc(abc: pyo3::Py<pyo3::PyAny>, py: Python) -> PyResult<Self> {
             let name = Self::_name(&abc, py)?;
             let partitioning_keys = Self::_partitioning_keys(&abc, py)?;
             let schema = Self::_schema(&abc, py)?;
@@ -272,8 +278,8 @@ pub mod pylib {
 
     impl SupportsPushdownFilters for PythonScanOperatorBridge {
         fn push_filters(&self, filters: &[ExprRef]) -> (Vec<ExprRef>, Vec<ExprRef>) {
-            Python::with_gil(|py| {
-                let py_filters: Vec<PyObject> = filters
+            Python::attach(|py| {
+                let py_filters: Vec<pyo3::Py<pyo3::PyAny>> = filters
                     .iter()
                     .map(|expr| Py::new(py, PyExpr::from(expr.clone())).unwrap().into())
                     .collect();
@@ -375,7 +381,7 @@ pub mod pylib {
         }
 
         fn to_scan_tasks(&self, pushdowns: Pushdowns) -> DaftResult<Vec<ScanTaskLikeRef>> {
-            let scan_tasks = Python::with_gil(|py| {
+            let scan_tasks = Python::attach(|py| {
                 let pypd = PyPushdowns(pushdowns.clone().into()).into_pyobject(py)?;
                 let pyiter =
                     self.operator
@@ -579,7 +585,7 @@ pub mod pylib {
         pub fn python_factory_func_scan_task(
             module: String,
             func_name: String,
-            func_args: Vec<PyObject>,
+            func_args: Vec<pyo3::Py<pyo3::PyAny>>,
             schema: PySchema,
             num_rows: Option<i64>,
             size_bytes: Option<u64>,

--- a/src/daft-scan/src/storage_config.rs
+++ b/src/daft-scan/src/storage_config.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "python")]
 use {
     common_io_config::python,
-    pyo3::{PyObject, PyResult, Python, pyclass, pymethods},
+    pyo3::{PyResult, Python, pyclass, pymethods},
     std::hash::Hash,
 };
 

--- a/src/daft-scheduler/src/adaptive.rs
+++ b/src/daft-scheduler/src/adaptive.rs
@@ -36,13 +36,13 @@ impl AdaptivePhysicalPlanScheduler {
         py: Python,
         cfg: PyDaftExecutionConfig,
     ) -> PyResult<Self> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let logical_plan = logical_plan_builder.builder.build();
             Ok(Self::new(logical_plan, cfg.config.clone()))
         })
     }
     pub fn next(&mut self, py: Python) -> PyResult<(Option<usize>, PhysicalPlanScheduler)> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let output = self.planner.next_stage()?;
             let sid = output.stage_id();
             Ok((sid, output.into()))
@@ -57,13 +57,13 @@ impl AdaptivePhysicalPlanScheduler {
         &mut self,
         stage_id: usize,
         partition_key: &str,
-        cache_entry: PyObject,
+        cache_entry: pyo3::Py<pyo3::PyAny>,
         num_partitions: usize,
         size_bytes: usize,
         num_rows: usize,
         py: Python,
     ) -> PyResult<()> {
-        py.allow_threads(|| {
+        py.detach(|| {
             let in_memory_info = InMemoryInfo::new(
                 Schema::empty().into(), // TODO thread in schema from in memory scan
                 partition_key.into(),

--- a/src/daft-session/src/python.rs
+++ b/src/daft-session/src/python.rs
@@ -58,13 +58,13 @@ impl PySession {
         source: &PyTableSource,
         replace: bool,
         py: Python,
-    ) -> PyResult<PyObject> {
+    ) -> PyResult<pyo3::Py<pyo3::PyAny>> {
         self.0
             .create_temp_table(name, source.as_ref(), replace)?
             .to_py(py)
     }
 
-    pub fn current_catalog(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    pub fn current_catalog(&self, py: Python<'_>) -> PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
         self.0.current_catalog()?.map(|c| c.to_py(py)).transpose()
     }
 
@@ -77,7 +77,7 @@ impl PySession {
         Ok(None)
     }
 
-    pub fn current_provider(&self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    pub fn current_provider(&self, py: Python<'_>) -> PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
         self.0.current_provider()?.map(|p| p.to_py(py)).transpose()
     }
 
@@ -85,15 +85,19 @@ impl PySession {
         Ok(self.0.current_model()?)
     }
 
-    pub fn get_catalog(&self, py: Python<'_>, name: &str) -> PyResult<PyObject> {
+    pub fn get_catalog(&self, py: Python<'_>, name: &str) -> PyResult<pyo3::Py<pyo3::PyAny>> {
         self.0.get_catalog(name)?.to_py(py)
     }
 
-    pub fn get_provider(&self, py: Python<'_>, name: &str) -> PyResult<PyObject> {
+    pub fn get_provider(&self, py: Python<'_>, name: &str) -> PyResult<pyo3::Py<pyo3::PyAny>> {
         self.0.get_provider(name)?.to_py(py)
     }
 
-    pub fn get_table(&self, py: Python<'_>, ident: &PyIdentifier) -> PyResult<PyObject> {
+    pub fn get_table(
+        &self,
+        py: Python<'_>,
+        ident: &PyIdentifier,
+    ) -> PyResult<pyo3::Py<pyo3::PyAny>> {
         self.0.get_table(ident.as_ref())?.to_py(py)
     }
 
@@ -140,7 +144,11 @@ impl PySession {
     }
 
     #[pyo3(signature = (function, alias = None))]
-    pub fn attach_function(&self, function: PyObject, alias: Option<String>) -> PyResult<()> {
+    pub fn attach_function(
+        &self,
+        function: pyo3::Py<pyo3::PyAny>,
+        alias: Option<String>,
+    ) -> PyResult<()> {
         let wrapped = WrappedUDFClass {
             inner: Arc::new(function),
         };

--- a/src/daft-sql/src/modules/python.rs
+++ b/src/daft-sql/src/modules/python.rs
@@ -26,13 +26,13 @@ impl SQLModule for SQLModulePython {
 }
 
 #[cfg(feature = "python")]
-fn lit_to_py_any(py: Python, expr: &daft_dsl::Expr) -> PyResult<PyObject> {
+fn lit_to_py_any(py: Python, expr: &daft_dsl::Expr) -> PyResult<pyo3::Py<pyo3::PyAny>> {
     match expr {
         Expr::List(exprs) => {
             let literals = exprs
                 .iter()
                 .map(|e| lit_to_py_any(py, e))
-                .collect::<PyResult<Vec<PyObject>>>()?;
+                .collect::<PyResult<Vec<pyo3::Py<pyo3::PyAny>>>>()?;
             literals.into_py_any(py)
         }
         Expr::Literal(lit) => lit.clone().into_py_any(py),
@@ -50,7 +50,7 @@ impl SQLFunction for WrappedUDFClass {
     ) -> crate::error::SQLPlannerResult<daft_dsl::ExprRef> {
         #[cfg(feature = "python")]
         {
-            let e: DaftResult<PyExpr> = pyo3::Python::with_gil(|py| {
+            let e: DaftResult<PyExpr> = pyo3::Python::attach(|py| {
                 let mut args = Vec::with_capacity(inputs.len());
                 let kwargs = PyDict::new(py);
 

--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -2059,7 +2059,7 @@ fn singleton_plan() -> DaftResult<LogicalPlanBuilder> {
         prelude::*,
         types::{IntoPyDict, PyList},
     };
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         // df = DataFrame._from_pydict({"":[""]})
         let df = py
             .import(intern!(py, "daft.dataframe.dataframe"))?

--- a/src/daft-sql/src/python.rs
+++ b/src/daft-sql/src/python.rs
@@ -42,7 +42,7 @@ pub fn sql_exec(
     session: &PySession,
     ctes: HashMap<String, PyLogicalPlanBuilder>,
     config: PyDaftPlanningConfig,
-) -> PyResult<Option<PyObject>> {
+) -> PyResult<Option<pyo3::Py<pyo3::PyAny>>> {
     // Prepare any externally provided CTEs.
     let ctes = ctes
         .into_iter()

--- a/src/daft-writers/src/lance.rs
+++ b/src/daft-writers/src/lance.rs
@@ -38,7 +38,7 @@ impl AsyncFileWriter for LanceWriter {
         self.bytes_written += data
             .size_bytes()
             .expect("MicroPartition should have size_bytes for LanceWriter");
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_micropartition = py
                 .import(pyo3::intern!(py, "daft.recordbatch"))?
                 .getattr(pyo3::intern!(py, "MicroPartition"))?

--- a/src/daft-writers/src/pyarrow.rs
+++ b/src/daft-writers/src/pyarrow.rs
@@ -4,12 +4,12 @@ use async_trait::async_trait;
 use common_error::DaftResult;
 use daft_micropartition::{MicroPartition, python::PyMicroPartition};
 use daft_recordbatch::{RecordBatch, python::PyRecordBatch};
-use pyo3::{PyObject, Python, types::PyAnyMethods};
+use pyo3::{Python, types::PyAnyMethods};
 
 use crate::{AsyncFileWriter, WriteResult};
 
 pub struct PyArrowWriter {
-    py_writer: PyObject,
+    py_writer: pyo3::Py<pyo3::PyAny>,
     is_closed: bool,
     bytes_written: usize,
 }
@@ -22,7 +22,7 @@ impl PyArrowWriter {
         io_config: Option<&daft_io::IOConfig>,
         partition_values: Option<&RecordBatch>,
     ) -> DaftResult<Self> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let file_writer_module = py.import(pyo3::intern!(py, "daft.io.writer"))?;
             let file_writer_class = file_writer_module.getattr("ParquetFileWriter")?;
             let _from_pyrecordbatch = py
@@ -61,7 +61,7 @@ impl PyArrowWriter {
         io_config: Option<&daft_io::IOConfig>,
         partition_values: Option<&RecordBatch>,
     ) -> DaftResult<Self> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let file_writer_module = py.import(pyo3::intern!(py, "daft.io.writer"))?;
             let file_writer_class = file_writer_module.getattr("CSVFileWriter")?;
             let _from_pyrecordbatch = py
@@ -101,7 +101,7 @@ impl PyArrowWriter {
         partition_values: Option<&RecordBatch>,
         io_config: Option<&daft_io::IOConfig>,
     ) -> DaftResult<Self> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let file_writer_module = py.import(pyo3::intern!(py, "daft.io.writer"))?;
             let file_writer_class = file_writer_module.getattr("IcebergWriter")?;
             let _from_pyrecordbatch = py
@@ -143,7 +143,7 @@ impl PyArrowWriter {
         partition_values: Option<&RecordBatch>,
         io_config: Option<&daft_io::IOConfig>,
     ) -> DaftResult<Self> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let file_writer_module = py.import(pyo3::intern!(py, "daft.io.writer"))?;
             let file_writer_class = file_writer_module.getattr("DeltalakeWriter")?;
             let _from_pyrecordbatch = py
@@ -185,7 +185,7 @@ impl AsyncFileWriter for PyArrowWriter {
     async fn write(&mut self, data: Self::Input) -> DaftResult<WriteResult> {
         assert!(!self.is_closed, "Cannot write to a closed PyArrowWriter");
         let rows_written = data.len();
-        let bytes_written = Python::with_gil(|py| {
+        let bytes_written = Python::attach(|py| {
             let py_micropartition = py
                 .import(pyo3::intern!(py, "daft.recordbatch"))?
                 .getattr(pyo3::intern!(py, "MicroPartition"))?
@@ -212,7 +212,7 @@ impl AsyncFileWriter for PyArrowWriter {
 
     async fn close(&mut self) -> DaftResult<Self::Result> {
         self.is_closed = true;
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let result = self
                 .py_writer
                 .call_method0(py, pyo3::intern!(py, "close"))?

--- a/src/daft-writers/src/sink.rs
+++ b/src/daft-writers/src/sink.rs
@@ -35,7 +35,7 @@ impl AsyncFileWriter for DataSinkWriter {
     async fn write(&mut self, data: Self::Input) -> DaftResult<WriteResult> {
         let rows_written = data.len();
         let mut bytes_written = 0;
-        let mp_result: PyRecordBatch = Python::with_gil(|py| -> pyo3::PyResult<_> {
+        let mp_result: PyRecordBatch = Python::attach(|py| -> pyo3::PyResult<_> {
             // Grab the current micropartition and pass it to the data sink.
             let py_micropartition = py
                 .import(pyo3::intern!(py, "daft.recordbatch"))?


### PR DESCRIPTION
## Changes Made

bumps pyo3 and related dependencies to 26

Pretty much just a find & replace /s/old/new

- `with_gil` -> `attach`
- `allow_threads` -> `detach`
- `PyObject` -> `Py<PyAny>`

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
