### PR TITLE
chore(dashboard): add README with build and architecture notes

### DIFF
--- a/src/daft-dashboard/README.md
+++ b/src/daft-dashboard/README.md
@@ -8,4 +8,4 @@ The frontend (Next.js, under `frontend/`) is statically embedded into the Rust b
 
 - **Backend**: Axum server (`src/`) exposes SSE streams and REST endpoints under `/client/`.
 - **Frontend**: Next.js app (`frontend/`) compiled to static assets, embedded in the binary.
-- **State**: `DashboardState` (in `src/state.rs`) holds query info in a `DashMap`. Query results (`RecordBatch`) are stored in `QueryState::Finished` but excluded from serialization (`#[serde(skip_serializing)]`) — served separately via `/client/query/{id}/results`.
+- **State**: `DashboardState` (in `src/state.rs`) holds query info in a `DashMap` (in memory, currently no persistence).

--- a/src/daft-dashboard/README.md
+++ b/src/daft-dashboard/README.md
@@ -1,0 +1,11 @@
+# daft-dashboard
+
+## Build
+
+The frontend (Next.js, under `frontend/`) is statically embedded into the Rust binary at compile time via `include_dir!` (see `src/assets.rs`). There is no separate dev server — **any frontend change requires `make build`** (or `make build-release`) from the repo root to take effect.
+
+## Architecture
+
+- **Backend**: Axum server (`src/`) exposes SSE streams and REST endpoints under `/client/`.
+- **Frontend**: Next.js app (`frontend/`) compiled to static assets, embedded in the binary.
+- **State**: `DashboardState` (in `src/state.rs`) holds query info in a `DashMap`. Query results (`RecordBatch`) are stored in `QueryState::Finished` but excluded from serialization (`#[serde(skip_serializing)]`) — served separately via `/client/query/{id}/results`.


### PR DESCRIPTION
## Summary
- Adds a `README.md` to `src/daft-dashboard/` documenting the non-obvious build requirement: the frontend is statically embedded in the Rust binary via `include_dir!`, so **any frontend change requires `make build`**.
- Includes a brief architecture overview (backend, frontend, state).

## Test plan
- [x] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)