### PR TITLE
feat(observability): Split duration into separate column in metrics DF

### DIFF
--- a/src/daft-local-plan/src/results.rs
+++ b/src/daft-local-plan/src/results.rs
@@ -79,6 +79,8 @@ impl ExecutionEngineFinalResult {
             types.append_value(node_info.node_type.to_string());
             categories.append_value(node_info.node_category.to_string());
             for (name, value) in stat_snapshot.to_stats() {
+                // Note: Always expect one stat for duration by the execution engine
+                // TODO: Add checks just in case
                 if name.as_ref() == CPU_US_KEY {
                     let Stat::Duration(cpu_us) = value else {
                         panic!("cpu us is always a Duration in stats");


### PR DESCRIPTION
## Changes Made

So now the metrics out look something like this:
```
╭────────┬────────────────────────────────┬─────────────┬───────────────┬──────────────┬───────────────────────────────────────────────────╮
│ id     ┆ name                           ┆ type        ┆ category      ┆ cpu us       ┆ stats                                             │
│ ---    ┆ ---                            ┆ ---         ┆ ---           ┆ ---          ┆ ---                                               │
│ UInt64 ┆ String                         ┆ String      ┆ String        ┆ Duration[us] ┆ Map[String: Struct[value: Float64, unit: String]] │
╞════════╪════════════════════════════════╪═════════════╪═══════════════╪══════════════╪═══════════════════════════════════════════════════╡
│ 0      ┆ Parquet Scan                   ┆ ScanTask    ┆ Source        ┆ 0µs          ┆ {"rows out": {value: 2000,                        │
│        ┆                                ┆             ┆               ┆              ┆ un…                                               │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 1      ┆ Limit 1000                     ┆ Limit       ┆ StreamingSink ┆ 0µs          ┆ {"rows in": {value: 1000,                         │
│        ┆                                ┆             ┆               ┆              ┆ uni…                                              │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 2      ┆ tokenize_encode(prompt, "cl10… ┆ Project     ┆ Intermediate  ┆ 2s 622889µs  ┆ {"rows in": {value: 1000,                         │
│        ┆                                ┆             ┆               ┆              ┆ uni…                                              │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 3      ┆ Filter                         ┆ Filter      ┆ Intermediate  ┆ 13544µs      ┆ {"rows in": {value: 1000,                         │
│        ┆                                ┆             ┆               ┆              ┆ uni…                                              │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 4      ┆ Explode                        ┆ Explode     ┆ Intermediate  ┆ 4661µs       ┆ {"rows in": {value: 105,                          │
│        ┆                                ┆             ┆               ┆              ┆ unit…                                             │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 5      ┆ Parquet Write                  ┆ Write       ┆ BlockingSink  ┆ 140869µs     ┆ {"rows in": {value: 82789,                        │
│        ┆                                ┆             ┆               ┆              ┆ un…                                               │
├╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ 6      ┆ Commit Write                   ┆ CommitWrite ┆ BlockingSink  ┆ 159µs        ┆ {"rows in": {value: 1,                            │
│        ┆                                ┆             ┆               ┆              ┆ unit: …                                           │
╰────────┴────────────────────────────────┴─────────────┴───────────────┴──────────────┴───────────────────────────────────────────────────╯
```

Just a bit neater IMO. We could also look into rounding by milliseconds in the rendering but pretty decent as is, so not worried about it too much.