### PR TITLE
WIP: adaptive dispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,11 +1090,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core 0.5.5",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1109,8 +1109,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -1144,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1155,7 +1154,6 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -2589,7 +2587,7 @@ name = "daft-dashboard"
 version = "0.3.0-dev0"
 dependencies = [
  "async-stream",
- "axum 0.8.4",
+ "axum 0.8.6",
  "common-metrics",
  "daft-recordbatch",
  "dashmap",
@@ -2983,7 +2981,7 @@ dependencies = [
  "common-scan-info",
  "common-system-info",
  "common-tracing",
- "console 0.16.1",
+ "console 0.15.11",
  "daft-context",
  "daft-core",
  "daft-csv",
@@ -3003,7 +3001,7 @@ dependencies = [
  "daft-writers",
  "futures",
  "indexmap 2.11.4",
- "indicatif 0.18.0",
+ "indicatif 0.18.2",
  "itertools 0.14.0",
  "kanal",
  "log",
@@ -3655,9 +3653,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dtor"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
 dependencies = [
  "dtor-proc-macro",
 ]
@@ -4873,9 +4871,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+checksum = "ade6dfcba0dfb62ad59e59e7241ec8912af34fd29e0e743e3db992bd278e8b65"
 dependencies = [
  "console 0.16.1",
  "portable-atomic",
@@ -6540,9 +6538,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d359e20231345f21a3b5b6aea7e73f4dc97e1712ef3bfe2d88997ac6a308d784"
+checksum = "2f8bae9ad5ba08b0b0ed2bb9c2bdbaeccc69cafca96d78cf0fbcea0d45d122bb"
 dependencies = [
  "arc-swap",
  "log",

--- a/src/daft-local-execution/src/adaptive_dispatcher.rs
+++ b/src/daft-local-execution/src/adaptive_dispatcher.rs
@@ -1,0 +1,254 @@
+use std::sync::Arc;
+
+use common_error::{DaftError, DaftResult};
+use common_runtime::get_compute_runtime;
+use daft_micropartition::MicroPartition;
+use tokio::sync::{Mutex, mpsc};
+
+use crate::{
+    RuntimeHandle,
+    buffer::RowBasedBuffer,
+    channel::{Sender, create_channel},
+    dispatcher::{DispatchSpawner, SpawnedDispatchResult},
+    pipeline::MorselSizeRequirement,
+    runtime_stats::InitializingCountingReceiver,
+};
+
+#[derive(Debug, Clone)]
+struct ChannelStats {
+    total_sent: Arc<Mutex<usize>>,
+    inflight_count: Arc<Mutex<usize>>,
+}
+
+impl ChannelStats {
+    fn new() -> Self {
+        Self {
+            total_sent: Arc::new(Mutex::new(0)),
+            inflight_count: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    async fn increment_sent(&self) {
+        let mut total = self.total_sent.lock().await;
+        let mut inflight = self.inflight_count.lock().await;
+        *total += 1;
+        *inflight += 1;
+    }
+
+    async fn decrement_inflight(&self) {
+        let mut inflight = self.inflight_count.lock().await;
+        *inflight = inflight.saturating_sub(1);
+    }
+
+    async fn get_stats(&self) -> (usize, usize) {
+        let total = *self.total_sent.lock().await;
+        let inflight = *self.inflight_count.lock().await;
+        (total, inflight)
+    }
+}
+
+/// Adaptive dispatcher that uses a shared queue and worker coroutines
+pub struct AdaptiveDispatcher {
+    morsel_size_lower_bound: usize,
+    morsel_size_upper_bound: usize,
+}
+
+impl AdaptiveDispatcher {
+    pub fn new(morsel_size_requirement: MorselSizeRequirement) -> Self {
+        let (lower_bound, upper_bound) = match morsel_size_requirement {
+            MorselSizeRequirement::Strict(size) => (size, size),
+            MorselSizeRequirement::Flexible(lower, upper) => (lower, upper),
+        };
+        Self {
+            morsel_size_lower_bound: lower_bound,
+            morsel_size_upper_bound: upper_bound,
+        }
+    }
+
+    async fn dispatch_inner(
+        worker_senders: Vec<Sender<Arc<MicroPartition>>>,
+        input_receivers: Vec<InitializingCountingReceiver>,
+        morsel_size_lower_bound: usize,
+        morsel_size_upper_bound: usize,
+    ) -> DaftResult<()> {
+        let (work_tx, work_rx) = mpsc::channel::<Arc<MicroPartition>>(worker_senders.len());
+        let work_rx = Arc::new(Mutex::new(work_rx));
+        let stats = ChannelStats::new();
+        let compute_runtime = get_compute_runtime();
+
+        let mut worker_tasks = vec![];
+        for (worker_idx, worker_sender) in worker_senders.into_iter().enumerate() {
+            let work_rx = Arc::clone(&work_rx);
+            let stats = stats.clone();
+
+            let worker_task = compute_runtime.spawn(async move {
+                log::debug!(
+                    "Worker {} started, will pull from shared work queue when idle",
+                    worker_idx
+                );
+                let mut processed_count = 0;
+
+                loop {
+                    let morsel = {
+                        let mut rx = work_rx.lock().await;
+                        let (_, inflight) = stats.get_stats().await;
+                        log::debug!(
+                            "Worker {}: got lock, waiting for morsel, queue size: {}",
+                            worker_idx,
+                            inflight
+                        );
+                        let morsel = match rx.recv().await {
+                            Some(morsel) => {
+                                log::debug!(
+                                    "Worker {}: got a morsel, queue size: {}",
+                                    worker_idx,
+                                    inflight - 1
+                                );
+                                morsel
+                            }
+                            None => {
+                                log::debug!(
+                                    "Worker {}: work queue closed, processed {} morsels total",
+                                    worker_idx,
+                                    processed_count
+                                );
+                                break;
+                            }
+                        };
+                        log::debug!("Worker {}: release lock", worker_idx);
+                        morsel
+                    };
+
+                    stats.decrement_inflight().await;
+                    if worker_sender.send(morsel.clone()).await.is_err() {
+                        log::debug!("Worker {}: send failed, exiting", worker_idx);
+                        break;
+                    } else {
+                        log::debug!("Worker {}: send morsel success", worker_idx);
+                    }
+
+                    processed_count += 1;
+                    if processed_count % 100 == 0 {
+                        log::debug!(
+                            "Worker {} processed {} morsels",
+                            worker_idx,
+                            processed_count
+                        );
+                    }
+                }
+            });
+
+            worker_tasks.push(worker_task);
+        }
+
+        let stats_value = stats.clone();
+        let producer_task = compute_runtime.spawn(async move {
+            log::debug!("Producer task started, pushing to shared work queue");
+            let mut total_morsels = 0;
+            let stats = stats_value.clone();
+
+            for receiver in input_receivers {
+                let mut buffer =
+                    RowBasedBuffer::new(morsel_size_lower_bound, morsel_size_upper_bound);
+
+                while let Some(morsel) = receiver.recv().await {
+                    buffer.push(&morsel);
+
+                    while let Some(ready_morsels) = buffer.pop_enough()? {
+                        for ready_morsel in ready_morsels {
+                            if work_tx.send(ready_morsel).await.is_err() {
+                                log::debug!("Producer: work queue send failed");
+                                return Ok::<(), DaftError>(());
+                            } else {
+                                let (_, inflight) = stats.get_stats().await;
+                                log::debug!(
+                                    "Producer send morsel success, queue size: {}",
+                                    inflight + 1
+                                );
+                            }
+                            stats.increment_sent().await;
+                            total_morsels += 1;
+                        }
+                    }
+                }
+
+                if let Some(last_morsel) = buffer.pop_all()? {
+                    if work_tx.send(last_morsel).await.is_err() {
+                        log::debug!("Producer: final work queue send failed");
+                        return Ok(());
+                    } else {
+                        let (_, inflight) = stats.get_stats().await;
+                        log::debug!("Producer send morsel success, queue size: {}", inflight + 1);
+                    }
+                    stats.increment_sent().await;
+                    total_morsels += 1;
+                }
+            }
+
+            log::debug!("Producer finished, sent {} morsels total", total_morsels);
+
+            drop(work_tx);
+
+            Ok(())
+        });
+
+        match producer_task.await {
+            Ok(Ok(())) => {
+                let (total_sent, inflight) = stats.get_stats().await;
+                log::info!(
+                    "Producer task completed successfully, Final stats - Total sent: {}, Inflight: {}",
+                    total_sent,
+                    inflight
+                );
+            }
+            Ok(Err(e)) => log::error!("Producer task failed with DaftError: {:?}", e),
+            Err(e) => log::error!("Producer task panicked: {:?}", e),
+        }
+
+        for (idx, worker_task) in worker_tasks.into_iter().enumerate() {
+            if let Err(e) = worker_task.await {
+                log::error!("Worker {} task failed: {:?}", idx, e);
+            }
+        }
+
+        let (total_sent, inflight) = stats.get_stats().await;
+        log::info!(
+            "Dispatcher shutdown - Total sent: {}, Inflight: {}",
+            total_sent,
+            inflight
+        );
+
+        log::info!("Adaptive dispatcher completed");
+        Ok(())
+    }
+}
+
+impl DispatchSpawner for AdaptiveDispatcher {
+    fn spawn_dispatch(
+        &self,
+        input_receivers: Vec<InitializingCountingReceiver>,
+        num_workers: usize,
+        runtime_handle: &mut RuntimeHandle,
+    ) -> SpawnedDispatchResult {
+        let (worker_senders, worker_receivers): (Vec<_>, Vec<_>) =
+            (0..num_workers).map(|_| create_channel(0)).unzip();
+
+        let morsel_size_lower_bound = self.morsel_size_lower_bound;
+        let morsel_size_upper_bound = self.morsel_size_upper_bound;
+
+        let task = runtime_handle.spawn(async move {
+            Self::dispatch_inner(
+                worker_senders,
+                input_receivers,
+                morsel_size_lower_bound,
+                morsel_size_upper_bound,
+            )
+            .await
+        });
+
+        SpawnedDispatchResult {
+            worker_receivers,
+            spawned_dispatch_task: task,
+        }
+    }
+}

--- a/src/daft-local-execution/src/dispatcher.rs
+++ b/src/daft-local-execution/src/dispatcher.rs
@@ -4,6 +4,7 @@ use common_error::DaftResult;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_micropartition::MicroPartition;
 
+pub use crate::adaptive_dispatcher::AdaptiveDispatcher;
 use crate::{
     RuntimeHandle, SpawnedTask,
     buffer::RowBasedBuffer,

--- a/src/daft-local-execution/src/intermediate_ops/distributed_actor_pool_project.rs
+++ b/src/daft-local-execution/src/intermediate_ops/distributed_actor_pool_project.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -211,6 +212,20 @@ impl IntermediateOperator for DistributedActorPoolProjectOperator {
         // We set the max concurrency to be the number of actor handles * 2 to such that each actor handle has 2 workers submitting to it.
         // This allows inputs to be queued up concurrently with UDF execution.
         Ok(self.actor_handles.len() * 2)
+    }
+
+    fn use_adaptive_balancer(&self) -> bool {
+        // TODO consider use a udf config to enable/disable adaptive balancer
+        env::var("DAFT_USE_ADAPTIVE_BALANCER")
+            .map(|val| val.to_lowercase() == "true" || val == "1")
+            .unwrap_or(false)
+    }
+
+    fn maintain_order(&self) -> bool {
+        // TODO consider how to define the maintain order or intermediate operator, from execution config?
+        env::var("DAFT_MAINTAIN_ORDER")
+            .map(|val| val.to_lowercase() == "true" || val == "1")
+            .unwrap_or(true)
     }
 
     fn morsel_size_requirement(&self) -> Option<MorselSizeRequirement> {

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -1,3 +1,4 @@
+mod adaptive_dispatcher;
 mod buffer;
 mod channel;
 mod dispatcher;


### PR DESCRIPTION
## Changes Made

Try to solve two problems:
1. let `maintain_order` configureable, Currently it's hardcode, which has some drawbacks that the RoundRobinDispatcher or RoundRobinReceiver might bock on fetch data from one receiver, and other receivers cannot be called, and the bring backpressure to upstream.
![img_v3_02ro_2c64b358-5645-4a28-9864-62110c408ehu](https://github.com/user-attachments/assets/9033d212-fac5-4051-9754-913b8f5680f3)

3. Implement a AdaptiveDispatcher or PullBasedDispatcher to solve the long-tail problem of UDF. The current dispatcher will split or coalesce Morsel with morsel requirement size and then dispatcher to UDFActor/UDFWorker, which only keep the balance from num_rows dimension, but different row might has different size, and the computing cost is different, it lead to some UDF instances complete computing quickly and idled, but other UDF instances is still running and there are some Morsels still pending. The reason of this case is which Morsel/MicroPartition will be dispatch to which UDFActor is pre-defined within RoundRobinDispatcher, which used the push mode. So we can add a new Dispatcher with pull mode by fetching morsel/MicroPartition from child/up stream receivers and send to a queue, and the downstream pull the morsel/MicroPartition from queue once it finished last morsel/MicroPartition.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
