### PR TITLE
test: force integration-test-io-credentialed to verify disk cleanup fix

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -444,7 +444,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [skipcheck, integration-test-build]
-    if: ${{ needs.skipcheck.outputs.skip == 'false' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     env:
       package-name: daft
     strategy:


### PR DESCRIPTION
## Purpose

This is a **test PR** to verify that the disk cleanup fix works for the `integration-test-io-credentialed` job.

This PR temporarily removes the `github.ref == 'refs/heads/main'` restriction so the job runs on this PR branch.

## Changes

1. Adds disk cleanup step to `integration-test-io-credentialed` job (from #5610)
2. Temporarily removes main branch restriction to test the fix

**Do not merge this PR** - it's only for testing. Merge #5610 instead.