### PR TITLE
feat: eliminate duplicate repartition with hash join

### DIFF
--- a/src/daft-distributed/src/pipeline_node/join/translate_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/translate_join.rs
@@ -78,12 +78,16 @@ impl LogicalPlanToPipelineNodeTranslator {
 
         let is_left_hash_partitioned = matches!(left_spec, ClusteringSpec::Hash(..))
             && is_partition_compatible(
-                &left_spec.partition_by(),
+                BoundExpr::bind_all(&left_spec.partition_by(), &left.config().schema)?
+                    .iter()
+                    .map(|e| e.inner()),
                 left_on.iter().map(|e| e.inner()),
             );
         let is_right_hash_partitioned = matches!(right_spec, ClusteringSpec::Hash(..))
             && is_partition_compatible(
-                &right_spec.partition_by(),
+                BoundExpr::bind_all(&right_spec.partition_by(), &right.config().schema)?
+                    .iter()
+                    .map(|e| e.inner()),
                 right_on.iter().map(|e| e.inner()),
             );
         let num_left_partitions = left_spec.num_partitions();

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -574,3 +574,132 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
         Ok(TreeNodeRecursion::Continue)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use common_daft_config::DaftExecutionConfig;
+    use daft_core::prelude::{DataType, Field, Schema};
+    use daft_dsl::{expr::bound_expr::BoundExpr, resolved_col};
+    use daft_logical_plan::{
+        JoinType,
+        partitioning::{HashRepartitionConfig, RepartitionSpec},
+        source_info::InMemoryInfo,
+    };
+
+    use super::*;
+    use crate::pipeline_node::{
+        in_memory_source::InMemorySourceNode, shuffles::repartition::RepartitionNode,
+    };
+
+    fn make_plan_config() -> PlanConfig {
+        PlanConfig::new(0, "test".into(), Arc::new(DaftExecutionConfig::default()))
+    }
+
+    fn make_schema() -> daft_schema::schema::SchemaRef {
+        let schema_dc = Schema::new(vec![
+            Field::new("A", DataType::Int64),
+            Field::new("B", DataType::Utf8),
+        ]);
+        schema_dc.into()
+    }
+
+    fn make_in_memory_node(
+        plan_cfg: &PlanConfig,
+        schema: daft_schema::schema::SchemaRef,
+        cache_key: &str,
+        num_parts: usize,
+    ) -> DistributedPipelineNode {
+        let info = InMemoryInfo::new(
+            schema.clone(),
+            cache_key.to_string(),
+            None,
+            num_parts,
+            0,
+            0,
+            None,
+            None,
+        );
+        let psets = Arc::new(HashMap::from([(cache_key.to_string(), vec![])]));
+        InMemorySourceNode::new(1, plan_cfg, info, psets).into_node()
+    }
+
+    #[test]
+    fn gen_shuffle_node_dedup_when_already_hash_partitioned() -> DaftResult<()> {
+        let plan_cfg = make_plan_config();
+        let schema = make_schema();
+        let child_source = make_in_memory_node(&plan_cfg, schema.clone(), "left", 4);
+
+        // child already hash-partitioned by A with 4 partitions
+        let initial_spec =
+            RepartitionSpec::Hash(HashRepartitionConfig::new(Some(4), vec![resolved_col("A")]));
+        let child_hash = RepartitionNode::new(
+            2,
+            &plan_cfg,
+            initial_spec.clone(),
+            4,
+            schema.clone(),
+            child_source,
+        )
+        .into_node();
+
+        let mut translator =
+            LogicalPlanToPipelineNodeTranslator::new(plan_cfg, Arc::new(HashMap::new()));
+        // ask to repartition by the same spec
+        let new_node =
+            translator.gen_shuffle_node(initial_spec, schema.clone(), child_hash.clone())?;
+        assert_eq!(new_node.node_id(), child_hash.node_id());
+        Ok(())
+    }
+
+    #[test]
+    fn hash_join_skips_shuffle_when_prepartitioned() -> DaftResult<()> {
+        let plan_cfg = make_plan_config();
+        let schema = make_schema();
+        let left_src = make_in_memory_node(&plan_cfg, schema.clone(), "left", 4);
+        let right_src = make_in_memory_node(&plan_cfg, schema.clone(), "right", 4);
+        let hash_spec =
+            RepartitionSpec::Hash(HashRepartitionConfig::new(Some(4), vec![resolved_col("A")]));
+        let left = RepartitionNode::new(
+            10,
+            &plan_cfg,
+            hash_spec.clone(),
+            4,
+            schema.clone(),
+            left_src,
+        )
+        .into_node();
+        let right = RepartitionNode::new(
+            20,
+            &plan_cfg,
+            hash_spec.clone(),
+            4,
+            schema.clone(),
+            right_src,
+        )
+        .into_node();
+
+        let mut translator =
+            LogicalPlanToPipelineNodeTranslator::new(plan_cfg, Arc::new(HashMap::new()));
+        let schema_dc: Schema = Schema::new(vec![
+            Field::new("A", DataType::Int64),
+            Field::new("B", DataType::Utf8),
+        ]);
+        let left_on = BoundExpr::bind_all(&vec![resolved_col("A")], &schema_dc)?;
+        let right_on = BoundExpr::bind_all(&vec![resolved_col("A")], &schema_dc)?;
+        let join = translator.gen_hash_join_nodes(
+            left.clone(),
+            right.clone(),
+            left_on,
+            right_on,
+            vec![false],
+            JoinType::Inner,
+            schema.clone(),
+        )?;
+        let children = join.children();
+        assert_eq!(children[0].node_id(), left.node_id());
+        assert_eq!(children[1].node_id(), right.node_id());
+        Ok(())
+    }
+}

