### PR TITLE
ci: Improve CI reliability via disk space reclamation and coverage optimization

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -28,11 +28,19 @@ jobs:
       with:
         tool-cache: false
         android: true
-        dotnet: false
+        dotnet: true
         haskell: true
         large-packages: false
-        docker-images: false
+        docker-images: true
         swap-storage: true
+    - name: Additional disk cleanup
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
     - uses: actions/checkout@v6
     - uses: moonrepo/setup-rust@v1
       with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -40,7 +40,6 @@ jobs:
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
     - uses: actions/checkout@v6
     - uses: moonrepo/setup-rust@v1
       with:

--- a/.github/workflows/nightly-publish-s3.yml
+++ b/.github/workflows/nightly-publish-s3.yml
@@ -204,7 +204,6 @@ jobs:
       contents: read
     steps:
     - name: Free Disk Space (Ubuntu)
-      if: ${{ (runner.os == 'Linux') }}
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: false
@@ -215,14 +214,12 @@ jobs:
         docker-images: true
         swap-storage: true
     - name: Additional disk cleanup
-      if: ${{ (runner.os == 'Linux') }}
       run: |
         sudo rm -rf /usr/share/swift || true
         sudo rm -rf /opt/hostedtoolcache/CodeQL || true
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true

--- a/.github/workflows/nightly-publish-s3.yml
+++ b/.github/workflows/nightly-publish-s3.yml
@@ -209,11 +209,20 @@ jobs:
       with:
         tool-cache: false
         android: true
-        dotnet: false
+        dotnet: true
         haskell: true
         large-packages: false
-        docker-images: false
+        docker-images: true
         swap-storage: true
+    - name: Additional disk cleanup
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -79,19 +79,21 @@ jobs:
       matrix:
         python-version: ['3.10', '3.13']
         daft-runner: [ray, native]
-        pyarrow-version: [8.0.0, 22.0.0]
+        pyarrow-version: ['22.0.0']
         os: [ubuntu-latest, macos-latest]
         on-main:
         - ${{ github.ref == 'refs/heads/main' }}
+        include:
+        # pyarrow compat test — runs without coverage instrumentation
+        - python-version: '3.10'
+          daft-runner: native
+          pyarrow-version: '8.0.0'
+          os: ubuntu-latest
+          on-main: ${{ github.ref == 'refs/heads/main' }}
+          coverage: false
         exclude:
-        - daft-runner: ray
-          pyarrow-version: 8.0.0
         - python-version: '3.10'
           os: macos-latest
-        - pyarrow-version: 8.0.0
-          os: macos-latest
-        - python-version: '3.13'
-          pyarrow-version: 8.0.0
         # don't run mac unit tests in PRs
         - os: macos-latest
           on-main: false
@@ -126,13 +128,13 @@ jobs:
         prefix-key: ${{ runner.os }}-build
         cache-all-crates: 'true'
     - name: Install cargo-llvm-cov
-      if: matrix.pyarrow-version != '8.0.0'
+      if: matrix.coverage != false
       uses: taiki-e/install-action@cargo-llvm-cov
       with:
         tool: cargo-llvm-cov@0.7.1
 
     - name: install llvm tools
-      if: matrix.pyarrow-version != '8.0.0'
+      if: matrix.coverage != false
       run: rustup component add llvm-tools-preview
 
     - name: Setup Python and uv
@@ -172,7 +174,7 @@ jobs:
         uv pip install pyarrow==${{ matrix.pyarrow-version }}
 
     - name: Build library and Test with pytest (with coverage)
-      if: matrix.pyarrow-version != '8.0.0'
+      if: matrix.coverage != false
       run: |
         set -o pipefail
         source .venv/bin/activate
@@ -200,7 +202,7 @@ jobs:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
 
     - name: Build library and Test with pytest (no coverage)
-      if: matrix.pyarrow-version == '8.0.0'
+      if: matrix.coverage == false
       run: |
         set -o pipefail
         source .venv/bin/activate
