### PR TITLE
feat: add `delimiter` option in `write_csv`

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1945,7 +1945,7 @@ class LogicalPlanBuilder:
         self,
         root_dir: str,
         write_mode: WriteMode,
-        file_format: FileFormat,
+        file_format_config: FileFormatConfig,
         partition_cols: list[PyExpr] | None = None,
         compression: str | None = None,
         io_config: IOConfig | None = None,

--- a/daft/io/writer.py
+++ b/daft/io/writer.py
@@ -183,6 +183,7 @@ class CSVFileWriter(FileWriterBase):
         file_idx: int,
         partition_values: RecordBatch | None = None,
         io_config: IOConfig | None = None,
+        delimiter: str | None = None,
     ):
         super().__init__(
             root_dir=root_dir,
@@ -194,12 +195,15 @@ class CSVFileWriter(FileWriterBase):
         self.file_handle = None
         self.current_writer: pacsv.CSVWriter | None = None
         self.is_closed = False
+        self.delimiter = delimiter
 
     def _create_writer(self, schema: pa.Schema) -> pacsv.CSVWriter:
         self.file_handle = self.fs.open_output_stream(self.full_path)
+        write_options = pacsv.WriteOptions(delimiter=self.delimiter) if self.delimiter is not None else None
         return pacsv.CSVWriter(
             self.file_handle,
             schema,
+            write_options=write_options,
         )
 
     def write(self, table: MicroPartition) -> int:

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 from daft.context import get_context
 from daft.daft import (
     CountMode,
-    FileFormat,
+    FileFormatConfig,
     IOConfig,
     JoinStrategy,
     JoinType,
@@ -331,14 +331,19 @@ class LogicalPlanBuilder:
         self,
         root_dir: str | pathlib.Path,
         write_mode: WriteMode,
-        file_format: FileFormat,
+        file_format_config: FileFormatConfig,
         io_config: IOConfig,
         partition_cols: list[Expression] | None = None,
         compression: str | None = None,
     ) -> LogicalPlanBuilder:
         part_cols_pyexprs = [expr._expr for expr in partition_cols] if partition_cols is not None else None
         builder = self._builder.table_write(
-            str(root_dir), write_mode, file_format, part_cols_pyexprs, compression, io_config
+            str(root_dir),
+            write_mode,
+            file_format_config,
+            part_cols_pyexprs,
+            compression,
+            io_config,
         )
         return LogicalPlanBuilder(builder)
 

--- a/src/common/file-formats/src/python.rs
+++ b/src/common/file-formats/src/python.rs
@@ -114,6 +114,12 @@ impl From<PyFileFormatConfig> for Arc<FileFormatConfig> {
     }
 }
 
