### PR TITLE
ci: preserve cell tags when cleaning notebooks

### DIFF
--- a/.github/workflows/notebook-checker.yml
+++ b/.github/workflows/notebook-checker.yml
@@ -11,12 +11,22 @@ env:
 jobs:
   notebook-check:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.10']
     steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: false
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: true
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -31,7 +41,7 @@ jobs:
         sudo apt install tesseract-ocr
         sudo apt install libtesseract-dev
     - name: Clean all notebook output
-      run: find . -name "*.ipynb" -print0 | xargs -0 nb-clean clean
+      run: find . -name "*.ipynb" -print0 | xargs -0 nb-clean clean --preserve-cell-metadata tags --
     - name: Run notebooks in docs
       run: find docs -name "*.ipynb" -not -path "*/quickstart.ipynb" -print0 | xargs -0 -I {} papermill {} /tmp/out.ipynb -p CI True --kernel python3 --no-progress-bar --cwd /tmp/
     - name: Run notebooks in tutorials


### PR DESCRIPTION
Depends on #5804. #5804 needs to be merged first.

## Summary
- Fix CI infrastructure issues in the notebook-checker workflow

## Changes

### 1. Preserve cell metadata tags
Added `--preserve-cell-metadata tags --` to the `nb-clean clean` command.

**Problem**: `nb-clean` was stripping all cell metadata, including the `parameters` tag that papermill needs to inject `CI=True`. Without this, notebooks run with `CI=False` (their default), processing full datasets instead of small test samples.

**Note**: The `--` separator is required because `--preserve-cell-metadata` accepts variable arguments and would otherwise consume the filenames.

### 2. Free disk space
Added `jlumbroso/free-disk-space@main` action to prevent "no space left on device" errors (same fix as #5711, #5733).

### 3. Increased timeout
Changed from 15 to 30 minutes to accommodate disk cleanup step + notebook execution.

## Status

✅ **Infrastructure is now working**:
- Disk cleanup step passes
- `nb-clean` preserves parameters tags
- `docs/` notebooks pass (quickstart skipped per #5804)

❌ **Remaining notebook bugs** (separate issues):
1. **Schema mismatch error** in `tutorials/window_functions/window_functions.ipynb` - Daft bug
2. **Missing `spacy` dependency** in `tutorials/common_crawl/getting_started_with_common_crawl.ipynb` - needs `spacy` installed in CI
3. **Missing parameters tag** in `tutorials/document_processing/document_processing_tutorial.ipynb` - can't inject `CI=True`

These notebook bugs should be fixed in separate PRs.

## Test Results

Latest run: https://github.com/Eventual-Inc/Daft/actions/runs/20158095342
- All infra steps passed
- Failed at "Run notebooks in tutorials" due to notebook bugs (not CI infra)

## Related PRs
- #5804 - Skip quickstart notebook (parent PR)
- #5711, #5733 - Similar disk cleanup fixes for other workflows
