### PR TITLE
fix: Handle Nones when embedding text with openai

### DIFF
--- a/daft/ai/openai/protocols/text_embedder.py
+++ b/daft/ai/openai/protocols/text_embedder.py
@@ -173,6 +173,9 @@ class OpenAITextEmbedder(TextEmbedder):
             curr_batch_token_count = 0
 
         for input_text in text:
+            # Handle None values by treating them as empty strings
+            if input_text is None:
+                input_text = ""
             input_text_token_count = len(input_text) // approx_chars_per_token
             if input_text_token_count > input_text_token_limit:
                 # Must process previous inputs first, if any, to maintain ordered outputs.

--- a/tests/ai/openai/test_openai_text_embedder.py
+++ b/tests/ai/openai/test_openai_text_embedder.py
@@ -220,6 +220,34 @@ def test_embed_text_empty_input(mock_text_embedder, mock_client):
     mock_client.embeddings.create.assert_not_called()
 
 
+def test_embed_text_with_none_values(mock_text_embedder, mock_client):
+    """Test that None values are handled gracefully and don't crash."""
+    mock_response = Mock(spec=CreateEmbeddingResponse)
+    mock_embeddings = []
+    for i in range(3):
+        mock_embedding = Mock(spec=OpenAIEmbedding)
+        mock_embedding.embedding = np.array([float(i), 0.2, 0.3] * 512, dtype=np.float32)  # 1536 dimensions
+        mock_embeddings.append(mock_embedding)
+    mock_response.data = mock_embeddings
+    mock_client.embeddings.create.return_value = mock_response
+
+    # Test with None values mixed with regular strings
+    result = mock_text_embedder.embed_text([None, "Hello", None])
+
+    assert len(result) == 3
+    for embedding in result:
+        assert isinstance(embedding, np.ndarray)
+        assert embedding.shape == (1536,)
+        assert embedding.dtype == np.float32
+
+    # Verify that None values were converted to empty strings
+    mock_client.embeddings.create.assert_called_once()
+    call_args = mock_client.embeddings.create.call_args
+    assert call_args[1]["input"] == ["", "Hello", ""]
+    assert call_args[1]["model"] == "text-embedding-3-small"
+    assert call_args[1]["encoding_format"] == "float"
+
+
 def test_embed_text_failure_with_zero_on_failure(mock_text_embedder, mock_client):
     """Test that failures are handled when zero_on_failure is True."""
     mock_client.embeddings.create.side_effect = Exception("API Error")


### PR DESCRIPTION
## Changes Made

If there is a null value, we get 
```
>           input_text_token_count = len(input_text) // approx_chars_per_token
E           TypeError: object of type 'NoneType' has no len()
```

This happened in the middle of my pipeline and crashed it.

Let's just use an empty string in this case.
