### PR TITLE
chore: Fix a minor ambiguity in the README docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ To see the full benchmarks, detailed setup, and logs, check out our `benchmarkin
 Contributing
 ------------
 
-We <3 developers! To start contributing to Daft, please read `CONTRIBUTING.md <https://github.com/Eventual-Inc/Daft/blob/main/CONTRIBUTING.md>`_. This document describes the development lifecycle and toolchain for working on Daft. It also details how to add new functionality to the core engine and expose it through a Python API.
+We ❤️ developers! To start contributing to Daft, please read `CONTRIBUTING.md <https://github.com/Eventual-Inc/Daft/blob/main/CONTRIBUTING.md>`_. This document describes the development lifecycle and toolchain for working on Daft. It also details how to add new functionality to the core engine and expose it through a Python API.
 
 Here's a list of `good first issues <https://github.com/Eventual-Inc/Daft/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22>`_ to get yourself warmed up with Daft. Comment in the issue to pick it up, and feel free to ask any questions!
 


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Change "We <3 developers!" to "We ❤️ developers!". I know this is a rather interesting expression, but some customers have interpreted this sentence as "Daft has no more than 3 full-time developers", mistakenly thinking that Daft is a personal project and thus being hesitant to adopt it in production easily.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
