### PR TITLE
test: Don't skip all pyarrow 8.0.0 tests

### DIFF
--- a/tests/io/lancedb/conftest.py
+++ b/tests/io/lancedb/conftest.py
@@ -9,9 +9,9 @@ from daft.dependencies import pa
 lance = pytest.importorskip("lance")
 
 
-def pytest_collection_modifyitems(config, items):
+@pytest.fixture(scope="session", autouse=True)
+def check_pyarrow_version():
+    """Check pyarrow version and skip all tests in this directory if version is too old."""
     pyarrow_version = Version(pa.__version__)
     if pyarrow_version < Version("9.0.0"):
-        skip_marker = pytest.mark.skip(reason=f"lance integration requires pyarrow>=9.0.0, but found {pyarrow_version}")
-        for item in items:
-            item.add_marker(skip_marker)
+        pytest.skip(f"lance integration requires pyarrow>=9.0.0, but found {pyarrow_version}")


### PR DESCRIPTION
## Changes Made

Literally all pyarrow 8.0.0 tests were getting skipped, see https://github.com/Eventual-Inc/Daft/actions/runs/20755576566/job/59596622227?pr=5930

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
