### PR TITLE
fix: use union instead of append_column in window agg to fix schema mismatch

### DIFF
--- a/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
@@ -184,10 +184,9 @@ impl BlockingSink for WindowPartitionAndOrderBySink {
                                                 ))?
                                                 .broadcast(partition.len())?
                                                 .rename(name.clone());
-                                            partition.append_column(
-                                                params.original_schema.clone(),
-                                                new_col,
-                                            )?
+                                            let agg_batch =
+                                                RecordBatch::from_nonempty_columns(vec![new_col])?;
+                                            partition.union(&agg_batch)?
                                         }
                                         WindowExpr::RowNumber => {
                                             partition.window_row_number(name.clone())?


### PR DESCRIPTION
## Changes Made

In `WindowPartitionAndOrderBySink::finalize`, the `Agg` branch used `append_column` with the full output schema (`params.original_schema`), even though only one window column had been added so far. This caused a `SchemaMismatch` error when an Agg expression (sum, mean, etc.) appeared before an Offset expression (lag/lead) on the same window spec.

The fix switches the Agg branch to use `union` (via `RecordBatch::from_nonempty_columns` + `union`), matching what the Rank, Offset, and RowNumber branches already do. This builds the schema from the actual columns present rather than using a pre-specified full output schema.

Also adds a regression test for this case.

## Related Issues

This fixes the nightly `[NIGHTLY] Notebook Checker` CI failure that has been occurring since PR #5547 was merged in November 2025.