### PR TITLE
perf(image): make image ops run in parallel via rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3031,7 +3031,6 @@ dependencies = [
  "daft-core",
  "daft-dsl",
  "daft-schema",
- "image",
  "log",
  "rayon",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
  "chrono-tz",
  "comfy-table 6.2.0",
  "common-pattern",
- "criterion",
+ "criterion 0.7.0",
  "crossbeam-channel",
  "csv",
  "csv-async",
@@ -2227,6 +2227,32 @@ checksum = "26bb92ecea20291efcf0009e2713d64b7e327dedb8ce780545250f24075429e2"
 
 [[package]]
 name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
@@ -2235,7 +2261,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.6.0",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -2246,6 +2272,16 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2991,10 +3027,13 @@ dependencies = [
  "base64 0.22.1",
  "common-error",
  "common-image",
+ "criterion 0.5.1",
  "daft-core",
  "daft-dsl",
  "daft-schema",
+ "image",
  "log",
+ "rayon",
  "serde",
  "typetag",
 ]
@@ -5213,6 +5252,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6243,7 +6293,7 @@ version = "0.17.2"
 dependencies = [
  "async-stream",
  "brotli 3.5.0",
- "criterion",
+ "criterion 0.7.0",
  "flate2",
  "futures",
  "indexmap 2.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,7 @@ dependencies = [
  "chrono-tz",
  "comfy-table 6.2.0",
  "common-pattern",
- "criterion 0.7.0",
+ "criterion",
  "crossbeam-channel",
  "csv",
  "csv-async",
@@ -2227,32 +2227,6 @@ checksum = "26bb92ecea20291efcf0009e2713d64b7e327dedb8ce780545250f24075429e2"
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot 0.5.0",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
@@ -2261,7 +2235,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.6.0",
+ "criterion-plot",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -2272,16 +2246,6 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3027,7 +2991,7 @@ dependencies = [
  "base64 0.22.1",
  "common-error",
  "common-image",
- "criterion 0.5.1",
+ "criterion",
  "daft-core",
  "daft-dsl",
  "daft-schema",
@@ -5251,17 +5215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6292,7 +6245,7 @@ version = "0.17.2"
 dependencies = [
  "async-stream",
  "brotli 3.5.0",
- "criterion 0.7.0",
+ "criterion",
  "flate2",
  "futures",
  "indexmap 2.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,6 +256,7 @@ bytes = "1.11.0"
 chrono = "0.4.38"
 chrono-tz = "0.10.4"
 comfy-table = "7.1.1"
+criterion = {version = "0.5", features = ["html_reports"]}
 csv = "1.3"
 common-daft-config = {path = "src/common/daft-config"}
 common-display = {path = "src/common/display", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,7 @@ bytes = "1.11.0"
 chrono = "0.4.38"
 chrono-tz = "0.10.4"
 comfy-table = "7.1.1"
-criterion = {version = "0.5", features = ["html_reports"]}
+criterion = {version = "0.7", features = ["html_reports"]}
 csv = "1.3"
 common-daft-config = {path = "src/common/daft-config"}
 common-display = {path = "src/common/display", default-features = false}

--- a/src/daft-image/Cargo.toml
+++ b/src/daft-image/Cargo.toml
@@ -17,7 +17,6 @@ rayon.workspace = true
 
 [dev-dependencies]
 criterion = {workspace = true}
-image = {workspace = true, features = ["jpeg", "png"]}
 
 [features]
 python = ["common-error/python", "common-image/python"]

--- a/src/daft-image/Cargo.toml
+++ b/src/daft-image/Cargo.toml
@@ -1,3 +1,7 @@
+[[bench]]
+harness = false
+name = "image_ops"
+
 [dependencies]
 arrow = {workspace = true}
 base64 = {workspace = true}
@@ -9,6 +13,11 @@ daft-schema = {path = "../daft-schema", default-features = false}
 log = {workspace = true}
 serde = {workspace = true}
 typetag = {workspace = true}
+rayon.workspace = true
+
+[dev-dependencies]
+criterion = {workspace = true}
+image = {workspace = true, features = ["jpeg", "png"]}
 
 [features]
 python = ["common-error/python", "common-image/python"]

--- a/src/daft-image/benches/image_ops.rs
+++ b/src/daft-image/benches/image_ops.rs
@@ -1,0 +1,230 @@
+use std::{borrow::Cow, time::Duration};
+
+use common_image::CowImage;
+use criterion::{Criterion, criterion_group, criterion_main};
+use daft_core::{
+    array::ops::image::{fixed_image_array_from_img_buffers, image_array_from_img_buffers},
+    prelude::*,
+};
+use daft_image::series;
+use daft_schema::prelude::{ImageFormat, ImageMode};
+
+const BATCH_SIZE: usize = 100;
+
+// ---------------------------------------------------------------------------
+// Test data generators
+// ---------------------------------------------------------------------------
+
+/// Generate deterministic pseudo-random pixel data for an image.
+fn make_pixel_data(width: u32, height: u32, channels: u8, seed: usize) -> Vec<u8> {
+    let size = (width as usize) * (height as usize) * (channels as usize);
+    let mut data = Vec::with_capacity(size);
+    // Simple LCG for deterministic, cheap pseudo-random fill.
+    let mut state: u64 = seed as u64 ^ 0xDEAD_BEEF;
+    for _ in 0..size {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        data.push((state >> 33) as u8);
+    }
+    data
+}
+
+/// Build an `ImageArray` (variable-shape) Series of RGB images.
+fn make_rgb_image_series(width: u32, height: u32, count: usize) -> Series {
+    let buffers: Vec<Option<CowImage>> = (0..count)
+        .map(|i| {
+            let pixels = make_pixel_data(width, height, 3, i);
+            Some(CowImage::from_raw(
+                &ImageMode::RGB,
+                width,
+                height,
+                Cow::Owned(pixels),
+            ))
+        })
+        .collect();
+    image_array_from_img_buffers("image", buffers.into_iter(), Some(ImageMode::RGB))
+        .unwrap()
+        .into_series()
+}
+
+/// Build a `FixedShapeImageArray` Series of RGB images.
+fn make_fixed_rgb_image_series(width: u32, height: u32, count: usize) -> Series {
+    let buffers: Vec<Option<CowImage>> = (0..count)
+        .map(|i| {
+            let pixels = make_pixel_data(width, height, 3, i);
+            Some(CowImage::from_raw(
+                &ImageMode::RGB,
+                width,
+                height,
+                Cow::Owned(pixels),
+            ))
+        })
+        .collect();
+    fixed_image_array_from_img_buffers("image", &buffers, &ImageMode::RGB, height, width)
+        .unwrap()
+        .into_series()
+}
+
+/// Build an `ImageArray` Series of RGBA images.
+fn make_rgba_image_series(width: u32, height: u32, count: usize) -> Series {
+    let buffers: Vec<Option<CowImage>> = (0..count)
+        .map(|i| {
+            let pixels = make_pixel_data(width, height, 4, i);
+            Some(CowImage::from_raw(
+                &ImageMode::RGBA,
+                width,
+                height,
+                Cow::Owned(pixels),
+            ))
+        })
+        .collect();
+    image_array_from_img_buffers("image", buffers.into_iter(), Some(ImageMode::RGBA))
+        .unwrap()
+        .into_series()
+}
+
+/// Encode images to a binary format and return as a Binary Series (for decode benchmarks).
+fn make_encoded_series(width: u32, height: u32, count: usize, format: ImageFormat) -> Series {
+    let encoded: Vec<Option<Vec<u8>>> = (0..count)
+        .map(|i| {
+            let pixels = make_pixel_data(width, height, 3, i);
+            let img = CowImage::from_raw(&ImageMode::RGB, width, height, Cow::Owned(pixels));
+            let mut buf = Vec::new();
+            let mut writer = std::io::BufWriter::new(std::io::Cursor::new(&mut buf));
+            img.encode(format, &mut writer).unwrap();
+            drop(writer);
+            Some(buf)
+        })
+        .collect();
+    let refs: Vec<Option<&[u8]>> = encoded.iter().map(|v| v.as_deref()).collect();
+    BinaryArray::from_iter("image", refs.into_iter()).into_series()
+}
+
+/// Build a bounding box Series for crop benchmarks.
+/// Returns a FixedSizeList(UInt32, 4) with [x, y, width, height] per row.
+fn make_bbox_series(x: u32, y: u32, w: u32, h: u32, count: usize) -> Series {
+    // Build flat UInt32 child: [x, y, w, h, x, y, w, h, ...]
+    let flat_data: Vec<u32> = (0..count).flat_map(|_| [x, y, w, h]).collect();
+    let flat_child = UInt32Array::from_vec("item", flat_data).into_series();
+    let field = Field::new(
+        "bbox",
+        DataType::FixedSizeList(Box::new(DataType::UInt32), 4),
+    );
+    FixedSizeListArray::new(field, flat_child, None).into_series()
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+fn bench_decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("decode");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+
+    let jpeg_series = make_encoded_series(224, 224, BATCH_SIZE, ImageFormat::JPEG);
+    group.bench_function("jpeg_224x224", |b| {
+        b.iter(|| series::decode(&jpeg_series, true, Some(ImageMode::RGB)).unwrap())
+    });
+
+    let png_series = make_encoded_series(224, 224, BATCH_SIZE, ImageFormat::PNG);
+    group.bench_function("png_224x224", |b| {
+        b.iter(|| series::decode(&png_series, true, Some(ImageMode::RGB)).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_resize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resize");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+
+    let images_512 = make_rgb_image_series(512, 512, BATCH_SIZE);
+    group.bench_function("512_to_224", |b| {
+        b.iter(|| series::resize(&images_512, 224, 224).unwrap())
+    });
+
+    let images_224 = make_rgb_image_series(224, 224, BATCH_SIZE);
+    group.bench_function("224_to_64", |b| {
+        b.iter(|| series::resize(&images_224, 64, 64).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_crop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("crop");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+
+    let images = make_rgb_image_series(512, 512, BATCH_SIZE);
+    // Center crop: (144, 144, 224, 224)
+    let bboxes = make_bbox_series(144, 144, 224, 224, BATCH_SIZE);
+
+    group.bench_function("512_center_crop_224", |b| {
+        b.iter(|| series::crop(&images, &bboxes).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_to_mode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("to_mode");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+
+    let rgba_images = make_rgba_image_series(224, 224, BATCH_SIZE);
+    group.bench_function("rgba_to_rgb", |b| {
+        b.iter(|| series::to_mode(&rgba_images, ImageMode::RGB).unwrap())
+    });
+
+    let rgb_images = make_rgb_image_series(224, 224, BATCH_SIZE);
+    group.bench_function("rgb_to_l", |b| {
+        b.iter(|| series::to_mode(&rgb_images, ImageMode::L).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("encode");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+
+    let images = make_rgb_image_series(224, 224, BATCH_SIZE);
+
+    group.bench_function("png_224x224", |b| {
+        b.iter(|| series::encode(&images, ImageFormat::PNG).unwrap())
+    });
+
+    group.bench_function("jpeg_224x224", |b| {
+        b.iter(|| series::encode(&images, ImageFormat::JPEG).unwrap())
+    });
+
+    group.finish();
+}
+
+fn bench_to_tensor(c: &mut Criterion) {
+    let mut group = c.benchmark_group("to_tensor");
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(5));
+
+    let images = make_fixed_rgb_image_series(224, 224, BATCH_SIZE);
+
+    group.bench_function("fixed_rgb_224x224", |b| {
+        b.iter(|| series::to_tensor(&images).unwrap())
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_decode,
+    bench_resize,
+    bench_crop,
+    bench_to_mode,
+    bench_encode,
+    bench_to_tensor
+);
+criterion_main!(benches);

--- a/src/daft-image/src/ops.rs
+++ b/src/daft-image/src/ops.rs
@@ -15,6 +15,7 @@ use daft_core::{
     prelude::ImageArray,
 };
 use daft_schema::image_property::ImageProperty;
+use rayon::prelude::*;
 
 use crate::{CountingWriter, iters::ImageBufferIter};
 
@@ -76,8 +77,11 @@ impl ImageOps for ImageArray {
     }
 
     fn to_mode(&self, mode: ImageMode) -> DaftResult<Self> {
-        let buffers = ImageBufferIter::new(self).map(|img| img.map(|img| img.into_mode(mode)));
-        image_array_from_img_buffers(self.name(), buffers, Some(mode))
+        let buffers: Vec<Option<CowImage>> = (0..self.len())
+            .into_par_iter()
+            .map(|i| self.as_image_obj(i).map(|img| img.into_mode(mode)))
+            .collect();
+        image_array_from_img_buffers(self.name(), buffers.into_iter(), Some(mode))
     }
 
     fn attribute(&self, attr: ImageProperty) -> DaftResult<DataArray<UInt32Type>> {
@@ -159,8 +163,9 @@ impl ImageOps for FixedShapeImageArray {
     where
         Self: Sized,
     {
-        let buffers: Vec<Option<CowImage>> = ImageBufferIter::new(self)
-            .map(|img| img.map(|img| img.into_mode(mode)))
+        let buffers: Vec<Option<CowImage>> = (0..self.len())
+            .into_par_iter()
+            .map(|i| self.as_image_obj(i).map(|img| img.into_mode(mode)))
             .collect();
 
         let (height, width) = match self.data_type() {
@@ -273,10 +278,15 @@ fn encode_images<Arr: AsImageObj>(
     }
 }
 
-fn resize_images<Arr: AsImageObj>(images: &Arr, w: u32, h: u32) -> Vec<Option<CowImage<'_>>> {
-    ImageBufferIter::new(images)
-        .map(|img| img.map(|img| img.resize(w, h)))
-        .collect::<Vec<_>>()
+fn resize_images<Arr: AsImageObj + Sync>(
+    images: &Arr,
+    w: u32,
+    h: u32,
+) -> Vec<Option<CowImage<'_>>> {
+    (0..images.len())
+        .into_par_iter()
+        .map(|i| images.as_image_obj(i).map(|img| img.resize(w, h)))
+        .collect()
 }
 
 fn crop_images<'a, Arr>(
@@ -284,15 +294,17 @@ fn crop_images<'a, Arr>(
     bboxes: &mut dyn Iterator<Item = Option<BBox>>,
 ) -> Vec<Option<CowImage<'a>>>
 where
-    Arr: AsImageObj,
+    Arr: AsImageObj + Sync,
 {
-    ImageBufferIter::new(images)
-        .zip(bboxes)
-        .map(|(img, bbox)| match (img, bbox) {
+    let bboxes: Vec<Option<BBox>> = bboxes.take(images.len()).collect();
+    (0..images.len())
+        .into_par_iter()
+        .zip(bboxes.into_par_iter())
+        .map(|(i, bbox)| match (images.as_image_obj(i), bbox) {
             (None, _) | (_, None) => None,
             (Some(img), Some(bbox)) => Some(img.crop(&bbox)),
         })
-        .collect::<Vec<_>>()
+        .collect()
 }
 
 #[must_use]


### PR DESCRIPTION
## Changes Made

use rayon's `par_iter` to improve performance on various image ops. 

| Operation | Speedup |
|---|---|
| resize (512→224) | ~9x |
| resize (224→64) | ~8x |
| center crop | ~2.5x |
| rgb→grayscale | ~2.8x |
| encode, rgba→rgb, to_tensor | no change |

### Raw Benchmarks 
```
resize/512_to_224       time:   [10.139 ms 10.248 ms 10.374 ms]
                        change: [-89.368% -89.246% -89.116%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 50 measurements (6.00%)
  2 (4.00%) high mild
  1 (2.00%) high severe
resize/224_to_64        time:   [1.6727 ms 1.7072 ms 1.7476 ms]
                        change: [-87.901% -87.478% -86.943%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 50 measurements (4.00%)
  1 (2.00%) high mild
  1 (2.00%) high severe

crop/512_center_crop_224
                        time:   [2.0640 ms 2.0934 ms 2.1345 ms]
                        change: [-60.818% -60.102% -59.423%] (p = 0.00 < 0.05)
                        Performance has improved.

to_mode/rgba_to_rgb     time:   [1.8285 ms 1.8796 ms 1.9286 ms]
                        change: [-5.5339% -2.2847% +0.4025%] (p = 0.16 > 0.05)
                        No change in performance detected.
to_mode/rgb_to_l        time:   [917.54 µs 921.96 µs 926.82 µs]
                        change: [-63.963% -63.611% -63.243%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 50 measurements (8.00%)
  4 (8.00%) high mild

encode/png_224x224      time:   [28.815 ms 28.947 ms 29.084 ms]
                        change: [+0.7619% +1.2867% +1.8204%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking encode/jpeg_224x224: Warming up for 1.0000 s
Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 6.2s, or reduce sample count to 40.
encode/jpeg_224x224     time:   [124.56 ms 124.90 ms 125.27 ms]
                        change: [-1.1331% -0.6728% -0.2024%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 50 measurements (10.00%)
  5 (10.00%) high mild

to_tensor/fixed_rgb_224x224
                        time:   [171.55 ns 172.97 ns 174.50 ns]
                        change: [-0.3803% +0.3319% +1.0248%] (p = 0.34 > 0.05)
                        No change in performance detected.
```
## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
