### PR TITLE
refactor(arrow-rs): use arrow-rs for delete map

### DIFF
--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -388,8 +388,15 @@ async fn get_delete_map(
                 let file_paths = get_column_by_name("file_path")?.downcast::<Utf8Array>()?;
                 let positions = get_column_by_name("pos")?.downcast::<Int64Array>()?;
 
-                for (file, pos) in file_paths.into_iter()
-                    .zip(positions.into_iter()).map(|(file, pos)| (file.expect("file should not be null in iceberg delete files"), *pos.expect("pos should not be null in iceberg delete files")))
+                for (file, pos) in file_paths
+                    .into_iter()
+                    .zip(positions.into_iter())
+                    .map(|(file, pos)| {
+                        (
+                            file.expect("file should not be null in iceberg delete files"),
+                            *pos.expect("pos should not be null in iceberg delete files"),
+                        )
+                    })
                 {
                     if delete_map.contains_key(file) {
                         delete_map.get_mut(file).unwrap().push(pos);


### PR DESCRIPTION
## Changes Made

Remove use of `as_arrow2` when getting delete map for iceberg scans

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
