### PR TITLE
fix(tests): make Ray conda UDF tests robust to unavailable Python micro versions

### DIFF
--- a/tests/ray/test_udf_ray_options.py
+++ b/tests/ray/test_udf_ray_options.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import platform
 import subprocess
 import sys
@@ -16,6 +17,37 @@ RAY_VERSION_TUPLE = tuple(map(int, RAY_VERSION.split(".")[:3]))
 PYTHON_MAJOR_MINOR = ".".join(platform.python_version().split(".")[:2])
 
 import daft
+
+
+def _conda_has_current_python() -> bool:
+    py_ver = platform.python_version()  # e.g. 3.10.20
+    try:
+        result = subprocess.run(
+            [
+                "conda",
+                "search",
+                "--json",
+                "--override-channels",
+                "-c",
+                "conda-forge",
+                "-c",
+                "defaults",
+                f"python={py_ver}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if result.returncode != 0:
+            return False
+        payload = json.loads(result.stdout or "{}")
+        return bool(payload.get("python"))
+    except Exception:
+        return False
+
+
+HAS_CONDA_CURRENT_PY = _conda_has_current_python()
 
 
 @pytest.fixture
@@ -88,8 +120,14 @@ def gen_email(names):
 
 
 @pytest.mark.skipif(
-    get_or_infer_runner_type() == "native" or sys.version_info[:2] not in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS,
-    reason=f"Native runner or Python version is {sys.version_info}",
+    get_or_infer_runner_type() == "native"
+    or sys.version_info[:2] not in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS
+    or not HAS_CONDA_CURRENT_PY,
+    reason=(
+        f"Native runner, unsupported Python version {sys.version_info}, "
+        f"or conda cannot resolve python={platform.python_version()} "
+        "required by Ray runtime_env conda pinning"
+    ),
 )
 def test_udf_with_conda_inject_dependencies(input_df):
     # missing required modules
@@ -134,8 +172,14 @@ def test_udf_with_conda_inject_dependencies(input_df):
 
 
 @pytest.mark.skipif(
-    get_or_infer_runner_type() == "native" or sys.version_info[:2] not in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS,
-    reason=f"Native runner or Python version is {sys.version_info}",
+    get_or_infer_runner_type() == "native"
+    or sys.version_info[:2] not in ray_constants.RUNTIME_ENV_CONDA_PY_VERSIONS
+    or not HAS_CONDA_CURRENT_PY,
+    reason=(
+        f"Native runner, unsupported Python version {sys.version_info}, "
+        f"or conda cannot resolve python={platform.python_version()} "
+        "required by Ray runtime_env conda pinning"
+    ),
 )
 def test_udf_with_prepared_conda_env(input_df):
     conda_env_name = f"test_udf_with_prepared_conda_env_{int(time.time())}"

--- a/tests/ray/test_udf_ray_options.py
+++ b/tests/ray/test_udf_ray_options.py
@@ -14,7 +14,6 @@ from daft import DataType, col, get_or_infer_runner_type, udf
 ray = pytest.importorskip("ray")
 RAY_VERSION = getattr(ray, "__version__", "0.0.0")
 RAY_VERSION_TUPLE = tuple(map(int, RAY_VERSION.split(".")[:3]))
-PYTHON_MAJOR_MINOR = ".".join(platform.python_version().split(".")[:2])
 
 import daft
 
@@ -139,7 +138,6 @@ def test_udf_with_conda_inject_dependencies(input_df):
                         "name": "test",
                         "channels": ["conda-forge", "defaults"],
                         "dependencies": [
-                            f"python={PYTHON_MAJOR_MINOR}",
                             "pip",
                             {"pip": ["daft"]},
                         ],
@@ -159,7 +157,6 @@ def test_udf_with_conda_inject_dependencies(input_df):
                 "conda": {
                     "channels": ["conda-forge", "defaults"],
                     "dependencies": [
-                        f"python={PYTHON_MAJOR_MINOR}",
                         "pip",
                         {"pip": ["daft", "faker"]},
                     ],
@@ -194,7 +191,7 @@ def test_udf_with_prepared_conda_env(input_df):
             "conda-forge",
             "-c",
             "defaults",
-            f"python={PYTHON_MAJOR_MINOR}",
+            f"python={platform.python_version()}",
             "pip",
             "&&",
             "conda",

--- a/tests/ray/test_udf_ray_options.py
+++ b/tests/ray/test_udf_ray_options.py
@@ -99,6 +99,7 @@ def test_udf_with_conda_inject_dependencies(input_df):
                 "runtime_env": {
                     "conda": {
                         "name": "test",
+                        "channels": ["conda-forge", "defaults"],
                         "dependencies": [
                             f"python={PYTHON_MAJOR_MINOR}",
                             "pip",
@@ -118,6 +119,7 @@ def test_udf_with_conda_inject_dependencies(input_df):
         ray_options={
             "runtime_env": {
                 "conda": {
+                    "channels": ["conda-forge", "defaults"],
                     "dependencies": [
                         f"python={PYTHON_MAJOR_MINOR}",
                         "pip",
@@ -144,6 +146,10 @@ def test_udf_with_prepared_conda_env(input_df):
             "-n",
             conda_env_name,
             "-y",
+            "-c",
+            "conda-forge",
+            "-c",
+            "defaults",
             f"python={PYTHON_MAJOR_MINOR}",
             "pip",
             "&&",

--- a/tests/ray/test_udf_ray_options.py
+++ b/tests/ray/test_udf_ray_options.py
@@ -13,6 +13,7 @@ from daft import DataType, col, get_or_infer_runner_type, udf
 ray = pytest.importorskip("ray")
 RAY_VERSION = getattr(ray, "__version__", "0.0.0")
 RAY_VERSION_TUPLE = tuple(map(int, RAY_VERSION.split(".")[:3]))
+PYTHON_MAJOR_MINOR = ".".join(platform.python_version().split(".")[:2])
 
 import daft
 
@@ -99,6 +100,7 @@ def test_udf_with_conda_inject_dependencies(input_df):
                     "conda": {
                         "name": "test",
                         "dependencies": [
+                            f"python={PYTHON_MAJOR_MINOR}",
                             "pip",
                             {"pip": ["daft"]},
                         ],
@@ -117,6 +119,7 @@ def test_udf_with_conda_inject_dependencies(input_df):
             "runtime_env": {
                 "conda": {
                     "dependencies": [
+                        f"python={PYTHON_MAJOR_MINOR}",
                         "pip",
                         {"pip": ["daft", "faker"]},
                     ],
@@ -141,7 +144,7 @@ def test_udf_with_prepared_conda_env(input_df):
             "-n",
             conda_env_name,
             "-y",
-            f"python={platform.python_version()}",
+            f"python={PYTHON_MAJOR_MINOR}",
             "pip",
             "&&",
             "conda",


### PR DESCRIPTION
## Changes Made
This updates tests/ray/test_udf_ray_options.py to avoid CI flakiness when Ray runtime_env conda setup cannot resolve the current Python micro version.

  What changed:

  - Added a preflight helper _conda_has_current_python() that checks whether conda can resolve python=<platform.python_version()> from conda-forge +
    defaults.
  - Added HAS_CONDA_CURRENT_PY gating to both conda-based Ray UDF tests:
      - test_udf_with_conda_inject_dependencies
      - test_udf_with_prepared_conda_env
  - Kept explicit channels (conda-forge, defaults) in conda specs.
  - Removed earlier manual python=major.minor test pinning to avoid confusion; tests now align with Ray’s own runtime_env exact micro pin behavior.

  Why:

  - Ray injects an exact Python micro constraint (for example 3.10.20.*) for conda runtime_env.
  - In some CI environments that micro version is not available via conda channels, causing RuntimeEnvSetupError before UDF behavior is exercised.
  - With this change, tests run only when environment prerequisites are satisfiable and otherwise skip with a clear reason, reducing false-negative CI
    failures while preserving test intent.
