### PR TITLE
refactor(arrow2): replace arrow2 iterators with custom daft-native iterators

### DIFF
--- a/src/daft-core/src/array/iterator.rs
+++ b/src/daft-core/src/array/iterator.rs
@@ -1,5 +1,7 @@
 use std::iter::{RepeatN, repeat_n};
 
+use arrow::buffer::NullBuffer;
+
 use crate::{
     array::{
         DataArray,
@@ -14,7 +16,7 @@ use crate::{
 #[derive(Clone)]
 pub struct PrimitiveIter<'a, N> {
     values: &'a [N],
-    nulls: Option<&'a daft_arrow::buffer::NullBuffer>,
+    nulls: Option<&'a NullBuffer>,
     index: usize,
     len: usize,
 }
@@ -136,7 +138,7 @@ pub struct BooleanIter<'a> {
     // TODO(arrow2): Uses arrow2 Bitmap because there's no safe way to convert an
     // arrow2 &Bitmap into an arrow-rs &BooleanBuffer. Once BooleanArray is backed by arrow-rs, then this needs to be changed.
     values: &'a daft_arrow::bitmap::Bitmap,
-    nulls: Option<&'a daft_arrow::buffer::NullBuffer>,
+    nulls: Option<&'a NullBuffer>,
     index: usize,
     len: usize,
 }

--- a/src/daft-core/src/array/iterator.rs
+++ b/src/daft-core/src/array/iterator.rs
@@ -1,4 +1,4 @@
-use std::iter::{RepeatN, repeat_n};
+use std::iter::{FusedIterator, RepeatN, repeat_n};
 
 use arrow::buffer::NullBuffer;
 
@@ -61,6 +61,7 @@ impl<N: Copy> DoubleEndedIterator for PrimitiveIter<'_, N> {
 }
 
 impl<N: Copy> ExactSizeIterator for PrimitiveIter<'_, N> {}
+impl<N: Copy> FusedIterator for PrimitiveIter<'_, N> {}
 
 impl<T: DaftPrimitiveType> DataArray<T> {
     pub fn iter(&self) -> PrimitiveIter<'_, T::Native> {
@@ -128,6 +129,7 @@ impl<A, T> DoubleEndedIterator for GenericArrayIter<'_, A, T> {
 }
 
 impl<A, T> ExactSizeIterator for GenericArrayIter<'_, A, T> {}
+impl<A, T> FusedIterator for GenericArrayIter<'_, A, T> {}
 
 // ---- Boolean ----
 
@@ -183,6 +185,7 @@ impl DoubleEndedIterator for BooleanIter<'_> {
 }
 
 impl ExactSizeIterator for BooleanIter<'_> {}
+impl FusedIterator for BooleanIter<'_> {}
 
 impl BooleanArray {
     pub fn iter(&self) -> BooleanIter<'_> {

--- a/src/daft-core/src/array/iterator.rs
+++ b/src/daft-core/src/array/iterator.rs
@@ -1,69 +1,288 @@
-use std::{
-    iter::{RepeatN, repeat_n},
-    slice::{ChunksExact, Iter},
-};
-
-use daft_arrow::{
-    array::ArrayValuesIter,
-    bitmap::utils::{BitmapIter, ZipValidity},
-};
+use std::iter::{RepeatN, repeat_n};
 
 use crate::{
     array::{
         DataArray,
-        ops::as_arrow::AsArrow,
         prelude::{NullArray, Utf8Array},
     },
     datatypes::{BinaryArray, BooleanArray, DaftPrimitiveType, FixedSizeBinaryArray},
 };
 
-macro_rules! impl_into_iter {
-    (
-        $array:ty
-        , $into_iter:ty
-        $(,)?
-    ) => {
-        impl<'a> IntoIterator for &'a $array {
-            type IntoIter = $into_iter;
-            type Item = <Self::IntoIter as IntoIterator>::Item;
+// ---- Primitive Iterator ----
 
-            #[inline]
-            fn into_iter(self) -> Self::IntoIter {
-                self.as_arrow2().into_iter()
-            }
-        }
-    };
+/// Iterator over a `DataArray<T>` yielding `Option<T::Native>` (by value).
+#[derive(Clone)]
+pub struct PrimitiveIter<'a, N> {
+    values: &'a [N],
+    nulls: Option<&'a daft_arrow::buffer::NullBuffer>,
+    index: usize,
+    len: usize,
 }
 
-// yields `bool`s
-impl_into_iter!(BooleanArray, ZipValidity<bool, BitmapIter<'a>, BitmapIter<'a>>);
+impl<N: Copy> Iterator for PrimitiveIter<'_, N> {
+    type Item = Option<N>;
 
-// both yield `&[u8]`s
-impl_into_iter!(
-    BinaryArray,
-    ZipValidity<&'a [u8], ArrayValuesIter<'a, daft_arrow::array::BinaryArray<i64>>, BitmapIter<'a>>,
-);
-impl_into_iter!(
-    FixedSizeBinaryArray,
-    ZipValidity<&'a [u8], ChunksExact<'a, u8>, BitmapIter<'a>>,
-);
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        let i = self.index;
+        self.index += 1;
+        Some(if self.nulls.is_none_or(|n| n.is_valid(i)) {
+            Some(self.values[i])
+        } else {
+            None
+        })
+    }
 
