### PR TITLE
fix: make `max_concurrency` control coroutine concurrency for async UDFs

### DIFF
--- a/daft/udf/__init__.py
+++ b/daft/udf/__init__.py
@@ -26,6 +26,7 @@ class _FuncDecorator:
         return_dtype: DataTypeLike | None = None,
         unnest: bool = False,
         use_process: bool | None = None,
+        max_concurrency: int | None = None,
         max_retries: int | None = None,
         on_error: Literal["raise", "log", "ignore"] | None = None,
     ) -> Callable[[Callable[P, T]], Func[P, T, None]]: ...
@@ -37,6 +38,7 @@ class _FuncDecorator:
         return_dtype: DataTypeLike | None = None,
         unnest: bool = False,
         use_process: bool | None = None,
+        max_concurrency: int | None = None,
         max_retries: int | None = None,
         on_error: Literal["raise", "log", "ignore"] | None = None,
     ) -> Func[P, T, None]: ...
@@ -48,6 +50,7 @@ class _FuncDecorator:
         return_dtype: DataTypeLike | None = None,
         unnest: bool = False,
         use_process: bool | None = None,
+        max_concurrency: int | None = None,
         max_retries: int | None = None,
         on_error: Literal["raise", "log", "ignore"] | None = None,
     ) -> Callable[[Callable[P, T]], Func[P, T, None]] | Func[P, T, None]:
@@ -221,7 +224,15 @@ class _FuncDecorator:
 
         def partial_func(fn: Callable[P, T]) -> Func[P, T, None]:
             return Func._from_func(
-                fn, return_dtype, unnest, use_process, False, None, max_retries=max_retries, on_error=on_error
+                fn,
+                return_dtype,
+                unnest,
+                use_process,
+                False,
+                None,
+                max_concurrency=max_concurrency,
+                max_retries=max_retries,
+                on_error=on_error,
             )
 
         return partial_func if fn is None else partial_func(fn)
@@ -232,6 +243,7 @@ class _FuncDecorator:
         return_dtype: DataTypeLike,
         unnest: bool = False,
         use_process: bool | None = None,
+        max_concurrency: int | None = None,
         batch_size: int | None = None,
         max_retries: int | None = None,
         on_error: Literal["raise", "log", "ignore"] | None = None,
