### PR TITLE
fix: handle FileNotFoundError in read_huggingface fallback

### DIFF
--- a/daft/io/huggingface/__init__.py
+++ b/daft/io/huggingface/__init__.py
@@ -11,6 +11,29 @@ if TYPE_CHECKING:
     from daft.dataframe import DataFrame
 
 
+def _fallback_to_datasets_library(repo: str, original_error: Exception) -> DataFrame:
+    """Fall back to using the datasets library when parquet files are not available."""
+    try:
+        from datasets import load_dataset
+    except ImportError:
+        raise ImportError(
+            "Parquet files are not available for this dataset. "
+            "Please install the datasets library for fallback support: pip install 'daft[huggingface]'"
+        ) from original_error
+
+    # Load dataset using datasets library and convert to Daft
+    import daft
+    from datasets import concatenate_datasets
+
+    # Load all splits and concatenate them to match the main path behavior
+    ds = load_dataset(repo)
+    all_data = concatenate_datasets([ds[split] for split in ds.keys()])
+    # Convert to arrow format for better compatibility
+    all_data = all_data.with_format("arrow")
+    arrow_table = all_data.data.table
+    return daft.from_arrow(arrow_table)
+
+
 @PublicAPI
 def read_huggingface(repo: str, io_config: IOConfig | None = None) -> DataFrame:
     """Create a DataFrame from a Hugging Face dataset.
@@ -24,29 +47,15 @@ def read_huggingface(repo: str, io_config: IOConfig | None = None) -> DataFrame:
     try:
         # Try the fast path: read parquet files directly
         return read_parquet(f"hf://datasets/{repo}", io_config=io_config)
+    except FileNotFoundError as e:
+        # No parquet files found (glob returned no matches)
+        # Fall back to using the datasets library
+        return _fallback_to_datasets_library(repo, e)
     except DaftCoreException as e:
         # Check if this is a 400 error (parquet files not yet available)
         if "Status(400" in str(e):
             # Fall back to using the datasets library
-            try:
-                from datasets import load_dataset
-            except ImportError:
-                raise ImportError(
-                    "Parquet files are not yet available for this dataset. "
-                    "Please install the datasets library for fallback support: pip install 'daft[huggingface]'"
-                ) from e
-
-            # Load dataset using datasets library and convert to Daft
-            import daft
-            from datasets import concatenate_datasets
-
-            # Load all splits and concatenate them to match the main path behavior
-            ds = load_dataset(repo)
-            all_data = concatenate_datasets([ds[split] for split in ds.keys()])
-            # Convert to arrow format for better compatibility
-            all_data = all_data.with_format("arrow")
-            arrow_table = all_data.data.table
-            return daft.from_arrow(arrow_table)
+            return _fallback_to_datasets_library(repo, e)
         else:
             # Re-raise other errors
             raise


### PR DESCRIPTION
## Summary

When HuggingFace's parquet API returns no files (glob returns no matches), `read_huggingface` now falls back to the `datasets` library instead of raising `FileNotFoundError`.

This fixes the failing `test_read_huggingface_datasets_doesnt_fail` integration test caused by HuggingFace's parquet conversion being unavailable for some datasets.

## Root Cause

The `huggingface/documentation-images` dataset's parquet API started returning empty results (`{}`) around 2025-12-17 14:30 UTC. This causes `read_parquet` to fail with `FileNotFoundError` when globbing for parquet files. The existing fallback only handled `DaftCoreException` with "Status(400" errors, not `FileNotFoundError`.

## CI Failure Details

| Run ID | Time (UTC) | Status | Error |
|--------|------------|--------|-------|
| [20306131203](https://github.com/Eventual-Inc/Daft/actions/runs/20306131203) | 14:25:15 | ✅ success | (last pass) |
| [20306481633](https://github.com/Eventual-Inc/Daft/actions/runs/20306481633) | 14:36:45 | ❌ failure | FileNotFoundError |
| [20310015416](https://github.com/Eventual-Inc/Daft/actions/runs/20310015416) | 16:33:02 | ❌ failure | FileNotFoundError |
| [20310356377](https://github.com/Eventual-Inc/Daft/actions/runs/20310356377) | 16:44:55 | ❌ failure | FileNotFoundError |

Example error from CI:
```
FileNotFoundError: File: hf://datasets/huggingface/documentation-images not found
Glob path had no matches: "hf://datasets/huggingface/documentation-images".
```

## Changes

- Added `FileNotFoundError` handling in `read_huggingface` to trigger fallback to datasets library
- Refactored fallback logic into `_fallback_to_datasets_library()` helper to avoid duplication

## Test Plan

- [x] Reproduced the failure locally before the fix
- [x] Verified all 7 HuggingFace integration tests pass with the fix:
  - `test_read_huggingface_datasets_doesnt_fail`
  - `test_read_huggingface[Eventual-Inc/sample-parquet-train-foo]`
  - `test_read_huggingface[fka/awesome-chatgpt-prompts-train-act]`
  - `test_read_huggingface[nebius/SWE-rebench-test-instance_id]`
  - `test_read_huggingface[SWE-Gym/SWE-Gym-train-instance_id]`
  - `test_read_huggingface_fallback_on_400_error`
  - `test_read_huggingface_multi_split_dataset`