### PR TITLE
fix(sql): resolve GROUP BY ambiguous column names for derived expressions

### DIFF
--- a/src/daft-sql/src/planner.rs
+++ b/src/daft-sql/src/planner.rs
@@ -610,7 +610,7 @@ impl SQLPlanner<'_> {
 
         let schema = self.current_plan_ref().schema();
 
-        // Build a map from inner expression → output column name.
+        // Build a map from inner expression to output column name.
         // GROUP BY expressions may be aliased (e.g. `(ClientIP - 1).alias("(ClientIP - 1)")`)
         // so we unwrap aliases to match against unaliased projection expressions.
         let groupby_name_map: HashMap<ExprRef, String> = groupby_exprs


### PR DESCRIPTION
GROUP BY with multiple derived expressions sharing a base column (e.g. `ClientIP - 1`, `ClientIP - 2`, `ClientIP - 3`) fails with `AmbiguousReference` because `BinaryOp::name()` returns only the left operand's name — all three resolve to `"ClientIP"`. When the `Aggregate` node builds its output schema via `exprs_to_schema()`, the duplicate field names trigger the ambiguity error.

The fix uses a mix of Daft-style and DuckDB-style naming for derived GROUP BY expressions: when multiple GROUP BY expressions share the same `name()`, non-trivial expressions (anything beyond a plain column reference) are aliased using the parenthesized SQL expression text from the AST. For example, `ClientIP - 1` becomes `(ClientIP - 1)`. Query engines like Spark do the same thing minus the parenthesis.

For backwards compatibility, when there are no `name()` conflicts, we do not alias the column name. For example, single derived expressions (e.g. `GROUP BY capitalize(col)`) still has a `name()` of `col`.

```sql
-- Previously failed with AmbiguousReference, now works:
SELECT ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3, COUNT(*) AS c
FROM hits
GROUP BY ClientIP, ClientIP - 1, ClientIP - 2, ClientIP - 3
ORDER BY c DESC
LIMIT 10;
```

```
╭──────────┬────────────────┬────────────────┬────────────────┬────────╮
│ ClientIP ┆ (ClientIP - 1) ┆ (ClientIP - 2) ┆ (ClientIP - 3) ┆ c      │
╰──────────┴────────────────┴────────────────┴────────────────┴────────╯
```