### PR TITLE
docs: update blog icon from bookmark to blog

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,7 +74,7 @@ extra:
     link: https://x.com/daftengine
   - icon: fontawesome/brands/youtube
     link: https://www.youtube.com/@daftengine
-  - icon: fontawesome/solid/bookmark
+  - icon: fontawesome/solid/blog
     link: https://www.daft.ai/blog
   generator: false
 # Additional Style


### PR DESCRIPTION
## Summary
Changed the blog link icon from bookmark to blog for better representation of the idea.

**Icon references:**
- Old: https://fontawesome.com/icons/bookmark?f=classic&s=solid
- New: https://fontawesome.com/icons/blog?f=classic&s=solid

## Screenshots

**Before:**

<img width="1447" height="961" alt="image" src="https://github.com/user-attachments/assets/b9b4d009-e975-4914-9f8d-ade538f6aad5" />

**After:**

<img width="1444" height="954" alt="image" src="https://github.com/user-attachments/assets/b211fc41-d7c0-4dc4-8c8f-9e2eaa73df80" />