### PR TITLE
fix(docs): handle non-interactive environments in quickstart notebook

### DIFF
--- a/docs/notebooks/quickstart.ipynb
+++ b/docs/notebooks/quickstart.ipynb
@@ -292,15 +292,18 @@
    "source": [
     "import os\n",
     "\n",
-    "try:\n",
-    "    from google.colab import userdata\n",
+    "if \"OPENAI_API_KEY\" not in os.environ:\n",
+    "    try:\n",
+    "        from google.colab import userdata\n",
     "\n",
-    "    os.environ[\"OPENAI_API_KEY\"] = userdata.get(\"OPENAI_API_KEY\")\n",
-    "except ImportError:\n",
-    "    from getpass import getpass\n",
+    "        os.environ[\"OPENAI_API_KEY\"] = userdata.get(\"OPENAI_API_KEY\")\n",
+    "    except ImportError:\n",
+    "        try:\n",
+    "            from getpass import getpass\n",
     "\n",
-    "    if \"OPENAI_API_KEY\" not in os.environ:\n",
-    "        os.environ[\"OPENAI_API_KEY\"] = getpass(\"Enter your OpenAI API key: \")"
+    "            os.environ[\"OPENAI_API_KEY\"] = getpass(\"Enter your OpenAI API key: \")\n",
+    "        except Exception:\n",
+    "            print(\"Not in an interactive environment. Please set the OPENAI_API_KEY environment variable.\")"
    ]
   },
   {

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -183,13 +183,17 @@ If you're running this in Google Colab or Jupyter, run the following cell to set
 
 ```python
 import os
-try:
-    from google.colab import userdata
-    os.environ["OPENAI_API_KEY"] = userdata.get("OPENAI_API_KEY")
-except ImportError:
-    from getpass import getpass
-    if "OPENAI_API_KEY" not in os.environ:
-        os.environ["OPENAI_API_KEY"] = getpass("Enter your OpenAI API key: ")
+
+if "OPENAI_API_KEY" not in os.environ:
+    try:
+        from google.colab import userdata
+        os.environ["OPENAI_API_KEY"] = userdata.get("OPENAI_API_KEY")
+    except ImportError:
+        try:
+            from getpass import getpass
+            os.environ["OPENAI_API_KEY"] = getpass("Enter your OpenAI API key: ")
+        except Exception:
+            print("Not in an interactive environment. Please set the OPENAI_API_KEY environment variable.")
 ```
 
 ```python


### PR DESCRIPTION
## Summary
- Fix CI failure in quickstart notebook where `getpass()` throws `StdinNotImplementedError` in non-interactive environments (Papermill)
- Check if `OPENAI_API_KEY` is already set before trying Colab or getpass
- Wrap `getpass()` call in try/except to gracefully handle non-interactive environments
- Print a helpful message when not in an interactive environment

## Details
The quickstart notebook (introduced in PR #5691) fails in the notebook-check CI job because:
1. `google.colab` is not available in CI
2. `getpass()` is called but fails since Papermill runs non-interactively

The fix:
1. First checks if `OPENAI_API_KEY` is already set (skips everything if so - this handles CI where the key is injected via environment)
2. Tries Colab's `userdata` first
3. Falls back to `getpass()`, but catches exceptions if it fails in non-interactive environments and prints a helpful message

**Related failure:** https://github.com/Eventual-Inc/Daft/actions/runs/20145924896

## Test plan
- [ ] CI notebook-check job passes