### PR TITLE
chore: Add basic usage instructions for daft-dashboard in development guide

### DIFF
--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -33,9 +33,22 @@ To set up your development environment:
 
 ### Note about Developing `daft-dashboard`
 
-If you wish to enable, or work on the daft-dashboard functionality, it does have an additional dependency of [bun.sh](https://bun.sh/).
+If you wish to enable, or work on the daft-dashboard functionality, it does have an additional dependency of [bun.sh](https://bun.sh/). You simply need to install bun, and everything else should work out of the box!
 
-You simply need to install bun, and everything else should work out of the box!
+Next (_make sure Daft is installed_), you can launch the dashboard using the `daft dashboard` command, for example:
+
+```bash
+# You can learn more about this command by `daft dashboard -h`
+daft dashboard -v -a 127.0.0.1 -p 3238
+```
+
+Before executing a specific Daft job, enable reporting query execution data to the dashboard by setting the `DAFT_DASHBOARD_URL` environment variable, for example:
+
+```bash
+export DAFT_DASHBOARD_URL="http://127.0.0.1:3238"
+```
+
+Next, you can access and view the dashboard through a web browser, for example, via address `http://127.0.0.1:3238`.
 
 ## Developing with Ray
 


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Add instructions on the basic usage of Daft Dashboard in the development guide to reduce the learning cost for developers.

Daft Dashboard is currently in the rapid development stage. There will be a dedicated article or page to introduce its functions and usage in detail later, but it is more appropriate to include it in the development guide at this stage.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
