### PR TITLE
fix: CountRows with Limit returns unexpected result when reading Lance dataset

### DIFF
--- a/src/daft-distributed/src/pipeline_node/mod.rs
+++ b/src/daft-distributed/src/pipeline_node/mod.rs
@@ -435,6 +435,29 @@ fn make_in_memory_task_from_materialized_outputs(
     )
 }
 
+fn make_empty_scan_task(
+    task_context: TaskContext,
+    input_schema: SchemaRef,
+    node: &Arc<dyn PipelineNodeImpl>,
+) -> SwordfishTask {
+    let transformed_plan = LocalPhysicalPlan::empty_scan(
+        input_schema,
+        LocalNodeContext {
+            origin_node_id: Some(node.node_id() as usize),
+            additional: None,
+        },
+    );
+    let psets = HashMap::new();
+    SwordfishTask::new(
+        task_context,
+        transformed_plan,
+        node.config().execution_config.clone(),
+        psets,
+        SchedulingStrategy::Spread,
+        node.context().to_hashmap(),
+    )
+}
+
 fn append_plan_to_existing_task<F>(
     submittable_task: SubmittableTask<SwordfishTask>,
     node: &Arc<dyn PipelineNodeImpl>,

--- a/tests/dataframe/test_explain.py
+++ b/tests/dataframe/test_explain.py
@@ -41,6 +41,8 @@ def test_explain_with_empty_scantask(input_df):
     input_df.limit(0).explain(True, file=string_io)
     expected = """
 
+* Limit: 0
+|
 * ScanTaskSource:
 |   Num Scan Tasks = 0
 |   Estimated Scan Bytes = 0

--- a/tests/io/lancedb/test_lancedb_count_pushdown_coverage.py
+++ b/tests/io/lancedb/test_lancedb_count_pushdown_coverage.py
@@ -61,6 +61,7 @@ class TestLanceCountResultFunction:
                 mock_pushdowns.aggregation_count_mode.return_value = CountMode.Valid
                 mock_pushdowns.aggregation_required_column_names.return_value = ["count"]
                 mock_pushdowns.columns = None
+                mock_pushdowns.limit = None
 
                 with patch.object(scan_op, "_create_regular_scan_tasks") as mock_regular_scan:
                     mock_regular_scan.return_value = iter([])

--- a/tests/io/lancedb/test_lancedb_reads.py
+++ b/tests/io/lancedb/test_lancedb_reads.py
@@ -315,16 +315,3 @@ def test_lancedb_limit_with_filter_and_fragment_grouping_single_task(large_lance
 
     result = df.to_pydict()
     assert result == {"big_int": [999]}
-
-
-def test_lancedb_limit_with_offset(large_lance_dataset_path):
-    lance_df = daft.read_lance(large_lance_dataset_path)
-
-    df = lance_df.offset(2).limit(17)
-    assert len(df.to_pylist()) == 17
-
-    df = lance_df.limit(10)
-    assert len(df.to_pylist()) == 10
-
-    df = lance_df.limit(1).offset(1)
-    assert len(df.to_pylist()) == 0


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Fix the following 3 issues:

1. The `can_absorb_limit` method of Lance ScanOperator returns `True`, which causes Daft to erase the GlobalLimit operator when optimizing the LogicalPlan. This further leads to unexpected results in the number of returned rows when Limit and Filter operators are added while Daft reads a Lance dataset. For example, the following example may return more than 1 row:

```python
daft.read_lance("/tmp/daft/lance").filter("id > 100").limit(1)
```

I still have some questions about the `can_absorb_limit` method, which have been explained in #5551.

2. The Lance ScanOperator has optimized `count_rows` by directly calling Lance's `count_rows()` API to return results. However, when combined with the Limit operator, the returned result is not as expected. For example, the following example may not return 1:

```python 
 daft.read_lance("/tmp/daft/lance").limit(1).count_rows()
```

3. For queries containing Limit and Offset, GlobalLimit may skip all returned data and no longer submit Limit Task to downstream. For aggregation scenarios, such as `count_rows()`, result `0` should be returned in this case. However, since there is no Task result to aggregate, it ultimately returns an empty `[]`. For example, the following example will cause `count_rows()` to throw an IndexError:

```python
daft.read_lance("/tmp/daft/lance").limit(1).offset(2).count_rows()
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