@@ -215,7 +217,7 @@ jobs:
         DAFT_RUNNER: ${{ matrix.daft-runner }}
 
     - name: Upload coverage report
-      if: matrix.pyarrow-version != '8.0.0'
+      if: matrix.coverage != false
       uses: actions/upload-artifact@v6
       with:
         name: coverage-reports-unit-tests-${{ join(matrix.*, '-') }}

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -81,6 +81,7 @@ jobs:
         daft-runner: [ray, native]
         pyarrow-version: ['22.0.0']
         os: [ubuntu-latest, macos-latest]
+        coverage: [true]
         on-main:
         - ${{ github.ref == 'refs/heads/main' }}
         include:

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -97,7 +97,7 @@ jobs:
           on-main: false
 
     steps:
-    - name: Free Disk Space (Ubuntu) # only run on ubuntu
+    - name: Free Disk Space (Ubuntu)
       if: ${{ (runner.os == 'Linux') }}
       uses: jlumbroso/free-disk-space@main
       with:
@@ -116,7 +116,6 @@ jobs:
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
 
     - uses: actions/checkout@v6
     - uses: moonrepo/setup-rust@v1
@@ -383,8 +382,7 @@ jobs:
         python-version: ['3.10']
         daft-runner: [ray, native]
     steps:
-    - name: Free Disk Space (Ubuntu) # only run on ubuntu
-      if: ${{ (runner.os == 'Linux') }}
+    - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: false
@@ -395,14 +393,12 @@ jobs:
         docker-images: true
         swap-storage: true
     - name: Additional disk cleanup
-      if: ${{ (runner.os == 'Linux') }}
       run: |
         sudo rm -rf /usr/share/swift || true
         sudo rm -rf /opt/hostedtoolcache/CodeQL || true
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -491,7 +487,6 @@ jobs:
       contents: read
     steps:
     - name: Free Disk Space (Ubuntu)
-      if: ${{ (runner.os == 'Linux') }}
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: false
@@ -502,14 +497,12 @@ jobs:
         docker-images: true
         swap-storage: true
     - name: Additional disk cleanup
-      if: ${{ (runner.os == 'Linux') }}
       run: |
         sudo rm -rf /usr/share/swift || true
         sudo rm -rf /opt/hostedtoolcache/CodeQL || true
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -600,8 +593,7 @@ jobs:
     env:
       package-name: daft
     steps:
-    - name: Free Disk Space (Ubuntu) # only run on ubuntu
-      if: ${{ (runner.os == 'Linux') }}
+    - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: false
@@ -612,14 +604,12 @@ jobs:
         docker-images: true
         swap-storage: true
     - name: Additional disk cleanup
-      if: ${{ (runner.os == 'Linux') }}
       run: |
         sudo rm -rf /usr/share/swift || true
         sudo rm -rf /opt/hostedtoolcache/CodeQL || true
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -707,8 +697,7 @@ jobs:
     env:
       package-name: daft
     steps:
-    - name: Free Disk Space (Ubuntu) # only run on ubuntu
-      if: ${{ (runner.os == 'Linux') }}
+    - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: false
@@ -719,14 +708,12 @@ jobs:
         docker-images: true
         swap-storage: true
     - name: Additional disk cleanup
-      if: ${{ (runner.os == 'Linux') }}
       run: |
         sudo rm -rf /usr/share/swift || true
         sudo rm -rf /opt/hostedtoolcache/CodeQL || true
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -925,7 +912,6 @@ jobs:
         daft-runner: [ray, native]
     steps:
     - name: Free Disk Space (Ubuntu)
-      if: ${{ (runner.os == 'Linux') }}
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: false
@@ -936,14 +922,12 @@ jobs:
         docker-images: true
         swap-storage: true
     - name: Additional disk cleanup
