### PR TITLE
fix: Optimize the display information of Join nodes in query plan

### DIFF
--- a/src/daft-distributed/src/pipeline_node/join/broadcast_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/broadcast_join.rs
@@ -172,17 +172,26 @@ impl PipelineNodeImpl for BroadcastJoinNode {
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
-        let mut res = vec!["Broadcast Join".to_string()];
+        let mut res = vec!["BroadcastJoin".to_string()];
+        res.push(format!("Type: {}", self.join_type));
         res.push(format!(
-            "Left on: {}",
-            self.left_on.iter().map(|e| e.to_string()).join(", ")
+            "Left: Join key = {}, Role = {}",
+            self.left_on.iter().map(|e| e.to_string()).join(", "),
+            if self.is_swapped {
+                "Receiver"
+            } else {
+                "Broadcaster"
+            }
         ));
         res.push(format!(
-            "Right on: {}",
-            self.right_on.iter().map(|e| e.to_string()).join(", ")
+            "Right: Join key = {}, Role = {}",
+            self.right_on.iter().map(|e| e.to_string()).join(", "),
+            if self.is_swapped {
+                "Broadcaster"
+            } else {
+                "Receiver"
+            }
         ));
-        res.push(format!("Join type: {}", self.join_type));
-        res.push(format!("Is swapped: {}", self.is_swapped));
         if let Some(null_equals_nulls) = &self.null_equals_nulls {
             res.push(format!(
                 "Null equals nulls: [{}]",

--- a/src/daft-distributed/src/pipeline_node/join/cross_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/cross_join.rs
@@ -161,9 +161,9 @@ impl PipelineNodeImpl for CrossJoinNode {
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
-        let mut res = vec!["Cross Join".to_string()];
-        res.push(format!("Left side: {}", self.left_node.name()));
-        res.push(format!("Right side: {}", self.right_node.name()));
+        let mut res = vec!["CrossJoin".to_string()];
+        res.push(format!("Left: Node name = {}", self.left_node.name()));
+        res.push(format!("Right: Node name = {}", self.right_node.name()));
         res
     }
 

--- a/src/daft-distributed/src/pipeline_node/join/hash_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/hash_join.rs
@@ -136,15 +136,22 @@ impl PipelineNodeImpl for HashJoinNode {
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {
         use itertools::Itertools;
-        let mut res = vec!["Hash Join".to_string()];
+        let mut res = vec!["HashJoin".to_string()];
+        res.push(format!("Type: {}", self.join_type));
         res.push(format!(
-            "Left on: {}",
+            "Left: Join key = {}",
             self.left_on.iter().map(|e| e.to_string()).join(", ")
         ));
         res.push(format!(
-            "Right on: {}",
+            "Right: Join key = {}",
             self.right_on.iter().map(|e| e.to_string()).join(", ")
         ));
+        if let Some(null_equals_nulls) = &self.null_equals_nulls {
+            res.push(format!(
+                "Null equals nulls: [{}]",
+                null_equals_nulls.iter().map(|b| b.to_string()).join(", ")
+            ));
+        }
         res
     }
 

--- a/src/daft-distributed/src/pipeline_node/join/sort_merge_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/sort_merge_join.rs
@@ -88,15 +88,17 @@ impl SortMergeJoinNode {
 
     fn multiline_display(&self) -> Vec<String> {
         use itertools::Itertools;
-        let mut res = vec!["Sort Merge Join".to_string()];
+        let mut res = vec!["SortMergeJoin".to_string()];
+        res.push(format!("Type: {}", self.join_type));
         res.push(format!(
-            "Left on: {}",
+            "Left: Join key = {}",
             self.left_on.iter().map(|e| e.to_string()).join(", ")
         ));
         res.push(format!(
-            "Right on: {}",
+            "Right: Join key = {}",
             self.right_on.iter().map(|e| e.to_string()).join(", ")
         ));
+        res.push(format!("Num partitions: {}", self.num_partitions));
         res
     }
 

--- a/tests/dataframe/test_explain.py
+++ b/tests/dataframe/test_explain.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import io
-
 import pytest
 
 import daft
 from daft import col, get_or_infer_runner_type, udf
 from daft.dependencies import pa
+from daft.functions import format
 from tests.conftest import get_tests_daft_runner_name
 from tests.utils import clean_explain_output, explain_to_text
 
@@ -20,13 +19,10 @@ def input_df(tmp_path):
 
 @pytest.mark.skipif(
     condition=get_tests_daft_runner_name() == "native",
-    reason="The physical plan displayed in Native and Ray mode is inconsistent.",
+    reason="The physical plan displayed in Native and Ray mode is inconsistent",
 )
 def test_explain_with_empty_scantask(input_df):
-    string_io = io.StringIO()
-    input_df.explain(True, file=string_io)
     expected = """
-
     * ScanTaskSource:
     |   Num Scan Tasks = 1
     |   Estimated Scan Bytes = 130
@@ -34,26 +30,153 @@ def test_explain_with_empty_scantask(input_df):
     |   Scan Tasks: [
     |   {daft.io.lance.lance_scan:_lancedb_table_factory_function}
     |   ]
-
     """
-    assert clean_explain_output(string_io.getvalue().split("== Physical Plan ==")[-1]) == clean_explain_output(expected)
+    assert clean_explain_output(explain_to_text(input_df, only_physical_plan=True)) == clean_explain_output(expected)
 
-    string_io = io.StringIO()
-    input_df.limit(0).explain(True, file=string_io)
     expected = """
+    * Limit: 0
+    |
+    * ScanTaskSource:
+    |   Num Scan Tasks = 0
+    |   Estimated Scan Bytes = 0
+    |   Pushdowns: {limit: 0}
+    |   Schema: {id#Int64}
+    |   Scan Tasks: [
+    |   ]
+    """
+    assert clean_explain_output(explain_to_text(input_df.limit(0), only_physical_plan=True)) == clean_explain_output(
+        expected
+    )
 
-* Limit: 0
-|
-* ScanTaskSource:
-|   Num Scan Tasks = 0
-|   Estimated Scan Bytes = 0
-|   Pushdowns: {limit: 0}
-|   Schema: {id#Int64}
-|   Scan Tasks: [
-|   ]
 
-"""
-    assert clean_explain_output(string_io.getvalue().split("== Physical Plan ==")[-1]) == clean_explain_output(expected)
+@pytest.fixture(scope="session")
+def small_df(tmp_path_factory):
+    df = daft.range(start=0, end=1000, partitions=10)
+    df = df.with_columns(
+        {
+            "s_name": format("user_{}", df["id"]),
+            "s_email": format("user_{}@daft.ai", df["id"]),
+        }
+    )
+
+    tmp_path = str(tmp_path_factory.mktemp("small"))
+    df.write_parquet(tmp_path)
+    return daft.read_parquet(tmp_path)
+
+
+@pytest.fixture(scope="session")
+def large_df(tmp_path_factory):
+    df = daft.range(start=0, end=9999, partitions=100)
+    df = df.with_columns(
+        {
+            "l_name": format("user_{}", df["id"]),
+            "l_email": format("user_{}@daft.ai", df["id"]),
+        }
+    )
+
+    tmp_path = str(tmp_path_factory.mktemp("large"))
+    df.write_parquet(tmp_path)
+    return daft.read_parquet(tmp_path)
+
+
+@pytest.mark.skipif(
+    condition=get_tests_daft_runner_name() == "native",
+    reason="Native Runner doesn't currently support displaying the ID of the nodes participating in the Join",
+)
+def test_explain_with_broadcast_join(small_df, large_df):
+    df = small_df.join(other=large_df, left_on="s_name", right_on="l_name", strategy="broadcast")
+    expected = """
+    * BroadcastJoin
+    |   Type: Inner
+    |   Left: Join key = col(1: s_name), Role = Broadcaster
+    |   Right: Join key = col(1: l_name), Role = Receiver
+    |   Null equals nulls: [false]
+        """
+    assert clean_explain_output(expected) in clean_explain_output(explain_to_text(df, only_physical_plan=True))
+
+    df = large_df.join(other=small_df, left_on="l_name", right_on="s_name", strategy="broadcast")
+    expected = """
+    * BroadcastJoin
+    |   Type: Inner
+    |   Left: Join key = col(1: l_name), Role = Receiver
+    |   Right: Join key = col(1: s_name), Role = Broadcaster
+    |   Null equals nulls: [false]
+        """
+    assert clean_explain_output(expected) in clean_explain_output(explain_to_text(df, only_physical_plan=True))
+
+
+@pytest.mark.skipif(
+    condition=get_tests_daft_runner_name() == "native",
+    reason="Native Runner doesn't currently support displaying the ID of the nodes participating in the Join",
+)
+def test_explain_with_cross_join(small_df, large_df):
+    df = small_df.join(other=large_df, how="cross")
+    expected = """
+    * CrossJoin
+    |   Left: Node name = ScanSource
+    |   Right: Node name = Project
+        """
+    assert clean_explain_output(expected) in clean_explain_output(explain_to_text(df, only_physical_plan=True))
+
+    df = large_df.join(other=small_df, how="cross")
+    expected = """
+    * CrossJoin
+    |   Left: Node name = ScanSource
+    |   Right: Node name = Project
+        """
+    assert clean_explain_output(expected) in clean_explain_output(explain_to_text(df, only_physical_plan=True))
+
+
+@pytest.mark.skipif(
+    condition=get_tests_daft_runner_name() == "native",
+    reason="Native Runner doesn't currently support displaying the ID of the nodes participating in the Join",
+)
+def test_explain_with_hash_join(small_df, large_df):
+    df = small_df.join(other=large_df, left_on="s_name", right_on="l_name", strategy="hash", how="left")
+    expected = """
+    * HashJoin
+    |   Type: Left
+    |   Left: Join key = col(1: s_name)
+    |   Right: Join key = col(1: l_name)
+    |   Null equals nulls: [false]
+        """
+    assert clean_explain_output(expected) in clean_explain_output(explain_to_text(df, only_physical_plan=True))
+
+    df = large_df.join(other=small_df, left_on="l_name", right_on="s_name", strategy="hash", how="right")
+    expected = """
+    * HashJoin
+    |   Type: Right
+    |   Left: Join key = col(1: l_name)
+    |   Right: Join key = col(1: s_name)
+    |   Null equals nulls: [false]
+        """
+    assert clean_explain_output(expected) in clean_explain_output(explain_to_text(df, only_physical_plan=True))
+
+
+@pytest.mark.skipif(
+    condition=get_tests_daft_runner_name() == "native",
+    reason="Native Runner doesn't currently support displaying the ID of the nodes participating in the Join",
+)
+def test_explain_with_sort_merged_join(small_df, large_df):
+    df = small_df.join(other=large_df, left_on="s_name", right_on="l_name", strategy="sort_merge")
+    expected = """
+    * SortMergeJoin
+    |   Type: Inner
+    |   Left: Join key = col(1: s_name)
+    |   Right: Join key = col(1: l_name)
+    |   Num partitions: 100
+        """
+    assert clean_explain_output(expected) in clean_explain_output(explain_to_text(df, only_physical_plan=True))
+
+    df = large_df.join(other=small_df, left_on="l_name", right_on="s_name", strategy="sort_merge")
+    expected = """
+    * SortMergeJoin
+    |   Type: Inner
+    |   Left: Join key = col(1: l_name)
+    |   Right: Join key = col(1: s_name)
+    |   Num partitions: 100
+        """
+    assert clean_explain_output(expected) in clean_explain_output(explain_to_text(df, only_physical_plan=True))
 
 
 @udf(return_dtype=daft.DataType.string(), num_cpus=0.1, num_gpus=0)
@@ -122,8 +245,7 @@ def test_explain_with_ray_options(input_df):
 
 def test_explain_with_explode_index_column():
     df = daft.from_pydict({"nested": [[1, 2], [3, 4]]})
-    string_io = io.StringIO()
-    df.explode("nested", index_column="idx").explain(True, file=string_io)
-    output = string_io.getvalue()
+    df = df.explode("nested", index_column="idx")
+    output = explain_to_text(df)
     assert "Explode" in output
     assert "Index column = idx" in output

--- a/tests/microbenchmarks/test_join.py
+++ b/tests/microbenchmarks/test_join.py
@@ -51,7 +51,6 @@ def test_join_simple(benchmark, num_samples, num_partitions, join_type) -> None:
     )
 
     # Run the benchmark.
-    # Run the benchmark.
     def bench_join() -> DataFrame:
         return left_table.join(right_table, on=["mycol"], how=join_type).collect()
 
@@ -147,7 +146,6 @@ def test_join_withdata(benchmark, num_samples, num_partitions, join_type) -> Non
         .collect()
     )
 
-    # Run the benchmark.
     # Run the benchmark.
     def bench_join() -> DataFrame:
         return left_table.join(right_table, on=["mykey"], how=join_type).collect()
@@ -260,7 +258,6 @@ def test_multicolumn_joins(benchmark, num_columns, num_samples, num_partitions, 
         .collect()
     )
 
-    # Run the benchmark.
     # Run the benchmark.
     def bench_join() -> DataFrame:
         # Use the unique column "nums" plus some redundant columns.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,7 +7,7 @@ from typing import Any
 import numpy as np
 import pyarrow as pa
 
-import daft
+from daft import DataFrame
 from daft.recordbatch import RecordBatch
 
 ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
@@ -58,7 +58,7 @@ def clean_explain_output(output: str) -> str:
     return output.strip()
 
 
-def explain_to_text(df: daft.DataFrame) -> str:
+def explain_to_text(df: DataFrame, only_physical_plan: bool = False) -> str:
     str_io = io.StringIO()
     df.explain(show_all=True, file=str_io)
-    return str_io.getvalue().strip()
+    return str_io.getvalue().split("== Physical Plan ==")[-1] if only_physical_plan else str_io.getvalue().strip()


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Currently, when displaying the query plan containing a "join" node using `explain`, we can't intuitively distinguish between the left and right tables, especially in the case of a Broadcast Join, which requires the `is_swapped` field to assist in judgment.

This PR mainly unifies the information format and elements of the Join nodes displayed in `explain`, and explicitly identifies the `Broadcaster` and `Receiver` for Broadcast Join. For example:

```text
== Physical Plan ==

* BroadcastJoin                                                                                                                                                                                       
|   Type: Inner
|   Left: Join key = col(1: l_name), Role = Receiver
|   Right: Join key = col(1: s_name), Role = Broadcaster
|   Null equals nulls: [false]
|\
| * ScanTaskSource:
| |   Num Scan Tasks = 100
| |   Estimated Scan Bytes = 728327
| |   Pushdowns: {filter: not(is_null(col(l_name)))}
| |   Schema: {id#Int64, l_name#Utf8, l_email#Utf8}
| |   Scan Tasks: [ ... ]
|
* Project: col(0: id) as right.id, col(1: s_name), col(2: s_email)
|   Resource request = None
|
* ScanTaskSource:
|   Num Scan Tasks = 10
|   Estimated Scan Bytes = 67702
|   Pushdowns: {filter: not(is_null(col(s_name)))}
|   Schema: {id#Int64, s_name#Utf8, s_email#Utf8}
|   Scan Tasks: [ ... ]
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
