### PR TITLE
feat: optionally keep the native progress bar visible after job completion

### DIFF
--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -40,10 +40,11 @@ use crate::{
     },
 };
 
+pub(crate) const PROGRESS_BAR_ENV_VAR: &str = "DAFT_PROGRESS_BAR";
+
 fn should_enable_progress_bar() -> bool {
-    let progress_var_name = "DAFT_PROGRESS_BAR";
-    if let Ok(val) = std::env::var(progress_var_name) {
-        matches!(val.trim().to_lowercase().as_str(), "1" | "true")
+    if let Ok(val) = std::env::var(PROGRESS_BAR_ENV_VAR) {
+        matches!(val.trim().to_lowercase().as_str(), "1" | "true" | "persist")
     } else {
         true // Return true when env var is not set
     }

--- a/src/daft-local-execution/src/runtime_stats/subscribers/progress_bar.rs
+++ b/src/daft-local-execution/src/runtime_stats/subscribers/progress_bar.rs
@@ -13,7 +13,7 @@ use log::Log;
 
 use crate::{
     PythonPrintTarget, STDOUT,
-    runtime_stats::{CPU_US_KEY, subscribers::RuntimeStatsSubscriber},
+    runtime_stats::{CPU_US_KEY, PROGRESS_BAR_ENV_VAR, subscribers::RuntimeStatsSubscriber},
 };
 
 /// Convert statistics to a message for progress bars
@@ -201,8 +201,14 @@ impl RuntimeStatsSubscriber for IndicatifProgressBarManager {
     }
 
     async fn finish(mut self: Box<Self>) -> DaftResult<()> {
-        self.pbars.clear();
-        self.multi_progress.clear()?;
+        let persist_progress_bar = std::env::var(PROGRESS_BAR_ENV_VAR)
+            .map(|val| val.trim().eq_ignore_ascii_case("persist"))
+            .unwrap_or(false);
+
+        if !persist_progress_bar {
+            self.pbars.clear();
+            self.multi_progress.clear()?;
+        }
         Ok(())
     }
 }

--- a/src/daft-local-execution/src/runtime_stats/subscribers/progress_bar.rs
+++ b/src/daft-local-execution/src/runtime_stats/subscribers/progress_bar.rs
@@ -203,7 +203,11 @@ impl RuntimeStatsSubscriber for IndicatifProgressBarManager {
     }
 
     async fn finish(mut self: Box<Self>) -> DaftResult<()> {
-        if !self.persist_on_finish {
+        if self.persist_on_finish {
+            for bar in &self.pbars {
+                bar.finish();
+            }
+        } else {
             self.pbars.clear();
             self.multi_progress.clear()?;
         }


### PR DESCRIPTION
## Changes Made

Allows setting `DAFT_PROGRESS_BAR=persist` in the native runner to keep the progress bar visible after the job finishes running (vs the default behavior where it shows during the run but vanishes when the job finishes).

## Related Issues

None

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
