### PR TITLE
chore(tests): migrate internal usages of daft.udf to cls/func

### DIFF
--- a/tests/cookbook/test_aggregations.py
+++ b/tests/cookbook/test_aggregations.py
@@ -6,9 +6,9 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import daft
 from daft.datatype import DataType
 from daft.expressions import col
-from daft.udf import udf
 from tests.conftest import assert_df_equals
 from tests.dataframe.test_aggregations import _assert_all_hashable
 
@@ -296,7 +296,7 @@ def test_sum_groupby_sorted(daft_df, service_requests_csv_pd_df, repartition_npa
 def test_map_groups(daft_df, service_requests_csv_pd_df, repartition_nparts, keys, with_morsel_size):
     """Test map_groups."""
 
-    @udf(return_dtype=DataType.float64())
+    @daft.func.batch(return_dtype=DataType.float64())
     def average_resolution_time(created_date, closed_date):
         # Calculate the time difference in seconds between created and closed date
         times = [

--- a/tests/dataframe/test_explain.py
+++ b/tests/dataframe/test_explain.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import warnings
+
 import pytest
+
+# This module tests legacy @daft.udf features (ray_options, override_options) with no new-API equivalent.
+warnings.filterwarnings("ignore", category=DeprecationWarning, message=r".*@daft\.udf.*")
+pytestmark = pytest.mark.filterwarnings(r"ignore:.*@daft\.udf.*:DeprecationWarning")
 
 import daft
 from daft import col, get_or_infer_runner_type, udf

--- a/tests/dataframe/test_into_batches.py
+++ b/tests/dataframe/test_into_batches.py
@@ -12,7 +12,7 @@ def test_large_partition_into_batches(make_df):
     df = df.into_batches(8)
 
     # Create a UDF that asserts each batch size is exactly 8
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def check_batch_size(data):
         batch_size = len(data.to_pylist())
         assert batch_size == 8, f"Expected batch size 8, got {batch_size}"
@@ -52,7 +52,7 @@ def test_into_batches_with_remainder():
     df = df.into_batches(8)
 
     # Create a UDF that checks batch sizes
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def check_batch_size(data):
         batch_size = len(data.to_pylist())
         assert batch_size == 8 or batch_size == 6, f"Expected batch size 8 or 6, got {batch_size}"
@@ -71,7 +71,7 @@ def test_into_batches_single_row():
     df = daft.from_pydict({"id": [42]})
     df = df.into_batches(8)
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def check_batch_size(data):
         batch_size = len(data.to_pylist())
         assert batch_size == 1, f"Expected batch size 1, got {batch_size}"

--- a/tests/dataframe/test_iter.py
+++ b/tests/dataframe/test_iter.py
@@ -5,7 +5,6 @@ import pyarrow as pa
 import pytest
 
 import daft
-from daft.errors import UDFException
 from tests.conftest import get_tests_daft_runner_name
 
 
@@ -164,7 +163,7 @@ def test_iter_exception(make_df):
     # Test that df.__iter__ actually returns results before completing execution.
     # We test this by raising an exception in a UDF if too many partitions are executed.
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def echo_or_trigger(s):
         trigger = max(s.to_pylist())
         if trigger >= 199:
@@ -179,16 +178,8 @@ def test_iter_exception(make_df):
         assert next(it) == {"a": 0, "b": 0}
 
         # Ensure the exception does trigger if execution continues.
-        with pytest.raises(UDFException) as exc_info:
+        with pytest.raises(MockException):
             list(it)
-
-        # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
-        if get_tests_daft_runner_name() == "ray":
-            assert "MockException" in str(exc_info.value)
-        else:
-            assert isinstance(exc_info.value.__cause__, MockException)
-
-        assert str(exc_info.value).endswith("failed when executing on inputs:\n  - a (Int64, length=2)")
 
 
 @pytest.mark.parametrize("dynamic_batching", [True, False])
@@ -196,7 +187,7 @@ def test_iter_partitions_exception(make_df, dynamic_batching):
     # Test that df.iter_partitions actually returns results before completing execution.
     # We test this by raising an exception in a UDF if too many partitions are executed.
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def echo_or_trigger(s):
         trigger = max(s.to_pylist())
         if trigger >= 199:
@@ -218,14 +209,7 @@ def test_iter_partitions_exception(make_df, dynamic_batching):
         assert part == {"a": [0, 1], "b": [0, 1]}
 
         # Ensure the exception does trigger if execution continues.
-        with pytest.raises(UDFException) as exc_info:
+        with pytest.raises(MockException):
             res = list(it)
             if get_tests_daft_runner_name() == "ray":
                 ray.get(res)
-
-        # Ray's wrapping of the exception loses information about the `.cause`, but preserves it in the string error message
-        if get_tests_daft_runner_name() == "ray":
-            assert "MockException" in str(exc_info.value)
-        else:
-            assert isinstance(exc_info.value.__cause__, MockException)
-        assert str(exc_info.value).endswith("failed when executing on inputs:\n  - a (Int64, length=2)")

--- a/tests/dataframe/test_map_groups.py
+++ b/tests/dataframe/test_map_groups.py
@@ -19,7 +19,7 @@ def test_map_groups(make_df, repartition_nparts, with_morsel_size):
         repartition=repartition_nparts,
     )
 
-    @daft.udf(return_dtype=daft.DataType.list(daft.DataType.float64()))
+    @daft.func.batch(return_dtype=daft.DataType.list(daft.DataType.float64()))
     def udf(a, b):
         a, b = a.to_pylist(), b.to_pylist()
         res = []
@@ -84,7 +84,7 @@ def test_map_groups_more_than_one_output_row(make_df, repartition_nparts, output
         repartition=repartition_nparts,
     )
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def udf(a):
         a = a.to_pylist()
         if len(a) == 0:

--- a/tests/dataframe/test_morsels.py
+++ b/tests/dataframe/test_morsels.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import os
 import re
 
 import pytest
@@ -11,13 +12,24 @@ from tests.utils import clean_explain_output
 
 pytestmark = pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="requires Native Runner to be in use")
 
