### PR TITLE
fix: Import or skip lance

### DIFF
--- a/tests/dataframe/test_explain.py
+++ b/tests/dataframe/test_explain.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 
-import lance
 import pytest
 
 import daft
@@ -13,6 +12,7 @@ from tests.utils import clean_explain_output
 
 @pytest.fixture
 def input_df(tmp_path):
+    lance = pytest.importorskip("lance")
     lance.write_dataset(pa.Table.from_pydict({"id": [id for id in range(16)]}), uri=tmp_path)
     return daft.read_lance(uri=str(tmp_path))
 


### PR DESCRIPTION
## Changes Made

The tests in `.github/workflows/build-wheel.yml` don't install testing or optional dependencies, which is why these failed on the nightly.

Perhaps we should consider adding a test suite in our PRs that test without testing or optional dependencies.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
