### PR TITLE
fix: report a more reasonable error message when select * from <some_keywords>

### DIFF
--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -34,7 +34,7 @@ use sqlparser::{
     },
     dialect::GenericDialect,
     parser::{Parser, ParserOptions},
-    tokenizer::Tokenizer,
+    tokenizer::{Token, Tokenizer},
 };
 
 use crate::{
@@ -260,7 +260,37 @@ impl SQLPlanner<'_> {
     }
 
     pub fn plan(&mut self, input: &str) -> SQLPlannerResult<Statement> {
-        let tokens = Tokenizer::new(&GenericDialect {}, input).tokenize()?;
+        let tokens: Vec<sqlparser::tokenizer::Token> =
+            Tokenizer::new(&GenericDialect {}, input).tokenize()?;
+
+        let from_positions: Vec<usize> = tokens
+            .iter()
+            .enumerate()
+            .filter_map(|(i, token)| match token {
+                Token::Word(w) if w.keyword == sqlparser::keywords::Keyword::FROM => Some(i),
+                _ => None,
+            })
+            .collect();
+
+        for pos in from_positions {
+            let next_token = tokens
+                .iter()
+                .skip(pos + 1)
+                .find(|token| !matches!(token, Token::Whitespace(_)));
+            if let Some(Token::Word(w)) = next_token {
+                match w.keyword {
+                    sqlparser::keywords::Keyword::LATERAL
+                    | sqlparser::keywords::Keyword::TABLE
+                    | sqlparser::keywords::Keyword::UNNEST => {
+                        invalid_operation_err!(
+                            "{} is a SQL keyword, not a valid table name",
+                            w.value
+                        )
+                    }
+                    _ => (),
+                }
+            }
+        }
 
         let mut parser = Parser::new(&GenericDialect {})
             .with_options(ParserOptions {

--- a/tests/sql/test_sql.py
+++ b/tests/sql/test_sql.py
@@ -188,6 +188,23 @@ def test_sql_function_register_globals(set_global_df):
         daft.sql("SELECT * FROM GLOBAL_DF", register_globals=False)
 
 
+def test_sql_function_table_name_is_keyword(set_global_df):
+    with pytest.raises(Exception, match="is a SQL keyword, not a valid table name"):
+        daft.sql("SELECT * FROM TABLE")
+    with pytest.raises(Exception, match="is a SQL keyword, not a valid table name"):
+        daft.sql("SELECT * FROM              TABLE")
+    with pytest.raises(Exception, match="is a SQL keyword, not a valid table name"):
+        daft.sql("SELECT * FROM\nTABLE")
+    with pytest.raises(Exception, match="is a SQL keyword, not a valid table name"):
+        daft.sql("SELECT * FROM\n\n   \t\tTABLE")
+    with pytest.raises(Exception, match="is a SQL keyword, not a valid table name"):
+        daft.sql("SELECT * FROM UNNEST")
+    with pytest.raises(Exception, match="is a SQL keyword, not a valid table name"):
+        daft.sql("SELECT * FROM LATERAL")
+    with pytest.raises(Exception, match="failed to parse sql"):
+        daft.sql("SELECT * FROM")
+
+
 def test_sql_function_raises_when_cant_get_frame(monkeypatch):
     monkeypatch.setattr("inspect.currentframe", lambda: None)
     with pytest.raises(DaftCoreException, match="Cannot get caller environment"):


### PR DESCRIPTION
## Changes Made

Changed `daft-sql/src/planner.rs` plan to be able to detect FROM <keyword> case before parser. So it won't result in a general parser error message

## Related Issues

Closes #4179

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
