### PR TITLE
fix(optimizer): allow column-alias projections in join reordering

### DIFF
--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -777,16 +777,34 @@ impl JoinGraphBuilder {
                 LogicalPlan::Project(Project {
                     input, projection, ..
                 }) => {
-                    // TODO(desmond): Currently we only support reordering through Project nodes that only project columns. Ideally we should
-                    // perform a projection pushup at the start of join reordering in order to separate out this logic from join graph construction,
-                    // and so that we can reorder joins that have more complex projections in between them.
-                    let reorderable_project = projection
+                    // Walk through projects that are pure column references
+                    // (original behavior) or non-narrowing alias renames.
+                    //
+                    // Pure column selects (even narrowing) are safe because they
+                    // add no renames to `final_name_map`.
+                    //
+                    // Alias renames require a non-narrowing check: narrowing
+                    // alias projects cause `final_name_map` renames to leak
+                    // across join boundaries when the same source appears on
+                    // multiple sides of a join (e.g. self-joins).
+                    let all_columns = projection
                         .iter()
                         .all(|e| matches!(e.as_ref(), Expr::Column(_)));
-                    if reorderable_project {
+                    let reorderable = all_columns || {
+                        let all_simple = projection.iter().all(|e| e.input_mapping().is_some());
+                        all_simple && {
+                            let input_names: HashSet<String> =
+                                input.schema().names().into_iter().collect();
+                            let mapped_inputs: HashSet<String> = projection
+                                .iter()
+                                .filter_map(|e| e.input_mapping())
+                                .collect();
+                            input_names.is_subset(&mapped_inputs)
+                        }
+                    };
+                    if reorderable {
                         plan = input;
                     } else {
-                        // Encountered a non-reorderable Project. Add the root plan at the top of the current linear chain as a relation to join.
                         self.add_relation(root_plan);
                         break;
                     }
@@ -1164,7 +1182,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Temporarily skipped - Join reordering algorithm needs to be updated to do a projection pushup"]
     fn test_create_join_graph_multiple_renames() {
         //                InnerJoin (a_beta = c)
         //                 /          \
@@ -1302,7 +1319,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "Temporarily skipped - Join reordering algorithm needs to be updated to do a projection pushup"]
+    #[ignore = "Requires scoped final_name_map to walk through narrowing projections"]
     fn test_create_join_graph_with_non_join_projections_and_filters() {
         //                InnerJoin (a = d)
         //                    /        \


### PR DESCRIPTION
The join graph builder's `process_node` checked reorderability of projections with `matches!(e.as_ref(), Expr::Column(_))`, which rejected `Alias(Column(_), _)` expressions. Any simple rename between joins (e.g. `col("a").alias("b")`) caused the entire subtree below to become a leaf relation, preventing join reordering across that boundary.

The fix adds a second path: when a project contains aliases (not just bare columns), we walk through it if the project is non-narrowing - every input column has a corresponding output expression, so no columns are dropped. Pure column-only projects preserve the original behavior.

Narrowing alias projects must remain barriers because `final_name_map` is global: walking through a narrowing alias project causes renames to leak across join boundaries when the same source appears on multiple sides of a join (e.g. self-joins). Handling this requires scoping `final_name_map` per join level, left as future work.

Un-ignores `test_create_join_graph_multiple_renames` (alias chains between joins). Updates the ignore reason on the remaining test.