### PR TITLE
chore(cargo): inherit edition/version from workspace in root package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,10 +111,10 @@ crate-type = ["cdylib"]
 name = "daft"
 
 [package]
-edition = "2024"
+edition = {workspace = true}
 name = "daft"
 publish = false
-version = "0.3.0-dev0"
+version = {workspace = true}
 # Exclude unnecessary files from sdist
 exclude = [
   "examples/dvector",


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
- Use workspace inheritance for edition/version in root [package]
- Remove redundant hardcoded values to align with workspace defaults

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
