### PR TITLE
ci: exclude Kaggle from link checker

### DIFF
--- a/.github/workflows/broken-link-checker.yml
+++ b/.github/workflows/broken-link-checker.yml
@@ -35,6 +35,7 @@ jobs:
             --exclude https://scarf.sh/ \
             --exclude https://static.scarf.sh/* \
             --exclude http://www.allaboutcookies.org/ \
+            --exclude https://www.kaggle.com/* \
             | tee "$LOG"
 
           # Only fail on 404s; print other broken links too (deduplicated).


### PR DESCRIPTION
## Summary
- Excludes `https://www.kaggle.com/*` from the broken link checker workflow
- Kaggle rate-limits or blocks automated link checkers, causing false 404 errors
- The links work fine in browsers (manually verified)

This is a fix for the failing [Check Broken Links on daft.ai](https://github.com/Eventual-Inc/Daft/actions/runs/19835857020) workflow.

## Test plan
- Link checker workflow should no longer report false 404s for Kaggle URLs