### PR TITLE
fix: into_batches should not allow downstream shuffle elision

### DIFF
--- a/src/daft-distributed/src/pipeline_node/into_batches.rs
+++ b/src/daft-distributed/src/pipeline_node/into_batches.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
-use daft_logical_plan::stats::StatsState;
+use daft_logical_plan::{partitioning::UnknownClusteringConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 use futures::StreamExt;
 
@@ -54,7 +54,12 @@ impl IntoBatchesNode {
         let config = PipelineNodeConfig::new(
             schema,
             plan_config.config.clone(),
-            child.config().clustering_spec.clone(),
+            Arc::new(
+                UnknownClusteringConfig::new(
+                    child.config().clustering_spec.num_partitions().max(2),
+                )
+                .into(),
+            ),
         );
         Self {
             config,

--- a/tests/dataframe/test_distinct.py
+++ b/tests/dataframe/test_distinct.py
@@ -158,3 +158,29 @@ def test_distinct_some_columns_derived(make_df, repartition_nparts, with_morsel_
     # Test drop_duplicates alias.
     result_df = daft_df.drop_duplicates("values").collect()
     assert len(result_df) == 2
+
+
+def test_distinct_after_into_batches(make_df, with_morsel_size):
+    """Regression test for https://github.com/Eventual-Inc/Daft/issues/6161.
+
+    into_batches + distinct should deduplicate globally, not per-batch.
+    """
+    vals = [
+        "jjtzwafmzk",
+        "fjinpogsnd",
+        "advcnkwdgr",
+        "lkloaeeuvg",
+        "qdmljqvqxv",
+        "bknitbecis",
+        "fgqrpbilay",
+        "advcnkwdgr",
+        "shsjofbzml",
+        "zyjbwskjyk",
+        "utbqewwxoc",
+        "qdmljqvqxv",
+        "ezocoaxmsd",
+        "qdmljqvqxv",
+    ]
+    daft_df = make_df({"val": vals})
+    result = daft_df.into_batches(4).distinct("val").count_rows()
+    assert result == len(set(vals))  # expect 11


### PR DESCRIPTION
## Changes Made

`IntoBatchesNode` was preserving its child's clustering spec, which could claim `num_partitions == 1` even though `into_batches` could splits data into multiple batches. This caused two cascading failures:

1. `distinct` saw `num_partitions == 1` in `needs_hash_repartition` and skipped the hash shuffle, so deduplication only happened within each batch and cross-batch duplicates survived.
2. The subsequent `count_rows()` aggregation also saw `num_partitions == 1` in `gen_gather_node` and skipped the gather step, so each batch produced its own independent count. Python's `count_rows()` then returned `to_pydict()["count"][0]` which is the distinct count from just the first batch rather than the global total.

We can avoid this by setting the clustering spec to `Unknown` with `num_partitions >= 2`. This ensures downstream operators correctly recognize that data is spread across multiple partitions and perform the necessary shuffles/gathers. It's best-effort since there can be more than 2 partitions, but we don't know at planning time how many partitions there will be.

## Related Issues

Closes #6161
