### PR TITLE
refactor(arrow2): migrate the extra easy kernels to arrow-rs

### DIFF
--- a/src/daft-core/src/array/mod.rs
+++ b/src/daft-core/src/array/mod.rs
@@ -232,7 +232,7 @@ impl<T> DataArray<T> {
         Self::new(Arc::new(self.field.rename(name)), self.data.clone()).unwrap()
     }
 
-    pub fn field(&self) -> &Field {
+    pub fn field(&self) -> &FieldRef {
         &self.field
     }
 }

--- a/src/daft-core/src/array/ops/apply.rs
+++ b/src/daft-core/src/array/ops/apply.rs
@@ -1,5 +1,6 @@
 use std::iter::zip;
 
+use arrow::buffer::NullBuffer;
 use common_error::{DaftError, DaftResult};
 
 use super::full::FullNull;
@@ -39,8 +40,7 @@ where
                 let lhs_nulls = self.nulls().map(|v| v.clone().into());
                 let rhs_nulls = rhs.nulls().map(|v| v.clone().into());
 
-                let nulls =
-                    daft_arrow::buffer::NullBuffer::union(lhs_nulls.as_ref(), rhs_nulls.as_ref());
+                let nulls = NullBuffer::union(lhs_nulls.as_ref(), rhs_nulls.as_ref());
                 let values = self.values();
                 let rhs_values = rhs.values();
 

--- a/src/daft-core/src/array/ops/clip.rs
+++ b/src/daft-core/src/array/ops/clip.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow::array::ArrowPrimitiveType;
 use common_error::{DaftError, DaftResult};
 use num_traits::{clamp, clamp_max, clamp_min};
@@ -42,7 +40,7 @@ where
                         (None, Some(r)) => Some(clamp_max(*value, *r)),
                         (None, None) => Some(*value),
                     });
-                let data_array = Self::from_iter(Arc::new(self.field().clone()), result)
+                let data_array = Self::from_iter(self.field().clone(), result)
                     .with_nulls(self.nulls().cloned())?;
                 Ok(data_array)
             }
@@ -63,7 +61,7 @@ where
                                     Some(l) => Some(clamp(*value, *l, r)),
                                     None => Some(clamp_max(*value, r)), // If left is null, we can just clamp_max
                                 });
-                        let data_array = Self::from_iter(Arc::new(self.field().clone()), result)
+                        let data_array = Self::from_iter(self.field().clone(), result)
                             .with_nulls(self.nulls().cloned())?;
                         Ok(data_array)
                     }
@@ -76,7 +74,7 @@ where
                                 None => Some(*value), // Left null, and right null, so we just don't do anything
                             },
                         );
-                        let data_array = Self::from_iter(Arc::new(self.field().clone()), result)
+                        let data_array = Self::from_iter(self.field().clone(), result)
                             .with_nulls(self.nulls().cloned())?;
                         Ok(data_array)
                     }
@@ -94,7 +92,7 @@ where
                                 None => Some(clamp_min(*value, l)), // Right null, so we can just clamp_min
                             },
                         );
-                        let data_array = Self::from_iter(Arc::new(self.field().clone()), result)
+                        let data_array = Self::from_iter(self.field().clone(), result)
                             .with_nulls(self.nulls().cloned())?;
                         Ok(data_array)
                     }
@@ -108,7 +106,7 @@ where
                                     Some(r) => Some(clamp_max(*value, *r)),
                                     None => Some(*value),
                                 });
-                        let data_array = Self::from_iter(Arc::new(self.field().clone()), result)
+                        let data_array = Self::from_iter(self.field().clone(), result)
                             .with_nulls(self.nulls().cloned())?;
                         Ok(data_array)
                     }

--- a/src/daft-core/src/array/ops/count.rs
+++ b/src/daft-core/src/array/ops/count.rs
@@ -1,5 +1,6 @@
 use std::{iter::repeat_n, sync::Arc};
 
+use arrow::buffer::NullBuffer;
 use common_error::DaftResult;
 
 use super::{DaftCountAggable, GroupIndices};
