### PR TITLE
fix: make df.into_partitions() work when input num == num_partitions

### DIFF
--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -234,9 +234,30 @@ impl IntoPartitionsNode {
 
         match num_input_tasks.cmp(&self.num_partitions) {
             std::cmp::Ordering::Equal => {
-                // Exact match - pass through as-is
-                for builder in input_builders {
-                    let _ = result_tx.send(builder).await;
+                if self
+                    .config
+                    .execution_config
+                    .enable_scan_task_split_and_merge
+                {
+                    let node_id = self.node_id();
+                    for builder in input_builders {
+                        let builder = builder.map_plan(self.as_ref(), |plan| {
+                            LocalPhysicalPlan::into_partitions(
+                                plan,
+                                1,
+                                StatsState::NotMaterialized,
+                                LocalNodeContext {
+                                    origin_node_id: Some(node_id as usize),
+                                    additional: None,
+                                },
+                            )
+                        });
+                        let _ = result_tx.send(builder).await;
+                    }
+                } else {
+                    for builder in input_builders {
+                        let _ = result_tx.send(builder).await;
+                    }
                 }
             }
             std::cmp::Ordering::Greater => {


### PR DESCRIPTION
## Changes Made

Coalesce multiple per-task outputs into a single MicroPartition in into_partition() execution, when input number is equal to num_partitions and set **enable_scan_tasks_split_and_merge** as True.
For example:
```
daft.set_execution_config(
        enable_scan_task_split_and_merge=True,
    )
df = daft.read_parquet(...)
df.into_partitions(df.num_partitions())

assert( len(list(df.iter_partitions())) == df.num_partitions() )
```

Before this pr, when we set enable_scan_task_split_and_merge=True,  the assertion above will wrong, because the micropartitions are not coalesced.
<!-- Describe what changes were made and why. Include implementation details if necessary. -->
