### PR TITLE
feat(subscribers): add JSONL event log subscriber

### DIFF
--- a/daft/subscribers/abc.py
+++ b/daft/subscribers/abc.py
@@ -22,6 +22,13 @@ class Subscriber(ABC):
     - During execution, emitting current stats of all running operators at regular intervals
     """
 
+    def close(self) -> None:
+        """Called when the subscriber is detached or the process is shutting down.
+
+        Override to release resources (file handles, connections, etc.).
+        """
+        pass
+
     @abstractmethod
     def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
         """Called when starting the run for a new query."""

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import atexit
 import json
 import time
-import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from io import TextIOWrapper
 
 from daft.context import get_context
 from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState, StatType
@@ -36,12 +36,6 @@ def _mono_ms() -> float:
     return time.monotonic() * 1000
 
 
-def _generate_run_id() -> str:
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
-    suffix = uuid.uuid4().hex[:4]
-    return f"run_{timestamp}_{suffix}"
-
-
 class EventLogSubscriber(Subscriber):
     """Experimental subscriber that writes query lifecycle events to a JSONL log.
 
@@ -49,14 +43,11 @@ class EventLogSubscriber(Subscriber):
     one JSON object per line with ``event``, ``ts``, and event-specific fields.
     """
 
-    def __init__(self, log_dir: str | Path, run_id: str | None = None) -> None:
+    def __init__(self, log_dir: str | Path) -> None:
         self._log_dir = Path(log_dir).expanduser().resolve()
-        self._run_id = run_id or _generate_run_id()
-        self._run_dir = self._log_dir / self._run_id
-        self._events_path = self._run_dir / "events.jsonl"
-        self._run_dir.mkdir(parents=True, exist_ok=True)
-        self._file = open(self._events_path, "a", buffering=1)  # line-buffered
+        self._log_dir.mkdir(parents=True, exist_ok=True)
         self._closed = False
+        self._query_files: dict[str, TextIOWrapper] = {}
 
         # Track start times for duration computation (monotonic ms).
         # TODO update the framework to pass this information
@@ -64,8 +55,6 @@ class EventLogSubscriber(Subscriber):
         self._optimization_starts: dict[str, float] = {}
         self._exec_starts: dict[str, float] = {}
         self._operator_starts: dict[tuple[str, int], float] = {}
-
-        self._write_session_header()
 
     def _clear_query_state(self, query_id: str) -> None:
         """Remove any leftover timing state for the given query."""
@@ -76,23 +65,55 @@ class EventLogSubscriber(Subscriber):
         for key in stale_operator_keys:
             self._operator_starts.pop(key, None)
 
-    def _write_session_header(self) -> None:
+    def _query_dir(self, query_id: str) -> Path:
+        return self._log_dir / query_id
+
+    def _events_path(self, query_id: str) -> Path:
+        return self._query_dir(query_id) / "events.jsonl"
+
+    def _get_query_file(self, query_id: str) -> TextIOWrapper | None:
+        if self._closed:
+            return None
+        query_file = self._query_files.get(query_id)
+        if query_file is not None:
+            return query_file
+
+        query_dir = self._query_dir(query_id)
+        query_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            query_file = open(self._events_path(query_id), "a", buffering=1)  # line-buffered
+        except OSError:
+            return None
+
+        self._query_files[query_id] = query_file
+        self._write_session_header(query_id)
+        return query_file
+
+    def _close_query_file(self, query_id: str) -> None:
+        query_file = self._query_files.pop(query_id, None)
+        if query_file is None:
+            return
+        query_file.close()
+
+    def _write_session_header(self, query_id: str) -> None:
         from daft import __version__ as daft_version
 
         self._write_event(
-            "session_started",
+            query_id,
+            "event_log_started",
             {
                 "daft_version": daft_version,
             },
         )
 
-    def _write_event(self, event_name: str, payload: dict[str, Any]) -> None:
-        if self._closed:
+    def _write_event(self, query_id: str, event_name: str, payload: dict[str, Any]) -> None:
+        query_file = self._get_query_file(query_id)
+        if query_file is None:
             return
-        record: dict[str, Any] = {"event": event_name, "ts": _iso_now()}
+        record: dict[str, Any] = {"event": event_name, "ts": _iso_now(), "query_id": query_id}
         record.update(payload)
         try:
-            self._file.write(json.dumps(record, default=_json_default) + "\n")
+            query_file.write(json.dumps(record, default=_json_default) + "\n")
         except OSError:
             pass  # Don't let logging failures affect query execution
 
@@ -100,20 +121,22 @@ class EventLogSubscriber(Subscriber):
         if self._closed:
             return
         self._closed = True
-        self._file.close()
+        for query_file in self._query_files.values():
+            query_file.close()
+        self._query_files.clear()
 
     # Query lifecycle
 
     def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
         self._query_starts[query_id] = _mono_ms()
-        self._write_event("query_started", {"query_id": query_id})
-        self._write_event("plan_unoptimized", {"query_id": query_id, "plan": metadata.unoptimized_plan})
+        self._write_event(query_id, "query_started", {})
+        self._write_event(query_id, "plan_unoptimized", {"plan": metadata.unoptimized_plan})
 
     def on_query_end(self, query_id: str, result: PyQueryResult) -> None:
         start = self._query_starts.pop(query_id, None)
         duration_ms = round(_mono_ms() - start) if start is not None else None
 
-        payload: dict[str, Any] = {"query_id": query_id}
+        payload: dict[str, Any] = {}
         if duration_ms is not None:
             payload["duration_ms"] = duration_ms
 
@@ -128,16 +151,17 @@ class EventLogSubscriber(Subscriber):
         else:
             payload["status"] = "dead"
 
-        self._write_event("query_ended", payload)
+        self._write_event(query_id, "query_ended", payload)
         self._clear_query_state(query_id)
+        self._close_query_file(query_id)
 
     # Result
 
     def on_result_out(self, query_id: str, result: PyMicroPartition) -> None:
         self._write_event(
+            query_id,
             "result_out",
             {
-                "query_id": query_id,
                 "rows": len(result),
             },
         )
@@ -146,32 +170,32 @@ class EventLogSubscriber(Subscriber):
 
     def on_optimization_start(self, query_id: str) -> None:
         self._optimization_starts[query_id] = _mono_ms()
-        self._write_event("optimization_started", {"query_id": query_id})
+        self._write_event(query_id, "optimization_started", {})
 
     def on_optimization_end(self, query_id: str, optimized_plan: str) -> None:
         start = self._optimization_starts.pop(query_id, None)
         duration_ms = round(_mono_ms() - start) if start is not None else None
 
-        payload: dict[str, Any] = {"query_id": query_id}
+        payload: dict[str, Any] = {}
         if duration_ms is not None:
             payload["duration_ms"] = duration_ms
 
-        self._write_event("optimization_ended", payload)
-        self._write_event("plan_optimized", {"query_id": query_id, "plan": optimized_plan})
+        self._write_event(query_id, "optimization_ended", payload)
+        self._write_event(query_id, "plan_optimized", {"plan": optimized_plan})
 
     # Execution
 
     def on_exec_start(self, query_id: str, physical_plan: str) -> None:
         self._exec_starts[query_id] = _mono_ms()
-        self._write_event("execution_started", {"query_id": query_id})
-        self._write_event("plan_physical", {"query_id": query_id, "plan": physical_plan})
+        self._write_event(query_id, "execution_started", {})
+        self._write_event(query_id, "plan_physical", {"plan": physical_plan})
 
     def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
         self._operator_starts[(query_id, node_id)] = _mono_ms()
         self._write_event(
+            query_id,
             "operator_started",
             {
-                "query_id": query_id,
                 "node_id": node_id,
             },
         )
@@ -182,9 +206,9 @@ class EventLogSubscriber(Subscriber):
             for name, (_stat_type, value) in node_stats.items():
                 metrics[name] = value
             self._write_event(
+                query_id,
                 "stats",
                 {
-                    "query_id": query_id,
                     "node_id": node_id,
                     "metrics": metrics,
                 },
@@ -195,29 +219,28 @@ class EventLogSubscriber(Subscriber):
         duration_ms = round(_mono_ms() - start) if start is not None else None
 
         payload: dict[str, Any] = {
-            "query_id": query_id,
             "node_id": node_id,
         }
         if duration_ms is not None:
             payload["duration_ms"] = duration_ms
 
-        self._write_event("operator_ended", payload)
+        self._write_event(query_id, "operator_ended", payload)
 
     def on_exec_end(self, query_id: str) -> None:
         start = self._exec_starts.pop(query_id, None)
         duration_ms = round(_mono_ms() - start) if start is not None else None
 
-        payload: dict[str, Any] = {"query_id": query_id}
+        payload: dict[str, Any] = {}
         if duration_ms is not None:
             payload["duration_ms"] = duration_ms
 
-        self._write_event("execution_ended", payload)
+        self._write_event(query_id, "execution_ended", payload)
 
 
 _EVENT_LOG_SUBSCRIBER: EventLogSubscriber | None = None
 
 
-def enable_event_log(dir: str | Path | None = None) -> None:
+def enable_event_log(log_dir: str | Path | None = None) -> None:
     """Experimental helper that attaches an event-log subscriber.
 
     This API is currently intended for local event-log capture through
