### PR TITLE
feat: add micro_commit_batch_size param in lance_compaction function

### DIFF
--- a/daft/io/lance/lance_compaction.py
+++ b/daft/io/lance/lance_compaction.py
@@ -30,8 +30,9 @@ def compact_files_internal(
     lance_ds: lance.LanceDataset,
     *,
     compaction_options: dict[str, Any] | None = None,
-    partition_num: int | None = None,
+    num_partitions: int | None = None,
     concurrency: int | None = None,
+    micro_commit_batch_size: int | None = None,
 ) -> CompactionMetrics | None:
     """Execute Lance file compaction in distributed environment using Daft UDF style."""
     logger.info("Starting UDF-style distributed compaction")
@@ -48,21 +49,35 @@ def compact_files_internal(
         logger.info("No compaction tasks needed")
         return None
 
-    effective_partition_num = partition_num or 1
-    effective_partition_num = min(num_tasks, effective_partition_num)
-    assert effective_partition_num > 0
-    if effective_partition_num == 1:
-        df = daft.from_pydict({"task": plan.tasks})
+    partition_num = None if num_partitions is None or num_partitions <= 1 else min(num_tasks, num_partitions)
+
+    tasks = plan.tasks
+    if micro_commit_batch_size is None or micro_commit_batch_size <= 0:
+        micro_commit_batch_size = num_tasks
     else:
-        df = daft.from_pydict({"task": plan.tasks}).repartition(effective_partition_num)
+        micro_commit_batch_size = min(micro_commit_batch_size, num_tasks)
 
-    WrappedRunner = daft.cls(
-        CompactionTaskUDF,
-        max_concurrency=concurrency,
-    )
-    df = df.select(WrappedRunner(lance_ds)(df["task"]).alias("rewrite"))
-    results = df.to_pandas()
+    with daft.execution_config_ctx(maintain_order=False):
+        for i in range(0, num_tasks, micro_commit_batch_size):
+            batch_tasks = tasks[i : i + micro_commit_batch_size]
+            df = daft.from_pydict({"task": batch_tasks})
+            if partition_num is not None:
+                df = df.repartition(partition_num)
 
-    metrics = Compaction.commit(lance_ds, results["rewrite"].to_list())
-    logger.info("Compaction completed successfully. Metrics: %s", metrics)
-    return metrics
+            WrappedRunner = daft.cls(
+                CompactionTaskUDF,
+                max_concurrency=concurrency,
+            )
+            df = df.select(WrappedRunner(lance_ds)(df["task"]).alias("rewrite"))
+            results = df.to_pandas()
+
+            metrics = Compaction.commit(lance_ds, results["rewrite"].to_list())
+            logger.info("Compaction completed successfully. Metrics: %s", metrics)
+
+    # When micro_commit_batch_size is not configured or is greater than or equal to num_tasks,we return the metrics data obtained from compact commit to lance.
+    # In other cases, batch compact commit is used, and the final metrics data cannot be obtained.
+
+    if micro_commit_batch_size == num_tasks:
+        return metrics
+
+    return None


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
Introduce micro_commit_batch_size in daft.io.lance.compact_files and thread it through to lance_compaction to control commit batching during compaction. Docs updated (docs/connectors/lance.md) and tests extended (tests/io/lancedb/test_lancedb_compaction.py). When committing all tasks in a single batch, return CompactionMetrics; for multi-batch commits, return None. No breaking changes; minimal risk as the parameter is additive and optional.
## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
