### PR TITLE
ci: increase integration-test-build timeout from 30 to 45 minutes

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -273,7 +273,7 @@ jobs:
     needs: skipcheck
     if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       package-name: daft
     strategy:


### PR DESCRIPTION
PR #6177 (OpenDAL) added ~110 new crate entries to Cargo.lock, which invalidated the Rust compilation cache. The `integration-test-build` job needs ~29 minutes for a full rebuild, but the 30-minute timeout causes it to be cancelled before the post-job cache save runs. This creates a deadlock: every subsequent build also misses the cache and times out.

Bumping to 45 minutes lets the first cache-miss build complete and save, after which subsequent builds should return to ~10 minutes.