### PR TITLE
fix: Fast failure when dashboard is enabled in Ray Runner

### DIFF
--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -6,6 +6,8 @@ use common_metrics::{NodeID, QueryID, QueryPlan, Stat, StatSnapshot};
 use common_runtime::{RuntimeRef, get_io_runtime};
 use daft_micropartition::{MicroPartition, MicroPartitionRef};
 use daft_recordbatch::RecordBatch;
+#[cfg(feature = "python")]
+use daft_runners::get_or_create_runner;
 use dashmap::DashMap;
 use reqwest::{Client, RequestBuilder};
 
@@ -42,6 +44,14 @@ impl DashboardSubscriber {
         let Ok(url) = std::env::var("DAFT_DASHBOARD_URL") else {
             return Ok(None);
         };
+
+        // TODO(zhenchao) remove it when we support Ray Runner
+        #[cfg(feature = "python")]
+        if get_or_create_runner()?.is_ray() {
+            return Err(DaftError::not_implemented(
+                "Dashboard isn't currently supported in Ray Runner",
+            ));
+        }
 
         const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 

--- a/src/daft-context/src/subscribers/mod.rs
+++ b/src/daft-context/src/subscribers/mod.rs
@@ -6,7 +6,7 @@ pub mod python;
 use std::{collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
-use common_error::DaftResult;
+use common_error::{DaftError, DaftResult};
 use common_metrics::{NodeID, QueryEndState, QueryID, QueryPlan, StatSnapshot};
 use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartitionRef;
@@ -48,9 +48,12 @@ pub fn default_subscribers() -> HashMap<String, Arc<dyn Subscriber>> {
         Ok(Some(s)) => {
             subscribers.insert("_dashboard".to_string(), Arc::new(s));
         }
-        Err(e) => {
-            log::error!("Failed to connect to the daft dashboard: {}", e);
-        }
+        Err(e) => match e {
+            DaftError::NotImplemented(msg) => {
+                panic!("{}", msg);
+            }
+            _ => log::error!("Failed to connect to the daft dashboard: {}", e),
+        },
         _ => {}
     }
 

--- a/src/daft-runners/src/runners.rs
+++ b/src/daft-runners/src/runners.rs
@@ -140,6 +140,14 @@ impl Runner {
         let runner = self.get_runner_ref();
         runner.clone_ref(py)
     }
+
+    pub fn is_native(&self) -> bool {
+        matches!(self, Self::Native(_))
+    }
+
+    pub fn is_ray(&self) -> bool {
+        matches!(self, Self::Ray(_))
+    }
 }
 
 #[derive(Debug)]

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -311,3 +311,22 @@ def test_set_scantask_max_parallelism_greater_than_partition_num():
         df = daft.range(start=0, end=1024, partitions=10)
         df.explain(show_all=True, file=str_io)
         assert "Num Parallel Scan Tasks = 10" in str_io.getvalue().strip()
+
+
+@pytest.mark.skipif(
+    get_tests_daft_runner_name() == "native", reason="Native Runner already supports enabling dashboard"
+)
+def test_enable_dashboard_for_ray_runner():
+    get_or_infer_runner_type_py_script = """
+import daft
+
+daft.range(start=0, end=1024, partitions=10).collect()
+    """
+
+    with with_null_env():
+        result = subprocess.run(
+            [sys.executable, "-c", get_or_infer_runner_type_py_script],
+            capture_output=True,
+            env={"DAFT_RUNNER": "ray", "DAFT_DASHBOARD_URL": "http://localhost:3238"},
+        )
+        assert "Dashboard isn't currently supported in Ray Runner" in result.stderr.decode()


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

The daft-dashboard currently only supports Native Runner, so we should gives a direct "not implemented" error message to users who enabled dashboard in Ray Runner, rather than a strange job failure.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
