### PR TITLE
fix: Unify the naming and type of URI parameter for Lance-related APIs

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -2686,7 +2686,7 @@ class DataFrame:
         on: Optional[Union[list[ColumnInputType], ColumnInputType]] = None,
         left_on: Optional[Union[list[ColumnInputType], ColumnInputType]] = None,
         right_on: Optional[Union[list[ColumnInputType], ColumnInputType]] = None,
-        how: Literal["inner", "inner", "left", "right", "outer", "anti", "semi", "cross"] = "inner",
+        how: Literal["inner", "left", "right", "outer", "anti", "semi", "cross"] = "inner",
         strategy: Optional[Literal["hash", "sort_merge", "broadcast"]] = None,
         prefix: Optional[str] = None,
         suffix: Optional[str] = None,

--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -1,5 +1,6 @@
 # ruff: noqa: I002
 # isort: dont-add-import: from __future__ import annotations
+import pathlib
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from daft import context
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
 
 @PublicAPI
 def read_lance(
-    url: str,
+    uri: Union[str, pathlib.Path],
     io_config: Optional[IOConfig] = None,
     version: Optional[Union[str, int]] = None,
     asof: Optional[str] = None,
@@ -36,7 +37,7 @@ def read_lance(
     """Create a DataFrame from a LanceDB table.
 
     Args:
-        url: URL to the LanceDB table (supports remote URLs to object stores such as `s3://` or `gs://`)
+        uri: The URI of the Lance table to read from (supports remote URLs to object stores such as `s3://` or `gs://`)
         io_config: A custom IOConfig to use when accessing LanceDB data. Defaults to None.
         version : optional, int | str
             If specified, load a specific version of the Lance dataset. Else, loads the
@@ -111,10 +112,10 @@ def read_lance(
         ) from e
 
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
-    storage_options = io_config_to_storage_options(io_config, url)
+    storage_options = io_config_to_storage_options(io_config, str(uri) if isinstance(uri, pathlib.Path) else uri)
 
     ds = lance.dataset(
-        url,
+        uri,
         storage_options=storage_options,
         version=version,
         asof=asof,
@@ -125,7 +126,6 @@ def read_lance(
         metadata_cache_size_bytes=metadata_cache_size_bytes,
     )
     lance_operator = LanceDBScanOperator(ds, fragment_group_size=fragment_group_size)
-
     handle = ScanOperatorHandle.from_python_scan_operator(lance_operator)
     builder = LogicalPlanBuilder.from_tabular_scan(scan_operator=handle)
     return DataFrame(builder)
@@ -133,7 +133,7 @@ def read_lance(
 
 @PublicAPI
 def merge_columns(
-    url: str,
+    uri: Union[str, pathlib.Path],
     io_config: Optional[IOConfig] = None,
     *,
     transform: Union[dict[str, str], "BatchUDF", Callable[["pa.lib.RecordBatch"], "pa.lib.RecordBatch"]] = None,
@@ -156,7 +156,7 @@ def merge_columns(
     from existing data using a transformation function. It does not return a DataFrame.
 
     Args:
-        url: URL to the LanceDB table (supports remote URLs to object stores such as `s3://` or `gs://`)
+        uri: The URI of the Lance table (supports remote URLs to object stores such as `s3://` or `gs://`)
         io_config: A custom IOConfig to use when accessing LanceDB data. Defaults to None.
         transform: A transformation function or UDF to apply to the data.
         read_columns: List of column names to read for the transformation.
@@ -195,10 +195,12 @@ def merge_columns(
             "Unable to import the `lance` package, please ensure that Daft is installed with the lance extra dependency: `pip install daft[lance]`"
         ) from e
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
-    storage_options = storage_options or io_config_to_storage_options(io_config, url)
+    storage_options = storage_options or io_config_to_storage_options(
+        io_config, str(uri) if isinstance(uri, pathlib.Path) else uri
+    )
 
     lance_ds = lance.dataset(
-        url,
+        uri,
         storage_options=storage_options,
         version=version,
         asof=asof,
@@ -211,7 +213,7 @@ def merge_columns(
 
     merge_columns_internal(
         lance_ds,
-        url,
+        uri,
         transform=transform,
         read_columns=read_columns,
         reader_schema=reader_schema,
@@ -223,7 +225,7 @@ def merge_columns(
 
 @PublicAPI
 def create_scalar_index(
-    url: str,
+    uri: Union[str, pathlib.Path],
     io_config: Optional[IOConfig] = None,
     *,
     column: str,
@@ -249,7 +251,7 @@ def create_scalar_index(
     merged and committed as a single index.
 
     Args:
-        url: URL to the LanceDB table (supports remote URLs to object stores such as `s3://` or `gs://`)
+        uri: The URI of the Lance table (supports remote URLs to object stores such as `s3://` or `gs://`)
         io_config: A custom IOConfig to use when accessing LanceDB data. Defaults to None.
         column: Column name to index
         index_type: Type of index to build ("INVERTED" or "FTS")
@@ -314,10 +316,12 @@ def create_scalar_index(
         ) from e
 
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
-    storage_options = storage_options or io_config_to_storage_options(io_config, url)
+    storage_options = storage_options or io_config_to_storage_options(
+        io_config, str(uri) if isinstance(uri, pathlib.Path) else uri
+    )
 
     lance_ds = lance.dataset(
-        url,
+        uri,
         storage_options=storage_options,
         version=version,
         asof=asof,
@@ -330,7 +334,7 @@ def create_scalar_index(
 
     create_scalar_index_internal(
         lance_ds=lance_ds,
-        uri=url,
+        uri=uri,
         column=column,
         index_type=index_type,
         name=name,

--- a/daft/io/lance/lance_merge_column.py
+++ b/daft/io/lance/lance_merge_column.py
@@ -7,6 +7,8 @@ from daft.datatype import DataType
 from daft.udf import udf
 
 if TYPE_CHECKING:
+    import pathlib
+
     import lance
 
     from daft.dependencies import pa
@@ -37,7 +39,7 @@ class FragmentHandler:
 
 def merge_columns_internal(
     lance_ds: lance.LanceDataset,
-    uri: str,
+    uri: str | pathlib.Path,
     *,
     transform: dict[str, str] | lance.udf.BatchUDF | Callable[[pa.RecordBatch], pa.RecordBatch],
     read_columns: list[str] | None = None,

--- a/daft/io/lance/lance_scalar_index.py
+++ b/daft/io/lance/lance_scalar_index.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pathlib
 
 import lance
 
@@ -92,7 +95,7 @@ class FragmentIndexHandler:
 
 def create_scalar_index_internal(
     lance_ds: lance.LanceDataset,
-    uri: str,
+    uri: str | pathlib.Path,
     *,
     column: str,
     index_type: str = "INVERTED",

--- a/tests/io/lancedb/test_lancedb_reads.py
+++ b/tests/io/lancedb/test_lancedb_reads.py
@@ -101,7 +101,7 @@ def test_lancedb_read_limit_large_dataset(large_lance_dataset_path, limit_size, 
 
 
 def test_lancedb_with_version(lance_dataset_path):
-    df = daft.read_lance(lance_dataset_path, version=1)
+    df = daft.read_lance(uri=lance_dataset_path, version=1)
     assert df.to_pydict() == data
 
     # test pushdown filters with limit and projection
@@ -147,7 +147,7 @@ def test_lancedb_read_parallelism_fragment_merging(large_lance_dataset_path):
     df_no_fragment_group = daft.read_lance(large_lance_dataset_path)
     assert len(lance.dataset(large_lance_dataset_path).get_fragments()) == df_no_fragment_group.num_partitions()
 
-    df = daft.read_lance(large_lance_dataset_path, fragment_group_size=3)
+    df = daft.read_lance(uri=large_lance_dataset_path, fragment_group_size=3)
     df.explain(show_all=True)
     assert df.num_partitions() == 4  # 10 fragments, group size 3 -> 4 scan tasks
 
@@ -273,7 +273,7 @@ class TestLanceDBCountPushdown:
         empty_data = {"a": [], "b": []}
         lance.write_dataset(pa.Table.from_pydict(empty_data), tmp_dir)
 
-        df = daft.read_lance(str(tmp_dir)).count()
+        df = daft.read_lance(tmp_dir).count()
 
         _ = capsys.readouterr()
         df.explain(True)
@@ -316,7 +316,7 @@ def test_lancedb_filter_then_limit_behavior(lance_dataset_path, enable_strict_fi
 
 def test_lancedb_limit_with_filter_and_fragment_grouping_single_task(large_lance_dataset_path):
     """Validate filter+limit correctness when fragment grouping is enabled."""
-    df = daft.read_lance(large_lance_dataset_path, fragment_group_size=4)
+    df = daft.read_lance(uri=large_lance_dataset_path, fragment_group_size=4)
     df = df.filter("big_int = 999").limit(1).select("big_int")
 
     result = df.to_pydict()

--- a/tests/io/lancedb/test_lancedb_scalar_index.py
+++ b/tests/io/lancedb/test_lancedb_scalar_index.py
@@ -66,7 +66,7 @@ def multi_fragment_lance_dataset(temp_dir):
         ],
     }
     text_dataset = daft.from_pydict(text_data)
-    text_dataset.write_lance(str(path), max_rows_per_file=2)
+    text_dataset.write_lance(uri=path, max_rows_per_file=2)
     return str(path)
 
 
@@ -88,7 +88,7 @@ def generate_multi_fragment_dataset(tmp_path, num_fragments=4, rows_per_fragment
     dataset = daft.from_pandas(df)
 
     path = Path(tmp_path) / "large_multi_fragment.lance"
-    dataset.write_lance(str(path), max_rows_per_file=rows_per_fragment)
+    dataset.write_lance(uri=path, max_rows_per_file=rows_per_fragment)
     return str(path)
 
 
@@ -101,7 +101,7 @@ class TestDistributedIndexing:
 
         # Build distributed index
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             concurrency=2,
@@ -129,7 +129,7 @@ class TestDistributedIndexing:
 
         # Build distributed index with custom name
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             name=custom_name,
@@ -148,7 +148,7 @@ class TestDistributedIndexing:
 
         # Build distributed index
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             concurrency=2,
@@ -176,7 +176,7 @@ class TestDistributedIndexing:
 
         # Build distributed index
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             concurrency=4,
@@ -202,7 +202,7 @@ class TestDistributedIndexing:
 
         with pytest.raises(ValueError, match="Column 'nonexistent' not found"):
             create_scalar_index(
-                url=dataset_uri,
+                uri=dataset_uri,
                 column="nonexistent",
                 index_type="INVERTED",
                 concurrency=2,
@@ -217,7 +217,7 @@ class TestDistributedIndexing:
             match=r"Distributed indexing currently only supports 'INVERTED' and 'FTS' index types, not 'INVALID'",
         ):
             create_scalar_index(
-                url=dataset_uri,
+                uri=dataset_uri,
                 column="text",
                 index_type="INVALID",
                 concurrency=2,
@@ -229,7 +229,7 @@ class TestDistributedIndexing:
 
         with pytest.raises(ValueError, match="concurrency must be positive"):
             create_scalar_index(
-                url=dataset_uri,
+                uri=dataset_uri,
                 column="text",
                 index_type="INVERTED",
                 concurrency=0,
@@ -241,7 +241,7 @@ class TestDistributedIndexing:
 
         with pytest.raises(ValueError, match="Column name cannot be empty"):
             create_scalar_index(
-                url=dataset_uri,
+                uri=dataset_uri,
                 column="",
                 index_type="INVERTED",
                 concurrency=2,
@@ -259,11 +259,11 @@ class TestDistributedIndexing:
         )
         dataset = daft.from_pandas(data)
         path = Path(temp_dir) / "non_string_test.lance"
-        dataset.write_lance(str(path), max_rows_per_file=2)
+        dataset.write_lance(uri=path, max_rows_per_file=2)
 
         with pytest.raises(TypeError, match="must be string type"):
             create_scalar_index(
-                url=str(path),
+                uri=path,
                 column="numeric_col",
                 index_type="INVERTED",
                 concurrency=2,
@@ -275,7 +275,7 @@ class TestDistributedIndexing:
 
         # Build distributed index with Daft options
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             concurrency=2,
@@ -292,7 +292,7 @@ class TestDistributedIndexing:
 
         # Build distributed index with storage options
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             concurrency=2,
@@ -309,7 +309,7 @@ class TestDistributedIndexing:
 
         # Build distributed index with additional kwargs
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             concurrency=2,
@@ -327,7 +327,7 @@ class TestDistributedIndexing:
 
         # First, create an index
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             name=index_name,
@@ -342,7 +342,7 @@ class TestDistributedIndexing:
         # The error might be raised as RuntimeError during distributed processing
         with pytest.raises((ValueError, RuntimeError)) as exc_info:
             create_scalar_index(
-                url=dataset_uri,
+                uri=dataset_uri,
                 column="text",
                 index_type="INVERTED",
                 name=index_name,
@@ -361,7 +361,7 @@ class TestDistributedIndexing:
 
         # First, create an index
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             name=index_name,
@@ -382,7 +382,7 @@ class TestDistributedIndexing:
 
         # Now create another index with the same name but replace=True
         create_scalar_index(
-            url=dataset_uri,
+            uri=dataset_uri,
             column="text",
             index_type="INVERTED",
             name=index_name,
@@ -419,17 +419,17 @@ class TestDistributedIndexing:
         }
         dataset = daft.from_pydict(data)
         path = Path(temp_dir) / "small_dataset.lance"
-        dataset.write_lance(str(path), max_rows_per_file=2)
+        dataset.write_lance(uri=path, max_rows_per_file=2)
 
         # Request more workers than fragments
         create_scalar_index(
-            url=str(path),
+            uri=path,
             column="text",
             index_type="INVERTED",
             concurrency=10,  # More than the 2 fragments
         )
 
         # Should still work and create the index
-        updated_dataset = lance.dataset(str(path))
+        updated_dataset = lance.dataset(path)
         indices = updated_dataset.list_indices()
         assert len(indices) > 0, "No indices found after building"


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Addressing some complaints from our customers. Currently, the `read_lance` API uses `url` as the parameter name, while the `write_lance` API uses `uri`, and the data types are inconsistent, leading to frequent errors. 

Therefore, referencing the definition of the lance dataset, this PR uniformly use `uri` as the parameter name and standardize the parameter type to `Union[str, pathlib.Path]`.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->

## Checklist

- [ ] Documented in API Docs (if applicable)
- [ ] Documented in User Guide (if applicable)
- [ ] If adding a new documentation page, doc is added to `docs/mkdocs.yml` navigation
- [ ] Documentation builds and is formatted properly
