### PR TITLE
refactor(arrow2)!: remaining arrow2 from daft-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,7 @@ dependencies = [
  "arrow",
  "arrow-row",
  "bincode",
+ "bytemuck",
  "chrono",
  "chrono-tz",
  "comfy-table 7.2.1",

--- a/src/daft-core/Cargo.toml
+++ b/src/daft-core/Cargo.toml
@@ -2,6 +2,7 @@
 arrow = {workspace = true}
 arrow-row = {workspace = true}
 bincode = {workspace = true}
+bytemuck = {version = "1", features = ["derive"]}
 daft-arrow = {path = "../daft-arrow"}
 chrono = {workspace = true}
 chrono-tz = {workspace = true}

--- a/src/daft-core/src/array/growable/bitmap_growable.rs
+++ b/src/daft-core/src/array/growable/bitmap_growable.rs
@@ -1,16 +1,15 @@
+use arrow::array::NullBufferBuilder;
+
 pub struct ArrowBitmapGrowable<'a> {
-    bitmap_refs: Vec<Option<&'a daft_arrow::buffer::NullBuffer>>,
-    mutable_bitmap: daft_arrow::buffer::NullBufferBuilder,
+    bitmap_refs: Vec<Option<&'a arrow::buffer::NullBuffer>>,
+    mutable_bitmap: NullBufferBuilder,
 }
 
 impl<'a> ArrowBitmapGrowable<'a> {
-    pub fn new(
-        bitmap_refs: Vec<Option<&'a daft_arrow::buffer::NullBuffer>>,
-        capacity: usize,
-    ) -> Self {
+    pub fn new(bitmap_refs: Vec<Option<&'a arrow::buffer::NullBuffer>>, capacity: usize) -> Self {
         Self {
             bitmap_refs,
-            mutable_bitmap: daft_arrow::buffer::NullBufferBuilder::new(capacity),
+            mutable_bitmap: arrow::array::NullBufferBuilder::new(capacity),
         }
     }
 
@@ -30,7 +29,7 @@ impl<'a> ArrowBitmapGrowable<'a> {
         self.mutable_bitmap.append_n_nulls(additional);
     }
 
-    pub fn build(mut self) -> Option<daft_arrow::buffer::NullBuffer> {
+    pub fn build(mut self) -> Option<arrow::buffer::NullBuffer> {
         self.mutable_bitmap.finish()
     }
 }

--- a/src/daft-core/src/array/list_array.rs
+++ b/src/daft-core/src/array/list_array.rs
@@ -186,7 +186,7 @@ impl ListArray {
         )))
     }
 
