### PR TITLE
fix(functions): strip all whitespace from run_process output

### DIFF
--- a/daft/functions/process.py
+++ b/daft/functions/process.py
@@ -67,7 +67,7 @@ def run_process(
                 raise ValueError("shell=False requires at least one argv token")
             tokens = [str(a) for a in argv]
             proc = subprocess.run(tokens, shell=False, stdout=subprocess.PIPE, text=True, check=True)
-        return proc.stdout.rstrip("\n") if proc.stdout is not None else None
+        return proc.stdout.strip() if proc.stdout is not None else None
 
     if isinstance(args, Expression):
         args = [args]

--- a/tests/dataframe/test_select_run_process.py
+++ b/tests/dataframe/test_select_run_process.py
@@ -16,7 +16,7 @@ def test_run_process_tokens_echo():
 @pytest.mark.parametrize("text,expected", [("abc", 4), ("", 1)])
 def test_run_process_shell_pipeline_wc(text: str, expected: int):
     df = daft.from_pydict({"x": [text]})
-    expr = run_process(format("echo {} | wc -c | tr -d ' '", df["x"]), shell=True, return_dtype=int)
+    expr = run_process(format("echo {} | wc -c", df["x"]), shell=True, return_dtype=int)
     out = df.select(expr.alias("n")).to_pylist()
     assert out == [{"n": expected}]
 


### PR DESCRIPTION
## Changes Made

The `wc` command outputs numbers with leading whitespace on macOS (e.g., `       4\n`), which caused `run_process(..., return_dtype=int)` to return `None` instead of the expected integer value.

### Root Cause
`process.py` was using `.rstrip("\n")` which only strips trailing newlines, leaving leading spaces intact. When casting to int, `"       4"` fails and returns `None`.

### Fix
Changed `.rstrip("\n")` to `.strip()` to handle all leading and trailing whitespace, fixing cross-platform compatibility.

Also removed the `| tr -d ' '` workaround from the test that was added in #5942 since it's no longer needed.

## Related Issues

Fixes the root cause of the issue addressed by #5942
Related to #5738