### PR TITLE
feat(metrics): add node phase attribute for multi-phase pipeline nodes

### DIFF
--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -138,12 +138,20 @@ pub const ATTR_QUERY_ID: &str = "query.id";
 // Node attributes
 pub const ATTR_NODE_ID: &str = "node.id";
 pub const ATTR_NODE_TYPE: &str = "node.type";
+pub const ATTR_NODE_PHASE: &str = "node.phase";
 
 // Units (UCUM)
 pub const UNIT_ROWS: &str = "{row}";
 pub const UNIT_BYTES: &str = "By";
 pub const UNIT_MICROSECONDS: &str = "us";
 pub const UNIT_TASKS: &str = "{task}";
+
+// Node context keys
+pub const CTX_NODE_PHASE: &str = "phase";
+
+// Node phase values
+pub const NODE_PHASE_0: &str = "0";
+pub const NODE_PHASE_1: &str = "1";
 
 #[cfg(feature = "python")]
 pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {

--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -146,13 +146,6 @@ pub const UNIT_BYTES: &str = "By";
 pub const UNIT_MICROSECONDS: &str = "us";
 pub const UNIT_TASKS: &str = "{task}";
 
-// Node context keys
-pub const CTX_NODE_PHASE: &str = "phase";
-
-// Node phase values
-pub const NODE_PHASE_0: &str = "0";
-pub const NODE_PHASE_1: &str = "1";
-
 #[cfg(feature = "python")]
 pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     use pyo3::types::PyModuleMethods;

--- a/src/common/metrics/src/ops.rs
+++ b/src/common/metrics/src/ops.rs
@@ -4,7 +4,7 @@ use bincode::{Decode, Encode};
 use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 
-use crate::{ATTR_NODE_ID, ATTR_NODE_TYPE, NodeID};
+use crate::{ATTR_NODE_ID, ATTR_NODE_PHASE, ATTR_NODE_TYPE, CTX_NODE_PHASE, NodeID};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Encode, Decode)]
 pub enum NodeType {
@@ -97,9 +97,15 @@ pub struct NodeInfo {
 
 impl NodeInfo {
     pub fn to_key_values(&self) -> Vec<KeyValue> {
-        vec![
+        let mut kvs = vec![
             KeyValue::new(ATTR_NODE_ID, self.id.to_string()),
             KeyValue::new(ATTR_NODE_TYPE, self.node_type.to_string()),
-        ]
+        ];
+        // Add node phase if found in the context. This happens
+        // in distributed nodes.
+        if let Some(phase) = self.context.get(CTX_NODE_PHASE) {
+            kvs.push(KeyValue::new(ATTR_NODE_PHASE, phase.clone()));
+        }
+        kvs
     }
 }

--- a/src/common/metrics/src/ops.rs
+++ b/src/common/metrics/src/ops.rs
@@ -4,7 +4,7 @@ use bincode::{Decode, Encode};
 use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 
-use crate::{ATTR_NODE_ID, ATTR_NODE_PHASE, ATTR_NODE_TYPE, CTX_NODE_PHASE, NodeID};
+use crate::{ATTR_NODE_ID, ATTR_NODE_PHASE, ATTR_NODE_TYPE, NodeID};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Encode, Decode)]
 pub enum NodeType {
@@ -92,6 +92,7 @@ pub struct NodeInfo {
     #[allow(dead_code)]
     pub node_type: NodeType,
     pub node_category: NodeCategory,
+    pub node_phase: Option<String>,
     pub context: HashMap<String, String>,
 }
 
@@ -101,9 +102,9 @@ impl NodeInfo {
             KeyValue::new(ATTR_NODE_ID, self.id.to_string()),
             KeyValue::new(ATTR_NODE_TYPE, self.node_type.to_string()),
         ];
-        // Add node phase if found in the context. This happens
-        // in distributed nodes.
-        if let Some(phase) = self.context.get(CTX_NODE_PHASE) {
+        // Add node phase if present. This is used by distributed
+        // pipeline nodes that have multiple execution phases.
+        if let Some(phase) = self.node_phase.as_ref() {
             kvs.push(KeyValue::new(ATTR_NODE_PHASE, phase.clone()));
         }
         kvs

--- a/src/daft-distributed/src/pipeline_node/actor_udf.rs
+++ b/src/daft-distributed/src/pipeline_node/actor_udf.rs
@@ -223,10 +223,7 @@ impl ActorUDF {
                 self.passthrough_columns.clone(),
                 self.required_columns.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self.node_id() as usize)),
             )
         })
     }

