### PR TITLE
fix: Fix empty dataframe `show` issue

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -4053,7 +4053,7 @@ class DataFrame:
                 if seen >= n:
                     break
 
-            preview_partition = MicroPartition.concat(tables)
+            preview_partition = MicroPartition.concat_or_empty(tables, self.schema())
             if len(preview_partition) > n:
                 preview_partition = preview_partition.slice(0, n)
             elif len(preview_partition) < n:

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -210,3 +210,11 @@ def test_show_with_many_columns():
  A   B   C   D   E   F   G   H   I   J    K    L    M    N    O    P    Q    R    S    T    U    V    W    X    Y    Z  
 ---+---+---+---+---+---+---+---+---+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----
  1   2   3   4   5   6   7   8   9   10   11   12   13   14   15   16   17   18   19   20   21   22   23   24   25   26 """[1:]
+
+
+def test_show_empty_dataframe_no_error_thrown():
+    # Construct an empty DataFrame and ensure preview construction does not error
+    df = daft.from_pydict({"A": []})
+    preview = df._construct_show_preview(8)
+    assert len(preview.partition) == 0
+    assert preview.total_rows == 0


### PR DESCRIPTION

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
Fixed the issue of throwing an exception when performing the show operation on empty dataframe, aligning with pandas behavior.  

When performing the show operation on empty dataframe, no exception is thrown and an empty result is returned.

## Related Issues

https://github.com/Eventual-Inc/Daft/issues/5594

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## How to test

new UT

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
