### PR TITLE
feat: Add global agg support for Dataframe `select`

### DIFF
--- a/src/daft-logical-plan/src/builder/resolve_expr.rs
+++ b/src/daft-logical-plan/src/builder/resolve_expr.rs
@@ -445,7 +445,7 @@ impl ExprResolver<'_> {
     fn validate_expr(&self, expr: ExprRef) -> DaftResult<ExprRef> {
         if has_agg(&expr) {
             return Err(DaftError::ValueError(format!(
-                "Aggregation expressions are currently only allowed in agg, pivot, and window: {expr}\nIf you would like to have this feature, please see https://github.com/Eventual-Inc/Daft/issues/1979#issue-2170913383",
+                "Aggregation expressions are currently only allowed in agg, pivot, window, or as a global aggregation in select(): {expr}\nIf you would like to have this feature, please see https://github.com/Eventual-Inc/Daft/issues/1979#issue-2170913383",
             )));
         }
 

--- a/tests/dataframe/test_select_global_agg.py
+++ b/tests/dataframe/test_select_global_agg.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import daft

--- a/tests/dataframe/test_select_global_agg.py
+++ b/tests/dataframe/test_select_global_agg.py
@@ -1,0 +1,57 @@
+import pytest
+
+import daft
+from daft import col, lit
+
+
+def test_select_global_agg_returns_single_row() -> None:
+    df = daft.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    res = df.select(col("a").sum().alias("sum_a")).collect().to_pydict()
+
+    assert res == {"sum_a": [6]}
+
+
+def test_select_global_agg_allows_literals() -> None:
+    df = daft.from_pydict({"a": [1, 2, 3]})
+
+    res = (
+        df.select(
+            col("a").sum().alias("sum_a"),
+            lit(1).alias("one"),
+        )
+        .collect()
+        .to_pydict()
+    )
+
+    assert res == {"sum_a": [6], "one": [1]}
+
+
+def test_select_global_agg_allows_multiple_aggs() -> None:
+    df = daft.from_pydict({"a": [1, 2, 3]})
+
+    res = (
+        df.select(
+            col("a").sum().alias("sum_a"),
+            col("a").count().alias("cnt_a"),
+        )
+        .collect()
+        .to_pydict()
+    )
+
+    assert res == {"sum_a": [6], "cnt_a": [3]}
+
+
+def test_select_global_agg_without_alias() -> None:
+    df = daft.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    res = df.select(col("a").sum()).collect().to_pydict()
+
+    assert res == {"a": [6]}
+
+
+def test_select_global_agg_rejects_non_agg_column_reference() -> None:
+    df = daft.from_pydict({"a": [1, 2, 3]})
+
+    with pytest.raises(ValueError, match="Expressions in aggregations"):
+        df.select(col("a").sum().alias("sum_a"), col("a")).collect()


### PR DESCRIPTION
## Changes Made

We encountered an issue about aggregate functions are not permitted in the SELECT statement unless a GROUP BY clause is specified.

for example:
```
from daft import col
import daft
df = daft.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
df = df.select(
col('a').sum().alias('sum')
)
df.show()
```

``` 
DaftCoreException: DaftError::ValueError Aggregation expressions are currently only allowed in agg, pivot, and window: sum(col(a))
```

This issue has been resolved in daft sql https://github.com/Eventual-Inc/Daft/pull/2799, but it is still not supported in dataframe. This PR is precisely aimed at addressing this issue.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
I found that a related issue already exists. https://github.com/Eventual-Inc/Daft/issues/1979