### PR TITLE
fix: No need extra 1 for `OffsetBufferBuilder`

### DIFF
--- a/src/daft-core/src/array/ops/utf8.rs
+++ b/src/daft-core/src/array/ops/utf8.rs
@@ -19,7 +19,7 @@ impl Utf8Array {
         let nulls = input.nulls().cloned();
 
         let mut values = Vec::<u8>::new();
-        let mut offsets = OffsetBufferBuilder::new(input.len() + 1);
+        let mut offsets = OffsetBufferBuilder::new(input.len());
         for span in input.offsets().windows(2) {
             let s = span[0] as usize;
             let e = span[1] as usize;

--- a/src/daft-functions-binary/src/kernels.rs
+++ b/src/daft-functions-binary/src/kernels.rs
@@ -37,7 +37,7 @@ impl BinaryArrayExtension for BinaryArray {
 
         //
         let mut values = Vec::<u8>::new();
-        let mut offsets = OffsetBufferBuilder::new(input.len() + 1);
+        let mut offsets = OffsetBufferBuilder::new(input.len());
         for span in input.offsets().windows(2) {
             let s = span[0] as usize;
             let e = span[1] as usize;
@@ -80,7 +80,7 @@ impl BinaryArrayExtension for BinaryArray {
         };
         //
         let mut values = Vec::<u8>::new();
-        let mut offsets = OffsetBufferBuilder::new(input.len() + 1);
+        let mut offsets = OffsetBufferBuilder::new(input.len());
         for (i, span) in input.offsets().windows(2).enumerate() {
             let s = span[0] as usize;
             let e = span[1] as usize;
@@ -159,7 +159,7 @@ impl BinaryArrayExtension for BinaryArray {
         //
         let mut values = Vec::<u8>::new();
 
-        let mut offsets = OffsetBufferBuilder::new(input.len() + 1);
+        let mut offsets = OffsetBufferBuilder::new(input.len());
         for (i, span) in input.offsets().windows(2).enumerate() {
             let s = span[0] as usize;
             let e = span[1] as usize;
@@ -199,7 +199,7 @@ impl BinaryArrayExtension for FixedSizeBinaryArray {
         let nulls = input.nulls().cloned();
         //
         let mut values = Vec::<u8>::new();
-        let mut offsets = OffsetBufferBuilder::new(input.len() + 1);
+        let mut offsets = OffsetBufferBuilder::new(input.len());
 
         for i in 0..chunks {
             let s = i * size;
@@ -244,7 +244,7 @@ impl BinaryArrayExtension for FixedSizeBinaryArray {
         //
         let mut values = Vec::<u8>::new();
 
-        let mut offsets = OffsetBufferBuilder::new(input.len() + 1);
+        let mut offsets = OffsetBufferBuilder::new(input.len());
         for i in 0..chunks {
             let s = i * size;
             let e = s + size;
@@ -278,7 +278,7 @@ impl BinaryArrayExtension for FixedSizeBinaryArray {
         let nulls = input.nulls().cloned();
 
         let mut values = Vec::<u8>::new();
-        let mut offsets = OffsetBufferBuilder::new(input.len() + 1);
+        let mut offsets = OffsetBufferBuilder::new(input.len());
 
         for i in 0..chunks {
             let s = i * size;
@@ -323,7 +323,7 @@ impl BinaryArrayExtension for FixedSizeBinaryArray {
         };
 
         let mut values = Vec::<u8>::new();
-        let mut offsets = OffsetBufferBuilder::new(input.len() + 1);
+        let mut offsets = OffsetBufferBuilder::new(input.len());
 
         for i in 0..chunks {
             let s = i * size;

--- a/src/daft-image/src/ops.rs
+++ b/src/daft-image/src/ops.rs
@@ -230,7 +230,7 @@ fn encode_images<Arr: AsImageObj>(
         Ok(BinaryArray::from_iter(images.name(), values.into_iter()))
     } else {
         // For non-TIFF formats, use a single buffer with manual offset/validity tracking for efficiency
-        let mut offsets = OffsetBufferBuilder::<i64>::new(images.len() + 1);
+        let mut offsets = OffsetBufferBuilder::<i64>::new(images.len());
         let mut null_builder = BooleanBufferBuilder::new(images.len());
         let buf = Vec::new();
         let mut writer: CountingWriter<std::io::BufWriter<_>> =


### PR DESCRIPTION
## Changes Made

No need extra 1 for `OffsetBufferBuilder`

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
