### PR TITLE
feat: Add Python Function data source info in explain

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1084,7 +1084,7 @@ class ScanTask:
         size_bytes: int | None,
         pushdowns: PyPushdowns | None,
         stats: PyRecordBatch | None,
-        source_type: str | None = None,
+        source_name: str | None = None,
     ) -> ScanTask:
         """Create a Python factory function Scan Task."""
         ...

--- a/daft/io/__shim.py
+++ b/daft/io/__shim.py
@@ -66,7 +66,7 @@ class _DataSourceShim(ScanOperator):
                 size_bytes=None,
                 pushdowns=pushdowns,
                 stats=None,
-                source_type=self.name(),
+                source_name=self.display_name(),
             )
 
     def as_pushdown_filter(self) -> SupportsPushdownFilters | None:

--- a/daft/io/_generator.py
+++ b/daft/io/_generator.py
@@ -119,5 +119,5 @@ class GeneratorScanOperator(ScanOperator):
                 size_bytes=None,
                 pushdowns=pushdowns,
                 stats=None,
-                source_type=self.name(),
+                source_name=self.display_name(),
             )

--- a/daft/io/iceberg/iceberg_scan.py
+++ b/daft/io/iceberg/iceberg_scan.py
@@ -278,6 +278,7 @@ class IcebergScanOperator(ScanOperator):
                 size_bytes=8,
                 pushdowns=pushdowns,
                 stats=None,
+                source_name=self.display_name(),
             )
         except Exception as e:
             logger.error("Failed to create Iceberg count pushdown task: %s, now falling back to regular scan", e)

--- a/daft/io/lance/lance_scan.py
+++ b/daft/io/lance/lance_scan.py
@@ -265,7 +265,7 @@ class LanceDBScanOperator(ScanOperator, SupportsPushdownFilters):
             size_bytes=None,
             pushdowns=pushdowns,
             stats=None,
-            source_type=self.name(),
+            source_name=self.display_name(),
         )
 
     def _create_scan_tasks_with_limit_and_no_filters(
@@ -318,7 +318,7 @@ class LanceDBScanOperator(ScanOperator, SupportsPushdownFilters):
                     size_bytes=self._estimate_size_bytes(fragment),
                     pushdowns=pushdowns,
                     stats=None,
-                    source_type=self.name(),
+                    source_name=self.display_name(),
                 )
 
     def _create_regular_scan_tasks(
@@ -353,7 +353,7 @@ class LanceDBScanOperator(ScanOperator, SupportsPushdownFilters):
                 size_bytes=size_bytes,
                 pushdowns=pushdowns,
                 stats=None,
-                source_type=self.name(),
+                source_name=self.display_name(),
             )
 
         # Use index-driven scan for point lookups with BTREE indices or nearest search.

--- a/daft/io/lance/rest_scan.py
+++ b/daft/io/lance/rest_scan.py
@@ -283,7 +283,7 @@ class LanceRestScanOperator(ScanOperator, SupportsPushdownFilters):
             size_bytes=None,
             pushdowns=pushdowns,
             stats=None,
-            source_type=self.name(),
+            source_name=self.display_name(),
         )
 
     def _create_regular_scan_tasks(
@@ -314,7 +314,7 @@ class LanceRestScanOperator(ScanOperator, SupportsPushdownFilters):
             size_bytes=None,  # Unknown for REST
             pushdowns=pushdowns,
             stats=None,
-            source_type=self.name(),
+            source_name=self.display_name(),
         )
 
     def _fetch_table_schema(self) -> Schema:

