### PR TITLE
feat: add native H3 geospatial functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "daft-file",
  "daft-functions",
  "daft-functions-binary",
+ "daft-functions-h3",
  "daft-functions-json",
  "daft-functions-list",
  "daft-functions-serde",
@@ -2722,6 +2723,18 @@ dependencies = [
  "flate2",
  "serde",
  "simdutf8",
+ "typetag",
+]
+
+[[package]]
+name = "daft-functions-h3"
+version = "0.3.0-dev0"
+dependencies = [
+ "common-error",
+ "daft-core",
+ "daft-dsl",
+ "h3o",
+ "serde",
  "typetag",
 ]
 
@@ -3854,6 +3867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_eq"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4250,6 +4269,25 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "h3o"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60271ce96dbb45e1ac18955e1b44e9e04dcea01df040819efdedc56c0058c367"
+dependencies = [
+ "ahash",
+ "either",
+ "float_eq",
+ "h3o-bit",
+ "libm",
+]
+
+[[package]]
+name = "h3o-bit"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b42eb4efef1f96510ae1a33b2682562a677d504641e9903a77bf5c666b9013e"
 
 [[package]]
 name = "half"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ daft-dsl = {path = "src/daft-dsl", default-features = false}
 daft-file = {path = "src/daft-file", default-features = false}
 daft-functions = {path = "src/daft-functions"}
 daft-functions-binary = {path = "src/daft-functions-binary", default-features = false}
+daft-functions-h3 = {path = "src/daft-functions-h3", default-features = false}
 daft-functions-json = {path = "src/daft-functions-json", default-features = false}
 daft-functions-list = {path = "src/daft-functions-list", default-features = false}
 daft-functions-serde = {path = "src/daft-functions-serde", default-features = false}
