### PR TITLE
fix(io): load all splits in read_huggingface fallback path

### DIFF
--- a/daft/io/huggingface/__init__.py
+++ b/daft/io/huggingface/__init__.py
@@ -38,11 +38,14 @@ def read_huggingface(repo: str, io_config: IOConfig | None = None) -> DataFrame:
 
             # Load dataset using datasets library and convert to Daft
             import daft
+            from datasets import concatenate_datasets
 
-            ds = load_dataset(repo, split="train")
+            # Load all splits and concatenate them to match the main path behavior
+            ds = load_dataset(repo)
+            all_data = concatenate_datasets([ds[split] for split in ds.keys()])
             # Convert to arrow format for better compatibility
-            ds = ds.with_format("arrow")
-            arrow_table = ds.data.table
+            all_data = all_data.with_format("arrow")
+            arrow_table = all_data.data.table
             return daft.from_arrow(arrow_table)
         else:
             # Re-raise other errors

--- a/tests/integration/io/huggingface/test_read_huggingface.py
+++ b/tests/integration/io/huggingface/test_read_huggingface.py
@@ -115,16 +115,4 @@ def test_read_huggingface_multi_split_dataset():
         fallback_result = df_fallback.to_pandas()
 
     # Both paths should return the same data
-    assert len(main_result) == len(fallback_result), (
-        f"Row count mismatch: main path returned {len(main_result)} rows, "
-        f"fallback path returned {len(fallback_result)} rows"
-    )
-
-    # Compare schemas
-    assert list(main_result.columns) == list(fallback_result.columns), "Schema mismatch between main and fallback paths"
-
-    # Compare data content by checking that the set of (text, label) pairs is identical
-    # We use sets because row order may differ between paths, and there are duplicate texts
-    main_set = set(zip(main_result["text"], main_result["label"]))
-    fallback_set = set(zip(fallback_result["text"], fallback_result["label"]))
-    assert main_set == fallback_set, "Data content mismatch between main and fallback paths"
+    assert_df_equals(main_result, fallback_result, sort_key=["text", "label"])


### PR DESCRIPTION
## Summary
- Fix the fallback path in `read_huggingface` to load all splits instead of hardcoding `split='train'`
- The fallback is triggered when the HuggingFace parquet API returns a 400 error

## Problem
The fallback path previously called `load_dataset(repo, split="train")`, which:
1. Failed for datasets that don't have a `train` split (e.g., `nebius/SWE-rebench` only has `test`)
2. Only loaded one split instead of all splits, unlike the main parquet path which reads all splits

## Solution
- Use `load_dataset(repo)` without a split parameter to get all splits as a `DatasetDict`
- Concatenate all splits using `concatenate_datasets()` to match the main path behavior

## Test plan
- Added integration test `test_read_huggingface_multi_split_dataset` using `stanfordnlp/imdb` (has train, test, and unsupervised splits)
- Test verifies both main path (read_parquet) and fallback path (mocked 400 error) return the same data