### PR TITLE
feat(dashboard): physical plan tree with live operator stats

### DIFF
--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -16,7 +16,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import LoadingPage from "@/components/loading";
 import { Status } from "./status";
 import { ExecutingState, OperatorInfo, QueryInfo } from "./types";
-import ProgressTable from "./progress-table";
+import PhysicalPlanTree from "./physical-plan-tree";
 import PlanVisualizer from "./plan-visualizer";
 
 /**
@@ -210,7 +210,7 @@ function QueryPageInner() {
                 query.state.status === "Setup"
               }
             >
-              Progress Table
+              Execution
             </TabsTrigger>
             <TabsTrigger
               value="optimized-plan"
@@ -234,7 +234,7 @@ function QueryPageInner() {
                   </p>
                 </div>
               ) : (
-                <ProgressTable exec_state={query.state as ExecutingState} />
+                <PhysicalPlanTree exec_state={query.state as ExecutingState} />
               )}
             </div>
           </TabsContent>

--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -254,7 +254,7 @@ function QueryPageInner() {
                 planJson={
                   "plan_info" in query.state
                     ? query.state.plan_info.optimized_plan
-                    : "{}"
+                    : ""
                 }
               />
             )}

--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -17,12 +17,7 @@ import LoadingPage from "@/components/loading";
 import { Status } from "./status";
 import { ExecutingState, OperatorInfo, QueryInfo } from "./types";
 import ProgressTable from "./progress-table";
-
-
-function formatPlanJSON(plan: string) {
-  const parsedPlan = JSON.parse(plan);
-  return JSON.stringify(parsedPlan, null, 2);
-}
+import PlanVisualizer from "./plan-visualizer";
 
 /**
  * Query detail page component
@@ -179,7 +174,7 @@ function QueryPageInner() {
                   </p>
                 </div>
                 {query.ray_dashboard_url && (
-                 <div>
+                  <div>
                     <h3 className={`${main.className} text-sm font-semibold text-zinc-400 mb-1`}>
                       Ray Dashboard
                     </h3>
@@ -191,8 +186,8 @@ function QueryPageInner() {
                     >
                       Open in Ray
                     </a>
-                 </div>
-               )}
+                  </div>
+                )}
               </div>
             </div>
           </div>
@@ -248,34 +243,28 @@ function QueryPageInner() {
             value="optimized-plan"
             className="mt-4 flex-1 overflow-auto"
           >
-            <div className="bg-zinc-900 p-4">
-              {query.state.status === "Pending" ? (
+            {query.state.status === "Pending" ? (
+              <div className="bg-zinc-900 p-4">
                 <p className={`${main.className} text-zinc-400`}>
                   Plan not yet optimized
                 </p>
-              ) : (
-                <pre
-                  className={`${main.className} text-sm font-mono text-zinc-300 whitespace-pre-wrap`}
-                >
-                  {"plan_info" in query.state
-                    ? formatPlanJSON(query.state.plan_info.optimized_plan)
-                    : "No optimized plan available"}
-                </pre>
-              )}
-            </div>
+              </div>
+            ) : (
+              <PlanVisualizer
+                planJson={
+                  "plan_info" in query.state
+                    ? query.state.plan_info.optimized_plan
+                    : "{}"
+                }
+              />
+            )}
           </TabsContent>
 
           <TabsContent
             value="unoptimized-plan"
             className="mt-4 flex-1 overflow-auto"
           >
-            <div className="bg-zinc-900 p-4">
-              <pre
-                className={`${main.className} text-sm font-mono text-zinc-300 whitespace-pre-wrap`}
-              >
-                {formatPlanJSON(query.unoptimized_plan)}
-              </pre>
-            </div>
+            <PlanVisualizer planJson={query.unoptimized_plan} />
           </TabsContent>
         </Tabs>
       </div>

--- a/src/daft-dashboard/frontend/src/app/query/physical-plan-tree.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/physical-plan-tree.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState } from "react";
+import { main } from "@/lib/utils";
+import { ExecutingState, OperatorInfo, PhysicalPlanNode } from "./types";
+import {
+  getStatusIcon,
+  getStatusBorderColor,
+  formatStatValue,
+  ROWS_IN_STAT_KEY,
+  ROWS_OUT_STAT_KEY,
+  DURATION_US_STAT_KEY,
+} from "./stats-utils";
+import ProgressTable from "./progress-table";
+
+const categoryColors: Record<string, { bg: string; border: string; text: string }> = {
+  Source: { bg: "bg-emerald-950", border: "border-emerald-700", text: "text-emerald-300" },
+  Filter: { bg: "bg-amber-950", border: "border-amber-700", text: "text-amber-300" },
+  Project: { bg: "bg-sky-950", border: "border-sky-700", text: "text-sky-300" },
+  Sort: { bg: "bg-violet-950", border: "border-violet-700", text: "text-violet-300" },
+  Join: { bg: "bg-rose-950", border: "border-rose-700", text: "text-rose-300" },
+  Aggregate: { bg: "bg-fuchsia-950", border: "border-fuchsia-700", text: "text-fuchsia-300" },
+  Sink: { bg: "bg-indigo-950", border: "border-indigo-700", text: "text-indigo-300" },
+};
+
+const defaultColor = { bg: "bg-zinc-900", border: "border-zinc-600", text: "text-zinc-300" };
+
+function getCategoryColor(node: PhysicalPlanNode) {
+  // Try node.type first (e.g. "Source", "Join"), then node.category
+  return categoryColors[node.type] ?? categoryColors[node.category] ?? defaultColor;
+}
+
+function PhysicalNodeCard({
+  node,
+  operator,
+}: {
+  node: PhysicalPlanNode;
+  operator?: OperatorInfo;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const catColor = getCategoryColor(node);
+  const status = operator?.status ?? "Pending";
+  const statusBorder = getStatusBorderColor(status);
+
+  const rowsIn = operator?.stats[ROWS_IN_STAT_KEY]?.value ?? 0;
+  const rowsOut = operator?.stats[ROWS_OUT_STAT_KEY]?.value ?? 0;
+
+  const extraStats = operator
+    ? Object.entries(operator.stats).filter(
+        ([key]) =>
+          ![ROWS_IN_STAT_KEY, ROWS_OUT_STAT_KEY, DURATION_US_STAT_KEY].includes(key),
+      )
+    : [];
+
+  return (
+    <div
+      className={`${catColor.bg} ${statusBorder} border-2 rounded-lg px-4 py-2.5 cursor-pointer
+        hover:brightness-125 transition-all min-w-[180px] max-w-[320px]`}
+      onClick={() => setExpanded(!expanded)}
+    >
+      {/* Header: status icon + name */}
+      <div className="flex items-center gap-2">
+        {getStatusIcon(status)}
+        <span
+          className={`${main.className} ${catColor.text} text-sm font-bold tracking-wide truncate`}
+        >
+          {node.name}
+        </span>
+        {extraStats.length > 0 && (
+          <span className="text-zinc-500 text-xs ml-auto">
+            {expanded ? "▾" : "▸"}
+          </span>
+        )}
+      </div>
+
+      {/* Rows in / out — always visible */}
+      {operator && (
+        <div className="mt-1.5 flex gap-3 text-xs font-mono text-zinc-400">
+          {!node.name.includes("Scan") && (
+            <span>
+              <span className="text-zinc-500">in:</span> {rowsIn.toLocaleString()}
+            </span>
+          )}
+          {!node.name.includes("Sink") && (
+            <span>
+              <span className="text-zinc-500">out:</span> {rowsOut.toLocaleString()}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Extra stats — expandable */}
+      {expanded && extraStats.length > 0 && (
+        <div className="mt-2 pt-2 border-t border-zinc-700/50 space-y-1">
+          {extraStats.map(([key, stat]) => (
+            <div key={key} className="flex justify-between gap-2">
+              <span
+                className={`${main.className} text-[10px] uppercase tracking-wider text-zinc-500`}
+              >
+                {key}
+              </span>
+              <span className={`${main.className} text-xs text-zinc-300 font-mono`}>
+                {formatStatValue(stat)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TreeNode({
+  node,
+  operators,
+}: {
+  node: PhysicalPlanNode;
+  operators: Record<number, OperatorInfo>;
+}) {
+  const hasChildren = node.children && node.children.length > 0;
+
+  return (
+    <div className="flex flex-col items-center min-w-0">
+      <PhysicalNodeCard node={node} operator={operators[node.id]} />
+
+      {hasChildren && (
+        <div className="flex flex-col items-center">
+          {/* Vertical line from parent */}
+          <div className="w-px h-6 bg-zinc-600" />
+
+          {node.children!.length > 1 ? (
+            <div className="flex items-start">
+              {node.children!.map((child, i) => {
+                const isFirst = i === 0;
+                const isLast = i === node.children!.length - 1;
+                return (
+                  <div key={i} className="flex flex-col items-center">
+                    {/* Horizontal + vertical connector */}
+                    <div className="flex w-full h-px">
+                      <div
+                        className={`flex-1 h-px ${isFirst ? "bg-transparent" : "bg-zinc-600"}`}
+                      />
+                      <div
+                        className={`flex-1 h-px ${isLast ? "bg-transparent" : "bg-zinc-600"}`}
+                      />
+                    </div>
+                    <div className="w-px h-6 bg-zinc-600" />
+                    <div className="px-3">
+                      <TreeNode node={child} operators={operators} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <TreeNode node={node.children![0]} operators={operators} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function PhysicalPlanTree({
+  exec_state,
+}: {
+  exec_state: ExecutingState;
+}) {
+  const [viewMode, setViewMode] = useState<"tree" | "table" | "json">("tree");
+
+  let plan: PhysicalPlanNode | null = null;
+  const planJson = exec_state.exec_info.physical_plan;
+  if (planJson) {
+    try {
+      plan = JSON.parse(planJson);
+    } catch {
+      // fall through — will show table
+    }
+  }
+
+  return (
+    <div className="bg-zinc-900 h-full flex flex-col">
+      {/* View toggle */}
+      <div className="flex items-center gap-2 px-4 pt-3 pb-2 border-b border-zinc-800">
+        {plan && (
+          <button
+            onClick={() => setViewMode("tree")}
+            className={`${main.className} text-xs px-3 py-1 rounded-md transition-colors ${
+              viewMode === "tree"
+                ? "bg-zinc-700 text-white"
+                : "text-zinc-400 hover:text-zinc-200"
+            }`}
+          >
+            Tree View
+          </button>
+        )}
+        <button
+          onClick={() => setViewMode("table")}
+          className={`${main.className} text-xs px-3 py-1 rounded-md transition-colors ${
+            viewMode === "table"
+              ? "bg-zinc-700 text-white"
+              : "text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          Table
+        </button>
+        {plan && (
+          <button
+            onClick={() => setViewMode("json")}
+            className={`${main.className} text-xs px-3 py-1 rounded-md transition-colors ${
+              viewMode === "json"
+                ? "bg-zinc-700 text-white"
+                : "text-zinc-400 hover:text-zinc-200"
+            }`}
+          >
+            JSON
+          </button>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        {viewMode === "tree" && plan ? (
+          <div className="relative flex justify-center py-6 px-4 overflow-auto">
+            <TreeNode node={plan} operators={exec_state.exec_info.operators} />
+          </div>
+        ) : viewMode === "json" && plan ? (
+          <pre
+            className={`${main.className} text-sm font-mono text-zinc-300 whitespace-pre-wrap p-4`}
+          >
+            {JSON.stringify(plan, null, 2)}
+          </pre>
+        ) : (
+          <ProgressTable exec_state={exec_state} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState } from "react";
+import { main } from "@/lib/utils";
+
+type PlanNode = {
+  type: string;
+  children: PlanNode[];
+  [key: string]: unknown;
+};
+
+function parsePlan(planJson: string): PlanNode {
+  return JSON.parse(planJson);
+}
+
+/** Extract display properties from a node (everything except type and children). */
+function getNodeProps(node: PlanNode): [string, unknown][] {
+  return Object.entries(node).filter(
+    ([key]) => key !== "type" && key !== "children",
+  );
+}
+
+const categoryColors: Record<string, { bg: string; border: string; text: string }> = {
+  Source: { bg: "bg-emerald-950", border: "border-emerald-700", text: "text-emerald-300" },
+  Filter: { bg: "bg-amber-950", border: "border-amber-700", text: "text-amber-300" },
+  Project: { bg: "bg-sky-950", border: "border-sky-700", text: "text-sky-300" },
+  Sort: { bg: "bg-violet-950", border: "border-violet-700", text: "text-violet-300" },
+  Join: { bg: "bg-rose-950", border: "border-rose-700", text: "text-rose-300" },
+  Aggregate: { bg: "bg-fuchsia-950", border: "border-fuchsia-700", text: "text-fuchsia-300" },
+};
+
+const defaultColor = { bg: "bg-zinc-900", border: "border-zinc-600", text: "text-zinc-300" };
+
+function getColor(nodeType: string) {
+  return categoryColors[nodeType] ?? defaultColor;
+}
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map((v) => String(v)).join(", ");
+  }
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  return String(value);
+}
+
+function NodeCard({
+  node,
+  isExpanded,
+  onToggle,
+}: {
+  node: PlanNode;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const color = getColor(node.type);
+  const props = getNodeProps(node);
+
+  return (
+    <div
+      className={`${color.bg} ${color.border} border rounded-lg px-4 py-2.5 cursor-pointer
+        hover:brightness-125 transition-all min-w-[160px] max-w-[320px]`}
+      onClick={onToggle}
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={`${main.className} ${color.text} text-sm font-bold tracking-wide`}
+        >
+          {node.type}
+        </span>
+        {props.length > 0 && (
+          <span className="text-zinc-500 text-xs ml-auto">
+            {isExpanded ? "▾" : "▸"}
+          </span>
+        )}
+      </div>
+      {isExpanded && props.length > 0 && (
+        <div className="mt-2 pt-2 border-t border-zinc-700/50 space-y-1">
+          {props.map(([key, value]) => (
+            <div key={key} className="flex flex-col">
+              <span
+                className={`${main.className} text-[10px] uppercase tracking-wider text-zinc-500`}
+              >
+                {key}
+              </span>
+              <span
+                className={`${main.className} text-xs text-zinc-300 break-all`}
+              >
+                {formatValue(value)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PlanTree({ node }: { node: PlanNode }) {
+  return (
+    <div className="relative flex justify-center py-6 px-4 overflow-auto">
+      <TreeNode node={node} />
+    </div>
+  );
+}
+
+function TreeNode({ node, depth = 0 }: { node: PlanNode; depth?: number }) {
+  const [expanded, setExpanded] = useState(true);
+  const hasChildren = node.children && node.children.length > 0;
+
+  return (
+    <div className="flex flex-col items-center min-w-0">
+      <NodeCard
+        node={node}
+        isExpanded={expanded}
+        onToggle={() => setExpanded(!expanded)}
+      />
+
+      {hasChildren && (
+        <div className="flex flex-col items-center">
+          {/* Vertical line from parent */}
+          <div className="w-px h-6 bg-zinc-600" />
+
+          {node.children.length > 1 ? (
+            <div className="flex items-start">
+              {node.children.map((child, i) => {
+                const isFirst = i === 0;
+                const isLast = i === node.children.length - 1;
+                return (
+                  <div key={i} className="flex flex-col items-center">
+                    {/* Horizontal + vertical connector */}
+                    <div className="flex w-full h-px">
+                      <div
+                        className={`flex-1 h-px ${isFirst ? "bg-transparent" : "bg-zinc-600"}`}
+                      />
+                      <div
+                        className={`flex-1 h-px ${isLast ? "bg-transparent" : "bg-zinc-600"}`}
+                      />
+                    </div>
+                    <div className="w-px h-6 bg-zinc-600" />
+                    <div className="px-3">
+                      <TreeNode node={child} depth={depth + 1} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <TreeNode node={node.children[0]} depth={depth + 1} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function PlanVisualizer({ planJson }: { planJson: string }) {
+  const [viewMode, setViewMode] = useState<"tree" | "json">("tree");
+
+  let plan: PlanNode;
+  try {
+    plan = parsePlan(planJson);
+  } catch {
+    return (
+      <div className="bg-zinc-900 p-4">
+        <pre
+          className={`${main.className} text-sm font-mono text-zinc-300 whitespace-pre-wrap`}
+        >
+          {planJson}
+        </pre>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-zinc-900 h-full flex flex-col">
+      {/* View toggle */}
+      <div className="flex items-center gap-2 px-4 pt-3 pb-2 border-b border-zinc-800">
+        <button
+          onClick={() => setViewMode("tree")}
+          className={`${main.className} text-xs px-3 py-1 rounded-md transition-colors ${
+            viewMode === "tree"
+              ? "bg-zinc-700 text-white"
+              : "text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          Tree View
+        </button>
+        <button
+          onClick={() => setViewMode("json")}
+          className={`${main.className} text-xs px-3 py-1 rounded-md transition-colors ${
+            viewMode === "json"
+              ? "bg-zinc-700 text-white"
+              : "text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          JSON
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        {viewMode === "tree" ? (
+          <PlanTree node={plan} />
+        ) : (
+          <pre
+            className={`${main.className} text-sm font-mono text-zinc-300 whitespace-pre-wrap p-4`}
+          >
+            {JSON.stringify(plan, null, 2)}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { main } from "@/lib/utils";
+import TreeLayout from "./tree-layout";
+import { categoryColors, defaultColor } from "./tree-colors";
 
 type PlanNode = {
   type: string;
@@ -19,17 +21,6 @@ function getNodeProps(node: PlanNode): [string, unknown][] {
     ([key]) => key !== "type" && key !== "children",
   );
 }
-
-const categoryColors: Record<string, { bg: string; border: string; text: string }> = {
-  Source: { bg: "bg-emerald-950", border: "border-emerald-700", text: "text-emerald-300" },
-  Filter: { bg: "bg-amber-950", border: "border-amber-700", text: "text-amber-300" },
-  Project: { bg: "bg-sky-950", border: "border-sky-700", text: "text-sky-300" },
-  Sort: { bg: "bg-violet-950", border: "border-violet-700", text: "text-violet-300" },
-  Join: { bg: "bg-rose-950", border: "border-rose-700", text: "text-rose-300" },
-  Aggregate: { bg: "bg-fuchsia-950", border: "border-fuchsia-700", text: "text-fuchsia-300" },
-};
-
-const defaultColor = { bg: "bg-zinc-900", border: "border-zinc-600", text: "text-zinc-300" };
 
 function getColor(nodeType: string) {
   return categoryColors[nodeType] ?? defaultColor;
@@ -100,61 +91,14 @@ function NodeCard({
   );
 }
 
-function PlanTree({ node }: { node: PlanNode }) {
-  return (
-    <div className="relative flex justify-center py-6 px-4 overflow-auto">
-      <TreeNode node={node} />
-    </div>
-  );
-}
-
-function TreeNode({ node, depth = 0 }: { node: PlanNode; depth?: number }) {
+function ExpandableNodeCard({ node }: { node: PlanNode }) {
   const [expanded, setExpanded] = useState(true);
-  const hasChildren = node.children && node.children.length > 0;
-
   return (
-    <div className="flex flex-col items-center min-w-0">
-      <NodeCard
-        node={node}
-        isExpanded={expanded}
-        onToggle={() => setExpanded(!expanded)}
-      />
-
-      {hasChildren && (
-        <div className="flex flex-col items-center">
-          {/* Vertical line from parent */}
-          <div className="w-px h-6 bg-zinc-600" />
-
-          {node.children.length > 1 ? (
-            <div className="flex items-start">
-              {node.children.map((child, i) => {
-                const isFirst = i === 0;
-                const isLast = i === node.children.length - 1;
-                return (
-                  <div key={i} className="flex flex-col items-center">
-                    {/* Horizontal + vertical connector */}
-                    <div className="flex w-full h-px">
-                      <div
-                        className={`flex-1 h-px ${isFirst ? "bg-transparent" : "bg-zinc-600"}`}
-                      />
-                      <div
-                        className={`flex-1 h-px ${isLast ? "bg-transparent" : "bg-zinc-600"}`}
-                      />
-                    </div>
-                    <div className="w-px h-6 bg-zinc-600" />
-                    <div className="px-3">
-                      <TreeNode node={child} depth={depth + 1} />
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            <TreeNode node={node.children[0]} depth={depth + 1} />
-          )}
-        </div>
-      )}
-    </div>
+    <NodeCard
+      node={node}
+      isExpanded={expanded}
+      onToggle={() => setExpanded(!expanded)}
+    />
   );
 }
 
@@ -205,7 +149,13 @@ export default function PlanVisualizer({ planJson }: { planJson: string }) {
       {/* Content */}
       <div className="flex-1 overflow-auto">
         {viewMode === "tree" ? (
-          <PlanTree node={plan} />
+          <div className="relative flex justify-center py-6 px-4 overflow-auto">
+            <TreeLayout
+              node={plan}
+              getChildren={(node) => node.children ?? []}
+              renderNode={(node) => <ExpandableNodeCard node={node} />}
+            />
+          </div>
         ) : (
           <pre
             className={`${main.className} text-sm font-mono text-zinc-300 whitespace-pre-wrap p-4`}

--- a/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/plan-visualizer.tsx
@@ -42,6 +42,9 @@ function formatValue(value: unknown): string {
   if (value === null || value === undefined) {
     return "—";
   }
+  if (typeof value === "object") {
+    return JSON.stringify(value, null, 2);
+  }
   return String(value);
 }
 

--- a/src/daft-dashboard/frontend/src/app/query/progress-table.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/progress-table.tsx
@@ -1,84 +1,13 @@
-import { AnimatedFish, Naruto } from "@/components/icons";
-import { ExecutingState, OperatorStatus, Stat } from "./types";
-
-const ROWS_IN_STAT_KEY = "rows.in";
-const ROWS_OUT_STAT_KEY = "rows.out";
-const DURATION_US_STAT_KEY = "duration";
-
-const getStatusIcon = (status: OperatorStatus) => {
-  switch (status) {
-    case "Finished":
-      return <Naruto />;
-    case "Executing":
-      return <AnimatedFish />;
-    case "Failed":
-      return (
-        <div className="w-5 h-5 flex items-center justify-center">
-          <div className="w-4 h-4 bg-red-500 rounded-full flex items-center justify-center">
-            <span className="text-white text-[10px] font-bold">!</span>
-          </div>
-        </div>
-      );
-    case "Pending":
-    default:
-      return (
-        <div className="w-5 h-5 border-2 border-zinc-400 border-t-transparent rounded-full animate-spin"></div>
-      );
-  }
-};
-
-const getStatusText = (status: OperatorStatus) => {
-  if (status === "Finished") {
-    return "Finished";
-  } else if (status === "Executing") {
-    return "Running";
-  } else if (status === "Failed") {
-    return "Failed";
-  } else {
-    return "Pending";
-  }
-};
-
-const getStatusColor = (status: OperatorStatus) => {
-  switch (status) {
-    case "Finished":
-      return "text-green-500";
-    case "Executing":
-      return "text-(--daft-accent)";
-    case "Failed":
-      return "text-red-500";
-    case "Pending":
-    default:
-      return "text-zinc-400";
-  }
-};
-
-// Get extra stats (all stats except the ones we're already displaying)
-const formatStatValue = (stat: Stat) => {
-  switch (stat.type) {
-    case "Count":
-      return stat.value.toLocaleString();
-    case "Bytes":
-      const bytes = stat.value;
-      if (bytes >= 1024 * 1024 * 1024) {
-        return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`;
-      } else if (bytes >= 1024 * 1024) {
-        return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
-      } else if (bytes >= 1024) {
-        return `${(bytes / 1024).toFixed(1)} KiB`;
-      } else {
-        return `${bytes} B`;
-      }
-    case "Percent":
-      return `${stat.value.toFixed(1)}%`;
-    case "Duration":
-      return `${stat.value.toFixed(1)}s`;
-    case "Float":
-      return stat.value.toFixed(2);
-    default:
-      return String((stat as any).value);
-  }
-};
+import { ExecutingState } from "./types";
+import {
+  getStatusIcon,
+  getStatusText,
+  getStatusColor,
+  formatStatValue,
+  ROWS_IN_STAT_KEY,
+  ROWS_OUT_STAT_KEY,
+  DURATION_US_STAT_KEY,
+} from "./stats-utils";
 
 export default function ProgressTable({
   exec_state,

--- a/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
@@ -22,7 +22,7 @@ export const getStatusIcon = (status: OperatorStatus) => {
     case "Pending":
     default:
       return (
-        <div className="w-5 h-5 border-2 border-zinc-400 border-t-transparent rounded-full animate-spin"></div>
+        <div className="w-5 h-5 shrink-0 border-2 border-zinc-400 border-t-transparent rounded-full animate-spin"></div>
       );
   }
 };

--- a/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/stats-utils.tsx
@@ -1,0 +1,94 @@
+import { AnimatedFish, Naruto } from "@/components/icons";
+import { OperatorStatus, Stat } from "./types";
+
+export const ROWS_IN_STAT_KEY = "rows.in";
+export const ROWS_OUT_STAT_KEY = "rows.out";
+export const DURATION_US_STAT_KEY = "duration";
+
+export const getStatusIcon = (status: OperatorStatus) => {
+  switch (status) {
+    case "Finished":
+      return <Naruto />;
+    case "Executing":
+      return <AnimatedFish />;
+    case "Failed":
+      return (
+        <div className="w-5 h-5 flex items-center justify-center">
+          <div className="w-4 h-4 bg-red-500 rounded-full flex items-center justify-center">
+            <span className="text-white text-[10px] font-bold">!</span>
+          </div>
+        </div>
+      );
+    case "Pending":
+    default:
+      return (
+        <div className="w-5 h-5 border-2 border-zinc-400 border-t-transparent rounded-full animate-spin"></div>
+      );
+  }
+};
+
+export const getStatusText = (status: OperatorStatus) => {
+  if (status === "Finished") {
+    return "Finished";
+  } else if (status === "Executing") {
+    return "Running";
+  } else if (status === "Failed") {
+    return "Failed";
+  } else {
+    return "Pending";
+  }
+};
+
+export const getStatusColor = (status: OperatorStatus) => {
+  switch (status) {
+    case "Finished":
+      return "text-green-500";
+    case "Executing":
+      return "text-(--daft-accent)";
+    case "Failed":
+      return "text-red-500";
+    case "Pending":
+    default:
+      return "text-zinc-400";
+  }
+};
+
+export const formatStatValue = (stat: Stat) => {
+  switch (stat.type) {
+    case "Count":
+      return stat.value.toLocaleString();
+    case "Bytes":
+      const bytes = stat.value;
+      if (bytes >= 1024 * 1024 * 1024) {
+        return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB`;
+      } else if (bytes >= 1024 * 1024) {
+        return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+      } else if (bytes >= 1024) {
+        return `${(bytes / 1024).toFixed(1)} KiB`;
+      } else {
+        return `${bytes} B`;
+      }
+    case "Percent":
+      return `${stat.value.toFixed(1)}%`;
+    case "Duration":
+      return `${stat.value.toFixed(1)}s`;
+    case "Float":
+      return stat.value.toFixed(2);
+    default:
+      return String((stat as any).value);
+  }
+};
+
+export const getStatusBorderColor = (status: OperatorStatus) => {
+  switch (status) {
+    case "Finished":
+      return "border-green-600";
+    case "Executing":
+      return "border-orange-500";
+    case "Failed":
+      return "border-red-600";
+    case "Pending":
+    default:
+      return "border-zinc-600";
+  }
+};

--- a/src/daft-dashboard/frontend/src/app/query/tree-colors.ts
+++ b/src/daft-dashboard/frontend/src/app/query/tree-colors.ts
@@ -1,0 +1,11 @@
+export const categoryColors: Record<string, { bg: string; border: string; text: string }> = {
+  Source: { bg: "bg-emerald-950", border: "border-emerald-700", text: "text-emerald-300" },
+  Filter: { bg: "bg-amber-950", border: "border-amber-700", text: "text-amber-300" },
+  Project: { bg: "bg-sky-950", border: "border-sky-700", text: "text-sky-300" },
+  Sort: { bg: "bg-violet-950", border: "border-violet-700", text: "text-violet-300" },
+  Join: { bg: "bg-rose-950", border: "border-rose-700", text: "text-rose-300" },
+  Aggregate: { bg: "bg-fuchsia-950", border: "border-fuchsia-700", text: "text-fuchsia-300" },
+  Sink: { bg: "bg-indigo-950", border: "border-indigo-700", text: "text-indigo-300" },
+};
+
+export const defaultColor = { bg: "bg-zinc-900", border: "border-zinc-600", text: "text-zinc-300" };

--- a/src/daft-dashboard/frontend/src/app/query/tree-layout.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/tree-layout.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { type ReactNode } from "react";
+
+type TreeLayoutProps<T> = {
+  node: T;
+  getChildren: (node: T) => T[];
+  renderNode: (node: T) => ReactNode;
+};
+
+export default function TreeLayout<T>({ node, getChildren, renderNode }: TreeLayoutProps<T>) {
+  const children = getChildren(node);
+
+  return (
+    <div className="flex flex-col items-center min-w-0">
+      {renderNode(node)}
+
+      {children.length > 0 && (
+        <div className="flex flex-col items-center">
+          {/* Vertical line from parent */}
+          <div className="w-px h-6 bg-zinc-600" />
+
+          {children.length > 1 ? (
+            <div className="flex items-start">
+              {children.map((child, i) => {
+                const isFirst = i === 0;
+                const isLast = i === children.length - 1;
+                return (
+                  <div key={i} className="flex flex-col items-center">
+                    {/* Horizontal + vertical connector */}
+                    <div className="flex w-full h-px">
+                      <div
+                        className={`flex-1 h-px ${isFirst ? "bg-transparent" : "bg-zinc-600"}`}
+                      />
+                      <div
+                        className={`flex-1 h-px ${isLast ? "bg-transparent" : "bg-zinc-600"}`}
+                      />
+                    </div>
+                    <div className="w-px h-6 bg-zinc-600" />
+                    <div className="px-3">
+                      <TreeLayout node={child} getChildren={getChildren} renderNode={renderNode} />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <TreeLayout node={children[0]} getChildren={getChildren} renderNode={renderNode} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/daft-dashboard/frontend/src/app/query/types.ts
+++ b/src/daft-dashboard/frontend/src/app/query/types.ts
@@ -41,9 +41,18 @@ export type OperatorInfo = {
   stats: Record<string, Stat>;
 };
 
+export type PhysicalPlanNode = {
+  id: number;
+  name: string;
+  type: string;
+  category: string;
+  children?: PhysicalPlanNode[];
+};
+
 export type ExecInfo = {
   exec_start_sec: number;
   operators: Record<number, OperatorInfo>;
+  physical_plan: string;
   // TODO: Logs
 };
 


### PR DESCRIPTION
## Summary
<img width="722" height="908" alt="image (3)" src="https://github.com/user-attachments/assets/f613d0af-2f25-4b3f-b45f-15999338c720" />

Renders the physical plan as a tree annotated with live operator stats, replacing the flat progress table as the default view
- Adds Tree View / Table / JSON toggle — table falls back to the existing ProgressTable
- Nodes show status icon, rows in/out (always visible), and expandable extra stats
- Border color reflects operator status (orange=executing, green=finished, red=failed, zinc=pending); background color reflects node category (source, filter, project, join, etc.)
- Extracts shared stat utilities (`getStatusIcon`, `formatStatValue`, etc.) into `stats-utils.tsx`

Depends on #6295.

## Test plan
- [x] `make build-release` compiles successfully
- [x] Tree renders with correct structure matching the physical plan
- [x] Nodes show live status icons and rows in/out during execution
- [x] Clicking nodes expands extra stats (e.g. Selectivity on Filter nodes)
- [x] Table view toggle still shows the original ProgressTable
- [x] Optimized/Unoptimized plan tabs still work
- [x] Pending spinner maintains circular shape on nodes with long names

🤖 Generated with [Claude Code](https://claude.com/claude-code)