### PR TITLE
refactor(arrow2): migrate concat.rs to arrow-rs

### DIFF
--- a/src/daft-core/src/array/ops/concat.rs
+++ b/src/daft-core/src/array/ops/concat.rs
@@ -1,70 +1,8 @@
-use std::sync::Arc;
-
 use common_error::{DaftError, DaftResult};
-use daft_arrow::array::Array;
 
 #[cfg(feature = "python")]
 use crate::prelude::PythonArray;
-use crate::{array::DataArray, datatypes::DaftPhysicalType, prelude::FromArrow};
-
-macro_rules! impl_variable_length_concat {
-    ($fn_name:ident, $arrow_type:ty, $create_fn: ident) => {
-        fn $fn_name(arrays: &[&dyn daft_arrow::array::Array]) -> DaftResult<Box<$arrow_type>> {
-            let mut num_rows: usize = 0;
-            let mut num_bytes: usize = 0;
-            let mut need_validity = false;
-            for arr in arrays {
-                let arr = arr.as_any().downcast_ref::<$arrow_type>().unwrap();
-
-                num_rows += arr.len();
-                num_bytes += arr.values().len();
-                need_validity |= arr.validity().map(|v| v.unset_bits() > 0).unwrap_or(false);
-            }
-            let mut offsets = daft_arrow::offset::Offsets::<i64>::with_capacity(num_rows);
-
-            let mut nulls = if need_validity {
-                Some(daft_arrow::buffer::NullBufferBuilder::new(num_rows))
-            } else {
-                None
-            };
-            let mut buffer = Vec::<u8>::with_capacity(num_bytes);
-
-            for arr in arrays {
-                let arr = arr.as_any().downcast_ref::<$arrow_type>().unwrap();
-                offsets.try_extend_from_slice(arr.offsets(), 0, arr.len())?;
-                if let Some(ref mut bitmap) = nulls {
-                    if let Some(v) = arr.validity() {
-                        for b in v.iter() {
-                            // TODO: Replace with .append_buffer in v57.1.0
-                            bitmap.append(b);
-                        }
-                    } else {
-                        bitmap.append_n_non_nulls(arr.len());
-                    }
-                }
-                let range = (*arr.offsets().first() as usize)..(*arr.offsets().last() as usize);
-                buffer.extend_from_slice(&arr.values().as_slice()[range]);
-            }
-            let dtype = arrays.first().unwrap().data_type().clone();
-            #[allow(unused_unsafe)]
-            let result_array = unsafe {
-                <$arrow_type>::$create_fn(
-                    dtype,
-                    offsets.into(),
-                    buffer.into(),
-                    daft_arrow::buffer::wrap_null_buffer(nulls.map(|mut v| v.finish()).flatten()),
-                )
-            }?;
-            Ok(Box::new(result_array))
-        }
-    };
-}
-impl_variable_length_concat!(
-    utf8_concat,
-    daft_arrow::array::Utf8Array<i64>,
-    try_new_unchecked
-);
-impl_variable_length_concat!(binary_concat, daft_arrow::array::BinaryArray<i64>, try_new);
+use crate::{array::DataArray, datatypes::DaftPhysicalType};
 
 impl<T> DataArray<T>
 where
@@ -78,36 +16,28 @@ where
         }
 
         if arrays.len() == 1 {
-            return Ok((*arrays.first().unwrap()).clone());
+            return Ok(arrays[0].clone());
         }
 
-        let field = &arrays.first().unwrap().field;
+        let field = &arrays[0].field;
 
-        let arrow_arrays: Vec<_> = arrays.iter().map(|s| s.data.as_ref()).collect();
-        match field.dtype {
-            crate::datatypes::DataType::Utf8 => {
-                let cat_array = utf8_concat(arrow_arrays.as_slice())?;
-                Self::new(field.clone(), cat_array)
-            }
-            crate::datatypes::DataType::Binary => {
-                let cat_array = binary_concat(arrow_arrays.as_slice())?;
-                Self::new(field.clone(), cat_array)
-            }
-            _ => {
-                let cat_array: Box<dyn Array> =
-                    daft_arrow::compute::concatenate::concatenate(arrow_arrays.as_slice())?;
-                Self::from_arrow2(field.clone(), cat_array)
-            }
-        }
+        let arrow_arrays: Vec<_> = arrays.iter().map(|s| s.to_arrow()).collect();
+        let arrow_refs: Vec<&dyn arrow::array::Array> =
+            arrow_arrays.iter().map(|a| a.as_ref()).collect();
+        let cat_array = arrow::compute::concat(&arrow_refs)?;
+        Self::from_arrow(field.clone(), cat_array)
     }
 }
 
 #[cfg(feature = "python")]
 impl PythonArray {
     pub fn concat(arrays: &[&Self]) -> DaftResult<Self> {
-        use daft_arrow::buffer::NullBufferBuilder;
+        use std::sync::Arc;
+
+        use arrow::array::NullBufferBuilder;
 
         use crate::datatypes::python::PythonBuffer;
+
         if arrays.is_empty() {
             return Err(DaftError::ValueError(
                 "Need at least 1 array to perform concat".to_string(),
@@ -115,10 +45,10 @@ impl PythonArray {
         }
 
         if arrays.len() == 1 {
-            return Ok((*arrays.first().unwrap()).clone());
+            return Ok(arrays[0].clone());
         }
 
-        let field = Arc::new(arrays.first().unwrap().field().clone());
+        let field = Arc::new(arrays[0].field().clone());
 
         let nulls = if arrays.iter().any(|a| a.nulls().is_some()) {
             let total_len = arrays.iter().map(|a| a.len()).sum();

--- a/src/daft-core/src/datatypes/python.rs
+++ b/src/daft-core/src/datatypes/python.rs
@@ -246,10 +246,10 @@ impl PythonArray {
         self.slice(0, num)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = Option<&Arc<Py<PyAny>>>> {
-        let nulls = self.nulls.clone();
+    pub fn iter(&self) -> impl Iterator<Item = Option<&Arc<Py<PyAny>>>> + '_ {
+        let nulls = self.nulls.as_ref();
         self.values.iter().enumerate().map(move |(i, v)| {
-            if nulls.as_ref().is_none_or(|n| n.is_valid(i)) {
+            if nulls.is_none_or(|n| n.is_valid(i)) {
                 Some(v)
             } else {
                 None


### PR DESCRIPTION
Remove the `impl_variable_length_concat` macro and its specialized UTF-8/Binary concat functions that operated on arrow2 types directly (`Utf8Array<i64>`, `BinaryArray<i64>`, `Offsets<i64>`, `wrap_null_buffer`). All concat paths now use `arrow::compute::concat`, eliminating the type-specific dispatch. Also switches `PythonArray::concat` to import `NullBufferBuilder` from arrow-rs directly instead of the `daft_arrow` re-export, and removes an unnecessary `NullBuffer` clone in `PythonArray::iter()`.

After this change, `concat.rs` has zero `arrow2` / `daft_arrow` references.