@@ -85,6 +86,7 @@ python = [
   "daft-dsl/python",
   "daft-file/python",
   "daft-functions-binary/python",
+  "daft-functions-h3/python",
   "daft-functions-json/python",
   "daft-functions-list/python",
   "daft-functions-utf8/python",
@@ -196,6 +198,7 @@ members = [
   "src/daft-file",
   "src/daft-functions",
   "src/daft-functions-binary",
+  "src/daft-functions-h3",
   "src/daft-functions-json",
   "src/daft-functions-list",
   "src/daft-functions-uri",
@@ -278,6 +281,7 @@ daft-ext = {path = "src/daft-ext"}
 daft-file = {path = "src/daft-file"}
 daft-functions = {path = "src/daft-functions"}
 daft-functions-binary = {path = "src/daft-functions-binary"}
+daft-functions-h3 = {path = "src/daft-functions-h3"}
 daft-functions-json = {path = "src/daft-functions-json"}
 daft-functions-list = {path = "src/daft-functions-list"}
 daft-functions-temporal = {path = "src/daft-functions-temporal"}
@@ -298,6 +302,7 @@ daft-sql = {path = "src/daft-sql"}
 dashmap = "6.1.0"
 educe = "0.6.0"
 futures = "0.3.30"
+h3o = "0.9"
 hashbrown = "0.16"
 html-escape = "0.2.13"
 image = {version = "0.25.10", default-features = false}

--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -71,6 +71,17 @@ from .similarity import (
 )
 
 from .file_ import file, file_size, video_file, audio_file, guess_mime_type
+from .h3 import (
+    h3_latlng_to_cell,
+    h3_cell_to_lat,
+    h3_cell_to_lng,
+    h3_cell_to_str,
+    h3_str_to_cell,
+    h3_cell_resolution,
+    h3_cell_is_valid,
+    h3_cell_parent,
+    h3_grid_distance,
+)
 
 from .image import (
     resize,
@@ -315,6 +326,15 @@ __all__ = [
     "format",
     "get",
     "guess_mime_type",
+    "h3_cell_is_valid",
+    "h3_cell_parent",
+    "h3_cell_resolution",
+    "h3_cell_to_lat",
+    "h3_cell_to_lng",
+    "h3_cell_to_str",
+    "h3_grid_distance",
+    "h3_latlng_to_cell",
+    "h3_str_to_cell",
     "hash",
     "hour",
     "ilike",

--- a/daft/functions/h3.py
+++ b/daft/functions/h3.py
@@ -1,6 +1,9 @@
 """H3 Functions.
 
-Hexagonal geospatial indexing functions backed by h3o.
+Functions for the `H3 <https://h3geo.org/>`_ hierarchical geospatial indexing system.
+
+All functions that take a cell index accept both UInt64 and Utf8 (hex string) columns.
+To convert between representations, use :func:`h3_str_to_cell` and :func:`h3_cell_to_str`.
 """
 
 from __future__ import annotations
@@ -14,40 +17,79 @@ def h3_latlng_to_cell(lat: Expression, lng: Expression, resolution: int) -> Expr
 
 
 def h3_cell_to_lat(cell: Expression) -> Expression:
-    """Returns the latitude of the center of an H3 cell."""
+    """Returns the latitude of the center of an H3 cell.
+
+    Args:
+        cell: H3 cell index (UInt64 or Utf8 hex string).
+    """
     return Expression._call_builtin_scalar_fn("h3_cell_to_lat", cell)
 
 
 def h3_cell_to_lng(cell: Expression) -> Expression:
-    """Returns the longitude of the center of an H3 cell."""
+    """Returns the longitude of the center of an H3 cell.
+
+    Args:
+        cell: H3 cell index (UInt64 or Utf8 hex string).
+    """
     return Expression._call_builtin_scalar_fn("h3_cell_to_lng", cell)
 
 
 def h3_cell_to_str(cell: Expression) -> Expression:
-    """Converts an H3 cell index (UInt64) to its hex string representation."""
+    """Converts an H3 cell index to its hex string representation.
+
+    Args:
+        cell: H3 cell index (UInt64 or Utf8 hex string).
+    """
     return Expression._call_builtin_scalar_fn("h3_cell_to_str", cell)
 
 
 def h3_str_to_cell(hex: Expression) -> Expression:
-    """Converts an H3 hex string to a cell index (UInt64)."""
+    """Converts an H3 hex string to a cell index (UInt64).
+
+    For maximum throughput, convert to UInt64 once at the top of a pipeline
+    and operate on integers throughout, rather than passing hex strings to
+    every function call.
+    """
     return Expression._call_builtin_scalar_fn("h3_str_to_cell", hex)
 
 
 def h3_cell_resolution(cell: Expression) -> Expression:
-    """Returns the resolution (0-15) of an H3 cell index."""
+    """Returns the resolution (0-15) of an H3 cell index.
+
+    Args:
+        cell: H3 cell index (UInt64 or Utf8 hex string).
+    """
     return Expression._call_builtin_scalar_fn("h3_cell_resolution", cell)
 
 
 def h3_cell_is_valid(cell: Expression) -> Expression:
-    """Returns true if the UInt64 value is a valid H3 cell index."""
+    """Returns true if the value is a valid H3 cell index.
+
+    Args:
+        cell: H3 cell index (UInt64 or Utf8 hex string).
+    """
     return Expression._call_builtin_scalar_fn("h3_cell_is_valid", cell)
 
 
 def h3_cell_parent(cell: Expression, resolution: int) -> Expression:
-    """Returns the parent cell index at the given resolution."""
+    """Returns the parent cell index at the given resolution.
+
+    The output type matches the input type: string in, string out.
+
+    Args:
+        cell: H3 cell index (UInt64 or Utf8 hex string).
+        resolution: Target resolution (0-15). Must be coarser (lower) than the cell's resolution.
+    """
     return Expression._call_builtin_scalar_fn("h3_cell_parent", cell, resolution=resolution)
 
 
 def h3_grid_distance(a: Expression, b: Expression) -> Expression:
-    """Returns the grid distance (number of H3 cells) between two cells."""
+    """Returns the grid distance (number of H3 cells) between two cells.
+
+    Returns null if cells are not comparable (different resolutions or pentagonal distortion).
+
+    Args:
+        a: H3 cell index (UInt64 or Utf8 hex string).
+        b: H3 cell index (UInt64 or Utf8 hex string).
+    """
     return Expression._call_builtin_scalar_fn("h3_grid_distance", a, b)

--- a/daft/functions/h3.py
+++ b/daft/functions/h3.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from daft.expressions import Expression
+
+
+def h3_latlng_to_cell(lat: Expression, lng: Expression, resolution: int) -> Expression:
+    """Converts latitude/longitude coordinates to an H3 cell index at the given resolution (0-15)."""
+    return Expression._call_builtin_scalar_fn("h3_latlng_to_cell", lat, lng, resolution=resolution)
+
+
+def h3_cell_to_lat(cell: Expression) -> Expression:
+    """Returns the latitude of the center of an H3 cell."""
+    return Expression._call_builtin_scalar_fn("h3_cell_to_lat", cell)
+
+
+def h3_cell_to_lng(cell: Expression) -> Expression:
+    """Returns the longitude of the center of an H3 cell."""
+    return Expression._call_builtin_scalar_fn("h3_cell_to_lng", cell)
+
+
+def h3_cell_to_str(cell: Expression) -> Expression:
+    """Converts an H3 cell index (UInt64) to its hex string representation."""
+    return Expression._call_builtin_scalar_fn("h3_cell_to_str", cell)
+
+
+def h3_str_to_cell(hex: Expression) -> Expression:
+    """Converts an H3 hex string to a cell index (UInt64)."""
+    return Expression._call_builtin_scalar_fn("h3_str_to_cell", hex)
+
+
+def h3_cell_resolution(cell: Expression) -> Expression:
+    """Returns the resolution (0-15) of an H3 cell index."""
+    return Expression._call_builtin_scalar_fn("h3_cell_resolution", cell)
+
+
+def h3_cell_is_valid(cell: Expression) -> Expression:
+    """Returns true if the UInt64 value is a valid H3 cell index."""
+    return Expression._call_builtin_scalar_fn("h3_cell_is_valid", cell)
+
+
+def h3_cell_parent(cell: Expression, resolution: int) -> Expression:
+    """Returns the parent cell index at the given resolution."""
+    return Expression._call_builtin_scalar_fn("h3_cell_parent", cell, resolution=resolution)
+
+
+def h3_grid_distance(a: Expression, b: Expression) -> Expression:
+    """Returns the grid distance (number of H3 cells) between two cells."""
+    return Expression._call_builtin_scalar_fn("h3_grid_distance", a, b)

--- a/daft/functions/h3.py
+++ b/daft/functions/h3.py
@@ -1,4 +1,7 @@
-"""H3 Geospatial Indexing Functions."""
+"""H3 Geospatial Indexing Functions.
+
+Functions for [H3](https://h3geo.org/), Uber's hierarchical hexagonal geospatial indexing system.
+"""
 
 from __future__ import annotations
 

--- a/daft/functions/h3.py
+++ b/daft/functions/h3.py
@@ -1,10 +1,4 @@
-"""H3 Functions.
-
-Functions for the `H3 <https://h3geo.org/>`_ hierarchical geospatial indexing system.
-
-All functions that take a cell index accept both UInt64 and Utf8 (hex string) columns.
-To convert between representations, use :func:`h3_str_to_cell` and :func:`h3_cell_to_str`.
-"""
+"""H3 Geospatial Indexing Functions."""
 
 from __future__ import annotations
 

--- a/daft/functions/h3.py
+++ b/daft/functions/h3.py
@@ -1,3 +1,8 @@
+"""H3 Functions.
+
+Hexagonal geospatial indexing functions backed by h3o.
+"""
+
 from __future__ import annotations
 
 from daft.expressions import Expression

--- a/src/daft-functions-h3/Cargo.toml
+++ b/src/daft-functions-h3/Cargo.toml
@@ -20,3 +20,6 @@ workspace = true
 name = "daft-functions-h3"
 edition.workspace = true
 version.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["serde"]

--- a/src/daft-functions-h3/Cargo.toml
+++ b/src/daft-functions-h3/Cargo.toml
@@ -1,0 +1,22 @@
+[dependencies]
+common-error = {path = "../common/error", default-features = false}
+daft-core = {path = "../daft-core", default-features = false}
+daft-dsl = {path = "../daft-dsl", default-features = false}
+h3o = {workspace = true}
+serde = {workspace = true}
+typetag = {workspace = true}
+
+[features]
+python = [
+  "common-error/python",
+  "daft-core/python",
+  "daft-dsl/python"
+]
+
+[lints]
+workspace = true
+
+[package]
+name = "daft-functions-h3"
+edition.workspace = true
+version.workspace = true

--- a/src/daft-functions-h3/src/cell_info.rs
+++ b/src/daft-functions-h3/src/cell_info.rs
@@ -1,0 +1,101 @@
+use daft_core::{
+    prelude::{BooleanArray, DataType as DT, UInt8Array},
+    series::IntoSeries,
+};
+use daft_dsl::functions::prelude::*;
+use h3o::CellIndex;
+
+use crate::utils::{ensure_cell_dtype, series_to_cell_indices};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct H3CellResolution;
+
+#[derive(FunctionArgs)]
+struct CellArg<T> {
+    cell: T,
+}
+
+#[typetag::serde]
+impl ScalarUDF for H3CellResolution {
+    fn name(&self) -> &'static str {
+        "h3_cell_resolution"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Returns the resolution (0-15) of an H3 cell index."
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let CellArg { cell } = args.try_into()?;
+        let cell = cell.to_field(schema)?;
+        ensure_cell_dtype("h3_cell_resolution", &cell)?;
+        Ok(Field::new(cell.name, DataType::UInt8))
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let CellArg { cell } = args.try_into()?;
+        let name = cell.name().to_string();
+        let cells = series_to_cell_indices(&cell)?;
+        let result: UInt8Array = cells
+            .into_iter()
+            .map(|opt| opt.map(|c| u8::from(c.resolution())))
+            .collect();
+        Ok(result.rename(&name).into_series())
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct H3CellIsValid;
+
+#[typetag::serde]
+impl ScalarUDF for H3CellIsValid {
+    fn name(&self) -> &'static str {
+        "h3_cell_is_valid"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Returns true if the value is a valid H3 cell index."
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let CellArg { cell } = args.try_into()?;
+        let cell = cell.to_field(schema)?;
+        ensure_cell_dtype("h3_cell_is_valid", &cell)?;
+        Ok(Field::new(cell.name, DataType::Boolean))
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let CellArg { cell } = args.try_into()?;
+        let name = cell.name().to_string();
+        // is_valid needs to distinguish null (-> null) from invalid (-> false),
+        // so we can't use series_to_cell_indices which collapses both to None.
+        let result: BooleanArray = match cell.data_type() {
+            DT::UInt64 => {
+                let arr = cell.u64()?;
+                arr.into_iter()
+                    .map(|opt| opt.map(|v| CellIndex::try_from(v).is_ok()))
+                    .collect()
+            }
+            DT::Utf8 => {
+                let arr = cell.utf8()?;
+                arr.into_iter()
+                    .map(|opt| opt.map(|s| s.parse::<CellIndex>().is_ok()))
+                    .collect()
+            }
+            dt => {
+                return Err(common_error::DaftError::TypeError(format!(
+                    "h3_cell_is_valid: cell must be UInt64 or Utf8, got {dt}"
+                )));
+            }
+        };
+        Ok(result.rename(&name).into_series())
+    }
+}

--- a/src/daft-functions-h3/src/cell_parent.rs
+++ b/src/daft-functions-h3/src/cell_parent.rs
@@ -1,0 +1,56 @@
+use daft_core::{prelude::UInt64Array, series::IntoSeries};
+use daft_dsl::functions::prelude::*;
+use h3o::Resolution;
+
+use crate::utils::{ensure_cell_dtype, series_to_cell_indices};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct H3CellParent;
+
+#[derive(FunctionArgs)]
+struct Args<T> {
+    cell: T,
+    resolution: u8,
+}
+
+#[typetag::serde]
+impl ScalarUDF for H3CellParent {
+    fn name(&self) -> &'static str {
+        "h3_cell_parent"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Returns the parent cell index at the given resolution. Resolution must be coarser (lower) than the cell's resolution."
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let Args { cell, resolution } = args.try_into()?;
+        let cell = cell.to_field(schema)?;
+        ensure_cell_dtype("h3_cell_parent", &cell)?;
+        ensure!(
+            resolution <= 15,
+            ValueError: "h3_cell_parent: resolution must be 0-15, got {resolution}"
+        );
+        Ok(Field::new(cell.name, DataType::UInt64))
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let Args { cell, resolution } = args.try_into()?;
+        let name = cell.name().to_string();
+        let res = Resolution::try_from(resolution).map_err(|e| {
+            common_error::DaftError::ValueError(format!(
+                "h3_cell_parent: invalid resolution {resolution}: {e}"
+            ))
+        })?;
+        let cells = series_to_cell_indices(&cell)?;
+        let result: UInt64Array = cells
+            .into_iter()
+            .map(|opt| opt.and_then(|c| c.parent(res)).map(u64::from))
+            .collect();
+        Ok(result.rename(&name).into_series())
+    }
+}

--- a/src/daft-functions-h3/src/cell_parent.rs
+++ b/src/daft-functions-h3/src/cell_parent.rs
@@ -1,8 +1,7 @@
-use daft_core::{prelude::UInt64Array, series::IntoSeries};
 use daft_dsl::functions::prelude::*;
 use h3o::Resolution;
 
-use crate::utils::{ensure_cell_dtype, series_to_cell_indices};
+use crate::utils::{cell_indices_to_series, ensure_cell_dtype, series_to_cell_indices};
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct H3CellParent;
@@ -31,7 +30,7 @@ impl ScalarUDF for H3CellParent {
             resolution <= 15,
             ValueError: "h3_cell_parent: resolution must be 0-15, got {resolution}"
         );
-        Ok(Field::new(cell.name, DataType::UInt64))
+        Ok(Field::new(cell.name, cell.dtype))
     }
 
     fn call(
@@ -41,16 +40,19 @@ impl ScalarUDF for H3CellParent {
     ) -> DaftResult<Series> {
         let Args { cell, resolution } = args.try_into()?;
         let name = cell.name().to_string();
+        let input_dtype = cell.data_type().clone();
         let res = Resolution::try_from(resolution).map_err(|e| {
             common_error::DaftError::ValueError(format!(
                 "h3_cell_parent: invalid resolution {resolution}: {e}"
             ))
         })?;
         let cells = series_to_cell_indices(&cell)?;
-        let result: UInt64Array = cells
-            .into_iter()
-            .map(|opt| opt.and_then(|c| c.parent(res)).map(u64::from))
-            .collect();
-        Ok(result.rename(&name).into_series())
+        Ok(cell_indices_to_series(
+            &name,
+            cells
+                .into_iter()
+                .map(move |opt| opt.and_then(|c| c.parent(res))),
+            &input_dtype,
+        ))
     }
 }

--- a/src/daft-functions-h3/src/cell_str.rs
+++ b/src/daft-functions-h3/src/cell_str.rs
@@ -1,0 +1,92 @@
+use daft_core::{
+    prelude::{UInt64Array, Utf8Array},
+    series::IntoSeries,
+};
+use daft_dsl::functions::prelude::*;
+use h3o::CellIndex;
+
+use crate::utils::{ensure_cell_dtype, series_to_cell_indices};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct H3CellToStr;
+
+#[derive(FunctionArgs)]
+struct CellArg<T> {
+    cell: T,
+}
+
+#[typetag::serde]
+impl ScalarUDF for H3CellToStr {
+    fn name(&self) -> &'static str {
+        "h3_cell_to_str"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Converts an H3 cell index (UInt64 or Utf8) to its hex string representation."
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let CellArg { cell } = args.try_into()?;
+        let cell = cell.to_field(schema)?;
+        ensure_cell_dtype("h3_cell_to_str", &cell)?;
+        Ok(Field::new(cell.name, DataType::Utf8))
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let CellArg { cell } = args.try_into()?;
+        let name = cell.name().to_string();
+        let cells = series_to_cell_indices(&cell)?;
+        let result: Utf8Array = cells
+            .into_iter()
+            .map(|opt| opt.map(|c| c.to_string()))
+            .collect();
+        Ok(result.rename(&name).into_series())
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct H3StrToCell;
+
+#[derive(FunctionArgs)]
+struct StrArg<T> {
+    hex: T,
+}
+
+#[typetag::serde]
+impl ScalarUDF for H3StrToCell {
+    fn name(&self) -> &'static str {
+        "h3_str_to_cell"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Converts an H3 hex string to a cell index (UInt64)."
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let StrArg { hex } = args.try_into()?;
+        let hex = hex.to_field(schema)?;
+        ensure!(
+            hex.dtype == DataType::Utf8,
+            TypeError: "h3_str_to_cell: hex must be Utf8, got {}", hex.dtype
+        );
+        Ok(Field::new(hex.name, DataType::UInt64))
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let StrArg { hex } = args.try_into()?;
+        let arr = hex.utf8()?;
+        let result: UInt64Array = arr
+            .into_iter()
+            .map(|opt| opt.and_then(|s| s.parse::<CellIndex>().ok().map(u64::from)))
+            .collect();
+        Ok(result.rename(arr.name()).into_series())
+    }
+}

--- a/src/daft-functions-h3/src/cell_to_latlng.rs
+++ b/src/daft-functions-h3/src/cell_to_latlng.rs
@@ -1,0 +1,81 @@
+use daft_core::{prelude::Float64Array, series::IntoSeries};
+use daft_dsl::functions::prelude::*;
+
+use crate::utils::{ensure_cell_dtype, series_to_cell_indices};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct H3CellToLat;
+
+#[derive(FunctionArgs)]
+struct CellArg<T> {
+    cell: T,
+}
+
+#[typetag::serde]
+impl ScalarUDF for H3CellToLat {
+    fn name(&self) -> &'static str {
+        "h3_cell_to_lat"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Returns the latitude of the center of an H3 cell."
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let CellArg { cell } = args.try_into()?;
+        let cell = cell.to_field(schema)?;
+        ensure_cell_dtype("h3_cell_to_lat", &cell)?;
+        Ok(Field::new(cell.name, DataType::Float64))
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let CellArg { cell } = args.try_into()?;
+        let name = cell.name().to_string();
+        let cells = series_to_cell_indices(&cell)?;
+        let result: Float64Array = cells
+            .into_iter()
+            .map(|opt| opt.map(|c| h3o::LatLng::from(c).lat()))
+            .collect();
+        Ok(result.rename(&name).into_series())
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct H3CellToLng;
+
+#[typetag::serde]
+impl ScalarUDF for H3CellToLng {
+    fn name(&self) -> &'static str {
+        "h3_cell_to_lng"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Returns the longitude of the center of an H3 cell."
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let CellArg { cell } = args.try_into()?;
+        let cell = cell.to_field(schema)?;
+        ensure_cell_dtype("h3_cell_to_lng", &cell)?;
+        Ok(Field::new(cell.name, DataType::Float64))
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let CellArg { cell } = args.try_into()?;
+        let name = cell.name().to_string();
+        let cells = series_to_cell_indices(&cell)?;
+        let result: Float64Array = cells
+            .into_iter()
+            .map(|opt| opt.map(|c| h3o::LatLng::from(c).lng()))
+            .collect();
+        Ok(result.rename(&name).into_series())
+    }
+}

--- a/src/daft-functions-h3/src/grid_distance.rs
+++ b/src/daft-functions-h3/src/grid_distance.rs
@@ -1,0 +1,54 @@
+use daft_core::{prelude::Int32Array, series::IntoSeries};
+use daft_dsl::functions::prelude::*;
+
+use crate::utils::{ensure_cell_dtype, series_to_cell_indices};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct H3GridDistance;
+
+#[derive(FunctionArgs)]
+struct Args<T> {
+    a: T,
+    b: T,
+}
+
+#[typetag::serde]
+impl ScalarUDF for H3GridDistance {
+    fn name(&self) -> &'static str {
+        "h3_grid_distance"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Returns the grid distance (number of H3 cells) between two cells. Returns null if cells are not comparable (different resolutions or pentagonal distortion)."
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let Args { a, b } = args.try_into()?;
+        let a = a.to_field(schema)?;
+        let b = b.to_field(schema)?;
+        ensure_cell_dtype("h3_grid_distance", &a)?;
+        ensure_cell_dtype("h3_grid_distance", &b)?;
+        Ok(Field::new(a.name, DataType::Int32))
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let Args { a, b } = args.try_into()?;
+        let name = a.name().to_string();
+        let a_cells = series_to_cell_indices(&a)?;
+        let b_cells = series_to_cell_indices(&b)?;
+
+        let result: Int32Array = a_cells
+            .into_iter()
+            .zip(b_cells)
+            .map(|(a_opt, b_opt)| match (a_opt, b_opt) {
+                (Some(a_cell), Some(b_cell)) => a_cell.grid_distance(b_cell).ok(),
+                _ => None,
+            })
+            .collect();
+        Ok(result.rename(&name).into_series())
+    }
+}

--- a/src/daft-functions-h3/src/latlng_to_cell.rs
+++ b/src/daft-functions-h3/src/latlng_to_cell.rs
@@ -1,0 +1,78 @@
+use daft_core::{prelude::UInt64Array, series::IntoSeries};
+use daft_dsl::functions::prelude::*;
+use h3o::{LatLng, Resolution};
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct H3LatLngToCell;
+
+#[derive(FunctionArgs)]
+struct Args<T> {
+    lat: T,
+    lng: T,
+    resolution: u8,
+}
+
+#[typetag::serde]
+impl ScalarUDF for H3LatLngToCell {
+    fn name(&self) -> &'static str {
+        "h3_latlng_to_cell"
+    }
+
+    fn docstring(&self) -> &'static str {
+        "Converts latitude/longitude coordinates to an H3 cell index at the given resolution (0-15)."
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let Args {
+            lat,
+            lng,
+            resolution,
+        } = args.try_into()?;
+        let lat = lat.to_field(schema)?;
+        let lng = lng.to_field(schema)?;
+        ensure!(
+            lat.dtype == DataType::Float64,
+            TypeError: "h3_latlng_to_cell: lat must be Float64, got {}", lat.dtype
+        );
+        ensure!(
+            lng.dtype == DataType::Float64,
+            TypeError: "h3_latlng_to_cell: lng must be Float64, got {}", lng.dtype
+        );
+        ensure!(
+            resolution <= 15,
+            ValueError: "h3_latlng_to_cell: resolution must be 0-15, got {resolution}"
+        );
+        Ok(Field::new(lat.name, DataType::UInt64))
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let Args {
+            lat,
+            lng,
+            resolution,
+        } = args.try_into()?;
+        let lat_arr = lat.f64()?;
+        let lng_arr = lng.f64()?;
+        let res = Resolution::try_from(resolution).map_err(|e| {
+            common_error::DaftError::ValueError(format!(
+                "h3_latlng_to_cell: invalid resolution {resolution}: {e}"
+            ))
+        })?;
+
+        let result: UInt64Array = lat_arr
+            .into_iter()
+            .zip(lng_arr)
+            .map(|(lat_opt, lng_opt)| match (lat_opt, lng_opt) {
+                (Some(lat), Some(lng)) => LatLng::new(lat, lng)
+                    .ok()
+                    .map(|ll| u64::from(ll.to_cell(res))),
+                _ => None,
+            })
+            .collect();
+        Ok(result.rename(lat_arr.name()).into_series())
+    }
+}

