### PR TITLE
 refactor(arrow2): remove series::try_from(name, arrow2_arr)

### DIFF
--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -73,7 +73,9 @@ where
         match dtype {
             #[cfg(feature = "python")]
             DataType::Python => {
-                Series::try_from((self.name(), self.data.clone()))?.cast_to_python()
+                let arr = self.data.clone();
+                let field = Arc::new(Field::new(self.name(), DataType::from(arr.data_type())));
+                Series::from_arrow(field, arr.into())?.cast_to_python()
             }
             _ => {
                 // Cast from DataArray to the target DataType

--- a/src/daft-core/src/series/from.rs
+++ b/src/daft-core/src/series/from.rs
@@ -46,8 +46,6 @@ mod tests {
     };
     use daft_schema::dtype::DataType;
 
-    use crate::datatypes::Field;
-
     static ARROW_DATA_TYPE: LazyLock<ArrowDataType> = LazyLock::new(|| {
         ArrowDataType::Map(
             Box::new(ArrowField::new(
@@ -100,7 +98,10 @@ mod tests {
         );
 
         let arrow_array: Box<dyn daft_arrow::array::Array> = Box::new(arrow_array);
-        let field = Arc::new(Field::new("test_map", DataType::from(arrow_array.data_type())));
+        let field = Arc::new(Field::new(
+            "test_map",
+            DataType::from(arrow_array.data_type()),
+        ));
         let series = Series::from_arrow(field, arrow_array.into())?;
 
         assert_eq!(

--- a/src/daft-core/src/series/from.rs
+++ b/src/daft-core/src/series/from.rs
@@ -1,12 +1,7 @@
-use std::sync::Arc;
-
-use common_error::{DaftError, DaftResult};
 use common_ndarray::NdArray;
-use daft_arrow::datatypes::ArrowDataType;
-use daft_schema::dtype::DaftDataType;
 
 use super::Series;
-use crate::{datatypes::Field, prelude::*, series::array_impl::IntoSeries};
+use crate::{prelude::*, series::array_impl::IntoSeries};
 
 impl Series {
     pub fn from_ndarray_flattened(arr: NdArray) -> Self {
@@ -40,21 +35,9 @@ impl Series {
     }
 }
 
-impl TryFrom<(&str, Box<dyn daft_arrow::array::Array>)> for Series {
-    type Error = DaftError;
-
-    fn try_from((name, array): (&str, Box<dyn daft_arrow::array::Array>)) -> DaftResult<Self> {
-        let source_arrow_type: &ArrowDataType = array.data_type();
-        let dtype = DaftDataType::from(source_arrow_type);
-
-        let field = Arc::new(Field::new(name, dtype));
-        Self::from_arrow(field, array.into())
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::LazyLock;
+    use std::sync::{Arc, LazyLock};
 
     use common_error::DaftResult;
     use daft_arrow::{
@@ -62,6 +45,8 @@ mod tests {
         datatypes::{ArrowDataType, ArrowField},
     };
     use daft_schema::dtype::DataType;
+
+    use crate::datatypes::Field;
 
     static ARROW_DATA_TYPE: LazyLock<ArrowDataType> = LazyLock::new(|| {
         ArrowDataType::Map(
@@ -114,10 +99,9 @@ mod tests {
             None,
         );
 
-        let series = Series::try_from((
-            "test_map",
-            Box::new(arrow_array) as Box<dyn daft_arrow::array::Array>,
-        ))?;
+        let arrow_array: Box<dyn daft_arrow::array::Array> = Box::new(arrow_array);
+        let field = Arc::new(Field::new("test_map", DataType::from(arrow_array.data_type())));
+        let series = Series::from_arrow(field, arrow_array.into())?;
 
         assert_eq!(
             series.data_type(),

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -674,7 +674,10 @@ impl ParquetFileReader {
                                     all_arrays
                                         .into_iter()
                                         .map(|a| {
-                                            let series_field = Arc::new(Field::new(field.name.as_str(), DataType::from(a.data_type())));
+                                            let series_field = Arc::new(Field::new(
+                                                field.name.as_str(),
+                                                DataType::from(a.data_type()),
+                                            ));
                                             Series::from_arrow(series_field, a.into())
                                         })
                                         .collect::<DaftResult<Vec<Series>>>()

--- a/src/daft-parquet/src/file.rs
+++ b/src/daft-parquet/src/file.rs
@@ -673,7 +673,10 @@ impl ParquetFileReader {
                                     }
                                     all_arrays
                                         .into_iter()
-                                        .map(|a| Series::try_from((field.name.as_str(), a)))
+                                        .map(|a| {
+                                            let series_field = Arc::new(Field::new(field.name.as_str(), DataType::from(a.data_type())));
+                                            Series::from_arrow(series_field, a.into())
+                                        })
                                         .collect::<DaftResult<Vec<Series>>>()
                                 })();
 

--- a/src/daft-parquet/src/statistics/column_range.rs
+++ b/src/daft-parquet/src/statistics/column_range.rs
@@ -324,18 +324,12 @@ impl<T: parquet2::types::NativeType + daft_core::datatypes::NumericNative>
             }
         }
         // fall back case
-        let lower = Series::try_from((
-            "lower",
-            Box::new(PrimitiveArray::<T>::from_vec(vec![lower]))
-                as Box<dyn daft_arrow::array::Array>,
-        ))
-        .unwrap();
-        let upper = Series::try_from((
-            "upper",
-            Box::new(PrimitiveArray::<T>::from_vec(vec![upper]))
-                as Box<dyn daft_arrow::array::Array>,
-        ))
-        .unwrap();
+        let lower_arr: Box<dyn daft_arrow::array::Array> = Box::new(PrimitiveArray::<T>::from_vec(vec![lower]));
+        let lower_field = Arc::new(Field::new("lower", DataType::from(lower_arr.data_type())));
+        let lower = Series::from_arrow(lower_field, lower_arr.into()).unwrap();
+        let upper_arr: Box<dyn daft_arrow::array::Array> = Box::new(PrimitiveArray::<T>::from_vec(vec![upper]));
+        let upper_field = Arc::new(Field::new("upper", DataType::from(upper_arr.data_type())));
+        let upper = Series::from_arrow(upper_field, upper_arr.into()).unwrap();
 
         Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?.into())
     }

--- a/src/daft-parquet/src/statistics/column_range.rs
+++ b/src/daft-parquet/src/statistics/column_range.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use daft_arrow::array::PrimitiveArray;
 use daft_core::prelude::*;
 use daft_stats::ColumnRangeStatistics;
 use parquet2::{
@@ -242,8 +241,11 @@ impl TryFrom<&FixedLenStatistics> for Wrap<ColumnRangeStatistics> {
     }
 }
 
-impl<T: parquet2::types::NativeType + daft_core::datatypes::NumericNative>
-    TryFrom<&PrimitiveStatistics<T>> for Wrap<ColumnRangeStatistics>
+impl<T> TryFrom<&PrimitiveStatistics<T>> for Wrap<ColumnRangeStatistics>
+where
+    T: Into<daft_core::lit::Literal>,
+    T: daft_core::datatypes::NumericNative,
+    T: parquet2::types::NativeType,
 {
     type Error = super::Error;
 
@@ -324,12 +326,12 @@ impl<T: parquet2::types::NativeType + daft_core::datatypes::NumericNative>
             }
         }
         // fall back case
-        let lower_arr: Box<dyn daft_arrow::array::Array> = Box::new(PrimitiveArray::<T>::from_vec(vec![lower]));
-        let lower_field = Arc::new(Field::new("lower", DataType::from(lower_arr.data_type())));
-        let lower = Series::from_arrow(lower_field, lower_arr.into()).unwrap();
-        let upper_arr: Box<dyn daft_arrow::array::Array> = Box::new(PrimitiveArray::<T>::from_vec(vec![upper]));
-        let upper_field = Arc::new(Field::new("upper", DataType::from(upper_arr.data_type())));
-        let upper = Series::from_arrow(upper_field, upper_arr.into()).unwrap();
+        let lower = Series::from_literals(vec![lower.into()])
+            .unwrap()
+            .rename("lower");
+        let upper = Series::from_literals(vec![upper.into()])
+            .unwrap()
+            .rename("upper");
 
         Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?.into())
     }

--- a/src/daft-parquet/src/stream_reader.rs
+++ b/src/daft-parquet/src/stream_reader.rs
@@ -496,7 +496,8 @@ pub async fn local_parquet_read_async(
                         let casted_arrays = v
                             .into_iter()
                             .map(move |a| {
-                                let field = Arc::new(Field::new(f_name, DataType::from(a.data_type())));
+                                let field =
+                                    Arc::new(Field::new(f_name, DataType::from(a.data_type())));
                                 Series::from_arrow(field, a.into())
                             })
                             .collect::<Result<Vec<_>, _>>()?;

--- a/src/daft-parquet/src/stream_reader.rs
+++ b/src/daft-parquet/src/stream_reader.rs
@@ -71,7 +71,8 @@ fn arrow_chunk_to_table(
                 let offset = row_range_start.saturating_sub(*index_so_far);
                 arr = arr.sliced(offset, arr.len() - offset);
             }
-            let series_result = Series::try_from((f_name, arr));
+            let field = Arc::new(Field::new(f_name, DataType::from(arr.data_type())));
+            let series_result = Series::from_arrow(field, arr.into());
             Some(series_result)
         })
         .collect::<DaftResult<Vec<_>>>()?;
@@ -494,7 +495,10 @@ pub async fn local_parquet_read_async(
                     } else {
                         let casted_arrays = v
                             .into_iter()
-                            .map(move |a| Series::try_from((f_name, a)))
+                            .map(move |a| {
+                                let field = Arc::new(Field::new(f_name, DataType::from(a.data_type())));
+                                Series::from_arrow(field, a.into())
+                            })
                             .collect::<Result<Vec<_>, _>>()?;
                         Series::concat(casted_arrays.iter().collect::<Vec<_>>().as_slice())
                     }


### PR DESCRIPTION
## Changes Made

found another straggler arrow2 based conversion. `Series::try_from((name, arrow2_arr))`. 

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
