### PR TITLE
ci: cache workspace crates and share rust caches across all workflows

### DIFF
--- a/.github/actions/restore-mtime/action.yaml
+++ b/.github/actions/restore-mtime/action.yaml
@@ -41,11 +41,15 @@ runs:
       #
       # touch -d "@epoch" is GNU-specific (Linux). macOS/BSD touch doesn't
       # support -d, so we fall back to touch -t with a formatted timestamp.
-      if touch -d @0 /dev/null 2>/dev/null; then
+      # Detection uses a temp file because /dev/null is root-owned and
+      # utimensat() requires ownership to change timestamps.
+      _tf=$(mktemp)
+      if touch -d @0 "$_tf" 2>/dev/null; then
         touch_epoch() { touch -d "@$1" "$2"; }
       else
         touch_epoch() { touch -t "$(date -r "$1" +%Y%m%d%H%M.%S)" "$2"; }
       fi
+      rm -f "$_tf"
       git log --raw --no-renames --no-merges --pretty=%ct --reverse \
         | awk '/^[0-9]+$/{t=$0;next} /^:[0-9]/{f=substr($0,index($0,"\t")+1); c[f]=t} END{for(f in c) printf "%s\t%s\n",c[f],f}' \
         | while IFS=$'\t' read -r ts file; do [ -f "$file" ] && touch_epoch "$ts" "$file"; done

--- a/.github/actions/restore-mtime/action.yaml
+++ b/.github/actions/restore-mtime/action.yaml
@@ -1,0 +1,44 @@
+name: Restore file mtimes from git history
+description: >
+  Restore each file's mtime to its last-commit timestamp so that cargo
+  fingerprints remain valid when the target/ directory is cached across
+  CI runs. Requires fetch-depth: 0 on the checkout step.
+runs:
+  using: composite
+  steps:
+  - name: Restore file mtimes for cargo fingerprinting
+    shell: bash
+    run: |
+      # actions/checkout sets all file mtimes to the checkout time, which
+      # invalidates cargo fingerprints and forces a full rebuild even when
+      # the cached target/ dir is restored.
+      #
+      # This pipeline walks the full git history to restore each file's
+      # mtime to its last-commit timestamp so cargo fingerprints match.
+      #
+      # git log outputs commits oldest-first (--reverse), each as:
+      #   <unix timestamp>       (--pretty=%ct: committer date in epoch seconds)
+      #   :<mode info> M\tfile   (--raw: one line per file touched in that commit)
+      #
+      # --no-merges: skips merge commits, whose combined diff omits cleanly
+      #   merged files — regular commits on each branch reliably list all
+      #   files they touched.
+      # --no-renames: prevents git from collapsing renames into a single
+      #   "R old\tnew" line that would break the awk tab parsing.
+      #
+      # awk processes line by line:
+      #   /^[0-9]+$/  — timestamp line: save in variable t
+      #   /^:[0-9]/   — raw diff line: extract filename (everything after
+      #                  the first tab) and map it to t in associative array c.
+      #                  Later commits overwrite earlier ones, so each file
+      #                  ends up with its most recent commit timestamp.
+      #   END         — print all "timestamp\tfilename" pairs.
+      #
+      # while loop reads each pair and touches the file with that timestamp.
+      #   IFS=$'\t'   — split on tab into ts and file
+      #   -r          — don't interpret backslashes in filenames as escapes
+      #   [ -f ]      — skip files that no longer exist on disk (deletions)
+      #   @$ts        — the @ tells touch to interpret the value as epoch seconds
+      git log --raw --no-renames --no-merges --pretty=%ct --reverse \
+        | awk '/^[0-9]+$/{t=$0;next} /^:[0-9]/{f=substr($0,index($0,"\t")+1); c[f]=t} END{for(f in c) printf "%s\t%s\n",c[f],f}' \
+        | while IFS=$'\t' read -r ts file; do [ -f "$file" ] && touch -d "@$ts" "$file"; done

