### PR TITLE
feat: Bind the name of the running UDF to the UDFActor

### DIFF
--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -55,6 +55,7 @@ impl UDFActors {
             None => (0.0, 1.0, 0),
         };
 
+        let actor_name = udf_properties.name.clone();
         let result =
             common_runtime::python::execute_python_coroutine::<_, Vec<Py<PyAny>>>(move |py| {
                 let ray_actor_pool_udf_module =
@@ -68,6 +69,7 @@ impl UDFActors {
                         cpu_request,
                         memory_request,
                         actor_ready_timeout,
+                        actor_name,
                     ),
                 )
             })


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

When diagnosing a job containing multiple Actor UDFs, it's not very intuitive to see which UDF a UDFActor is running on the Ray UI. Therefore, this PR attempts to implement binding the name of the running UDF to the UDFActor. Like this:

<img width="1634" height="1196" alt="image" src="https://github.com/user-attachments/assets/22b4f310-bf88-4871-b74d-5f2151daba55" />


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