+NOOP_QUAL = "tests.dataframe.test_morsels.make_noop_udf.<locals>.noop"
+CONCURRENCY = os.cpu_count()
+
 
 def make_noop_udf(batch_size: int, dtype: daft.DataType = daft.DataType.int64()):
-    @daft.udf(return_dtype=dtype, batch_size=batch_size, concurrency=1)
+    @daft.func.batch(return_dtype=dtype, batch_size=batch_size)
     def noop(x: dtype) -> dtype:
         return x
 
     return noop
+
+
+def _extract_noop_ids(plan_text):
+    return re.findall(r"noop-\d+-\d+", plan_text)
+
+
+def _noop_func_id(noop_id):
+    return NOOP_QUAL + noop_id.removeprefix("noop")
 
 
 # TODO: Add snapshot tests in Rust for the explain output of the following tests.
@@ -30,26 +42,26 @@ def test_batch_size_from_udf_propagated_to_scan(dynamic_batching):
         df = df.select(make_noop_udf(10)(daft.col("a")))
         string_io = io.StringIO()
         df.explain(True, file=string_io)
-        expected = """
+        captured = string_io.getvalue().split("== Physical Plan ==")[-1]
+        [noop_id] = _extract_noop_ids(captured)
+        expected = f"""
 
-    * UDF tests.dataframe.test_morsels.make_noop_udf.<locals>.noop:
-    |   Expr = py_udf(col(0: a)) as a
+    * UDF {NOOP_QUAL}:
+    |   Expr = {_noop_func_id(noop_id)}(col(0: a)) as a
     |   Passthrough Columns = []
-    |   Properties = { batch_size = 10, concurrency = 1, async = false, scalar = false }
-    |   Resource request = None
-    |   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+    |   Properties = {{ batch_size = 10, concurrency = {CONCURRENCY}, on_error = raise, async = false, scalar = false }}
+    |   Resource request = {{ num_gpus = 0 }}
+    |   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
     |   Batch Size = 10
     |
     * InMemoryScan:
     |   Schema = a#Int64
     |   Size bytes = 40
