### PR TITLE
chore: add deprecation warnings on other arrow2 arrays

### DIFF
--- a/src/arrow2/src/array/binary/mod.rs
+++ b/src/arrow2/src/array/binary/mod.rs
@@ -58,6 +58,7 @@ mod data;
 /// * Two consecutives `offsets` casted (`as`) to `usize` are valid slices of `values`.
 /// * `len` is equal to `validity.len()`, when defined.
 #[derive(Clone)]
+#[deprecated(note = "arrow2 migration")]
 pub struct BinaryArray<O: Offset> {
     data_type: DataType,
     offsets: OffsetsBuffer<O>,

--- a/src/arrow2/src/array/primitive/mod.rs
+++ b/src/arrow2/src/array/primitive/mod.rs
@@ -51,6 +51,7 @@ pub use mutable::*;
 ///
 /// ```
 #[derive(Clone)]
+#[deprecated(note = "arrow2 migration")]
 pub struct PrimitiveArray<T: NativeType> {
     data_type: DataType,
     values: Buffer<T>,

--- a/src/arrow2/src/array/primitive/mutable.rs
+++ b/src/arrow2/src/array/primitive/mutable.rs
@@ -17,6 +17,7 @@ use super::{check, PrimitiveArray};
 /// The Arrow's equivalent to `Vec<Option<T>>` where `T` is byte-size (e.g. `i32`).
 /// Converting a [`MutablePrimitiveArray`] into a [`PrimitiveArray`] is `O(1)`.
 #[derive(Debug, Clone)]
+#[deprecated(note = "arrow2 migration")]
 pub struct MutablePrimitiveArray<T: NativeType> {
     data_type: DataType,
     values: Vec<T>,

--- a/src/daft-functions-list/src/series.rs
+++ b/src/daft-functions-list/src/series.rs
@@ -101,6 +101,7 @@ impl SeriesListExtension for Series {
                 let data_array = struct_array.struct_()?.children[0].list().unwrap();
                 let offsets = data_array.offsets();
                 let array = Box::new(
+                    #[allow(deprecated, reason = "arrow2 migration")]
                     daft_arrow::array::PrimitiveArray::from_vec(
                         offsets.lengths().map(|l| l as u64).collect(),
                     )

--- a/src/daft-warc/src/lib.rs
+++ b/src/daft-warc/src/lib.rs
@@ -3,6 +3,7 @@ use std::{num::NonZeroUsize, sync::Arc};
 use chrono::{DateTime, Utc};
 use common_error::{DaftError, DaftResult};
 use common_runtime::{get_compute_runtime, get_io_runtime};
+#[allow(deprecated, reason = "arrow2 migration")]
 use daft_arrow::array::{
     MutableArray, MutableBinaryArray, MutablePrimitiveArray, MutableUtf8Array,
 };
@@ -121,7 +122,9 @@ struct WarcRecordBatchBuilder {
     record_id_array: MutableUtf8Array<i64>,
     warc_target_uri_array: MutableUtf8Array<i64>,
     warc_type_array: MutableUtf8Array<i64>,
+    #[allow(deprecated, reason = "arrow2 migration")]
     warc_date_array: MutablePrimitiveArray<i64>,
+    #[allow(deprecated, reason = "arrow2 migration")]
     warc_content_length_array: MutablePrimitiveArray<i64>,
     warc_identified_payload_type_array: MutableUtf8Array<i64>,
     content_array: MutableBinaryArray<i64>,
@@ -154,7 +157,9 @@ impl WarcRecordBatchBuilder {
                 chunk_size,
                 Self::DEFAULT_STRING_LENGTH * chunk_size,
             ),
+            #[allow(deprecated, reason = "arrow2 migration")]
             warc_date_array: MutablePrimitiveArray::with_capacity(chunk_size),
+            #[allow(deprecated, reason = "arrow2 migration")]
             warc_content_length_array: MutablePrimitiveArray::with_capacity(chunk_size),
             warc_identified_payload_type_array: MutableUtf8Array::with_capacities(
                 chunk_size,
@@ -209,6 +214,7 @@ impl WarcRecordBatchBuilder {
         self.record_id_array.len()
     }
 
+    #[allow(deprecated, reason = "arrow2 migration")]
     fn process_arrays(&mut self) -> DaftResult<Option<RecordBatch>> {
         let num_records = self.content_array.len();
         if num_records == 0 {


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

Will also update the `arrow-rs-migration` to remove the allows
