### PR TITLE
feat: better display for FileArrays

### DIFF
--- a/src/daft-core/src/file/mod.rs
+++ b/src/daft-core/src/file/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "python")]
 pub mod python;
 
-use std::{marker::PhantomData, sync::Arc};
+use std::{fmt, marker::PhantomData, sync::Arc};
 
 use common_io_config::IOConfig;
 pub use daft_schema::media_type::MediaType;
@@ -75,9 +75,26 @@ impl FileReference {
     }
 }
 
-impl std::fmt::Display for FileReference {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "File({:?})", self)
+impl fmt::Display for FileReference {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.inner {
+            DataOrReference::Reference(path, config) => {
+                write!(
+                    f,
+                    "{}(path: {}{})",
+                    self.media_type,
+                    path,
+                    if config.is_some() {
+                        " [with config]"
+                    } else {
+                        ""
+                    }
+                )
+            }
+            DataOrReference::Data(data) => {
+                write!(f, "{}(in-memory: {} bytes)", self.media_type, data.len())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Changes Made

Now renders files as 
```
# for file variants
{MediaType}(path: {file.path}) 
# for bytes variants
{MediaType}(in-memory: {bytes.len} len)
```


## Related Issues

Closes https://github.com/Eventual-Inc/Daft/issues/5477

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
