### PR TITLE
ci: replace Swatinem/rust-cache with sccache for integration-test-build

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -299,10 +299,8 @@ jobs:
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
-    - uses: Swatinem/rust-cache@v2
-      with:
-        prefix-key: ${{ runner.os }}-integration-build
-        cache-all-crates: "true"
+    - name: Run sccache-cache
+      uses: mozilla-actions/sccache-action@v0.0.9
     - uses: actions/setup-node@v6
       with:
         node-version: "22"
@@ -319,6 +317,9 @@ jobs:
       run: |
         source .venv/bin/activate
         maturin build --release --compatibility linux --out dist
+      env:
+        SCCACHE_GHA_ENABLED: "true"
+        RUSTC_WRAPPER: "sccache"
     - name: Upload wheels
       uses: actions/upload-artifact@v6
       with:


### PR DESCRIPTION
Replaces `Swatinem/rust-cache` with `mozilla-actions/sccache-action` for the `integration-test-build` job. The Rust cache has been getting evicted frequently (repo is at ~9 GB of the 10 GB GitHub Actions cache limit), causing full cold builds that exceed the job timeout ([example](https://github.com/Eventual-Inc/Daft/actions/runs/22172157962/job/64112220739)).

sccache caches individual compilation units rather than the entire `target/` directory, which means:
- ~3-5x smaller cache footprint (300-500 MB vs 1.5 GB)
- Graceful degradation on partial eviction (vs all-or-nothing with Swatinem)
- Cross-job cache sharing by content hash (a crate compiled in `unit-test` is reusable by `integration-test-build`)

This is scoped to `integration-test-build` only as an experiment. If successful, we can roll it out to the other jobs. Previous attempts (#3145, #4338) targeted the release wheel-building workflows on BuildJet runners, not the PR test suite — this is the first attempt on the GHA-hosted jobs where eviction is the actual bottleneck.

See #6244