### PR TITLE
feat(io)!: add filename provider support for parquet, csv, json, and upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,6 +2926,7 @@ dependencies = [
  "daft-dsl",
  "daft-io",
  "futures",
+ "pyo3",
  "serde",
  "tokio",
  "typetag",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ python = [
   "daft-functions-list/python",
   "daft-functions-utf8/python",
   "daft-functions/python",
+  "daft-functions-uri/python",
   "daft-image/python",
   "daft-io/python",
   "daft-json/python",

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1915,6 +1915,8 @@ class LogicalPlanBuilder:
         partition_cols: list[PyExpr] | None = None,
         compression: str | None = None,
         io_config: IOConfig | None = None,
+        filename_provider: Any | None = None,
+        write_uuid: str | None = None,
     ) -> LogicalPlanBuilder: ...
     def iceberg_write(
         self,

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     import ray
     import torch
 
-    from daft.io import DataSink
+    from daft.io import DataSink, FilenameProvider
     from daft.io.catalog import DataCatalogTable
     from daft.io.sink import WriteResultType
     from daft.unity_catalog import UnityCatalogTable
@@ -767,10 +767,11 @@ class DataFrame:
         write_mode: Literal["append", "overwrite", "overwrite-partitions"] = "append",
         partition_cols: list[ColumnInputType] | None = None,
         io_config: IOConfig | None = None,
+        filename_provider: "FilenameProvider | None" = None,
     ) -> "DataFrame":
         """Writes the DataFrame as parquet files, returning a new DataFrame with paths to the files that were written.
 
-        Files will be written to `<root_dir>/*` with randomly generated UUIDs as the file names.
+        Files will be written to `<root_dir>/*` using a configurable filename pattern.
 
         Args:
             root_dir (str): root file path to write parquet files to.
@@ -807,6 +808,15 @@ class DataFrame:
         if partition_cols is not None:
             cols = self.__column_input_to_expression(tuple(partition_cols))
 
+        # Derive a write UUID and default filename provider.
+        import uuid
+
+        from daft.io.filename_provider import _DefaultFilenameProvider
+
+        write_uuid = uuid.uuid4().hex
+        if filename_provider is None:
+            filename_provider = _DefaultFilenameProvider()
+
         builder = self._builder.write_tabular(
             root_dir=root_dir,
             partition_cols=cols,
@@ -814,6 +824,8 @@ class DataFrame:
             file_format=FileFormat.Parquet,
             compression=compression,
             io_config=io_config,
+            filename_provider=filename_provider,
+            write_uuid=write_uuid,
         )
         # Block and write, then retrieve data
         write_df = DataFrame(builder)
@@ -833,10 +845,11 @@ class DataFrame:
         write_mode: Literal["append", "overwrite", "overwrite-partitions"] = "append",
         partition_cols: list[ColumnInputType] | None = None,
         io_config: IOConfig | None = None,
+        filename_provider: "FilenameProvider | None" = None,
     ) -> "DataFrame":
         """Writes the DataFrame as CSV files, returning a new DataFrame with paths to the files that were written.
 
-        Files will be written to `<root_dir>/*` with randomly generated UUIDs as the file names.
+        Files will be written to `<root_dir>/*` using a configurable filename pattern.
 
         Args:
             root_dir (str): root file path to write parquet files to.
@@ -873,12 +886,23 @@ class DataFrame:
         if partition_cols is not None:
             cols = self.__column_input_to_expression(tuple(partition_cols))
 
+        # Derive a write UUID and default filename provider.
+        import uuid
+
+        from daft.io.filename_provider import _DefaultFilenameProvider
+
+        write_uuid = uuid.uuid4().hex
+        if filename_provider is None:
+            filename_provider = _DefaultFilenameProvider()
+
         builder = self._builder.write_tabular(
             root_dir=root_dir,
             partition_cols=cols,
             write_mode=WriteMode.from_str(write_mode),
             file_format=FileFormat.Csv,
             io_config=io_config,
+            filename_provider=filename_provider,
+            write_uuid=write_uuid,
         )
 
         # Block and write, then retrieve data
@@ -899,10 +923,11 @@ class DataFrame:
         write_mode: Literal["append", "overwrite", "overwrite-partitions"] = "append",
         partition_cols: list[ColumnInputType] | None = None,
         io_config: IOConfig | None = None,
+        filename_provider: "FilenameProvider | None" = None,
     ) -> "DataFrame":
         """Writes the DataFrame as JSON files, returning a new DataFrame with paths to the files that were written.
 
-        Files will be written to `<root_dir>/*` with randomly generated UUIDs as the file names.
+        Files will be written to `<root_dir>/*` using a configurable filename pattern.
 
         Args:
             root_dir (str): root file path to write JSON files to.
@@ -937,12 +962,23 @@ class DataFrame:
         if partition_cols is not None:
             cols = self.__column_input_to_expression(tuple(partition_cols))
 
+        # Derive a write UUID and default filename provider.
+        import uuid
+
+        from daft.io.filename_provider import _DefaultFilenameProvider
+
+        write_uuid = uuid.uuid4().hex
+        if filename_provider is None:
+            filename_provider = _DefaultFilenameProvider()
+
         builder = self._builder.write_tabular(
             root_dir=root_dir,
             partition_cols=cols,
             write_mode=WriteMode.from_str(write_mode),
             file_format=FileFormat.Json,
             io_config=io_config,
+            filename_provider=filename_provider,
+            write_uuid=write_uuid,
         )
         # Block and write, then retrieve data
         write_df = DataFrame(builder)

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -30,7 +30,7 @@ from daft.logical.schema import Field, Schema
 
 if TYPE_CHECKING:
     from daft.dependencies import pc
-    from daft.io import IOConfig
+    from daft.io import FilenameProvider, IOConfig
     from daft.series import Series
     from daft.udf.legacy import BoundUDFArgs, InitArgsType, UninitializedUdf
     from daft.window import Window
@@ -1469,6 +1469,8 @@ class Expression:
         max_connections: int = 32,
         on_error: Literal["raise", "null"] = "raise",
         io_config: IOConfig | None = None,
+        filename_provider: FilenameProvider | None = None,
+        filename_provider_row: Expression | None = None,
     ) -> Expression:
         """Uploads a column of binary data to the provided location(s) (also supports S3, local etc).
 
