### PR TITLE
feat: Nightly installations under nightly.daft.ai

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -154,6 +154,17 @@ pip install -U "daft[all]"
 
 
 
+## Nightly Builds
+
+Nightly builds are published daily from the latest `main` branch. These are useful for testing upcoming features and bug fixes before they are released on PyPI.
+
+```bash
+pip install daft --pre --extra-index-url https://nightly.daft.ai
+```
+
+!!! warning "Stability"
+    Nightly builds may contain unstable or experimental changes. They are not recommended for production use.
+
 ## Troubleshooting Legacy CPU Support
 
 If you encounter `Illegal instruction` errors, your CPU may lack support for advanced instruction sets like [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions). Use the LTS version instead:


### PR DESCRIPTION
## Changes Made

Wired up https://nightly.daft.ai as a syntactic sugar for the index of our nightly wheels, so users should now be able to install nightly Daft via `uv pip install daft --pre --extra-index-url https://nightly.daft.ai`