-    |   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+    |   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
     |   Batch Size = 10
 
     """
-        assert clean_explain_output(string_io.getvalue().split("== Physical Plan ==")[-1]) == clean_explain_output(
-            expected
-        )
+        assert clean_explain_output(captured) == clean_explain_output(expected)
 
 
 def test_batch_size_from_udf_propagated_through_ops_to_scan():
@@ -72,13 +84,14 @@ def test_batch_size_from_udf_propagated_through_ops_to_scan():
     # Match the id inside col(0: id-...)
     m = re.search(r"col\(0: (id-[a-f0-9\-]+)\)", captured)
     id_placeholder = m.group(1) if m else ""
+    [noop_id] = _extract_noop_ids(captured)
     expected = f"""
 
-* UDF tests.dataframe.test_morsels.make_noop_udf.<locals>.noop:
-|   Expr = py_udf(col(0: __TruncateRootUDF_0-0-0__)) as data
+* UDF {NOOP_QUAL}:
+|   Expr = {_noop_func_id(noop_id)}(col(0: __TruncateRootUDF_0-0-0__)) as data
 |   Passthrough Columns = []
-|   Properties = {{ batch_size = 10, concurrency = 1, async = false, scalar = false }}
-|   Resource request = None
+|   Properties = {{ batch_size = 10, concurrency = {CONCURRENCY}, on_error = raise, async = false, scalar = false }}
+|   Resource request = {{ num_gpus = 0 }}
 |   Batch Size = 10
 |
 * Project: col(0: __TruncateRootUDF_0-0-0__) as __TruncateRootUDF_0-0-0__
@@ -196,40 +209,42 @@ def test_batch_size_from_multiple_udfs_do_not_override_each_other():
     df = df.select(make_noop_udf(30)(daft.col("a")))
     string_io = io.StringIO()
     df.explain(True, file=string_io)
-    expected = """
+    captured = string_io.getvalue().split("== Physical Plan ==")[-1]
+    noop_ids = _extract_noop_ids(captured)
+    expected = f"""
 
-* UDF tests.dataframe.test_morsels.make_noop_udf.<locals>.noop:
-|   Expr = py_udf(col(0: __TruncateRootUDF_0-0-0__)) as a
+* UDF {NOOP_QUAL}:
+|   Expr = {_noop_func_id(noop_ids[0])}(col(0: __TruncateRootUDF_0-0-0__)) as a
 |   Passthrough Columns = []
-|   Properties = { batch_size = 30, concurrency = 1, async = false, scalar = false }
-|   Resource request = None
-|   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+|   Properties = {{ batch_size = 30, concurrency = {CONCURRENCY}, on_error = raise, async = false, scalar = false }}
+|   Resource request = {{ num_gpus = 0 }}
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = 30
 |
-* UDF tests.dataframe.test_morsels.make_noop_udf.<locals>.noop:
-|   Expr = py_udf(col(0: __TruncateRootUDF_1-0-0__)) as __TruncateRootUDF_0-0-0__
+* UDF {NOOP_QUAL}:
+|   Expr = {_noop_func_id(noop_ids[1])}(col(0: __TruncateRootUDF_1-0-0__)) as __TruncateRootUDF_0-0-0__
 |   Passthrough Columns = []
-|   Properties = { batch_size = 20, concurrency = 1, async = false, scalar = false }
-|   Resource request = None
-|   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+|   Properties = {{ batch_size = 20, concurrency = {CONCURRENCY}, on_error = raise, async = false, scalar = false }}
+|   Resource request = {{ num_gpus = 0 }}
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = 20
 |
-* UDF tests.dataframe.test_morsels.make_noop_udf.<locals>.noop:
-|   Expr = py_udf(col(0: a)) as __TruncateRootUDF_1-0-0__
+* UDF {NOOP_QUAL}:
+|   Expr = {_noop_func_id(noop_ids[2])}(col(0: a)) as __TruncateRootUDF_1-0-0__
 |   Passthrough Columns = []
-|   Properties = { batch_size = 10, concurrency = 1, async = false, scalar = false }
-|   Resource request = None
-|   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+|   Properties = {{ batch_size = 10, concurrency = {CONCURRENCY}, on_error = raise, async = false, scalar = false }}
+|   Resource request = {{ num_gpus = 0 }}
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = 10
 |
 * InMemoryScan:
 |   Schema = a#Int64
 |   Size bytes = 40
