### PR TITLE
fix: Remove pop_all assertion

### DIFF
--- a/src/daft-local-execution/src/buffer.rs
+++ b/src/daft-local-execution/src/buffer.rs
@@ -97,7 +97,6 @@ impl RowBasedBuffer {
 
     // Pop all morsels in the buffer regardless of the threshold
     pub fn pop_all(&mut self) -> DaftResult<Option<Arc<MicroPartition>>> {
-        assert!(self.curr_len < self.upper_bound);
         if self.buffer.is_empty() {
             Ok(None)
         } else {


### PR DESCRIPTION
## Changes Made

This was failing https://github.com/Eventual-Inc/Daft/actions/runs/20347885747/job/58464760614 because of the failed assertion.

I believe this is due to https://github.com/Eventual-Inc/Daft/pull/5676/changes#diff-a77514cfe53156c701c4b3b7426dc9d2c0d257deb52dae53fba976f51fcf8daf, which changed the way the buffer gets popped to be one by one instead of as many as possible, so we don't need the assertion anymore

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
