### PR TITLE
fix: Render Map columns as python dicts instead of list[struct] in terminal prints

### DIFF
--- a/daft/functions/list.py
+++ b/daft/functions/list.py
@@ -34,13 +34,9 @@ def value_counts(list_expr: Expression) -> Expression:
         │ ---          ┆ ---                 │
         │ List[String] ┆ Map[String: UInt64] │
         ╞══════════════╪═════════════════════╡
-        │ [a, b, a]    ┆ [{key: a,           │
-        │              ┆ value: 2,           │
-        │              ┆ }, {key: …          │
+        │ [a, b, a]    ┆ {"a": 2, "b": 1}    │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-        │ [b, c, b, c] ┆ [{key: b,           │
-        │              ┆ value: 2,           │
-        │              ┆ }, {key: …          │
+        │ [b, c, b, c] ┆ {"b": 2, "c": 2}    │
         ╰──────────────┴─────────────────────╯
         <BLANKLINE>
         (Showing first 2 of 2 rows)

--- a/daft/functions/misc.py
+++ b/daft/functions/misc.py
@@ -681,15 +681,11 @@ def map_get(expr: Expression, key: Expression) -> Expression:
         │ ---                ┆ ---   │
         │ Map[String: Int64] ┆ Int64 │
         ╞════════════════════╪═══════╡
-        │ [{key: a,          ┆ 1     │
-        │ value: 1,          ┆       │
-        │ }]                 ┆       │
+        │ {"a": 1}           ┆ 1     │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
-        │ []                 ┆ None  │
+        │ {}                 ┆ None  │
         ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┤
-        │ [{key: b,          ┆ None  │
-        │ value: 2,          ┆       │
-        │ }]                 ┆       │
+        │ {"b": 2}           ┆ None  │
         ╰────────────────────┴───────╯
         <BLANKLINE>
         (Showing first 3 of 3 rows)


### PR DESCRIPTION
## Changes Made

Before: See issue

```
╭────────┬────────────────────────────────┬─────────────┬───────────────┬───────────────────────────────────────────────────╮
│ id     ┆ name                           ┆ type        ┆ category      ┆ stats                                             │
│ ---    ┆ ---                            ┆ ---         ┆ ---           ┆ ---                                               │
│ UInt64 ┆ String                         ┆ String      ┆ String        ┆ Map[String: Struct[value: Float64, unit: String]] │
╞════════╪════════════════════════════════╪═════════════╪═══════════════╪═══════════════════════════════════════════════════╡
│ 0      ┆ Parquet Scan                   ┆ ScanTask    ┆ Source        ┆ {"cpu us": {value: 0,                             │
│        ┆                                ┆             ┆               ┆ unit: µ…                                          │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 1      ┆ Limit 1000                     ┆ Limit       ┆ StreamingSink ┆ {"cpu us": {value: 0,                             │
│        ┆                                ┆             ┆               ┆ unit: µ…                                          │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 2      ┆ tokenize_encode(prompt, "cl10… ┆ Project     ┆ Intermediate  ┆ {"cpu us": {value: 2543028,                       │
│        ┆                                ┆             ┆               ┆ u…                                                │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 3      ┆ Filter                         ┆ Filter      ┆ Intermediate  ┆ {"cpu us": {value: 13038,                         │
│        ┆                                ┆             ┆               ┆ uni…                                              │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 4      ┆ Explode                        ┆ Explode     ┆ Intermediate  ┆ {"cpu us": {value: 4905,                          │
│        ┆                                ┆             ┆               ┆ unit…                                             │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 5      ┆ Parquet Write                  ┆ Write       ┆ BlockingSink  ┆ {"cpu us": {value: 121249,                        │
│        ┆                                ┆             ┆               ┆ un…                                               │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 6      ┆ Commit Write                   ┆ CommitWrite ┆ BlockingSink  ┆ {"cpu us": {value: 351,                           │
│        ┆                                ┆             ┆               ┆ unit:…                                            │
╰────────┴────────────────────────────────┴─────────────┴───────────────┴───────────────────────────────────────────────────╯
```

## Related Issues
Closes #6194 
