### PR TITLE
fix: Incorrect buffer pool calculation strategy when reading CSV

### DIFF
--- a/src/common/file-formats/src/file_format_config.rs
+++ b/src/common/file-formats/src/file_format_config.rs
@@ -245,7 +245,7 @@ impl CsvSourceConfig {
     /// * `delimiter` - The character delmiting individual cells in the CSV data.
     /// * `has_headers` - Whether the CSV has a header row; if so, it will be skipped during data parsing.
     /// * `buffer_size` - Size of the buffer (in bytes) used by the streaming reader.
-    /// * `chunk_size` - Size of the chunks (in bytes) deserialized in parallel by the streaming reader.
+    /// * `chunk_size` - Size of the chunks (in rows) deserialized in parallel by the streaming reader.
     #[allow(clippy::too_many_arguments)]
     #[new]
     #[pyo3(signature = (

--- a/src/daft-csv/src/options.rs
+++ b/src/daft-csv/src/options.rs
@@ -369,7 +369,7 @@ impl CsvReadOptions {
     /// # Arguments:
     ///
     /// * `buffer_size` - Size of the buffer (in bytes) used by the streaming reader.
-    /// * `chunk_size` - Size of the chunks (in bytes) deserialized in parallel by the streaming reader.
+    /// * `chunk_size` - Size of the chunks (in rows) deserialized in parallel by the streaming reader.
     #[new]
     #[pyo3(signature = (buffer_size=None, chunk_size=None))]
     #[must_use]


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Currently, the `chunk_size` parameter of ScanTask is calculated by the `MorselSizeRequirement` strategy (as shown below), and its corresponding unit is "rows". However, `read_csv` treats it as "bytes" during processing, which is inconsistent with the behavior of APIs such as `read_parquet` and `read_json`. This results in the data of each batch usually being much smaller than the expected value of the `batch_size` parameter.

```rust
let chunk_size = match self.morsel_size_requirement {
    MorselSizeRequirement::Strict(size) => size,
    MorselSizeRequirement::Flexible(_, upper) => upper,
};
```

For example, in our scenario, the `batch_size` of the UDF is 1024, but in reality, only 3 rows of data are passed to the UDF each time. Because Daft estimates that each row of data is approximately 300~400 bytes, dividing by 1024 gives that about 3 rows of data need to be read each time.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
