### PR TITLE
ci: fix bun install by using node 20

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -88,6 +88,11 @@ jobs:
           echo "CFLAGS=-msse3 -mssse3 -msse4.1 -msse4.2 -mpopcnt -mcx16 -mavx -mavx2 -mfma -mbmi -mbmi2 -mlzcnt -mpclmul -mmovbe -mtune=skylake" >> $GITHUB_ENV
         fi
 
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: 20
+
     - name: Build dashboard with Bun
       working-directory: ./src/daft-dashboard/frontend
       run: |


### PR DESCRIPTION
## Changes Made

The release build currently fails because the buildjet machines have Node 18 but for some reason, Nextjs requires Node 20. 

https://github.com/Eventual-Inc/Daft/actions/runs/19058572716/job/54433734320

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
