### PR TITLE
perf!: lazy-load lance to speed up `import daft`

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -130,7 +130,6 @@ from daft.io import (
     IOConfig,
     from_glob_path,
     _range as range,
-    read_lance,
     read_csv,
     read_deltalake,
     read_hudi,
@@ -149,12 +148,20 @@ from daft.viz import register_viz_hook
 from daft.window import Window
 from daft.file import File, VideoFile, AudioFile
 
-import daft.context as context
-import daft.io as io
-import daft.runners as runners
-import daft.datasets as datasets
-import daft.functions as functions
-import daft.gravitino as gravitino
+from daft import context
+from daft import io
+from daft import runners
+from daft import datasets
+from daft import functions
+from daft import gravitino
+
+
+# Lance is lazy-loaded because lance_namespace pulls in ~450ms of pydantic models.
+def __getattr__(name: str) -> object:
+    if name == "read_lance":
+        return getattr(io, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "AudioFile",
@@ -242,7 +249,7 @@ __all__ = [
     "read_huggingface",
     "read_iceberg",
     "read_json",
-    "read_lance",
+    "read_lance",  # noqa: F822
     "read_mcap",
     "read_parquet",
     "read_sql",

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from daft.scarf_telemetry import track_import_on_scarf
 
@@ -157,6 +158,10 @@ from daft import gravitino
 
 
 # Lance is lazy-loaded because lance_namespace pulls in ~450ms of pydantic models.
+if TYPE_CHECKING:
+    from daft.io import read_lance
+
+
 def __getattr__(name: str) -> object:
     if name == "read_lance":
         return getattr(io, name)
@@ -249,7 +254,7 @@ __all__ = [
     "read_huggingface",
     "read_iceberg",
     "read_json",
-    "read_lance",  # noqa: F822
+    "read_lance",
     "read_mcap",
     "read_parquet",
     "read_sql",

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -13,6 +13,7 @@ from daft.daft import (
     UnityConfig,
     HuggingFaceConfig,
 )
+from daft.lazy_import import LazyImport
 from daft.io._csv import read_csv
 from daft.io.delta_lake._deltalake import read_deltalake
 from daft.io.hudi._hudi import read_hudi
@@ -31,8 +32,6 @@ from daft.io.source import DataSource, DataSourceTask
 from daft.io.av import read_video_frames
 
 # Lance is lazy-loaded because lance_namespace pulls in ~450ms of pydantic models.
-from daft.lazy_import import LazyImport
-
 _lance = LazyImport("daft.io.lance")
 
 

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from daft.daft import (
     AzureConfig,
     CosConfig,
@@ -32,6 +34,9 @@ from daft.io.source import DataSource, DataSourceTask
 from daft.io.av import read_video_frames
 
 # Lance is lazy-loaded because lance_namespace pulls in ~450ms of pydantic models.
+if TYPE_CHECKING:
+    from daft.io.lance._lance import read_lance
+
 _lance = LazyImport("daft.io.lance")
 
 
@@ -66,7 +71,7 @@ __all__ = [
     "read_huggingface",
     "read_iceberg",
     "read_json",
-    "read_lance",  # noqa: F822
+    "read_lance",
     "read_mcap",
     "read_parquet",
     "read_sql",

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -17,9 +17,6 @@ from daft.io._csv import read_csv
 from daft.io.delta_lake._deltalake import read_deltalake
 from daft.io.hudi._hudi import read_hudi
 from daft.io.iceberg._iceberg import read_iceberg
-from daft.io.lance._lance import read_lance, merge_columns, merge_columns_df
-from daft.io.lance.rest_config import LanceRestConfig
-from daft.io.lance.rest_write import write_lance_rest, create_lance_table_rest, register_lance_table_rest
 from daft.io._json import read_json
 from daft.io._parquet import read_parquet
 from daft.io._sql import read_sql
@@ -32,6 +29,18 @@ from daft.io.file_path import from_glob_path
 from daft.io.sink import DataSink
 from daft.io.source import DataSource, DataSourceTask
 from daft.io.av import read_video_frames
+
+# Lance is lazy-loaded because lance_namespace pulls in ~450ms of pydantic models.
+from daft.lazy_import import LazyImport
+
+_lance = LazyImport("daft.io.lance")
+
+
+def __getattr__(name: str) -> object:
+    if name == "read_lance":
+        return getattr(_lance, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "AzureConfig",
@@ -46,28 +55,22 @@ __all__ = [
     "HTTPConfig",
     "HuggingFaceConfig",
     "IOConfig",
-    "LanceRestConfig",
     "S3Config",
     "S3Credentials",
     "TosConfig",
     "UnityConfig",
     "_range",
-    "create_lance_table_rest",
     "from_glob_path",
-    "merge_columns",
-    "merge_columns_df",
     "read_csv",
     "read_deltalake",
     "read_hudi",
     "read_huggingface",
     "read_iceberg",
     "read_json",
-    "read_lance",
+    "read_lance",  # noqa: F822
     "read_mcap",
     "read_parquet",
     "read_sql",
     "read_video_frames",
     "read_warc",
-    "register_lance_table_rest",
-    "write_lance_rest",
 ]

--- a/daft/io/lance/__init__.py
+++ b/daft/io/lance/__init__.py
@@ -1,4 +1,4 @@
-from ._lance import create_scalar_index, compact_files, merge_columns, merge_columns_df
+from ._lance import compact_files, create_scalar_index, merge_columns, merge_columns_df, read_lance
 from .rest_config import LanceRestConfig
 from .rest_write import write_lance_rest, create_lance_table_rest, register_lance_table_rest
 
@@ -9,6 +9,7 @@ __all__ = [
     "create_scalar_index",
     "merge_columns",
     "merge_columns_df",
+    "read_lance",
     "register_lance_table_rest",
     "write_lance_rest",
 ]


### PR DESCRIPTION
**Breaking change:** 6 lance-specific symbols (`LanceRestConfig`, `merge_columns`, `merge_columns_df`, `write_lance_rest`, `create_lance_table_rest`, `register_lance_table_rest`) are no longer re-exported from `daft.io`. They remain available through `daft.io.lance` where all actual usage goes.

---

`lance_namespace_urllib3_client` (218 pydantic models + 7 REST API modules) dominates `import daft` time. Profiling on `main` with `python -X importtime`:

| Module | Import Time | % of Total |
|--------|------------|------------|
| lance_namespace_urllib3_client | ~310ms | 58.2% |
| lance_namespace REST models | ~88ms | 16.5% |
| pydantic | ~47ms | 8.9% |
| daft core | ~45ms | 8.5% |
| Third-party (misc) | ~25ms | 4.7% |
| Other lance internals | ~17ms | 3.2% |
| **Total** | **~532ms** | **100%** |

The fix defers `daft.io.lance` using the existing `LazyImport` utility (same pattern as PR #2826 for pyarrow/ray/numpy). The lance subpackage is only loaded when `daft.read_lance()` is actually called.

**Before:** ~530ms
**After:** ~75ms