### PR TITLE
fix: Preserve materialized stats when splitting granular projections

### DIFF
--- a/src/daft-logical-plan/src/builder/mod.rs
+++ b/src/daft-logical-plan/src/builder/mod.rs
@@ -866,7 +866,6 @@ impl LogicalPlanBuilder {
                     },
                 )
                 .with_default_optimizations()
-                .enrich_with_stats(Some(execution_config.clone()))
                 .when(
                     !cfg.as_ref()
                         .is_some_and(|conf| conf.disable_join_reordering),
@@ -874,6 +873,7 @@ impl LogicalPlanBuilder {
                 )
                 .simplify_expressions()
                 .split_granular_projections()
+                .enrich_with_stats(Some(execution_config))
                 .build();
 
             let optimized_plan = optimizer.optimize(
@@ -939,10 +939,11 @@ impl LogicalPlanBuilder {
             .when(
                 !cfg.as_ref()
                     .is_some_and(|conf| conf.disable_join_reordering),
-                |builder| builder.reorder_joins(Some(execution_config)),
+                |builder| builder.reorder_joins(Some(execution_config.clone())),
             )
             .simplify_expressions()
             .split_granular_projections()
+            .enrich_with_stats(Some(execution_config))
             .build();
 
         let optimized_plan = optimizer.optimize(

--- a/src/daft-logical-plan/src/optimization/rules/granular_projections.rs
+++ b/src/daft-logical-plan/src/optimization/rules/granular_projections.rs
@@ -10,7 +10,7 @@ use daft_dsl::{
 use itertools::Itertools;
 
 use super::OptimizerRule;
-use crate::{LogicalPlan, ops::Project};
+use crate::{LogicalPlan, ops::Project, stats::StatsState};
 
 /// This rule will split projections into multiple projections such that expressions that
 /// need their own granular morsel sizing will be isolated. Right now it will be any async function that has a preferred batch size,
@@ -186,9 +186,11 @@ impl SplitGranularProjection {
                 }
             }
 
-            last_child = Arc::new(LogicalPlan::Project(
-                Project::try_new(last_child, out_exprs).unwrap(),
-            ));
+            let mut project = Project::try_new(last_child, out_exprs).unwrap();
+            if matches!(project.input.stats_state(), StatsState::Materialized(_)) {
+                project = project.with_materialized_stats();
+            }
+            last_child = Arc::new(LogicalPlan::Project(project));
         }
 
         // Only expose the columns that are in the original projection, not the inputs
@@ -201,9 +203,11 @@ impl SplitGranularProjection {
             .map(|c| resolved_col(Arc::from(c.0)).alias(Arc::from(c.1)))
             .collect_vec();
 
-        last_child = Arc::new(LogicalPlan::Project(
-            Project::try_new(last_child, last_fields).unwrap(),
-        ));
+        let mut project = Project::try_new(last_child, last_fields).unwrap();
+        if matches!(project.input.stats_state(), StatsState::Materialized(_)) {
+            project = project.with_materialized_stats();
+        }
+        last_child = Arc::new(LogicalPlan::Project(project));
 
         Ok(Transformed::yes(last_child))
     }

--- a/tests/dataframe/test_explain.py
+++ b/tests/dataframe/test_explain.py
@@ -284,3 +284,25 @@ def test_explain_with_explode_index_column():
     output = explain_to_text(df)
     assert "Explode" in output
     assert "Index column = idx" in output
+
+
+def test_explain_when_join_with_download():
+    df1 = daft.from_pydict(
+        {
+            "name": ["a", "b"],
+            "url": ["https://www.daft.ai/"] * 2,
+        }
+    ).with_column("bytes", col("url").download())
+
+    df2 = daft.from_pydict(
+        {
+            "name": ["a", "b"],
+            "value": [1, 2],
+        }
+    )
+
+    df = df1.join(df2, on="name", prefix="df2_")
+
+    output = explain_to_text(df, only_physical_plan=True)
+    assert "url_download" in output
+    assert "Join" in output

--- a/tests/dataframe/test_morsels.py
+++ b/tests/dataframe/test_morsels.py
@@ -92,12 +92,15 @@ def test_batch_size_from_udf_propagated_through_ops_to_scan():
 |   Passthrough Columns = []
 |   Properties = {{ batch_size = 10, concurrency = {CONCURRENCY}, on_error = raise, async = false, scalar = false }}
 |   Resource request = {{ num_gpus = 0 }}
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 156 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = 10
 |
 * Project: col(0: __TruncateRootUDF_0-0-0__) as __TruncateRootUDF_0-0-0__
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 156 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = Range(0, 10]
 |
 * Project: image_decode(col(0: {id_placeholder}), lit("raise"), lit(PyObject(RGB))) as __TruncateRootUDF_0-0-0__, col(1: data)
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 156 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = Range(0, 10]
 |
 * Project: url_download(col(0: data), lit(true), lit("raise"), lit(32), lit(PyObject(IOConfig:
@@ -190,6 +193,7 @@ def test_batch_size_from_udf_propagated_through_ops_to_scan():
 |   HuggingFaceConfig
 |   Anonymous = false
 |   ))) as {id_placeholder}, col(0: data)
+|   Stats = {{ Approx num rows = 5, Approx size bytes = 156 B, Accumulated selectivity = 1.00 }}
 |   Batch Size = Range(0, 10]
 |
 * InMemoryScan:


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Fix a painc error occurs where executing explain on a dataframe containing `join` and `download` operators in Ray Runner. For example:

```python
df1 = daft.from_pydict(
    {
        "name": ["a", "b"],
        "url": ["https://www.daft.ai/"] * 2,
    }
).with_column("bytes", col("url").download())

df2 = daft.from_pydict(
    {
        "name": ["a", "b"],
        "value": [1, 2],
    }
)

df = df1.join(df2, on="name", prefix="df2_")
df.explain(True)
```

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
