### PR TITLE
perf: Remove thread count restriction for scheduler runtime

### DIFF
--- a/src/daft-distributed/src/utils/runtime.rs
+++ b/src/daft-distributed/src/utils/runtime.rs
@@ -9,7 +9,6 @@ pub fn get_or_init_runtime() -> &'static Runtime {
     let runtime_ref = RUNTIME.get_or_init(|| {
         let mut tokio_runtime_builder = tokio::runtime::Builder::new_multi_thread();
         tokio_runtime_builder.enable_all();
-        tokio_runtime_builder.worker_threads(1);
         tokio_runtime_builder.thread_name_fn(move || "Daft-Scheduler".to_string());
         let tokio_runtime = tokio_runtime_builder
             .build()


### PR DESCRIPTION
## Changes Made
<img width="1752" height="761" alt="image" src="https://github.com/user-attachments/assets/e6184528-8ba7-4eaa-b6f4-8db6d378a448" />
It often happens that the head node still has a lot of resources, but the scheduling cannot be applied. Therefore, I have removed the restriction here.
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
