### PR TITLE
fix: preserve show options without setting format

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -4545,7 +4545,7 @@ class DataFrame:
         Args:
             n: number of rows to show. Defaults to 8.
             format (PreviewFormat): the box-drawing format e.g. "fancy" or "markdown".
-            verbose (bool): verbose will print header info
+            verbose (bool): if True, headers include the column's data type.
             max_width (int): global max column width
             align (PreviewAlign): global column align
             columns (list[PreviewColumn]): column overrides

--- a/src/common/display/src/table_display.rs
+++ b/src/common/display/src/table_display.rs
@@ -1,6 +1,9 @@
 pub use comfy_table;
 
 const BOLD_TABLE_HEADERS_IN_DISPLAY: &str = "DAFT_BOLD_TABLE_HEADERS";
+const DEFAULT_WIDTH_IF_NO_TTY: u16 = 120;
+const EXPECTED_COL_WIDTH: usize = 18;
+const DOTS: &str = "…";
 
 pub trait StrValue {
     fn str_value(&self, idx: usize) -> String;
@@ -10,20 +13,21 @@ pub trait HTMLValue {
     fn html_value(&self, idx: usize) -> String;
 }
 
+fn maybe_apply_width(table: &mut comfy_table::Table) {
+    if table.width().is_none() && !table.is_tty() {
+        table.set_width(DEFAULT_WIDTH_IF_NO_TTY);
+    }
+}
+
 // this should be factored out to a common crate
 fn create_table_cell(value: &str) -> comfy_table::Cell {
-    let mut attributes = vec![];
+    let mut cell = comfy_table::Cell::new(value);
     if std::env::var(BOLD_TABLE_HEADERS_IN_DISPLAY)
         .as_deref()
         .unwrap_or("1")
         == "1"
     {
-        attributes.push(comfy_table::Attribute::Bold);
-    }
-
-    let mut cell = comfy_table::Cell::new(value);
-    if !attributes.is_empty() {
-        cell = cell.add_attributes(attributes);
+        cell = cell.add_attribute(comfy_table::Attribute::Bold);
     }
     cell
 }
@@ -32,30 +36,19 @@ pub fn make_schema_vertical_table(
     fields: impl Iterator<Item = (String, String, String)>,
 ) -> comfy_table::Table {
     let mut table = comfy_table::Table::new();
-    let default_width_if_no_tty = 120usize;
-
     let fields: Vec<_> = fields.collect();
-
-    let has_metadata = fields.iter().any(|(_, _, meta)| !meta.is_empty());
-
     table
         .load_preset(comfy_table::presets::UTF8_FULL)
         .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
         .set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
-    if table.width().is_none() && !table.is_tty() {
-        table.set_width(default_width_if_no_tty as u16);
+
+    maybe_apply_width(&mut table);
+
+    let mut header = vec![create_table_cell("column_name"), create_table_cell("type")];
+    let has_metadata = fields.iter().any(|(_, _, meta)| !meta.is_empty());
+    if has_metadata {
+        header.push(create_table_cell("metadata"));
     }
-
-    let header = if has_metadata {
-        vec![
-            create_table_cell("column_name"),
-            create_table_cell("type"),
-            create_table_cell("metadata"),
-        ]
-    } else {
-        vec![create_table_cell("column_name"), create_table_cell("type")]
-    };
-
     table.set_header(header);
 
     for (name, dtype, metadata) in fields {
@@ -68,61 +61,93 @@ pub fn make_schema_vertical_table(
     table
 }
 
-pub fn make_comfy_table<S: AsRef<str>>(
-    fields: &[S],
-    columns: Option<&[&dyn StrValue]>,
-    num_rows: Option<usize>,
-    max_col_width: Option<usize>,
-) -> comfy_table::Table {
-    const DOTS: &str = "…";
+#[derive(Clone, Copy)]
+pub struct TableColumnOptions {
+    pub max_width: Option<usize>,
+    pub align: Option<comfy_table::CellAlignment>,
+}
 
-    let mut table = comfy_table::Table::new();
+#[derive(Clone)]
+pub struct TableBuildOptions {
+    pub preset: &'static str,
+    pub modifiers: &'static [&'static str],
+    pub content_arrangement: Option<comfy_table::ContentArrangement>,
+    pub use_terminal_width: bool,
+}
 
-    let default_width_if_no_tty = 120usize;
-
-    table
-        .load_preset(comfy_table::presets::UTF8_FULL)
-        .apply_modifier(comfy_table::modifiers::UTF8_ROUND_CORNERS)
-        .set_content_arrangement(comfy_table::ContentArrangement::Dynamic);
-    if table.width().is_none() && !table.is_tty() {
-        table.set_width(default_width_if_no_tty as u16);
+impl Default for TableBuildOptions {
+    fn default() -> Self {
+        Self {
+            preset: comfy_table::presets::UTF8_FULL,
+            modifiers: &[comfy_table::modifiers::UTF8_ROUND_CORNERS],
+            content_arrangement: Some(comfy_table::ContentArrangement::Dynamic),
+            use_terminal_width: true,
+        }
     }
-    let terminal_width = table
-        .width()
-        .expect("should have already been set with default") as usize;
+}
 
-    let expected_col_width = 18usize;
-
-    let max_cols = (terminal_width.div_ceil(expected_col_width) - 1).max(1);
-    let num_columns = fields.len();
-
-    let (head_cols, tail_cols) = if num_columns > max_cols {
-        let head_cols = max_cols.div_ceil(2);
-        let tail_cols = max_cols / 2;
-        (head_cols, tail_cols)
-    } else {
-        (num_columns, 0)
-    };
-
+fn build_header_cells<S: AsRef<str>>(
+    fields: &[S],
+    head_cols: usize,
+    tail_cols: usize,
+) -> Vec<comfy_table::Cell> {
     let mut header = fields
         .iter()
         .take(head_cols)
         .map(|field| create_table_cell(field.as_ref()))
         .collect::<Vec<_>>();
+
     if tail_cols > 0 {
-        let unseen_cols = num_columns - (head_cols + tail_cols);
-        header.push(
-            create_table_cell(&format!("{DOTS}\n\n({unseen_cols} hidden)"))
-                .set_alignment(comfy_table::CellAlignment::Center),
-        );
+        let unseen_cols = fields.len() - (head_cols + tail_cols);
+        let ellipsis = format!("{DOTS}\n\n({unseen_cols} hidden)");
+        header.push(create_table_cell(&ellipsis).set_alignment(comfy_table::CellAlignment::Center));
         header.extend(
             fields
                 .iter()
-                .skip(num_columns - tail_cols)
+                .skip(fields.len() - tail_cols)
                 .map(|field| create_table_cell(field.as_ref())),
         );
     }
 
+    header
+}
+
+pub fn build_table<S: AsRef<str>>(
+    fields: &[S],
+    columns: Option<&[&dyn StrValue]>,
+    num_rows: Option<usize>,
+    column_options: Option<&[TableColumnOptions]>,
+    global_max_width: Option<usize>,
+    options: TableBuildOptions,
+) -> comfy_table::Table {
+    let mut table = comfy_table::Table::new();
+
+    table.load_preset(options.preset);
+    for modifier in options.modifiers {
+        table.apply_modifier(modifier);
+    }
+    if let Some(arrangement) = options.content_arrangement {
+        table.set_content_arrangement(arrangement);
+    }
+    maybe_apply_width(&mut table);
+
+    let num_columns = fields.len();
+    let (head_cols, tail_cols) = if options.use_terminal_width {
+        let terminal_width = table
+            .width()
+            .expect("should have already been set with default")
+            as usize;
+        let max_cols = (terminal_width.div_ceil(EXPECTED_COL_WIDTH) - 1).max(1);
+        if num_columns > max_cols {
+            (max_cols.div_ceil(2), max_cols / 2)
+        } else {
+            (num_columns, 0)
+        }
+    } else {
+        (num_columns, 0)
+    };
+
+    let header = build_header_cells(fields, head_cols, tail_cols);
     if let Some(columns) = columns
         && !columns.is_empty()
     {
@@ -132,22 +157,35 @@ pub fn make_comfy_table<S: AsRef<str>>(
         for i in 0..len {
             let all_cols = columns
                 .iter()
-                .map(|s| {
+                .enumerate()
+                .map(|(idx, s)| {
                     let mut str_val = s.str_value(i);
-                    let str_val_len = str_val.char_indices().count();
-                    if let Some(max_col_width) = max_col_width
-                        && str_val_len > max_col_width - DOTS.len()
+                    let max_width = column_options
+                        .and_then(|opts| opts.get(idx))
+                        .and_then(|opts| opts.max_width)
+                        .or(global_max_width);
+
+                    if let Some(max_width) = max_width
+                        && str_val.char_indices().count() > max_width - DOTS.len()
                     {
                         str_val = format!(
                             "{}{DOTS}",
                             &str_val
                                 .char_indices()
-                                .take(max_col_width - DOTS.len())
+                                .take(max_width - DOTS.len())
                                 .map(|(_, c)| c)
                                 .collect::<String>()
                         );
                     }
-                    str_val
+
+                    let mut cell = comfy_table::Cell::new(str_val);
+                    if let Some(align) = column_options
+                        .and_then(|opts| opts.get(idx))
+                        .and_then(|opts| opts.align)
+                    {
+                        cell = cell.set_alignment(align);
+                    }
+                    cell
                 })
                 .collect::<Vec<_>>();
 
@@ -163,5 +201,22 @@ pub fn make_comfy_table<S: AsRef<str>>(
     } else {
         table.add_row(header);
     }
+
     table
+}
+
+pub fn make_comfy_table<S: AsRef<str>>(
+    fields: &[S],
+    columns: Option<&[&dyn StrValue]>,
+    num_rows: Option<usize>,
+    max_col_width: Option<usize>,
+) -> comfy_table::Table {
+    build_table(
+        fields,
+        columns,
+        num_rows,
+        None,
+        max_col_width,
+        TableBuildOptions::default(),
+    )
 }

--- a/src/daft-recordbatch/src/preview.rs
+++ b/src/daft-recordbatch/src/preview.rs
@@ -1,7 +1,7 @@
 use std::fmt::{Display, Formatter};
 
-use comfy_table::{Cell, CellAlignment, Table as ComfyTable};
-use common_display::table_display::StrValue;
+use comfy_table::{CellAlignment, Table as ComfyTable};
+use common_display::table_display::{StrValue, TableBuildOptions, TableColumnOptions, build_table};
 use common_error::DaftError;
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,7 @@ pub struct Preview {
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PreviewFormat {
-    /// Fancy box drawing (default).
+    /// Fancy box drawing.
     Fancy,
     /// No box drawing.
     Plain,
@@ -96,7 +96,7 @@ impl Preview {
     pub fn default(preview: RecordBatch) -> Self {
         Self {
             batch: preview,
-            format: PreviewFormat::Fancy,
+            format: PreviewFormat::default(),
             options: PreviewOptions::default(),
         }
     }
@@ -123,10 +123,15 @@ impl TryFrom<&str> for PreviewFormat {
             "latex" => Ok(Self::Latex),
             "html" => Ok(Self::Html),
             _ => Err(DaftError::ValueError(format!(
-                "Unknown preview format: {}",
-                s
+                "Unknown preview format: {s}"
             ))),
         }
+    }
+}
+
+impl Default for PreviewFormat {
+    fn default() -> Self {
+        Self::Fancy
     }
 }
 
@@ -160,30 +165,23 @@ impl Display for Preview {
 impl Preview {
     /// Create a ComfyTable.
     fn create_table(&self) -> ComfyTable {
-        let mut table = ComfyTable::new();
-        self.load_preset(&mut table);
-        self.push_header(&mut table);
-        self.push_body(&mut table);
-        table
+        let headers = self.headers();
+        let column_options = self.column_options();
+        let columns = self.columns();
+        let preset = self.table_preset();
+        let table_options = Self::table_build_options(preset);
+        build_table(
+            &headers,
+            Some(&columns),
+            Some(self.batch.len()),
+            Some(&column_options),
+            self.options.max_width,
+            table_options,
+        )
     }
 
-    /// Daft has its own format presets.
-    fn load_preset(&self, table: &mut ComfyTable) {
-        let preset = match self.format {
-            PreviewFormat::Fancy => presets::FANCY,
-            PreviewFormat::Plain => presets::PLAIN,
-            PreviewFormat::Simple => presets::SIMPLE,
-            PreviewFormat::Grid => presets::GRID,
-            PreviewFormat::Markdown => presets::MARKDOWN,
-            _ => unreachable!("given format `{:?}` has no preset", self.format),
-        };
-        table.load_preset(preset);
-    }
-
-    /// Push the header row to the table.
-    fn push_header(&self, table: &mut ComfyTable) {
-        let row: Vec<Cell> = self
-            .batch
+    fn headers(&self) -> Vec<String> {
+        self.batch
             .schema
             .into_iter()
             .enumerate()
@@ -197,85 +195,71 @@ impl Preview {
                     info = overrides.info.clone().unwrap_or(info);
                 }
                 // Create header cell with possible info.
-                if !self.options.verbose {
-                    Cell::new(text)
-                } else if self.format == PreviewFormat::Fancy {
-                    Cell::new(format!("{}\n---\n{}", text, info))
+                if self.options.verbose {
+                    if self.format == PreviewFormat::Fancy {
+                        format!("{text}\n---\n{info}")
+                    } else {
+                        format!("{text} ({info})")
+                    }
                 } else {
-                    Cell::new(format!("{} ({})", text, info))
+                    text
                 }
             })
-            .collect();
-        table.set_header(row);
+            .collect()
     }
 
-    /// Push the body rows to the table.
-    fn push_body(&self, table: &mut ComfyTable) {
-        let total_rows = self.batch.len();
+    fn column_options(&self) -> Vec<TableColumnOptions> {
+        self.batch
+            .schema
+            .into_iter()
+            .enumerate()
+            .map(|(idx, _)| {
+                // Use column overrides if any, falling back to the global settings.
+                let mut max_width = self.options.max_width;
+                let mut align = self.options.align;
+                if let Some(overrides) = self.options.column(idx) {
+                    max_width = overrides.max_width.or(max_width);
+                    align = overrides.align.or(align);
+                }
+                // If some alignment, translate to comfy_table
+                let align = align.map(|align| match align {
+                    PreviewAlign::Auto => CellAlignment::Left,
+                    PreviewAlign::Left => CellAlignment::Left,
+                    PreviewAlign::Center => CellAlignment::Center,
+                    PreviewAlign::Right => CellAlignment::Right,
+                });
+                TableColumnOptions { max_width, align }
+            })
+            .collect()
+    }
 
-        // Add target rows
-        for o in 0..total_rows {
-            let row: Vec<Cell> = self
-                .batch
-                .columns
-                .iter()
-                .enumerate()
-                .map(|(idx, series)| {
-                    // Unfortunately actually plumbing the formatting would make this too much work right now.
-                    let mut text = series.as_materialized_series().str_value(o);
-                    let mut alignment = CellAlignment::Left;
+    fn columns(&self) -> Vec<&dyn StrValue> {
+        self.batch
+            .columns
+            .iter()
+            .map(|c| c.as_materialized_series() as &dyn StrValue)
+            .collect()
+    }
 
-                    // Use column overrides if any, falling back to the global settings.
-                    let mut max_width = self.options.max_width;
-                    let mut align: Option<PreviewAlign> = self.options.align;
-                    if let Some(overrides) = self.options.column(idx) {
-                        max_width = overrides.max_width.or(max_width);
-                        align = overrides.align.or(align);
-                    }
-
-                    // Truncate cell content if over max length.
-                    if let Some(max_width) = max_width {
-                        text = truncate(text, max_width, magic::DOTS);
-                    }
-
-                    // If some alignment, translate to comfy_table
-                    if let Some(align) = &align {
-                        alignment = match align {
-                            PreviewAlign::Auto => CellAlignment::Left,
-                            PreviewAlign::Left => CellAlignment::Left,
-                            PreviewAlign::Center => CellAlignment::Center,
-                            PreviewAlign::Right => CellAlignment::Right,
-                        };
-                    }
-
-                    // Use global overrides
-                    Cell::new(text).set_alignment(alignment)
-                })
-                .collect();
-            table.add_row(row);
+    fn table_preset(&self) -> &'static str {
+        match self.format {
+            PreviewFormat::Fancy => presets::FANCY,
+            PreviewFormat::Plain => presets::PLAIN,
+            PreviewFormat::Simple => presets::SIMPLE,
+            PreviewFormat::Grid => presets::GRID,
+            PreviewFormat::Markdown => presets::MARKDOWN,
+            _ => unreachable!("given format `{:?}` has no preset", self.format),
         }
     }
-}
 
-/// Truncate a string, appending the
-fn truncate(text: String, max_width: usize, suffix: &str) -> String {
-    if text.len() < max_width {
-        return text;
+    fn table_build_options(preset: &'static str) -> TableBuildOptions {
+        TableBuildOptions {
+            preset,
+            modifiers: &[],
+            content_arrangement: None,
+            use_terminal_width: false,
+        }
     }
-    format!(
-        "{}{suffix}",
-        &text
-            .char_indices()
-            .take(max_width - suffix.len())
-            .map(|(_, c)| c)
-            .collect::<String>()
-    )
-}
-
-/// Formatting magic strings.
-mod magic {
-    /// Fancy dots aka ellipse for truncated columns.
-    pub const DOTS: &str = "…";
 }
 
 /// Preset strings for the text art tables.

--- a/src/daft-recordbatch/src/python.rs
+++ b/src/daft-recordbatch/src/python.rs
@@ -226,16 +226,20 @@ impl PyRecordBatch {
     }
 
     /// Helper to create a rust Preview and use its Display impl.
-    #[pyo3(signature = (format, options))]
-    pub fn preview(&self, format: &str, options: Option<&str>) -> PyResult<String> {
-        let format = PreviewFormat::try_from(format)?;
-        let options = match options {
-            Some(json) => serde_json::from_str::<PreviewOptions>(json)
-                .expect("PreviewOptions produced invalid json."),
-            None => PreviewOptions::default(),
+    #[pyo3(signature = (format=None, options=None))]
+    pub fn preview(&self, format: Option<&str>, options: Option<&str>) -> PyResult<String> {
+        let format = if let Some(fmt) = format {
+            PreviewFormat::try_from(fmt)?
+        } else {
+            PreviewFormat::default()
         };
-        let preview = self.record_batch.clone();
-        let preview = Preview::new(preview, format, options);
+        let options = if let Some(json) = options {
+            serde_json::from_str::<PreviewOptions>(json)
+                .expect("PreviewOptions produced invalid json.")
+        } else {
+            PreviewOptions::default()
+        };
+        let preview = Preview::new(self.record_batch.clone(), format, options);
         Ok(preview.to_string())
     }
 

--- a/tests/dataframe/test_show.py
+++ b/tests/dataframe/test_show.py
@@ -186,6 +186,22 @@ def test_show_with_wide_columns():
  This is a very long text that exceeds the default max_width.   Another extremely long piece of text that also exceeds the default max_width. """[1:]
 
 
+def test_show_default_respects_options():
+    df = daft.from_pydict(
+        {
+            "strings": ["this is a really long string that should not be be truncated"],
+        }
+    )
+
+    out = show(df, format=None, max_width=1000)
+    assert out == """
+╭──────────────────────────────────────────────────────────────╮
+│ strings                                                      │
+╞══════════════════════════════════════════════════════════════╡
+│ this is a really long string that should not be be truncated │
+╰──────────────────────────────────────────────────────────────╯"""[1:]
+
+
 def test_show_with_many_columns():
     df = daft.from_pylist(
         [


### PR DESCRIPTION
## Changes Made

- Pass in `format=None` to Rust `preview` binding and use default PreviewFormat in that case.
- Make `table_display.rs` single source of truth for configuring and printing tables.
- Check `PYTEST_CURRENT_TEST` instead of custom `DAFT_BOLD_TABLE_HEADERS`flag during tests.

## Related Issues

Closes #4147.
