### PR TITLE
refactor(arrow2): switch to arrow-rs backed arrays

### DIFF
--- a/src/daft-core/src/array/ops/arithmetic.rs
+++ b/src/daft-core/src/array/ops/arithmetic.rs
@@ -151,7 +151,7 @@ impl Add for &FixedSizeBinaryArray {
 impl Add for &Utf8Array {
     type Output = DaftResult<Utf8Array>;
     fn add(self, rhs: Self) -> Self::Output {
-        let result = Arc::new(add_utf8_arrays(&self.as_arrow()?, &rhs.as_arrow()?)?);
+        let result = Arc::new(add_utf8_arrays(self.as_arrow()?, rhs.as_arrow()?)?);
 
         Utf8Array::from_arrow(Field::new(self.name(), DataType::Utf8), result)
     }

--- a/src/daft-core/src/array/ops/as_arrow.rs
+++ b/src/daft-core/src/array/ops/as_arrow.rs
@@ -1,8 +1,3 @@
-use daft_arrow::{
-    array::{self},
-    types::months_days_ns,
-};
-
 use crate::{
     array::{DataArray, FixedSizeListArray, ListArray, StructArray},
     datatypes::{
@@ -13,90 +8,65 @@ use crate::{
 };
 
 pub trait AsArrow {
-    type Arrow2Output;
     type ArrowOutput;
-
     /// This does not correct for the logical types and will just yield the physical type of the array.
     /// For example, a TimestampArray will yield an arrow Int64Array rather than a arrow Timestamp Array.
     /// To get a corrected arrow type, see `.to_arrow()`.
-    #[deprecated(note = "arrow2 migration")]
-    fn as_arrow2(&self) -> &Self::Arrow2Output;
-    fn as_arrow(&self) -> common_error::DaftResult<Self::ArrowOutput>;
+    fn as_arrow(&self) -> common_error::DaftResult<&Self::ArrowOutput>;
 }
 
 impl<T> AsArrow for DataArray<T>
 where
     T: DaftPrimitiveType,
 {
-    type Arrow2Output = array::PrimitiveArray<T::Native>;
     type ArrowOutput = arrow::array::PrimitiveArray<<T::Native as NumericNative>::ARROWTYPE>;
 
-    // For DataArray<T: DaftNumericType>, retrieve the underlying Arrow2 PrimitiveArray.
-    fn as_arrow2(&self) -> &Self::Arrow2Output {
-        self.data().as_any().downcast_ref().unwrap()
-    }
-
-    fn as_arrow(&self) -> common_error::DaftResult<Self::ArrowOutput> {
-        Ok(self
-            .to_arrow()
+    fn as_arrow(&self) -> common_error::DaftResult<&Self::ArrowOutput> {
+        self.data
             .as_any()
             .downcast_ref::<Self::ArrowOutput>()
             .ok_or_else(|| {
                 common_error::DaftError::TypeError(
                     "Failed to downcast to arrow array type".to_string(),
                 )
-            })?
-            .clone())
+            })
     }
 }
 
 macro_rules! impl_asarrow_dataarray {
-    ($da:ident, $arrow2_output:ty, $arrow_output:ty) => {
+    ($da:ident, $arrow_output:ty) => {
         impl AsArrow for $da {
-            type Arrow2Output = $arrow2_output;
             type ArrowOutput = $arrow_output;
 
-            fn as_arrow2(&self) -> &Self::Arrow2Output {
-                self.data().as_any().downcast_ref().unwrap()
-            }
-
-            fn as_arrow(&self) -> common_error::DaftResult<Self::ArrowOutput> {
-                Ok(self
-                    .to_arrow()
+            fn as_arrow(&self) -> common_error::DaftResult<&Self::ArrowOutput> {
+                self.data
                     .as_any()
                     .downcast_ref::<Self::ArrowOutput>()
                     .ok_or_else(|| {
                         common_error::DaftError::TypeError(
                             "Failed to downcast to arrow array type".to_string(),
                         )
-                    })?
-                    .clone())
+                    })
             }
         }
     };
 }
 
 macro_rules! impl_asarrow_logicalarray {
-    ($da:ident, $arrow2_output:ty, $arrow_output:ty) => {
+    ($da:ident, $arrow_output:ty) => {
         impl AsArrow for $da {
-            type Arrow2Output = $arrow2_output;
             type ArrowOutput = $arrow_output;
 
-            fn as_arrow2(&self) -> &Self::Arrow2Output {
-                self.physical.data().as_any().downcast_ref().unwrap()
-            }
-
-            fn as_arrow(&self) -> common_error::DaftResult<Self::ArrowOutput> {
-                let arrow_arr = self.to_arrow()?;
-                Ok(arrow_arr
+            fn as_arrow(&self) -> common_error::DaftResult<&Self::ArrowOutput> {
+                self.physical
+                    .data
                     .as_any()
                     .downcast_ref::<Self::ArrowOutput>()
                     .ok_or_else(|| {
                         common_error::DaftError::TypeError(
                             "Failed to downcast to arrow array type".to_string(),
                         )
-                    })?
-                    .clone())
+                    })
             }
         }
     };
@@ -104,94 +74,38 @@ macro_rules! impl_asarrow_logicalarray {
 macro_rules! impl_asarrow_nested {
     ($da:ident, $arrow_output:ty) => {
         impl AsArrow for $da {
-            type Arrow2Output = ();
             type ArrowOutput = $arrow_output;
 
-            fn as_arrow2(&self) -> &Self::Arrow2Output {
+            fn as_arrow(&self) -> common_error::DaftResult<&Self::ArrowOutput> {
                 unimplemented!()
-            }
-
-            fn as_arrow(&self) -> common_error::DaftResult<Self::ArrowOutput> {
-                let arrow_arr = self.to_arrow()?;
-                Ok(arrow_arr
-                    .as_any()
-                    .downcast_ref::<Self::ArrowOutput>()
-                    .ok_or_else(|| {
-                        common_error::DaftError::TypeError(
-                            "Failed to downcast to arrow array type".to_string(),
-                        )
-                    })?
-                    .clone())
             }
         }
     };
 }
 
-impl_asarrow_dataarray!(NullArray, array::NullArray, arrow::array::NullArray);
-impl_asarrow_dataarray!(
-    Utf8Array,
-    array::Utf8Array<i64>,
-    arrow::array::LargeStringArray
-);
-impl_asarrow_dataarray!(
-    BooleanArray,
-    array::BooleanArray,
-    arrow::array::BooleanArray
-);
-impl_asarrow_dataarray!(
-    BinaryArray,
-    array::BinaryArray<i64>,
-    arrow::array::LargeBinaryArray
-);
-impl_asarrow_dataarray!(
-    FixedSizeBinaryArray,
-    array::FixedSizeBinaryArray,
-    arrow::array::FixedSizeBinaryArray
-);
-impl_asarrow_dataarray!(
-    IntervalArray,
-    array::PrimitiveArray<months_days_ns>,
-    arrow::array::IntervalMonthDayNanoArray
-);
+impl_asarrow_dataarray!(NullArray, arrow::array::NullArray);
+impl_asarrow_dataarray!(Utf8Array, arrow::array::LargeStringArray);
+impl_asarrow_dataarray!(BooleanArray, arrow::array::BooleanArray);
+impl_asarrow_dataarray!(BinaryArray, arrow::array::LargeBinaryArray);
+impl_asarrow_dataarray!(FixedSizeBinaryArray, arrow::array::FixedSizeBinaryArray);
+impl_asarrow_dataarray!(IntervalArray, arrow::array::IntervalMonthDayNanoArray);
 
-impl_asarrow_logicalarray!(
-    DateArray,
-    array::PrimitiveArray<i32>,
-    arrow::array::Date32Array
-);
-impl_asarrow_logicalarray!(
-    TimeArray,
-    array::PrimitiveArray<i64>,
-    arrow::array::Time64NanosecondArray
-);
-
-impl_asarrow_logicalarray!(
-    DurationArray,
-    array::PrimitiveArray<i64>,
-    arrow::array::DurationMillisecondArray
-);
-
-impl_asarrow_logicalarray!(
-    TimestampArray,
-    array::PrimitiveArray<i64>,
-    arrow::array::TimestampMicrosecondArray
-);
-
+impl_asarrow_logicalarray!(DateArray, arrow::array::Int32Array);
+impl_asarrow_logicalarray!(TimeArray, arrow::array::Int64Array);
+impl_asarrow_logicalarray!(DurationArray, arrow::array::Int64Array);
+impl_asarrow_logicalarray!(TimestampArray, arrow::array::Int64Array);
 impl_asarrow_nested!(ListArray, arrow::array::LargeListArray);
 impl_asarrow_nested!(FixedSizeListArray, arrow::array::FixedSizeListArray);
 impl_asarrow_nested!(StructArray, arrow::array::StructArray);
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
-
     use arrow::array::Array;
     use common_error::DaftResult;
-    use rstest::rstest;
 
-    use crate::{prelude::*, series};
+    use crate::prelude::*;
 
-    macro_rules! test_primitive_into_arrow {
+    macro_rules! test_primitive_as_arrow {
         ($test_name:ident, $array_type:ty, $values:expr) => {
             #[test]
             fn $test_name() -> DaftResult<()> {
@@ -207,27 +121,19 @@ mod test {
         };
     }
 
-    test_primitive_into_arrow!(test_into_arrow_int8, Int8Array, vec![1i8, 2, 3]);
-    test_primitive_into_arrow!(test_into_arrow_int16, Int16Array, vec![1i16, 2, 3]);
-    test_primitive_into_arrow!(test_into_arrow_int32, Int32Array, vec![1i32, 2, 3]);
-    test_primitive_into_arrow!(test_into_arrow_int64, Int64Array, vec![1i64, 2, 3]);
-    test_primitive_into_arrow!(test_into_arrow_uint8, UInt8Array, vec![1u8, 2, 3]);
-    test_primitive_into_arrow!(test_into_arrow_uint16, UInt16Array, vec![1u16, 2, 3]);
-    test_primitive_into_arrow!(test_into_arrow_uint32, UInt32Array, vec![1u32, 2, 3]);
-    test_primitive_into_arrow!(test_into_arrow_uint64, UInt64Array, vec![1u64, 2, 3]);
-    test_primitive_into_arrow!(
-        test_into_arrow_float32,
-        Float32Array,
-        vec![1.0f32, 2.0, 3.0]
-    );
-    test_primitive_into_arrow!(
-        test_into_arrow_float64,
-        Float64Array,
-        vec![1.0f64, 2.0, 3.0]
-    );
+    test_primitive_as_arrow!(test_as_arrow_int8, Int8Array, vec![1i8, 2, 3]);
+    test_primitive_as_arrow!(test_as_arrow_int16, Int16Array, vec![1i16, 2, 3]);
+    test_primitive_as_arrow!(test_as_arrow_int32, Int32Array, vec![1i32, 2, 3]);
+    test_primitive_as_arrow!(test_as_arrow_int64, Int64Array, vec![1i64, 2, 3]);
+    test_primitive_as_arrow!(test_as_arrow_uint8, UInt8Array, vec![1u8, 2, 3]);
+    test_primitive_as_arrow!(test_as_arrow_uint16, UInt16Array, vec![1u16, 2, 3]);
+    test_primitive_as_arrow!(test_as_arrow_uint32, UInt32Array, vec![1u32, 2, 3]);
+    test_primitive_as_arrow!(test_as_arrow_uint64, UInt64Array, vec![1u64, 2, 3]);
+    test_primitive_as_arrow!(test_as_arrow_float32, Float32Array, vec![1.0f32, 2.0, 3.0]);
+    test_primitive_as_arrow!(test_as_arrow_float64, Float64Array, vec![1.0f64, 2.0, 3.0]);
 
     #[test]
-    fn test_into_arrow_null() -> DaftResult<()> {
+    fn test_as_arrow_null() -> DaftResult<()> {
         let arr = NullArray::full_null("test", &DataType::Null, 3);
         let arrow_arr = arr.as_arrow()?;
         assert_eq!(arrow_arr.len(), 3);
@@ -236,7 +142,7 @@ mod test {
     }
 
     #[test]
-    fn test_into_arrow_utf8() -> DaftResult<()> {
+    fn test_as_arrow_utf8() -> DaftResult<()> {
         let arr = Utf8Array::from_slice("test", &["a", "b", "c"]);
         let arrow_arr = arr.as_arrow()?;
         assert_eq!(arrow_arr.len(), 3);
@@ -248,7 +154,7 @@ mod test {
     }
 
     #[test]
-    fn test_into_arrow_boolean() -> DaftResult<()> {
+    fn test_as_arrow_boolean() -> DaftResult<()> {
         let arr = BooleanArray::from_vec("test", vec![true, false, true]);
         let arrow_arr = arr.as_arrow()?;
         assert_eq!(arrow_arr.len(), 3);
@@ -257,7 +163,7 @@ mod test {
     }
 
     #[test]
-    fn test_into_arrow_binary() -> DaftResult<()> {
+    fn test_as_arrow_binary() -> DaftResult<()> {
         let arr = BinaryArray::from_values("test", vec![b"a".as_slice(), b"b", b"c"].into_iter());
         let arrow_arr = arr.as_arrow()?;
         assert_eq!(arrow_arr.len(), 3);
@@ -269,7 +175,7 @@ mod test {
     }
 
     #[test]
-    fn test_into_arrow_fixed_size_binary() -> DaftResult<()> {
+    fn test_as_arrow_fixed_size_binary() -> DaftResult<()> {
         let arr = FixedSizeBinaryArray::from_iter(
             "test",
             vec![
@@ -291,151 +197,50 @@ mod test {
     }
 
     #[test]
-    fn test_into_arrow_date() -> DaftResult<()> {
+    fn test_as_arrow_date() -> DaftResult<()> {
         let arr = DateArray::new(
             Field::new("test", DataType::Date),
             Int32Array::from_slice("", &[1, 2, 3]),
         );
         let arrow_arr = arr.as_arrow()?;
         assert_eq!(arrow_arr.len(), 3);
-        assert_eq!(arrow_arr.data_type(), &arrow::datatypes::DataType::Date32);
+        assert_eq!(arrow_arr.data_type(), &arrow::datatypes::DataType::Int32);
         Ok(())
     }
 
     #[test]
-    fn test_into_arrow_time() -> DaftResult<()> {
+    fn test_as_arrow_time() -> DaftResult<()> {
         let arr = TimeArray::new(
             Field::new("test", DataType::Time(TimeUnit::Nanoseconds)),
             Int64Array::from_slice("", &[1, 2, 3]),
         );
         let arrow_arr = arr.as_arrow()?;
         assert_eq!(arrow_arr.len(), 3);
-        assert_eq!(
-            arrow_arr.data_type(),
-            &arrow::datatypes::DataType::Time64(arrow::datatypes::TimeUnit::Nanosecond)
-        );
+        assert_eq!(arrow_arr.data_type(), &arrow::datatypes::DataType::Int64);
         Ok(())
     }
 
     #[test]
-    fn test_into_arrow_duration() -> DaftResult<()> {
+    fn test_as_arrow_duration() -> DaftResult<()> {
         let arr = DurationArray::new(
             Field::new("test", DataType::Duration(TimeUnit::Milliseconds)),
             Int64Array::from_slice("", &[1000, 2000, 3000]),
         );
         let arrow_arr = arr.as_arrow()?;
         assert_eq!(arrow_arr.len(), 3);
-        assert_eq!(
-            arrow_arr.data_type(),
-            &arrow::datatypes::DataType::Duration(arrow::datatypes::TimeUnit::Millisecond)
-        );
+        assert_eq!(arrow_arr.data_type(), &arrow::datatypes::DataType::Int64);
         Ok(())
     }
 
     #[test]
-    fn test_into_arrow_timestamp() -> DaftResult<()> {
+    fn test_as_arrow_timestamp() -> DaftResult<()> {
         let arr = TimestampArray::new(
             Field::new("test", DataType::Timestamp(TimeUnit::Microseconds, None)),
             Int64Array::from_slice("", &[1000000, 2000000, 3000000]),
         );
         let arrow_arr = arr.as_arrow()?;
         assert_eq!(arrow_arr.len(), 3);
-        assert_eq!(
-            arrow_arr.data_type(),
-            &arrow::datatypes::DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, None)
-        );
-        Ok(())
-    }
-
-    #[rstest]
-    #[case(series![1u8, 2u8, 3u8])]
-    #[case(series![1i8, 2i8, 3i8])]
-    #[case(series![1i16, 2i16, 3i16])]
-    #[case(series![1i32, 2i32, 3i32])]
-    #[case(series![1i64, 2i64, 3i64])]
-    #[case(series![1f32, 2f32, 3f32])]
-    #[case(series![1f64, 2f64, 3f64])]
-    #[case(series!["a", "b", "c"])]
-    #[case(series![true, false, false])]
-    #[case(Series::empty("test", &DataType::Null))]
-    #[case(Series::empty("test", &DataType::Utf8))]
-    #[case(Series::empty("test", &DataType::Int32))]
-    #[case(Series::empty("test", &DataType::Float64))]
-    fn test_into_arrow_list(#[case] data: Series) -> DaftResult<()> {
-        let arr = ListArray::from_series("test", vec![Some(data.clone()), None])?;
-        let arrow_arr = arr.as_arrow()?;
-        assert_eq!(arrow_arr.len(), 2);
-        assert_eq!(
-            arrow_arr.data_type(),
-            &arrow::datatypes::DataType::LargeList(Arc::new(arrow::datatypes::Field::new(
-                "item",
-                data.data_type().to_arrow()?,
-                true
-            )))
-        );
-
-        Ok(())
-    }
-
-    #[rstest]
-    #[case(series![1u8, 2u8, 3u8])]
-    #[case(series![1i8, 2i8, 3i8])]
-    #[case(series![1i16, 2i16, 3i16])]
-    #[case(series![1i32, 2i32, 3i32])]
-    #[case(series![1i64, 2i64, 3i64])]
-    #[case(series![1f32, 2f32, 3f32])]
-    #[case(series![1f64, 2f64, 3f64])]
-    #[case(series!["a", "b", "c"])]
-    #[case(series![true, false, false])]
-    #[case(Series::empty("literal", &DataType::Null))]
-    #[case(Series::empty("literal", &DataType::Utf8))]
-    #[case(Series::empty("literal", &DataType::Int32))]
-    #[case(Series::empty("literal", &DataType::Float64))]
-    fn test_into_arrow_fixed_size_list(#[case] data: Series) -> DaftResult<()> {
-        let arr = FixedSizeListArray::new(
-            Field::new(
-                "test",
-                DataType::FixedSizeList(Box::new(data.data_type().clone()), 1),
-            ),
-            data.clone(),
-            None,
-        );
-        let arrow_arr = arr.as_arrow()?;
-        assert_eq!(arrow_arr.len(), arr.len());
-        assert_eq!(arrow_arr.null_count(), arr.null_count());
-        assert_eq!(arrow_arr.value_length() as usize, arr.fixed_element_len());
-        assert_eq!(
-            arrow_arr.data_type(),
-            &arrow::datatypes::DataType::FixedSizeList(
-                Arc::new(arrow::datatypes::Field::new(
-                    "literal",
-                    data.data_type().to_arrow()?,
-                    true
-                )),
-                1
-            )
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_into_arrow_struct() -> DaftResult<()> {
-        let field1 = Int32Array::from_slice("a", &[1, 2, 3]);
-        let field2 = Utf8Array::from_slice("b", &["x", "y", "z"]);
-        let arr = StructArray::new(
-            Field::new(
-                "test",
-                DataType::Struct(vec![
-                    Field::new("a", DataType::Int32),
-                    Field::new("b", DataType::Utf8),
-                ]),
-            ),
-            vec![field1.into_series(), field2.into_series()],
-            None,
-        );
-        let arrow_arr = arr.as_arrow()?;
-        assert_eq!(arrow_arr.len(), 3);
+        assert_eq!(arrow_arr.data_type(), &arrow::datatypes::DataType::Int64);
         Ok(())
     }
 }

--- a/src/daft-core/src/array/ops/bool_agg.rs
+++ b/src/daft-core/src/array/ops/bool_agg.rs
@@ -17,12 +17,12 @@ impl DaftBoolAggable for DataArray<BooleanType> {
     type Output = DaftResult<Self>;
 
     fn bool_and(&self) -> Self::Output {
-        let value = bool_and(&self.as_arrow()?);
+        let value = bool_and(self.as_arrow()?);
         Ok(Self::from_iter(self.name(), std::iter::once(value)))
     }
 
     fn bool_or(&self) -> Self::Output {
-        let value = bool_or(&self.as_arrow()?);
+        let value = bool_or(self.as_arrow()?);
         Ok(Self::from_iter(self.name(), std::iter::once(value)))
     }
 

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -73,7 +73,7 @@ where
         match dtype {
             #[cfg(feature = "python")]
             DataType::Python => {
-                Series::try_from((self.name(), self.data.clone()))?.cast_to_python()
+                Series::from_arrow(self.field().clone(), self.data.clone())?.cast_to_python()
             }
             _ => {
                 // Cast from DataArray to the target DataType

--- a/src/daft-core/src/array/ops/compare_agg.rs
+++ b/src/daft-core/src/array/ops/compare_agg.rs
@@ -62,14 +62,14 @@ where
     fn min(&self) -> Self::Output {
         let primitive_arr = self.as_arrow()?;
 
-        let result = arrow::compute::min(&primitive_arr);
+        let result = arrow::compute::min(primitive_arr);
         Ok(Self::from_iter(self.field.clone(), std::iter::once(result)))
     }
 
     fn max(&self) -> Self::Output {
         let primitive_arr = self.as_arrow()?;
 
-        let result = arrow::compute::max(&primitive_arr);
+        let result = arrow::compute::max(primitive_arr);
         Ok(Self::from_iter(self.field.clone(), std::iter::once(result)))
     }
     fn grouped_min(&self, groups: &GroupIndices) -> Self::Output {
@@ -135,13 +135,13 @@ impl DaftCompareAggable for DataArray<Utf8Type> {
     fn min(&self) -> Self::Output {
         let arrow_array = self.as_arrow()?;
 
-        let result = arrow::compute::min_string(&arrow_array);
+        let result = arrow::compute::min_string(arrow_array);
         Ok(Self::from_iter(self.name(), std::iter::once(result)))
     }
     fn max(&self) -> Self::Output {
         let arrow_array = self.as_arrow()?;
 
-        let result = arrow::compute::max_string(&arrow_array);
+        let result = arrow::compute::max_string(arrow_array);
         Ok(Self::from_iter(self.name(), std::iter::once(result)))
     }
 
@@ -194,13 +194,13 @@ impl DaftCompareAggable for DataArray<BinaryType> {
     fn min(&self) -> Self::Output {
         let arrow_array = self.as_arrow()?;
 
-        let result = arrow::compute::min_binary(&arrow_array);
+        let result = arrow::compute::min_binary(arrow_array);
         Ok(Self::from_iter(self.name(), std::iter::once(result)))
     }
     fn max(&self) -> Self::Output {
         let arrow_array = self.as_arrow()?;
 
-        let result = arrow::compute::max_binary(&arrow_array);
+        let result = arrow::compute::max_binary(arrow_array);
         Ok(Self::from_iter(self.name(), std::iter::once(result)))
     }
 
@@ -264,7 +264,7 @@ impl DaftCompareAggable for DataArray<FixedSizeBinaryType> {
             unreachable!("FixedSizeBinaryArray must have DataType::FixedSizeBinary(..)");
         };
 
-        let result = arrow::compute::min_fixed_size_binary(&arrow_array);
+        let result = arrow::compute::min_fixed_size_binary(arrow_array);
         Ok(Self::from_iter(self.name(), std::iter::once(result), *size))
     }
     fn max(&self) -> Self::Output {
@@ -274,7 +274,7 @@ impl DaftCompareAggable for DataArray<FixedSizeBinaryType> {
             unreachable!("FixedSizeBinaryArray must have DataType::FixedSizeBinary(..)");
         };
 
-        let result = arrow::compute::max_fixed_size_binary(&arrow_array);
+        let result = arrow::compute::max_fixed_size_binary(arrow_array);
         Ok(Self::from_iter(self.name(), std::iter::once(result), *size))
     }
 
@@ -328,13 +328,13 @@ impl DaftCompareAggable for DataArray<BooleanType> {
     fn min(&self) -> Self::Output {
         let arrow_array = self.as_arrow()?;
 
-        let result = arrow::compute::min_boolean(&arrow_array);
+        let result = arrow::compute::min_boolean(arrow_array);
         Ok(Self::from_iter(self.name(), std::iter::once(result)))
     }
     fn max(&self) -> Self::Output {
         let arrow_array = self.as_arrow()?;
 
-        let result = arrow::compute::max_boolean(&arrow_array);
+        let result = arrow::compute::max_boolean(arrow_array);
         Ok(Self::from_iter(self.name(), std::iter::once(result)))
     }
 

--- a/src/daft-core/src/array/ops/comparison.rs
+++ b/src/daft-core/src/array/ops/comparison.rs
@@ -688,7 +688,7 @@ where
 impl Not for &BooleanArray {
     type Output = DaftResult<BooleanArray>;
     fn not(self) -> Self::Output {
-        let arrow_arr = arrow::compute::not(&self.as_arrow()?)?;
+        let arrow_arr = arrow::compute::not(self.as_arrow()?)?;
 
         BooleanArray::from_arrow(
             Field::new(self.name(), DataType::Boolean),

--- a/src/daft-core/src/array/ops/filter.rs
+++ b/src/daft-core/src/array/ops/filter.rs
@@ -13,7 +13,7 @@ where
     T: DaftArrowBackedType,
 {
     pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
-        let result = arrow::compute::filter(self.to_arrow().as_ref(), &mask.as_arrow()?)?;
+        let result = arrow::compute::filter(self.to_arrow().as_ref(), mask.as_arrow()?)?;
 
         Self::from_arrow(self.field().clone(), result)
     }
@@ -21,21 +21,21 @@ where
 
 impl ListArray {
     pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
-        let filtered = arrow::compute::filter(self.to_arrow()?.as_ref(), &mask.as_arrow()?)?;
+        let filtered = arrow::compute::filter(self.to_arrow()?.as_ref(), mask.as_arrow()?)?;
         Self::from_arrow(self.field().clone(), filtered)
     }
 }
 
 impl FixedSizeListArray {
     pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
-        let filtered = arrow::compute::filter(self.to_arrow()?.as_ref(), &mask.as_arrow()?)?;
+        let filtered = arrow::compute::filter(self.to_arrow()?.as_ref(), mask.as_arrow()?)?;
         Self::from_arrow(self.field().clone(), filtered)
     }
 }
 
 impl StructArray {
     pub fn filter(&self, mask: &BooleanArray) -> DaftResult<Self> {
-        let filtered = arrow::compute::filter(self.to_arrow()?.as_ref(), &mask.as_arrow()?)?;
+        let filtered = arrow::compute::filter(self.to_arrow()?.as_ref(), mask.as_arrow()?)?;
         Self::from_arrow(self.field().clone(), filtered)
     }
 }

--- a/src/daft-core/src/array/ops/get.rs
+++ b/src/daft-core/src/array/ops/get.rs
@@ -36,6 +36,8 @@ where
         let arrow_array = self.as_arrow().unwrap();
         let is_valid = arrow_array.nulls().is_none_or(|nulls| nulls.is_valid(idx));
         if is_valid {
+            Self::native_layout_assert();
+
             Some(unsafe {
                 // SAFETY:
                 // T::Native is guaranteed to also be `ArrowPrimitiveType::Native`.

--- a/src/daft-core/src/array/ops/hash.rs
+++ b/src/daft-core/src/array/ops/hash.rs
@@ -36,7 +36,7 @@ where
     ) -> DaftResult<UInt64Array> {
         let as_arrowed = self.as_arrow()?;
         let seed_arr = seed.map(|v| v.as_arrow()).transpose()?;
-        let result = kernels::hashing::hash(&as_arrowed, seed_arr.as_ref(), hash_function)?;
+        let result = kernels::hashing::hash(&as_arrowed, seed_arr, hash_function)?;
         let field = Arc::new(Field::new(self.name(), DataType::UInt64));
         UInt64Array::from_arrow(field, Arc::new(result))
     }
@@ -54,7 +54,7 @@ impl Utf8Array {
     ) -> DaftResult<UInt64Array> {
         let as_arrowed = self.as_arrow()?;
         let seed_arr = seed.map(|v| v.as_arrow()).transpose()?;
-        let result = kernels::hashing::hash(&as_arrowed, seed_arr.as_ref(), hash_function)?;
+        let result = kernels::hashing::hash(&as_arrowed, seed_arr, hash_function)?;
         let field = Arc::new(Field::new(self.name(), DataType::UInt64));
         UInt64Array::from_arrow(field, Arc::new(result))
     }
@@ -88,7 +88,7 @@ impl BinaryArray {
     ) -> DaftResult<UInt64Array> {
         let as_arrowed = self.as_arrow()?;
         let seed_arr = seed.map(|v| v.as_arrow()).transpose()?;
-        let result = kernels::hashing::hash(&as_arrowed, seed_arr.as_ref(), hash_function)?;
+        let result = kernels::hashing::hash(&as_arrowed, seed_arr, hash_function)?;
         let field = Arc::new(Field::new(self.name(), DataType::UInt64));
         UInt64Array::from_arrow(field, Arc::new(result))
     }
@@ -116,7 +116,7 @@ impl FixedSizeBinaryArray {
     ) -> DaftResult<UInt64Array> {
         let as_arrowed = self.as_arrow()?;
         let seed_arr = seed.map(|v| v.as_arrow()).transpose()?;
-        let result = kernels::hashing::hash(&as_arrowed, seed_arr.as_ref(), hash_function)?;
+        let result = kernels::hashing::hash(&as_arrowed, seed_arr, hash_function)?;
         let field = Arc::new(Field::new(self.name(), DataType::UInt64));
         UInt64Array::from_arrow(field, Arc::new(result))
     }
@@ -144,7 +144,7 @@ impl BooleanArray {
     ) -> DaftResult<UInt64Array> {
         let as_arrowed = self.as_arrow()?;
         let seed_arr = seed.map(|v| v.as_arrow()).transpose()?;
-        let result = kernels::hashing::hash(&as_arrowed, seed_arr.as_ref(), hash_function)?;
+        let result = kernels::hashing::hash(&as_arrowed, seed_arr, hash_function)?;
         let field = Arc::new(Field::new(self.name(), DataType::UInt64));
         UInt64Array::from_arrow(field, Arc::new(result))
     }
@@ -161,7 +161,7 @@ impl NullArray {
     ) -> DaftResult<UInt64Array> {
         let as_arrowed = self.as_arrow()?;
         let seed_arr = seed.map(|v| v.as_arrow()).transpose()?;
-        let result = kernels::hashing::hash(&as_arrowed, seed_arr.as_ref(), hash_function)?;
+        let result = kernels::hashing::hash(&as_arrowed, seed_arr, hash_function)?;
         let field = Arc::new(Field::new(self.name(), DataType::UInt64));
         UInt64Array::from_arrow(field, Arc::new(result))
     }

--- a/src/daft-core/src/array/ops/minhash.rs
+++ b/src/daft-core/src/array/ops/minhash.rs
@@ -61,7 +61,7 @@ impl DaftMinHash for Utf8Array {
         let mut output: UInt32Builder = UInt32Builder::with_capacity(num_hashes * self.len());
         let mut alloc = VecDeque::new();
 
-        for elem in &internal_arrow_representation {
+        for elem in internal_arrow_representation {
             let Some(elem) = elem else {
                 output.append_nulls(num_hashes);
                 continue;

--- a/src/daft-core/src/array/ops/time.rs
+++ b/src/daft-core/src/array/ops/time.rs
@@ -342,7 +342,7 @@ impl TimestampArray {
         }
 
         let mut builder = arrow::array::Int64Builder::with_capacity(physical.len());
-        for ts in &physical {
+        for ts in physical {
             match ts {
                 None => builder.append_null(),
                 Some(ts) => {

--- a/src/daft-core/src/array/serdes.rs
+++ b/src/daft-core/src/array/serdes.rs
@@ -223,7 +223,9 @@ impl serde::Serialize for IntervalArray {
         s.serialize_entry("field", self.field())?;
         s.serialize_entry(
             "values",
-            &IterSer::new((0..self.len()).map(|i| self.get(i))),
+            &IterSer::new(
+                (0..self.len()).map(|i| self.get(i).map(|v| (v.months, v.days, v.nanoseconds))),
+            ),
         )?;
         s.end()
     }

--- a/src/daft-core/src/array/values.rs
+++ b/src/daft-core/src/array/values.rs
@@ -1,3 +1,4 @@
+use arrow::array::Array;
 use common_error::{DaftError, DaftResult};
 
 use crate::prelude::{AsArrow, BinaryArray, BooleanArray, Utf8Array};
@@ -8,13 +9,14 @@ impl Utf8Array {
     /// NOTE: this will error if there are any null values.
     /// If you need to handle nulls, use the `.iter()` method instead.
     pub fn values(&self) -> DaftResult<impl Iterator<Item = &str>> {
-        let arrow2_arr = self.as_arrow2();
+        let arr = self.as_arrow()?;
         if self.null_count() > 0 {
             return Err(DaftError::ComputeError(
                 "Utf8Array::values with nulls".to_string(),
             ));
         }
-        Ok(arrow2_arr.values_iter())
+        let iter = (0..arr.len()).map(|i| arr.value(i));
+        Ok(iter)
     }
 }
 
@@ -24,13 +26,14 @@ impl BinaryArray {
     /// NOTE: this will error if there are any null values.
     /// If you need to handle nulls, use the `.iter()` method instead.
     pub fn values(&self) -> DaftResult<impl Iterator<Item = &[u8]>> {
-        let arrow2_arr = self.as_arrow2();
+        let arr = self.as_arrow()?;
         if self.null_count() > 0 {
             return Err(DaftError::ComputeError(
                 "BinaryArray::values with nulls".to_string(),
             ));
         }
-        Ok(arrow2_arr.values_iter())
+        let iter = (0..arr.len()).map(|i| arr.value(i));
+        Ok(iter)
     }
 }
 

--- a/src/daft-core/src/datatypes/interval.rs
+++ b/src/daft-core/src/datatypes/interval.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Display, ops::Neg};
 
+use arrow::datatypes::IntervalMonthDayNano;
 use common_error::DaftResult;
 use daft_arrow::types::months_days_ns;
 #[cfg(feature = "python")]
@@ -231,6 +232,16 @@ impl From<months_days_ns> for IntervalValue {
             months: value.months(),
             days: value.days(),
             nanoseconds: value.ns(),
+        }
+    }
+}
+
+impl From<IntervalMonthDayNano> for IntervalValue {
+    fn from(value: IntervalMonthDayNano) -> Self {
+        Self {
+            months: value.months,
+            days: value.days,
+            nanoseconds: value.nanoseconds,
         }
     }
 }

--- a/src/daft-core/src/datatypes/logical.rs
+++ b/src/daft-core/src/datatypes/logical.rs
@@ -93,7 +93,7 @@ impl<L: DaftLogicalType> LogicalArrayImpl<L, DataArray<L::PhysicalType>> {
 
     pub fn to_arrow(&self) -> DaftResult<ArrayRef> {
         let arrow_field = self.field().to_arrow()?;
-        let physical = arrow::array::make_array(self.physical.to_data());
+        let physical = self.physical.to_arrow();
 
         Ok(arrow::compute::cast(
             physical.as_ref(),

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -2,11 +2,7 @@ mod agg_ops;
 mod infer_datatype;
 mod matching;
 
-use arrow::{
-    array::ArrowNumericType,
-    buffer::{Buffer, ScalarBuffer},
-    datatypes::ArrowNativeType,
-};
+use arrow::{array::ArrowNumericType, datatypes::ArrowNativeType};
 pub use infer_datatype::InferDataType;
 pub mod prelude;
 use std::ops::{Add, Div, Mul, Rem, Sub};
@@ -35,7 +31,7 @@ pub use crate::array::{DataArray, FixedSizeListArray, file_array::FileArray};
 #[cfg(feature = "python")]
 use crate::prelude::PythonArray;
 use crate::{
-    array::{ListArray, StructArray, ops::as_arrow::AsArrow},
+    array::{ListArray, StructArray},
     file::{DaftMediaType, FileType},
 };
 
@@ -462,15 +458,3 @@ pub type Utf8Array = DataArray<Utf8Type>;
 pub type ExtensionArray = DataArray<ExtensionType>;
 pub type IntervalArray = DataArray<IntervalType>;
 pub type Decimal128Array = DataArray<Decimal128Type>;
-
-impl<T: DaftPrimitiveType> DataArray<T> {
-    pub fn as_slice(&self) -> &[T::Native] {
-        self.as_arrow2().values().as_slice()
-    }
-
-    pub fn values(&self) -> ScalarBuffer<T::Native> {
-        // this is fully zero copy to convert the values into an arrow-rs ScalarBuffer
-        let arrow_buffer = Buffer::from(self.as_arrow2().values().clone());
-        ScalarBuffer::from(arrow_buffer)
-    }
-}

--- a/src/daft-core/src/series/ops/partitioning.rs
+++ b/src/daft-core/src/series/ops/partitioning.rs
@@ -97,12 +97,11 @@ impl Series {
         assert!(n >= 0, "Expected n to be non negative, got {n}");
         let hashes = self.murmur3_32()?;
         let buckets = hashes.into_iter().map(|v| v.map(|v| (v & i32::MAX) % n));
-        let array = Box::new(daft_arrow::array::Int32Array::from_iter(buckets));
-        Ok(Int32Array::new(
-            Field::new(format!("{}_bucket", self.name()), DataType::Int32).into(),
-            array,
+
+        Ok(Int32Array::from_iter(
+            Field::new(format!("{}_bucket", self.name()), DataType::Int32),
+            buckets,
         )
-        .unwrap()
         .into_series())
     }
 

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -1113,27 +1113,18 @@ pub fn read_parquet_statistics(
         .collect::<DaftResult<Vec<_>>>()?;
     assert_eq!(all_tuples.len(), uris.len());
 
-    let row_count_series = UInt64Array::new(
-        Field::new("row_count", DataType::UInt64).into(),
-        Box::new(daft_arrow::array::UInt64Array::from_iter(
-            all_tuples.iter().map(|v| v.0.map(|v| v as u64)),
-        )),
-    )
-    .unwrap();
-    let row_group_series = UInt64Array::new(
-        Field::new("row_group_count", DataType::UInt64).into(),
-        Box::new(daft_arrow::array::UInt64Array::from_iter(
-            all_tuples.iter().map(|v| v.1.map(|v| v as u64)),
-        )),
-    )
-    .unwrap();
-    let version_series = Int32Array::new(
-        Field::new("version", DataType::Int32).into(),
-        Box::new(daft_arrow::array::Int32Array::from_iter(
-            all_tuples.iter().map(|v| v.2),
-        )),
-    )
-    .unwrap();
+    let row_count_series = UInt64Array::from_iter(
+        Field::new("row_count", DataType::UInt64),
+        all_tuples.iter().map(|v| v.0.map(|v| v as u64)),
+    );
+    let row_group_series = UInt64Array::from_iter(
+        Field::new("row_group_count", DataType::UInt64),
+        all_tuples.iter().map(|v| v.1.map(|v| v as u64)),
+    );
+    let version_series = Int32Array::from_iter(
+        Field::new("version", DataType::Int32),
+        all_tuples.iter().map(|v| v.2),
+    );
 
     RecordBatch::from_nonempty_columns(vec![
         uris.clone(),


### PR DESCRIPTION
## Changes Made

- Removes arrow2 based DataArray::new
- Updates DataArray.data to be backed by ArrayRef instead of arrow2 array
- Updates as_arrow to match original arrow2 behavior (returns physical array, no corrections for logical arrays)

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