@@ -230,7 +253,7 @@ def enable_event_log(dir: str | Path | None = None) -> None:
         atexit.register(disable_event_log)
         _EVENT_LOG_ATEXIT_REGISTERED = True
 
-    subscriber = EventLogSubscriber(dir or _DEFAULT_EVENT_LOG_DIR)
+    subscriber = EventLogSubscriber(log_dir or _DEFAULT_EVENT_LOG_DIR)
     try:
         get_context().attach_subscriber(_EVENT_LOG_ALIAS, subscriber)
     except Exception:

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -122,7 +122,10 @@ class EventLogSubscriber(Subscriber):
             return
         self._closed = True
         for query_file in self._query_files.values():
-            query_file.close()
+            try:
+                query_file.close()
+            except OSError:
+                pass
         self._query_files.clear()
 
     # Query lifecycle

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -77,12 +77,12 @@ class EventLogSubscriber(Subscriber):
             self._operator_starts.pop(key, None)
 
     def _write_session_header(self) -> None:
-        import daft
+        from daft import __version__ as daft_version
 
         self._write_event(
             "session_started",
             {
-                "daft_version": daft.__version__,
+                "daft_version": daft_version,
             },
         )
 
@@ -91,7 +91,10 @@ class EventLogSubscriber(Subscriber):
             return
         record: dict[str, Any] = {"event": event_name, "ts": _iso_now()}
         record.update(payload)
