### PR TITLE
docs: update index overview page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Daft is a high-performance data engine providing simple and reliable data processing for any modality and scale.
+Daft is a high-performance data engine designed for AI and multimodal workloads, providing simple, reliable data processing for images, audio, video, and structured data at any scale.
 
 <style>
   .daft-pipeline-component {


### PR DESCRIPTION
Updates the documentation index page to better reflect Daft's capabilities:

- Update multimodal processing feature to mention audio, video, and embeddings instead of tensors
- Remove ML ecosystem integration feature
- Add new feature highlighting built-in AI operations
- Update connectivity links to point to internal documentation
- Add Hugging Face to cloud storage options
- Rewrite introduction to emphasize AI and multimodal workloads

---

## Internal

Closes EVE-1205
Closes EVE-1170
Closes EVE-1169
Closes EVE-1174