### PR TITLE
ci: [TEST] flaky macOS job baseline (no fix)

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -92,9 +92,9 @@ jobs:
           os: macos-latest
         - python-version: '3.13'
           pyarrow-version: 8.0.0
-        # don't run mac unit tests in PRs
-        - os: macos-latest
-          on-main: false
+        # temporarily enabled for testing flaky macOS job
+        # - os: macos-latest
+        #   on-main: false
 
     steps:
     - name: Free Disk Space (Ubuntu) # only run on ubuntu


### PR DESCRIPTION
**Do not merge.** This PR temporarily enables the macOS Ray job on PRs to establish a baseline for flaky test comparison. See #6163.