### PR TITLE
fix: Fix type annotation check on Python 3.14

### DIFF
--- a/daft/api_annotations.py
+++ b/daft/api_annotations.py
@@ -97,14 +97,14 @@ def type_check_function(func: Callable[..., Any], *args: Any, **kwargs: Any) -> 
         if origin_T is None:
             return isinstance(value, T)
 
-        # T is a generic type, like `typing.List` or builtin container like `list`
-        if isinstance(origin_T, type):
-            return isinstance(value, origin_T)
-
         # T is a `typing.Union`
         if origin_T is Union:
             union_types = get_args(T)
             return any(isinstance_helper(value, union_type) for union_type in union_types)
+
+        # T is a generic type, like `typing.List` or builtin container like `list`
+        if isinstance(origin_T, type):
+            return isinstance(value, origin_T)
 
         # T is a `typing.Literal`
         if origin_T is Literal:


### PR DESCRIPTION
## Changes Made

Before Python 3.14, `isinstance(typing.Union, type)` is false. In Python 3.14, it's true. Thus, to fix the problem, I moved the `isinstance(origin_T, type)` check after the check for `typing.Union`.

## Related Issues

Addresses #5545 (and closes #5536, but technically that's already closed). I don't think we should close the original PR until we add tests for 3.14, wdyt @colin-ho?