### PR TITLE
refactor(arrow2): move the auto conversion logic into array init

### DIFF
--- a/src/daft-core/src/array/mod.rs
+++ b/src/daft-core/src/array/mod.rs
@@ -396,11 +396,9 @@ mod tests {
         ));
 
         let result = Series::from_arrow(daft_fld, Arc::new(list));
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("inner types must match"),
-            "Expected inner type mismatch error, got: {err}"
+            result.is_err(),
+            "Expected type mismatch error for List<u64> → List<u32>"
         );
     }
 

--- a/src/daft-core/src/array/ops/from_arrow.rs
+++ b/src/daft-core/src/array/ops/from_arrow.rs
@@ -80,6 +80,14 @@ impl FromArrow for ListArray {
             )));
         };
 
+        // Auto-cast from List (i32 offsets) to LargeList (i64 offsets) if needed
+        let arrow_arr = if matches!(arrow_arr.data_type(), arrow::datatypes::DataType::List(_)) {
+            let target = field.dtype.to_arrow()?;
+            arrow::compute::cast(arrow_arr.as_ref(), &target)?
+        } else {
+            arrow_arr
+        };
+
         let list_arr = arrow_arr.as_list::<i64>();
         let arrow_child_array = list_arr.values();
         let child_series = Series::from_arrow(

--- a/src/daft-core/src/array/ops/search_sorted.rs
+++ b/src/daft-core/src/array/ops/search_sorted.rs
@@ -4,7 +4,7 @@ use common_error::DaftResult;
 
 use crate::{
     array::DataArray,
-    datatypes::{DaftArrowBackedType, UInt64Array},
+    datatypes::{DaftArrowBackedType, DataType, Field, UInt64Array},
     kernels::search_sorted,
 };
 
@@ -19,6 +19,9 @@ where
             descending,
         )?;
 
-        DataArray::from_arrow(self.field.clone(), Arc::new(array))
+        DataArray::from_arrow(
+            Field::new(self.field.name.as_str(), DataType::UInt64),
+            Arc::new(array),
+        )
     }
 }

--- a/src/daft-core/src/python/series.rs
+++ b/src/daft-core/src/python/series.rs
@@ -536,11 +536,6 @@ impl ToPyArrow for Series {
     ) -> pyo3::PyResult<pyo3::Bound<'py, pyo3::PyAny>> {
         let array = self.to_arrow()?;
         let target_field = self.field().to_arrow()?;
-        let array = if array.data_type() != target_field.data_type() {
-            arrow::compute::cast(&array, target_field.data_type()).map_err(DaftError::from)?
-        } else {
-            array
-        };
 
         let schema = Box::new(arrow::ffi::FFI_ArrowSchema::try_from(target_field).map_err(
             |e| {

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -1685,6 +1685,9 @@ impl AsRef<Self> for RecordBatch {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
+    use arrow_array::ArrayRef;
     use common_error::DaftResult;
     use daft_core::prelude::*;
     use daft_dsl::{expr::bound_expr::BoundExpr, resolved_col};
@@ -1727,6 +1730,61 @@ mod test {
         let ipc_stream = table.to_ipc_stream()?;
         let roundtrip_table = RecordBatch::from_ipc_stream(&ipc_stream)?;
         assert_eq!(table, roundtrip_table);
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_arrow_auto_casts_small_types() -> DaftResult<()> {
+        use arrow::{
+            array::{
+                BinaryArray, Int32Array as ArrowInt32Array, ListArray as ArrowListArray,
+                StringArray,
+            },
+            buffer::OffsetBuffer,
+        };
+
+        // Small Utf8 (arrow StringArray)
+        let utf8_arr: ArrayRef =
+            Arc::new(StringArray::from(vec![Some("hello"), None, Some("world")]));
+
+        // Small Binary
+        let binary_arr: ArrayRef = Arc::new(BinaryArray::from(vec![
+            Some(b"abc" as &[u8]),
+            None,
+            Some(b"def"),
+        ]));
+
+        // Small List (i32 offsets) of Int32: [[1, 2], null, [3]]
+        let values = ArrowInt32Array::from(vec![1, 2, 3]);
+        let offsets = OffsetBuffer::new(vec![0i32, 2, 2, 3].into());
+        let list_field = Arc::new(arrow::datatypes::Field::new(
+            "item",
+            arrow::datatypes::DataType::Int32,
+            true,
+        ));
+        let list_arr: ArrayRef = Arc::new(ArrowListArray::new(
+            list_field,
+            offsets,
+            Arc::new(values),
+            Some(vec![true, false, true].into()),
+        ));
+
+        let schema = Schema::new(vec![
+            Field::new("utf8_col", DataType::Utf8),
+            Field::new("binary_col", DataType::Binary),
+            Field::new("list_col", DataType::List(Box::new(DataType::Int32))),
+        ]);
+
+        let rb = RecordBatch::from_arrow(schema, vec![utf8_arr, binary_arr, list_arr])?;
+
+        assert_eq!(rb.num_rows(), 3);
+        assert_eq!(rb.get_column(0).data_type(), &DataType::Utf8);
+        assert_eq!(rb.get_column(1).data_type(), &DataType::Binary);
+        assert_eq!(
+            rb.get_column(2).data_type(),
+            &DataType::List(Box::new(DataType::Int32))
+        );
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Changes Made

In all cases when we receive an arrow array, We were implicitly correcting the type into a daft type where possible. Such as arrow::utf8 -> daft::utf8 _(arrow::largeutf8)_. 


The old `cast_array_for_daft_if_needed` approach is a caller side obligation...  every place that ingests an arrow array has to remember to call it before constructing a Daft array. This led to the casting logic being duplicated across multiple callsites. 

By moving the casting into the array level `from_arrow` constructors (`DataArray::from_arrow`, `ListArray::from_arrow`), the invariant is self-enforcing. it's impossible to construct a Daft array with the wrong arrow type regardless of how you got there. Callers no longer need to know about Daft's internal type coercions at all. 

This inadvertently eliminates the duplication in `PySeries::from_arrow` and `record_batch_from_arrow` and makes every future ingestion path correct by default. 


It also co-locates the coercion logic with the type information that defines it (DataType::to_arrow()), so there's a single source of truth rather than a parallel `coerce_to_daft_compatible_type` function that has to manually mirror the same mappings.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
