### PR TITLE
refactor(arrow2): remove as_arrow2 from ops/get

### DIFF
--- a/src/daft-core/src/array/serdes.rs
+++ b/src/daft-core/src/array/serdes.rs
@@ -223,7 +223,9 @@ impl serde::Serialize for IntervalArray {
         s.serialize_entry("field", self.field())?;
         s.serialize_entry(
             "values",
-            &IterSer::new((0..self.len()).map(|i| self.get(i))),
+            &IterSer::new(
+                (0..self.len()).map(|i| self.get(i).map(|i| (i.months, i.days, i.nanoseconds))),
+            ),
         )?;
         s.end()
     }

--- a/src/daft-core/src/datatypes/interval.rs
+++ b/src/daft-core/src/datatypes/interval.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Display, ops::Neg};
 
+use arrow::datatypes::IntervalMonthDayNano;
 use common_error::DaftResult;
 use daft_arrow::types::months_days_ns;
 #[cfg(feature = "python")]
@@ -231,6 +232,15 @@ impl From<months_days_ns> for IntervalValue {
             months: value.months(),
             days: value.days(),
             nanoseconds: value.ns(),
+        }
+    }
+}
+impl From<IntervalMonthDayNano> for IntervalValue {
+    fn from(value: IntervalMonthDayNano) -> Self {
+        Self {
+            months: value.months,
+            days: value.days,
+            nanoseconds: value.nanoseconds,
         }
     }
 }

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -2,11 +2,7 @@ mod agg_ops;
 mod infer_datatype;
 mod matching;
 
-use arrow::{
-    array::ArrowNumericType,
-    buffer::{Buffer, ScalarBuffer},
-    datatypes::ArrowNativeType,
-};
+use arrow::{array::ArrowNumericType, buffer::ScalarBuffer, datatypes::ArrowNativeType};
 pub use infer_datatype::InferDataType;
 pub mod prelude;
 use std::ops::{Add, Div, Mul, Rem, Sub};
@@ -470,7 +466,7 @@ impl<T: DaftPrimitiveType> DataArray<T> {
 
     pub fn values(&self) -> ScalarBuffer<T::Native> {
         // this is fully zero copy to convert the values into an arrow-rs ScalarBuffer
-        let arrow_buffer = Buffer::from(self.as_arrow2().values().clone());
-        ScalarBuffer::from(arrow_buffer)
+        let buffer = self.as_arrow().unwrap().values().clone();
+        ScalarBuffer::from(buffer.into_inner())
     }
 }

--- a/src/daft-functions/src/length.rs
+++ b/src/daft-functions/src/length.rs
@@ -81,42 +81,6 @@ impl ScalarUDF for Length {
                 )));
             }
         })
-
-        // let (offsets, validity) = match input.data_type() {
-        //     DataType::Binary => {
-        //         let arrow_arr = input.binary()?.as_arrow2();
-        //         (arrow_arr.offsets(), arrow_arr.validity())
-        //     }
-        //     DataType::List(_) => {
-        //         let list_arr = input.list()?;
-        //         (list_arr.offsets(), list_arr.validity())
-        //     }
-        //     DataType::FixedSizeBinary(length) | DataType::FixedSizeList(_, length) => {
-        //         let validity = input.validity();
-
-        //         let length_arr =
-        //             UInt64Array::from((input.name(), vec![*length as u64; input.len()]))
-        //                 .with_validity(validity.cloned())?;
-
-        //         return Ok(length_arr.into_series());
-        //     }
-        //     DataType::Utf8 => {
-        //         let arrow_arr = input.utf8()?.as_arrow2();
-        //         (arrow_arr.offsets(), arrow_arr.validity())
-        //     }
-        //     DataType::Null => return Ok(input),
-        //     dtype => {
-        //         return Err(DaftError::TypeError(format!(
-        //             "Expected input to 'length' function to be utf8, binary, or list, but received {}",
-        //             dtype
-        //         )));
-        //     }
-        // };
-
-        // let length_vec = offsets.lengths().map(|l| l as u64).collect::<Vec<_>>();
-        // let length_arr =
-        //     UInt64Array::from((input.name(), length_vec)).with_validity(validity.cloned())?;
-        // Ok(length_arr.into_series())
     }
 
     fn get_return_field(


### PR DESCRIPTION
## Changes Made

Note, this doesnt fully refactor ops/get as theres some dependency on the actual `data` migration to get references for `&str` or `&[u8]`. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