--- a/src/daft-functions-h3/src/lib.rs
+++ b/src/daft-functions-h3/src/lib.rs
@@ -1,0 +1,25 @@
+use daft_dsl::functions::{FunctionModule, FunctionRegistry};
+
+mod cell_info;
+mod cell_parent;
+mod cell_str;
+mod cell_to_latlng;
+mod grid_distance;
+mod latlng_to_cell;
+mod utils;
+
+pub struct H3Functions;
+
+impl FunctionModule for H3Functions {
+    fn register(parent: &mut FunctionRegistry) {
+        parent.add_fn(latlng_to_cell::H3LatLngToCell);
+        parent.add_fn(cell_to_latlng::H3CellToLat);
+        parent.add_fn(cell_to_latlng::H3CellToLng);
+        parent.add_fn(cell_str::H3CellToStr);
+        parent.add_fn(cell_str::H3StrToCell);
+        parent.add_fn(cell_info::H3CellResolution);
+        parent.add_fn(cell_info::H3CellIsValid);
+        parent.add_fn(cell_parent::H3CellParent);
+        parent.add_fn(grid_distance::H3GridDistance);
+    }
+}

--- a/src/daft-functions-h3/src/utils.rs
+++ b/src/daft-functions-h3/src/utils.rs
@@ -1,5 +1,8 @@
 use common_error::DaftResult;