-        self._file.write(json.dumps(record, default=_json_default) + "\n")
+        try:
+            self._file.write(json.dumps(record, default=_json_default) + "\n")
+        except OSError:
+            pass  # Don't let logging failures affect query execution
 
     def close(self) -> None:
         if self._closed:
@@ -226,8 +229,13 @@ def enable_event_log(dir: str | Path | None = None) -> None:
     if not _EVENT_LOG_ATEXIT_REGISTERED:
         atexit.register(disable_event_log)
         _EVENT_LOG_ATEXIT_REGISTERED = True
+
     subscriber = EventLogSubscriber(dir or _DEFAULT_EVENT_LOG_DIR)
-    get_context().attach_subscriber(_EVENT_LOG_ALIAS, subscriber)
+    try:
+        get_context().attach_subscriber(_EVENT_LOG_ALIAS, subscriber)
+    except Exception:
+        subscriber.close()
+        raise
     _EVENT_LOG_SUBSCRIBER = subscriber
 
 

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import atexit
+import json
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+from daft.context import get_context
+from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState, StatType
+from daft.subscribers.abc import Subscriber
+
+_EVENT_LOG_ALIAS = "_daft_event_log"
+_DEFAULT_EVENT_LOG_DIR = Path("~/.daft/events").expanduser()
+_EVENT_LOG_ATEXIT_REGISTERED = False
+
+
+def _json_default(obj: object) -> object:
+    """JSON serializer for types not handled by the default encoder."""
+    if isinstance(obj, timedelta):
+        return round(obj.total_seconds() * 1000)
+    return str(obj)
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _mono_ms() -> float:
+    """Monotonic clock in milliseconds for duration measurement."""
+    return time.monotonic() * 1000
+
+
+def _generate_run_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+    suffix = uuid.uuid4().hex[:4]
+    return f"run_{timestamp}_{suffix}"
+
+
+class EventLogSubscriber(Subscriber):
+    """Experimental subscriber that writes query lifecycle events to a JSONL log.
+
+    Events follow the schema documented in the diagnostics plan:
+    one JSON object per line with ``event``, ``ts``, and event-specific fields.
+    """
+
+    def __init__(self, log_dir: str | Path, run_id: str | None = None) -> None:
+        self._log_dir = Path(log_dir).expanduser().resolve()
+        self._run_id = run_id or _generate_run_id()
+        self._run_dir = self._log_dir / self._run_id
+        self._events_path = self._run_dir / "events.jsonl"
+        self._run_dir.mkdir(parents=True, exist_ok=True)
+        self._file = open(self._events_path, "a", buffering=1)  # line-buffered
+        self._closed = False
+
+        # Track start times for duration computation (monotonic ms).
+        # TODO update the framework to pass this information
+        self._query_starts: dict[str, float] = {}
+        self._optimization_starts: dict[str, float] = {}
+        self._exec_starts: dict[str, float] = {}
+        self._operator_starts: dict[tuple[str, int], float] = {}
+
+        self._write_session_header()
+
+    def _clear_query_state(self, query_id: str) -> None:
+        """Remove any leftover timing state for the given query."""
+        self._optimization_starts.pop(query_id, None)
+        self._exec_starts.pop(query_id, None)
+
+        stale_operator_keys = [key for key in self._operator_starts if key[0] == query_id]
+        for key in stale_operator_keys:
+            self._operator_starts.pop(key, None)
+
+    def _write_session_header(self) -> None:
+        import daft
+
+        self._write_event(
+            "session_started",
+            {
+                "daft_version": daft.__version__,
+            },
+        )
+
+    def _write_event(self, event_name: str, payload: dict[str, Any]) -> None:
+        if self._closed:
+            return
+        record: dict[str, Any] = {"event": event_name, "ts": _iso_now()}
+        record.update(payload)
+        self._file.write(json.dumps(record, default=_json_default) + "\n")
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._file.close()
+
+    # Query lifecycle
+
+    def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
+        self._query_starts[query_id] = _mono_ms()
+        self._write_event("query_started", {"query_id": query_id})
+        self._write_event("plan_unoptimized", {"query_id": query_id, "plan": metadata.unoptimized_plan})
+
+    def on_query_end(self, query_id: str, result: PyQueryResult) -> None:
+        start = self._query_starts.pop(query_id, None)
+        duration_ms = round(_mono_ms() - start) if start is not None else None
+
+        payload: dict[str, Any] = {"query_id": query_id}
+        if duration_ms is not None:
+            payload["duration_ms"] = duration_ms
+
+        if result.end_state == QueryEndState.Finished:
+            payload["status"] = "ok"
+        elif result.end_state == QueryEndState.Failed:
+            payload["status"] = "failed"
+            if result.error_message:
+                payload["error_message"] = result.error_message
+        elif result.end_state == QueryEndState.Canceled:
+            payload["status"] = "canceled"
+        else:
+            payload["status"] = "dead"
+
+        self._write_event("query_ended", payload)
+        self._clear_query_state(query_id)
+
+    # Result
+
+    def on_result_out(self, query_id: str, result: PyMicroPartition) -> None:
+        self._write_event(
+            "result_out",
+            {
+                "query_id": query_id,
+                "rows": len(result),
+            },
+        )
+
+    # Optimization
+
+    def on_optimization_start(self, query_id: str) -> None:
+        self._optimization_starts[query_id] = _mono_ms()
+        self._write_event("optimization_started", {"query_id": query_id})
+
+    def on_optimization_end(self, query_id: str, optimized_plan: str) -> None:
+        start = self._optimization_starts.pop(query_id, None)
+        duration_ms = round(_mono_ms() - start) if start is not None else None
+
+        payload: dict[str, Any] = {"query_id": query_id}
+        if duration_ms is not None:
+            payload["duration_ms"] = duration_ms
+
+        self._write_event("optimization_ended", payload)
+        self._write_event("plan_optimized", {"query_id": query_id, "plan": optimized_plan})
+
+    # Execution
+
+    def on_exec_start(self, query_id: str, physical_plan: str) -> None:
+        self._exec_starts[query_id] = _mono_ms()
+        self._write_event("execution_started", {"query_id": query_id})
+        self._write_event("plan_physical", {"query_id": query_id, "plan": physical_plan})
+
+    def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
+        self._operator_starts[(query_id, node_id)] = _mono_ms()
+        self._write_event(
+            "operator_started",
+            {
+                "query_id": query_id,
+                "node_id": node_id,
+            },
+        )
+
+    def on_exec_emit_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
+        for node_id, node_stats in stats.items():
+            metrics: dict[str, Any] = {}
+            for name, (_stat_type, value) in node_stats.items():
+                metrics[name] = value
+            self._write_event(
+                "stats",
+                {
+                    "query_id": query_id,
+                    "node_id": node_id,
+                    "metrics": metrics,
+                },
+            )
+
+    def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
+        start = self._operator_starts.pop((query_id, node_id), None)
+        duration_ms = round(_mono_ms() - start) if start is not None else None
+
+        payload: dict[str, Any] = {
+            "query_id": query_id,
+            "node_id": node_id,
+        }
+        if duration_ms is not None:
+            payload["duration_ms"] = duration_ms
+
+        self._write_event("operator_ended", payload)
+
+    def on_exec_end(self, query_id: str) -> None:
+        start = self._exec_starts.pop(query_id, None)
+        duration_ms = round(_mono_ms() - start) if start is not None else None
+
+        payload: dict[str, Any] = {"query_id": query_id}
+        if duration_ms is not None:
+            payload["duration_ms"] = duration_ms
+
+        self._write_event("execution_ended", payload)
+
+
+_EVENT_LOG_SUBSCRIBER: EventLogSubscriber | None = None
+
+
+def enable_event_log(dir: str | Path | None = None) -> None:
+    """Experimental helper that attaches an event-log subscriber.
+
+    This API is currently intended for local event-log capture through
+    `enable_event_log()` / `disable_event_log()`.
+    """
+    global _EVENT_LOG_ATEXIT_REGISTERED, _EVENT_LOG_SUBSCRIBER
+    if _EVENT_LOG_SUBSCRIBER is not None:
+        disable_event_log()
+    if not _EVENT_LOG_ATEXIT_REGISTERED:
+        atexit.register(disable_event_log)
+        _EVENT_LOG_ATEXIT_REGISTERED = True
+    subscriber = EventLogSubscriber(dir or _DEFAULT_EVENT_LOG_DIR)
+    get_context().attach_subscriber(_EVENT_LOG_ALIAS, subscriber)
+    _EVENT_LOG_SUBSCRIBER = subscriber
+
+
+def disable_event_log() -> None:
+    """Detach the global EventLogSubscriber from the Daft context."""
+    global _EVENT_LOG_SUBSCRIBER
+    subscriber = _EVENT_LOG_SUBSCRIBER
+    if subscriber is None:
+        return
+    _EVENT_LOG_SUBSCRIBER = None
+    try:
+        get_context().detach_subscriber(_EVENT_LOG_ALIAS)
+    except Exception:
+        pass
+    subscriber.close()
+
+
+__all__ = ["EventLogSubscriber", "disable_event_log", "enable_event_log"]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+
+import pytest
+
+import daft
+from daft.context import get_context
+from daft.daft import PyQueryMetadata, PyQueryResult, QueryEndState
+from daft.subscribers import events as subscriber_events
+from daft.subscribers.events import _EVENT_LOG_ALIAS, EventLogSubscriber, disable_event_log, enable_event_log
+from tests.conftest import get_tests_daft_runner_name
+
+pytestmark = pytest.mark.skipif(
+    get_tests_daft_runner_name() != "native", reason="Only Native Runner supports subscribers right now"
+)
+
+
+@pytest.fixture(autouse=True)
+def cleanup_event_log() -> Iterator[None]:
+    disable_event_log()
+    yield
+    disable_event_log()
+
+
+def _load_events(path):
+    with path.open() as f:
+        return [json.loads(line) for line in f]
+
+
+def _make_query_metadata() -> PyQueryMetadata:
+    df = daft.from_pydict({"x": [1, 2, 3]})
+    return PyQueryMetadata(
+        df.schema()._schema,
+        df._builder.repr_json(),
+        "Native (Swordfish)",
+        ray_dashboard_url=None,
+        entrypoint="pytest",
+    )
+
+
+def test_event_log_subscriber_writes_session_header(tmp_path):
+    subscriber = EventLogSubscriber(tmp_path, run_id="testrun")
+    subscriber.close()
+
+    events = _load_events(tmp_path / "testrun" / "events.jsonl")
+    assert len(events) == 1
+    assert events[0]["event"] == "session_started"
+    assert "daft_version" in events[0]
+
+
+def test_event_log_subscriber_writes_query_lifecycle_events(tmp_path):
+    subscriber = EventLogSubscriber(tmp_path, run_id="testrun")
+
+    try:
+        query_id = "q_success"
+        metadata = _make_query_metadata()
+
+        subscriber.on_query_start(query_id, metadata)
+        subscriber.on_query_end(query_id, PyQueryResult(QueryEndState.Finished, "Query finished"))
+    finally:
+        subscriber.close()
+
+    events = _load_events(tmp_path / "testrun" / "events.jsonl")
+    event_names = [event["event"] for event in events]
+    assert event_names == ["session_started", "query_started", "plan_unoptimized", "query_ended"]
+
+    query_ended = events[-1]
+    assert query_ended["query_id"] == query_id
+    assert query_ended["status"] == "ok"
+    assert query_ended["duration_ms"] >= 0
+
+
+def test_on_query_end_clears_stale_timing_state_for_failed_query(tmp_path):
+    subscriber = EventLogSubscriber(tmp_path, run_id="testrun")
+
+    try:
+        query_id = "q_failed"
+        metadata = _make_query_metadata()
+
+        subscriber.on_query_start(query_id, metadata)
+        subscriber.on_optimization_start(query_id)
+        subscriber.on_exec_start(query_id, '{"nodes":{}}')
+        subscriber.on_exec_operator_start(query_id, 1)
+        subscriber.on_exec_operator_start(query_id, 2)
+
+        subscriber.on_query_end(query_id, PyQueryResult(QueryEndState.Failed, "boom"))
+
+        assert query_id not in subscriber._query_starts
+        assert query_id not in subscriber._optimization_starts
+        assert query_id not in subscriber._exec_starts
+        assert all(qid != query_id for qid, _ in subscriber._operator_starts)
+    finally:
+        subscriber.close()
+
+
+def test_on_query_end_only_clears_ended_query_state(tmp_path):
+    subscriber = EventLogSubscriber(tmp_path, run_id="testrun")
+
+    try:
+        ended_query_id = "q_ended"
+        live_query_id = "q_live"
+        metadata = _make_query_metadata()
+
+        subscriber.on_query_start(ended_query_id, metadata)
+        subscriber.on_optimization_start(ended_query_id)
+        subscriber.on_exec_start(ended_query_id, '{"nodes":{}}')
+        subscriber.on_exec_operator_start(ended_query_id, 1)
+
+        subscriber.on_query_start(live_query_id, metadata)
+        subscriber.on_optimization_start(live_query_id)
+        subscriber.on_exec_start(live_query_id, '{"nodes":{}}')
+        subscriber.on_exec_operator_start(live_query_id, 9)
+
+        subscriber.on_query_end(ended_query_id, PyQueryResult(QueryEndState.Canceled, "canceled"))
+
+        assert ended_query_id not in subscriber._query_starts
+        assert ended_query_id not in subscriber._optimization_starts
+        assert ended_query_id not in subscriber._exec_starts
+        assert all(qid != ended_query_id for qid, _ in subscriber._operator_starts)
+
+        assert live_query_id in subscriber._query_starts
+        assert live_query_id in subscriber._optimization_starts
+        assert live_query_id in subscriber._exec_starts
+        assert (live_query_id, 9) in subscriber._operator_starts
+    finally:
+        subscriber.close()
+
+
+def test_enable_event_log_attach_and_disable_close(tmp_path):
+    enable_event_log(tmp_path)
+    subscriber = subscriber_events._EVENT_LOG_SUBSCRIBER
+
+    assert subscriber is not None
+    assert subscriber._events_path.exists()
+
+    df = daft.from_pydict({"x": [1, 2, 3]}).with_column("y", daft.col("x") + 1)
+    df.collect()
+
+    disable_event_log()
+
+    assert subscriber_events._EVENT_LOG_SUBSCRIBER is None
+    assert subscriber._closed is True
+
+    events = _load_events(subscriber._events_path)
+    event_names = [event["event"] for event in events]
+    assert "query_started" in event_names
+    assert "query_ended" in event_names
+
+    with pytest.raises(Exception):
+        get_context().detach_subscriber(_EVENT_LOG_ALIAS)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -41,17 +41,14 @@ def _make_query_metadata() -> PyQueryMetadata:
 
 
 def test_event_log_subscriber_writes_session_header(tmp_path):
