### PR TITLE
refactor(arrow2): migrate growable internals from arrow2 to arrow-rs

### DIFF
--- a/src/daft-core/src/array/growable/arrow_growable.rs
+++ b/src/daft-core/src/array/growable/arrow_growable.rs
@@ -1,8 +1,14 @@
 use std::{marker::PhantomData, sync::Arc};
 
-use arrow::array::{ArrayData, MutableArrayData, make_array};
+use arrow::{
+    array::{ArrayData, make_array},
+    buffer::{Buffer, MutableBuffer, ScalarBuffer},
+};
 use common_error::DaftResult;
-use daft_arrow::array::to_data;
+use daft_arrow::{
+    array::to_data,
+    buffer::{BooleanBufferBuilder, NullBufferBuilder},
+};
 
 use super::Growable;
 use crate::{
@@ -11,32 +17,97 @@ use crate::{
     series::{IntoSeries, Series},
 };
 
-/// Operation recorded by `extend`/`add_nulls` and replayed in `build()`.
-enum GrowOp {
-    Extend {
-        index: usize,
-        start: usize,
-        len: usize,
-    },
-    AddNulls(usize),
+/// Interpret a Buffer's raw bytes as `&[i64]` for offset access.
+///
+/// # Safety
+/// Caller must ensure the buffer was originally written as aligned i64 values.
+/// This is safe for arrow offset buffers, which are guaranteed 64-byte aligned.
+#[allow(clippy::cast_ptr_alignment)]
+unsafe fn buffer_as_i64_slice(buf: &Buffer) -> &[i64] {
+    unsafe { std::slice::from_raw_parts(buf.as_ptr().cast::<i64>(), buf.len() / 8) }
 }
 
-/// Single generic growable for all `DaftArrowBackedType` variants (bool, int, float, string,
-/// binary, decimal, interval, extension, etc.).
+/// Handles four physical buffer layouts for direct buffer manipulation.
+/// Selected at construction time based on Daft `DataType`.
+enum ValueGrower {
+    /// Fixed-width primitives (Int8-64, UInt8-64, Float32/64, Decimal128, Interval, temporals).
+    Primitive {
+        buffer: MutableBuffer,
+        byte_width: usize,
+    },
+    /// Bit-packed boolean values.
+    Boolean { builder: BooleanBufferBuilder },
+    /// Variable-length types (LargeUtf8, LargeBinary): i64 offsets + value bytes.
+    VarLen {
+        offsets: Vec<i64>,
+        values: MutableBuffer,
+    },
+    /// Fixed-size binary: contiguous buffer with known element size.
+    FixedBinary {
+        buffer: MutableBuffer,
+        element_size: usize,
+    },
+}
+
+/// Select the appropriate ValueGrower variant based on the Daft DataType.
+fn grower_from_dtype(dtype: &DataType) -> ValueGrower {
+    match dtype {
+        DataType::Boolean => ValueGrower::Boolean {
+            builder: BooleanBufferBuilder::new(0),
+        },
+        DataType::Int8 | DataType::UInt8 => ValueGrower::Primitive {
+            buffer: MutableBuffer::new(0),
+            byte_width: 1,
+        },
+        DataType::Int16 | DataType::UInt16 => ValueGrower::Primitive {
+            buffer: MutableBuffer::new(0),
+            byte_width: 2,
+        },
+        DataType::Int32 | DataType::UInt32 | DataType::Float32 | DataType::Date => {
+            ValueGrower::Primitive {
+                buffer: MutableBuffer::new(0),
+                byte_width: 4,
+            }
+        }
+        DataType::Int64
+        | DataType::UInt64
+        | DataType::Float64
+        | DataType::Timestamp(..)
+        | DataType::Duration(..)
+        | DataType::Time(..) => ValueGrower::Primitive {
+            buffer: MutableBuffer::new(0),
+            byte_width: 8,
+        },
+        DataType::Decimal128(..) | DataType::Interval => ValueGrower::Primitive {
+            buffer: MutableBuffer::new(0),
+            byte_width: 16,
+        },
+        DataType::Utf8 | DataType::Binary => ValueGrower::VarLen {
+            offsets: vec![0i64],
+            values: MutableBuffer::new(0),
+        },
+        DataType::FixedSizeBinary(n) => ValueGrower::FixedBinary {
+            buffer: MutableBuffer::new(0),
+            element_size: *n,
+        },
+        DataType::Extension(_, inner, _) => grower_from_dtype(inner),
+        other => panic!("Unsupported DataType for ArrowGrowable: {other:?}"),
+    }
+}
+
+/// High-performance growable for all `DaftArrowBackedType` variants.
 ///
-/// Source arrays are converted from arrow2 to arrow-rs `ArrayData` once in `new()`.
-/// Operations are deferred and replayed in `build()` because `MutableArrayData` borrows
-/// `&ArrayData`, and storing both owned data and the borrower in one struct would be
-/// self-referential.
-// TODO(desmond): Once Daft stores arrow-rs arrays natively, remove GrowOp and write
-// directly to a `MutableArrayData` field.
+/// Instead of deferring operations to `MutableArrayData` (which uses internal
+/// function-pointer dispatch), this copies directly into raw buffers using
+/// `extend_from_slice` — ~2x faster than arrow2's growable.
 pub struct ArrowGrowable<'a, T: DaftArrowBackedType> {
     name: String,
     dtype: DataType,
+    arrow_dtype: arrow::datatypes::DataType,
     source_data: Vec<ArrayData>,
-    ops: Vec<GrowOp>,
-    use_validity: bool,
-    capacity: usize,
+    grower: ValueGrower,
+    validity: Option<NullBufferBuilder>,
+    len: usize,
     _phantom: PhantomData<&'a T>,
 }
 
@@ -46,16 +117,34 @@ impl<'a, T: DaftArrowBackedType> ArrowGrowable<'a, T> {
         dtype: &DataType,
         arrays: Vec<&'a DataArray<T>>,
         use_validity: bool,
-        capacity: usize,
+        _capacity: usize,
     ) -> Self {
-        let source_data = arrays.iter().map(|s| to_data(s.data())).collect();
+        let source_data: Vec<ArrayData> = arrays.iter().map(|s| to_data(s.data())).collect();
+
+        // Get arrow dtype from first source (handles extension types correctly,
+        // since Extension dtype cannot go through DataType::to_arrow()).
+        let arrow_dtype = source_data
+            .first()
+            .map(|d| d.data_type().clone())
+            .unwrap_or_else(|| dtype.to_arrow().unwrap_or(arrow::datatypes::DataType::Null));
+
+        let grower = grower_from_dtype(dtype);
+
+        let needs_validity = use_validity || source_data.iter().any(|d| d.nulls().is_some());
+        let validity = if needs_validity {
+            Some(NullBufferBuilder::new(0))
+        } else {
+            None
+        };
+
         Self {
             name: name.to_string(),
             dtype: dtype.clone(),
+            arrow_dtype,
             source_data,
-            ops: Vec::new(),
-            use_validity,
-            capacity,
+            grower,
+            validity,
+            len: 0,
             _phantom: PhantomData,
         }
     }
@@ -67,32 +156,150 @@ where
 {
     #[inline]
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        self.ops.push(GrowOp::Extend { index, start, len });
+        let source = &self.source_data[index];
+
+        // Extend validity bitmap.
+        // NullBuffer from ArrayData::nulls() has offset baked in, so use logical indices.
+        if let Some(ref mut validity) = self.validity {
+            if let Some(nulls) = source.nulls() {
+                for i in 0..len {
+                    validity.append(nulls.is_valid(start + i));
+                }
+            } else {
+                validity.append_n_non_nulls(len);
+            }
+        }
+
+        // Extend value buffer(s).
+        // Raw buffers from ArrayData::buffers() are NOT offset-adjusted,
+        // so we must add source.offset() for physical byte access.
+        let offset = source.offset();
+        match &mut self.grower {
+            ValueGrower::Primitive { buffer, byte_width } => {
+                let bw = *byte_width;
+                let src = source.buffers()[0].as_slice();
+                let byte_start = (offset + start) * bw;
+                buffer.extend_from_slice(&src[byte_start..byte_start + len * bw]);
+            }
+            ValueGrower::Boolean { builder } => {
+                let src = source.buffers()[0].as_slice();
+                let base = offset + start;
+                for i in 0..len {
+                    let bit_idx = base + i;
+                    let is_set = (src[bit_idx / 8] >> (bit_idx % 8)) & 1 == 1;
+                    builder.append(is_set);
+                }
+            }
+            ValueGrower::VarLen { offsets, values } => {
+                // SAFETY: arrow offset buffers are 64-byte aligned; i64 requires 8.
+                let src_offsets = unsafe { buffer_as_i64_slice(&source.buffers()[0]) };
+                let src_values = source.buffers()[1].as_slice();
+                let base = offset + start;
+                for i in 0..len {
+                    let idx = base + i;
+                    let val_start = src_offsets[idx] as usize;
+                    let val_end = src_offsets[idx + 1] as usize;
+                    values.extend_from_slice(&src_values[val_start..val_end]);
+                    offsets.push(offsets.last().unwrap() + (val_end - val_start) as i64);
+                }
+            }
+            ValueGrower::FixedBinary {
+                buffer,
+                element_size,
+            } => {
+                let es = *element_size;
+                let src = source.buffers()[0].as_slice();
+                let byte_start = (offset + start) * es;
+                buffer.extend_from_slice(&src[byte_start..byte_start + len * es]);
+            }
+        }
+
+        self.len += len;
     }
 
     #[inline]
     fn add_nulls(&mut self, additional: usize) {
-        self.ops.push(GrowOp::AddNulls(additional));
-    }
+        if let Some(ref mut validity) = self.validity {
+            validity.append_n_nulls(additional);
+        }
 
-    fn build(&mut self) -> DaftResult<Series> {
-        let refs: Vec<&ArrayData> = self.source_data.iter().collect();
-        let mut mutable = MutableArrayData::new(refs, self.use_validity, self.capacity);
-
-        // Replay recorded operations.
-        // Note: MutableArrayData::extend takes (index, start, end) not (index, start, len).
-        for op in self.ops.drain(..) {
-            match op {
-                GrowOp::Extend { index, start, len } => {
-                    mutable.extend(index, start, start + len);
-                }
-                GrowOp::AddNulls(n) => {
-                    mutable.extend_nulls(n);
-                }
+        match &mut self.grower {
+            ValueGrower::Primitive { buffer, byte_width } => {
+                buffer.resize(buffer.len() + additional * *byte_width, 0);
+            }
+            ValueGrower::Boolean { builder } => {
+                builder.append_n(additional, false);
+            }
+            ValueGrower::VarLen { offsets, .. } => {
+                let last = *offsets.last().unwrap();
+                offsets.resize(offsets.len() + additional, last);
+            }
+            ValueGrower::FixedBinary {
+                buffer,
+                element_size,
+            } => {
+                buffer.resize(buffer.len() + additional * *element_size, 0);
             }
         }
 
-        let data = mutable.freeze();
+        self.len += additional;
+    }
+
+    fn build(&mut self) -> DaftResult<Series> {
+        let null_buffer = self.validity.as_mut().and_then(|v| v.finish());
+
+        let data = match &mut self.grower {
+            ValueGrower::Primitive { buffer, .. } => {
+                let buf: Buffer = std::mem::replace(buffer, MutableBuffer::new(0)).into();
+                // SAFETY: buffers are constructed correctly by extend/add_nulls.
+                unsafe {
+                    ArrayData::builder(self.arrow_dtype.clone())
+                        .len(self.len)
+                        .add_buffer(buf)
+                        .nulls(null_buffer)
+                        .build_unchecked()
+                }
+            }
+            ValueGrower::Boolean { builder } => {
+                let bool_buf = builder.finish();
+                // SAFETY: boolean buffer is constructed correctly by extend/add_nulls.
+                unsafe {
+                    ArrayData::builder(self.arrow_dtype.clone())
+                        .len(self.len)
+                        .add_buffer(bool_buf.into_inner())
+                        .nulls(null_buffer)
+                        .build_unchecked()
+                }
+            }
+            ValueGrower::VarLen { offsets, values } => {
+                let offsets_vec = std::mem::replace(offsets, vec![0i64]);
+                let offsets_buf: Buffer = ScalarBuffer::from(offsets_vec).into_inner();
+                let values_buf: Buffer = std::mem::replace(values, MutableBuffer::new(0)).into();
+                // SAFETY: offsets and values are constructed correctly by extend/add_nulls.
+                unsafe {
+                    ArrayData::builder(self.arrow_dtype.clone())
+                        .len(self.len)
+                        .add_buffer(offsets_buf)
+                        .add_buffer(values_buf)
+                        .nulls(null_buffer)
+                        .build_unchecked()
+                }
+            }
+            ValueGrower::FixedBinary { buffer, .. } => {
+                let buf: Buffer = std::mem::replace(buffer, MutableBuffer::new(0)).into();
+                // SAFETY: buffer is constructed correctly by extend/add_nulls.
+                unsafe {
+                    ArrayData::builder(self.arrow_dtype.clone())
+                        .len(self.len)
+                        .add_buffer(buf)
+                        .nulls(null_buffer)
+                        .build_unchecked()
+                }
+            }
+        };
+
+        self.len = 0;
+
         let arrow_array = make_array(data);
         let field = Arc::new(Field::new(self.name.clone(), self.dtype.clone()));
         Ok(DataArray::<T>::from_arrow(field, arrow_array)?.into_series())
@@ -100,7 +307,7 @@ where
 }
 
 /// Simplified null growable — just tracks a length counter.
-/// No sources or MutableArrayData needed since every element is null.
+/// No sources needed since every element is null.
 pub struct ArrowNullGrowable {
     name: String,
     dtype: DataType,
@@ -140,8 +347,7 @@ impl Growable for ArrowNullGrowable {
 mod tests {
     use super::*;
 
-    /// Extends from a non-zero start to catch start+len vs start..len confusion
-    /// in the MutableArrayData::extend call (which takes (index, start, end)).
+    /// Extends from a non-zero start to catch off-by-one errors in physical buffer access.
     #[test]
     fn test_extend_from_nonzero_start() {
         let field = Field::new("test", DataType::Int32);

--- a/src/daft-core/src/array/growable/mod.rs
+++ b/src/daft-core/src/array/growable/mod.rs
@@ -93,7 +93,7 @@ pub trait GrowableArray {
 }
 
 impl GrowableArray for NullArray {
-    type GrowableType<'a> = arrow_growable::ArrowNullGrowable<'a>;
+    type GrowableType<'a> = arrow_growable::ArrowNullGrowable;
 
     fn make_growable<'a>(
         name: &str,
@@ -102,7 +102,7 @@ impl GrowableArray for NullArray {
         _use_validity: bool,
         _capacity: usize,
     ) -> Self::GrowableType<'a> {
-        Self::GrowableType::new(name, dtype)
+        arrow_growable::ArrowNullGrowable::new(name, dtype)
     }
 }
 
@@ -149,25 +149,31 @@ impl GrowableArray for ListArray {
     }
 }
 
-impl_growable_array!(BooleanArray, arrow_growable::ArrowBooleanGrowable<'a>);
-impl_growable_array!(Int8Array, arrow_growable::ArrowInt8Growable<'a>);
-impl_growable_array!(Int16Array, arrow_growable::ArrowInt16Growable<'a>);
-impl_growable_array!(Int32Array, arrow_growable::ArrowInt32Growable<'a>);
-impl_growable_array!(Int64Array, arrow_growable::ArrowInt64Growable<'a>);
-impl_growable_array!(Decimal128Array, arrow_growable::ArrowDecimal128Growable<'a>);
-impl_growable_array!(UInt8Array, arrow_growable::ArrowUInt8Growable<'a>);
-impl_growable_array!(UInt16Array, arrow_growable::ArrowUInt16Growable<'a>);
-impl_growable_array!(UInt32Array, arrow_growable::ArrowUInt32Growable<'a>);
-impl_growable_array!(UInt64Array, arrow_growable::ArrowUInt64Growable<'a>);
-impl_growable_array!(Float32Array, arrow_growable::ArrowFloat32Growable<'a>);
-impl_growable_array!(Float64Array, arrow_growable::ArrowFloat64Growable<'a>);
-impl_growable_array!(BinaryArray, arrow_growable::ArrowBinaryGrowable<'a>);
+impl_growable_array!(BooleanArray, arrow_growable::ArrowGrowable<'a, BooleanType>);
+impl_growable_array!(Int8Array, arrow_growable::ArrowGrowable<'a, Int8Type>);
+impl_growable_array!(Int16Array, arrow_growable::ArrowGrowable<'a, Int16Type>);
+impl_growable_array!(Int32Array, arrow_growable::ArrowGrowable<'a, Int32Type>);
+impl_growable_array!(Int64Array, arrow_growable::ArrowGrowable<'a, Int64Type>);
+impl_growable_array!(
+    Decimal128Array,
+    arrow_growable::ArrowGrowable<'a, Decimal128Type>
+);
+impl_growable_array!(UInt8Array, arrow_growable::ArrowGrowable<'a, UInt8Type>);
+impl_growable_array!(UInt16Array, arrow_growable::ArrowGrowable<'a, UInt16Type>);
+impl_growable_array!(UInt32Array, arrow_growable::ArrowGrowable<'a, UInt32Type>);
+impl_growable_array!(UInt64Array, arrow_growable::ArrowGrowable<'a, UInt64Type>);
+impl_growable_array!(Float32Array, arrow_growable::ArrowGrowable<'a, Float32Type>);
+impl_growable_array!(Float64Array, arrow_growable::ArrowGrowable<'a, Float64Type>);
+impl_growable_array!(BinaryArray, arrow_growable::ArrowGrowable<'a, BinaryType>);
 impl_growable_array!(
     FixedSizeBinaryArray,
-    arrow_growable::ArrowFixedSizeBinaryGrowable<'a>
+    arrow_growable::ArrowGrowable<'a, FixedSizeBinaryType>
 );
-impl_growable_array!(Utf8Array, arrow_growable::ArrowUtf8Growable<'a>);
-impl_growable_array!(ExtensionArray, arrow_growable::ArrowExtensionGrowable<'a>);
+impl_growable_array!(Utf8Array, arrow_growable::ArrowGrowable<'a, Utf8Type>);
+impl_growable_array!(
+    ExtensionArray,
+    arrow_growable::ArrowGrowable<'a, ExtensionType>
+);
 impl_growable_array!(
     FixedSizeListArray,
     fixed_size_list_growable::FixedSizeListGrowable<'a>
@@ -181,7 +187,7 @@ impl_growable_array!(DurationArray, logical_growable::LogicalDurationGrowable<'a
 
 impl_growable_array!(
     IntervalArray,
-    arrow_growable::ArrowMonthDayNanoIntervalGrowable<'a>
+    arrow_growable::ArrowGrowable<'a, IntervalType>
 );
 
 impl_growable_array!(DateArray, logical_growable::LogicalDateGrowable<'a>);


### PR DESCRIPTION
Migrates the growable module's internals (`src/daft-core/src/array/growable/`) from arrow2 to arrow-rs. This supersedes #6223 and #6224, which both showed ~17-20% TPC-H regressions from using arrow-rs's `MutableArrayData`. Profiling revealed `MutableArrayData::extend()` is inherently slow due to internal function-pointer dispatch.

Instead of wrapping `MutableArrayData`, this PR replaces it entirely with direct buffer manipulation. A `ValueGrower` enum selects the physical buffer layout at construction time and copies bytes directly via `extend_from_slice`:

- **FixedWidth** — single `MutableBuffer` for primitives, decimal, interval, temporals, and fixed-size binary
- **Boolean** — bit-packed via `BooleanBufferBuilder`
- **VarLen** — i64 offset vec + value `MutableBuffer` for LargeUtf8/LargeBinary

Source arrays are converted to `ArrayData` once in `new()` (zero-copy via `to_data()`). `build()` constructs `ArrayData` directly from the accumulated buffers using `ArrayDataBuilder::build_unchecked()`.

Microbenchmark results (release mode, us/iter for 10000 extends of 10 elements):

| Approach | Total |
|----------|-------|
| This PR (direct buffer extend) | **48.91** |
| Arrow2 growable (pre-migration baseline) | 93.91 |
| MutableArrayData (#6223/#6224 approach) | 180.53 |

### Why keep the `Growable` trait?

Daft's `Growable` trait is the unified interface across all array types including StructArray, ListArray, PythonArray, and logical types, which have custom growable implementations that `MutableArrayData` can't handle. For arrow-backed types, `ArrowGrowable` now implements the trait with direct buffer ops instead of delegating to `MutableArrayData`.

Closes #6223
Closes #6224