### PR TITLE
docs: warning for Common Crawl dataset API instability

### DIFF
--- a/docs/datasets/common-crawl.md
+++ b/docs/datasets/common-crawl.md
@@ -4,6 +4,10 @@
 
 Daft provides a simple, performant, and responsible way to access Common Crawl data.
 
+!!! warning "Warning"
+
+    These APIs are in beta and may be subject to change as the Common Crawl dataset continues to be developed.
+
 ## Prerequisites for access within the AWS Cloud
 
 Common Crawl data is hosted by [Amazon Web Services' Open Data Sets Sponsorships program](https://aws.amazon.com/opendata/) which makes it freely accessible.


### PR DESCRIPTION
The Common Crawl dataset is being actively developed and is not yet stabilized. Breaking charges are possible until this warning is removed.

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [x] Documentation builds and is formatted properly
