### PR TITLE
chore: removes unnecessary pushdown builder code

### DIFF
--- a/examples/hello/src/lib.rs
+++ b/examples/hello/src/lib.rs
@@ -49,12 +49,19 @@ impl DaftScalarFunction for Greet {
     }
 
     fn call(&self, args: Vec<ArrowData>) -> DaftResult<ArrowData> {
+        // Extract the first (and only) argument from the function call, this is the mutual type.
         let data = args.into_iter().next().unwrap();
+
+        // Convert the ArrowData input structs to FFI-compatible Arrow array and schema so we can get it into the arrow-rs library.
         let ffi_array: arrow::ffi::FFI_ArrowArray = data.array.into();
         let ffi_schema: arrow::ffi::FFI_ArrowSchema = data.schema.into();
+
+        // Now make it into an arrow-rs string array.
         let arrow_data = unsafe { arrow::ffi::from_ffi(ffi_array, &ffi_schema) }?;
         let input = arrow::array::make_array(arrow_data);
         let names = input.as_string::<i64>();
+
+        // Actually do the computation: build a result array of "Hello, <name>!" strings.
         let mut builder = StringBuilder::with_capacity(names.len(), names.len() * 16);
         for i in 0..names.len() {
             if names.is_null(i) {
@@ -64,7 +71,11 @@ impl DaftScalarFunction for Greet {
             }
         }
         let output = builder.finish();
+
+        // Convert the result array back to FFI-compatible objects required by Daft.
         let (out_arr, out_sch) = arrow::ffi::to_ffi(&output.to_data())?;
+
+        // Wrap as Daft's ArrowData for integration with Python and Daft machinery.
         Ok(ArrowData {
             array: out_arr.into(),
             schema: out_sch.into(),

--- a/src/daft-scan/src/pushdowns.rs
+++ b/src/daft-scan/src/pushdowns.rs
@@ -12,7 +12,7 @@ pub trait SupportsPushdownFilters {
     fn push_filters(&self, filter: &[ExprRef]) -> (Vec<ExprRef>, Vec<ExprRef>);
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Pushdowns {
     /// Optional filters to apply to the source data.
     pub filters: Option<ExprRef>,
@@ -33,12 +33,6 @@ pub struct Pushdowns {
     /// This is used to indicate that the scan operator can perform an aggregation.
     /// This is useful for scans that can perform aggregations like `count`
     pub aggregation: Option<ExprRef>,
-}
-
-impl Default for Pushdowns {
-    fn default() -> Self {
-        Self::new(None, None, None, None, None, None)
-    }
 }
 
 impl Pushdowns {
@@ -73,13 +67,8 @@ impl Pushdowns {
     #[must_use]
     pub fn with_limit(&self, limit: Option<usize>) -> Self {
         Self {
-            filters: self.filters.clone(),
-            partition_filters: self.partition_filters.clone(),
-            columns: self.columns.clone(),
             limit,
-            sharder: self.sharder.clone(),
-            pushed_filters: self.pushed_filters.clone(),
-            aggregation: self.aggregation.clone(),
+            ..self.clone()
         }
     }
 
@@ -87,77 +76,47 @@ impl Pushdowns {
     pub fn with_filters(&self, filters: Option<ExprRef>) -> Self {
         Self {
             filters,
-            partition_filters: self.partition_filters.clone(),
-            columns: self.columns.clone(),
-            limit: self.limit,
-            sharder: self.sharder.clone(),
-            pushed_filters: self.pushed_filters.clone(),
-            aggregation: self.aggregation.clone(),
+            ..self.clone()
         }
     }
 
     #[must_use]
     pub fn with_partition_filters(&self, partition_filters: Option<ExprRef>) -> Self {
         Self {
-            filters: self.filters.clone(),
             partition_filters,
-            columns: self.columns.clone(),
-            limit: self.limit,
-            sharder: self.sharder.clone(),
-            pushed_filters: self.pushed_filters.clone(),
-            aggregation: self.aggregation.clone(),
+            ..self.clone()
         }
     }
 
     #[must_use]
     pub fn with_columns(&self, columns: Option<Arc<Vec<String>>>) -> Self {
         Self {
-            filters: self.filters.clone(),
-            partition_filters: self.partition_filters.clone(),
             columns,
-            limit: self.limit,
-            sharder: self.sharder.clone(),
-            pushed_filters: self.pushed_filters.clone(),
-            aggregation: self.aggregation.clone(),
+            ..self.clone()
         }
     }
 
     #[must_use]
     pub fn with_sharder(&self, sharder: Option<Sharder>) -> Self {
         Self {
-            filters: self.filters.clone(),
-            partition_filters: self.partition_filters.clone(),
-            columns: self.columns.clone(),
-            limit: self.limit,
             sharder,
-            pushed_filters: self.pushed_filters.clone(),
-            aggregation: self.aggregation.clone(),
+            ..self.clone()
         }
     }
 
     #[must_use]
     pub fn with_pushed_filters(&self, pushed_filters: Option<Vec<ExprRef>>) -> Self {
         Self {
-            filters: self.filters.clone(),
-            partition_filters: self.partition_filters.clone(),
-            columns: self.columns.clone(),
-            limit: self.limit,
-            sharder: self.sharder.clone(),
             pushed_filters,
-            aggregation: self.aggregation.clone(),
+            ..self.clone()
         }
     }
 
     #[must_use]
     pub fn with_aggregation(&self, aggregation: Option<ExprRef>) -> Self {
         Self {
-            filters: self.filters.clone(),
-            partition_filters: self.partition_filters.clone(),
-            columns: self.columns.clone(),
-            limit: self.limit,
-            sharder: self.sharder.clone(),
-            pushed_filters: self.pushed_filters.clone(),
             aggregation,
+            ..self.clone()
         }
     }
 


### PR DESCRIPTION
## Changes Made

Uses the spread operator to remove a bunch of extra code that requires maintenance. This is stack on the rchowell/source-cleanup branch (and PR). 

## Related Issues

- Closes #6401 
