### PR TITLE
fix: Fix broken benchmark blog link

### DIFF
--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -6,7 +6,7 @@
 
     These benchmarks showcase [Flotilla](https://www.daft.ai/blog/introducing-flotilla-simplifying-multimodal-data-processing-at-scale), Daft's distributed engine optimized for multimodal data processing.
 
-    [Daft vs Spark vs Ray Data: Benchmarks for Multimodal AI Workloads](https://www.daft.ai/blog/benchmarks-for-modalities-workloads) - Full methodology and technical deep-dive.
+    [Daft vs Spark vs Ray Data: Benchmarks for Multimodal AI Workloads](https://www.daft.ai/blog/benchmarks-for-multimodal-ai-workloads) - Full methodology and technical deep-dive.
 
 Modern AI workloads demand simple, fast, and scalable data engines. Daft is purpose-built for these workloads, excelling where traditional big data frameworks fall short.
 


### PR DESCRIPTION
## Changes Made

Fix benchmark blog link from https://www.daft.ai/blog/benchmarks-for-modalities-workloads -> https://www.daft.ai/blog/benchmarks-for-multimodal-ai-workloads

For future reference, the broken link checker will inform which links are broken (scroll to the bottom of the job logs). https://github.com/Eventual-Inc/Daft/actions/runs/19213730401/job/54919854287

<img width="792" height="433" alt="Screenshot 2025-11-10 at 3 42 39 PM" src="https://github.com/user-attachments/assets/e9d9af65-5c9d-490e-a68e-ee862039272c" />

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
