### PR TITLE
ci: Skip Windows Rust Tests in PRs

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1096,7 +1096,7 @@ jobs:
     needs: skipcheck
     if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     runs-on: ${{ matrix.os }}-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Changes Made

Based on issues we're seeing with the Rust Windows tests timing out due to cache misses, I increased the timeouts. Also based on external discussions, we believe it should be fine to skip the windows tests on PR CI and only run when merging in main.

Note that we still run the Daft import tests on Windows in PR CI.