### PR TITLE
fix: Support custom models in openai text embedder

### DIFF
--- a/daft/ai/openai/protocols/text_embedder.py
+++ b/daft/ai/openai/protocols/text_embedder.py
@@ -83,7 +83,7 @@ class OpenAITextEmbedderDescriptor(TextEmbedderDescriptor):
         return _models[self.model_name].dimensions
 
     def get_udf_options(self) -> UDFOptions:
-        return get_http_udf_options()
+        return UDFOptions(concurrency=None, num_gpus=None)
 
     def instantiate(self) -> TextEmbedder:
         return OpenAITextEmbedder(


### PR DESCRIPTION
## Changes Made

Currently the openai text embedder asserts that the model must be an openai model, however this does not work if user passes in a custom BASE_URL that routes to an openai compatible server of a open source model like qwen.

This PR elides the model check if user passes in BASE_URL, and also allows user to pass in custom `embedding_dimensions`

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
