### PR TITLE
refactor(arrow2): introduce DaftParquetMetadata adapter to decouple crates from parquet2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,7 +3176,6 @@ dependencies = [
  "daft-warc",
  "dashmap",
  "futures",
- "parquet2",
  "pyo3",
  "snafu",
  "tokio",

--- a/src/daft-micropartition/Cargo.toml
+++ b/src/daft-micropartition/Cargo.toml
@@ -17,7 +17,6 @@ daft-stats = {path = "../daft-stats", default-features = false}
 daft-warc = {path = "../daft-warc", default-features = false}
 dashmap = {workspace = true}
 futures = {workspace = true}
-parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 snafu = {workspace = true}
 tokio = {workspace = true}

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -15,14 +15,13 @@ use daft_dsl::{AggExpr, Expr, ExprRef};
 use daft_io::{IOClient, IOConfig, IOStatsRef};
 use daft_json::{JsonConvertOptions, JsonParseOptions, JsonReadOptions};
 use daft_parquet::{
-    infer_arrow_schema_from_metadata,
+    DaftParquetMetadata, infer_arrow_schema_from_metadata,
     read::{ParquetSchemaInferenceOptions, read_parquet_bulk, read_parquet_metadata_bulk},
 };
 use daft_recordbatch::RecordBatch;
 use daft_stats::{ColumnRangeStatistics, PartitionSpec, TableMetadata, TableStatistics};
 use daft_warc::WarcConvertOptions;
 use futures::{Future, Stream};
-use parquet2::metadata::FileMetaData;
 use snafu::ResultExt;
 
 use crate::DaftCoreComputeSnafu;
@@ -592,7 +591,7 @@ pub fn read_parquet_into_micropartition<T: AsRef<str>>(
     schema_infer_options: &ParquetSchemaInferenceOptions,
     catalog_provided_schema: Option<SchemaRef>,
     field_id_mapping: Option<Arc<BTreeMap<i32, Field>>>,
-    parquet_metadata: Option<Vec<Arc<FileMetaData>>>,
+    parquet_metadata: Option<Vec<Arc<DaftParquetMetadata>>>,
     chunk_size: Option<usize>,
     aggregation_pushdown: Option<&Expr>,
 ) -> DaftResult<MicroPartition> {

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -641,8 +641,10 @@ pub fn read_parquet_into_micropartition<T: AsRef<str>>(
         let schemas = metadata
             .iter()
             .map(|m| {
-                let schema =
-                    infer_arrow_schema_from_metadata(m, Some((*schema_infer_options).into()))?;
+                let schema = infer_arrow_schema_from_metadata(
+                    m.as_parquet2(),
+                    Some((*schema_infer_options).into()),
+                )?;
                 let daft_schema = Schema::from(schema);
                 DaftResult::Ok(Arc::new(daft_schema))
             })
@@ -666,8 +668,10 @@ pub fn read_parquet_into_micropartition<T: AsRef<str>>(
         let schemas = metadata
             .iter()
             .map(|m| {
-                let schema =
-                    infer_arrow_schema_from_metadata(m, Some((*schema_infer_options).into()))?;
+                let schema = infer_arrow_schema_from_metadata(
+                    m.as_parquet2(),
+                    Some((*schema_infer_options).into()),
+                )?;
                 let daft_schema = schema.into();
                 DaftResult::Ok(Arc::new(daft_schema))
             })
@@ -677,7 +681,7 @@ pub fn read_parquet_into_micropartition<T: AsRef<str>>(
 
     // Handle count pushdown aggregation optimization.
     if let Some(Expr::Agg(AggExpr::Count(_, _))) = aggregation_pushdown {
-        let count: usize = metadata.iter().map(|m| m.num_rows).sum();
+        let count: usize = metadata.iter().map(|m| m.num_rows()).sum();
         let count_field = daft_core::datatypes::Field::new(
             aggregation_pushdown.unwrap().name(),
             daft_core::datatypes::DataType::UInt64,

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -8,6 +8,8 @@ use snafu::Snafu;
 
 mod file;
 pub mod metadata;
+mod metadata_adapter;
+pub use metadata_adapter::{DaftParquetMetadata, DaftRowGroupMetaData};
 #[cfg(feature = "python")]
 pub mod python;
 pub mod read;

--- a/src/daft-parquet/src/metadata_adapter.rs
+++ b/src/daft-parquet/src/metadata_adapter.rs
@@ -51,7 +51,10 @@ impl DaftParquetMetadata {
     }
 
     /// Iterate over (index, row_group_metadata) pairs without cloning.
-    pub fn row_groups_ref(&self) -> impl Iterator<Item = (usize, &Pq2RowGroupMetaData)> + '_ {
+    #[allow(dead_code)]
+    pub(crate) fn row_groups_ref(
+        &self,
+    ) -> impl Iterator<Item = (usize, &Pq2RowGroupMetaData)> + '_ {
         self.inner.row_groups.iter().map(|(&idx, rg)| (idx, rg))
     }
 
@@ -64,7 +67,7 @@ impl DaftParquetMetadata {
     }
 
     /// Get a specific row group by its original index without cloning.
-    pub fn get_row_group_ref(&self, index: usize) -> Option<&Pq2RowGroupMetaData> {
+    pub(crate) fn get_row_group_ref(&self, index: usize) -> Option<&Pq2RowGroupMetaData> {
         self.inner.row_groups.get(&index)
     }
 
@@ -94,11 +97,6 @@ impl DaftParquetMetadata {
     /// This is a transitional API. Consuming code should prefer the adapter methods
     /// above. This will be removed once the arrow-rs migration is complete.
     pub fn as_parquet2(&self) -> &Pq2FileMetaData {
-        &self.inner
-    }
-
-    /// Borrow the underlying parquet2 metadata without cloning.
-    pub fn parquet2_ref(&self) -> &Pq2FileMetaData {
         &self.inner
     }
 
@@ -147,7 +145,8 @@ impl DaftRowGroupMetaData {
     }
 
     /// Column chunk metadata for this row group.
-    pub fn columns(&self) -> &[Pq2ColumnChunkMetaData] {
+    #[allow(dead_code)]
+    pub(crate) fn columns(&self) -> &[Pq2ColumnChunkMetaData] {
         self.inner.columns()
     }
 

--- a/src/daft-parquet/src/metadata_adapter.rs
+++ b/src/daft-parquet/src/metadata_adapter.rs
@@ -1,0 +1,228 @@
+//! Daft-owned parquet metadata types that decouple consuming crates from parquet2.
+//!
+//! These adapter types wrap `parquet2::metadata::*` today and will be extended
+//! with an `ArrowRs` variant when the core read pipeline migrates to arrow-rs.
+
+use indexmap::IndexMap;
+use parquet2::metadata::{
+    ColumnChunkMetaData as Pq2ColumnChunkMetaData, FileMetaData as Pq2FileMetaData,
+    RowGroupMetaData as Pq2RowGroupMetaData,
+};
+use serde::{Deserialize, Serialize};
+
+/// Row group list preserving original indices through filter/split operations.
+pub type RowGroupList = IndexMap<usize, DaftRowGroupMetaData>;
+
+/// Daft-owned parquet file metadata.
+///
+/// Wraps the underlying parquet library's metadata and provides a stable API
+/// that consuming crates (daft-scan, daft-micropartition) depend on.
+///
+/// Currently backed by `parquet2::metadata::FileMetaData`. When the arrow-rs
+/// migration completes, an `ArrowRs` variant will be added.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
+pub struct DaftParquetMetadata {
+    inner: Pq2FileMetaData,
+}
+
+impl DaftParquetMetadata {
+    /// Total number of rows across all row groups.
+    pub fn num_rows(&self) -> usize {
+        self.inner.num_rows
+    }
+
+    /// Number of row groups in this file.
+    pub fn num_row_groups(&self) -> usize {
+        self.inner.row_groups.len()
+    }
+
+    /// Parquet file version.
+    pub fn version(&self) -> i32 {
+        self.inner.version
+    }
+
+    /// Iterate over (index, row_group_metadata) pairs, preserving original indices.
+    pub fn row_groups(&self) -> impl Iterator<Item = (usize, DaftRowGroupMetaData)> + '_ {
+        self.inner
+            .row_groups
+            .iter()
+            .map(|(&idx, rg)| (idx, DaftRowGroupMetaData::from_parquet2(rg.clone())))
+    }
+
+    /// Get a specific row group by its original index.
+    pub fn get_row_group(&self, index: usize) -> Option<DaftRowGroupMetaData> {
+        self.inner
+            .row_groups
+            .get(&index)
+            .map(|rg| DaftRowGroupMetaData::from_parquet2(rg.clone()))
+    }
+
+    /// Check if a row group index exists.
+    pub fn contains_row_group(&self, index: usize) -> bool {
+        self.inner.row_groups.contains_key(&index)
+    }
+
+    /// Get the set of row group indices.
+    pub fn row_group_indices(&self) -> impl Iterator<Item = usize> + '_ {
+        self.inner.row_groups.keys().copied()
+    }
+
+    /// Clone this metadata with a different set of row groups.
+    pub fn clone_with_row_groups(&self, num_rows: usize, row_groups: RowGroupList) -> Self {
+        let pq2_row_groups: indexmap::IndexMap<usize, Pq2RowGroupMetaData> = row_groups
+            .into_iter()
+            .map(|(idx, rg)| (idx, rg.into_parquet2()))
+            .collect();
+        Self {
+            inner: self.inner.clone_with_row_groups(num_rows, pq2_row_groups),
+        }
+    }
+
+    /// Access the underlying parquet2 FileMetaData.
+    ///
+    /// This is a transitional API. Consuming code should prefer the adapter methods
+    /// above. This will be removed once the arrow-rs migration is complete.
+    pub fn as_parquet2(&self) -> &Pq2FileMetaData {
+        &self.inner
+    }
+
+    /// Consume and return the underlying parquet2 FileMetaData.
+    pub fn into_parquet2(self) -> Pq2FileMetaData {
+        self.inner
+    }
+}
+
+impl From<Pq2FileMetaData> for DaftParquetMetadata {
+    fn from(inner: Pq2FileMetaData) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<DaftParquetMetadata> for Pq2FileMetaData {
+    fn from(adapter: DaftParquetMetadata) -> Self {
+        adapter.inner
+    }
+}
+
+/// Allow transparent Arc<DaftParquetMetadata> → &FileMetaData access for gradual migration.
+impl std::ops::Deref for DaftParquetMetadata {
+    type Target = Pq2FileMetaData;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Daft-owned row group metadata.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(transparent)]
+pub struct DaftRowGroupMetaData {
+    inner: Pq2RowGroupMetaData,
+}
+
+impl DaftRowGroupMetaData {
+    fn from_parquet2(inner: Pq2RowGroupMetaData) -> Self {
+        Self { inner }
+    }
+
+    fn into_parquet2(self) -> Pq2RowGroupMetaData {
+        self.inner
+    }
+
+    /// Number of rows in this row group.
+    pub fn num_rows(&self) -> usize {
+        self.inner.num_rows()
+    }
+
+    /// Total compressed size of this row group in bytes.
+    pub fn compressed_size(&self) -> usize {
+        self.inner.compressed_size()
+    }
+
+    /// Column chunk metadata for this row group.
+    pub fn columns(&self) -> &[Pq2ColumnChunkMetaData] {
+        self.inner.columns()
+    }
+
+    /// Access the underlying parquet2 RowGroupMetaData.
+    pub fn as_parquet2(&self) -> &Pq2RowGroupMetaData {
+        &self.inner
+    }
+}
+
+impl From<Pq2RowGroupMetaData> for DaftRowGroupMetaData {
+    fn from(inner: Pq2RowGroupMetaData) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<DaftRowGroupMetaData> for Pq2RowGroupMetaData {
+    fn from(adapter: DaftRowGroupMetaData) -> Self {
+        adapter.inner
+    }
+}
+
+impl std::ops::Deref for DaftRowGroupMetaData {
+    type Target = Pq2RowGroupMetaData;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use parquet2::metadata::SchemaDescriptor;
+
+    use super::*;
+
+    fn make_test_schema(name: &str) -> SchemaDescriptor {
+        SchemaDescriptor::new(name.to_string(), vec![])
+    }
+
+    #[test]
+    fn test_daft_metadata_serde_roundtrip() {
+        let file_meta = Pq2FileMetaData {
+            version: 2,
+            num_rows: 1000,
+            created_by: Some("test".to_string()),
+            row_groups: IndexMap::new(),
+            key_value_metadata: None,
+            schema_descr: make_test_schema("test"),
+            column_orders: None,
+        };
+
+        let adapter = DaftParquetMetadata::from(file_meta.clone());
+
+        // Serialize both and compare (bincode v2 API)
+        let config = bincode::config::legacy();
+        let adapter_bytes = bincode::serde::encode_to_vec(&adapter, config).unwrap();
+        let file_meta_bytes = bincode::serde::encode_to_vec(&file_meta, config).unwrap();
+        assert_eq!(adapter_bytes, file_meta_bytes);
+
+        // Deserialize back
+        let (roundtripped, _): (DaftParquetMetadata, _) =
+            bincode::serde::decode_from_slice(&adapter_bytes, config).unwrap();
+        assert_eq!(roundtripped.num_rows(), 1000);
+        assert_eq!(roundtripped.version(), 2);
+    }
+
+    #[test]
+    fn test_deref_to_file_metadata() {
+        let file_meta = Pq2FileMetaData {
+            version: 2,
+            num_rows: 500,
+            created_by: None,
+            row_groups: IndexMap::new(),
+            key_value_metadata: None,
+            schema_descr: make_test_schema("test"),
+            column_orders: None,
+        };
+
+        let adapter = DaftParquetMetadata::from(file_meta);
+        // Through Deref, we can access FileMetaData fields directly
+        assert_eq!(adapter.num_rows, 500);
+        assert_eq!(adapter.schema().name(), "test");
+    }
+}

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -222,7 +222,7 @@ impl GlobScanOperator {
                     let first_metadata = Some((
                         first_filepath.clone(),
                         TableMetadata {
-                            length: metadata.num_rows,
+                            length: metadata.num_rows(),
                         },
                     ));
                     (schema, first_metadata, first_filepath)

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -13,11 +13,11 @@ use common_display::DisplayAs;
 use common_error::DaftError;
 use common_file_formats::FileFormatConfig;
 use common_scan_info::{Pushdowns, ScanTaskLike, ScanTaskLikeRef};
+use daft_parquet::DaftParquetMetadata;
 use daft_schema::schema::{Schema, SchemaRef};
 use daft_stats::{PartitionSpec, TableMetadata, TableStatistics};
 use either::Either;
 use itertools::Itertools;
-use parquet2::metadata::FileMetaData;
 use serde::{Deserialize, Serialize};
 
 mod anonymous;
@@ -145,7 +145,7 @@ pub enum DataSource {
         metadata: Option<TableMetadata>,
         partition_spec: Option<PartitionSpec>,
         statistics: Option<TableStatistics>,
-        parquet_metadata: Option<Arc<FileMetaData>>,
+        parquet_metadata: Option<Arc<DaftParquetMetadata>>,
     },
     Database {
         path: String,
@@ -233,7 +233,7 @@ impl DataSource {
     }
 
     #[must_use]
-    pub fn get_parquet_metadata(&self) -> Option<&Arc<FileMetaData>> {
+    pub fn get_parquet_metadata(&self) -> Option<&Arc<DaftParquetMetadata>> {
         match self {
             Self::File {
                 parquet_metadata, ..

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -703,7 +703,7 @@ pub mod pylib {
             iceberg_delete_files: None,
             metadata: if has_metadata.unwrap_or(false) {
                 Some(TableMetadata {
-                    length: metadata.num_rows,
+                    length: metadata.num_rows(),
                 })
             } else {
                 None


### PR DESCRIPTION
Introduces `DaftParquetMetadata` and `DaftRowGroupMetaData` wrapper types in `daft-parquet` that decouple `daft-scan`, `daft-micropartition`, and `daft-local-execution` from direct `parquet2::metadata` imports. This is prep for the parquet reader migration from parquet2/arrow2 to arrow-rs (#5741).

The adapter exposes a stable API (`num_rows()`, `row_groups()`, `clone_with_row_groups()`, etc.) that consuming crates program against, with `as_parquet2()` / `into_parquet2()` escape hatches for code that still needs the underlying types. Conversion to parquet2 internals is deferred to the point of use — only `stream_parquet`, `read_parquet_bulk_async`, and `split_by_row_groups` convert at the boundary where raw parquet2 access is needed.

`#[serde(transparent)]` ensures serialization is wire-compatible with the existing `FileMetaData` format (verified by bincode roundtrip test). When the arrow-rs migration completes, the adapter will gain an `ArrowRs` variant without requiring changes to consuming crates.