### PR TITLE
docs: improve docstrings of IO read methods for remote URLs

### DIFF
--- a/daft/io/_csv.py
+++ b/daft/io/_csv.py
@@ -37,7 +37,7 @@ def read_csv(
     """Creates a DataFrame from CSV file(s).
 
     Args:
-        path (str): Path to CSV (allows for wildcards)
+        path (str): Path to CSV (allows for wildcards; supports remote URLs to object stores such as ``s3://`` or ``gs://``)
         infer_schema (bool): Whether to infer the schema of the CSV, defaults to True.
         schema (dict[str, DataType]): A schema that is used as the definitive schema for the CSV if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred.
         has_headers (bool): Whether the CSV has a header or not, defaults to True
@@ -54,11 +54,16 @@ def read_csv(
         DataFrame: parsed DataFrame
 
     Examples:
+        Read a CSV file from a local path:
         >>> df = daft.read_csv("/path/to/file.csv")
         >>> df = daft.read_csv("/path/to/directory")
         >>> df = daft.read_csv("/path/to/files-*.csv")
-        >>> df = daft.read_csv("s3://path/to/files-*.csv")
 
+        Read a CSV file from a public S3 bucket:
+        >>> from daft.io import S3Config, IOConfig
+        >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
+        >>> df = daft.read_csv("s3://path/to/files-*.csv", io_config=io_config)
+        >>> df.show()
     """
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of CSV filepaths")

--- a/daft/io/_json.py
+++ b/daft/io/_json.py
@@ -31,7 +31,7 @@ def read_json(
     """Creates a DataFrame from line-delimited JSON file(s).
 
     Args:
-        path (str): Path to JSON files (allows for wildcards)
+        path (str): Path to JSON files (allows for wildcards; supports remote URLs to object stores such as ``s3://`` or ``gs://``)
         infer_schema (bool): Whether to infer the schema of the JSON, defaults to True.
         schema (dict[str, DataType]): A schema that is used as the definitive schema for the JSON if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred.
         io_config (IOConfig): Config to be used with the native downloader
@@ -43,11 +43,16 @@ def read_json(
         DataFrame: parsed DataFrame
 
     Examples:
+        Read a JSON file from a local path:
         >>> df = daft.read_json("/path/to/file.json")
         >>> df = daft.read_json("/path/to/directory")
         >>> df = daft.read_json("/path/to/files-*.json")
-        >>> df = daft.read_json("s3://path/to/files-*.json")
 
+        Read a JSON file from a public S3 bucket:
+        >>> from daft.io import S3Config, IOConfig
+        >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
+        >>> df = daft.read_json("s3://path/to/files-*.json", io_config=io_config)
+        >>> df.show()
     """
     if isinstance(path, list) and len(path) == 0:
         raise ValueError("Cannot read DataFrame from from empty list of JSON filepaths")

--- a/daft/io/_parquet.py
+++ b/daft/io/_parquet.py
@@ -32,7 +32,7 @@ def read_parquet(
     """Creates a DataFrame from Parquet file(s).
 
     Args:
-        path (str): Path to Parquet file (allows for wildcards)
+        path (str): Path to Parquet file (allows for wildcards; supports remote URLs to object stores such as ``s3://`` or ``gs://``)
         row_groups (List[int] or List[List[int]]): List of row groups to read corresponding to each file.
         infer_schema (bool): Whether to infer the schema of the Parquet, defaults to True.
         schema (dict[str, DataType]): A schema that is used as the definitive schema for the Parquet file if infer_schema is False, otherwise it is used as a schema hint that is applied after the schema is inferred.
@@ -48,12 +48,16 @@ def read_parquet(
         DataFrame: parsed DataFrame
 
     Examples:
+        Read a Parquet file from a local path:
         >>> df = daft.read_parquet("/path/to/file.parquet")
         >>> df = daft.read_parquet("/path/to/directory")
         >>> df = daft.read_parquet("/path/to/files-*.parquet")
-        >>> df = daft.read_parquet("s3://path/to/files-*.parquet")
-        >>> df = daft.read_parquet("gs://path/to/files-*.parquet")
 
+        Read a Parquet file from a public S3 bucket:
+        >>> from daft.io import S3Config, IOConfig
+        >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
+        >>> df = daft.read_parquet("s3://path/to/files-*.parquet", io_config=io_config)
+        >>> df.show()
     """
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
 

--- a/daft/io/_warc.py
+++ b/daft/io/_warc.py
@@ -26,7 +26,7 @@ def read_warc(
     """Creates a DataFrame from WARC or gzipped WARC file(s). This is an experimental feature and the API may change in the future.
 
     Args:
-        path (Union[str, List[str]]): Path to WARC file (allows for wildcards)
+        path (Union[str, List[str]]): Path to WARC file (allows for wildcards; supports remote URLs to object stores such as ``s3://`` or ``gs://``)
         io_config (Optional[IOConfig]): Config to be used with the native downloader
         file_path_column (Optional[str]): Include the source path(s) as a column with this name. Defaults to None.
         _multithreaded_io (Optional[bool]): Whether to use multithreading for IO threads. Setting this to False can be helpful in reducing
@@ -39,12 +39,16 @@ def read_warc(
             and one column "warc_headers" with the remaining headers of the WARC record stored as a JSON string.
 
     Examples:
+        Read a WARC file from a local path:
         >>> df = daft.read_warc("/path/to/file.warc")
         >>> df = daft.read_warc("/path/to/directory")
         >>> df = daft.read_warc("/path/to/files-*.warc")
-        >>> df = daft.read_warc("s3://path/to/files-*.warc")
-        >>> df = daft.read_warc("gs://path/to/files-*.warc")
 
+        Read a WARC file from a public S3 bucket:
+        >>> from daft.io import S3Config, IOConfig
+        >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
+        >>> df = daft.read_warc("s3://path/to/files-*.warc", io_config=io_config)
+        >>> df.show()
     """
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
 

--- a/daft/io/delta_lake/_deltalake.py
+++ b/daft/io/delta_lake/_deltalake.py
@@ -31,8 +31,9 @@ def read_deltalake(
     """Create a DataFrame from a Delta Lake table.
 
     Args:
-        table: Either a URI for the Delta Lake table or a :class:`~daft.io.catalog.DataCatalogTable` instance
-            referencing a table in a data catalog, such as AWS Glue Data Catalog or Databricks Unity Catalog.
+        table: Either a URI for the Delta Lake table (supports remote URLs to object stores such as ``s3://`` or ``gs://``)
+            or a :class:`~daft.io.catalog.DataCatalogTable` instance referencing a table in a data catalog,
+            such as AWS Glue Data Catalog or Databricks Unity Catalog.
         version (optional): If int is passed, read the table with specified version number. Otherwise if string or datetime,
             read the timestamp version of the table. Strings must be RFC 3339 and ISO 8601 date and time format.
             Datetimes are assumed to be UTC timezone unless specified. By default, read the latest version of the table.
@@ -49,11 +50,17 @@ def read_deltalake(
         This function requires the use of [deltalake](https://delta-io.github.io/delta-rs/), a Python library for interacting with Delta Lake.
 
     Examples:
+        Read a Delta Lake table from a local path:
         >>> df = daft.read_deltalake("some-table-uri")
         >>>
-        >>> # Filters on this dataframe can now be pushed into
-        >>> # the read operation from Delta Lake.
+        >>> # Filters on this dataframe can now be pushed into the read operation from Delta Lake.
         >>> df = df.where(df["foo"] > 5)
+        >>> df.show()
+
+        Read a Delta Lake table from a public S3 bucket:
+        >>> from daft.io import S3Config, IOConfig
+        >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
+        >>> df = daft.read_deltalake("s3://daft-public-data/test_fixtures/delta_table/", io_config=io_config)
         >>> df.show()
     """
     from daft.io.delta_lake.delta_lake_scan import DeltaLakeScanOperator

--- a/daft/io/hudi/_hudi.py
+++ b/daft/io/hudi/_hudi.py
@@ -18,15 +18,25 @@ def read_hudi(
     """Create a DataFrame from a Hudi table.
 
     Args:
-        table_uri: URI to the Hudi table.
+        table_uri: URI to the Hudi table (supports remote URLs to object stores such as ``s3://`` or ``gs://``).
         io_config: A custom IOConfig to use when accessing Hudi table object storage data. Defaults to None.
 
     Returns:
         DataFrame: A DataFrame with the schema converted from the specified Hudi table.
 
+    Note:
+        This function requires the use of Apache Hudi. To ensure that this is installed with Daft, you may install: ``pip install -U daft[hudi]``
+
     Examples:
+        Read a Hudi table from a local path:
         >>> df = daft.read_hudi("some-table-uri")
         >>> df = df.where(df["foo"] > 5)
+        >>> df.show()
+
+        Read a Hudi table from a public S3 bucket:
+        >>> from daft.io import S3Config, IOConfig
+        >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
+        >>> df = daft.read_hudi("s3://bucket/path/to/hudi_table/", io_config=io_config)
         >>> df.show()
     """
     from daft.io.hudi.hudi_scan import HudiScanOperator

--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -61,7 +61,9 @@ def read_iceberg(
     """Create a DataFrame from an Iceberg table.
 
     Args:
-        table (str or pyiceberg.table.Table): [PyIceberg Table](https://py.iceberg.apache.org/reference/pyiceberg/table/#pyiceberg.table.Table) created using the PyIceberg library
+        table (str or pyiceberg.table.Table): A path to an Iceberg metadata file (supports remote URLs to object stores
+            such as ``s3://`` or ``gs://``) or a [PyIceberg Table](https://py.iceberg.apache.org/reference/pyiceberg/table/#pyiceberg.table.Table)
+            created using the PyIceberg library.
         snapshot_id (int, optional): Snapshot ID of the table to query
         io_config (IOConfig, optional): A custom IOConfig to use when accessing Iceberg object storage data. If provided, configurations set in `table` are ignored.
 
@@ -73,16 +75,21 @@ def read_iceberg(
         official project for Python.
 
     Examples:
+        Read an Iceberg table from a PyIceberg table:
         >>> import pyiceberg
         >>>
         >>> table = pyiceberg.Table(...)
         >>> df = daft.read_iceberg(table)
         >>>
-        >>> # Filters on this dataframe can now be pushed into
-        >>> # the read operation from Iceberg
+        >>> # Filters on this dataframe can now be pushed into the read operation from Iceberg
         >>> df = df.where(df["foo"] > 5)
         >>> df.show()
 
+        Read an Iceberg table from S3 using IOConfig:
+        >>> from daft.io import S3Config, IOConfig
+        >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
+        >>> df = daft.read_iceberg("s3://bucket/path/to/iceberg/metadata.json", io_config=io_config)
+        >>> df.show()
     """
     from pyiceberg.table import StaticTable
 

--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -100,21 +100,21 @@ def read_lance(
 
     Examples:
         Read a local LanceDB table:
-        >>> df = daft.read_lance("s3://my-lancedb-bucket/data/")
+        >>> df = daft.read_lance("/path/to/lance/data/")
+        >>> df.show()
+
+        Read a LanceDB table and specify a version:
+        >>> df = daft.read_lance("/path/to/lance/data/", version=1)
+        >>> df.show()
+
+        Read a LanceDB table with fragment grouping:
+        >>> df = daft.read_lance("/path/to/lance/data/", fragment_group_size=5)
         >>> df.show()
 
         Read a LanceDB table from a public S3 bucket:
-        >>> from daft.io import S3Config
-        >>> s3_config = S3Config(region="us-west-2", anonymous=True)
-        >>> df = daft.read_lance("s3://daft-public-data/lance/words-test-dataset", io_config=s3_config)
-        >>> df.show()
-
-        Read a local LanceDB table and specify a version:
-        >>> df = daft.read_lance("s3://my-lancedb-bucket/data/", version=1)
-        >>> df.show()
-
-        Read a local LanceDB table with fragment grouping:
-        >>> df = daft.read_lance("s3://my-lancedb-bucket/data/", fragment_group_size=5)
+        >>> from daft.io import S3Config, IOConfig
+        >>> io_config = IOConfig(s3=S3Config(region="us-west-2", anonymous=True))
+        >>> df = daft.read_lance("s3://daft-public-data/lance/words-test-dataset", io_config=io_config)
         >>> df.show()
     """
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
@@ -297,7 +297,9 @@ def merge_columns_df(
         >>> import daft
         >>> # Read the existing table with row addresses
         >>> df = daft.read_lance(
-        ...     "s3://my-lancedb-bucket/data/", default_scan_options={"with_row_address": True}, include_fragment_id=True
+        ...     "s3://my-lancedb-bucket/data/",
+        ...     default_scan_options={"with_row_address": True},
+        ...     include_fragment_id=True,
         ... )
         >>> # Add new columns based on existing data
         >>> df = df.with_column("doubled_c", df["c"] * 2)


### PR DESCRIPTION
## Changes Made

Updated documentation for various read functions to clarify that they now support remote URLs to object stores (e.g., `s3://` and `gs://`). 

## Related Issues

Closes #2395
