### PR TITLE
docs: fix broken Bodo benchmark link

### DIFF
--- a/docs/benchmarks/index.md
+++ b/docs/benchmarks/index.md
@@ -346,7 +346,7 @@ We note two interesting results here:
 Our benchmarking scripts and code can be found in the [distributed-query-benchmarks](https://github.com/Eventual-Inc/distributed-query-benchmarking) GitHub repository.
 
 - TPC-H queries for Daft were written by us.
-- TPC-H queries for SparkSQL was adapted from [this repository](https://github.com/bodo-ai/Bodo/blob/main/benchmarks/tpch/pyspark_notebook.ipynb).
+- TPC-H queries for SparkSQL was adapted from [this repository](https://github.com/bodo-ai/Bodo/blob/ec18c281c450ca463b55194c45ba11bcf986d04f/benchmarks/tpch/pyspark_notebook.ipynb).
 - TPC-H queries for Dask and Modin were adapted from these repositories for questions [Q1-7](https://github.com/pola-rs/tpch) and [Q8-10](https://github.com/xprobe-inc/benchmarks/tree/main/tpch).
 
 ### Infrastructure


### PR DESCRIPTION
## Summary

Fixes broken link in the TPC-H benchmarks documentation.

The file `benchmarks/tpch/pyspark_notebook.ipynb` in the `bodo-ai/Bodo` repo was reorganized/removed, causing a 404. This pins the link to the commit that existed when the reference was originally added (Dec 2024).

## Context

This was causing the nightly `check-links` CI job to fail:
- https://github.com/Eventual-Inc/Daft/actions/runs/19974612660/job/57287581046

Note: The CI also reports a 404 for `https://lancedb.github.io/lance/` but that fix is already on main (#5724) and will be included in the next release.

## Test Plan

- [x] Verify the pinned link works: https://github.com/bodo-ai/Bodo/blob/ec18c281c450ca463b55194c45ba11bcf986d04f/benchmarks/tpch/pyspark_notebook.ipynb