### PR TITLE
ci: fix restore-mtime exit code when last file is deleted on macos runners

### DIFF
--- a/.github/actions/restore-mtime/action.yaml
+++ b/.github/actions/restore-mtime/action.yaml
@@ -37,7 +37,7 @@ runs:
       # while loop reads each pair and touches the file with that timestamp.
       #   IFS=$'\t'   — split on tab into ts and file
       #   -r          — don't interpret backslashes in filenames as escapes
-      #   [ -f ]      — skip files that no longer exist on disk (deletions)
+      #   if [ -f ]   — skip files that no longer exist on disk (deletions)
       #
       # touch -d "@epoch" is GNU-specific (Linux). macOS/BSD touch doesn't
       # support -d, so we fall back to touch -t with a formatted timestamp.
@@ -52,4 +52,4 @@ runs:
       rm -f "$_tf"
       git log --raw --no-renames --no-merges --pretty=%ct --reverse \
         | awk '/^[0-9]+$/{t=$0;next} /^:[0-9]/{f=substr($0,index($0,"\t")+1); c[f]=t} END{for(f in c) printf "%s\t%s\n",c[f],f}' \
-        | while IFS=$'\t' read -r ts file; do [ -f "$file" ] && touch_epoch "$ts" "$file"; done
+        | while IFS=$'\t' read -r ts file; do if [ -f "$file" ]; then touch_epoch "$ts" "$file"; fi; done

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -24,6 +24,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Temporary job to verify restore-mtime works on both Linux and macOS.
+  # TODO: Remove this job once verified.
+  test-restore-mtime:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/restore-mtime
+    - name: Verify file mtimes were restored
+      shell: bash
+      run: |
+        # Pick a file that has existed for a long time and check its mtime
+        # is older than the checkout time (i.e., restore-mtime did something)
+        checkout_time=$(date +%s)
+        file_mtime=$(stat -c %Y Cargo.toml 2>/dev/null || stat -f %m Cargo.toml)
+        echo "Cargo.toml mtime: $file_mtime ($(date -r "$file_mtime" 2>/dev/null || date -d "@$file_mtime" 2>/dev/null))"
+        echo "Checkout time:    $checkout_time"
+        if [ "$file_mtime" -ge "$checkout_time" ]; then
+          echo "ERROR: Cargo.toml mtime ($file_mtime) >= checkout time ($checkout_time)"
+          echo "restore-mtime did not work!"
+          exit 1
+        fi
+        echo "OK: Cargo.toml mtime is in the past, restore-mtime worked."
+
   skipcheck:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -24,35 +24,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Temporary job to verify restore-mtime works on both Linux and macOS.
-  # TODO: Remove this job once verified.
-  test-restore-mtime:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
-    - name: Verify file mtimes were restored
-      shell: bash
-      run: |
-        # Pick a file that has existed for a long time and check its mtime
-        # is older than the checkout time (i.e., restore-mtime did something)
-        checkout_time=$(date +%s)
-        file_mtime=$(stat -c %Y Cargo.toml 2>/dev/null || stat -f %m Cargo.toml)
-        echo "Cargo.toml mtime: $file_mtime ($(date -r "$file_mtime" 2>/dev/null || date -d "@$file_mtime" 2>/dev/null))"
-        echo "Checkout time:    $checkout_time"
-        if [ "$file_mtime" -ge "$checkout_time" ]; then
-          echo "ERROR: Cargo.toml mtime ($file_mtime) >= checkout time ($checkout_time)"
-          echo "restore-mtime did not work!"
-          exit 1
-        fi
-        echo "OK: Cargo.toml mtime is in the past, restore-mtime worked."
-
   skipcheck:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
GitHub Actions `shell: bash` runs with `set -eo pipefail`. The `[ -f "$file" ] && touch_epoch` pattern returns exit code 1 when the file doesn't exist on disk (deleted in a later commit), and if this happens on the last iteration of the while loop, `pipefail` propagates that exit code and kills the step.

Switch to `if/then/fi` so a non-existent file is a no-op with exit code 0.

Verified with a temporary smoke-test job on both `ubuntu-latest` (11s) and `macos-latest` (54s) that confirmed mtimes are correctly restored on both platforms.

Fixes the restore-mtime failures seen on macOS runners in #6264.