--- a/src/daft-distributed/src/pipeline_node/aggregate.rs
+++ b/src/daft-distributed/src/pipeline_node/aggregate.rs
@@ -141,10 +141,7 @@ impl PipelineNodeImpl for AggregateNode {
                     self_clone.aggs.clone(),
                     self_clone.config.schema.clone(),
                     StatsState::NotMaterialized,
-                    LocalNodeContext {
-                        origin_node_id: Some(self_clone.node_id() as usize),
-                        additional: None,
-                    },
+                    LocalNodeContext::new(Some(self_clone.node_id() as usize)),
                 )
             } else {
                 LocalPhysicalPlan::hash_aggregate(
@@ -153,10 +150,7 @@ impl PipelineNodeImpl for AggregateNode {
                     self_clone.group_by.clone(),
                     self_clone.config.schema.clone(),
                     StatsState::NotMaterialized,
-                    LocalNodeContext {
-                        origin_node_id: Some(self_clone.node_id() as usize),
-                        additional: None,
-                    },
+                    LocalNodeContext::new(Some(self_clone.node_id() as usize)),
                 )
             }
         })

--- a/src/daft-distributed/src/pipeline_node/distinct.rs
+++ b/src/daft-distributed/src/pipeline_node/distinct.rs
@@ -99,10 +99,7 @@ impl PipelineNodeImpl for DistinctNode {
                 self_clone.columns.clone(),
                 self_clone.config.schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self_clone.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self_clone.node_id() as usize)),
             )
         })
     }

--- a/src/daft-distributed/src/pipeline_node/explode.rs
+++ b/src/daft-distributed/src/pipeline_node/explode.rs
@@ -175,10 +175,7 @@ impl PipelineNodeImpl for ExplodeNode {
                 index_column.clone(),
                 schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             )
         })
     }

--- a/src/daft-distributed/src/pipeline_node/filter.rs
+++ b/src/daft-distributed/src/pipeline_node/filter.rs
@@ -156,10 +156,7 @@ impl PipelineNodeImpl for FilterNode {
                 input,
                 predicate.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             )
         })
     }

--- a/src/daft-distributed/src/pipeline_node/glob_scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/glob_scan_source.rs
@@ -89,10 +89,7 @@ impl PipelineNodeImpl for GlobScanSourceNode {
             self.config.schema.clone(),
             StatsState::NotMaterialized,
             self.io_config.clone(),
-            LocalNodeContext {
-                origin_node_id: Some(self.node_id() as usize),
-                additional: None,
-            },
+            LocalNodeContext::new(Some(self.node_id() as usize)),
         );
         let glob_paths = self.glob_paths.clone().to_vec();
         let builder = SwordfishTaskBuilder::new(glob_scan_plan, self.as_ref())

--- a/src/daft-distributed/src/pipeline_node/in_memory_source.rs
+++ b/src/daft-distributed/src/pipeline_node/in_memory_source.rs
@@ -70,10 +70,7 @@ impl InMemorySourceNode {
             self.info.source_schema.clone(),
             partition_ref.size_bytes(),
             StatsState::NotMaterialized,
-            LocalNodeContext {
-                origin_node_id: Some(self.node_id() as usize),
-                additional: None,
-            },
+            LocalNodeContext::new(Some(self.node_id() as usize)),
         );
 
         SwordfishTaskBuilder::new(in_memory_scan, self.as_ref())

--- a/src/daft-distributed/src/pipeline_node/into_partitions.rs
+++ b/src/daft-distributed/src/pipeline_node/into_partitions.rs
@@ -134,10 +134,7 @@ impl IntoPartitionsNode {
                 in_memory_scan,
                 1,
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self.node_id() as usize)),
             );
             let builder =
                 SwordfishTaskBuilder::new(plan, self.as_ref()).with_psets(self.node_id(), psets);