--- a/.github/actions/restore-mtime/action.yaml
+++ b/.github/actions/restore-mtime/action.yaml
@@ -38,7 +38,14 @@ runs:
       #   IFS=$'\t'   — split on tab into ts and file
       #   -r          — don't interpret backslashes in filenames as escapes
       #   [ -f ]      — skip files that no longer exist on disk (deletions)
-      #   @$ts        — the @ tells touch to interpret the value as epoch seconds
+      #
+      # touch -d "@epoch" is GNU-specific (Linux). macOS/BSD touch doesn't
+      # support -d, so we fall back to touch -t with a formatted timestamp.
+      if touch -d @0 /dev/null 2>/dev/null; then
+        touch_epoch() { touch -d "@$1" "$2"; }
+      else
+        touch_epoch() { touch -t "$(date -r "$1" +%Y%m%d%H%M.%S)" "$2"; }
+      fi
       git log --raw --no-renames --no-merges --pretty=%ct --reverse \
         | awk '/^[0-9]+$/{t=$0;next} /^:[0-9]/{f=substr($0,index($0,"\t")+1); c[f]=t} END{for(f in c) printf "%s\t%s\n",c[f],f}' \
-        | while IFS=$'\t' read -r ts file; do [ -f "$file" ] && touch -d "@$ts" "$file"; done
+        | while IFS=$'\t' read -r ts file; do [ -f "$file" ] && touch_epoch "$ts" "$file"; done

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -41,13 +41,18 @@ jobs:
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ runner.os }}-build
+        shared-key: ${{ runner.os }}-dev-build
         cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -22,13 +22,18 @@ jobs:
     timeout-minutes: 45
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ runner.os }}-profile
+        shared-key: ${{ runner.os }}-integration-build
         cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -121,13 +121,18 @@ jobs:
         sudo rm -rf /opt/hostedtoolcache/node || true
 
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
     - uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: ${{ runner.os }}-build
+        shared-key: ${{ runner.os }}-dev-build
         cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Install cargo-llvm-cov
       if: matrix.coverage != false
       uses: taiki-e/install-action@cargo-llvm-cov
@@ -284,41 +289,7 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-    - name: Restore file mtimes for cargo fingerprinting
-      run: |
-        # actions/checkout sets all file mtimes to the checkout time, which
-        # invalidates cargo fingerprints and forces a full rebuild even when
-        # the cached target/ dir is restored.
-        #
-        # This pipeline walks the full git history to restore each file's
-        # mtime to its last-commit timestamp so cargo fingerprints match.
-        #
-        # git log outputs commits oldest-first (--reverse), each as:
-        #   <unix timestamp>       (--pretty=%ct: committer date in epoch seconds)
-        #   :<mode info> M\tfile   (--raw: one line per file touched in that commit)
-        #
-        # --no-merges: skips merge commits, whose combined diff omits cleanly
-        #   merged files — regular commits on each branch reliably list all
-        #   files they touched.
-        # --no-renames: prevents git from collapsing renames into a single
-        #   "R old\tnew" line that would break the awk tab parsing.
-        #
-        # awk processes line by line:
-        #   /^[0-9]+$/  — timestamp line: save in variable t
-        #   /^:[0-9]/   — raw diff line: extract filename (everything after
-        #                  the first tab) and map it to t in associative array c.
-        #                  Later commits overwrite earlier ones, so each file
-        #                  ends up with its most recent commit timestamp.
-        #   END         — print all "timestamp\tfilename" pairs.
-        #
-        # while loop reads each pair and touches the file with that timestamp.
-        #   IFS=$'\t'   — split on tab into ts and file
-        #   -r          — don't interpret backslashes in filenames as escapes
-        #   [ -f ]      — skip files that no longer exist on disk (deletions)
-        #   @$ts        — the @ tells touch to interpret the value as epoch seconds
-        git log --raw --no-renames --no-merges --pretty=%ct --reverse \
-          | awk '/^[0-9]+$/{t=$0;next} /^:[0-9]/{f=substr($0,index($0,"\t")+1); c[f]=t} END{for(f in c) printf "%s\t%s\n",c[f],f}' \
-          | while IFS=$'\t' read -r ts file; do [ -f "$file" ] && touch -d "@$ts" "$file"; done
+    - uses: ./.github/actions/restore-mtime
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -1255,15 +1226,19 @@ jobs:
       RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
     - uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: dev-bench
