### PR TITLE
ci: skip quickstart notebook in notebook-checker workflow

### DIFF
--- a/.github/workflows/notebook-checker.yml
+++ b/.github/workflows/notebook-checker.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Clean all notebook output
       run: find . -name "*.ipynb" -print0 | xargs -0 nb-clean clean
     - name: Run notebooks in docs
-      run: find docs -name "*.ipynb" -print0 | xargs -0 -I {} papermill {} /tmp/out.ipynb -p CI True --kernel python3 --no-progress-bar --cwd /tmp/
+      run: find docs -name "*.ipynb" -not -path "*/quickstart.ipynb" -print0 | xargs -0 -I {} papermill {} /tmp/out.ipynb -p CI True --kernel python3 --no-progress-bar --cwd /tmp/
     - name: Run notebooks in tutorials
       run: find tutorials -name "*.ipynb" -print0 | xargs -0 -I {} papermill {} /tmp/out.ipynb -p CI True --kernel python3 --no-progress-bar --cwd /tmp/
     - name: Send Slack notification on failure


### PR DESCRIPTION
## Summary
- Skip the quickstart notebook in the notebook-checker CI workflow

## Details
The quickstart notebook (added in #5691) requires an OpenAI API key for the AI inference examples. In CI (Papermill), it fails with `StdinNotImplementedError` when `getpass()` is called in a non-interactive environment.

This PR skips the quickstart notebook until we have a proper solution for testing notebooks with API dependencies (e.g., mocking, CI secrets, or conditional cell execution).

**Related failure:** https://github.com/Eventual-Inc/Daft/actions/runs/20145924896

## Test plan
- [ ] CI notebook-checker workflow passes (when manually triggered)