### PR TITLE
refactor(arrow2): migrate DataArray full_null/empty to arrow-rs

### DIFF
--- a/src/daft-core/src/array/ops/full.rs
+++ b/src/daft-core/src/array/ops/full.rs
@@ -31,11 +31,11 @@ where
             T::get_dtype()
         );
 
-        let arrow_dtype = dtype.to_arrow2();
+        let arrow_dtype = dtype.to_arrow();
         match arrow_dtype {
-            Ok(arrow_dtype) => Self::new(
+            Ok(arrow_dtype) => Self::from_arrow(
                 Arc::new(Field::new(name.to_string(), dtype.clone())),
-                daft_arrow::array::new_null_array(arrow_dtype, length),
+                arrow::array::new_null_array(&arrow_dtype, length),
             )
             .unwrap(),
             Err(e) => panic!("Cannot create DataArray from non-arrow dtype: {e}"),
@@ -43,11 +43,11 @@ where
     }
 
     fn empty(name: &str, dtype: &DataType) -> Self {
-        let arrow_dtype = dtype.to_arrow2();
+        let arrow_dtype = dtype.to_arrow();
         match arrow_dtype {
-            Ok(arrow_dtype) => Self::new(
+            Ok(arrow_dtype) => Self::from_arrow(
                 Arc::new(Field::new(name.to_string(), dtype.clone())),
-                daft_arrow::array::new_empty_array(arrow_dtype),
+                arrow::array::new_empty_array(&arrow_dtype),
             )
             .unwrap(),
             Err(e) => panic!("Cannot create DataArray from non-arrow dtype: {e}"),


### PR DESCRIPTION
## Summary

- Migrate `DataArray<T>`'s `FullNull` impl from arrow2 to arrow-rs in `src/daft-core/src/array/ops/full.rs`
- Replace `dtype.to_arrow2()` with `dtype.to_arrow()`
- Replace `daft_arrow::array::new_null_array` / `new_empty_array` (arrow2) with `arrow::array::new_null_array` / `new_empty_array` (arrow-rs)
- Replace `DataArray::new` (arrow2 input) with `DataArray::from_arrow` (arrow-rs input)

Note: The other `FullNull` impls (FixedSizeListArray, ListArray, StructArray, PythonArray, LogicalArray) were already using arrow-rs compatible types (`NullBuffer`, `Series`, etc.) and required no changes.

Ref: #5741

## Test plan

- [x] `cargo check -p daft-core` passes
- [x] `cargo test -p daft-core -- array::ops::full` — all 6 tests pass
- [x] All pre-commit hooks pass (formatting, clippy, cargo check default + all features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)