### PR TITLE
chore: address review feedback from #6208

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = ["maturin>=1.5.0,<2.0.0"]
 [project]
 authors = [{name = "Eventual Inc", email = "daft@eventualcomputing.com"}]
 dependencies = [
-  "pyarrow >= 8.0.0,< 24.0.0",
+  "pyarrow >= 8.0.0,<24.0.0",
   "fsspec<2026.3.0",
   "tqdm<4.68.0",
   "typing-extensions >= 4.0.0; python_version < '3.11'",
@@ -106,7 +106,7 @@ dev = [
   "jax==0.6.2",
   "jaxtyping==0.3.7",
   # Pyarrow
-  "pyarrow >= 8.0.0,< 24.0.0",
+  "pyarrow >= 8.0.0,<24.0.0",
   "pyarrow-stubs==20.0.0.20251215",
   # Ray
   "ray[data, client]==2.53.0",
@@ -146,7 +146,6 @@ dev = [
   # AI
   "vllm==0.11.0",
   "openai==2.20.0",
-  # Downgraded to 1.2.0 for httpx 0.27.2 compatibility (1.3.0+ requires httpx>=0.28.1)
   "google-genai==1.63.0",
   # AV
   "av==16.1.0",

--- a/tests/integration/delta_lake/conftest.py
+++ b/tests/integration/delta_lake/conftest.py
@@ -257,6 +257,24 @@ def s3_path(
     return s3_uri, io_config, None
 
 
+@pytest.fixture(scope="function")
+def s3_path_with_glue(
+    s3_path: tuple[str, daft.io.IOConfig, DataCatalogTable | None],
+    glue_table: DataCatalogTable,
+) -> tuple[str, daft.io.IOConfig, DataCatalogTable]:
+    uri, io_config, _ = s3_path
+    return uri, io_config, glue_table
+
+
+@pytest.fixture(scope="function")
+def s3_path_with_unity(
+    s3_path: tuple[str, daft.io.IOConfig, DataCatalogTable | None],
+    unity_table_s3: DataCatalogTable,
+) -> tuple[str, daft.io.IOConfig, DataCatalogTable]:
+    uri, io_config, _ = s3_path
+    return uri, io_config, unity_table_s3
+
+
 ###############################
 ### Azure-specific fixtures ###
 ###############################
@@ -341,6 +359,15 @@ def az_path(
 
 
 @pytest.fixture(scope="function")
+def az_path_with_unity(
+    az_path: tuple[str, daft.io.IOConfig, None],
+    unity_table_az: DataCatalogTable,
+) -> Iterator[tuple[str, daft.io.IOConfig, DataCatalogTable]]:
+    uri, io_config, _ = az_path
+    yield uri, io_config, unity_table_az
+
+
+@pytest.fixture(scope="function")
 def local_path(tmp_path: pathlib.Path, data_dir: str) -> tuple[str, None, None]:
     path = os.path.join(tmp_path, data_dir)
     os.mkdir(path)
@@ -352,9 +379,12 @@ def local_path(tmp_path: pathlib.Path, data_dir: str) -> tuple[str, None, None]:
     params=[
         pytest.param("local_path", marks=pytest.mark.local),
         pytest.param("s3_path", marks=pytest.mark.s3),
+        pytest.param("s3_path_with_glue", marks=(pytest.mark.s3, pytest.mark.glue)),
+        pytest.param("s3_path_with_unity", marks=(pytest.mark.s3, pytest.mark.unity)),
         # Azure tests require starting a Docker container + mock server that (1) requires a dev Docker dependency, and
         # (2) takes 15+ seconds to start on every run, so we current mark it as an integration test.
         pytest.param("az_path", marks=(pytest.mark.az, pytest.mark.integration)),
+        pytest.param("az_path_with_unity", marks=(pytest.mark.az, pytest.mark.integration, pytest.mark.unity)),
     ],
 )
 def cloud_paths(


### PR DESCRIPTION
## Summary
Follow-up to #6208 (dependency bump PR) addressing Greptile review comments that landed after merge.

- Remove stale comment on `google-genai` that referenced the old 1.2.0 version and httpx 0.27.2 — the actual version is now 1.63.0 with httpx 0.28.1
- Fix inconsistent `pyarrow` version constraint spacing (`< 24.0.0` → `<24.0.0`) to match the rest of the file
- Restore Glue/Unity catalog test coverage lost in the `pytest-lazy-fixture` removal by creating composed fixtures (`s3_path_with_glue`, `s3_path_with_unity`, `az_path_with_unity`) and adding them as params in `cloud_paths`

## Test plan
- [ ] CI passes — the new fixtures use the same marks (`glue`, `unity`) as before, so they'll only run in the catalog integration test job

🤖 Generated with [Claude Code](https://claude.com/claude-code)