-use daft_core::{prelude::DataType, series::Series};
+use daft_core::{
+    prelude::{DataType, UInt64Array, Utf8Array},
+    series::{IntoSeries, Series},
+};
 use h3o::CellIndex;
 
 /// Parses a Series (UInt64 or Utf8) into a Vec of Option<CellIndex>.
@@ -22,6 +25,25 @@ pub fn series_to_cell_indices(series: &Series) -> DaftResult<Vec<Option<CellInde
         dt => Err(common_error::DaftError::TypeError(format!(
             "expected UInt64 or Utf8 for H3 cell index, got {dt}"
         ))),
+    }
+}
+
+/// Converts cell indices back to a Series, matching the input dtype.
+/// If input was Utf8, returns hex strings. If UInt64, returns u64 values.
+pub fn cell_indices_to_series(
+    name: &str,
+    cells: impl Iterator<Item = Option<CellIndex>>,
+    input_dtype: &DataType,
+) -> Series {
+    match input_dtype {
+        DataType::Utf8 => {
+            let result: Utf8Array = cells.map(|opt| opt.map(|c| c.to_string())).collect();
+            result.rename(name).into_series()
+        }
+        _ => {
+            let result: UInt64Array = cells.map(|opt| opt.map(u64::from)).collect();
+            result.rename(name).into_series()
+        }
     }
 }
 

