### PR TITLE
fix: Executing `explain` will panic when ScanTask is empty

### DIFF
--- a/tests/dataframe/test_explain.py
+++ b/tests/dataframe/test_explain.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import io
+
+import lance
+import pytest
+
+import daft
+from daft.dependencies import pa
+from tests.conftest import get_tests_daft_runner_name
+from tests.utils import clean_explain_output
+
+
+@pytest.fixture
+def input_df(tmp_path):
+    lance.write_dataset(pa.Table.from_pydict({"id": [id for id in range(16)]}), uri=tmp_path)
+    return daft.read_lance(url=str(tmp_path))
+
+
+@pytest.mark.skipif(
+    condition=get_tests_daft_runner_name() == "native",
+    reason="The physical plan displayed in Native and Ray mode is inconsistent.",
+)
+def test_explain_with_empty_scantask(input_df):
+    string_io = io.StringIO()
+    input_df.explain(True, file=string_io)
+    expected = """
+
+    * ScanTaskSource:
+    |   Num Scan Tasks = 1
+    |   Estimated Scan Bytes = 0
+    |   Schema: {id#Int64}
+    |   Scan Tasks: [
+    |   {daft.io.lance.lance_scan:_lancedb_table_factory_function}
+    |   ]
+
+    """
+    assert clean_explain_output(string_io.getvalue().split("== Physical Plan ==")[-1]) == clean_explain_output(expected)
+
+    string_io = io.StringIO()
+    input_df.limit(0).explain(True, file=string_io)
+    expected = """
+
+* ScanTaskSource:
+|   Num Scan Tasks = 0
+|   Estimated Scan Bytes = 0
+|   Pushdowns: {limit: 0}
+|   Schema: {id#Int64}
+|   Scan Tasks: [
+|   ]
+
+"""
+    assert clean_explain_output(string_io.getvalue().split("== Physical Plan ==")[-1]) == clean_explain_output(expected)

--- a/tests/dataframe/test_morsels.py
+++ b/tests/dataframe/test_morsels.py
@@ -7,16 +7,9 @@ import pytest
 
 import daft
 from tests.conftest import get_tests_daft_runner_name
+from tests.utils import clean_explain_output
 
 pytestmark = pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires Native Runner to be in use")
-
-_pattern = re.compile("|".join(map(re.escape, ["\n", "|", " ", "*", "\\"])))
-_rep = {"\n": "", "|": "", " ": "", "*": "", "\\": ""}
-
-
-def clean_explain_output(output: str) -> str:
-    output = _pattern.sub(lambda m: _rep[m.group(0)], output)
-    return output.strip()
 
 
 def make_noop_udf(batch_size: int, dtype: daft.DataType = daft.DataType.int64()):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -47,3 +47,10 @@ def random_numerical_embedding(
         v = rng.random(size=(size,), dtype=np.float32)
         c = np.rint(v * mult_for_int_like)
         return c.astype(dtype)
+
+
+def clean_explain_output(output: str) -> str:
+    _pattern = re.compile("|".join(map(re.escape, ["\n", "|", " ", "*", "\\"])))
+    _rep = {"\n": "", "|": "", " ": "", "*": "", "\\": ""}
+    output = _pattern.sub(lambda m: _rep[m.group(0)], output)
+    return output.strip()


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Fix the issue where a painc error would occur when running `explain(show_all=True)` in on-ray mode if ScanTask was empty, for example:

```python
# export DAFT_RUNNER=ray

df = daft.read_lance(url="/tmp/lance").limit(0)
df.explain(show_all=True)
```

Then will report the following error:

```text
thread '<unnamed>' (3141581) panicked at src/daft-distributed/src/pipeline_node/scan_source.rs:159:32:
index out of bounds: the len is 0 but the index is 0
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Traceback (most recent call last):
  File "/opt/workspace/github/daft-examples/test.py", line 42, in <module>
    df.explain(show_all=True)
  File "/opt/workspace/github/daft-examples/.venv/lib/python3.12/site-packages/daft/api_annotations.py", line 32, in _wrap
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/workspace/github/daft-examples/.venv/lib/python3.12/site-packages/daft/dataframe/dataframe.py", line 293, in explain
    print_to_file(distributed_plan.repr_ascii(simple))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pyo3_runtime.PanicException: index out of bounds: the len is 0 but the index is 0
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