@@ -183,10 +180,7 @@ impl IntoPartitionsNode {
                     plan,
                     num_outputs,
                     StatsState::NotMaterialized,
-                    LocalNodeContext {
-                        origin_node_id: Some(self.node_id() as usize),
-                        additional: None,
-                    },
+                    LocalNodeContext::new(Some(self.node_id() as usize)),
                 )
             });
             // Build and submit
@@ -250,10 +244,7 @@ impl IntoPartitionsNode {
                                 plan,
                                 1,
                                 StatsState::NotMaterialized,
-                                LocalNodeContext {
-                                    origin_node_id: Some(node_id as usize),
-                                    additional: None,
-                                },
+                                LocalNodeContext::new(Some(node_id as usize)),
                             )
                         });
                         let _ = result_tx.send(builder).await;

--- a/src/daft-distributed/src/pipeline_node/join/broadcast_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/broadcast_join.rs
@@ -133,10 +133,7 @@ impl BroadcastJoinNode {
                         self.join_type,
                         self.config.schema.clone(),
                         StatsState::NotMaterialized,
-                        LocalNodeContext {
-                            origin_node_id: Some(self.node_id() as usize),
-                            additional: None,
-                        },
+                        LocalNodeContext::new(Some(self.node_id() as usize)),
                     )
                 })
                 .with_psets(self.node_id(), broadcast_psets.clone());

--- a/src/daft-distributed/src/pipeline_node/join/cross_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/cross_join.rs
@@ -90,10 +90,7 @@ impl CrossJoinNode {
                                 right_plan,
                                 self.config.schema.clone(),
                                 StatsState::NotMaterialized,
-                                LocalNodeContext {
-                                    origin_node_id: Some(self.node_id() as usize),
-                                    additional: None,
-                                },
+                                LocalNodeContext::new(Some(self.node_id() as usize)),
                             )
                         },
                     );
@@ -113,10 +110,7 @@ impl CrossJoinNode {
                                 right_plan,
                                 self.config.schema.clone(),
                                 StatsState::NotMaterialized,
-                                LocalNodeContext {
-                                    origin_node_id: Some(self.node_id() as usize),
-                                    additional: None,
-                                },
+                                LocalNodeContext::new(Some(self.node_id() as usize)),
                             )
                         },
                     );

--- a/src/daft-distributed/src/pipeline_node/join/hash_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/hash_join.rs
@@ -142,10 +142,7 @@ impl PipelineNodeImpl for HashJoinNode {
                                 self.join_type,
                                 self.config.schema.clone(),
                                 StatsState::NotMaterialized,
-                                LocalNodeContext {
-                                    origin_node_id: Some(self.node_id() as usize),
-                                    additional: None,
-                                },
+                                LocalNodeContext::new(Some(self.node_id() as usize)),
                             )
                         },
                     )

--- a/src/daft-distributed/src/pipeline_node/join/sort_merge_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/sort_merge_join.rs
@@ -134,10 +134,7 @@ impl SortMergeJoinNode {
             self.join_type,
             self.config.schema.clone(),
             StatsState::NotMaterialized,
-            LocalNodeContext {
-                origin_node_id: Some(self.node_id() as usize),
-                additional: None,
-            },
+            LocalNodeContext::new(Some(self.node_id() as usize)),
         );
 
         // Create the task

--- a/src/daft-distributed/src/pipeline_node/monotonically_increasing_id.rs
+++ b/src/daft-distributed/src/pipeline_node/monotonically_increasing_id.rs
@@ -102,10 +102,7 @@ impl PipelineNodeImpl for MonotonicallyIncreasingIdNode {
                 ),
                 schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             )
         })
     }

--- a/src/daft-distributed/src/pipeline_node/pivot.rs
+++ b/src/daft-distributed/src/pipeline_node/pivot.rs
@@ -117,10 +117,7 @@ impl PipelineNodeImpl for PivotNode {
                 false,
                 self_clone.config.schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self_clone.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self_clone.node_id() as usize)),
             )
         };
 

--- a/src/daft-distributed/src/pipeline_node/project.rs
+++ b/src/daft-distributed/src/pipeline_node/project.rs
@@ -111,10 +111,7 @@ impl PipelineNodeImpl for ProjectNode {
                 projection.clone(),
                 schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             )
         };
 

--- a/src/daft-distributed/src/pipeline_node/sample.rs
+++ b/src/daft-distributed/src/pipeline_node/sample.rs
@@ -115,10 +115,7 @@ impl PipelineNodeImpl for SampleNode {
                 with_replacement,
                 seed,
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             )
         };
 

