### PR TITLE
chore: deprecate llm_generate function

### DIFF
--- a/daft/functions/llm.py
+++ b/daft/functions/llm.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Literal
 
 from daft import DataType, Expression, Series, udf
@@ -81,6 +82,12 @@ def llm_generate(
     Note:
         Make sure the required provider packages are installed (e.g. vllm, transformers, openai).
     """
+    warnings.warn(
+        "This method is deprecated and will be removed in v0.8.0. Use daft.functions.prompt instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     cls: Any = None
     if provider == "vllm":
         cls = _vLLMGenerator


### PR DESCRIPTION
## Changes Made

deprecates `llm_generate` in favor of `prompt`

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
