### PR TITLE
fix(dataframe): preserve field order in from_pylist

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -692,12 +692,15 @@ class DataFrame:
     @classmethod
     def _from_pylist(cls, data: list[dict[str, Any]]) -> "DataFrame":
         """Creates a DataFrame from a list of dictionaries."""
-        headers: set[str] = set()
+        headers_ordered: list[str] = []
+        seen_headers: set[str] = set()
         for row in data:
             if not isinstance(row, dict):
                 raise ValueError(f"Expected list of dictionaries of {{column_name: value}}, received: {type(row)}")
-            headers.update(row.keys())
-        headers_ordered = sorted(list(headers))
+            for key in row.keys():
+                if key not in seen_headers:
+                    seen_headers.add(key)
+                    headers_ordered.append(key)
         return cls._from_pydict(data={header: [row.get(header, None) for row in data] for header in headers_ordered})
 
     @classmethod

--- a/tests/dataframe/test_creation.py
+++ b/tests/dataframe/test_creation.py
@@ -116,6 +116,17 @@ def test_create_dataframe_list_ragged_keys() -> None:
     }
 
 
+def test_create_dataframe_list_preserves_field_order() -> None:
+    df = daft.from_pylist(
+        [
+            {"z": 1, "a": 2},
+            {"m": 3, "z": 4},
+            {"a": 5, "b": 6},
+        ]
+    )
+    assert df.column_names == ["z", "a", "m", "b"]
+
+
 def test_create_dataframe_list_empty_dicts() -> None:
     df = daft.from_pylist([{}, {}, {}])
     assert df.column_names == []


### PR DESCRIPTION
## Summary

This PR fixes column ordering in `daft.from_pylist` so that output columns follow first-seen key order from the input `list[dict]`, instead of alphabetical sorting.

## Changes

- Updated `DataFrame._from_pylist` in `daft/dataframe/dataframe.py`:
- Replaced `set + sorted` header collection with first-seen ordered collection.
- Preserved ragged-key semantics via `row.get(header, None)`.
- Added test in `tests/dataframe/test_creation.py`:
- `test_create_dataframe_list_preserves_field_order`
- Verifies output order is `['z', 'a', 'm', 'b']`.

## Behavior Change

- Previous behavior: columns were alphabetically sorted.
- New behavior: columns keep first-seen key order.

## Local Validation

- `DAFT_RUNNER=native make test EXTRA_ARGS="-v tests/dataframe/test_creation.py::test_create_dataframe_list_ragged_keys tests/dataframe/test_creation.py::test_create_dataframe_list_preserves_field_order"`
- `DAFT_RUNNER=native make test EXTRA_ARGS="-v tests/dataframe/test_creation.py"`

## Related Issue

Fixes #4591