### PR TITLE
fix: allows appending nulls to lists, null is compatible with all types

### DIFF
--- a/src/daft-functions-list/src/append.rs
+++ b/src/daft-functions-list/src/append.rs
@@ -56,7 +56,7 @@ impl ScalarUDF for ListAppend {
         let input_exploded = input.to_exploded_field()?;
 
         ensure!(
-            input_exploded.dtype == other.dtype,
+            input_exploded.dtype == other.dtype || other.dtype.is_null(),
             TypeError: "Cannot append value of type {} to list of type {}",
             other.dtype,
             input_exploded.dtype


### PR DESCRIPTION
## Changes Made

- Allows appending nulls to lists, null is compatible with all types
- Adds null literal test from the customer issue

## Related Issues

- Closes #5898 
