### PR TITLE
fix: upgrade Ray dev dependency to fix memory corruption

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,8 +110,7 @@ dev = [
   "pyarrow==22.0.0",
   "pyarrow-stubs==19.4",
   # Ray
-  "ray[data, client]==2.48.0; python_version >= '3.13' or platform_system != \"Linux\" or platform_machine != \"x86_64\"",
-  "ray[data, client]==2.34.0; python_version < '3.13' and platform_system == \"Linux\" and platform_machine == \"x86_64\"",
+  "ray[data, client]==2.48.0",
   # Lance
   "pylance>=0.37.0",
   # Iceberg


### PR DESCRIPTION
## Summary

Upgrades Ray dev dependency from 2.34.0 to 2.48.0 for Linux x86_64, fixing flaky memory corruption crashes in `integration-test-catalogs` CI job.

## Problem

Ray 2.34.0 has a memory corruption bug where the `deleted_generator_ids_` map in `ObjectRefGenerator.__del__()` → `AsyncDelObjectRefStream()` is accessed concurrently by multiple threads without synchronization. This causes intermittent failures with error:
```
free(): invalid next size (normal)
```

Example failed run: https://github.com/Eventual-Inc/Daft/actions/runs/19643761235/job/56254846045

## Root Cause

The platform-specific Ray pin was introduced in #5479 (Drop Python 3.9) to work around Dask compatibility issues—Ray 2.48.0 requires Dask 2024.11.0+, which needs Python ≥3.10 ([#5027](https://github.com/Eventual-Inc/Daft/issues/5027)). Since Python 3.9 is no longer supported, this workaround is obsolete.

## Fix

Remove the platform-specific pin and use Ray 2.48.0 for all platforms, which includes fix [ray-project/ray#50740](https://github.com/ray-project/ray/pull/50740) that adds mutex synchronization for concurrent access to generator IDs.

Related Ray issue: [ray-project/ray#50802](https://github.com/ray-project/ray/issues/50802)

## Test plan

- [ ] CI passes without flaky failures in `integration-test-catalogs`