### PR TITLE
refactor: Migrate hll_merge.rs from arrow2 to arrow-rs

### DIFF
--- a/src/daft-core/src/array/ops/hll_merge.rs
+++ b/src/daft-core/src/array/ops/hll_merge.rs
@@ -1,3 +1,4 @@
+use arrow::array::Array;
 use common_error::DaftResult;
 use hyperloglog::HyperLogLog;
 
@@ -10,8 +11,9 @@ impl DaftHllMergeAggable for FixedSizeBinaryArray {
     type Output = DaftResult<UInt64Array>;
 
     fn hll_merge(&self) -> Self::Output {
+        let arrow_array = self.as_arrow()?;
         let mut final_hll = HyperLogLog::default();
-        for byte_slice in self.as_arrow2().iter().flatten() {
+        for byte_slice in arrow_array.iter().flatten() {
             let hll = HyperLogLog::new_with_byte_slice(byte_slice);
             final_hll.merge(&hll);
         }
@@ -21,12 +23,13 @@ impl DaftHllMergeAggable for FixedSizeBinaryArray {
     }
 
     fn grouped_hll_merge(&self, groups: &GroupIndices) -> Self::Output {
-        let data = self.as_arrow2();
+        let data = self.as_arrow()?;
         let mut counts = Vec::with_capacity(groups.len());
         for group in groups {
             let mut final_hll = HyperLogLog::default();
             for &index in group {
-                if let Some(byte_slice) = data.get(index as _) {
+                if data.is_valid(index as usize) {
+                    let byte_slice = data.value(index as usize);
                     let hll = HyperLogLog::new_with_byte_slice(byte_slice);
                     final_hll.merge(&hll);
                 }


### PR DESCRIPTION
## Summary
- Replace `as_arrow2()` with `as_arrow()` (arrow-rs) in both `hll_merge` and `grouped_hll_merge`
- Replace `data.get(index)` (arrow2 Option-returning accessor) with `data.is_valid(index)` + `data.value(index)` (arrow-rs pattern)
- Add `arrow::array::Array` trait import for `is_valid` method

## Test plan
- [x] `cargo check -p daft-core` passes
- [x] All pre-commit hooks pass (rustfmt, clippy, cargo check default + all features)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)