### PR TITLE
refactor(arrow2): add arrow-rs parquet reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6145,6 +6145,7 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
+ "futures",
  "half",
  "hashbrown 0.16.1",
  "lz4_flex 0.12.0",
@@ -6156,6 +6157,7 @@ dependencies = [
  "simdutf8",
  "snap 1.1.1",
  "thrift",
+ "tokio",
  "twox-hash",
  "zstd",
 ]

--- a/src/daft-parquet/Cargo.toml
+++ b/src/daft-parquet/Cargo.toml
@@ -19,6 +19,7 @@ futures = {workspace = true}
 indexmap = {workspace = true}
 itertools = {workspace = true}
 log = {workspace = true}
+parquet = {workspace = true, features = ["async"]}
 parquet2 = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 rayon = {workspace = true}

--- a/src/daft-parquet/src/arrow_bridge.rs
+++ b/src/daft-parquet/src/arrow_bridge.rs
@@ -1,0 +1,160 @@
+use std::sync::Arc;
+
+use arrow::{
+    array::{ArrayRef, RecordBatch as ArrowRecordBatch},
+    compute::cast,
+};
+use common_error::DaftResult;
+use daft_core::prelude::*;
+use daft_recordbatch::RecordBatch;
+
+/// Cast an arrow-rs array to the type Daft expects, if needed.
+///
+/// The arrow-rs parquet reader produces small-offset types (Utf8, Binary, List)
+/// while Daft expects large-offset types (LargeUtf8, LargeBinary, LargeList).
+/// This function casts to the expected type when there's a mismatch.
+/// For extension types (Tensor, etc.) where `to_arrow()` is unsupported,
+/// the array is returned as-is and downstream conversion handles it.
+fn coerce_to_daft_compatible(array: &ArrayRef, daft_field: &Field) -> DaftResult<ArrayRef> {
+    let expected = match daft_field.dtype.to_arrow() {
+        Ok(dt) => dt,
+        Err(_) => return Ok(array.clone()),
+    };
+    if array.data_type() == &expected {
+        return Ok(array.clone());
+    }
+    cast(array.as_ref(), &expected).map_err(|e| {
+        common_error::DaftError::ComputeError(format!(
+            "Failed to cast column '{}' from {:?} to {:?}: {}",
+            daft_field.name,
+            array.data_type(),
+            expected,
+            e
+        ))
+    })
+}
+
+/// Convert an arrow-rs `RecordBatch` to a Daft `RecordBatch`.
+///
+/// Each column in the arrow-rs batch is paired with the corresponding field from the
+/// Daft schema (matched by column index), cast to the expected Daft arrow type if needed,
+/// and converted via `Series::from_arrow`.
+/// The Daft schema must have the same number of fields as the arrow-rs batch columns.
+pub fn arrowrs_to_daft_recordbatch(
+    arrow_rb: &ArrowRecordBatch,
+    daft_schema: &Schema,
+) -> DaftResult<RecordBatch> {
+    let num_rows = arrow_rb.num_rows();
+
+    if daft_schema.len() != arrow_rb.num_columns() {
+        return Err(common_error::DaftError::SchemaMismatch(format!(
+            "Arrow-rs RecordBatch has {} columns but Daft schema has {} fields",
+            arrow_rb.num_columns(),
+            daft_schema.len(),
+        )));
+    }
+
+    let columns: Vec<Series> = daft_schema
+        .into_iter()
+        .zip(arrow_rb.columns())
+        .map(|(field, array)| {
+            let coerced = coerce_to_daft_compatible(array, field)?;
+            Series::from_arrow(Arc::new(field.clone()), coerced)
+        })
+        .collect::<DaftResult<Vec<_>>>()?;
+
+    Ok(RecordBatch::new_unchecked(
+        Arc::new(daft_schema.clone()),
+        columns,
+        num_rows,
+    ))
+}
+
+/// Convert multiple arrow-rs `RecordBatch`es into a single Daft `RecordBatch`
+/// by converting each batch and concatenating the results.
+pub fn arrowrs_batches_to_daft_recordbatch(
+    arrow_batches: &[ArrowRecordBatch],
+    daft_schema: &Schema,
+) -> DaftResult<RecordBatch> {
+    if arrow_batches.is_empty() {
+        return Ok(RecordBatch::empty(Some(Arc::new(daft_schema.clone()))));
+    }
+
+    if arrow_batches.len() == 1 {
+        return arrowrs_to_daft_recordbatch(&arrow_batches[0], daft_schema);
+    }
+
+    let daft_batches: Vec<RecordBatch> = arrow_batches
+        .iter()
+        .map(|batch| arrowrs_to_daft_recordbatch(batch, daft_schema))
+        .collect::<DaftResult<Vec<_>>>()?;
+
+    RecordBatch::concat(daft_batches.iter().collect::<Vec<_>>().as_slice())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::{
+        array::{Int32Array, RecordBatch as ArrowRecordBatch, StringArray},
+        datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
+    };
+    use daft_core::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn test_basic_conversion() {
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("a", ArrowDataType::Int32, true),
+            ArrowField::new("b", ArrowDataType::Utf8, true),
+        ]));
+
+        let arrow_rb = ArrowRecordBatch::try_new(
+            arrow_schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec!["x", "y", "z"])),
+            ],
+        )
+        .unwrap();
+
+        let daft_schema = Schema::new(vec![
+            Field::new("a", DataType::Int32),
+            Field::new("b", DataType::Utf8),
+        ]);
+
+        let result = arrowrs_to_daft_recordbatch(&arrow_rb, &daft_schema).unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.num_columns(), 2);
+    }
+
+    #[test]
+    fn test_empty_batch_conversion() {
+        let daft_schema = Schema::new(vec![Field::new("a", DataType::Int32)]);
+        let result = arrowrs_batches_to_daft_recordbatch(&[], &daft_schema).unwrap();
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_schema_mismatch_error() {
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "a",
+            ArrowDataType::Int32,
+            true,
+        )]));
+
+        let arrow_rb =
+            ArrowRecordBatch::try_new(arrow_schema, vec![Arc::new(Int32Array::from(vec![1]))])
+                .unwrap();
+
+        let daft_schema = Schema::new(vec![
+            Field::new("a", DataType::Int32),
+            Field::new("b", DataType::Utf8),
+        ]);
+
+        let result = arrowrs_to_daft_recordbatch(&arrow_rb, &daft_schema);
+        assert!(result.is_err());
+    }
+}