-|   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = 10
 
 """
-    assert clean_explain_output(string_io.getvalue().split("== Physical Plan ==")[-1]) == clean_explain_output(expected)
+    assert clean_explain_output(captured) == clean_explain_output(expected)
 
 
 def test_batch_size_from_udf_not_propagated_through_agg():
@@ -238,29 +253,31 @@ def test_batch_size_from_udf_not_propagated_through_agg():
     df = df.select(make_noop_udf(10)(daft.col("a")))
     string_io = io.StringIO()
     df.explain(True, file=string_io)
-    expected = """
+    captured = string_io.getvalue().split("== Physical Plan ==")[-1]
+    [noop_id] = _extract_noop_ids(captured)
+    expected = f"""
 
-* UDF tests.dataframe.test_morsels.make_noop_udf.<locals>.noop:
-|   Expr = py_udf(col(0: a)) as a
+* UDF {NOOP_QUAL}:
+|   Expr = {_noop_func_id(noop_id)}(col(0: a)) as a
 |   Passthrough Columns = []
-|   Properties = { batch_size = 10, concurrency = 1, async = false, scalar = false }
-|   Resource request = None
-|   Stats = { Approx num rows = 4, Approx size bytes = 32 B, Accumulated selectivity = 0.80 }
+|   Properties = {{ batch_size = 10, concurrency = {CONCURRENCY}, on_error = raise, async = false, scalar = false }}
+|   Resource request = {{ num_gpus = 0 }}
+|   Stats = {{ Approx num rows = 4, Approx size bytes = 32 B, Accumulated selectivity = 0.80 }}
 |   Batch Size = 10
 |
 * GroupedAggregate:
 |   Group by: col(0: a)
-|   Stats = { Approx num rows = 4, Approx size bytes = 32 B, Accumulated selectivity = 0.80 }
+|   Stats = {{ Approx num rows = 4, Approx size bytes = 32 B, Accumulated selectivity = 0.80 }}
 |
 * InMemoryScan:
 |   Schema = a#Int64
 |   Size bytes = 40
-|   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = Range(0, 131072]
 
 """
 
-    assert clean_explain_output(string_io.getvalue().split("== Physical Plan ==")[-1]) == clean_explain_output(expected)
+    assert clean_explain_output(captured) == clean_explain_output(expected)
 
 
 def test_batch_size_from_udf_not_propagated_through_join():
@@ -270,18 +287,20 @@ def test_batch_size_from_udf_not_propagated_through_join():
     df = df.select(make_noop_udf(10)(daft.col("a")))
     string_io = io.StringIO()
     df.explain(True, file=string_io)
-    expected = """
+    captured = string_io.getvalue().split("== Physical Plan ==")[-1]
+    [noop_id] = _extract_noop_ids(captured)
+    expected = f"""
 
-* UDF tests.dataframe.test_morsels.make_noop_udf.<locals>.noop:
-|   Expr = py_udf(col(0: a)) as a
+* UDF {NOOP_QUAL}:
+|   Expr = {_noop_func_id(noop_id)}(col(0: a)) as a
 |   Passthrough Columns = []
-|   Properties = { batch_size = 10, concurrency = 1, async = false, scalar = false }
-|   Resource request = None
-|   Stats = { Approx num rows = 5, Approx size bytes = 37 B, Accumulated selectivity = 0.90 }
+|   Properties = {{ batch_size = 10, concurrency = {CONCURRENCY}, on_error = raise, async = false, scalar = false }}
+|   Resource request = {{ num_gpus = 0 }}
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 37 B, Accumulated selectivity = 0.90 }}
 |   Batch Size = 10
 |
 * Project: col(0: a)
-|   Stats = { Approx num rows = 5, Approx size bytes = 37 B, Accumulated selectivity = 0.90 }
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 37 B, Accumulated selectivity = 0.90 }}
 |   Batch Size = Range(0, 10]
 |
 * HashJoin(Inner):
@@ -289,31 +308,31 @@ def test_batch_size_from_udf_not_propagated_through_join():
 |   Track Indices: true
 |   Key Schema: a#Int64
 |   Null equals Nulls = [false]
-|   Stats = { Approx num rows = 5, Approx size bytes = 37 B, Accumulated selectivity = 0.90 }
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 37 B, Accumulated selectivity = 0.90 }}
 |   Batch Size = Range(0, 10]
 |\
 | * Filter: not(is_null(col(0: b)))
