### PR TITLE
fix(ci): restore Rust code coverage by pinning cargo-llvm-cov

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -120,6 +120,8 @@ jobs:
         cache-all-crates: 'true'
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
+      with:
+        tool: cargo-llvm-cov@0.7.1
 
     - name: install llvm tools
       run: rustup component add llvm-tools-preview
@@ -1333,9 +1335,10 @@ jobs:
         path: ./report-output
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v5
+      with:
+        directory: ./report-output
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        files: ./report-output/*
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v2.1.1
       if: ${{ failure() && (github.event_name == 'push') }}


### PR DESCRIPTION
## Changes Made

Project coverage on Codecov dropped from ~73% to ~43% around Jan 26. Python coverage was unaffected (steady at 68%) — the entire drop was in Rust coverage.

**Root cause:** [`cargo-llvm-cov` v0.8.0](https://github.com/taiki-e/cargo-llvm-cov/releases/tag/v0.8.0) changed default behavior so that `cargo llvm-cov report` excludes untested workspace members from the report:

> **Compatibility Note:** When `--workspace` or `--package` is not used, this will exclude other untested workspace members from the report that were previously implicitly included.

The unit-test job installs `cargo-llvm-cov@latest` (unpinned), so it silently upgraded from v0.7.1 to v0.8.x. Since the unit-test job uses the `report` subcommand — which [does not support `--workspace`](https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#github-actions-and-codecov) — our 80+ workspace crates were dropped from the Rust coverage report.

Note: the [recommended usage](https://github.com/taiki-e/cargo-llvm-cov?tab=readme-ov-file#github-actions-and-codecov) is `cargo llvm-cov --workspace --lcov` (top-level command), which supports `--workspace`. But the unit-test job can't use that because it runs **pytest** (not `cargo test`) against the instrumented library, then uses `cargo llvm-cov report` to generate the report from profraw data.

**Fixes:**

1. **Pin `cargo-llvm-cov` to v0.7.1** in the unit-test job — the last version before the breaking behavioral change. This matches the approach in the `rust-tests-platform` job which already pins to `0.6.14`.
2. **Fix Codecov upload config** — `files` was incorrectly set as an `env` var instead of an action input (`with`). Changed to `with: directory:` which the action actually reads. Previously only worked by accident via auto-discovery.

## Related Issues

Closes #6143