### PR TITLE
chore: remove arrow dep from common-image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,7 +1871,6 @@ dependencies = [
  "bincode",
  "common-error",
  "common-ndarray",
- "daft-arrow",
  "daft-schema",
  "image",
  "ndarray",

--- a/src/common/image/Cargo.toml
+++ b/src/common/image/Cargo.toml
@@ -1,5 +1,4 @@
 [dependencies]
-daft-arrow = {path = "../../daft-arrow"}
 common-error = {path = "../error", default-features = false}
 common-ndarray = {workspace = true}
 daft-schema = {path = "../../daft-schema", default-features = false}

--- a/src/common/image/src/bbox.rs
+++ b/src/common/image/src/bbox.rs
@@ -1,19 +1,2 @@
 #[derive(Clone)]
 pub struct BBox(pub u32, pub u32, pub u32, pub u32);
-
-impl BBox {
-    pub fn from_u32_arrow_array(arr: &dyn daft_arrow::array::Array) -> Self {
-        assert!(arr.len() == 4);
-        let mut iter = arr
-            .as_any()
-            .downcast_ref::<daft_arrow::array::UInt32Array>()
-            .unwrap()
-            .iter();
-        Self(
-            *iter.next().unwrap().unwrap(),
-            *iter.next().unwrap().unwrap(),
-            *iter.next().unwrap().unwrap(),
-            *iter.next().unwrap().unwrap(),
-        )
-    }
-}


### PR DESCRIPTION
## Changes Made

removes daft-arrow from common-image. 

This simplifies the arrow2-arrowrs migration

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
