### PR TITLE
docs: add Python version requirement to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,8 @@ Installation
 
 Install Daft with ``pip install daft``.
 
+Requires Python 3.10 or higher.
+
 For more advanced installations (e.g. installing from source or with extra dependencies such as Ray and AWS utilities), please see our `Installation Guide <https://docs.daft.ai/en/stable/install/>`_
 
 Quickstart


### PR DESCRIPTION
## Summary
- Adds Python 3.10+ requirement to README installation section for consistency with quickstart documentation

## Test plan
- [x] Verified Python version requirement in pyproject.toml (line 23: `requires-python = ">=3.10"`)
- [x] Verified consistency with quickstart.md which states "Daft requires **Python 3.10 or higher**"