@@ -1477,7 +1479,15 @@ class Expression:
         """
         from daft.functions import upload
 
-        return upload(self, location, max_connections, on_error, io_config)
+        return upload(
+            self,
+            location,
+            max_connections=max_connections,
+            on_error=on_error,
+            io_config=io_config,
+            filename_provider=filename_provider,
+            filename_provider_row=filename_provider_row,
+        )
 
     def date(self) -> Expression:
         """Retrieves the date for a datetime column."""

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -25,6 +25,7 @@ from daft.io.mcap._mcap import read_mcap
 from daft.io._range import _range
 from daft.io.catalog import DataCatalogTable, DataCatalogType
 from daft.io.file_path import from_glob_path
+from daft.io.filename_provider import FilenameProvider
 from daft.io.sink import DataSink
 from daft.io.source import DataSource, DataSourceTask
 from daft.io.av import read_video_frames
@@ -36,6 +37,7 @@ __all__ = [
     "DataSink",
     "DataSource",
     "DataSourceTask",
+    "FilenameProvider",
     "GCSConfig",
     "HTTPConfig",
     "HuggingFaceConfig",

--- a/daft/io/filename_provider.py
+++ b/daft/io/filename_provider.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class FilenameProvider(ABC):
+    """Strategy interface for generating filenames during writes.
+
+    Implement this interface to customize how Daft names output files when writing
+    tabular data or uploading via :func:`daft.functions.upload`.
+
+    Implement :meth:`get_filename_for_block` when writing block-oriented outputs
+    (for example, :meth:`daft.DataFrame.write_parquet` and
+    :meth:`daft.DataFrame.write_csv`). Implement :meth:`get_filename_for_row`
+    when generating per-row filenames (for example,
+    :func:`daft.functions.upload`).
+
+    Filenames **must** be deterministic and unique for a given combination of
+    ``write_uuid`` and index parameters.
+    """
+
+    @abstractmethod
+    def get_filename_for_block(
+        self,
+        write_uuid: str,
+        task_index: int,
+        block_index: int,
+        file_idx: int,
+        ext: str,
+    ) -> str:
+        """Generate a filename for a block-oriented output file.
+
+        Args:
+            write_uuid: Identifier for the logical write operation. A single call
+                to :meth:`daft.DataFrame.write_parquet`,
+                :meth:`daft.DataFrame.write_csv`, or
+                :func:`daft.functions.upload` shares the same ``write_uuid``.
+            task_index: Index of the write task within the job.
+            block_index: Index of the block *within* the task.
+            file_idx: Monotonically increasing index for files within the task.
+            ext: Suggested file extension (for example, ``"parquet"`` or
+                ``"csv"``).
+
+        Returns:
+            The basename of the output file, **without** any directory
+            components.
+        """
+
+    @abstractmethod
+    def get_filename_for_row(
+        self,
+        row: dict[str, Any],
+        write_uuid: str,
+        task_index: int,
+        block_index: int,
+        row_index: int,
+        ext: str,
+    ) -> str:
+        """Generate a filename for a single-row output.
+
+        Args:
+            row: A mapping representing the row being written. Implementations
+                should treat this as read-only.
+            write_uuid: Identifier for the logical write operation.
+            task_index: Index of the write task within the job.
+            block_index: Index of the block *within* the task.
+            row_index: Index of the row *within* the block.
+            ext: Suggested file extension. For URL uploads this may be an empty
+                string when Daft does not know the desired extension.
+
+        Returns:
+            The basename of the output file, **without** any directory
+            components.
+        """
+
+
+class _DefaultFilenameProvider(FilenameProvider):
+    """Default filename provider used by Daft when none is supplied.
+
+    The pattern is::
+
+        <write_uuid>_<task_index>_<block_index>_<row_or_file_index>.<ext>
+
+    where indices are zero-padded to six digits. This mirrors Ray Data's
+    default behaviour and greatly reduces the chance of collisions when
+    writing concurrently.
+    """
+
+    def get_filename_for_block(
+        self,
+        write_uuid: str,
+        task_index: int,
+        block_index: int,
+        file_idx: int,
+        ext: str,
+    ) -> str:  # pragma: no cover - exercised via higher-level IO tests
+        base = f"{write_uuid}_{task_index:06d}_{block_index:06d}_{file_idx:06d}"
+        return f"{base}.{ext}" if ext else base
+
+    def get_filename_for_row(
+        self,
+        row: dict[str, Any],
+        write_uuid: str,
+        task_index: int,
+        block_index: int,
+        row_index: int,
+        ext: str,
+    ) -> str:  # pragma: no cover - exercised via higher-level IO tests
+        base = f"{write_uuid}_{task_index:06d}_{block_index:06d}_{row_index:06d}"
+        return f"{base}.{ext}" if ext else base

--- a/daft/logical/builder.py
+++ b/daft/logical/builder.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
     from pyiceberg.table import Table as IcebergTable
 
-    from daft.io import DataSink
+    from daft.io import DataSink, FilenameProvider
     from daft.runners.partitioning import PartitionCacheEntry
 
 
@@ -335,10 +335,19 @@ class LogicalPlanBuilder:
         io_config: IOConfig,
         partition_cols: list[Expression] | None = None,
         compression: str | None = None,
+        filename_provider: FilenameProvider | None = None,
+        write_uuid: str | None = None,
     ) -> LogicalPlanBuilder:
         part_cols_pyexprs = [expr._expr for expr in partition_cols] if partition_cols is not None else None
         builder = self._builder.table_write(
-            str(root_dir), write_mode, file_format, part_cols_pyexprs, compression, io_config
+            str(root_dir),
+            write_mode,
+            file_format,
+            part_cols_pyexprs,
+            compression,
+            io_config,
+            filename_provider,
+            write_uuid,
         )
         return LogicalPlanBuilder(builder)
 

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -108,6 +108,74 @@ Daft offers a variety of approaches to creating a DataFrame from reading various
     options:
         heading_level: 3
 
+## FilenameProvider
+
+Daft allows customizing filenames generated during writes via [`daft.io.FilenameProvider`][daft.io.FilenameProvider].
+
+The `filename_provider` argument can be used in the following scenarios:
+
+- `DataFrame.write_parquet(..., filename_provider=...)`
+- `DataFrame.write_csv(..., filename_provider=...)`
+- `daft.functions.url.upload(..., filename_provider=...)`
+
+`FilenameProvider` receives a `write_uuid` at the start of a logical write operation, and all files generated in that operation share this UUID. Depending on the write mode, Daft calls:
+
+- `get_filename_for_block(write_uuid, task_index, block_index, file_idx, ext)`: For block-based writes, such as `write_parquet` / `write_csv`.
+- `get_filename_for_row(row, write_uuid, task_index, block_index, row_index, ext)`: For row-based writes, such as `functions.url.upload` when uploading to a single directory.
+
+Daft's built-in default implementation [`_DefaultFilenameProvider`][daft.io.filename_provider._DefaultFilenameProvider] uses the following pattern to generate filenames:
+
+```text
+<write_uuid>_<task_index>_<block_index>_<row_or_file_index>.<ext>
+```
+
+### Example: Custom Parquet Filenames
+
+```python
+import daft
+from daft.io import FilenameProvider
+
+
+class LabelledParquetProvider(FilenameProvider):
+    def get_filename_for_block(self, write_uuid, task_index, block_index, file_idx, ext):
+        return f"part-{task_index}-{block_index}-{file_idx}.{ext}"
+
+    def get_filename_for_row(self, row, write_uuid, task_index, block_index, row_index, ext):
+        # Not used for block-based writes; can raise an error
+        raise NotImplementedError
+
+
+df = daft.from_pydict({"x": [1, 2, 3]})
+# Generates filenames like "part-0-0-0.parquet"
+df.write_parquet("output_dir", filename_provider=LabelledParquetProvider())
+```
+
+### Example: Custom Filenames for Uploads
+
+```python
+import os
+
+import daft
+from daft.io import FilenameProvider
+
+
+class ImageUploadProvider(FilenameProvider):
+    def get_filename_for_block(self, *args, **kwargs):  # pragma: no cover - unused
+        raise NotImplementedError
+
+    def get_filename_for_row(self, row, write_uuid, task_index, block_index, row_index, ext):
+        return f"image-{row_index}.bin"
+
+
+df = daft.from_pydict({"bytes": [b"a", b"b", b"c"]})
+folder = "./uploads"
+
+# Resulting local paths will look like "uploads/image-0.bin", "uploads/image-1.bin", etc.
+df = df.with_column("path", df["bytes"].upload(folder, filename_provider=ImageUploadProvider()))
+result = df.collect()
+print(result.to_pydict()["path"])
+```
+
 ## User-Defined
 
 Daft supports diverse input sources and output sinks, this section covers lower-level APIs which we are evolving for more advanced usage.

--- a/src/daft-dsl/src/functions/python/runtime_py_object.rs
+++ b/src/daft-dsl/src/functions/python/runtime_py_object.rs
@@ -2,8 +2,10 @@
 
 use std::sync::Arc;
 
+use common_error::{DaftError, DaftResult};
 #[cfg(feature = "python")]
 use common_py_serde::PyObjectWrapper;
+use daft_core::lit::{FromLiteral, Literal};
 use serde::{Deserialize, Serialize};
 
 /// A wrapper around PyObject that is safe to use even when the Python feature flag isn't turned on
@@ -41,6 +43,30 @@ impl RuntimePyObject {
     #[cfg(feature = "python")]
     pub fn unwrap(self) -> Arc<pyo3::Py<pyo3::PyAny>> {
         self.obj.0
+    }
+}
+
+impl FromLiteral for RuntimePyObject {
+    fn try_from_literal(lit: &Literal) -> DaftResult<Self> {
+        #[cfg(feature = "python")]
+        {
+            if let Literal::Python(py_obj) = lit {
+                // Clone the underlying Arc<Py<PyAny>> and wrap it in a RuntimePyObject
+                return Ok(Self::new(py_obj.0.clone()));
+            }
+
+            Err(DaftError::TypeError(format!(
+                "Expected Python literal for RuntimePyObject, received: {lit}"
+            )))
+        }
+
+        #[cfg(not(feature = "python"))]
+        {
+            let _ = lit;
+            // When Python is disabled, we still need to produce a value, but it will never
+            // actually be used because no Python execution can occur.
+            Ok(Self {})
+        }
     }
 }
 

--- a/src/daft-functions-uri/Cargo.toml
+++ b/src/daft-functions-uri/Cargo.toml
@@ -7,11 +7,18 @@ daft-core = {path = "../daft-core", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-io = {path = "../daft-io", default-features = false}
 futures = {workspace = true}
+pyo3 = {workspace = true, optional = true}
 serde = {workspace = true}
 tokio = {workspace = true}
 typetag = {workspace = true}
 url = {workspace = true}
 uuid = {workspace = true}
+
+[features]
+python = [
+  "dep:pyo3",
+  "daft-dsl/python"
+]
 
 [lints]
 workspace = true

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -196,7 +196,7 @@ impl ConcreteTreeNode for Box<dyn PipelineNode> {
 /// It generates a plan_id, and node ids for each plan.
 pub struct RuntimeContext {
     index_counter: std::cell::RefCell<usize>,
-    context: HashMap<String, String>,
+    pub context: HashMap<String, String>,
 }
 
 impl RuntimeContext {
@@ -209,6 +209,10 @@ impl RuntimeContext {
             index_counter: std::cell::RefCell::new(0),
             context,
         }
+    }
+
+    pub fn get_context_value(&self, key: &str) -> Option<&String> {
+        self.context.get(key)
     }
 
     pub fn next_id(&self) -> usize {
@@ -1330,11 +1334,15 @@ fn physical_plan_to_pipeline(
                 (FileFormat::Json, false) => WriteFormat::Json,
                 (_, _) => panic!("Unsupported file format"),
             };
+            let partition_idx = ctx
+                .get_context_value("task_id")
+                .and_then(|s| s.parse::<usize>().ok());
             let write_sink = WriteSink::new(
                 write_format,
                 writer_factory,
                 file_info.partition_cols.clone(),
                 file_schema.clone(),
+                partition_idx,
             );
             BlockingSinkNode::new(
                 Arc::new(write_sink),
@@ -1406,11 +1414,15 @@ fn physical_plan_to_pipeline(
             };
             let writer_factory =
                 daft_writers::make_catalog_writer_factory(catalog_type, &partition_by, cfg);
+            let partition_idx = ctx
+                .get_context_value("task_id")
+                .and_then(|s| s.parse::<usize>().ok());
             let write_sink = WriteSink::new(
                 write_format,
                 writer_factory,
                 partition_by,
                 file_schema.clone(),
+                partition_idx,
             );
             BlockingSinkNode::new(
                 Arc::new(write_sink),
@@ -1433,11 +1445,15 @@ fn physical_plan_to_pipeline(
         }) => {
             let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let writer_factory = daft_writers::make_lance_writer_factory(lance_info.clone());
+            let partition_idx = ctx
+                .get_context_value("task_id")
+                .and_then(|s| s.parse::<usize>().ok());
             let write_sink = WriteSink::new(
                 WriteFormat::Lance,
                 writer_factory,
                 None,
                 file_schema.clone(),
+                partition_idx,
             );
             BlockingSinkNode::new(
                 Arc::new(write_sink),
@@ -1460,11 +1476,15 @@ fn physical_plan_to_pipeline(
             let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             let writer_factory =
                 daft_writers::make_data_sink_writer_factory(data_sink_info.clone());
+            let partition_idx = ctx
+                .get_context_value("task_id")
+                .and_then(|s| s.parse::<usize>().ok());
             let write_sink = WriteSink::new(
                 WriteFormat::DataSink(data_sink_info.name.clone()),
                 writer_factory,
                 None,
                 file_schema.clone(),
+                partition_idx,
             );
             BlockingSinkNode::new(
                 Arc::new(write_sink),

--- a/src/daft-local-execution/src/sinks/write.rs
+++ b/src/daft-local-execution/src/sinks/write.rs
@@ -119,6 +119,7 @@ pub(crate) struct WriteSink {
     writer_factory: Arc<dyn WriterFactory<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
     partition_by: Option<Vec<BoundExpr>>,
     file_schema: SchemaRef,
+    partition_idx: Option<usize>,
 }
 
 impl WriteSink {
@@ -129,12 +130,14 @@ impl WriteSink {
         >,
         partition_by: Option<Vec<BoundExpr>>,
         file_schema: SchemaRef,
+        partition_idx: Option<usize>,
     ) -> Self {
         Self {
             write_format,
             writer_factory,
             partition_by,
             file_schema,
+            partition_idx,
         }
     }
 }
@@ -217,7 +220,9 @@ impl BlockingSink for WriteSink {
     }
 
     fn make_state(&self) -> DaftResult<Self::State> {
-        let writer = self.writer_factory.create_writer(0, None)?;
+        let writer = self
+            .writer_factory
+            .create_writer(self.partition_idx.unwrap_or(0), None)?;
         Ok(WriteState::new(writer))
     }
 

--- a/src/daft-logical-plan/src/builder/mod.rs
+++ b/src/daft-logical-plan/src/builder/mod.rs
@@ -29,6 +29,7 @@ use {
     crate::sink_info::{CatalogInfo, IcebergCatalogInfo},
     common_daft_config::PyDaftPlanningConfig,
     common_io_config::python::IOConfig as PyIOConfig,
+    common_py_serde::PyObjectWrapper,
     daft_dsl::python::PyExpr,
     // daft_scan::python::pylib::ScanOperatorHandle,
     daft_schema::python::schema::PySchema,
@@ -694,6 +695,7 @@ impl LogicalPlanBuilder {
         Ok(self.with_new_plan(logical_plan))
     }
 
+    #[cfg(not(feature = "python"))]
     pub fn table_write(
         &self,
         root_dir: &str,
@@ -716,6 +718,42 @@ impl LogicalPlanBuilder {
             partition_cols,
             compression,
             io_config,
+            None,
+        ));
+
+        let logical_plan: LogicalPlan =
+            ops::Sink::try_new(self.plan.clone(), sink_info.into())?.into();
+        Ok(self.with_new_plan(logical_plan))
+    }
+
+    #[cfg(feature = "python")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn table_write(
+        &self,
+        root_dir: &str,
+        write_mode: WriteMode,
+        file_format: FileFormat,
+        partition_cols: Option<Vec<ExprRef>>,
+        compression: Option<String>,
+        io_config: Option<IOConfig>,
+        filename_provider: Option<PyObjectWrapper>,
+        write_uuid: Option<String>,
+    ) -> DaftResult<Self> {
+        let expr_resolver = ExprResolver::default();
+
+        let partition_cols = partition_cols
+            .map(|cols| expr_resolver.resolve(cols, self.plan.clone()))
+            .transpose()?;
+
+        let sink_info = SinkInfo::OutputFileInfo(OutputFileInfo::new(
+            root_dir.into(),
+            write_mode,
+            file_format,
+            partition_cols,
+            compression,
+            io_config,
+            filename_provider,
+            write_uuid,
         ));
 
         let logical_plan: LogicalPlan =
@@ -1355,13 +1393,16 @@ impl PyLogicalPlanBuilder {
             .into())
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (
         root_dir,
         write_mode,
         file_format,
         partition_cols=None,
         compression=None,
-        io_config=None
+        io_config=None,
+        filename_provider=None,
+        write_uuid=None
     ))]
     pub fn table_write(
         &self,
@@ -1371,6 +1412,8 @@ impl PyLogicalPlanBuilder {
         partition_cols: Option<Vec<PyExpr>>,
         compression: Option<String>,
         io_config: Option<common_io_config::python::IOConfig>,
+        filename_provider: Option<Py<PyAny>>,
+        write_uuid: Option<String>,
     ) -> PyResult<Self> {
         Ok(self
             .builder
@@ -1381,6 +1424,8 @@ impl PyLogicalPlanBuilder {
                 partition_cols.map(pyexprs_to_exprs),
                 compression,
                 io_config.map(|cfg| cfg.config),
+                filename_provider.map(|obj| PyObjectWrapper::from(Arc::new(obj))),
+                write_uuid,
             )?
             .into())
     }

--- a/src/daft-writers/src/csv_writer.rs
+++ b/src/daft-writers/src/csv_writer.rs
@@ -54,11 +54,15 @@ use daft_io::{IOConfig, SourceType, parse_url, utils::ObjectPath};
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 
+#[cfg(not(feature = "python"))]
+use crate::utils::build_filename;
+#[cfg(feature = "python")]
+use crate::utils::build_filename_with_provider;
 use crate::{
     AsyncFileWriter,
     batch_file_writer::BatchFileWriter,
     storage_backend::{FileStorageBackend, ObjectStorageBackend, StorageBackend},
-    utils::build_filename,
+    utils::FilenameProvider,
 };
 
 pub(crate) fn native_csv_writer_supported(file_schema: &SchemaRef) -> DaftResult<bool> {
@@ -88,9 +92,22 @@ pub(crate) fn create_native_csv_writer(
     file_idx: usize,
     partition_values: Option<&RecordBatch>,
     io_config: Option<IOConfig>,
+    filename_provider: Option<FilenameProvider>,
+    write_uuid: Option<String>,
 ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>>
 {
     let (source_type, root_dir) = parse_url(root_dir)?;
+    #[cfg(feature = "python")]
+    let filename = build_filename_with_provider(
+        source_type,
+        root_dir.as_ref(),
+        partition_values,
+        file_idx,
+        "csv",
+        filename_provider,
+        write_uuid.as_deref(),
+    )?;
+    #[cfg(not(feature = "python"))]
     let filename = build_filename(
         source_type,
         root_dir.as_ref(),

--- a/src/daft-writers/src/json_writer.rs
+++ b/src/daft-writers/src/json_writer.rs
@@ -7,11 +7,15 @@ use daft_io::{IOConfig, SourceType, parse_url, utils::ObjectPath};
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 
+#[cfg(not(feature = "python"))]
+use crate::utils::build_filename;
+#[cfg(feature = "python")]
+use crate::utils::build_filename_with_provider;
 use crate::{
     AsyncFileWriter,
     batch_file_writer::BatchFileWriter,
     storage_backend::{FileStorageBackend, ObjectStorageBackend, StorageBackend},
-    utils::build_filename,
+    utils::FilenameProvider,
 };
 
 type JsonFinishFn<B> =
@@ -32,10 +36,23 @@ pub(crate) fn create_native_json_writer(
     file_idx: usize,
     partition_values: Option<&RecordBatch>,
     io_config: Option<IOConfig>,
+    filename_provider: Option<FilenameProvider>,
+    write_uuid: Option<String>,
 ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>>
 {
     // Parse the root directory and add partition values if present.
     let (source_type, root_dir) = parse_url(root_dir)?;
+    #[cfg(feature = "python")]
+    let filename = build_filename_with_provider(
+        source_type,
+        root_dir.as_ref(),
+        partition_values,
+        file_idx,
+        "json",
+        filename_provider,
+        write_uuid.as_deref(),
+    )?;
+    #[cfg(not(feature = "python"))]
     let filename = build_filename(
         source_type,
         root_dir.as_ref(),

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -20,10 +20,14 @@ use parquet::{
     schema::types::SchemaDescriptor,
 };
 
+#[cfg(not(feature = "python"))]
+use crate::utils::build_filename;
+#[cfg(feature = "python")]
+use crate::utils::build_filename_with_provider;
 use crate::{
     AsyncFileWriter, WriteResult,
     storage_backend::{FileStorageBackend, ObjectStorageBackend, StorageBackend},
-    utils::build_filename,
+    utils::FilenameProvider,
 };
 
 type ColumnWriterFuture = dyn Future<Output = DaftResult<ArrowColumnChunk>> + Send;
@@ -69,10 +73,23 @@ pub(crate) fn create_native_parquet_writer(
     file_idx: usize,
     partition_values: Option<&RecordBatch>,
     io_config: Option<IOConfig>,
+    filename_provider: Option<FilenameProvider>,
+    write_uuid: Option<String>,
 ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Arc<MicroPartition>, Result = Option<RecordBatch>>>>
 {
     // Parse the root directory and add partition values if present.
     let (source_type, root_dir) = parse_url(root_dir)?;
+    #[cfg(feature = "python")]
+    let filename = build_filename_with_provider(
+        source_type,
+        root_dir.as_ref(),
+        partition_values,
+        file_idx,
+        "parquet",
+        filename_provider,
+        write_uuid.as_deref(),
+    )?;
+    #[cfg(not(feature = "python"))]
     let filename = build_filename(
         source_type,
         root_dir.as_ref(),

--- a/src/daft-writers/src/partition.rs
+++ b/src/daft-writers/src/partition.rs
@@ -23,6 +23,7 @@ struct PartitionedWriter {
     writer_factory: Arc<dyn WriterFactory<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>>,
     partition_by: Vec<BoundExpr>,
     is_closed: bool,
+    partition_idx: usize,
 }
 
 impl PartitionedWriter {
@@ -31,6 +32,7 @@ impl PartitionedWriter {
             dyn WriterFactory<Input = Arc<MicroPartition>, Result = Vec<RecordBatch>>,
         >,
         partition_by: Vec<BoundExpr>,
+        partition_idx: usize,
     ) -> Self {
         Self {
             per_partition_writers: HashMap::new(),
@@ -38,6 +40,7 @@ impl PartitionedWriter {
             writer_factory,
             partition_by,
             is_closed: false,
+            partition_idx,
         }
     }
 
@@ -93,7 +96,7 @@ impl AsyncFileWriter for PartitionedWriter {
                 RawEntryMut::Vacant(entry) => {
                     let mut writer = self
                         .writer_factory
-                        .create_writer(0, Some(partition_value_row.as_ref()))?;
+                        .create_writer(self.partition_idx, Some(partition_value_row.as_ref()))?;
                     let write_result = writer
                         .write(Arc::new(MicroPartition::new_loaded(
                             table.schema.clone(),
@@ -181,12 +184,13 @@ impl WriterFactory for PartitionedWriterFactory {
 
     fn create_writer(
         &self,
-        _file_idx: usize,
+        file_idx: usize,
         _partition_values: Option<&RecordBatch>,
     ) -> DaftResult<Box<dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>>> {
         Ok(Box::new(PartitionedWriter::new(
             self.writer_factory.clone(),
             self.partition_cols.clone(),
+            file_idx,
         ))
             as Box<
                 dyn AsyncFileWriter<Input = Self::Input, Result = Self::Result>,

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 import datetime
 import decimal
+import os
+import re
+import uuid
 
 import pyarrow as pa
 import pytest
 
 import daft
 from daft import DataType, TimeUnit
+from daft.io import FilenameProvider
+from tests.conftest import get_tests_daft_runner_name
+
+from ..integration.io.conftest import minio_create_bucket
 
 PYARROW_GE_11_0_0 = tuple(int(s) for s in pa.__version__.split(".") if s.isnumeric()) >= (11, 0, 0)
 
@@ -101,3 +108,100 @@ def test_write_and_read_empty_csv(tmp_path_factory):
     df.write_csv(empty_csv_files, write_mode="overwrite")
 
     assert daft.read_csv(empty_csv_files).to_pydict() == {"a": []}
+
+
+class RecordingBlockFilenameProvider(FilenameProvider):
+    """FilenameProvider used to test CSV block-oriented writes.
+
+    The implementation mirrors the parquet tests but uses the "csv" extension.
+    """
+
+    def __init__(self) -> None:  # pragma: no cover - exercised via higher-level IO tests
+        self.calls: list[tuple[str, int, int, int, str]] = []
+
+    def get_filename_for_block(
+        self,
+        write_uuid: str,
+        task_index: int,
+        block_index: int,
+        file_idx: int,
+        ext: str,
+    ) -> str:
+        self.calls.append((write_uuid, task_index, block_index, file_idx, ext))
+        return f"csv-{write_uuid}-{task_index}-{block_index}-{file_idx}.{ext}"
+
+    def get_filename_for_row(
+        self,
+        row: dict[str, object],
+        write_uuid: str,
+        task_index: int,
+        block_index: int,
+        row_index: int,
+        ext: str,
+    ) -> str:  # pragma: no cover - not used in these tests
+        raise AssertionError("get_filename_for_row should not be called for block writes")
+
+
+def _extract_basenames(paths: list[str]) -> list[str]:
+    basenames: list[str] = []
+    for path in paths:
+        # Handle file:// prefix
+        if path.startswith("file://"):
+            path = path[len("file://") :]
+        # Handle S3 paths by taking everything after the bucket
+        elif "://" in path:
+            path = path.split("://", 1)[1].split("/", 1)[1]
+        basenames.append(os.path.basename(path))
+    return basenames
+
+
+def _check_filename_provider_results(basenames, prefix, extension, provider):
+    assert basenames
+    # Pattern: <prefix>-<uuid>-<task>-<block>-<file>.<extension>
+    uuid_pattern = r"[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    pattern = re.compile(rf"{prefix}-({uuid_pattern})-\d+-\d+-\d+\.{extension}")
+
+    matches = [pattern.match(name) for name in basenames]
+    assert all(matches), f"Some filenames did not match the pattern: {basenames}"
+
+    # Verify all files share the same write UUID
+    uuids = {m.group(1) for m in matches if m}
+    assert len(uuids) == 1
+
+    # In non-distributed mode, we can also check the provider's internal call record
+    if get_tests_daft_runner_name() != "ray":
+        assert len(provider.calls) == len(basenames)
+        assert {call[0] for call in provider.calls} == uuids
+        assert {call[4] for call in provider.calls} == {extension}
+
+
+def test_filename_provider_csv_local(tmp_path) -> None:
+    data = {"a": [1, 2, 3], "b": ["x", "y", "z"]}
+    df = daft.from_pydict(data).repartition(2)
+
+    provider = RecordingBlockFilenameProvider()
+    result_df = df.write_csv(str(tmp_path), filename_provider=provider)
+    basenames = _extract_basenames(result_df.to_pydict()["path"])
+    _check_filename_provider_results(basenames, "csv", "csv", provider)
+
+
+@pytest.mark.integration()
+def test_filename_provider_csv_s3(minio_io_config) -> None:
+    bucket_name = "filename-provider-csv"
+    data = {"a": [1, 2, 3], "b": ["x", "y", "z"]}
+
+    provider = RecordingBlockFilenameProvider()
+
+    with minio_create_bucket(minio_io_config=minio_io_config, bucket_name=bucket_name):
+        result_df = (
+            daft.from_pydict(data)
+            .repartition(2)
+            .write_csv(
+                f"s3://{bucket_name}/csv-writes-{uuid.uuid4()!s}",
+                partition_cols=["b"],
+                io_config=minio_io_config,
+                filename_provider=provider,
+            )
+        )
+        basenames = _extract_basenames(result_df.to_pydict()["path"])
+        _check_filename_provider_results(basenames, "csv", "csv", provider)

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import os
+import re
+
 import pytest
 
 import daft
+from daft.io import FilenameProvider
+from tests.conftest import get_tests_daft_runner_name
 
 
 def _make_skippable_dir(tmp_path, files):
@@ -61,3 +66,80 @@ def test_read_json_skip_multiple_empty_files_in_dir(tmp_path):
     # Multiple empties must be skipped; only valid.json contributes rows and schema.
     assert len(df.schema()) == 1
     assert df.count_rows() == 1
+
+
+class RecordingBlockFilenameProvider(FilenameProvider):
+    """Simple FilenameProvider used to test JSON block-oriented writes.
+
+    Mirrors the parquet and CSV tests but uses the "json" extension.
+    """
+
+    def __init__(self) -> None:  # pragma: no cover - exercised via higher-level IO tests
+        self.calls: list[tuple[str, int, int, int, str]] = []
+
+    def get_filename_for_block(
+        self,
+        write_uuid: str,
+        task_index: int,
+        block_index: int,
+        file_idx: int,
+        ext: str,
+    ) -> str:
+        # Record the call so that tests can assert on the arguments.
+        self.calls.append((write_uuid, task_index, block_index, file_idx, ext))
+        # Deterministic pattern that makes it easy to assert on basename.
+        return f"block-{write_uuid}-{task_index}-{block_index}-{file_idx}.{ext}"
+
+    def get_filename_for_row(
+        self,
+        row: dict[str, object],
+        write_uuid: str,
+        task_index: int,
+        block_index: int,
+        row_index: int,
+        ext: str,
+    ) -> str:  # pragma: no cover - not used in these tests
+        raise AssertionError("get_filename_for_row should not be called for block writes")
+
+
+def _extract_basenames(paths: list[str]) -> list[str]:
+    basenames: list[str] = []
+    for path in paths:
+        # Handle file:// prefix
+        if path.startswith("file://"):
+            path = path[len("file://") :]
+        # Handle S3 paths by taking everything after the bucket
+        elif "://" in path:
+            path = path.split("://", 1)[1].split("/", 1)[1]
+        basenames.append(os.path.basename(path))
+    return basenames
+
+
+def _check_filename_provider_results(basenames, prefix, extension, provider):
+    assert basenames
+    # Pattern: <prefix>-<uuid>-<task>-<block>-<file>.<extension>
+    uuid_pattern = r"[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+    pattern = re.compile(rf"{prefix}-({uuid_pattern})-\d+-\d+-\d+\.{extension}")
+
+    matches = [pattern.match(name) for name in basenames]
+    assert all(matches), f"Some filenames did not match the pattern: {basenames}"
+
+    # Verify all files share the same write UUID
+    uuids = {m.group(1) for m in matches if m}
+    assert len(uuids) == 1
+
+    # In non-distributed mode, we can also check the provider's internal call record
+    if get_tests_daft_runner_name() != "ray":
+        assert len(provider.calls) == len(basenames)
+        assert {call[0] for call in provider.calls} == uuids
+        assert {call[4] for call in provider.calls} == {extension}
+
+
+def test_filename_provider_json_local(tmp_path) -> None:
+    data = {"a": [1, 2, 3]}
+    df = daft.from_pydict(data).repartition(2)
+
+    provider = RecordingBlockFilenameProvider()
+    result_df = df.write_json(str(tmp_path), filename_provider=provider)
+    basenames = _extract_basenames(result_df.to_pydict()["path"])
+    _check_filename_provider_results(basenames, "block", "json", provider)


### PR DESCRIPTION
This change brings Daft in line with Ray Data's `FilenameProvider` concept, giving users deterministic and customizable control over output filenames across different sinks, while preserving the existing default naming scheme when no provider is supplied.

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
