### PR TITLE
fix: add disk cleanup to integration-test-io-credentialed job

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -458,6 +458,17 @@ jobs:
       id-token: write
       contents: read
     steps:
+    - name: Free Disk Space (Ubuntu)
+      if: ${{ (runner.os == 'Linux') }}
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: false
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: true
     - uses: actions/checkout@v4
       with:
         submodules: true


### PR DESCRIPTION
## Changes Made

Add disk cleanup step to `integration-test-io-credentialed` job to prevent disk space failures.

## Related Issues

Fixes the MinIO storage full errors causing integration test failures on main (commits cce8b5a52, def3836b4, and 88ea033b6).

Related to the broader disk space issue affecting CI jobs:
- #5589 - Fixed disk space in docgen workflow
- #5609 - Fixed disk space in doctests job

## Test Plan

CI will run with the disk cleanup step, preventing the `XMinioStorageFull` errors that were occurring.

Verified in test PR #5611 where both `integration-test-io-credentialed (3.10, native)` and `integration-test-io-credentialed (3.10, ray)` passed successfully.