@@ -15,7 +16,7 @@ use crate::{
 fn grouped_count_arrow_bitmap(
     groups: &GroupIndices,
     mode: &CountMode,
-    arrow_bitmap: Option<&daft_arrow::buffer::NullBuffer>,
+    arrow_bitmap: Option<&NullBuffer>,
 ) -> Vec<u64> {
     match mode {
         CountMode::All => groups.iter().map(|g| g.len() as u64).collect(),
@@ -36,12 +37,8 @@ fn grouped_count_arrow_bitmap(
     }
 }
 
-/// Helper to perform a count on a validity map of type daft_arrow::buffer::NullBuffer
-fn count_arrow_bitmap(
-    mode: &CountMode,
-    arrow_bitmap: Option<&daft_arrow::buffer::NullBuffer>,
-    arr_len: usize,
-) -> u64 {
+/// Helper to perform a count on a validity map of type NullBuffer
+fn count_arrow_bitmap(mode: &CountMode, arrow_bitmap: Option<&NullBuffer>, arr_len: usize) -> u64 {
     match mode {
         CountMode::All => arr_len as u64,
         CountMode::Valid => match arrow_bitmap {

--- a/src/daft-core/src/array/ops/filter.rs
+++ b/src/daft-core/src/array/ops/filter.rs
@@ -13,7 +13,6 @@ use crate::{
         growable::{Growable, GrowableArray},
     },
     datatypes::{BooleanArray, DaftArrayType, DaftArrowBackedType, DataType},
-    prelude::FromArrow,
 };
 
 impl<T> DataArray<T>
@@ -21,8 +20,9 @@ where
     T: DaftArrowBackedType,
 {
     pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
-        let result = daft_arrow::compute::filter::filter(self.data(), mask.as_arrow2())?;
-        Self::from_arrow2(self.field.clone(), result)
+        let result = arrow::compute::filter(self.to_arrow().as_ref(), &mask.as_arrow()?)?;
+
+        Self::from_arrow(self.field().clone(), result)
     }
 }
 

--- a/src/daft-core/src/array/ops/mean.rs
+++ b/src/daft-core/src/array/ops/mean.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use common_error::DaftResult;
-use daft_arrow::array::PrimitiveArray;
 
 use super::{DaftCountAggable, DaftSumAggable};
 use crate::{
@@ -16,19 +15,16 @@ impl DaftMeanAggable for DataArray<Float64Type> {
 
     fn mean(&self) -> Self::Output {
         let stats = stats::calculate_stats(self)?;
-        let data = PrimitiveArray::from([stats.mean]).boxed();
-        let field = Arc::new(Field::new(self.field.name.clone(), DataType::Float64));
-        Self::new(field, data)
+
+        let field = Arc::new(Field::new(self.name(), DataType::Float64));
+        Ok(Self::from_iter(field, std::iter::once(stats.mean)))
     }
 
     fn grouped_mean(&self, groups: &GroupIndices) -> Self::Output {
         let grouped_means = stats::grouped_stats(self, groups)?.map(|(stats, _)| stats.mean);
-        let data = Box::new(PrimitiveArray::from_iter(grouped_means));
-        Ok(Self::new(
-            Field::new(self.field.name.clone(), DataType::Float64).into(),
-            data,
-        )
-        .unwrap())
+
+        let field = Arc::new(Field::new(self.name(), DataType::Float64));
+        Ok(Self::from_iter(field, grouped_means))
     }
 }
 

--- a/src/daft-core/src/array/ops/skew.rs
+++ b/src/daft-core/src/array/ops/skew.rs
@@ -1,5 +1,4 @@
 use common_error::DaftResult;
-use daft_arrow::array::PrimitiveArray;
 
 use crate::{
     array::{
@@ -17,9 +16,8 @@ impl DaftSkewAggable for DataArray<Float64Type> {
         let stats = stats::calculate_stats(self)?;
         let values = self.into_iter().flatten().copied();
         let skew = stats::calculate_skew(stats, values);
-        let field = self.field.clone();
-        let data = PrimitiveArray::<f64>::from([skew]).boxed();
-        Self::new(field, data)
+
+        Ok(Self::from_iter(self.field().clone(), std::iter::once(skew)))
     }
 
     fn grouped_skew(&self, groups: &GroupIndices) -> Self::Output {
@@ -29,8 +27,6 @@ impl DaftSkewAggable for DataArray<Float64Type> {
             stats::calculate_skew(stats, values)
         });
 
-        let field = self.field.clone();
-        let data = PrimitiveArray::<f64>::from_iter(grouped_skew_iter).boxed();
-        Self::new(field, data)
+        Ok(Self::from_iter(self.field().clone(), grouped_skew_iter))
     }
 }

--- a/src/daft-core/src/array/ops/sparse_tensor.rs
+++ b/src/daft-core/src/array/ops/sparse_tensor.rs
@@ -52,14 +52,7 @@ mod tests {
 
         let values_array = ListArray::new(
             Field::new("values", DataType::List(Box::new(DataType::Int64))),
-            Int64Array::new(
-                Field::new("item", DataType::Int64).into(),
-                Box::new(daft_arrow::array::Int64Array::from_iter(
-                    [Some(1), Some(2), Some(0), Some(3)].iter(),
-                )),
-            )
-            .unwrap()
-            .into_series(),
+            Int64Array::from_slice("item", &[1, 2, 0, 3]).into_series(),
             daft_arrow::offset::OffsetsBuffer::<i64>::try_from(vec![0, 2, 3, 4])?,
             Some(nulls.clone()),
         )
@@ -67,14 +60,7 @@ mod tests {
 
         let indices_array = ListArray::new(
             Field::new("indices", DataType::List(Box::new(DataType::UInt64))),
-            UInt64Array::new(
-                Field::new("item", DataType::UInt64).into(),
-                Box::new(daft_arrow::array::UInt64Array::from_iter(
-                    [Some(1), Some(2), Some(0), Some(2)].iter(),
-                )),
-            )
-            .unwrap()
-            .into_series(),
+            UInt64Array::from_slice("item", &[1, 2, 0, 2]).into_series(),
             daft_arrow::offset::OffsetsBuffer::<i64>::try_from(vec![0, 2, 3, 4])?,
             Some(nulls.clone()),
         )
@@ -82,14 +68,7 @@ mod tests {
 
         let shapes_array = ListArray::new(
             Field::new("shape", DataType::List(Box::new(DataType::UInt64))),
-            UInt64Array::new(
-                Field::new("item", DataType::UInt64).into(),
-                Box::new(daft_arrow::array::UInt64Array::from_iter(
-                    [Some(3), Some(3), Some(3)].iter(),
-                )),
-            )
-            .unwrap()
-            .into_series(),
+            UInt64Array::from_slice("item", &[3, 3, 3]).into_series(),
             daft_arrow::offset::OffsetsBuffer::<i64>::try_from(vec![0, 1, 2, 3])?,
             Some(nulls.clone()),
         )

--- a/src/daft-core/src/array/ops/stddev.rs
+++ b/src/daft-core/src/array/ops/stddev.rs
@@ -1,5 +1,4 @@
 use common_error::DaftResult;
-use daft_arrow::array::PrimitiveArray;
 
 use crate::{
     array::{
@@ -17,9 +16,10 @@ impl DaftStddevAggable for DataArray<Float64Type> {
         let stats = stats::calculate_stats(self)?;
         let values = self.into_iter().flatten().copied();
         let stddev = stats::calculate_stddev(stats, values);
-        let field = self.field.clone();
-        let data = PrimitiveArray::<f64>::from([stddev]).boxed();
-        Self::new(field, data)
+        Ok(Self::from_iter(
+            self.field().clone(),
+            std::iter::once(stddev),
+        ))
     }
 
     fn grouped_stddev(&self, groups: &GroupIndices) -> Self::Output {
@@ -27,8 +27,7 @@ impl DaftStddevAggable for DataArray<Float64Type> {
             let values = group.iter().filter_map(|&index| self.get(index as _));
             stats::calculate_stddev(stats, values)
         });
-        let field = self.field.clone();
-        let data = PrimitiveArray::<f64>::from_iter(grouped_stddevs_iter).boxed();
-        Self::new(field, data)
+
+        Ok(Self::from_iter(self.field().clone(), grouped_stddevs_iter))
     }
 }

--- a/src/daft-core/src/array/ops/struct_.rs
+++ b/src/daft-core/src/array/ops/struct_.rs
@@ -1,5 +1,5 @@
+use arrow::buffer::NullBuffer;
 use common_error::{DaftError, DaftResult};
-use daft_arrow::buffer::NullBuffer;
 
 use crate::{array::StructArray, series::Series};
 

--- a/src/daft-core/src/array/ops/tensor.rs
+++ b/src/daft-core/src/array/ops/tensor.rs
@@ -24,8 +24,7 @@ mod tests {
 
     #[test]
     fn test_tensor_to_sparse_roundtrip() -> DaftResult<()> {
-        let raw_nulls = vec![true, false, true];
-        let nulls = daft_arrow::buffer::NullBuffer::from(raw_nulls.as_slice());
+        let nulls = daft_arrow::buffer::NullBuffer::from(&[true, false, true]);
         let flat_child =
             Int64Array::from_slice("item", &[0, 1, 2, 100, 101, 102, 0, 0, 3]).into_series();
         let list_array = ListArray::new(
@@ -35,7 +34,7 @@ mod tests {
             Some(nulls.clone()),
         )
         .into_series();
-        let flat_child = Int64Array::from_slice("item", &[3, 3, 3]).into_series();
+        let flat_child = UInt64Array::from_slice("item", &[3, 3, 3]).into_series();
 
         let shapes_array = ListArray::new(
             Field::new("shape", DataType::List(Box::new(DataType::UInt64))),
@@ -55,7 +54,7 @@ mod tests {
         let sparse_tensor_dtype = DataType::SparseTensor(Box::new(DataType::Int64), false);
         let sparse_tensor_array = tensor_array.cast(&sparse_tensor_dtype)?;
         let roundtrip_tensor = sparse_tensor_array.cast(&dtype)?;
-        assert!(tensor_array.to_arrow2().eq(&roundtrip_tensor.to_arrow2()));
+        assert!(tensor_array.to_arrow()?.eq(&roundtrip_tensor.to_arrow()?));
         Ok(())
     }
 
@@ -72,7 +71,7 @@ mod tests {
             DataType::FixedShapeSparseTensor(Box::new(DataType::Int64), vec![3], false);
         let sparse_tensor_array = tensor_array.cast(&sparse_tensor_dtype)?;
         let roundtrip_tensor = sparse_tensor_array.cast(&dtype)?;
-        assert!(tensor_array.to_arrow2().eq(&roundtrip_tensor.to_arrow2()));
+        assert!(tensor_array.to_arrow()?.eq(&roundtrip_tensor.to_arrow()?));
         Ok(())
     }
 }

--- a/src/daft-core/src/array/ops/tensor.rs
+++ b/src/daft-core/src/array/ops/tensor.rs
@@ -26,42 +26,20 @@ mod tests {
     fn test_tensor_to_sparse_roundtrip() -> DaftResult<()> {
         let raw_nulls = vec![true, false, true];
         let nulls = daft_arrow::buffer::NullBuffer::from(raw_nulls.as_slice());
-
+        let flat_child =
+            Int64Array::from_slice("item", &[0, 1, 2, 100, 101, 102, 0, 0, 3]).into_series();
         let list_array = ListArray::new(
             Field::new("data", DataType::List(Box::new(DataType::Int64))),
-            Int64Array::new(
-                Field::new("item", DataType::Int64).into(),
-                Box::new(daft_arrow::array::Int64Array::from_iter(
-                    [
-                        Some(0),
-                        Some(1),
-                        Some(2),
-                        Some(100),
-                        Some(101),
-                        Some(102),
-                        Some(0),
-                        Some(0),
-                        Some(3),
-                    ]
-                    .iter(),
-                )),
-            )
-            .unwrap()
-            .into_series(),
+            flat_child,
             daft_arrow::offset::OffsetsBuffer::<i64>::try_from(vec![0, 3, 6, 9])?,
             Some(nulls.clone()),
         )
         .into_series();
+        let flat_child = Int64Array::from_slice("item", &[3, 3, 3]).into_series();
+
         let shapes_array = ListArray::new(
             Field::new("shape", DataType::List(Box::new(DataType::UInt64))),
-            UInt64Array::new(
-                Field::new("item", DataType::UInt64).into(),
-                Box::new(daft_arrow::array::UInt64Array::from_iter(
-                    [Some(3), Some(3), Some(3)].iter(),
-                )),
-            )
-            .unwrap()
-            .into_series(),
+            flat_child,
             daft_arrow::offset::OffsetsBuffer::<i64>::try_from(vec![0, 1, 2, 3])?,
             Some(nulls.clone()),
         )

--- a/src/daft-core/src/array/ops/utf8.rs
+++ b/src/daft-core/src/array/ops/utf8.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, LargeBinaryArray, OffsetBufferBuilder};
+use arrow::array::{Array, ArrayRef, BufferBuilder, LargeBinaryArray, OffsetBufferBuilder};
 use common_error::DaftResult;
 
 use crate::{
@@ -18,7 +18,8 @@ impl Utf8Array {
         let buffer = input.values();
         let nulls = input.nulls().cloned();
 
-        let mut values = Vec::<u8>::new();
+        let mut values = BufferBuilder::new(buffer.capacity());
+
         let mut offsets = OffsetBufferBuilder::new(input.len());
         for span in input.offsets().windows(2) {
             let s = span[0] as usize;


### PR DESCRIPTION
## Changes Made

migrates some of the easiest kernels over to arrow2. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
