### PR TITLE
ci: increase integration-test-sql timeout from 30 to 45 minutes

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -632,7 +632,7 @@ jobs:
 
   integration-test-sql:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     needs: [skipcheck, integration-test-build]
     if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     env:


### PR DESCRIPTION
The `integration-test-sql` job runs both native and Ray test suites sequentially. CI setup (~18 min) plus native tests (~8 min) consumed 26 of the 30-minute timeout, leaving only ~4 minutes for the Ray run which needs ~8 minutes. This caused consistent cancellations on the Ray leg despite all tests passing.

Bump the timeout to 45 minutes to provide sufficient headroom for both runs.

Failing run: https://github.com/Eventual-Inc/Daft/actions/runs/22158674450/job/64071895304