### PR TITLE
fix: Allow `is_in` to accept sets, tuples, and other iterables

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -1169,7 +1169,7 @@ class Expression:
 
         return fill_null(self, fill_value)
 
-    def is_in(self, other: Any) -> Expression:
+    def is_in(self, other: Iterable[Any] | Expression) -> Expression:
         """Checks if values in the Expression are in the provided iterable.
 
         Args:

--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -1170,7 +1170,10 @@ class Expression:
         return fill_null(self, fill_value)
 
     def is_in(self, other: Any) -> Expression:
-        """Checks if values in the Expression are in the provided list.
+        """Checks if values in the Expression are in the provided iterable.
+
+        Args:
+            other: An iterable (list, set, tuple, etc.), Expression, or array-like object containing the values to check against
 
         Tip: See Also
             [`daft.functions.is_in`](https://docs.daft.ai/en/stable/api/functions/is_in/)

--- a/daft/functions/misc.py
+++ b/daft/functions/misc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any, Literal
 
 import daft.daft as native
@@ -226,7 +227,7 @@ def fill_null(expr: Expression, fill_value: Expression) -> Expression:
     return Expression._from_pyexpr(expr._expr.fill_null(fill_value._expr))
 
 
-def is_in(expr: Expression, other: Any) -> Expression:
+def is_in(expr: Expression, other: Iterable[Any] | Expression) -> Expression:
     """Checks if values in the Expression are in the provided iterable.
 
     Args:
@@ -258,17 +259,10 @@ def is_in(expr: Expression, other: Any) -> Expression:
         (Showing first 3 of 3 rows)
 
     """
-    from collections.abc import Iterable
-
-    # Convert sets, tuples, and other non-string iterables to lists
-    # We exclude strings because they are iterable but should not be treated as a list of characters
-    if isinstance(other, (set, tuple, frozenset)):
+    # Convert non-list iterables (sets, tuples, generators, ranges, etc.) to lists
+    # Exclude strings/bytes since they are iterable but should not be treated as sequences of characters/bytes
+    if isinstance(other, Iterable) and not isinstance(other, (str, bytes, Expression)):
         other = list(other)
-    elif isinstance(other, Iterable) and not isinstance(other, (str, bytes, Expression)):
-        # For other iterables that are not lists, convert to list
-        # This handles generators, ranges, dict_keys, etc.
-        if not isinstance(other, list):
-            other = list(other)
 
     if isinstance(other, list):
         other = [Expression._to_expression(item) for item in other]

--- a/daft/functions/misc.py
+++ b/daft/functions/misc.py
@@ -227,10 +227,14 @@ def fill_null(expr: Expression, fill_value: Expression) -> Expression:
 
 
 def is_in(expr: Expression, other: Any) -> Expression:
-    """Checks if values in the Expression are in the provided list.
+    """Checks if values in the Expression are in the provided iterable.
+
+    Args:
+        expr: The expression to check
+        other: An iterable (list, set, tuple, etc.), Expression, or array-like object containing the values to check against
 
     Returns:
-        Expression (Boolean Expression): expression indicating whether values are in the provided list
+        Expression (Boolean Expression): expression indicating whether values are in the provided iterable
 
     Examples:
         >>> import daft
@@ -254,6 +258,18 @@ def is_in(expr: Expression, other: Any) -> Expression:
         (Showing first 3 of 3 rows)
 
     """
+    from collections.abc import Iterable
+
+    # Convert sets, tuples, and other non-string iterables to lists
+    # We exclude strings because they are iterable but should not be treated as a list of characters
+    if isinstance(other, (set, tuple, frozenset)):
+        other = list(other)
+    elif isinstance(other, Iterable) and not isinstance(other, (str, bytes, Expression)):
+        # For other iterables that are not lists, convert to list
+        # This handles generators, ranges, dict_keys, etc.
+        if not isinstance(other, list):
+            other = list(other)
+
     if isinstance(other, list):
         other = [Expression._to_expression(item) for item in other]
     elif not isinstance(other, Expression):


### PR DESCRIPTION
Previously, `is_in` only accepted lists. Now it accepts any iterable (sets, tuples, frozensets, ranges, generators, dict_keys, etc.) by converting them to lists before processing.

Strings and bytes are explicitly excluded since they are iterable but should not be treated as a sequence of characters/bytes.

Fixes #6107

The regression was introduced in https://github.com/Eventual-Inc/Daft/pull/5086

This commit refactored many functions including moving is_in to `daft/functions/misc.py`. Looking at the implementation that was added, we went from

```
        if isinstance(other, Collection):
            other = [Expression._to_expression(item) for item in other]
```
to
```
    if isinstance(other, list):
        other = [Expression._to_expression(item) for item in other]
```
