### PR TITLE
docs: fix lance documentation and update desc of merge_columns

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1543,10 +1543,10 @@ class DataFrame:
             - File paths: "/path/to/lance/data/" or cloud URIs like "s3://bucket/path"
             - REST URIs: "rest://namespace/table_name" (requires rest_config)
           mode: The write mode. One of "create", "append", "overwrite", or "merge".
-          - "create" will create the dataset if it does not exist, otherwise raise an error.
-          - "append" will append to the existing dataset if it exists, otherwise raise an error.
-          - "overwrite" will overwrite the existing dataset if it exists, otherwise raise an error.
-          - "merge" will add new columns to the existing dataset.
+              - "create" will create the dataset if it does not exist, otherwise raise an error.
+              - "append" will append to the existing dataset if it exists, otherwise raise an error.
+              - "overwrite" will overwrite the existing dataset if it exists, otherwise raise an error.
+              - "merge" will add new columns to the existing dataset.
           io_config (IOConfig, optional): configurations to use when interacting with remote storage.
           rest_config (RestConfig, optional): Configuration for REST-based Lance services. Required when using REST URIs.
           schema (Schema | pyarrow.Schema, optional): Desired schema to enforce during write.
@@ -1556,8 +1556,9 @@ class DataFrame:
               on the pyarrow schema is preserved during create/overwrite.
             - If the target Lance dataset already exists, the data will be cast to the existing table schema
               to ensure compatibility unless ``mode="overwrite"``.
-          left_on/right_on (Optional[str]): Only supported in ``mode="merge"``. Specify the join key for aligning rows when merging new columns.
+          left_on (Optional[str]): Only supported in ``mode="merge"``. Specify the join key for aligning rows when merging new columns.
               - If omitted, defaults to ``"_rowaddr"``.
+          right_on (Optional[str]): Only supported in ``mode="merge"``. Specify the join key for aligning rows when merging new columns.
               - If ``right_on`` is omitted, it defaults to the value of ``left_on``.
               - The DataFrame passed to ``write_lance(mode="merge")`` must contain ``fragment_id`` and the join key column specified by ``right_on`` (or ``_rowaddr`` by default).
           **kwargs: Additional keyword arguments to pass to the Lance writer.

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -17,7 +17,7 @@ from daft.io._csv import read_csv
 from daft.io.delta_lake._deltalake import read_deltalake
 from daft.io.hudi._hudi import read_hudi
 from daft.io.iceberg._iceberg import read_iceberg
-from daft.io.lance._lance import read_lance, merge_columns, merge_columns_df, update_columns_df
+from daft.io.lance._lance import read_lance, merge_columns, merge_columns_df, update_columns
 from daft.io.lance.rest_config import LanceRestConfig
 from daft.io.lance.rest_write import write_lance_rest, create_lance_table_rest, register_lance_table_rest
 from daft.io._json import read_json
