### PR TITLE
test: fix flaky OpenAI test by using pattern constraint for hex color format

### DIFF
--- a/tests/integration/ai/test_openai.py
+++ b/tests/integration/ai/test_openai.py
@@ -422,7 +422,10 @@ def test_prompt_with_image_structured_output(session, use_chat_completions, metr
     import numpy as np
 
     class ImageAnalysis(BaseModel):
-        dominant_color: str = Field(..., description="The dominant color in the image in hex format")
+        # Pattern constrains OpenAI to return a valid hex color with # prefix
+        dominant_color: str = Field(
+            ..., description="The dominant color in the image in hex format", pattern=r"^#[0-9a-fA-F]{6}$"
+        )
         description: str = Field(..., description="Brief description of the image")
 
     # Create a simple test image (a blue square)


### PR DESCRIPTION
## Summary
- OpenAI's structured output sometimes returns `0000FF` instead of `#0000FF`
- Added a `pattern` constraint to the Pydantic model to enforce hex color format with `#` prefix: `pattern=r"^#[0-9a-fA-F]{6}$"`
- This constrains OpenAI's structured output at the API level to always return the `#` prefix, rather than loosening the test assertion

## Test Plan
- CI should pass for `test_prompt_with_image_structured_output`
- Tested locally: ran 10 iterations (20 test cases total since the test is parametrized for both Responses API and Chat Completions API) with 100% pass rate
