### PR TITLE
chore!: bump minimum PyArrow version from 8.0.0 to 14.0.0

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -80,19 +80,19 @@ jobs:
       matrix:
         python-version: ['3.10', '3.13']
         daft-runner: [ray, native]
-        pyarrow-version: [8.0.0, 19.0.1]
+        pyarrow-version: [14.0.0, 19.0.1]
         os: [ubuntu-latest, macos-latest]
         on-main:
         - ${{ github.ref == 'refs/heads/main' }}
         exclude:
         - daft-runner: ray
-          pyarrow-version: 8.0.0
+          pyarrow-version: 14.0.0
         - python-version: '3.10'
           os: macos-latest
-        - pyarrow-version: 8.0.0
+        - pyarrow-version: 14.0.0
           os: macos-latest
         - python-version: '3.13'
-          pyarrow-version: 8.0.0
+          pyarrow-version: 14.0.0
         # don't run mac unit tests in PRs
         - os: macos-latest
           on-main: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["maturin>=1.5.0,<2.0.0"]
 [project]
 authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]
 dependencies = [
-  "pyarrow >= 8.0.0",
+  "pyarrow >= 14.0.0",
   "fsspec",
   "tqdm",
   "typing-extensions >= 4.0.0; python_version < '3.11'",
@@ -37,7 +37,7 @@ clickhouse = ["clickhouse_connect"]
 deltalake = ["deltalake <= 1.2.1"]
 gcp = []
 google = ["google-genai"]
-hudi = ["pyarrow >= 8.0.0"]
+hudi = ["pyarrow >= 14.0.0"]
 huggingface = ["huggingface-hub", "datasets"]
 # TODO: pyiceberg 0.9.1 has a bug https://github.com/apache/iceberg-python/issues/1979. It was not
 # triggered because we specify pyiceberg == 0.7.0 in requrements-dev.txt which hide this problem.

--- a/tests/catalog/test_iceberg.py
+++ b/tests/catalog/test_iceberg.py
@@ -12,10 +12,7 @@ from daft.logical.schema import Field, Schema
 
 CATALOG_ALIAS = "_test_catalog_iceberg"
 
-# skip if pyarrow < 9
 pyiceberg = pytest.importorskip("pyiceberg")
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(PYARROW_LOWER_BOUND_SKIP, reason="iceberg not supported on old versions of pyarrow")
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/delta_lake/test_table_read.py
+++ b/tests/integration/delta_lake/test_table_read.py
@@ -8,12 +8,6 @@ from daft.io.object_store_options import io_config_to_storage_options
 from daft.logical.schema import Schema
 from tests.utils import assert_pyarrow_tables_equal
 
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(
-    PYARROW_LOWER_BOUND_SKIP,
-    reason="deltalake not supported on older versions of pyarrow",
-)
-
 
 def test_deltalake_read_basic(tmp_path, base_table):
     deltalake = pytest.importorskip("deltalake")

--- a/tests/integration/delta_lake/test_table_read_pushdowns.py
+++ b/tests/integration/delta_lake/test_table_read_pushdowns.py
@@ -16,12 +16,6 @@ import daft
 from daft.logical.schema import Schema
 from tests.utils import assert_pyarrow_tables_equal
 
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(
-    PYARROW_LOWER_BOUND_SKIP,
-    reason="deltalake not supported on older versions of pyarrow",
-)
-
 
 def test_read_predicate_pushdown_on_data(deltalake_table):
     deltalake = pytest.importorskip("deltalake")

--- a/tests/integration/delta_lake/test_table_write.py
+++ b/tests/integration/delta_lake/test_table_write.py
@@ -14,12 +14,6 @@ from daft.io.object_store_options import io_config_to_storage_options
 from daft.logical.schema import Schema
 from tests.conftest import get_tests_daft_runner_name
 
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(
-    PYARROW_LOWER_BOUND_SKIP,
-    reason="deltalake not supported on older versions of pyarrow",
-)
-
 
 class _FakeCommitProperties:
     def __init__(self, custom_metadata):

--- a/tests/integration/iceberg/conftest.py
+++ b/tests/integration/iceberg/conftest.py
@@ -3,18 +3,12 @@ from __future__ import annotations
 from collections.abc import Generator, Iterator
 from typing import TypeAlias, TypeVar
 
-import pyarrow as pa
 import pytest
 
 import daft
 import daft.catalog
 
 pyiceberg = pytest.importorskip("pyiceberg")
-
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(
-    PYARROW_LOWER_BOUND_SKIP, reason="iceberg writes not supported on old versions of pyarrow"
-)
 
 import tenacity
 from pyiceberg.catalog import Catalog, load_catalog

--- a/tests/io/hudi/test_table_read.py
+++ b/tests/io/hudi/test_table_read.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 import datetime
 
-import pyarrow as pa
-import pytest
-
 import daft
-
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(PYARROW_LOWER_BOUND_SKIP, reason="hudi not supported on old versions of pyarrow")
 
 
 def test_read_table(get_testing_table_for_supported_cases):

--- a/tests/io/iceberg/test_iceberg_writes.py
+++ b/tests/io/iceberg/test_iceberg_writes.py
@@ -11,10 +11,6 @@ from tests.conftest import get_tests_daft_runner_name
 
 pyiceberg = pytest.importorskip("pyiceberg")
 
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(PYARROW_LOWER_BOUND_SKIP, reason="iceberg not supported on old versions of pyarrow")
-
-
 from pyiceberg.catalog.sql import SqlCatalog
 from pyiceberg.partitioning import UNPARTITIONED_PARTITION_SPEC, PartitionField, PartitionSpec
 from pyiceberg.schema import Schema

--- a/tests/io/lancedb/test_lancedb_factory_function.py
+++ b/tests/io/lancedb/test_lancedb_factory_function.py
@@ -10,9 +10,6 @@ import pytest
 from daft.io.lance.lance_scan import _lancedb_table_factory_function
 from daft.recordbatch import RecordBatch
 
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(PYARROW_LOWER_BOUND_SKIP, reason="lance not supported on old versions of pyarrow")
-
 # Import-or-skip lance once at module level so individual tests don't need to do this
 lance = pytest.importorskip("lance")
 

--- a/tests/io/lancedb/test_lancedb_reads.py
+++ b/tests/io/lancedb/test_lancedb_reads.py
@@ -10,9 +10,6 @@ from daft import col
 TABLE_NAME = "my_table"
 data = {"vector": [[1.1, 1.2], [0.2, 1.8]], "lat": [45.5, 40.1], "long": [-122.7, -74.1], "big_int": [1, 2]}
 
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(PYARROW_LOWER_BOUND_SKIP, reason="lance not supported on old versions of pyarrow")
-
 
 @pytest.fixture(scope="function")
 def lance_dataset_path(tmp_path_factory):

--- a/tests/io/lancedb/test_lancedb_writes.py
+++ b/tests/io/lancedb/test_lancedb_writes.py
@@ -21,9 +21,6 @@ data2 = {
     "long": [-123.7, -75.1],
 }
 
-PYARROW_LOWER_BOUND_SKIP = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) < (9, 0, 0)
-pytestmark = pytest.mark.skipif(PYARROW_LOWER_BOUND_SKIP, reason="lance not supported on old versions of pyarrow")
-
 
 @pytest.fixture(scope="function")
 def lance_dataset_path(tmp_path_factory):


