### PR TITLE
chore: Allows `make clean` to skip cleaning the python virtual environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,7 @@ build-release: check-toolchain .venv  ## Compile and install a faster Daft binar
 
 .PHONY: build-whl
 build-whl: check-toolchain .venv  ## Compile Daft for development, only generate whl file without installation
-	cargo clean --target-dir target
-	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin build
+	@unset CONDA_PREFIX && PYO3_PYTHON=$(VENV_BIN)/python $(VENV_BIN)/maturin build --release
 
 .PHONY: test
 test: .venv build  ## Run tests
@@ -114,12 +113,14 @@ lint: check-toolchain .venv  ## Lint Python and Rust code
 	source $(VENV_BIN)/activate && pre-commit run clippy --all-files
 
 .PHONY: precommit
-precommit:  check-toolchain .venv  ## Run all pre-commit hooks
+precommit: check-toolchain .venv  ## Run all pre-commit hooks
 	source $(VENV_BIN)/activate && pre-commit run --all-files
 
 .PHONY: clean
 clean:
+ifneq ($(SKIP_VENV),true)
 	rm -rf $(VENV)
+endif
 	rm -rf ./target
 	rm -rf ./site
 	rm -f daft/daft.abi3.so

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -30,6 +30,7 @@ To set up your development environment:
 9. `make precommit`: run all pre-commit hooks, must install pre-commit first(pip install pre-commit)
 10. `make build-release`: perform a full release build of Daft
 11. `make build-whl`: recompile your code after modifying any Rust code in `src/` for development, only generate `whl` file without installation
+12. `make clean`: clean all build artifacts, including the python virtual environment. You can skip cleaning the virtual environment by setting `SKIP_VENV=true`
 
 ### Note about Developing `daft-dashboard`
 


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Two optimizations:

1. When executing `make clean`, allow skipping the deletion of the `.venv` directory by setting `SKIP_VENV=true`, default is false.

2. Add the `--release` parameter to `make build-whl`, and remove `cargo clean --target-dir ./target`, delegating the cleanup of build artifacts to `make clean`.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
