### PR TITLE
docs: remove redundant Table of Contents from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,16 +18,6 @@ Daft: High-Performance Data Engine for AI and Multimodal Workloads
 * **Universal connectivity:** Access data anywhere (S3, GCS, Iceberg, Delta Lake, Hugging Face, Unity Catalog)
 * **Out-of-box reliability:** Intelligent memory management and sensible defaults eliminate configuration headaches
 
-**Table of Contents**
-
-* `About Daft`_
-* `Getting Started`_
-* `Benchmarks`_
-* `Contributing`_
-* `Telemetry`_
-* `Related Projects`_
-* `License`_
-
 About Daft
 ----------
 


### PR DESCRIPTION
## Summary
- Removes the manual Table of Contents section from README.rst
- GitHub now provides a built-in ToC feature that auto-generates navigation from headings, making this redundant

## Test plan
- [x] Verify README renders correctly on GitHub

## Internal
Closes EVE-1268