### PR TITLE
refactor(arrow2): remove deprecated usages from daft-functions-utf8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,6 +2944,7 @@ name = "daft-functions-utf8"
 version = "0.3.0-dev0"
 dependencies = [
  "aho-corasick",
+ "arrow",
  "chrono",
  "chrono-tz",
  "common-error",

--- a/src/daft-functions-utf8/Cargo.toml
+++ b/src/daft-functions-utf8/Cargo.toml
@@ -1,4 +1,5 @@
 [dependencies]
+arrow = "54.2.1"
 aho-corasick = "1.1.3"
 daft-arrow = {path = "../daft-arrow"}
 chrono = {workspace = true}

--- a/src/daft-functions-utf8/src/count_matches.rs
+++ b/src/daft-functions-utf8/src/count_matches.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::{iter, sync::Arc};
 
 use aho_corasick::{AhoCorasickBuilder, MatchKind};
@@ -127,13 +126,13 @@ fn count_matches_impl(
         .with_validity(arr.validity().cloned());
     }
 
-    let patterns = patterns.as_arrow2().iter().flatten();
+    let patterns = patterns.into_iter().flatten();
     let ac = AhoCorasickBuilder::new()
         .ascii_case_insensitive(!case_sensitive)
         .match_kind(MatchKind::LeftmostLongest)
         .build(patterns)
         .map_err(|e| DaftError::ComputeError(format!("Error creating string automaton: {}", e)))?;
-    let iter = arr.as_arrow2().iter().map(|opt| {
+    let iter = arr.into_iter().map(|opt| {
         opt.map(|s| {
             let results = ac.find_iter(s);
             if whole_word {

--- a/src/daft-functions-utf8/src/endswith.rs
+++ b/src/daft-functions-utf8/src/endswith.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use common_error::DaftResult;
 use daft_core::{
     prelude::{DataType, Field, Schema},
@@ -63,10 +62,7 @@ fn endswith_impl(s: &Series, pattern: &Series) -> DaftResult<Series> {
 #[cfg(test)]
 mod tests {
     use common_error::DaftResult;
-    use daft_core::{
-        prelude::{AsArrow, Utf8Array},
-        series::IntoSeries,
-    };
+    use daft_core::{prelude::Utf8Array, series::IntoSeries};
 
     #[test]
     fn check_endswith_utf_arrays_broadcast() -> DaftResult<()> {
@@ -90,9 +86,9 @@ mod tests {
         let result = result.bool()?;
 
         assert_eq!(result.len(), 3);
-        assert!(result.as_arrow2().value(0));
-        assert!(result.as_arrow2().value(1));
-        assert!(!result.as_arrow2().value(2));
+        assert!(result.get(0).unwrap());
+        assert!(result.get(1).unwrap());
+        assert!(!result.get(2).unwrap());
         Ok(())
     }
 
@@ -121,9 +117,9 @@ mod tests {
         let result = result.bool()?;
 
         assert_eq!(result.len(), 3);
-        assert!(result.as_arrow2().value(0));
-        assert!(!result.as_arrow2().value(1));
-        assert!(result.as_arrow2().value(2));
+        assert!(result.get(0).unwrap());
+        assert!(!result.get(1).unwrap());
+        assert!(result.get(2).unwrap());
         Ok(())
     }
 }

--- a/src/daft-functions-utf8/src/left.rs
+++ b/src/daft-functions-utf8/src/left.rs
@@ -1,10 +1,7 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use common_error::{DaftError, DaftResult};
 use daft_core::{
     array::DataArray,
-    prelude::{
-        AsArrow, DaftIntegerType, DaftNumericType, DataType, Field, FullNull, Schema, Utf8Array,
-    },
+    prelude::{DaftIntegerType, DaftNumericType, DataType, Field, FullNull, Schema, Utf8Array},
     series::{IntoSeries, Series},
     with_match_integer_daft_types,
 };
@@ -112,7 +109,7 @@ where
         }
         _ => {
             let arrow_result = self_iter
-                .zip(nchars.as_arrow2().iter())
+                .zip(nchars.into_iter())
                 .map(|(val, n)| match (val, n) {
                     (Some(val), Some(nchar)) => {
                         let nchar: usize = NumCast::from(*nchar).ok_or_else(|| {

--- a/src/daft-functions-utf8/src/length_bytes.rs
+++ b/src/daft-functions-utf8/src/length_bytes.rs
@@ -1,7 +1,8 @@
-#![allow(deprecated, reason = "arrow2 migration")]
+use std::sync::Arc;
+
 use common_error::DaftResult;
 use daft_core::{
-    prelude::{AsArrow, DataType, Field, Schema, UInt64Array, Utf8Array},
+    prelude::{DataType, Field, Schema, UInt64Array, Utf8Array},
     series::{IntoSeries, Series},
 };
 use daft_dsl::{
@@ -44,14 +45,13 @@ pub fn utf8_length_bytes(input: ExprRef) -> ExprRef {
 }
 
 fn length_bytes_impl(arr: &Utf8Array) -> DaftResult<UInt64Array> {
-    let self_arrow = arr.as_arrow2();
-    let arrow_result = self_arrow
-        .iter()
-        .map(|val| {
-            let v = val?;
-            Some(v.len() as u64)
-        })
-        .collect::<daft_arrow::array::UInt64Array>()
-        .with_validity(self_arrow.validity().cloned());
-    Ok(UInt64Array::from((arr.name(), Box::new(arrow_result))))
+    let iter = arr.into_iter().map(|val| {
+        let v = val?;
+        Some(v.len() as u64)
+    });
+
+    Ok(UInt64Array::from_iter(
+        Arc::new(Field::new(arr.name(), DataType::UInt64)),
+        iter,
+    ))
 }

--- a/src/daft-functions-utf8/src/normalize.rs
+++ b/src/daft-functions-utf8/src/normalize.rs
@@ -1,7 +1,6 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use common_error::{DaftResult, ensure};
 use daft_core::{
-    prelude::{AsArrow, Field, Schema, Utf8Array},
+    prelude::{Field, Schema, Utf8Array},
     series::{IntoSeries, Series},
 };
 use daft_dsl::{
@@ -71,7 +70,7 @@ fn normalize_impl(
     input.with_utf8_array(|arr| {
         Ok(Utf8Array::from_iter(
             arr.name(),
-            arr.as_arrow2().iter().map(|maybe_s| {
+            arr.into_iter().map(|maybe_s| {
                 if let Some(s) = maybe_s {
                     let mut s = if white_space {
                         s.trim().to_string()

--- a/src/daft-functions-utf8/src/pad.rs
+++ b/src/daft-functions-utf8/src/pad.rs
@@ -1,10 +1,9 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::iter::RepeatN;
 
 use common_error::{DaftError, DaftResult};
 use daft_core::{
     array::DataArray,
-    prelude::{AsArrow, DaftIntegerType, DaftNumericType, DataType, FullNull, Utf8Array},
+    prelude::{DaftIntegerType, DaftNumericType, DataType, FullNull, Utf8Array},
     series::{IntoSeries, Series},
     with_match_integer_daft_types,
 };
@@ -130,7 +129,7 @@ where
             Utf8Array::from((arr.name(), Box::new(arrow_result)))
         }
         _ => {
-            let length_iter = length.as_arrow2().iter();
+            let length_iter = length.into_iter();
             let arrow_result = self_iter
                 .zip(length_iter)
                 .zip(padchar_iter)

--- a/src/daft-functions-utf8/src/regexp_count.rs
+++ b/src/daft-functions-utf8/src/regexp_count.rs
@@ -1,6 +1,6 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::sync::Arc;
 
+use arrow::array::{ArrayRef, UInt64Builder};
 use common_error::{DaftError, DaftResult, ensure};
 use daft_core::prelude::*;
 use daft_dsl::{
@@ -67,8 +67,7 @@ fn regexp_count_impl(arr: &Utf8Array, patterns: &Utf8Array) -> DaftResult<UInt64
             .map_err(|e| DaftError::ValueError(format!("Invalid regex pattern: {}", e)))?;
 
         let iter = arr
-            .as_arrow2()
-            .iter()
+            .into_iter()
             // Note, this is optimized by the compiler to not materialize values
             .map(|opt| opt.map(|s| regex.find_iter(s).count() as u64));
 
@@ -77,21 +76,25 @@ fn regexp_count_impl(arr: &Utf8Array, patterns: &Utf8Array) -> DaftResult<UInt64
             iter,
         ))
     } else {
-        let res = arr
-            .as_arrow2()
-            .iter()
-            .zip(patterns.as_arrow2().iter())
-            .map(|(val, pat)| {
-                let Some(val) = val else { return Ok(None) };
-                let Some(pat) = pat else { return Ok(None) };
+        let mut arr_builder = UInt64Builder::with_capacity(arr.len());
+        for (val, pattern) in arr.into_iter().zip(patterns.into_iter()) {
+            let Some(val) = val else {
+                arr_builder.append_null();
+                continue;
+            };
+            let Some(pat) = pattern else {
+                arr_builder.append_null();
+                continue;
+            };
+            let regex = regex::Regex::new(pat)
+                .map_err(|e| DaftError::ValueError(format!("Invalid regex pattern: {}", e)))?;
 
-                let regex = regex::Regex::new(pat)
-                    .map_err(|e| DaftError::ValueError(format!("Invalid regex pattern: {}", e)))?;
+            arr_builder.append_value(regex.find_iter(val).count() as u64);
+        }
 
-                Ok(Some(regex.find_iter(val).count() as u64))
-            })
-            .collect::<DaftResult<daft_arrow::array::UInt64Array>>()?;
+        let field = Arc::new(Field::new(arr.name(), DataType::UInt64));
+        let arr: ArrayRef = Arc::new(arr_builder.finish());
 
-        Ok(UInt64Array::from((arr.name(), Box::new(res))))
+        UInt64Array::from_arrow(field, arr.into())
     }
 }

--- a/src/daft-functions-utf8/src/regexp_extract.rs
+++ b/src/daft-functions-utf8/src/regexp_extract.rs
@@ -1,7 +1,6 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use common_error::{DaftError, DaftResult, ensure};
 use daft_core::{
-    prelude::{AsArrow, DataType, Field, FullNull, Schema, Utf8Array},
+    prelude::{DataType, Field, FullNull, Schema, Utf8Array},
     series::{IntoSeries, Series},
 };
 use daft_dsl::{
@@ -99,10 +98,7 @@ fn extract_impl(s: &Utf8Array, pattern: &Utf8Array, index: usize) -> DaftResult<
             regex_extract_first_match(self_iter, regex_iter, index, s.name())?
         }
         _ => {
-            let regex_iter = pattern
-                .as_arrow2()
-                .iter()
-                .map(|pat| pat.map(regex::Regex::new));
+            let regex_iter = pattern.into_iter().map(|pat| pat.map(regex::Regex::new));
             regex_extract_first_match(self_iter, regex_iter, index, s.name())?
         }
     };

--- a/src/daft-functions-utf8/src/regexp_extract_all.rs
+++ b/src/daft-functions-utf8/src/regexp_extract_all.rs
@@ -1,9 +1,8 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use common_error::{DaftError, DaftResult, ensure};
 use daft_arrow::array::Array;
 use daft_core::{
     array::ListArray,
-    prelude::{AsArrow, DataType, Field, FullNull, Schema, Utf8Array},
+    prelude::{DataType, Field, FullNull, Schema, Utf8Array},
     series::{IntoSeries, Series},
 };
 use daft_dsl::{
@@ -109,10 +108,7 @@ fn extract_all_impl(arr: &Utf8Array, pattern: &Utf8Array, index: usize) -> DaftR
             regex_extract_all_matches(self_iter, regex_iter, index, expected_size, arr.name())?
         }
         _ => {
-            let regex_iter = pattern
-                .as_arrow2()
-                .iter()
-                .map(|pat| pat.map(regex::Regex::new));
+            let regex_iter = pattern.into_iter().map(|pat| pat.map(regex::Regex::new));
             regex_extract_all_matches(self_iter, regex_iter, index, expected_size, arr.name())?
         }
     };

--- a/src/daft-functions-utf8/src/regexp_match.rs
+++ b/src/daft-functions-utf8/src/regexp_match.rs
@@ -1,7 +1,6 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use common_error::DaftResult;
 use daft_core::{
-    prelude::{AsArrow, BooleanArray, DataType, Field, FullNull, Schema, Utf8Array},
+    prelude::{BooleanArray, DataType, Field, FullNull, Schema, Utf8Array},
     series::{IntoSeries, Series},
 };
 use daft_dsl::{
@@ -67,7 +66,6 @@ fn match_impl(arr: &Utf8Array, pattern: &Utf8Array) -> DaftResult<BooleanArray> 
             Some(pattern_v) => {
                 let re = regex::Regex::new(pattern_v)?;
                 let arrow_result: daft_arrow::array::BooleanArray = arr
-                    .as_arrow2()
                     .into_iter()
                     .map(|arr_v| Some(re.is_match(arr_v?)))
                     .collect();


### PR DESCRIPTION
## Changes Made

gets rid of deprecated usages in daft-functions-utf8, and moves over some of the kernels. 



## Note for reviewers
I didn't fully swap out all of the kernels in this PR. many of them are still using arrow2. this crate has A LOT of arrow2 usage. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
