### PR TITLE
test: strip whitespace from process output for run_process test

### DIFF
--- a/tests/dataframe/test_select_run_process.py
+++ b/tests/dataframe/test_select_run_process.py
@@ -16,7 +16,7 @@ def test_run_process_tokens_echo():
 @pytest.mark.parametrize("text,expected", [("abc", 4), ("", 1)])
 def test_run_process_shell_pipeline_wc(text: str, expected: int):
     df = daft.from_pydict({"x": [text]})
-    expr = run_process(format("echo {} | wc -c", df["x"]), shell=True, return_dtype=int)
+    expr = run_process(format("echo {} | wc -c | tr -d ' '", df["x"]), shell=True, return_dtype=int)
     out = df.select(expr.alias("n")).to_pylist()
     assert out == [{"n": expected}]
 


### PR DESCRIPTION
## Changes Made

The `wc` command adds leading whitespace on Mac but not on Linux which is why this test failure was not caught in the PR test runs. This change makes the outputs consistent.

## Related Issues

#5738
