### PR TITLE
feat(observability): add process-level memory and CPU monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2323,6 +2323,7 @@ dependencies = [
  "pyo3",
  "pyo3-log",
  "sysinfo",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
 ]
 
@@ -2972,7 +2973,10 @@ dependencies = [
  "pyo3-async-runtimes",
  "rand 0.9.2",
  "serde_json",
+ "smallvec",
  "snafu",
+ "sysinfo",
+ "tikv-jemalloc-ctl",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7725,6 +7729,17 @@ dependencies = [
  "lazy_static",
  "regex",
  "rustc-hash 1.1.0",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ debug = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 libc = {workspace = true}
+tikv-jemalloc-ctl = {version = "0.6.0", features = ["stats"]}
 tikv-jemallocator = {version = "0.6.0", features = [
   "disable_initial_exec_tls"
 ]}

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2356,6 +2356,8 @@ class StatType(Enum):
     FLOAT = 3
     DURATION = 5
 
+PROCESS_STATS_NODE_ID: int
+
 # TODO(void001): Implement Dead state
 class QueryEndState(Enum):
     Finished = 0

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2356,8 +2356,6 @@ class StatType(Enum):
     FLOAT = 3
     DURATION = 5
 
-PROCESS_STATS_NODE_ID: int
-
 # TODO(void001): Implement Dead state
 class QueryEndState(Enum):
     Finished = 0

--- a/daft/subscribers/abc.py
+++ b/daft/subscribers/abc.py
@@ -79,5 +79,12 @@ class Subscriber(ABC):
         """Called when a query has finished executing."""
         pass
 
+    def on_process_stats(self, query_id: str, stats: Mapping[str, tuple[StatType, Any]]) -> None:
+        """Called with process-level stats (memory, CPU) on each tick.
+
+        Override to capture process-level metrics. Not abstract - defaults to no-op.
+        """
+        pass
+
 
 __all__ = ["StatType", "Subscriber"]

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from io import TextIOWrapper
 
 from daft.context import get_context
-from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState, StatType
+from daft.daft import PROCESS_STATS_NODE_ID, PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState, StatType
 from daft.subscribers.abc import Subscriber
 
 _EVENT_LOG_ALIAS = "_daft_event_log"
@@ -208,14 +208,17 @@ class EventLogSubscriber(Subscriber):
             metrics: dict[str, Any] = {}
             for name, (_stat_type, value) in node_stats.items():
                 metrics[name] = value
-            self._write_event(
-                query_id,
-                "stats",
-                {
-                    "node_id": node_id,
-                    "metrics": metrics,
-                },
-            )
+            if node_id == PROCESS_STATS_NODE_ID:
+                self._write_event(query_id, "process_stats", {"metrics": metrics})
+            else:
+                self._write_event(
+                    query_id,
+                    "stats",
+                    {
+                        "node_id": node_id,
+                        "metrics": metrics,
+                    },
+                )
 
     def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
         start = self._operator_starts.pop((query_id, node_id), None)

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from io import TextIOWrapper
 
 from daft.context import get_context
-from daft.daft import PROCESS_STATS_NODE_ID, PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState, StatType
+from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState, StatType
 from daft.subscribers.abc import Subscriber
 
 _EVENT_LOG_ALIAS = "_daft_event_log"
@@ -208,17 +208,20 @@ class EventLogSubscriber(Subscriber):
             metrics: dict[str, Any] = {}
             for name, (_stat_type, value) in node_stats.items():
                 metrics[name] = value
-            if node_id == PROCESS_STATS_NODE_ID:
-                self._write_event(query_id, "process_stats", {"metrics": metrics})
-            else:
-                self._write_event(
-                    query_id,
-                    "stats",
-                    {
-                        "node_id": node_id,
-                        "metrics": metrics,
-                    },
-                )
+            self._write_event(
+                query_id,
+                "stats",
+                {
+                    "node_id": node_id,
+                    "metrics": metrics,
+                },
+            )
+
+    def on_process_stats(self, query_id: str, stats: Mapping[str, tuple[StatType, Any]]) -> None:
+        metrics: dict[str, Any] = {}
+        for name, (_stat_type, value) in stats.items():
+            metrics[name] = value
+        self._write_event(query_id, "process_stats", {"metrics": metrics})
 
     def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
         start = self._operator_starts.pop((query_id, node_id), None)

--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -27,8 +27,6 @@ pub type QueryID = Arc<str>;
 pub type QueryPlan = Arc<str>;
 /// Unique identifier for a node in the execution plan.
 pub type NodeID = usize;
-/// Sentinel NodeID for process-level stats (not tied to any operator).
-pub const PROCESS_STATS_NODE_ID: NodeID = usize::MAX;
 
 #[cfg_attr(feature = "python", pyclass(module = "daft.daft", eq, from_py_object))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -165,6 +163,5 @@ pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_class::<StatType>()?;
     parent.add_class::<PyOperatorMetrics>()?;
     parent.add_class::<QueryEndState>()?;
-    parent.add("PROCESS_STATS_NODE_ID", PROCESS_STATS_NODE_ID)?;
     Ok(())
 }

--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -27,6 +27,8 @@ pub type QueryID = Arc<str>;
 pub type QueryPlan = Arc<str>;
 /// Unique identifier for a node in the execution plan.
 pub type NodeID = usize;
+/// Sentinel NodeID for process-level stats (not tied to any operator).
+pub const PROCESS_STATS_NODE_ID: NodeID = usize::MAX;
 
 #[cfg_attr(feature = "python", pyclass(module = "daft.daft", eq, from_py_object))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -141,11 +143,18 @@ pub const ATTR_NODE_ID: &str = "node.id";
 pub const ATTR_NODE_TYPE: &str = "node.type";
 pub const ATTR_NODE_PHASE: &str = "node.phase";
 
+// Process-level metrics
+pub const PROCESS_JEMALLOC_ALLOCATED_KEY: &str = "process.memory.jemalloc.allocated";
+pub const PROCESS_JEMALLOC_RESIDENT_KEY: &str = "process.memory.jemalloc.resident";
+pub const PROCESS_RSS_KEY: &str = "process.memory.rss";
+pub const PROCESS_CPU_PERCENT_KEY: &str = "process.cpu.percent";
+
 // Units (UCUM)
 pub const UNIT_ROWS: &str = "{row}";
 pub const UNIT_BYTES: &str = "By";
 pub const UNIT_MICROSECONDS: &str = "us";
 pub const UNIT_TASKS: &str = "{task}";
+pub const UNIT_PERCENT: &str = "%";
 
 #[cfg(feature = "python")]
 pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
@@ -156,5 +165,6 @@ pub fn register_modules(parent: &Bound<PyModule>) -> PyResult<()> {
     parent.add_class::<StatType>()?;
     parent.add_class::<PyOperatorMetrics>()?;
     parent.add_class::<QueryEndState>()?;
+    parent.add("PROCESS_STATS_NODE_ID", PROCESS_STATS_NODE_ID)?;
     Ok(())
 }

--- a/src/common/metrics/src/meters.rs
+++ b/src/common/metrics/src/meters.rs
@@ -70,11 +70,17 @@ impl Gauge {
         meter: &opentelemetry::metrics::Meter,
         name: impl Into<Cow<'static, str>>,
         description: Option<Cow<'static, str>>,
+        unit: Option<Cow<'static, str>>,
     ) -> Self {
         let normalized_name = normalize_name(name);
         let builder = meter.f64_gauge(normalized_name);
         let builder = if let Some(description) = description {
             builder.with_description(description)
+        } else {
+            builder
+        };
+        let builder = if let Some(unit) = unit {
+            builder.with_unit(unit)
         } else {
             builder
         };
@@ -134,9 +140,13 @@ impl Meter {
         Self { otel }
     }
 
-    pub fn test_scope(name: &'static str) -> Self {
+    pub fn global_scope(name: &'static str) -> Self {
         let otel = global::meter(name);
         Self { otel }
+    }
+
+    pub fn test_scope(name: &'static str) -> Self {
+        Self::global_scope(name)
     }
 
     pub fn u64_counter(&self, name: impl Into<Cow<'static, str>>) -> Counter {
@@ -153,7 +163,16 @@ impl Meter {
     }
 
     pub fn f64_gauge(&self, name: impl Into<Cow<'static, str>>) -> Gauge {
-        Gauge::new(&self.otel, name, None)
+        Gauge::new(&self.otel, name, None, None)
+    }
+
+    pub fn f64_gauge_with_desc_and_unit(
+        &self,
+        name: impl Into<Cow<'static, str>>,
+        description: Option<Cow<'static, str>>,
+        unit: Option<Cow<'static, str>>,
+    ) -> Gauge {
+        Gauge::new(&self.otel, name, description, unit)
     }
 
     pub fn i64_up_down_counter(&self, name: impl Into<Cow<'static, str>>) -> UpDownCounter {

--- a/src/daft-context/src/subscribers/mod.rs
+++ b/src/daft-context/src/subscribers/mod.rs
@@ -57,6 +57,11 @@ pub trait Subscriber: Send + Sync + std::fmt::Debug + 'static {
     }
     async fn on_exec_operator_end(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()>;
     async fn on_exec_end(&self, query_id: QueryID) -> DaftResult<()>;
+    /// Called with process-level stats (memory, CPU) on each tick.
+    /// Default no-op; only subscribers interested in process stats need to override.
+    async fn on_process_stats(&self, _query_id: QueryID, _stats: Stats) -> DaftResult<()> {
+        Ok(())
+    }
     async fn on_exec_end_with_id(&self, query_id: QueryID, _execution_id: &str) -> DaftResult<()> {
         self.on_exec_end(query_id).await
     }

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -143,4 +143,21 @@ impl Subscriber for PySubscriberWrapper {
             Ok(())
         })
     }
+
+    async fn on_process_stats(&self, query_id: QueryID, stats: Stats) -> DaftResult<()> {
+        Python::attach(|py| {
+            let stat_map = stats
+                .iter()
+                .map(|(name, stat)| (name.to_string(), stat.clone().into_py_contents(py).unwrap()))
+                .collect::<HashMap<_, _>>();
+            let py_stats = stat_map.into_pyobject(py)?;
+
+            self.0.call_method1(
+                py,
+                intern!(py, "on_process_stats"),
+                (query_id.to_string(), py_stats),
+            )?;
+            Ok(())
+        })
+    }
 }

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -44,6 +44,7 @@ pin-project = "1"
 pyo3 = {workspace = true, optional = true}
 pyo3-async-runtimes = {workspace = true, optional = true}
 rand = {workspace = true}
+smallvec = {workspace = true}
 snafu = {workspace = true}
 tokio = {workspace = true, features = ["test-util"]}
 tokio-stream = {workspace = true}
@@ -52,6 +53,10 @@ tracing = {workspace = true}
 serde_json = {workspace = true}
 opentelemetry = {workspace = true}
 dashmap = {workspace = true}
+sysinfo = {workspace = true}
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemalloc-ctl = {version = "0.6.0", features = ["stats"]}
 
 [features]
 python = [

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -1,3 +1,4 @@
+mod process_stats;
 mod progress_bar;
 mod values;
 
@@ -27,6 +28,14 @@ use tracing::{Instrument, instrument::Instrumented};
 pub use values::{DefaultRuntimeStats, RuntimeStats};
 
 use crate::pipeline::PipelineNode;
+
+fn should_enable_process_monitor() -> bool {
+    if let Ok(val) = std::env::var("DAFT_PROCESS_MONITOR_ENABLED") {
+        matches!(val.trim().to_lowercase().as_str(), "1" | "true")
+    } else {
+        false // Disabled by default; enable with DAFT_PROCESS_MONITOR_ENABLED=true
+    }
+}
 
 fn should_enable_progress_bar() -> bool {
     if std::env::var("DAFT_FLOTILLA_WORKER").is_ok() {
@@ -169,6 +178,13 @@ impl RuntimeStatsManager {
         let node_tx = Arc::new(node_tx);
         let (finish_tx, mut finish_rx) = oneshot::channel::<QueryEndState>();
 
+        let mut process_stats = if should_enable_process_monitor() {
+            let meter = opentelemetry::global::meter("daft");
+            process_stats::ProcessStatsCollector::new(&meter)
+        } else {
+            None
+        };
+
         let event_loop = async move {
             let mut interval = interval(throttle_interval);
             let mut active_nodes = HashSet::with_capacity(node_map.len());
@@ -220,7 +236,11 @@ impl RuntimeStatsManager {
                     }
 
                     _ = interval.tick() => {
-                        if active_nodes.is_empty() {
+                        if let Some(ps) = &mut process_stats {
+                            snapshot_container.push((common_metrics::PROCESS_STATS_NODE_ID, ps.sample()));
+                        }
+
+                        if active_nodes.is_empty() && snapshot_container.is_empty() {
                             continue;
                         }
 

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -153,6 +153,7 @@ impl RuntimeStatsManager {
         };
 
         let throttle_interval = Duration::from_millis(200);
+        let enable_process_monitor = should_enable_process_monitor();
         Ok(Self::new_impl(
             handle,
             query_id,
@@ -161,10 +162,12 @@ impl RuntimeStatsManager {
             progress_bar,
             node_map,
             throttle_interval,
+            enable_process_monitor,
         ))
     }
 
     // Mostly used for testing purposes so we can inject our own subscribers and throttling interval
+    #[allow(clippy::too_many_arguments)]
     fn new_impl(
         handle: &Handle,
         query_id: QueryID,
@@ -173,12 +176,13 @@ impl RuntimeStatsManager {
         progress_bar: Option<Box<dyn ProgressBar>>,
         node_map: HashMap<NodeID, (Arc<NodeInfo>, Arc<dyn RuntimeStats>)>,
         throttle_interval: Duration,
+        enable_process_monitor: bool,
     ) -> Self {
         let (node_tx, mut node_rx) = mpsc::unbounded_channel::<(usize, bool)>();
         let node_tx = Arc::new(node_tx);
         let (finish_tx, mut finish_rx) = oneshot::channel::<QueryEndState>();
 
-        let mut process_stats = if should_enable_process_monitor() {
+        let mut process_stats = if enable_process_monitor {
             let meter = opentelemetry::global::meter("daft");
             process_stats::ProcessStatsCollector::new(&meter)
         } else {
@@ -471,6 +475,7 @@ mod tests {
             None,
             HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
             throttle_interval,
+            false,
         );
         let handle = stats_manager.handle();
 
@@ -536,6 +541,7 @@ mod tests {
             None,
             HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
             throttle_interval,
+            false,
         );
         let handle = stats_manager.handle();
 
@@ -613,6 +619,7 @@ mod tests {
             None,
             HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
             throttle_interval,
+            false,
         );
         let handle = stats_manager.handle();
 
@@ -673,6 +680,7 @@ mod tests {
             None,
             HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
             throttle_interval,
+            false,
         );
         let handle = stats_manager.handle();
 
@@ -710,6 +718,7 @@ mod tests {
             None,
             HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
             throttle_interval,
+            false,
         );
         let handle = stats_manager.handle();
 
@@ -738,5 +747,131 @@ mod tests {
         );
         assert_eq!(event[1], (ROWS_IN_KEY.into(), Stat::Count(100)));
         assert_eq!(event[2], (ROWS_OUT_KEY.into(), Stat::Count(50)));
+    }
+
+    /// Mock subscriber that tracks on_process_stats calls.
+    #[derive(Debug)]
+    struct ProcessStatsMockSubscriber {
+        process_stats_calls: AtomicU64,
+    }
+
+    impl ProcessStatsMockSubscriber {
+        fn new() -> Self {
+            Self {
+                process_stats_calls: AtomicU64::new(0),
+            }
+        }
+
+        fn get_process_stats_calls(&self) -> u64 {
+            self.process_stats_calls
+                .load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl Subscriber for ProcessStatsMockSubscriber {
+        fn on_query_start(&self, _: QueryID, _: Arc<QueryMetadata>) -> DaftResult<()> {
+            Ok(())
+        }
+        fn on_query_end(&self, _: QueryID, _: QueryResult) -> DaftResult<()> {
+            Ok(())
+        }
+        fn on_result_out(&self, _: QueryID, _: MicroPartitionRef) -> DaftResult<()> {
+            Ok(())
+        }
+        fn on_optimization_start(&self, _: QueryID) -> DaftResult<()> {
+            Ok(())
+        }
+        fn on_optimization_end(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
+            Ok(())
+        }
+        fn on_exec_start(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
+            Ok(())
+        }
+        async fn on_exec_end(&self, _: QueryID) -> DaftResult<()> {
+            Ok(())
+        }
+        async fn on_exec_operator_start(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
+            Ok(())
+        }
+        async fn on_exec_operator_end(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
+            Ok(())
+        }
+        async fn on_exec_emit_stats(
+            &self,
+            _: QueryID,
+            _: Arc<Vec<(NodeID, Stats)>>,
+        ) -> DaftResult<()> {
+            Ok(())
+        }
+        async fn on_process_stats(&self, _: QueryID, _: Stats) -> DaftResult<()> {
+            self.process_stats_calls
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_process_stats_delivered_to_subscriber_when_enabled() {
+        let subscriber = Arc::new(ProcessStatsMockSubscriber::new());
+        let throttle_interval = Duration::from_millis(50);
+        let node_stat = Arc::new(DefaultRuntimeStats::new(
+            &global::meter("test_process_stats_enabled"),
+            &node_info_from_id(0),
+        )) as Arc<dyn RuntimeStats>;
+
+        let stats_manager = RuntimeStatsManager::new_impl(
+            &tokio::runtime::Handle::current(),
+            "test_ps_enabled".into(),
+            serde_json::Value::Null,
+            vec![subscriber.clone()],
+            None,
+            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat))]),
+            throttle_interval,
+            true, // enable process monitor
+        );
+
+        // Let a few ticks fire
+        sleep(Duration::from_millis(150)).await;
+
+        assert!(
+            subscriber.get_process_stats_calls() >= 1,
+            "on_process_stats should be called at least once, got {}",
+            subscriber.get_process_stats_calls()
+        );
+
+        stats_manager.finish(QueryEndState::Finished).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_process_stats_not_delivered_when_disabled() {
+        let subscriber = Arc::new(ProcessStatsMockSubscriber::new());
+        let throttle_interval = Duration::from_millis(50);
+        let node_stat = Arc::new(DefaultRuntimeStats::new(
+            &global::meter("test_process_stats_disabled"),
+            &node_info_from_id(0),
+        )) as Arc<dyn RuntimeStats>;
+
+        let stats_manager = RuntimeStatsManager::new_impl(
+            &tokio::runtime::Handle::current(),
+            "test_ps_disabled".into(),
+            serde_json::Value::Null,
+            vec![subscriber.clone()],
+            None,
+            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat))]),
+            throttle_interval,
+            false, // disable process monitor
+        );
+
+        // Let a few ticks fire
+        sleep(Duration::from_millis(150)).await;
+
+        assert_eq!(
+            subscriber.get_process_stats_calls(),
+            0,
+            "on_process_stats should not be called when monitor is disabled"
+        );
+
+        stats_manager.finish(QueryEndState::Finished).await;
     }
 }

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -237,10 +237,17 @@ impl RuntimeStatsManager {
 
                     _ = interval.tick() => {
                         if let Some(ps) = &mut process_stats {
-                            snapshot_container.push((common_metrics::PROCESS_STATS_NODE_ID, ps.sample()));
+                            let ps_stats = ps.sample();
+                            for res in future::join_all(subscribers.iter().map(|subscriber| {
+                                subscriber.on_process_stats(query_id.clone(), ps_stats.clone())
+                            })).await {
+                                if let Err(e) = res {
+                                    log::error!("Failed to emit process stats: {}", e);
+                                }
+                            }
                         }
 
-                        if active_nodes.is_empty() && snapshot_container.is_empty() {
+                        if active_nodes.is_empty() {
                             continue;
                         }
 

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -183,7 +183,7 @@ impl RuntimeStatsManager {
         let (finish_tx, mut finish_rx) = oneshot::channel::<QueryEndState>();
 
         let mut process_stats = if enable_process_monitor {
-            let meter = opentelemetry::global::meter("daft");
+            let meter = common_metrics::Meter::global_scope("daft-process-monitor");
             process_stats::ProcessStatsCollector::new(&meter)
         } else {
             None
@@ -816,7 +816,7 @@ mod tests {
         let subscriber = Arc::new(ProcessStatsMockSubscriber::new());
         let throttle_interval = Duration::from_millis(50);
         let node_stat = Arc::new(DefaultRuntimeStats::new(
-            &global::meter("test_process_stats_enabled"),
+            &Meter::test_scope("test_process_stats_enabled"),
             &node_info_from_id(0),
         )) as Arc<dyn RuntimeStats>;
 
@@ -848,7 +848,7 @@ mod tests {
         let subscriber = Arc::new(ProcessStatsMockSubscriber::new());
         let throttle_interval = Duration::from_millis(50);
         let node_stat = Arc::new(DefaultRuntimeStats::new(
-            &global::meter("test_process_stats_disabled"),
+            &Meter::test_scope("test_process_stats_disabled"),
             &node_info_from_id(0),
         )) as Arc<dyn RuntimeStats>;
 

--- a/src/daft-local-execution/src/runtime_stats/process_stats.rs
+++ b/src/daft-local-execution/src/runtime_stats/process_stats.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 use common_metrics::{
-    Gauge, PROCESS_CPU_PERCENT_KEY, PROCESS_JEMALLOC_ALLOCATED_KEY, PROCESS_JEMALLOC_RESIDENT_KEY,
-    PROCESS_RSS_KEY, Stat, Stats,
+    Gauge, Meter, PROCESS_CPU_PERCENT_KEY, PROCESS_JEMALLOC_ALLOCATED_KEY,
+    PROCESS_JEMALLOC_RESIDENT_KEY, PROCESS_RSS_KEY, Stat, Stats, UNIT_BYTES, UNIT_PERCENT,
 };
-use opentelemetry::{KeyValue, metrics::Meter};
+use opentelemetry::KeyValue;
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, get_current_pid};
 
 pub struct ProcessStatsCollector {
@@ -41,26 +41,26 @@ impl ProcessStatsCollector {
 
         Some(Self {
             #[cfg(not(target_env = "msvc"))]
-            jemalloc_allocated: Gauge::new(
-                meter,
+            jemalloc_allocated: meter.f64_gauge_with_desc_and_unit(
                 PROCESS_JEMALLOC_ALLOCATED_KEY,
                 Some("Bytes currently allocated by the application via jemalloc".into()),
+                Some(UNIT_BYTES.into()),
             ),
             #[cfg(not(target_env = "msvc"))]
-            jemalloc_resident: Gauge::new(
-                meter,
+            jemalloc_resident: meter.f64_gauge_with_desc_and_unit(
                 PROCESS_JEMALLOC_RESIDENT_KEY,
                 Some("Resident bytes from jemalloc's perspective".into()),
+                Some(UNIT_BYTES.into()),
             ),
-            rss: Gauge::new(
-                meter,
+            rss: meter.f64_gauge_with_desc_and_unit(
                 PROCESS_RSS_KEY,
                 Some("OS-level resident set size of the process".into()),
+                Some(UNIT_BYTES.into()),
             ),
-            cpu_percent: Gauge::new(
-                meter,
+            cpu_percent: meter.f64_gauge_with_desc_and_unit(
                 PROCESS_CPU_PERCENT_KEY,
                 Some("Process CPU utilization percentage".into()),
+                Some(UNIT_PERCENT.into()),
             ),
             system: System::new(),
             pid,
@@ -148,13 +148,11 @@ impl ProcessStatsCollector {
 
 #[cfg(test)]
 mod tests {
-    use opentelemetry::global;
-
     use super::*;
 
     #[test]
     fn test_process_stats_collector_creation() {
-        let meter = global::meter("test_process_stats");
+        let meter = Meter::test_scope("test_process_stats");
         let collector = ProcessStatsCollector::new(&meter);
         assert!(
             collector.is_some(),
@@ -164,7 +162,7 @@ mod tests {
 
     #[test]
     fn test_process_stats_sample_returns_stats() {
-        let meter = global::meter("test_process_stats_sample");
+        let meter = Meter::test_scope("test_process_stats_sample");
         let mut collector = ProcessStatsCollector::new(&meter).unwrap();
 
         let stats = collector.sample();
@@ -183,7 +181,7 @@ mod tests {
     #[cfg(not(target_env = "msvc"))]
     #[test]
     fn test_jemalloc_stats_nonzero() {
-        let meter = global::meter("test_jemalloc_stats");
+        let meter = Meter::test_scope("test_jemalloc_stats");
         let collector = ProcessStatsCollector::new(&meter).unwrap();
 
         let (allocated, resident) = collector.sample_jemalloc();

--- a/src/daft-local-execution/src/runtime_stats/process_stats.rs
+++ b/src/daft-local-execution/src/runtime_stats/process_stats.rs
@@ -1,0 +1,194 @@
+use std::sync::Arc;
+
+use common_metrics::{
+    Gauge, PROCESS_CPU_PERCENT_KEY, PROCESS_JEMALLOC_ALLOCATED_KEY, PROCESS_JEMALLOC_RESIDENT_KEY,
+    PROCESS_RSS_KEY, Stat, Stats,
+};
+use opentelemetry::{KeyValue, metrics::Meter};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, get_current_pid};
+
+pub struct ProcessStatsCollector {
+    // OTEL gauges
+    #[cfg(not(target_env = "msvc"))]
+    jemalloc_allocated: Gauge,
+    #[cfg(not(target_env = "msvc"))]
+    jemalloc_resident: Gauge,
+    rss: Gauge,
+    cpu_percent: Gauge,
+    // sysinfo state
+    system: System,
+    pid: sysinfo::Pid,
+    // OTEL labels
+    labels: Vec<KeyValue>,
+}
+
+impl ProcessStatsCollector {
+    pub fn new(meter: &Meter) -> Option<Self> {
+        let pid = match get_current_pid() {
+            Ok(pid) => pid,
+            Err(e) => {
+                log::warn!("Failed to get current PID for process monitor: {e}");
+                return None;
+            }
+        };
+
+        let role = if std::env::var("DAFT_FLOTILLA_WORKER").is_ok() {
+            "worker"
+        } else {
+            "driver"
+        };
+        let labels = vec![KeyValue::new("daft.process.role", role)];
+
+        Some(Self {
+            #[cfg(not(target_env = "msvc"))]
+            jemalloc_allocated: Gauge::new(
+                meter,
+                PROCESS_JEMALLOC_ALLOCATED_KEY,
+                Some("Bytes currently allocated by the application via jemalloc".into()),
+            ),
+            #[cfg(not(target_env = "msvc"))]
+            jemalloc_resident: Gauge::new(
+                meter,
+                PROCESS_JEMALLOC_RESIDENT_KEY,
+                Some("Resident bytes from jemalloc's perspective".into()),
+            ),
+            rss: Gauge::new(
+                meter,
+                PROCESS_RSS_KEY,
+                Some("OS-level resident set size of the process".into()),
+            ),
+            cpu_percent: Gauge::new(
+                meter,
+                PROCESS_CPU_PERCENT_KEY,
+                Some("Process CPU utilization percentage".into()),
+            ),
+            system: System::new(),
+            pid,
+            labels,
+        })
+    }
+
+    /// Called on each tick from the RuntimeStatsManager event loop.
+    /// Returns a Stats snapshot for inclusion in the subscriber pipeline.
+    pub fn sample(&mut self) -> Stats {
+        // Collect sysinfo stats (RSS, CPU)
+        let (rss_bytes, cpu_pct) = self.sample_sysinfo();
+
+        // Update OTEL gauges
+        self.rss.update(rss_bytes as f64, &self.labels);
+        self.cpu_percent.update(cpu_pct as f64, &self.labels);
+
+        // Build stats entries
+        let rss_key: Arc<str> = PROCESS_RSS_KEY.into();
+        let cpu_key: Arc<str> = PROCESS_CPU_PERCENT_KEY.into();
+
+        // Collect jemalloc stats and update OTEL gauges
+        #[cfg(not(target_env = "msvc"))]
+        let (jemalloc_allocated_bytes, jemalloc_resident_bytes) = {
+            let (a, r) = self.sample_jemalloc();
+            self.jemalloc_allocated.update(a as f64, &self.labels);
+            self.jemalloc_resident.update(r as f64, &self.labels);
+            (a, r)
+        };
+
+        #[cfg(not(target_env = "msvc"))]
+        let entries = smallvec::smallvec![
+            (rss_key, Stat::Bytes(rss_bytes)),
+            (cpu_key, Stat::Percent(cpu_pct as f64)),
+            (
+                Arc::from(PROCESS_JEMALLOC_ALLOCATED_KEY),
+                Stat::Bytes(jemalloc_allocated_bytes)
+            ),
+            (
+                Arc::from(PROCESS_JEMALLOC_RESIDENT_KEY),
+                Stat::Bytes(jemalloc_resident_bytes)
+            ),
+        ];
+
+        #[cfg(target_env = "msvc")]
+        let entries = smallvec::smallvec![
+            (rss_key, Stat::Bytes(rss_bytes)),
+            (cpu_key, Stat::Percent(cpu_pct as f64)),
+        ];
+
+        Stats(entries)
+    }
+
+    #[cfg(not(target_env = "msvc"))]
+    fn sample_jemalloc(&self) -> (u64, u64) {
+        use tikv_jemalloc_ctl::{epoch, stats};
+
+        // Advance the epoch to refresh jemalloc's internal stats cache.
+        if let Err(e) = epoch::advance() {
+            log::warn!("Failed to advance jemalloc epoch: {e}");
+            return (0, 0);
+        }
+
+        let allocated = stats::allocated::read().unwrap_or(0) as u64;
+        let resident = stats::resident::read().unwrap_or(0) as u64;
+        (allocated, resident)
+    }
+
+    fn sample_sysinfo(&mut self) -> (u64, f32) {
+        self.system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[self.pid]),
+            false,
+            ProcessRefreshKind::nothing().with_memory().with_cpu(),
+        );
+
+        match self.system.process(self.pid) {
+            Some(process) => (process.memory(), process.cpu_usage()),
+            None => {
+                log::warn!("Failed to find current process in sysinfo");
+                (0, 0.0)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::global;
+
+    use super::*;
+
+    #[test]
+    fn test_process_stats_collector_creation() {
+        let meter = global::meter("test_process_stats");
+        let collector = ProcessStatsCollector::new(&meter);
+        assert!(
+            collector.is_some(),
+            "ProcessStatsCollector should be created successfully"
+        );
+    }
+
+    #[test]
+    fn test_process_stats_sample_returns_stats() {
+        let meter = global::meter("test_process_stats_sample");
+        let mut collector = ProcessStatsCollector::new(&meter).unwrap();
+
+        let stats = collector.sample();
+        // Should have at least RSS and CPU entries
+        assert!(stats.0.len() >= 2);
+
+        // RSS should be the first entry and non-zero
+        let (name, value) = &stats.0[0];
+        assert_eq!(name.as_ref(), PROCESS_RSS_KEY);
+        match value {
+            Stat::Bytes(b) => assert!(*b > 0, "RSS should be non-zero"),
+            _ => panic!("Expected Stat::Bytes for RSS"),
+        }
+    }
+
+    #[cfg(not(target_env = "msvc"))]
+    #[test]
+    fn test_jemalloc_stats_nonzero() {
+        let meter = global::meter("test_jemalloc_stats");
+        let collector = ProcessStatsCollector::new(&meter).unwrap();
+
+        let (allocated, resident) = collector.sample_jemalloc();
+        assert!(allocated > 0, "jemalloc allocated should be non-zero");
+        assert!(resident > 0, "jemalloc resident should be non-zero");
+        assert!(resident >= allocated, "resident should be >= allocated");
+    }
+}


### PR DESCRIPTION
Adds a `ProcessStatsCollector` that samples jemalloc allocator stats (allocated, resident) and OS-level process stats (RSS, CPU%) on each 200ms tick of the RuntimeStatsManager event loop. Stats are emitted as OTEL gauges and flow through the subscriber pipeline, appearing as `process_stats` events in the JSONL event log.

This is the first step toward memory observability in Daft. When a user hits OOM, the memory timeline shows whether it was a gradual climb, a sudden spike, or a plateau that tipped over.

**Metrics collected:**
- `daft.process.memory.rss` - OS-level resident set size (full process including Python heap)
- `daft.process.memory.jemalloc.allocated` - bytes allocated by Rust code via jemalloc
- `daft.process.memory.jemalloc.resident` - jemalloc's RSS footprint (includes fragmentation/overhead)
- `daft.process.cpu.percent` - process CPU utilization. This appears as a % utilization for all threads in the process. e.g. maxing out 8 cores should give 800%.

**How it works:**
- Piggybacks on the existing RuntimeStatsManager 200ms tick (query-scoped, no new background task)
- OTEL gauges update every tick; the PeriodicReader exports at its own interval (default 500ms)
- Process stats are pushed into the subscriber pipeline with a sentinel `PROCESS_STATS_NODE_ID`
- The JSONL EventLogSubscriber recognizes this and writes clean `process_stats` events (no node_id)
- Disabled by default; enable with `DAFT_PROCESS_MONITOR_ENABLED=true`

**JSONL event log output:**
```json
{
  "event": "process_stats",
  "ts": "2026-03-19T01:46:01.631Z",
  "query_id": "tidy-wolf-ecca29",
  "metrics": {
    "process.memory.rss": 123437056,
    "process.memory.jemalloc.allocated": 14702224,
    "process.memory.jemalloc.resident": 26918912,
    "process.cpu.percent": 0.0
  }
}
```

## Example

For the following demo script:
```
import time
import daft

@daft.udf(return_dtype=daft.DataType.int64())
def slow_identity(col):
    """UDF that sleeps to keep the query alive long enough for log lines."""
    time.sleep(3)
    return col

left = daft.from_pydict({
    "key": list(range(5_000_000)),
    "val_left": list(range(5_000_000)),
})
right = daft.from_pydict({
    "key": list(range(5_000_000)),
    "val_right": [x * 2 for x in range(5_000_000)],
})
joined = left.join(right, on="key")
joined = joined.with_column("out", slow_identity(daft.col("val_left")))
joined.collect()
```

We get the following OTEL metrics.

### CPU
![BAB09B8C-64DA-4AF8-AD7F-6B714A784F6A](https://github.com/user-attachments/assets/4c027e75-8b52-4b25-ba53-b982292d7eac)

### RSS
![9C9D842E-1419-4246-95B8-26C19C76FF95](https://github.com/user-attachments/assets/0e07cbbf-4f5c-4e7a-9111-8f47ab87df3b)

### jemalloc resident size
![8F54CCAA-3F04-4E57-8B11-03CA3FCE4CEA](https://github.com/user-attachments/assets/92555d23-1da5-45a7-a4f2-043505191fc6)

### jemalloc allocated size
![92EEDF91-957F-4FD9-9D63-B4A56532E2C4](https://github.com/user-attachments/assets/7487d185-81df-4bb9-8ad2-43ebe4596a13)

## JSONL log
Here's an example of what the stats look like in the jsonl log:
```
{"event": "process_stats", "ts": "2026-03-19T02:06:51.329Z", "query_id": "happy-oak-6ed651", "metrics": {"process.memory.jemalloc.allocated": 433453544, "process.memory.jemalloc.resident": 456081408, "process.memory.rss": 518995968, "process.cpu.percent": 0.0}}
{"event": "stats", "ts": "2026-03-19T02:06:51.329Z", "query_id": "happy-oak-6ed651", "node_id": 3, "metrics": {"rows.out": 0, "selectivity": 0.0, "duration": 0, "rows.in": 5000000}}
{"event": "operator_started", "ts": "2026-03-19T02:06:51.330Z", "query_id": "happy-oak-6ed651", "node_id": 4}
{"event": "stats", "ts": "2026-03-19T02:06:51.526Z", "query_id": "happy-oak-6ed651", "node_id": 1, "metrics": {"rows.out": 786432, "selectivity": 15.728639999999999, "rows.in": 5000000, "duration": 2}}
{"event": "stats", "ts": "2026-03-19T02:06:51.526Z", "query_id": "happy-oak-6ed651", "node_id": 4, "metrics": {"rows.in": 524288, "rows.out": 0, "duration": 357}}
{"event": "stats", "ts": "2026-03-19T02:06:51.526Z", "query_id": "happy-oak-6ed651", "node_id": 3, "metrics": {"rows.out": 262144, "selectivity": 5.2428799999999995, "rows.in": 5000000, "duration": 45}}
{"event": "process_stats", "ts": "2026-03-19T02:06:51.526Z", "query_id": "happy-oak-6ed651", "metrics": {"process.memory.jemalloc.resident": 486113280, "process.memory.rss": 546488320, "process.memory.jemalloc.allocated": 462749672, "process.cpu.percent": 2.4333395957946777}}
{"event": "process_stats", "ts": "2026-03-19T02:06:51.726Z", "query_id": "happy-oak-6ed651", "metrics": {"process.cpu.percent": 51.5637092590332, "process.memory.rss": 571752448, "process.memory.jemalloc.allocated": 491437016, "process.memory.jemalloc.resident": 514916352}}
```