@@ -307,7 +319,17 @@ class _FuncDecorator:
         """
 
         def partial_func(fn: Callable[P, T]) -> Func[P, T, None]:
-            return Func._from_func(fn, return_dtype, unnest, use_process, True, batch_size, max_retries, on_error)
+            return Func._from_func(
+                fn,
+                return_dtype,
+                unnest,
+                use_process,
+                True,
+                batch_size,
+                max_concurrency=max_concurrency,
+                max_retries=max_retries,
+                on_error=on_error,
+            )
 
         return partial_func
 
@@ -353,7 +375,7 @@ def cls(
               Fractional values between 0 and 1.0, such as 0.5, are supported. This can be useful when running multiple small models on the same GPU.
               However, fractional values greater than 1.0, such as 1.5 or 2.5, are not supported.
         use_process: Whether to run each instance of the class in a separate process. If unset, Daft will automatically choose based on runtime performance.
-        max_concurrency: The maximum number of concurrent instances of the class.
+        max_concurrency: The maximum number of concurrent invocations. For sync methods, this controls the number of actor pool processes. For async methods, this controls the number of concurrent coroutines.
         name_override: The name to display for the UDF class in the plan and progress bars.
 
     Daft classes allow you to initialize a class instance once, and then reuse it for multiple rows of data.

--- a/daft/udf/__init__.py
+++ b/daft/udf/__init__.py
@@ -60,6 +60,7 @@ class _FuncDecorator:
             return_dtype: The data type that this function should return or yield. If not specified, it is derived from the function's return type hint.
             unnest: Whether to unnest/flatten out return type fields into columns. Return dtype must be `DataType.struct(..)` when this is set to true.
             use_process: Whether to run each instance of the function in a separate process. If unset, Daft will automatically choose based on runtime performance.
+            max_concurrency: The maximum number of concurrent coroutines for async functions. Only valid for async functions; raises an error if used with synchronous functions.
 
         Daft function variants:
         - **Row-wise** (1 row in, 1 row out) - the default variant
@@ -254,6 +255,7 @@ class _FuncDecorator:
             return_dtype: The data type that this function should return.
             unnest: Whether to unnest/flatten out return type fields into columns. Return dtype must be `DataType.struct(..)` when this is set to true.
             use_process: Whether to run each instance of the function in a separate process. If unset, Daft will automatically choose based on runtime performance.
+            max_concurrency: The maximum number of concurrent coroutines for async functions. Only valid for async functions; raises an error if used with synchronous functions.
             batch_size: The max number of rows in each input batch.
 
         Batch functions receive `daft.Series` arguments, and return a `daft.Series`, `list`, `numpy.ndarray`, or `pyarrow.Array`.

--- a/daft/udf/udf_v2.py
+++ b/daft/udf/udf_v2.py
@@ -95,6 +95,12 @@ class Func(Generic[P, T, C]):
         is_generator = inspect.isgeneratorfunction(fn)
         is_async = inspect.iscoroutinefunction(fn)
 
+        if max_concurrency is not None and not is_async:
+            raise ValueError(
+                "`max_concurrency` on a synchronous `@daft.func` has no effect. "
+                "Use `@daft.cls` for actor pool concurrency or an async function for coroutine concurrency."
+            )
+
         return_dtype = cls._get_return_dtype(fn, return_dtype, is_generator, is_batch)
 
         return Func(
@@ -163,12 +169,6 @@ class Func(Generic[P, T, C]):
 
         if not self.is_batch and self.batch_size is not None:
             raise ValueError("Non-batch Daft functions cannot have a batch size.")
-
-        if self.max_concurrency is not None and not self.is_async and self.gpus == 0:
-            raise ValueError(
-                "`max_concurrency` on a synchronous `@daft.func` has no effect. "
-                "Use `@daft.cls` for actor pool concurrency or an async function for coroutine concurrency."
-            )
 
         if self.is_async and self.is_generator:
             raise ValueError("Daft functions do not yet support both async and generator functions.")

--- a/daft/udf/udf_v2.py
+++ b/daft/udf/udf_v2.py
@@ -76,7 +76,8 @@ class Func(Generic[P, T, C]):
         use_process: bool | None,
         is_batch: bool,
         batch_size: int | None,
-        max_retries: int | None,
+        max_concurrency: int | None = None,
+        max_retries: int | None = None,
         on_error: Literal["raise", "log", "ignore"] | None = None,
         name_override: str | None = None,
     ) -> Func[P, T, None]:
@@ -106,7 +107,7 @@ class Func(Generic[P, T, C]):
             unnest,
             0,
             use_process,
-            None,
+            max_concurrency,
             max_retries,
             on_error,
             return_dtype,

--- a/daft/udf/udf_v2.py
+++ b/daft/udf/udf_v2.py
@@ -164,6 +164,12 @@ class Func(Generic[P, T, C]):
         if not self.is_batch and self.batch_size is not None:
             raise ValueError("Non-batch Daft functions cannot have a batch size.")
 
+        if self.max_concurrency is not None and not self.is_async and self.gpus == 0:
+            raise ValueError(
+                "`max_concurrency` on a synchronous `@daft.func` has no effect. "
+                "Use `@daft.cls` for actor pool concurrency or an async function for coroutine concurrency."
+            )
+
         if self.is_async and self.is_generator:
             raise ValueError("Daft functions do not yet support both async and generator functions.")
 

--- a/docs/custom-code/cls.md
+++ b/docs/custom-code/cls.md
@@ -162,6 +162,21 @@ df = daft.from_pydict({"urls": ["https://api.example.com/1", "https://api.exampl
 df = df.select(client.fetch_data(df["urls"]))
 ```
 
+When `max_concurrency` is set on a class with async methods, it controls the number of concurrent coroutines rather than the number of actor pool processes:
+
+```python
+@daft.cls(max_concurrency=10)
+class APIClient:
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+
+    async def fetch_data(self, url: str) -> str:
+        async with aiohttp.ClientSession() as session:
+            headers = {"Authorization": f"Bearer {self.api_key}"}
+            async with session.get(url, headers=headers) as response:
+                return await response.text()
+```
+
 #### Generator Methods
 
 ```python

--- a/docs/custom-code/func.md
+++ b/docs/custom-code/func.md
@@ -189,6 +189,16 @@ df = daft.from_pydict({
 df = df.select(fetch_url(df["urls"]))
 ```
 
+Use `max_concurrency` to limit the number of concurrent coroutines, for example to rate-limit API calls:
+
+```python
+@daft.func(max_concurrency=10)
+async def fetch_url(url: str) -> str:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as response:
+            return await response.text()
+```
+
 ### Generator Functions
 
 Generator functions use `yield` to produce multiple output rows per input row. Other columns in the DataFrame are automatically broadcast to match the number of generated values. You may only use one generator function per DataFrame operation.

--- a/docs/custom-code/migration.md
+++ b/docs/custom-code/migration.md
@@ -174,6 +174,4 @@ async def my_api_call(prompt: str) -> str:
 
 - Specifying granular CPU and memory resource requests is not yet supported in the new API. We found that the behavior of the `num_cpus` and `memory_bytes` parameters in the legacy API were unclear, and that they were largely used to control the concurrency of the UDF. In those cases, consider using `max_concurrency` instead.
 
-- There is currently no method to control the number of concurrent calls to async UDFs in the new API.
-
 If you have any questions or feedback about the new UDF API, please submit an [issue on GitHub](https://github.com/Eventual-Inc/Daft/issues) or reach out to us on [Slack](https://join.slack.com/t/dist-data/shared_invite/zt-2e77olvxw-uyZcPPV1SRchhi8ah6ZCtg).

--- a/src/daft-dsl/src/functions/python/mod.rs
+++ b/src/daft-dsl/src/functions/python/mod.rs
@@ -386,7 +386,7 @@ impl UDFProperties {
     }
 
     pub fn is_actor_pool_udf(&self) -> bool {
-        self.concurrency.is_some()
+        self.concurrency.is_some() && !self.is_async
     }
 
     #[must_use]

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -583,10 +583,7 @@ fn physical_plan_to_pipeline(
             context,
         }) => {
             let child_node = physical_plan_to_pipeline(input, cfg, ctx, input_senders)?;
-            if udf_properties.is_async
-                && udf_properties.concurrency.is_none()
-                && !udf_properties.use_process.unwrap_or(false)
-            {
+            if udf_properties.is_async && !udf_properties.use_process.unwrap_or(false) {
                 let async_sink = AsyncUdfSink::new(
                     expr.clone(),
                     udf_properties.clone(),

--- a/src/daft-local-execution/src/streaming_sink/async_udf.rs
+++ b/src/daft-local-execution/src/streaming_sink/async_udf.rs
@@ -242,7 +242,11 @@ impl StreamingSink for AsyncUdfSink {
 
                             // Force drain tasks until the number of inflight tasks is less than the concurrency limit
                             let mut num_inflight_tasks = state.task_set.len();
-                            let max_inflight_tasks = get_max_inflight_tasks();
+                            let max_inflight_tasks = params
+                                .udf_properties
+                                .concurrency
+                                .map(|c| c.get())
+                                .unwrap_or_else(get_max_inflight_tasks);
                             while num_inflight_tasks > max_inflight_tasks {
                                 if let Some(join_res) = state.task_set.join_next().await {
                                     let batch = join_res??;

--- a/tests/udf/test_batch_udf.py
+++ b/tests/udf/test_batch_udf.py
@@ -381,6 +381,14 @@ def test_async_batch_udf_max_concurrency(max_concurrency):
     assert actual == {"x": [1, 2, 3]}
 
 
+def test_sync_batch_func_max_concurrency_raises():
+    with pytest.raises(ValueError, match="max_concurrency.*synchronous"):
+
+        @daft.func.batch(return_dtype=DataType.int64(), max_concurrency=2)
+        def my_sync_batch(a: Series) -> Series:
+            return a
+
+
 def test_async_batch_on_error_ignore():
     @daft.func.batch(on_error="ignore", return_dtype=int)
     async def raise_err(x):

--- a/tests/udf/test_row_wise_udf.py
+++ b/tests/udf/test_row_wise_udf.py
@@ -143,6 +143,14 @@ def test_row_wise_async_udf_max_concurrency(max_concurrency):
     assert sorted(result["x"]) == [5, 7, 9]
 
 
+def test_sync_func_max_concurrency_raises():
+    with pytest.raises(ValueError, match="max_concurrency.*synchronous"):
+
+        @daft.func(max_concurrency=2)
+        def my_sync_add(a: int, b: int) -> int:
+            return a + b
+
+
 def test_row_wise_udf_unnest():
     @daft.func(
         return_dtype=daft.DataType.struct(

--- a/tests/udf/test_row_wise_udf.py
+++ b/tests/udf/test_row_wise_udf.py
@@ -131,6 +131,18 @@ def test_row_wise_async_udf():
     assert sorted(async_df.to_pydict()["x"]) == ["5", "7", "9"]
 
 
+@pytest.mark.parametrize("max_concurrency", [1, 2])
+def test_row_wise_async_udf_max_concurrency(max_concurrency):
+    @daft.func(max_concurrency=max_concurrency)
+    async def my_async_add(a: int, b: int) -> int:
+        await asyncio.sleep(0.01)
+        return a + b
+
+    df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
+    result = df.select(my_async_add(col("x"), col("y"))).to_pydict()
+    assert sorted(result["x"]) == [5, 7, 9]
+
+
 def test_row_wise_udf_unnest():
     @daft.func(
         return_dtype=daft.DataType.struct(


### PR DESCRIPTION
## Summary
- `max_concurrency` now means "max concurrent invocations" — actor pool processes for sync class methods, coroutine limits for async functions/methods
- Async UDFs with `max_concurrency` set now correctly route through `AsyncUdfSink` instead of the sync actor pool path
- Added `max_concurrency` parameter to `@daft.func` and `@daft.func.batch` to control async max concurrency, (previously only the DAFT_MAX_ASYNC_UDF_INFLIGHT_TASKS env var could do this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)