### PR TITLE
refactor: Migrate product.rs from arrow2 to arrow-rs

### DIFF
--- a/src/daft-core/src/array/ops/product.rs
+++ b/src/daft-core/src/array/ops/product.rs
@@ -1,5 +1,5 @@
+use arrow::array::Array;
 use common_error::DaftResult;
-use daft_arrow::array::Array;
 
 use super::{DaftProductAggable, as_arrow::AsArrow};
 use crate::{array::ops::GroupIndices, datatypes::*};
@@ -9,14 +9,14 @@ macro_rules! impl_daft_numeric_agg {
             type Output = DaftResult<DataArray<$T>>;
 
             fn product(&self) -> Self::Output {
-                let primitive_arr = self.as_arrow2();
+                let primitive_arr = self.as_arrow()?;
                 let product_value =
                     primitive_arr
                         .iter()
                         .flatten()
                         .fold(None, |acc, val| match acc {
-                            None => Some(*val),
-                            Some(acc_val) => Some(acc_val * *val),
+                            None => Some(val),
+                            Some(acc_val) => Some(acc_val * val),
                         });
 
                 Ok(DataArray::<$T>::from_iter(
@@ -26,7 +26,7 @@ macro_rules! impl_daft_numeric_agg {
             }
 
             fn grouped_product(&self, groups: &GroupIndices) -> Self::Output {
-                let arrow_array = self.as_arrow2();
+                let arrow_array = self.as_arrow()?;
                 let product_per_group = if arrow_array.null_count() > 0 {
                     DataArray::<$T>::from_iter(
                         self.field.clone(),


### PR DESCRIPTION
## Summary
- Replace `daft_arrow::array::Array` (arrow2) with `arrow::array::Array` (arrow-rs)
- Replace `as_arrow2()` with `as_arrow()` in both `product()` and `grouped_product()`
- Remove `*val` dereferences — arrow-rs `PrimitiveArray::iter()` yields `Option<T>` by value, unlike arrow2 which yields `Option<&T>`

## Test plan
- [x] `cargo check -p daft-core` passes
- [x] All pre-commit hooks pass (rustfmt, clippy, cargo check default + all features)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)