--- a/src/common/file-formats/src/file_format_config.rs
+++ b/src/common/file-formats/src/file_format_config.rs
@@ -24,7 +24,7 @@ pub enum FileFormatConfig {
     Database(DatabaseSourceConfig),
     #[cfg(feature = "python")]
     PythonFunction {
-        source_type: Option<String>,
+        source_name: Option<String>,
         module_name: Option<String>,
         function_name: Option<String>,
     },
@@ -53,12 +53,12 @@ impl FileFormatConfig {
             Self::Database(_) => "Database".to_string(),
             #[cfg(feature = "python")]
             Self::PythonFunction {
-                source_type,
+                source_name,
                 module_name,
-                function_name: _,
+                ..
             } => {
-                if let Some(source_type) = source_type {
-                    format!("{}(Python)", source_type)
+                if let Some(source_name) = source_name {
+                    format!("{}(Python)", source_name)
                 } else if let Some(module_name) = module_name {
                     // Infer type from module name
                     format!("{}(Python)", module_name)
@@ -79,7 +79,23 @@ impl FileFormatConfig {
             #[cfg(feature = "python")]
             Self::Database(source) => source.multiline_display(),
             #[cfg(feature = "python")]
-            Self::PythonFunction { .. } => vec![],
+            Self::PythonFunction {
+                source_name,
+                module_name,
+                function_name,
+            } => {
+                let mut res = vec![];
+                if let Some(source_name) = source_name {
+                    res.push(format!("Source = {source_name}"));
+                }
+                if let Some(module_name) = module_name {
+                    res.push(format!("Module = {module_name}"));
+                }
+                if let Some(function_name) = function_name {
+                    res.push(format!("Function = {function_name}"));
+                }
+                res
+            }
         }
     }
 }

--- a/src/common/file-formats/src/lib.rs
+++ b/src/common/file-formats/src/lib.rs
@@ -21,11 +21,7 @@ impl From<&FileFormatConfig> for FileFormat {
             #[cfg(feature = "python")]
             FileFormatConfig::Database(_) => Self::Database,
             #[cfg(feature = "python")]
-            FileFormatConfig::PythonFunction {
-                source_type: _,
-                module_name: _,
-                function_name: _,
-            } => Self::Python,
+            FileFormatConfig::PythonFunction { .. } => Self::Python,
         }
     }
 }

--- a/src/common/file-formats/src/python.rs
+++ b/src/common/file-formats/src/python.rs
@@ -75,11 +75,7 @@ impl PyFileFormatConfig {
                 .clone()
                 .into_pyobject(py)
                 .map(|c| c.unbind().into_any()),
-            FileFormatConfig::PythonFunction {
-                source_type: _,
-                module_name: _,
-                function_name: _,
-            } => Ok(py.None()),
+            FileFormatConfig::PythonFunction { .. } => Ok(py.None()),
         }
     }
 

