### PR TITLE
fix(test): bump actor UDF timeout from 10s to 60s to reduce flakiness

### DIFF
--- a/tests/expressions/test_legacy_udf.py
+++ b/tests/expressions/test_legacy_udf.py
@@ -689,7 +689,7 @@ def test_udf_fails_with_no_actors_schedulable():
 
 @pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Tests Flotilla-specific behavior")
 def test_udf_succeeds_with_some_actors_schedulable():
-    with execution_config_ctx(actor_udf_ready_timeout=10):
+    with execution_config_ctx(actor_udf_ready_timeout=60):
         df = daft.from_pydict({"a": [1, 2, 3]})
 
         # Request for 100 actors, with 1 cpu. Not all will be scheduled, but the query can still run.


### PR DESCRIPTION
## Changes Made

Bumps `actor_udf_ready_timeout` from 10 to 60 seconds in `test_udf_succeeds_with_some_actors_schedulable`.

The test requests 100 Ray actors on macOS CI runners with constrained CPU resources. Ray frequently cannot schedule any actors within 10 seconds, causing a high failure rate on the `unit-test (3.13, ray, 22.0.0, macos-latest, true)` job on `main`.

This only changes the maximum wait time before declaring failure. In the happy path (actors start quickly), the test completes immediately - a higher timeout does not slow down passing runs.

## Evidence

Recent runs of `unit-test (3.13, ray, 22.0.0, macos-latest, true)` on `main` (7 most recent non-cancelled):

| Run | Commit | Job Result | Failing Test(s) |
|-----|--------|------------|-----------------|
| [Feb 10 07:23](https://github.com/Eventual-Inc/Daft/actions/runs/21855580451/job/63071608653) | `ab4182b` | Pass | - |
| [Feb 10 02:00](https://github.com/Eventual-Inc/Daft/actions/runs/21848669879/job/63050252466) | `9aef5c3` | **Fail** | `test_udf_succeeds_with_some_actors_schedulable` (10s timeout) |
| [Feb 10 00:45](https://github.com/Eventual-Inc/Daft/actions/runs/21846914393/job/63044850456) | `14be351` | **Fail** | `test_udf_succeeds_with_some_actors_schedulable` (10s timeout) |
| [Feb 10 00:07](https://github.com/Eventual-Inc/Daft/actions/runs/21845968297/job/63041770540) | `7912543` | **Fail** | `test_udf_succeeds_with_some_actors_schedulable` (10s) + `test_cls[2]`, `test_cls_method_without_decorator[2]` (120s) |
| [Feb 09 23:33](https://github.com/Eventual-Inc/Daft/actions/runs/21845119936/job/63039090502) | `de28b9b` | Pass | - |
| [Feb 09 23:09](https://github.com/Eventual-Inc/Daft/actions/runs/21844480054/job/63036994312) | `469fe82` | **Fail** | `test_transformers_image_embedder_other` (unrelated HuggingFace network error) |
| [Feb 09 22:49](https://github.com/Eventual-Inc/Daft/actions/runs/21843920703/job/63035135762) | `5651f0b` | Pass | - |

**Job success rate**: 3/7 (43%). This fix would have prevented 2 of the 4 failures (the two caused solely by the 10s timeout).

## Testing

The macOS job only runs on `main`, not on PRs. To validate, two test PRs with the macOS job temporarily enabled:

- **Baseline (no fix)**: #6167 - [macOS Ray job **failed**](https://github.com/Eventual-Inc/Daft/actions/runs/21883639665/job/63172747749): `test_udf_succeeds_with_some_actors_schedulable` timed out at 10s, confirming the flakiness.
- **With fix (10s -> 60s)**: #6168 - [macOS Ray job](https://github.com/Eventual-Inc/Daft/actions/runs/21886392471/job/63182222016): `test_udf_succeeds_with_some_actors_schedulable` **passed** with the 60s timeout. The job still failed due to `test_cls[2]` timing out at the default 120s - a separate issue where the macOS runner was too slow to start any Ray actors even after 2 minutes (same pattern as historical run `7912543` above).

## Related Issues

Addresses flaky CI failures on macOS Ray test job.