-// yields `&str`s
-impl_into_iter!(
-    Utf8Array,
-    ZipValidity<&'a str, ArrayValuesIter<'a, daft_arrow::array::Utf8Array<i64>>, BitmapIter<'a>>,
-);
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let rem = self.len - self.index;
+        (rem, Some(rem))
+    }
+}
 
-impl<'a, T> IntoIterator for &'a DataArray<T>
-where
-    T: DaftPrimitiveType,
-{
-    type IntoIter = ZipValidity<&'a T::Native, Iter<'a, T::Native>, BitmapIter<'a>>;
-    type Item = <Self::IntoIter as IntoIterator>::Item;
+impl<N: Copy> DoubleEndedIterator for PrimitiveIter<'_, N> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        self.len -= 1;
+        let i = self.len;
+        Some(if self.nulls.is_none_or(|n| n.is_valid(i)) {
+            Some(self.values[i])
+        } else {
+            None
+        })
+    }
+}
+
+impl<N: Copy> ExactSizeIterator for PrimitiveIter<'_, N> {}
+
+impl<T: DaftPrimitiveType> DataArray<T> {
+    pub fn iter(&self) -> PrimitiveIter<'_, T::Native> {
+        PrimitiveIter {
+            values: self.as_slice(),
+            nulls: self.nulls(),
+            index: 0,
+            len: self.len(),
+        }
+    }
+}
+
+impl<'a, T: DaftPrimitiveType> IntoIterator for &'a DataArray<T> {
+    type Item = Option<T::Native>;
+    type IntoIter = PrimitiveIter<'a, T::Native>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.as_arrow2().into_iter()
+        self.iter()
+    }
+}
+
+// ---- Generic index-based iterator ----
+// Used for Utf8, Binary, and FixedSizeBinary arrays.
+// Stores a reference to the daft array and uses .get(idx) for value access,
+// avoiding any direct dependency on arrow2 types.
+
+#[derive(Clone)]
+pub struct GenericArrayIter<'a, A, T> {
+    array: &'a A,
+    get_fn: fn(&'a A, usize) -> Option<T>,
+    index: usize,
+    len: usize,
+}
+
+impl<A, T> Iterator for GenericArrayIter<'_, A, T> {
+    type Item = Option<T>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        let i = self.index;
+        self.index += 1;
+        Some((self.get_fn)(self.array, i))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let rem = self.len - self.index;
+        (rem, Some(rem))
+    }
+}
+
+impl<A, T> DoubleEndedIterator for GenericArrayIter<'_, A, T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        self.len -= 1;
+        let i = self.len;
+        Some((self.get_fn)(self.array, i))
+    }
+}
+
+impl<A, T> ExactSizeIterator for GenericArrayIter<'_, A, T> {}
+
+// ---- Boolean ----
+
+/// Iterator over a `BooleanArray` yielding `Option<bool>`.
+/// Reads bits directly from the underlying bitmap, avoiding per-element bounds checks.
+#[derive(Clone)]
+pub struct BooleanIter<'a> {
+    // TODO(arrow2): Uses arrow2 Bitmap because there's no safe way to convert an
+    // arrow2 &Bitmap into an arrow-rs &BooleanBuffer. Once BooleanArray is backed by arrow-rs, then this needs to be changed.
+    values: &'a daft_arrow::bitmap::Bitmap,
+    nulls: Option<&'a daft_arrow::buffer::NullBuffer>,
+    index: usize,
+    len: usize,
+}
+
+impl Iterator for BooleanIter<'_> {
+    type Item = Option<bool>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        let i = self.index;
+        self.index += 1;
+        Some(if self.nulls.is_none_or(|n| n.is_valid(i)) {
+            Some(self.values.get_bit(i))
+        } else {
+            None
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let rem = self.len - self.index;
+        (rem, Some(rem))
+    }
+}
+
+impl DoubleEndedIterator for BooleanIter<'_> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index >= self.len {
+            return None;
+        }
+        self.len -= 1;
+        let i = self.len;
+        Some(if self.nulls.is_none_or(|n| n.is_valid(i)) {
+            Some(self.values.get_bit(i))
+        } else {
+            None
+        })
+    }
+}
+
+impl ExactSizeIterator for BooleanIter<'_> {}
+
+impl BooleanArray {
+    pub fn iter(&self) -> BooleanIter<'_> {
+        BooleanIter {
+            values: self.as_bitmap(),
+            nulls: self.nulls(),
+            index: 0,
+            len: self.len(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a BooleanArray {
+    type Item = Option<bool>;
+    type IntoIter = BooleanIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+// ---- Utf8 ----
+
+pub type Utf8Iter<'a> = GenericArrayIter<'a, Utf8Array, &'a str>;
+
+impl Utf8Array {
+    pub fn iter(&self) -> Utf8Iter<'_> {
+        GenericArrayIter {
+            array: self,
+            get_fn: Self::get,
+            index: 0,
+            len: self.len(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Utf8Array {
+    type Item = Option<&'a str>;
+    type IntoIter = Utf8Iter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+// ---- Binary ----
+
+pub type BinaryIter<'a> = GenericArrayIter<'a, BinaryArray, &'a [u8]>;
+
+impl BinaryArray {
+    pub fn iter(&self) -> BinaryIter<'_> {
+        GenericArrayIter {
+            array: self,
+            get_fn: Self::get,
+            index: 0,
+            len: self.len(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a BinaryArray {
+    type Item = Option<&'a [u8]>;
+    type IntoIter = BinaryIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+// ---- FixedSizeBinary ----
+
+pub type FixedSizeBinaryIter<'a> = GenericArrayIter<'a, FixedSizeBinaryArray, &'a [u8]>;
+
+impl FixedSizeBinaryArray {
+    pub fn iter(&self) -> FixedSizeBinaryIter<'_> {
+        GenericArrayIter {
+            array: self,
+            get_fn: Self::get,
+            index: 0,
+            len: self.len(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a FixedSizeBinaryArray {
+    type Item = Option<&'a [u8]>;
+    type IntoIter = FixedSizeBinaryIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+// ---- Null ----
+
+impl NullArray {
+    pub fn iter(&self) -> RepeatN<Option<()>> {
+        repeat_n(None, self.len())
     }
 }
 
@@ -73,6 +292,6 @@ impl IntoIterator for &'_ NullArray {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        repeat_n(None, self.len())
+        self.iter()
     }
 }

--- a/src/daft-core/src/array/ops/approx_count_distinct.rs
+++ b/src/daft-core/src/array/ops/approx_count_distinct.rs
@@ -12,7 +12,7 @@ impl DaftApproxCountDistinctAggable for UInt64Array {
 
     fn approx_count_distinct(&self) -> Self::Output {
         let mut set = HashSet::with_capacity_and_hasher(self.len(), IdentityBuildHasher::default());
-        for &value in self.into_iter().flatten() {
+        for value in self.iter().flatten() {
             set.insert(value);
         }
         let count = set.len() as u64;

--- a/src/daft-core/src/array/ops/approx_sketch.rs
+++ b/src/daft-core/src/array/ops/approx_sketch.rs
@@ -22,11 +22,11 @@ impl DaftApproxSketchAggable for &DataArray<Float64Type> {
                     (acc, None) => acc,
                     (None, Some(v)) => {
                         let mut sketch = DDSketch::new(Config::defaults());
-                        sketch.add(*v);
+                        sketch.add(v);
                         Some(sketch)
                     }
                     (Some(mut acc), Some(v)) => {
-                        acc.add(*v);
+                        acc.add(v);
                         Some(acc)
                     }
                 });

--- a/src/daft-core/src/array/ops/clip.rs
+++ b/src/daft-core/src/array/ops/clip.rs
@@ -35,9 +35,9 @@ where
                     .zip(left_bound.into_iter())
                     .zip(right_bound.into_iter())
                     .map(|((value, left), right)| match (left, right) {
-                        (Some(l), Some(r)) => Some(clamp(*value, *l, *r)),
-                        (Some(l), None) => Some(clamp_min(*value, *l)),
-                        (None, Some(r)) => Some(clamp_max(*value, *r)),
+                        (Some(l), Some(r)) => Some(clamp(*value, l, r)),
+                        (Some(l), None) => Some(clamp_min(*value, l)),
+                        (None, Some(r)) => Some(clamp_max(*value, r)),
                         (None, None) => Some(*value),
                     });
                 let data_array = Self::from_iter(self.field().clone(), result)
@@ -58,7 +58,7 @@ where
                                 .iter()
                                 .zip(left_bound.into_iter())
                                 .map(move |(value, left)| match left {
-                                    Some(l) => Some(clamp(*value, *l, r)),
+                                    Some(l) => Some(clamp(*value, l, r)),
                                     None => Some(clamp_max(*value, r)), // If left is null, we can just clamp_max
                                 });
                         let data_array = Self::from_iter(self.field().clone(), result)
@@ -70,7 +70,7 @@ where
                         // In this case, right_bound is null, so we can just do a simple clamp_min
                         let result = values.iter().zip(left_bound.into_iter()).map(
                             |(value, left)| match left {
-                                Some(l) => Some(clamp_min(*value, *l)),
+                                Some(l) => Some(clamp_min(*value, l)),
                                 None => Some(*value), // Left null, and right null, so we just don't do anything
                             },
                         );
@@ -88,7 +88,7 @@ where
                         let values = self.values();
                         let result = values.iter().zip(right_bound.into_iter()).map(
                             move |(value, right)| match right {
-                                Some(r) => Some(clamp(*value, l, *r)),
+                                Some(r) => Some(clamp(*value, l, r)),
                                 None => Some(clamp_min(*value, l)), // Right null, so we can just clamp_min
                             },
                         );
@@ -103,7 +103,7 @@ where
                                 .iter()
                                 .zip(right_bound.into_iter())
                                 .map(|(value, right)| match right {
-                                    Some(r) => Some(clamp_max(*value, *r)),
+                                    Some(r) => Some(clamp_max(*value, r)),
                                     None => Some(*value),
                                 });
                         let data_array = Self::from_iter(self.field().clone(), result)

--- a/src/daft-core/src/array/ops/concat_agg.rs
+++ b/src/daft-core/src/array/ops/concat_agg.rs
@@ -236,8 +236,8 @@ mod test {
                 .downcast::<Int64Array>()
                 .unwrap()
                 .into_iter()
-                .collect::<Vec<Option<&i64>>>(),
-            vec![Some(&0), Some(&1), Some(&1), Some(&2), None, None]
+                .collect::<Vec<Option<i64>>>(),
+            vec![Some(0), Some(1), Some(1), Some(2), None, None]
         );
         Ok(())
     }
@@ -287,8 +287,8 @@ mod test {
                 .downcast::<Int64Array>()
                 .unwrap()
                 .into_iter()
-                .collect::<Vec<Option<&i64>>>(),
-            vec![Some(&0), Some(&0), Some(&0)]
+                .collect::<Vec<Option<i64>>>(),
+            vec![Some(0), Some(0), Some(0)]
         );
 
         let element_1 = concatted.get(1).unwrap();
@@ -297,8 +297,8 @@ mod test {
                 .downcast::<Int64Array>()
                 .unwrap()
                 .into_iter()
-                .collect::<Vec<Option<&i64>>>(),
-            vec![Some(&1), None, None]
+                .collect::<Vec<Option<i64>>>(),
+            vec![Some(1), None, None]
         );
 
         let element_2 = concatted.get(2).unwrap();
@@ -307,8 +307,8 @@ mod test {
                 .downcast::<Int64Array>()
                 .unwrap()
                 .into_iter()
-                .collect::<Vec<Option<&i64>>>(),
-            vec![Some(&2), None]
+                .collect::<Vec<Option<i64>>>(),
+            vec![Some(2), None]
         );
 
         let element_3 = concatted.get(3);

--- a/src/daft-core/src/array/ops/get.rs
+++ b/src/daft-core/src/array/ops/get.rs
@@ -247,10 +247,7 @@ mod tests {
             assert_eq!(element.data_type(), &DataType::Int32);
 
             let element = element.i32()?;
-            let data = element
-                .into_iter()
-                .map(|x| x.copied())
-                .collect::<Vec<Option<i32>>>();
+            let data = element.into_iter().collect::<Vec<Option<i32>>>();
             let expected = ((i * 3) as i32..((i + 1) * 3) as i32)
                 .map(Some)
                 .collect::<Vec<Option<i32>>>();
@@ -275,10 +272,7 @@ mod tests {
         assert_eq!(element.len(), 3);
         assert_eq!(element.data_type(), &DataType::Int32);
         let element = element.i32()?;
-        let data = element
-            .into_iter()
-            .map(|x| x.copied())
-            .collect::<Vec<Option<i32>>>();
+        let data = element.into_iter().collect::<Vec<Option<i32>>>();
         let expected = vec![Some(0), Some(1), Some(2)];
         assert_eq!(data, expected);
 
@@ -291,10 +285,7 @@ mod tests {
         assert_eq!(element.len(), 3);
         assert_eq!(element.data_type(), &DataType::Int32);
         let element = element.i32()?;
-        let data = element
-            .into_iter()
-            .map(|x| x.copied())
-            .collect::<Vec<Option<i32>>>();
+        let data = element.into_iter().collect::<Vec<Option<i32>>>();
         let expected = vec![Some(6), Some(7), Some(8)];
         assert_eq!(data, expected);
 
@@ -313,18 +304,12 @@ mod tests {
         let l = list_arr.list()?;
         let element = l.get(0).unwrap();
         let element = element.i32()?;
-        let data = element
-            .into_iter()
-            .map(|x| x.copied())
-            .collect::<Vec<Option<i32>>>();
+        let data = element.into_iter().collect::<Vec<Option<i32>>>();
         let expected = vec![Some(0), Some(1), Some(2)];
         assert_eq!(data, expected);
         let element = l.get(2).unwrap();
         let element = element.i32()?;
-        let data = element
-            .into_iter()
-            .map(|x| x.copied())
-            .collect::<Vec<Option<i32>>>();
+        let data = element.into_iter().collect::<Vec<Option<i32>>>();
         let expected = vec![Some(6), Some(7), Some(8)];
         assert_eq!(data, expected);
 

--- a/src/daft-core/src/array/ops/groups.rs
+++ b/src/daft-core/src/array/ops/groups.rs
@@ -173,7 +173,7 @@ impl IntoGroups for Float32Array {
                 f.map(|v| {
                     match v.is_nan() {
                         true => f32::NAN,
-                        false => *v,
+                        false => v,
                     }
                     .to_bits()
                 })
@@ -197,7 +197,7 @@ impl IntoUniqueIdxs for Float32Array {
                 f.map(|v| {
                     match v.is_nan() {
                         true => f32::NAN,
-                        false => *v,
+                        false => v,
                     }
                     .to_bits()
                 })
@@ -221,7 +221,7 @@ impl IntoGroups for Float64Array {
                 f.map(|v| {
                     match v.is_nan() {
                         true => f64::NAN,
-                        false => *v,
+                        false => v,
                     }
                     .to_bits()
                 })
@@ -245,7 +245,7 @@ impl IntoUniqueIdxs for Float64Array {
                 f.map(|v| {
                     match v.is_nan() {
                         true => f64::NAN,
-                        false => *v,
+                        false => v,
                     }
                     .to_bits()
                 })

--- a/src/daft-core/src/array/ops/mean.rs
+++ b/src/daft-core/src/array/ops/mean.rs
@@ -34,7 +34,7 @@ impl DataArray<Decimal128Type> {
         let means = self
             .into_iter()
             .zip(counts)
-            .map(|(sum, count)| sum.zip(count).map(|(s, c)| s / (*c as i128)));
+            .map(|(sum, count)| sum.zip(count).map(|(s, c)| s / (c as i128)));
         Ok(Self::from_iter(self.field.clone(), means))
     }
 }

--- a/src/daft-core/src/array/ops/skew.rs
+++ b/src/daft-core/src/array/ops/skew.rs
@@ -14,7 +14,7 @@ impl DaftSkewAggable for DataArray<Float64Type> {
 
     fn skew(&self) -> Self::Output {
         let stats = stats::calculate_stats(self)?;
-        let values = self.into_iter().flatten().copied();
+        let values = self.into_iter().flatten();
         let skew = stats::calculate_skew(stats, values);
 
         Ok(Self::from_iter(self.field().clone(), std::iter::once(skew)))

--- a/src/daft-core/src/array/ops/stddev.rs
+++ b/src/daft-core/src/array/ops/stddev.rs
@@ -14,7 +14,7 @@ impl DaftStddevAggable for DataArray<Float64Type> {
 
     fn stddev(&self) -> Self::Output {
         let stats = stats::calculate_stats(self)?;
-        let values = self.into_iter().flatten().copied();
+        let values = self.into_iter().flatten();
         let stddev = stats::calculate_stddev(stats, values);
         Ok(Self::from_iter(
             self.field().clone(),

--- a/src/daft-core/src/array/ops/take.rs
+++ b/src/daft-core/src/array/ops/take.rs
@@ -95,8 +95,8 @@ impl ListArray {
                     new_offsets.push(*new_offsets.last().unwrap());
                 }
                 Some(i) => {
-                    let start = self.offsets()[*i as usize] as usize;
-                    let end = self.offsets()[*i as usize + 1] as usize;
+                    let start = self.offsets()[i as usize] as usize;
+                    let end = self.offsets()[i as usize + 1] as usize;
                     child_indices.extend(start..end);
                     new_offsets.push(*new_offsets.last().unwrap() + (end - start) as i64);
                     nulls_builder.append(self.is_valid(i.to_usize()));

--- a/src/daft-core/src/array/ops/variance.rs
+++ b/src/daft-core/src/array/ops/variance.rs
@@ -14,7 +14,7 @@ impl DaftVarianceAggable for DataArray<Float64Type> {
 
     fn var(&self, ddof: usize) -> Self::Output {
         let stats = stats::calculate_stats(self)?;
-        let values = self.into_iter().flatten().copied();
+        let values = self.into_iter().flatten();
         let variance = stats::calculate_variance(stats, values, ddof);
         Ok(Self::from_iter(
             self.field().clone(),

--- a/src/daft-core/src/series/mod.rs
+++ b/src/daft-core/src/series/mod.rs
@@ -85,7 +85,7 @@ impl Series {
 
         for (idx, hash) in hashed_series.into_iter().enumerate() {
             let hash = match hash {
-                Some(&hash) => hash,
+                Some(hash) => hash,
                 None => continue,
             };
             let entry = probe_table.raw_entry_v1().from_hash(hash, |other| {

--- a/src/daft-functions-utf8/src/left.rs
+++ b/src/daft-functions-utf8/src/left.rs
@@ -123,7 +123,7 @@ where
                 .zip(nchars.into_iter())
                 .map(|(val, n)| match (val, n) {
                     (Some(val), Some(nchar)) => {
-                        let nchar: usize = NumCast::from(*nchar).ok_or_else(|| {
+                        let nchar: usize = NumCast::from(nchar).ok_or_else(|| {
                             DaftError::ComputeError(format!(
                                 "Error in left: failed to cast rhs as usize {nchar}"
                             ))

--- a/src/daft-functions-utf8/src/pad.rs
+++ b/src/daft-functions-utf8/src/pad.rs
@@ -139,7 +139,7 @@ where
                 .zip(padchar_iter)
                 .map(|((val, len), padchar)| match (val, len, padchar) {
                     (Some(val), Some(len), Some(padchar)) => {
-                        let len: usize = NumCast::from(*len).ok_or_else(|| {
+                        let len: usize = NumCast::from(len).ok_or_else(|| {
                             DaftError::ComputeError(format!(
                                 "Error in pad: failed to cast length as usize {len}"
                             ))

--- a/src/daft-functions-utf8/src/repeat.rs
+++ b/src/daft-functions-utf8/src/repeat.rs
@@ -113,7 +113,7 @@ where
             .zip(n.into_iter())
             .map(|(val, n)| match (val, n) {
                 (Some(val), Some(n)) => {
-                    let n: usize = NumCast::from(*n).ok_or_else(|| {
+                    let n: usize = NumCast::from(n).ok_or_else(|| {
                         DaftError::ComputeError(format!(
                             "Error in repeat: failed to cast rhs as usize {n}"
                         ))

--- a/src/daft-functions-utf8/src/substr.rs
+++ b/src/daft-functions-utf8/src/substr.rs
@@ -156,7 +156,7 @@ where
                 _ => {
                     let length_iter = length.into_iter().map(|l| match l {
                         Some(l) => {
-                            let l: usize = NumCast::from(*l).ok_or_else(|| {
+                            let l: usize = NumCast::from(l).ok_or_else(|| {
                                 DaftError::ComputeError(format!(
                                     "Error in repeat: failed to cast length as usize {l}"
                                 ))
@@ -191,7 +191,7 @@ where
         _ => {
             let start_iter = start.into_iter().map(|s| match s {
                 Some(s) => {
-                    let s: usize = NumCast::from(*s).ok_or_else(|| {
+                    let s: usize = NumCast::from(s).ok_or_else(|| {
                         DaftError::ComputeError(format!(
                             "Error in repeat: failed to cast length as usize {s}"
                         ))

--- a/src/daft-functions-utf8/src/utils.rs
+++ b/src/daft-functions-utf8/src/utils.rs
@@ -4,7 +4,7 @@ use arrow::array::{Datum, Scalar};
 use common_error::{DaftError, DaftResult, ensure};
 use daft_arrow::ArrowError;
 use daft_core::{
-    array::DataArray,
+    array::{DataArray, iterator::Utf8Iter},
     prelude::{BooleanArray, DaftPhysicalType, DataType, Field, FullNull, Schema, Utf8Array},
     series::{IntoSeries, Series},
 };
@@ -13,13 +13,7 @@ use itertools::Itertools;
 
 pub(crate) enum BroadcastedStrIter<'a> {
     Repeat(std::iter::RepeatN<Option<&'a str>>),
-    NonRepeat(
-        daft_arrow::bitmap::utils::ZipValidity<
-            &'a str,
-            daft_arrow::array::ArrayValuesIter<'a, daft_arrow::array::Utf8Array<i64>>,
-            daft_arrow::bitmap::utils::BitmapIter<'a>,
-        >,
-    ),
+    NonRepeat(Utf8Iter<'a>),
 }
 
 impl<'a> Iterator for BroadcastedStrIter<'a> {

--- a/src/daft-functions/src/slice.rs
+++ b/src/daft-functions/src/slice.rs
@@ -161,7 +161,7 @@ fn list_slice(
     let start_iter = start.into_iter().cycle().take(output_len);
 
     let end_iter: Box<dyn Iterator<Item = Option<i64>>> = if let Some(end) = end {
-        Box::new(end.into_iter().map(|i| i.copied()).cycle().take(output_len))
+        Box::new(end.into_iter().cycle().take(output_len))
     } else {
         Box::new(input_iter.clone().map(|i| i.map(|i| i.len() as i64)))
     };
@@ -170,7 +170,7 @@ fn list_slice(
         .zip(end_iter)
         .zip(input_iter)
         .map(|((s, e), i)| {
-            let (Some(s), Some(e), Some(i)) = (s.copied(), e, i) else {
+            let (Some(s), Some(e), Some(i)) = (s, e, i) else {
                 return Ok(None);
             };
 
@@ -199,7 +199,7 @@ fn binary_slice<'a>(
     let start_iter = start.into_iter().cycle().take(output_len);
 
     let end_iter: Box<dyn Iterator<Item = Option<i64>>> = if let Some(end) = end {
-        Box::new(end.into_iter().map(|i| i.copied()).cycle().take(output_len))
+        Box::new(end.into_iter().cycle().take(output_len))
     } else {
         Box::new(input_iter.clone().map(|i| i.map(|i| i.len() as i64)))
     };
@@ -208,7 +208,7 @@ fn binary_slice<'a>(
         .zip(end_iter)
         .zip(input_iter)
         .map(|((s, e), i)| {
-            let (Some(s), Some(e), Some(i)) = (s.copied(), e, i) else {
+            let (Some(s), Some(e), Some(i)) = (s, e, i) else {
                 return None;
             };
 

--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -392,7 +392,7 @@ async fn get_delete_map(
                     .map(|(file, pos)| {
                         (
                             file.expect("file should not be null in iceberg delete files"),
-                            *pos.expect("pos should not be null in iceberg delete files"),
+                            pos.expect("pos should not be null in iceberg delete files"),
                         )
                     })
                 {

--- a/src/daft-recordbatch/src/ops/explode.rs
+++ b/src/daft-recordbatch/src/ops/explode.rs
@@ -14,7 +14,7 @@ use crate::RecordBatch;
 fn lengths_to_indices(lengths: &UInt64Array, capacity: usize) -> DaftResult<UInt64Array> {
     let mut indices = Vec::with_capacity(capacity);
     for (i, l) in lengths.into_iter().enumerate() {
-        let l = std::cmp::max(*l.unwrap_or(&1), 1u64);
+        let l = std::cmp::max(l.unwrap_or(1), 1u64);
         (0..l).for_each(|_| indices.push(i as u64));
     }
     Ok(UInt64Array::from_vec("indices", indices))
@@ -29,7 +29,7 @@ fn generate_explode_indices(
 ) -> DaftResult<UInt64Array> {
     let mut indices = Vec::with_capacity(capacity);
     for len in lengths {
-        if let Some(&l) = len
+        if let Some(l) = len
             && l > 0
         {
             indices.extend((0..l).map(Some));

--- a/src/daft-recordbatch/src/ops/groups.rs
+++ b/src/daft-recordbatch/src/ops/groups.rs
@@ -80,7 +80,7 @@ impl RecordBatch {
         let mut group_begin_indices: Option<(usize, usize)> = None;
 
         for (argarray_index, table_index) in argsort_array.into_iter().enumerate() {
-            let table_index = *table_index.unwrap() as usize;
+            let table_index = table_index.unwrap() as usize;
 
             match group_begin_indices {
                 None => group_begin_indices = Some((table_index, argarray_index)),

--- a/src/daft-recordbatch/src/ops/joins/mod.rs
+++ b/src/daft-recordbatch/src/ops/joins/mod.rs
@@ -172,8 +172,8 @@ impl RecordBatch {
 
                 for (li, ri) in lidx.into_iter().zip(ridx.into_iter()) {
                     match (li, ri) {
-                        (Some(i), _) => growable.extend(0, *i as usize, 1),
-                        (None, Some(i)) => growable.extend(1, *i as usize, 1),
+                        (Some(i), _) => growable.extend(0, i as usize, 1),
+                        (None, Some(i)) => growable.extend(1, i as usize, 1),
                         (None, None) => unreachable!("Join should not have None for both sides"),
                     }
                 }


### PR DESCRIPTION
## Summary
- Rewrites `iterator.rs` to remove arrow2 iterator types (`ZipValidity`, `BitmapIter`, `ArrayValuesIter`) from the public API
- Introduces custom iterator types: `PrimitiveIter` (raw slice + NullBuffer), `BooleanIter` (direct bitmap bit reads), and `GenericArrayIter` (index-based `.get()` for Utf8/Binary/FixedSizeBinary)
- Primitive items now yield `Option<T::Native>` by value (was `Option<&T::Native>`), matching arrow-rs conventions
- All array types gain `.iter()` methods for ergonomic iteration (no more `(&array).into_iter()`)

## Test plan
- [x] `cargo check` passes for the full workspace
- [x] All pre-commit hooks pass (clippy, fmt, cargo check default + all features)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)