### PR TITLE
refactor(arrow2): remove DataType::to_arrow

### DIFF
--- a/src/daft-core/src/array/mod.rs
+++ b/src/daft-core/src/array/mod.rs
@@ -62,10 +62,11 @@ impl<T> DataArray<T> {
             physical_field.dtype
         );
 
-        if let Ok(expected_arrow_physical_type) = physical_field.dtype.to_arrow() {
+        if let Ok(arrow_field) = physical_field.to_arrow() {
+            let expected_arrow_physical_type = arrow_field.data_type();
             // since daft's Utf8 always maps to Arrow's LargeUtf8, we need to handle this special case
             // If the expected physical type is LargeUtf8, but the actual Arrow type is Utf8, we need to convert it
-            if expected_arrow_physical_type == arrow::datatypes::DataType::LargeUtf8
+            if expected_arrow_physical_type == &arrow::datatypes::DataType::LargeUtf8
                 && arrow_arr.data_type() == &arrow::datatypes::DataType::Utf8
             {
                 let arr = cast(arrow_arr.as_ref(), &arrow::datatypes::DataType::LargeUtf8)?;

--- a/src/daft-core/src/array/ops/as_arrow.rs
+++ b/src/daft-core/src/array/ops/as_arrow.rs
@@ -366,11 +366,7 @@ mod test {
         assert_eq!(arrow_arr.len(), 2);
         assert_eq!(
             arrow_arr.data_type(),
-            &arrow::datatypes::DataType::LargeList(Arc::new(arrow::datatypes::Field::new(
-                "item",
-                data.data_type().to_arrow()?,
-                true
-            )))
+            &arrow::datatypes::DataType::LargeList(Arc::new(data.field().to_arrow()?))
         );
 
         Ok(())
@@ -405,14 +401,7 @@ mod test {
         assert_eq!(arrow_arr.value_length() as usize, arr.fixed_element_len());
         assert_eq!(
             arrow_arr.data_type(),
-            &arrow::datatypes::DataType::FixedSizeList(
-                Arc::new(arrow::datatypes::Field::new(
-                    "literal",
-                    data.data_type().to_arrow()?,
-                    true
-                )),
-                1
-            )
+            &arrow::datatypes::DataType::FixedSizeList(Arc::new(data.field().to_arrow()?), 1)
         );
 
         Ok(())

--- a/src/daft-core/src/array/ops/from_arrow.rs
+++ b/src/daft-core/src/array/ops/from_arrow.rs
@@ -406,7 +406,7 @@ impl FromArrow for PythonArray {
         assert_eq!(field.dtype, DataType::Python);
 
         let physical_arrow_array =
-            arrow::compute::cast(arrow_arr.as_ref(), &DataType::Binary.to_arrow()?)?;
+            arrow::compute::cast(arrow_arr.as_ref(), &arrow::datatypes::DataType::LargeBinary)?;
 
         let physical_arrow_array = physical_arrow_array
             .as_any()
@@ -445,11 +445,11 @@ macro_rules! impl_logical_from_arrow {
             fn from_arrow<F: Into<FieldRef>>(field: F, arrow_arr: ArrayRef) -> DaftResult<Self> {
                 let field: FieldRef = field.into();
                   let target_convert = field.to_physical();
-                  let target_convert_arrow = target_convert.dtype.to_arrow()?;
+                  let target_convert_arrow = target_convert.to_arrow()?;
 
                   let physical_arrow_array = arrow::compute::cast(
                       arrow_arr.as_ref(),
-                      &target_convert_arrow,
+                      target_convert_arrow.data_type(),
                   )?;
 
                   let physical =
@@ -559,9 +559,10 @@ where
     fn from_arrow<F: Into<FieldRef>>(field: F, arrow_arr: ArrayRef) -> DaftResult<Self> {
         let field: FieldRef = field.into();
         let target_convert = field.to_physical();
-        let target_convert_arrow = target_convert.dtype.to_arrow()?;
+        let target_convert_fild = target_convert.to_arrow()?;
+        let target_convert_arrow = target_convert_fild.data_type();
 
-        let physical_arrow_array = arrow::compute::cast(arrow_arr.as_ref(), &target_convert_arrow)?;
+        let physical_arrow_array = arrow::compute::cast(arrow_arr.as_ref(), target_convert_arrow)?;
 
         let physical =
                <<FileType<T> as DaftLogicalType>::PhysicalType as DaftDataType>::ArrayType::from_arrow(

--- a/src/daft-recordbatch/src/ops/groups.rs
+++ b/src/daft-recordbatch/src/ops/groups.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use common_error::DaftResult;
 use daft_core::{
     array::ops::{


### PR DESCRIPTION
## Changes Made

removes `DataType::to_arrow` as it does not preserve the extension type, and could easily cause misuse. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
