### PR TITLE
fix(dashboard): sort extra stats alphabetically to prevent flicker

### DIFF
--- a/src/daft-dashboard/frontend/src/app/query/physical-plan-tree.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/physical-plan-tree.tsx
@@ -55,10 +55,12 @@ function PhysicalNodeCard({
 
   const cpuTimeStat = operator?.stats[DURATION_US_STAT_KEY];
   const extraStats = operator
-    ? Object.entries(operator.stats).filter(
-        ([key]) =>
-          ![ROWS_IN_STAT_KEY, ROWS_OUT_STAT_KEY, DURATION_US_STAT_KEY].includes(key),
-      )
+    ? Object.entries(operator.stats)
+        .filter(
+          ([key]) =>
+            ![ROWS_IN_STAT_KEY, ROWS_OUT_STAT_KEY, DURATION_US_STAT_KEY].includes(key),
+        )
+        .sort(([a], [b]) => a.localeCompare(b))
     : [];
   const hasExpandable = extraStats.length > 0 || cpuTimeStat;
 

--- a/src/daft-dashboard/frontend/src/app/query/progress-table.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/progress-table.tsx
@@ -79,6 +79,7 @@ export default function ProgressTable({
                       DURATION_US_STAT_KEY,
                     ].includes(key)
                 )
+                .sort(([a], [b]) => a.localeCompare(b))
                 .map(
                   ([key, stat]) =>
                     `${key.charAt(0).toUpperCase() + key.slice(1)}: ${formatStatValue(stat)}`


### PR DESCRIPTION
## Summary
- Dashboard "rows written" and "bytes written" stats flickered (swapped order) during query execution because the backend's `HashMap<String, Stat>` has non-deterministic iteration order
- Sort extra stats alphabetically by key in both `progress-table.tsx` and `physical-plan-tree.tsx` before rendering

## Test plan
- [x] `npm run build` passes with no errors
- [x] Run a query with a Sink operator and confirm "bytes written" and "rows written" maintain stable order

🤖 Generated with [Claude Code](https://claude.com/claude-code)