### PR TITLE
chore(arrow2): simplify deprecation markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,7 +1812,6 @@ version = "0.3.0-dev0"
 dependencies = [
  "arrow",
  "arrow-schema",
- "daft-arrow",
  "pyo3",
 ]
 
@@ -3206,7 +3205,6 @@ dependencies = [
  "async-stream",
  "bincode",
  "bytes",
- "common-arrow-ffi",
  "common-error",
  "common-runtime",
  "daft-arrow",

--- a/src/common/arrow-ffi/Cargo.toml
+++ b/src/common/arrow-ffi/Cargo.toml
@@ -1,7 +1,6 @@
 [dependencies]
 arrow = {workspace = true, features = ["ffi"]}
 arrow-schema = {workspace = true}
-daft-arrow = {path = "../../daft-arrow"}
 pyo3 = {workspace = true}
 
 [lints]

--- a/src/common/arrow-ffi/src/lib.rs
+++ b/src/common/arrow-ffi/src/lib.rs
@@ -5,8 +5,6 @@
 //! depending on the `arrow-pyarrow` crate because it pins a different version of `pyo3` than
 //! the one used in this workspace, making it incompatible with our codebase.
 
-#![allow(deprecated, reason = "arrow2->arrow migration")]
-
 use std::{
     ffi::CStr,
     ptr::{addr_of, addr_of_mut},
@@ -19,7 +17,6 @@ use arrow::{
     ffi_stream::FFI_ArrowArrayStream,
 };
 use arrow_schema::{Field, Schema};
-use daft_arrow::array::Array;
 use pyo3::{
     exceptions::{PyTypeError, PyValueError},
     ffi::Py_uintptr_t,
@@ -28,7 +25,6 @@ use pyo3::{
     pybacked::PyBackedStr,
     types::{PyCapsule, PyList, PyTuple},
 };
-pub type ArrayRef = Box<dyn Array>;
 const ARROW_SCHEMA_CAPSULE_NAME: &CStr = c"arrow_schema";
 const ARROW_ARRAY_CAPSULE_NAME: &CStr = c"arrow_array";
 

--- a/src/daft-arrow/src/lib.rs
+++ b/src/daft-arrow/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated, reason = "arrow2 migration")]
+
 // Re-export arrow2::* modules for centralized access
 pub use arrow_array::{self, temporal_conversions};
 // IPC module that exports arrow-ipc functionality
@@ -15,12 +17,9 @@ pub mod io {
         /// Assigns every dictionary field a unique ID
         /// This is the same as arrow2::io::ipc::write::default_ipc_fields
         pub fn default_ipc_fields(fields: &[Field]) -> Vec<IpcField> {
-            #[allow(deprecated, reason = "arrow2 migration")]
             use arrow2::datatypes::DataType;
 
-            #[allow(deprecated, reason = "arrow2 migration")]
             fn default_ipc_field(data_type: &DataType, current_id: &mut i64) -> IpcField {
-                #[allow(deprecated, reason = "arrow2 migration")]
                 use DataType::*;
                 match data_type.to_logical_type() {
                     Map(inner, ..) | FixedSizeList(inner, _) | LargeList(inner) | List(inner) => {
@@ -98,7 +97,6 @@ pub mod datatypes {
     pub use arrow2::datatypes::*;
 
     #[deprecated(note = "use arrow instead of arrow2")]
-    #[allow(deprecated, reason = "arrow2 migration")]
     pub fn arrow2_field_to_arrow(field: Field) -> arrow_schema::Field {
         use arrow_schema::{Field as ArrowField, UnionFields};
 

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2->arrow migration")]
 use std::{
     iter::repeat_n,
     ops::{Div, Mul},

--- a/src/daft-core/src/array/ops/comparison.rs
+++ b/src/daft-core/src/array/ops/comparison.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2->arrow migration")]
 use std::{
     cmp::Ordering,
     ops::{BitAnd, BitOr, BitXor, Not},

--- a/src/daft-core/src/array/ops/filter.rs
+++ b/src/daft-core/src/array/ops/filter.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2->arrow migration")]
 use std::borrow::Cow;
 
 use common_error::DaftResult;

--- a/src/daft-csv/src/lib.rs
+++ b/src/daft-csv/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated, reason = "arrow2 migration")]
+
 use common_error::DaftError;
 use snafu::Snafu;
 

--- a/src/daft-csv/src/local.rs
+++ b/src/daft-csv/src/local.rs
@@ -308,7 +308,6 @@ async fn get_schema_and_estimators(
     )
     .await?;
 
-    #[allow(deprecated, reason = "arrow2 migration")]
     let mut schema = if let Some(schema) = convert_options.schema.clone() {
         schema.to_arrow2()?
     } else {

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -483,7 +483,6 @@ async fn read_csv_single_into_stream(
     io_client: Arc<IOClient>,
     io_stats: Option<IOStatsRef>,
 ) -> DaftResult<(impl TableStream + Send, Vec<Field>)> {
-    #[allow(deprecated, reason = "arrow2 migration")]
     let (mut schema, estimated_mean_row_size, estimated_std_row_size) =
         if let Some(schema) = convert_options.schema {
             (schema.to_arrow2()?, None, None)
@@ -716,7 +715,6 @@ pub fn fields_to_projection_indices(
 }
 
 #[cfg(test)]
-#[allow(deprecated, reason = "arrow2 migration")]
 mod tests {
     use std::sync::Arc;
 
@@ -737,7 +735,6 @@ mod tests {
     use crate::{CsvConvertOptions, CsvParseOptions, CsvReadOptions, char_to_byte};
 
     #[allow(clippy::too_many_arguments)]
-    #[allow(deprecated, reason = "arrow2 migration")]
     fn check_equal_local_arrow2(
         path: &str,
         out: &RecordBatch,

--- a/src/daft-decoding/src/lib.rs
+++ b/src/daft-decoding/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(deprecated, reason = "arrow2 migration")]
+
 //! Utilities for decoding data from various sources into both array data and metadata (e.g. schema inference)
 pub mod deserialize;
 pub mod inference;

--- a/src/daft-functions-list/src/kernels.rs
+++ b/src/daft-functions-list/src/kernels.rs
@@ -1,5 +1,4 @@
 #![allow(deprecated, reason = "arrow2 migration")]
-
 use std::{iter::repeat_n, sync::Arc};
 
 use arrow::array::{BooleanBufferBuilder, BooleanBuilder, make_comparator};

--- a/src/daft-functions-serde/src/format/json.rs
+++ b/src/daft-functions-serde/src/format/json.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};
@@ -26,7 +25,6 @@ pub(crate) fn deserialize(input: &Utf8Array, dtype: &DataType) -> DaftResult<Ser
         .collect::<DaftResult<Vec<_>>>()?;
     let json_array = Value::Array(json_items);
     // convert the JSON Array into an arrow2 Array
-    #[allow(deprecated, reason = "arrow2 migration")]
     let arrow2_field = field.to_arrow2()?;
     let arrow2_dtype = ArrowDataType::LargeList(Box::new(arrow2_field));
     let arrow2_array = read::deserialize(&json_array, arrow2_dtype)?;
@@ -49,7 +47,6 @@ pub fn try_deserialize(input: &Utf8Array, dtype: &DataType) -> DaftResult<Series
     let json_items: Vec<Value> = input.into_iter().map(try_parse_item).collect();
     let json_array = Value::Array(json_items);
     // convert the JSON Array into an arrow2 Array
-    #[allow(deprecated, reason = "arrow2 migration")]
     let arrow2_field = field.to_arrow2()?;
     let arrow2_dtype = ArrowDataType::LargeList(Box::new(arrow2_field));
     let arrow2_array = read::deserialize(&json_array, arrow2_dtype)?;
@@ -67,7 +64,6 @@ pub fn try_parse_item(item: Option<&str>) -> Value<'_> {
 pub fn serialize(input: Series) -> DaftResult<Utf8Array> {
     // setup inputs
     let name = input.name();
-    #[allow(deprecated, reason = "arrow2 migration")]
     let input = input.to_arrow2();
     let nulls = input.validity().cloned();
     // setup outputs

--- a/src/daft-functions-serde/src/lib.rs
+++ b/src/daft-functions-serde/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated, reason = "arrow2 migration")]
+
 use daft_dsl::functions::{FunctionModule, FunctionRegistry};
 
 mod deserialize;

--- a/src/daft-functions-tokenize/src/decode.rs
+++ b/src/daft-functions-tokenize/src/decode.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};

--- a/src/daft-functions-tokenize/src/encode.rs
+++ b/src/daft-functions-tokenize/src/encode.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::sync::Arc;
 
 use arrow::array::{ArrayBuilder, ArrayRef, UInt32Builder};

--- a/src/daft-functions-utf8/src/lib.rs
+++ b/src/daft-functions-utf8/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(deprecated, reason = "arrow2 migration")]
-
 mod capitalize;
 mod case;
 mod contains;

--- a/src/daft-json/src/decoding.rs
+++ b/src/daft-json/src/decoding.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::{borrow::Borrow, fmt::Write};
 
 use chrono::{Datelike, Timelike};

--- a/src/daft-json/src/inference.rs
+++ b/src/daft-json/src/inference.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
-
 use std::{borrow::Borrow, collections::HashSet};
 
 use daft_arrow::{

--- a/src/daft-json/src/lib.rs
+++ b/src/daft-json/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated, reason = "arrow2 migration")]
+
 use common_error::DaftError;
 use futures::stream::TryChunksError;
 use snafu::Snafu;

--- a/src/daft-json/src/local.rs
+++ b/src/daft-json/src/local.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::{borrow::Cow, collections::HashSet, num::NonZeroUsize, sync::Arc};
 
 use common_error::DaftResult;
@@ -70,7 +69,6 @@ pub fn read_json_local(
     }
 }
 
-#[allow(deprecated, reason = "arrow2 migration")]
 pub fn read_json_array_impl(
     bytes: &[u8],
     schema: Schema,
@@ -277,7 +275,6 @@ impl<'a> JsonReader<'a> {
         Ok(tbl)
     }
 
-    #[allow(deprecated, reason = "arrow2 migration")]
     fn parse_json_chunk(&self, bytes: &[u8], chunk_size: usize) -> DaftResult<RecordBatch> {
         let mut scratch = vec![];
         let scratch = &mut scratch;

--- a/src/daft-json/src/read.rs
+++ b/src/daft-json/src/read.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 
 use common_error::{DaftError, DaftResult};
@@ -421,7 +420,6 @@ pub async fn stream_json(
     Ok(Box::pin(tables))
 }
 
-#[allow(deprecated, reason = "arrow2 migration")]
 async fn read_json_single_into_stream(
     uri: String,
     convert_options: JsonConvertOptions,
@@ -638,7 +636,6 @@ fn parse_into_column_array_chunk_stream(
 }
 
 #[cfg(test)]
-#[allow(deprecated, reason = "arrow2 migration")]
 mod tests {
     use std::{collections::HashSet, io::BufRead, sync::Arc};
 
@@ -1058,7 +1055,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated, reason = "arrow2 migration")]
     fn test_json_read_local_all_null_column() -> DaftResult<()> {
         let file = format!(
             "{}/test/iris_tiny_all_null_column.jsonl",

--- a/src/daft-json/src/schema.rs
+++ b/src/daft-json/src/schema.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::{collections::HashSet, sync::Arc};
 
 use common_error::DaftResult;

--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::{
     collections::{HashMap, HashSet},
     future::Future,

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::Display,

--- a/src/daft-parquet/Cargo.toml
+++ b/src/daft-parquet/Cargo.toml
@@ -4,7 +4,6 @@ async-compat = {workspace = true}
 daft-arrow = {path = "../daft-arrow"}
 async-stream = {workspace = true}
 bytes = {workspace = true}
-common-arrow-ffi = {path = "../common/arrow-ffi", default-features = false, optional = true}
 common-error = {path = "../common/error", default-features = false}
 common-runtime = {path = "../common/runtime", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
@@ -30,7 +29,7 @@ bincode = {workspace = true}
 path_macro = {workspace = true}
 
 [features]
-python = ["dep:pyo3", "common-error/python", "daft-core/python", "daft-io/python", "daft-recordbatch/python", "daft-stats/python", "daft-dsl/python", "dep:common-arrow-ffi"]
+python = ["dep:pyo3", "common-error/python", "daft-core/python", "daft-io/python", "daft-recordbatch/python", "daft-stats/python", "daft-dsl/python"]
 
 [lints]
 workspace = true

--- a/src/daft-parquet/src/python.rs
+++ b/src/daft-parquet/src/python.rs
@@ -1,4 +1,3 @@
-use common_arrow_ffi::ArrayRef;
 use pyo3::prelude::*;
 
 pub mod pylib {
@@ -336,7 +335,7 @@ pub mod pylib {
 
 fn to_py_array<'py>(
     py: Python<'py>,
-    array: ArrayRef,
+    array: Box<dyn daft_arrow::array::Array>,
     pyarrow: &Bound<'py, PyModule>,
 ) -> PyResult<Bound<'py, PyAny>> {
     let field = daft_arrow::datatypes::Field::new("", array.data_type().clone(), true);

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
@@ -97,7 +96,6 @@ impl Default for ParquetSchemaInferenceOptions {
 impl From<ParquetSchemaInferenceOptions> for SchemaInferenceOptions {
     fn from(value: ParquetSchemaInferenceOptions) -> Self {
         Self {
-            #[allow(deprecated, reason = "arrow2 migration")]
             int96_coerce_to_timeunit: value.coerce_int96_timestamp_unit.to_arrow2(),
             string_encoding: value.string_encoding,
         }

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -150,7 +150,6 @@ impl RecordBatch {
     }
 
     #[deprecated(note = "arrow2 migration")]
-    #[allow(deprecated, reason = "arrow2 migration")]
     pub fn get_inner_arrow_arrays(
         &self,
     ) -> impl Iterator<Item = Box<dyn daft_arrow::array::Array>> + '_ {
@@ -1616,7 +1615,6 @@ impl RecordBatch {
 impl TryFrom<RecordBatch> for arrow_array::RecordBatch {
     type Error = DaftError;
 
-    #[allow(deprecated, reason = "arrow2 migration")]
     fn try_from(record_batch: RecordBatch) -> DaftResult<Self> {
         let schema = Arc::new(record_batch.schema.to_arrow2()?.into());
         let columns = record_batch

--- a/src/daft-recordbatch/src/ops/explode.rs
+++ b/src/daft-recordbatch/src/ops/explode.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};

--- a/src/daft-recordbatch/src/ops/groups.rs
+++ b/src/daft-recordbatch/src/ops/groups.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use common_error::DaftResult;
 use daft_core::{
     array::ops::{

--- a/src/daft-recordbatch/src/ops/joins/mod.rs
+++ b/src/daft-recordbatch/src/ops/joins/mod.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::{collections::HashSet, sync::Arc};
 
 use common_error::{DaftError, DaftResult};

--- a/src/daft-recordbatch/src/ops/pivot.rs
+++ b/src/daft-recordbatch/src/ops/pivot.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use common_error::{DaftError, DaftResult};
 use daft_core::{array::ops::IntoGroups, prelude::*};
 use daft_dsl::expr::bound_expr::BoundExpr;

--- a/src/daft-recordbatch/src/ops/window_states/count_distinct.rs
+++ b/src/daft-recordbatch/src/ops/window_states/count_distinct.rs
@@ -23,7 +23,6 @@ impl CountDistinctWindowState {
     pub fn new(source: &Series, total_length: usize) -> Self {
         let hashed = source.hash_with_nulls(None).unwrap();
 
-        #[allow(deprecated, reason = "arrow2 migration")]
         let array = source.to_arrow().unwrap();
 
         let comparator =

--- a/src/daft-recordbatch/src/probeable/probe_set.rs
+++ b/src/daft-recordbatch/src/probeable/probe_set.rs
@@ -72,13 +72,11 @@ impl ProbeSet {
 
         let hashes = input.hash_rows()?;
 
-        #[allow(deprecated, reason = "arrow2 migration")]
         let input_arrays = input
             .columns
             .iter()
             .map(|s| Ok(s.as_physical()?.to_arrow2()))
             .collect::<DaftResult<Vec<_>>>()?;
-        #[allow(deprecated, reason = "arrow2 migration")]
         let iter = hashes.as_arrow2().clone().into_iter();
 
         Ok(iter.enumerate().map(move |(idx, h)| {
@@ -112,7 +110,6 @@ impl ProbeSet {
         assert!(table_idx < (1 << (64 - Self::TABLE_IDX_SHIFT)));
         assert!(table.len() < (1 << Self::TABLE_IDX_SHIFT));
 
-        #[allow(deprecated, reason = "arrow2 migration")]
         let current_arrays = table
             .columns
             .iter()

--- a/src/daft-recordbatch/src/probeable/probe_table.rs
+++ b/src/daft-recordbatch/src/probeable/probe_table.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};
@@ -75,7 +74,6 @@ impl ProbeTable {
 
         let hashes = input.hash_rows()?;
 
-        #[allow(deprecated, reason = "arrow2 migration")]
         let input_arrays = input
             .columns
             .iter()
@@ -116,7 +114,6 @@ impl ProbeTable {
 
         assert!(table_idx < (1 << (64 - Self::TABLE_IDX_SHIFT)));
         assert!(table.len() < (1 << Self::TABLE_IDX_SHIFT));
-        #[allow(deprecated, reason = "arrow2 migration")]
         let current_arrays = table
             .columns
             .iter()

--- a/src/daft-scan/src/hive.rs
+++ b/src/daft-scan/src/hive.rs
@@ -15,7 +15,6 @@ fn parse_hive_value_to_dtype(
     if value.is_empty() {
         return Ok(Series::full_null(field_name, target_dtype, 1));
     }
-    #[allow(deprecated, reason = "arrow2 migration")]
     let arrow_dtype = target_dtype.to_arrow2().map_err(|e| {
         common_error::DaftError::ValueError(format!("Failed to convert dtype to arrow: {}", e))
     })?;

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated, reason = "arrow2 migration")]
+
 use std::{
     any::Any,
     borrow::Cow,

--- a/src/daft-schema/src/dtype.rs
+++ b/src/daft-schema/src/dtype.rs
@@ -5,7 +5,6 @@ use std::{
 
 use arrow_schema::IntervalUnit;
 use common_error::{DaftError, DaftResult};
-#[allow(deprecated, reason = "arrow2 migration")]
 use daft_arrow::datatypes::DataType as ArrowType;
 use serde::{Deserialize, Serialize};
 
@@ -322,7 +321,6 @@ impl DataType {
     }
 
     #[deprecated(note = "use `to_arrow` instead")]
-    #[allow(deprecated, reason = "arrow2 migration")]
     pub fn to_arrow2(&self) -> DaftResult<ArrowType> {
         match self {
             Self::Null => Ok(ArrowType::Null),
@@ -495,7 +493,6 @@ impl DataType {
     #[inline]
     /// Is this DataType convertible to Arrow?
     pub fn is_arrow(&self) -> bool {
-        #[allow(deprecated, reason = "arrow2 migration")]
         self.to_arrow2().is_ok()
     }
 
@@ -1057,7 +1054,6 @@ impl DataType {
     }
 }
 
-#[allow(deprecated, reason = "arrow2 migration")]
 #[expect(
     clippy::fallible_impl_from,
     reason = "https://github.com/Eventual-Inc/Daft/issues/3015"

--- a/src/daft-schema/src/field.rs
+++ b/src/daft-schema/src/field.rs
@@ -93,7 +93,6 @@ impl Field {
     }
 
     #[deprecated(note = "use .to_arrow")]
-    #[allow(deprecated, reason = "arrow2 migration")]
     pub fn to_arrow2(&self) -> DaftResult<ArrowField> {
         Ok(
             ArrowField::new(self.name.clone(), self.dtype.to_arrow2()?, true)

--- a/src/daft-schema/src/lib.rs
+++ b/src/daft-schema/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated, reason = "arrow2 migration")]
 pub mod dtype;
 pub mod field;
 pub mod image_format;

--- a/src/daft-schema/src/schema.rs
+++ b/src/daft-schema/src/schema.rs
@@ -239,7 +239,6 @@ impl Schema {
     }
 
     #[deprecated(note = "use .to_arrow instead")]
-    #[allow(deprecated, reason = "arrow2 migration")]
     pub fn to_arrow2(&self) -> DaftResult<daft_arrow::datatypes::Schema> {
         let arrow_fields: DaftResult<Vec<daft_arrow::datatypes::Field>> =
             self.fields.iter().map(Field::to_arrow2).collect();
@@ -437,14 +436,12 @@ impl DisplayAs for Schema {
         }
     }
 }
-#[allow(deprecated, reason = "arrow2 migration")]
 impl From<daft_arrow::datatypes::Schema> for Schema {
     fn from(arrow_schema: daft_arrow::datatypes::Schema) -> Self {
         (&arrow_schema).into()
     }
 }
 
-#[allow(deprecated, reason = "arrow2 migration")]
 impl From<&daft_arrow::datatypes::Schema> for Schema {
     fn from(arrow_schema: &daft_arrow::datatypes::Schema) -> Self {
         let daft_fields: Vec<Field> = arrow_schema.fields.iter().map(|f| f.into()).collect();

--- a/src/daft-shuffles/src/server/flight_server.rs
+++ b/src/daft-shuffles/src/server/flight_server.rs
@@ -73,7 +73,6 @@ impl FlightService for ShuffleFlightServer {
         unimplemented!("Get schema is not supported for shuffle server")
     }
 
-    #[allow(deprecated, reason = "arrow2 migration")]
     async fn do_get(
         &self,
         request: Request<Ticket>,
@@ -102,9 +101,8 @@ impl FlightService for ShuffleFlightServer {
             .try_flatten();
 
         #[allow(unused)]
-        #[allow(deprecated, reason = "arrow2 migration")]
         let schema =
-            self.shuffle_cache.schema().to_arrow2().map_err(|e| {
+            self.shuffle_cache.schema().to_arrow().map_err(|e| {
                 Status::internal(format!("Error converting schema to arrow: {}", e))
             })?;
 

--- a/src/daft-warc/src/lib.rs
+++ b/src/daft-warc/src/lib.rs
@@ -212,7 +212,6 @@ impl WarcRecordBatchBuilder {
         self.record_id_array.len()
     }
 
-    #[allow(deprecated, reason = "arrow2 migration")]
     fn process_arrays(&mut self) -> DaftResult<Option<RecordBatch>> {
         let num_records = self.content_array.len();
         if num_records == 0 {

--- a/src/daft-writers/src/lib.rs
+++ b/src/daft-writers/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(deprecated, reason = "arrow2 migration")]
 mod batch;
 mod batch_file_writer;
 mod csv_writer;

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -7,6 +7,7 @@ use daft_core::prelude::*;
 use daft_io::{IOConfig, SourceType, parse_url, utils::ObjectPath};
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
+#[allow(deprecated)]
 use parquet::{
     arrow::{
         ArrowSchemaConverter,
@@ -240,6 +241,7 @@ impl<B: StorageBackend> ParquetWriter<B> {
         record_batches: &[RecordBatch],
     ) -> DaftResult<VecDeque<Pin<Box<ColumnWriterFuture>>>> {
         // Get leaf column writers. For example, a struct<int, int> column produces two leaf column writers.
+        #[allow(deprecated)]
         let column_writers = get_column_writers(
             &self.parquet_schema,
             &self.writer_properties,


### PR DESCRIPTION
## Changes Made

simplifies the deprecation markers by just using the lib `#![allow(deprecated` instead of the individual callsite ones `#[allow(deprecated`. This makes it easier to toggle the deprecation warnings for a crate while working on arrow refactor stuff. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
