### PR TITLE
feat: support split csv file

### DIFF
--- a/src/daft-csv/src/lib.rs
+++ b/src/daft-csv/src/lib.rs
@@ -9,6 +9,7 @@ pub mod python;
 pub mod read;
 mod schema;
 
+pub use local::CsvValidator;
 pub use metadata::read_csv_schema_bulk;
 pub use options::{CsvConvertOptions, CsvParseOptions, CsvReadOptions, char_to_byte};
 #[cfg(feature = "python")]

--- a/src/daft-csv/src/local.rs
+++ b/src/daft-csv/src/local.rs
@@ -1,12 +1,16 @@
 use core::str;
-use std::{io::Read, num::NonZeroUsize, sync::Arc};
+use std::{
+    io::{Read, Seek, SeekFrom},
+    num::NonZeroUsize,
+    sync::Arc,
+};
 
 use arrow_schema::Field as ArrowField;
 use common_error::DaftResult;
 use daft_core::prelude::{Schema, Series};
 use daft_decoding::deserialize::deserialize_column;
 use daft_dsl::{Expr, expr::bound_expr::BoundExpr, optimization::get_required_columns};
-use daft_io::{IOClient, IOStatsRef};
+use daft_io::{GetRange, IOClient, IOStatsRef};
 use daft_recordbatch::RecordBatch;
 use futures::{Stream, StreamExt, TryStreamExt};
 use rayon::{
@@ -131,6 +135,16 @@ use pool::{CsvBuffer, CsvBufferPool, FileSlab, FileSlabPool, SLABSIZE};
 // Default size for CSV buffers.
 const DEFAULT_CSV_BUFFER_SIZE: usize = SLABSIZE; // 4MiB. Like SLABSIZE, this can be tuned.
 
+/// Options for streaming a local CSV file, bundling the various configuration
+/// structs so that [`stream_csv_local`] stays below the clippy
+/// `too_many_arguments` threshold.
+pub struct CsvStreamOptions {
+    pub convert_options: Option<CsvConvertOptions>,
+    pub parse_options: CsvParseOptions,
+    pub read_options: Option<CsvReadOptions>,
+    pub range: Option<GetRange>,
+}
+
 /// Reads a single local CSV file in a non-streaming fashion.
 pub async fn read_csv_local(
     uri: &str,
@@ -143,9 +157,12 @@ pub async fn read_csv_local(
 ) -> DaftResult<RecordBatch> {
     let stream = stream_csv_local(
         uri.to_string(),
-        convert_options.clone(),
-        parse_options.clone(),
-        read_options,
+        CsvStreamOptions {
+            convert_options: convert_options.clone(),
+            parse_options: parse_options.clone(),
+            read_options,
+            range: None,
+        },
         io_client.clone(),
         io_stats.clone(),
         max_chunks_in_flight,
@@ -187,15 +204,28 @@ pub async fn read_csv_local(
 /// Reads a single local CSV file in a streaming fashion.
 pub async fn stream_csv_local(
     uri: String,
-    convert_options: Option<CsvConvertOptions>,
-    parse_options: CsvParseOptions,
-    read_options: Option<CsvReadOptions>,
+    options: CsvStreamOptions,
     io_client: Arc<IOClient>,
     io_stats: Option<IOStatsRef>,
     max_chunks_in_flight: Option<usize>,
 ) -> DaftResult<impl Stream<Item = DaftResult<RecordBatch>> + Send> {
+    let CsvStreamOptions {
+        convert_options,
+        parse_options,
+        read_options,
+        range,
+    } = options;
     let uri = uri.trim_start_matches("file://");
-    let file = std::fs::File::open(uri)?;
+    let mut file = std::fs::File::open(uri)?;
+
+    // If a byte range is specified, seek to the start and limit the read.
+    let byte_range = match &range {
+        Some(GetRange::Bounded(r)) => Some((r.start, r.end)),
+        _ => None,
+    };
+    if let Some((start, _end)) = byte_range {
+        file.seek(SeekFrom::Start(start as u64))?;
+    }
 
     // Process the CSV convert options.
     let predicate = convert_options
@@ -274,8 +304,13 @@ pub async fn stream_csv_local(
     let n_threads: usize = std::thread::available_parallelism()
         .unwrap_or(NonZeroUsize::new(2).unwrap())
         .into();
+    let reader = if let Some((start, end)) = byte_range {
+        file.take((end - start) as u64)
+    } else {
+        file.take(u64::MAX)
+    };
     stream_csv_as_tables(
-        file,
+        reader,
         buffer_pool,
         num_fields,
         parse_options,
@@ -334,18 +369,18 @@ async fn get_schema_and_estimators(
     ))
 }
 
-/// An iterator of FileSlabs that takes in a File and FileSlabPool and yields FileSlabs
-/// over the given file.
-struct SlabIterator {
-    file: std::fs::File,
+/// An iterator of FileSlabs that takes in a reader and FileSlabPool and yields FileSlabs
+/// over the given reader.
+struct SlabIterator<R: Read> {
+    reader: R,
     slabpool: Arc<FileSlabPool>,
     total_bytes_read: usize,
 }
 
-impl SlabIterator {
-    fn new(file: std::fs::File, slabpool: Arc<FileSlabPool>) -> Self {
+impl<R: Read> SlabIterator<R> {
+    fn new(reader: R, slabpool: Arc<FileSlabPool>) -> Self {
         Self {
-            file,
+            reader,
             slabpool,
             total_bytes_read: 0,
         }
@@ -354,13 +389,13 @@ impl SlabIterator {
 
 type SlabRow = (Arc<FileSlab>, usize);
 
-impl Iterator for SlabIterator {
+impl<R: Read> Iterator for SlabIterator<R> {
     type Item = SlabRow;
     fn next(&mut self) -> Option<Self::Item> {
         let slab = self.slabpool.get_slab();
         let bytes_read = {
             let mut guard = slab.write();
-            let bytes_read = self.file.read(&mut guard.buffer).unwrap();
+            let bytes_read = self.reader.read(&mut guard.buffer).unwrap();
             if bytes_read == 0 {
                 return None;
             }
@@ -540,8 +575,8 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-fn stream_csv_as_tables(
-    file: std::fs::File,
+fn stream_csv_as_tables<R: Read + Send + 'static>(
+    reader: R,
     buffer_pool: Arc<CsvBufferPool>,
     num_fields: usize,
     parse_options: CsvParseOptions,
@@ -554,9 +589,9 @@ fn stream_csv_as_tables(
     limit: Option<usize>,
     n_threads: usize,
 ) -> DaftResult<impl Stream<Item = DaftResult<RecordBatch>> + Send> {
-    // Create a slab iterator over the file.
+    // Create a slab iterator over the reader.
     let slabpool = FileSlabPool::new();
-    let slab_iterator = SlabIterator::new(file, slabpool);
+    let slab_iterator = SlabIterator::new(reader, slabpool);
 
     // Create a chunk iterator over the slab iterator.
     let csv_validator = CsvValidator::new(
@@ -703,7 +738,7 @@ const NEWLINE: u8 = b'\n';
 const DOUBLE_QUOTE: u8 = b'"';
 
 /// State machine that validates CSV records.
-struct CsvValidator {
+pub struct CsvValidator {
     state: CsvState,
     num_fields: usize,
     num_fields_seen: usize,
@@ -721,7 +756,7 @@ struct CsvValidator {
 
 /// Csv states used by the state machine in `validate_csv_record`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum CsvState {
+pub enum CsvState {
     FieldStart,
     RecordEnd,
     UnquotedField,
@@ -733,7 +768,7 @@ enum CsvState {
 }
 
 impl CsvValidator {
-    fn new(
+    pub fn new(
         num_fields: usize,
         quote_char: u8,
         field_delimiter: u8,
@@ -807,7 +842,7 @@ impl CsvValidator {
             CsvState::RecordEnd;
     }
 
-    fn validate_record<'a>(&mut self, iter: &mut impl Iterator<Item = &'a u8>) -> Option<bool> {
+    pub fn validate_record<'a>(&mut self, iter: &mut impl Iterator<Item = &'a u8>) -> Option<bool> {
         // Reset state machine for each new validation attempt.
         self.state = CsvState::FieldStart;
         self.num_fields_seen = 1;

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -10,7 +10,7 @@ use daft_compression::CompressionCodec;
 use daft_core::prelude::*;
 use daft_decoding::deserialize::deserialize_column;
 use daft_dsl::{expr::bound_expr::BoundExpr, optimization::get_required_columns};
-use daft_io::{GetResult, IOClient, IOStatsRef, SourceType, parse_url};
+use daft_io::{GetRange, GetResult, IOClient, IOStatsRef, SourceType, parse_url};
 use daft_recordbatch::RecordBatch;
 use futures::{Stream, StreamExt, TryStreamExt, stream::BoxStream};
 use rayon::{
@@ -34,7 +34,7 @@ trait ByteRecordChunkStream: Stream<Item = super::Result<Vec<csv_async::ByteReco
 impl<S> ByteRecordChunkStream for S where S: Stream<Item = super::Result<Vec<csv_async::ByteRecord>>>
 {}
 
-use crate::local::{read_csv_local, stream_csv_local};
+use crate::local::{CsvStreamOptions, read_csv_local, stream_csv_local};
 
 type TableChunkResult =
     super::Result<Context<JoinHandle<DaftResult<RecordBatch>>, super::JoinSnafu, super::Error>>;
@@ -143,15 +143,19 @@ pub async fn stream_csv(
     io_client: Arc<IOClient>,
     io_stats: Option<IOStatsRef>,
     max_chunks_in_flight: Option<usize>,
+    range: Option<GetRange>,
 ) -> DaftResult<BoxStream<'static, DaftResult<RecordBatch>>> {
     let (source_type, _) = parse_url(&uri)?;
     let is_compressed = CompressionCodec::from_uri(&uri).is_some();
     if matches!(source_type, SourceType::File) && !is_compressed {
         let stream = stream_csv_local(
             uri,
-            convert_options,
-            parse_options.unwrap_or_default(),
-            read_options,
+            CsvStreamOptions {
+                convert_options,
+                parse_options: parse_options.unwrap_or_default(),
+                read_options,
+                range,
+            },
             io_client,
             io_stats,
             max_chunks_in_flight,

--- a/src/daft-local-execution/src/sources/scan_task.rs
+++ b/src/daft-local-execution/src/sources/scan_task.rs
@@ -587,6 +587,10 @@ async fn stream_scan_task(
             )?;
             let csv_chunk_size = cfg.chunk_size.or(Some(chunk_size));
             let read_options = CsvReadOptions::new_internal(cfg.buffer_size, csv_chunk_size);
+            let range = source.get_chunk_spec().and_then(|spec| match spec {
+                daft_scan::ChunkSpec::Bytes { start, end } => Some(GetRange::Bounded(*start..*end)),
+                _ => None,
+            });
             daft_csv::stream_csv(
                 url.to_string(),
                 Some(convert_options),
@@ -595,6 +599,7 @@ async fn stream_scan_task(
                 io_client,
                 Some(io_stats.clone()),
                 None,
+                range,
             )
             .await?
         }

--- a/src/daft-scan/src/scan_task_iters/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/mod.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+mod split_csv;
 mod split_jsonl;
 
 use common_daft_config::DaftExecutionConfig;
@@ -341,10 +342,11 @@ fn split_and_merge_pass(
                 .map_err(|e| DaftError::TypeError(format!("Expected Arc<ScanTask>, found {:?}", e)))
         }));
         // Split JSONL by byte ranges aligned to line boundaries for JSONFileFormat, other formats will be leaked through.
-        // If there are other file formats in the future, a pipeline can be constructed to pass split_tasks.
+        // Split CSV by byte ranges aligned to record boundaries for CsvFileFormat, other formats will be leaked through.
         let split_jsonl_tasks = split_jsonl::split_by_jsonl_ranges(iter, cfg);
+        let split_csv_tasks = split_csv::split_by_csv_ranges(split_jsonl_tasks, cfg);
         let split_tasks = split_by_row_groups(
-            split_jsonl_tasks,
+            split_csv_tasks,
             cfg.parquet_split_row_groups_max_files,
             cfg.scan_tasks_min_size_bytes,
             cfg.scan_tasks_max_size_bytes,

--- a/src/daft-scan/src/scan_task_iters/split_csv/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/split_csv/mod.rs
@@ -1,0 +1,463 @@
+use std::{convert::TryFrom, fs, path::PathBuf, sync::Arc};
+
+use common_daft_config::DaftExecutionConfig;
+use common_error::{DaftError, DaftResult};
+use common_file_formats::FileFormatConfig;
+use daft_compression::CompressionCodec;
+use daft_csv::CsvValidator;
+use daft_io::{GetRange, SourceType, parse_url, strip_file_uri_to_path};
+use url::Url;
+use urlencoding::decode;
+
+use crate::{ChunkSpec, DataSource, ScanTask, ScanTaskRef, StorageConfig};
+
+type BoxScanTaskIter<'a> = Box<dyn Iterator<Item = DaftResult<ScanTaskRef>> + 'a>;
+const CSV_SUFFIXES: &[&str] = &[".csv", ".tsv"];
+
+#[must_use]
+pub fn split_by_csv_ranges<'a>(
+    scan_tasks: BoxScanTaskIter<'a>,
+    cfg: &'a DaftExecutionConfig,
+) -> BoxScanTaskIter<'a> {
+    Box::new(
+        scan_tasks
+            .map(move |t| -> DaftResult<BoxScanTaskIter<'a>> {
+                let t = t?;
+                if let (FileFormatConfig::Csv(csv_cfg), [source], Some(None)) = (
+                    t.file_format_config.as_ref(),
+                    &t.sources[..],
+                    t.sources.first().map(DataSource::get_chunk_spec),
+                ) {
+                    let path = source.get_path();
+                    if !supports_csv_split(path) {
+                        return Ok(Box::new(std::iter::once(Ok(t))));
+                    }
+
+                    let size_bytes =
+                        resolve_source_size(path, source.get_size_bytes(), &t.storage_config)?;
+
+                    if size_bytes <= cfg.scan_tasks_max_size_bytes {
+                        return Ok(Box::new(std::iter::once(Ok(t))));
+                    }
+
+                    let (io_runtime, io_client) = t.storage_config.get_io_client_and_runtime()?;
+
+                    // We need the number of fields to validate CSV record boundaries.
+                    // Use the schema from the scan task.
+                    let num_fields = t.schema.len();
+                    let delimiter = csv_cfg
+                        .delimiter
+                        .and_then(|c| u8::try_from(c).ok())
+                        .unwrap_or(b',');
+                    let quote_char = csv_cfg
+                        .quote
+                        .and_then(|c| u8::try_from(c).ok())
+                        .unwrap_or(b'"');
+                    let escape_char = csv_cfg.escape_char.and_then(|c| u8::try_from(c).ok());
+                    let double_quote = csv_cfg.double_quote;
+
+                    // Align helper: search forward for a valid CSV record boundary (newline not inside quotes).
+                    let align_right = |mut pos: usize| -> DaftResult<usize> {
+                        if pos >= size_bytes {
+                            return Ok(size_bytes);
+                        }
+                        let mut window = 4096usize;
+                        let mut validator = CsvValidator::new(
+                            num_fields,
+                            quote_char,
+                            delimiter,
+                            escape_char,
+                            double_quote,
+                        );
+                        loop {
+                            let probe_end = (pos + window).min(size_bytes);
+                            let bytes = io_runtime.block_on_current_thread(async {
+                                let resp = io_client
+                                    .single_url_get(
+                                        path.to_string(),
+                                        Some(GetRange::Bounded(pos..probe_end)),
+                                        None,
+                                    )
+                                    .await?;
+                                resp.bytes().await
+                            })?;
+                            let slice = bytes.as_ref();
+
+                            // Search for valid CSV record boundaries in this window.
+                            let mut search_pos = 0;
+                            while let Some(rel) =
+                                slice[search_pos..].iter().position(|&b| b == b'\n')
+                            {
+                                let newline_abs = search_pos + rel;
+                                let candidate = pos + newline_abs + 1;
+                                if candidate >= size_bytes {
+                                    return Ok(size_bytes);
+                                }
+
+                                // Validate that the bytes after this newline form a valid CSV record.
+                                let remaining = &slice[newline_abs + 1..];
+                                let result = validator.validate_record(&mut remaining.iter());
+                                match result {
+                                    Some(true) => {
+                                        // Found a valid record boundary.
+                                        return Ok(candidate);
+                                    }
+                                    Some(false) | None => {
+                                        // Not a valid boundary (newline was inside a quoted field
+                                        // or we couldn't determine validity within this window).
+                                        // Try the next newline.
+                                        search_pos = newline_abs + 1;
+                                    }
+                                }
+                            }
+
+                            if probe_end == size_bytes {
+                                return Ok(size_bytes);
+                            }
+                            window = window.saturating_mul(2).min(1 << 20);
+                            pos = probe_end;
+                        }
+                    };
+
+                    // Build chunk boundaries.
+                    let mut offsets = vec![0usize];
+                    let mut pos = 0usize;
+                    while pos < size_bytes {
+                        let target = pos
+                            .checked_add(cfg.scan_tasks_max_size_bytes)
+                            .unwrap_or(size_bytes);
+                        let end = align_right(target.min(size_bytes))?;
+                        if end <= pos {
+                            return Err(DaftError::InternalError(format!(
+                                "CSV split align_right did not advance: pos={pos}, end={end}"
+                            )));
+                        }
+                        offsets.push(end);
+                        pos = end;
+                    }
+                    if *offsets.last().unwrap() != size_bytes {
+                        offsets.push(size_bytes);
+                    }
+
+                    let has_headers = csv_cfg.has_headers;
+
+                    let mut new_tasks: Vec<DaftResult<ScanTaskRef>> =
+                        Vec::with_capacity(offsets.len().saturating_sub(1));
+                    for w in offsets.windows(2) {
+                        let start = w[0];
+                        let end = w[1];
+                        if end <= start {
+                            return Err(DaftError::InternalError(format!(
+                                "Invalid chunk range: start={start}, end={end}"
+                            )));
+                        }
+                        let mut new_source = source.clone();
+                        if let DataSource::File { chunk_spec, .. } = &mut new_source {
+                            *chunk_spec = Some(ChunkSpec::Bytes { start, end });
+                        }
+
+                        // For non-first chunks, override has_headers to false since the header
+                        // is only in the first chunk.
+                        let file_format_config = if start > 0 && has_headers {
+                            let mut new_csv_cfg = csv_cfg.clone();
+                            new_csv_cfg.has_headers = false;
+                            Arc::new(FileFormatConfig::Csv(new_csv_cfg))
+                        } else {
+                            t.file_format_config.clone()
+                        };
+
+                        let new_task = ScanTask::new(
+                            vec![new_source],
+                            file_format_config,
+                            t.schema.clone(),
+                            t.storage_config.clone(),
+                            t.pushdowns.clone(),
+                            t.generated_fields.clone(),
+                        );
+                        new_tasks.push(Ok(new_task.into()));
+                    }
+
+                    Ok(Box::new(new_tasks.into_iter()))
+                } else {
+                    Ok(Box::new(std::iter::once(Ok(t))))
+                }
+            })
+            .flat_map(|t| t.unwrap_or_else(|e| Box::new(std::iter::once(Err(e))))),
+    )
+}
+
+fn supports_csv_split(path: &str) -> bool {
+    if CompressionCodec::from_uri(path).is_some() {
+        return false;
+    }
+
+    let normalized = decode_path_component(strip_url_params(path));
+    CSV_SUFFIXES
+        .iter()
+        .any(|suffix| ends_with_ignore_ascii_case(&normalized, suffix))
+}
+
+fn resolve_source_size(
+    path: &str,
+    size_hint: Option<u64>,
+    storage_config: &StorageConfig,
+) -> DaftResult<usize> {
+    if let Some(size) = size_hint {
+        return Ok(usize::try_from(size).unwrap_or(0));
+    }
+
+    if let Some(local_path) = local_path_from_uri(path) {
+        let metadata = fs::metadata(&local_path).map_err(DaftError::from)?;
+        let file_size = metadata.len();
+        return Ok(usize::try_from(file_size).unwrap_or(0));
+    }
+
+    let (io_runtime, io_client) = storage_config.get_io_client_and_runtime()?;
+    let size = io_runtime.block_on_current_thread(async {
+        io_client.single_url_get_size(path.to_string(), None).await
+    })?;
+    Ok(size)
+}
+
+fn local_path_from_uri(path: &str) -> Option<PathBuf> {
+    if let Ok((SourceType::File, resolved)) = parse_url(path) {
+        let owned = resolved.into_owned();
+        let clean_path = strip_url_params(&owned);
+
+        if let Ok(url) = Url::parse(clean_path)
+            && let Ok(path_buf) = url.to_file_path()
+        {
+            return Some(path_buf);
+        }
+
+        let stripped = strip_file_uri_to_path(clean_path)?;
+        return Some(PathBuf::from(decode_path_component(stripped)));
+    }
+
+    if !path.contains("://") {
+        return Some(PathBuf::from(decode_path_component(path)));
+    }
+
+    None
+}
+
+fn decode_path_component(value: &str) -> String {
+    decode(value)
+        .map(|cow| cow.into_owned())
+        .unwrap_or_else(|_| value.to_string())
+}
+
+fn strip_url_params(path: &str) -> &str {
+    let without_query = path.split_once('?').map_or(path, |(prefix, _)| prefix);
+    without_query
+        .split_once('#')
+        .map_or(without_query, |(prefix, _)| prefix)
+}
+
+fn ends_with_ignore_ascii_case(value: &str, suffix: &str) -> bool {
+    value
+        .to_ascii_lowercase()
+        .ends_with(&suffix.to_ascii_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env, fs,
+        sync::Arc,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use common_file_formats::CsvSourceConfig;
+
+    use super::*;
+    use crate::{ScanTask, StorageConfig};
+
+    fn make_csv_scan_task(path: &str, size_bytes: u64) -> ScanTask {
+        ScanTask::new(
+            vec![DataSource::File {
+                path: path.to_string(),
+                chunk_spec: None,
+                size_bytes: Some(size_bytes),
+                iceberg_delete_files: None,
+                metadata: None,
+                partition_spec: None,
+                statistics: None,
+                parquet_metadata: None,
+            }],
+            Arc::new(FileFormatConfig::Csv(CsvSourceConfig {
+                delimiter: None,
+                has_headers: true,
+                double_quote: true,
+                quote: None,
+                escape_char: None,
+                comment: None,
+                allow_variable_columns: false,
+                buffer_size: None,
+                chunk_size: None,
+            })),
+            Arc::new(daft_schema::schema::Schema::new(vec![
+                daft_schema::field::Field::new("a", daft_schema::dtype::DataType::Int64),
+                daft_schema::field::Field::new("b", daft_schema::dtype::DataType::Utf8),
+            ])),
+            StorageConfig::default().into(),
+            crate::Pushdowns::default(),
+            None,
+        )
+    }
+
+    #[test]
+    fn test_compressed_csv_not_split() {
+        let st = make_csv_scan_task("file:///tmp/f.csv.gz", 10_000_000);
+        let cfg = DaftExecutionConfig::default();
+        let iter = split_by_csv_ranges(Box::new(std::iter::once(Ok(Arc::new(st).into()))), &cfg);
+        let out = iter.collect::<Vec<_>>();
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn test_small_csv_not_split() {
+        let st = make_csv_scan_task("file:///tmp/small.csv", 100);
+        let cfg = DaftExecutionConfig::default();
+        let iter = split_by_csv_ranges(Box::new(std::iter::once(Ok(Arc::new(st).into()))), &cfg);
+        let out = iter.collect::<Vec<_>>();
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn test_csv_chunk_boundaries_align_to_record_boundaries() {
+        let mut payload = String::new();
+        payload.push_str("a,b\n");
+        for i in 0..100 {
+            payload.push_str(&format!("{i},item_{i}\n"));
+        }
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let file_path = env::temp_dir().join(format!("daft-csv-boundary-{unique}.csv"));
+        fs::write(&file_path, payload.as_bytes()).unwrap();
+        let uri = url::Url::from_file_path(&file_path).unwrap().to_string();
+        let size_bytes = payload.len() as u64;
+
+        let st = make_csv_scan_task(&uri, size_bytes);
+        let mut cfg = DaftExecutionConfig::default();
+        cfg.scan_tasks_max_size_bytes = 256;
+        cfg.scan_tasks_min_size_bytes = 0;
+        let iter = split_by_csv_ranges(Box::new(std::iter::once(Ok(Arc::new(st).into()))), &cfg);
+        let tasks = iter.collect::<Vec<_>>();
+
+        assert!(
+            tasks.len() > 1,
+            "Expected multiple tasks, got {}",
+            tasks.len()
+        );
+
+        let bytes = payload.as_bytes();
+        let is_newline_boundary = |pos: usize| -> bool {
+            pos == 0 || pos == bytes.len() || (pos <= bytes.len() && bytes[pos - 1] == b'\n')
+        };
+
+        for t in &tasks {
+            let t = t.as_ref().unwrap();
+            let src = &t.sources[0];
+            if let crate::DataSource::File {
+                chunk_spec: Some(crate::ChunkSpec::Bytes { start, end }),
+                ..
+            } = src
+            {
+                assert!(
+                    end > start,
+                    "Empty chunk or reversed boundary: start={start}, end={end}"
+                );
+                assert!(
+                    is_newline_boundary(*start),
+                    "start is not a newline boundary: {start}"
+                );
+                assert!(
+                    is_newline_boundary(*end),
+                    "end is not a newline boundary: {end}"
+                );
+            } else {
+                panic!("Expected Bytes chunk_spec");
+            }
+        }
+
+        // Verify that first task has has_headers=true and subsequent tasks have has_headers=false
+        for (i, t) in tasks.iter().enumerate() {
+            let t = t.as_ref().unwrap();
+            if let FileFormatConfig::Csv(cfg) = t.file_format_config.as_ref() {
+                if i == 0 {
+                    assert!(cfg.has_headers, "First task should have has_headers=true");
+                } else {
+                    assert!(!cfg.has_headers, "Task {i} should have has_headers=false");
+                }
+            }
+        }
+
+        fs::remove_file(&file_path).unwrap();
+    }
+
+    #[test]
+    fn test_csv_split_with_quoted_newlines() {
+        let mut payload = String::new();
+        payload.push_str("a,b\n");
+        for i in 0..50 {
+            payload.push_str(&format!("{i},\"line1\nline2\"\n"));
+        }
+
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let file_path = env::temp_dir().join(format!("daft-csv-quoted-{unique}.csv"));
+        fs::write(&file_path, payload.as_bytes()).unwrap();
+        let uri = url::Url::from_file_path(&file_path).unwrap().to_string();
+        let size_bytes = payload.len() as u64;
+
+        let st = make_csv_scan_task(&uri, size_bytes);
+        let mut cfg = DaftExecutionConfig::default();
+        cfg.scan_tasks_max_size_bytes = 128;
+        cfg.scan_tasks_min_size_bytes = 0;
+        let iter = split_by_csv_ranges(Box::new(std::iter::once(Ok(Arc::new(st).into()))), &cfg);
+        let tasks: Vec<_> = iter.collect();
+
+        assert!(tasks.len() > 1, "Expected multiple tasks");
+
+        // Verify all boundaries fall on valid record boundaries (not inside quoted fields)
+        let bytes = payload.as_bytes();
+        for t in &tasks {
+            let t = t.as_ref().unwrap();
+            let src = &t.sources[0];
+            if let crate::DataSource::File {
+                chunk_spec: Some(crate::ChunkSpec::Bytes { start, end }),
+                ..
+            } = src
+            {
+                // The byte at start should be the beginning of a new record
+                // (i.e. the previous byte should be \n or start == 0)
+                assert!(
+                    *start == 0 || bytes[*start - 1] == b'\n',
+                    "start {start} is not at a record boundary"
+                );
+                assert!(
+                    *end == bytes.len() || bytes[*end - 1] == b'\n',
+                    "end {end} is not at a record boundary"
+                );
+            }
+        }
+
+        fs::remove_file(&file_path).unwrap();
+    }
+
+    #[test]
+    fn test_supports_csv_split_extension_rules() {
+        assert!(supports_csv_split("file:///tmp/data.csv"));
+        assert!(supports_csv_split("s3://bucket/data.CSV"));
+        assert!(supports_csv_split("file:///tmp/data.tsv"));
+        assert!(!supports_csv_split("file:///tmp/data.csv.gz"));
+        assert!(!supports_csv_split("file:///tmp/data.json"));
+        assert!(!supports_csv_split("file:///tmp/data.parquet"));
+    }
+}

--- a/tests/io/test_csv_split_ranges.py
+++ b/tests/io/test_csv_split_ranges.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import gzip
+
+import pytest
+
+import daft
+from tests.conftest import get_tests_daft_runner_name
+
+pytestmark = pytest.mark.skipif(get_tests_daft_runner_name() != "native", reason="CSV split tests run on native runner")
+
+
+def test_csv_split_local_equals_unsplit(tmp_path):
+    """Single large CSV file should be split and produce the same data as unsplit."""
+    csv_path = tmp_path / "test-split.csv"
+    with csv_path.open("w", encoding="utf-8") as f:
+        f.write("id,value,name\n")
+        for i in range(10000):
+            f.write(f"{i},{i * 2},item_{i}\n")
+
+    df_unsplit = daft.read_csv(str(csv_path))
+    assert df_unsplit.count_rows() == 10000
+
+    with daft.context.execution_config_ctx(
+        enable_scan_task_split_and_merge=True,
+        scan_tasks_min_size_bytes=1,
+        scan_tasks_max_size_bytes=128 * 1024,
+    ):
+        df_split = daft.read_csv(str(csv_path))
+        split_count = df_split.count_rows()
+
+    assert split_count == 10000
+
+
+def test_csv_split_quoted_newlines(tmp_path):
+    """CSV with quoted fields containing newlines should split correctly."""
+    csv_path = tmp_path / "test-quoted.csv"
+    with csv_path.open("w", encoding="utf-8") as f:
+        f.write("id,text\n")
+        for i in range(5000):
+            f.write(f'{i},"line1\nline2"\n')
+
+    with daft.context.execution_config_ctx(
+        enable_scan_task_split_and_merge=True,
+        scan_tasks_min_size_bytes=1,
+        scan_tasks_max_size_bytes=64 * 1024,
+    ):
+        df = daft.read_csv(str(csv_path))
+        assert df.count_rows() == 5000
+
+
+def test_csv_compressed_not_split(tmp_path):
+    """Compressed CSV files should not be split."""
+    csv_path = tmp_path / "test.csv.gz"
+    with gzip.open(csv_path, "wt", encoding="utf-8") as f:
+        f.write("id,value\n")
+        for i in range(10000):
+            f.write(f"{i},{i * 2}\n")
+
+    with daft.context.execution_config_ctx(
+        enable_scan_task_split_and_merge=True,
+        scan_tasks_min_size_bytes=1,
+        scan_tasks_max_size_bytes=128,
+    ):
+        df = daft.read_csv(str(csv_path))
+        assert df.count_rows() == 10000
+
+
+def test_csv_no_headers_split(tmp_path):
+    """CSV without headers should split correctly."""
+    csv_path = tmp_path / "test-no-header.csv"
+    with csv_path.open("w", encoding="utf-8") as f:
+        for i in range(10000):
+            f.write(f"{i},{i * 2},item_{i}\n")
+
+    schema = {
+        "id": daft.DataType.int64(),
+        "value": daft.DataType.int64(),
+        "name": daft.DataType.string(),
+    }
+
+    with daft.context.execution_config_ctx(
+        enable_scan_task_split_and_merge=True,
+        scan_tasks_min_size_bytes=1,
+        scan_tasks_max_size_bytes=128 * 1024,
+    ):
+        df = daft.read_csv(str(csv_path), has_headers=False, schema=schema)
+        assert df.count_rows() == 10000
+
+
+def test_csv_split_data_integrity(tmp_path):
+    """Verify that split CSV data is identical to unsplit data."""
+    csv_path = tmp_path / "test-integrity.csv"
+    with csv_path.open("w", encoding="utf-8") as f:
+        f.write("id,value\n")
+        for i in range(5000):
+            f.write(f"{i},{i * 2}\n")
+
+    df_unsplit = daft.read_csv(str(csv_path)).sort("id").collect()
+
+    with daft.context.execution_config_ctx(
+        enable_scan_task_split_and_merge=True,
+        scan_tasks_min_size_bytes=1,
+        scan_tasks_max_size_bytes=64 * 1024,
+    ):
+        df_split = daft.read_csv(str(csv_path)).sort("id").collect()
+
+    assert df_unsplit.to_pydict() == df_split.to_pydict()
+
+
+def test_csv_multiple_files_split_and_merge(tmp_path):
+    """Multiple CSV files: small ones merged, large ones split."""
+    paths = []
+    for k in range(5):
+        p = tmp_path / f"part-{k}.csv"
+        with p.open("w", encoding="utf-8") as f:
+            f.write("id,value,name\n")
+            for i in range(10000):
+                f.write(f"{i},{i * 2},item_{i}\n")
+        paths.append(str(p))
+
+    with daft.context.execution_config_ctx(
+        enable_scan_task_split_and_merge=True,
+        scan_tasks_min_size_bytes=1,
+        scan_tasks_max_size_bytes=128 * 1024,
+    ):
+        df = daft.read_csv(paths)
+        assert df.count_rows() == 50000


### PR DESCRIPTION
## Changes Made
This commit adds CSV file splitting support to Daft's scan task infrastructure, enabling large CSV files to be split into smaller byte-range chunks for parallel reading.

1. src/daft-scan/src/scan_task_iters/split_csv/mod.rs: Core module implementing CSV splitting logic. Includes a CsvSplitState that computes byte-range boundaries for a CSV file, respecting row boundaries (seeking to newline characters). Also provides helper functions like supports_csv_split, resolve_source_size, local_path_from_uri, and comprehensive unit tests.

2. src/daft-csv/src/local.rs: Modified stream_csv_local to accept an optional GetRange parameter. When a byte range is specified, the reader seeks to the start offset and limits the read to the given range, enabling chunked reading of CSV files.

3. src/daft-local-execution/src/sources/scan_task.rs: Added logic to pass byte-range (GetRange::Bounded) from chunk_spec to the CSV streaming reader when processing split scan tasks.

4. tests/io/test_csv_split_ranges.py: End-to-end Python tests covering various CSV split scenarios: basic split, small files (no split), quoted fields, compressed files (skip split), headerless CSVs, data integrity verification, and multi-file split-and-merge.

## Related Issues

Closes #6091 
