### PR TITLE
fix: Don't update lockfile in package builds

### DIFF
--- a/src/daft-dashboard/build.rs
+++ b/src/daft-dashboard/build.rs
@@ -57,7 +57,7 @@ fn default_main(out_dir: &str) -> Result<(), Box<dyn std::error::Error>> {
     // Install dependencies
     let install_status = Command::new("bun")
         .current_dir("./frontend")
-        .args(["install"])
+        .args(["install", "--frozen-lockfile"])
         .status()?;
 
     if cfg!(debug_assertions) {


### PR DESCRIPTION
## Changes Made

We should avoid updating the file on package builds (including LSPs). Only when someone explicitly runs `bun install` in the frontend folder should the lockfile get updated.
