### PR TITLE
chore: Improve Common Crawl Benchmark 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,6 +3093,7 @@ dependencies = [
  "arrow-schema",
  "bincode",
  "common-error",
+ "common-file-formats",
  "common-io-config",
  "common-metrics",
  "common-py-serde",

--- a/benchmarking/common_crawl/extract.py
+++ b/benchmarking/common_crawl/extract.py
@@ -45,6 +45,7 @@ def process_html(html_bytes: bytes | None):
 @daft.udf(
     return_dtype=daft.DataType.struct({"extracted_text": daft.DataType.string(), "text_length": daft.DataType.int32()}),
     batch_size=128,
+    use_process=True,
 )
 def daft_extract_text(content: daft.Series):
     """Daft UDF to extract text from HTML content using OWM.

--- a/benchmarking/common_crawl/extract.py
+++ b/benchmarking/common_crawl/extract.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import ftfy
-import ray
 from bs4 import BeautifulSoup
 
 import daft
-
-ray.init()
-daft.set_runner_ray()
 
 
 def process_html(html_bytes: bytes | None):

--- a/daft/io/_warc.py
+++ b/daft/io/_warc.py
@@ -83,6 +83,5 @@ def read_warc(
         storage_config=storage_config,
         file_path_column=file_path_column,
         hive_partitioning=False,
-        skip_glob=True,
     )
     return DataFrame(builder)

--- a/src/daft-distributed/src/pipeline_node/scan_source.rs
+++ b/src/daft-distributed/src/pipeline_node/scan_source.rs
@@ -114,6 +114,7 @@ impl ScanSourceNode {
     fn make_source_task(self: &Arc<Self>, scan_task: ScanTaskLikeRef) -> SwordfishTaskBuilder {
         let physical_scan = LocalPhysicalPlan::physical_scan(
             self.node_id(),
+            Some(scan_task.file_format_config()),
             self.pushdowns.clone(),
             self.config.schema.clone(),
             StatsState::NotMaterialized,

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -313,6 +313,7 @@ fn physical_plan_to_pipeline(
         }
         LocalPhysicalPlan::PhysicalScan(PhysicalScan {
             source_id,
+            file_format_config,
             pushdowns,
             schema,
             stats_state,
@@ -321,7 +322,13 @@ fn physical_plan_to_pipeline(
             let (tx, rx) = create_unbounded_channel::<(InputId, Vec<ScanTaskLikeRef>)>();
             input_senders.insert(*source_id, InputSender::ScanTasks(tx));
 
-            let scan_task_source = ScanTaskSource::new(rx, pushdowns.clone(), schema.clone(), cfg);
+            let scan_task_source = ScanTaskSource::new(
+                rx,
+                file_format_config.clone(),
+                pushdowns.clone(),
+                schema.clone(),
+                cfg,
+            );
             SourceNode::new(
                 Box::new(scan_task_source),
                 stats_state.clone(),

--- a/src/daft-local-plan/Cargo.toml
+++ b/src/daft-local-plan/Cargo.toml
@@ -2,6 +2,7 @@
 common-metrics = {path = "../common/metrics", default-features = false}
 common-error = {path = "../common/error", default-features = false}
 common-io-config = {path = "../common/io-config", default-features = false}
+common-file-formats = {path = "../common/file-formats", default-features = false}
 common-py-serde = {path = "../common/py-serde", default-features = false}
 common-resource-request = {path = "../common/resource-request", default-features = false}
 common-scan-info = {path = "../common/scan-info", default-features = false}

--- a/src/daft-local-plan/src/plan.rs
+++ b/src/daft-local-plan/src/plan.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use common_error::{DaftError, DaftResult, ensure};
+use common_file_formats::FileFormatConfig;
 use common_io_config::IOConfig;
 #[cfg(feature = "python")]
 use common_py_serde::{PyObjectWrapper, deserialize_py_object, serialize_py_object};
@@ -236,6 +237,7 @@ impl LocalPhysicalPlan {
 
     pub fn physical_scan(
         source_id: SourceId,
+        file_format_config: Option<Arc<FileFormatConfig>>,
         pushdowns: Pushdowns,
         schema: SchemaRef,
         stats_state: StatsState,
@@ -243,6 +245,7 @@ impl LocalPhysicalPlan {
     ) -> LocalPhysicalPlanRef {
         Self::PhysicalScan(PhysicalScan {
             source_id,
+            file_format_config,
             pushdowns,
             schema,
             stats_state,
@@ -1802,6 +1805,7 @@ impl DynTreeNode for LocalPhysicalPlan {
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct PhysicalScan {
     pub source_id: SourceId,
+    pub file_format_config: Option<Arc<FileFormatConfig>>,
     pub pushdowns: Pushdowns,
     pub schema: SchemaRef,
     pub stats_state: StatsState,

--- a/src/daft-local-plan/src/translate.rs
+++ b/src/daft-local-plan/src/translate.rs
@@ -55,11 +55,16 @@ fn translate_helper(
                         }
                         ScanState::Tasks(scan_tasks) => (**scan_tasks).clone(),
                     };
+
+                    let format_config = scan_tasks
+                        .first()
+                        .map(|scan_task| scan_task.file_format_config());
                     let source_id = source_counter.next();
                     inputs.insert(source_id, Input::ScanTasks(scan_tasks));
 
                     LocalPhysicalPlan::physical_scan(
                         source_id,
+                        format_config,
                         info.pushdowns.clone(),
                         source.output_schema.clone(),
                         source.stats_state.clone(),

--- a/src/daft-micropartition/src/micropartition.rs
+++ b/src/daft-micropartition/src/micropartition.rs
@@ -362,7 +362,7 @@ pub fn read_warc_into_micropartition(
     schema: SchemaRef,
     io_config: Arc<IOConfig>,
     multithreaded_io: bool,
-    io_stats: Option<IOStatsRef>,
+    io_stats: IOStatsRef,
 ) -> DaftResult<MicroPartition> {
     let io_client = daft_io::get_io_client(multithreaded_io, io_config)?;
     let convert_options = WarcConvertOptions {

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -843,7 +843,7 @@ impl PyMicroPartition {
                 schema.into(),
                 io_config.unwrap_or_default().config.into(),
                 multithreaded_io.unwrap_or(true),
-                None,
+                IOStatsContext::new("read_warc"),
             )
         })?;
         Ok(mp.into())

--- a/src/daft-warc/src/lib.rs
+++ b/src/daft-warc/src/lib.rs
@@ -678,12 +678,11 @@ mod tests {
         )?;
 
         let warc_file_size = std::fs::metadata(&warc_file)?.len() as usize;
-        let warc_gz_file_size = std::fs::metadata(&warc_gz_file)?.len() as usize;
         let bytes_read = io_stats.load_bytes_read();
         assert_eq!(
             bytes_read,
-            warc_file_size + warc_gz_file_size,
-            "IO stats should record the bytes read correctly"
+            warc_file_size * 2,
+            "IO stats should record the bytes read correctly (post-gzip inflation)"
         );
         Ok(())
     }


### PR DESCRIPTION
## Changes Made

I was using the common crawl benchmark in our repo to test some things, and I noticed a whole bunch of problems. This PR is a small amalgamation of features to fix those problems.

* Add back Scan Operator names that was removed during the streaming sources PR (@colin-ho LMK if you're ok with the solution)
* Fix WARC byte counting
* Fix bug with glob paths in WARC reads