### PR TITLE
test: Add missing result parameter to on_query_end in Google AI test

### DIFF
--- a/tests/integration/ai/test_google.py
+++ b/tests/integration/ai/test_google.py
@@ -62,7 +62,8 @@ class PromptMetricsSubscriber(Subscriber):
         for node_id, stats in all_stats.items():
             self.node_stats[query_id][node_id] = dict(stats)
 
-    def on_query_end(self, query_id: str) -> None:
+    def on_query_end(self, query_id: str, result: Any) -> None:
+        """Called when a query has completed."""
         pass
 
     def on_result_out(self, query_id: str, result: PyMicroPartition) -> None:


### PR DESCRIPTION
The PromptMetricsSubscriber class in test_google.py was missing the required `result` parameter in its `on_query_end` method. This caused the CI integration-test-ai-credentialed job to fail because the method signature didn't match the abstract Subscriber class interface.

