### PR TITLE
ci: cache workspace crate artifacts in integration build

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -338,7 +338,10 @@ jobs:
       with:
         shared-key: ${{ runner.os }}-integration-build
         cache-all-crates: "true"
-        save-if: ${{ github.ref == 'refs/heads/main' }}
+        cache-workspace-crates: "true"
+        # TODO: revert to main-only before merge:
+        # save-if: ${{ github.ref == 'refs/heads/main' }}
+        save-if: true
     - uses: actions/setup-node@v6
       with:
         node-version: "22"

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -339,9 +339,7 @@ jobs:
         shared-key: ${{ runner.os }}-integration-build
         cache-all-crates: "true"
         cache-workspace-crates: "true"
-        # TODO: revert to main-only before merge:
-        # save-if: ${{ github.ref == 'refs/heads/main' }}
-        save-if: true
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - uses: actions/setup-node@v6
       with:
         node-version: "22"


### PR DESCRIPTION
Add `cache-workspace-crates: "true"` to the Swatinem/rust-cache config for the integration-test-build job.

`cache-all-crates` only controls registry cleanup (downloaded `.crate` files and extracted sources in `~/.cargo/registry/`). Workspace crate fingerprints, build script outputs, and compiled `.rlib`/`.rmeta` artifacts in `target/` are cleaned by `cleanTargetDir()` during cache save — which builds its keep-list from `getPackagesOutsideWorkspaceRoot()`, explicitly excluding workspace members. This caused all ~70 local crates to recompile from scratch every run (~25 min at `opt-level=3`).

`cache-workspace-crates: "true"` adds workspace members to the keep-list so their artifacts survive the save cleanup.

## Results

Tested on this PR with temporary `save-if: true` to bootstrap the cache:

| Metric | Cold cache | Warm cache |
|---|---|---|
| Cache restore | 2s | 21s |
| Build wheels | **36 min** | **10 sec** |
| Total job | ~37 min | ~1 min 41 sec |

Combined with the restore-mtime fix from #6246 (source file mtimes older than cached dep-info mtimes), cargo now sees all workspace crates as fresh.

See #6244, #6246.