### PR TITLE
fix(test): read all splits in HuggingFace integration tests

### DIFF
--- a/tests/integration/io/huggingface/test_read_huggingface.py
+++ b/tests/integration/io/huggingface/test_read_huggingface.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 from datasets import load_dataset
 
@@ -23,19 +24,19 @@ def test_read_huggingface_datasets_doesnt_fail():
 
 @pytest.mark.integration()
 @pytest.mark.parametrize(
-    "path, split, sort_key",
+    "path, sort_key",
     [
-        ("Eventual-Inc/sample-parquet", "train", "foo"),
-        ("fka/awesome-chatgpt-prompts", "train", "act"),
-        ("nebius/SWE-rebench", "test", "instance_id"),
-        ("SWE-Gym/SWE-Gym", "train", "instance_id"),
-        # ("HuggingFaceFW/fineweb", "train", "id")
+        ("Eventual-Inc/sample-parquet", "foo"),
+        ("fka/awesome-chatgpt-prompts", "act"),
+        ("nebius/SWE-rebench", "instance_id"),
+        ("SWE-Gym/SWE-Gym", "instance_id"),
+        # ("HuggingFaceFW/fineweb", "id")
     ],
 )
-def test_read_huggingface(path, split, sort_key):
-    ds = load_dataset(path, split=split)
-    ds = ds.with_format("arrow")
-    expected = ds.to_pandas()
+def test_read_huggingface(path, sort_key):
+    # Load all splits and concatenate them to match what daft.read_huggingface() does
+    ds = load_dataset(path)
+    expected = pd.concat([ds[s].with_format("arrow").to_pandas() for s in ds.keys()], ignore_index=True)
 
     df = daft.read_huggingface(path)
     actual = df.to_pandas()
@@ -62,10 +63,9 @@ def test_read_huggingface_fallback_on_400_error():
         # Verify read_parquet was called with the correct HF path
         mock_read_parquet.assert_called_once_with(f"hf://datasets/{repo}", io_config=None)
 
-        # Load expected data using datasets library
-        ds = load_dataset(repo, split="train")
-        ds = ds.with_format("arrow")
-        expected = ds.to_pandas()
+        # Load expected data using datasets library (all splits)
+        ds = load_dataset(repo)
+        expected = pd.concat([ds[s].with_format("arrow").to_pandas() for s in ds.keys()], ignore_index=True)
 
         # Compare the results
         actual = df.to_pandas()


### PR DESCRIPTION
## Summary

`daft.read_huggingface()` reads all splits (both main parquet path and fallback datasets path), so tests should do the same. Previously tests specified individual splits which caused failures when datasets like `nebius/SWE-rebench` added new splits.

## Changes

- Remove `split` parameter from `test_read_huggingface` parametrization
- Always concatenate all splits when loading reference data
- Fix same issue in `test_read_huggingface_fallback_on_400_error`

## Related Issue

Fixes failing CI: https://github.com/Eventual-Inc/Daft/actions/runs/20478810048