### PR TITLE
refactor(arrow2): migrate BinaryArray iceberg_truncate to arrow-rs

### DIFF
--- a/src/daft-core/src/array/ops/truncate.rs
+++ b/src/daft-core/src/array/ops/truncate.rs
@@ -3,7 +3,6 @@ use std::ops::Rem;
 use common_error::DaftResult;
 use num_traits::ToPrimitive;
 
-use super::as_arrow::AsArrow;
 use crate::{
     array::DataArray,
     datatypes::{
@@ -70,12 +69,11 @@ impl Utf8Array {
 
 impl BinaryArray {
     pub fn iceberg_truncate(&self, w: i64) -> DaftResult<Self> {
-        let as_arrow = self.as_arrow2();
-        let substring = daft_arrow::compute::substring::binary_substring(as_arrow, 0, &Some(w));
-        Ok(Self::new(
-            Field::new(self.name(), DataType::Binary).into(),
-            Box::new(substring),
-        )
-        .unwrap())
+        let result = arrow::compute::kernels::substring::substring(
+            self.to_arrow().as_ref(),
+            0,
+            Some(w as _),
+        )?;
+        Self::from_arrow(Field::new(self.name(), DataType::Binary), result)
     }
 }


### PR DESCRIPTION
## Summary

- Migrate `BinaryArray::iceberg_truncate` from arrow2 `binary_substring` to arrow-rs `substring` kernel
- Mirrors the existing `Utf8Array::iceberg_truncate` pattern (migrated in a prior PR)
- Removes unused `AsArrow` import — `truncate.rs` is now fully arrow2-free

Ref: #5741

## Test plan

- [x] `cargo check -p daft-core` passes
- [x] All pre-commit hooks pass (formatting, clippy, cargo check default + all features)
- [x] No dedicated unit tests for truncate exist; functionality exercised through integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)