### PR TITLE
fix: overriding dimensions for openai embedding models

### DIFF
--- a/daft/ai/openai/protocols/text_embedder.py
+++ b/daft/ai/openai/protocols/text_embedder.py
@@ -83,7 +83,8 @@ class OpenAITextEmbedderDescriptor(TextEmbedderDescriptor):
             model = _models[self.model_name]
             if self.dimensions is not None:
                 if model.supports_overriding_dimensions:
-                    self.embed_options["supports_overriding_dimensions"] = True
+                    if "supports_overriding_dimensions" not in self.embed_options:
+                        self.embed_options["supports_overriding_dimensions"] = True
                 else:
                     raise ValueError(
                         f"OpenAI embedding model '{self.model_name}' does not support specifying dimensions"

--- a/tests/ai/openai/test_openai_text_embedder.py
+++ b/tests/ai/openai/test_openai_text_embedder.py
@@ -575,7 +575,7 @@ def test_embed_text_batch_rate_limit_fallback(mock_text_embedder, mock_client):
             assert embedding.dtype == np.float32
 
 
-def test_supports_overriding_dimensions_default_false(mock_client):
+def test_supports_overriding_dimensions_default_true(mock_client):
     """Test that when supports_overriding_dimensions is False (default), dimensions are NOT included."""
     descriptor = OpenAITextEmbedderDescriptor(
         provider_name="openai",
@@ -601,7 +601,7 @@ def test_supports_overriding_dimensions_default_false(mock_client):
         input=["Hello world"],
         model="text-embedding-3-small",
         encoding_format="float",
-        dimensions=omit,
+        dimensions=256,
     )
 
 


### PR DESCRIPTION
## Changes Made

When overriding the embedding dimension to `embed_text` with the OpenAI provider, it would fail with this message:
```
daft.exceptions.DaftTypeError: Can not cast Tensor array to FixedShapeTensor array with type FixedShapeTensor(Float32, [256]): Tensor array has shapes different than [256];
```

This was because we were only passing in the dimensions when `embed_options["supports_overriding_dimensions"]` was true, but that was not set, even though we hardcoded the support in the `_models` variable.

This PR sets the `supports_overriding_dimensions` option when the OpenAI model supports it, fixing the issue.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
