### PR TITLE
feat: Support additional `OTEL_*` configuration envs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,7 @@ name = "common-tracing"
 version = "0.3.0-dev0"
 dependencies = [
  "common-runtime",
+ "log",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/src/common/tracing/Cargo.toml
+++ b/src/common/tracing/Cargo.toml
@@ -6,6 +6,7 @@ opentelemetry_sdk = {workspace = true}
 tracing = {workspace = true}
 tracing-opentelemetry = {version = "0.32", default-features = false, features = ["metrics"]}
 tracing-subscriber = {workspace = true}
+log = {workspace = true}
 
 [lints]
 workspace = true

--- a/src/common/tracing/src/config.rs
+++ b/src/common/tracing/src/config.rs
@@ -1,0 +1,110 @@
+use std::time::Duration;
+
+// These match the OTEL_EXPORTER_OTLP_* environment variables from:
+// https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#endpoint-configuration
+use opentelemetry_otlp::{
+    OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+    OTEL_EXPORTER_OTLP_METRICS_ENDPOINT, OTEL_EXPORTER_OTLP_PROTOCOL,
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, Protocol,
+};
+
+/// Environment variable for the general OTLP endpoint.
+pub const ENV_OLD_OTLP_ENDPOINT: &str = "DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT";
+/// Environment variable for metrics export interval in milliseconds.
+/// Mimics the official env since it's not exported out
+pub const ENV_METRICS_EXPORT_INTERVAL_MS: &str = "OTEL_METRIC_EXPORT_INTERVAL";
+
+fn parse_protocol(s: &str) -> Protocol {
+    match s {
+        "grpc" => Protocol::Grpc,
+        "http/json" => Protocol::HttpJson,
+        "http/protobuf" => Protocol::HttpBinary,
+        _ => Protocol::Grpc,
+    }
+}
+
+/// OpenTelemetry/OTLP configuration loaded from environment variables.
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// General OTLP endpoint (e.g. from `DAFT_DEV_OTEL_EXPORTER_OTLP_ENDPOINT`).
+    pub otlp_endpoint: Option<String>,
+    /// Communication protocol for the OTLP endpoint.
+    pub otlp_protocol: Protocol,
+    /// OTLP endpoint for metrics; overrides `otlp_endpoint` when set.
+    pub otlp_metrics_endpoint: Option<String>,
+    /// OTLP endpoint for logs; overrides `otlp_endpoint` when set.
+    pub otlp_logs_endpoint: Option<String>,
+    /// OTLP endpoint for traces; overrides `otlp_endpoint` when set.
+    pub otlp_traces_endpoint: Option<String>,
+    /// Metrics export interval in milliseconds.
+    pub metrics_export_interval_ms: Option<u64>,
+}
+
+impl Config {
+    /// Load config from environment variables.
+    pub fn from_env() -> Self {
+        let otlp_endpoint = if let Ok(endpoint) = std::env::var(OTEL_EXPORTER_OTLP_ENDPOINT) {
+            Some(endpoint)
+        } else if let Ok(endpoint) = std::env::var(ENV_OLD_OTLP_ENDPOINT) {
+            log::warn!(
+                "Using deprecated environment variable {} for OTLP endpoint. Use {} instead.",
+                ENV_OLD_OTLP_ENDPOINT,
+                OTEL_EXPORTER_OTLP_ENDPOINT
+            );
+            Some(endpoint)
+        } else {
+            None
+        };
+
+        // Note that even though the OTEL SDK can detect these automatically, we still need them
+        // to enable the OTLP exporters
+        Self {
+            otlp_endpoint,
+            otlp_protocol: parse_protocol(
+                std::env::var(OTEL_EXPORTER_OTLP_PROTOCOL)
+                    .ok()
+                    .unwrap_or_else(|| "grpc".to_string())
+                    .as_str(),
+            ),
+            otlp_metrics_endpoint: std::env::var(OTEL_EXPORTER_OTLP_METRICS_ENDPOINT).ok(),
+            otlp_logs_endpoint: std::env::var(OTEL_EXPORTER_OTLP_LOGS_ENDPOINT).ok(),
+            otlp_traces_endpoint: std::env::var(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT).ok(),
+            metrics_export_interval_ms: std::env::var(ENV_METRICS_EXPORT_INTERVAL_MS)
+                .ok()
+                .and_then(|s| s.parse().ok()),
+        }
+    }
+
+    /// Returns whether OpenTelemetry should be enabled (any endpoint is set).
+    pub fn enabled(&self) -> bool {
+        self.otlp_endpoint.is_some()
+            || self.otlp_metrics_endpoint.is_some()
+            || self.otlp_logs_endpoint.is_some()
+            || self.otlp_traces_endpoint.is_some()
+    }
+
+    pub fn metrics_endpoint(&self) -> Option<&str> {
+        self.otlp_metrics_endpoint
+            .as_deref()
+            .or(self.otlp_endpoint.as_deref())
+    }
+
+    pub fn logs_endpoint(&self) -> Option<&str> {
+        self.otlp_logs_endpoint
+            .as_deref()
+            .or(self.otlp_endpoint.as_deref())
+    }
+
+    pub fn traces_endpoint(&self) -> Option<&str> {
+        self.otlp_traces_endpoint
+            .as_deref()
+            .or(self.otlp_endpoint.as_deref())
+    }
+
+    /// Metrics export interval. Defaults to 500 ms when not set.
+    pub fn metrics_export_interval(&self) -> Duration {
+        self.metrics_export_interval_ms
+            .map(Duration::from_millis)
+            .unwrap_or(Duration::from_millis(500))
+    }
+}

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -105,7 +105,10 @@ impl StatisticsManager {
         subscribers: Vec<Box<dyn StatisticsSubscriber>>,
     ) -> DaftResult<StatisticsManagerRef> {
         let scope = InstrumentationScope::builder("daft.distributed.node_stats")
-            .with_attributes(vec![KeyValue::new("query_id", query_id.to_string())])
+            .with_attributes(vec![
+                KeyValue::new("query_id", query_id.to_string()),
+                KeyValue::new("runner", "ray".to_string()),
+            ])
             .build();
         let meter = global::meter_with_scope(scope);
 

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -105,10 +105,7 @@ impl StatisticsManager {
         subscribers: Vec<Box<dyn StatisticsSubscriber>>,
     ) -> DaftResult<StatisticsManagerRef> {
         let scope = InstrumentationScope::builder("daft.distributed.node_stats")
-            .with_attributes(vec![
-                KeyValue::new("query_id", query_id.to_string()),
-                KeyValue::new("runner", "ray".to_string()),
-            ])
+            .with_attributes(vec![KeyValue::new("query_id", query_id.to_string())])
             .build();
         let meter = global::meter_with_scope(scope);
 

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use common_metrics::{Counter, StatSnapshot};
+use common_metrics::{CPU_US_KEY, Counter, ROWS_IN_KEY, ROWS_OUT_KEY, StatSnapshot};
 use opentelemetry::{
     KeyValue,
     metrics::{Meter, UpDownCounter},
@@ -32,20 +32,10 @@ impl RuntimeNodeManager {
             node_id,
             node_kv,
             runtime_stats,
-            active_tasks: meter
-                .i64_up_down_counter("daft.distributed.node_stats.active_tasks")
-                .build(),
-            completed_tasks: Counter::new(
-                meter,
-                "daft.distributed.node_stats.completed_tasks",
-                None,
-            ),
-            failed_tasks: Counter::new(meter, "daft.distributed.node_stats.failed_tasks", None),
-            cancelled_tasks: Counter::new(
-                meter,
-                "daft.distributed.node_stats.cancelled_tasks",
-                None,
-            ),
+            active_tasks: meter.i64_up_down_counter("active_tasks").build(),
+            completed_tasks: Counter::new(meter, "completed_tasks", None),
+            failed_tasks: Counter::new(meter, "failed_tasks", None),
+            cancelled_tasks: Counter::new(meter, "cancelled_tasks", None),
         }
     }
 
@@ -91,25 +81,16 @@ pub struct DefaultRuntimeStats {
 
 impl DefaultRuntimeStats {
     pub fn new(meter: &Meter, node_id: NodeID) -> Self {
-        let node_kv = vec![KeyValue::new("node_id", node_id.to_string())];
+        let node_kv = vec![
+            KeyValue::new("node_id", node_id.to_string()),
+            KeyValue::new("runner", "ray".to_string()),
+        ];
 
         Self {
             node_kv,
-            completed_rows_in: Counter::new(
-                meter,
-                "daft.distributed.node_stats.completed_rows_in",
-                None,
-            ),
-            completed_rows_out: Counter::new(
-                meter,
-                "daft.distributed.node_stats.completed_rows_out",
-                None,
-            ),
-            completed_cpu_us: Counter::new(
-                meter,
-                "daft.distributed.node_stats.completed_cpu_us",
-                None,
-            ),
+            completed_rows_in: Counter::new(meter, ROWS_IN_KEY, None),
+            completed_rows_out: Counter::new(meter, ROWS_OUT_KEY, None),
+            completed_cpu_us: Counter::new(meter, CPU_US_KEY, None),
         }
     }
 }

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -81,10 +81,7 @@ pub struct DefaultRuntimeStats {
 
 impl DefaultRuntimeStats {
     pub fn new(meter: &Meter, node_id: NodeID) -> Self {
-        let node_kv = vec![
-            KeyValue::new("node_id", node_id.to_string()),
-            KeyValue::new("runner", "ray".to_string()),
-        ];
+        let node_kv = vec![KeyValue::new("node_id", node_id.to_string())];
 
         Self {
             node_kv,

--- a/src/daft-local-execution/src/intermediate_ops/explode.rs
+++ b/src/daft-local-execution/src/intermediate_ops/explode.rs
@@ -9,7 +9,7 @@ use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_functions_list::explode;
 use daft_micropartition::MicroPartition;
 use itertools::Itertools;
-use opentelemetry::{KeyValue, global};
+use opentelemetry::{KeyValue, metrics::Meter};
 use tracing::{Span, instrument};
 
 use super::intermediate_op::{
@@ -25,14 +25,13 @@ pub struct ExplodeStats {
 }
 
 impl ExplodeStats {
-    pub fn new(id: usize) -> Self {
-        let meter = global::meter("daft.local.node_stats");
+    pub fn new(meter: &Meter, id: usize) -> Self {
         let node_kv = vec![KeyValue::new("node_id", id.to_string())];
 
         Self {
-            cpu_us: Counter::new(&meter, CPU_US_KEY, None),
-            rows_in: Counter::new(&meter, ROWS_IN_KEY, None),
-            rows_out: Counter::new(&meter, ROWS_OUT_KEY, None),
+            cpu_us: Counter::new(meter, CPU_US_KEY, None),
+            rows_in: Counter::new(meter, ROWS_IN_KEY, None),
+            rows_out: Counter::new(meter, ROWS_OUT_KEY, None),
             node_kv,
         }
     }
@@ -141,8 +140,8 @@ impl IntermediateOperator for ExplodeOperator {
         NodeType::Explode
     }
 
-    fn make_runtime_stats(&self, id: usize) -> Arc<dyn RuntimeStats> {
-        Arc::new(ExplodeStats::new(id))
+    fn make_runtime_stats(&self, meter: &Meter, id: usize) -> Arc<dyn RuntimeStats> {
+        Arc::new(ExplodeStats::new(meter, id))
     }
     fn batching_strategy(&self) -> DaftResult<Self::BatchingStrategy> {
         Ok(crate::dynamic_batching::StaticBatchingStrategy::new(

--- a/src/daft-local-execution/src/intermediate_ops/udf.rs
+++ b/src/daft-local-execution/src/intermediate_ops/udf.rs
@@ -27,7 +27,7 @@ use daft_dsl::{
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use itertools::Itertools;
-use opentelemetry::{KeyValue, global, metrics::Meter};
+use opentelemetry::{KeyValue, metrics::Meter};
 #[cfg(feature = "python")]
 use pyo3::{Py, prelude::*};
 use tracing::{Span, instrument};
@@ -91,17 +91,16 @@ impl RuntimeStats for UdfRuntimeStats {
 }
 
 impl UdfRuntimeStats {
-    fn new(id: usize) -> Self {
-        let meter = global::meter("daft.local.node_stats");
+    fn new(meter: &Meter, id: usize) -> Self {
         let node_kv = vec![KeyValue::new("node_id", id.to_string())];
 
         Self {
-            cpu_us: Counter::new(&meter, CPU_US_KEY, None),
-            rows_in: Counter::new(&meter, ROWS_IN_KEY, None),
-            rows_out: Counter::new(&meter, ROWS_OUT_KEY, None),
+            cpu_us: Counter::new(meter, CPU_US_KEY, None),
+            rows_in: Counter::new(meter, ROWS_IN_KEY, None),
+            rows_out: Counter::new(meter, ROWS_OUT_KEY, None),
             custom_counters: Mutex::new(HashMap::new()),
             node_kv,
-            meter,
+            meter: meter.clone(), // Cheap to clone, Arc under the hood
         }
     }
 
@@ -479,8 +478,8 @@ impl IntermediateOperator for UdfOperator {
         NodeType::UDFProject
     }
 
-    fn make_runtime_stats(&self, id: usize) -> Arc<dyn RuntimeStats> {
-        Arc::new(UdfRuntimeStats::new(id))
+    fn make_runtime_stats(&self, meter: &Meter, id: usize) -> Arc<dyn RuntimeStats> {
+        Arc::new(UdfRuntimeStats::new(meter, id))
     }
 
     fn multiline_display(&self) -> Vec<String> {

--- a/src/daft-local-execution/src/join/join_node.rs
+++ b/src/daft-local-execution/src/join/join_node.rs
@@ -24,7 +24,7 @@ use crate::{
     channel::{Receiver, Sender, create_channel},
     dynamic_batching::{BatchManager, StaticBatchingStrategy},
     join::join_operator::{JoinOperator, ProbeOutput},
-    pipeline::{MorselSizeRequirement, PipelineNode, RuntimeContext},
+    pipeline::{BuilderContext, MorselSizeRequirement, PipelineNode},
     runtime_stats::{RuntimeStats, RuntimeStatsManagerHandle},
 };
 
@@ -76,12 +76,12 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
         left: Box<dyn PipelineNode>,
         right: Box<dyn PipelineNode>,
         plan_stats: StatsState,
-        ctx: &RuntimeContext,
+        ctx: &BuilderContext,
         context: &LocalNodeContext,
     ) -> Self {
         let name: Arc<str> = op.name().into();
         let node_info = ctx.next_node_info(name, op.op_type(), NodeCategory::Intermediate, context);
-        let runtime_stats = op.make_runtime_stats(node_info.id);
+        let runtime_stats = op.make_runtime_stats(&ctx.meter, node_info.id);
 
         let morsel_size_requirement = op.morsel_size_requirement().unwrap_or_default();
         Self {

--- a/src/daft-local-execution/src/join/join_operator.rs
+++ b/src/daft-local-execution/src/join/join_operator.rs
@@ -4,6 +4,7 @@ use common_error::DaftResult;
 use common_metrics::ops::NodeType;
 use common_runtime::get_compute_pool_num_threads;
 use daft_micropartition::MicroPartition;
+use opentelemetry::metrics::Meter;
 
 use crate::{
     ExecutionTaskSpawner, OperatorOutput,
@@ -87,8 +88,8 @@ pub(crate) trait JoinOperator: Send + Sync {
     fn multiline_display(&self) -> Vec<String>;
 
     /// Create runtime stats
-    fn make_runtime_stats(&self, id: usize) -> Arc<dyn RuntimeStats> {
-        Arc::new(crate::runtime_stats::DefaultRuntimeStats::new(id))
+    fn make_runtime_stats(&self, meter: &Meter, id: usize) -> Arc<dyn RuntimeStats> {
+        Arc::new(crate::runtime_stats::DefaultRuntimeStats::new(meter, id))
     }
 
     /// Maximum number of concurrent probe workers

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -9,7 +9,10 @@ use common_display::{
 };
 use common_error::{DaftError, DaftResult};
 use common_file_formats::FileFormat;
-use common_metrics::ops::{NodeCategory, NodeInfo, NodeType};
+use common_metrics::{
+    QueryID,
+    ops::{NodeCategory, NodeInfo, NodeType},
+};
 use daft_core::{join::JoinSide, prelude::Schema};
 use daft_dsl::{common_treenode::ConcreteTreeNode, join::get_common_join_cols};
 use daft_local_plan::{
@@ -27,6 +30,7 @@ use daft_micropartition::{
 use daft_scan::ScanTaskRef;
 use daft_writers::make_physical_writer_factory;
 use indexmap::IndexSet;
+use opentelemetry::{InstrumentationScope, KeyValue, global, metrics::Meter};
 use snafu::ResultExt;
 
 use crate::{
@@ -184,19 +188,26 @@ impl ConcreteTreeNode for Box<dyn PipelineNode> {
 
 /// Single use context for translating a physical plan to a Pipeline.
 /// It generates a plan_id, and node ids for each plan.
-pub struct RuntimeContext {
+pub struct BuilderContext {
     index_counter: std::cell::RefCell<usize>,
+    pub meter: Meter,
     context: HashMap<String, String>,
 }
 
-impl RuntimeContext {
+impl BuilderContext {
     pub fn new() -> Self {
-        Self::new_with_context(HashMap::new())
+        Self::new_with_context("".into(), HashMap::new())
     }
 
-    pub fn new_with_context(context: HashMap<String, String>) -> Self {
+    pub fn new_with_context(query_id: QueryID, context: HashMap<String, String>) -> Self {
+        let scope = InstrumentationScope::builder("daft.local.node_stats")
+            .with_attributes(vec![KeyValue::new("query_id", query_id.to_string())])
+            .build();
+        let meter = global::meter_with_scope(scope);
+
         Self {
             index_counter: std::cell::RefCell::new(0),
+            meter,
             context,
         }
     }
@@ -320,7 +331,7 @@ pub fn translate_physical_plan_to_pipeline(
     physical_plan: &LocalPhysicalPlan,
     psets: &(impl PartitionSetCache<MicroPartitionRef, Arc<MicroPartitionSet>> + ?Sized),
     cfg: &Arc<DaftExecutionConfig>,
-    ctx: &RuntimeContext,
+    ctx: &BuilderContext,
 ) -> crate::Result<Box<dyn PipelineNode>> {
     let mut pipeline_node = physical_plan_to_pipeline(physical_plan, psets, cfg, ctx)?;
     pipeline_node.propagate_morsel_size_requirement(
@@ -334,7 +345,7 @@ fn physical_plan_to_pipeline(
     physical_plan: &LocalPhysicalPlan,
     psets: &(impl PartitionSetCache<MicroPartitionRef, Arc<MicroPartitionSet>> + ?Sized),
     cfg: &Arc<DaftExecutionConfig>,
-    ctx: &RuntimeContext,
+    ctx: &BuilderContext,
 ) -> crate::Result<Box<dyn PipelineNode>> {
     use daft_local_plan::PhysicalScan;
 

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -308,6 +308,7 @@ mod tests {
     };
     use daft_context::{QueryMetadata, QueryResult, Subscriber};
     use daft_micropartition::MicroPartitionRef;
+    use opentelemetry::global;
     use tokio::time::{Duration, sleep};
 
     use super::*;
@@ -395,7 +396,8 @@ mod tests {
         let mock_subscriber = Arc::new(MockSubscriber::new());
         let mock_state = mock_subscriber.state.clone();
 
-        let node_stat = Arc::new(DefaultRuntimeStats::new(0)) as Arc<dyn RuntimeStats>;
+        let node_stat = Arc::new(DefaultRuntimeStats::new(&global::meter("test_stats"), 0))
+            as Arc<dyn RuntimeStats>;
         let throttle_interval = Duration::from_millis(50);
         let stats_manager = RuntimeStatsManager::new_impl(
             &tokio::runtime::Handle::current(),
@@ -456,7 +458,8 @@ mod tests {
         let state1 = subscriber1.state.clone();
         let state2 = subscriber2.state.clone();
 
-        let node_stat = Arc::new(DefaultRuntimeStats::new(0)) as Arc<dyn RuntimeStats>;
+        let node_stat = Arc::new(DefaultRuntimeStats::new(&global::meter("test_stats"), 0))
+            as Arc<dyn RuntimeStats>;
         let throttle_interval = Duration::from_millis(50);
         let stats_manager = RuntimeStatsManager::new_impl(
             &tokio::runtime::Handle::current(),
@@ -529,7 +532,8 @@ mod tests {
         let mock_subscriber = Arc::new(MockSubscriber::new());
         let state = mock_subscriber.state.clone();
 
-        let node_stat = Arc::new(DefaultRuntimeStats::new(0)) as Arc<dyn RuntimeStats>;
+        let node_stat = Arc::new(DefaultRuntimeStats::new(&global::meter("test_stats"), 0))
+            as Arc<dyn RuntimeStats>;
         let throttle_interval = Duration::from_millis(50);
         let stats_manager = RuntimeStatsManager::new_impl(
             &tokio::runtime::Handle::current(),
@@ -551,7 +555,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_runtime_stats_context_operations() {
-        let node_stat = Arc::new(DefaultRuntimeStats::new(0));
+        let node_stat = Arc::new(DefaultRuntimeStats::new(&global::meter("test_stats"), 0));
 
         // Test initial state
         let StatSnapshot::Default(stats) = node_stat.snapshot() else {
@@ -582,7 +586,8 @@ mod tests {
         let mock_subscriber = Arc::new(MockSubscriber::new());
         let state = mock_subscriber.state.clone();
 
-        let node_stat = Arc::new(DefaultRuntimeStats::new(0)) as Arc<dyn RuntimeStats>;
+        let node_stat = Arc::new(DefaultRuntimeStats::new(&global::meter("test_stats"), 0))
+            as Arc<dyn RuntimeStats>;
         let throttle_interval = Duration::from_millis(50);
         let stats_manager = RuntimeStatsManager::new_impl(
             &tokio::runtime::Handle::current(),
@@ -616,7 +621,8 @@ mod tests {
 
         // Use 500ms for the throttle interval.
         let throttle_interval = Duration::from_millis(500);
-        let node_stat = Arc::new(DefaultRuntimeStats::new(0)) as Arc<dyn RuntimeStats>;
+        let node_stat = Arc::new(DefaultRuntimeStats::new(&global::meter("test_stats"), 0))
+            as Arc<dyn RuntimeStats>;
         let stats_manager = RuntimeStatsManager::new_impl(
             &tokio::runtime::Handle::current(),
             "test_query_id".into(),

--- a/src/daft-local-execution/src/runtime_stats/values.rs
+++ b/src/daft-local-execution/src/runtime_stats/values.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, atomic::Ordering};
 use common_metrics::{
     CPU_US_KEY, Counter, ROWS_IN_KEY, ROWS_OUT_KEY, StatSnapshot, snapshot::DefaultSnapshot,
 };
-use opentelemetry::{KeyValue, global};
+use opentelemetry::{KeyValue, metrics::Meter};
 
 // ----------------------- General Traits for Runtime Stat Collection ----------------------- //
 
@@ -34,14 +34,13 @@ pub struct DefaultRuntimeStats {
 }
 
 impl DefaultRuntimeStats {
-    pub fn new(id: usize) -> Self {
-        let meter = global::meter("daft.local.node_stats");
+    pub fn new(meter: &Meter, id: usize) -> Self {
         let node_kv = vec![KeyValue::new("node_id", id.to_string())];
 
         Self {
-            cpu_us: Counter::new(&meter, CPU_US_KEY, None),
-            rows_in: Counter::new(&meter, ROWS_IN_KEY, None),
-            rows_out: Counter::new(&meter, ROWS_OUT_KEY, None),
+            cpu_us: Counter::new(meter, CPU_US_KEY, None),
+            rows_in: Counter::new(meter, ROWS_IN_KEY, None),
+            rows_out: Counter::new(meter, ROWS_OUT_KEY, None),
             node_kv,
         }
     }

--- a/src/daft-local-execution/src/sinks/write.rs
+++ b/src/daft-local-execution/src/sinks/write.rs
@@ -9,7 +9,7 @@ use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use daft_writers::{AsyncFileWriter, WriteResult, WriterFactory};
-use opentelemetry::{KeyValue, global};
+use opentelemetry::{KeyValue, metrics::Meter};
 use tracing::{Span, instrument};
 
 use super::blocking_sink::{
@@ -27,15 +27,14 @@ struct WriteStats {
 }
 
 impl WriteStats {
-    pub fn new(id: usize) -> Self {
-        let meter = global::meter("daft.local.node_stats");
+    pub fn new(meter: &Meter, id: usize) -> Self {
         let node_kv = vec![KeyValue::new("node_id", id.to_string())];
 
         Self {
-            cpu_us: Counter::new(&meter, CPU_US_KEY, None),
-            rows_in: Counter::new(&meter, ROWS_IN_KEY, None),
-            rows_written: Counter::new(&meter, "rows written", None),
-            bytes_written: Counter::new(&meter, "bytes written", None),
+            cpu_us: Counter::new(meter, CPU_US_KEY, None),
+            rows_in: Counter::new(meter, ROWS_IN_KEY, None),
+            rows_written: Counter::new(meter, "rows written", None),
+            bytes_written: Counter::new(meter, "bytes written", None),
 
             node_kv,
         }
@@ -217,8 +216,8 @@ impl BlockingSink for WriteSink {
         Ok(WriteState::new(writer))
     }
 
-    fn make_runtime_stats(&self, id: usize) -> Arc<dyn RuntimeStats> {
-        Arc::new(WriteStats::new(id))
+    fn make_runtime_stats(&self, meter: &Meter, id: usize) -> Arc<dyn RuntimeStats> {
+        Arc::new(WriteStats::new(meter, id))
     }
 
     fn multiline_display(&self) -> Vec<String> {

--- a/tools/observability/opentelemetry/docker-compose.yml
+++ b/tools/observability/opentelemetry/docker-compose.yml
@@ -1,11 +1,12 @@
 services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib
+    container_name: collector
     volumes:
     - ./otelcol-config.yml:/etc/otelcol-contrib/config.yaml
     ports:
     - 4317:4317   # OTLP gRPC receiver
-
+    - 9464:9464   # Prometheus scrape endpoint
   jaeger:
     image: jaegertracing/jaeger:2.5.0
     ports:
@@ -13,11 +14,9 @@ services:
     environment:
     - COLLECTOR_OTLP_ENABLED=true
   prometheus:
-    image: prom/prometheus:v3.3.1
+    image: prom/prometheus:v3.5.1
     container_name: prometheus
-    command:
-    - --web.enable-otlp-receiver
     volumes:
-    - ./prometheus.yml:/prometheus/prometheus.yml
+    - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
     - "9090:9090"

--- a/tools/observability/opentelemetry/otelcol-config.yml
+++ b/tools/observability/opentelemetry/otelcol-config.yml
@@ -5,18 +5,24 @@ receivers:
         endpoint: 0.0.0.0:4317
 exporters:
   debug:
+    verbosity: normal
   otlp:
     endpoint: "jaeger:4317"
     tls:
       insecure: true
-  otlphttp/prometheus:
-    endpoint: "http://prometheus:9090/api/v1/otlp"
-    tls:
-      insecure: true
+  prometheus:
+    endpoint: 0.0.0.0:9464
 processors:
   batch:
     timeout: 200ms
     send_batch_size: 1024
+  transform:
+    metric_statements:
+    - context: datapoint
+      statements:
+      - set(attributes["service.instance.id"], resource.attributes["service.instance.id"])
+      - set(attributes["service.name"], resource.attributes["service.name"])
+      - set(attributes["service.namespace"], resource.attributes["service.namespace"])
 service:
   pipelines:
     traces:
@@ -25,5 +31,5 @@ service:
       exporters: [otlp, debug]
     metrics:
       receivers: [otlp]
-      processors: [batch]
-      exporters: [otlphttp/prometheus, debug]
+      processors: [batch, transform]
+      exporters: [prometheus, debug]

--- a/tools/observability/opentelemetry/prometheus.yml
+++ b/tools/observability/opentelemetry/prometheus.yml
@@ -3,11 +3,10 @@ global:
   scrape_timeout: 3s
   evaluation_interval: 30s
 
-otlp:
-  promote_resource_attributes:
-  - service.instance.id
-  - service.name
-  - service.namespace
+scrape_configs:
+- job_name: 'daft'
+  static_configs:
+  - targets: ['collector:9464']
 
 storage:
   tsdb:


### PR DESCRIPTION
## Changes Made

Extend support for `OTEL_*` configuration parameters for configuring Daft OTEL exports. Should be possible now directly export metrics to Prometheus now, for example (based on their docs https://prometheus.io/docs/guides/opentelemetry/#configuring-prometheus):

```sh
# One shell
prometheus --web.enable-otlp-receiver

# Another shell
export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://localhost:9090/api/v1/otlp/v1/metrics
python ...
```

## Related Issues

Partially implements #6144. Needs more testing on completeness.