### PR TITLE
ci: Fix nightly workflow permissions

### DIFF
--- a/.github/workflows/nightly-publish-s3.yml
+++ b/.github/workflows/nightly-publish-s3.yml
@@ -285,6 +285,9 @@ jobs:
 
   benchmark-local-tpch:
     needs: [publish]
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/benchmark-local-tpch.yml
     with:
       daft_index_url: https://d1p3klp2t5517h.cloudfront.net/builds/nightly
@@ -316,6 +319,9 @@ jobs:
 
   benchmark-distributed-tpch:
     needs: [publish]
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/benchmark-distributed-tpch.yml
     with:
       daft_index_url: https://d1p3klp2t5517h.cloudfront.net/builds/nightly


### PR DESCRIPTION
## Changes Made

The nightly workflows were missing required permissions to run. Updated them to include `contents: read` and `id-token: write`.
