### PR TITLE
feat(io): implement write_sql with SQLDataSink and explicit dtype support

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -772,9 +772,8 @@ class DataFrame:
         table_name: str,
         conn: str | Callable[[], "Connection"],
         write_mode: Literal["append", "overwrite", "fail"] = "append",
-        chunk_size: int | None = None,
         column_types: dict[str, Any] | None = None,
-        non_primitive_handling: Literal["bytes", "str", "error", "none"] | None = None,
+        non_primitive_handling: Literal["bytes", "str", "error"] | None = None,
     ) -> "DataFrame":
         """Write the DataFrame to a SQL database and return write metrics.
 
@@ -789,17 +788,19 @@ class DataFrame:
             table_name (str): Name of the table to write to.
             conn (str | Callable[[], "Connection"]): Connection string or factory.
             write_mode (str): Mode to write to the table. "append", "overwrite", or "fail". Defaults to "append".
-            chunk_size (int): Number of rows to write at a time. Defaults to None.
             column_types (Optional[Dict[str, Any]]): Optional mapping from column names to
                 SQLAlchemy types to use when creating the table or casting columns.
                 Passed through to the underlying SQL engine when creating or writing
                 the table.
-            non_primitive_handling (Literal["bytes", "str", "error", "none"] | None):
-                Controls how non-primitive columns are normalized before reaching SQL; see paragraph above for the default text behavior (``None``/``"none"``/``"str"``), the ``"bytes"`` option, and the ``"error"`` fail-fast mode.
+            non_primitive_handling (Literal["bytes", "str", "error"] | None):
+                Controls how non-primitive columns are normalized before reaching SQL; default ``None`` behaves like ``"str"``. Accepted values are ``"str"``, ``"bytes"``, and ``"error"``.
 
         Returns:
             DataFrame: A single-row DataFrame containing aggregate write metrics with
                 columns ``total_written_rows`` and ``total_written_bytes``.
+
+        Warning:
+            This features is early in development and will likely experience API changes.
 
         Note:
             Primitive columns still rely on pandas/SQLAlchemy (or ``column_types``) for concrete SQL types, while non-primitive columns are pre-normalized in Python according to ``non_primitive_handling`` before reaching the SQL driver.
@@ -845,7 +846,6 @@ class DataFrame:
             table_name=table_name,
             conn=conn,
             write_mode=write_mode,
-            chunk_size=chunk_size,
             column_types=column_types,
             df_schema=self.schema(),
             non_primitive_handling=non_primitive_handling,

--- a/daft/io/_sql.py
+++ b/daft/io/_sql.py
@@ -154,10 +154,9 @@ class SQLDataSink(DataSink[dict[str, Any] | None]):
     table_name: str
     conn: str | Callable[[], "Connection"]
     write_mode: Literal["append", "overwrite", "fail"]
-    chunk_size: int | None
     column_types: Any | None
     df_schema: Schema
-    non_primitive_handling: Literal["bytes", "str", "error", "none"] | None = None
+    non_primitive_handling: Literal["bytes", "str", "error"] | None = None
 
     def __post_init__(self) -> None:
         # Schema of the final result returned by ``finalize``.
@@ -240,7 +239,7 @@ class SQLDataSink(DataSink[dict[str, Any] | None]):
                 "Drop or cast these columns, or choose 'str' or 'bytes' handling instead."
             )
 
-        if handling is None or handling in ("none", "str"):
+        if handling is None or handling == "str":
             mode = "str"
         elif handling == "bytes":
             mode = "bytes"
@@ -360,7 +359,6 @@ class SQLDataSink(DataSink[dict[str, Any] | None]):
                     con=connection,
                     if_exists="append",
                     index=False,
-                    chunksize=self.chunk_size,
                     dtype=self.column_types,
                 )
                 connection.commit()

--- a/tests/integration/sql/test_write_sql.py
+++ b/tests/integration/sql/test_write_sql.py
@@ -92,14 +92,12 @@ def test_write_sql_invalid_mode(test_db):
 
 
 @pytest.mark.integration()
-@pytest.mark.parametrize("chunk_size", [None, 10, 500])
-def test_write_sql_chunk_sizes(test_db, chunk_size):
+def test_write_sql_chunk_sizes(test_db):
     table_name = f"write_test_chunk_size_{uuid.uuid4().hex}"
     num_rows = 2000
     df = daft.from_pydict({"id": list(range(num_rows)), "val": [f"val_{i}" for i in range(num_rows)]})
 
-    write_kwargs = {} if chunk_size is None else {"chunk_size": chunk_size}
-    df.write_sql(table_name, test_db, **write_kwargs)
+    df.write_sql(table_name, test_db)
 
     read_df = daft.read_sql(f"SELECT * FROM {table_name}", test_db).collect()
     assert len(read_df) == num_rows
@@ -317,8 +315,7 @@ def test_write_sql_dtype_with_connection_factory(test_db):
 
 
 @pytest.mark.integration()
-@pytest.mark.parametrize("chunk_size", [None, 50])
-def test_write_sql_dtype_with_chunking(test_db, chunk_size):
+def test_write_sql_dtype_with_chunking(test_db):
     table_name = f"write_test_dtype_chunk_{uuid.uuid4().hex}"
 
     num_rows = 100
@@ -331,8 +328,7 @@ def test_write_sql_dtype_with_chunking(test_db, chunk_size):
 
     column_types = {"id": Integer(), "name": String(length=64), "created_at": DateTime()}
 
-    write_kwargs = {} if chunk_size is None else {"chunk_size": chunk_size}
-    df.write_sql(table_name, test_db, column_types=column_types, **write_kwargs)
+    df.write_sql(table_name, test_db, column_types=column_types)
 
     read_df = daft.read_sql(f"SELECT * FROM {table_name}", test_db).sort("id").collect()
     expected_df = daft.from_pydict(data).sort("id").collect()
@@ -388,7 +384,7 @@ def test_write_sql_non_primitive_types_no_warning_explicit(test_db):
     # Verify NO warning is issued when non_primitive_handling is set
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")  # Cause all warnings to always be triggered.
-        df.write_sql(table_name, test_db, non_primitive_handling="none")
+        df.write_sql(table_name, test_db, non_primitive_handling="str")
         # Filter for our specific warning
         relevant_warnings = [
             x for x in w if issubclass(x.category, UserWarning) and "Detected non-primitive columns" in str(x.message)


### PR DESCRIPTION
## Summary
This PR introduces DataFrame.write_sql() , enabling users to write Daft DataFrames to SQL databases (e.g., PostgreSQL, SQLite) via SQLAlchemy.

It implements a robust, distributed SQLDataSink that:

1. Handles Distributed Writes : Uses the DataSink pattern to manage driver-side table initialization and worker-side parallel writes.
2. Supports Explicit Types : Exposes a dtype parameter to allow users to override default type inference with specific SQLAlchemy types (addressing type verification concerns).
3. Ensures Connection Safety : Manages connection lifecycles properly across distributed workers to avoid socket serialization issues.
## Key Changes
### 1. New Public API: DataFrame.write_sql
- Location : daft/dataframe/dataframe.py
- Signature :
  ```
  def write_sql(
      self,
      table_name: str,
      conn: str | Callable[[], "Connection"],
      write_mode: Literal["append",  "overwrite", "fail"] = "append",
      chunk_size: int | None = None,
      dtype: dict[str, Any] | None = None  # 
      <--- NEW: Explicit type control
  ) -> DataFrame: ...
  ```
- Behavior : Delegates to SQLDataSink and returns a DataFrame with write metrics ( total_written_rows , total_written_bytes ).
### 2. Internal Implementation: SQLDataSink
- Location : daft/io/_sql.py
- Architecture :
  - start() (Driver) : Handles write_mode logic.
    - fail : Checks existence, raises error if table exists, creates table schema if not.
    - overwrite : Replaces table with new schema.
    - append : Creates table if not exists, ensuring schema readiness for workers.
  - write() (Workers) :
    - Creates independent SQLAlchemy engines/connections per task (no pickling of connections).
    - Converts MicroPartitions to Pandas.
    - Uses pd.to_sql with the user-provided dtype to write data efficiently.
    - Ensures proper resource cleanup ( engine.dispose() ).
### 3. Tests
- Location : tests/integration/sql/test_write_sql.py
- Coverage :
  - Sources : Verified with PyDict, CSV, and JSON sources.
  - Modes : Comprehensive tests for append , overwrite , and fail modes.
  - Type Verification : Added specific tests ( test_write_sql_dtype_basic_types ) that use sqlalchemy.inspect to verify that columns are created with the correct SQL types when dtype is provided.
  - Connection Factory : Verified support for passing a connection factory function (crucial for pickling compatibility).
## Addressing Previous Concerns (Type Verification)
This implementation addresses concerns about type safety (raised in previous discussions) by:

1. Leveraging Pandas' mature type inference for standard types.
2. Providing the dtype "escape hatch" for complex scenarios, giving users full control over the target schema definition.
3. Including integration tests that explicitly verify schema creation correctness.
## Checklist
- I have added comprehensive unit/integration tests.
- I have updated the documentation (docstrings included).
- I have verified that connections are properly closed and disposed of.




Thank you very much for the idea provided by https://github.com/Eventual-Inc/Daft/pull/5471
## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
