### PR TITLE
chore: Make the partition threshold to use `pre_shuffle_merge` configurable

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -181,6 +181,7 @@ def set_execution_config(
     default_morsel_size: int | None = None,
     shuffle_algorithm: str | None = None,
     pre_shuffle_merge_threshold: int | None = None,
+    pre_shuffle_merge_partition_threshold: int | None = None,
     scantask_max_parallel: int | None = None,
     native_parquet_writer: bool | None = None,
     min_cpu_per_task: float | None = None,
@@ -228,6 +229,7 @@ def set_execution_config(
         default_morsel_size: Default size of morsels used for the new local executor. Defaults to 131072 rows.
         shuffle_algorithm: The shuffle algorithm to use. Defaults to "auto", which will let Daft determine the algorithm. Options are "map_reduce", "pre_shuffle_merge", and "flight_shuffle".
         pre_shuffle_merge_threshold: Memory threshold in bytes for pre-shuffle merge. Defaults to 1GB
+        pre_shuffle_merge_partition_threshold: Number of partitions threshold to enable pre-shuffle merge when shuffle_algorithm is "auto". Defaults to 200.
         scantask_max_parallel: Set the max parallelism for running scan tasks simultaneously. Currently, this only works for Native Runner. If set to 0, all available CPUs will be used. Defaults to 8.
         native_parquet_writer: Whether to use the native parquet writer vs the pyarrow parquet writer. Defaults to `True`.
         min_cpu_per_task: Minimum CPU per task in the Ray runner. Defaults to 0.5.
@@ -268,6 +270,7 @@ def set_execution_config(
             default_morsel_size=default_morsel_size,
             shuffle_algorithm=shuffle_algorithm,
             pre_shuffle_merge_threshold=pre_shuffle_merge_threshold,
+            pre_shuffle_merge_partition_threshold=pre_shuffle_merge_partition_threshold,
             scantask_max_parallel=scantask_max_parallel,
             native_parquet_writer=native_parquet_writer,
             min_cpu_per_task=min_cpu_per_task,

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2248,6 +2248,7 @@ class PyDaftExecutionConfig:
         default_morsel_size: int | None = None,
         shuffle_algorithm: str | None = None,
         pre_shuffle_merge_threshold: int | None = None,
+        pre_shuffle_merge_partition_threshold: int | None = None,
         scantask_max_parallel: int | None = None,
         native_parquet_writer: bool | None = None,
         min_cpu_per_task: float | None = None,
@@ -2306,6 +2307,8 @@ class PyDaftExecutionConfig:
     def shuffle_algorithm(self) -> str: ...
     @property
     def pre_shuffle_merge_threshold(self) -> int: ...
+    @property
+    def pre_shuffle_merge_partition_threshold(self) -> int: ...
     @property
     def min_cpu_per_task(self) -> float: ...
     @property

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -131,6 +131,7 @@ pub struct DaftExecutionConfig {
     pub default_morsel_size: NonZeroUsize,
     pub shuffle_algorithm: String,
     pub pre_shuffle_merge_threshold: usize,
+    pub pre_shuffle_merge_partition_threshold: usize,
     pub scantask_max_parallel: usize,
     pub native_parquet_writer: bool,
     pub min_cpu_per_task: f64,
@@ -176,6 +177,7 @@ impl Default for DaftExecutionConfig {
             default_morsel_size: NonZeroUsize::new(128 * 1024).unwrap(),
             shuffle_algorithm: "auto".to_string(),
             pre_shuffle_merge_threshold: 1024 * 1024 * 1024, // 1GB
+            pre_shuffle_merge_partition_threshold: 200,
             scantask_max_parallel: 8,
             native_parquet_writer: true,
             min_cpu_per_task: 0.5,

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -113,6 +113,7 @@ impl PyDaftExecutionConfig {
         default_morsel_size=None,
         shuffle_algorithm=None,
         pre_shuffle_merge_threshold=None,
+        pre_shuffle_merge_partition_threshold=None,
         scantask_max_parallel=None,
         native_parquet_writer=None,
         min_cpu_per_task=None,
@@ -149,6 +150,7 @@ impl PyDaftExecutionConfig {
         default_morsel_size: Option<usize>,
         shuffle_algorithm: Option<&str>,
         pre_shuffle_merge_threshold: Option<usize>,
+        pre_shuffle_merge_partition_threshold: Option<usize>,
         scantask_max_parallel: Option<usize>,
         native_parquet_writer: Option<bool>,
         min_cpu_per_task: Option<f64>,
@@ -235,6 +237,7 @@ impl PyDaftExecutionConfig {
                     )
                 })?;
         }
+
         if let Some(shuffle_algorithm) = shuffle_algorithm {
             if !matches!(
                 shuffle_algorithm,
@@ -246,8 +249,13 @@ impl PyDaftExecutionConfig {
             }
             config.shuffle_algorithm = shuffle_algorithm.to_string();
         }
+
         if let Some(pre_shuffle_merge_threshold) = pre_shuffle_merge_threshold {
             config.pre_shuffle_merge_threshold = pre_shuffle_merge_threshold;
+        }
+
+        if let Some(pre_shuffle_merge_partition_threshold) = pre_shuffle_merge_partition_threshold {
+            config.pre_shuffle_merge_partition_threshold = pre_shuffle_merge_partition_threshold;
         }
 
         if let Some(scantask_max_parallel) = scantask_max_parallel {
@@ -402,17 +410,25 @@ impl PyDaftExecutionConfig {
     fn get_read_sql_partition_size_bytes(&self) -> PyResult<usize> {
         Ok(self.config.read_sql_partition_size_bytes)
     }
+
     #[getter]
     fn default_morsel_size(&self) -> PyResult<usize> {
         Ok(self.config.default_morsel_size.get())
     }
+
     #[getter]
     fn shuffle_algorithm(&self) -> PyResult<&str> {
         Ok(self.config.shuffle_algorithm.as_str())
     }
+
     #[getter]
     fn pre_shuffle_merge_threshold(&self) -> PyResult<usize> {
         Ok(self.config.pre_shuffle_merge_threshold)
+    }
+
+    #[getter]
+    fn pre_shuffle_merge_partition_threshold(&self) -> PyResult<usize> {
+        Ok(self.config.pre_shuffle_merge_partition_threshold)
     }
 
     #[getter]

--- a/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
+++ b/src/daft-distributed/src/pipeline_node/shuffles/translate_shuffle.rs
@@ -97,8 +97,11 @@ impl LogicalPlanToPipelineNodeTranslator {
             "auto" => {
                 let total_num_partitions = input_num_partitions * target_num_partitions;
                 let geometric_mean = (total_num_partitions as f64).sqrt() as usize;
-                const PARTITION_THRESHOLD_TO_USE_PRE_SHUFFLE_MERGE: usize = 200;
-                Ok(geometric_mean > PARTITION_THRESHOLD_TO_USE_PRE_SHUFFLE_MERGE)
+                Ok(geometric_mean
+                    > self
+                        .plan_config
+                        .config
+                        .pre_shuffle_merge_partition_threshold)
             }
             _ => Ok(false), // Default to naive map_reduce for unknown strategies
         }


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

When `shuffle_algorithm=auto`, it currently calculates the geometric mean value of partitions on the Map side and Reduce side, and hardcodes the use of `pre_shuffle_merge` when the value exceeds 200. This PR turns this threshold into a configuration item to enhance flexibility in task tuning.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
