### PR TITLE
chore: add deprecation to daft.udf

### DIFF
--- a/daft/udf/legacy.py
+++ b/daft/udf/legacy.py
@@ -611,6 +611,7 @@ def udf(
     warnings.warn(
         "The `@daft.udf` decorator is deprecated since Daft version >= 0.7.0 and will be removed in >= 0.8.0. Please use `@daft.func` and `@daft.cls` instead.\nSee the migration guide for more details: https://docs.daft.ai/en/stable/custom-code/migration/",
         category=DeprecationWarning,
+        stacklevel=2,
     )
 
     inferred_return_dtype = DataType._infer(return_dtype)


### PR DESCRIPTION
## Changes Made

Formally deprecates the `@daft.udf` decorator.

## Related Issues

DF-1340