### PR DESCRIPTION
## Summary

Bumps the minimum PyArrow version from 8.0.0 to 14.0.0.

## Context

Commit [f174bc0](https://github.com/Eventual-Inc/Daft/commit/f174bc0cf28875ea71e18b39382ab4f890a654a5) (`perf: optimize setting lance schema (#5704)`) failed on the PyArrow 8.0.0 test matrix:

- **Failing job:** `unit-test (3.10, native, 8.0.0, ubuntu-latest, true)`
- **Error:** `Process completed with exit code 139` (segmentation fault)
- **Workflow run:** https://github.com/Eventual-Inc/Daft/actions/runs/19808075853

### Root Cause

The failure is likely caused by a dependency incompatibility:

1. **Daft requires `pylance >= 0.37.0`** for Lance support
2. **pylance 0.37.0 requires `pyarrow >= 14`** ([PyPI](https://pypi.org/pypi/pylance/0.37.0/json))
3. **The CI matrix was testing PyArrow 8.0.0**, which is incompatible with pylance

PyArrow 8.0.0 is from May 2022, and PyArrow 14.0.0 is from November 2023. Bumping to 14.0.0 aligns with pylance's requirements and removes an invalid test configuration.

## Changes

- **pyproject.toml:** Update `pyarrow >= 8.0.0` → `pyarrow >= 14.0.0`
- **.github/workflows/pr-test-suite.yml:** Update CI matrix from `[8.0.0, 19.0.1]` → `[14.0.0, 19.0.1]`
- **Test files:** Remove obsolete `PYARROW_LOWER_BOUND_SKIP` markers (no longer needed since minimum is now >= 14)