-| |   Stats = { Approx num rows = 5, Approx size bytes = 38 B, Accumulated selectivity = 0.95 }
+| |   Stats = {{ Approx num rows = 5, Approx size bytes = 38 B, Accumulated selectivity = 0.95 }}
 | |   Batch Size = Range(0, 10]
 | |
 | * InMemoryScan:
 | |   Schema = b#Int64
 | |   Size bytes = 40
-| |   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+| |   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 | |   Batch Size = Range(0, 10]
 |
 | * Filter: not(is_null(col(0: a)))
-| |   Stats = { Approx num rows = 5, Approx size bytes = 38 B, Accumulated selectivity = 0.95 }
+| |   Stats = {{ Approx num rows = 5, Approx size bytes = 38 B, Accumulated selectivity = 0.95 }}
 | |   Batch Size = Range(0, 131072]
 | |
 | * InMemoryScan:
 | |   Schema = a#Int64
 | |   Size bytes = 40
-| |   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+| |   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 | |   Batch Size = Range(0, 131072]
 
 """
-    assert clean_explain_output(string_io.getvalue().split("== Physical Plan ==")[-1]) == clean_explain_output(expected)
+    assert clean_explain_output(captured) == clean_explain_output(expected)
 
 
 def test_batch_size_from_into_batches():
@@ -366,26 +385,27 @@ def test_batch_size_from_into_batches_before_udf():
     df = df.select(make_noop_udf(10)(daft.col("a")))
     string_io = io.StringIO()
     df.explain(True, file=string_io)
-    print(string_io.getvalue())
-    expected = """
+    captured = string_io.getvalue().split("== Physical Plan ==")[-1]
+    [noop_id] = _extract_noop_ids(captured)
+    expected = f"""
 
-* UDF tests.dataframe.test_morsels.make_noop_udf.<locals>.noop:
-|   Expr = py_udf(col(0: a)) as a
+* UDF {NOOP_QUAL}:
+|   Expr = {_noop_func_id(noop_id)}(col(0: a)) as a
 |   Passthrough Columns = []
-|   Properties = { batch_size = 10, concurrency = 1, async = false, scalar = false }
-|   Resource request = None
-|   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+|   Properties = {{ batch_size = 10, concurrency = {CONCURRENCY}, on_error = raise, async = false, scalar = false }}
+|   Resource request = {{ num_gpus = 0 }}
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = 10
 |
 * IntoBatches: 10
-|   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = Range(8, 10]
 |
 * InMemoryScan:
 |   Schema = a#Int64
 |   Size bytes = 40
-|   Stats = { Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 40 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = Range(8, 10]
 
 """
-    assert clean_explain_output(string_io.getvalue().split("== Physical Plan ==")[-1]) == clean_explain_output(expected)
+    assert clean_explain_output(captured) == clean_explain_output(expected)

--- a/tests/expressions/test_legacy_udf.py
+++ b/tests/expressions/test_legacy_udf.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import os
 import threading
+import warnings
 
 import httpx
 import numpy as np
 import pyarrow as pa
 import pytest
 from openai import APIStatusError
+
+# This module intentionally tests the deprecated @daft.udf API for backward compatibility.
+warnings.filterwarnings("ignore", category=DeprecationWarning, message=r".*@daft\.udf.*")
+pytestmark = pytest.mark.filterwarnings(r"ignore:.*@daft\.udf.*:DeprecationWarning")
 
 import daft
 from daft import col

--- a/tests/functions/test_codecs.py
+++ b/tests/functions/test_codecs.py
@@ -245,7 +245,7 @@ def test_try_decode_utf8():
 def test_try_decode_utf8_perf():
     from daft import DataType as dt
 
-    @daft.udf(return_dtype=dt.string())
+    @daft.func.batch(return_dtype=dt.string())
     def try_decode_utf8_udf(binary_series):
         strings = []
         for binary in binary_series:

--- a/tests/integration/ray/test_autoscaling.py
+++ b/tests/integration/ray/test_autoscaling.py
@@ -52,7 +52,7 @@ def test_basic_autoscaling_cluster_with_existing_workers():
 
     with autoscaling_cluster_context(head_resources, worker_node_types):
 