-    pub fn with_nulls(&self, nulls: Option<daft_arrow::buffer::NullBuffer>) -> DaftResult<Self> {
+    pub fn with_nulls(&self, nulls: Option<arrow::buffer::NullBuffer>) -> DaftResult<Self> {
         if let Some(v) = &nulls
             && v.len() != self.len()
         {

--- a/src/daft-core/src/array/ops/arrow/sort/primitive/common.rs
+++ b/src/daft-core/src/array/ops/arrow/sort/primitive/common.rs
@@ -2,7 +2,8 @@ use arrow::{
     array::{PrimitiveArray, types::UInt64Type},
     buffer::NullBuffer,
 };
-use daft_arrow::array::ord::DynComparator;
+
+use crate::utils::ord::DynComparator;
 
 pub fn idx_sort<F>(
     nulls: Option<&NullBuffer>,

--- a/src/daft-core/src/array/ops/comparison.rs
+++ b/src/daft-core/src/array/ops/comparison.rs
@@ -12,10 +12,10 @@ use arrow::{
     },
     buffer::{BooleanBuffer, NullBuffer},
     compute::kernels::cmp,
+    error::ArrowError,
 };
 use arrow_row::{RowConverter, SortField};
 use common_error::{DaftError, DaftResult};
-use daft_arrow::ArrowError;
 use num_traits::{NumCast, ToPrimitive};
 
 use super::{DaftCompare, DaftLogical, as_arrow::AsArrow};
@@ -994,8 +994,8 @@ impl_scalar_compare!(
 
 #[cfg(test)]
 mod tests {
+    use arrow::buffer::NullBuffer;
     use common_error::{DaftError, DaftResult};
-    use daft_arrow::buffer::NullBuffer;
     use rstest::rstest;
 
     use crate::{

--- a/src/daft-core/src/array/ops/concat_agg.rs
+++ b/src/daft-core/src/array/ops/concat_agg.rs
@@ -32,7 +32,7 @@ impl DaftConcatAggable for ListArray {
         // The concat will successfully return a single non-null element.
         let new_nulls = match self.nulls() {
             Some(nulls) if nulls.null_count() == self.len() => {
-                Some(daft_arrow::buffer::NullBuffer::new_null(1))
+                Some(arrow::buffer::NullBuffer::new_null(1))
             }
             _ => None,
         };
@@ -103,7 +103,7 @@ impl DaftConcatAggable for ListArray {
         let new_validities = if all_valid {
             None
         } else {
-            Some(daft_arrow::buffer::NullBuffer::from(group_valids))
+            Some(arrow::buffer::NullBuffer::from(group_valids))
         };
 
         Ok(Self::new(
@@ -121,7 +121,7 @@ impl DaftConcatAggable for DataArray<Utf8Type> {
     fn concat(&self) -> Self::Output {
         let new_nulls = match self.nulls() {
             Some(nulls) if nulls.null_count() == self.len() => {
-                Some(daft_arrow::buffer::NullBuffer::new_null(1))
+                Some(arrow::buffer::NullBuffer::new_null(1))
             }
             _ => None,
         };
@@ -185,9 +185,7 @@ mod test {
             )
             .into_series(),
             OffsetBuffer::new_zeroed(3),
-            Some(daft_arrow::buffer::NullBuffer::from_iter(repeat_n(
-                false, 3,
-            ))),
+            Some(arrow::buffer::NullBuffer::from_iter(repeat_n(false, 3))),
         );
 
         // Expected: [None]
@@ -195,9 +193,7 @@ mod test {
         assert_eq!(concatted.len(), 1);
         assert_eq!(
             concatted.nulls(),
-            Some(&daft_arrow::buffer::NullBuffer::from_iter(repeat_n(
-                false, 1
-            )))
+            Some(&arrow::buffer::NullBuffer::from_iter(repeat_n(false, 1)))
         );
         Ok(())
     }
@@ -221,7 +217,7 @@ mod test {
             )
             .into_series(),
             OffsetBuffer::new(vec![0, 1, 3, 5, 6, 6, 6, 7].into()),
-            Some(daft_arrow::buffer::NullBuffer::from(vec![
+            Some(arrow::buffer::NullBuffer::from(vec![
                 true, true, true, true, true, false, false,
             ])),
         );
@@ -264,7 +260,7 @@ mod test {
             )
             .into_series(),
             OffsetBuffer::new(vec![0, 1, 3, 5, 6, 8, 8, 8, 9].into()),
-            Some(daft_arrow::buffer::NullBuffer::from(vec![
+            Some(arrow::buffer::NullBuffer::from(vec![
                 true, true, true, true, true, false, false, false,
             ])),
         );
@@ -276,7 +272,7 @@ mod test {
         assert_eq!(concatted.len(), 4);
         assert_eq!(
             concatted.nulls(),
-            Some(&daft_arrow::buffer::NullBuffer::from(vec![
+            Some(&arrow::buffer::NullBuffer::from(vec![
                 true, true, true, false
             ]))
         );

--- a/src/daft-core/src/array/ops/count.rs
+++ b/src/daft-core/src/array/ops/count.rs
@@ -12,7 +12,7 @@ use crate::{
     datatypes::*,
 };
 
-/// Helper to perform a grouped count on a validity map of type daft_arrow::buffer::NullBuffer
+/// Helper to perform a grouped count on a validity map of type arrow::buffer::NullBuffer
 fn grouped_count_arrow_bitmap(
     groups: &GroupIndices,
     mode: &CountMode,

--- a/src/daft-core/src/array/ops/full.rs
+++ b/src/daft-core/src/array/ops/full.rs
@@ -78,7 +78,7 @@ where
 
 impl FullNull for FixedSizeListArray {
     fn full_null(name: &str, dtype: &DataType, length: usize) -> Self {
-        let nulls = daft_arrow::buffer::NullBuffer::from_iter(repeat_n(false, length));
+        let nulls = arrow::buffer::NullBuffer::from_iter(repeat_n(false, length));
 
         match dtype {
             DataType::FixedSizeList(child_dtype, size) => {
@@ -109,7 +109,7 @@ impl FullNull for FixedSizeListArray {
 
 impl FullNull for ListArray {
     fn full_null(name: &str, dtype: &DataType, length: usize) -> Self {
-        let nulls = daft_arrow::buffer::NullBuffer::from_iter(repeat_n(false, length));
+        let nulls = arrow::buffer::NullBuffer::from_iter(repeat_n(false, length));
 
         match dtype {
             DataType::List(child_dtype) => {
@@ -142,7 +142,7 @@ impl FullNull for ListArray {
 
 impl FullNull for StructArray {
     fn full_null(name: &str, dtype: &DataType, length: usize) -> Self {
-        let nulls = daft_arrow::buffer::NullBuffer::from_iter(repeat_n(false, length));
+        let nulls = arrow::buffer::NullBuffer::from_iter(repeat_n(false, length));
         match dtype {
             DataType::Struct(children) => {
                 let field = Field::new(name, dtype.clone());
@@ -177,7 +177,7 @@ impl FullNull for PythonArray {
         let pynone = Arc::new(Python::attach(|py: Python| py.None()));
         let values = vec![pynone; length];
 
-        let validity = daft_arrow::buffer::NullBuffer::new_null(length);
+        let validity = arrow::buffer::NullBuffer::new_null(length);
 
         let field = Arc::new(Field::new(name, dtype.clone()));
         Self::new(field, values.into(), Some(validity))

--- a/src/daft-core/src/array/ops/get.rs
+++ b/src/daft-core/src/array/ops/get.rs
@@ -351,7 +351,7 @@ mod tests {
         let field = Field::new("foo", DataType::FixedSizeList(Box::new(DataType::Int32), 3));
         let flat_child = Int32Array::from_vec("foo", (0..9).collect::<Vec<i32>>());
         let raw_nulls = vec![true, false, true];
-        let nulls = Some(daft_arrow::buffer::NullBuffer::from(raw_nulls.as_slice()));
+        let nulls = Some(arrow::buffer::NullBuffer::from(raw_nulls.as_slice()));
         let arr = FixedSizeListArray::new(field, flat_child.into_series(), nulls);
         assert_eq!(arr.len(), 3);
 
@@ -386,7 +386,7 @@ mod tests {
         let field = Field::new("foo", DataType::FixedSizeList(Box::new(DataType::Int32), 3));
         let flat_child = Int32Array::from_vec("foo", (0..9).collect::<Vec<i32>>());
         let raw_nulls = vec![true, false, true];
-        let nulls = Some(daft_arrow::buffer::NullBuffer::from(raw_nulls.as_slice()));
+        let nulls = Some(arrow::buffer::NullBuffer::from(raw_nulls.as_slice()));
         let arr = FixedSizeListArray::new(field, flat_child.into_series(), nulls);
         let list_dtype = DataType::List(Box::new(DataType::Int32));
         let list_arr = arr.cast(&list_dtype)?;

--- a/src/daft-core/src/array/ops/null.rs
+++ b/src/daft-core/src/array/ops/null.rs
@@ -74,9 +74,9 @@ impl PythonArray {
                 nulls.clone().into_inner()
             }
         } else if is_null {
-            daft_arrow::buffer::NullBuffer::new_null(self.len()).into_inner()
+            arrow::buffer::NullBuffer::new_null(self.len()).into_inner()
         } else {
-            daft_arrow::buffer::NullBuffer::new_valid(self.len()).into_inner()
+            arrow::buffer::NullBuffer::new_valid(self.len()).into_inner()
         };
 
         BooleanArray::from_arrow(

--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -3,9 +3,9 @@ use std::{cmp::Ordering, sync::Arc};
 use arrow::{
     array::{Array, ArrayRef, ArrowPrimitiveType},
     compute::{SortOptions, sort_to_indices},
+    datatypes::ArrowNativeType,
 };
 use common_error::{DaftError, DaftResult};
-use daft_arrow::types::Index;
 
 use super::as_arrow::AsArrow;
 #[cfg(feature = "python")]
@@ -113,8 +113,8 @@ where
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
                     match r.cmp(l) {
@@ -130,8 +130,8 @@ where
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
                     match l.cmp(r) {
@@ -194,8 +194,8 @@ impl Float32Array {
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
                     match cmp_float::<f32>(r, l) {
@@ -211,8 +211,8 @@ impl Float32Array {
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
                     match cmp_float::<f32>(l, r) {
@@ -275,8 +275,8 @@ impl Float64Array {
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
                     match cmp_float::<f64>(r, l) {
@@ -292,8 +292,8 @@ impl Float64Array {
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
                     match cmp_float::<f64>(l, r) {
@@ -356,8 +356,8 @@ impl Decimal128Array {
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
                     match r.cmp(l) {
@@ -373,8 +373,8 @@ impl Decimal128Array {
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
                     match l.cmp(r) {
@@ -426,8 +426,8 @@ impl NullArray {
         let result = multi_column_idx_sort(
             self.nulls(),
             |a: &u64, b: &u64| {
-                let a = a.to_usize();
-                let b = b.to_usize();
+                let a = a.to_usize().unwrap();
+                let b = b.to_usize().unwrap();
                 others_cmp(a, b)
             },
             &others_cmp,
@@ -483,8 +483,8 @@ impl BooleanArray {
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { arrow_array.value_unchecked(a) };
                     let r = unsafe { arrow_array.value_unchecked(b) };
                     match r.cmp(&l) {
@@ -500,8 +500,8 @@ impl BooleanArray {
             multi_column_idx_sort(
                 arrow_array.nulls(),
                 |a: &u64, b: &u64| {
-                    let a = a.to_usize();
-                    let b = b.to_usize();
+                    let a = a.to_usize().unwrap();
+                    let b = b.to_usize().unwrap();
                     let l = unsafe { arrow_array.value_unchecked(a) };
                     let r = unsafe { arrow_array.value_unchecked(b) };
                     match l.cmp(&r) {
@@ -575,8 +575,8 @@ macro_rules! impl_binary_like_sort {
                     multi_column_idx_sort(
                         self.to_data().nulls(),
                         |a: &u64, b: &u64| {
-                            let a = a.to_usize();
-                            let b = b.to_usize();
+                            let a = a.to_usize().unwrap();
+                            let b = b.to_usize().unwrap();
                             let l = unsafe { &arrow_array.value_unchecked(a) };
                             let r = unsafe { &arrow_array.value_unchecked(b) };
                             match r.cmp(&l) {
@@ -592,8 +592,8 @@ macro_rules! impl_binary_like_sort {
                     multi_column_idx_sort(
                         self.to_data().nulls(),
                         |a: &u64, b: &u64| {
-                            let a = a.to_usize();
-                            let b = b.to_usize();
+                            let a = a.to_usize().unwrap();
+                            let b = b.to_usize().unwrap();
                             let l = unsafe { &arrow_array.value_unchecked(a) };
                             let r = unsafe { &arrow_array.value_unchecked(b) };
                             match l.cmp(&r) {

--- a/src/daft-core/src/array/ops/sort.rs
+++ b/src/daft-core/src/array/ops/sort.rs
@@ -1,16 +1,11 @@
-use std::sync::Arc;
+use std::{cmp::Ordering, sync::Arc};
 
 use arrow::{
-    array::{Array, ArrowPrimitiveType},
-    compute::SortOptions,
+    array::{Array, ArrayRef, ArrowPrimitiveType},
+    compute::{SortOptions, sort_to_indices},
 };
-use common_error::DaftResult;
-use daft_arrow::{
-    array::ord::{self, DynComparator},
-    // A real tragedy. Arrow-rs has all these functions but uses 32 bit indices instead of 64 bit indices.
-    compute::sort::sort_to_indices,
-    types::Index,
-};
+use common_error::{DaftError, DaftResult};
+use daft_arrow::types::Index;
 
 use super::as_arrow::AsArrow;
 #[cfg(feature = "python")]
@@ -37,6 +32,8 @@ use crate::{
     prelude::UInt64Array,
     series::Series,
 };
+/// Compare the values at two arbitrary indices in two arrays.
+pub type DynComparator = Box<dyn Fn(usize, usize) -> Ordering + Send + Sync>;
 
 pub fn build_multi_array_compare(
     arrays: &[Series],
@@ -363,7 +360,7 @@ impl Decimal128Array {
                     let b = b.to_usize();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
-                    match ord::total_cmp(r, l) {
+                    match r.cmp(l) {
                         std::cmp::Ordering::Equal => others_cmp(a, b),
                         v => v,
                     }
@@ -380,7 +377,7 @@ impl Decimal128Array {
                     let b = b.to_usize();
                     let l = unsafe { &arrow_array.value_unchecked(a) };
                     let r = unsafe { &arrow_array.value_unchecked(b) };
-                    match ord::total_cmp(l, r) {
+                    match l.cmp(r) {
                         std::cmp::Ordering::Equal => others_cmp(a, b),
                         v => v,
                     }
@@ -451,16 +448,23 @@ impl NullArray {
 
 impl BooleanArray {
     pub fn argsort(&self, descending: bool, nulls_first: bool) -> DaftResult<UInt64Array> {
-        let options = daft_arrow::compute::sort::SortOptions {
+        if self.len() > u32::MAX as usize {
+            return Err(DaftError::ComputeError(format!(
+                "Cannot argsort array with {} elements (max {})",
+                self.len(),
+                u32::MAX
+            )));
+        }
+        let options = arrow::compute::SortOptions {
             descending,
             nulls_first,
         };
-        let arrow2_arr: Box<dyn daft_arrow::array::Array> = self.to_arrow().into();
+        let arr = self.to_arrow();
 
-        let result: Box<dyn daft_arrow::array::Array> =
-            Box::new(sort_to_indices::<u64>(arrow2_arr.as_ref(), &options, None)?);
+        let result: ArrayRef = Arc::new(sort_to_indices(arr.as_ref(), Some(options), None)?);
+        let result = arrow::compute::cast(&result, &arrow::datatypes::DataType::UInt64)?;
 
-        UInt64Array::from_arrow(Field::new(self.name(), DataType::UInt64), result.into())
+        UInt64Array::from_arrow(Field::new(self.name(), DataType::UInt64), result)
     }
 
     pub fn argsort_multikey(
@@ -533,16 +537,24 @@ macro_rules! impl_binary_like_sort {
     ($da:ident) => {
         impl $da {
             pub fn argsort(&self, descending: bool, nulls_first: bool) -> DaftResult<UInt64Array> {
-                let options = daft_arrow::compute::sort::SortOptions {
+                if self.len() > u32::MAX as usize {
+                    return Err(DaftError::ComputeError(format!(
+                        "Cannot argsort array with {} elements (max {})",
+                        self.len(),
+                        u32::MAX
+                    )));
+                }
+                let options = arrow::compute::SortOptions {
                     descending,
                     nulls_first,
                 };
-                let arrow2_arr: Box<dyn daft_arrow::array::Array> = self.to_arrow().into();
+                let arr = self.to_arrow();
 
-                let result: Box<dyn daft_arrow::array::Array> =
-                    Box::new(sort_to_indices::<u64>(arrow2_arr.as_ref(), &options, None)?);
+                let result: ArrayRef =
+                    Arc::new(sort_to_indices(arr.as_ref(), Some(options), None)?);
+                let result = arrow::compute::cast(&result, &arrow::datatypes::DataType::UInt64)?;
 
-                UInt64Array::from_arrow(Field::new(self.name(), DataType::UInt64), result.into())
+                UInt64Array::from_arrow(Field::new(self.name(), DataType::UInt64), result)
             }
 
             pub fn argsort_multikey(

--- a/src/daft-core/src/array/ops/sparse_tensor.rs
+++ b/src/daft-core/src/array/ops/sparse_tensor.rs
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn test_sparse_tensor_to_fixed_shape_sparse_tensor_roundtrip() -> DaftResult<()> {
         let raw_nulls = vec![true, false, true];
-        let nulls = daft_arrow::buffer::NullBuffer::from(raw_nulls.as_slice());
+        let nulls = arrow::buffer::NullBuffer::from(raw_nulls.as_slice());
 
         let values_array = ListArray::new(
             Field::new("values", DataType::List(Box::new(DataType::Int64))),

--- a/src/daft-core/src/array/ops/struct_.rs
+++ b/src/daft-core/src/array/ops/struct_.rs
@@ -30,8 +30,8 @@ impl StructArray {
 
 #[cfg(test)]
 mod tests {
+    use arrow::buffer::NullBuffer;
     use common_error::DaftResult;
-    use daft_arrow::buffer::NullBuffer;
 
     use crate::prelude::*;
 

--- a/src/daft-core/src/array/ops/take.rs
+++ b/src/daft-core/src/array/ops/take.rs
@@ -1,9 +1,9 @@
 use arrow::{
     array::NullBufferBuilder,
     buffer::{NullBuffer, OffsetBuffer},
+    datatypes::ArrowNativeType,
 };
 use common_error::DaftResult;
-use daft_arrow::types::Index;
 
 use crate::{
     array::{
@@ -61,7 +61,7 @@ impl FixedSizeListArray {
                     child_indices.extend(std::iter::repeat_n(0, fixed_size as _));
                 }
                 Some(i) => {
-                    let i = i.to_usize();
+                    let i = i.to_usize().unwrap();
                     nulls_builder.append(self.is_valid(i));
                     let start: u64 = i as u64 * fixed_size as u64;
                     child_indices.extend(start..start + fixed_size as u64);
@@ -99,7 +99,7 @@ impl ListArray {
                     let end = self.offsets()[i as usize + 1] as usize;
                     child_indices.extend(start..end);
                     new_offsets.push(*new_offsets.last().unwrap() + (end - start) as i64);
-                    nulls_builder.append(self.is_valid(i.to_usize()));
+                    nulls_builder.append(self.is_valid(i.to_usize().unwrap()));
                 }
             }
         }
@@ -121,7 +121,7 @@ impl StructArray {
         let nulls = self.nulls().map(|v| {
             NullBuffer::from_iter(idx.into_iter().map(|i| match i {
                 None => false,
-                Some(i) => v.is_valid(i.to_usize()),
+                Some(i) => v.is_valid(i.to_usize().unwrap()),
             }))
         });
         Ok(Self::new(
@@ -162,7 +162,7 @@ impl PythonArray {
                     growable.add_nulls(1);
                 }
                 Some(i) => {
-                    growable.extend(0, i.to_usize(), 1);
+                    growable.extend(0, i.to_usize().unwrap(), 1);
                 }
             }
         }

--- a/src/daft-core/src/array/ops/tensor.rs
+++ b/src/daft-core/src/array/ops/tensor.rs
@@ -25,7 +25,7 @@ mod tests {
 
     #[test]
     fn test_tensor_to_sparse_roundtrip() -> DaftResult<()> {
-        let nulls = daft_arrow::buffer::NullBuffer::from(&[true, false, true]);
+        let nulls = arrow::buffer::NullBuffer::from(&[true, false, true]);
         let flat_child =
             Int64Array::from_slice("item", &[0, 1, 2, 100, 101, 102, 0, 0, 3]).into_series();
         let list_array = ListArray::new(
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn test_fixed_shape_tensor_to_fixed_shape_sparse_roundtrip() -> DaftResult<()> {
         let raw_nulls = vec![true, false, true];
-        let nulls = daft_arrow::buffer::NullBuffer::from(raw_nulls.as_slice());
+        let nulls = arrow::buffer::NullBuffer::from(raw_nulls.as_slice());
         let field = Field::new("foo", DataType::FixedSizeList(Box::new(DataType::Int64), 3));
         let flat_child = Int64Array::from_vec("foo", (0..9).collect::<Vec<i64>>());
         let arr = FixedSizeListArray::new(field, flat_child.into_series(), Some(nulls));

--- a/src/daft-core/src/array/ops/time.rs
+++ b/src/daft-core/src/array/ops/time.rs
@@ -6,7 +6,7 @@ use arrow::{
     datatypes::IntervalMonthDayNano,
     error::ArrowError,
 };
-use chrono::{Duration, NaiveDate, NaiveDateTime, NaiveTime};
+use chrono::{DateTime, Duration, NaiveDate, NaiveTime};
 use common_error::{DaftError, DaftResult};
 
 use super::as_arrow::AsArrow;
@@ -418,7 +418,7 @@ impl TimestampArray {
     }
 
     pub fn unix_date(&self) -> DaftResult<UInt64Array> {
-        const UNIX_EPOCH_DATE: NaiveDate = NaiveDateTime::UNIX_EPOCH.date();
+        const UNIX_EPOCH_DATE: NaiveDate = DateTime::UNIX_EPOCH.naive_utc().date();
         let DataType::Timestamp(tu, _tz) = self.data_type() else {
             unreachable!("TimestampArray must have Timestamp datatype")
         };

--- a/src/daft-core/src/array/struct_array.rs
+++ b/src/daft-core/src/array/struct_array.rs
@@ -15,7 +15,7 @@ pub struct StructArray {
 
     /// Column representations
     pub children: Vec<Series>,
-    nulls: Option<daft_arrow::buffer::NullBuffer>,
+    nulls: Option<arrow::buffer::NullBuffer>,
     len: usize,
 }
 
@@ -29,7 +29,7 @@ impl StructArray {
     pub fn new<F: Into<Arc<Field>>>(
         field: F,
         children: Vec<Series>,
-        nulls: Option<daft_arrow::buffer::NullBuffer>,
+        nulls: Option<arrow::buffer::NullBuffer>,
     ) -> Self {
         let field: Arc<Field> = field.into();
         match &field.as_ref().dtype {
@@ -94,7 +94,7 @@ impl StructArray {
         }
     }
 
-    pub fn nulls(&self) -> Option<&daft_arrow::buffer::NullBuffer> {
+    pub fn nulls(&self) -> Option<&arrow::buffer::NullBuffer> {
         self.nulls.as_ref()
     }
 
@@ -202,7 +202,7 @@ impl StructArray {
         )) as _)
     }
 
-    pub fn with_nulls(&self, nulls: Option<daft_arrow::buffer::NullBuffer>) -> DaftResult<Self> {
+    pub fn with_nulls(&self, nulls: Option<arrow::buffer::NullBuffer>) -> DaftResult<Self> {
         if let Some(v) = &nulls
             && v.len() != self.len()
         {

--- a/src/daft-core/src/datatypes/interval.rs
+++ b/src/daft-core/src/datatypes/interval.rs
@@ -2,7 +2,6 @@ use std::{fmt::Display, ops::Neg};
 
 use arrow::datatypes::IntervalMonthDayNano;
 use common_error::DaftResult;
-use daft_arrow::types::months_days_ns;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -226,16 +225,6 @@ impl IntervalValue {
     }
 }
 
-impl From<months_days_ns> for IntervalValue {
-    fn from(value: months_days_ns) -> Self {
-        Self {
-            months: value.months(),
-            days: value.days(),
-            nanoseconds: value.ns(),
-        }
-    }
-}
-
 impl From<IntervalMonthDayNano> for IntervalValue {
     fn from(value: IntervalMonthDayNano) -> Self {
         Self {
@@ -243,12 +232,6 @@ impl From<IntervalMonthDayNano> for IntervalValue {
             days: value.days,
             nanoseconds: value.nanoseconds,
         }
-    }
-}
-
-impl From<IntervalValue> for months_days_ns {
-    fn from(value: IntervalValue) -> Self {
-        Self(value.months, value.days, value.nanoseconds)
     }
 }
 

--- a/src/daft-core/src/datatypes/mod.rs
+++ b/src/daft-core/src/datatypes/mod.rs
@@ -3,17 +3,17 @@ mod infer_datatype;
 mod matching;
 
 use arrow::{array::ArrowNumericType, datatypes::ArrowNativeType};
+use bytemuck::Pod;
 pub use infer_datatype::InferDataType;
 pub mod prelude;
-use std::ops::{Add, Div, Mul, Rem, Sub};
+use std::{
+    ops::{Add, Div, Mul, Rem, Sub},
+    panic::RefUnwindSafe,
+};
 
 pub use agg_ops::{
     try_mean_aggregation_supertype, try_product_supertype, try_skew_aggregation_supertype,
     try_stddev_aggregation_supertype, try_sum_supertype, try_variance_aggregation_supertype,
-};
-use daft_arrow::{
-    compute::comparison::Simd8,
-    types::{NativeType, simd::Simd},
 };
 // Import DataType enum
 pub use daft_schema::dtype::DataType;
@@ -291,12 +291,9 @@ impl DaftDataType for PythonType {
 pub trait NumericNative:
     ArrowNativeType
     + PartialOrd
-    + NativeType
     + Num
     + NumCast
     + Zero
-    + Simd
-    + Simd8
     + std::iter::Sum<Self>
     + Add<Output = Self>
     + Sub<Output = Self>
@@ -307,6 +304,15 @@ pub trait NumericNative:
     + FromPrimitive
     + ToPrimitive
     + Serialize
+    + Pod
+    + Send
+    + Sync
+    + Sized
+    + RefUnwindSafe
+    + std::fmt::Debug
+    + std::fmt::Display
+    + PartialEq
+    + Default
 {
     type DAFTTYPE: DaftNumericType;
     type ARROWTYPE: ArrowNumericType;

--- a/src/daft-core/src/datatypes/python.rs
+++ b/src/daft-core/src/datatypes/python.rs
@@ -131,17 +131,6 @@ impl PythonArray {
         }
     }
 
-    #[deprecated(note = "arrow2 migration")]
-    pub fn to_pickled_arrow2(&self) -> DaftResult<daft_arrow::array::BinaryArray<i64>> {
-        let pickled = Python::attach(|py| {
-            self.iter()
-                .map(|v| v.map(|obj| pickle_dumps(py, obj)).transpose())
-                .collect::<PyResult<Vec<_>>>()
-        })?;
-
-        Ok(daft_arrow::array::BinaryArray::from(pickled))
-    }
-
     pub fn to_pickled_arrow(&self) -> DaftResult<arrow::array::LargeBinaryArray> {
         Python::attach(|py| {
             self.iter()

--- a/src/daft-core/src/lib.rs
+++ b/src/daft-core/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(iterator_try_reduce)]
 #![feature(if_let_guard)]
-#![allow(deprecated, reason = "arrow2 migration")]
+// #![allow(deprecated, reason = "arrow2 migration")]
 
 pub mod array;
 pub mod count_mode;

--- a/src/daft-core/src/lib.rs
+++ b/src/daft-core/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(iterator_try_reduce)]
 #![feature(if_let_guard)]
-// #![allow(deprecated, reason = "arrow2 migration")]
 
 pub mod array;
 pub mod count_mode;

--- a/src/daft-core/src/prelude.rs
+++ b/src/daft-core/src/prelude.rs
@@ -2,7 +2,6 @@
 //!
 //! This module re-exports commonly used items from the Daft core library.
 
-// Re-export arrow2 bitmap
 pub use daft_arrow::bitmap;
 pub use daft_schema::image_property::ImageProperty;
 // Re-export core series structures

--- a/src/daft-core/src/series/array_impl/data_array.rs
+++ b/src/daft-core/src/series/array_impl/data_array.rs
@@ -41,14 +41,11 @@ macro_rules! impl_series_like_for_data_array {
                 self
             }
 
-            fn with_nulls(
-                &self,
-                nulls: Option<daft_arrow::buffer::NullBuffer>,
-            ) -> DaftResult<Series> {
+            fn with_nulls(&self, nulls: Option<arrow::buffer::NullBuffer>) -> DaftResult<Series> {
                 Ok(self.0.with_nulls(nulls)?.into_series())
             }
 
-            fn nulls(&self) -> Option<&daft_arrow::buffer::NullBuffer> {
+            fn nulls(&self) -> Option<&arrow::buffer::NullBuffer> {
                 self.0.nulls()
             }
 

--- a/src/daft-core/src/series/array_impl/logical_array.rs
+++ b/src/daft-core/src/series/array_impl/logical_array.rs
@@ -38,15 +38,12 @@ macro_rules! impl_series_like_for_logical_array {
                 self
             }
 
-            fn with_nulls(
-                &self,
-                nulls: Option<daft_arrow::buffer::NullBuffer>,
-            ) -> DaftResult<Series> {
+            fn with_nulls(&self, nulls: Option<arrow::buffer::NullBuffer>) -> DaftResult<Series> {
                 let new_array = self.0.physical.with_nulls(nulls)?;
                 Ok($da::new(self.0.field.clone(), new_array).into_series())
             }
 
-            fn nulls(&self) -> Option<&daft_arrow::buffer::NullBuffer> {
+            fn nulls(&self) -> Option<&arrow::buffer::NullBuffer> {
                 self.0.physical.nulls()
             }
 
@@ -216,11 +213,11 @@ where
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
-    fn with_nulls(&self, nulls: Option<daft_arrow::buffer::NullBuffer>) -> DaftResult<Series> {
+    fn with_nulls(&self, nulls: Option<arrow::buffer::NullBuffer>) -> DaftResult<Series> {
         let new_array = self.0.physical.with_nulls(nulls)?;
         Ok(FileArray::<T>::new(self.0.field.clone(), new_array).into_series())
     }
-    fn nulls(&self) -> Option<&daft_arrow::buffer::NullBuffer> {
+    fn nulls(&self) -> Option<&arrow::buffer::NullBuffer> {
         self.0.physical.nulls()
     }
     fn broadcast(&self, num: usize) -> DaftResult<Series> {

--- a/src/daft-core/src/series/array_impl/nested_array.rs
+++ b/src/daft-core/src/series/array_impl/nested_array.rs
@@ -38,14 +38,11 @@ macro_rules! impl_series_like_for_nested_arrays {
                 self
             }
 
-            fn with_nulls(
-                &self,
-                nulls: Option<daft_arrow::buffer::NullBuffer>,
-            ) -> DaftResult<Series> {
+            fn with_nulls(&self, nulls: Option<arrow::buffer::NullBuffer>) -> DaftResult<Series> {
                 Ok(self.0.with_nulls(nulls)?.into_series())
             }
 
-            fn nulls(&self) -> Option<&daft_arrow::buffer::NullBuffer> {
+            fn nulls(&self) -> Option<&arrow::buffer::NullBuffer> {
                 self.0.nulls()
             }
 

--- a/src/daft-core/src/series/array_impl/python_array.rs
+++ b/src/daft-core/src/series/array_impl/python_array.rs
@@ -22,11 +22,11 @@ impl SeriesLike for ArrayWrapper<PythonArray> {
         self
     }
 
-    fn with_nulls(&self, nulls: Option<daft_arrow::buffer::NullBuffer>) -> DaftResult<Series> {
+    fn with_nulls(&self, nulls: Option<arrow::buffer::NullBuffer>) -> DaftResult<Series> {
         Ok(self.0.with_nulls(nulls)?.into_series())
     }
 
-    fn nulls(&self) -> Option<&daft_arrow::buffer::NullBuffer> {
+    fn nulls(&self) -> Option<&arrow::buffer::NullBuffer> {
         self.0.nulls().map(|v| v.into())
     }
 

--- a/src/daft-core/src/series/from_lit.rs
+++ b/src/daft-core/src/series/from_lit.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};
 use common_image::CowImage;
-use daft_arrow::trusted_len::TrustedLen;
 use indexmap::IndexMap;
 use itertools::Itertools;
 
@@ -91,7 +90,7 @@ pub(crate) fn combine_lit_types(left: &DataType, right: &DataType) -> Option<Dat
 /// Creates a series from an iterator of `Result<Literal>`.
 /// It also captures any errors occurred during iteration
 /// It returns a Series, along with an IndexMap<row_idx, error>
-pub fn series_from_literals_iter<I: ExactSizeIterator<Item = DaftResult<Literal>> + TrustedLen>(
+pub fn series_from_literals_iter<I: ExactSizeIterator<Item = DaftResult<Literal>>>(
     values: I,
     dtype: Option<DataType>,
 ) -> DaftResult<Series> {
@@ -280,7 +279,7 @@ pub fn series_from_literals_iter<I: ExactSizeIterator<Item = DaftResult<Literal>
                 })
                 .collect::<DaftResult<_>>()?;
 
-            let nulls = daft_arrow::buffer::NullBuffer::from_iter(
+            let nulls = arrow::buffer::NullBuffer::from_iter(
                 values
                     .iter()
                     .map(|(_, v)| v.as_ref().is_ok_and(|v| v != &Literal::Null)),
@@ -365,7 +364,7 @@ pub fn series_from_literals_iter<I: ExactSizeIterator<Item = DaftResult<Literal>
                 })
                 .unzip();
 
-            let nulls = daft_arrow::buffer::NullBuffer::from(nulls);
+            let nulls = arrow::buffer::NullBuffer::from(nulls);
 
             let flat_child = Series::concat(&data.iter().collect::<Vec<_>>())?;
 

--- a/src/daft-core/src/series/mod.rs
+++ b/src/daft-core/src/series/mod.rs
@@ -11,7 +11,6 @@ pub use array_impl::{ArrayWrapper, IntoSeries};
 use arrow::array::ArrayRef;
 use common_display::table_display::{StrValue, make_comfy_table};
 use common_error::DaftResult;
-use daft_arrow::trusted_len::TrustedLen;
 use derive_more::Display;
 use indexmap::{IndexMap, map::RawEntryApiV1};
 pub use ops::cast_series_to_supertype;
@@ -171,11 +170,11 @@ impl Series {
         )
     }
 
-    pub fn with_nulls(&self, nulls: Option<daft_arrow::buffer::NullBuffer>) -> DaftResult<Self> {
+    pub fn with_nulls(&self, nulls: Option<arrow::buffer::NullBuffer>) -> DaftResult<Self> {
         self.inner.with_nulls(nulls)
     }
 
-    pub fn nulls(&self) -> Option<&daft_arrow::buffer::NullBuffer> {
+    pub fn nulls(&self) -> Option<&arrow::buffer::NullBuffer> {
         self.inner.nulls()
     }
 
@@ -236,7 +235,7 @@ impl Series {
         self.inner.get_lit(idx)
     }
 
-    pub fn to_literals(&self) -> impl ExactSizeIterator<Item = Literal> + use<'_> + TrustedLen {
+    pub fn to_literals(&self) -> impl ExactSizeIterator<Item = Literal> + use<'_> {
         (0..self.len()).map(|i| self.get_lit(i))
     }
 }

--- a/src/daft-core/src/series/ops/hash.rs
+++ b/src/daft-core/src/series/ops/hash.rs
@@ -1,5 +1,5 @@
+use arrow::buffer::NullBuffer;
 use common_error::DaftResult;
-use daft_arrow::buffer::NullBuffer;
 use daft_hash::HashFunctionKind;
 
 use crate::{

--- a/src/daft-core/src/series/ops/take.rs
+++ b/src/daft-core/src/series/ops/take.rs
@@ -1,6 +1,5 @@
 use common_display::table_display::StrValue;
 use common_error::DaftResult;
-use daft_arrow::types::IndexRange;
 
 use crate::{
     datatypes::Utf8Array,
@@ -26,8 +25,7 @@ impl Series {
     }
 
     pub fn to_str_values(&self) -> DaftResult<Self> {
-        let iter =
-            IndexRange::new(0i64, self.len() as i64).map(|i| Some(self.str_value(i as usize)));
+        let iter = (0..self.len()).map(|i| Some(self.str_value(i)));
         let array = Utf8Array::from_iter(self.name(), iter);
         Ok(array.into_series())
     }

--- a/src/daft-core/src/series/series_like.rs
+++ b/src/daft-core/src/series/series_like.rs
@@ -15,8 +15,8 @@ pub trait SeriesLike: Send + Sync + Any + std::fmt::Debug {
     fn into_series(&self) -> Series;
     fn to_arrow(&self) -> DaftResult<ArrayRef>;
     fn as_any(&self) -> &dyn std::any::Any;
-    fn with_nulls(&self, nulls: Option<daft_arrow::buffer::NullBuffer>) -> DaftResult<Series>;
-    fn nulls(&self) -> Option<&daft_arrow::buffer::NullBuffer>;
+    fn with_nulls(&self, nulls: Option<arrow::buffer::NullBuffer>) -> DaftResult<Series>;
+    fn nulls(&self) -> Option<&arrow::buffer::NullBuffer>;
     fn min(&self, groups: Option<&GroupIndices>) -> DaftResult<Series>;
     fn max(&self, groups: Option<&GroupIndices>) -> DaftResult<Series>;
     fn agg_list(&self, groups: Option<&GroupIndices>) -> DaftResult<Series>;

--- a/src/daft-core/src/utils/arrow.rs
+++ b/src/daft-core/src/utils/arrow.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated, reason = "arrow2 migration")]
+
 use std::{
     collections::HashMap,
     sync::{LazyLock, Mutex},

--- a/src/daft-core/src/utils/mod.rs
+++ b/src/daft-core/src/utils/mod.rs
@@ -1,5 +1,6 @@
 pub mod arrow;
 pub mod display;
 pub mod identity_hash_set;
+pub(crate) mod ord;
 pub mod stats;
 pub mod supertype;

--- a/src/daft-core/src/utils/ord.rs
+++ b/src/daft-core/src/utils/ord.rs
@@ -1,0 +1,4 @@
+use std::cmp::Ordering;
+
+/// Compare the values at two arbitrary indices in two arrays.
+pub type DynComparator = Box<dyn Fn(usize, usize) -> Ordering + Send + Sync>;


### PR DESCRIPTION
## Changes Made

removes all remaining arrow2 code from daft-core except for `src/daft-core/src/utils/arrow.rs`. This is still used in the io kernels, and we need to keep it around until they are also migrated off arrow2. 

This is technically a breaking change as we now only support 2^32 length arrays for argsort instead of 2^64. Although the likelyhood of actually performing an argsort this large is very low, I still wanted to mark this as a breaking change as those workloads will now error out.


## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
