### PR TITLE
ci:  Accept pandas StringDtype in schema override tests

### DIFF
--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -633,7 +633,7 @@ def test_create_dataframe_csv_schema_hints_override_types(valid_data: list[dict[
         assert list(pd_df.columns) == COL_NAMES
         assert len(pd_df) == len(valid_data)
 
-        assert pd_df["sepal_length"].dtype == "object"
+        assert pd_df["sepal_length"].dtype in ("object", "string")
         assert pd_df["sepal_length"][0] == str(valid_data[0]["sepal_length"])
 
 
@@ -882,7 +882,7 @@ def test_create_dataframe_json_schema_override_types(valid_data: list[dict[str, 
         assert list(pd_df.columns) == COL_NAMES
         assert len(pd_df) == len(valid_data)
 
-        assert pd_df["sepal_length"].dtype == "object"
+        assert pd_df["sepal_length"].dtype in ("object", "string")
         assert pd_df["sepal_length"][0] == str(valid_data[0]["sepal_length"])
 
 
@@ -1179,7 +1179,7 @@ def test_create_dataframe_parquet_schema_override_types(valid_data: list[dict[st
         assert list(pd_df.columns) == COL_NAMES
         assert len(pd_df) == len(valid_data)
 
-        assert pd_df["sepal_length"].dtype == "object"
+        assert pd_df["sepal_length"].dtype in ("object", "string")
         assert pd_df["sepal_length"][0] == str(valid_data[0]["sepal_length"])
 
 


### PR DESCRIPTION
## Changes Made

Fixes 3 failing tests in tests/dataframe/test_creation.py that are breaking the nightly build on Python 3.11:
- test_create_dataframe_csv_schema_hints_override_types
- test_create_dataframe_json_schema_override_types
- test_create_dataframe_parquet_schema_override_types

These tests assert that a string-overridden column has dtype == "object", but newer pandas versions (with future.infer_string enabled by default) return StringDtype(na_value=nan) instead. The assertions now accept both "object" and "string".

This is a test-only change — Daft behavior is unaffected. The nightly publish job was being skipped because these test failures caused the build to fail before reaching the publish step.

## Related Issues

Nightly build failure: https://github.com/Eventual-Inc/Daft/actions/runs/21853132290