--- a/src/daft-distributed/src/pipeline_node/scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/scan_source.rs
@@ -142,73 +142,77 @@ impl PipelineNodeImpl for ScanSourceNode {
     }
 
     fn multiline_display(&self, verbose: bool) -> Vec<String> {
-        fn base_display(scan: &ScanSourceNode) -> Vec<String> {
-            let num_scan_tasks = scan.scan_tasks.len();
-            let total_bytes: usize = scan
-                .scan_tasks
-                .iter()
-                .map(|st| {
-                    st.estimate_in_memory_size_bytes(Some(scan.config.execution_config.as_ref()))
-                        .or_else(|| st.size_bytes_on_disk())
-                        .unwrap_or(0)
-                })
-                .sum();
+        let mut res = vec!["ScanTaskSource:".to_string()];
 
-            #[allow(unused_mut)]
-            let mut s = vec![
-                "ScanTaskSource:".to_string(),
-                format!("Num Scan Tasks = {num_scan_tasks}"),
-                format!("Estimated Scan Bytes = {total_bytes}"),
-            ];
+        let num_scan_tasks = self.scan_tasks.len();
+        let total_bytes: usize = self
+            .scan_tasks
+            .iter()
+            .map(|st| {
+                st.estimate_in_memory_size_bytes(Some(self.config.execution_config.as_ref()))
+                    .or_else(|| st.size_bytes_on_disk())
+                    .unwrap_or(0)
+            })
+            .sum();
+        res.push(format!("Num Scan Tasks = {num_scan_tasks}"));
+        res.push(format!("Estimated Scan Bytes = {total_bytes}"));
 
-            if num_scan_tasks == 0 {
-                return s;
-            }
-
-            #[cfg(feature = "python")]
-            if let FileFormatConfig::Database(config) =
-                scan.scan_tasks[0].file_format_config().as_ref()
-            {
-                if num_scan_tasks == 1 {
-                    s.push(format!("SQL Query = {}", &config.sql));
-                } else {
-                    s.push(format!("SQL Queries = [{},..]", &config.sql));
+        if let Some(ffc) = self
+            .scan_tasks
+            .first()
+            .map(|s| s.file_format_config())
+            .as_deref()
+        {
+            match ffc {
+                #[cfg(feature = "python")]
+                FileFormatConfig::Database(config) => {
+                    if num_scan_tasks == 1 {
+                        res.push(format!("SQL Query = {}", &config.sql));
+                    } else {
+                        res.push(format!("SQL Queries = [{},..]", &config.sql));
+                    }
                 }
+                #[cfg(feature = "python")]
+                FileFormatConfig::PythonFunction { source_name, .. } => {
+                    res.push(format!(
+                        "Source = {}",
+                        source_name.clone().unwrap_or_else(|| "None".to_string())
+                    ));
+                }
+                _ => {}
             }
-            s
         }
 
-        let mut s = base_display(self);
-        if !verbose {
+        if verbose {
+            res.push("Scan Tasks: [".to_string());
+            for st in self.scan_tasks.iter() {
+                res.push(st.as_ref().display_as(DisplayLevel::Verbose));
+            }
+        } else {
             let pushdown = &self.pushdowns;
             if !pushdown.is_empty() {
-                s.push(pushdown.display_as(DisplayLevel::Compact));
+                res.push(pushdown.display_as(DisplayLevel::Compact));
             }
 
             let schema = &self.config.schema;
-            s.push(format!(
+            res.push(format!(
                 "Schema: {{{}}}",
                 schema.display_as(DisplayLevel::Compact)
             ));
 
-            s.push("Scan Tasks: [".to_string());
+            res.push("Scan Tasks: [".to_string());
             let tasks = self.scan_tasks.iter();
             for (i, st) in tasks.enumerate() {
                 if i < 3 || i >= self.scan_tasks.len() - 3 {
-                    s.push(st.as_ref().display_as(DisplayLevel::Compact));
+                    res.push(st.as_ref().display_as(DisplayLevel::Compact));
                 } else if i == 3 {
-                    s.push("...".to_string());
+                    res.push("...".to_string());
                 }
             }
-        } else {
-            s.push("Scan Tasks: [".to_string());
-
-            for st in self.scan_tasks.iter() {
-                s.push(st.as_ref().display_as(DisplayLevel::Verbose));
-            }
         }
-        s.push("]".to_string());
-        s
+
+        res.push("]".to_string());
+        res
     }
 
     fn runtime_stats(&self, meter: &Meter) -> RuntimeStatsRef {

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -329,11 +329,7 @@ impl GlobScanOperator {
                     ));
                 }
                 #[cfg(feature = "python")]
-                FileFormatConfig::PythonFunction {
-                    source_type: _,
-                    module_name: _,
-                    function_name: _,
-                } => {
+                FileFormatConfig::PythonFunction { .. } => {
                     return Err(DaftError::ValueError(
                         "Cannot glob a PythonFunction source".to_string(),
                     ));

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -773,13 +773,9 @@ impl ScanTask {
                             }
                         }
                         #[cfg(feature = "python")]
-                        FileFormatConfig::Database(_) => 1.0,
-                        #[cfg(feature = "python")]
-                        FileFormatConfig::PythonFunction {
-                            source_type: _,
-                            module_name: _,
-                            function_name: _,
-                        } => 1.0,
+                        FileFormatConfig::Database(_) | FileFormatConfig::PythonFunction { .. } => {
+                            1.0
+                        }
                     };
                     let in_mem_size: f64 = (file_size as f64) * inflation_factor;
                     let read_row_size = if self.is_warc() {
@@ -970,7 +966,7 @@ impl ScanTask {
 impl DisplayAs for ScanTask {
     fn display_as(&self, level: common_display::DisplayLevel) -> String {
         // take first 3 and last 3 if more than 6 sources
-        let condensed_sources = if self.sources.len() <= 6 {
+        let mut condensed_sources = if self.sources.len() <= 6 {
             self.sources.iter().map(|s| s.display_as(level)).join(", ")
         } else {
             let len = self.sources.len();
@@ -984,6 +980,16 @@ impl DisplayAs for ScanTask {
                     _ => None,
                 })
                 .join(", ")
+        };
+
+        #[cfg(feature = "python")]
+        if let FileFormatConfig::PythonFunction { .. } = self.file_format_config.as_ref() {
+            // For Python Function, only display the first source, which makes it more readable
+            if self.sources.len() > 1 {
+                condensed_sources = format!("{}, ...", self.sources[0].display_as(level));
+            } else {
+                condensed_sources = self.sources.iter().map(|s| s.display_as(level)).join(", ");
+            }
         };
 
         match level {

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -580,7 +580,7 @@ pub mod pylib {
             size_bytes=None,
             pushdowns=None,
             stats=None,
-            source_type=None
+            source_name=None
         ))]
         pub fn python_factory_func_scan_task(
             module: String,
@@ -591,7 +591,7 @@ pub mod pylib {
             size_bytes: Option<u64>,
             pushdowns: Option<PyPushdowns>,
             stats: Option<PyRecordBatch>,
-            source_type: Option<String>,
+            source_name: Option<String>,
         ) -> PyResult<Self> {
             let statistics = stats
                 .map(|s| TableStatistics::from_stats_table(&s.record_batch))
@@ -612,7 +612,7 @@ pub mod pylib {
 
             // Create enhanced FileFormatConfig with context information
             let file_format_config = Arc::new(FileFormatConfig::PythonFunction {
-                source_type,
+                source_name,
                 module_name: Some(module),
                 function_name: Some(func_name),
             });


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Currently, for `Datasource` implemented using the Python SDK, `explain` does not display dataset identification information (such as URI or table). This PR primarily adds a `Source` field to the `ScanTaskSource` node to reveal this information. For example:

<img width="654" height="327" alt="image" src="https://github.com/user-attachments/assets/e0ad97b9-f567-41b8-9393-5566c87bab6e" />

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