--- a/src/daft-distributed/src/pipeline_node/scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/scan_source.rs
@@ -117,10 +117,7 @@ impl ScanSourceNode {
             self.pushdowns.clone(),
             self.config.schema.clone(),
             StatsState::NotMaterialized,
-            LocalNodeContext {
-                origin_node_id: Some(self.node_id() as usize),
-                additional: None,
-            },
+            LocalNodeContext::new(Some(self.node_id() as usize)),
         );
 
         SwordfishTaskBuilder::new(physical_scan, self.as_ref())
@@ -222,10 +219,7 @@ impl PipelineNodeImpl for ScanSourceNode {
         if self.scan_tasks.is_empty() {
             let transformed_plan = LocalPhysicalPlan::empty_scan(
                 self.config.schema.clone(),
-                LocalNodeContext {
-                    origin_node_id: Some(self.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self.node_id() as usize)),
             );
             let empty_scan_task = SwordfishTaskBuilder::new(transformed_plan, self.as_ref());
             TaskBuilderStream::new(stream::iter(std::iter::once(empty_scan_task)).boxed())

--- a/src/daft-distributed/src/pipeline_node/shuffles/flight_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/flight_shuffle.rs
@@ -121,10 +121,7 @@ impl FlightShuffleNode {
                 server_cache_mapping.clone(),
                 self.config.schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self.context.node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self.context.node_id as usize)),
             );
 
             // For flight shuffle, we create a task directly with the flight shuffle read plan
@@ -187,10 +184,7 @@ impl PipelineNodeImpl for FlightShuffleNode {
                     self.shuffle_dirs.clone(),
                     self.compression.clone(),
                     StatsState::NotMaterialized,
-                    LocalNodeContext {
-                        origin_node_id: Some(self.context.node_id as usize),
-                        additional: None,
-                    },
+                    LocalNodeContext::new(Some(self.context.node_id as usize)),
                 )
             });
 

--- a/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/repartition.rs
@@ -140,10 +140,7 @@ impl PipelineNodeImpl for RepartitionNode {
                 self_clone.num_partitions,
                 self_clone.config.schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self_clone.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self_clone.node_id() as usize)),
             )
         });
 

--- a/src/daft-distributed/src/pipeline_node/sink.rs
+++ b/src/daft-distributed/src/pipeline_node/sink.rs
@@ -133,10 +133,7 @@ impl SinkNode {
                 file_schema,
                 info.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             ),
             #[cfg(feature = "python")]
             SinkInfo::CatalogInfo(info) => match &info.catalog {
@@ -147,10 +144,7 @@ impl SinkNode {
                     data_schema,
                     file_schema,
                     StatsState::NotMaterialized,
-                    LocalNodeContext {
-                        origin_node_id: Some(node_id as usize),
-                        additional: None,
-                    },
+                    LocalNodeContext::new(Some(node_id as usize)),
                 ),
                 daft_logical_plan::CatalogType::Lance(info) => LocalPhysicalPlan::lance_write(
                     input,
@@ -158,10 +152,7 @@ impl SinkNode {
                     data_schema,
                     file_schema,
                     StatsState::NotMaterialized,
-                    LocalNodeContext {
-                        origin_node_id: Some(node_id as usize),
-                        additional: None,
-                    },
+                    LocalNodeContext::new(Some(node_id as usize)),
                 ),
             },
             #[cfg(feature = "python")]
@@ -170,10 +161,7 @@ impl SinkNode {
                 data_sink_info.clone(),
                 file_schema,
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             ),
         }
     }
@@ -202,10 +190,7 @@ impl SinkNode {
             file_schema,
             info,
             StatsState::NotMaterialized,
-            LocalNodeContext {
-                origin_node_id: Some(self.node_id() as usize),
-                additional: None,
-            },
+            LocalNodeContext::new(Some(self.node_id() as usize)),
         );
         let builder =
             SwordfishTaskBuilder::new(plan, self.as_ref()).with_psets(self.node_id(), psets);