-    subscriber = EventLogSubscriber(tmp_path, run_id="testrun")
+    subscriber = EventLogSubscriber(tmp_path)
     subscriber.close()
 
-    events = _load_events(tmp_path / "testrun" / "events.jsonl")
-    assert len(events) == 1
-    assert events[0]["event"] == "session_started"
-    assert "daft_version" in events[0]
+    assert list(tmp_path.rglob("events.jsonl")) == []
 
 
 def test_event_log_subscriber_writes_query_lifecycle_events(tmp_path):
-    subscriber = EventLogSubscriber(tmp_path, run_id="testrun")
+    subscriber = EventLogSubscriber(tmp_path)
 
     try:
         query_id = "q_success"
@@ -62,9 +59,9 @@ def test_event_log_subscriber_writes_query_lifecycle_events(tmp_path):
     finally:
         subscriber.close()
 
-    events = _load_events(tmp_path / "testrun" / "events.jsonl")
+    events = _load_events(tmp_path / query_id / "events.jsonl")
     event_names = [event["event"] for event in events]
-    assert event_names == ["session_started", "query_started", "plan_unoptimized", "query_ended"]
+    assert event_names == ["event_log_started", "query_started", "plan_unoptimized", "query_ended"]
 
     query_ended = events[-1]
     assert query_ended["query_id"] == query_id
