### PR TITLE
refactor(arrow-rs): Remove arrow2 from the search_sorted kernel

### DIFF
--- a/src/daft-core/src/array/ops/arrow/comparison.rs
+++ b/src/daft-core/src/array/ops/arrow/comparison.rs
@@ -1,10 +1,13 @@
 #![allow(deprecated, reason = "arrow2->arrow migration")]
 use arrow::{
-    array::{Array, ArrowPrimitiveType, FixedSizeListArray, LargeListArray, PrimitiveArray},
+    array::{
+        Array, ArrowPrimitiveType, FixedSizeListArray, LargeListArray, PrimitiveArray,
+        make_comparator,
+    },
+    compute::SortOptions,
     datatypes::{Float32Type, Float64Type},
 };
 use common_error::DaftResult;
-use daft_arrow::array::ord::build_compare;
 use num_traits::Float;
 
 use crate::{
@@ -96,9 +99,7 @@ fn build_is_equal_with_nan(
             Ok(build_is_equal_fixed_size_list(left, right))
         }
         _ => {
-            let left2 = daft_arrow::array::from_data(&left.to_data());
-            let right2 = daft_arrow::array::from_data(&right.to_data());
-            let comp = build_compare(left2.as_ref(), right2.as_ref())?;
+            let comp = make_comparator(left, right, SortOptions::new(false, false))?;
             Ok(Box::new(move |i, j| comp(i, j).is_eq()))
         }
     }

--- a/src/daft-core/src/array/ops/arrow/comparison.rs
+++ b/src/daft-core/src/array/ops/arrow/comparison.rs
@@ -1,19 +1,12 @@
-#![allow(deprecated, reason = "arrow2->arrow migration")]
 use arrow::{
-    array::{
-        Array, ArrowPrimitiveType, FixedSizeListArray, LargeListArray, PrimitiveArray,
-        make_comparator,
-    },
+    array::{Array, ArrowPrimitiveType, PrimitiveArray, make_comparator},
     compute::SortOptions,
-    datatypes::{Float32Type, Float64Type},
+    datatypes::{DataType, Float32Type, Float64Type},
 };
 use common_error::DaftResult;
 use num_traits::Float;
 
-use crate::{
-    kernels::search_sorted::{build_is_valid, cmp_float},
-    series::Series,
-};
+use crate::{kernels::search_sorted::cmp_float, series::Series};
 
 fn build_is_equal_float<T>(
     left: &dyn Array,
@@ -41,62 +34,17 @@ where
     }
 }
 