--- a/src/daft-distributed/src/pipeline_node/sort.rs
+++ b/src/daft-distributed/src/pipeline_node/sort.rs
@@ -138,20 +138,14 @@ pub(crate) fn create_sample_tasks(
                 true,
                 None,
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(pipeline_node.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(pipeline_node.node_id() as usize)),
             );
             let plan = LocalPhysicalPlan::project(
                 sample,
                 sample_by.clone(),
                 sample_schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(pipeline_node.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(pipeline_node.node_id() as usize)),
             );
             let builder = SwordfishTaskBuilder::new(plan, pipeline_node)
                 .with_psets(pipeline_node.node_id(), psets);
@@ -186,10 +180,7 @@ pub(crate) fn create_range_repartition_tasks(
                 input_schema.clone(),
                 mo.size_bytes(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             );
             let plan = LocalPhysicalPlan::repartition(
                 in_memory_source_plan,
@@ -202,10 +193,7 @@ pub(crate) fn create_range_repartition_tasks(
                 num_partitions,
                 input_schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             );
             let builder = SwordfishTaskBuilder::new(plan, pipeline_node)
                 .with_psets(node_id, mo.into_inner().0);
@@ -300,10 +288,7 @@ impl SortNode {
                 self.descending.clone(),
                 self.nulls_first.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self.node_id() as usize)),
             );
             let task =
                 SwordfishTaskBuilder::new(plan, self.as_ref()).with_psets(self.node_id(), psets);
@@ -372,10 +357,7 @@ impl SortNode {
                 self.descending.clone(),
                 self.nulls_first.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self.node_id() as usize)),
             );
             let task =
                 SwordfishTaskBuilder::new(plan, self.as_ref()).with_psets(self.node_id(), psets);

--- a/src/daft-distributed/src/pipeline_node/top_n.rs
+++ b/src/daft-distributed/src/pipeline_node/top_n.rs
@@ -126,10 +126,7 @@ impl PipelineNodeImpl for TopNNode {
                 self_clone.limit,
                 self_clone.offset,
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self_clone.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self_clone.node_id() as usize)),
             )
         })
     }

--- a/src/daft-distributed/src/pipeline_node/udf.rs
+++ b/src/daft-distributed/src/pipeline_node/udf.rs
@@ -213,10 +213,7 @@ impl PipelineNodeImpl for UDFNode {
                 passthrough_columns.clone(),
                 schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(node_id as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(node_id as usize)),
             )
         };
 

--- a/src/daft-distributed/src/pipeline_node/unpivot.rs
+++ b/src/daft-distributed/src/pipeline_node/unpivot.rs
@@ -112,10 +112,7 @@ impl PipelineNodeImpl for UnpivotNode {
                 self_clone.value_name.clone(),
                 self_clone.config.schema.clone(),
                 StatsState::NotMaterialized,
-                LocalNodeContext {
-                    origin_node_id: Some(self_clone.node_id() as usize),
-                    additional: None,
-                },
+                LocalNodeContext::new(Some(self_clone.node_id() as usize)),
             )
         };
 

--- a/src/daft-distributed/src/pipeline_node/vllm.rs
+++ b/src/daft-distributed/src/pipeline_node/vllm.rs
@@ -102,10 +102,7 @@ impl VLLMNode {
                     self.output_column_name.clone(),
                     self.config.schema.clone(),
                     StatsState::NotMaterialized,
-                    LocalNodeContext {
-                        origin_node_id: Some(self.node_id() as usize),
-                        additional: None,
-                    },
+                    LocalNodeContext::new(Some(self.node_id() as usize)),
                 )
             });
 

--- a/src/daft-distributed/src/pipeline_node/window.rs
+++ b/src/daft-distributed/src/pipeline_node/window.rs
@@ -58,10 +58,7 @@ impl WindowNodePartitionOnly {
             StatsState::NotMaterialized,
             self.agg_exprs.clone(),
             self.base.aliases.clone(),
-            LocalNodeContext {
-                origin_node_id: Some(self.base.context.node_id as usize),
-                additional: None,
-            },
+            LocalNodeContext::new(Some(self.base.context.node_id as usize)),
         )
     }
 
@@ -100,10 +97,7 @@ impl WindowNodePartitionAndOrderBy {
             StatsState::NotMaterialized,
             self.window_exprs.clone(),
             self.base.aliases.clone(),
-            LocalNodeContext {
-                origin_node_id: Some(self.base.context.node_id as usize),
-                additional: None,
-            },
+            LocalNodeContext::new(Some(self.base.context.node_id as usize)),
         )
     }
 
