### PR TITLE
fix: Fix native executor closing

### DIFF
--- a/src/daft-local-execution/src/run.rs
+++ b/src/daft-local-execution/src/run.rs
@@ -38,7 +38,7 @@ use crate::{
         translate_physical_plan_to_pipeline, viz_pipeline_ascii, viz_pipeline_mermaid,
     },
     resource_manager::get_or_init_memory_manager,
-    runtime_stats::{QueryEndState, RuntimeStatsManager},
+    runtime_stats::RuntimeStatsManager,
 };
 
 /// Global tokio runtime shared by all NativeExecutor instances
@@ -225,6 +225,7 @@ impl NativeExecutor {
 
                 while let Some(val) = receiver.recv().await {
                     if tx.send(val).await.is_err() {
+                        runtime_handle.shutdown().await?;
                         return Ok(());
                     }
                 }
@@ -232,28 +233,21 @@ impl NativeExecutor {
                 runtime_handle.shutdown().await
             };
 
-            let (result, finish_status) = tokio::select! {
+            let result = tokio::select! {
                 biased;
                 () = cancel.cancelled() => {
                     log::info!("Execution engine cancelled");
-                (Ok(()), QueryEndState::Cancelled)
+                    Ok(())
                 }
                 _ = tokio::signal::ctrl_c() => {
                     log::info!("Received Ctrl-C, shutting down execution engine");
-                (Ok(()), QueryEndState::Cancelled)
+                    Ok(())
                 }
-                result = execution_task => {
-                    let status = if result.is_err() {
-                        QueryEndState::Failed
-                    } else {
-                        QueryEndState::Finished
-                    };
-                    (result, status)
-                },
+                result = execution_task => result,
             };
 
             // Finish the stats manager
-            let final_stats = stats_manager.finish(finish_status).await;
+            let final_stats = stats_manager.finish().await;
 
             // TODO: Move into a runtime stats subscriber
             if enable_explain_analyze {

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -85,7 +85,7 @@ impl RuntimeStatsManager {
         node_map: &HashMap<NodeID, (Arc<NodeInfo>, Arc<dyn RuntimeStats>)>,
         progress_bar: Option<&dyn ProgressBar>,
         subscribers: &[Arc<dyn Subscriber>],
-        err_context: &str,
+        err_context: &'static str,
     ) {
         let runtime_stats = &node_map[&node_id].1;
         let snapshot = runtime_stats.flush();


### PR DESCRIPTION
## Changes Made

I keep getting
```
RuntimeStatsManager finished with active nodes {0}
Exception ignored in: <async_generator object NativeExecutor.run.<locals>.stream_results at 0x1035baea0>
Traceback (most recent call last):
  File "/Users/colinho/Desktop/Eventual/.venv/lib/python3.13/site-packages/daft/execution/native_executor.py", line 63, in stream_results
    result = await result_handle.finish()
RuntimeError: no running event loo
```

on `df.show()`



## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
