### PR TITLE
chore: enable task split and merge by default

### DIFF
--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -147,7 +147,7 @@ impl std::fmt::Debug for DaftExecutionConfig {
 impl Default for DaftExecutionConfig {
     fn default() -> Self {
         Self {
-            enable_scan_task_split_and_merge: false,
+            enable_scan_task_split_and_merge: true,
             scan_tasks_min_size_bytes: 96 * 1024 * 1024, // 96MB
             scan_tasks_max_size_bytes: 384 * 1024 * 1024, // 384MB
             max_sources_per_scan_task: 10,


### PR DESCRIPTION
## Changes Made

Enable the task split and merge by defualt, it's effective on small files case, I did a test about 4.9k files join 60k files on flotilla mode, there are 35% improvement.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
