### PR TITLE
fix(ai): resolve intermittent meta tensor error in classify_text/classify_image

### DIFF
--- a/daft/ai/transformers/protocols/image_classifier.py
+++ b/daft/ai/transformers/protocols/image_classifier.py
@@ -19,7 +19,6 @@ from daft.ai.utils import get_gpu_udf_options, get_torch_device
 from daft.dependencies import tf, torch
 
 # Global lock to prevent concurrent model loading which can cause meta tensor issues
-# See: https://github.com/huggingface/transformers/issues/36247
 _model_loading_lock = threading.Lock()
 
 if TYPE_CHECKING:
@@ -94,9 +93,7 @@ class TransformersImageClassifier(ImageClassifier):
         self._model = model_name_or_path
         self._options = options
 
-        # Workaround for transformers issue #36247: Meta tensor error with concurrent loading
-        # Use a lock to prevent concurrent model loading which triggers the meta tensor bug
-        # See: https://github.com/huggingface/transformers/issues/36247
+        # Use a lock to prevent concurrent model loading which triggers meta tensor errors
         with _model_loading_lock:
             self._pipeline = pipeline(
                 task="zero-shot-image-classification",

--- a/daft/ai/transformers/protocols/text_classifier.py
+++ b/daft/ai/transformers/protocols/text_classifier.py
@@ -18,7 +18,6 @@ from daft.ai.typing import ClassifyTextOptions
 from daft.ai.utils import get_gpu_udf_options, get_torch_device
 
 # Global lock to prevent concurrent model loading which can cause meta tensor issues
-# See: https://github.com/huggingface/transformers/issues/36247
 _model_loading_lock = threading.Lock()
 
 if TYPE_CHECKING:
@@ -73,9 +72,7 @@ class TransformersTextClassifier(TextClassifier):
         self._model = model_name_or_path
         self._options = options
 
-        # Workaround for transformers issue #36247: BART meta tensor error
-        # Use a lock to prevent concurrent model loading which triggers the meta tensor bug
-        # See: https://github.com/huggingface/transformers/issues/36247
+        # Use a lock to prevent concurrent model loading which triggers meta tensor errors
         with _model_loading_lock:
             self._pipeline = pipeline(
                 task="zero-shot-classification",


### PR DESCRIPTION
## Summary

Fixes #5707

Resolves intermittent `NotImplementedError: Cannot copy out of meta tensor; no data!` error in `classify_text()` and `classify_image()` when dynamic batching is enabled.

## Problem

`classify_text()` and `classify_image()` fail intermittently (~20-40% of the time) with:
```
NotImplementedError: Cannot copy out of meta tensor; no data!
```

**Key characteristics:**
- Intermittent failure (not deterministic)
- More reproducible with dynamic batching enabled
- Fails during model initialization, not inference
- Particularly affects BART models (e.g., `facebook/bart-large-mnli`)

## Root Cause

When Daft's dynamic batching creates multiple UDF worker instances concurrently, they all try to load the transformers pipeline simultaneously. This triggers a **race condition in transformers' model loading code** where some model parameters get stuck as meta tensors (placeholders without actual data) instead of being properly materialized.

## Solution

Add a global lock to serialize model loading across all worker threads:

```python
import threading

_model_loading_lock = threading.Lock()

def __init__(self, model_name_or_path: str, **options):
    with _model_loading_lock:
        self._pipeline = pipeline(
            task="zero-shot-classification",
            model=model_name_or_path,
            device=get_torch_device(),
        )
```

**Applied to:**
- `daft/ai/transformers/protocols/text_classifier.py`
- `daft/ai/transformers/protocols/image_classifier.py`

## Testing

Created synthetic test with dynamic batching enabled:
```python
daft.set_execution_config(
    default_morsel_size=12,
    enable_dynamic_batching=True,
    dynamic_batching_strategy="auto"
)
```

**Results:**
- **Without lock:** ~40% failure rate (30 iterations)
- **With lock:** 0% failure rate (30 iterations) ✓

## Investigation Details

### Test Results Summary

Tested various approaches before arriving at the lock solution:
- `device_map=None` only: ~40% failure rate
- `device_map=None` + `low_cpu_mem_usage=False`: ~43% failure rate
- `device_map=None` + `low_cpu_mem_usage=False` + CPU-first loading: ~23% failure rate
- **Lock only: 0% failure rate** ← Final solution

### Why This Works

The lock ensures only one worker loads the model at a time, preventing the concurrent access that triggers the meta tensor race condition in transformers. Each worker still loads its own model copy (no sharing), but initialization happens serially.

### Performance Impact

**Negligible:**
- Lock only affects initialization time (one-time per worker)
- Inference runs in parallel without locks
- Workers typically initialize serially anyway due to memory constraints

## Caveats

**Note:** This may be papering over a deeper issue in transformers. The lock eliminates the race condition but doesn't address the underlying meta tensor bug in the upstream library. An upstream fix in transformers would be ideal long-term.

## References

- **Issue #5707:** https://github.com/Eventual-Inc/Daft/issues/5707
- **Transformers issue #36247:** https://github.com/huggingface/transformers/issues/36247
- **Environment:** Transformers 4.57.1, PyTorch 2.8.0, MPS (Apple Silicon)