### PR TITLE
chore: Intermediate op single input

### DIFF
--- a/src/daft-local-execution/src/intermediate_ops/distributed_actor_pool_project.rs
+++ b/src/daft-local-execution/src/intermediate_ops/distributed_actor_pool_project.rs
@@ -281,10 +281,10 @@ impl IntermediateOperator for DistributedActorPoolProjectOperator {
         }
     }
 
-    fn max_concurrency(&self) -> DaftResult<usize> {
+    fn max_concurrency(&self) -> usize {
         // We set the max concurrency to be the number of actor handles * 2 to such that each actor handle has 2 workers submitting to it.
         // This allows inputs to be queued up concurrently with UDF execution.
-        Ok(self.actor_handles.len() * 2)
+        self.actor_handles.len() * 2
     }
 
     fn morsel_size_requirement(&self) -> Option<MorselSizeRequirement> {

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -63,8 +63,8 @@ pub(crate) trait IntermediateOperator: Send + Sync {
     /// The maximum number of concurrent workers that can be spawned for this operator.
     /// Each worker will has its own IntermediateOperatorState.
     /// This method should be overridden if the operator needs to limit the number of concurrent workers, i.e. UDFs with resource requests.
-    fn max_concurrency(&self) -> DaftResult<usize> {
-        Ok(get_compute_pool_num_threads())
+    fn max_concurrency(&self) -> usize {
+        get_compute_pool_num_threads()
     }
 
     fn morsel_size_requirement(&self) -> Option<MorselSizeRequirement> {
@@ -76,7 +76,7 @@ pub(crate) trait IntermediateOperator: Send + Sync {
 
 pub struct IntermediateNode<Op: IntermediateOperator> {
     intermediate_op: Arc<Op>,
-    children: Vec<Box<dyn PipelineNode>>,
+    child: Box<dyn PipelineNode>,
     runtime_stats: Arc<dyn RuntimeStats>,
     plan_stats: StatsState,
     morsel_size_requirement: MorselSizeRequirement,
@@ -107,7 +107,7 @@ struct ExecutionContext<Op: IntermediateOperator> {
 impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
     pub(crate) fn new(
         intermediate_op: Arc<Op>,
-        children: Vec<Box<dyn PipelineNode>>,
+        child: Box<dyn PipelineNode>,
         plan_stats: StatsState,
         ctx: &BuilderContext,
         context: &LocalNodeContext,
@@ -125,7 +125,7 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
             .unwrap_or_default();
         Self {
             intermediate_op,
-            children,
+            child,
             runtime_stats,
             plan_stats,
             morsel_size_requirement,
@@ -236,7 +236,7 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
         mut receiver: Receiver<Arc<MicroPartition>>,
         ctx: &mut ExecutionContext<Op>,
         stats_manager: &RuntimeStatsManagerHandle,
-    ) -> DaftResult<OperatorControlFlow> {
+    ) -> DaftResult<()> {
         let (lower, upper) = ctx.batch_manager.initial_requirements().values();
         let mut buffer = RowBasedBuffer::new(lower, upper);
         let mut input_closed = false;
@@ -250,7 +250,7 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
                 Some(join_result) = ctx.task_set.join_next(), if !ctx.task_set.is_empty() => {
                     let control = Self::handle_task_completion(join_result??, ctx).await?;
                     if !control.should_continue() {
-                        return Ok(OperatorControlFlow::Break);
+                        return Ok(()); // Break
                     }
 
                     // After completing a task, update bounds and try to spawn more tasks
@@ -304,14 +304,14 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
             while let Some(join_result) = ctx.task_set.join_next().await {
                 let control = Self::handle_task_completion(join_result??, ctx).await?;
                 if !control.should_continue() {
-                    return Ok(OperatorControlFlow::Break);
+                    return Ok(()); // Break
                 }
             }
         }
 
         debug_assert_eq!(ctx.task_set.len(), 0, "TaskSet should be empty after loop");
 
-        Ok(OperatorControlFlow::Continue)
+        Ok(())
     }
 }
 
@@ -365,20 +365,17 @@ impl<Op: IntermediateOperator + 'static> TreeDisplay for IntermediateNode<Op> {
     }
 
     fn get_children(&self) -> Vec<&dyn TreeDisplay> {
-        self.children.iter().map(|v| v.as_tree_display()).collect()
+        vec![self.child.as_tree_display()]
     }
 }
 
 impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
     fn children(&self) -> Vec<&dyn PipelineNode> {
-        self.children
-            .iter()
-            .map(std::convert::AsRef::as_ref)
-            .collect()
+        vec![self.child.as_ref()]
     }
 
     fn boxed_children(&self) -> Vec<&Box<dyn PipelineNode>> {
-        self.children.iter().collect()
+        vec![&self.child]
     }
 
     fn name(&self) -> Arc<str> {
@@ -396,12 +393,10 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
             downstream_requirement,
         );
         self.morsel_size_requirement = combined_morsel_size_requirement;
-        for child in &mut self.children {
-            child.propagate_morsel_size_requirement(
-                combined_morsel_size_requirement,
-                default_requirement,
-            );
-        }
+        self.child.propagate_morsel_size_requirement(
+            combined_morsel_size_requirement,
+            default_requirement,
+        );
     }
 
     fn start(
@@ -410,16 +405,9 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
         runtime_handle: &mut ExecutionRuntimeContext,
     ) -> crate::Result<Receiver<Arc<MicroPartition>>> {
         // 1. Start children and wrap receivers
-        let mut child_result_receivers = Vec::with_capacity(self.children.len());
-        for child in &self.children {
-            let child_result_receiver = child.start(maintain_order, runtime_handle)?;
-            child_result_receivers.push(child_result_receiver);
-        }
+        let child_result_receiver = self.child.start(maintain_order, runtime_handle)?;
         // 2. Setup
         let op = self.intermediate_op.clone();
-        let max_concurrency = op.max_concurrency().context(PipelineExecutionSnafu {
-            node_name: self.name().to_string(),
-        })?;
         let (destination_sender, destination_receiver) = create_channel(1);
 
         // 3. Create task spawner
@@ -438,10 +426,9 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
         runtime_handle.spawn(
             async move {
                 // Initialize state pool with max_concurrency states
-                let mut state_pool = HashMap::new();
-                for i in 0..max_concurrency {
-                    state_pool.insert(i, op.make_state());
-                }
+                let state_pool = (0..op.max_concurrency())
+                    .map(|i| (i, op.make_state()))
+                    .collect();
 
                 // Create batch manager and task set
                 let batch_manager = Arc::new(BatchManager::new(op.batching_strategy().context(
@@ -461,14 +448,8 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
                     batch_manager,
                     runtime_stats,
                 };
-                for receiver in child_result_receivers {
-                    if !Self::process_input(node_id, receiver, &mut ctx, &stats_manager)
-                        .await?
-                        .should_continue()
-                    {
-                        break;
-                    }
-                }
+                Self::process_input(node_id, child_result_receiver, &mut ctx, &stats_manager)
+                    .await?;
 
                 // Finalize node after processing completes
                 stats_manager.finalize_node(node_id);

--- a/src/daft-local-execution/src/intermediate_ops/project.rs
+++ b/src/daft-local-execution/src/intermediate_ops/project.rs
@@ -212,8 +212,8 @@ impl IntermediateOperator for ProjectOperator {
         res
     }
 
-    fn max_concurrency(&self) -> DaftResult<usize> {
-        Ok(self.max_concurrency)
+    fn max_concurrency(&self) -> usize {
+        self.max_concurrency
     }
 
     fn morsel_size_requirement(&self) -> Option<MorselSizeRequirement> {

--- a/src/daft-local-execution/src/intermediate_ops/udf.rs
+++ b/src/daft-local-execution/src/intermediate_ops/udf.rs
@@ -548,8 +548,8 @@ impl IntermediateOperator for UdfOperator {
         }
     }
 
-    fn max_concurrency(&self) -> DaftResult<usize> {
-        Ok(self.concurrency)
+    fn max_concurrency(&self) -> usize {
+        self.concurrency
     }
 
     fn morsel_size_requirement(&self) -> Option<MorselSizeRequirement> {

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -537,7 +537,7 @@ fn physical_plan_to_pipeline(
             let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             IntermediateNode::new(
                 Arc::new(proj_op),
-                vec![child_node],
+                child_node,
                 stats_state.clone(),
                 ctx,
                 context,
@@ -585,7 +585,7 @@ fn physical_plan_to_pipeline(
                 })?;
                 IntermediateNode::new(
                     Arc::new(proj_op),
-                    vec![child_node],
+                    child_node,
                     stats_state.clone(),
                     ctx,
                     context,
@@ -622,7 +622,7 @@ fn physical_plan_to_pipeline(
             let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             IntermediateNode::new(
                 Arc::new(distributed_actor_pool_project_op),
-                vec![child_node],
+                child_node,
                 stats_state.clone(),
                 ctx,
                 context,
@@ -661,7 +661,7 @@ fn physical_plan_to_pipeline(
             let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             IntermediateNode::new(
                 Arc::new(filter_op),
-                vec![child_node],
+                child_node,
                 stats_state.clone(),
                 ctx,
                 context,
@@ -680,7 +680,7 @@ fn physical_plan_to_pipeline(
             let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             IntermediateNode::new(
                 Arc::new(into_batches_op),
-                vec![child_node],
+                child_node,
                 stats_state.clone(),
                 ctx,
                 context,
@@ -699,7 +699,7 @@ fn physical_plan_to_pipeline(
             let child_node = physical_plan_to_pipeline(input, psets, cfg, ctx)?;
             IntermediateNode::new(
                 Arc::new(explode_op),
-                vec![child_node],
+                child_node,
                 stats_state.clone(),
                 ctx,
                 context,
@@ -820,7 +820,7 @@ fn physical_plan_to_pipeline(
             );
             IntermediateNode::new(
                 Arc::new(unpivot_op),
-                vec![child_node],
+                child_node,
                 stats_state.clone(),
                 ctx,
                 context,


### PR DESCRIPTION
## Changes Made

Intermediate ops only accept single inputs now, simplifies code a bit.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
