### PR TITLE
fix: Cleanup imports from dashboard daemon PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,7 +1928,7 @@ dependencies = [
  "bincode",
  "common-py-serde",
  "enum_dispatch",
- "indicatif 0.17.11",
+ "indicatif",
  "itertools 0.14.0",
  "opentelemetry",
  "pyo3",
@@ -2057,19 +2057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.2",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2541,9 +2528,8 @@ name = "daft-cli"
 version = "0.3.0-dev0"
 dependencies = [
  "clap",
- "console 0.16.2",
+ "console",
  "daft-dashboard",
- "libc",
  "pyo3",
  "tokio",
  "tracing-subscriber",
@@ -3047,7 +3033,7 @@ dependencies = [
  "common-scan-info",
  "common-system-info",
  "common-tracing",
- "console 0.16.2",
+ "console",
  "daft-context",
  "daft-core",
  "daft-csv",
@@ -3066,7 +3052,7 @@ dependencies = [
  "daft-writers",
  "futures",
  "indexmap 2.13.0",
- "indicatif 0.18.3",
+ "indicatif",
  "itertools 0.14.0",
  "log",
  "opentelemetry",
@@ -5056,24 +5042,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console 0.15.11",
- "number_prefix",
- "portable-atomic",
- "unicode-width 0.2.2",
- "web-time",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console 0.16.2",
+ "console",
  "portable-atomic",
  "unicode-width 0.2.2",
  "unit-prefix",
@@ -5786,12 +5759,6 @@ dependencies = [
  "autocfg",
  "libm",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "numpy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2530,6 +2530,7 @@ dependencies = [
  "clap",
  "console",
  "daft-dashboard",
+ "libc",
  "pyo3",
  "tokio",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,6 +294,7 @@ html-escape = "0.2.13"
 image = {version = "0.25.9", default-features = false}
 indexmap = "2.9.0"
 indicatif = "0.18"
+console = "0.16"
 itertools = "0.14"
 jaq-core = "2.2.1"
 jaq-json = {version = "1.1.3", features = ["serde_json"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ inherits = "dev"
 debug = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-libc = {version = "^0.2.150", default-features = false}
+libc = {workspace = true}
 tikv-jemallocator = {version = "0.6.0", features = [
   "disable_initial_exec_tls"
 ]}
@@ -354,6 +354,7 @@ typetag = "0.2.21"
 url = "2.4.0"
 uuid = {version = "1.19.0", features = ["v4"]}
 xxhash-rust = {version = "0.8.15", features = ["const_xxh3", "const_xxh64", "const_xxh32", "xxh64", "xxh3", "xxh32"]}
+libc = {version = "^0.2.150", default-features = false}
 
 [workspace.dependencies.arrow2]
 features = ["serde_types"]

--- a/src/common/metrics/Cargo.toml
+++ b/src/common/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [dependencies]
 common-py-serde = {path = "../py-serde", default-features = false}
-indicatif = "0.17"
+indicatif = {workspace = true}
 serde = {workspace = true}
 bincode = {workspace = true}
 smallvec = {workspace = true, features = ["serde"]}

--- a/src/daft-cli/Cargo.toml
+++ b/src/daft-cli/Cargo.toml
@@ -1,13 +1,10 @@
 [dependencies]
 clap = {version = "4.5", features = ["derive"], optional = true}
 daft-dashboard = {path = "../daft-dashboard", optional = true}
-console = "0.16"
+console = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 tokio = {workspace = true, optional = true}
 tracing-subscriber = {workspace = true}
-
-[target.'cfg(unix)'.dependencies]
-libc = {version = "0.2.180"}
 
 [features]
 python = ["dep:pyo3", "dep:clap", "dep:tokio", "dep:daft-dashboard"]

--- a/src/daft-cli/Cargo.toml
+++ b/src/daft-cli/Cargo.toml
@@ -6,6 +6,9 @@ pyo3 = {workspace = true, optional = true}
 tokio = {workspace = true, optional = true}
 tracing-subscriber = {workspace = true}
 
+[target.'cfg(unix)'.dependencies]
+libc = {workspace = true}
+
 [features]
 python = ["dep:pyo3", "dep:clap", "dep:tokio", "dep:daft-dashboard"]
 

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -15,7 +15,7 @@ common-runtime = {path = "../common/runtime", default-features = false}
 common-scan-info = {path = "../common/scan-info", default-features = false}
 common-system-info = {path = "../common/system-info", default-features = false}
 common-tracing = {path = "../common/tracing", default-features = false}
-console = "*"
+console = {workspace = true}
 daft-core = {path = "../daft-core", default-features = false}
 daft-context = {path = "../daft-context", default-features = false}
 daft-csv = {path = "../daft-csv", default-features = false}


### PR DESCRIPTION
## Changes Made

Cleaned up some of the imports, particularly the manual `libc` import, from the daft-dashboard daemon PR.