### PR TITLE
fix: update hypothesis test to use new expression API

### DIFF
--- a/tests/property_based_testing/test_sort.py
+++ b/tests/property_based_testing/test_sort.py
@@ -196,7 +196,7 @@ class DataframeSortStateMachine(RuleBasedStateMachine):
             DataType.float64(): lambda e, other: e + other,
             DataType.bool(): lambda e, other: e | other,
             # No meaningful binary operations supported for these yet
-            DataType.date(): lambda e, other: e.dt.year(),
+            DataType.date(): lambda e, other: e.year(),
             DataType.binary(): lambda e, other: e,
             DataType.null(): lambda e, other: e,
         }


### PR DESCRIPTION
## Summary

Fixes the nightly property-based test failure: https://github.com/Eventual-Inc/Daft/actions/runs/19835912383

The `.dt` namespace on `Expression` was removed in #5619. This updates the property-based test to call `.year()` directly on the expression instead of `.dt.year()`.

## Test plan

- [x] Verified test fails before fix
- [x] Verified test passes after fix with 1000 examples