### PR TITLE
fix: change assertion from < to <= in buffer pop_all()

### DIFF
--- a/src/daft-local-execution/src/buffer.rs
+++ b/src/daft-local-execution/src/buffer.rs
@@ -97,7 +97,7 @@ impl RowBasedBuffer {
 
     // Pop all morsels in the buffer regardless of the threshold
     pub fn pop_all(&mut self) -> DaftResult<Option<Arc<MicroPartition>>> {
-        assert!(self.curr_len < self.upper_bound);
+        assert!(self.curr_len <= self.upper_bound);
         if self.buffer.is_empty() {
             Ok(None)
         } else {


### PR DESCRIPTION
## Summary
Fixes random buffer assertion panic causing ~20% of macOS unit test runs to fail.

## Problem
Tests were failing with:
```
assertion failed: self.curr_len < self.upper_bound
```

This occurred when the buffer's current row count (`curr_len`) exactly equaled the target batch size (`upper_bound`), then `pop_all()` was called to flush remaining data at end-of-stream.

## Fix
Changed the assertion from `<` to `<=`:
```rust
// Before
assert!(self.curr_len < self.upper_bound);

// After  
assert!(self.curr_len <= self.upper_bound);
```

The invariant `curr_len <= upper_bound` makes sense: when flushing remaining data, we should have at most one batch worth of data left.

## Failing Runs
- https://github.com/Eventual-Inc/Daft/actions/runs/20347885747/job/58464760614
- https://github.com/Eventual-Inc/Daft/actions/runs/20322294319

## Verification
This is a draft PR to run CI and verify the fix. Will re-run the macOS unit test job multiple times to confirm consistent passes.