### PR TITLE
chore: rename DataSource enum to ScanSource

### DIFF
--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -17,7 +17,7 @@ use daft_io::{IOStatsContext, python::IOConfig};
 use daft_json::{JsonConvertOptions, JsonParseOptions, JsonReadOptions};
 use daft_parquet::read::ParquetSchemaInferenceOptions;
 use daft_recordbatch::{RecordBatch, python::PyRecordBatch};
-use daft_scan::{DataSource, ScanTaskRef, storage_config::StorageConfig};
+use daft_scan::{ScanSource, ScanTaskRef, storage_config::StorageConfig};
 use daft_stats::{TableMetadata, TableStatistics};
 use pyo3::{PyTypeInfo, exceptions::PyValueError, prelude::*, types::PyBytes};
 use snafu::ResultExt;
@@ -1085,7 +1085,7 @@ pub fn read_pyfunc_into_table_iter(
     let table_iterators = scan_task.sources.iter().map(|source| {
         // Call Python function to create an Iterator (Grabs the GIL and then releases it)
         match source {
-            DataSource::PythonFactoryFunction {
+            ScanSource::PythonFactoryFunction {
                 module,
                 func_name,
                 func_args,

--- a/src/daft-scan/src/anonymous.rs
+++ b/src/daft-scan/src/anonymous.rs
@@ -4,8 +4,8 @@ use common_error::DaftResult;
 use daft_schema::schema::SchemaRef;
 
 use crate::{
-    ChunkSpec, DataSource, FileFormatConfig, ParquetSourceConfig, PartitionField, Pushdowns,
-    ScanOperator, ScanTask, ScanTaskRef, SourceConfig, storage_config::StorageConfig,
+    ChunkSpec, FileFormatConfig, ParquetSourceConfig, PartitionField, Pushdowns, ScanOperator,
+    ScanSource, ScanTask, ScanTaskRef, SourceConfig, storage_config::StorageConfig,
 };
 #[derive(Debug)]
 pub struct AnonymousScanOperator {
@@ -104,7 +104,7 @@ impl ScanOperator for AnonymousScanOperator {
             .map(|(f, rg)| {
                 let chunk_spec = rg.map(ChunkSpec::Parquet);
                 Arc::new(ScanTask::new(
-                    vec![DataSource::File {
+                    vec![ScanSource::File {
                         path: f,
                         chunk_spec,
                         size_bytes: None,

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -19,8 +19,8 @@ use futures::{Stream, StreamExt, TryStreamExt, stream::BoxStream};
 use snafu::Snafu;
 
 use crate::{
-    ChunkSpec, CsvSourceConfig, DataSource, FileFormatConfig, ParquetSourceConfig, PartitionField,
-    Pushdowns, ScanOperator, ScanTask, ScanTaskRef, SourceConfig,
+    ChunkSpec, CsvSourceConfig, FileFormatConfig, ParquetSourceConfig, PartitionField, Pushdowns,
+    ScanOperator, ScanSource, ScanTask, ScanTaskRef, SourceConfig,
     hive::{hive_partitions_to_fields, hive_partitions_to_series, parse_hive_partitioning},
     storage_config::StorageConfig,
 };
@@ -576,7 +576,7 @@ impl ScanOperator for GlobScanOperator {
                         .flatten();
                     let chunk_spec = row_group.map(ChunkSpec::Parquet);
                     Ok(Some(ScanTask::new(
-                        vec![DataSource::File {
+                        vec![ScanSource::File {
                             metadata: if let Some(first_filepath) = first_filepath
                                 && path == *first_filepath
                             {

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -154,7 +154,7 @@ impl ChunkSpec {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum DataSource {
+pub enum ScanSource {
     File {
         path: String,
         chunk_spec: Option<ChunkSpec>,
@@ -183,7 +183,7 @@ pub enum DataSource {
     },
 }
 
-impl Hash for DataSource {
+impl Hash for ScanSource {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Hash everything except for cached parquet metadata.
         match self {
@@ -240,7 +240,7 @@ impl Hash for DataSource {
     }
 }
 
-impl DataSource {
+impl ScanSource {
     #[must_use]
     pub fn get_path(&self) -> &str {
         match self {
@@ -418,7 +418,7 @@ impl DataSource {
     }
 }
 
-impl DisplayAs for DataSource {
+impl DisplayAs for ScanSource {
     fn display_as(&self, level: common_display::DisplayLevel) -> String {
         match level {
             common_display::DisplayLevel::Compact | common_display::DisplayLevel::Default => {
@@ -443,7 +443,7 @@ impl DisplayAs for DataSource {
 #[derive(PartialEq, Serialize, Deserialize, Hash)]
 #[cfg_attr(debug_assertions, derive(Debug))]
 pub struct ScanTask {
-    pub sources: Vec<DataSource>,
+    pub sources: Vec<ScanSource>,
 
     /// Schema to use when reading the DataSources.
     ///
@@ -492,7 +492,7 @@ fn warc_column_sizes() -> &'static HashMap<&'static str, usize> {
 impl ScanTask {
     #[must_use]
     pub fn new(
-        sources: Vec<DataSource>,
+        sources: Vec<ScanSource>,
         source_config: Arc<SourceConfig>,
         schema: SchemaRef,
         storage_config: Arc<StorageConfig>,
@@ -693,7 +693,7 @@ impl ScanTask {
         self.sources
             .iter()
             .filter_map(|s| match s {
-                DataSource::File { path, .. } => Some(path.clone()),
+                ScanSource::File { path, .. } => Some(path.clone()),
                 _ => None,
             })
             .collect()
@@ -788,7 +788,7 @@ impl ScanTask {
         self.sources
             .first()
             .and_then(|s| match s {
-                DataSource::File { path, .. } => {
+                ScanSource::File { path, .. } => {
                     let filename = std::path::Path::new(path);
                     Some(
                         filename
@@ -981,13 +981,13 @@ mod test {
     use itertools::Itertools;
 
     use crate::{
-        DataSource, FileFormatConfig, ParquetSourceConfig, Pushdowns, ScanOperator, ScanTask,
+        FileFormatConfig, ParquetSourceConfig, Pushdowns, ScanOperator, ScanSource, ScanTask,
         SourceConfig, WarcSourceConfig, glob::GlobScanOperator, storage_config::StorageConfig,
     };
 
     fn make_scan_task(num_sources: usize) -> ScanTask {
         let sources = (0..num_sources)
-            .map(|i| DataSource::File {
+            .map(|i| ScanSource::File {
                 path: format!("test{i}"),
                 chunk_spec: None,
                 size_bytes: None,
@@ -1134,7 +1134,7 @@ mod test {
 
     #[test]
     fn test_warc_memory_estimation_with_extremely_large_row_count() {
-        let sources = vec![DataSource::File {
+        let sources = vec![ScanSource::File {
             path: "test.warc.gz".to_string(),
             chunk_spec: None,
             size_bytes: Some(1_000_000),
@@ -1176,7 +1176,7 @@ mod test {
 
     #[test]
     fn test_warc_memory_estimation_with_large_row_count_f64() {
-        let sources = vec![DataSource::File {
+        let sources = vec![ScanSource::File {
             path: "test.warc.gz".to_string(),
             chunk_spec: None,
             size_bytes: Some(1_000_000_000_000), // 1TB file
@@ -1217,7 +1217,7 @@ mod test {
 
     #[test]
     fn test_warc_memory_estimation_valid_edge_case() {
-        let sources = vec![DataSource::File {
+        let sources = vec![ScanSource::File {
             path: "test.warc.gz".to_string(),
             chunk_spec: None,
             size_bytes: Some(10_000_000), // 10MB
@@ -1258,7 +1258,7 @@ mod test {
 
     #[test]
     fn test_schema_row_size_estimation_with_extremely_large_row_count() {
-        let sources = vec![DataSource::File {
+        let sources = vec![ScanSource::File {
             path: "test.parquet".to_string(),
             chunk_spec: None,
             size_bytes: Some(1_000_000),
@@ -1305,7 +1305,7 @@ mod test {
 
     #[test]
     fn test_schema_row_size_estimation_with_nested_schema() {
-        let sources = vec![DataSource::File {
+        let sources = vec![ScanSource::File {
             path: "test.parquet".to_string(),
             chunk_spec: None,
             size_bytes: Some(100_000_000), // 100MB
@@ -1353,7 +1353,7 @@ mod test {
 
     #[test]
     fn test_schema_row_size_estimation_with_large_file_no_metadata() {
-        let sources = vec![DataSource::File {
+        let sources = vec![ScanSource::File {
             path: "test.parquet".to_string(),
             chunk_spec: None,
             size_bytes: Some(u64::MAX / 100), // Very large file
@@ -1397,7 +1397,7 @@ mod test {
 
     #[test]
     fn test_schema_row_size_estimation_valid_case() {
-        let sources = vec![DataSource::File {
+        let sources = vec![ScanSource::File {
             path: "test.parquet".to_string(),
             chunk_spec: None,
             size_bytes: Some(1_000_000),
@@ -1441,7 +1441,7 @@ mod test {
 
     #[test]
     fn test_overflow_protection_with_infinity() {
-        let sources = vec![DataSource::File {
+        let sources = vec![ScanSource::File {
             path: "test.parquet".to_string(),
             chunk_spec: None,
             size_bytes: Some(u64::MAX), // Maximum possible file size

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -182,9 +182,8 @@ pub mod pylib {
 
     use super::{PyFileFormatConfig, PythonTablesFactoryArgs};
     use crate::{
-        DataSource, DatabaseSourceConfig, FileFormatConfig, PartitionField, Pushdowns,
-        ScanOperator, ScanOperatorRef, ScanTask, ScanTaskRef, SourceConfig,
-        SupportsPushdownFilters,
+        DatabaseSourceConfig, FileFormatConfig, PartitionField, Pushdowns, ScanOperator,
+        ScanOperatorRef, ScanSource, ScanTask, ScanTaskRef, SourceConfig, SupportsPushdownFilters,
         anonymous::AnonymousScanOperator,
         glob::GlobScanOperator,
         python::pylib_scan_info::{PyPartitionField, PyPushdowns},
@@ -601,7 +600,7 @@ pub mod pylib {
 
             let metadata = num_rows.map(|n| TableMetadata { length: n as usize });
 
-            let data_source = DataSource::File {
+            let data_source = ScanSource::File {
                 path: file,
                 chunk_spec: None,
                 size_bytes,
@@ -649,7 +648,7 @@ pub mod pylib {
             let statistics = stats
                 .map(|s| TableStatistics::from_stats_table(&s.record_batch))
                 .transpose()?;
-            let data_source = DataSource::Database {
+            let data_source = ScanSource::Database {
                 path: url,
                 size_bytes,
                 metadata: num_rows.map(|n| TableMetadata { length: n as usize }),
@@ -694,7 +693,7 @@ pub mod pylib {
             let statistics = stats
                 .map(|s| TableStatistics::from_stats_table(&s.record_batch))
                 .transpose()?;
-            let data_source = DataSource::PythonFactoryFunction {
+            let data_source = ScanSource::PythonFactoryFunction {
                 module: module.clone(),
                 func_name: func_name.clone(),
                 func_args: PythonTablesFactoryArgs::new(
@@ -782,7 +781,7 @@ pub mod pylib {
                 None,
             ),
         )?;
-        let data_source = DataSource::File {
+        let data_source = ScanSource::File {
             path: uri.to_string(),
             chunk_spec: None,
             size_bytes: Some(file_size),

--- a/src/daft-scan/src/scan_task_iters/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/mod.rs
@@ -9,7 +9,7 @@ use daft_parquet::{RowGroupList, read::read_parquet_metadata};
 use indexmap::IndexMap;
 
 use crate::{
-    ChunkSpec, DataSource, FileFormatConfig, ParquetSourceConfig, Pushdowns, ScanTask, ScanTaskRef,
+    ChunkSpec, FileFormatConfig, ParquetSourceConfig, Pushdowns, ScanSource, ScanTask, ScanTaskRef,
     SourceConfig,
 };
 
@@ -224,7 +224,7 @@ fn split_by_row_groups(
                     ) = (
                         t.source_config.as_ref(),
                         &t.sources[..],
-                        t.sources.first().map(DataSource::get_chunk_spec),
+                        t.sources.first().map(ScanSource::get_chunk_spec),
                         t.pushdowns.limit,
                     ) && source
                         .get_size_bytes()
@@ -266,7 +266,7 @@ fn split_by_row_groups(
                             if curr_size_bytes >= min_size_bytes || Some(i) == last_original_index {
                                 let mut new_source = source.clone();
 
-                                if let DataSource::File {
+                                if let ScanSource::File {
                                     chunk_spec,
                                     size_bytes,
                                     parquet_metadata,
@@ -280,10 +280,10 @@ fn split_by_row_groups(
                                     *chunk_spec = Some(ChunkSpec::Parquet(curr_row_group_indices));
                                     *size_bytes = Some(curr_size_bytes as u64);
                                 } else {
-                                    unreachable!("Parquet file format should only be used with DataSource::File");
+                                    unreachable!("Parquet file format should only be used with ScanSource::File");
                                 }
 
-                                if let DataSource::File {
+                                if let ScanSource::File {
                                     metadata: Some(metadata),
                                     ..
                                 } = &mut new_source

--- a/src/daft-scan/src/scan_task_iters/split_jsonl/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/split_jsonl/mod.rs
@@ -8,7 +8,7 @@ use url::Url;
 use urlencoding::decode;
 
 use crate::{
-    ChunkSpec, DataSource, FileFormatConfig, JsonSourceConfig, ScanTask, ScanTaskRef, SourceConfig,
+    ChunkSpec, FileFormatConfig, JsonSourceConfig, ScanSource, ScanTask, ScanTaskRef, SourceConfig,
     StorageConfig,
 };
 
@@ -32,7 +32,7 @@ pub fn split_by_jsonl_ranges<'a>(
                 ) = (
                     t.source_config.as_ref(),
                     &t.sources[..],
-                    t.sources.first().map(DataSource::get_chunk_spec),
+                    t.sources.first().map(ScanSource::get_chunk_spec),
                 ) {
                     let path = source.get_path();
                     if !supports_split(path) {
@@ -109,7 +109,7 @@ pub fn split_by_jsonl_ranges<'a>(
                         let end = w[1];
                         assert!(end > start, "Invalid chunk range: start={start}, end={end}");
                         let mut new_source = source.clone();
-                        if let DataSource::File { chunk_spec, .. } = &mut new_source {
+                        if let ScanSource::File { chunk_spec, .. } = &mut new_source {
                             *chunk_spec = Some(ChunkSpec::Bytes { start, end });
                         }
                         let new_task = ScanTask::new(
@@ -234,7 +234,7 @@ mod tests {
 
     fn make_scan_task(path: &str, size_bytes: u64) -> ScanTask {
         ScanTask::new(
-            vec![DataSource::File {
+            vec![ScanSource::File {
                 path: path.to_string(),
                 chunk_spec: None,
                 size_bytes: Some(size_bytes),
@@ -309,7 +309,7 @@ mod tests {
         for t in tasks {
             let t = t.unwrap();
             let src = &t.sources[0];
-            if let crate::DataSource::File {
+            if let crate::ScanSource::File {
                 chunk_spec: Some(crate::ChunkSpec::Bytes { start, end }),
                 ..
             } = src

--- a/src/daft-scan/src/test_utils.rs
+++ b/src/daft-scan/src/test_utils.rs
@@ -6,7 +6,7 @@ use daft_schema::schema::SchemaRef;
 use daft_stats::TableMetadata;
 
 use crate::{
-    DataSource, FileFormatConfig, PartitionField, Pushdowns, ScanOperator, ScanTask, ScanTaskRef,
+    FileFormatConfig, PartitionField, Pushdowns, ScanOperator, ScanSource, ScanTask, ScanTaskRef,
     SourceConfig, SupportsPushdownFilters, storage_config::StorageConfig,
 };
 
@@ -68,7 +68,7 @@ impl ScanOperator for DummyScanOperator {
             .map(|i| {
                 let metadata = self.num_rows_per_task.map(|n| TableMetadata { length: n });
                 Arc::new(ScanTask::new(
-                    vec![DataSource::File {
+                    vec![ScanSource::File {
                         path: format!("dummy_file_{}.txt", i),
                         chunk_spec: None,
                         size_bytes: None,


### PR DESCRIPTION
## Motivation

In the public Python API we use DataSource and DataSink for the interfaces which implementing reading and writing data. These are what back various read_ and write_ APIs. We have this other type that goes inside a scan task which is coincidentally named 'DataSource' which is confusing. I am going to use the name DataSource and DataSink for Rust traits which mirror the python interfaces, so this refactor frees up the name to avoid confusion.

## Changes Made

This is just a rename to avoid near-term confusion.

## Related Issues

Related to #6398 but does not close it.