### PR TITLE
fix: Use Tokio FS for Flight Server Reads

### DIFF
--- a/src/daft-shuffles/Cargo.toml
+++ b/src/daft-shuffles/Cargo.toml
@@ -14,7 +14,7 @@ daft-writers = {path = "../daft-writers", default-features = false}
 futures = {workspace = true}
 itertools = {workspace = true}
 pyo3 = {workspace = true, optional = true}
-tokio = {workspace = true}
+tokio = {workspace = true, features = ["fs", "io-util"]}
 tonic = {workspace = true}
 
 [features]

--- a/src/daft-shuffles/src/server/stream.rs
+++ b/src/daft-shuffles/src/server/stream.rs
@@ -1,123 +1,101 @@
-use std::io::ErrorKind;
+use std::io::{ErrorKind, SeekFrom};
 
 use arrow_flight::FlightData;
 use common_error::{DaftError, DaftResult};
 use futures::Stream;
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
 
 /// Reading state maintenance
 struct ReadState<R> {
     // The reader to read from
     reader: R,
-    // The buffer to store the data
-    data_buffer: Vec<u8>,
-    // The buffer to store the message
-    message_buffer: Vec<u8>,
 }
 
 /// State machine for stream processing
 enum StreamState<R> {
     // A tuple of the current read state and the flight data to be sent
     Ready((ReadState<R>, FlightData)),
-    // The read state is not done, continue reading
-    Continue(ReadState<R>),
     // The read state is done, no more data to read
     Done,
 }
 
-const CONTINUATION_MARKER: [u8; 4] = [0xff; 4];
+const CONTINUATION_MARKER: i32 = -1;
 
 /// A reader that reads arrow ipc files in stream format and converts them to FlightData for serving
 /// over flight. This is an optimization where we skip converting the ipc files to RecordBatches
 /// and instead read the data directly into FlightData, since we already know that the data is in
 /// arrow ipc stream format.
