### PR TITLE
fix: Undetach flotilla runner

### DIFF
--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -295,7 +295,6 @@ class FlotillaRunner:
             name=FLOTILLA_RUNNER_NAME,
             namespace=FLOTILLA_RUNNER_NAMESPACE,
             get_if_exists=True,
-            lifetime="detached",
             scheduling_strategy=(
                 ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
                     node_id=head_node_id,


### PR DESCRIPTION
## Changes Made

The benefit of a detached flotilla runner is that concurrent jobs on the same cluster use the same runner and swordfish workers can be resued, however, actors are not getting torn down or scaled down when job is cancelled or idle.

The latter situation seems more pressing, and so this PR reverts back to a non detached actor, and in the future we should test for these cases if we implement detached again

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
