### PR TITLE
ci: Add pytz and numpy to wheel build test dependencies

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -187,7 +187,7 @@ jobs:
         retry_wait_seconds: 10
         command: |
           source venv/bin/activate
-          pip install ray pytest pandas dist/*.whl --force-reinstall
+          pip install ray pytest pandas pytz numpy dist/*.whl --force-reinstall
           rm -rf daft
     - name: Run dataframe tests
       run: |


### PR DESCRIPTION
## Changes Made

Updated the build-wheel workflow to include `pytz` and `numpy` in the pip install command for the dataframe tests job. These dependencies are now explicitly installed alongside the existing `ray`, `pytest`, and `pandas` packages before running the dataframe tests.

This ensures that all required dependencies are available during the test execution, preventing potential import errors or test failures due to missing packages.

## Related Issues

<!-- Link to related GitHub issues if applicable -->

https://claude.ai/code/session_019GJn5ESmtvSzBAq7W8jtdU