### PR TITLE
refactor(arrow2): replace arrow2 based buffer with custom impl

### DIFF
--- a/src/daft-core/src/array/ops/concat.rs
+++ b/src/daft-core/src/array/ops/concat.rs
@@ -105,7 +105,9 @@ where
 #[cfg(feature = "python")]
 impl PythonArray {
     pub fn concat(arrays: &[&Self]) -> DaftResult<Self> {
-        use daft_arrow::buffer::{Buffer, NullBufferBuilder};
+        use daft_arrow::buffer::NullBufferBuilder;
+
+        use crate::datatypes::python::PythonBuffer;
         if arrays.is_empty() {
             return Err(DaftError::ValueError(
                 "Need at least 1 array to perform concat".to_string(),
@@ -138,7 +140,10 @@ impl PythonArray {
             None
         };
 
-        let values = Buffer::from_iter(arrays.iter().flat_map(|a| a.values().iter().cloned()));
+        let values: PythonBuffer = arrays
+            .iter()
+            .flat_map(|a| a.values().iter().cloned())
+            .collect();
 
         Ok(Self::new(field, values, nulls))
     }

--- a/src/daft-core/src/array/ops/full.rs
+++ b/src/daft-core/src/array/ops/full.rs
@@ -185,7 +185,7 @@ impl FullNull for PythonArray {
 
     fn empty(name: &str, dtype: &DataType) -> Self {
         let field = Arc::new(Field::new(name, dtype.clone()));
-        Self::new(field, daft_arrow::buffer::Buffer::new(), None)
+        Self::new(field, Vec::new().into(), None)
     }
 }
 

--- a/src/daft-core/src/datatypes/python.rs
+++ b/src/daft-core/src/datatypes/python.rs
@@ -1,13 +1,8 @@
-use std::sync::Arc;
+use std::{fmt, ops::Deref, sync::Arc};
 
-use arrow::array::ArrayRef;
+use arrow::{array::ArrayRef, buffer::NullBuffer};
 use common_error::{DaftError, DaftResult};
 use common_py_serde::pickle_dumps;
-use daft_arrow::{
-    array::Array,
-    bitmap::utils::ZipValidity,
-    buffer::{Buffer, NullBuffer},
-};
 use daft_schema::{dtype::DataType, field::Field};
 use pyo3::{Py, PyAny, PyResult, Python};
 
@@ -16,10 +11,79 @@ use crate::{
     series::{ArrayWrapper, IntoSeries, Series},
 };
 
+/// A lightweight buffer for holding `Arc<Py<PyAny>>` values, replacing
+/// `arrow2::buffer::Buffer<Arc<Py<PyAny>>>` which cannot be represented
+/// by arrow-rs's byte-oriented `Buffer`.
+#[derive(Clone)]
+pub struct PythonBuffer {
+    data: Arc<Vec<Arc<Py<PyAny>>>>,
+    offset: usize,
+    length: usize,
+}
+
+impl PythonBuffer {
+    /// Returns an O(1) sliced view of this buffer.
+    pub fn sliced(self, offset: usize, length: usize) -> Self {
+        assert!(
+            offset + length <= self.length,
+            "slice {}..{} out of bounds for buffer of length {}",
+            offset,
+            offset + length,
+            self.length
+        );
+        Self {
+            data: self.data,
+            offset: self.offset + offset,
+            length,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.length
+    }
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+}
+
+impl From<Vec<Arc<Py<PyAny>>>> for PythonBuffer {
+    fn from(vec: Vec<Arc<Py<PyAny>>>) -> Self {
+        let length = vec.len();
+        Self {
+            data: Arc::new(vec),
+            offset: 0,
+            length,
+        }
+    }
+}
+
+impl FromIterator<Arc<Py<PyAny>>> for PythonBuffer {
+    fn from_iter<I: IntoIterator<Item = Arc<Py<PyAny>>>>(iter: I) -> Self {
+        Vec::from_iter(iter).into()
+    }
+}
+
+impl Deref for PythonBuffer {
+    type Target = [Arc<Py<PyAny>>];
+
+    fn deref(&self) -> &[Arc<Py<PyAny>>] {
+        &self.data[self.offset..self.offset + self.length]
+    }
+}
+
+impl fmt::Debug for PythonBuffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PythonBuffer")
+            .field("len", &self.length)
+            .field("offset", &self.offset)
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PythonArray {
     field: Arc<Field>,
-    values: Buffer<Arc<Py<PyAny>>>,
+    values: PythonBuffer,
     nulls: Option<NullBuffer>,
 }
 
@@ -35,11 +99,7 @@ impl PythonArray {
     /// Create a new PythonArray.
     ///
     /// Elements in `values` that are None must have validity set to false.
-    pub fn new(
-        field: Arc<Field>,
-        values: Buffer<Arc<Py<PyAny>>>,
-        nulls: Option<NullBuffer>,
-    ) -> Self {
+    pub fn new(field: Arc<Field>, values: PythonBuffer, nulls: Option<NullBuffer>) -> Self {
         assert_eq!(
             field.dtype,
             DataType::Python,
@@ -95,7 +155,10 @@ impl PythonArray {
     pub fn to_arrow2(&self) -> DaftResult<Box<dyn daft_arrow::array::Array>> {
         let arrow_logical_type = self.data_type().to_arrow2().unwrap();
         let physical_arrow_array = self.to_pickled_arrow2()?;
-        let logical_arrow_array = physical_arrow_array.convert_logical_type(arrow_logical_type);
+        let logical_arrow_array = daft_arrow::array::Array::convert_logical_type(
+            &physical_arrow_array,
+            arrow_logical_type,
+        );
         Ok(logical_arrow_array)
     }
 
@@ -143,7 +206,7 @@ impl PythonArray {
         Ok(Self::new(self.field.clone(), new_values, new_nulls))
     }
 
-    pub fn values(&self) -> &Buffer<Arc<Py<PyAny>>> {
+    pub fn values(&self) -> &PythonBuffer {
         &self.values
     }
 
@@ -184,7 +247,14 @@ impl PythonArray {
     }
 
     pub fn iter(&self) -> impl Iterator<Item = Option<&Arc<Py<PyAny>>>> {
-        ZipValidity::new(self.values.iter(), self.nulls().map(|v| v.iter()))
+        let nulls = self.nulls.clone();
+        self.values.iter().enumerate().map(move |(i, v)| {
+            if nulls.as_ref().is_none_or(|n| n.is_valid(i)) {
+                Some(v)
+            } else {
+                None
+            }
+        })
     }
 }
 


### PR DESCRIPTION
## Changes Made

replaces arrow2::Buffer with a custom lightweight buffer (`PythonBuffer`) that shares same behavior and performance characteristics. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
