### PR TITLE
feat: Add statistics info to ScanTask when reading Lance dataset

### DIFF
--- a/tests/dataframe/test_explain.py
+++ b/tests/dataframe/test_explain.py
@@ -28,7 +28,7 @@ def test_explain_with_empty_scantask(input_df):
 
     * ScanTaskSource:
     |   Num Scan Tasks = 1
-    |   Estimated Scan Bytes = 0
+    |   Estimated Scan Bytes = 347
     |   Schema: {id#Int64}
     |   Scan Tasks: [
     |   {daft.io.lance.lance_scan:_lancedb_table_factory_function}


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Currently, when constructing the ScanTask corresponding to `read_lance`, the statistics info such as `num_rows` and `size_bytes` are not set. This PR supplements these statistics info.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