-pub struct FlightDataStreamReader<R: AsyncRead + Unpin> {
+pub struct FlightDataStreamReader<R: AsyncRead + AsyncSeek + Unpin> {
     state: Option<ReadState<R>>,
 }
 
-impl<R: AsyncRead + Unpin> FlightDataStreamReader<R> {
+impl<R: AsyncRead + AsyncSeek + Unpin> FlightDataStreamReader<R> {
     pub async fn try_new(mut reader: R) -> DaftResult<Self> {
         // Skip stream metadata in the file since we don't need it when sending data over flight
         skip_stream_metadata(&mut reader).await?;
         Ok(Self {
-            state: Some(ReadState {
-                reader,
-                data_buffer: Vec::new(),
-                message_buffer: Vec::new(),
-            }),
+            state: Some(ReadState { reader }),
         })
     }
 
     pub fn into_stream(self) -> impl Stream<Item = DaftResult<FlightData>> {
         futures::stream::unfold(self.state, |state| async move {
-            let mut current = state?;
-            loop {
-                match process_next(current).await {
-                    Ok(StreamState::Ready((next_state, data))) => {
-                        return Some((Ok(data), Some(next_state)));
-                    }
-                    Ok(StreamState::Continue(next_state)) => {
-                        current = next_state;
-                    }
-                    Ok(StreamState::Done) => return None,
-                    Err(e) => return Some((Err(e), None)),
-                }
+            let current = state?;
+            match process_next(current).await {
+                Ok(StreamState::Ready((next_state, data))) => Some((Ok(data), Some(next_state))),
+                Ok(StreamState::Done) => None,
+                Err(e) => Some((Err(e), None)),
             }
         })
     }
 }
 
 /// Skip stream metadata on reader. We don't need it when sending data over flight.
-pub async fn skip_stream_metadata<R: AsyncRead + Unpin>(reader: &mut R) -> DaftResult<()> {
-    let mut meta_buf = [0u8; 4];
-    AsyncReadExt::read_exact(reader, &mut meta_buf).await?;
-
-    if meta_buf == CONTINUATION_MARKER {
-        AsyncReadExt::read_exact(reader, &mut meta_buf).await?;
+pub async fn skip_stream_metadata<R: AsyncRead + AsyncSeek + Unpin>(
+    reader: &mut R,
+) -> DaftResult<()> {
+    let mut meta_len = reader.read_i32_le().await?;
+    if meta_len == CONTINUATION_MARKER {
+        meta_len = reader.read_i32_le().await?;
     }
-    let meta_len = i32::from_le_bytes(meta_buf);
 
-    let meta_len = meta_len
+    let meta_len: u64 = meta_len
         .try_into()
         .map_err(|_| arrow_schema::ArrowError::IpcError("NegativeFooterLength".to_string()))?;
 
-    let mut meta_buffer = vec![0u8; meta_len];
-    AsyncReadExt::read_exact(reader, &mut meta_buffer).await?;
-
+    reader.seek(SeekFrom::Current(meta_len as i64)).await?;
     Ok(())
 }
 
 /// Process next IPC message into FlightData
 async fn process_next<R: AsyncRead + Unpin>(mut state: ReadState<R>) -> DaftResult<StreamState<R>> {
-    let mut meta_buf = [0u8; 4];
-
-    match AsyncReadExt::read_exact(&mut state.reader, &mut meta_buf).await {
-        Ok(_) => {}
+    let mut meta_len = match state.reader.read_i32_le().await {
+        Ok(meta_len) => meta_len,
         Err(e) if e.kind() == ErrorKind::UnexpectedEof => {
-            return Ok(StreamState::Continue(state));
+            // TODO: Should we return an error here?
+            return Ok(StreamState::Done);
         }
         Err(e) => return Err(DaftError::from(e)),
+    };
+
+    if meta_len == CONTINUATION_MARKER {
+        meta_len = state.reader.read_i32_le().await?;
     }
 
-    if meta_buf == CONTINUATION_MARKER {
-        AsyncReadExt::read_exact(&mut state.reader, &mut meta_buf).await?;
-    }
-    let meta_length = i32::from_le_bytes(meta_buf);
-
-    let meta_length: usize = meta_length
+    let meta_len: usize = meta_len
         .try_into()
         .map_err(|_| arrow_schema::ArrowError::IpcError("NegativeFooterLength".to_string()))?;
 
-    if meta_length == 0 {
+    if meta_len == 0 {
         return Ok(StreamState::Done);
     }
 
     // Read message header
-    state.message_buffer.resize(meta_length, 0);
-    AsyncReadExt::read_exact(&mut state.reader, &mut state.message_buffer).await?;
+    let mut message_buffer = vec![0; meta_len];
+    state.reader.read_exact(&mut message_buffer).await?;
 
     // Read message body length
-    let message = arrow_ipc::root_as_message(&state.message_buffer)
+    let message = arrow_ipc::root_as_message(&message_buffer)
         .map_err(|e| DaftError::InternalError(format!("Invalid flatbuffer message: {e}")))?;
 
     let body_length: usize = message
@@ -126,11 +104,8 @@ async fn process_next<R: AsyncRead + Unpin>(mut state: ReadState<R>) -> DaftResu
         .map_err(|_| DaftError::InternalError("Unexpected negative integer".to_string()))?;
 
     // Read message body
-    state.data_buffer.resize(body_length, 0);
-    AsyncReadExt::read_exact(&mut state.reader, &mut state.data_buffer).await?;
-
-    let message_buffer = std::mem::take(&mut state.message_buffer);
-    let data_buffer = std::mem::take(&mut state.data_buffer);
+    let mut data_buffer = vec![0; body_length];
+    state.reader.read_exact(&mut data_buffer).await?;
 
     let flight_data = FlightData {
         data_header: message_buffer.into(),


### PR DESCRIPTION
## Changes Made

Instead of the current blocking IO approach, which could potentially block the IO runtime. Tokio uses a separate spawn_blocking pool in the background.

Also did some other cleanup