### PR TITLE
ci: include dashboard assets in maturin sdist for manylinux builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,10 @@ skip = "tests/series/*,target,.git,.venv,venv,data,*.csv,*.csv.*,*.html,*.json,*
 [tool.maturin]
 # "python" tells pyo3 we want to build an extension module (skips linking against libpython.so)
 features = ["python"]
+# Include pre-built dashboard frontend assets in the sdist so they're available
+# inside maturin's Docker container for manylinux builds (the assets are gitignored
+# but built in a prior CI step).
+include = [{path = "src/daft-dashboard/frontend/out/**/*", format = "sdist"}]
 
 [tool.mypy]
 exclude = ['daft/pickle/*.py$']


### PR DESCRIPTION
All three Linux manylinux wheel builds (x86 LTS, x86, aarch64) have been failing in nightly CI with:

```
thread 'main' panicked at src/daft-dashboard/build.rs:12:13:
Dashboard assets are required for release builds
```

The `build-wheel.yml` workflow runs `npm run build` to generate dashboard assets at `src/daft-dashboard/frontend/out/` on the host, then invokes maturin to build inside a Docker container. Since maturin 1.12.x, source files are copied into a temp directory inside the container, and this copy respects `.gitignore`. The root `.gitignore` has `out/**`, so the pre-built assets are excluded from the copy, causing the `ci_main` build script to panic.

Fix this by adding a maturin `include` directive in `pyproject.toml` that forces the `frontend/out/` contents into the source distribution regardless of `.gitignore`.