### PR TITLE
docs: simplify getting started tip in introduction

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -500,9 +500,9 @@ Start local, scale global—without changing a line of code. Daft's Rust-powered
 
 !!! tip "Looking to get started with Daft ASAP?"
 
-    The Daft Guide is a useful resource to take deeper dives into specific Daft concepts, but if you are ready to jump into code you may wish to take a look at these resources:
+    If you are ready to jump into code, take a look at these resources:
 
-    1. [Quickstart](quickstart.md): Itching to run some Daft code? Hit the ground running with our 10 minute quickstart notebook.
+    1. [Quickstart](quickstart.md): Itching to run some Daft code? Hit the ground running with our 10 minute quickstart.
 
     2. [Examples](examples/index.md): See Daft in action with use cases across text, images, audio, and more.
 


### PR DESCRIPTION
## Summary
- Remove unclear reference to "Daft Guide" that was never defined
- Remove "notebook" from quickstart description (it's a regular docs page)

## Changes
Simplified the "Looking to get started with Daft ASAP?" tip section to be more direct and accurate.

## Screenshots

Before
<img width="1118" height="287" alt="image" src="https://github.com/user-attachments/assets/24bfb87b-d103-46b9-aa34-f4f45cb1a74b" />

After
<img width="968" height="224" alt="image" src="https://github.com/user-attachments/assets/4398ab29-5deb-4417-a27b-6ec662dbfec3" />
