### PR TITLE
docs: Clarify imagenet benchmark setup

### DIFF
--- a/benchmarking/ai/image_classification/README.md
+++ b/benchmarking/ai/image_classification/README.md
@@ -1,6 +1,6 @@
 # Image Classification Benchmark
 
-Classifies **803,580 images** using ResNet18 model. Downloads images, applies preprocessing transforms, and runs inference to predict ImageNet labels across distributed GPU nodes.
+Classifies **803,580 rows** (80,358 unique images, each repeated 10x) using ResNet18 model. Downloads images, applies preprocessing transforms, and runs inference to predict ImageNet labels across distributed GPU nodes.
 
 **Input Dataset**: ImageNet benchmark dataset (S3 parquet format)
 **Output Format**: Parquet with image URLs and predicted labels


### PR DESCRIPTION
## Changes Made

Clarify imagenet benchmark setup: it contains 803,580 rows but only 80,358 unique images (each repeated 10x) using ResNet18 model.