@@ -73,7 +70,7 @@ def test_event_log_subscriber_writes_query_lifecycle_events(tmp_path):
 
 
 def test_on_query_end_clears_stale_timing_state_for_failed_query(tmp_path):
-    subscriber = EventLogSubscriber(tmp_path, run_id="testrun")
+    subscriber = EventLogSubscriber(tmp_path)
 
     try:
         query_id = "q_failed"
@@ -96,7 +93,7 @@ def test_on_query_end_clears_stale_timing_state_for_failed_query(tmp_path):
 
 
 def test_on_query_end_only_clears_ended_query_state(tmp_path):
-    subscriber = EventLogSubscriber(tmp_path, run_id="testrun")
+    subscriber = EventLogSubscriber(tmp_path)
 
     try:
         ended_query_id = "q_ended"
@@ -133,7 +130,6 @@ def test_enable_event_log_attach_and_disable_close(tmp_path):
     subscriber = subscriber_events._EVENT_LOG_SUBSCRIBER
 
     assert subscriber is not None
-    assert subscriber._events_path.exists()
 
     df = daft.from_pydict({"x": [1, 2, 3]}).with_column("y", daft.col("x") + 1)
     df.collect()
@@ -143,7 +139,10 @@ def test_enable_event_log_attach_and_disable_close(tmp_path):
     assert subscriber_events._EVENT_LOG_SUBSCRIBER is None
     assert subscriber._closed is True
 
