### PR TITLE
feat: Adding otel logger collector for collecting UDF errors.

### DIFF
--- a/src/common/tracing/src/lib.rs
+++ b/src/common/tracing/src/lib.rs
@@ -8,18 +8,21 @@ use opentelemetry::{KeyValue, global, trace::TracerProvider};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     Resource,
+    logs::SdkLoggerProvider,
     metrics::PeriodicReader,
     trace::{Sampler, SdkTracerProvider},
 };
 use tracing_subscriber::{layer::SubscriberExt, prelude::*};
 
-static GLOBAL_TRACER_PROVIDER: LazyLock<
-    Mutex<Option<opentelemetry_sdk::trace::SdkTracerProvider>>,
-> = LazyLock::new(|| Mutex::new(None));
+static GLOBAL_TRACER_PROVIDER: LazyLock<Mutex<Option<SdkTracerProvider>>> =
+    LazyLock::new(|| Mutex::new(None));
 
 static GLOBAL_METER_PROVIDER: LazyLock<
     Mutex<Option<opentelemetry_sdk::metrics::SdkMeterProvider>>,
 > = LazyLock::new(|| Mutex::new(None));
+
+pub static GLOBAL_LOGGER_PROVIDER: LazyLock<Mutex<Option<SdkLoggerProvider>>> =
+    LazyLock::new(|| Mutex::new(None));
 
 const OTEL_EXPORTER_OTLP_ENDPOINT: &str = "DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT";
 
@@ -41,12 +44,37 @@ pub fn init_opentelemetry_providers() {
     ioruntime.block_on_current_thread(async {
         init_otlp_metrics_provider(&otlp_endpoint).await;
         init_otlp_tracer_provider(&otlp_endpoint).await;
+        init_otlp_logger_provider(&otlp_endpoint).await;
     });
 }
 
 pub fn flush_opentelemetry_providers() {
     flush_oltp_tracer_provider();
     flush_oltp_metrics_provider();
+    flush_oltp_logger_provider();
+}
+
+async fn init_otlp_logger_provider(otlp_endpoint: &str) {
+    let mut lg = GLOBAL_LOGGER_PROVIDER.lock().unwrap();
+    assert!(lg.is_none(), "Expected logger provider to be None on init");
+
+    let resource = Resource::builder()
+        .with_attribute(KeyValue::new("service.name", "daft"))
+        .build();
+
+    let log_exporter = opentelemetry_otlp::LogExporter::builder()
+        .with_tonic()
+        .with_endpoint(otlp_endpoint)
+        .with_timeout(Duration::from_secs(10))
+        .build()
+        .expect("Failed to build OTLP logger exporter.");
+
+    let logger_provider: SdkLoggerProvider = SdkLoggerProvider::builder()
+        .with_batch_exporter(log_exporter)
+        .with_resource(resource)
+        .build();
+
+    *lg = Some(logger_provider);
 }
 
 async fn init_otlp_metrics_provider(otlp_endpoint: &str) {
@@ -88,6 +116,15 @@ pub fn flush_oltp_metrics_provider() {
     }
 }
 
+pub fn flush_oltp_logger_provider() {
+    let lg = GLOBAL_LOGGER_PROVIDER.lock().unwrap();
+    if let Some(logger_provider) = lg.as_ref()
+        && let Err(e) = logger_provider.force_flush()
+    {
+        eprintln!("Failed to flush OTLP logger provider: {}", e);
+    }
+}
+
 async fn init_otlp_tracer_provider(otlp_endpoint: &str) {
     let mut mg = GLOBAL_TRACER_PROVIDER.lock().unwrap();
     assert!(mg.is_none(), "Expected tracer provider to be None on init");
@@ -103,7 +140,7 @@ async fn init_otlp_tracer_provider(otlp_endpoint: &str) {
         .build()
         .expect("Failed to build OTLP span exporter for tracing");
 
-    let tracer_provider: SdkTracerProvider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+    let tracer_provider: SdkTracerProvider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
         .with_resource(resource)
         .with_sampler(Sampler::AlwaysOn)


### PR DESCRIPTION
## Changes Made

Added an otel log collector to enable otel-based logging for collecting errors from UDF invocations. Doesn't wire in any logging subscribers so existing log (`log!`, `info!`, etc..) are unaffected.
