### PR TITLE
fix(optimizer): Fix bug with pushing filters through anti-joinsI s

### DIFF
--- a/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
@@ -344,16 +344,17 @@ impl PushDownFilter {
                     let pred_cols = HashSet::<_>::from_iter(get_required_columns(&predicate));
 
                     // Extract join key column names for anti/semi join handling
-                    let join_key_cols: HashSet<String> = if matches!(join_type, JoinType::Anti | JoinType::Semi) {
-                        let (_, left_keys, right_keys, _) = on.split_eq_preds();
-                        left_keys
-                            .iter()
-                            .chain(right_keys.iter())
-                            .filter_map(|e| e.input_mapping())
-                            .collect()
-                    } else {
-                        HashSet::new()
-                    };
+                    let join_key_cols: HashSet<String> =
+                        if matches!(join_type, JoinType::Anti | JoinType::Semi) {
+                            let (_, left_keys, right_keys, _) = on.split_eq_preds();
+                            left_keys
+                                .iter()
+                                .chain(right_keys.iter())
+                                .filter_map(|e| e.input_mapping())
+                                .collect()
+                        } else {
+                            HashSet::new()
+                        };
 
                     match (
                         pred_cols.is_subset(&left_cols),


### PR DESCRIPTION
## Changes Made

- Fix incorrect filter pushdown to the right side of anti/semi joins when a non-join-key column exists in both input schemas 
- When PushDownAntiSemiJoin pushes a join through a filter, PushDownFilter would then incorrectly push the filter to both sides of the join if the filtered column name existed in both schemas — even though anti/semi join output only contains left columns
- The fix distinguishes between join key columns (safe to push to both sides) and non-join-key columns (only push to the left side for anti/semi joins)

## Related Issues

Closes #6086
