### PR TITLE
fix(video): correct keyframe seek timestamp calculation for start_time

### DIFF
--- a/daft/file/video.py
+++ b/daft/file/video.py
@@ -119,8 +119,7 @@ class VideoFile(File):
 
                     # Check end time if specified
                     if end_time is not None:
-                        frame_time = frame.time
-                        if frame_time and frame_time > end_time:
+                        if frame.time and frame.time > end_time:
                             break
 
                     yield frame.to_image()


### PR DESCRIPTION
## Changes Made
`VideoFile.keyframes()` computed an incorrect seek timestamp when `start_time > 0`. The previous implementation used `start_time * time_base`, which keeps the effective seek position near 0 for small `time_base` values (for example `1/30000`). As a result, the `start_time` parameter was effectively ignored and keyframes were decoded from the beginning of the video.

This also affected the `daft.functions.video_keyframes()` UDF, which delegates to `VideoFile.keyframes()`. Users expecting to extract keyframes from a later time range (for example starting at 10 seconds) instead received frames starting close to time 0.
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues
#5949 
<!-- Link to related GitHub issues, e.g., "Closes #123" -->
