### PR TITLE
fix(ci): add disk cleanup to integration-test-ai job

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -819,6 +819,17 @@ jobs:
         python-version: ['3.10']
         daft-runner: [ray, native]
     steps:
+    - name: Free Disk Space (Ubuntu)
+      if: ${{ (runner.os == 'Linux') }}
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: false
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: true
     - uses: actions/checkout@v6
       with:
         submodules: true


### PR DESCRIPTION
## Changes Made

Add disk cleanup step to `integration-test-ai` job in the PR test suite workflow to prevent disk space failures when installing heavy AI dependencies.

## Related Issues

Fixes the "no space left on device" errors causing `integration-test-ai` failures starting December 2:
- Error: `No space left on device: '/home/runner/actions-runner/cached/_diag/Worker_...'`

Related to the broader disk space issue affecting CI jobs:
- #5589
- #5609
- #5610
- #5711

## Root Cause

GitHub Actions runners have limited disk space. The combination of:
1. Large Python dependencies (torch, tensorflow, vllm ~2GB+)
2. Rust compilation artifacts

...exceeds available disk space, causing the runner worker process to crash.

Disk space became borderline after GitHub updated the `ubuntu-latest` runner image from `ubuntu24/20251102.99` to `ubuntu24/20251112.124` in November (see #5711). The `integration-test-ai` job failures are intermittent due to borderline disk space - sometimes there's just enough, sometimes not.

## Timeline Evidence

| Date | Run | Runner Image | Branch | Commit | integration-test-ai Result |
|------|-----|--------------|--------|--------|---------------------------|
| Dec 2, 04:14 | [19846881482](https://github.com/Eventual-Inc/Daft/actions/runs/19846881482) | `20251112.124.1` | main | `37623e1` | ✅ Success |
| Dec 2, 04:58 | [19847729052](https://github.com/Eventual-Inc/Daft/actions/runs/19847729052) | `20251112.124.1` | main | `699e213` | ✅ Success |
| Dec 2, 07:43 | [19851013864](https://github.com/Eventual-Inc/Daft/actions/runs/19851013864) | `20251112.124.1` | dataframe-hashing-function | `7b01545` | ✅ Success |
| Dec 2, 12:50 | [19859197086](https://github.com/Eventual-Inc/Daft/actions/runs/19859197086) | `20251112.124.1` | zhenchao-lance-stats | `e96d6cd` | ✅ Success |
| Dec 2, 17:26 | [19867603566](https://github.com/Eventual-Inc/Daft/actions/runs/19867603566) | `20251112.124.1` | slade/daft-arrow-crate | `00d2eba` | ✅ Success |
| **Dec 2, 18:33** | [19869482423](https://github.com/Eventual-Inc/Daft/actions/runs/19869482423) | `20251112.124.1` | main | `15adbc3` | ❌ **First Failure** |
| **Dec 2, 18:42** | [19869705631](https://github.com/Eventual-Inc/Daft/actions/runs/19869705631) | `20251112.124.1` | fix/macos-timeout (PR #5731) | `eb69f98` | ❌ Failure |

## Test Plan

- [ ] Verify `integration-test-ai` jobs pass on this PR

## Internal

Closes EVE-1300