### PR TITLE
feat: add custom date and timestamp formatting for CSV writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3449,6 +3449,7 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "chrono",
+ "chrono-tz",
  "common-daft-config",
  "common-error",
  "common-file-formats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3448,6 +3448,7 @@ dependencies = [
  "arrow-json",
  "arrow-schema",
  "async-trait",
+ "chrono",
  "common-daft-config",
  "common-error",
  "common-file-formats",

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1875,6 +1875,8 @@ class PyFormatSinkOption:
         quote: str | None = None,
         escape: str | None = None,
         header: bool | None = None,
+        date_format: str | None = None,
+        timestamp_format: str | None = None,
     ) -> PyFormatSinkOption: ...
     @classmethod
     def json(cls, ignore_null_fields: bool | None = None) -> PyFormatSinkOption: ...

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -851,6 +851,8 @@ class DataFrame:
         quote: str | None = None,
         escape: str | None = None,
         header: bool | None = True,
+        date_format: str | None = None,
+        timestamp_format: str | None = None,
     ) -> "DataFrame":
         r"""Writes the DataFrame as CSV files, returning a new DataFrame with paths to the files that were written.
 
@@ -865,6 +867,8 @@ class DataFrame:
             quote (Optional[str], optional): Single-character quote used around fields containing delimiters default `"`.
             escape (Optional[str], optional): Single-character escape for special characters default `\\`.
             header (Optional[bool], optional): Whether to write a header row with column names, default True.
+            date_format (Optional[str], optional): Format string for date columns. Uses chrono strftime format (e.g., "%Y-%m-%d", "%d/%m/%Y"). Defaults to None (ISO 8601 format).
+            timestamp_format (Optional[str], optional): Format string for timestamp columns. Uses chrono strftime format (e.g., "%Y-%m-%d %H:%M:%S", "%+"). Defaults to None (ISO 8601 format).
 
         Returns:
             DataFrame: The filenames that were written out as strings.
@@ -895,7 +899,14 @@ class DataFrame:
         if partition_cols is not None:
             cols = column_inputs_to_expressions(tuple(partition_cols))
 
-        file_format_option = PyFormatSinkOption.csv(delimiter=delimiter, quote=quote, escape=escape, header=header)
+        file_format_option = PyFormatSinkOption.csv(
+            delimiter=delimiter,
+            quote=quote,
+            escape=escape,
+            header=header,
+            date_format=date_format,
+            timestamp_format=timestamp_format,
+        )
         builder = self._builder.write_tabular(
             root_dir=root_dir,
             partition_cols=cols,

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -876,10 +876,35 @@ class DataFrame:
         Note:
             This call is **blocking** and will execute the DataFrame when called
 
+            **Timezone handling**: For timezone-aware timestamp columns, the timestamps are converted
+            to the target timezone before formatting. For example, a timestamp stored as UTC but with
+            timezone "America/New_York" will be formatted in Eastern Time, not UTC. If the timezone
+            string is invalid, an error will be raised.
+
         Examples:
+            Basic usage:
+
             >>> import daft
             >>> df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
             >>> df.write_csv("output_dir", write_mode="overwrite")  # doctest: +SKIP
+
+            Custom date format (e.g., DD/MM/YYYY):
+
+            >>> import datetime
+            >>> df = daft.from_pydict({"date": [datetime.date(2024, 1, 15)]})
+            >>> df.write_csv("output_dir", date_format="%d/%m/%Y")  # doctest: +SKIP
+            # Output: 15/01/2024
+
+            Custom timestamp format:
+
+            >>> df = daft.from_pydict({"ts": [datetime.datetime(2024, 1, 15, 10, 30, 45)]})
+            >>> df.write_csv("output_dir", timestamp_format="%Y-%m-%d %H:%M:%S")  # doctest: +SKIP
+            # Output: 2024-01-15 10:30:45
+
+            ISO 8601 / RFC 3339 timestamp format:
+
+            >>> df.write_csv("output_dir", timestamp_format="%+")  # doctest: +SKIP
+            # Output: 2024-01-15T10:30:45+00:00
 
         Tip:
             See also [`df.write_parquet()`][daft.DataFrame.write_parquet] and [`df.write_json()`][daft.DataFrame.write_json]

--- a/src/daft-logical-plan/src/sink_info.rs
+++ b/src/daft-logical-plan/src/sink_info.rs
@@ -322,6 +322,8 @@ pub struct CsvFormatOption {
     pub quote: Option<u8>,
     pub escape: Option<u8>,
     pub header: Option<bool>,
+    pub date_format: Option<String>,
+    pub timestamp_format: Option<String>,
 }
 
 impl Default for CsvFormatOption {
@@ -331,6 +333,8 @@ impl Default for CsvFormatOption {
             quote: Some(b'"'),
             escape: Some(b'\\'),
             header: Some(true),
+            date_format: None,
+            timestamp_format: None,
         }
     }
 }
@@ -390,6 +394,8 @@ impl PyFormatSinkOption {
         quote: Option<char>,
         escape: Option<char>,
         header: Option<bool>,
+        date_format: Option<String>,
+        timestamp_format: Option<String>,
     ) -> Self {
         let to_u8 = |c: Option<char>| -> Option<u8> {
             c.and_then(|ch| if ch.is_ascii() { Some(ch as u8) } else { None })
@@ -400,6 +406,8 @@ impl PyFormatSinkOption {
                 quote: to_u8(quote),
                 escape: to_u8(escape),
                 header,
+                date_format,
+                timestamp_format,
             }),
         }
     }

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -6,6 +6,7 @@ arrow-json = {workspace = true}
 arrow-schema = {workspace = true}
 async-trait = {workspace = true}
 chrono = {workspace = true}
+chrono-tz = {workspace = true}
 common-daft-config = {path = "../common/daft-config", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -5,6 +5,7 @@ arrow-ipc = {workspace = true}
 arrow-json = {workspace = true}
 arrow-schema = {workspace = true}
 async-trait = {workspace = true}
+chrono = {workspace = true}
 common-daft-config = {path = "../common/daft-config", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-file-formats = {path = "../common/file-formats", default-features = false}

--- a/src/daft-writers/src/pyarrow.rs
+++ b/src/daft-writers/src/pyarrow.rs
@@ -82,6 +82,8 @@ impl PyArrowWriter {
                 .delimiter
                 .map(|b| String::from_utf8(vec![b]).unwrap_or_else(|_| ",".to_string()));
             let header = format_option.header;
+            let date_format = format_option.date_format.clone();
+            let timestamp_format = format_option.timestamp_format.clone();
             let py_writer = file_writer_class.call1((
                 root_dir,
                 file_idx,
@@ -91,6 +93,8 @@ impl PyArrowWriter {
                 }),
                 delimiter,
                 header,
+                date_format,
+                timestamp_format,
             ))?;
             Ok(Self {
                 py_writer: py_writer.into(),

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -402,3 +402,27 @@ def test_write_csv_no_custom_format_preserves_default(tmp_path):
     assert "2024-01-15" in text
     assert "2024-12-31" in text
     assert "id,date,timestamp" in text
+
+
+def test_write_csv_invalid_date_format_raises_error(tmp_path):
+    """Test that invalid date format strings raise a clear error."""
+    dates = [datetime.date(2024, 1, 15)]
+    df = daft.from_pydict({"date": dates})
+
+    with pytest.raises(Exception) as exc_info:
+        df.write_csv(str(tmp_path), date_format="%Q")
+
+    # Check that the error message is clear about the invalid format
+    assert "Invalid date format string" in str(exc_info.value)
+
+
+def test_write_csv_invalid_timestamp_format_raises_error(tmp_path):
+    """Test that invalid timestamp format strings raise a clear error."""
+    timestamps = [datetime.datetime(2024, 1, 15, 10, 30, 45)]
+    df = daft.from_pydict({"timestamp": timestamps})
+
+    with pytest.raises(Exception) as exc_info:
+        df.write_csv(str(tmp_path), timestamp_format="%Q")
+
+    # Check that the error message is clear about the invalid format
+    assert "Invalid timestamp format string" in str(exc_info.value)


### PR DESCRIPTION
## Changes Made

This PR implements custom date and timestamp formatting for CSV writes, addressing issue #3788.

### Implementation Details

**Backend (Rust):**
- Added `date_format` and `timestamp_format` fields to `CsvFormatOption` struct in `src/daft-logical-plan/src/sink_info.rs`
- Updated `PyFormatSinkOption::csv()` to accept the new parameters
- Implemented custom formatting logic in `src/daft-writers/src/csv_writer.rs`:
  - Supports Date32, Date64, and all Timestamp types (second, millisecond, microsecond, nanosecond)
  - Uses chrono's strftime format specifiers for flexible formatting
  - **Properly handles timezone-aware timestamps** - preserves timezone information instead of converting to UTC
  - Converts formatted dates/timestamps to strings when custom formats are provided
- Added chrono and chrono-tz dependencies to `daft-writers` crate

**Frontend (Python):**
- Added `date_format` and `timestamp_format` parameters to `DataFrame.write_csv()` in `daft/dataframe/dataframe.py`
- Updated type stubs in `daft/daft/__init__.pyi`
- Added comprehensive documentation with format examples

**Testing:**
- Added 5 new test cases in `tests/io/test_csv.py`:
  - Custom date formatting (dd/MM/yyyy style)
  - Custom timestamp formatting
  - Combined date and timestamp formatting
  - ISO 8601 / RFC 3339 format (%+)
  - **Timezone-aware timestamp formatting** (verifies timezone preservation)

### Usage Example

```python
# Basic date and timestamp formatting
df.write_csv(
    "output.csv", 
    date_format="%d/%m/%Y",           # dd/MM/yyyy format
    timestamp_format="%Y-%m-%d %H:%M:%S"
)

# ISO 8601 format
df.write_csv("output.csv", timestamp_format="%+")

# Timezone-aware timestamps preserve their timezone
df = daft.from_arrow(pa.table({
    "ts": pa.array([...], type=pa.timestamp("us", tz="America/New_York"))
}))
df.write_csv("output.csv", timestamp_format="%Y-%m-%d %H:%M:%S %Z")
# Timestamps will be formatted in New York time, not UTC
```

All format strings follow [chrono's strftime specification](https://docs.rs/chrono/latest/chrono/format/strftime/index.html).

## Related Issues

Closes #3788