### PR TITLE
perf: Only Serialize Required Cols in Actor UDFs

### DIFF
--- a/daft/execution/ray_actor_pool_udf.py
+++ b/daft/execution/ray_actor_pool_udf.py
@@ -74,7 +74,7 @@ def get_ready_actors_by_location(
 
 
 async def start_udf_actors(
-    projection: list[PyExpr],
+    projection: PyExpr,
     num_actors: int,
     num_gpus_per_actor: float,
     num_cpus_per_actor: float,
@@ -83,7 +83,7 @@ async def start_udf_actors(
     timeout: int,
     actor_name: str | None = None,
 ) -> list[UDFActorHandle]:
-    expr_projection = ExpressionsProjection([Expression._from_pyexpr(expr) for expr in projection])
+    expr_projection = ExpressionsProjection([Expression._from_pyexpr(projection)])
 
     udf_options = validate_and_normalize_ray_options(
         {

--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use common_error::DaftResult;
 use common_py_serde::PyObjectWrapper;
 use common_runtime::JoinSet;
-use daft_dsl::{expr::bound_expr::BoundExpr, functions::python::UDFProperties, python::PyExpr};
+use daft_dsl::{
+    expr::bound_expr::BoundExpr, functions::python::UDFProperties, python::PyExpr,
+    utils::remap_used_cols,
+};
 use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
@@ -23,25 +26,21 @@ use crate::{
 };
 
 #[derive(Debug)]
-
 enum UDFActors {
-    Uninitialized(Vec<BoundExpr>, UDFProperties),
+    Uninitialized(BoundExpr, UDFProperties),
     Initialized { actors: Vec<PyObjectWrapper> },
 }
 
 impl UDFActors {
     // TODO: This is a blocking call, and should be done asynchronously.
     async fn initialize_actors(
-        projection: &[BoundExpr],
+        udf_expr: &BoundExpr,
         udf_properties: &UDFProperties,
         actor_ready_timeout: usize,
     ) -> DaftResult<Vec<PyObjectWrapper>> {
-        let py_exprs = projection
-            .iter()
-            .map(|e| PyExpr {
-                expr: e.inner().clone(),
-            })
-            .collect::<Vec<_>>();
+        let py_expr = PyExpr {
+            expr: udf_expr.inner().clone(),
+        };
         let num_actors = udf_properties
             .concurrency
             .expect("ActorUDF should have concurrency specified");
@@ -68,7 +67,7 @@ impl UDFActors {
                 ray_actor_pool_udf_module.call_method1(
                     pyo3::intern!(py, "start_udf_actors"),
                     (
-                        py_exprs,
+                        py_expr,
                         num_actors,
                         gpu_request,
                         cpu_request,
@@ -120,7 +119,9 @@ pub(crate) struct ActorUDF {
     config: PipelineNodeConfig,
     context: PipelineNodeContext,
     child: DistributedPipelineNode,
-    projection: Vec<BoundExpr>,
+    udf_expr: BoundExpr,
+    passthrough_columns: Vec<BoundExpr>,
+    required_columns: Vec<usize>,
     udf_properties: UDFProperties,
     actor_ready_timeout: usize,
 }
@@ -132,7 +133,8 @@ impl ActorUDF {
     pub fn new(
         node_id: NodeID,
         plan_config: &PlanConfig,
-        projection: Vec<BoundExpr>,
+        udf_expr: BoundExpr,
+        passthrough_columns: Vec<BoundExpr>,
         udf_properties: UDFProperties,
         schema: SchemaRef,
         child: DistributedPipelineNode,
@@ -148,11 +150,14 @@ impl ActorUDF {
             plan_config.config.clone(),
             child.config().clustering_spec.clone(),
         );
+        let (udf_expr, required_columns) = remap_used_cols(udf_expr);
         Ok(Self {
             config,
             context,
             child,
-            projection,
+            udf_expr,
+            passthrough_columns,
+            required_columns,
             udf_properties,
             actor_ready_timeout: plan_config.config.actor_udf_ready_timeout,
         })
@@ -168,7 +173,7 @@ impl ActorUDF {
         result_tx: Sender<SwordfishTaskBuilder>,
     ) -> DaftResult<()> {
         let mut udf_actors =
-            UDFActors::Uninitialized(self.projection.clone(), self.udf_properties.clone());
+            UDFActors::Uninitialized(self.udf_expr.clone(), self.udf_properties.clone());
 
         let mut running_tasks = JoinSet::new();
         while let Some(builder) = input_task_stream.next().await {
@@ -212,6 +217,8 @@ impl ActorUDF {
                 self.udf_properties.batch_size,
                 memory_request,
                 self.config.schema.clone(),
+                self.passthrough_columns.clone(),
+                self.required_columns.clone(),
                 StatsState::NotMaterialized,
                 LocalNodeContext {
                     origin_node_id: Some(self.node_id() as usize),
@@ -239,9 +246,10 @@ impl PipelineNodeImpl for ActorUDF {
         use itertools::Itertools;
         let mut res = vec![
             format!("ActorUDF: {}", self.udf_properties.name),
+            format!("Expr = {}", self.udf_expr),
             format!(
-                "Projection = [{}]",
-                self.projection.iter().map(|e| e.to_string()).join(", ")
+                "Passthrough Columns = [{}]",
+                self.passthrough_columns.iter().join(", ")
             ),
             format!(
                 "Properties = {{ {} }}",

--- a/src/daft-distributed/src/pipeline_node/translate.rs
+++ b/src/daft-distributed/src/pipeline_node/translate.rs
@@ -158,18 +158,14 @@ impl TreeNodeVisitor for LogicalPlanToPipelineNodeTranslator {
             LogicalPlan::UDFProject(udf) if udf.is_actor_pool_udf() => {
                 #[cfg(feature = "python")]
                 {
-                    let projection = udf
-                        .passthrough_columns
-                        .iter()
-                        .chain(std::iter::once(&udf.expr))
-                        .cloned()
-                        .collect::<Vec<_>>();
-                    let projection =
-                        BoundExpr::bind_all(projection.as_slice(), &udf.input.schema())?;
+                    let udf_expr = BoundExpr::try_new(udf.expr.clone(), &udf.input.schema())?;
+                    let passthrough_columns =
+                        BoundExpr::bind_all(&udf.passthrough_columns, &udf.input.schema())?;
                     crate::pipeline_node::actor_udf::ActorUDF::new(
                         self.get_next_pipeline_node_id(),
                         &self.plan_config,
-                        projection,
+                        udf_expr,
+                        passthrough_columns,
                         udf.udf_properties.clone(),
                         udf.projected_schema.clone(),
                         self.curr_node.pop().unwrap(),

--- a/src/daft-dsl/src/lib.rs
+++ b/src/daft-dsl/src/lib.rs
@@ -12,6 +12,8 @@ pub use common_metrics::operator_metrics;
 mod visitor;
 
 mod treenode;
+pub mod utils;
+
 pub use common_treenode;
 pub use expr::{
     AggExpr, ApproxPercentileParams, Column, Expr, ExprRef, PlanRef, ResolvedColumn, SketchType,

--- a/src/daft-dsl/src/utils.rs
+++ b/src/daft-dsl/src/utils.rs
@@ -1,0 +1,51 @@
+use std::{collections::HashMap, sync::Arc};
+
+use common_treenode::{Transformed, TreeNode};
+
+use crate::{
+    Column, Expr, ExprRef,
+    expr::{BoundColumn, bound_expr::BoundExpr},
+};
+
+/// Given an expression, extract the indexes of used columns and remap them to
+/// new indexes from 0...count-1, where count is the # of used columns.
+///
+/// Note that if there are no used columns, we just return the first
+/// because we can't execute UDFs on empty recordbatches.
+pub fn remap_used_cols(expr: BoundExpr) -> (BoundExpr, Vec<usize>) {
+    let mut count = 0;
+    let mut cols_to_idx = HashMap::new();
+    let new_expr = expr
+        .into_inner()
+        .transform_down(|expr: ExprRef| {
+            if let Expr::Column(Column::Bound(BoundColumn { index, field })) = expr.as_ref() {
+                if !cols_to_idx.contains_key(index) {
+                    cols_to_idx.insert(*index, count);
+                    count += 1;
+                }
+
+                let new_index = cols_to_idx[index];
+                Ok(Transformed::yes(Arc::new(Expr::Column(Column::Bound(
+                    BoundColumn {
+                        index: new_index,
+                        field: field.clone(),
+                    },
+                )))))
+            } else {
+                Ok(Transformed::no(expr))
+            }
+        })
+        .expect("Error occurred when visiting for required columns");
+
+    let required_cols = if cols_to_idx.is_empty() {
+        vec![0]
+    } else {
+        let mut required_cols = vec![0; count];
+        for (original_idx, final_idx) in cols_to_idx {
+            required_cols[final_idx] = original_idx;
+        }
+        required_cols
+    };
+
+    (BoundExpr::new_unchecked(new_expr.data), required_cols)
+}

--- a/src/daft-local-execution/src/intermediate_ops/distributed_actor_pool_project.rs
+++ b/src/daft-local-execution/src/intermediate_ops/distributed_actor_pool_project.rs
@@ -7,11 +7,14 @@ use std::{
     vec,
 };
 
-use common_error::DaftResult;
+use common_error::{DaftError, DaftResult};
 use common_metrics::ops::NodeType;
-use daft_micropartition::MicroPartition;
+use daft_core::prelude::{Schema, SchemaRef};
+use daft_dsl::expr::bound_expr::BoundExpr;
 #[cfg(feature = "python")]
 use daft_micropartition::python::PyMicroPartition;
+use daft_micropartition::{MicroPartition, partitioning::Partition};
+use itertools::Itertools;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use rand::Rng;
@@ -106,6 +109,9 @@ pub(crate) struct DistributedActorPoolProjectOperator {
     actor_handles: Vec<ActorHandle>,
     batch_size: Option<usize>,
     memory_request: u64,
+    passthrough_columns: Vec<BoundExpr>, // Columns that no need to be passed to UDFActor for processing
+    required_columns: Vec<usize>,        // UDF input columns
+    schema: SchemaRef,                   // Output schema
     counter: AtomicUsize,
 }
 
@@ -114,6 +120,9 @@ impl DistributedActorPoolProjectOperator {
         actor_handles: Vec<impl Into<ActorHandle>>,
         batch_size: Option<usize>,
         memory_request: u64,
+        passthrough_columns: Vec<BoundExpr>,
+        required_columns: Vec<usize>,
+        schema: SchemaRef,
     ) -> DaftResult<Self> {
         let actor_handles: Vec<ActorHandle> = actor_handles.into_iter().map(|e| e.into()).collect();
         let (local_actor_handles, remote_actor_handles) =
@@ -134,6 +143,9 @@ impl DistributedActorPoolProjectOperator {
             actor_handles,
             batch_size,
             memory_request,
+            passthrough_columns,
+            required_columns,
+            schema,
             counter: AtomicUsize::new(init_counter),
         })
     }
@@ -149,17 +161,78 @@ impl IntermediateOperator for DistributedActorPoolProjectOperator {
         state: Self::State,
         task_spawner: &ExecutionTaskSpawner,
     ) -> IntermediateOpExecuteResult<Self> {
-        let memory_request = self.memory_request;
         #[cfg(feature = "python")]
         {
+            let memory_request = self.memory_request;
+            let required_columns = self.required_columns.clone();
+            let passthrough_columns = self.passthrough_columns.clone();
+            let output_schema = self.schema.clone();
+
             let fut = task_spawner.spawn_with_memory_request(
                 memory_request,
                 async move {
-                    let res =
-                        state.actor_handle.eval_input(input).await.map(|result| {
-                            IntermediateOperatorResult::NeedMoreInput(Some(result))
-                        })?;
-                    Ok((state, res))
+                    // Prune input by required cols
+                    let input_schema = input.schema();
+                    let pruned_input = Arc::new(MicroPartition::new_loaded(
+                        Arc::new(Schema::new(
+                            required_columns
+                                .iter()
+                                .map(|idx| input_schema[*idx].clone()),
+                        )),
+                        Arc::new(
+                            input
+                                .clone()
+                                .record_batches()
+                                .iter()
+                                .map(|batch| batch.get_columns(required_columns.as_slice()))
+                                .collect::<Vec<_>>(),
+                        ),
+                        None,
+                    ));
+
+                    // Call the UDF with pruned input
+                    let eval_output = state.actor_handle.eval_input(pruned_input.clone()).await?;
+                    if eval_output.schema().fields().len() != 1 {
+                        return Err(DaftError::InternalError(format!(
+                            "UDF output schema must be a single column, but got '{}'",
+                            eval_output.schema().field_names().join(", ")
+                        )));
+                    }
+
+                    if pruned_input.num_rows() != eval_output.num_rows() {
+                        return Err(DaftError::InternalError(format!(
+                            "The number of rows is mismatch between UDF input {} and output {}",
+                            pruned_input.num_rows(),
+                            eval_output.num_rows()
+                        )));
+                    }
+
+                    // Combine the eval output with passthrough columns
+                    let mut output_batches = Vec::with_capacity(input.num_rows());
+                    for (input_record, output_record) in input
+                        .record_batches()
+                        .iter()
+                        .zip(eval_output.record_batches().iter())
+                    {
+                        let passthrough_record =
+                            input_record.eval_expression_list(passthrough_columns.as_slice())?;
+
+                        output_batches.push(passthrough_record.append_column(
+                            output_schema.clone(),
+                            output_record.get_column(0).clone(),
+                        )?);
+                    }
+
+                    Ok((
+                        state,
+                        IntermediateOperatorResult::NeedMoreInput(Some(Arc::new(
+                            MicroPartition::new_loaded(
+                                output_schema.clone(),
+                                Arc::new(output_batches),
+                                None,
+                            ),
+                        ))),
+                    ))
                 },
                 Span::current(),
             );

--- a/src/daft-local-execution/src/intermediate_ops/udf.rs
+++ b/src/daft-local-execution/src/intermediate_ops/udf.rs
@@ -21,11 +21,8 @@ use daft_core::{prelude::SchemaRef, series::Series};
 #[cfg(feature = "python")]
 use daft_dsl::python::PyExpr;
 use daft_dsl::{
-    Column, Expr, ExprRef,
-    common_treenode::{Transformed, TreeNode},
-    expr::{BoundColumn, bound_expr::BoundExpr},
-    functions::python::UDFProperties,
-    operator_metrics::OperatorMetrics,
+    expr::bound_expr::BoundExpr, functions::python::UDFProperties,
+    operator_metrics::OperatorMetrics, utils::remap_used_cols,
 };
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
@@ -46,49 +43,6 @@ use crate::{
     pipeline::{MorselSizeRequirement, NodeName},
     runtime_stats::RuntimeStats,
 };
-
-/// Given an expression, extract the indexes of used columns and remap them to
-/// new indexes from 0...count-1, where count is the # of used columns.
-///
-/// Note that if there are no used columns, we just return the first
-/// because we can't execute UDFs on empty recordbatches.
-pub(crate) fn remap_used_cols(expr: BoundExpr) -> (BoundExpr, Vec<usize>) {
-    let mut count = 0;
-    let mut cols_to_idx = HashMap::new();
-    let new_expr = expr
-        .into_inner()
-        .transform_down(|expr: ExprRef| {
-            if let Expr::Column(Column::Bound(BoundColumn { index, field })) = expr.as_ref() {
-                if !cols_to_idx.contains_key(index) {
-                    cols_to_idx.insert(*index, count);
-                    count += 1;
-                }
-
-                let new_index = cols_to_idx[index];
-                Ok(Transformed::yes(Arc::new(Expr::Column(Column::Bound(
-                    BoundColumn {
-                        index: new_index,
-                        field: field.clone(),
-                    },
-                )))))
-            } else {
-                Ok(Transformed::no(expr))
-            }
-        })
-        .expect("Error occurred when visiting for required columns");
-
-    let required_cols = if cols_to_idx.is_empty() {
-        vec![0]
-    } else {
-        let mut required_cols = vec![0; count];
-        for (original_idx, final_idx) in cols_to_idx {
-            required_cols[final_idx] = original_idx;
-        }
-        required_cols
-    };
-
-    (BoundExpr::new_unchecked(new_expr.data), required_cols)
-}
 
 struct UdfRuntimeStats {
     meter: Meter,

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -588,6 +588,9 @@ fn physical_plan_to_pipeline(
                 actor_objects,
                 batch_size,
                 memory_request,
+                schema,
+                passthrough_columns,
+                required_columns,
                 stats_state,
                 context,
                 ..
@@ -597,6 +600,9 @@ fn physical_plan_to_pipeline(
                 actor_objects.clone(),
                 *batch_size,
                 *memory_request,
+                passthrough_columns.clone(),
+                required_columns.clone(),
+                schema.clone(),
             )
             .with_context(|_| PipelineCreationSnafu {
                 plan_name: physical_plan.name(),

--- a/src/daft-local-execution/src/streaming_sink/async_udf.rs
+++ b/src/daft-local-execution/src/streaming_sink/async_udf.rs
@@ -14,7 +14,7 @@ use common_runtime::JoinSet;
 use daft_core::{prelude::SchemaRef, series::Series};
 use daft_dsl::{
     expr::bound_expr::BoundExpr, functions::python::UDFProperties,
-    operator_metrics::OperatorMetrics,
+    operator_metrics::OperatorMetrics, utils::remap_used_cols,
 };
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
@@ -28,7 +28,6 @@ use super::base::{
 };
 use crate::{
     ExecutionTaskSpawner,
-    intermediate_ops::udf::remap_used_cols,
     pipeline::{MorselSizeRequirement, NodeName},
     runtime_stats::RuntimeStats,
 };

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -388,12 +388,15 @@ impl LocalPhysicalPlan {
     }
 
     #[cfg(feature = "python")]
+    #[allow(clippy::too_many_arguments)]
     pub fn distributed_actor_pool_project(
         input: LocalPhysicalPlanRef,
         actor_objects: Vec<PyObjectWrapper>,
         batch_size: Option<usize>,
         memory_request: u64,
         schema: SchemaRef,
+        passthrough_columns: Vec<BoundExpr>,
+        required_columns: Vec<usize>,
         stats_state: StatsState,
         context: LocalNodeContext,
     ) -> LocalPhysicalPlanRef {
@@ -403,6 +406,8 @@ impl LocalPhysicalPlan {
             batch_size,
             memory_request,
             schema,
+            passthrough_columns,
+            required_columns,
             stats_state,
             context,
         })
@@ -1481,6 +1486,8 @@ impl LocalPhysicalPlan {
                     batch_size,
                     memory_request,
                     context,
+                    passthrough_columns,
+                    required_columns,
                     ..
                 }) => Self::distributed_actor_pool_project(
                     new_child.clone(),
@@ -1488,6 +1495,8 @@ impl LocalPhysicalPlan {
                     *batch_size,
                     *memory_request,
                     schema.clone(),
+                    passthrough_columns.clone(),
+                    required_columns.clone(),
                     StatsState::NotMaterialized,
                     context.clone(),
                 ),
@@ -1730,6 +1739,8 @@ pub struct DistributedActorPoolProject {
     pub batch_size: Option<usize>,
     pub memory_request: u64,
     pub schema: SchemaRef,
+    pub passthrough_columns: Vec<BoundExpr>,
+    pub required_columns: Vec<usize>,
     pub stats_state: StatsState,
     pub context: LocalNodeContext,
 }

--- a/tests/udf/test_cls.py
+++ b/tests/udf/test_cls.py
@@ -9,10 +9,13 @@ import daft
 from daft import DataType
 
 
-def test_cls():
-    df = daft.from_pydict({"a": ["foo", "bar", "baz"]})
+@pytest.mark.parametrize("concurrency", [None, 2])
+def test_cls(concurrency):
+    df = daft.from_pydict(
+        {"a": ["foo", "bar", "baz"], "b": [1, 2, 3], "c": [True, None, True]},
+    )
 
-    @daft.cls
+    @daft.cls(max_concurrency=concurrency)
     class RepeatN:
         def __init__(self, n: int):
             self.n = n
@@ -27,6 +30,9 @@ def test_cls():
     repeat_2 = RepeatN(2)
     result = df.select(repeat_2(df["a"]))
     assert result.to_pydict() == {"a": ["foofoo", "barbar", "bazbaz"]}
+
+    result = df.select(repeat_2(df["a"]), "b")
+    assert result.to_pydict() == {"a": ["foofoo", "barbar", "bazbaz"], "b": [1, 2, 3]}
 
     result = df.select(repeat_2.repeat_list(df["a"]))
     assert result.to_pydict() == {"a": [["foo", "foo"], ["bar", "bar"], ["baz", "baz"]]}
@@ -50,10 +56,11 @@ def test_cls_scalar_eval():
     assert repeat_2.repeat_list("foo") == ["foo", "foo"]
 
 
-def test_cls_method_without_decorator():
-    df = daft.from_pydict({"a": [1, 2, 3]})
+@pytest.mark.parametrize("concurrency", [None, 2])
+def test_cls_method_without_decorator(concurrency):
+    df = daft.from_pydict({"a": [1, 2, 3], "b": ["foo", "bar", "baz"]})
 
-    @daft.cls
+    @daft.cls(max_concurrency=concurrency)
     class Multiplier:
         def __init__(self, factor: int):
             self.factor = factor
@@ -62,14 +69,15 @@ def test_cls_method_without_decorator():
             return x * self.factor
 
     m = Multiplier(5)
-    result = df.select(m.multiply(df["a"]))
-    assert result.to_pydict() == {"a": [5, 10, 15]}
+    result = df.select("b", m.multiply(df["a"]))
+    assert result.to_pydict() == {"b": ["foo", "bar", "baz"], "a": [5, 10, 15]}
 
 
-def test_cls_multiple_instances():
-    df = daft.from_pydict({"a": [10, 20, 30]})
+@pytest.mark.parametrize("concurrency", [None, 2])
+def test_cls_multiple_instances(concurrency):
+    df = daft.from_pydict({"a": [10, 20, 30], "b": ["foo", "bar", "baz"]})
 
-    @daft.cls
+    @daft.cls(max_concurrency=concurrency)
     class Adder:
         def __init__(self, increment: int):
             self.increment = increment
@@ -83,16 +91,18 @@ def test_cls_multiple_instances():
     result = df.select(
         adder_1.add(df["a"]).alias("plus_1"),
         adder_10.add(df["a"]).alias("plus_10"),
+        "b",
     )
     assert result.to_pydict() == {
         "plus_1": [11, 21, 31],
         "plus_10": [20, 30, 40],
+        "b": ["foo", "bar", "baz"],
     }
 
 
 @pytest.mark.parametrize("concurrency", [None, 1, 2])
 def test_cls_async_method(concurrency):
-    df = daft.from_pydict({"a": [1, 2, 3]})
+    df = daft.from_pydict({"a": [1, 2, 3], "b": ["foo", "bar", "baz"]})
 
     @daft.cls(max_concurrency=concurrency)
     class AsyncProcessor:
@@ -104,14 +114,17 @@ def test_cls_async_method(concurrency):
             return x * 2
 
     processor = AsyncProcessor(0.01)
-    result = df.select(processor.process(df["a"]))
-    assert sorted(result.to_pydict()["a"]) == [2, 4, 6]
+    result = df.select(processor.process(df["a"]), "b")
+    result = result.to_pydict()
+    assert sorted(result["a"]) == [2, 4, 6]
+    assert sorted(result["b"]) == ["bar", "baz", "foo"]
 
 
-def test_cls_generator_method():
+@pytest.mark.parametrize("concurrency", [None, 2])
+def test_cls_generator_method(concurrency):
     df = daft.from_pydict({"id": [0, 1, 2], "n": [0, 2, 3]})
 
-    @daft.cls
+    @daft.cls(max_concurrency=concurrency)
     class RepeatGenerator:
         def __init__(self, value: str):
             self.value = value
@@ -128,10 +141,11 @@ def test_cls_generator_method():
     }
 
 
-def test_cls_unnest_struct():
-    df = daft.from_pydict({"a": [1, 2, 3]})
+@pytest.mark.parametrize("concurrency", [None, 2])
+def test_cls_unnest_struct(concurrency):
+    df = daft.from_pydict({"a": [1, 2, 3], "b": ["foo", "bar", "baz"]})
 
-    @daft.cls
+    @daft.cls(max_concurrency=concurrency)
     class Processor:
         def __init__(self, multiplier: int):
             self.multiplier = multiplier
@@ -144,8 +158,9 @@ def test_cls_unnest_struct():
             return {"doubled": x * self.multiplier, "name": f"value_{x}"}
 
     processor = Processor(2)
-    result = df.select(processor.process(df["a"]))
+    result = df.select("b", processor.process(df["a"]))
     assert result.to_pydict() == {
+        "b": ["foo", "bar", "baz"],
         "doubled": [2, 4, 6],
         "name": ["value_1", "value_2", "value_3"],
     }
@@ -183,10 +198,11 @@ def test_cls_multiple_methods():
     assert result.to_pydict() == expected
 
 
-def test_cls_with_complex_init():
-    df = daft.from_pydict({"a": [1, 2, 3]})
+@pytest.mark.parametrize("concurrency", [None, 2])
+def test_cls_with_complex_init(concurrency):
+    df = daft.from_pydict({"a": [1, 2, 3], "b": ["foo", "bar", "baz"]})
 
-    @daft.cls
+    @daft.cls(max_concurrency=concurrency)
     class Calculator:
         def __init__(self, multiplier: int, offset: int, name: str):
             self.multiplier = multiplier
@@ -203,17 +219,20 @@ def test_cls_with_complex_init():
     result = df.select(
         calc.compute(df["a"]).alias("result"),
         calc.get_name(df["a"]).alias("name"),
+        "b",
     )
     assert result.to_pydict() == {
         "result": [15, 25, 35],
         "name": ["calc_1", "calc_2", "calc_3"],
+        "b": ["foo", "bar", "baz"],
     }
 
 
-def test_cls_with_list_operations():
-    df = daft.from_pydict({"lists": [[1, 2, 3], [4, 5], [6, 7, 8, 9]]})
+@pytest.mark.parametrize("concurrency", [None, 2])
+def test_cls_with_list_operations(concurrency):
+    df = daft.from_pydict({"id": [0, 1, 2], "lists": [[1, 2, 3], [4, 5], [6, 7, 8, 9]]})
 
-    @daft.cls
+    @daft.cls(max_concurrency=concurrency)
     class ListProcessor:
         def __init__(self, threshold: int):
             self.threshold = threshold
@@ -227,19 +246,22 @@ def test_cls_with_list_operations():
 
     processor = ListProcessor(5)
     result = df.select(
+        "id",
         processor.filter_above(df["lists"]).alias("filtered"),
         processor.count_above(df["lists"]).alias("count"),
     )
     assert result.to_pydict() == {
+        "id": [0, 1, 2],
         "filtered": [[], [], [6, 7, 8, 9]],
         "count": [0, 0, 4],
     }
 
 
-def test_cls_batch_method():
-    df = daft.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
+@pytest.mark.parametrize("concurrency", [None, 2])
+def test_cls_batch_method(concurrency):
+    df = daft.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9], "d": [10, 11, 12]})
 
-    @daft.cls
+    @daft.cls(max_concurrency=concurrency)
     class BatchAdder:
         def __init__(self, offset: int):
             self.offset = offset


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Continue to complete the unfinished work in #5069. PR #5069 optimized Process UDFs by only serializing the required columns that UDFs need to process. We found in our customer scenarios that Actor UDFs also require such optimization, especially when there are some large columns in data rows (such as very large JSON objects), this problem becomes extremely prominent.

We simulated a small scenario as shown below for testing, where `bytes` corresponds to a large field, but the UDF actually only needs to process small fields such as `height` and `width`. The running results based on the ImageNet dataset (approximately 1.28 million images) show that __this optimization can bring about a 35% performance improvement in this test scenario__.

```python
@daft.udf(
    return_dtype=daft.DataType.float32(),
    batch_size=8,
    num_cpus=0.25,
    num_gpus=0,
    concurrency=32,
)
class ImageProcessor:

    def __init__(self):
        pass

    def __call__(self, width, height):
        return [0.0 for _, _ in zip(width, height)]


start_time = time.time()
df = (daft
      .read_parquet(path="s3://ai/dataset/url_ILSVRC2012/*.parquet", io_config=IO_CONFIG)
      .with_column('bytes', col('url').download(io_config=IO_CONFIG))
      .with_column('labels', ImageProcessor(col('height'), col('width')))
      )

for part in df.iter_partitions():
    pass

print(f"Elapse: {(time.time() - start_time) * 1000:.2f}ms")
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