@@ -154,10 +148,7 @@ impl WindowNodePartitionAndDynamicFrame {
             StatsState::NotMaterialized,
             self.agg_exprs.clone(),
             self.base.aliases.clone(),
-            LocalNodeContext {
-                origin_node_id: Some(self.base.context.node_id as usize),
-                additional: None,
-            },
+            LocalNodeContext::new(Some(self.base.context.node_id as usize)),
         )
     }
 
@@ -208,10 +199,7 @@ impl WindowNodeOrderByOnly {
             StatsState::NotMaterialized,
             self.window_exprs.clone(),
             self.base.aliases.clone(),
-            LocalNodeContext {
-                origin_node_id: Some(self.base.context.node_id as usize),
-                additional: None,
-            },
+            LocalNodeContext::new(Some(self.base.context.node_id as usize)),
         )
     }
 

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -116,6 +116,7 @@ impl StatisticsManager {
                 id: node.node_id() as usize,
                 node_type: node.context().node_type.clone(),
                 node_category: node.context().node_category.clone(),
+                node_phase: None,
                 context: HashMap::new(),
             });
             runtime_node_managers.insert(

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -242,6 +242,8 @@ impl BuilderContext {
             self.context.clone()
         };
 
+        let node_phase = node_context.phase.clone();
+
         NodeInfo {
             name,
             id: node_context
@@ -249,6 +251,7 @@ impl BuilderContext {
                 .unwrap_or_else(|| self.next_id()),
             node_type,
             node_category,
+            node_phase,
             context,
         }
     }

--- a/src/daft-local-execution/src/runtime_stats/values.rs
+++ b/src/daft-local-execution/src/runtime_stats/values.rs
@@ -37,7 +37,6 @@ pub struct DefaultRuntimeStats {
 impl DefaultRuntimeStats {
     pub fn new(meter: &Meter, node_info: &NodeInfo) -> Self {
         let node_kv = node_info.to_key_values();
-
         Self {
             duration_us: Counter::new(meter, DURATION_KEY, None, Some(UNIT_MICROSECONDS.into())),
             rows_in: Counter::new(meter, ROWS_IN_KEY, None, Some(UNIT_ROWS.into())),

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -32,7 +32,28 @@ use crate::SourceId;
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct LocalNodeContext {
     pub origin_node_id: Option<usize>,
+    pub phase: Option<String>,
     pub additional: Option<HashMap<String, String>>,
+}
+
+impl LocalNodeContext {
+    pub fn new(origin_node_id: Option<usize>) -> Self {
+        Self {
+            origin_node_id,
+            phase: None,
+            additional: None,
+        }
+    }
+
+    pub fn with_phase(mut self, phase: impl Into<String>) -> Self {
+        self.phase = Some(phase.into());
+        self
+    }
+
+    pub fn with_additional(mut self, additional: HashMap<String, String>) -> Self {
+        self.additional = Some(additional);
+        self
+    }
 }
 
 pub type LocalPhysicalPlanRef = Arc<LocalPhysicalPlan>;


### PR DESCRIPTION
## Changes Made

This PR adds phase-aware node metrics and wires phase context through distributed pipeline nodes so per-phase stats are emitted consistently.

* Added `phase` field to LocalNodeContext for tracking multi execution nodes
* Updated NodeInfo::to_key_values() to include node.phase when phase is present in node context.
* Updated distributed nodes to use phase context constants instead of ad-hoc "stage" strings.
* Fixed IntoBatches so all rebatch outputs (including trailing end-of-stream flush) are tagged with rebatch phase context.
* Preserved initial-vs-rebatch phase labeling in IntoBatches and first-vs-second phase labeling in Limit.

## Related Issues

https://github.com/Eventual-Inc/Daft/discussions/5155

<img width="1463" height="683" alt="daft_rows_in_with_phase" src="https://github.com/user-attachments/assets/15c52c42-7e5d-4769-bbfd-4c12c3687f27" />

<img width="1458" height="853" alt="daft_rows_out_with_phase" src="https://github.com/user-attachments/assets/81edadd1-8f40-44f8-a747-97d7cce5bc9f" />