--- a/src/daft-parquet/src/arrowrs_reader.rs
+++ b/src/daft-parquet/src/arrowrs_reader.rs
@@ -1,0 +1,845 @@
+//! Arrow-rs based parquet reader.
+//!
+//! This module provides a parquet reader built on the arrow-rs `parquet` crate,
+//! replacing the parquet2/arrow2 decode pipeline. It uses [`DaftAsyncFileReader`]
+//! as the IO bridge for remote reads, and the sync `ParquetRecordBatchReaderBuilder`
+//! with `std::fs::File` for local reads (avoiding IOClient overhead).
+
+use std::sync::Arc;
+
+use common_error::DaftResult;
+use daft_core::prelude::*;
+use daft_dsl::{ExprRef, expr::bound_expr::BoundExpr};
+use daft_io::{IOClient, IOStatsRef};
+use daft_recordbatch::RecordBatch;
+use daft_stats::TruthValue;
+use futures::{StreamExt, TryStreamExt, stream::BoxStream};
+use parquet::{
+    arrow::{
+        ProjectionMask,
+        arrow_reader::{ArrowReaderMetadata, ArrowReaderOptions, ParquetRecordBatchReaderBuilder},
+        async_reader::{AsyncFileReader, ParquetRecordBatchStreamBuilder},
+    },
+    file::metadata::ParquetMetaData,
+};
+use rayon::prelude::*;
+
+use crate::{
+    async_reader::DaftAsyncFileReader,
+    read::ParquetSchemaInferenceOptions,
+    schema_inference::{arrow_schema_to_daft_schema, infer_schema_from_parquet_metadata_arrowrs},
+    statistics::arrowrs_row_group_metadata_to_table_stats,
+};
+
+/// Default batch size for the arrow-rs reader (number of rows per batch).
+const DEFAULT_BATCH_SIZE: usize = 8192;
+
+/// Convert a parquet error to a DaftError.
+fn parquet_err(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> common_error::DaftError {
+    common_error::DaftError::External(e.into())
+}
+
+/// Build a `ProjectionMask` from the given column names and arrow schema.
+fn build_projection_mask(
+    col_set: &std::collections::HashSet<&str>,
+    arrow_schema: &arrow::datatypes::Schema,
+    parquet_schema: &parquet::schema::types::SchemaDescriptor,
+) -> ProjectionMask {
+    ProjectionMask::roots(
+        parquet_schema,
+        arrow_schema
+            .fields()
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| col_set.contains(f.name().as_str()))
+            .map(|(i, _)| i),
+    )
+}
+
+/// Project a Daft schema to only the columns in `col_set`.
+fn project_daft_schema(schema: &Schema, col_set: &std::collections::HashSet<&str>) -> Schema {
+    Schema::new(
+        schema
+            .into_iter()
+            .filter(|f| col_set.contains(f.name.as_str()))
+            .cloned(),
+    )
+}
+
+/// Infer the arrow and Daft schemas from parquet metadata with Daft options.
+fn infer_schemas(
+    parquet_metadata: &ParquetMetaData,
+    schema_infer_options: &ParquetSchemaInferenceOptions,
+) -> DaftResult<(arrow::datatypes::Schema, Schema)> {
+    let arrow_schema = infer_schema_from_parquet_metadata_arrowrs(
+        parquet_metadata,
+        Some(schema_infer_options.coerce_int96_timestamp_unit),
+        schema_infer_options.string_encoding
+            == daft_arrow::io::parquet::read::schema::StringEncoding::Raw,
+    )
+    .map_err(parquet_err)?;
+    let daft_schema = arrow_schema_to_daft_schema(&arrow_schema)?;
+    Ok((arrow_schema, daft_schema))
+}
+
+/// Read a single parquet file into a Daft [`RecordBatch`] using the arrow-rs reader.
+///
+/// This is the arrow-rs equivalent of the parquet2-based `read_parquet_single`.
+#[allow(clippy::too_many_arguments)]
+pub async fn read_parquet_single_arrowrs(
+    uri: &str,
+    columns: Option<&[&str]>,
+    start_offset: Option<usize>,
+    num_rows: Option<usize>,
+    row_groups: Option<&[i64]>,
+    predicate: Option<ExprRef>,
+    io_client: Arc<IOClient>,
+    io_stats: Option<IOStatsRef>,
+    schema_infer_options: ParquetSchemaInferenceOptions,
+    metadata: Option<Arc<ParquetMetaData>>,
+    batch_size: Option<usize>,
+) -> DaftResult<RecordBatch> {
+    // 1. Create the async file reader and fetch metadata.
+    let mut reader = DaftAsyncFileReader::new(uri.to_string(), io_client, io_stats, metadata, None);
+    let parquet_metadata = reader.get_metadata(None).await.map_err(parquet_err)?;
+
+    // 2. Infer schema with Daft options (INT96 coercion, string encoding).
+    let (arrow_schema, daft_schema) = infer_schemas(&parquet_metadata, &schema_infer_options)?;
+
+    // 3. Build the stream builder with our custom schema.
+    let options = ArrowReaderOptions::new().with_schema(Arc::new(arrow_schema.clone()));
+    let arrow_reader_metadata =
+        ArrowReaderMetadata::try_new(parquet_metadata.clone(), options).map_err(parquet_err)?;
+    let builder = ParquetRecordBatchStreamBuilder::new_with_metadata(reader, arrow_reader_metadata);
+
+    // 4. Apply column projection.
+    let (projected_daft_schema, builder) = if let Some(cols) = columns {
+        let col_set: std::collections::HashSet<&str> = cols.iter().copied().collect();
+        let mask = build_projection_mask(&col_set, &arrow_schema, builder.parquet_schema());
+        (
+            project_daft_schema(&daft_schema, &col_set),
+            builder.with_projection(mask),
+        )
+    } else {
+        (daft_schema, builder)
+    };
+
+    // 5. Determine which row groups to read (with predicate-based pruning).
+    let rg_indices = prune_row_groups(
+        &parquet_metadata,
+        row_groups,
+        predicate.as_ref(),
+        &projected_daft_schema,
+        uri,
+    )?;
+
+    if rg_indices.is_empty() {
+        return Ok(RecordBatch::empty(Some(Arc::new(projected_daft_schema))));
+    }
+
+    // 6. Apply row groups, offset, limit, and batch size.
+    let mut builder = builder.with_row_groups(rg_indices);
+    if let Some(offset) = start_offset {
+        builder = builder.with_offset(offset);
+    }
+    if let Some(limit) = num_rows {
+        builder = builder.with_limit(limit);
+    }
+    builder = builder.with_batch_size(batch_size.unwrap_or(DEFAULT_BATCH_SIZE));
+
+    // 7. Build the stream and collect all batches.
+    let stream = builder.build().map_err(parquet_err)?;
+    let arrow_batches: Vec<arrow::array::RecordBatch> =
+        stream.try_collect().await.map_err(parquet_err)?;
+
+    // 8. Convert to Daft RecordBatch.
+    crate::arrow_bridge::arrowrs_batches_to_daft_recordbatch(&arrow_batches, &projected_daft_schema)
+}
+
+/// Read a local parquet file using the sync arrow-rs reader with parallel row group decode.
+///
+/// This avoids the overhead of `DaftAsyncFileReader` + `IOClient` for local files
+/// by using `std::fs::File` directly with `ParquetRecordBatchReaderBuilder`.
+/// Row groups are decoded in parallel using rayon, matching the parquet2 reader's
+/// parallelism strategy.
+#[allow(clippy::too_many_arguments)]
+pub fn local_parquet_read_arrowrs(
+    path: &str,
+    columns: Option<&[&str]>,
+    start_offset: Option<usize>,
+    num_rows: Option<usize>,
+    row_groups: Option<&[i64]>,
+    predicate: Option<ExprRef>,
+    schema_infer_options: ParquetSchemaInferenceOptions,
+    batch_size: Option<usize>,
+) -> DaftResult<RecordBatch> {
+    // 1. Open the file and read metadata once.
+    let file = std::fs::File::open(path).map_err(|e| {
+        parquet_err(format!(
+            "Failed to open local parquet file '{}': {}",
+            path, e
+        ))
+    })?;
+
+    let arrow_reader_metadata =
+        ArrowReaderMetadata::load(&file, ArrowReaderOptions::new()).map_err(parquet_err)?;
+    let parquet_metadata = arrow_reader_metadata.metadata().clone();
+
+    // 2. Infer schema with Daft options.
+    let (arrow_schema, daft_schema) = infer_schemas(&parquet_metadata, &schema_infer_options)?;
+
+    // 3. Rebuild metadata with our custom schema.
+    let options = ArrowReaderOptions::new().with_schema(Arc::new(arrow_schema.clone()));
+    let arrow_reader_metadata =
+        ArrowReaderMetadata::try_new(parquet_metadata.clone(), options).map_err(parquet_err)?;
+
+    // 4. Compute column projection.
+    let col_set: Option<std::collections::HashSet<&str>> =
+        columns.map(|cols| cols.iter().copied().collect());
+
+    let projected_daft_schema = if let Some(ref col_set) = col_set {
+        project_daft_schema(&daft_schema, col_set)
+    } else {
+        daft_schema
+    };
+
+    // 5. Row group pruning.
+    let rg_indices = prune_row_groups(
+        &parquet_metadata,
+        row_groups,
+        predicate.as_ref(),
+        &projected_daft_schema,
+        path,
+    )?;
+
+    if rg_indices.is_empty() {
+        return Ok(RecordBatch::empty(Some(Arc::new(projected_daft_schema))));
+    }
+
+    // 6. Apply offset and limit: trim row groups to only those we need.
+    let start = start_offset.unwrap_or(0);
+    let limit = num_rows;
+    // Use a large batch size so each row group produces a single batch,
+    // matching parquet2's behavior and avoiding per-batch concat overhead.
+    // Default to reading each row group as a single batch.
+    let batch_size = batch_size.unwrap_or_else(|| {
+        // Calculate the max row group size to use as batch size.
+        rg_indices
+            .iter()
+            .map(|&idx| parquet_metadata.row_group(idx).num_rows() as usize)
+            .max()
+            .unwrap_or(256 * 1024)
+    });
+
+    // Trim the row group list if we have an offset/limit so we don't decode
+    // row groups we'll never use.
+    let rg_indices = if start > 0 || limit.is_some() {
+        let mut trimmed = Vec::new();
+        let mut cumulative_rows = 0usize;
+        let rows_needed = start + limit.unwrap_or(usize::MAX - start);
+        for &rg_idx in &rg_indices {
+            let rg_rows = parquet_metadata.row_group(rg_idx).num_rows() as usize;
+            if cumulative_rows >= rows_needed {
+                break;
+            }
+            trimmed.push(rg_idx);
+            cumulative_rows += rg_rows;
+        }
+        trimmed
+    } else {
+        rg_indices
+    };
+
+    // 7a. Fast path for single row group: skip rayon dispatch, use limit/offset directly.
+    if rg_indices.len() == 1 {
+        let mut rg_builder =
+            ParquetRecordBatchReaderBuilder::new_with_metadata(file, arrow_reader_metadata);
+        if let Some(ref col_set) = col_set {
+            let mask = build_projection_mask(col_set, &arrow_schema, rg_builder.parquet_schema());
+            rg_builder = rg_builder.with_projection(mask);
+        }
+        rg_builder = rg_builder
+            .with_row_groups(rg_indices)
+            .with_batch_size(batch_size);
+        if let Some(off) = start_offset {
+            rg_builder = rg_builder.with_offset(off);
+        }
+        if let Some(lim) = limit {
+            rg_builder = rg_builder.with_limit(lim);
+        }
+        let reader = rg_builder.build().map_err(parquet_err)?;
+        let arrow_batches: Vec<arrow::array::RecordBatch> =
+            reader.collect::<Result<Vec<_>, _>>().map_err(parquet_err)?;
+        return crate::arrow_bridge::arrowrs_batches_to_daft_recordbatch(
+            &arrow_batches,
+            &projected_daft_schema,
+        );
+    }
+
+    // 7b. Decode row groups in parallel using rayon.
+    //    Each thread opens its own file handle (cheap syscall). This is better than
+    //    reading the entire file into memory because the arrow-rs reader uses seeks
+    //    to read only the projected column chunks, which is critical for projection
+    //    performance on wide tables.
+    let path_owned = path.to_string();
+    let arrow_reader_metadata = Arc::new(arrow_reader_metadata);
+
+    let rg_batches: Vec<DaftResult<Vec<arrow::array::RecordBatch>>> = rg_indices
+        .par_iter()
+        .map(|&rg_idx| {
+            let file = std::fs::File::open(&path_owned)
+                .map_err(|e| parquet_err(format!("Failed to open '{}': {}", path_owned, e)))?;
+            let mut builder = ParquetRecordBatchReaderBuilder::new_with_metadata(
+                file,
+                (*arrow_reader_metadata).clone(),
+            );
+            if let Some(ref col_set) = col_set {
+                let mask = build_projection_mask(col_set, &arrow_schema, builder.parquet_schema());
+                builder = builder.with_projection(mask);
+            }
+            let reader = builder
+                .with_row_groups(vec![rg_idx])
+                .with_batch_size(batch_size)
+                .build()
+                .map_err(parquet_err)?;
+            reader.collect::<Result<Vec<_>, _>>().map_err(parquet_err)
+        })
+        .collect();
+
+    // 8. Flatten batches from all row groups, applying offset/limit.
+    let mut all_batches = Vec::new();
+    let mut rows_skipped = 0usize;
+    let mut rows_collected = 0usize;
+
+    for rg_result in rg_batches {
+        let batches = rg_result?;
+        for batch in batches {
+            let batch_rows = batch.num_rows();
+
+            // Handle offset: skip initial rows.
+            if rows_skipped < start {
+                let skip_in_batch = (start - rows_skipped).min(batch_rows);
+                rows_skipped += skip_in_batch;
+                if skip_in_batch == batch_rows {
+                    continue;
+                }
+                // Partially skip this batch.
+                let remaining = batch.slice(skip_in_batch, batch_rows - skip_in_batch);
+                let take = if let Some(lim) = limit {
+                    remaining.num_rows().min(lim - rows_collected)
+                } else {
+                    remaining.num_rows()
+                };
+                all_batches.push(remaining.slice(0, take));
+                rows_collected += take;
+            } else {
+                let take = if let Some(lim) = limit {
+                    batch_rows.min(lim - rows_collected)
+                } else {
+                    batch_rows
+                };
+                if take < batch_rows {
+                    all_batches.push(batch.slice(0, take));
+                } else {
+                    all_batches.push(batch);
+                }
+                rows_collected += take;
+            }
+
+            if limit.is_some_and(|lim| rows_collected >= lim) {
+                break;
+            }
+        }
+        if limit.is_some_and(|lim| rows_collected >= lim) {
+            break;
+        }
+    }
+
+    // 9. Convert to Daft RecordBatch.
+    crate::arrow_bridge::arrowrs_batches_to_daft_recordbatch(&all_batches, &projected_daft_schema)
+}
+
+/// Stream a single parquet file as Daft [`RecordBatch`]es using the arrow-rs reader.
+///
+/// This is the arrow-rs equivalent of the parquet2-based `stream_parquet_single`.
+#[allow(clippy::too_many_arguments)]
+pub async fn stream_parquet_single_arrowrs(
+    uri: &str,
+    columns: Option<&[&str]>,
+    start_offset: Option<usize>,
+    num_rows: Option<usize>,
+    row_groups: Option<&[i64]>,
+    predicate: Option<ExprRef>,
+    io_client: Arc<IOClient>,
+    io_stats: Option<IOStatsRef>,
+    schema_infer_options: ParquetSchemaInferenceOptions,
+    metadata: Option<Arc<ParquetMetaData>>,
+    batch_size: Option<usize>,
+) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
+    // 1. Create the async file reader and fetch metadata.
+    let mut reader = DaftAsyncFileReader::new(uri.to_string(), io_client, io_stats, metadata, None);
+    let parquet_metadata = reader.get_metadata(None).await.map_err(parquet_err)?;
+
+    // 2. Infer schema with Daft options.
+    let (arrow_schema, daft_schema) = infer_schemas(&parquet_metadata, &schema_infer_options)?;
+
+    // 3. Build the stream builder with our custom schema.
+    let options = ArrowReaderOptions::new().with_schema(Arc::new(arrow_schema.clone()));
+    let arrow_reader_metadata =
+        ArrowReaderMetadata::try_new(parquet_metadata.clone(), options).map_err(parquet_err)?;
+    let builder = ParquetRecordBatchStreamBuilder::new_with_metadata(reader, arrow_reader_metadata);
+
+    // 4. Apply column projection.
+    let (projected_daft_schema, builder) = if let Some(cols) = columns {
+        let col_set: std::collections::HashSet<&str> = cols.iter().copied().collect();
+        let mask = build_projection_mask(&col_set, &arrow_schema, builder.parquet_schema());
+        (
+            project_daft_schema(&daft_schema, &col_set),
+            builder.with_projection(mask),
+        )
+    } else {
+        (daft_schema, builder)
+    };
+
+    // 5. Row group pruning.
+    let rg_indices = prune_row_groups(
+        &parquet_metadata,
+        row_groups,
+        predicate.as_ref(),
+        &projected_daft_schema,
+        uri,
+    )?;
+
+    if rg_indices.is_empty() {
+        return Ok(futures::stream::empty().boxed());
+    }
+
+    // 6. Apply row groups, offset, limit, and batch size.
+    let mut builder = builder.with_row_groups(rg_indices);
+    if let Some(offset) = start_offset {
+        builder = builder.with_offset(offset);
+    }
+    if let Some(limit) = num_rows {
+        builder = builder.with_limit(limit);
+    }
+    builder = builder.with_batch_size(batch_size.unwrap_or(DEFAULT_BATCH_SIZE));
+
+    // 7. Build the stream, mapping each arrow-rs batch to a Daft RecordBatch.
+    let stream = builder.build().map_err(parquet_err)?;
+    let daft_schema = Arc::new(projected_daft_schema);
+    let mapped = stream.map(move |result| {
+        let arrow_batch = result.map_err(parquet_err)?;
+        crate::arrow_bridge::arrowrs_to_daft_recordbatch(&arrow_batch, &daft_schema)
+    });
+
+    Ok(mapped.boxed())
+}
+
+/// Determine which row groups to read, applying predicate-based pruning.
+///
+/// Returns the list of row group indices to read. If `requested_row_groups` is Some,
+/// only those are considered; otherwise all row groups are candidates.
+fn prune_row_groups(
+    metadata: &ParquetMetaData,
+    requested_row_groups: Option<&[i64]>,
+    predicate: Option<&ExprRef>,
+    schema: &Schema,
+    uri: &str,
+) -> DaftResult<Vec<usize>> {
+    let num_row_groups = metadata.num_row_groups();
+
+    // Determine candidate row groups.
+    let candidates: Vec<usize> = if let Some(rgs) = requested_row_groups {
+        rgs.iter()
+            .map(|&i| {
+                let idx = i as usize;
+                if idx >= num_row_groups {
+                    Err(common_error::DaftError::ValueError(format!(
+                        "Row group index {} out of bounds for '{}' (has {} row groups)",
+                        i, uri, num_row_groups
+                    )))
+                } else {
+                    Ok(idx)
+                }
+            })
+            .collect::<DaftResult<Vec<_>>>()?
+    } else {
+        (0..num_row_groups).collect()
+    };
+
+    // If no predicate, return all candidates.
+    let predicate = match predicate {
+        Some(p) => p,
+        None => return Ok(candidates),
+    };
+
+    // Bind the predicate expression to the schema.
+    let bound_pred = BoundExpr::try_new((*predicate).clone(), schema).map_err(|e| {
+        common_error::DaftError::ValueError(format!(
+            "Failed to bind predicate for row group pruning on '{}': {}",
+            uri, e
+        ))
+    })?;
+
+    // Evaluate the predicate against each row group's statistics.
+    let mut result = Vec::with_capacity(candidates.len());
+    for rg_idx in candidates {
+        let rg_meta = metadata.row_group(rg_idx);
+        match arrowrs_row_group_metadata_to_table_stats(rg_meta, schema) {
+            Ok(stats) => {
+                let evaled = stats.eval_expression(&bound_pred)?;
+                if evaled.to_truth_value() != TruthValue::False {
+                    result.push(rg_idx);
+                }
+                // else: predicate definitively false for this RG, skip it
+            }
+            Err(_) => {
+                // If stats are unavailable/unparsable, include the RG (be conservative).
+                result.push(rg_idx);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::{
+        array::Int32Array,
+        datatypes::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema},
+    };
+    use parquet::{arrow::ArrowWriter, file::reader::FileReader};
+
+    use super::*;
+
+    /// Create parquet metadata from an in-memory parquet file.
+    fn create_test_parquet_metadata() -> Arc<parquet::file::metadata::ParquetMetaData> {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("a", ArrowDataType::Int32, true),
+            ArrowField::new("b", ArrowDataType::Int32, true),
+        ]));
+
+        let mut buf = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut buf, schema.clone(), None).unwrap();
+
+        let batch = arrow::array::RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50])),
+            ],
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read back the metadata from the in-memory buffer.
+        let reader =
+            parquet::file::serialized_reader::SerializedFileReader::new(bytes::Bytes::from(buf))
+                .unwrap();
+        Arc::new(reader.metadata().clone())
+    }
+
+    #[test]
+    fn test_prune_row_groups_no_predicate() {
+        let metadata = create_test_parquet_metadata();
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32),
+            Field::new("b", DataType::Int32),
+        ]);
+
+        let result = prune_row_groups(&metadata, None, None, &schema, "test.parquet").unwrap();
+        // Should return all row groups.
+        assert_eq!(result.len(), metadata.num_row_groups());
+    }
+
+    #[test]
+    fn test_prune_row_groups_with_selection() {
+        let metadata = create_test_parquet_metadata();
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32),
+            Field::new("b", DataType::Int32),
+        ]);
+
+        // Request specific row group 0.
+        let result =
+            prune_row_groups(&metadata, Some(&[0]), None, &schema, "test.parquet").unwrap();
+        assert_eq!(result, vec![0]);
+    }
+
+    #[test]
+    fn test_prune_row_groups_out_of_bounds() {
+        let metadata = create_test_parquet_metadata();
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32),
+            Field::new("b", DataType::Int32),
+        ]);
+
+        // Request out-of-bounds row group.
+        let result = prune_row_groups(&metadata, Some(&[999]), None, &schema, "test.parquet");
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_read_parquet_single_arrowrs_from_local_file() {
+        use daft_io::IOConfig;
+
+        // Write a test parquet file to a temp directory.
+        let dir = std::env::temp_dir().join("daft_parquet_test_arrowrs");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("test.parquet");
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("x", ArrowDataType::Int32, true),
+            ArrowField::new("y", ArrowDataType::Utf8, true),
+        ]));
+
+        let file = std::fs::File::create(&file_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), None).unwrap();
+        let batch = arrow::array::RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![10, 20, 30])),
+                Arc::new(arrow::array::StringArray::from(vec!["a", "b", "c"])),
+            ],
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        // Read through the new reader.
+        let uri = file_path.to_str().unwrap();
+        let io_client = Arc::new(IOClient::new(IOConfig::default().into()).unwrap());
+
+        let result = read_parquet_single_arrowrs(
+            uri,
+            None, // all columns
+            None, // no offset
+            None, // no limit
+            None, // all row groups
+            None, // no predicate
+            io_client,
+            None, // no io_stats
+            ParquetSchemaInferenceOptions::default(),
+            None, // no cached metadata
+            None, // default batch size
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.num_columns(), 2);
+
+        // Verify column names.
+        assert_eq!(result.schema.fields()[0].name, "x");
+        assert_eq!(result.schema.fields()[1].name, "y");
+
+        // Clean up.
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn test_read_parquet_single_arrowrs_with_column_projection() {
+        use daft_io::IOConfig;
+
+        let dir = std::env::temp_dir().join("daft_parquet_test_arrowrs_proj");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("test.parquet");
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("x", ArrowDataType::Int32, true),
+            ArrowField::new("y", ArrowDataType::Utf8, true),
+            ArrowField::new("z", ArrowDataType::Float64, true),
+        ]));
+
+        let file = std::fs::File::create(&file_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), None).unwrap();
+        let batch = arrow::array::RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
+                Arc::new(arrow::array::StringArray::from(vec![
+                    "a", "b", "c", "d", "e",
+                ])),
+                Arc::new(arrow::array::Float64Array::from(vec![
+                    1.0, 2.0, 3.0, 4.0, 5.0,
+                ])),
+            ],
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let uri = file_path.to_str().unwrap();
+        let io_client = Arc::new(IOClient::new(IOConfig::default().into()).unwrap());
+
+        // Read only columns "x" and "z".
+        let result = read_parquet_single_arrowrs(
+            uri,
+            Some(&["x", "z"]),
+            None,
+            None,
+            None,
+            None,
+            io_client,
+            None,
+            ParquetSchemaInferenceOptions::default(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.len(), 5);
+        assert_eq!(result.num_columns(), 2);
+        assert_eq!(result.schema.fields()[0].name, "x");
+        assert_eq!(result.schema.fields()[1].name, "z");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn test_read_parquet_single_arrowrs_with_limit() {
+        use daft_io::IOConfig;
+
+        let dir = std::env::temp_dir().join("daft_parquet_test_arrowrs_limit");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("test.parquet");
+
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "val",
+            ArrowDataType::Int32,
+            true,
+        )]));
+
+        let file = std::fs::File::create(&file_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), None).unwrap();
+        let batch = arrow::array::RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![
+                1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+            ]))],
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let uri = file_path.to_str().unwrap();
+        let io_client = Arc::new(IOClient::new(IOConfig::default().into()).unwrap());
+
+        // Read with limit of 3.
+        let result = read_parquet_single_arrowrs(
+            uri,
+            None,
+            None,
+            Some(3), // limit
+            None,
+            None,
+            io_client,
+            None,
+            ParquetSchemaInferenceOptions::default(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.len(), 3);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn test_stream_parquet_single_arrowrs() {
+        use daft_io::IOConfig;
+
+        let dir = std::env::temp_dir().join("daft_parquet_test_arrowrs_stream");
+        std::fs::create_dir_all(&dir).unwrap();
+        let file_path = dir.join("test.parquet");
+
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            ArrowDataType::Int32,
+            true,
+        )]));
+
+        let file = std::fs::File::create(&file_path).unwrap();
+        let mut writer = ArrowWriter::try_new(file, schema.clone(), None).unwrap();
+        let batch = arrow::array::RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]))],
+        )
+        .unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+
+        let uri = file_path.to_str().unwrap();
+        let io_client = Arc::new(IOClient::new(IOConfig::default().into()).unwrap());
+
+        let mut stream = stream_parquet_single_arrowrs(
+            uri,
+            None,
+            None,
+            None,
+            None,
+            None,
+            io_client,
+            None,
+            ParquetSchemaInferenceOptions::default(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let mut total_rows = 0;
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            total_rows += batch.len();
+        }
+        assert_eq!(total_rows, 5);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn test_read_existing_mvp_parquet() {
+        use daft_io::IOConfig;
+
+        // Read the existing MVP test fixture through the new reader.
+        let mvp_path = path_macro::path!(
+            env!("CARGO_MANIFEST_DIR")
+                / ".."
+                / ".."
+                / "tests"
+                / "assets"
+                / "parquet-data"
+                / "mvp.parquet"
+        );
+        let uri = mvp_path.to_str().unwrap();
+        let io_client = Arc::new(IOClient::new(IOConfig::default().into()).unwrap());
+
+        let result = read_parquet_single_arrowrs(
+            uri,
+            None,
+            None,
+            None,
+            None,
+            None,
+            io_client,
+            None,
+            ParquetSchemaInferenceOptions::default(),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // The MVP parquet file should have some rows and columns.
+        assert!(result.len() > 0, "MVP parquet should have rows");
+        assert!(result.num_columns() > 0, "MVP parquet should have columns");
+    }
+}

--- a/src/daft-parquet/src/async_reader.rs
+++ b/src/daft-parquet/src/async_reader.rs
@@ -1,0 +1,271 @@
+use std::{ops::Range, sync::Arc};
+
+use bytes::Bytes;
+use daft_io::{IOClient, IOStatsRef};
+use futures::{FutureExt, future::BoxFuture};
+use parquet::{
+    arrow::{arrow_reader::ArrowReaderOptions, async_reader::AsyncFileReader},
+    errors::ParquetError,
+    file::metadata::ParquetMetaData,
+};
+
+use crate::read_planner::{CoalescePass, ReadPlanner, SplitLargeRequestPass};
+
+/// Maximum hole size for the coalesce pass (1 MB).
+const COALESCE_MAX_HOLE_SIZE: usize = 1024 * 1024;
+
+/// Maximum request size for the coalesce pass (16 MB).
+const COALESCE_MAX_REQUEST_SIZE: usize = 16 * 1024 * 1024;
+
+/// Maximum request size for the split-large-request pass (24 MB).
+const SPLIT_MAX_REQUEST_SIZE: usize = 24 * 1024 * 1024;
+
+/// Split threshold for the split-large-request pass (24 MB).
+const SPLIT_THRESHOLD: usize = 24 * 1024 * 1024;
+
+/// Parquet footer magic bytes: PAR1
+const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
+
+/// Footer size: 4 bytes metadata length + 4 bytes magic
+const FOOTER_SIZE: usize = 8;
+
+/// Default initial read size from the end of the file to try to capture the footer in one read.
+const DEFAULT_FOOTER_READ_SIZE: usize = 64 * 1024;
+
+/// An implementation of the arrow-rs [`AsyncFileReader`] trait that uses Daft's
+/// [`IOClient`] and [`ReadPlanner`] for fetching byte ranges.
+///
+/// This bridges Daft's I/O layer with the arrow-rs parquet reader, enabling
+/// efficient coalesced and split I/O when reading parquet files from any
+/// source that Daft supports (local, S3, GCS, Azure, HTTP, etc.).
+pub struct DaftAsyncFileReader {
+    uri: String,
+    io_client: Arc<IOClient>,
+    io_stats: Option<IOStatsRef>,
+    metadata: Option<Arc<ParquetMetaData>>,
+    file_size: Option<usize>,
+}
+
+impl DaftAsyncFileReader {
+    /// Create a new `DaftAsyncFileReader`.
+    ///
+    /// # Arguments
+    /// * `uri` - The URI of the parquet file.
+    /// * `io_client` - The Daft IOClient for performing I/O.
+    /// * `io_stats` - Optional I/O statistics tracker.
+    /// * `metadata` - Optional pre-cached parquet metadata.
+    /// * `file_size` - Optional known file size (avoids a HEAD request when fetching the footer).
+    pub fn new(
+        uri: String,
+        io_client: Arc<IOClient>,
+        io_stats: Option<IOStatsRef>,
+        metadata: Option<Arc<ParquetMetaData>>,
+        file_size: Option<usize>,
+    ) -> Self {
+        Self {
+            uri,
+            io_client,
+            io_stats,
+            metadata,
+            file_size,
+        }
+    }
+
+    /// Helper: fetch a single byte range from the file as `Bytes`.
+    async fn fetch_range(
+        io_client: &Arc<IOClient>,
+        uri: &str,
+        range: Range<usize>,
+        io_stats: Option<&IOStatsRef>,
+    ) -> Result<Bytes, ParquetError> {
+        let get_result = io_client
+            .single_url_get(
+                uri.to_string(),
+                Some(daft_io::range::GetRange::Bounded(range)),
+                io_stats.cloned(),
+            )
+            .await
+            .map_err(|e| ParquetError::External(Box::new(e)))?;
+        get_result
+            .bytes()
+            .await
+            .map_err(|e| ParquetError::External(Box::new(e)))
+    }
+}
+
+impl AsyncFileReader for DaftAsyncFileReader {
+    fn get_bytes(&mut self, range: Range<u64>) -> BoxFuture<'_, Result<Bytes, ParquetError>> {
+        let io_client = self.io_client.clone();
+        let uri = self.uri.clone();
+        let io_stats = self.io_stats.clone();
+        let usize_range = range.start as usize..range.end as usize;
+
+        async move { Self::fetch_range(&io_client, &uri, usize_range, io_stats.as_ref()).await }
+            .boxed()
+    }
+
+    fn get_byte_ranges(
+        &mut self,
+        ranges: Vec<Range<u64>>,
+    ) -> BoxFuture<'_, Result<Vec<Bytes>, ParquetError>> {
+        let io_client = self.io_client.clone();
+        let uri = self.uri.clone();
+        let io_stats = self.io_stats.clone();
+
+        async move {
+            if ranges.is_empty() {
+                return Ok(vec![]);
+            }
+
+            // Convert u64 ranges to usize ranges for the ReadPlanner.
+            let usize_ranges: Vec<Range<usize>> = ranges
+                .iter()
+                .map(|r| r.start as usize..r.end as usize)
+                .collect();
+
+            // Build a ReadPlanner with coalescing and splitting passes.
+            let mut planner = ReadPlanner::new(&uri);
+            for range in &usize_ranges {
+                planner.add_range(range.start, range.end);
+            }
+            planner.add_pass(Box::new(CoalescePass {
+                max_hole_size: COALESCE_MAX_HOLE_SIZE,
+                max_request_size: COALESCE_MAX_REQUEST_SIZE,
+            }));
+            planner.add_pass(Box::new(SplitLargeRequestPass {
+                max_request_size: SPLIT_MAX_REQUEST_SIZE,
+                split_threshold: SPLIT_THRESHOLD,
+            }));
+            planner
+                .run_passes()
+                .map_err(|e| ParquetError::External(Box::new(e)))?;
+
+            let ranges_container = planner
+                .collect(io_client, io_stats)
+                .map_err(|e| ParquetError::External(Box::new(e)))?;
+
+            // For each originally requested range, extract the bytes from the
+            // coalesced/split container.
+            let mut results = Vec::with_capacity(usize_ranges.len());
+            for range in &usize_ranges {
+                let bytes = ranges_container
+                    .get_range_bytes(range.clone())
+                    .await
+                    .map_err(|e| ParquetError::External(Box::new(e)))?;
+                results.push(bytes);
+            }
+
+            Ok(results)
+        }
+        .boxed()
+    }
+
+    fn get_metadata(
+        &mut self,
+        _options: Option<&ArrowReaderOptions>,
+    ) -> BoxFuture<'_, Result<Arc<ParquetMetaData>, ParquetError>> {
+        async move {
+            // Return cached metadata if available.
+            if let Some(ref metadata) = self.metadata {
+                return Ok(metadata.clone());
+            }
+
+            let io_client = self.io_client.clone();
+            let uri = self.uri.clone();
+            let io_stats = self.io_stats.clone();
+
+            // Determine file size if we don't already know it.
+            let file_size = match self.file_size {
+                Some(size) => size,
+                None => {
+                    let size = io_client
+                        .single_url_get_size(uri.clone(), io_stats.clone())
+                        .await
+                        .map_err(|e| ParquetError::External(Box::new(e)))?;
+                    self.file_size = Some(size);
+                    size
+                }
+            };
+
+            if file_size < FOOTER_SIZE + 4 {
+                // Minimum valid parquet: 4 bytes magic (header) + 4 bytes metadata_len + 4 bytes magic (footer) = 12
+                return Err(ParquetError::General(format!(
+                    "File too small to be a valid Parquet file: {} bytes (need at least 12)",
+                    file_size
+                )));
+            }
+
+            // Read the last N bytes (or the whole file if it's small).
+            let footer_read_size = DEFAULT_FOOTER_READ_SIZE.min(file_size);
+            let footer_start = file_size - footer_read_size;
+            let data =
+                Self::fetch_range(&io_client, &uri, footer_start..file_size, io_stats.as_ref())
+                    .await?;
+
+            // Validate magic bytes at the end.
+            if data.len() < FOOTER_SIZE {
+                return Err(ParquetError::General(format!(
+                    "Footer read returned {} bytes, expected at least {}",
+                    data.len(),
+                    FOOTER_SIZE
+                )));
+            }
+            let magic = &data[data.len() - 4..];
+            if magic != PARQUET_MAGIC {
+                return Err(ParquetError::General(format!(
+                    "Invalid Parquet file '{}': footer magic is {:?}, expected {:?}",
+                    uri, magic, PARQUET_MAGIC
+                )));
+            }
+
+            // Parse the metadata length (4 bytes, little-endian, just before the magic).
+            let metadata_len = i32::from_le_bytes(
+                data[data.len() - 8..data.len() - 4]
+                    .try_into()
+                    .expect("slice is exactly 4 bytes"),
+            );
+            if metadata_len < 0 {
+                return Err(ParquetError::General(format!(
+                    "Invalid Parquet metadata length: {}",
+                    metadata_len
+                )));
+            }
+            let metadata_len = metadata_len as usize;
+            let footer_total = FOOTER_SIZE + metadata_len;
+
+            if footer_total > file_size {
+                return Err(ParquetError::General(format!(
+                    "Parquet footer size ({}) exceeds file size ({})",
+                    footer_total, file_size
+                )));
+            }
+
+            // If our initial read didn't capture the full metadata, fetch the remainder.
+            let metadata_bytes = if footer_total <= data.len() {
+                // The full metadata + footer is within what we already read.
+                let offset = data.len() - footer_total;
+                data.slice(offset..offset + metadata_len)
+            } else {
+                // Need to fetch more data from the file.
+                let metadata_start = file_size - footer_total;
+                let metadata_end = file_size - FOOTER_SIZE;
+                Self::fetch_range(
+                    &io_client,
+                    &uri,
+                    metadata_start..metadata_end,
+                    io_stats.as_ref(),
+                )
+                .await?
+            };
+
+            // Decode the thrift-encoded FileMetaData.
+            let metadata =
+                parquet::file::metadata::ParquetMetaDataReader::decode_metadata(&metadata_bytes)?;
+
+            let metadata = Arc::new(metadata);
+            self.metadata = Some(metadata.clone());
+            Ok(metadata)
+        }
+        .boxed()
+    }
+}

