### PR TITLE
fix: update AI integration tests for new Subscriber interface

### DIFF
--- a/tests/integration/ai/test_google.py
+++ b/tests/integration/ai/test_google.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field
 
 import daft
 import daft.context
-from daft.daft import PyMicroPartition, PyNodeInfo
+from daft.daft import PyMicroPartition
 from daft.functions.ai import prompt
 from daft.subscribers import StatType, Subscriber
 from tests.conftest import get_tests_daft_runner_name
@@ -74,7 +74,7 @@ class PromptMetricsSubscriber(Subscriber):
     def on_optimization_end(self, query_id: str, optimized_plan: str) -> None:
         pass
 
-    def on_exec_start(self, query_id: str, node_infos: list[PyNodeInfo]) -> None:
+    def on_exec_start(self, query_id: str, physical_plan: str) -> None:
         pass
 
     def on_exec_operator_start(self, query_id: str, node_id: int) -> None:

--- a/tests/integration/ai/test_openai.py
+++ b/tests/integration/ai/test_openai.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel, Field
 
 import daft
 import daft.context
-from daft.daft import PyMicroPartition, PyNodeInfo
+from daft.daft import PyMicroPartition
 from daft.functions.ai import embed_text, prompt
 from daft.subscribers import StatType, Subscriber
 from tests.conftest import get_tests_daft_runner_name
@@ -79,7 +79,7 @@ class PromptMetricsSubscriber(Subscriber):
         """Called when planning for a query has completed."""
         pass
 
-    def on_exec_start(self, query_id: str, node_infos: list[PyNodeInfo]) -> None:
+    def on_exec_start(self, query_id: str, physical_plan: str) -> None:
         """Called when starting to execute a query."""
         pass
 


### PR DESCRIPTION
## Summary
- Remove `PyNodeInfo` import from AI integration tests (class was removed in #5709)
- Update `on_exec_start` signature from `list[PyNodeInfo]` to `physical_plan: str`

## Related Issues
Fixes CI failure: https://github.com/Eventual-Inc/Daft/actions/runs/19975024162

The `integration-test-ai-credentialed` jobs were failing with:
```
ImportError: cannot import name 'PyNodeInfo' from 'daft.daft'
```

This was caused by #5709 which changed the Subscriber interface but didn't update these test files.

## Test Plan
- [x] Verified locally that tests can be collected without import errors
- [ ] CI should pass for AI credentialed integration tests