### PR TITLE
fix(test): use read_huggingface instead of read_parquet for HF test

### DIFF
--- a/tests/integration/io/huggingface/test_read_huggingface.py
+++ b/tests/integration/io/huggingface/test_read_huggingface.py
@@ -15,7 +15,7 @@ from tests.conftest import assert_df_equals
 def test_read_huggingface_datasets_doesnt_fail():
     # run it multiple times to ensure it doesn't fail
     for _ in range(10):
-        df = daft.read_parquet("hf://datasets/huggingface/documentation-images")
+        df = daft.read_huggingface("huggingface/documentation-images")
         schema = df.schema()
         expected = daft.Schema.from_pydict({"image": dt.struct({"bytes": dt.binary(), "path": dt.string()})})
         assert schema == expected


### PR DESCRIPTION
## Summary

Fixes the failing `test_read_huggingface_datasets_doesnt_fail` integration test by changing it to use `daft.read_huggingface()` instead of `daft.read_parquet()` with an `hf://` URL.

## Background

The test was failing in CI with a 400 error from HuggingFace:
```
DaftError::External Unable to open file https://huggingface.co/api/datasets/huggingface/documentation-images/parquet/default/validation/0.parquet: reqwest::Error { kind: Status(400, None), url: "..." }
```

See failing job: https://github.com/Eventual-Inc/Daft/actions/runs/19945103061/job/57194286939

## Why this fix works

PR #5650 added a fallback mechanism to `read_huggingface()` that catches 400 errors and falls back to the `datasets` library. However, the test was calling `read_parquet()` directly with an `hf://` URL, bypassing this fallback.

## Test plan

- [x] Local test passes:
  ```
  DAFT_RUNNER=native .venv/bin/pytest -v -m integration \
    tests/integration/io/huggingface/test_read_huggingface.py::test_read_huggingface_datasets_doesnt_fail
  
  PASSED (4.33s)
  ```
- [x] CI verification via #5756 (temporarily enables credentialed tests on PRs)