--- a/src/daft-parquet/src/async_reader.rs
+++ b/src/daft-parquet/src/async_reader.rs
@@ -138,13 +138,13 @@ impl AsyncFileReader for DaftAsyncFileReader {
             for range in &usize_ranges {
                 planner.add_range(range.start, range.end);
             }
-            planner.add_pass(Box::new(CoalescePass {
-                max_hole_size: COALESCE_MAX_HOLE_SIZE,
-                max_request_size: COALESCE_MAX_REQUEST_SIZE,
-            }));
             planner.add_pass(Box::new(SplitLargeRequestPass {
                 max_request_size: SPLIT_MAX_REQUEST_SIZE,
                 split_threshold: SPLIT_THRESHOLD,
+            }));
+            planner.add_pass(Box::new(CoalescePass {
+                max_hole_size: COALESCE_MAX_HOLE_SIZE,
+                max_request_size: COALESCE_MAX_REQUEST_SIZE,
             }));
             planner
                 .run_passes()

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -6,6 +6,12 @@ use daft_arrow::io::parquet::read::schema::{SchemaInferenceOptions, infer_schema
 use daft_core::prelude::SchemaRef;
 use snafu::Snafu;
 
+// Building blocks for the arrow-rs parquet reader migration.
+// These modules will be used when the arrow-rs reader is wired in.
+#[allow(dead_code)]
+mod arrow_bridge;
+#[allow(dead_code)]
+mod async_reader;
 mod file;
 pub mod metadata;
 mod metadata_adapter;
@@ -13,10 +19,14 @@ pub use metadata_adapter::{DaftParquetMetadata, DaftRowGroupMetaData};
 #[cfg(feature = "python")]
 pub mod python;
 pub mod read;
-mod statistics;
-mod utils;
-pub use statistics::row_group_metadata_to_table_stats;
 mod read_planner;
+#[allow(dead_code)]
+mod schema_inference;
+mod statistics;
+pub use statistics::{
+    arrowrs_row_group_metadata_to_table_stats, row_group_metadata_to_table_stats,
+};
+mod utils;
 mod stream_reader;
 
 #[cfg(feature = "python")]

--- a/src/daft-parquet/src/lib.rs
+++ b/src/daft-parquet/src/lib.rs
@@ -6,11 +6,8 @@ use daft_arrow::io::parquet::read::schema::{SchemaInferenceOptions, infer_schema
 use daft_core::prelude::SchemaRef;
 use snafu::Snafu;
 
-// Building blocks for the arrow-rs parquet reader migration.
-// These modules will be used when the arrow-rs reader is wired in.
-#[allow(dead_code)]
 mod arrow_bridge;
-#[allow(dead_code)]
+mod arrowrs_reader;
 mod async_reader;
 mod file;
 pub mod metadata;
@@ -20,14 +17,13 @@ pub use metadata_adapter::{DaftParquetMetadata, DaftRowGroupMetaData};
 pub mod python;
 pub mod read;
 mod read_planner;
-#[allow(dead_code)]
 mod schema_inference;
 mod statistics;
 pub use statistics::{
     arrowrs_row_group_metadata_to_table_stats, row_group_metadata_to_table_stats,
 };
-mod utils;
 mod stream_reader;
+mod utils;
 
 #[cfg(feature = "python")]
 pub use python::register_modules;

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -208,8 +208,8 @@ async fn read_parquet_single(
     }
 
     // Arrow-rs reader path: enabled via DAFT_PARQUET_READER=arrowrs.
-    // Does not yet support field_id_mapping or delete_rows.
-    if use_arrowrs_reader() && field_id_mapping.is_none() && delete_rows.is_none() {
+    // Does not yet support delete_rows.
+    if use_arrowrs_reader() && delete_rows.is_none() {
         let columns_ref: Option<Vec<&str>> = columns_to_read
             .as_ref()
             .map(|v| v.iter().map(|s| s.as_str()).collect());
@@ -227,6 +227,7 @@ async fn read_parquet_single(
                     .map(|c| c.iter().map(|s| (*s).to_string()).collect());
                 let row_groups_owned = row_groups.as_deref().map(|r| r.to_vec());
                 let predicate = predicate.clone();
+                let field_id_mapping = field_id_mapping.clone();
                 move || {
                     let col_refs: Option<Vec<&str>> = columns_ref_owned
                         .as_ref()
@@ -240,6 +241,7 @@ async fn read_parquet_single(
                         predicate,
                         schema_infer_options,
                         chunk_size,
+                        field_id_mapping,
                     )
                 }
             })
@@ -258,6 +260,7 @@ async fn read_parquet_single(
                 schema_infer_options,
                 None,
                 chunk_size,
+                field_id_mapping,
             )
             .await?
         };
@@ -510,7 +513,8 @@ async fn stream_parquet_single(
     }
 
     // Arrow-rs reader path: enabled via DAFT_PARQUET_READER=arrowrs.
-    if use_arrowrs_reader() && field_id_mapping.is_none() && delete_rows.is_none() {
+    // Does not yet support delete_rows.
+    if use_arrowrs_reader() && delete_rows.is_none() {
         let columns_ref: Option<Vec<&str>> = columns_to_read
             .as_ref()
             .map(|v| v.iter().map(|s| s.as_str()).collect());
@@ -529,6 +533,7 @@ async fn stream_parquet_single(
                         .map(|c| c.iter().map(|s| (*s).to_string()).collect());
                     let row_groups_owned = row_groups.as_deref().map(|r| r.to_vec());
                     let predicate = predicate.clone();
+                    let field_id_mapping = field_id_mapping.clone();
                     move || {
                         let col_refs: Option<Vec<&str>> = columns_ref_owned
                             .as_ref()
@@ -542,6 +547,7 @@ async fn stream_parquet_single(
                             predicate,
                             schema_infer_options,
                             chunk_size,
+                            field_id_mapping,
                         )
                     }
                 })
@@ -561,6 +567,7 @@ async fn stream_parquet_single(
                     schema_infer_options,
                     None,
                     chunk_size,
+                    field_id_mapping,
                 )
                 .await?
             };

--- a/src/daft-parquet/src/read_planner.rs
+++ b/src/daft-parquet/src/read_planner.rs
@@ -287,6 +287,10 @@ impl RangesContainer {
     ///
     /// This resolves all underlying cache entries that overlap the requested range
     /// and concatenates the slices into a single `Bytes` value.
+    ///
+    /// This is the arrow-rs counterpart to `get_range_reader()`. Arrow-rs requires
+    /// fully materialized `Bytes` per column chunk (via `AsyncFileReader::get_byte_ranges`),
+    /// whereas parquet2 consumed column chunks incrementally as `AsyncRead` streams.
     pub async fn get_range_bytes(self: &Arc<Self>, range: Range<usize>) -> DaftResult<Bytes> {
         let mut current_pos = range.start;
         let mut curr_index;

--- a/src/daft-parquet/src/schema_inference.rs
+++ b/src/daft-parquet/src/schema_inference.rs
@@ -1,0 +1,402 @@
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use common_error::DaftResult;
+
+/// Infer an arrow-rs schema from arrow-rs parquet metadata, with optional post-processing
+/// for INT96 timestamp coercion and raw string encoding.
+///
+/// This is the arrow-rs native alternative to `infer_arrow_schema_from_metadata` which uses
+/// arrow2-based inference.
+pub fn infer_schema_from_parquet_metadata_arrowrs(
+    metadata: &parquet::file::metadata::ParquetMetaData,
+    coerce_int96_timestamp_unit: Option<daft_core::prelude::TimeUnit>,
+    string_encoding_raw: bool,
+) -> Result<Schema, arrow::error::ArrowError> {
+    let file_metadata = metadata.file_metadata();
+    let schema_descr = file_metadata.schema_descr();
+    let key_value_metadata = file_metadata.key_value_metadata();
+
+    // Use the arrow-rs parquet crate's built-in conversion
+    let mut arrow_schema =
+        parquet::arrow::parquet_to_arrow_schema(schema_descr, key_value_metadata)?;
+
+    // Post-process: coerce INT96 timestamps (which come as Nanosecond) to the desired unit
+    if let Some(target_unit) = coerce_int96_timestamp_unit {
+        let target_arrow_unit = target_unit.to_arrow();
+        if target_arrow_unit != TimeUnit::Nanosecond {
+            let new_fields: Vec<Field> = arrow_schema
+                .fields()
+                .iter()
+                .map(|f| coerce_timestamp_field(f.as_ref(), &target_arrow_unit))
+                .collect();
+            arrow_schema = Schema::new_with_metadata(new_fields, arrow_schema.metadata().clone());
+        }
+    }
+
+    // Post-process: convert string types to binary if raw encoding is requested
+    if string_encoding_raw {
+        let new_fields: Vec<Field> = arrow_schema
+            .fields()
+            .iter()
+            .map(|f| coerce_strings_to_binary_field(f.as_ref()))
+            .collect();
+        arrow_schema = Schema::new_with_metadata(new_fields, arrow_schema.metadata().clone());
+    }
+
+    // Post-process: promote small-offset types to large-offset types.
+    // Arrow-rs parquet reader produces Utf8/Binary/List (i32 offsets) by default,
+    // but Daft expects LargeUtf8/LargeBinary/LargeList (i64 offsets).
+    // By putting the large types in the schema we pass to ArrowReaderOptions::with_schema(),
+    // arrow-rs will produce the large types directly, avoiding a post-decode cast.
+    {
+        let new_fields: Vec<Field> = arrow_schema
+            .fields()
+            .iter()
+            .map(|f| promote_to_large_offsets_field(f.as_ref()))
+            .collect();
+        arrow_schema = Schema::new_with_metadata(new_fields, arrow_schema.metadata().clone());
+    }
+
+    Ok(arrow_schema)
+}
+
+/// Recursively coerce all `Timestamp(Nanosecond, tz)` fields to `Timestamp(target_unit, tz)`.
+fn coerce_timestamp_field(field: &Field, target_unit: &TimeUnit) -> Field {
+    let new_dtype = coerce_timestamp_datatype(field.data_type(), target_unit);
+    match new_dtype {
+        Some(dt) => field.as_ref().clone().with_data_type(dt),
+        None => field.as_ref().clone(),
+    }
+}
+
+fn coerce_timestamp_datatype(dtype: &DataType, target_unit: &TimeUnit) -> Option<DataType> {
+    match dtype {
+        DataType::Timestamp(TimeUnit::Nanosecond, tz) => {
+            Some(DataType::Timestamp(*target_unit, tz.clone()))
+        }
+        DataType::List(inner) => {
+            let new_inner = coerce_timestamp_field(inner.as_ref(), target_unit);
+            if &new_inner != inner.as_ref() {
+                Some(DataType::List(new_inner.into()))
+            } else {
+                None
+            }
+        }
+        DataType::LargeList(inner) => {
+            let new_inner = coerce_timestamp_field(inner.as_ref(), target_unit);
+            if &new_inner != inner.as_ref() {
+                Some(DataType::LargeList(new_inner.into()))
+            } else {
+                None
+            }
+        }
+        DataType::FixedSizeList(inner, size) => {
+            let new_inner = coerce_timestamp_field(inner.as_ref(), target_unit);
+            if &new_inner != inner.as_ref() {
+                Some(DataType::FixedSizeList(new_inner.into(), *size))
+            } else {
+                None
+            }
+        }
+        DataType::Struct(fields) => {
+            let new_fields: Vec<Field> = fields
+                .iter()
+                .map(|f| coerce_timestamp_field(f.as_ref(), target_unit))
+                .collect();
+            if new_fields
+                .iter()
+                .zip(fields.iter())
+                .any(|(a, b)| a != b.as_ref())
+            {
+                Some(DataType::Struct(new_fields.into()))
+            } else {
+                None
+            }
+        }
+        DataType::Map(inner, sorted) => {
+            let new_inner = coerce_timestamp_field(inner.as_ref(), target_unit);
+            if &new_inner != inner.as_ref() {
+                Some(DataType::Map(new_inner.into(), *sorted))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Recursively promote small-offset types (Utf8, Binary, List) to large-offset
+/// types (LargeUtf8, LargeBinary, LargeList).
+fn promote_to_large_offsets_field(field: &Field) -> Field {
+    let new_dtype = promote_to_large_offsets_datatype(field.data_type());
+    match new_dtype {
+        Some(dt) => field.as_ref().clone().with_data_type(dt),
+        None => field.as_ref().clone(),
+    }
+}
+
+fn promote_to_large_offsets_datatype(dtype: &DataType) -> Option<DataType> {
+    match dtype {
+        DataType::Utf8 => Some(DataType::LargeUtf8),
+        DataType::Binary => Some(DataType::LargeBinary),
+        DataType::List(inner) => {
+            let new_inner = promote_to_large_offsets_field(inner.as_ref());
+            Some(DataType::LargeList(new_inner.into()))
+        }
+        DataType::LargeList(inner) => {
+            let new_inner = promote_to_large_offsets_field(inner.as_ref());
+            if &new_inner != inner.as_ref() {
+                Some(DataType::LargeList(new_inner.into()))
+            } else {
+                None
+            }
+        }
+        DataType::Struct(fields) => {
+            let new_fields: Vec<Field> = fields
+                .iter()
+                .map(|f| promote_to_large_offsets_field(f.as_ref()))
+                .collect();
+            if new_fields
+                .iter()
+                .zip(fields.iter())
+                .any(|(a, b)| a != b.as_ref())
+            {
+                Some(DataType::Struct(new_fields.into()))
+            } else {
+                None
+            }
+        }
+        DataType::Map(inner, sorted) => {
+            let new_inner = promote_to_large_offsets_field(inner.as_ref());
+            if &new_inner != inner.as_ref() {
+                Some(DataType::Map(new_inner.into(), *sorted))
+            } else {
+                None
+            }
+        }
+        DataType::FixedSizeList(inner, size) => {
+            let new_inner = promote_to_large_offsets_field(inner.as_ref());
+            if &new_inner != inner.as_ref() {
+                Some(DataType::FixedSizeList(new_inner.into(), *size))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Recursively convert all Utf8/LargeUtf8 fields to Binary/LargeBinary.
+fn coerce_strings_to_binary_field(field: &Field) -> Field {
+    let new_dtype = coerce_strings_to_binary_datatype(field.data_type());
+    match new_dtype {
+        Some(dt) => field.as_ref().clone().with_data_type(dt),
+        None => field.as_ref().clone(),
+    }
+}
+
+fn coerce_strings_to_binary_datatype(dtype: &DataType) -> Option<DataType> {
+    match dtype {
+        DataType::Utf8 => Some(DataType::Binary),
+        DataType::LargeUtf8 => Some(DataType::LargeBinary),
+        DataType::List(inner) => {
+            let new_inner = coerce_strings_to_binary_field(inner.as_ref());
+            if &new_inner != inner.as_ref() {
+                Some(DataType::List(new_inner.into()))
+            } else {
+                None
+            }
+        }
+        DataType::LargeList(inner) => {
+            let new_inner = coerce_strings_to_binary_field(inner.as_ref());
+            if &new_inner != inner.as_ref() {
+                Some(DataType::LargeList(new_inner.into()))
+            } else {
+                None
+            }
+        }
+        DataType::FixedSizeList(inner, size) => {
+            let new_inner = coerce_strings_to_binary_field(inner.as_ref());
+            if &new_inner != inner.as_ref() {
+                Some(DataType::FixedSizeList(new_inner.into(), *size))
+            } else {
+                None
+            }
+        }
+        DataType::Struct(fields) => {
+            let new_fields: Vec<Field> = fields
+                .iter()
+                .map(|f| coerce_strings_to_binary_field(f.as_ref()))
+                .collect();
+            if new_fields
+                .iter()
+                .zip(fields.iter())
+                .any(|(a, b)| a != b.as_ref())
+            {
+                Some(DataType::Struct(new_fields.into()))
+            } else {
+                None
+            }
+        }
+        DataType::Map(inner, sorted) => {
+            let new_inner = coerce_strings_to_binary_field(inner.as_ref());
+            if &new_inner != inner.as_ref() {
+                Some(DataType::Map(new_inner.into(), *sorted))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Convert an arrow-rs `Schema` to a Daft `Schema`.
+///
+/// This uses the existing `TryFrom<&arrow_schema::Schema>` implementation on `daft_core::prelude::Schema`.
+pub fn arrow_schema_to_daft_schema(
+    arrow_schema: &Schema,
+) -> DaftResult<daft_core::prelude::Schema> {
+    daft_core::prelude::Schema::try_from(arrow_schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+
+    use super::*;
+
+    #[test]
+    fn test_coerce_timestamp_nanosecond_to_microsecond() {
+        let schema = Schema::new(vec![
+            Field::new("ts", DataType::Timestamp(TimeUnit::Nanosecond, None), true),
+            Field::new("name", DataType::Utf8, true),
+            Field::new(
+                "ts_tz",
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+                true,
+            ),
+            // This one should NOT be coerced (already Microsecond)
+            Field::new(
+                "ts_us",
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                true,
+            ),
+        ]);
+
+        let target = TimeUnit::Microsecond;
+        let new_fields: Vec<Field> = schema
+            .fields()
+            .iter()
+            .map(|f| coerce_timestamp_field(f.as_ref(), &target))
+            .collect();
+        let result = Schema::new(new_fields);
+
+        assert_eq!(
+            result.field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+        assert_eq!(result.field(1).data_type(), &DataType::Utf8);
+        assert_eq!(
+            result.field(2).data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+        );
+        assert_eq!(
+            result.field(3).data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, None)
+        );
+    }
+
+    #[test]
+    fn test_coerce_strings_to_binary() {
+        let schema = Schema::new(vec![
+            Field::new("s", DataType::Utf8, true),
+            Field::new("ls", DataType::LargeUtf8, true),
+            Field::new("i", DataType::Int32, true),
+        ]);
+
+        let new_fields: Vec<Field> = schema
+            .fields()
+            .iter()
+            .map(|f| coerce_strings_to_binary_field(f.as_ref()))
+            .collect();
+        let result = Schema::new(new_fields);
+
+        assert_eq!(result.field(0).data_type(), &DataType::Binary);
+        assert_eq!(result.field(1).data_type(), &DataType::LargeBinary);
+        assert_eq!(result.field(2).data_type(), &DataType::Int32);
+    }
+
+    #[test]
+    fn test_coerce_nested_timestamp() {
+        let inner_field = Field::new(
+            "item",
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            true,
+        );
+        let schema = Schema::new(vec![Field::new(
+            "list_col",
+            DataType::List(Arc::new(inner_field)),
+            true,
+        )]);
+
+        let target = TimeUnit::Millisecond;
+        let new_fields: Vec<Field> = schema
+            .fields()
+            .iter()
+            .map(|f| coerce_timestamp_field(f.as_ref(), &target))
+            .collect();
+        let result = Schema::new(new_fields);
+
+        match result.field(0).data_type() {
+            DataType::List(inner) => {
+                assert_eq!(
+                    inner.data_type(),
+                    &DataType::Timestamp(TimeUnit::Millisecond, None)
+                );
+            }
+            other => panic!("Expected List, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_coerce_nested_strings_to_binary() {
+        let struct_fields = vec![
+            Field::new("a", DataType::Utf8, true),
+            Field::new("b", DataType::Int64, true),
+        ];
+        let schema = Schema::new(vec![Field::new(
+            "struct_col",
+            DataType::Struct(struct_fields.into()),
+            true,
+        )]);
+
+        let new_fields: Vec<Field> = schema
+            .fields()
+            .iter()
+            .map(|f| coerce_strings_to_binary_field(f.as_ref()))
+            .collect();
+        let result = Schema::new(new_fields);
+
+        match result.field(0).data_type() {
+            DataType::Struct(fields) => {
+                assert_eq!(fields[0].data_type(), &DataType::Binary);
+                assert_eq!(fields[1].data_type(), &DataType::Int64);
+            }
+            other => panic!("Expected Struct, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_arrow_schema_to_daft_schema() {
+        let schema = Schema::new(vec![
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Utf8, true),
+        ]);
+
+        let daft_schema = arrow_schema_to_daft_schema(&schema).unwrap();
+        assert_eq!(daft_schema.len(), 2);
+        assert_eq!(daft_schema.fields()[0].name, "a");
+        assert_eq!(daft_schema.fields()[1].name, "b");
+    }
+}

--- a/src/daft-parquet/src/statistics/column_range.rs
+++ b/src/daft-parquet/src/statistics/column_range.rs
@@ -12,7 +12,10 @@ use snafu::{OptionExt, ResultExt};
 
 use super::{
     DaftStatsSnafu, MissingParquetColumnStatisticsSnafu, UnableToParseUtf8FromBinarySnafu, Wrap,
-    utils::{convert_i96_to_i64_timestamp, convert_i128},
+    utils::{
+        arrowrs_timeunit_to_daft, convert_i96_to_i64_timestamp, convert_i96_to_i64_timestamp_daft,
+        convert_i128,
+    },
 };
 
 impl TryFrom<&BooleanStatistics> for Wrap<ColumnRangeStatistics> {
@@ -437,4 +440,312 @@ pub fn parquet_statistics_to_column_range_statistics(
 
     // Cast to ensure that the ColumnRangeStatistics now contain the targeted Daft **logical** type
     daft_stats.and_then(|s| s.cast(daft_dtype).context(DaftStatsSnafu))
+}
+
+// ============================================================================
+// Arrow-rs parquet statistics conversion (parallel to parquet2 path above)
+// ============================================================================
+
+use parquet::{
+    basic::{ConvertedType as ArrowConvertedType, LogicalType as ArrowLogicalType},
+    data_type::{ByteArray as ArrowByteArray, Int96 as ArrowInt96},
+    file::statistics::Statistics as ArrowStatistics,
+    schema::types::ColumnDescriptor as ArrowColumnDescriptor,
+};
+
+/// Converts arrow-rs parquet statistics to ColumnRangeStatistics.
+///
+/// This is the arrow-rs equivalent of [`parquet_statistics_to_column_range_statistics`].
+pub fn arrowrs_statistics_to_column_range_statistics(
+    stats: &ArrowStatistics,
+    col_descr: &ArrowColumnDescriptor,
+    daft_dtype: &DataType,
+) -> Result<ColumnRangeStatistics, super::Error> {
+    let daft_stats = match stats {
+        ArrowStatistics::Boolean(s) => {
+            let (Some(&lower), Some(&upper)) = (s.min_opt(), s.max_opt()) else {
+                return Ok(ColumnRangeStatistics::Missing);
+            };
+            ColumnRangeStatistics::new(
+                Some(BooleanArray::from_slice("lower", &[lower]).into_series()),
+                Some(BooleanArray::from_slice("upper", &[upper]).into_series()),
+            )?
+        }
+        ArrowStatistics::Int32(s) => {
+            let (Some(&lower), Some(&upper)) = (s.min_opt(), s.max_opt()) else {
+                return Ok(ColumnRangeStatistics::Missing);
+            };
+            convert_int32_arrowrs(lower, upper, col_descr)?
+        }
+        ArrowStatistics::Int64(s) => {
+            let (Some(&lower), Some(&upper)) = (s.min_opt(), s.max_opt()) else {
+                return Ok(ColumnRangeStatistics::Missing);
+            };
+            convert_int64_arrowrs(lower, upper, col_descr)?
+        }
+        ArrowStatistics::Int96(s) => {
+            let (Some(lower), Some(upper)) = (s.min_opt(), s.max_opt()) else {
+                return Ok(ColumnRangeStatistics::Missing);
+            };
+            convert_int96_arrowrs(lower, upper, col_descr)?
+        }
+        ArrowStatistics::Float(s) => {
+            let (Some(&lower), Some(&upper)) = (s.min_opt(), s.max_opt()) else {
+                return Ok(ColumnRangeStatistics::Missing);
+            };
+            let lower = Float32Array::from_slice("lower", &[lower]).into_series();
+            let upper = Float32Array::from_slice("upper", &[upper]).into_series();
+            ColumnRangeStatistics::new(Some(lower), Some(upper))?
+        }
+        ArrowStatistics::Double(s) => {
+            let (Some(&lower), Some(&upper)) = (s.min_opt(), s.max_opt()) else {
+                return Ok(ColumnRangeStatistics::Missing);
+            };
+            let lower = Float64Array::from_slice("lower", &[lower]).into_series();
+            let upper = Float64Array::from_slice("upper", &[upper]).into_series();
+            ColumnRangeStatistics::new(Some(lower), Some(upper))?
+        }
+        ArrowStatistics::ByteArray(s) => {
+            let (Some(lower), Some(upper)) = (s.min_opt(), s.max_opt()) else {
+                return Ok(ColumnRangeStatistics::Missing);
+            };
+            convert_byte_array_arrowrs(lower, upper, col_descr)?
+        }
+        ArrowStatistics::FixedLenByteArray(s) => {
+            let (Some(lower), Some(upper)) = (s.min_opt(), s.max_opt()) else {
+                return Ok(ColumnRangeStatistics::Missing);
+            };
+            convert_fixed_len_arrowrs(lower, upper, col_descr)?
+        }
+    };
+
+    // Cast to ensure that the ColumnRangeStatistics contain the targeted Daft **logical** type
+    daft_stats.cast(daft_dtype).context(DaftStatsSnafu)
+}
+
+fn make_timestamp_column_range_statistics_daft(
+    tu: daft_core::datatypes::TimeUnit,
+    is_adjusted_to_utc: bool,
+    lower: i64,
+    upper: i64,
+) -> super::Result<ColumnRangeStatistics> {
+    let lower_arr = Int64Array::from_slice("lower", &[lower]);
+    let upper_arr = Int64Array::from_slice("upper", &[upper]);
+    let tz = if is_adjusted_to_utc {
+        Some("+00:00".to_string())
+    } else {
+        None
+    };
+    let dtype = daft_core::datatypes::DataType::Timestamp(tu, tz);
+    let lower = TimestampArray::new(
+        daft_core::datatypes::Field::new("lower", dtype.clone()),
+        lower_arr,
+    )
+    .into_series();
+    let upper = TimestampArray::new(daft_core::datatypes::Field::new("upper", dtype), upper_arr)
+        .into_series();
+    Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?)
+}
+
+fn convert_int32_arrowrs(
+    lower: i32,
+    upper: i32,
+    col_descr: &ArrowColumnDescriptor,
+) -> super::Result<ColumnRangeStatistics> {
+    if let Some(ref ltype) = col_descr.logical_type()
+        && matches!(ltype, ArrowLogicalType::Date)
+    {
+        return make_date_column_range_statistics(lower, upper);
+    }
+
+    if col_descr.converted_type() == ArrowConvertedType::DATE {
+        return make_date_column_range_statistics(lower, upper);
+    }
+
+    // Fallback: plain Int32
+    let lower = Int32Array::from_slice("lower", &[lower]).into_series();
+    let upper = Int32Array::from_slice("upper", &[upper]).into_series();
+    Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?)
+}
+
+fn convert_int64_arrowrs(
+    lower: i64,
+    upper: i64,
+    col_descr: &ArrowColumnDescriptor,
+) -> super::Result<ColumnRangeStatistics> {
+    if let Some(ArrowLogicalType::Timestamp {
+        is_adjusted_to_u_t_c,
+        unit,
+    }) = col_descr.logical_type()
+    {
+        let daft_tu = arrowrs_timeunit_to_daft(unit);
+        return make_timestamp_column_range_statistics_daft(
+            daft_tu,
+            is_adjusted_to_u_t_c,
+            lower,
+            upper,
+        );
+    }
+
+    match col_descr.converted_type() {
+        ArrowConvertedType::TIMESTAMP_MICROS => {
+            return make_timestamp_column_range_statistics_daft(
+                daft_core::datatypes::TimeUnit::Microseconds,
+                false,
+                lower,
+                upper,
+            );
+        }
+        ArrowConvertedType::TIMESTAMP_MILLIS => {
+            return make_timestamp_column_range_statistics_daft(
+                daft_core::datatypes::TimeUnit::Milliseconds,
+                false,
+                lower,
+                upper,
+            );
+        }
+        _ => {}
+    }
+
+    // Fallback: plain Int64
+    let lower = Int64Array::from_slice("lower", &[lower]).into_series();
+    let upper = Int64Array::from_slice("upper", &[upper]).into_series();
+    Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?)
+}
+
+fn convert_int96_arrowrs(
+    lower: &ArrowInt96,
+    upper: &ArrowInt96,
+    col_descr: &ArrowColumnDescriptor,
+) -> super::Result<ColumnRangeStatistics> {
+    let lower_data = lower.data();
+    let upper_data = upper.data();
+    let lower_raw: [u32; 3] = [lower_data[0], lower_data[1], lower_data[2]];
+    let upper_raw: [u32; 3] = [upper_data[0], upper_data[1], upper_data[2]];
+
+    if let Some(ArrowLogicalType::Timestamp {
+        is_adjusted_to_u_t_c,
+        unit,
+    }) = col_descr.logical_type()
+    {
+        let daft_tu = arrowrs_timeunit_to_daft(unit);
+        let lower_ts = convert_i96_to_i64_timestamp_daft(lower_raw, daft_tu);
+        let upper_ts = convert_i96_to_i64_timestamp_daft(upper_raw, daft_tu);
+        return make_timestamp_column_range_statistics_daft(
+            daft_tu,
+            is_adjusted_to_u_t_c,
+            lower_ts,
+            upper_ts,
+        );
+    }
+
+    match col_descr.converted_type() {
+        ArrowConvertedType::TIMESTAMP_MICROS => {
+            let tu = daft_core::datatypes::TimeUnit::Microseconds;
+            let lower_ts = convert_i96_to_i64_timestamp_daft(lower_raw, tu);
+            let upper_ts = convert_i96_to_i64_timestamp_daft(upper_raw, tu);
+            return make_timestamp_column_range_statistics_daft(tu, false, lower_ts, upper_ts);
+        }
+        ArrowConvertedType::TIMESTAMP_MILLIS => {
+            let tu = daft_core::datatypes::TimeUnit::Milliseconds;
+            let lower_ts = convert_i96_to_i64_timestamp_daft(lower_raw, tu);
+            let upper_ts = convert_i96_to_i64_timestamp_daft(upper_raw, tu);
+            return make_timestamp_column_range_statistics_daft(tu, false, lower_ts, upper_ts);
+        }
+        _ => {}
+    }
+
+    // INT96 without logical/converted type: return Missing (matches parquet2 behavior)
+    Ok(ColumnRangeStatistics::Missing)
+}
+
+fn convert_byte_array_arrowrs(
+    lower: &ArrowByteArray,
+    upper: &ArrowByteArray,
+    col_descr: &ArrowColumnDescriptor,
+) -> super::Result<ColumnRangeStatistics> {
+    let lower_bytes = lower.data();
+    let upper_bytes = upper.data();
+
+    if let Some(ref ltype) = col_descr.logical_type() {
+        match ltype {
+            ArrowLogicalType::String
+            | ArrowLogicalType::Enum
+            | ArrowLogicalType::Uuid
+            | ArrowLogicalType::Json => {
+                let lower_str = String::from_utf8(lower_bytes.to_vec())
+                    .context(UnableToParseUtf8FromBinarySnafu)?;
+                let upper_str = String::from_utf8(upper_bytes.to_vec())
+                    .context(UnableToParseUtf8FromBinarySnafu)?;
+                let lower =
+                    Utf8Array::from_slice("lower", [lower_str.as_str()].as_slice()).into_series();
+                let upper =
+                    Utf8Array::from_slice("upper", [upper_str.as_str()].as_slice()).into_series();
+                return Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?);
+            }
+            ArrowLogicalType::Decimal { precision, scale } => {
+                return make_decimal_column_range_statistics(
+                    *precision as usize,
+                    *scale as usize,
+                    lower_bytes,
+                    upper_bytes,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    match col_descr.converted_type() {
+        ArrowConvertedType::UTF8 | ArrowConvertedType::ENUM | ArrowConvertedType::JSON => {
+            let lower_str = String::from_utf8(lower_bytes.to_vec())
+                .context(UnableToParseUtf8FromBinarySnafu)?;
+            let upper_str = String::from_utf8(upper_bytes.to_vec())
+                .context(UnableToParseUtf8FromBinarySnafu)?;
+            let lower =
+                Utf8Array::from_slice("lower", [lower_str.as_str()].as_slice()).into_series();
+            let upper =
+                Utf8Array::from_slice("upper", [upper_str.as_str()].as_slice()).into_series();
+            return Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?);
+        }
+        ArrowConvertedType::DECIMAL => {
+            let p = col_descr.type_precision() as usize;
+            let s = col_descr.type_scale() as usize;
+            return make_decimal_column_range_statistics(p, s, lower_bytes, upper_bytes);
+        }
+        _ => {}
+    }
+
+    // Fallback: BinaryArray
+    let lower = BinaryArray::from_values("lower", std::iter::once(lower_bytes)).into_series();
+    let upper = BinaryArray::from_values("upper", std::iter::once(upper_bytes)).into_series();
+    Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?)
+}
+
+fn convert_fixed_len_arrowrs(
+    lower: &ArrowByteArray,
+    upper: &ArrowByteArray,
+    col_descr: &ArrowColumnDescriptor,
+) -> super::Result<ColumnRangeStatistics> {
+    let lower_bytes = lower.data();
+    let upper_bytes = upper.data();
+
+    if let Some(ArrowLogicalType::Decimal { precision, scale }) = col_descr.logical_type() {
+        return make_decimal_column_range_statistics(
+            precision as usize,
+            scale as usize,
+            lower_bytes,
+            upper_bytes,
+        );
+    }
+
+    if col_descr.converted_type() == ArrowConvertedType::DECIMAL {
+        let p = col_descr.type_precision() as usize;
+        let s = col_descr.type_scale() as usize;
+        return make_decimal_column_range_statistics(p, s, lower_bytes, upper_bytes);
+    }
+
+    // Fallback: BinaryArray
+    let lower = BinaryArray::from_values("lower", std::iter::once(lower_bytes)).into_series();
+    let upper = BinaryArray::from_values("upper", std::iter::once(upper_bytes)).into_series();
+    Ok(ColumnRangeStatistics::new(Some(lower), Some(upper))?)
 }

--- a/src/daft-parquet/src/statistics/mod.rs
+++ b/src/daft-parquet/src/statistics/mod.rs
@@ -6,7 +6,9 @@ use snafu::Snafu;
 mod column_range;
 mod table_stats;
 mod utils;
-pub use table_stats::row_group_metadata_to_table_stats;
+pub use table_stats::{
+    arrowrs_row_group_metadata_to_table_stats, row_group_metadata_to_table_stats,
+};
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]

--- a/src/daft-parquet/src/statistics/table_stats.rs
+++ b/src/daft-parquet/src/statistics/table_stats.rs
@@ -6,7 +6,9 @@ use daft_stats::{ColumnRangeStatistics, TableStatistics};
 use indexmap::IndexMap;
 use snafu::ResultExt;
 
-use super::column_range::parquet_statistics_to_column_range_statistics;
+use super::column_range::{
+    arrowrs_statistics_to_column_range_statistics, parquet_statistics_to_column_range_statistics,
+};
 
 pub fn row_group_metadata_to_table_stats(
     metadata: &crate::metadata::RowGroupMetaData,
@@ -38,6 +40,58 @@ pub fn row_group_metadata_to_table_stats(
                     .context(super::UnableToParseParquetColumnStatisticsSnafu)?
                     .and_then(|v| {
                         parquet_statistics_to_column_range_statistics(v.as_ref(), &field.dtype).ok()
+                    })
+                    .unwrap_or(ColumnRangeStatistics::Missing)
+            } else {
+                ColumnRangeStatistics::Missing
+            })
+        })
+        .collect::<DaftResult<_>>()?;
+
+    Ok(TableStatistics::new(columns, Arc::new(schema.clone())))
+}
+
+/// Convert arrow-rs RowGroupMetaData to TableStatistics.
+///
+/// This is the arrow-rs equivalent of [`row_group_metadata_to_table_stats`].
+pub fn arrowrs_row_group_metadata_to_table_stats(
+    metadata: &parquet::file::metadata::RowGroupMetaData,
+    schema: &Schema,
+) -> DaftResult<TableStatistics> {
+    // Create a map from {field_name: (statistics, column_descriptor)} for easy access
+    let mut parquet_column_metadata: IndexMap<&str, _> = metadata
+        .columns()
+        .iter()
+        .map(|col| {
+            let top_level_column_name = col
+                .column_descr()
+                .path()
+                .parts()
+                .first()
+                .expect("Parquet schema should have at least one entry in path");
+            (
+                top_level_column_name.as_str(),
+                (col.statistics(), col.column_descr()),
+            )
+        })
+        .collect();
+
+    // Iterate through the schema and construct ColumnRangeStatistics per field
+    let columns = schema
+        .into_iter()
+        .map(|field| {
+            Ok(if ColumnRangeStatistics::supports_dtype(&field.dtype) {
+                parquet_column_metadata
+                    .swap_remove(field.name.as_str())
+                    .and_then(|(stats_opt, col_descr)| {
+                        stats_opt.and_then(|stats| {
+                            arrowrs_statistics_to_column_range_statistics(
+                                stats,
+                                col_descr,
+                                &field.dtype,
+                            )
+                            .ok()
+                        })
                     })
                     .unwrap_or(ColumnRangeStatistics::Missing)
             } else {

--- a/src/daft-parquet/src/statistics/utils.rs
+++ b/src/daft-parquet/src/statistics/utils.rs
@@ -43,3 +43,42 @@ pub fn convert_i96_to_i64_timestamp(value: [u32; 3], tu: TimeUnit) -> i64 {
         TimeUnit::Milliseconds => int96_to_i64_ms(value),
     }
 }
+
+/// Standalone INT96 to nanosecond timestamp conversion (no parquet2 dependency).
+#[inline]
+fn int96_to_i64_ns_standalone(value: [u32; 3]) -> i64 {
+    const JULIAN_DAY_OF_EPOCH: i64 = 2_440_588;
+    const SECONDS_PER_DAY: i64 = 86_400;
+    const NANOS_PER_SECOND: i64 = 1_000_000_000;
+
+    let day = i64::from(value[2]);
+    let nanoseconds = (i64::from(value[1]) << 32) + i64::from(value[0]);
+    let seconds = (day - JULIAN_DAY_OF_EPOCH) * SECONDS_PER_DAY;
+
+    seconds * NANOS_PER_SECOND + nanoseconds
+}
+
+/// Convert INT96 value to i64 timestamp using Daft's TimeUnit (parquet2-agnostic).
+#[inline]
+pub fn convert_i96_to_i64_timestamp_daft(
+    value: [u32; 3],
+    tu: daft_core::datatypes::TimeUnit,
+) -> i64 {
+    match tu {
+        daft_core::datatypes::TimeUnit::Nanoseconds => int96_to_i64_ns_standalone(value),
+        daft_core::datatypes::TimeUnit::Microseconds => int96_to_i64_us(value),
+        daft_core::datatypes::TimeUnit::Milliseconds => int96_to_i64_ms(value),
+        daft_core::datatypes::TimeUnit::Seconds => {
+            int96_to_i64_ns_standalone(value) / 1_000_000_000
+        }
+    }
+}
+
+/// Convert arrow-rs parquet TimeUnit to Daft TimeUnit.
+pub fn arrowrs_timeunit_to_daft(unit: parquet::basic::TimeUnit) -> daft_core::datatypes::TimeUnit {
+    match unit {
+        parquet::basic::TimeUnit::MILLIS => daft_core::datatypes::TimeUnit::Milliseconds,
+        parquet::basic::TimeUnit::MICROS => daft_core::datatypes::TimeUnit::Microseconds,
+        parquet::basic::TimeUnit::NANOS => daft_core::datatypes::TimeUnit::Nanoseconds,
+    }
+}


### PR DESCRIPTION
Adds an arrow-rs parquet reader behind an env var gate (`DAFT_PARQUET_READER=arrowrs`) as the foundation for replacing the parquet2-based reader. The arrow2/parquet2 reader remains the default.

The arrow-rs reader is **feature-complete** with the parquet2 reader — all Iceberg features (field_id_mapping, delete_rows) are supported, and the only remaining guard is the env var toggle.

## Baseline Benchmarks (c6a.4xlarge, 16 vCPU, 32 GB)

Benchmarks run with `pytest-benchmark` on synthetic parquet files (2M rows, 8 row groups). Commands:

```bash
# Filter pushdown (1%, 10%, 50%, 90% selectivity × int/float/string/compound predicates)
DAFT_PARQUET_READER=<reader> pytest benchmarking/parquet/test_filter_pushdown.py --benchmark-only

# Types & codecs (nested List/Struct/Map, snappy/zstd/gzip/none)
DAFT_PARQUET_READER=<reader> pytest benchmarking/parquet/test_types_and_codecs.py --benchmark-only
```

| Workload | arrowrs vs parquet2 | Notes |
|---|---|---|
| Nested types (List, Struct, Map) | **2-4x faster** | arrow-rs native nested type decode |
| Projection (1/20 cols) | ~parity | |
| Scalar types + codecs | ~parity | |
| Filter pushdown (all selectivities) | **~1.3x slower** | Post-read filtering; see Phase 6 below |

The filter regression is expected: both readers currently do post-read filtering, but the arrow-rs path has conversion overhead (arrow-rs RecordBatch → Daft RecordBatch). Phase 6 will eliminate this by pushing predicates into the decode pipeline.

## Changes

**`arrowrs_reader.rs`** — three entry points:
- `read_parquet_single_arrowrs()` (async, remote files via `DaftAsyncFileReader`)
- `local_parquet_read_arrowrs()` (sync, local files with rayon-parallel row group decode)
- `stream_parquet_single_arrowrs()` (async streaming)
- Row group pruning via column statistics, column projection, row limits, start offsets
- `field_id_mapping` support for Iceberg schema evolution

**`read.rs`** — dispatch + Iceberg features:
- `use_arrowrs_reader()` env var check dispatches to arrow-rs path
- `apply_delete_rows()` shared helper for Iceberg positional deletes (used by both reader paths)
- `delete_rows` support in both single-read and streaming paths

**`metadata.rs`** — field ID mapping for arrow-rs:
- `apply_field_ids_to_arrowrs_parquet_metadata()` rewrites arrow-rs `ParquetMetaData` to rename/filter columns per Iceberg field ID mapping
- `rewrite_arrowrs_type_with_field_ids()` recursively rebuilds immutable `Arc<Type>` trees

**`async_reader.rs`** — `DaftAsyncFileReader` implementing arrow-rs `AsyncFileReader` trait:
- Bridges Daft's `IOClient` + `ReadPlanner` to arrow-rs
- `get_byte_ranges()` with split + coalesce passes matching parquet2 constants

**`schema_inference.rs`** — arrow-rs native schema inference:
- INT96 timestamp coercion, string-to-binary, large offset promotion

**`arrow_bridge.rs`** — arrow-rs RecordBatch → Daft RecordBatch conversion

**Statistics** — arrow-rs equivalents for row group pruning

## Upcoming (stacked PRs)

- **Phase 6: Late materialization** — `RowFilter` / `ArrowPredicate` to push predicates into the decode pipeline (skip decoding non-matching rows). This will resolve the filter regression and make filters *faster* than parquet2. Also `RowSelection` for delete_rows to skip deleted rows during decode.
- **Phase 7: Cleanup** — flip arrow-rs to default, delete `src/parquet2/` (94 files) and `src/arrow2/src/io/parquet/read/` (50+ files)