### PR TITLE
refactor(arrow2): migrates sparse-tensor to arrow-rs

### DIFF
--- a/src/daft-core/src/array/ops/sparse_tensor.rs
+++ b/src/daft-core/src/array/ops/sparse_tensor.rs
@@ -88,10 +88,13 @@ mod tests {
             sparse_tensor_array.cast(&fixed_shape_sparse_tensor_dtype)?;
         let roundtrip_tensor = fixed_shape_sparse_tensor_array.cast(&dtype)?;
 
-        let round_trip_tensor_arrow = roundtrip_tensor.to_arrow2();
-        let sparse_tensor_array_arrow = sparse_tensor_array.to_arrow2();
+        let round_trip_tensor_arrow = roundtrip_tensor.to_arrow()?;
+        let sparse_tensor_array_arrow = sparse_tensor_array.to_arrow()?;
 
-        assert_eq!(round_trip_tensor_arrow, sparse_tensor_array_arrow);
+        assert_eq!(
+            round_trip_tensor_arrow.to_data(),
+            sparse_tensor_array_arrow.to_data()
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Changes Made

Removes arrow2 usage from the tests.