--- a/src/daft-functions-h3/src/utils.rs
+++ b/src/daft-functions-h3/src/utils.rs
@@ -1,0 +1,37 @@
+use common_error::DaftResult;
+use daft_core::{prelude::DataType, series::Series};
+use h3o::CellIndex;
+
+/// Parses a Series (UInt64 or Utf8) into a Vec of Option<CellIndex>.
+pub fn series_to_cell_indices(series: &Series) -> DaftResult<Vec<Option<CellIndex>>> {
+    match series.data_type() {
+        DataType::UInt64 => {
+            let arr = series.u64()?;
+            Ok(arr
+                .into_iter()
+                .map(|opt| opt.and_then(|v| CellIndex::try_from(v).ok()))
+                .collect())
+        }
+        DataType::Utf8 => {
+            let arr = series.utf8()?;
+            Ok(arr
+                .into_iter()
+                .map(|opt| opt.and_then(|s| s.parse::<CellIndex>().ok()))
+                .collect())
+        }
+        dt => Err(common_error::DaftError::TypeError(format!(
+            "expected UInt64 or Utf8 for H3 cell index, got {dt}"
+        ))),
+    }
+}
+
+/// Validates that a field's dtype is UInt64 or Utf8 (valid H3 cell representations).
+pub fn ensure_cell_dtype(func_name: &str, field: &daft_core::prelude::Field) -> DaftResult<()> {
+    if field.dtype != DataType::UInt64 && field.dtype != DataType::Utf8 {
+        return Err(common_error::DaftError::TypeError(format!(
+            "{func_name}: cell must be UInt64 or Utf8, got {}",
+            field.dtype
+        )));
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ pub mod pylib {
         functions_registry.register::<daft_functions_binary::BinaryFunctions>();
         functions_registry.register::<daft_functions_list::ListFunctions>();
         functions_registry.register::<daft_functions_utf8::Utf8Functions>();
+        functions_registry.register::<daft_functions_h3::H3Functions>();
         functions_registry.register::<daft_functions_json::JsonFunctions>();
         functions_registry.register::<daft_functions_serde::SerdeFunctions>();
         functions_registry.register::<daft_functions_temporal::TemporalFunctions>();

--- a/tests/expressions/test_h3.py
+++ b/tests/expressions/test_h3.py
@@ -161,8 +161,13 @@ class TestH3CellParent:
     def test_parent_string(self):
         df = daft.from_pydict({"hex": [SF_RES7_HEX]})
         df = df.with_column("parent", h3_cell_parent(col("hex"), 5))
-        result = df.select(h3_cell_resolution(col("parent")).alias("res")).to_pydict()
-        assert result["res"][0] == 5
+        result = df.to_pydict()
+        # String in -> string out
+        assert isinstance(result["parent"][0], str)
+        # And it's a valid hex string at the right resolution
+        parent_df = daft.from_pydict({"p": result["parent"]})
+        res = parent_df.select(h3_cell_resolution(col("p")).alias("res")).to_pydict()
+        assert res["res"][0] == 5
 
     def test_parent_null_on_finer_resolution(self):
         df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})

--- a/tests/expressions/test_h3.py
+++ b/tests/expressions/test_h3.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import pytest
+
+import daft
+from daft import col
+from daft.functions.h3 import (
+    h3_cell_is_valid,
+    h3_cell_parent,
+    h3_cell_resolution,
+    h3_cell_to_lat,
+    h3_cell_to_lng,
+    h3_cell_to_str,
+    h3_grid_distance,
+    h3_latlng_to_cell,
+    h3_str_to_cell,
+)
+
+# Known test vector: San Francisco (37.7749, -122.4194) at resolution 7
+SF_LAT = 37.7749
+SF_LNG = -122.4194
+SF_RES7_HEX = "872830828ffffff"
+
+
+class TestH3LatLngToCell:
+    def test_basic(self):
+        df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})
+        result = df.select(h3_latlng_to_cell(col("lat"), col("lng"), 7)).to_pydict()
+        cell = result["lat"][0]
+        assert cell is not None
+        assert isinstance(cell, int)
+
+    def test_multiple_rows(self):
+        df = daft.from_pydict(
+            {
+                "lat": [SF_LAT, 48.8566, 0.0],
+                "lng": [SF_LNG, 2.3522, 0.0],
+            }
+        )
+        result = df.select(h3_latlng_to_cell(col("lat"), col("lng"), 7)).to_pydict()
+        assert len(result["lat"]) == 3
+        assert all(v is not None for v in result["lat"])
+
+    def test_null_handling(self):
+        df = daft.from_pydict({"lat": [SF_LAT, None], "lng": [SF_LNG, -122.0]})
+        result = df.select(h3_latlng_to_cell(col("lat"), col("lng"), 7)).to_pydict()
+        assert result["lat"][0] is not None
+        assert result["lat"][1] is None
+
+    def test_resolution_range(self):
+        df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})
+        for res in [0, 7, 15]:
+            result = df.select(h3_latlng_to_cell(col("lat"), col("lng"), res)).to_pydict()
+            assert result["lat"][0] is not None
+
+
+class TestH3CellToLatLng:
+    def test_roundtrip_uint64(self):
+        df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})
+        df = df.with_column("cell", h3_latlng_to_cell(col("lat"), col("lng"), 7))
+        result = df.select(
+            h3_cell_to_lat(col("cell")).alias("out_lat"),
+            h3_cell_to_lng(col("cell")).alias("out_lng"),
+        ).to_pydict()
+        assert pytest.approx(result["out_lat"][0], abs=0.01) == SF_LAT
+        assert pytest.approx(result["out_lng"][0], abs=0.01) == SF_LNG
+
+    def test_roundtrip_string(self):
+        df = daft.from_pydict({"hex": [SF_RES7_HEX]})
+        result = df.select(
+            h3_cell_to_lat(col("hex")).alias("lat"),
+            h3_cell_to_lng(col("hex")).alias("lng"),
+        ).to_pydict()
+        assert pytest.approx(result["lat"][0], abs=0.01) == SF_LAT
+        assert pytest.approx(result["lng"][0], abs=0.01) == SF_LNG
+
+    def test_null_handling(self):
+        df = daft.from_pydict({"cell": [None]}).with_column("cell", col("cell").cast(daft.DataType.uint64()))
+        result = df.select(h3_cell_to_lat(col("cell"))).to_pydict()
+        assert result["cell"][0] is None
+
+    def test_invalid_cell(self):
+        df = daft.from_pydict({"cell": [0, 1, 999]}).with_column("cell", col("cell").cast(daft.DataType.uint64()))
+        result = df.select(h3_cell_to_lat(col("cell"))).to_pydict()
+        assert all(v is None for v in result["cell"])
+
+    def test_invalid_string(self):
+        df = daft.from_pydict({"cell": ["not_valid", ""]})
+        result = df.select(h3_cell_to_lat(col("cell"))).to_pydict()
+        assert all(v is None for v in result["cell"])
+
+
+class TestH3CellStr:
+    def test_cell_to_str_from_uint64(self):
+        df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})
+        df = df.with_column("cell", h3_latlng_to_cell(col("lat"), col("lng"), 7))
+        result = df.select(h3_cell_to_str(col("cell")).alias("hex")).to_pydict()
+        hex_str = result["hex"][0]
+        assert hex_str is not None
+        assert isinstance(hex_str, str)
+        assert len(hex_str) == 15
+
+    def test_cell_to_str_from_string(self):
+        # Passing a string through cell_to_str normalizes it
+        df = daft.from_pydict({"hex": [SF_RES7_HEX]})
+        result = df.select(h3_cell_to_str(col("hex")).alias("out")).to_pydict()
+        assert result["out"][0] == SF_RES7_HEX
+
+    def test_str_to_cell_roundtrip(self):
+        df = daft.from_pydict({"hex": [SF_RES7_HEX]})
+        df = df.with_column("cell", h3_str_to_cell(col("hex")))
+        df = df.with_column("back", h3_cell_to_str(col("cell")))
+        result = df.to_pydict()
+        assert result["back"][0] == SF_RES7_HEX
+
+    def test_str_to_cell_invalid(self):
+        df = daft.from_pydict({"hex": ["not_a_cell", "", None]})
+        result = df.select(h3_str_to_cell(col("hex"))).to_pydict()
+        assert all(v is None for v in result["hex"])
+
+
+class TestH3CellInfo:
+    def test_resolution_uint64(self):
+        df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})
+        df = df.with_column("cell", h3_latlng_to_cell(col("lat"), col("lng"), 7))
+        result = df.select(h3_cell_resolution(col("cell")).alias("res")).to_pydict()
+        assert result["res"][0] == 7
+
+    def test_resolution_string(self):
+        df = daft.from_pydict({"hex": [SF_RES7_HEX]})
+        result = df.select(h3_cell_resolution(col("hex")).alias("res")).to_pydict()
+        assert result["res"][0] == 7
+
+    def test_is_valid_uint64(self):
+        df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})
+        df = df.with_column("cell", h3_latlng_to_cell(col("lat"), col("lng"), 7))
+        result = df.select(h3_cell_is_valid(col("cell")).alias("valid")).to_pydict()
+        assert result["valid"][0] is True
+
+    def test_is_valid_string(self):
+        df = daft.from_pydict({"hex": [SF_RES7_HEX, "not_valid", None]})
+        result = df.select(h3_cell_is_valid(col("hex"))).to_pydict()
+        assert result["hex"][0] is True
+        assert result["hex"][1] is False
+        assert result["hex"][2] is None
+
+    def test_is_valid_invalid_uint64(self):
+        df = daft.from_pydict({"cell": [0, 42, 999999]}).with_column("cell", col("cell").cast(daft.DataType.uint64()))
+        result = df.select(h3_cell_is_valid(col("cell"))).to_pydict()
+        assert all(v is False for v in result["cell"])
+
+
+class TestH3CellParent:
+    def test_parent_uint64(self):
+        df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})
+        df = df.with_column("cell", h3_latlng_to_cell(col("lat"), col("lng"), 7))
+        df = df.with_column("parent", h3_cell_parent(col("cell"), 5))
+        result = df.select(h3_cell_resolution(col("parent")).alias("res")).to_pydict()
+        assert result["res"][0] == 5
+
+    def test_parent_string(self):
+        df = daft.from_pydict({"hex": [SF_RES7_HEX]})
+        df = df.with_column("parent", h3_cell_parent(col("hex"), 5))
+        result = df.select(h3_cell_resolution(col("parent")).alias("res")).to_pydict()
+        assert result["res"][0] == 5
+
+    def test_parent_null_on_finer_resolution(self):
+        df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})
+        df = df.with_column("cell", h3_latlng_to_cell(col("lat"), col("lng"), 3))
+        result = df.select(h3_cell_parent(col("cell"), 5)).to_pydict()
+        assert result["cell"][0] is None
+
+
+class TestH3GridDistance:
+    def test_same_cell(self):
+        df = daft.from_pydict({"lat": [SF_LAT], "lng": [SF_LNG]})
+        df = df.with_column("cell", h3_latlng_to_cell(col("lat"), col("lng"), 7))
+        result = df.select(h3_grid_distance(col("cell"), col("cell")).alias("dist")).to_pydict()
+        assert result["dist"][0] == 0
+
+    def test_same_cell_string(self):
+        df = daft.from_pydict({"hex": [SF_RES7_HEX]})
+        result = df.select(h3_grid_distance(col("hex"), col("hex")).alias("dist")).to_pydict()
+        assert result["dist"][0] == 0
+
+    def test_neighbors(self):
+        df = daft.from_pydict(
+            {
+                "lat_a": [SF_LAT],
+                "lng_a": [SF_LNG],
+                "lat_b": [SF_LAT + 0.001],
+                "lng_b": [SF_LNG],
+            }
+        )
+        df = df.with_column("a", h3_latlng_to_cell(col("lat_a"), col("lng_a"), 7))
+        df = df.with_column("b", h3_latlng_to_cell(col("lat_b"), col("lng_b"), 7))
+        result = df.select(h3_grid_distance(col("a"), col("b")).alias("dist")).to_pydict()
+        dist = result["dist"][0]
+        assert dist is not None
+        assert dist >= 0
+
+    def test_null_handling(self):
+        df = (
+            daft.from_pydict({"a": [None], "b": [None]})
+            .with_column("a", col("a").cast(daft.DataType.uint64()))
+            .with_column("b", col("b").cast(daft.DataType.uint64()))
+        )
+        result = df.select(h3_grid_distance(col("a"), col("b")).alias("dist")).to_pydict()
+        assert result["dist"][0] is None