-        key: ${{ runner.os }}-benchmark-build
+        shared-key: ${{ runner.os }}-dev-bench-build
         cache-all-crates: "true"
+        cache-workspace-crates: "true"
         cache-provider: buildjet
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -1339,6 +1314,10 @@ jobs:
           on-main: false
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
+      if: ${{ matrix.os != 'Windows' }}
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
@@ -1348,8 +1327,10 @@ jobs:
         # skip on windows because it misses the cache and is very slow (~15 minutes)
       if: ${{ matrix.os != 'Windows' }}
       with:
-        key: ${{ runner.os }}-rust-build
+        shared-key: ${{ runner.os }}-dev-build
         cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Free Disk Space (Ubuntu)
       if: ${{ matrix.os == 'ubuntu' }}
       uses: jlumbroso/free-disk-space@main
@@ -1447,13 +1428,18 @@ jobs:
         sudo rm -rf /opt/hostedtoolcache/Ruby || true
         sudo rm -rf /opt/hostedtoolcache/node || true
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
     - uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: ${{ runner.os }}-build
+        shared-key: ${{ runner.os }}-dev-build
         cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -1538,13 +1524,19 @@ jobs:
           on-main: false
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
+      if: ${{ runner.os != 'Windows' }}
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
     - uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: ${{ runner.os }}-build
+        shared-key: ${{ runner.os }}-dev-build
         cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
@@ -1632,6 +1624,9 @@ jobs:
       python-version: "3.10"
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -1647,8 +1642,10 @@ jobs:
         cache: false
     - uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: ${{ runner.os }}-build
+        shared-key: ${{ runner.os }}-dev-build
         cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - uses: actions/cache@v5
       id: pre-commit-cache

--- a/.github/workflows/property-based-tests.yml
+++ b/.github/workflows/property-based-tests.yml
@@ -22,13 +22,18 @@ jobs:
         daft_runner: [ray, native]
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ runner.os }}-build
+        shared-key: ${{ runner.os }}-integration-build
         cache-all-crates: "true"
+        cache-workspace-crates: "true"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Setup Python ${{ matrix.python-version  }} and UV
       uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
Extract the inline restore-mtime script into a reusable composite action (`.github/actions/restore-mtime/`) and apply the full cargo cache treatment to all 10 jobs that use Swatinem/rust-cache:

- `fetch-depth: 0` on checkout (full history for mtime restoration)
- `restore-mtime` composite action (deterministic source file timestamps for cargo fingerprinting)
- `cache-workspace-crates: "true"` (preserve workspace crate artifacts in cache — the key fix from #6261)
- `shared-key` by cargo profile (consolidate caches instead of one per job)
- `save-if: main-only` (single source of truth, avoids PR cache pollution and LRU eviction)

Cache keys are shared by cargo profile:
- `Linux-dev-build`: unit-test, rust-tests, doctests, test-imports, style, docgen (build-docs.yml)
- `Linux-integration-build`: integration-test-build, profile-daft, property-based-tests
- `Linux-dev-bench-build`: benchmark-codspeed (buildjet, separate cache provider)

Previously each job maintained its own cache via `prefix-key`, resulting in ~8 separate cache entries for the same profile. Consolidating to 3 shared keys frees significant space against the 10 GB repo cache limit.

On the integration-test-build job (#6261), this approach reduced Build wheels from 36 min to 10 sec on warm cache. Expect similar improvements for unit-test (~8 min build) and benchmark-codspeed (~25 min compile + link).

See #6244, #6246, #6261.