### PR TITLE
refactor(arrow-rs): Remove arrow2 use in jq kernel

### DIFF
--- a/src/daft-functions-json/src/jq.rs
+++ b/src/daft-functions-json/src/jq.rs
@@ -167,7 +167,6 @@ mod jaq {
 }
 
 #[cfg(test)]
-#[allow(deprecated, reason = "arrow2 migration")]
 mod tests {
     use daft_core::prelude::{AsArrow, Utf8Array};
 


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
