### PR TITLE
chore: remove broken docpublish job from build-docs workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,5 +1,5 @@
-# This workflow will build the Daft docs and optionally publishes them to Netlify
-# for easy previews.
+# This workflow will build the Daft docs.
+# Documentation previews are handled by Read the Docs integration.
 
 name: Build docs
 
@@ -68,41 +68,3 @@ jobs:
       with:
         name: html-docs
         path: site
-  docpublish:
-    runs-on: ubuntu-latest
-    needs: docgen
-    # Only publish to netlify on:
-    # 1. If the previous doc building step didn't fail
-    # 2. If this is a PR from the current repo (since it needs access to secrets)
-    # 3. If it has the `documentation` label
-    if: |
-      success() &&
-      (github.event.pull_request != null) &&
-      (github.event.pull_request.head.repo.full_name == github.repository) &&
-      contains(github.event.pull_request.labels.*.name, 'docs')
-    steps:
-    - name: Download built HTML docs
-      uses: actions/download-artifact@v4
-      with:
-        name: html-docs
-        path: ./built_html
-    - name: Add a robots.txt to disable indexing of docs
-      run: |
-        echo "User-agent: *" > ./built_html/robots.txt
-        echo "Disallow: /" >> ./built_html/robots.txt
-    - name: Deploy to Netlify
-      uses: nwtgck/actions-netlify@v3.0
-      with:
-        publish-dir: ./built_html
-        production-branch: main
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        enable-pull-request-comment: true
-        enable-commit-comment: false
-        overwrites-pull-request-comment: true
-        enable-github-deployment: false
-        alias: deploy-preview-${{ github.event.number }}
-        deploy-message: 'Deploy preview for PR #${{ github.event.number }} (current built commit: ${{ github.sha }})'
-    env:
-      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-    timeout-minutes: 1


### PR DESCRIPTION
## Summary
Removes the broken `docpublish` job from the build-docs workflow that has been consistently timing out since September 2024.

## Context
After investigation in #5629, we discovered:
- The `docpublish` job was attempting to deploy documentation to Netlify
- It has been timing out consistently since the 1-minute timeout was introduced in PR #2803 (Sept 2024)
- Even with increased timeouts (5 minutes, 10 minutes), the Netlify deployment never completes
- **Read the Docs already provides documentation preview functionality** for all PRs, making this Netlify deployment redundant

## Investigation findings
- No successful `docpublish` runs were found in the workflow history
- The job only ran for PRs from the same repository with the `docs` label
- Most PRs had the job skipped due to not meeting these conditions
- Read the Docs integration is working perfectly and provides preview links for all documentation PRs

## Changes
- Removed the entire `docpublish` job from `.github/workflows/build-docs.yml`
- Updated workflow comment to reflect that Read the Docs handles documentation previews

## Related Issues
- Closes #5629 (attempted to fix timeout but discovered the job is redundant)
- Related to #5605, #5604 (previous attempts to fix the timeout)