### PR TITLE
docs(lance): document scalar index creation

### DIFF
--- a/docs/connectors/lance.md
+++ b/docs/connectors/lance.md
@@ -415,7 +415,7 @@ Daft's distributed implementation currently supports `INVERTED`, `FTS`, and `BTR
     df.show()
     ```
 
-#### Build a BTREE index for faster range filters
+#### Build a BTREE index for faster point-lookup filters
 
 === "🐍 Python"
 
@@ -431,8 +431,12 @@ Daft's distributed implementation currently supports `INVERTED`, `FTS`, and `BTR
         name="price_btree",
     )
 
+    # BTREE index accelerates equality / IS IN / IS NULL point lookups.
+    # Range filters (>, <, BETWEEN) fall back to per-fragment scanning in Daft's
+    # current scanner layer and do not use the index.
     df = daft.read_lance(uri)
-    df.where(df["price"] > 30).show()
+    df.where(df["price"] == 30).show()
+    ```
     ```
 
 ### Data Evolution


### PR DESCRIPTION
Add a new section to the Lance connector docs describing how to build scalar indexes with `daft.io.lance.create_scalar_index`, including examples for inverted/full-text search and BTREE range filtering.

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
