### PR TITLE
fix: Actually clone the repo before publishing quickstart helm chart

### DIFF
--- a/.github/workflows/publish-daft-quickstart-chart.yml
+++ b/.github/workflows/publish-daft-quickstart-chart.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - main
     paths:
+    - '.github/workflows/publish-daft-quickstart-chart.yml'
     - 'k8s/charts/quickstart/**'
   workflow_dispatch:
 
@@ -15,10 +16,18 @@ jobs:
       contents: write
       id-token: write
     steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4
     - name: Install Helm
       uses: azure/setup-helm@v4
       with:
         version: 'latest'
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Publish Production Helm Chart
       run: |
         version="$(grep '^version:' k8s/charts/quickstart/Chart.yaml | sed 's/version: //')"


### PR DESCRIPTION
## Changes Made

Fix quickstart chart build.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
