### PR TITLE
fix(dashboard): ensure query_end fires when generator is abandoned early

### DIFF
--- a/daft/runners/native_runner.py
+++ b/daft/runners/native_runner.py
@@ -139,6 +139,15 @@ class NativeRunner(Runner[MicroPartition]):
                 except Exception:
                     pass
                 yield result
+        except GeneratorExit:
+            # Generator was abandoned (e.g., .show() breaking out early after collecting
+            # enough rows). Notify subscribers so the dashboard transitions out of Finalizing.
+            try:
+                query_result = PyQueryResult(QueryEndState.Finished, "Query finished")
+                ctx._notify_query_end(query_id, query_result)
+            except Exception as e:
+                logger.warning("Failed to send query end notification: %s", e)
+            return  # type: ignore[return-value]
         except StopIteration as e:
             query_result = PyQueryResult(QueryEndState.Finished, "Query finished")
             ctx._notify_query_end(query_id, query_result)

--- a/src/daft-dashboard/README.md
+++ b/src/daft-dashboard/README.md
@@ -8,4 +8,4 @@ The frontend (Next.js, under `frontend/`) is statically embedded into the Rust b
 
 - **Backend**: Axum server (`src/`) exposes SSE streams and REST endpoints under `/client/`.
 - **Frontend**: Next.js app (`frontend/`) compiled to static assets, embedded in the binary.
-- **State**: `DashboardState` (in `src/state.rs`) holds query info in a `DashMap`. Query results (`RecordBatch`) are stored in `QueryState::Finished` but excluded from serialization (`#[serde(skip_serializing)]`) — served separately via `/client/query/{id}/results`.
+- **State**: `DashboardState` (in `src/state.rs`) holds query info in a `DashMap` (in memory, currently no persistence).

--- a/src/daft-dashboard/README.md
+++ b/src/daft-dashboard/README.md
@@ -1,0 +1,11 @@
+# daft-dashboard
+
+## Build
+
+The frontend (Next.js, under `frontend/`) is statically embedded into the Rust binary at compile time via `include_dir!` (see `src/assets.rs`). There is no separate dev server — **any frontend change requires `make build`** (or `make build-release`) from the repo root to take effect.
+
+## Architecture
+
+- **Backend**: Axum server (`src/`) exposes SSE streams and REST endpoints under `/client/`.
+- **Frontend**: Next.js app (`frontend/`) compiled to static assets, embedded in the binary.
+- **State**: `DashboardState` (in `src/state.rs`) holds query info in a `DashMap`. Query results (`RecordBatch`) are stored in `QueryState::Finished` but excluded from serialization (`#[serde(skip_serializing)]`) — served separately via `/client/query/{id}/results`.

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -139,6 +139,41 @@ def test_capture_states(monkeypatch):
     assert "Query canceled by the user" in subscriber.end_messages[query_id]
 
 
+def test_show_fires_query_end():
+    """Regression test for DF-1664.
+
+    .show() abandons the run_iter generator early, which must still fire
+    on_query_end so the dashboard transitions out of Finalizing.
+    """
+    subscriber = MockSubscriber()
+    ctx = daft.context.get_context()
+    ctx.attach_subscriber("mock", subscriber)
+
+    try:
+        # Sanity check: .collect() on a transformed DataFrame fires on_query_end.
+        df = daft.from_pydict({"x": list(range(100))})
+        df = df.with_column("y", daft.col("x") + 1)
+        df.collect()
+
+        query_id = subscriber.query_ids[-1]
+        assert query_id in subscriber.end_states, "collect() should fire on_query_end"
+        assert subscriber.end_states[query_id] == QueryEndState.Finished
+
+        # The actual bug: .show() on a transformed DataFrame does NOT fire on_query_end,
+        # because _construct_show_preview breaks out of the run_iter generator early.
+        df = daft.from_pydict({"x": list(range(100))})
+        df = df.with_column("y", daft.col("x") + 1)
+        df.show()
+
+        query_id = subscriber.query_ids[-1]
+        assert query_id in subscriber.end_states, (
+            "on_query_end was not called — query would be stuck in Finalizing on the dashboard"
+        )
+        assert subscriber.end_states[query_id] == QueryEndState.Finished
+    finally:
+        ctx.detach_subscriber("mock")
+
+
 def test_subscriber_template():
     subscriber = MockSubscriber()
     ctx = daft.context.get_context()


### PR DESCRIPTION
> **PR Stack:**
> 1. #6323 — `sam/dashboard-readme`
> 2. **#6326 — `sam/finalizing-forever` (this PR)**

## Summary
- When `.show()` collects enough rows, it breaks out of the `run_iter` generator early. Python sends `GeneratorExit` (a `BaseException`) which none of the existing exception handlers caught, so `_notify_query_end` was never called and the dashboard stayed stuck in "Finalizing" forever.
- Handle `GeneratorExit` in `run_iter` to notify subscribers before returning.
- Add regression test that verifies `on_query_end` fires for both `.collect()` and `.show()`.

Closes DF-1664

## Test plan
- [x] New test `test_show_fires_query_end` reproduces the bug (fails without the fix, passes with it)
- [x] All existing subscriber tests pass (`tests/test_subscribers.py`)
- [x] Manually verified with the dashboard — query transitions from Finalizing to Finished

🤖 Generated with [Claude Code](https://claude.com/claude-code)