### PR TITLE
refactor(arrow2): migrate BooleanArray bitmap access to arrow-rs

### DIFF
--- a/src/daft-core/src/array/boolean.rs
+++ b/src/daft-core/src/array/boolean.rs
@@ -5,12 +5,7 @@ use crate::datatypes::BooleanArray;
 
 impl BooleanArray {
     pub fn to_bitmap(&self) -> BooleanBuffer {
-        self.to_arrow()
-            .as_any()
-            .downcast_ref::<arrow::array::BooleanArray>()
-            .expect("BooleanArray data is always boolean")
-            .values()
-            .clone()
+        self.as_arrow().expect("BooleanArray").values().clone()
     }
     pub fn false_count(&self) -> usize {
         self.as_arrow().expect("BooleanArray").false_count()

--- a/src/daft-core/src/array/boolean.rs
+++ b/src/daft-core/src/array/boolean.rs
@@ -1,8 +1,14 @@
-use super::ops::as_arrow::AsArrow;
+use arrow::buffer::BooleanBuffer;
+
 use crate::datatypes::BooleanArray;
 
 impl BooleanArray {
-    pub fn as_bitmap(&self) -> &daft_arrow::bitmap::Bitmap {
-        self.as_arrow2().values()
+    pub fn to_bitmap(&self) -> BooleanBuffer {
+        self.to_arrow()
+            .as_any()
+            .downcast_ref::<arrow::array::BooleanArray>()
+            .expect("BooleanArray data is always boolean")
+            .values()
+            .clone()
     }
 }

--- a/src/daft-core/src/array/values.rs
+++ b/src/daft-core/src/array/values.rs
@@ -40,13 +40,14 @@ impl BooleanArray {
     /// NOTE: this will error if there are any null values.
     /// If you need to handle nulls, use the `.iter()` method instead.
     pub fn values(&self) -> DaftResult<impl Iterator<Item = bool>> {
-        let arrow2_arr = self.as_arrow2();
         if self.null_count() > 0 {
             return Err(DaftError::ComputeError(
                 "BooleanArray::values with nulls".to_string(),
             ));
         }
-        Ok(arrow2_arr.values_iter())
+        let bitmap = self.to_bitmap();
+        let len = bitmap.len();
+        Ok((0..len).map(move |i| bitmap.value(i)))
     }
 }
 

--- a/src/daft-core/src/series/serdes.rs
+++ b/src/daft-core/src/series/serdes.rs
@@ -178,7 +178,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                             .map(|s| s.unwrap())
                             .collect::<Vec<_>>();
 
-                        let nulls = nulls.map(|v| v.bool().unwrap().as_bitmap().clone().into());
+                        let nulls = nulls.map(|v| v.bool().unwrap().to_bitmap().into());
                         Ok(StructArray::new(Arc::new(field), children, nulls).into_series())
                     }
                     DataType::List(..) => {
@@ -186,7 +186,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                         let nulls = all_series
                             .pop()
                             .ok_or_else(|| serde::de::Error::missing_field("validity"))?;
-                        let nulls = nulls.map(|v| v.bool().unwrap().as_bitmap().clone().into());
+                        let nulls = nulls.map(|v| v.bool().unwrap().to_bitmap().into());
                         let offsets_series = all_series
                             .pop()
                             .ok_or_else(|| serde::de::Error::missing_field("offsets"))?
@@ -209,7 +209,7 @@ impl<'d> serde::Deserialize<'d> for Series {
                             .ok_or_else(|| serde::de::Error::missing_field("flat_child"))?
                             .unwrap();
 
-                        let nulls = nulls.map(|v| v.bool().unwrap().as_bitmap().clone().into());
+                        let nulls = nulls.map(|v| v.bool().unwrap().to_bitmap().into());
                         Ok(FixedSizeListArray::new(field, flat_child, nulls).into_series())
                     }
                     DataType::Decimal128(..) => Ok(Decimal128Array::from_iter(


### PR DESCRIPTION
Migrates `BooleanArray`'s bitmap access from arrow2 `Bitmap` to arrow-rs `BooleanBuffer`, eliminating `daft_arrow::bitmap` and `as_arrow2()` usage from `boolean.rs`, `iterator.rs`, `values.rs`, `serdes.rs`, and `RecordBatch` filter row counting.

## Changes Made

- **`BooleanArray::as_bitmap()` → `to_bitmap()`**: Returns an owned `BooleanBuffer` via zero-copy FFI conversion (`to_arrow()` + downcast + `values().clone()`). Renamed from `as_*` to `to_*` to reflect owned return value per Rust convention.
- **`BooleanIter`**: Stores owned `BooleanBuffer` instead of borrowed `&arrow2::Bitmap`. Uses `BooleanBuffer::value(i)` instead of `Bitmap::get_bit(i)`. Removes the arrow2 TODO comment.
- **`BooleanArray::values()`**: Uses `to_bitmap()` instead of `as_arrow2().values_iter()`.
- **`serdes.rs`**: Drops `.clone()` since `to_bitmap()` returns owned value.
- **`RecordBatch::filter_mask`**: Replaces `daft_arrow::bitmap::and()` + `.unset_bits()` with arrow-rs `BitAnd` on `BooleanBuffer` + `count_set_bits()`.

Addresses #5741