### PR TITLE
docs: fix broken links causing CI failure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ When proposing features, please include:
 
 ## Contributing Code
 
-For detailed development instructions, see our [Development Guide](https://docs.daft.ai/en/stable/contributing-to-daft/).
+For detailed development instructions, see our [Development Guide](https://docs.daft.ai/en/stable/contributing/development/).
 
 ## Contributor Community
 

--- a/docs/api/ai.md
+++ b/docs/api/ai.md
@@ -11,7 +11,7 @@ Feature coverage table:
 
 
 !!! note
-    Open an issue on our [GitHub](https://github.com/daft-data/daft/issues/new/choose) if you would like to see support for a feature.
+    Open an issue on our [GitHub](https://github.com/Eventual-Inc/Daft/issues/new/choose) if you would like to see support for a feature.
 
 
 ## Functions


### PR DESCRIPTION
## Summary

Fix two broken links that have been causing the "Check Broken Links on daft.ai" CI workflow to fail.

### Changes

1. **CONTRIBUTING.md**: Updated docs link from `/contributing-to-daft/` to `/contributing/development/` (the docs structure was reorganized)

2. **docs/api/ai.md**: Updated GitHub link from `daft-data/daft` to `Eventual-Inc/Daft` (the repository was migrated)