### PR TITLE
fix: Dashboard Verbose Tracing Error

### DIFF
--- a/src/daft-cli/src/python.rs
+++ b/src/daft-cli/src/python.rs
@@ -51,14 +51,14 @@ fn run_dashboard(py: Python, args: DashboardArgs) {
     let socket_addr = SocketAddr::from((args.addr, args.port));
 
     // Set the subscriber for the detached run
-    tracing_subscriber::registry()
+    let _ = tracing_subscriber::registry()
         .with(
             tracing_subscriber::EnvFilter::builder()
                 .with_default_directive(filter)
                 .from_env_lossy(),
         )
         .with(tracing_subscriber::fmt::layer())
-        .init();
+        .try_init();
 
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
## Changes Made

Fix the follow error that's appearing on the dashboard on main:

```
thread '<unnamed>' (44336394) panicked at /Users/slade/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-subscriber-0.3.20/src/util.rs:91:14:
failed to set global default subscriber: SetLoggerError(())
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "/Users/slade/daft/test/.venv/bin/daft", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/slade/daft/test/daft/cli.py", line 9, in main
    cli(sys.argv)
pyo3_runtime.PanicException: failed to set global default subscriber: SetLoggerError(())
```

Two potential follow ups:
* Some way in CI to test if just starting the dashboard works?
* A more permanent fix by moving away from Rust logging to tracing entirely
