### PR TITLE
chore: remove docs feedback widget

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,21 +63,6 @@ extra:
   analytics:
     provider: google
     property: G-YN4QSRPV0K
-    feedback:
-      title: Was this page helpful?
-      ratings:
-      - icon: material/emoticon-happy-outline
-        name: This page was helpful
-        data: 1
-        note: >-
-          Thanks for your feedback!
-      - icon: material/emoticon-sad-outline
-        name: This page could be improved
-        data: 0
-        note: >-
-          Thanks for your feedback! Help us improve this page by
-          <a href="https://github.com/Eventual-Inc/Daft/issues" target="_blank"
-          rel="noopener">submitting an issue</a> on our Daft repo.
   social:
   - icon: fontawesome/brands/github
     link: https://github.com/Eventual-Inc/Daft


### PR DESCRIPTION
## Changes Made

Removed the feedback widget from the documentation as it was not providing actionable insights. Analysis showed only 42 feedback events over the past year without page-level details or sentiment data.

## Internal

https://eventualgroup.slack.com/archives/C08KRLQD448/p1762886358510419