### PR TITLE
fix(dashboard): make dashboard subscriber non blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,6 +2575,9 @@ dependencies = [
  "log",
  "pyo3",
  "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
  "uuid 1.19.0",
 ]
 

--- a/src/daft-context/Cargo.toml
+++ b/src/daft-context/Cargo.toml
@@ -16,6 +16,9 @@ log = {workspace = true}
 dashmap = {workspace = true}
 # Client for submitting to dashboard server
 reqwest = {workspace = true, default_features = false}
+serde = {workspace = true}
+serde_json = {workspace = true}
+tokio = {workspace = true}
 uuid = {workspace = true, features = ["v4"]}
 
 [features]

--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -339,7 +339,7 @@ impl Subscriber for DashboardSubscriber {
 
         self.enqueue_json(
             format!("engine/query/{}/plan_end", query_id),
-            "optimization end",
+            "optimization_end",
             &daft_dashboard::engine::PlanEndArgs {
                 plan_end_sec: secs_from_epoch(),
                 optimized_plan,
@@ -359,7 +359,7 @@ impl Subscriber for DashboardSubscriber {
 
         self.enqueue_json(
             format!("engine/query/{}/exec/start", query_id),
-            "exec start",
+            "exec_start",
             &daft_dashboard::engine::ExecStartArgs {
                 exec_start_sec: secs_from_epoch(),
                 physical_plan,

--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -1,4 +1,10 @@
-use std::{sync::Arc, time::SystemTime};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::SystemTime,
+};
 
 use async_trait::async_trait;
 use common_error::{DaftError, DaftResult};
@@ -8,16 +14,28 @@ use daft_micropartition::{MicroPartition, MicroPartitionRef};
 use daft_recordbatch::RecordBatch;
 use dashmap::DashMap;
 use reqwest::{Client, RequestBuilder};
+use tokio::{sync::mpsc, task::JoinHandle};
 use uuid::Uuid;
 
 use crate::subscribers::{QueryMetadata, QueryResult, Subscriber};
 
-/// Get the number of seconds from the current timesince the UNIX epoch
+const TOTAL_ROWS: usize = 10;
+const DASHBOARD_EVENT_LIMIT: usize = 512;
+const DASHBOARD_SHUTDOWN_TIMEOUT_MS: u64 = 500;
+
+/// Get the number of seconds from the current time since the UNIX epoch
 fn secs_from_epoch() -> f64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()
         .as_secs_f64()
+}
+
+#[derive(Debug)]
+struct DashboardEvent {
+    path: String,
+    context: &'static str,
+    body: Option<Vec<u8>>,
 }
 
 pub struct DashboardSubscriber {
@@ -27,6 +45,10 @@ pub struct DashboardSubscriber {
     preview_rows: DashMap<QueryID, MicroPartitionRef>,
     execution_ids: DashMap<QueryID, String>,
     worker_id: Option<String>,
+
+    dashboard_tx: Option<mpsc::Sender<DashboardEvent>>,
+    dashboard_worker: Option<JoinHandle<()>>,
+    dropped_events: AtomicU64,
 }
 
 impl std::fmt::Debug for DashboardSubscriber {
@@ -38,6 +60,14 @@ impl std::fmt::Debug for DashboardSubscriber {
             .field("preview_rows", &self.preview_rows)
             .field("execution_ids", &self.execution_ids)
             .field("worker_id", &self.worker_id)
+            .field("dashboard_tx", &self.dashboard_tx.is_some())
+            .field("dashboard_worker", &self.dashboard_worker.is_some())
+            .field(
+                "dropped_events",
+                &self
+                    .dropped_events
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            )
             .finish()
     }
 }
@@ -55,6 +85,7 @@ impl DashboardSubscriber {
                 // if it's a localhost uri we can skip ssl verification
                 .danger_accept_invalid_certs(true)
                 .danger_accept_invalid_hostnames(true)
+                .connect_timeout(std::time::Duration::from_secs(3))
                 .timeout(std::time::Duration::from_secs(5))
                 .user_agent(USER_AGENT)
                 .build()
@@ -62,22 +93,30 @@ impl DashboardSubscriber {
         } else {
             // TODO: Auth handling?
             Client::builder()
+                .connect_timeout(std::time::Duration::from_secs(3))
                 .timeout(std::time::Duration::from_secs(5))
                 .user_agent(USER_AGENT)
                 .build()
                 .map_err(|e| DaftError::External(Box::new(e)))?
         };
 
-        let url_clone = url.clone();
-        let client_clone = client.clone();
         let runtime = get_io_runtime(false);
+
+        let (dashboard_tx, dashboard_rx) = mpsc::channel(DASHBOARD_EVENT_LIMIT);
+        let worker_url = url.clone();
+        let worker_client = client.clone();
+        let dashboard_worker = runtime.runtime.handle().spawn(async move {
+            Self::dashboard_worker_loop(worker_url, worker_client, dashboard_rx).await;
+        });
 
         // Validate that we can connect to the dashboard
         // We log a warning if we can't connect, but we still return the subscriber
         // because the dashboard might come up later.
+        let ping_url = format!("{}/api/ping", url);
+        let ping_client = client.clone();
         if let Err(e) = runtime.block_within_async_context(async move {
-            client
-                .get(format!("{}/api/ping", url))
+            ping_client
+                .get(ping_url)
                 .send()
                 .await
                 .map_err(|e| DaftError::ConnectTimeout(Box::new(e)))?
@@ -85,7 +124,7 @@ impl DashboardSubscriber {
                 .map_err(|e| DaftError::External(Box::new(e)))?;
             Ok::<_, DaftError>(())
         }) {
-            log::warn!("Failed to connect to dashboard at {}: {}", url_clone, e);
+            log::warn!("Failed to connect to dashboard at {}: {}", url, e);
         }
 
         let worker_id = if std::env::var("DAFT_FLOTILLA_WORKER").is_ok() {
@@ -95,12 +134,15 @@ impl DashboardSubscriber {
         };
 
         Ok(Some(Self {
-            url: url_clone,
-            client: client_clone,
+            url,
+            client,
             runtime,
             preview_rows: DashMap::new(),
             execution_ids: DashMap::new(),
             worker_id,
+            dashboard_tx: Some(dashboard_tx),
+            dashboard_worker: Some(dashboard_worker),
+            dropped_events: AtomicU64::new(0),
         }))
     }
 
@@ -113,9 +155,85 @@ impl DashboardSubscriber {
             .map_err(|e| DaftError::External(Box::new(e)))?;
         Ok(())
     }
+
+    fn try_enqueue(&self, event: DashboardEvent) {
+        let Some(tx) = &self.dashboard_tx else {
+            return; // shutdown in progress
+        };
+
+        if tx.try_send(event).is_err() {
+            let dropped = self.dropped_events.fetch_add(1, Ordering::Relaxed) + 1;
+            if dropped.is_multiple_of(100) {
+                log::warn!("Dropped {dropped} dashboard events because queue is full");
+            }
+        }
+    }
+
+    fn enqueue_json<T: serde::Serialize>(&self, path: String, context: &'static str, payload: &T) {
+        match serde_json::to_vec(payload) {
+            Ok(body) => self.try_enqueue(DashboardEvent {
+                path,
+                context,
+                body: Some(body),
+            }),
+            Err(e) => log::error!("Failed to serialize dashboard payload for {context}: {e}"),
+        }
+    }
+
+    fn enqueue_no_body(&self, path: String, context: &'static str) {
+        self.try_enqueue(DashboardEvent {
+            path,
+            context,
+            body: None,
+        });
+    }
+
+    async fn dashboard_worker_loop(
+        url: String,
+        client: Client,
+        mut rx: mpsc::Receiver<DashboardEvent>,
+    ) {
+        while let Some(event) = rx.recv().await {
+            let mut req = client.post(format!("{}/{}", url, event.path));
+            if let Some(body) = event.body {
+                req = req
+                    .header(reqwest::header::CONTENT_TYPE, "application/json")
+                    .body(body);
+            }
+
+            if let Err(e) = Self::handle_request(req).await {
+                log::error!("Failed to notify {}: {}", event.context, e);
+            }
+        }
+    }
 }
 
-const TOTAL_ROWS: usize = 10;
+impl Drop for DashboardSubscriber {
+    fn drop(&mut self) {
+        // Close channel so worker drains buffered events and exits.
+        let _ = self.dashboard_tx.take();
+
+        // Wait up to timeout for clean drain; then force abort.
+        if let Some(mut worker) = self.dashboard_worker.take() {
+            let shutdown = self.runtime.block_within_async_context(async move {
+                if tokio::time::timeout(
+                    std::time::Duration::from_millis(DASHBOARD_SHUTDOWN_TIMEOUT_MS),
+                    &mut worker,
+                )
+                .await
+                .is_err()
+                {
+                    log::warn!("Dashboard worker did not drain in time, aborting");
+                    worker.abort();
+                }
+            });
+
+            if let Err(e) = shutdown {
+                log::warn!("Dashboard worker shutdown encountered an error: {e}");
+            }
+        }
+    }
+}
 
 #[async_trait]
 impl Subscriber for DashboardSubscriber {
@@ -123,36 +241,22 @@ impl Subscriber for DashboardSubscriber {
         if std::env::var("DAFT_FLOTILLA_WORKER").is_ok() {
             return Ok(());
         }
-        let url = self.url.clone();
-        let client = self.client.clone();
-        let unoptimized_plan = metadata.unoptimized_plan.clone();
-        let runner = Some(metadata.runner.clone());
-        let ray_dashboard_url = metadata.ray_dashboard_url.clone();
-        let entrypoint = metadata.entrypoint.clone();
-        let start_sec = secs_from_epoch();
-        let qid = query_id.clone();
-
-        self.runtime.block_within_async_context(async move {
-            if let Err(e) = Self::handle_request(
-                client
-                    .post(format!("{}/engine/query/{}/start", url, qid))
-                    .json(&daft_dashboard::engine::StartQueryArgs {
-                        start_sec,
-                        unoptimized_plan,
-                        runner,
-                        ray_dashboard_url,
-                        entrypoint,
-                    }),
-            )
-            .await
-            {
-                log::error!("Failed to notify query start: {}", e);
-            }
-        })?;
 
         self.preview_rows.insert(
-            query_id,
+            query_id.clone(),
             Arc::new(MicroPartition::empty(Some(metadata.output_schema.clone()))),
+        );
+
+        self.enqueue_json(
+            format!("engine/query/{}/start", query_id),
+            "query_start",
+            &daft_dashboard::engine::StartQueryArgs {
+                start_sec: secs_from_epoch(),
+                unoptimized_plan: metadata.unoptimized_plan.clone(),
+                runner: Some(metadata.runner.clone()),
+                ray_dashboard_url: metadata.ray_dashboard_url.clone(),
+                entrypoint: metadata.entrypoint.clone(),
+            },
         );
         Ok(())
     }
@@ -200,28 +304,16 @@ impl Subscriber for DashboardSubscriber {
             None
         };
 
-        let end_sec = secs_from_epoch();
-        let url = self.url.clone();
-        let client = self.client.clone();
-        let end_state = end_result.end_state;
-        let error_message = end_result.error_message;
-
-        self.runtime.block_within_async_context(async move {
-            if let Err(e) = Self::handle_request(
-                client
-                    .post(format!("{}/engine/query/{}/end", url, query_id))
-                    .json(&daft_dashboard::engine::FinalizeArgs {
-                        end_sec,
-                        end_state,
-                        error_message,
-                        results: results_ipc,
-                    }),
-            )
-            .await
-            {
-                log::error!("Failed to notify query end: {}", e);
-            }
-        })?;
+        self.enqueue_json(
+            format!("engine/query/{}/end", query_id),
+            "query_end",
+            &daft_dashboard::engine::FinalizeArgs {
+                end_sec: secs_from_epoch(),
+                end_state: end_result.end_state,
+                error_message: end_result.error_message,
+                results: results_ipc,
+            },
+        );
         Ok(())
     }
 
@@ -229,21 +321,14 @@ impl Subscriber for DashboardSubscriber {
         if std::env::var("DAFT_FLOTILLA_WORKER").is_ok() {
             return Ok(());
         }
-        let url = self.url.clone();
-        let client = self.client.clone();
-        let plan_start_sec = secs_from_epoch();
 
-        self.runtime.block_within_async_context(async move {
-            if let Err(e) = Self::handle_request(
-                client
-                    .post(format!("{}/engine/query/{}/plan_start", url, query_id))
-                    .json(&daft_dashboard::engine::PlanStartArgs { plan_start_sec }),
-            )
-            .await
-            {
-                log::error!("Failed to notify optimization start: {}", e);
-            }
-        })?;
+        self.enqueue_json(
+            format!("engine/query/{}/plan_start", query_id),
+            "optimization_start",
+            &daft_dashboard::engine::PlanStartArgs {
+                plan_start_sec: secs_from_epoch(),
+            },
+        );
         Ok(())
     }
 
@@ -251,24 +336,15 @@ impl Subscriber for DashboardSubscriber {
         if std::env::var("DAFT_FLOTILLA_WORKER").is_ok() {
             return Ok(());
         }
-        let url = self.url.clone();
-        let client = self.client.clone();
-        let plan_end_sec = secs_from_epoch();
 
-        self.runtime.block_within_async_context(async move {
-            if let Err(e) = Self::handle_request(
-                client
-                    .post(format!("{}/engine/query/{}/plan_end", url, query_id))
-                    .json(&daft_dashboard::engine::PlanEndArgs {
-                        plan_end_sec,
-                        optimized_plan,
-                    }),
-            )
-            .await
-            {
-                log::error!("Failed to notify optimization end: {}", e);
-            }
-        })?;
+        self.enqueue_json(
+            format!("engine/query/{}/plan_end", query_id),
+            "optimization end",
+            &daft_dashboard::engine::PlanEndArgs {
+                plan_end_sec: secs_from_epoch(),
+                optimized_plan,
+            },
+        );
         Ok(())
     }
 
@@ -281,24 +357,14 @@ impl Subscriber for DashboardSubscriber {
         self.execution_ids
             .insert(query_id.clone(), execution_id.to_string());
 
-        let url = self.url.clone();
-        let client = self.client.clone();
-        let exec_start_sec = secs_from_epoch();
-
-        self.runtime.block_within_async_context(async move {
-            if let Err(e) = Self::handle_request(
-                client
-                    .post(format!("{}/engine/query/{}/exec/start", url, query_id))
-                    .json(&daft_dashboard::engine::ExecStartArgs {
-                        exec_start_sec,
-                        physical_plan,
-                    }),
-            )
-            .await
-            {
-                log::error!("Failed to notify exec start: {}", e);
-            }
-        })?;
+        self.enqueue_json(
+            format!("engine/query/{}/exec/start", query_id),
+            "exec start",
+            &daft_dashboard::engine::ExecStartArgs {
+                exec_start_sec: secs_from_epoch(),
+                physical_plan,
+            },
+        );
         Ok(())
     }
 
@@ -307,11 +373,10 @@ impl Subscriber for DashboardSubscriber {
     }
 
     async fn on_exec_operator_start(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()> {
-        let _ = Self::handle_request(self.client.post(format!(
-            "{}/engine/query/{}/exec/{}/start",
-            self.url, query_id, node_id
-        )))
-        .await;
+        self.enqueue_no_body(
+            format!("engine/query/{}/exec/{}/start", query_id, node_id),
+            "exec_operator_start",
+        );
         Ok(())
     }
 
@@ -321,30 +386,26 @@ impl Subscriber for DashboardSubscriber {
         execution_id: &str,
         stats: Arc<Vec<(NodeID, Stats)>>,
     ) -> DaftResult<()> {
-        Self::handle_request(
-            self.client
-                .post(format!(
-                    "{}/engine/query/{}/exec/emit_stats",
-                    self.url, query_id
-                ))
-                .json(&daft_dashboard::engine::ExecEmitStatsArgsSend {
-                    source_id: execution_id.to_string(),
-                    stats: stats
-                        .iter()
-                        .map(|(node_id, snapshot)| {
-                            (
-                                *node_id,
-                                snapshot
-                                    .0
-                                    .iter()
-                                    .map(|(name, stat)| (name.to_string(), stat.clone()))
-                                    .collect(),
-                            )
-                        })
-                        .collect(),
-                }),
-        )
-        .await?;
+        self.enqueue_json(
+            format!("engine/query/{}/exec/emit_stats", query_id),
+            "exec_emit_stats",
+            &daft_dashboard::engine::ExecEmitStatsArgsSend {
+                source_id: execution_id.to_string(),
+                stats: stats
+                    .iter()
+                    .map(|(node_id, snapshot)| {
+                        (
+                            *node_id,
+                            snapshot
+                                .0
+                                .iter()
+                                .map(|(name, stat)| (name.to_string(), stat.clone()))
+                                .collect(),
+                        )
+                    })
+                    .collect(),
+            },
+        );
         Ok(())
     }
 
@@ -370,27 +431,23 @@ impl Subscriber for DashboardSubscriber {
     }
 
     async fn on_exec_operator_end(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()> {
-        let _ = Self::handle_request(self.client.post(format!(
-            "{}/engine/query/{}/exec/{}/end",
-            self.url, query_id, node_id
-        )))
-        .await;
+        self.enqueue_no_body(
+            format!("engine/query/{}/exec/{}/end", query_id, node_id),
+            "exec_operator_end",
+        );
         Ok(())
     }
 
     async fn on_exec_end_with_id(&self, query_id: QueryID, _execution_id: &str) -> DaftResult<()> {
         self.execution_ids.remove(&query_id);
 
-        let exec_end_sec = secs_from_epoch();
-        let url = self.url.clone();
-        let client = self.client.clone();
-
-        let _ = Self::handle_request(
-            client
-                .post(format!("{}/engine/query/{}/exec/end", url, query_id))
-                .json(&daft_dashboard::engine::ExecEndArgs { exec_end_sec }),
-        )
-        .await;
+        self.enqueue_json(
+            format!("engine/query/{}/exec/end", query_id),
+            "exec_end",
+            &daft_dashboard::engine::ExecEndArgs {
+                exec_end_sec: secs_from_epoch(),
+            },
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Changes Made

This makes the dashboard metrics subscriber non blocking. If you run a daft job with dashboard url configured but the dashboard is not reachable the pipeline will block forever. This changes make the subscriber non block so it does not block pipeline execution.


