### PR TITLE
fix: Drop table error in current active session

### DIFF
--- a/daft/session.py
+++ b/daft/session.py
@@ -750,7 +750,7 @@ def drop_namespace(identifier: Identifier | str) -> None:
 
 def drop_table(identifier: Identifier | str) -> None:
     """Drops the table in the current session's active catalog."""
-    return _session().drop_namespace(identifier)
+    return _session().drop_table(identifier)
 
 
 ###


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Fix the implementation error in `daft.drop_table(...)`, which currently deletes the entire namespace.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