-      if: ${{ (runner.os == 'Linux') }}
       run: |
         sudo rm -rf /usr/share/swift || true
         sudo rm -rf /opt/hostedtoolcache/CodeQL || true
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -1271,7 +1255,7 @@ jobs:
       with:
         key: ${{ runner.os }}-rust-build
         cache-all-crates: 'true'
-    - name: Free Disk Space (Ubuntu) # only run on ubuntu
+    - name: Free Disk Space (Ubuntu)
       if: ${{ matrix.os == 'ubuntu' }}
       uses: jlumbroso/free-disk-space@main
       with:
@@ -1290,7 +1274,6 @@ jobs:
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
     - name: Generate code coverage
       run: mkdir -p report-output && cargo llvm-cov  --no-default-features --workspace --exclude common-arrow-ffi --lcov --output-path ./report-output/lcov.info
     - name: Upload coverage report
@@ -1350,7 +1333,6 @@ jobs:
       python-version: '3.10'
     steps:
     - name: Free Disk Space (Ubuntu)
-      if: ${{ (runner.os == 'Linux') }}
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: false
@@ -1361,14 +1343,12 @@ jobs:
         docker-images: true
         swap-storage: true
     - name: Additional disk cleanup
-      if: ${{ (runner.os == 'Linux') }}
       run: |
         sudo rm -rf /usr/share/swift || true
         sudo rm -rf /opt/hostedtoolcache/CodeQL || true
         sudo rm -rf /opt/hostedtoolcache/go || true
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
-        df -h
     - uses: actions/checkout@v6
     - uses: moonrepo/setup-rust@v1
       with:

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -126,11 +126,13 @@ jobs:
         prefix-key: ${{ runner.os }}-build
         cache-all-crates: 'true'
     - name: Install cargo-llvm-cov
+      if: matrix.pyarrow-version != '8.0.0'
       uses: taiki-e/install-action@cargo-llvm-cov
       with:
         tool: cargo-llvm-cov@0.7.1
 
     - name: install llvm tools
+      if: matrix.pyarrow-version != '8.0.0'
       run: rustup component add llvm-tools-preview
 
     - name: Setup Python and uv
@@ -169,7 +171,8 @@ jobs:
         source .venv/bin/activate
         uv pip install pyarrow==${{ matrix.pyarrow-version }}
 
-    - name: Build library and Test with pytest
+    - name: Build library and Test with pytest (with coverage)
+      if: matrix.pyarrow-version != '8.0.0'
       run: |
         set -o pipefail
         source .venv/bin/activate
@@ -196,7 +199,23 @@ jobs:
 
         DAFT_RUNNER: ${{ matrix.daft-runner }}
 
+    - name: Build library and Test with pytest (no coverage)
+      if: matrix.pyarrow-version == '8.0.0'
+      run: |
+        set -o pipefail
+        source .venv/bin/activate
+        maturin develop --uv
+        pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
+        pytest -n auto --ignore tests/integration --durations=0 | ./tools/capture-durations.sh "pytest_output.txt"
+        python tools/aggregate_test_durations.py pytest_output.txt
+      env:
+        RAY_CONDA_HOME: ${{ env.CONDA_HOME }}
+        CONDA_EXE: ${{ env.CONDA_HOME }}/bin/conda
+
+        DAFT_RUNNER: ${{ matrix.daft-runner }}
+
     - name: Upload coverage report
+      if: matrix.pyarrow-version != '8.0.0'
       uses: actions/upload-artifact@v6
       with:
         name: coverage-reports-unit-tests-${{ join(matrix.*, '-') }}

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -103,11 +103,20 @@ jobs:
       with:
         tool-cache: false
         android: true
-        dotnet: false
+        dotnet: true
         haskell: true
         large-packages: false
-        docker-images: false
+        docker-images: true
         swap-storage: true
+    - name: Additional disk cleanup
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
 
     - uses: actions/checkout@v6
     - uses: moonrepo/setup-rust@v1
