### PR TITLE
feat(lance): refine distributed scalar index support with new types and parameters

### DIFF
--- a/daft/io/lance/utils.py
+++ b/daft/io/lance/utils.py
@@ -13,11 +13,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def distribute_fragments_balanced(fragments: list[Any], concurrency: int) -> list[dict[str, list[int]]]:
+def distribute_fragments_balanced(fragments: list[Any], fragment_group_size: int) -> list[dict[str, list[int]]]:
     """Distribute fragments across workers using a balanced algorithm considering fragment sizes."""
-    if not fragments:
-        return [{"fragment_ids": []} for _ in range(concurrency)]
+    if fragment_group_size <= 0:
+        raise ValueError("fragment_group_size must be a positive integer")
 
+    if not fragments:
+        return []
+
+    num_groups = max(1, len(fragments) // fragment_group_size)
+    num_groups = max(1, (len(fragments) + fragment_group_size - 1) // fragment_group_size)
     # Get fragment information (ID and size)
     fragment_info = []
     for fragment in fragments:
@@ -38,13 +43,13 @@ def distribute_fragments_balanced(fragments: list[Any], concurrency: int) -> lis
     fragment_info.sort(key=lambda x: x["size"], reverse=True)
 
     # Initialize fragment groups for each worker
-    fragment_group_list: list[list[int]] = [[] for _ in range(concurrency)]
-    group_size_list = [0] * concurrency
+    fragment_group_list: list[list[int]] = [[] for _ in range(num_groups)]
+    group_size_list = [0] * num_groups
 
     # Greedy assignment: assign each fragment to the worker with minimum workload
     for frag_info in fragment_info:
         # Find the worker with the minimum current workload
-        min_workload_idx = min(range(concurrency), key=lambda i: group_size_list[i])
+        min_workload_idx = min(range(num_groups), key=lambda i: group_size_list[i])
 
         # Assign fragment to this worker
         fragment_group_list[min_workload_idx].append(frag_info["id"])
@@ -53,15 +58,22 @@ def distribute_fragments_balanced(fragments: list[Any], concurrency: int) -> lis
     # Log distribution statistics for debugging
     total_size = sum(frag_info["size"] for frag_info in fragment_info)
     logger.info(
-        "Fragment distribution statistics: Total fragments=%d, Total size=%d, Workers=%d",
+        "Fragment distribution statistics: Total fragments=%d, Total size=%d, Fragment group size=%d, the num of Fragment group=%d",
         len(fragment_info),
         total_size,
-        concurrency,
+        fragment_group_size,
+        num_groups,
     )
 
     for i, (batch, workload) in enumerate(zip(fragment_group_list, group_size_list)):
         percentage = (workload / total_size * 100) if total_size > 0 else 0
-        logger.info("Worker %d: %d fragments, workload: %d (%d%%)", i, len(batch), workload, percentage)
+        logger.info(
+            "Worker %d: %d fragments, workload: %d (%d%%)",
+            i,
+            len(batch),
+            workload,
+            percentage,
+        )
 
     # Filter out empty batches (shouldn't happen with proper input validation)
     non_empty_batches = [{"fragment_ids": batch} for batch in fragment_group_list if batch]


### PR DESCRIPTION

## Changes Made
## Summary

This PR enhances the distributed scalar index creation for LanceDB, introducing support for additional index types and providing finer control over parallelism and load balancing.

## Key Changes

1.  **Expanded Index Support**:
    *   Added distributed execution support for `INVERTED`, `FTS` (Full-Text Search), and `BTREE` index types.
    *   Previously, these might have fallen back to single-threaded execution or were not fully supported in the distributed path.

2.  **Enhanced Parallelism & Control**:
    *   **`partition_num`**: Added a new parameter to `create_scalar_index` to control the number of partitions when repartitioning fragment batches. This allows for better utilization of distributed workers.
    *   **`fragment_group_size`**: Exposed this parameter to allow users to configure how many fragments are grouped into a single processing batch (defaults to 10).
    *   **`max_concurrency`**: Added a parameter to limit the maximum number of concurrent indexing tasks.

3.  **Smart Load Balancing**:
    *   Implemented `distribute_fragments_balanced` in `daft/io/lance/utils.py`.
    *   This logic distributes fragments to workers based on their row counts (size) rather than just count, ensuring a more even workload distribution and preventing "straggler" tasks caused by large fragments.

4.  **API & Testing**:
    *   Updated the public API `daft.io.lance.create_scalar_index` to accept the new parameters.
    *   Added comprehensive tests in `tests/io/lancedb/test_lancedb_scalar_index.py` covering the new index types and configuration parameters.
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
