### PR TITLE
chore(observability): Split dashboard cli into separate start / stop subcommands

### DIFF
--- a/src/daft-cli/src/dashboard.rs
+++ b/src/daft-cli/src/dashboard.rs
@@ -36,29 +36,29 @@ enum DashboardCommand {
 struct StartArgs {
     /// The address to launch the dashboard on
     #[arg(short, long, default_value = "0.0.0.0")]
-    pub addr: IpAddr,
+    addr: IpAddr,
     /// The port to launch the dashboard on
     #[arg(short, long, default_value_t = daft_dashboard::DEFAULT_SERVER_PORT)]
-    pub port: u16,
+    port: u16,
     /// Log HTTP requests and responses from server
     #[arg(short, long)]
-    pub verbose: bool,
+    verbose: bool,
     /// Run the dashboard in daemon mode
     #[arg(short, long)]
-    pub daemon: bool,
+    daemon: bool,
     /// The directory used to store the PID file
     #[arg(long)]
-    pub pid_dir: Option<String>,
+    pid_dir: Option<String>,
     /// The directory used to store the LOG file
     #[arg(long)]
-    pub log_dir: Option<String>,
+    log_dir: Option<String>,
 }
 
 #[derive(Args)]
 struct StopArgs {
     /// The directory used to store the PID file
     #[arg(long)]
-    pub pid_dir: Option<String>,
+    pid_dir: Option<String>,
 }
 
 pub fn run(py: Python, args: DashboardArgs) {

--- a/src/daft-cli/src/dashboard.rs
+++ b/src/daft-cli/src/dashboard.rs
@@ -10,84 +10,65 @@ use std::{
     sync::OnceLock,
 };
 
-use clap::Args;
+use clap::{Args, Subcommand};
 use pyo3::prelude::*;
 use tracing_subscriber::{self, filter::Directive, layer::SubscriberExt, util::SubscriberInitExt};
 
 const ENV_DAFT_DASHBOARD_PID_DIR: &str = "DAFT_DASHBOARD_PID_DIR";
 const ENV_DAFT_DASHBOARD_LOG_DIR: &str = "DAFT_DASHBOARD_LOG_DIR";
 
+/// Dashboard command: holds the start/stop subcommand.
 #[derive(Args)]
 pub(crate) struct DashboardArgs {
-    /// The address to launch the dashboard on
-    #[arg(short, long, default_value = "0.0.0.0")]
-    addr: IpAddr,
-    #[arg(short, long, default_value_t = daft_dashboard::DEFAULT_SERVER_PORT)]
-    /// The port to launch the dashboard on
-    port: u16,
-    /// Start to run dashboard server
-    #[arg(short, long, conflicts_with = "stop")]
-    start: bool,
-    /// Stop the currently running dashboard server
-    #[arg(long, conflicts_with = "start")]
-    stop: bool,
-    #[arg(short, long)]
-    /// Log HTTP requests and responses from server
-    verbose: bool,
-    /// Run the dashboard in daemon mode
-    #[arg(short, long, conflicts_with = "stop")]
-    daemon: bool,
-    /// The directory used to store the PID file
-    #[arg(long)]
-    pid_dir: Option<String>,
-    /// The directory used to store the LOG file
-    #[arg(long, conflicts_with = "stop")]
-    log_dir: Option<String>,
+    #[command(subcommand)]
+    command: DashboardCommand,
 }
 
-struct StartOptions {
+#[derive(Subcommand)]
+enum DashboardCommand {
+    /// Start the dashboard server
+    Start(StartArgs),
+    /// Stop a currently running background dashboard server
+    Stop(StopArgs),
+}
+
+#[derive(Args)]
+struct StartArgs {
+    /// The address to launch the dashboard on
+    #[arg(short, long, default_value = "0.0.0.0")]
     pub addr: IpAddr,
+    /// The port to launch the dashboard on
+    #[arg(short, long, default_value_t = daft_dashboard::DEFAULT_SERVER_PORT)]
     pub port: u16,
+    /// Log HTTP requests and responses from server
+    #[arg(short, long)]
     pub verbose: bool,
+    /// Run the dashboard in daemon mode
+    #[arg(short, long)]
     pub daemon: bool,
+    /// The directory used to store the PID file
+    #[arg(long)]
     pub pid_dir: Option<String>,
+    /// The directory used to store the LOG file
+    #[arg(long)]
     pub log_dir: Option<String>,
 }
 
-struct StopOptions {
+#[derive(Args)]
+struct StopArgs {
+    /// The directory used to store the PID file
+    #[arg(long)]
     pub pid_dir: Option<String>,
 }
 
 pub fn run(py: Python, args: DashboardArgs) {
-    if args.start {
-        start(
-            py,
-            StartOptions {
-                addr: args.addr,
-                port: args.port,
-                verbose: args.verbose,
-                daemon: args.daemon,
-                pid_dir: args.pid_dir,
-                log_dir: args.log_dir,
-            },
-        );
-    } else if args.stop {
-        stop(StopOptions {
-            pid_dir: args.pid_dir,
-        });
-    } else {
-        eprintln!(
-            "{}",
-            console::style(
-                "❌ Invalid parameter. Try 'daft dashboard --help' for more information."
-            )
-            .red()
-            .bold()
-        );
+    match args.command {
+        DashboardCommand::Start(opts) => start(py, opts),
+        DashboardCommand::Stop(opts) => stop(opts),
     }
 }
 
-fn start(py: Python, opts: StartOptions) {
+fn start(py: Python, opts: StartArgs) {
     let pid_path = get_pid_filepath(opts.pid_dir.clone());
     if pid_path.exists() {
         println!(
@@ -113,7 +94,7 @@ fn start(py: Python, opts: StartOptions) {
             cmd.arg("-m")
                 .arg("daft.cli")
                 .arg("dashboard")
-                .arg("--start")
+                .arg("start")
                 .arg("--addr")
                 .arg(opts.addr.to_string())
                 .arg("--port")
@@ -240,7 +221,7 @@ fn start(py: Python, opts: StartOptions) {
     }
 }
 
-fn stop(opts: StopOptions) {
+fn stop(opts: StopArgs) {
     let pid_path = get_pid_filepath(opts.pid_dir.clone());
     let pid = match read_pid(opts.pid_dir) {
         Ok(pid) => pid,

--- a/tests/integration/test_dashboard.py
+++ b/tests/integration/test_dashboard.py
@@ -36,7 +36,7 @@ def dashboard_url():
         random_port = s.getsockname()[1]
 
     # Start the dashboard server as a subprocess, simulating real user behavior
-    # "daft dashboard --port <port>"
+    # "daft dashboard start --port <port>"
     import os
     import shutil
     import subprocess
@@ -49,7 +49,7 @@ def dashboard_url():
         if not os.path.exists(daft_bin):
             raise RuntimeError("Could not find 'daft' executable")
 
-    cmd = [daft_bin, "dashboard", "--start", "--port", str(random_port)]
+    cmd = [daft_bin, "dashboard", "start", "--port", str(random_port)]
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     url = f"http://127.0.0.1:{random_port}"


### PR DESCRIPTION
## Changes Made

Follow up from https://github.com/Eventual-Inc/Daft/pull/5993 to split the cli args into subcommands to make it a bit neater to use.
