### PR TITLE
feat(ai): Add HTTP URL direct passthrough for images and videos in prompt function

### DIFF
--- a/tests/ai/openai/test_openai_prompter.py
+++ b/tests/ai/openai/test_openai_prompter.py
@@ -1438,6 +1438,7 @@ def test_openai_prompter_is_image_url_various_extensions():
         "https://example.com/image.avif",
         "https://example.com/image.ico",
         "https://example.com/image.jp2",
+        "https://example.com/image.j2k",
     ]
 
     for url in image_urls:


### PR DESCRIPTION
## Changes Made
This PR adds support for HTTP/HTTPS URL direct passthrough for images and videos in the prompt function. Previously, all media content had to be downloaded and base64-encoded before being sent to the LLM. Now, publicly accessible URLs are passed directly to the model, significantly reducing I/O overhead and memory consumption.


Core Implementation ( daft/ai/openai/protocols/prompter.py ):

- Added IMAGE_EXTENSIONS and VIDEO_EXTENSIONS constants for URL type detection
- Added _is_http_url() method to detect HTTP/HTTPS URLs
- Added _is_image_url() method to identify image URLs by extension
- Added _is_video_url() method to identify video URLs by extension
- Added _build_image_url_message() method for direct image URL passthrough
- Added _build_video_url_message() method for direct video URL passthrough
- Modified _process_str_message() to automatically detect and handle media URLs
Supported Formats :

- Images (14 formats) : .jpg , .jpeg , .png , .gif , .webp , .bmp , .tiff , .tif , .svg , .heic , .heif , .avif , .ico , .jp2
- Videos (18 formats) : .mp4 , .mpeg , .mpg , .mov , .avi , .webm , .mkv , .flv , .wmv , .m4v , .3gp , .3g2 , .rm , .rmvb , .ogv , .ogg , .ts , .asf<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