-        @daft.udf(return_dtype=daft.DataType.list(daft.DataType.string()))
+        @daft.func.batch(return_dtype=daft.DataType.list(daft.DataType.string()))
         def fake_udf_needs_2_cpus(x):
             time.sleep(1)
             return x
@@ -76,10 +76,14 @@ def test_basic_autoscaling_gpu_cluster():
 
     with autoscaling_cluster_context(head_resources, worker_node_types):
         # Test basic Daft operations on the autoscaling cluster
-        @daft.udf(return_dtype=daft.DataType.list(daft.DataType.string()), num_gpus=2)
-        def fake_gpu_udf(x):
-            visible_devices = cuda_visible_devices()
-            return [visible_devices] * len(x)
+        @daft.cls(gpus=2)
+        class FakeGpuUdf:
+            @daft.method.batch(return_dtype=daft.DataType.list(daft.DataType.string()))
+            def __call__(self, x):
+                visible_devices = cuda_visible_devices()
+                return [visible_devices] * len(x)
+
+        fake_gpu_udf = FakeGpuUdf()
 
         df = daft.from_pydict({"x": [1, 2, 3, 4, 5], "y": [6, 7, 8, 9, 10]})
         result = df.select(fake_gpu_udf(col("x"))).to_pydict()

--- a/tests/ray/test_udf_ray_options.py
+++ b/tests/ray/test_udf_ray_options.py
@@ -5,8 +5,13 @@ import platform
 import subprocess
 import sys
 import time
+import warnings
 
 import pytest
+
+# This module tests legacy @daft.udf features (ray_options, conda runtime_env) with no new-API equivalent.
+warnings.filterwarnings("ignore", category=DeprecationWarning, message=r".*@daft\.udf.*")
+pytestmark = pytest.mark.filterwarnings(r"ignore:.*@daft\.udf.*:DeprecationWarning")
 import ray._private.ray_constants as ray_constants
 
 from daft import DataType, col, get_or_infer_runner_type, udf

--- a/tests/sql/test_sql_udfs.py
+++ b/tests/sql/test_sql_udfs.py
@@ -10,10 +10,11 @@ import daft
 def test_sql_udf():
     df = daft.from_pydict({"a": [1, 2, 3]})
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def multiply_by_n(data, n):
         return [i * n for i in data]
 
+    daft.attach_function(multiply_by_n)
     bindings = {"df": df}
 
     expected = {"b": [2, 4, 6]}
@@ -26,14 +27,16 @@ def test_sql_udf_ambigious_name():
     df = daft.from_pydict({"a": [1, 2, 3]})
     bindings = {"df": df}
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def multiply_by_n(data, n):
         return [i * n for i in data]
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def MULTIPLY_BY_N(data, n):
         return [i * n for i in data]
 
+    daft.attach_function(multiply_by_n)
+    daft.attach_function(MULTIPLY_BY_N)
     with pytest.raises(Exception, match="Invalid operation: Ambigiuous identifier for Function: found"):
         daft.sql("select multiply_by_n(a, n:=2) from df", **bindings).to_pydict()
 
@@ -42,10 +45,11 @@ def test_sql_udf_multi_column():
     df = daft.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
     bindings = {"df": df}
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def multiply(a, b):
         return a * b
 
+    daft.attach_function(multiply)
     expected = {"a": [4, 10, 18]}
     actual = daft.sql("select multiply(a, b) as a from df", **bindings).to_pydict()
     assert actual == expected
@@ -55,10 +59,11 @@ def test_sql_udf_multi_column_and_kwargs():
     df = daft.from_pydict({"first_name": ["Alice", "Bob", "Charlie"], "last_name": ["Smith", "Johnson", "Williams"]})
     bindings = {"df": df}
 
-    @daft.udf(return_dtype=str)
+    @daft.func.batch(return_dtype=str)
     def make_greeting(a, b, greeting="hello"):
         return [f"{greeting}, {a} {b}" for a, b in zip(a, b)]
 