### PR DESCRIPTION
Adds native [H3](https://h3geo.org/) hexagonal geospatial indexing functions to Daft. This PR covers the core functions for coordinate conversion, cell inspection, hierarchy traversal, and grid distance.

```python
from daft.functions.h3 import h3_latlng_to_cell, h3_cell_to_str, h3_cell_parent

df = daft.from_pydict({"lat": [37.7749, 48.8566], "lng": [-122.4194, 2.3522]})
df = df.with_column("cell", h3_latlng_to_cell(col("lat"), col("lng"), 7))
df = df.with_column("hex", h3_cell_to_str(col("cell")))
df = df.with_column("parent", h3_cell_parent(col("hex"), 5))  # string in -> string out
```

All cell-input functions accept both UInt64 and Utf8 (hex string) columns, so users can operate directly on string H3 data without an explicit conversion step. Functions that return cell indices preserve the input type: string in, string out.

For users who want maximum throughput, converting to UInt64 once at the top of a pipeline with `h3_str_to_cell` avoids repeated string parsing.

## Functions

| Function | Input | Output |
|---|---|---|
| `h3_latlng_to_cell` | lat (f64), lng (f64), resolution (0-15) | UInt64 |
| `h3_cell_to_lat` | cell (UInt64 or Utf8) | Float64 |
| `h3_cell_to_lng` | cell (UInt64 or Utf8) | Float64 |
| `h3_cell_to_str` | cell (UInt64 or Utf8) | Utf8 |
| `h3_str_to_cell` | hex (Utf8) | UInt64 |
| `h3_cell_resolution` | cell (UInt64 or Utf8) | UInt8 |
| `h3_cell_is_valid` | cell (UInt64 or Utf8) | Boolean |
| `h3_cell_parent` | cell (UInt64 or Utf8), resolution (0-15) | same as input |
| `h3_grid_distance` | a (UInt64 or Utf8), b (UInt64 or Utf8) | Int32 |

Invalid cell indices produce null (not errors). Resolution is validated eagerly at plan time.

## Benchmarks: native vs UDF on hex string columns (1M rows, Apple M-series)

Compared against what a user would do today - wrapping the `h3` Python library in a `@daft.func.batch` UDF. Both paths operate on hex string columns to reflect real-world usage where H3 data arrives as strings.

| Function | Native | UDF (h3-py) | Speedup |
|---|---|---|---|
| `latlng_to_cell` | 329ms | 1,698ms | **5.2x** |
| `cell_to_lat` | 185ms | 1,221ms | **6.6x** |
| `cell_parent` (str->str) | 73ms | 1,302ms | **17.9x** |
| `cell_resolution` | 39ms | 919ms | **23.5x** |
| `str_to_cell` | 37ms | 904ms | **24.6x** |

The speedup comes from eliminating Python loop overhead, `to_pylist()` serialization, and per-element Python function call costs.

## Follow-up PRs

- List-returning functions: `cell_children`, `grid_disk`, `grid_ring`, `cell_to_boundary`
- Advanced ops: `compact`/`uncompact`, `polygon_to_cells`