### PR TITLE
fix: Expose `json_target_filesize` execution config

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -171,6 +171,7 @@ def set_execution_config(
     parquet_inflation_factor: float | None = None,
     csv_target_filesize: int | None = None,
     csv_inflation_factor: float | None = None,
+    json_target_filesize: int | None = None,
     json_inflation_factor: float | None = None,
     text_inflation_factor: float | None = None,
     shuffle_aggregation_default_partitions: int | None = None,
@@ -216,6 +217,7 @@ def set_execution_config(
         parquet_inflation_factor: Inflation Factor of parquet files (In-Memory-Size / File-Size) ratio. Defaults to 3.0
         csv_target_filesize: Target File Size when writing out CSV Files. Defaults to 512MB
         csv_inflation_factor: Inflation Factor of CSV files (In-Memory-Size / File-Size) ratio. Defaults to 0.5
+        json_target_filesize: Target File Size when writing out JSON Files. Defaults to 512MB
         json_inflation_factor: Inflation Factor of JSON files (In-Memory-Size / File-Size) ratio. Defaults to 0.25
         text_inflation_factor: Inflation Factor of Text files (In-Memory-Size / File-Size) ratio. Defaults to 1.0
         shuffle_aggregation_default_partitions: Maximum number of partitions to create when performing aggregations on the Ray Runner. Defaults to 200, unless the number of input partitions is less than 200.
@@ -254,6 +256,7 @@ def set_execution_config(
             parquet_inflation_factor=parquet_inflation_factor,
             csv_target_filesize=csv_target_filesize,
             csv_inflation_factor=csv_inflation_factor,
+            json_target_filesize=json_target_filesize,
             json_inflation_factor=json_inflation_factor,
             text_inflation_factor=text_inflation_factor,
             shuffle_aggregation_default_partitions=shuffle_aggregation_default_partitions,

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2243,6 +2243,7 @@ class PyDaftExecutionConfig:
         parquet_inflation_factor: float | None = None,
         csv_target_filesize: int | None = None,
         csv_inflation_factor: float | None = None,
+        json_target_filesize: int | None = None,
         json_inflation_factor: float | None = None,
         text_inflation_factor: float | None = None,
         shuffle_aggregation_default_partitions: int | None = None,
@@ -2289,6 +2290,8 @@ class PyDaftExecutionConfig:
     def csv_target_filesize(self) -> int: ...
     @property
     def csv_inflation_factor(self) -> float: ...
+    @property
+    def json_target_filesize(self) -> int: ...
     @property
     def json_inflation_factor(self) -> float: ...
     @property

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -103,6 +103,7 @@ impl PyDaftExecutionConfig {
         parquet_inflation_factor=None,
         csv_target_filesize=None,
         csv_inflation_factor=None,
+        json_target_filesize=None,
         json_inflation_factor=None,
         text_inflation_factor=None,
         shuffle_aggregation_default_partitions=None,
@@ -137,6 +138,7 @@ impl PyDaftExecutionConfig {
         parquet_inflation_factor: Option<f64>,
         csv_target_filesize: Option<usize>,
         csv_inflation_factor: Option<f64>,
+        json_target_filesize: Option<usize>,
         json_inflation_factor: Option<f64>,
         text_inflation_factor: Option<f64>,
         shuffle_aggregation_default_partitions: Option<usize>,
@@ -198,6 +200,9 @@ impl PyDaftExecutionConfig {
         }
         if let Some(csv_inflation_factor) = csv_inflation_factor {
             config.csv_inflation_factor = csv_inflation_factor;
+        }
+        if let Some(json_target_filesize) = json_target_filesize {
+            config.json_target_filesize = json_target_filesize;
         }
         if let Some(json_inflation_factor) = json_inflation_factor {
             config.json_inflation_factor = json_inflation_factor;
@@ -355,6 +360,11 @@ impl PyDaftExecutionConfig {
     #[getter]
     fn get_csv_inflation_factor(&self) -> PyResult<f64> {
         Ok(self.config.csv_inflation_factor)
+    }
+
+    #[getter]
+    fn get_json_target_filesize(&self) -> PyResult<usize> {
+        Ok(self.config.json_target_filesize)
     }
 
     #[getter]

--- a/tests/cookbook/test_write.py
+++ b/tests/cookbook/test_write.py
@@ -302,3 +302,27 @@ def test_csv_partitioned_write_with_some_empty_partitions(tmp_path, with_morsel_
 
     read_back = daft.read_csv(tmp_path.as_posix() + "/**/*.csv").sort("x").to_pydict()
     assert read_back == data
+
+
+@pytest.fixture()
+def smaller_json_target_filesize():
+    with daft.execution_config_ctx(json_target_filesize=1024):
+        yield
+
+
+def test_json_write_multifile(tmp_path, smaller_json_target_filesize):
+    data = {"x": list(range(1_000))}
+    df = daft.from_pydict(data)
+    df2 = df.write_json(tmp_path)
+    assert len(df2) > 1
+    read_back = daft.read_json(tmp_path.as_posix() + "/*.json").sort(by="x").to_pydict()
+    assert read_back == data
+
+
+def test_json_write_multifile_with_partitioning(tmp_path, smaller_json_target_filesize):
+    data = {"x": list(range(1_000))}
+    df = daft.from_pydict(data)
+    df2 = df.write_json(tmp_path, partition_cols=[df["x"].alias("y") % 2])
+    assert len(df2) >= 4
+    read_back = daft.read_json(tmp_path.as_posix() + "/**/*.json").sort(by="x").to_pydict()
+    assert read_back["x"] == data["x"]

--- a/tests/io/test_json_roundtrip.py
+++ b/tests/io/test_json_roundtrip.py
@@ -541,3 +541,32 @@ def test_write_json_invalid_timestamp_format_raises_error(tmp_path):
 
     # Check that the error message is clear about the invalid format
     assert "Invalid timestamp format string" in str(exc_info.value)
+
+
+def test_write_json_target_filesize(tmp_path):
+    """Test that json_target_filesize parameter controls file splitting."""
+    data = {"x": list(range(10_000))}
+    df = daft.from_pydict(data)
+
+    with daft.execution_config_ctx(json_target_filesize=1024):
+        output_files = df.write_json(str(tmp_path))
+
+    assert len(output_files) > 1, "Expected multiple files to be written with small target filesize"
+
+    read_back = daft.read_json(str(tmp_path) + "/*.json").sort(by="x").to_pydict()
+    assert read_back == data
+
+
+def test_write_json_target_filesize_with_partitioning(tmp_path):
+    """Test that json_target_filesize works correctly with partitioning."""
+    data = {"x": list(range(10_000)), "partition": [i % 3 for i in range(10_000)]}
+    df = daft.from_pydict(data)
+
+    with daft.execution_config_ctx(json_target_filesize=1024):
+        output_files = df.write_json(str(tmp_path), partition_cols=["partition"])
+
+    assert len(output_files) >= 3, "Expected at least 3 partitions"
+
+    read_back = daft.read_json(str(tmp_path) + "/**/*.json").sort(by="x").to_pydict()
+    assert read_back["x"] == data["x"]
+    assert read_back["partition"] == data["partition"]


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

Expose the `json_target_filesize` configuration to allow users to set the json file size when writing JSON.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