+impl From<PyFileFormatConfig> for FileFormatConfig {
+    fn from(file_format_config: PyFileFormatConfig) -> Self {
+        (*file_format_config.0).clone()
+    }
+}
+
 impl From<Arc<FileFormatConfig>> for PyFileFormatConfig {
     fn from(file_format_config: Arc<FileFormatConfig>) -> Self {
         Self(file_format_config)

--- a/src/daft-distributed/src/pipeline_node/sink.rs
+++ b/src/daft-distributed/src/pipeline_node/sink.rs
@@ -178,7 +178,10 @@ impl PipelineNodeImpl for SinkNode {
 
         match self.sink_info.as_ref() {
             SinkInfo::OutputFileInfo(output_file_info) => {
-                res.push(format!("Sink: {:?}", output_file_info.file_format));
+                res.push(format!(
+                    "Sink: {:?}",
+                    output_file_info.file_format_config.file_format()
+                ));
                 res.extend(output_file_info.multiline_display());
             }
             #[cfg(feature = "python")]

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -1321,7 +1321,10 @@ fn physical_plan_to_pipeline(
                 .with_context(|_| PipelineCreationSnafu {
                     plan_name: physical_plan.name(),
                 })?;
-            let write_format = match (file_info.file_format, file_info.partition_cols.is_some()) {
+            let write_format = match (
+                file_info.file_format_config.file_format(),
+                file_info.partition_cols.is_some(),
+            ) {
                 (FileFormat::Parquet, true) => WriteFormat::PartitionedParquet,
                 (FileFormat::Parquet, false) => WriteFormat::Parquet,
                 (FileFormat::Csv, true) => WriteFormat::PartitionedCsv,

--- a/src/daft-local-execution/src/sinks/commit_write.rs
+++ b/src/daft-local-execution/src/sinks/commit_write.rs
@@ -93,7 +93,7 @@ impl BlockingSink for CommitWriteSink {
                     if written_file_path_record_batches.is_empty()
                         && file_info.partition_cols.is_none()
                     {
-                        match file_info.file_format {
+                        match file_info.file_format_config.file_format() {
                             FileFormat::Parquet | FileFormat::Csv => {
                                 let writer_factory =
                                     daft_writers::physical::PhysicalWriterFactory::new(
@@ -113,10 +113,10 @@ impl BlockingSink for CommitWriteSink {
                                     written_file_path_record_batches.push(rb);
                                 }
                             }
-                            _ => {
+                            file_format => {
                                 log::warn!(
                                     "No data written for {:?} file format, and not empty file created.",
-                                    file_info.file_format
+                                    file_format
                                 );
                             }
                         }

--- a/src/daft-logical-plan/src/builder/mod.rs
+++ b/src/daft-logical-plan/src/builder/mod.rs
@@ -6,12 +6,10 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(feature = "python")]
-use common_daft_config::PyDaftExecutionConfig;
 use common_daft_config::{DaftExecutionConfig, DaftPlanningConfig};
 use common_display::mermaid::MermaidDisplayOptions;
 use common_error::{DaftError, DaftResult};
-use common_file_formats::{FileFormat, WriteMode};
+use common_file_formats::{FileFormatConfig, WriteMode};
 use common_io_config::IOConfig;
 use common_scan_info::{PhysicalScanInfo, Pushdowns, ScanOperatorRef, Sharder, ShardingStrategy};
 use common_treenode::TreeNode;
@@ -27,7 +25,9 @@ use resolve_expr::ExprResolver;
 #[cfg(feature = "python")]
 use {
     crate::sink_info::{CatalogInfo, IcebergCatalogInfo},
+    common_daft_config::PyDaftExecutionConfig,
     common_daft_config::PyDaftPlanningConfig,
+    common_file_formats::python::PyFileFormatConfig,
     common_io_config::python::IOConfig as PyIOConfig,
     daft_dsl::python::PyExpr,
     // daft_scan::python::pylib::ScanOperatorHandle,
@@ -698,7 +698,7 @@ impl LogicalPlanBuilder {
         &self,
         root_dir: &str,
         write_mode: WriteMode,
-        file_format: FileFormat,
+        file_format_config: FileFormatConfig,
         partition_cols: Option<Vec<ExprRef>>,
         compression: Option<String>,
         io_config: Option<IOConfig>,
@@ -712,7 +712,7 @@ impl LogicalPlanBuilder {
         let sink_info = SinkInfo::OutputFileInfo(OutputFileInfo::new(
             root_dir.into(),
             write_mode,
-            file_format,
+            file_format_config,
             partition_cols,
             compression,
             io_config,
@@ -1358,7 +1358,7 @@ impl PyLogicalPlanBuilder {
     #[pyo3(signature = (
         root_dir,
         write_mode,
-        file_format,
+        file_format_config,
         partition_cols=None,
         compression=None,
         io_config=None
@@ -1367,7 +1367,7 @@ impl PyLogicalPlanBuilder {
         &self,
         root_dir: &str,
         write_mode: WriteMode,
-        file_format: FileFormat,
+        file_format_config: PyFileFormatConfig,
         partition_cols: Option<Vec<PyExpr>>,
         compression: Option<String>,
         io_config: Option<common_io_config::python::IOConfig>,
@@ -1377,7 +1377,7 @@ impl PyLogicalPlanBuilder {
             .table_write(
                 root_dir,
                 write_mode,
-                file_format,
+                file_format_config.into(),
                 partition_cols.map(pyexprs_to_exprs),
                 compression,
                 io_config.map(|cfg| cfg.config),

--- a/src/daft-logical-plan/src/ops/sink.rs
+++ b/src/daft-logical-plan/src/ops/sink.rs
@@ -93,7 +93,10 @@ impl Sink {
 
         match self.sink_info.as_ref() {
             SinkInfo::OutputFileInfo(output_file_info) => {
-                res.push(format!("Sink: {:?}", output_file_info.file_format));
+                res.push(format!(
+                    "Sink: {:?}",
+                    output_file_info.file_format_config.file_format()
+                ));
                 res.extend(output_file_info.multiline_display());
             }
             #[cfg(feature = "python")]

--- a/src/daft-logical-plan/src/sink_info.rs
+++ b/src/daft-logical-plan/src/sink_info.rs
@@ -1,7 +1,7 @@
 use std::{hash::Hash, sync::Arc};
 
 use common_error::DaftResult;
-use common_file_formats::{FileFormat, WriteMode};
+use common_file_formats::{FileFormatConfig, WriteMode};
 use common_io_config::IOConfig;
 #[cfg(feature = "python")]
 use common_py_serde::{deserialize_py_object, serialize_py_object};
@@ -27,7 +27,7 @@ pub enum SinkInfo<E = ExprRef> {
 pub struct OutputFileInfo<E = ExprRef> {
     pub root_dir: String,
     pub write_mode: WriteMode,
-    pub file_format: FileFormat,
+    pub file_format_config: FileFormatConfig,
     pub partition_cols: Option<Vec<E>>,
     pub compression: Option<String>,
     pub io_config: Option<IOConfig>,
@@ -187,7 +187,7 @@ where
     pub fn new(
         root_dir: String,
         write_mode: WriteMode,
-        file_format: FileFormat,
+        file_format_config: FileFormatConfig,
         partition_cols: Option<Vec<E>>,
         compression: Option<String>,
         io_config: Option<IOConfig>,
@@ -195,7 +195,7 @@ where
         Self {
             root_dir,
             write_mode,
-            file_format,
+            file_format_config,
             partition_cols,
             compression,
             io_config,
@@ -213,6 +213,7 @@ where
         if let Some(ref compression) = self.compression {
             res.push(format!("Compression = {}", compression));
         }
+        res.extend(self.file_format_config.multiline_display());
         res.push(format!("Root dir = {}", self.root_dir));
         match &self.io_config {
             None => res.push("IOConfig = None".to_string()),
@@ -245,7 +246,7 @@ impl OutputFileInfo {
         Ok(OutputFileInfo {
             root_dir: self.root_dir,
             write_mode: self.write_mode,
-            file_format: self.file_format,
+            file_format_config: self.file_format_config,
             partition_cols: self
                 .partition_cols
                 .map(|cols| BoundExpr::bind_all(&cols, schema))

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -104,7 +104,7 @@ pub fn make_physical_writer_factory(
         file_schema.clone(),
         cfg.native_parquet_writer,
     )?;
-    match file_info.file_format {
+    match file_info.file_format_config.file_format() {
         FileFormat::Parquet => {
             let file_size_calculator = TargetInMemorySizeBytesCalculator::new(
                 cfg.parquet_target_filesize,

--- a/tests/io/test_writes_config.py
+++ b/tests/io/test_writes_config.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import csv
+
+import pyarrow.parquet as pq
+
+import daft
+
+
+def test_write_csv_default_delimiter(tmp_path):
+    df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+    out_dir = tmp_path / "out_default"
+    df.write_csv(str(out_dir))
+
+    files = list(out_dir.glob("*.csv"))
+    assert len(files) > 0
+
+    for f in files:
+        with open(f) as csvfile:
+            content = csvfile.read()
+            assert "," in content
+
+            csvfile.seek(0)
+            reader = csv.reader(csvfile)
+            header = next(reader)
+            assert header == ["x", "y"]
+            rows = list(reader)
+            assert rows[0] == ["1", "a"]
+
+
+def test_write_csv_custom_delimiter(tmp_path):
+    df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+    out_dir = tmp_path / "out_pipe"
+    delimiter = "|"
+    df.write_csv(str(out_dir), delimiter=delimiter)
+
+    files = list(out_dir.glob("*.csv"))
+    assert len(files) > 0
+
+    for f in files:
+        with open(f) as csvfile:
+            content = csvfile.read()
+            assert "|" in content
+            assert "," not in content
+
+            csvfile.seek(0)
+            reader = csv.reader(csvfile, delimiter="|")
+            header = next(reader)
+            assert header == ["x", "y"]
+            rows = list(reader)
+            assert rows[0] == ["1", "a"]
+
+
+def test_write_csv_tab_delimiter(tmp_path):
+    df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+    out_dir = tmp_path / "out_tab"
+    delimiter = "\t"
+    df.write_csv(str(out_dir), delimiter=delimiter)
+
+    files = list(out_dir.glob("*.csv"))
+    assert len(files) > 0
+
+    for f in files:
+        with open(f) as csvfile:
+            content = csvfile.read()
+            assert "\t" in content
+
+            csvfile.seek(0)
+            reader = csv.reader(csvfile, delimiter="\t")
+            header = next(reader)
+            assert header == ["x", "y"]
+            rows = list(reader)
+            assert rows[0] == ["1", "a"]
+
+
+def test_write_parquet_config(tmp_path):
+    df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+    out_dir = tmp_path / "out_parquet"
+    df.write_parquet(str(out_dir))
+
+    files = list(out_dir.glob("*.parquet"))
+    assert len(files) > 0
+
+    # Verify we can read it back
+    table = pq.read_table(files[0])
+    assert table.column("x").to_pylist() == [1, 2, 3]
+    assert table.column("y").to_pylist() == ["a", "b", "c"]
+
+
+def test_write_json_config(tmp_path):
+    # JSON write is only supported for native runner currently
+    df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
+    out_dir = tmp_path / "out_json"
+    df.write_json(str(out_dir))
+
+    files = list(out_dir.glob("*.json"))
+    assert len(files) > 0
+
+    # Simple verification of content
+    with open(files[0]) as f:
+        lines = f.readlines()
+        assert len(lines) == 3
+        assert '"x":1' in lines[0]
+        assert '"y":"a"' in lines[0]


### PR DESCRIPTION
## Changes Made

Add `delimiter` option to `write_csv`. On the implementation side, use `FileFormatConfig` to capture delimiter value, and replace `FileFormat` since the `file_format` method in the config provides the value.

## Related Issues

Closes #3786
