### PR TITLE
fix: Check if deletion vector propagation is supported in deltalake

### DIFF
--- a/daft/io/delta_lake/delta_lake_scan.py
+++ b/daft/io/delta_lake/delta_lake_scan.py
@@ -175,6 +175,7 @@ class DeltaLakeScanOperator(ScanOperator):
             if not self._ignore_deletion_vectors:
                 raise NotImplementedError(
                     "Delta Lake deletion vectors are not yet supported; please let the Daft team know if you'd like to see this feature!\n"
+                    "Note that for Delta Lake versions 1.2.0 and newer, deletion vectors are not included in add actions.\n"
                     "Deletion records can be dropped from this table to allow it to be read with Daft: https://docs.delta.io/latest/delta-drop-feature.html\n"
                     "Alternatively, you can set ignore_deletion_vectors=True to skip checking for deletion vectors."
                 )
@@ -194,7 +195,6 @@ class DeltaLakeScanOperator(ScanOperator):
         if not self._ignore_deletion_vectors and "deletionVector" in add_actions.schema.names:
             raise NotImplementedError(
                 "Delta Lake deletion vectors are not yet supported; please let the Daft team know if you'd like to see this feature!\n"
-                "Note that for Delta Lake versions 1.2.0 and newer, deletion vectors are not included in add actions.\n"
                 "Deletion records can be dropped from this table to allow it to be read with Daft: https://docs.delta.io/latest/delta-drop-feature.html\n"
                 "Alternatively, you can set ignore_deletion_vectors=True to skip checking for deletion vectors."
             )


### PR DESCRIPTION
## Changes Made
This checks if the deltalake library supports deletion vector propagation and then forces the user to set `ignore_deletion_vectors=True` to continue. When this flag is set daft will read deleted rows. Reference PR https://github.com/Eventual-Inc/Daft/pull/5758

## Related Issues
