### PR TITLE
fix(rustfmt): ignore parquet directories

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
+unstable_features = true
 group_imports = "StdExternalCrate"
-ignore = ["src/arrow2", "src/parquet2"]
+ignore = ["src/arrow2", "src/parquet2", "src/parquet-format-safe"]
 imports_granularity = "Crate"


### PR DESCRIPTION
## Changes Made

Fix issue where running `cargo fmt` formats files in `src/parquet-format-safe` but pre-commit in CI rejects them. We need to include `unstable_features = true` in `rustfmt.toml` since `ignore` option is unstable.

https://github.com/rust-lang/rustfmt/blob/main/Configurations.md

https://github.com/rust-lang/rustfmt/issues/3395


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
