### PR TITLE
test: Filter null bytes from generated column names in property-based tests

### DIFF
--- a/tests/property_based_testing/strategies.py
+++ b/tests/property_based_testing/strategies.py
@@ -140,7 +140,7 @@ def columns_dict(
     num_cols = draw(integers(min_value=0, max_value=2), label="Number of additional columns")
     additional_column_names = draw(
         lists(
-            text().filter(lambda name: name not in requested_columns.keys() and name != "*"),
+            text().filter(lambda name: name not in requested_columns.keys() and name != "*" and "\0" not in name),
             min_size=num_cols,
             max_size=num_cols,
             unique=True,


### PR DESCRIPTION
## Summary
- Filters embedded null bytes (`\0`) from Hypothesis-generated column names in property-based tests
- Fixes a panic in `arrow-rs` FFI layer (`FFI_ArrowSchema::with_name` calls `CString::new(name).unwrap()`) triggered when Ray serializes columns with null bytes in their names
- The failing CI run: https://github.com/Eventual-Inc/Daft/actions/runs/22042235355

## Root Cause

The Hypothesis `text()` strategy can generate strings containing null bytes. When such a string is used as a column name and the test runs on the Ray runner, the serialization path (`Series.__reduce__` → `to_arrow()` → Arrow C Data Interface) hits a panic in `arrow-rs v57.2.0` at `arrow-schema/src/ffi.rs:165`:

```rust
// FFI_ArrowSchema::with_name() - panics instead of returning error
self.name = CString::new(name).unwrap().into_raw();
```

Null bytes in column names are inherently invalid for the Arrow C Data Interface (which uses null-terminated C strings), so filtering them from generated test data is the correct fix. The upstream `arrow-rs` bug (`.unwrap()` instead of error propagation) still exists in v57.3.0.