### PR TITLE
fix: canonicalize negative NaN in multi-column sort comparator

### DIFF
--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -54,6 +54,8 @@ pub fn build_multi_array_compare(
 /// arrow-rs `make_comparator` uses IEEE 754 total ordering where -NaN < -Inf < ... < +Inf < +NaN.
 /// Daft's sort contract treats ALL NaN as greater than regular values, so we normalize
 /// negative NaN to positive NaN before comparison.
+///
+/// TODO: Replace this with a custom `cmp_float`-based comparator to avoid the allocation.
 fn canonicalize_nan(array: ArrayRef) -> ArrayRef {
     if let Some(f64_arr) = array.as_any().downcast_ref::<ArrowFloat64Array>() {
         let canonical: ArrowFloat64Array = f64_arr


### PR DESCRIPTION
## Changes Made

Fixes one of the bugs causing the nightly ["Run property based tests with Hypothesis"](https://github.com/Eventual-Inc/Daft/actions/workflows/property-based-tests.yml) workflow to fail since Feb 2: negative NaN sorts before regular values in multi-column sort.

Failing runs caused by this bug:
- [Feb 10 (ray job)](https://github.com/Eventual-Inc/Daft/actions/runs/21880931284)
- [Feb 16 (both jobs)](https://github.com/Eventual-Inc/Daft/actions/runs/22076216982)

### Root cause

`build_multi_array_bicompare` uses arrow-rs `make_comparator` for secondary sort columns. arrow-rs follows IEEE 754 total ordering where **negative NaN sorts before all values** (`-NaN < -Inf < ... < +Inf < +NaN`). Daft's sort contract treats **all NaN as greater than regular values** regardless of sign.

Single-column sort already handles this correctly via `cmp_float`. The bug only affects multi-column sort when a float column is a secondary key and contains a negative NaN (which hypothesis `floats()` can generate).

### Fix

Canonicalize negative NaN to positive NaN in float arrays before passing them to `make_comparator`. This is a small allocation trade-off (one new array per float column per sort) in exchange for a simple, targeted fix. A zero-allocation alternative would be to replace `make_comparator` with a custom comparator using `cmp_float` for float types, but that adds more code complexity.

### Verification

- Unit test: `test_negative_nan_multicolumn_sort` fails before fix, passes after (with a contrasting `test_negative_nan_single_column_sort` that already passes)
- Hypothesis: `HYPOTHESIS_MAX_EXAMPLES=10000 --hypothesis-seed=0` passes locally (same config as nightly CI)