### PR TITLE
docs: Fix broken links to the url modality and various datatypes

### DIFF
--- a/daft/functions/datetime.py
+++ b/daft/functions/datetime.py
@@ -1168,7 +1168,7 @@ def date_trunc(interval: str, expr: Expression, relative_to: Expression | None =
 def to_unix_epoch(expr: Expression, time_unit: str | TimeUnit | None = None) -> Expression:
     """Converts a datetime column to a Unix timestamp with the specified time unit. (default: seconds).
 
-    See [daft.datatype.TimeUnit](https://docs.daft.ai/en/stable/api/datatypes/#daft.datatype.DataType.timeunit) for more information on time units and valid values.
+    See [daft.datatype.TimeUnit](https://docs.daft.ai/en/stable/api/datatypes/all_datatypes/#daft.datatype.DataType.timeunit) for more information on time units and valid values.
 
     Examples:
         >>> import daft

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,6 +158,8 @@ plugins:
       migration/dask_migration.md: index.md
       resources/benchmarks/tpch.md: benchmarks/index.md
       core_concepts.md: index.md
+      api/datatypes/index.md: api/datatypes/all_datatypes.md
+      modalities/urls.md: modalities/files.md
 - mkdocstrings:
     custom_templates: docs/templates
     handlers:

--- a/tutorials/document_processing/document_processing_tutorial.ipynb
+++ b/tutorials/document_processing/document_processing_tutorial.ipynb
@@ -399,7 +399,7 @@
    "source": [
     "### Generating Daft Datatypes from Pydantic\n",
     "\n",
-    "We also need to define a function that will let us easily generate Daft DataTypes from our Pydantic classes using PyArrow. We'll use this function, `daft_pyarrow_datatype`, to let us automatically generate the [`daft.DataType`](https://docs.daft.ai/en/stable/api/datatypes/):"
+    "We also need to define a function that will let us easily generate Daft DataTypes from our Pydantic classes using PyArrow. We'll use this function, `daft_pyarrow_datatype`, to let us automatically generate the [`daft.DataType`](https://docs.daft.ai/en/stable/api/datatypes/all_datatypes/):"
    ]
   },
   {


### PR DESCRIPTION
## Changes Made

 The nightly [broken link checker](https://github.com/Eventual-Inc/Daft/actions/runs/22042207446) is failing due to 4 URLs returning HTTP 404:

  | Broken URL | Root Cause |
  |---|---|
  | `docs.daft.ai/.../api/datatypes/` | No index page for the `api/datatypes/` directory |
  | `docs.daft.ai/.../api/datatypes/#...DataType.timeunit` | Same — hardcoded link to non-existent index |
  | `docs.daft.ai/.../api/datatypes/#...DataType.embedding` | Same — linked from daft.ai website |
  | `docs.daft.ai/.../modalities/urls/` | Page deleted by #6074 with no redirect |

  **Fixes:**

  1. **mkdocs.yml** — Added two redirect rules:
     - `api/datatypes/index.md` → `api/datatypes/all_datatypes.md`
     - `modalities/urls.md` → `modalities/files.md`
  2. **daft/functions/datetime.py** — Fixed hardcoded URL in `to_unix_epoch` docstring to point to `api/datatypes/all_datatypes/` instead of `api/datatypes/`
  3. **tutorials/.../document_processing_tutorial.ipynb** — Same fix for hardcoded URL in markdown cell
