### PR TITLE
ci: Add pyarrow to wheel build test dependencies

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -187,7 +187,7 @@ jobs:
         retry_wait_seconds: 10
         command: |
           source venv/bin/activate
-          pip install ray pytest pandas pytz numpy dist/*.whl --force-reinstall
+          pip install ray pytest pandas pytz numpy pyarrow dist/*.whl --force-reinstall
           rm -rf daft
     - name: Run dataframe tests
       run: |


### PR DESCRIPTION
## Changes Made

Added `pyarrow` to the pip install command in the build-wheel workflow's test step. This ensures that PyArrow is available when running the dataframe tests, which likely depend on it for Arrow-based data operations and serialization.

The change updates the dependency installation line to include `pyarrow` alongside other core dependencies like `ray`, `pytest`, `pandas`, `pytz`, and `numpy`.

## Related Issues

<!-- Link to related GitHub issues if applicable -->

https://claude.ai/code/session_01AQAqWAAYWJqsNFmyuQmjDB