### PR TITLE
ci: Reduce xdist workers on macOS to fix Ray actor timeout

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -73,7 +73,7 @@ jobs:
     needs: skipcheck
     if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 75
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -181,8 +181,13 @@ jobs:
         source .venv/bin/activate
         cargo llvm-cov clean --workspace
         maturin develop --uv
+        # Limit xdist workers on macOS: with only 3 CPUs, "-n auto" (3 workers) causes
+        # excessive resource contention when each worker spins up its own Ray cluster,
+        # leading to UDF actor scheduling timeouts.
+        # See runner specs: https://docs.github.com/en/actions/reference/runners/github-hosted-runners
+        if [ "$RUNNER_OS" == "macOS" ]; then PYTEST_WORKERS=2; else PYTEST_WORKERS=auto; fi
         pytest --ignore tests/integration --collect-only -qq # run this to ensure no weird imports that result in `Collector` errors
-        pytest -n auto --cov=daft --ignore tests/integration --durations=0 | ./tools/capture-durations.sh "pytest_output.txt"
+        pytest -n $PYTEST_WORKERS --cov=daft --ignore tests/integration --durations=0 | ./tools/capture-durations.sh "pytest_output.txt"
         python tools/aggregate_test_durations.py pytest_output.txt
         coverage combine -a --data-file='.coverage' || true
         mkdir -p report-output


### PR DESCRIPTION
## Summary
 - Root cause: test_cls[2] on unit-test (3.13, ray, 22.0.0, macos-latest) failed with RuntimeError: UDF actors failed to start within 120 seconds. macOS-latest runners have only 3 CPUs (M1) and 7 GB RAM (runner specs). With pytest -n auto (3 workers), each xdist worker spins up its own Ray cluster, creating 15+ processes competing for 3 physical CPUs. This prevents Ray from scheduling UDF actors within the 120s timeout.
- Why Linux is unaffected: Ubuntu runners have 4 CPUs and 16 GB RAM — more than double the memory and an extra core. This gives enough headroom for multiple Ray clusters to coexist. The same test passes on Ubuntu in 9.56s.
- Fix: Use pytest -n 2 on macOS instead of -n auto to reduce resource contention
- Timeout bump: Increase unit-test job timeout from 75 to 90 minutes to accommodate the reduced parallelism (macOS Ray job already takes ~1h with 3 workers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)