### PR TITLE
refactor(arrow2): remove more arrow2 usages in daft-core

### DIFF
--- a/src/daft-core/src/array/ops/arithmetic.rs
+++ b/src/daft-core/src/array/ops/arithmetic.rs
@@ -1,6 +1,7 @@
 use std::{
     iter::zip,
     ops::{Add, Div, Mul, Rem, Sub},
+    sync::Arc,
 };
 
 use arrow::buffer::NullBuffer;
@@ -147,15 +148,12 @@ impl Add for &FixedSizeBinaryArray {
     }
 }
 
-#[allow(
-    deprecated,
-    reason = "arrow2->arrow migration: add_utf8_arrays still uses arrow2"
-)]
 impl Add for &Utf8Array {
     type Output = DaftResult<Utf8Array>;
     fn add(self, rhs: Self) -> Self::Output {
-        let result = Box::new(add_utf8_arrays(self.as_arrow2(), rhs.as_arrow2())?);
-        Ok(Utf8Array::new(Field::new(self.name(), DataType::Utf8).into(), result).unwrap())
+        let result = Arc::new(add_utf8_arrays(&self.as_arrow()?, &rhs.as_arrow()?)?);
+
+        Utf8Array::from_arrow(Field::new(self.name(), DataType::Utf8), result)
     }
 }
 

--- a/src/daft-core/src/kernels/utf8.rs
+++ b/src/daft-core/src/kernels/utf8.rs
@@ -3,8 +3,8 @@
 // src/array/ops/utf8.rs instead
 // ****************************************************************************************
 
+use arrow::array::{Array, LargeStringArray};
 use common_error::{DaftError, DaftResult};
-use daft_arrow::array::Utf8Array;
 
 fn concat_strings(l: &str, r: &str) -> String {
     // fastest way to concat strings according to https://github.com/hoodie/concatenation_benchmarks-rs
@@ -14,49 +14,46 @@ fn concat_strings(l: &str, r: &str) -> String {
     s
 }
 
-fn add_utf8_scalar(arr: &Utf8Array<i64>, other: &str) -> DaftResult<Utf8Array<i64>> {
-    let result: Utf8Array<i64> = arr
+fn add_utf8_scalar(arr: &LargeStringArray, other: &str) -> DaftResult<LargeStringArray> {
+    let result: LargeStringArray = arr
         .into_iter()
         .map(|v| v.map(|v| concat_strings(v, other)))
         .collect();
     Ok(result)
 }
 
-fn add_scalar_utf8(prefix: &str, arr: &Utf8Array<i64>) -> DaftResult<Utf8Array<i64>> {
-    let result: Utf8Array<i64> = arr
+fn add_scalar_utf8(prefix: &str, arr: &LargeStringArray) -> DaftResult<LargeStringArray> {
+    let result: LargeStringArray = arr
         .into_iter()
         .map(|v| v.map(|v| concat_strings(prefix, v)))
         .collect();
     Ok(result)
 }
 
-pub fn add_utf8_arrays(lhs: &Utf8Array<i64>, rhs: &Utf8Array<i64>) -> DaftResult<Utf8Array<i64>> {
+pub fn add_utf8_arrays(
+    lhs: &LargeStringArray,
+    rhs: &LargeStringArray,
+) -> DaftResult<LargeStringArray> {
     if rhs.len() == 1 {
-        let is_valid = match rhs.validity() {
-            Some(nulls) => nulls.get_bit(0),
+        let is_valid = match rhs.nulls() {
+            Some(nulls) => nulls.is_valid(0),
             None => true,
         };
 
         return match is_valid {
             true => add_utf8_scalar(lhs, rhs.value(0)),
-            false => Ok(Utf8Array::new_null(
-                daft_arrow::datatypes::DataType::LargeUtf8,
-                lhs.len(),
-            )),
+            false => Ok(LargeStringArray::new_null(lhs.len())),
         };
     }
     if lhs.len() == 1 {
-        let is_valid = match lhs.validity() {
-            Some(nulls) => nulls.get_bit(0),
+        let is_valid = match lhs.nulls() {
+            Some(nulls) => nulls.is_valid(0),
             None => true,
         };
 
         return match is_valid {
             true => add_scalar_utf8(lhs.value(0), rhs),
-            false => Ok(Utf8Array::new_null(
-                daft_arrow::datatypes::DataType::LargeUtf8,
-                rhs.len(),
-            )),
+            false => Ok(LargeStringArray::new_null(rhs.len())),
         };
     }
 
@@ -68,7 +65,7 @@ pub fn add_utf8_arrays(lhs: &Utf8Array<i64>, rhs: &Utf8Array<i64>) -> DaftResult
         )));
     }
 
-    let result: Utf8Array<i64> = lhs
+    let result: LargeStringArray = lhs
         .into_iter()
         .zip(rhs)
         .map(|(l, r)| match (l, r) {
@@ -85,8 +82,8 @@ mod tests {
 
     #[test]
     fn check_add_utf_arrays() -> DaftResult<()> {
-        let l = Utf8Array::<i64>::from(vec!["a".into(), "b".into(), "c".into()]);
-        let r = Utf8Array::<i64>::from(vec!["1".into(), "2".into(), "3".into()]);
+        let l = LargeStringArray::from_iter_values(vec!["a", "b", "c"]);
+        let r = LargeStringArray::from_iter_values(vec!["1", "2", "3"]);
         let result = add_utf8_arrays(&l, &r)?;
         assert_eq!(result.len(), 3);
         assert_eq!(result.value(0), "a1");
@@ -97,8 +94,8 @@ mod tests {
 
     #[test]
     fn check_add_utf_arrays_broadcast_left() -> DaftResult<()> {
-        let l = Utf8Array::<i64>::from(vec!["a".into()]);
-        let r = Utf8Array::<i64>::from(vec!["1".into(), "2".into(), "3".into()]);
+        let l = LargeStringArray::from_iter_values(vec!["a"]);
+        let r = LargeStringArray::from_iter_values(vec!["1", "2", "3"]);
         let result = add_utf8_arrays(&l, &r)?;
         assert_eq!(result.len(), 3);
         assert_eq!(result.value(0), "a1");
@@ -109,8 +106,8 @@ mod tests {
 
     #[test]
     fn check_add_utf_arrays_broadcast_right() -> DaftResult<()> {
-        let l = Utf8Array::<i64>::from(vec!["a".into(), "b".into(), "c".into()]);
-        let r = Utf8Array::<i64>::from(vec!["1".into()]);
+        let l = LargeStringArray::from_iter_values(vec!["a", "b", "c"]);
+        let r = LargeStringArray::from_iter_values(vec!["1"]);
         let result = add_utf8_arrays(&l, &r)?;
         assert_eq!(result.len(), 3);
         assert_eq!(result.value(0), "a1");


### PR DESCRIPTION
## Changes Made

- refactors `add_utf8_arrays` to use arrow-rs
- removes various arrow2 references from `cast.rs` 
  - note: cast isnt fully refactored, this was just a quick drive-by for the easy stuff.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
