### PR TITLE
perf: dont eval empty recordbatches

### DIFF
--- a/src/daft-recordbatch/src/python.rs
+++ b/src/daft-recordbatch/src/python.rs
@@ -36,9 +36,6 @@ impl PyRecordBatch {
     }
 
     pub fn eval_expression_list(&self, py: Python, exprs: Vec<PyExpr>) -> PyResult<Self> {
-        if self.record_batch.is_empty() && exprs.iter().all(|e| !daft_dsl::has_agg(&e.expr)) {
-            return Ok(self.clone());
-        }
         let converted_exprs = BoundExpr::bind_all(&exprs, &self.record_batch.schema)?;
         py.detach(|| {
             Ok(self


### PR DESCRIPTION
## Changes Made

checks if the recordbatch/micropartition is empty. if so, skips trying to evaluate. 

Also adds `Clone` to micropartition. All of it's contents are `Clone` and are mostly `Arc`'d so this is a very cheap clone

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
