### PR TITLE
docs: fix broken Lance documentation link

### DIFF
--- a/docs/connectors/lance.md
+++ b/docs/connectors/lance.md
@@ -1,6 +1,6 @@
 # Reading from and Writing to Lance
 
-[Lance](https://lancedb.github.io/lancedb/) is a next-generation columnar storage format for multimodal datasets (images, video, audio, and general columnar data). It supports local POSIX filesystems and cloud object stores (e.g., S3/GCS). Lance is known for extremely fast random access, zero-copy reads, deep integration with PyArrow/DuckDB, and strong performance for vector retrieval workloads.
+[Lance](https://lance.org/) is a next-generation columnar storage format for multimodal datasets (images, video, audio, and general columnar data). It supports local POSIX filesystems and cloud object stores (e.g., S3/GCS). Lance is known for extremely fast random access, zero-copy reads, deep integration with PyArrow/DuckDB, and strong performance for vector retrieval workloads.
 
 Daft currently supports:
 


### PR DESCRIPTION
## Summary
- Fixes broken link to Lance documentation in `docs/connectors/lance.md`
- The old URL `https://lancedb.github.io/lance/` now returns 404
- Updated to `https://lancedb.github.io/lancedb/`

This is one of the fixes needed for the failing [Check Broken Links on daft.ai](https://github.com/Eventual-Inc/Daft/actions/runs/19835857020) workflow.

## Test plan
- Link checker workflow should pass after this fix (along with blog post fixes in the CMS)