### PR TITLE
fix: use floor_char_boundary for progress bar name truncation

### DIFF
--- a/src/daft-local-execution/src/runtime_stats/progress_bar.rs
+++ b/src/daft-local-execution/src/runtime_stats/progress_bar.rs
@@ -322,3 +322,28 @@ mod python {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use common_metrics::ops::NodeInfo;
+
+    use super::IndicatifProgressBarManager;
+
+    #[test]
+    fn test_truncate_multibyte_utf8_name() {
+        // 'ê' is 2 bytes in UTF-8. 14 ASCII + 4×2-byte = 22 bytes total.
+        // Truncation at byte 15 lands inside a multi-byte char and panics.
+        let node_info = Arc::new(NodeInfo {
+            name: Arc::from("aaaaaaaaaaaaaaêêêê"),
+            id: 0,
+            ..Default::default()
+        });
+        let mut map = HashMap::new();
+        map.insert(0, node_info);
+
+        // This should not panic.
+        let _manager = IndicatifProgressBarManager::new(&map);
+    }
+}

--- a/src/daft-local-execution/src/runtime_stats/progress_bar.rs
+++ b/src/daft-local-execution/src/runtime_stats/progress_bar.rs
@@ -152,7 +152,10 @@ impl IndicatifProgressBarManager {
         );
 
         let formatted_prefix = if node_info.name.len() > MAX_PIPELINE_NAME_LEN {
-            format!("{}...", &node_info.name[..MAX_PIPELINE_NAME_LEN - 3])
+            let truncate_at = node_info
+                .name
+                .floor_char_boundary(MAX_PIPELINE_NAME_LEN - 3);
+            format!("{}...", &node_info.name[..truncate_at])
         } else {
             format!("{:>1$}", node_info.name, max_name_len)
         };


### PR DESCRIPTION
## Changes Made

The progress bar name truncation in `progress_bar.rs:155` uses byte-index slicing to shorten long operation names. When the slice offset lands inside a multi-byte UTF-8 character (e.g. `ê`), Rust panics with `byte index 15 is not a char boundary`.

This has been causing 9 consecutive nightly Hypothesis test failures since Feb 3 (`test (3.10, native)` job).

**Fix:** Replace `&name[..MAX_PIPELINE_NAME_LEN - 3]` with `&name[..name.floor_char_boundary(MAX_PIPELINE_NAME_LEN - 3)]`, which rounds down to the nearest valid char boundary.

Also adds a unit test that reproduces the exact panic.

## Related Issues

Fixes nightly Hypothesis CI failure in [Run property based tests with Hypothesis](https://github.com/Eventual-Inc/Daft/actions/runs/21921434809).