### PR TITLE
docs: add Try Daft Cloud link to documentation navigation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -97,6 +97,7 @@
         * [USE](sql/statements/use.md)
     * [Data Types](sql/datatypes.md)
     * [Window Functions](sql/window_functions.md)
+* [Try Daft Cloud](https://www.eventual.ai/early-access)
 
 <!--
 TODO


### PR DESCRIPTION
## Changes Made

Add a new external link to the Daft Cloud early access page in the top navigation bar after the SQL Reference section.

## Checklist

- [x] Documentation builds and is formatted properly