@@ -56,7 +56,6 @@ __all__ = [
     "from_glob_path",
     "merge_columns",
     "merge_columns_df",
-    "update_columns_df",
     "read_csv",
     "read_deltalake",
     "read_hudi",
@@ -71,4 +70,5 @@ __all__ = [
     "read_warc",
     "register_lance_table_rest",
     "write_lance_rest",
+    "update_columns",
 ]

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -17,7 +17,7 @@ from daft.io._csv import read_csv
 from daft.io.delta_lake._deltalake import read_deltalake
 from daft.io.hudi._hudi import read_hudi
 from daft.io.iceberg._iceberg import read_iceberg
-from daft.io.lance._lance import read_lance, merge_columns, merge_columns_df
+from daft.io.lance._lance import read_lance, merge_columns, merge_columns_df, update_columns_df
 from daft.io.lance.rest_config import LanceRestConfig
 from daft.io.lance.rest_write import write_lance_rest, create_lance_table_rest, register_lance_table_rest
 from daft.io._json import read_json
@@ -56,6 +56,7 @@ __all__ = [
     "from_glob_path",
     "merge_columns",
     "merge_columns_df",
+    "update_columns_df",
     "read_csv",
     "read_deltalake",
     "read_hudi",

--- a/daft/io/lance/__init__.py
+++ b/daft/io/lance/__init__.py
@@ -1,4 +1,4 @@
-from ._lance import create_scalar_index, compact_files, merge_columns, merge_columns_df, update_columns_df
+from ._lance import create_scalar_index, compact_files, merge_columns, merge_columns_df, update_columns
 from .rest_config import LanceRestConfig
 from .rest_write import write_lance_rest, create_lance_table_rest, register_lance_table_rest
 
@@ -9,7 +9,7 @@ __all__ = [
     "create_scalar_index",
     "merge_columns",
     "merge_columns_df",
-    "update_columns_df",
+    "update_columns",
     "register_lance_table_rest",
     "write_lance_rest",
 ]

--- a/daft/io/lance/__init__.py
+++ b/daft/io/lance/__init__.py
@@ -1,4 +1,4 @@
-from ._lance import create_scalar_index, compact_files, merge_columns, merge_columns_df
+from ._lance import create_scalar_index, compact_files, merge_columns, merge_columns_df, update_columns_df
 from .rest_config import LanceRestConfig
 from .rest_write import write_lance_rest, create_lance_table_rest, register_lance_table_rest
 
@@ -9,6 +9,7 @@ __all__ = [
     "create_scalar_index",
     "merge_columns",
     "merge_columns_df",
+    "update_columns_df",
     "register_lance_table_rest",
     "write_lance_rest",
 ]

--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -54,17 +54,18 @@ def read_lance(
         io_config: A custom IOConfig to use when accessing LanceDB data. Defaults to None.
         rest_config: Configuration for REST-based Lance services. Required when using REST URIs.
         version : optional, int | str
+        version: optional, int | str
             If specified, load a specific version of the Lance dataset. Else, loads the
             latest version. A version number (`int`) or a tag (`str`) can be provided.
-        asof : optional, datetime or str
+        asof: optional, datetime or str
             If specified, find the latest version created on or earlier than the given
             argument value. If a version is already specified, this arg is ignored.
-        block_size : optional, int
+        block_size: optional, int
             Block size in bytes. Provide a hint for the size of the minimal I/O request.
-        commit_lock : optional, lance.commit.CommitLock
+        commit_lock: optional, lance.commit.CommitLock
             A custom commit lock.  Only needed if your object store does not support
             atomic commits.  See the user guide for more details.
-        index_cache_size : optional, int
+        index_cache_size: optional, int
             Index cache size. Index cache is a LRU cache with TTL. This number specifies the
             number of index pages, for example, IVF partitions, to be cached in
             the host memory. Default value is ``256``.
@@ -73,7 +74,7 @@ def read_lance(
             page equals the combination of the pq code (``np.array([n,pq], dtype=uint8))``
             Approximately, ``n = Total Rows / number of IVF partitions``.
             ``pq = number of PQ sub-vectors``.
-        default_scan_options : optional, dict
+        default_scan_options: optional, dict
             Default scan options that are used when scanning the dataset.  This accepts
             the same arguments described in :py:meth:`lance.LanceDataset.scanner`.  The
             arguments will be applied to any scan operation.
@@ -88,14 +89,14 @@ def read_lance(
             like this:
             default_scan_options = {"with_row_address": True, "with_row_id" : True,  "batch_size": 1024}
             more see: https://lance-format.github.io/lance-python-doc/dataset.html
-        metadata_cache_size_bytes : optional, int
+        metadata_cache_size_bytes: optional, int
             Size of the metadata cache in bytes. This cache is used to store metadata
             information about the dataset, such as schema and statistics. If not specified,
             a default size will be used.
-        fragment_group_size : optional, int
+        fragment_group_size: optional, int
             Number of fragments to group together in a single scan task. If None or <= 1,
             each fragment will be processed individually (default behavior).
-        include_fragment_id : Optional, bool
+        include_fragment_id: Optional, bool
             Whether to display fragment_id.
             if you have the behavior of 'merge_columns_df' or 'write_lance(mode = 'merge')', the `include_fragment_id` must be set to True
 

--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -377,6 +377,72 @@ def merge_columns_df(
 
 
 @PublicAPI
+def update_columns_df(
+    df: DataFrame,
+    uri: str | pathlib.Path,
+    io_config: IOConfig | None = None,
+    *,
+    read_columns: list[str] | None = None,
+    storage_options: dict[str, Any] | None = None,
+    daft_remote_args: dict[str, Any] | None = None,
+    concurrency: int | None = None,
+    version: int | str | None = None,
+    asof: str | None = None,
+    block_size: int | None = None,
+    commit_lock: Any | None = None,
+    index_cache_size: int | None = None,
+    default_scan_options: dict[str, Any] | None = None,
+    metadata_cache_size_bytes: int | None = None,
+    batch_size: int | None = None,
+    left_on: str | None = "_rowid",
+    right_on: str | None = None,
+) -> None:
+    """Row-level column update entrypoint using a DataFrame.
+
+    This function updates existing columns in a LanceDB table in-place by joining
+    per-fragment data from a DataFrame and applying LanceFragment.update_columns.
+    """
+
+    io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
+    storage_options = storage_options or io_config_to_storage_options(io_config, uri)
+
+    # Build Lance dataset handle for committing
+    lance_ds = construct_lance_dataset(
+        uri,
+        storage_options=storage_options,
+        version=version,
+        asof=asof,
+        block_size=block_size,
+        commit_lock=commit_lock,
+        index_cache_size=index_cache_size,
+        default_scan_options=default_scan_options,
+        metadata_cache_size_bytes=metadata_cache_size_bytes,
+    )
+
+    effective_left_on = left_on or "_rowid"
+    effective_right_on = right_on or effective_left_on
+    effective_batch_size = (
+        batch_size if batch_size is not None else daft_remote_args.get("batch_size", None) if daft_remote_args else None
+    )
+
+    # Import here to avoid circular imports
+    from daft.io.lance.lance_update_column import update_columns_from_df
+
+    update_columns_from_df(
+        df=df,
+        lance_ds=lance_ds,
+        uri=uri,
+        read_columns=read_columns,
+        storage_options=storage_options,
+        daft_remote_args=daft_remote_args,
+        concurrency=concurrency,
+        left_on=effective_left_on,
+        right_on=effective_right_on,
+        batch_size=effective_batch_size,
+    )
+
+
+@PublicAPI
 def create_scalar_index(
     uri: str | pathlib.Path,
     io_config: IOConfig | None = None,

--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -377,7 +377,7 @@ def merge_columns_df(
 
 
 @PublicAPI
-def update_columns_df(
+def update_columns(
     df: DataFrame,
     uri: str | pathlib.Path,
     io_config: IOConfig | None = None,
@@ -402,7 +402,6 @@ def update_columns_df(
     This function updates existing columns in a LanceDB table in-place by joining
     per-fragment data from a DataFrame and applying LanceFragment.update_columns.
     """
-
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
     storage_options = storage_options or io_config_to_storage_options(io_config, uri)
 

--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -1,7 +1,6 @@
 # ruff: noqa: I002
 # isort: dont-add-import: from __future__ import annotations
 import pathlib
-import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -228,13 +227,6 @@ def merge_columns(
         ...     return batch.append_column("new_column", pc.multiply(batch["c"], 2))
         >>> daft.io.lance.merge_columns("s3://my-lancedb-bucket/data/", transform=double_score)
     """
-    warnings.warn(
-        "daft.io.lance.merge_columns is deprecated and will be removed in a future release. "
-        "Please use daft.io.lance.merge_columns_df instead.",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
-
     if transform is None:
         raise ValueError(
             "merge_columns requires a `transform` function; prefer using merge_columns_df with a prepared DataFrame if no transform is needed."

--- a/daft/io/lance/lance_update_column.py
+++ b/daft/io/lance/lance_update_column.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import daft
+import daft.pickle
+
+# mypy: disable-error-code="import-untyped"
+from daft.datatype import DataType
+from daft.udf import cls as daft_cls
+from daft.udf import method
+from daft.udf import udf as legacy_udf
+
+if TYPE_CHECKING:
+    import pathlib
+    from collections.abc import Callable
+
+    import lance
+
+    from daft.dependencies import pa
+
+
+_FRAGMENT_UPDATE_HANDLER_RETURN_DTYPE = DataType.struct(
+    {"fragment_meta": DataType.binary(), "fields_modified": DataType.binary()}
+)
+
+
+@legacy_udf(return_dtype=_FRAGMENT_UPDATE_HANDLER_RETURN_DTYPE)
+class GroupFragmentUpdateUDF:
+    def __init__(
+        self,
+        lance_ds: "lance.LanceDataset",
+        left_on: str = "_rowid",
+        right_on: str | None = None,
+        read_columns: list[str] | None = None,
+        batch_size: int | None = 9223372036854775807,
+    ):
+        """Per-group update handler that directly invokes Lance fragment.update_columns.
+
+        Args:
+            lance_ds: Target Lance dataset.
+            left_on: Key column on the Lance fragment (default "_rowid").
+            right_on: Key column name present in the provided reader data (defaults to left_on).
+            read_columns: Names for columns provided to the handler via map_groups (must include right_on).
+            batch_size: Optional batch size when building RecordBatchReader from the provided data.
+        """
+        self.lance_ds = lance_ds
+        self.left_on = left_on
+        self.right_on = right_on or left_on
+        self.read_columns = read_columns or []
+        self.batch_size = batch_size
+
+    def __call__(self, *cols: Any) -> list[dict[str, bytes]]:
+        from daft.dependencies import pa as _pa
+
+        if len(cols) == 0:
+            return []
+
+        # Last argument is the fragment_id series, preceding args are data columns as per read_columns
+        *data_cols, fragment_ids = cols
+        ids = fragment_ids.to_pylist() if hasattr(fragment_ids, "to_pylist") else list(fragment_ids)
+        if len(ids) == 0:
+            return []
+        frag_id = ids[0]
+
+        if len(self.read_columns) != len(data_cols):
+            raise ValueError(
+                f"GroupFragmentUpdateUDF expected {len(self.read_columns)} data columns, "
+                f"received {len(data_cols)}."
+            )
+
+        arrays: list[_pa.Array] = []
+
+        for col_name, s in zip(self.read_columns, data_cols):
+            pylist = s.to_pylist() if hasattr(s, "to_pylist") else list(s)
+
+            if col_name == self.right_on:
+                # Enforce join key types: UInt64 for "_rowid", Int64 for other integer keys.
+                if self.right_on == "_rowid":
+                    key_arr = _pa.array(pylist, type=_pa.uint64())
+                else:
+                    pylist_int = [None if v is None else int(v) for v in pylist]
+                    key_arr = _pa.array(pylist_int, type=_pa.int64())
+
+                arrays.append(key_arr)
+            else:
+                arr = _pa.array(pylist)
+                if _pa.types.is_integer(arr.type):
+                    arrays.append(arr.cast(_pa.int64()))
+                else:
+                    arrays.append(arr)
+
+        tbl = _pa.Table.from_arrays(arrays, names=self.read_columns)
+
+        # Ensure the join key exists in the reader data
+        if self.right_on not in tbl.schema.names:
+            hint = (
+                " Read from Lance with default_scan_options={'with_row_id': True} to expose '_rowid'."
+                if self.right_on == "_rowid"
+                else ""
+            )
+            raise ValueError(
+                f"Reader data missing join key '{self.right_on}'. "
+                f"Ensure the DataFrame includes this column.{hint}"
+            )
+
+        # After building the table, ensure the join key field is the correct type; cast if necessary
+        join_idx = tbl.schema.get_field_index(self.right_on)
+        if join_idx != -1:
+            join_field = tbl.schema.field(join_idx)
+            expected_type = _pa.uint64() if self.right_on == "_rowid" else _pa.int64()
+            if join_field.type != expected_type and _pa.types.is_integer(join_field.type):
+                fields = []
+                for i, name in enumerate(tbl.schema.names):
+                    if name == self.right_on:
+                        fields.append(_pa.field(name, expected_type))
+                    else:
+                        fields.append(tbl.schema.field(i))
+                coerced_schema = _pa.schema(fields)
+                tbl = tbl.cast(coerced_schema)
+
+        # Build RecordBatchReader from table batches
+        batches = tbl.to_batches(max_chunksize=self.batch_size) if self.batch_size is not None else tbl.to_batches()
+        reader = _pa.RecordBatchReader.from_batches(tbl.schema, batches)
+
+        fragment = self.lance_ds.get_fragment(frag_id)
+        fragment_meta, fields_modified = fragment.update_columns(
+            reader, left_on=self.left_on, right_on=self.right_on
+        )
+
+        return [
+            {
+                "fragment_meta": daft.pickle.dumps(fragment_meta),
+                "fields_modified": daft.pickle.dumps(fields_modified),
+            }
+        ]
+
+
+def update_columns_from_df(
+    df: daft.DataFrame,
+    lance_ds: "lance.LanceDataset",
+    uri: str | "pathlib.Path",
+    *,
+    read_columns: list[str] | None = None,
+    storage_options: dict[str, Any] | None = None,
+    daft_remote_args: dict[str, Any] | None = None,
+    concurrency: int | None = None,
+    left_on: str | None = "_rowid",
+    right_on: str | None = None,
+    batch_size: int | None = 9223372036854775807,
+) -> "lance.LanceDataset":
+    import lance
+
+    # Validate required keys
+    if "fragment_id" not in df.column_names:
+        raise ValueError("DataFrame must contain 'fragment_id' column for row-level update workflow")
+
+    effective_left_on = left_on or "_rowid"
+    join_key = right_on or effective_left_on
+
+    if join_key not in df.column_names:
+        hint = (
+            " Read with default_scan_options={'with_row_id': True} to expose '_rowid'."
+            if join_key == "_rowid"
+            else ""
+        )
+        raise ValueError(
+            f"DataFrame must contain join key column '{join_key}'." f"{hint}"
+        )
+
+    meta_columns = {"_rowid", "_rowaddr"}
+
+    # Compute dataset existing field names robustly
+    existing_fields: set[str] = set()
+    try:
+        existing_fields = {getattr(f, "name", str(f)) for f in lance_ds.schema}
+    except Exception:
+        names = []
+        try:
+            names = list(getattr(lance_ds.schema, "names", []))
+        except Exception:
+            try:
+                names = [getattr(f, "name", str(f)) for f in getattr(lance_ds.schema, "fields", [])]
+            except Exception:
+                names = []
+        existing_fields = set(names)
+
+    if read_columns is None:
+        update_cols: list[str] = []
+        for c in df.column_names:
+            if c in ("fragment_id", join_key):
+                continue
+            if c in meta_columns:
+                raise ValueError(
+                    f"Cannot update metadata column '{c}' via update_columns_from_df; remove it from the DataFrame."
+                )
+            if c not in existing_fields:
+                raise ValueError(
+                    f"Column '{c}' does not exist in the target dataset; "
+                    f"update_columns_from_df only updates existing columns."
+                )
+            update_cols.append(c)
+
+        if len(update_cols) == 0:
+            raise ValueError(
+                "No columns to update; DataFrame must contain at least one existing dataset column "
+                "besides join key and 'fragment_id'."
+            )
+
+        read_columns = [join_key] + update_cols
+    else:
+        if join_key not in read_columns:
+            raise ValueError(f"read_columns must include the join key '{join_key}'.")
+
+        # Validate columns in read_columns
+        for c in read_columns:
+            if c not in df.column_names:
+                raise ValueError(f"Column '{c}' specified in read_columns is not present in the DataFrame.")
+
+        for c in read_columns:
+            if c == join_key:
+                continue
+            if c in meta_columns:
+                raise ValueError(
+                    f"Cannot update metadata column '{c}' via update_columns_from_df; remove it from read_columns."
+                )
+            if c not in existing_fields:
+                raise ValueError(
+                    f"Column '{c}' does not exist in the target dataset; "
+                    f"update_columns_from_df only updates existing columns."
+                )
+
+    handler_udf = GroupFragmentUpdateUDF.with_init_args(  # type: ignore[attr-defined]
+        lance_ds,
+        effective_left_on,
+        join_key,
+        read_columns,
+        batch_size,
+    )
+
+    # map_groups: pass data columns followed by fragment_id
+    grouped = df.groupby("fragment_id").map_groups(
+        handler_udf(*(df[c] for c in read_columns), df["fragment_id"]).alias("commit_message")
+    )
+
+    commit_messages = grouped.collect().to_pydict()["commit_message"]
+
+    updated_fragments = []
+    all_fields_modified: set[int] = set()
+
+    for commit_message in commit_messages:
+        fragment_meta_bytes = commit_message["fragment_meta"]
+        fields_modified_bytes = commit_message["fields_modified"]
+
+        if fragment_meta_bytes is None or fields_modified_bytes is None:
+            continue
+
+        fragment_meta = daft.pickle.loads(fragment_meta_bytes)
+        fields_modified = daft.pickle.loads(fields_modified_bytes)
+        updated_fragments.append(fragment_meta)
+        for fid in fields_modified:
+            all_fields_modified.add(int(fid))
+
+    if not updated_fragments:
+        # Nothing to update; return original dataset handle.
+        return lance_ds
+
+    op = lance.LanceOperation.Update(
+        updated_fragments=updated_fragments,
+        fields_modified=sorted(all_fields_modified),
+    )
+
+    return lance_ds.commit(
+        uri,
+        op,
+        read_version=lance_ds.version,
+        storage_options=storage_options,
+    )

--- a/daft/io/lance/lance_update_column.py
+++ b/daft/io/lance/lance_update_column.py
@@ -7,17 +7,12 @@ import daft.pickle
 
 # mypy: disable-error-code="import-untyped"
 from daft.datatype import DataType
-from daft.udf import cls as daft_cls
-from daft.udf import method
 from daft.udf import udf as legacy_udf
 
 if TYPE_CHECKING:
     import pathlib
-    from collections.abc import Callable
 
     import lance
-
-    from daft.dependencies import pa
 
 
 _FRAGMENT_UPDATE_HANDLER_RETURN_DTYPE = DataType.struct(
@@ -29,19 +24,19 @@ _FRAGMENT_UPDATE_HANDLER_RETURN_DTYPE = DataType.struct(
 class GroupFragmentUpdateUDF:
     def __init__(
         self,
-        lance_ds: "lance.LanceDataset",
+        lance_ds: lance.LanceDataset,
         left_on: str = "_rowid",
         right_on: str | None = None,
         read_columns: list[str] | None = None,
         batch_size: int | None = 9223372036854775807,
     ):
-        """Per-group update handler that directly invokes Lance fragment.update_columns.
+        """Per-group update handler that invokes Lance fragment.update_columns.
 
         Args:
             lance_ds: Target Lance dataset.
             left_on: Key column on the Lance fragment (default "_rowid").
             right_on: Key column name present in the provided reader data (defaults to left_on).
-            read_columns: Names for columns provided to the handler via map_groups (must include right_on).
+            read_columns: Names for columns provided to the handler (must include right_on).
             batch_size: Optional batch size when building RecordBatchReader from the provided data.
         """
         self.lance_ds = lance_ds
@@ -58,21 +53,17 @@ class GroupFragmentUpdateUDF:
 
         # Last argument is the fragment_id series, preceding args are data columns as per read_columns
         *data_cols, fragment_ids = cols
+
+        # In map_groups, all fragment_ids in this batch are the same
         ids = fragment_ids.to_pylist() if hasattr(fragment_ids, "to_pylist") else list(fragment_ids)
         if len(ids) == 0:
             return []
         frag_id = ids[0]
 
-        if len(self.read_columns) != len(data_cols):
-            raise ValueError(
-                f"GroupFragmentUpdateUDF expected {len(self.read_columns)} data columns, "
-                f"received {len(data_cols)}."
-            )
-
+        # Extract rows for this fragment (all rows in the group)
         arrays: list[_pa.Array] = []
-
         for col_name, s in zip(self.read_columns, data_cols):
-            pylist = s.to_pylist() if hasattr(s, "to_pylist") else list(s)
+            pylist = s.to_pylist()
 
             if col_name == self.right_on:
                 # Enforce join key types: UInt64 for "_rowid", Int64 for other integer keys.
@@ -81,7 +72,6 @@ class GroupFragmentUpdateUDF:
                 else:
                     pylist_int = [None if v is None else int(v) for v in pylist]
                     key_arr = _pa.array(pylist_int, type=_pa.int64())
-
                 arrays.append(key_arr)
             else:
                 arr = _pa.array(pylist)
@@ -92,54 +82,25 @@ class GroupFragmentUpdateUDF:
 
         tbl = _pa.Table.from_arrays(arrays, names=self.read_columns)
 
-        # Ensure the join key exists in the reader data
-        if self.right_on not in tbl.schema.names:
-            hint = (
-                " Read from Lance with default_scan_options={'with_row_id': True} to expose '_rowid'."
-                if self.right_on == "_rowid"
-                else ""
-            )
-            raise ValueError(
-                f"Reader data missing join key '{self.right_on}'. "
-                f"Ensure the DataFrame includes this column.{hint}"
-            )
-
-        # After building the table, ensure the join key field is the correct type; cast if necessary
-        join_idx = tbl.schema.get_field_index(self.right_on)
-        if join_idx != -1:
-            join_field = tbl.schema.field(join_idx)
-            expected_type = _pa.uint64() if self.right_on == "_rowid" else _pa.int64()
-            if join_field.type != expected_type and _pa.types.is_integer(join_field.type):
-                fields = []
-                for i, name in enumerate(tbl.schema.names):
-                    if name == self.right_on:
-                        fields.append(_pa.field(name, expected_type))
-                    else:
-                        fields.append(tbl.schema.field(i))
-                coerced_schema = _pa.schema(fields)
-                tbl = tbl.cast(coerced_schema)
-
-        # Build RecordBatchReader from table batches
         batches = tbl.to_batches(max_chunksize=self.batch_size) if self.batch_size is not None else tbl.to_batches()
         reader = _pa.RecordBatchReader.from_batches(tbl.schema, batches)
 
         fragment = self.lance_ds.get_fragment(frag_id)
-        fragment_meta, fields_modified = fragment.update_columns(
-            reader, left_on=self.left_on, right_on=self.right_on
-        )
+        fragment_meta, fields_modified = fragment.update_columns(reader, left_on=self.left_on, right_on=self.right_on)
 
-        return [
-            {
-                "fragment_meta": daft.pickle.dumps(fragment_meta),
-                "fields_modified": daft.pickle.dumps(fields_modified),
-            }
-        ]
+        res = {
+            "fragment_meta": daft.pickle.dumps(fragment_meta),
+            "fields_modified": daft.pickle.dumps(fields_modified),
+        }
+
+        # Return a single result for the entire group
+        return [res]
 
 
 def update_columns_from_df(
     df: daft.DataFrame,
-    lance_ds: "lance.LanceDataset",
-    uri: str | "pathlib.Path",
+    lance_ds: lance.LanceDataset,
+    uri: str | pathlib.Path,
     *,
     read_columns: list[str] | None = None,
     storage_options: dict[str, Any] | None = None,
@@ -148,7 +109,7 @@ def update_columns_from_df(
     left_on: str | None = "_rowid",
     right_on: str | None = None,
     batch_size: int | None = 9223372036854775807,
-) -> "lance.LanceDataset":
+) -> lance.LanceDataset:
     import lance
 
     # Validate required keys
@@ -160,13 +121,9 @@ def update_columns_from_df(
 
     if join_key not in df.column_names:
         hint = (
-            " Read with default_scan_options={'with_row_id': True} to expose '_rowid'."
-            if join_key == "_rowid"
-            else ""
+            " Read with default_scan_options={'with_row_id': True} to expose '_rowid'." if join_key == "_rowid" else ""
         )
-        raise ValueError(
-            f"DataFrame must contain join key column '{join_key}'." f"{hint}"
-        )
+        raise ValueError(f"DataFrame must contain join key column '{join_key}'.{hint}")
 
     meta_columns = {"_rowid", "_rowaddr"}
 
@@ -238,7 +195,7 @@ def update_columns_from_df(
         batch_size,
     )
 
-    # map_groups: pass data columns followed by fragment_id
+    # Use map_groups for per-fragment processing.
     grouped = df.groupby("fragment_id").map_groups(
         handler_udf(*(df[c] for c in read_columns), df["fragment_id"]).alias("commit_message")
     )

--- a/docs/connectors/lance.md
+++ b/docs/connectors/lance.md
@@ -1,6 +1,6 @@
 # Reading from and Writing to Lance
 
-[Lance](https://lance.org/) is a next-generation columnar storage format for multimodal datasets (images, video, audio, and general columnar data). It supports local POSIX filesystems and cloud object stores (e.g., S3/GCS). Lance is known for extremely fast random access, zero-copy reads, deep integration with PyArrow/DuckDB, and strong performance for vector retrieval workloads.
+[Lance](https://lance.org/) is a next-generation columnar storage format for multimodal datasets (images, video, audio, and general columnar data). It supports local POSIX filesystems and cloud object stores (e.g. S3/GCS). Lance is known for extremely fast random access, zero-copy reads, deep integration with PyArrow/DuckDB, and strong performance for vector retrieval workloads.
 
 Daft currently supports:
 

--- a/tests/io/lancedb/test_lance_update_evolution.py
+++ b/tests/io/lancedb/test_lance_update_evolution.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+from daft.dependencies import pa
+
+
+@pytest.fixture(scope="function")
+def lance_dataset_path(tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("lance_update_evolution")
+    yield str(tmp_dir)
+
+
+def test_update_evolution_rowid(lance_dataset_path):
+    # Dataset with two fragments
+    data1 = {
+        "id": [1, 2],
+        "value": [10, 20],
+    }
+    data2 = {
+        "id": [3, 4],
+        "value": [30, 40],
+    }
+
+    df1 = daft.from_pydict(data1)
+    df2 = daft.from_pydict(data2)
+    df1.write_lance(lance_dataset_path, mode="create")
+    df2.write_lance(lance_dataset_path, mode="append")
+
+    # Read with _rowid and fragment_id enabled
+    df_loaded = daft.read_lance(
+        lance_dataset_path,
+        default_scan_options={"with_row_id": True},
+        include_fragment_id=True,
+    )
+    assert "fragment_id" in df_loaded.column_names
+    assert "_rowid" in df_loaded.column_names
+
+    pa_schema = df_loaded.schema().to_pyarrow_schema()
+    assert pa_schema.field("fragment_id").type == pa.int64()
+
+    # Prepare updates: bump value by +100 for all rows using _rowid as join key
+    df_update = (
+        df_loaded.select("_rowid", "fragment_id", "value")
+        .with_column("value", daft.col("value") + 100)
+        .select("_rowid", "fragment_id", "value")
+    )
+
+    daft.io.lance.update_columns_df(
+        df_update,
+        lance_dataset_path,
+        read_columns=["_rowid", "value"],
+        batch_size=1024,
+    )
+
+    df_after = daft.read_lance(lance_dataset_path)
+    out = df_after.select("id", "value").to_pydict()
+
+    assert out["id"] == [1, 2, 3, 4]
+    assert out["value"] == [110, 120, 130, 140]
+
+
+def test_update_evolution_business_key(lance_dataset_path):
+    # Dataset with stable business key id
+    data1 = {
+        "id": [1, 2],
+        "score": [10.0, 20.0],
+    }
+    data2 = {
+        "id": [3, 4],
+        "score": [30.0, 40.0],
+    }
+
+    df1 = daft.from_pydict(data1)
+    df2 = daft.from_pydict(data2)
+    df1.write_lance(lance_dataset_path, mode="create")
+    df2.write_lance(lance_dataset_path, mode="append")
+
+    df_loaded = daft.read_lance(
+        lance_dataset_path,
+        default_scan_options={"with_row_id": True},
+        include_fragment_id=True,
+    )
+    assert "fragment_id" in df_loaded.column_names
+
+    # Reader contains {id} + updated score (+ fragment_id for grouping)
+    df_update = (
+        df_loaded.select("id", "fragment_id", "score")
+        .with_column("score", daft.col("score") * 10.0)
+        .select("id", "fragment_id", "score")
+    )
+
+    daft.io.lance.update_columns_df(
+        df_update,
+        lance_dataset_path,
+        read_columns=["id", "score"],
+        batch_size=1024,
+        left_on="id",
+        right_on="id",
+    )
+
+    df_after = daft.read_lance(lance_dataset_path)
+    out = df_after.select("id", "score").to_pydict()
+
+    assert out["id"] == [1, 2, 3, 4]
+    # All scores should be multiplied by 10
+    assert out["score"] == [100.0, 200.0, 300.0, 400.0]


### PR DESCRIPTION
- Fix `write_lance` docstring indentation in `daft/dataframe/dataframe.py` to resolve Griffe warnings.
- Update `docs/connectors/lance.md` with correct `write_lance(mode="merge")` examples, including custom key merging and filtering.
- Deprecate `merge_columns` in documentation in favor of `write_lance(mode="merge")`.
- Fix parameter ordering in `compact_files` documentation.

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
