### PR TITLE
ci: increase integration-test-build timeout from 45 to 90 minutes

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -273,7 +273,7 @@ jobs:
     needs: skipcheck
     if: ${{ needs.skipcheck.outputs.skip == 'false' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     env:
       package-name: daft
     strategy:


### PR DESCRIPTION
The 45-minute timeout from #6241 is still not enough — the build timed out again in [this run](https://github.com/Eventual-Inc/Daft/actions/runs/22172157962/job/64112220739) because the Rust cache (`Swatinem/rust-cache`) missed entirely, forcing a cold build of all 676 crates. Bumping to 90 minutes so the cold build can complete and repopulate the cache.

Longer term we should investigate `sccache` or larger runners to make cold builds more robust.