### PR TITLE
refactor(arrow-rs): migrate multi-key sort comparator to Arrow-rs

### DIFF
--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -57,9 +57,19 @@ pub fn build_multi_array_bicompare(
         .zip(descending.iter())
         .zip(nulls_first.iter())
     {
+        // Use the Arrow-rs export path to obtain canonical Arrow arrays,
+        // then bridge them into the legacy arrow2-based comparator builder.
+        let l_arrow = l.to_arrow()?;
+        let r_arrow = r.to_arrow()?;
+
+        #[allow(deprecated, reason = "arrow2 migration")]
+        let l_arrow2: Box<dyn daft_arrow::array::Array> = Box::from(l_arrow.as_ref() as &dyn Array);
+        #[allow(deprecated, reason = "arrow2 migration")]
+        let r_arrow2: Box<dyn daft_arrow::array::Array> = Box::from(r_arrow.as_ref() as &dyn Array);
+
         cmp_list.push(build_nulls_first_compare_with_nulls(
-            l.to_arrow2().as_ref(),
-            r.to_arrow2().as_ref(),
+            l_arrow2.as_ref(),
+            r_arrow2.as_ref(),
             *desc,
             *nf,
         )?);


### PR DESCRIPTION
## Changes Made
Migrate the multi-column sort comparator construction path from Arrow2 to the Arrow-rs-based export, focusing specifically on `build_multi_array_bicompare` in `src/daft-core/src/array/ops/sort.rs`.

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
- Refactor `build_multi_array_bicompare` to remove direct reliance on `Series::to_arrow2()`.

- For each `(left[i], right[i])` series pair:
    - Use the Arrow-rs export path `Series::to_arrow()` to obtain canonical `arrow::array::ArrayRef` representations.

    - Bridge these Arrow-rs arrays into the legacy Arrow2 `daft_arrow::array::Array` representation via the existing `From<&dyn arrow_array::Array> for Box<dyn Array>` conversion (behind the `arrow` feature).

    - Pass the bridged Arrow2 arrays into `kernels::search_sorted::build_nulls_first_compare_with_nulls` to construct per-column `DynComparator`s that respect both `descending` (reversed sort direction) and `nulls_first` (null ordering) semantics.
- Keep the combined multi-column comparator logic unchanged: the returned comparator still iterates the per-column comparators and returns on the first non-`Equal` ordering.

## Related Issues
Part of Daft’s staged Arrow2 → Arrow-rs migration (https://github.com/Eventual-Inc/Daft/discussions/5741).
<!-- Link to related GitHub issues, e.g., "Closes #123" -->