-fn build_is_equal_list(
-    left: &dyn Array,
-    right: &dyn Array,
-) -> Box<dyn Fn(usize, usize) -> bool + Send + Sync> {
-    let left = left
-        .as_any()
-        .downcast_ref::<LargeListArray>()
-        .unwrap()
-        .clone();
-    let right = right
-        .as_any()
-        .downcast_ref::<LargeListArray>()
-        .unwrap()
-        .clone();
-
-    Box::new(move |i, j| left.value(i).to_data() == right.value(j).to_data())
-}
-
-fn build_is_equal_fixed_size_list(
-    left: &dyn Array,
-    right: &dyn Array,
-) -> Box<dyn Fn(usize, usize) -> bool + Send + Sync> {
-    let left = left
-        .as_any()
-        .downcast_ref::<FixedSizeListArray>()
-        .unwrap()
-        .clone();
-    let right = right
-        .as_any()
-        .downcast_ref::<FixedSizeListArray>()
-        .unwrap()
-        .clone();
-
-    Box::new(move |i, j| left.value(i).to_data() == right.value(j).to_data())
-}
-
 fn build_is_equal_with_nan(
     left: &dyn Array,
     right: &dyn Array,
     nan_equal: bool,
 ) -> DaftResult<Box<dyn Fn(usize, usize) -> bool + Send + Sync>> {
-    use arrow::datatypes::DataType;
     match (left.data_type(), right.data_type()) {
         (DataType::Float32, DataType::Float32) => {
             Ok(build_is_equal_float::<Float32Type>(left, right, nan_equal))
         }
         (DataType::Float64, DataType::Float64) => {
             Ok(build_is_equal_float::<Float64Type>(left, right, nan_equal))
-        }
-        (DataType::LargeList(f1), DataType::LargeList(f2)) if *f1 == *f2 => {
-            Ok(build_is_equal_list(left, right))
-        }
-        (DataType::FixedSizeList(f1, l1), DataType::FixedSizeList(f2, l2))
-            if *l1 == *l2 && *f1 == *f2 =>
-        {
-            Ok(build_is_equal_fixed_size_list(left, right))
         }
         _ => {
             let comp = make_comparator(left, right, SortOptions::new(false, false))?;
@@ -112,25 +60,16 @@ pub fn build_is_equal(
     nan_equal: bool,
 ) -> DaftResult<Box<dyn Fn(usize, usize) -> bool + Send + Sync>> {
     let is_equal_fn = build_is_equal_with_nan(left, right, nan_equal)?;
-    let left_is_valid = build_is_valid(left);
-    let right_is_valid = build_is_valid(right);
 
-    if nulls_equal {
-        Ok(Box::new(move |i: usize, j: usize| {
-            match (left_is_valid(i), right_is_valid(j)) {
-                (true, true) => is_equal_fn(i, j),
-                (false, false) => true,
-                _ => false,
-            }
-        }))
-    } else {
-        Ok(Box::new(move |i: usize, j: usize| {
-            match (left_is_valid(i), right_is_valid(j)) {
-                (true, true) => is_equal_fn(i, j),
-                _ => false,
-            }
-        }))
-    }
+    let left_data = left.to_data();
+    let right_data = right.to_data();
+    Ok(Box::new(move |i: usize, j: usize| {
+        match (left_data.is_valid(i), right_data.is_valid(j)) {
+            (true, true) => is_equal_fn(i, j),
+            (false, false) => nulls_equal,
+            _ => false,
+        }
+    }))
 }
 
 pub fn build_multi_array_is_equal(

--- a/src/daft-core/src/array/ops/arrow/sort/primitive/sort.rs
+++ b/src/daft-core/src/array/ops/arrow/sort/primitive/sort.rs
@@ -18,9 +18,9 @@
 use arrow::{
     array::{Array, ArrowPrimitiveType, NullBufferBuilder, PrimitiveArray},
     buffer::{Buffer, NullBuffer, ScalarBuffer},
+    compute::SortOptions,
     datatypes::ArrowNativeType,
 };
-use daft_arrow::compute::sort::SortOptions;
 
 /// # Safety
 /// `indices[i] < values.len()` for all i
@@ -164,9 +164,9 @@ where
 mod tests {
     use arrow::{
         array::{ArrowPrimitiveType, PrimitiveArray},
+        compute::SortOptions,
         datatypes::Int8Type,
     };
-    use daft_arrow::compute::sort::SortOptions;
 
     use super::sort_by;
 

--- a/src/daft-core/src/array/ops/search_sorted.rs
+++ b/src/daft-core/src/array/ops/search_sorted.rs
@@ -13,8 +13,11 @@ where
     T: DaftArrowBackedType + 'static,
 {
     pub fn search_sorted(&self, keys: &Self, descending: bool) -> DaftResult<UInt64Array> {
-        let array =
-            search_sorted::search_sorted(self.data.as_ref(), keys.data.as_ref(), descending)?;
+        let array = search_sorted::search_sorted(
+            self.to_arrow().as_ref(),
+            keys.to_arrow().as_ref(),
+            descending,
+        )?;
 
         DataArray::from_arrow(self.field.clone(), Arc::new(array))
     }

--- a/src/daft-core/src/array/ops/search_sorted.rs
+++ b/src/daft-core/src/array/ops/search_sorted.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use common_error::DaftResult;
 
 use crate::{
@@ -14,6 +16,6 @@ where
         let array =
             search_sorted::search_sorted(self.data.as_ref(), keys.data.as_ref(), descending)?;
 
-        Ok(DataArray::from((self.name(), Box::new(array))))
+        DataArray::from_arrow(self.field.clone(), Arc::new(array))
     }
 }

--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -58,8 +58,8 @@ pub fn build_multi_array_bicompare(
         .zip(nulls_first.iter())
     {
         cmp_list.push(build_nulls_first_compare_with_nulls(
-            l.to_arrow2().as_ref(),
-            r.to_arrow2().as_ref(),
+            l.to_arrow()?.as_ref(),
+            r.to_arrow()?.as_ref(),
             *desc,
             *nf,
         )?);

--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -1,11 +1,14 @@
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrowPrimitiveType};
-use common_error::DaftResult;
+use arrow::{
+    array::{Array, ArrowPrimitiveType, make_comparator},
+    compute::SortOptions,
+};
+use common_error::{DaftError, DaftResult};
 use daft_arrow::{
     array::ord::{self, DynComparator},
     // A real tragedy. Arrow-rs has all these functions but uses 32 bit indices instead of 64 bit indices.
-    compute::sort::{SortOptions, sort, sort_to_indices},
+    compute::sort::{sort, sort_to_indices},
     types::Index,
 };
 
@@ -30,7 +33,7 @@ use crate::{
         },
     },
     file::DaftMediaType,
-    kernels::search_sorted::{build_nulls_first_compare_with_nulls, cmp_float},
+    kernels::search_sorted::cmp_float,
     prelude::UInt64Array,
     series::Series,
 };
@@ -57,12 +60,14 @@ pub fn build_multi_array_bicompare(
         .zip(descending.iter())
         .zip(nulls_first.iter())
     {
-        cmp_list.push(build_nulls_first_compare_with_nulls(
-            l.to_arrow()?.as_ref(),
-            r.to_arrow()?.as_ref(),
-            *desc,
-            *nf,
-        )?);
+        cmp_list.push(
+            make_comparator(
+                l.to_arrow()?.as_ref(),
+                r.to_arrow()?.as_ref(),
+                SortOptions::new(*desc, *nf),
+            )
+            .map_err(DaftError::ArrowRsError)?,
+        );
     }
 
     let combined_comparator = Box::new(move |a_idx: usize, b_idx: usize| -> std::cmp::Ordering {
@@ -447,7 +452,7 @@ impl NullArray {
 
 impl BooleanArray {
     pub fn argsort(&self, descending: bool, nulls_first: bool) -> DaftResult<UInt64Array> {
-        let options = SortOptions {
+        let options = daft_arrow::compute::sort::SortOptions {
             descending,
             nulls_first,
         };
@@ -512,7 +517,7 @@ impl BooleanArray {
     }
 
     pub fn sort(&self, descending: bool, nulls_first: bool) -> DaftResult<Self> {
-        let options = SortOptions {
+        let options = daft_arrow::compute::sort::SortOptions {
             descending,
             nulls_first,
         };
@@ -527,7 +532,7 @@ macro_rules! impl_binary_like_sort {
     ($da:ident) => {
         impl $da {
             pub fn argsort(&self, descending: bool, nulls_first: bool) -> DaftResult<UInt64Array> {
-                let options = SortOptions {
+                let options = daft_arrow::compute::sort::SortOptions {
                     descending,
                     nulls_first,
                 };
@@ -594,7 +599,7 @@ macro_rules! impl_binary_like_sort {
             }
 
             pub fn sort(&self, descending: bool, nulls_first: bool) -> DaftResult<Self> {
-                let options = SortOptions {
+                let options = daft_arrow::compute::sort::SortOptions {
                     descending,
                     nulls_first,
                 };

--- a/src/daft-core/src/kernels/search_sorted.rs
+++ b/src/daft-core/src/kernels/search_sorted.rs
@@ -155,7 +155,7 @@ fn search_sorted_boolean_array(
     let mut left = 0_usize;
     let mut right = array_size;
 
-    // For boolean arrays, we know there can only be three possible values: true, false, and null.s
+    // For boolean arrays, we know there can only be three possible values: true, false, and null
     // We can pre-compute the results for these three values and then reuse them to compute the results for the keys.
     let pre_computed_keys = &[Some(true), Some(false), None];
     let mut pre_computed_results: [u64; 3] = [0, 0, 0];
@@ -397,7 +397,7 @@ pub fn build_partial_compare_with_nulls(
     right: &dyn ArrowArray,
     reversed: bool,
 ) -> DaftResult<DynPartialComparator> {
-    let comparator = make_comparator(left, right, SortOptions::new(reversed, false))?;
+    let comparator = make_comparator(left, right, SortOptions::new(false, false))?;
     let left_is_valid = build_is_valid(left);
     let right_is_valid = build_is_valid(right);
 

--- a/src/daft-recordbatch/src/ops/joins/merge_join.rs
+++ b/src/daft-recordbatch/src/ops/joins/merge_join.rs
@@ -83,10 +83,9 @@ pub fn merge_inner_join(
     // Construct comparator over all join keys.
     let mut cmp_list = Vec::with_capacity(left.num_columns());
     for (left_series, right_series) in left.columns.iter().zip(right.columns.iter()) {
-        #[allow(deprecated, reason = "arrow2 migration")]
         cmp_list.push(build_partial_compare_with_nulls(
-            left_series.to_arrow2().as_ref(),
-            right_series.to_arrow2().as_ref(),
+            left_series.to_arrow()?.as_ref(),
+            right_series.to_arrow()?.as_ref(),
             false,
         )?);
     }

--- a/src/daft-recordbatch/src/ops/search_sorted.rs
+++ b/src/daft-recordbatch/src/ops/search_sorted.rs
@@ -42,18 +42,19 @@ unsafe fn multicol_search_sorted(
     keys: &[Series],
     descending: &[bool],
 ) -> DaftResult<UInt64Array> {
-    #[allow(deprecated, reason = "arrow2 migration")]
-    let data_arrow_vec: Vec<_> = data.iter().map(|s| s.to_arrow2()).collect();
-    #[allow(deprecated, reason = "arrow2 migration")]
-    let keys_arrow_vec: Vec<_> = keys.iter().map(|s| s.to_arrow2()).collect();
+    let data_arrow_rs_vec: Vec<_> = data
+        .iter()
+        .map(|s| s.to_arrow())
+        .collect::<DaftResult<Vec<_>>>()?;
 
-    let data_arrow_ref_vec = data_arrow_vec.iter().map(|s| s.as_ref()).collect();
-    let keys_arrow_ref_vec = keys_arrow_vec.iter().map(|s| s.as_ref()).collect();
+    let keys_arrow_rs_vec: Vec<_> = keys
+        .iter()
+        .map(|s| s.to_arrow())
+        .collect::<DaftResult<Vec<_>>>()?;
 
-    let indices = search_sorted_multi_array(
-        &data_arrow_ref_vec,
-        &keys_arrow_ref_vec,
-        &Vec::from(descending),
-    )?;
+    let data_refs: Vec<_> = data_arrow_rs_vec.iter().map(|a| a.as_ref()).collect();
+    let keys_refs: Vec<_> = keys_arrow_rs_vec.iter().map(|a| a.as_ref()).collect();
+
+    let indices = search_sorted_multi_array(&data_refs, &keys_refs, &Vec::from(descending))?;
     DataArray::from_arrow(Field::new("indices", DataType::UInt64), Arc::new(indices))
 }

--- a/src/daft-recordbatch/src/ops/search_sorted.rs
+++ b/src/daft-recordbatch/src/ops/search_sorted.rs
@@ -1,6 +1,10 @@
+use std::sync::Arc;
+
 use common_error::{DaftError, DaftResult};
 use daft_core::{
-    array::DataArray, datatypes::UInt64Array, kernels::search_sorted::search_sorted_multi_array,
+    array::DataArray,
+    datatypes::{DataType, Field, UInt64Array},
+    kernels::search_sorted::search_sorted_multi_array,
     series::Series,
 };
 
@@ -51,5 +55,5 @@ unsafe fn multicol_search_sorted(
         &keys_arrow_ref_vec,
         &Vec::from(descending),
     )?;
-    Ok(DataArray::from(("indices", Box::new(indices))))
+    DataArray::from_arrow(Field::new("indices", DataType::UInt64), Arc::new(indices))
 }

--- a/src/daft-recordbatch/src/ops/search_sorted.rs
+++ b/src/daft-recordbatch/src/ops/search_sorted.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};
 use daft_core::{
-    array::DataArray,
     datatypes::{DataType, Field, UInt64Array},
     kernels::search_sorted::search_sorted_multi_array,
     series::Series,
@@ -56,5 +55,5 @@ unsafe fn multicol_search_sorted(
     let keys_refs: Vec<_> = keys_arrow_rs_vec.iter().map(|a| a.as_ref()).collect();
 
     let indices = search_sorted_multi_array(&data_refs, &keys_refs, &Vec::from(descending))?;
-    DataArray::from_arrow(Field::new("indices", DataType::UInt64), Arc::new(indices))
+    UInt64Array::from_arrow(Field::new("indices", DataType::UInt64), Arc::new(indices))
 }


### PR DESCRIPTION
Remove arrow2 from the search_sorted kernel, which also affects some comparison kernels.