### PR TITLE
fix: Handle account-scoped ADLS properties in Iceberg IO config conversion

### DIFF
--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -34,12 +34,13 @@ def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> I
                 nonlocal any_props_set
                 any_props_set = True
                 return value, None
-        prefix = f"{base_key}."
-        for key, value in props.items():
-            if key.startswith(prefix) and value:
-                any_props_set = True
-                account_name = key[len(prefix) :].split(".")[0]
-                return value, account_name
+        for candidate_key in (base_key, *alternate_keys):
+            prefix = f"{candidate_key}."
+            for key, value in props.items():
+                if key.startswith(prefix) and value:
+                    any_props_set = True
+                    account_name = key[len(prefix) :].split(".")[0]
+                    return value, account_name
         return None, None
 
     sas_token, scoped_account = get_adls_property_value("adls.sas-token", "adlfs.sas-token")

--- a/daft/io/iceberg/_iceberg.py
+++ b/daft/io/iceberg/_iceberg.py
@@ -27,6 +27,30 @@ def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> I
                 return property_value
         return None
 
+    def get_adls_property_value(base_key: str, *alternate_keys: str) -> tuple[Any | None, str | None]:
+        """Try exact key match first, then fall back to account-scoped keys (e.g. adls.sas-token.<account>.dfs.core.windows.net)."""
+        for key in (base_key, *alternate_keys):
+            if value := props.get(key):
+                nonlocal any_props_set
+                any_props_set = True
+                return value, None
+        prefix = f"{base_key}."
+        for key, value in props.items():
+            if key.startswith(prefix) and value:
+                any_props_set = True
+                account_name = key[len(prefix) :].split(".")[0]
+                return value, account_name
+        return None, None
+
+    sas_token, scoped_account = get_adls_property_value("adls.sas-token", "adlfs.sas-token")
+    access_key, scoped_account_from_key = get_adls_property_value("adls.account-key", "adlfs.account-key")
+    scoped_account = scoped_account or scoped_account_from_key
+
+    storage_account = get_first_property_value("adls.account-name", "adlfs.account-name")
+    if storage_account is None and scoped_account is not None:
+        storage_account = scoped_account
+        any_props_set = True
+
     io_config = IOConfig(
         s3=S3Config(
             endpoint_url=get_first_property_value("s3.endpoint"),
@@ -36,9 +60,9 @@ def _convert_iceberg_file_io_properties_to_io_config(props: dict[str, Any]) -> I
             session_token=get_first_property_value("s3.session-token", "client.session-token"),
         ),
         azure=AzureConfig(
-            storage_account=get_first_property_value("adls.account-name", "adlfs.account-name"),
-            access_key=get_first_property_value("adls.account-key", "adlfs.account-key"),
-            sas_token=get_first_property_value("adls.sas-token", "adlfs.sas-token"),
+            storage_account=storage_account,
+            access_key=access_key,
+            sas_token=sas_token,
             tenant_id=get_first_property_value("adls.tenant-id", "adlfs.tenant-id"),
             client_id=get_first_property_value("adls.client-id", "adlfs.client-id"),
             client_secret=get_first_property_value("adls.client-secret", "adlfs.client-secret"),

--- a/tests/io/iceberg/test_iceberg_io_config.py
+++ b/tests/io/iceberg/test_iceberg_io_config.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from daft.io.iceberg._iceberg import _convert_iceberg_file_io_properties_to_io_config
+
+
+def test_exact_adls_properties():
+    props = {
+        "adls.account-name": "myaccount",
+        "adls.sas-token": "mytoken",
+        "adls.account-key": "mykey",
+        "adls.tenant-id": "mytenant",
+        "adls.client-id": "myclient",
+        "adls.client-secret": "mysecret",
+    }
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    azure = io_config.azure
+    assert azure.storage_account == "myaccount"
+    assert azure.sas_token == "mytoken"
+    assert azure.access_key == "mykey"
+    assert azure.tenant_id == "mytenant"
+    assert azure.client_id == "myclient"
+    assert azure.client_secret == "mysecret"
+
+
+def test_scoped_sas_token_extracts_account():
+    props = {
+        "adls.sas-token.myaccount.dfs.core.windows.net": "scoped-token",
+    }
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    azure = io_config.azure
+    assert azure.sas_token == "scoped-token"
+    assert azure.storage_account == "myaccount"
+
+
+def test_scoped_account_key_extracts_account():
+    props = {
+        "adls.account-key.myaccount.dfs.core.windows.net": "scoped-key",
+    }
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    azure = io_config.azure
+    assert azure.access_key == "scoped-key"
+    assert azure.storage_account == "myaccount"
+
+
+def test_exact_key_takes_precedence_over_scoped():
+    props = {
+        "adls.sas-token": "exact-token",
+        "adls.sas-token.myaccount.dfs.core.windows.net": "scoped-token",
+        "adls.account-name": "exactaccount",
+    }
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    azure = io_config.azure
+    assert azure.sas_token == "exact-token"
+    assert azure.storage_account == "exactaccount"
+
+
+def test_explicit_account_name_not_overridden_by_scoped():
+    props = {
+        "adls.account-name": "explicit-account",
+        "adls.sas-token.scopedaccount.dfs.core.windows.net": "scoped-token",
+    }
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    azure = io_config.azure
+    assert azure.storage_account == "explicit-account"
+    assert azure.sas_token == "scoped-token"
+
+
+def test_empty_props_returns_none():
+    io_config = _convert_iceberg_file_io_properties_to_io_config({})
+    assert io_config is None
+
+
+def test_s3_properties_still_work():
+    props = {
+        "s3.endpoint": "https://s3.example.com",
+        "s3.region": "us-east-1",
+        "s3.access-key-id": "mykey",
+        "s3.secret-access-key": "mysecret",
+        "s3.session-token": "mytoken",
+    }
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    s3 = io_config.s3
+    assert s3.endpoint_url == "https://s3.example.com"
+    assert s3.region_name == "us-east-1"
+    assert s3.key_id == "mykey"
+    assert s3.access_key == "mysecret"
+    assert s3.session_token == "mytoken"

--- a/tests/io/iceberg/test_iceberg_io_config.py
+++ b/tests/io/iceberg/test_iceberg_io_config.py
@@ -70,6 +70,17 @@ def test_explicit_account_name_not_overridden_by_scoped():
     assert azure.sas_token == "scoped-token"
 
 
+def test_scoped_adlfs_alternate_key_prefix():
+    props = {
+        "adlfs.sas-token.myaccount.dfs.core.windows.net": "adlfs-scoped-token",
+    }
+    io_config = _convert_iceberg_file_io_properties_to_io_config(props)
+    assert io_config is not None
+    azure = io_config.azure
+    assert azure.sas_token == "adlfs-scoped-token"
+    assert azure.storage_account == "myaccount"
+
+
 def test_empty_props_returns_none():
     io_config = _convert_iceberg_file_io_properties_to_io_config({})
     assert io_config is None


### PR DESCRIPTION
## Summary
- When using Polaris catalog with ADLS vended credentials, PyIceberg returns account-scoped property keys like `adls.sas-token.<account>.dfs.core.windows.net` instead of plain `adls.sas-token`. These were silently ignored, causing auth failures.
- Added `get_adls_property_value()` helper that tries exact key match first, then falls back to scanning for scoped keys and extracts the account name from the suffix.
- Uses the scoped account name as fallback for `storage_account` when `adls.account-name` isn't explicitly set.

Closes #6357

## Test plan
- [x] `test_exact_adls_properties` — existing exact-match behavior preserved
- [x] `test_scoped_sas_token_extracts_account` — scoped SAS token + account extraction
- [x] `test_scoped_account_key_extracts_account` — scoped account key + account extraction
- [x] `test_exact_key_takes_precedence_over_scoped` — exact key wins over scoped
- [x] `test_explicit_account_name_not_overridden_by_scoped` — explicit account name preserved
- [x] `test_empty_props_returns_none` — no props returns None
- [x] `test_s3_properties_still_work` — S3 config unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)