### PR TITLE
fix: Add absolute diff threshold to embed_text integration test

### DIFF
--- a/tests/integration/ai/test_huggingface.py
+++ b/tests/integration/ai/test_huggingface.py
@@ -35,4 +35,4 @@ def test_embed_text():
     expected = list(manually_embed_text(text))
 
     for a, e in zip(actual, expected):
-        assert np.allclose(a, e)
+        assert np.allclose(a, e, atol=1e-5)


### PR DESCRIPTION
## Changes Made

Add a threshold to stop it from failing all the time

https://github.com/Eventual-Inc/Daft/actions/runs/19232433877/job/54974931361
```
for a, e in zip(actual, expected):
>           assert np.allclose(a, e)
E           assert False
E            +  where False = <function allclose at 0x7fdeb189cb70>(array([-6.27718195e-02,  5.49588241e-02,  5.21648489e-02,  8.57899934e-02,\n       -8.27489048e-02, -7.45730177e-02,  6...e-02, -1.34112686e-02,\n        6.51348010e-02,  5.09059094e-02,  5.14835529e-02,  7.09215319e-03],\n      dtype=float32), array([-6.27717227e-02,  5.49587943e-02,  5.21648340e-02,  8.57899785e-02,\n       -8.27489123e-02, -7.45729432e-02,  6...e-02, -1.34112518e-02,\n        6.51347265e-02,  5.09059168e-02,  5.14836311e-02,  7.09219277e-03],\n      dtype=float32))
E            +    where <function allclose at 0x7fdeb189cb70> = np.allclose
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
