### PR TITLE
docs: fix quickstart connector links formatting

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -384,7 +384,7 @@ Now that you have a basic sense of Daft's functionality and features, here are s
 
     This same pipeline can process thousands or millions of products by leveraging Daft's distributed computing capabilities. Check out our [distributed computing guide](distributed/index.md) to run this analysis at scale on Ray or Kubernetes clusters.
 
-#### Work with your favorite table and catalog formats:
+**Work with your favorite table and catalog formats:**
 
 <div class="grid cards" markdown>
 
@@ -407,7 +407,7 @@ Now that you have a basic sense of Daft's functionality and features, here are s
 
 </div> -->
 
-#### Explore our [Examples](examples/index.md) to see Daft in action:
+**Explore our [Examples](examples/index.md) to see Daft in action:**
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
## Summary
- Remove bold formatting from connector and example link text
- Fix "AWS S3Tables" → "AWS S3 Tables" (proper spacing per AWS docs)

## Test plan
- [x] Preview the quickstart page to verify links render correctly

## Before and after screenshots
<img width="1072" height="676" alt="image" src="https://github.com/user-attachments/assets/b467aec1-4791-4ea6-8390-ad4b3b1ea8b2" />
<img width="1103" height="699" alt="image" src="https://github.com/user-attachments/assets/0b58e16c-9f10-4711-8bdb-2f9dbab97b0f" />

## Internal
Closes EVE-1272