### PR TITLE
fix(dashboard): request notification permission before enabling notifications

### DIFF
--- a/src/daft-dashboard/frontend/src/components/notifications-provider.tsx
+++ b/src/daft-dashboard/frontend/src/components/notifications-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 
 export type NotificationSettings = {
   onQueryStart: boolean;
@@ -24,13 +24,49 @@ export function useNotifications() {
 
 // ---------------------- Provider ---------------------- //
 
+async function requestNotificationPermission(): Promise<boolean> {
+  if (!("Notification" in window)) {
+    console.warn("This browser does not support notifications");
+    return false;
+  }
+  if (Notification.permission === "granted") {
+    return true;
+  }
+  if (Notification.permission === "denied") {
+    console.warn("Notification permission was previously denied");
+    return false;
+  }
+  const result = await Notification.requestPermission();
+  return result === "granted";
+}
+
 export function NotificationsProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const [onQueryStart, setOnQueryStart] = useState(false);
-  const [onQueryEnd, setOnQueryEnd] = useState(false);
+  const [onQueryStart, setOnQueryStartRaw] = useState(false);
+  const [onQueryEnd, setOnQueryEndRaw] = useState(false);
+
+  const setOnQueryStart = useCallback((newVal: boolean) => {
+    if (newVal) {
+      requestNotificationPermission().then(granted => {
+        setOnQueryStartRaw(granted);
+      });
+    } else {
+      setOnQueryStartRaw(false);
+    }
+  }, []);
+
+  const setOnQueryEnd = useCallback((newVal: boolean) => {
+    if (newVal) {
+      requestNotificationPermission().then(granted => {
+        setOnQueryEndRaw(granted);
+      });
+    } else {
+      setOnQueryEndRaw(false);
+    }
+  }, []);
 
   return (
     <NotificationsContext.Provider


### PR DESCRIPTION
## Summary
- The dashboard notification toggles ("On Query Start" / "On Query End") checked `Notification.permission === "granted"` before firing notifications, but never called `Notification.requestPermission()`. Since the browser default is `"default"`, notifications were silently skipped.
- Now `Notification.requestPermission()` is called when the user enables either toggle. If permission is denied (or the browser doesn't support it), the toggle stays off.

## Test plan
- [x] Enable "On Query End" in the dashboard notification settings
- [x] Verify browser permission prompt appears
- [x] Grant permission and run a query — verify macOS notification appears when query finishes
- [x] Deny permission and verify the toggle stays off

🤖 Generated with [Claude Code](https://claude.com/claude-code)