+    daft.attach_function(make_greeting)
     expected = {
         "greeting1": ["hello, Alice Smith", "hello, Bob Johnson", "hello, Charlie Williams"],
         "greeting2": ["hi, Alice Smith", "hi, Bob Johnson", "hi, Charlie Williams"],
@@ -86,10 +91,11 @@ def test_sql_udf_kwargs_dont_work_as_positional():
     [("1.23", float), ("1", int), ("'hello'", str), ("['hello']", daft.DataType.list(daft.DataType.string()))],
 )
 def test_sql_udf_various_datatypes(value, return_type):
-    @daft.udf(return_dtype=return_type)
+    @daft.func.batch(return_dtype=return_type)
     def udf(column, literal):
         return [literal for i in column]
 
+    daft.attach_function(udf)
     df = daft.from_pydict({"x": [i for i in range(10)]})
 
     bindings = {"df": df}
@@ -110,10 +116,11 @@ def test_sql_udf_various_datatypes(value, return_type):
 
 
 def test_sql_udf_unregister():
-    @daft.udf(return_dtype=str)
+    @daft.func.batch(return_dtype=str)
     def my_udf(column, literal):
         return ["hello" for i in column]
 
+    daft.attach_function(my_udf)
     daft.detach_function("my_udf")
     with pytest.raises(Exception, match="Function `my_udf` not found"):
         daft.sql("select my_udf(1, literal:='world')").to_pydict()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -216,7 +216,7 @@ import daft
 
 print(daft.runners.get_or_infer_runner_type())
 
-@daft.udf(return_dtype=daft.DataType.string())
+@daft.func.batch(return_dtype=daft.DataType.string())
 def my_udf(foo):
     runner_type = daft.runners.get_or_infer_runner_type()
     return [f"{runner_type}_{f}" for f in foo]
@@ -244,7 +244,7 @@ daft.set_runner_native()
 
 print(daft.runners.get_or_infer_runner_type())
 
-@daft.udf(return_dtype=daft.DataType.string())
+@daft.func.batch(return_dtype=daft.DataType.string())
 def my_udf(foo):
     runner_type = daft.runners.get_or_infer_runner_type()
     return [f"{runner_type}_{f}" for f in foo]
@@ -268,7 +268,7 @@ daft.set_runner_ray()
 print(daft.runners.get_or_infer_runner_type())
 
 
-@daft.udf(return_dtype=daft.DataType.string())
+@daft.func.batch(return_dtype=daft.DataType.string())
 def my_udf(foo):
     runner_type = daft.runners.get_or_infer_runner_type()
     return [f"{runner_type}_{f}" for f in foo]

--- a/tests/test_resource_requests.py
+++ b/tests/test_resource_requests.py
@@ -2,8 +2,13 @@ from __future__ import annotations
 
 import copy
 import os
+import warnings
 
 import pytest
+
+# This module tests legacy @daft.udf features (override_options, with_concurrency) with no new-API equivalent.
+warnings.filterwarnings("ignore", category=DeprecationWarning, message=r".*@daft\.udf.*")
+pytestmark = pytest.mark.filterwarnings(r"ignore:.*@daft\.udf.*:DeprecationWarning")
 import ray
 
 import daft

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -84,15 +84,15 @@ def test_capture_states(monkeypatch):
     def inject_keyboard_interrupt():
         threading.Timer(2.0, lambda: signal.raise_signal(signal.SIGINT)).start()
 
-    @daft.udf(return_dtype=daft.DataType.string())
+    @daft.func.batch(return_dtype=daft.DataType.string())
     def failing_udf(_s: daft.Series):
         raise ValueError("This UDF will fail forever")
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def success_udf(s: daft.Series):
         return s
 
-    @daft.udf(return_dtype=daft.DataType.int64())
+    @daft.func.batch(return_dtype=daft.DataType.int64())
     def long_running_udf(s: daft.Series):
         time.sleep(10)
         return s
@@ -115,7 +115,7 @@ def test_capture_states(monkeypatch):
     df = daft.from_pydict({"x": ["1", "2", "3"]})
     df = df.with_column("y", failing_udf(df["x"]))
 
-    with pytest.raises(daft.errors.UDFException):
+    with pytest.raises(ValueError):
         df.collect()
 
     query_id = subscriber.query_ids[-1]


### PR DESCRIPTION
update tests to remove a bunch of deprecation warnings in CI/tests

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
