### PR TITLE
docs: changed dev url to a live link to prevent 404

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ When proposing features, please include:
 
 ## Contributing Code
 
-For detailed development instructions, see our [Development Guide](https://docs.daft.ai/en/stable/contributing/development).
+For detailed development instructions, see our [Development Guide](https://docs.daft.ai/en/stable/contributing-to-daft/).
 
 ## Contributor Community
 


### PR DESCRIPTION
## Changes Made
updated link in CONTRIBUTING.md to use working link

## Related Issues
N/A