### PR TITLE
refactor(arrow-rs): migrate is_in and get_lit ops to Arrow-rs arrays

### DIFF
--- a/src/daft-core/src/array/ops/get_lit.rs
+++ b/src/daft-core/src/array/ops/get_lit.rs
@@ -67,7 +67,12 @@ impl TensorArray {
             && let (Some(data), Some(shape)) =
                 (self.data_array().get(idx), self.shape_array().get(idx))
         {
-            let shape = shape.u64().unwrap().as_arrow2().values().to_vec();
+            let shape_array = shape
+                .u64()
+                .expect("TensorArray::get_lit: shape array must be UInt64")
+                .as_arrow()
+                .expect("TensorArray::get_lit: failed to convert shape to Arrow array");
+            let shape = shape_array.values().to_vec();
             Literal::Tensor { data, shape }
         } else {
             Literal::Null
@@ -96,7 +101,12 @@ impl SparseTensorArray {
                 self.shape_array().get(idx),
             )
         {
-            let shape = shape.u64().unwrap().as_arrow2().values().to_vec();
+            let shape_array = shape
+                .u64()
+                .expect("SparseTensorArray::get_lit: shape array must be UInt64")
+                .as_arrow()
+                .expect("SparseTensorArray::get_lit: failed to convert shape to Arrow array");
+            let shape = shape_array.values().to_vec();
 
             Literal::SparseTensor {
                 values,


### PR DESCRIPTION
Migrate two core array operations from `arrow2` to `arrow-rs`:
- `is_in`: switch to `AsArrow::as_arrow()` and build membership sets via Arrow-rs iterators (`HashSet` for integers, `BTreeSet<FloatWrapper<_>>` for floats).
- `get_lit` (Tensor/SparseTensor): read `shape` via Arrow-rs `UInt64Array.values().to_vec()`.

Part of Daft’s staged Arrow2 → Arrow-rs migration (#5741). This change removes Arrow2 usage in these operators while preserving semantics and keeping null handling intact.

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
## Changes
- `src/daft-core/src/array/ops/is_in.rs`: Arrow-rs iterators + set membership; float handled via `FloatWrapper`.
- `src/daft-core/src/array/ops/get_lit.rs`: shape extraction using Arrow-rs `UInt64Array` with clearer error messages.


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
