### PR TITLE
chore: add .values method for utf8Array

### DIFF
--- a/src/daft-core/src/array/utf8.rs
+++ b/src/daft-core/src/array/utf8.rs
@@ -1,33 +1,20 @@
-use arrow::datatypes::ArrowNativeType;
 use common_error::{DaftError, DaftResult};
 
 use crate::prelude::{AsArrow, Utf8Array};
 
 impl Utf8Array {
-    /// Convert the Utf8Array into Vec<String>
+    /// Returns an iterator of `&str` over the non-null values in this array.
     ///
-    /// NOTE: this will error if there are any null values
-    /// If you need to preserve the null values, use .iter() instead
-    pub fn into_values(self) -> DaftResult<Vec<String>> {
-        let arrow_arr = self.as_arrow()?;
-
-        let (offsets, data, None) = arrow_arr.into_parts() else {
+    /// NOTE: this will error if there are any null values.
+    /// If you need to handle nulls, use the `.iter()` method instead.
+    pub fn values(&self) -> DaftResult<impl Iterator<Item = &str>> {
+        let arrow2_arr = self.as_arrow2();
+        if arrow2_arr.validity().is_some() {
             return Err(DaftError::ComputeError(
-                "Utf8Array::into_values with nulls".to_string(),
+                "Utf8Array::values with nulls".to_string(),
             ));
-        };
-
-        let data_bytes = data.as_slice();
-
-        Ok((0..offsets.len() - 1)
-            .map(|i| {
-                let start = offsets[i].as_usize();
-                let end = offsets[i + 1].as_usize();
-                std::str::from_utf8(&data_bytes[start..end])
-                    .expect("arrow should guarantee valid UTF-8")
-                    .to_string()
-            })
-            .collect::<Vec<String>>())
+        }
+        Ok(arrow2_arr.values_iter())
     }
 }
 
@@ -36,21 +23,24 @@ mod tests {
     use crate::prelude::Utf8Array;
 
     #[test]
-    fn test_into_values() {
+    fn test_values() {
         let array = Utf8Array::from_slice("test", &["hello", "world"]);
-        let values = array.into_values().unwrap();
+        let values: Vec<&str> = array.values().unwrap().collect();
         assert_eq!(values, vec!["hello", "world"]);
     }
 
     #[test]
-    fn test_into_values_with_nulls() {
+    fn test_values_with_nulls() {
         let array =
             Utf8Array::from_iter("test", vec![Some("hello"), None, Some("world")].into_iter());
-        let values = array.into_values().unwrap_err();
+        let result = array.values();
+        assert!(result.is_err());
         assert!(
-            values
+            result
+                .err()
+                .unwrap()
                 .to_string()
-                .contains("Utf8Array::into_values with nulls")
+                .contains("Utf8Array::values with nulls")
         );
     }
 }

--- a/src/daft-local-execution/src/streaming_sink/vllm.rs
+++ b/src/daft-local-execution/src/streaming_sink/vllm.rs
@@ -344,16 +344,17 @@ impl VLLMSink {
         let prompts = batch.eval_expression(&expr_input)?;
 
         // TODO: handle nulls
-        prompts
+        Ok(prompts
             .utf8()
-            .cloned()
             .map_err(|_| {
                 DaftError::type_error(format!(
                     "Expected input to `prompt` to be string, got {}",
                     prompts.data_type()
                 ))
             })?
-            .into_values()
+            .values()?
+            .map(str::to_string)
+            .collect())
     }
 }
 


### PR DESCRIPTION
## Changes Made

makes utf8array consistent with other apis by providing a `.values()` method

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
