### PR TITLE
feat(metrics): add node_plan_id for distributed stats attribution

### DIFF
--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -136,7 +136,7 @@ pub const ATTR_EXECUTION_RUNNER: &str = "execution.runner";
 pub const ATTR_QUERY_ID: &str = "query.id";
 
 // Node attributes
-pub const ATTR_NODE_PLAN_ID: &str = "node.plan_id";
+pub const ATTR_NODE_ORIGIN_ID: &str = "node.origin_id";
 pub const ATTR_NODE_ID: &str = "node.id";
 pub const ATTR_NODE_TYPE: &str = "node.type";
 pub const ATTR_NODE_PHASE: &str = "node.phase";

--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -136,6 +136,7 @@ pub const ATTR_EXECUTION_RUNNER: &str = "execution.runner";
 pub const ATTR_QUERY_ID: &str = "query.id";
 
 // Node attributes
+pub const ATTR_NODE_PLAN_ID: &str = "node.plan_id";
 pub const ATTR_NODE_ID: &str = "node.id";
 pub const ATTR_NODE_TYPE: &str = "node.type";
 pub const ATTR_NODE_PHASE: &str = "node.phase";

--- a/src/common/metrics/src/ops.rs
+++ b/src/common/metrics/src/ops.rs
@@ -4,7 +4,7 @@ use bincode::{Decode, Encode};
 use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 
