### PR TITLE
fix: add disk cleanup to doctests job

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1181,6 +1181,17 @@ jobs:
     env:
       python-version: '3.10'
     steps:
+    - name: Free Disk Space (Ubuntu)
+      if: ${{ (runner.os == 'Linux') }}
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: false
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: true
     - uses: actions/checkout@v4
     - uses: moonrepo/setup-rust@v1
       with:


### PR DESCRIPTION
## Summary

Adds the `free-disk-space` action to the doctests job in `pr-test-suite.yml` to prevent "No space left on device" failures.

The doctests job was missing this cleanup step while other jobs in the same workflow already have it. This brings it in line with the rest of the CI configuration.

## Related

- #5589 - Fixed disk space issues in `build-docs.yml`
- #5607 - Experienced doctests disk space failure (run [19446979338](https://github.com/Eventual-Inc/Daft/actions/runs/19446979338))
- #5602 - Experienced doctests disk space failures on multiple runs:
  - [19439370399](https://github.com/Eventual-Inc/Daft/actions/runs/19439370399)
  - [19440357799](https://github.com/Eventual-Inc/Daft/actions/runs/19440357799)
  - [19442517234](https://github.com/Eventual-Inc/Daft/actions/runs/19442517234)

## Changes

- Added `jlumbroso/free-disk-space` action to doctests job
- Removes Android SDK and Haskell tooling (not needed for Python/Rust project)
- Keeps .NET (consistent with other jobs in `pr-test-suite.yml`)
