### PR TITLE
test(io): remove flaky test_read_huggingface_http_urls test

### DIFF
--- a/tests/integration/io/huggingface/test_read_huggingface.py
+++ b/tests/integration/io/huggingface/test_read_huggingface.py
@@ -44,25 +44,6 @@ def test_read_huggingface(path, split, sort_key):
 
 
 @pytest.mark.integration()
-@pytest.mark.parametrize(
-    "path, schema",
-    [
-        (
-            "https://huggingface.co/api/datasets/huggingface/documentation-images/parquet/default/train/0.parquet",
-            daft.Schema.from_pydict({"image": dt.struct({"bytes": dt.binary(), "path": dt.string()})}),
-        ),
-        (
-            "https://huggingface.co/api/datasets/Anthropic/hh-rlhf/parquet/default/train/0.parquet",
-            daft.Schema.from_pydict({"chosen": dt.string(), "rejected": dt.string()}),
-        ),
-    ],
-)
-def test_read_huggingface_http_urls(path, schema):
-    df = daft.read_parquet(path)
-    assert df.schema() == schema
-
-
-@pytest.mark.integration()
 def test_read_huggingface_fallback_on_400_error():
     """Test that read_huggingface falls back to datasets library when parquet files return 400 error."""
     repo = "Eventual-Inc/sample-parquet"


### PR DESCRIPTION
## Summary

Remove `test_read_huggingface_http_urls` which was causing `integration-test-io` CI failures due to HuggingFace API intermittently returning HTTP 400 errors.

## Analysis

### Timeline of Recent Failures

| Run ID | Date | integration-test-io | HuggingFace HTTP URLs Test | Branch |
|--------|------|---------------------|---------------------------|--------|
| [20139561377](https://github.com/Eventual-Inc/Daft/actions/runs/20139561377) | 2025-12-11 16:09 | failure | **FAILED** | dependabot/cargo/minor-302a5b8b8f |
| [20138427972](https://github.com/Eventual-Inc/Daft/actions/runs/20138427972) | 2025-12-11 15:31 | failure | **FAILED** | main |
| [20135447407](https://github.com/Eventual-Inc/Daft/actions/runs/20135447407) | 2025-12-11 13:53 | success | passed | skip-empty-rb-github |
| [20135405386](https://github.com/Eventual-Inc/Daft/actions/runs/20135405386) | 2025-12-11 13:52 | success | passed | csv-options |
| [20133699083](https://github.com/Eventual-Inc/Daft/actions/runs/20133699083) | 2025-12-11 12:51 | success | passed | zhenchao-bugfix |
| [20133496256](https://github.com/Eventual-Inc/Daft/actions/runs/20133496256) | 2025-12-11 12:43 | success | passed | skip-empty-rb-github |
| [20131580365](https://github.com/Eventual-Inc/Daft/actions/runs/20131580365) | 2025-12-11 11:28 | success | passed | gravitino_split2 |
| [20124879805](https://github.com/Eventual-Inc/Daft/actions/runs/20124879805) | 2025-12-11 07:06 | success | passed | main |
| [20121554818](https://github.com/Eventual-Inc/Daft/actions/runs/20121554818) | 2025-12-11 04:04 | success | passed | fix--openai-import-errors |

### Root Cause

The test hits `https://huggingface.co/api/datasets/.../parquet/...` URLs which intermittently return HTTP 400 errors. When this happens, all 4 integration-test-io job variants fail together:
- integration-test-io (3.10, native)
- integration-test-io (3.10, ray)
- integration-test-io-credentialed (3.10, native)
- integration-test-io-credentialed (3.10, ray)

### Why This Test Doesn't Provide Unique Coverage

1. **Reading parquet from HTTPS URLs** is already tested by `test_reads_public_data.py` using stable Daft-controlled S3 URLs
2. **The `huggingface/documentation-images` dataset** is already tested by `test_read_huggingface_datasets_doesnt_fail` via `daft.read_huggingface()`
3. **`read_huggingface()` internally calls `read_parquet()`**, so the same code path is exercised through the proper API

The removed test was essentially testing "can we fetch from a third-party API that might be down" rather than testing Daft functionality.

## Test Plan

- [ ] CI passes without flaky failures from this test