--- a/src/daft-dsl/src/expr/mod.rs
+++ b/src/daft-dsl/src/expr/mod.rs
@@ -2140,16 +2140,19 @@ impl FromStr for Operator {
     }
 }
 
-// Check if one set of columns is a reordering of the other
+// Check if two sets of partition expressions are compatible (order-insensitive)
+// Compare by semantic identifiers based on expression names, so that Resolved vs Bound
+// columns with the same names are treated as compatible regardless of object identity.
 pub fn is_partition_compatible<'a, A, B>(a: A, b: B) -> bool
 where
     A: IntoIterator<Item = &'a ExprRef>,
     B: IntoIterator<Item = &'a ExprRef>,
 {
-    // sort a and b by name
-    let a_set: HashSet<&ExprRef> = HashSet::from_iter(a);
-    let b_set: HashSet<&ExprRef> = HashSet::from_iter(b);
-    a_set == b_set
+    let to_name_set =
+        |iter: A| -> HashSet<String> { iter.into_iter().map(|e| e.name().to_string()).collect() };
+    let a_names = to_name_set(a);
+    let b_names = to_name_set(b);
+    a_names == b_names
 }
 
 pub fn has_agg(expr: &ExprRef) -> bool {

--- a/src/daft-dsl/src/expr/tests.rs
+++ b/src/daft-dsl/src/expr/tests.rs
@@ -81,3 +81,31 @@ fn check_arithmetic_type_with_columns() -> DaftResult<()> {
 
     Ok(())
 }
+
+#[test]
+fn partition_compatibility_resolved_vs_bound_order_insensitive() -> DaftResult<()> {
+    // Schema with columns a, b
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::Int64),
+        Field::new("b", DataType::Utf8),
+    ]);
+
+    // Resolved columns in one order
+    let resolved_cols = vec![resolved_col("a"), resolved_col("b")];
+    // Bound columns in reversed order
+    let bound_cols = BoundExpr::bind_all(&vec![resolved_col("b"), resolved_col("a")], &schema)?;
+
+    assert!(is_partition_compatible(
+        &resolved_cols,
+        bound_cols.iter().map(|e| e.inner()),
+    ));
+
+    // Differing names should be incompatible
+    let differing_resolved = vec![resolved_col("a"), resolved_col("c")];
+    assert!(!is_partition_compatible(
+        &differing_resolved,
+        bound_cols.iter().map(|e| e.inner()),
+    ));
+
+    Ok(())
+}


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Eliminate duplicate repartition with hash join, for example:

```text
== Physical Plan ==

* Hash Join
|   Left on: col(5: audio_segment_path)
|   Right on: col(0: audio_segment_path)
|\
| * Repartition: Hash
| |   Num partitions = Some(40)
| |   By = col(0: audio_segment_path)
| |
| * Project: col(0: audio_segment_path), col(2: language_code), get(col(1:
| |     language_result)) as language_name
| |   Resource request = None
| |
| * Filter: not_null(col(2: language_code))
| |
| * Project: col(0: audio_segment_path), col(1: language_result), get(col(1:
| |     language_result)) as language_code
| |   Resource request = None
| |
| * ActorUDF:
| |   Projection = [col(0: audio_segment_path), py_udf(col(0: audio_segment_path))
| |     as language_result]
| |   UDF = audio_language_detection.AudioLanguageDetection
| |   Concurrency = 320
| |   Resource request = { num_gpus = 0.25 }
| |
| * Repartition: Hash
| |   Num partitions = Some(40)
| |   By = col(audio_segment_path)
| |
| * Pre-Shuffle Merge
| |   Threshold: 1073741824
| |
| * ScanTaskSource:
| |   Num Scan Tasks = 26180
| |   Estimated Scan Bytes = 41699304922
| |   Pushdowns: {projection: [audio_segment_path], filter:
| |     not(is_null(col(audio_segment_path)))}
| |   Schema: {audio_path#Utf8, denoise_audio_path#Utf8, normalized_audio_path#Utf8,
| |     speaker_segments#List(Struct([Field { name: "start", dtype: Float32,
| |     metadata: {} }, Field { name: "end", dtype: Float32, metadata:
| |     {} }, Field { name: "speaker", dtype: Utf8, metadata: {} }])),
| |     speaker_segments_merged_tts#List(Struct([Field { name: "start",
| |     dtype: Float32, metadata: {} }, Field { name: "end", dtype: Float32,
| |     metadata: {} }, Field { name: "speaker", dtype: Utf8, metadata: {} }])),
| |     audio_segment_path#Utf8, start#Float32, end#Float32, speaker#Utf8}
| |   Scan Tasks: [...]
|
* Repartition: Hash
|   Num partitions = Some(40)
|   By = col(5: audio_segment_path)
|
* Repartition: Hash
|   Num partitions = Some(40)
|   By = col(audio_segment_path)
|
* Pre-Shuffle Merge
|   Threshold: 1073741824
|
* ScanTaskSource:
|   Num Scan Tasks = 26180
|   Estimated Scan Bytes = 41699304922
|   Pushdowns: {filter: not(is_null(col(audio_segment_path)))}
|   Schema: {audio_path#Utf8, denoise_audio_path#Utf8, normalized_audio_path#Utf8,
|     speaker_segments#List(Struct([Field { name: "start", dtype: Float32,
|     metadata: {} }, Field { name: "end", dtype: Float32, metadata:
|     {} }, Field { name: "speaker", dtype: Utf8, metadata: {} }])),
|     speaker_segments_merged_tts#List(Struct([Field { name: "start", dtype: Float32,
|     metadata: {} }, Field { name: "end", dtype: Float32, metadata: {} }, Field
|     { name: "speaker", dtype: Utf8, metadata: {} }])), audio_segment_path#Utf8,
|     start#Float32, end#Float32, speaker#Utf8}
|   Scan Tasks: [...]
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