-    events = _load_events(subscriber._events_path)
+    event_logs = list(tmp_path.rglob("events.jsonl"))
+    assert len(event_logs) == 1
+
+    events = _load_events(event_logs[0])
     event_names = [event["event"] for event in events]
     assert "query_started" in event_names
     assert "query_ended" in event_names

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -40,7 +40,7 @@ def _make_query_metadata() -> PyQueryMetadata:
     )
 
 
-def test_event_log_subscriber_writes_session_header(tmp_path):
+def test_no_files_created_without_query(tmp_path):
     subscriber = EventLogSubscriber(tmp_path)
     subscriber.close()
 


### PR DESCRIPTION
## Changes Made
EventLogSubscriber writes query lifecycle events (start, optimization, execution, operator, stats) to a per-run JSONL file under ~/.daft/events/ directory as the default. This is configurable. Includes enable_event_log()/disable_event_log() helpers for global attachment with atexit cleanup.

Each query log is contained in a directory with following format `<log_dir>/<query_id>/events.jsonl`. 

This is experimental and the api will probably change in future PRs. 

## Related Issues


sample log
```
{"event": "session_started", "ts": "2026-03-17T23:33:49.916Z", "daft_version": "0.3.0-dev0"}
{"event": "query_started", "ts": "2026-03-17T23:33:53.867Z", "query_id": "nimble-falcon-57ee1d"}
{"event": "plan_unoptimized", "ts": "2026-03-17T23:33:53.867Z", "query_id": "nimble-falcon-57ee1d", "plan": "{\"children\":[{\"batch_size\":10000,\"children\":[{\"children\":[{\"children\":[{\"children\":[],\"type\":\"Source\"}],\"projection\":[\"col(VendorID)\",\"col(total_amount)\",\"col(tpep_pickup_datetime)\"],\"type\":\"Project\"}],\"limit\":100000,\"type\":\"Limit\"}],\"type\":\"IntoBatches\"}],\"type\":\"Sink\"}"}
{"event": "optimization_started", "ts": "2026-03-17T23:33:53.867Z", "query_id": "nimble-falcon-57ee1d"}
{"event": "optimization_ended", "ts": "2026-03-17T23:33:54.164Z", "query_id": "nimble-falcon-57ee1d", "duration_ms": 298}
{"event": "plan_optimized", "ts": "2026-03-17T23:33:54.165Z", "query_id": "nimble-falcon-57ee1d", "plan": "{\"children\":[{\"batch_size\":10000,\"children\":[{\"children\":[{\"children\":[{\"children\":[],\"type\":\"Source\"}],\"limit\":100000,\"type\":\"Limit\"}],\"projection\":[\"col(VendorID)\",\"col(total_amount)\",\"col(tpep_pickup_datetime)\"],\"type\":\"Project\"}],\"type\":\"IntoBatches\"}],\"type\":\"Sink\"}"}
{"event": "execution_started", "ts": "2026-03-17T23:33:54.178Z", "query_id": "nimble-falcon-57ee1d"}
{"event": "plan_physical", "ts": "2026-03-17T23:33:54.178Z", "query_id": "nimble-falcon-57ee1d", "plan": "{\"approx_stats\":{\"approx_stats\":{\"acc_selectivity\":1.0,\"num_rows\":0,\"size_bytes\":0}},\"category\":\"BlockingSink\",\"children\":[{\"approx_stats\":{\"approx_stats\":{\"acc_selectivity\":1.0,\"num_rows\":0,\"size_bytes\":0}},\"category\":\"BlockingSink\",\"children\":[{\"approx_stats\":{\"approx_stats\":{\"acc_selectivity\":1.0,\"num_rows\":100000,\"size_bytes\":2400000}},\"category\":\"Intermediate\",\"children\":[{\"approx_stats\":{\"approx_stats\":{\"acc_selectivity\":1.0,\"num_rows\":100000,\"size_bytes\":2400000}},\"category\":\"Intermediate\",\"children\":[{\"approx_stats\":{\"approx_stats\":{\"acc_selectivity\":1.0,\"num_rows\":100000,\"size_bytes\":2400000}},\"category\":\"StreamingSink\",\"children\":[{\"approx_stats\":{\"approx_stats\":{\"acc_selectivity\":1.0,\"num_rows\":100000,\"size_bytes\":2400000}},\"category\":\"Source\",\"id\":0,\"name\":\"Read Parquet\",\"type\":\"ScanTask\"}],\"id\":1,\"name\":\"Limit 100000\",\"type\":\"Limit\"}],\"id\":2,\"name\":\"Rename & Reorder\",\"type\":\"Project\"}],\"id\":3,\"name\":\"Into Batches of 10000\",\"type\":\"IntoBatches\"}],\"id\":4,\"name\":\"CSV Write\",\"type\":\"Write\"}],\"id\":5,\"name\":\"Commit Write\",\"type\":\"CommitWrite\"}"}
{"event": "operator_started", "ts": "2026-03-17T23:33:54.365Z", "query_id": "nimble-falcon-57ee1d", "node_id": 0}
{"event": "stats", "ts": "2026-03-17T23:33:54.370Z", "query_id": "nimble-falcon-57ee1d", "node_id": 0, "metrics": {"bytes.read": 0, "rows.out": 0, "duration": 0}}
{"event": "stats", "ts": "2026-03-17T23:33:54.555Z", "query_id": "nimble-falcon-57ee1d", "node_id": 0, "metrics": {"bytes.read": 0, "rows.out": 0, "duration": 0}}
{"event": "stats", "ts": "2026-03-17T23:33:54.754Z", "query_id": "nimble-falcon-57ee1d", "node_id": 0, "metrics": {"rows.out": 0, "duration": 0, "bytes.read": 65536}}
{"event": "operator_started", "ts": "2026-03-17T23:33:54.901Z", "query_id": "nimble-falcon-57ee1d", "node_id": 1}
{"event": "operator_started", "ts": "2026-03-17T23:33:54.903Z", "query_id": "nimble-falcon-57ee1d", "node_id": 2}
{"event": "operator_started", "ts": "2026-03-17T23:33:54.905Z", "query_id": "nimble-falcon-57ee1d", "node_id": 3}
{"event": "operator_started", "ts": "2026-03-17T23:33:54.906Z", "query_id": "nimble-falcon-57ee1d", "node_id": 4}
{"event": "stats", "ts": "2026-03-17T23:33:54.953Z", "query_id": "nimble-falcon-57ee1d", "node_id": 3, "metrics": {"duration": 0, "rows.in": 60000, "rows.out": 50000}}
{"event": "stats", "ts": "2026-03-17T23:33:54.953Z", "query_id": "nimble-falcon-57ee1d", "node_id": 0, "metrics": {"bytes.read": 1653009, "duration": 0, "rows.out": 78091}}
{"event": "stats", "ts": "2026-03-17T23:33:54.953Z", "query_id": "nimble-falcon-57ee1d", "node_id": 1, "metrics": {"rows.out": 78091, "duration": 0, "rows.in": 78091}}
{"event": "stats", "ts": "2026-03-17T23:33:54.953Z", "query_id": "nimble-falcon-57ee1d", "node_id": 2, "metrics": {"rows.in": 78091, "rows.out": 78091, "duration": 1}}
{"event": "stats", "ts": "2026-03-17T23:33:54.953Z", "query_id": "nimble-falcon-57ee1d", "node_id": 4, "metrics": {"rows.written": 30000, "duration": 82, "rows.in": 30000, "bytes.written": 720000}}
{"event": "stats", "ts": "2026-03-17T23:33:54.970Z", "query_id": "nimble-falcon-57ee1d", "node_id": 1, "metrics": {"rows.in": 100000, "rows.out": 100000, "duration": 0}}
{"event": "operator_ended", "ts": "2026-03-17T23:33:54.970Z", "query_id": "nimble-falcon-57ee1d", "node_id": 1, "duration_ms": 69}
{"event": "stats", "ts": "2026-03-17T23:33:54.971Z", "query_id": "nimble-falcon-57ee1d", "node_id": 0, "metrics": {"duration": 0, "rows.out": 100000, "bytes.read": 2164041}}
{"event": "operator_ended", "ts": "2026-03-17T23:33:54.971Z", "query_id": "nimble-falcon-57ee1d", "node_id": 0, "duration_ms": 606}
{"event": "stats", "ts": "2026-03-17T23:33:54.989Z", "query_id": "nimble-falcon-57ee1d", "node_id": 2, "metrics": {"duration": 1, "rows.in": 100000, "rows.out": 100000}}
{"event": "operator_ended", "ts": "2026-03-17T23:33:54.989Z", "query_id": "nimble-falcon-57ee1d", "node_id": 2, "duration_ms": 87}
{"event": "stats", "ts": "2026-03-17T23:33:55.022Z", "query_id": "nimble-falcon-57ee1d", "node_id": 3, "metrics": {"rows.out": 100000, "rows.in": 100000, "duration": 0}}
{"event": "operator_ended", "ts": "2026-03-17T23:33:55.023Z", "query_id": "nimble-falcon-57ee1d", "node_id": 3, "duration_ms": 118}
{"event": "stats", "ts": "2026-03-17T23:33:55.037Z", "query_id": "nimble-falcon-57ee1d", "node_id": 4, "metrics": {"rows.in": 100000, "bytes.written": 2400000, "rows.written": 100000, "duration": 254}}
{"event": "operator_ended", "ts": "2026-03-17T23:33:55.037Z", "query_id": "nimble-falcon-57ee1d", "node_id": 4, "duration_ms": 131}
{"event": "operator_started", "ts": "2026-03-17T23:33:55.037Z", "query_id": "nimble-falcon-57ee1d", "node_id": 5}
{"event": "stats", "ts": "2026-03-17T23:33:55.049Z", "query_id": "nimble-falcon-57ee1d", "node_id": 5, "metrics": {"rows.in": 1, "rows.out": 1, "duration": 29}}
{"event": "operator_ended", "ts": "2026-03-17T23:33:55.049Z", "query_id": "nimble-falcon-57ee1d", "node_id": 5, "duration_ms": 12}
{"event": "execution_ended", "ts": "2026-03-17T23:33:55.049Z", "query_id": "nimble-falcon-57ee1d", "duration_ms": 871}
{"event": "result_out", "ts": "2026-03-17T23:33:55.050Z", "query_id": "nimble-falcon-57ee1d", "rows": 1}
{"event": "query_ended", "ts": "2026-03-17T23:33:55.050Z", "query_id": "nimble-falcon-57ee1d", "duration_ms": 1183, "status": "ok"}

```