-use crate::{ATTR_NODE_ID, ATTR_NODE_PHASE, ATTR_NODE_PLAN_ID, ATTR_NODE_TYPE, NodeID};
+use crate::{ATTR_NODE_ID, ATTR_NODE_ORIGIN_ID, ATTR_NODE_PHASE, ATTR_NODE_TYPE, NodeID};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Encode, Decode)]
 pub enum NodeType {
@@ -89,7 +89,7 @@ impl Display for NodeCategory {
 pub struct NodeInfo {
     pub name: Arc<str>,
     pub id: NodeID,
-    pub node_plan_id: NodeID,
+    pub node_origin_id: NodeID,
     #[allow(dead_code)]
     pub node_type: NodeType,
     pub node_category: NodeCategory,
@@ -100,7 +100,7 @@ pub struct NodeInfo {
 impl NodeInfo {
     pub fn to_key_values(&self) -> Vec<KeyValue> {
         let mut kvs = vec![
-            KeyValue::new(ATTR_NODE_PLAN_ID, self.node_plan_id.to_string()),
+            KeyValue::new(ATTR_NODE_ORIGIN_ID, self.node_origin_id.to_string()),
             KeyValue::new(ATTR_NODE_ID, self.id.to_string()),
             KeyValue::new(ATTR_NODE_TYPE, self.node_type.to_string()),
         ];

--- a/src/common/metrics/src/ops.rs
+++ b/src/common/metrics/src/ops.rs
@@ -89,8 +89,8 @@ impl Display for NodeCategory {
 pub struct NodeInfo {
     pub name: Arc<str>,
     pub id: NodeID,
-    #[allow(dead_code)]
     pub node_plan_id: NodeID,
+    #[allow(dead_code)]
     pub node_type: NodeType,
     pub node_category: NodeCategory,
     pub node_phase: Option<String>,

--- a/src/common/metrics/src/ops.rs
+++ b/src/common/metrics/src/ops.rs
@@ -4,7 +4,7 @@ use bincode::{Decode, Encode};
 use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 
-use crate::{ATTR_NODE_ID, ATTR_NODE_PHASE, ATTR_NODE_TYPE, NodeID};
+use crate::{ATTR_NODE_ID, ATTR_NODE_PHASE, ATTR_NODE_PLAN_ID, ATTR_NODE_TYPE, NodeID};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, Encode, Decode)]
 pub enum NodeType {
@@ -90,6 +90,7 @@ pub struct NodeInfo {
     pub name: Arc<str>,
     pub id: NodeID,
     #[allow(dead_code)]
+    pub node_plan_id: NodeID,
     pub node_type: NodeType,
     pub node_category: NodeCategory,
     pub node_phase: Option<String>,
@@ -99,6 +100,7 @@ pub struct NodeInfo {
 impl NodeInfo {
     pub fn to_key_values(&self) -> Vec<KeyValue> {
         let mut kvs = vec![
+            KeyValue::new(ATTR_NODE_PLAN_ID, self.node_plan_id.to_string()),
             KeyValue::new(ATTR_NODE_ID, self.id.to_string()),
             KeyValue::new(ATTR_NODE_TYPE, self.node_type.to_string()),
         ];

--- a/src/daft-distributed/src/pipeline_node/into_batches.rs
+++ b/src/daft-distributed/src/pipeline_node/into_batches.rs
@@ -1,11 +1,15 @@
 use std::sync::Arc;
 
 use common_error::DaftResult;
-use common_metrics::ops::{NodeCategory, NodeType};
+use common_metrics::{
+    StatSnapshot,
+    ops::{NodeCategory, NodeInfo, NodeType},
+};
 use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
 use daft_logical_plan::{partitioning::UnknownClusteringConfig, stats::StatsState};
 use daft_schema::schema::SchemaRef;
 use futures::StreamExt;
+use opentelemetry::metrics::Meter;
 
 use super::{PipelineNodeImpl, TaskBuilderStream};
 use crate::{
@@ -18,11 +22,47 @@ use crate::{
         scheduler::SchedulerHandle,
         task::{SwordfishTask, SwordfishTaskBuilder},
     },
+    statistics::{
+        RuntimeStats,
+        stats::{BaseCounters, RuntimeStatsRef},
+    },
     utils::channel::{Sender, create_channel},
 };
 
 const INITIAL_BATCH_PHASE: &str = "local";
 const REBATCH_PHASE: &str = "rebatch";
+
+pub struct IntoBatchesStats {
+    base: BaseCounters,
+}
+
+impl IntoBatchesStats {
+    pub fn new(meter: &Meter, context: &PipelineNodeContext) -> Self {
+        Self {
+            base: BaseCounters::new(meter, context),
+        }
+    }
+}
+
+impl RuntimeStats for IntoBatchesStats {
+    fn handle_worker_node_stats(&self, node_info: &NodeInfo, snapshot: &StatSnapshot) {
+        if let StatSnapshot::Default(snapshot) = snapshot {
+            self.base.add_duration_us(snapshot.cpu_us);
+            if let Some(phase) = &node_info.node_phase {
+                // Track input rows for the initial local batching pass and output rows for the rebatch pass.
+                if phase == INITIAL_BATCH_PHASE {
+                    self.base.add_rows_in(snapshot.rows_in);
+                } else if phase == REBATCH_PHASE {
+                    self.base.add_rows_out(snapshot.rows_out);
+                }
+            }
+        }
+    }
+
+    fn export_snapshot(&self) -> StatSnapshot {
+        self.base.export_default_snapshot()
+    }
+}
 
 pub(crate) struct IntoBatchesNode {
     config: PipelineNodeConfig,
@@ -160,6 +200,10 @@ impl PipelineNodeImpl for IntoBatchesNode {
 
     fn children(&self) -> Vec<DistributedPipelineNode> {
         vec![self.child.clone()]
+    }
+
+    fn runtime_stats(&self, meter: &Meter) -> RuntimeStatsRef {
+        Arc::new(IntoBatchesStats::new(meter, self.context()))
     }
 
     fn multiline_display(&self, _verbose: bool) -> Vec<String> {

--- a/src/daft-distributed/src/pipeline_node/limit.rs
+++ b/src/daft-distributed/src/pipeline_node/limit.rs
@@ -2,27 +2,27 @@ use std::{cmp::Ordering, collections::VecDeque, sync::Arc};
 
 use common_error::DaftResult;
 use common_metrics::{
-    Counter, DURATION_KEY, ROWS_IN_KEY, ROWS_OUT_KEY, StatSnapshot, UNIT_MICROSECONDS, UNIT_ROWS,
+    StatSnapshot,
     ops::{NodeCategory, NodeInfo, NodeType},
-    snapshot::DefaultSnapshot,
 };
 use daft_local_plan::{LocalNodeContext, LocalPhysicalPlan};
 use daft_logical_plan::stats::StatsState;
 use daft_schema::schema::SchemaRef;
 use futures::StreamExt;
-use opentelemetry::{KeyValue, metrics::Meter};
+use opentelemetry::metrics::Meter;
 
 use super::{DistributedPipelineNode, MaterializedOutput, PipelineNodeImpl, TaskBuilderStream};
 use crate::{
-    pipeline_node::{
-        NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext, metrics::key_values_from_context,
-    },
+    pipeline_node::{NodeID, NodeName, PipelineNodeConfig, PipelineNodeContext},
     plan::{PlanConfig, PlanExecutionContext, TaskIDCounter},
     scheduling::{
         scheduler::SchedulerHandle,
         task::{SwordfishTask, SwordfishTaskBuilder},
     },
-    statistics::{RuntimeStats, stats::RuntimeStatsRef},
+    statistics::{
+        RuntimeStats,
+        stats::{BaseCounters, RuntimeStatsRef},
+    },
     utils::channel::{Sender, create_channel},
 };
 
@@ -30,31 +30,14 @@ const FIRST_LIMIT_PHASE: &str = "local-limit";
 const SECOND_LIMIT_PHASE: &str = "post-limit";
 
 pub struct LimitStats {
-    duration_us: Counter,
-    rows_in: Counter,
-    rows_out: Counter,
-    node_kv: Vec<KeyValue>,
+    base: BaseCounters,
 }
 
 impl LimitStats {
     pub fn new(meter: &Meter, context: &PipelineNodeContext) -> Self {
-        let node_kv = key_values_from_context(context);
         Self {
-            duration_us: Counter::new(meter, DURATION_KEY, None, Some(UNIT_MICROSECONDS.into())),
-            rows_in: Counter::new(meter, ROWS_IN_KEY, None, Some(UNIT_ROWS.into())),
-            rows_out: Counter::new(meter, ROWS_OUT_KEY, None, Some(UNIT_ROWS.into())),
-            node_kv,
+            base: BaseCounters::new(meter, context),
         }
-    }
-
-    fn add_cpu_us(&self, cpu_us: u64) {
-        self.duration_us.add(cpu_us, self.node_kv.as_slice());
-    }
-    fn add_rows_in(&self, rows: u64) {
-        self.rows_in.add(rows, self.node_kv.as_slice());
-    }
-    fn add_rows_out(&self, rows: u64) {
-        self.rows_out.add(rows, self.node_kv.as_slice());
     }
 }
 
@@ -62,22 +45,22 @@ impl RuntimeStats for LimitStats {
     fn handle_worker_node_stats(&self, node_info: &NodeInfo, snapshot: &StatSnapshot) {
         match snapshot {
             StatSnapshot::Default(snapshot) => {
-                self.add_cpu_us(snapshot.cpu_us);
+                self.base.add_duration_us(snapshot.cpu_us);
                 if let Some(phase) = &node_info.node_phase {
                     // The first limit is used for pruning, the second limit is for the final output
                     if phase == FIRST_LIMIT_PHASE {
-                        self.add_rows_in(snapshot.rows_in);
+                        self.base.add_rows_in(snapshot.rows_in);
                     } else if phase == SECOND_LIMIT_PHASE {
-                        self.add_rows_out(snapshot.rows_out);
+                        self.base.add_rows_out(snapshot.rows_out);
                     }
                 }
             }
             StatSnapshot::Source(snapshot) => {
-                self.add_cpu_us(snapshot.cpu_us);
+                self.base.add_duration_us(snapshot.cpu_us);
                 if let Some(phase) = &node_info.node_phase
                     && phase == SECOND_LIMIT_PHASE
                 {
-                    self.add_rows_out(snapshot.rows_out);
+                    self.base.add_rows_out(snapshot.rows_out);
                 }
             }
             _ => {} // Limit don't receive stats from other Swordfish nodes
@@ -85,11 +68,7 @@ impl RuntimeStats for LimitStats {
     }
 
     fn export_snapshot(&self) -> StatSnapshot {
-        StatSnapshot::Default(DefaultSnapshot {
-            cpu_us: self.duration_us.load(std::sync::atomic::Ordering::SeqCst),
-            rows_in: self.rows_in.load(std::sync::atomic::Ordering::SeqCst),
-            rows_out: self.rows_out.load(std::sync::atomic::Ordering::SeqCst),
-        })
+        self.base.export_default_snapshot()
     }
 }
 

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -114,6 +114,7 @@ impl StatisticsManager {
             let node_info = Arc::new(NodeInfo {
                 name: node.name().to_string().into(),
                 id: node.node_id() as usize,
+                node_plan_id: node.node_id() as usize,
                 node_type: node.context().node_type.clone(),
                 node_category: node.context().node_category.clone(),
                 node_phase: None,
@@ -143,7 +144,7 @@ impl StatisticsManager {
 
         let mut subscribers = self.subscribers.lock().unwrap();
         for (i, subscriber) in subscribers.iter_mut().enumerate() {
-            tracing::info!(target: STATISTICS_LOG_TARGET, "StatisticsManager calling subscriber {}", i);
+            tracing::debug!(target: STATISTICS_LOG_TARGET, "StatisticsManager calling subscriber {}", i);
             subscriber.handle_event(&event)?;
         }
         Ok(())

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -114,7 +114,7 @@ impl StatisticsManager {
             let node_info = Arc::new(NodeInfo {
                 name: node.name().to_string().into(),
                 id: node.node_id() as usize,
-                node_plan_id: node.node_id() as usize,
+                node_origin_id: node.node_id() as usize,
                 node_type: node.context().node_type.clone(),
                 node_category: node.context().node_category.clone(),
                 node_phase: None,

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -69,7 +69,7 @@ impl RuntimeNodeManager {
 
                 for (node_info, snapshot) in &stats.nodes {
                     // Local nodes are associated to this node through the node_plan_id
-                    if self.node_info.node_plan_id == node_info.node_plan_id {
+                    if self.node_info.node_origin_id == node_info.node_origin_id {
                         self.runtime_stats
                             .handle_worker_node_stats(node_info, snapshot);
                     }

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -68,7 +68,8 @@ impl RuntimeNodeManager {
                 self.completed_tasks.add(1, self.node_kv.as_slice());
 
                 for (node_info, snapshot) in &stats.nodes {
-                    if node_info.id == self.node_info.id {
+                    // Local nodes are associated to this node through the node_plan_id
+                    if self.node_info.node_plan_id == node_info.node_plan_id {
                         self.runtime_stats
                             .handle_worker_node_stats(node_info, snapshot);
                     }
@@ -87,27 +88,53 @@ impl RuntimeNodeManager {
     }
 }
 
-pub struct DefaultRuntimeStats {
+pub struct BaseCounters {
+    duration_us: Counter,
+    rows_in: Counter,
+    rows_out: Counter,
     node_kv: Vec<KeyValue>,
-    completed_rows_in: Counter,
-    completed_rows_out: Counter,
-    completed_cpu_us: Counter,
+}
+
+impl BaseCounters {
+    pub fn new(meter: &Meter, context: &PipelineNodeContext) -> Self {
+        let node_kv = key_values_from_context(context);
+        Self {
+            duration_us: Counter::new(meter, DURATION_KEY, None, Some(UNIT_MICROSECONDS.into())),
+            rows_in: Counter::new(meter, ROWS_IN_KEY, None, Some(UNIT_ROWS.into())),
+            rows_out: Counter::new(meter, ROWS_OUT_KEY, None, Some(UNIT_ROWS.into())),
+            node_kv,
+        }
+    }
+
+    pub fn add_duration_us(&self, v: u64) {
+        self.duration_us.add(v, self.node_kv.as_slice());
+    }
+
+    pub fn add_rows_in(&self, v: u64) {
+        self.rows_in.add(v, self.node_kv.as_slice());
+    }
+
+    pub fn add_rows_out(&self, v: u64) {
+        self.rows_out.add(v, self.node_kv.as_slice());
+    }
+
+    pub fn export_default_snapshot(&self) -> StatSnapshot {
+        StatSnapshot::Default(DefaultSnapshot {
+            cpu_us: self.duration_us.load(Ordering::Relaxed),
+            rows_in: self.rows_in.load(Ordering::Relaxed),
+            rows_out: self.rows_out.load(Ordering::Relaxed),
+        })
+    }
+}
+
+pub struct DefaultRuntimeStats {
+    base: BaseCounters,
 }
 
 impl DefaultRuntimeStats {
     pub fn new(meter: &Meter, context: &PipelineNodeContext) -> Self {
-        let node_kv = key_values_from_context(context);
-
         Self {
-            node_kv,
-            completed_rows_in: Counter::new(meter, ROWS_IN_KEY, None, Some(UNIT_ROWS.into())),
-            completed_rows_out: Counter::new(meter, ROWS_OUT_KEY, None, Some(UNIT_ROWS.into())),
-            completed_cpu_us: Counter::new(
-                meter,
-                DURATION_KEY,
-                None,
-                Some(UNIT_MICROSECONDS.into()),
-            ),
+            base: BaseCounters::new(meter, context),
         }
     }
 }
@@ -119,19 +146,12 @@ impl RuntimeStats for DefaultRuntimeStats {
             return;
         };
 
-        self.completed_cpu_us
-            .add(snapshot.cpu_us, self.node_kv.as_slice());
-        self.completed_rows_in
-            .add(snapshot.rows_in, self.node_kv.as_slice());
-        self.completed_rows_out
-            .add(snapshot.rows_out, self.node_kv.as_slice());
+        self.base.add_duration_us(snapshot.cpu_us);
+        self.base.add_rows_in(snapshot.rows_in);
+        self.base.add_rows_out(snapshot.rows_out);
     }
 
     fn export_snapshot(&self) -> StatSnapshot {
-        StatSnapshot::Default(DefaultSnapshot {
-            cpu_us: self.completed_cpu_us.load(Ordering::Relaxed),
-            rows_in: self.completed_rows_in.load(Ordering::Relaxed),
-            rows_out: self.completed_rows_out.load(Ordering::Relaxed),
-        })
+        self.base.export_default_snapshot()
     }
 }

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -68,7 +68,7 @@ impl RuntimeNodeManager {
                 self.completed_tasks.add(1, self.node_kv.as_slice());
 
                 for (node_info, snapshot) in &stats.nodes {
-                    // Local nodes are associated to this node through the node_plan_id
+                    // Local nodes are associated to this node through the node_origin_id
                     if self.node_info.node_origin_id == node_info.node_origin_id {
                         self.runtime_stats
                             .handle_worker_node_stats(node_info, snapshot);

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -244,14 +244,14 @@ impl BuilderContext {
 
         let id = self.next_id();
         // Keep a unique local runtime node id (`id`), but preserve the originating
-        // distributed plan node id (`node_plan_id`) when available so metrics/stats
+        // distributed plan node id (`node_origin_id`) when available so metrics/stats
         // from local execution can be attributed back to the distributed node.
-        let node_plan_id = node_context.origin_node_id.unwrap_or(id);
+        let node_origin_id = node_context.origin_node_id.unwrap_or(id);
 
         NodeInfo {
             name,
             id,
-            node_origin_id: node_plan_id,
+            node_origin_id,
             node_type,
             node_category,
             node_phase,

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -242,11 +242,16 @@ impl BuilderContext {
 
         let node_phase = node_context.phase.clone();
 
+        let id = self.next_id();
+        // Keep a unique local runtime node id (`id`), but preserve the originating
+        // distributed plan node id (`node_plan_id`) when available so metrics/stats
+        // from local execution can be attributed back to the distributed node.
+        let node_plan_id = node_context.origin_node_id.unwrap_or(id);
+
         NodeInfo {
             name,
-            id: node_context
-                .origin_node_id
-                .unwrap_or_else(|| self.next_id()),
+            id,
+            node_plan_id,
             node_type,
             node_category,
             node_phase,

--- a/src/daft-local-execution/src/pipeline.rs
+++ b/src/daft-local-execution/src/pipeline.rs
@@ -251,7 +251,7 @@ impl BuilderContext {
         NodeInfo {
             name,
             id,
-            node_plan_id,
+            node_origin_id: node_plan_id,
             node_type,
             node_category,
             node_phase,


### PR DESCRIPTION
## Changes Made

* Decouple local execution node IDs from distributed plan node IDs by introducing node_plan_id, so metrics from local workers can be correctly attributed back to their originating distributed pipeline node. 
* Extract common counter boilerplate (duration_us, rows_in, rows_out) into a reusable BaseCounters struct and add runtime stats for IntoBatchesNode.

## Related Issues

https://github.com/Eventual-Inc/Daft/discussions/5155
