### PR TITLE
fix(arrow2): reinterpret physical array as logical type after cast fallback

### DIFF
--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -191,7 +191,19 @@ where
                             &target_arrow_physical_type,
                         )
                     {
-                        arrow::compute::cast(data_to_cast.as_ref(), &target_arrow_physical_type)?
+                        // Cast to the physical type first (e.g. UInt16 -> Int32), then
+                        // reinterpret as the logical type (e.g. Int32 -> Date32) so that
+                        // downstream from_arrow receives the expected arrow type.
+                        let physical = arrow::compute::cast(
+                            data_to_cast.as_ref(),
+                            &target_arrow_physical_type,
+                        )?;
+                        let data = physical
+                            .into_data()
+                            .into_builder()
+                            .data_type(target_arrow_type)
+                            .build()?;
+                        arrow::array::make_array(data)
                     } else {
                         return Err(DaftError::TypeError(format!(
                             "can not cast {:?} to type: {:?}: Arrow types not castable, {:?}, {:?}",

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -1138,6 +1138,29 @@ def test_series_cast_date_numeric(dtype, result_n1, result_0, result_p1) -> None
     assert casted.to_pylist() == [-1, 0, 1]
 
 
+@pytest.mark.parametrize(
+    "source_dtype",
+    [
+        DataType.uint8(),
+        DataType.uint16(),
+        DataType.uint32(),
+        DataType.int8(),
+        DataType.int16(),
+        DataType.int32(),
+    ],
+)
+def test_series_cast_numeric_to_date(source_dtype) -> None:
+    """Casting integer types to Date should work via the physical type (Int32) fallback.
+
+    Regression test: UInt16 -> Date panicked because arrow-rs doesn't support
+    direct UInt16 -> Date32 casting, and the physical-type fallback produced an
+    Int32Array that wasn't reinterpreted as Date32Array before downstream use.
+    """
+    series = Series.from_pylist([0, 1, 2]).cast(source_dtype)
+    casted = series.cast(DataType.date())
+    assert casted.to_pylist() == [date(1970, 1, 1), date(1970, 1, 2), date(1970, 1, 3)]
+
+
 def test_cast_date_to_timestamp():
     from datetime import date, datetime
 


### PR DESCRIPTION
`DataArray::cast` has a fallback path for when arrow-rs can't cast directly to a logical arrow type (e.g. `UInt16 -> Date32`). It casts to the physical type instead (`UInt16 -> Int32`), but the resulting `Int32Array` was passed directly to `Series::from_arrow` with a `Date` field. `DateArray::from_arrow` then called `arr.as_primitive::<Date32Type>()` on the `Int32Array`, causing a panic with message `"primitive array"`.

The fix reinterprets the physical array as the logical arrow type (e.g. `Int32 -> Date32`) via `into_data().into_builder().data_type(...).build()` before passing it downstream. No buffer data is copied — `to_data()` bumps Arc refcounts on the underlying buffers, and `build()` runs an O(1) layout validation (buffer count and length checks, not a data scan).

Discovered via ClickBench — the `hits.parquet` dataset stores `EventDate` as `UInt16`, and casting to `Date` panicked on 8 of 43 queries (Q7, Q24, Q37–Q43).

Regression introduced in #6239.