### PR TITLE
fix: Register extension type before reading from Lance

### DIFF
--- a/daft/io/lance/lance_scan.py
+++ b/daft/io/lance/lance_scan.py
@@ -13,6 +13,7 @@ from daft.daft import CountMode, PyExpr, PyPartitionField, PyPushdowns, PyRecord
 from daft.dependencies import pa
 from daft.expressions import Expression
 from daft.io.scan import ScanOperator
+from daft.datatype import _ensure_registered_super_ext_type
 from daft.logical.schema import Schema
 from daft.recordbatch import RecordBatch
 
@@ -131,6 +132,8 @@ class LanceDBScanOperator(ScanOperator, SupportsPushdownFilters):
         self._fragment_group_size = fragment_group_size
         self._include_fragment_id = include_fragment_id
         self._enable_strict_filter_pushdown = get_context().daft_planning_config.enable_strict_filter_pushdown
+        # Ensure Daft extension type is registered so PyArrow can deserialize it from Lance
+        _ensure_registered_super_ext_type()
         base = self._ds.schema
         if self._include_fragment_id:
             new_schema = pa.schema([*base, pa.field("fragment_id", pa.int64())], metadata=base.metadata)

--- a/daft/io/lance/lance_scan.py
+++ b/daft/io/lance/lance_scan.py
@@ -10,10 +10,10 @@ if TYPE_CHECKING:
 
 from daft.context import get_context
 from daft.daft import CountMode, PyExpr, PyPartitionField, PyPushdowns, PyRecordBatch, ScanTask
+from daft.datatype import _ensure_registered_super_ext_type
 from daft.dependencies import pa
 from daft.expressions import Expression
 from daft.io.scan import ScanOperator
-from daft.datatype import _ensure_registered_super_ext_type
 from daft.logical.schema import Schema
 from daft.recordbatch import RecordBatch
 

--- a/daft/schema.py
+++ b/daft/schema.py
@@ -82,6 +82,8 @@ class Schema:
         Returns:
             Schema: Converted Daft schema
         """
+        # Ensure Daft extension type is registered so PyArrow can deserialize it
+        _ensure_registered_super_ext_type()
         # NOTE: This does not retain schema-level metadata, as Daft Schemas do not have a metadata field.
         fields = []
         for pa_field in pa_schema:

--- a/daft/schema.py
+++ b/daft/schema.py
@@ -82,8 +82,6 @@ class Schema:
         Returns:
             Schema: Converted Daft schema
         """
-        # Ensure Daft extension type is registered so PyArrow can deserialize it
-        _ensure_registered_super_ext_type()
         # NOTE: This does not retain schema-level metadata, as Daft Schemas do not have a metadata field.
         fields = []
         for pa_field in pa_schema:


### PR DESCRIPTION
## Summary
Fixes Embedding type being read as List when reading from Lance without a prior write in the same process.

## Problem
When reading a Lance dataset containing `Embedding[Float32; 512]`, it would be returned as `List[Float32; 512]`. This happened because PyArrow's extension type wasn't registered before Lance read the schema.

## Fix
Call `_ensure_registered_super_ext_type()` in `LanceScanOperator.__init__` before accessing `self._ds.schema`.

## Test plan
- Added test that writes embeddings in a separate process, then reads in the current process (where extension type wouldn't be registered yet)