### PR TITLE
feat: add --addr flag to daft-dashboard cli

### DIFF
--- a/src/daft-dashboard/src/lib.rs
+++ b/src/daft-dashboard/src/lib.rs
@@ -5,7 +5,10 @@ pub mod engine;
 pub mod python;
 pub(crate) mod state;
 
-use std::{net::Ipv4Addr, sync::Arc};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    sync::Arc,
+};
 
 use axum::{
     Json, Router,
@@ -28,6 +31,7 @@ use tracing::Level;
 
 use crate::state::{DashboardState, GLOBAL_DASHBOARD_STATE};
 
+// NOTE(void001): default listen to all ipv4 address, which pose a security risk in production environment
 pub const DEFAULT_SERVER_ADDR: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
 pub const DEFAULT_SERVER_PORT: u16 = 3238;
 
@@ -274,6 +278,7 @@ async fn ping() -> StatusCode {
 }
 
 pub async fn launch_server(
+    addr: IpAddr,
     port: u16,
     shutdown_fn: impl Future<Output = ()> + Send + 'static,
 ) -> std::io::Result<()> {
@@ -303,7 +308,7 @@ pub async fn launch_server(
         .with_state(GLOBAL_DASHBOARD_STATE.clone());
 
     // Start the server
-    let listener = TcpListener::bind((DEFAULT_SERVER_ADDR, port)).await?;
+    let listener = TcpListener::bind((addr, port)).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_fn)
         .await

--- a/src/daft-dashboard/src/python.rs
+++ b/src/daft-dashboard/src/python.rs
@@ -83,7 +83,7 @@ pub fn launch(noop_if_initialized: bool) -> PyResult<ConnectionHandle> {
         }
     }
 
-    let port = super::DEFAULT_SERVER_PORT; // TODO: Make configurable
+    let port = super::DEFAULT_SERVER_PORT;
     let (send, recv) = oneshot::channel::<()>();
 
     let handle = ConnectionHandle {
@@ -93,7 +93,12 @@ pub fn launch(noop_if_initialized: bool) -> PyResult<ConnectionHandle> {
     let _ = std::thread::spawn(move || {
         DASHBOARD_ENABLED.store(true, Ordering::SeqCst);
         let res = tokio_runtime().block_on(async {
-            super::launch_server(port, async move { recv.await.unwrap() }).await
+            super::launch_server(
+                std::net::IpAddr::V4(super::DEFAULT_SERVER_ADDR),
+                port,
+                async move { recv.await.unwrap() },
+            )
+            .await
         });
         DASHBOARD_ENABLED.store(false, Ordering::SeqCst);
         res


### PR DESCRIPTION
## Changes Made

- Add `--addr` flag to daft dashboard, so that it can support arbitrary address
- Add warning when running `daft-dashboard` with addr 0.0.0.0 or :: to
      avoid accidentally exposing the service to the external network

**NOTE**: Will first make daft-cli work, the python.rs will get changed in another patch

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
