### PR TITLE
WIP: feat: Add BFloat16 data type support backed by Float32 physical storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,7 @@ name = "common-ndarray"
 version = "0.3.0-dev0"
 dependencies = [
  "common-py-serde",
+ "half",
  "ndarray",
  "numpy",
  "pyo3",
@@ -5938,6 +5939,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aac2e6a6e4468ffa092ad43c39b81c79196c2bb773b8db4085f695efe3bba17"
 dependencies = [
+ "half",
  "libc",
  "ndarray",
  "num-complex",

--- a/daft/udf/legacy.py
+++ b/daft/udf/legacy.py
@@ -182,6 +182,8 @@ def run_udf(
     elif isinstance(results[0], list):
         result_list = [x for res in results for x in res]
         return Series.from_pylist(result_list, name=name, dtype=return_dtype)._series
+    elif isinstance(results[0], dict):
+        return Series.from_pylist(results, name=name, dtype=return_dtype)._series
     elif np.module_available() and isinstance(results[0], np.ndarray):  # type: ignore[attr-defined]
         np_results = cast("list[np.ndarray[Any, Any]]", results)
         result_np = np.concatenate(np_results)

--- a/docs/api/datatypes/type_conversions.md
+++ b/docs/api/datatypes/type_conversions.md
@@ -87,6 +87,8 @@ To check the inferred DataType for a Python type, use [`DataType.infer_from_type
 | `daft.File`                                                                               | File                                |
 | Everything else                                                                           | Python                              |
 
+> **BF16 note**: `torch.bfloat16` is a dtype instance rather than a type, and `DataType.infer_from_type` only accepts `type` / `GenericAlias`, so it will not recognize `torch.bfloat16`. BF16 data (e.g. `torch.Tensor(dtype=torch.bfloat16)` or `numpy.ndarray(dtype=ml_dtypes.bfloat16)`) is handled by value in the object-to-Daft conversion path (Rust side `Literal::from_pyobj`), rather than by type in `infer_from_type`.
+
 #### jaxtyping
 
 The [`jaxtyping`](https://docs.kidger.site/jaxtyping/) library provides data type and shape type annotations for array/tensor types from various libraries, including NumPy, PyTorch, TensorFlow, and JAX. Daft is able to natively infer the inner dtype and shape from `jaxtyping` types.
@@ -112,6 +114,7 @@ The following table show the mapping from `jaxtyping` types to Daft DataType. Th
 | `Int64`<br>`Int`<br>`Integer`  | Int64             |
 | `UInt64`<br>`UInt`             | UInt64            |
 | `Float32`                      | Float32           |
+| `BFloat16`                     | BFloat16          |
 | `Float64`<br>`Float`<br>`Real` | Float64           |
 | Everything else                | Python            |
 

--- a/src/common/ndarray/Cargo.toml
+++ b/src/common/ndarray/Cargo.toml
@@ -1,8 +1,9 @@
 [dependencies]
 common-py-serde = {path = "../py-serde", default-features = false}
 ndarray = {workspace = true}
-numpy = {workspace = true, optional = true}
+numpy = {workspace = true, optional = true, features = ["half"]}
 pyo3 = {workspace = true, optional = true}
+half = "2"
 
 [features]
 python = ["dep:pyo3", "dep:numpy", "common-py-serde/python"]

--- a/src/common/ndarray/src/lib.rs
+++ b/src/common/ndarray/src/lib.rs
@@ -4,6 +4,7 @@ mod python;
 #[cfg(feature = "python")]
 use common_py_serde::PyObjectWrapper;
 use ndarray::ArrayD;
+use half::bf16;
 #[cfg(feature = "python")]
 pub use python::NumpyArray;
 
@@ -16,6 +17,7 @@ pub enum NdArray {
     U32(ArrayD<u32>),
     I64(ArrayD<i64>),
     U64(ArrayD<u64>),
+    BFloat16(ArrayD<bf16>),
     F32(ArrayD<f32>),
     F64(ArrayD<f64>),
     #[cfg(feature = "python")]
@@ -33,6 +35,7 @@ impl NdArray {
             Self::U32(arr) => arr.shape(),
             Self::I64(arr) => arr.shape(),
             Self::U64(arr) => arr.shape(),
+            Self::BFloat16(arr) => arr.shape(),
             Self::F32(arr) => arr.shape(),
             Self::F64(arr) => arr.shape(),
             #[cfg(feature = "python")]

--- a/src/common/ndarray/src/python.rs
+++ b/src/common/ndarray/src/python.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use numpy::{PyArrayDyn, PyArrayMethods, ToPyArray};
 use pyo3::prelude::*;
+use pyo3::exceptions::PyTypeError;
+use half::bf16;
 
 use crate::NdArray;
 
-#[derive(FromPyObject, IntoPyObject)]
+#[derive(Debug)]
 /// Wrapper around rust-numpy PyArrayDyn to support dynamic types
 pub enum NumpyArray<'py> {
     I8(Bound<'py, PyArrayDyn<i8>>),
@@ -16,9 +18,67 @@ pub enum NumpyArray<'py> {
     U32(Bound<'py, PyArrayDyn<u32>>),
     I64(Bound<'py, PyArrayDyn<i64>>),
     U64(Bound<'py, PyArrayDyn<u64>>),
+    BFloat16(Bound<'py, PyArrayDyn<bf16>>),
     F32(Bound<'py, PyArrayDyn<f32>>),
     F64(Bound<'py, PyArrayDyn<f64>>),
     Py(Bound<'py, PyArrayDyn<Py<PyAny>>>),
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for NumpyArray<'py> {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<i8>>>() { return Ok(NumpyArray::I8(val)); }
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<u8>>>() { return Ok(NumpyArray::U8(val)); }
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<i16>>>() { return Ok(NumpyArray::I16(val)); }
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<u16>>>() { return Ok(NumpyArray::U16(val)); }
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<i32>>>() { return Ok(NumpyArray::I32(val)); }
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<u32>>>() { return Ok(NumpyArray::U32(val)); }
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<i64>>>() { return Ok(NumpyArray::I64(val)); }
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<u64>>>() { return Ok(NumpyArray::U64(val)); }
+        
+        // Check for BFloat16 safely
+        // We need to check the dtype name string because rust-numpy's extraction for bf16 
+        // can panic if the environment doesn't have the bfloat16 type registered correctly,
+        // or when checking against non-bf16 arrays in some versions.
+        let is_bfloat16 = ob.getattr("dtype")
+            .and_then(|dt| dt.getattr("name"))
+            .and_then(|name| name.extract::<String>())
+            .map(|name| name == "bfloat16")
+            .unwrap_or(false);
+
+        if is_bfloat16 {
+             if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<bf16>>>() { return Ok(NumpyArray::BFloat16(val)); }
+        }
+
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<f32>>>() { return Ok(NumpyArray::F32(val)); }
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<f64>>>() { return Ok(NumpyArray::F64(val)); }
+        if let Ok(val) = ob.extract::<Bound<'py, PyArrayDyn<Py<PyAny>>>>() { return Ok(NumpyArray::Py(val)); }
+
+        Err(PyTypeError::new_err("Could not convert to NumpyArray"))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for NumpyArray<'py> {
+    type Target = PyAny;
+    type Output = Bound<'py, PyAny>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, _py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        match self {
+            NumpyArray::I8(b) => Ok(b.into_any()),
+            NumpyArray::U8(b) => Ok(b.into_any()),
+            NumpyArray::I16(b) => Ok(b.into_any()),
+            NumpyArray::U16(b) => Ok(b.into_any()),
+            NumpyArray::I32(b) => Ok(b.into_any()),
+            NumpyArray::U32(b) => Ok(b.into_any()),
+            NumpyArray::I64(b) => Ok(b.into_any()),
+            NumpyArray::U64(b) => Ok(b.into_any()),
+            NumpyArray::BFloat16(b) => Ok(b.into_any()),
+            NumpyArray::F32(b) => Ok(b.into_any()),
+            NumpyArray::F64(b) => Ok(b.into_any()),
+            NumpyArray::Py(b) => Ok(b.into_any()),
+        }
+    }
 }
 
 impl<'py> NumpyArray<'py> {
@@ -32,6 +92,7 @@ impl<'py> NumpyArray<'py> {
             Self::U32(arr) => NdArray::U32(arr.to_owned_array()),
             Self::I64(arr) => NdArray::I64(arr.to_owned_array()),
             Self::U64(arr) => NdArray::U64(arr.to_owned_array()),
+            Self::BFloat16(arr) => NdArray::BFloat16(arr.to_owned_array()),
             Self::F32(arr) => NdArray::F32(arr.to_owned_array()),
             Self::F64(arr) => NdArray::F64(arr.to_owned_array()),
             Self::Py(arr) => NdArray::Py(
@@ -51,6 +112,7 @@ impl<'py> NumpyArray<'py> {
             NdArray::U32(arr) => Self::U32(arr.to_pyarray(py)),
             NdArray::I64(arr) => Self::I64(arr.to_pyarray(py)),
             NdArray::U64(arr) => Self::U64(arr.to_pyarray(py)),
+            NdArray::BFloat16(arr) => Self::BFloat16(arr.to_pyarray(py)),
             NdArray::F32(arr) => Self::F32(arr.to_pyarray(py)),
             NdArray::F64(arr) => Self::F64(arr.to_pyarray(py)),
             NdArray::Py(arr) => Self::Py(

--- a/src/daft-core/src/array/growable/logical_growable.rs
+++ b/src/daft-core/src/array/growable/logical_growable.rs
@@ -86,6 +86,7 @@ impl_logical_growable!(
 impl_logical_growable!(LogicalImageGrowable, ImageType);
 impl_logical_growable!(LogicalTensorGrowable, TensorType);
 impl_logical_growable!(LogicalMapGrowable, MapType);
+impl_logical_growable!(LogicalBFloat16Growable, BFloat16Type);
 pub type LogicalFileGrowable<'a, T> = LogicalGrowable<FileType<T>, <<<FileType<T> as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType as GrowableArray>::GrowableType<'a>>;
 
 impl<'a, T> LogicalFileGrowable<'a, T>

--- a/src/daft-core/src/array/growable/mod.rs
+++ b/src/daft-core/src/array/growable/mod.rs
@@ -209,6 +209,7 @@ impl_growable_array!(
 impl_growable_array!(ImageArray, logical_growable::LogicalImageGrowable<'a>);
 impl_growable_array!(TensorArray, logical_growable::LogicalTensorGrowable<'a>);
 impl_growable_array!(MapArray, map_growable::MapGrowable<'a>);
+impl_growable_array!(BFloat16Array, logical_growable::LogicalBFloat16Growable<'a>);
 impl<T> GrowableArray for FileArray<T>
 where
     T: DaftMediaType,

--- a/src/daft-core/src/array/ops/from_arrow.rs
+++ b/src/daft-core/src/array/ops/from_arrow.rs
@@ -539,6 +539,7 @@ impl_logical_from_arrow!(FixedShapeTensorType);
 impl_logical_from_arrow!(SparseTensorType);
 impl_logical_from_arrow!(FixedShapeSparseTensorType);
 impl_logical_from_arrow!(FixedShapeImageType);
+impl_logical_from_arrow!(BFloat16Type);
 impl<T> FromArrow for LogicalArray<FileType<T>>
 where
     T: DaftMediaType,

--- a/src/daft-core/src/array/ops/repr.rs
+++ b/src/daft-core/src/array/ops/repr.rs
@@ -12,7 +12,7 @@ use crate::{
         logical::{
             DateArray, DurationArray, EmbeddingArray, FixedShapeImageArray,
             FixedShapeSparseTensorArray, FixedShapeTensorArray, ImageArray, MapArray,
-            SparseTensorArray, TensorArray, TimeArray, TimestampArray,
+            SparseTensorArray, TensorArray, TimeArray, TimestampArray, BFloat16Array,
         },
     },
     file::DaftMediaType,
@@ -201,6 +201,16 @@ impl TimestampArray {
             },
         );
         Ok(res)
+    }
+}
+
+impl BFloat16Array {
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        let val = self.physical.get(idx);
+        match val {
+            None => Ok("None".to_string()),
+            Some(v) => Ok(format!("{}", v)),
+        }
     }
 }
 

--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -16,7 +16,7 @@ use crate::{
         logical::{
             DateArray, DurationArray, EmbeddingArray, FixedShapeImageArray,
             FixedShapeSparseTensorArray, FixedShapeTensorArray, ImageArray, MapArray,
-            SparseTensorArray, TensorArray, TimeArray, TimestampArray,
+            SparseTensorArray, TensorArray, TimeArray, TimestampArray, BFloat16Array,
         },
     },
     file::DaftMediaType,
@@ -736,6 +736,13 @@ impl FixedShapeSparseTensorArray {
 impl FixedShapeTensorArray {
     pub fn sort(&self, _descending: bool, _nulls_first: bool) -> DaftResult<Self> {
         todo!("impl sort for FixedShapeTensorArray")
+    }
+}
+
+impl BFloat16Array {
+    pub fn sort(&self, descending: bool, nulls_first: bool) -> DaftResult<Self> {
+        let new_array = self.physical.sort(descending, nulls_first)?;
+        Ok(Self::new(self.field.clone(), new_array))
     }
 }
 

--- a/src/daft-core/src/array/ops/take.rs
+++ b/src/daft-core/src/array/ops/take.rs
@@ -64,6 +64,7 @@ impl_logicalarray_take!(SparseTensorArray);
 impl_logicalarray_take!(FixedShapeSparseTensorArray);
 impl_logicalarray_take!(FixedShapeTensorArray);
 impl_logicalarray_take!(MapArray);
+impl_logicalarray_take!(BFloat16Array);
 impl<T> FileArray<T>
 where
     T: DaftMediaType,

--- a/src/daft-core/src/array/prelude.rs
+++ b/src/daft-core/src/array/prelude.rs
@@ -3,7 +3,7 @@ pub use super::{DataArray, FixedSizeListArray, ListArray, StructArray};
 pub use crate::datatypes::logical::{
     DateArray, DurationArray, EmbeddingArray, FixedShapeImageArray, FixedShapeSparseTensorArray,
     FixedShapeTensorArray, ImageArray, LogicalArray, MapArray, SparseTensorArray, TensorArray,
-    TimeArray, TimestampArray,
+    TimeArray, TimestampArray, BFloat16Array,
 };
 #[cfg(feature = "python")]
 pub use crate::datatypes::python::PythonArray;

--- a/src/daft-core/src/datatypes/logical.rs
+++ b/src/daft-core/src/datatypes/logical.rs
@@ -6,7 +6,7 @@ use common_error::DaftResult;
 use super::{
     DaftArrayType, DaftDataType, DataArray, DataType, DurationType, EmbeddingType,
     FixedShapeImageType, FixedShapeSparseTensorType, FixedShapeTensorType, FixedSizeListArray,
-    ImageType, MapType, SparseTensorType, TensorType, TimeType, TimestampType,
+    ImageType, MapType, SparseTensorType, TensorType, TimeType, TimestampType, BFloat16Type,
 };
 use crate::{
     array::{ListArray, StructArray},
@@ -275,6 +275,7 @@ pub type SparseTensorArray = LogicalArray<SparseTensorType>;
 pub type FixedShapeSparseTensorArray = LogicalArray<FixedShapeSparseTensorType>;
 pub type FixedShapeImageArray = LogicalArray<FixedShapeImageType>;
 pub type MapArray = LogicalArray<MapType>;
+pub type BFloat16Array = LogicalArray<BFloat16Type>;
 
 pub trait DaftImageryType: DaftLogicalType {}
 

--- a/src/daft-core/src/datatypes/matching.rs
+++ b/src/daft-core/src/datatypes/matching.rs
@@ -19,6 +19,7 @@ macro_rules! with_match_daft_types {
             DataType::Duration(_) => __with_ty__! { DurationType },
             DataType::Embedding(..) => __with_ty__! { EmbeddingType },
             DataType::Extension(_, _, _) => __with_ty__! { ExtensionType },
+            DataType::BFloat16 => __with_ty__! { BFloat16Type },
             DataType::FixedShapeImage(..) => __with_ty__! { FixedShapeImageType },
             DataType::FixedShapeSparseTensor(..) => __with_ty__! { FixedShapeSparseTensorType },
             DataType::FixedShapeTensor(..) => __with_ty__! { FixedShapeTensorType },

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -250,6 +250,7 @@ impl_daft_logical_data_array_datatype!(TimestampType, Unknown, Int64Type);
 impl_daft_logical_data_array_datatype!(DateType, Date, Int32Type);
 impl_daft_logical_data_array_datatype!(TimeType, Unknown, Int64Type);
 impl_daft_logical_data_array_datatype!(DurationType, Unknown, Int64Type);
+impl_daft_logical_data_array_datatype!(BFloat16Type, BFloat16, Float32Type);
 impl_daft_logical_data_array_datatype!(ImageType, Unknown, StructType);
 impl_daft_logical_data_array_datatype!(TensorType, Unknown, StructType);
 impl_daft_logical_data_array_datatype!(SparseTensorType, Unknown, StructType);

--- a/src/daft-core/src/datatypes/prelude.rs
+++ b/src/daft-core/src/datatypes/prelude.rs
@@ -20,7 +20,7 @@ pub use super::{
     DaftNumericType, DaftPhysicalType,
 };
 pub use crate::datatypes::{
-    DateType, Decimal128Type, DurationType, EmbeddingType, FixedShapeImageType,
+    BFloat16Type, DateType, Decimal128Type, DurationType, EmbeddingType, FixedShapeImageType,
     FixedShapeSparseTensorType, FixedShapeTensorType, ImageType, IntervalType, MapType,
     SparseTensorType, TensorType, TimeType, TimestampType, logical::DaftImageryType,
 };

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -203,6 +203,7 @@ impl_series_like_for_logical_array!(FixedShapeTensorArray);
 impl_series_like_for_logical_array!(SparseTensorArray);
 impl_series_like_for_logical_array!(FixedShapeSparseTensorArray);
 impl_series_like_for_logical_array!(MapArray);
+impl_series_like_for_logical_array!(BFloat16Array);
 
 impl<T> SeriesLike for ArrayWrapper<FileArray<T>>
 where

--- a/src/daft-core/src/series/from.rs
+++ b/src/daft-core/src/series/from.rs
@@ -36,6 +36,17 @@ impl Series {
             NdArray::U32(arr) => UInt32Array::from((name, arr.flatten().to_vec())).into_series(),
             NdArray::I64(arr) => Int64Array::from((name, arr.flatten().to_vec())).into_series(),
             NdArray::U64(arr) => UInt64Array::from((name, arr.flatten().to_vec())).into_series(),
+            NdArray::BFloat16(arr) => {
+                // BFloat16 is a logical type whose physical storage is Float32.
+                // Upsample here to keep the underlying Series representation consistent with
+                // `DataType::BFloat16.to_physical() == DataType::Float32`.
+                let vec_f32: Vec<f32> = arr
+                    .flatten()
+                    .iter()
+                    .map(|x| (*x).to_f32())
+                    .collect();
+                Float32Array::from((name, vec_f32)).into_series()
+            }
             NdArray::F32(arr) => Float32Array::from((name, arr.flatten().to_vec())).into_series(),
             NdArray::F64(arr) => Float64Array::from((name, arr.flatten().to_vec())).into_series(),
             #[cfg(feature = "python")]

--- a/src/daft-core/src/series/serdes.rs
+++ b/src/daft-core/src/series/serdes.rs
@@ -150,7 +150,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         *size,
                     )
                     .into_series()),
-                    DataType::Extension(..) => {
+                    DataType::Extension(..) | DataType::BFloat16 => {
                         let physical = map.next_value::<Series>()?;
                         let physical = physical.to_arrow2();
                         let ext_array =

--- a/src/daft-recordbatch/src/repr_html.rs
+++ b/src/daft-recordbatch/src/repr_html.rs
@@ -109,7 +109,7 @@ pub fn html_value(s: &Series, idx: usize, truncate: bool) -> String {
             let arr = s.map().unwrap();
             arr.html_value(idx, truncate)
         }
-        DataType::Extension(_, _, _) => {
+        DataType::Extension(_, _, _) | DataType::BFloat16 => {
             let arr = s.downcast::<ExtensionArray>().unwrap();
             arr.html_value(idx, truncate)
         }

--- a/src/daft-schema/src/python/datatype.rs
+++ b/src/daft-schema/src/python/datatype.rs
@@ -145,6 +145,11 @@ impl PyDataType {
     }
 
     #[staticmethod]
+    pub fn bfloat16() -> PyResult<Self> {
+        Ok(DataType::BFloat16.into())
+    }
+
+    #[staticmethod]
     pub fn float32() -> PyResult<Self> {
         Ok(DataType::Float32.into())
     }

--- a/src/daft-stats/src/column_stats/mod.rs
+++ b/src/daft-stats/src/column_stats/mod.rs
@@ -88,7 +88,7 @@ impl ColumnRangeStatistics {
             // Numeric types
             DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 |
             DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 |
-            DataType::Float32 | DataType::Float64 | DataType::Decimal128(..) | DataType::Boolean |
+            DataType::BFloat16 | DataType::Float32 | DataType::Float64 | DataType::Decimal128(..) | DataType::Boolean |
 
             // String types
             DataType::Utf8 | DataType::Binary | DataType::FixedSizeBinary(..) |

--- a/tests/io/test_bfloat16_parquet_roundtrip.py
+++ b/tests/io/test_bfloat16_parquet_roundtrip.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+import daft
+from daft import DataType, Series
+
+PYARROW_GE_8_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (8, 0, 0)
+
+
+@pytest.mark.skipif(
+    not PYARROW_GE_8_0_0,
+    reason="PyArrow <8.0.0 has limited Parquet coverage for complex types",
+)
+def test_roundtrip_bfloat16_tensor_parquet(tmp_path) -> None:
+    """Parquet round-trip for a Tensor[BFloat16] column.
+
+    This verifies that a tensor column with logical dtype Tensor[BFloat16] can be
+    written to and read back from Parquet via the Arrow extension type
+    "daft.bfloat16", while using Float32 as the physical storage type.
+    """
+
+    torch = pytest.importorskip("torch")
+    if not hasattr(torch, "bfloat16"):
+        pytest.skip("torch.bfloat16 is not available")
+
+    # Construct a small column of BF16 tensors, including a None value.
+    tensor_data = [torch.randn(2, 2, dtype=torch.bfloat16), None]
+
+    s = Series.from_pylist(
+        tensor_data,
+        dtype=DataType.tensor(DataType.bfloat16()),
+        pyobj="allow",
+    )
+
+    expected_dtype = DataType.tensor(DataType.bfloat16())
+
+    df_before = daft.from_pydict({"tensor_col": s})
+    assert df_before.schema()["tensor_col"].dtype == expected_dtype
+
+    # Duplicate rows to exercise a slightly larger round-trip.
+    df_before = df_before.concat(df_before)
+
+    df_before.write_parquet(str(tmp_path))
+    df_roundtrip = daft.read_parquet(str(tmp_path))
+
+    # Logical dtype should be preserved as Tensor[BFloat16].
+    assert df_roundtrip.schema()["tensor_col"].dtype == expected_dtype
+
+    out_after = df_roundtrip.to_pydict()["tensor_col"]
+    assert len(out_after) == 4
+
+    # Each non-null element should be materializable as a NumPy array that can
+    # be safely upcast to float32, reflecting the logical BF16 + physical F32
+    # storage strategy.
+    for arr in out_after:
+        if arr is None:
+            continue
+        
+        if isinstance(arr, torch.Tensor):
+            assert arr.dtype == torch.bfloat16
+            arr = arr.float().numpy()
+
+        assert isinstance(arr, np.ndarray)
+        np.asarray(arr, dtype=np.float32)

--- a/tests/test_datatype_inference.py
+++ b/tests/test_datatype_inference.py
@@ -234,6 +234,19 @@ def test_infer_from_jaxtyping(dtype_class, expected_dtype, shape_spec, expected_
     assert actual_datatype == expected_datatype
 
 
+def test_infer_from_jaxtyping_bfloat16():
+    if not hasattr(jaxtyping, "BFloat16"):
+        pytest.skip("jaxtyping.BFloat16 is not available")
+
+    # dtype-only, no shape
+    dtype_only = dt._infer_from_jaxtyping(jaxtyping.BFloat16[torch.Tensor, "..."])
+    assert dtype_only == dt.tensor(dt.bfloat16())
+
+    # fixed shape
+    fixed_shape = dt._infer_from_jaxtyping(jaxtyping.BFloat16[torch.Tensor, "3 4"])
+    assert fixed_shape == dt.tensor(dt.bfloat16(), shape=(3, 4))
+
+
 @pytest.mark.parametrize(
     "user_provided_object, expected_datatype",
     [

--- a/tests/udf/test_bfloat16_e2e.py
+++ b/tests/udf/test_bfloat16_e2e.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+import numpy as np
+import pytest
+
+import daft
+from daft import DataType, col
+
+
+class BFloat16StructOut(TypedDict):
+    len: int
+    # The runtime value will be a tensor/ndarray; we keep the annotation loose to
+    # avoid importing optional torch at module import time.
+    bfloat16: object
+
+
+def test_row_wise_udf_struct_with_bfloat16_tensor() -> None:
+    """Row-wise UDF that returns a Struct containing a BFloat16 tensor.
+
+    This reproduces the scenario of issue #5293, but with an explicit struct
+    return dtype so that the resulting column has logical type Struct[len: Int64,
+    bfloat16: Tensor[BFloat16]] instead of falling back to Python.
+    """
+
+    torch = pytest.importorskip("torch")
+
+    if not hasattr(torch, "bfloat16"):
+        pytest.skip("torch.bfloat16 is not available")
+
+    @daft.func(
+        return_dtype=DataType.struct(
+            {
+                "len": DataType.int64(),
+                "bfloat16": DataType.tensor(DataType.bfloat16()),
+            }
+        )
+    )
+    def bf16_struct_udf(x: "torch.Tensor") -> BFloat16StructOut:  # type: ignore[name-defined]
+        assert x.dtype == torch.bfloat16
+        return {"len": int(x.shape[0]), "bfloat16": x}
+
+    df = daft.from_pydict({"x": [torch.randn(4, dtype=torch.bfloat16)]})
+
+    df_struct = df.select(bf16_struct_udf(col("x")).alias("s"))
+
+    # The struct column should have the expected logical dtype.
+    expected_struct_dtype = DataType.struct(
+        {"len": DataType.int64(), "bfloat16": DataType.tensor(DataType.bfloat16())}
+    )
+    assert df_struct.schema()["s"].dtype == expected_struct_dtype
+
+    # struct.get("bfloat16") should yield a Tensor[BFloat16] column, not Python.
+    df_extracted = df_struct.select(
+        col("s").get("len").alias("len"),
+        col("s").get("bfloat16").alias("bfloat16"),
+    )
+
+    assert df_extracted.schema()["len"].dtype == DataType.int64()
+    assert df_extracted.schema()["bfloat16"].dtype == DataType.tensor(DataType.bfloat16())
+
+    out = df_extracted.to_pydict()
+    assert out["len"] == [4]
+
+    arr = out["bfloat16"][0]
+    assert isinstance(arr, (np.ndarray, torch.Tensor))
+    if isinstance(arr, torch.Tensor):
+        assert arr.dtype == torch.bfloat16
+        # Torch BFloat16 cannot be directly converted to numpy; cast to float32 first.
+        arr = arr.float()
+    assert arr.shape == (4,)
+    # Values should be safely representable as float32 (BF16 -> F32 upcast).
+    np.asarray(arr, dtype=np.float32)
+
+
+def test_row_wise_udf_bfloat16_with_jaxtyping() -> None:
+    """Row-wise UDF using jaxtyping.BFloat16 annotations.
+
+    This exercises the end-to-end path where a BF16 tensor argument is annotated
+    with jaxtyping.BFloat16[...] and the UDF explicitly declares a
+    Tensor[BFloat16] return dtype.
+    """
+
+    jaxtyping_mod = pytest.importorskip("jaxtyping")
+    if not hasattr(jaxtyping_mod, "BFloat16"):
+        pytest.skip("jaxtyping.BFloat16 is not available")
+
+    from jaxtyping import BFloat16, jaxtyped  # type: ignore[import]
+
+    torch = pytest.importorskip("torch")
+    if not hasattr(torch, "bfloat16"):
+        pytest.skip("torch.bfloat16 is not available")
+
+    @jaxtyped
+    @daft.func(return_dtype=DataType.tensor(DataType.bfloat16()))
+    def my_udf_jax(x: BFloat16[torch.Tensor, "batch dim"]) -> torch.Tensor:
+        return x
+
+    df = daft.from_pydict({"x": [torch.randn(2, dtype=torch.bfloat16)]})
+    df_out = df.select(my_udf_jax(col("x")).alias("x_bf16"))
+
+    assert df_out.schema()["x_bf16"].dtype == DataType.tensor(DataType.bfloat16())
+
+    out_arr = df_out.to_pydict()["x_bf16"][0]
+    assert isinstance(out_arr, (np.ndarray, torch.Tensor))
+    if isinstance(out_arr, torch.Tensor):
+        assert out_arr.dtype == torch.bfloat16
+        out_arr = out_arr.float()
+    assert out_arr.shape == (2,)
+    # Again, BF16 values should be convertible to float32 without issues.
+    np.asarray(out_arr, dtype=np.float32)


### PR DESCRIPTION
This commit introduces native support for the BFloat16 data type in Daft, addressing performance bottlenecks associated with using Python objects for ML tensors.

Key features:
1. **Logical BFloat16 Type**: Adds `DataType.bfloat16()` which behaves logically as a 16-bit brain floating point number.
2. **Float32 Physical Storage**: Uses 32-bit floats for underlying storage. This ensures zero precision loss (as BF16 is a truncated FP32) while leveraging existing vectorized Float32 kernels for high performance.
3. **Seamless Interop**:
   - Supports ingestion from `torch.bfloat16` tensors and `ml_dtypes.bfloat16` numpy arrays.
   - `to_pylist()` reconstructs `torch.bfloat16` tensors (if torch is available) or returns float32 numpy arrays, preserving type fidelity.
   - Integrates with `jaxtyping` for type inference.
4. **Arrow Compatibility**: Implements Arrow Extension Type (`daft.bfloat16`) for serialization and interoperability.

This implementation eliminates the overhead of `DataType.Python` for BF16 data, significantly improving memory usage and processing speed for ML workloads.

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
