### PR TITLE
chore: remove extra from build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ hooks: .venv
 
 .PHONY: build
 build: check-toolchain .venv  ## Compile and install Daft for development
-	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin develop --extras=all --uv
+	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin develop --uv
 
 .PHONY: build-release
 build-release: check-toolchain .venv  ## Compile and install a faster Daft binary


### PR DESCRIPTION
## Changes Made

Remove `--extras=all` of `make build` command since all optional groups have been installed via `make .venv`, otherwise, during uv parse the `all` group, and found it's a recursive reference, and then parsing `daft[aws]`, will fetch the depencies from Pypi and then install the latest daft version and its dependencies instead of using the dependencies from current project.

For example, running `make build` on main branch:
```
➜  Daft git:(github-main) ✗ make build
Toolchain is correct, continuing with build
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support
🐍 Not using a specific python interpreter
📡 Using build options features from pyproject.toml
Resolved 119 packages in 1.98s
Prepared 1 package in 23.45s
Uninstalled 1 package in 2ms
Installed 1 package in 9ms
 - daft==0.3.0.dev0 (from file:///Users/bytedance/workspace/bd/emr-products/Daft)
 + daft==0.6.9
warning: The package `daft==0.6.9` does not have an extra named `sentence-transformers`
   Compiling indexmap v2.11.4
   Compiling pyo3-build-config v0.26.0
   Compiling xxhash-rust v0.8.15
   Compiling mime_guess v2.0.5
   Compiling common-macros v0.3.0-dev0 (/Users/bytedance/workspace/bd/emr-products/Daft/src/common/macros)
   Compiling tokio-stream v0.1.17
   Compiling opentelemetry v0.31.0
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