@@ -380,11 +389,20 @@ jobs:
       with:
         tool-cache: false
         android: true
-        dotnet: false
+        dotnet: true
         haskell: true
         large-packages: false
-        docker-images: false
+        docker-images: true
         swap-storage: true
+    - name: Additional disk cleanup
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -478,11 +496,20 @@ jobs:
       with:
         tool-cache: false
         android: true
-        dotnet: false
+        dotnet: true
         haskell: true
         large-packages: false
-        docker-images: false
+        docker-images: true
         swap-storage: true
+    - name: Additional disk cleanup
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -579,11 +606,20 @@ jobs:
       with:
         tool-cache: false
         android: true
-        dotnet: false
+        dotnet: true
         haskell: true
         large-packages: false
-        docker-images: false
+        docker-images: true
         swap-storage: true
+    - name: Additional disk cleanup
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -677,11 +713,20 @@ jobs:
       with:
         tool-cache: false
         android: true
-        dotnet: false
+        dotnet: true
         haskell: true
         large-packages: false
-        docker-images: false
+        docker-images: true
         swap-storage: true
+    - name: Additional disk cleanup
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -885,11 +930,20 @@ jobs:
       with:
         tool-cache: false
         android: true
-        dotnet: false
+        dotnet: true
         haskell: true
         large-packages: false
-        docker-images: false
+        docker-images: true
         swap-storage: true
+    - name: Additional disk cleanup
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
     - uses: actions/checkout@v6
       with:
         submodules: true
@@ -1222,6 +1276,21 @@ jobs:
       uses: jlumbroso/free-disk-space@main
       with:
         tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: true
+        swap-storage: true
+    - name: Additional disk cleanup
+      if: ${{ matrix.os == 'ubuntu' }}
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
     - name: Generate code coverage
       run: mkdir -p report-output && cargo llvm-cov  --no-default-features --workspace --exclude common-arrow-ffi --lcov --output-path ./report-output/lcov.info
     - name: Upload coverage report
@@ -1286,11 +1355,20 @@ jobs:
       with:
         tool-cache: false
         android: true
-        dotnet: false
+        dotnet: true
         haskell: true
         large-packages: false
-        docker-images: false
+        docker-images: true
         swap-storage: true
+    - name: Additional disk cleanup
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        sudo rm -rf /usr/share/swift || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+        sudo rm -rf /opt/hostedtoolcache/go || true
+        sudo rm -rf /opt/hostedtoolcache/Ruby || true
+        sudo rm -rf /opt/hostedtoolcache/node || true
+        df -h
     - uses: actions/checkout@v6
     - uses: moonrepo/setup-rust@v1
       with:


### PR DESCRIPTION
## Summary
- **Free disk space**: Enable dotnet/docker removal in `jlumbroso/free-disk-space`, add cleanup of `/usr/share/swift` and unneeded hostedtoolcache entries (CodeQL, go, Ruby, node). Applied across `pr-test-suite.yml`, `build-docs.yml`, and `nightly-publish-s3.yml`.
- **Coverage optimization**: Skip `cargo-llvm-cov` instrumentation for the pyarrow 8.0.0 compat matrix entry — it runs the same tests as the primary 22.0.0 entries, so coverage is already captured.
- **Cleanup**: Remove redundant `if: runner.os == 'Linux'` guards from Linux-only jobs, drop noisy `df -h` from cleanup steps, move 8.0.0 compat entry to explicit `include` with `coverage: false` matrix boolean.

Addresses "No space left on device" runner failures (e.g. [#6193 CI](https://github.com/Eventual-Inc/Daft/pull/6193)).

## Test plan
- [ ] Verify all CI jobs still pass (especially the pyarrow 8.0.0 compat entry and rust-tests-platform)
- [ ] Confirm coverage upload still works for primary matrix entries
- [ ] Check that no coverage regression appears in Codecov after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)