### PR TITLE
fix: remove flaky datasets from read_huggingface tests

### DIFF
--- a/tests/integration/io/huggingface/test_read_huggingface.py
+++ b/tests/integration/io/huggingface/test_read_huggingface.py
@@ -28,9 +28,7 @@ def test_read_huggingface_datasets_doesnt_fail():
     [
         ("Eventual-Inc/sample-parquet", "foo"),
         ("fka/awesome-chatgpt-prompts", "act"),
-        ("nebius/SWE-rebench", "instance_id"),
         ("SWE-Gym/SWE-Gym", "instance_id"),
-        # ("HuggingFaceFW/fineweb", "id")
     ],
 )
 def test_read_huggingface(path, sort_key):


### PR DESCRIPTION
This pull request makes a minor adjustment to the HuggingFace dataset integration tests by removing a dataset from the test parameterization. This helps keep the test suite focused and potentially avoids issues with unavailable or problematic datasets.

* Removed the `("nebius/SWE-rebench", "instance_id")` entry from the test parameterization in `test_read_huggingface` to streamline test coverage.## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
