### PR TITLE
chore: Disable cargo check in local dev

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -1655,7 +1655,7 @@ jobs:
     - name: Python And Rust Style Check
       run: |
         source .venv/bin/activate
-        pre-commit run --all-files -v
+        pre-commit run --all-files -v --hook-stage pre-commit --hook-stage manual
 
     - name: Send Slack notification on failure
       uses: slackapi/slack-github-action@v2.1.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,6 +81,11 @@ repos:
   hooks:
   - id: uv-lock
 
+- repo: https://github.com/abravalheri/validate-pyproject
+  rev: v0.24.1
+  hooks:
+  - id: validate-pyproject
+
 - repo: local
   hooks:
   - id: check-invalid-deps
@@ -106,6 +111,7 @@ repos:
     language: system
     types: [rust]
     pass_filenames: false
+    stages: [manual]
     args: [--workspace, --all-targets, -v]
 
   - id: cargo-check-all-features
@@ -115,6 +121,7 @@ repos:
     language: system
     types: [rust]
     pass_filenames: false
+    stages: [manual]
     args: [--workspace, --all-features, --all-targets]
 
   - id: clippy
@@ -125,9 +132,3 @@ repos:
     args: [--workspace, --all-features, --, -D, warnings]
     types: [rust]
     pass_filenames: false
-
-
-- repo: https://github.com/abravalheri/validate-pyproject
-  rev: v0.24.1
-  hooks:
-  - id: validate-pyproject

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,6 +129,6 @@ repos:
     description: Lint rust sources
     entry: cargo clippy
     language: system
-    args: [--workspace, --all-features, --, -D, warnings]
+    args: [--workspace, --all-features, --all-targets, --, -D, warnings]
     types: [rust]
     pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ lint: check-toolchain .venv  ## Lint Python and Rust code
 
 .PHONY: precommit
 precommit: check-toolchain .venv  ## Run all pre-commit hooks
-	source $(VENV_BIN)/activate && pre-commit run --all-files
+	source $(VENV_BIN)/activate && pre-commit run --all-files --hook-stage pre-commit --hook-stage manual
 
 .PHONY: clean
 clean:

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -298,7 +298,7 @@ mod tests {
         // ENV_DAFT_DEV_DISABLE_JOIN_REORDERING
         {
             let cfg = DaftPlanningConfig::from_env();
-            assert_eq!(cfg.disable_join_reordering, false);
+            assert!(!cfg.disable_join_reordering);
 
             unsafe {
                 std::env::set_var(
@@ -307,7 +307,7 @@ mod tests {
                 );
             }
             let cfg = DaftPlanningConfig::from_env();
-            assert_eq!(cfg.disable_join_reordering, true);
+            assert!(cfg.disable_join_reordering);
 
             unsafe {
                 std::env::set_var(
@@ -316,7 +316,7 @@ mod tests {
                 );
             }
             let cfg = DaftPlanningConfig::from_env();
-            assert_eq!(cfg.disable_join_reordering, false);
+            assert!(!cfg.disable_join_reordering);
 
             unsafe {
                 std::env::remove_var(DaftPlanningConfig::ENV_DAFT_DEV_DISABLE_JOIN_REORDERING);
@@ -326,7 +326,7 @@ mod tests {
         // ENV_DAFT_DEV_ENABLE_STRICT_FILTER_PUSHDOWN
         {
             let cfg = DaftPlanningConfig::from_env();
-            assert_eq!(cfg.enable_strict_filter_pushdown, false);
+            assert!(!cfg.enable_strict_filter_pushdown);
 
             unsafe {
                 std::env::set_var(
@@ -335,7 +335,7 @@ mod tests {
                 );
             }
             let cfg = DaftPlanningConfig::from_env();
-            assert_eq!(cfg.enable_strict_filter_pushdown, false);
+            assert!(!cfg.enable_strict_filter_pushdown);
 
             unsafe {
                 std::env::set_var(
@@ -344,7 +344,7 @@ mod tests {
                 );
             }
             let cfg = DaftPlanningConfig::from_env();
-            assert_eq!(cfg.enable_strict_filter_pushdown, true);
+            assert!(cfg.enable_strict_filter_pushdown);
 
             unsafe {
                 std::env::remove_var(
@@ -418,19 +418,19 @@ mod tests {
         // ENV_DAFT_NATIVE_PARQUET_WRITER
         {
             let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.native_parquet_writer, true);
+            assert!(cfg.native_parquet_writer);
 
             unsafe {
                 std::env::set_var(DaftExecutionConfig::ENV_DAFT_NATIVE_PARQUET_WRITER, "false");
             }
             let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.native_parquet_writer, false);
+            assert!(!cfg.native_parquet_writer);
 
             unsafe {
                 std::env::set_var(DaftExecutionConfig::ENV_DAFT_NATIVE_PARQUET_WRITER, "1");
             }
             let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.native_parquet_writer, true);
+            assert!(cfg.native_parquet_writer);
 
             unsafe {
                 std::env::remove_var(DaftExecutionConfig::ENV_DAFT_NATIVE_PARQUET_WRITER);
@@ -487,19 +487,19 @@ mod tests {
         // ENV_DAFT_MAINTAIN_ORDER
         {
             let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.maintain_order, true);
+            assert!(cfg.maintain_order);
 
             unsafe {
                 std::env::set_var(DaftExecutionConfig::ENV_DAFT_MAINTAIN_ORDER, "false");
             }
             let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.maintain_order, false);
+            assert!(!cfg.maintain_order);
 
             unsafe {
                 std::env::set_var(DaftExecutionConfig::ENV_DAFT_MAINTAIN_ORDER, "1");
             }
             let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.maintain_order, true);
+            assert!(cfg.maintain_order);
 
             unsafe {
                 std::env::remove_var(DaftExecutionConfig::ENV_DAFT_MAINTAIN_ORDER);

--- a/src/common/runtime/src/joinset.rs
+++ b/src/common/runtime/src/joinset.rs
@@ -268,7 +268,7 @@ mod tests {
         for i in 0..1000000 {
             join_set.spawn(async move {
                 // random sleep between 0 and 1000ms
-                let sleep_duration = rand::thread_rng().gen_range(0..1000);
+                let sleep_duration = rand::rng().random_range(0..1000);
                 sleep(Duration::from_millis(sleep_duration)).await;
                 i
             });

--- a/src/daft-algebra/src/simplify/boolean.rs
+++ b/src/daft-algebra/src/simplify/boolean.rs
@@ -332,39 +332,39 @@ mod tests {
 
         // a == true
         let expr = eq(col_a.clone(), lit(true));
-        let result = simplify_binary_compare(expr.clone(), &schema)?;
+        let result = simplify_binary_compare(expr, &schema)?;
         assert_eq!(result, Transformed::yes(col_a.clone()));
 
         let expr = eq(lit(true), col_a.clone());
-        let result = simplify_binary_compare(expr.clone(), &schema)?;
+        let result = simplify_binary_compare(expr, &schema)?;
         assert_eq!(result, Transformed::yes(col_a.clone()));
 
         // a == false
         let expr = eq(col_a.clone(), lit(false));
-        let result = simplify_binary_compare(expr.clone(), &schema)?;
+        let result = simplify_binary_compare(expr, &schema)?;
         assert_eq!(result, Transformed::yes(col_a.clone().not()));
 
         let expr = eq(lit(false), col_a.clone());
-        let result = simplify_binary_compare(expr.clone(), &schema)?;
+        let result = simplify_binary_compare(expr, &schema)?;
         assert_eq!(result, Transformed::yes(col_a.clone().not()));
 
         // a != true
         let expr = neq(col_a.clone(), lit(true));
-        let result = simplify_binary_compare(expr.clone(), &schema)?;
+        let result = simplify_binary_compare(expr, &schema)?;
         assert_eq!(result, Transformed::yes(col_a.clone().not()));
 
         let expr = neq(lit(true), col_a.clone());
-        let result = simplify_binary_compare(expr.clone(), &schema)?;
+        let result = simplify_binary_compare(expr, &schema)?;
         assert_eq!(result, Transformed::yes(col_a.clone().not()));
 
         // a != false
         let expr = neq(col_a.clone(), lit(false));
-        let result = simplify_binary_compare(expr.clone(), &schema)?;
+        let result = simplify_binary_compare(expr, &schema)?;
         assert_eq!(result, Transformed::yes(col_a.clone()));
 
         let expr = neq(lit(false), col_a.clone());
-        let result = simplify_binary_compare(expr.clone(), &schema)?;
-        assert_eq!(result, Transformed::yes(col_a.clone()));
+        let result = simplify_binary_compare(expr, &schema)?;
+        assert_eq!(result, Transformed::yes(col_a));
 
         Ok(())
     }

--- a/src/daft-algebra/src/simplify/numeric.rs
+++ b/src/daft-algebra/src/simplify/numeric.rs
@@ -197,7 +197,7 @@ mod tests {
         // Test subtraction with 0.
         let expr = sub(col_expr.clone(), lit(0));
         let simplified = simplify_numeric_expr(expr, &empty_schema)?;
-        assert_eq!(simplified, Transformed::yes(col_expr.clone()));
+        assert_eq!(simplified, Transformed::yes(col_expr));
 
         Ok(())
     }
@@ -213,7 +213,7 @@ mod tests {
         assert_eq!(simplified, Transformed::no(expr));
 
         // 0 - a should not be simplified.
-        let expr = sub(lit(0), col_expr.clone());
+        let expr = sub(lit(0), col_expr);
         let simplified = simplify_numeric_expr(expr.clone(), &empty_schema)?;
         assert_eq!(simplified, Transformed::no(expr));
 

--- a/src/daft-core/src/array/fixed_size_list_array.rs
+++ b/src/daft-core/src/array/fixed_size_list_array.rs
@@ -296,10 +296,7 @@ mod tests {
     /// Helper that returns a FixedSizeListArray, with each list element at len=3
     fn get_i32_fixed_size_list_array(nulls: &[bool]) -> FixedSizeListArray {
         let field = Field::new("foo", DataType::FixedSizeList(Box::new(DataType::Int32), 3));
-        let flat_child = Int32Array::from_values(
-            "foo",
-            (0i32..(nulls.len() * 3) as i32).collect::<Vec<i32>>(),
-        );
+        let flat_child = Int32Array::from_values("foo", 0i32..(nulls.len() * 3) as i32);
         FixedSizeListArray::new(
             field,
             flat_child.into_series(),

--- a/src/daft-core/src/array/growable/arrow_growable.rs
+++ b/src/daft-core/src/array/growable/arrow_growable.rs
@@ -290,7 +290,7 @@ mod tests {
     fn test_extend_from_nonzero_start() {
         let field = Field::new("test", DataType::Int32);
         let src = Int32Array::from_iter(
-            field.clone(),
+            field,
             vec![Some(10), Some(20), Some(30), Some(40), Some(50)],
         );
         let mut growable =

--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -1984,26 +1984,26 @@ mod tests {
     fn test_utf8_to_float64_with_whitespace() {
         let utf8_array = Utf8Array::from_iter(
             "test",
-            vec![Some("  3.14  "), Some("-2.5"), Some("  1e10  "), None].into_iter(),
+            vec![Some("  3.13  "), Some("-2.5"), Some("  1e10  "), None].into_iter(),
         );
         let result = utf8_array
             .cast(&DataType::Float64)
             .expect("Failed to cast Utf8 to Float64");
 
         let values: Vec<Option<f64>> = result.f64().unwrap().into_iter().collect();
-        assert_eq!(values, vec![Some(3.14), Some(-2.5), Some(1e10), None]);
+        assert_eq!(values, vec![Some(3.13), Some(-2.5), Some(1e10), None]);
     }
 
     #[test]
     fn test_utf8_to_float32_with_whitespace() {
         let utf8_array =
-            Utf8Array::from_iter("test", vec![Some("  3.14  "), Some("  -2.5  ")].into_iter());
+            Utf8Array::from_iter("test", vec![Some("  3.13  "), Some("  -2.5  ")].into_iter());
         let result = utf8_array
             .cast(&DataType::Float32)
             .expect("Failed to cast Utf8 to Float32");
 
         let values: Vec<Option<f32>> = result.f32().unwrap().into_iter().collect();
-        assert_eq!(values, vec![Some(3.14_f32), Some(-2.5_f32)]);
+        assert_eq!(values, vec![Some(3.13_f32), Some(-2.5_f32)]);
     }
 
     #[test]

--- a/src/daft-core/src/array/ops/comparison.rs
+++ b/src/daft-core/src/array/ops/comparison.rs
@@ -1159,7 +1159,7 @@ mod tests {
         let inner2 = Int64Array::from_slice("item", &[3, 4]).into_series();
 
         let left_rows = vec![Some(
-            ListArray::from_series("inner", vec![Some(inner1.clone())])?.into_series(),
+            ListArray::from_series("inner", vec![Some(inner1)])?.into_series(),
         )];
         let right_rows = vec![Some(
             ListArray::from_series("inner", vec![Some(inner2)])?.into_series(),

--- a/src/daft-core/src/array/ops/from_arrow.rs
+++ b/src/daft-core/src/array/ops/from_arrow.rs
@@ -702,7 +702,7 @@ mod tests {
     #[test]
     fn test_arrow_roundtrip_logical_fixed_shape_tensor() -> DaftResult<()> {
         let shape = vec![3u64, 224u64, 224u64];
-        let size: usize = shape.clone().iter().map(|v| *v as usize).product();
+        let size: usize = shape.iter().map(|v| *v as usize).product();
 
         let data = Series::from_literals(vec![Literal::Float32(0.0f32); size])?;
 

--- a/src/daft-core/src/series/from_lit.rs
+++ b/src/daft-core/src/series/from_lit.rs
@@ -600,7 +600,7 @@ mod test {
         let series = Series::from_literals(expected.clone()).unwrap();
         let actual = series.to_literals().collect::<Vec<_>>();
 
-        assert_eq!(expected, actual)
+        assert_eq!(expected, actual);
     }
 
     #[test]

--- a/src/daft-core/src/series/ops/time.rs
+++ b/src/daft-core/src/series/ops/time.rs
@@ -441,7 +441,7 @@ mod tests {
     #[test]
     fn strftime_timestamp_microseconds() -> DaftResult<()> {
         // 2023-01-01T12:00:00 in microseconds since epoch
-        let ts_us: Vec<i64> = vec![1672574400_000_000];
+        let ts_us: Vec<i64> = vec![1_672_574_400_000_000];
         let physical = Int64Array::from_slice("ts", &ts_us);
         let ts = TimestampArray::new(
             Field::new("ts", DataType::Timestamp(TimeUnit::Microseconds, None)),

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -828,16 +828,14 @@ mod tests {
         let mut fields = merge_schema(&headers, &mut column_types);
 
         // Apply column name overrides (for no-header case).
-        if !has_header {
-            if let Some(ref names) = column_names {
-                fields = fields
-                    .into_iter()
-                    .zip(names.iter())
-                    .map(|(field, name)| {
-                        arrow_schema::Field::new(*name, field.data_type().clone(), true)
-                    })
-                    .collect();
-            }
+        if !has_header && let Some(ref names) = column_names {
+            fields = fields
+                .into_iter()
+                .zip(names.iter())
+                .map(|(field, name)| {
+                    arrow_schema::Field::new(*name, field.data_type().clone(), true)
+                })
+                .collect();
         }
 
         // Determine projection indices.
@@ -865,15 +863,10 @@ mod tests {
             .collect();
 
         // Compare schema.
-        let reference_schema = Schema::new(
-            projected_fields
-                .iter()
-                .map(|f| {
-                    let daft_dtype = daft_schema::dtype::DataType::try_from(f.data_type()).unwrap();
-                    daft_core::datatypes::Field::new(f.name().as_str(), daft_dtype)
-                })
-                .collect::<Vec<_>>(),
-        );
+        let reference_schema = Schema::new(projected_fields.iter().map(|f| {
+            let daft_dtype = daft_schema::dtype::DataType::try_from(f.data_type()).unwrap();
+            daft_core::datatypes::Field::new(f.name().as_str(), daft_dtype)
+        }));
         assert_eq!(
             out.schema.as_ref(),
             &reference_schema,

--- a/src/daft-distributed/src/pipeline_node/materialize.rs
+++ b/src/daft-distributed/src/pipeline_node/materialize.rs
@@ -222,9 +222,7 @@ mod tests {
         verify_materialized_results(
             &results,
             &partition_specs,
-            &std::iter::repeat(false)
-                .take(partition_specs.len())
-                .collect::<Vec<_>>(),
+            &std::iter::repeat_n(false, partition_specs.len()).collect::<Vec<_>>(),
         );
         test_context.cleanup().await?;
         Ok(())
@@ -265,9 +263,7 @@ mod tests {
         verify_materialized_results(
             &results,
             &partition_specs,
-            &std::iter::repeat(false)
-                .take(partition_specs.len())
-                .collect::<Vec<_>>(),
+            &std::iter::repeat_n(false, partition_specs.len()).collect::<Vec<_>>(),
         );
         test_context.cleanup().await?;
         Ok(())

--- a/src/daft-distributed/src/scheduling/dispatcher.rs
+++ b/src/daft-distributed/src/scheduling/dispatcher.rs
@@ -520,7 +520,7 @@ mod tests {
             .iter()
             .map(|task| task.task_context().task_id)
             .collect();
-        failed_task_ids.sort();
+        failed_task_ids.sort_unstable();
         assert_eq!(failed_task_ids, vec![1, 2, 3]);
 
         // Verify worker state: Workers 1 and 3 should be dead, worker 2 should be alive

--- a/src/daft-distributed/src/scheduling/scheduler/default.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/default.rs
@@ -259,7 +259,7 @@ mod tests {
         // Verify distribution - worker3 should have 2 tasks (most slots), worker2 should have 1 task, worker1 should have 0 tasks
         assert_eq!(*worker_task_counts.get(&worker_3).unwrap(), 2);
         assert_eq!(*worker_task_counts.get(&worker_2).unwrap(), 1);
-        assert!(worker_task_counts.get(&worker_1).is_none());
+        assert!(!worker_task_counts.contains_key(&worker_1));
     }
 
     #[test]
@@ -385,8 +385,8 @@ mod tests {
         let worker_2: WorkerId = Arc::from("worker2");
 
         let workers = setup_workers(&[
-            (worker_1.clone(), 1), // 1 slot available
-            (worker_2.clone(), 1), // 1 slot available
+            (worker_1, 1), // 1 slot available
+            (worker_2, 1), // 1 slot available
         ]);
 
         let mut scheduler: DefaultScheduler<MockTask> = setup_scheduler(&workers);
@@ -495,7 +495,7 @@ mod tests {
     // 2. Task 2 (2 CPUs) to worker 2 or 3 (2 slots available)
     // 3. Task 3 (3 CPUs) is unscheduled (no worker has 3 slots available)
     #[test]
-    #[ignore]
+    #[ignore = "This test is currently failing because the scheduler is currently not optimal, we should fix this by using a bin packing algorithm."]
     fn test_default_scheduler_with_resource_request_scheduling_small_tasks_first() {
         let worker_1: WorkerId = Arc::from("worker1");
         let worker_2: WorkerId = Arc::from("worker2");
@@ -628,7 +628,7 @@ mod tests {
 
         // Create a worker with only 1 slot available
         let workers = setup_workers(&[
-            (worker_1.clone(), 1), // 1 slot available
+            (worker_1, 1), // 1 slot available
         ]);
 
         let mut scheduler: DefaultScheduler<MockTask> = setup_scheduler(&workers);
@@ -660,8 +660,8 @@ mod tests {
 
         // Create workers with sufficient capacity
         let workers = setup_workers(&[
-            (worker_1.clone(), 2), // 2 slots available
-            (worker_2.clone(), 3), // 3 slots available
+            (worker_1, 2), // 2 slots available
+            (worker_2, 3), // 3 slots available
         ]);
 
         let mut scheduler: DefaultScheduler<MockTask> = setup_scheduler(&workers);

--- a/src/daft-distributed/src/scheduling/scheduler/linear.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/linear.rs
@@ -167,11 +167,7 @@ mod tests {
         let worker_2: WorkerId = Arc::from("worker2");
         let worker_3: WorkerId = Arc::from("worker3");
 
-        let workers = setup_workers(&[
-            (worker_1.clone(), 1),
-            (worker_2.clone(), 2),
-            (worker_3.clone(), 3),
-        ]);
+        let workers = setup_workers(&[(worker_1, 1), (worker_2, 2), (worker_3, 3)]);
 
         let mut scheduler: LinearScheduler<MockTask> = setup_scheduler(&workers);
 
@@ -198,7 +194,7 @@ mod tests {
         // Update worker state to reflect that the workers are all idle
         let worker_snapshots = workers
             .values()
-            .map(|worker| WorkerSnapshot::from(worker))
+            .map(WorkerSnapshot::from)
             .collect::<Vec<_>>();
         scheduler.update_worker_state(&worker_snapshots);
 
@@ -214,11 +210,7 @@ mod tests {
         let worker_2: WorkerId = Arc::from("worker2");
         let worker_3: WorkerId = Arc::from("worker3");
 
-        let workers = setup_workers(&[
-            (worker_1.clone(), 1),
-            (worker_2.clone(), 1),
-            (worker_3.clone(), 2),
-        ]);
+        let workers = setup_workers(&[(worker_1.clone(), 1), (worker_2.clone(), 1), (worker_3, 2)]);
 
         let mut scheduler: LinearScheduler<MockTask> = setup_scheduler(&workers);
 
@@ -249,7 +241,7 @@ mod tests {
         // Update worker state to reflect that the workers are all idle
         let worker_snapshots = workers
             .values()
-            .map(|worker| WorkerSnapshot::from(worker))
+            .map(WorkerSnapshot::from)
             .collect::<Vec<_>>();
         scheduler.update_worker_state(&worker_snapshots);
 
@@ -306,7 +298,7 @@ mod tests {
         // Update worker state to reflect that the workers are all idle
         let worker_snapshots = workers
             .values()
-            .map(|worker| WorkerSnapshot::from(worker))
+            .map(WorkerSnapshot::from)
             .collect::<Vec<_>>();
         scheduler.update_worker_state(&worker_snapshots);
 
@@ -326,7 +318,7 @@ mod tests {
         let worker_1: WorkerId = Arc::from("worker1");
         let worker_2: WorkerId = Arc::from("worker2");
 
-        let workers = setup_workers(&[(worker_1.clone(), 1), (worker_2.clone(), 1)]);
+        let workers = setup_workers(&[(worker_1, 1), (worker_2, 1)]);
 
         let mut scheduler: LinearScheduler<MockTask> = setup_scheduler(&workers);
 

--- a/src/daft-distributed/src/scheduling/scheduler/mod.rs
+++ b/src/daft-distributed/src/scheduling/scheduler/mod.rs
@@ -272,7 +272,7 @@ pub(super) mod test_utils {
         scheduler.update_worker_state(
             workers
                 .values()
-                .map(|w| WorkerSnapshot::from(w))
+                .map(WorkerSnapshot::from)
                 .collect::<Vec<_>>()
                 .as_slice(),
         );

--- a/src/daft-distributed/src/scheduling/task.rs
+++ b/src/daft-distributed/src/scheduling/task.rs
@@ -579,14 +579,14 @@ pub(super) mod tests {
             let task_id = task_context.task_id;
             Self {
                 task_context,
-                task_name: "".into(),
+                task_name: String::new(),
                 priority: MockTaskPriority { priority: 0 },
                 scheduling_strategy: SchedulingStrategy::Spread,
                 resource_request: TaskResourceRequest::new(ResourceRequest::default()),
                 task_result: MaterializedOutput::new(
                     vec![partition_ref],
                     "".into(),
-                    "".into(),
+                    String::new(),
                     task_id,
                 ),
                 cancel_notifier: Arc::new(Mutex::new(None)),
@@ -698,7 +698,7 @@ pub(super) mod tests {
                     match failure {
                         MockTaskFailure::Error(error_message) => {
                             return TaskStatus::Failed {
-                                error: DaftError::InternalError(error_message.clone()),
+                                error: DaftError::InternalError(error_message),
                             };
                         }
                         MockTaskFailure::Panic(error_message) => {

--- a/src/daft-dsl/src/functions/function_args.rs
+++ b/src/daft-dsl/src/functions/function_args.rs
@@ -484,7 +484,7 @@ mod tests {
         assert_eq!(*third, 2);
         // can't access it by position since it's a named argument.
         let third = args.required(2);
-        assert!(third.is_err())
+        assert!(third.is_err());
     }
 
     #[test]

--- a/src/daft-ext-core/src/function.rs
+++ b/src/daft-ext-core/src/function.rs
@@ -140,7 +140,7 @@ mod tests {
             Ok(export_schema(&Schema::new(vec![field])))
         }
 
-        fn call(&self, mut args: Vec<ArrowData>) -> DaftResult<ArrowData> {
+        fn call(&self, args: Vec<ArrowData>) -> DaftResult<ArrowData> {
             let input_array = import_array(args.into_iter().next().unwrap());
             let input = input_array
                 .as_any()

--- a/src/daft-functions/src/coalesce.rs
+++ b/src/daft-functions/src/coalesce.rs
@@ -223,7 +223,7 @@ mod tests {
         let ctx = EvalContext {
             row_count: s0.len(),
         };
-        let args = FunctionArgs::new_unnamed(vec![s0.clone(), s1.clone(), s2.clone()]);
+        let args = FunctionArgs::new_unnamed(vec![s0, s1, s2]);
         let output = coalesce.call(args, &ctx).unwrap();
         let actual = output.utf8().unwrap();
         let expected = Utf8Array::full_null("s0", &DataType::Utf8, 100);
@@ -260,7 +260,7 @@ mod tests {
         let ctx = EvalContext {
             row_count: s0.len(),
         };
-        let args = FunctionArgs::new_unnamed(vec![s0.clone(), s1.clone(), s2.clone()]);
+        let args = FunctionArgs::new_unnamed(vec![s0, s1, s2]);
         let output = coalesce.call(args, &ctx).unwrap();
 
         let expected = Utf8Array::from_iter(

--- a/src/daft-image/benches/image_ops.rs
+++ b/src/daft-image/benches/image_ops.rs
@@ -30,18 +30,17 @@ fn make_pixel_data(width: u32, height: u32, channels: u8, seed: usize) -> Vec<u8
 
 /// Build an `ImageArray` (variable-shape) Series of RGB images.
 fn make_rgb_image_series(width: u32, height: u32, count: usize) -> Series {
-    let buffers: Vec<Option<CowImage>> = (0..count)
-        .map(|i| {
-            let pixels = make_pixel_data(width, height, 3, i);
-            Some(CowImage::from_raw(
-                &ImageMode::RGB,
-                width,
-                height,
-                Cow::Owned(pixels),
-            ))
-        })
-        .collect();
-    image_array_from_img_buffers("image", buffers.into_iter(), Some(ImageMode::RGB))
+    let buffers = (0..count).map(|i| {
+        let pixels = make_pixel_data(width, height, 3, i);
+        Some(CowImage::from_raw(
+            &ImageMode::RGB,
+            width,
+            height,
+            Cow::Owned(pixels),
+        ))
+    });
+
+    image_array_from_img_buffers("image", buffers, Some(ImageMode::RGB))
         .unwrap()
         .into_series()
 }
@@ -66,18 +65,17 @@ fn make_fixed_rgb_image_series(width: u32, height: u32, count: usize) -> Series 
 
 /// Build an `ImageArray` Series of RGBA images.
 fn make_rgba_image_series(width: u32, height: u32, count: usize) -> Series {
-    let buffers: Vec<Option<CowImage>> = (0..count)
-        .map(|i| {
-            let pixels = make_pixel_data(width, height, 4, i);
-            Some(CowImage::from_raw(
-                &ImageMode::RGBA,
-                width,
-                height,
-                Cow::Owned(pixels),
-            ))
-        })
-        .collect();
-    image_array_from_img_buffers("image", buffers.into_iter(), Some(ImageMode::RGBA))
+    let buffers = (0..count).map(|i| {
+        let pixels = make_pixel_data(width, height, 4, i);
+        Some(CowImage::from_raw(
+            &ImageMode::RGBA,
+            width,
+            height,
+            Cow::Owned(pixels),
+        ))
+    });
+
+    image_array_from_img_buffers("image", buffers, Some(ImageMode::RGBA))
         .unwrap()
         .into_series()
 }
@@ -95,8 +93,8 @@ fn make_encoded_series(width: u32, height: u32, count: usize, format: ImageForma
             Some(buf)
         })
         .collect();
-    let refs: Vec<Option<&[u8]>> = encoded.iter().map(|v| v.as_deref()).collect();
-    BinaryArray::from_iter("image", refs.into_iter()).into_series()
+    let refs = encoded.iter().map(|v| v.as_deref());
+    BinaryArray::from_iter("image", refs).into_series()
 }
 
 /// Build a bounding box Series for crop benchmarks.
@@ -123,12 +121,12 @@ fn bench_decode(c: &mut Criterion) {
 
     let jpeg_series = make_encoded_series(224, 224, BATCH_SIZE, ImageFormat::JPEG);
     group.bench_function("jpeg_224x224", |b| {
-        b.iter(|| series::decode(&jpeg_series, true, Some(ImageMode::RGB)).unwrap())
+        b.iter(|| series::decode(&jpeg_series, true, Some(ImageMode::RGB)).unwrap());
     });
 
     let png_series = make_encoded_series(224, 224, BATCH_SIZE, ImageFormat::PNG);
     group.bench_function("png_224x224", |b| {
-        b.iter(|| series::decode(&png_series, true, Some(ImageMode::RGB)).unwrap())
+        b.iter(|| series::decode(&png_series, true, Some(ImageMode::RGB)).unwrap());
     });
 
     group.finish();
@@ -141,12 +139,12 @@ fn bench_resize(c: &mut Criterion) {
 
     let images_512 = make_rgb_image_series(512, 512, BATCH_SIZE);
     group.bench_function("512_to_224", |b| {
-        b.iter(|| series::resize(&images_512, 224, 224).unwrap())
+        b.iter(|| series::resize(&images_512, 224, 224).unwrap());
     });
 
     let images_224 = make_rgb_image_series(224, 224, BATCH_SIZE);
     group.bench_function("224_to_64", |b| {
-        b.iter(|| series::resize(&images_224, 64, 64).unwrap())
+        b.iter(|| series::resize(&images_224, 64, 64).unwrap());
     });
 
     group.finish();
@@ -162,7 +160,7 @@ fn bench_crop(c: &mut Criterion) {
     let bboxes = make_bbox_series(144, 144, 224, 224, BATCH_SIZE);
 
     group.bench_function("512_center_crop_224", |b| {
-        b.iter(|| series::crop(&images, &bboxes).unwrap())
+        b.iter(|| series::crop(&images, &bboxes).unwrap());
     });
 
     group.finish();
@@ -175,12 +173,12 @@ fn bench_to_mode(c: &mut Criterion) {
 
     let rgba_images = make_rgba_image_series(224, 224, BATCH_SIZE);
     group.bench_function("rgba_to_rgb", |b| {
-        b.iter(|| series::to_mode(&rgba_images, ImageMode::RGB).unwrap())
+        b.iter(|| series::to_mode(&rgba_images, ImageMode::RGB).unwrap());
     });
 
     let rgb_images = make_rgb_image_series(224, 224, BATCH_SIZE);
     group.bench_function("rgb_to_l", |b| {
-        b.iter(|| series::to_mode(&rgb_images, ImageMode::L).unwrap())
+        b.iter(|| series::to_mode(&rgb_images, ImageMode::L).unwrap());
     });
 
     group.finish();
@@ -194,11 +192,11 @@ fn bench_encode(c: &mut Criterion) {
     let images = make_rgb_image_series(224, 224, BATCH_SIZE);
 
     group.bench_function("png_224x224", |b| {
-        b.iter(|| series::encode(&images, ImageFormat::PNG).unwrap())
+        b.iter(|| series::encode(&images, ImageFormat::PNG).unwrap());
     });
 
     group.bench_function("jpeg_224x224", |b| {
-        b.iter(|| series::encode(&images, ImageFormat::JPEG).unwrap())
+        b.iter(|| series::encode(&images, ImageFormat::JPEG).unwrap());
     });
 
     group.finish();
@@ -212,7 +210,7 @@ fn bench_to_tensor(c: &mut Criterion) {
     let images = make_fixed_rgb_image_series(224, 224, BATCH_SIZE);
 
     group.bench_function("fixed_rgb_224x224", |b| {
-        b.iter(|| series::to_tensor(&images).unwrap())
+        b.iter(|| series::to_tensor(&images).unwrap());
     });
 
     group.finish();

--- a/src/daft-io/src/google_cloud.rs
+++ b/src/daft-io/src/google_cloud.rs
@@ -641,6 +641,6 @@ mod tests {
         let checksum = format!("{:x}", md5::compute(all_bytes));
         assert_eq!(checksum, expected_md5);
 
-        test_full_get(client, &test_file_path, &bytes).await
+        test_full_get(client, test_file_path, &bytes).await
     }
 }

--- a/src/daft-io/src/gravitino.rs
+++ b/src/daft-io/src/gravitino.rs
@@ -527,12 +527,11 @@ mod tests {
         let catalog_name = segments.next().unwrap();
         let schema_name = segments.next().unwrap();
         let fileset_name = segments.next().unwrap();
-        let remaining: Vec<&str> = segments.collect();
 
         assert_eq!(catalog_name, "catalog");
         assert_eq!(schema_name, "schema");
         assert_eq!(fileset_name, "fileset");
-        assert!(remaining.is_empty());
+        assert_eq!(segments.next(), None);
     }
 
     #[test]
@@ -543,12 +542,9 @@ mod tests {
         assert_eq!(url.scheme(), "gvfs");
         assert_eq!(url.host_str(), Some("fileset"));
 
-        let segments: Vec<&str> = url
-            .path_segments()
-            .unwrap()
-            .filter(|s| !s.is_empty())
-            .collect();
-        assert_eq!(segments.len(), 3);
+        let segments = url.path_segments().unwrap().filter(|s| !s.is_empty());
+
+        assert_eq!(segments.count(), 3);
     }
 
     // Tests for glob path base extraction logic
@@ -630,8 +626,7 @@ mod tests {
         let gvfs_base_path = "gvfs://fileset/catalog/schema/fileset/";
         let file_path = "s3://bucket/path/data/file.parquet";
 
-        if file_path.starts_with(storage_base_path) {
-            let relative_path = &file_path[storage_base_path.len()..];
+        if let Some(relative_path) = file_path.strip_prefix(storage_base_path) {
             let transformed_path = format!("{}{}", gvfs_base_path, relative_path);
             assert_eq!(
                 transformed_path,
@@ -646,8 +641,7 @@ mod tests {
         let gvfs_base_path = "gvfs://fileset/cat/sch/fs/";
         let file_path = "s3://bucket/prefix/year=2023/month=01/data.parquet";
 
-        if file_path.starts_with(storage_base_path) {
-            let relative_path = &file_path[storage_base_path.len()..];
+        if let Some(relative_path) = file_path.strip_prefix(storage_base_path) {
             let transformed_path = format!("{}{}", gvfs_base_path, relative_path);
             assert_eq!(
                 transformed_path,
@@ -686,10 +680,10 @@ mod tests {
     fn test_path_segments_with_empty_components() {
         let path = "gvfs://fileset/catalog//fileset/file.parquet";
         let url = url::Url::parse(path).unwrap();
-        let segments: Vec<&str> = url.path_segments().unwrap().collect();
+        let mut segments = url.path_segments().unwrap();
 
         // URL parsing normalizes empty segments
-        assert!(segments.contains(&""));
+        assert!(segments.any(|x| x.is_empty()));
     }
 
     // Tests for combined name format
@@ -730,7 +724,7 @@ mod tests {
     // Tests for itertools join usage
     #[test]
     fn test_path_segments_join() {
-        let segments = vec!["path", "to", "file.parquet"];
+        let segments = ["path", "to", "file.parquet"];
         let joined = segments.iter().join("/");
         assert_eq!(joined, "path/to/file.parquet");
     }
@@ -744,7 +738,7 @@ mod tests {
 
     #[test]
     fn test_path_segments_join_single() {
-        let segments = vec!["file.parquet"];
+        let segments = ["file.parquet"];
         let joined = segments.iter().join("/");
         assert_eq!(joined, "file.parquet");
     }

--- a/src/daft-io/src/http.rs
+++ b/src/daft-io/src/http.rs
@@ -424,6 +424,6 @@ mod tests {
         let checksum = format!("{:x}", md5::compute(all_bytes));
         assert_eq!(checksum, parquet_expected_md5);
 
-        test_full_get(client, &parquet_file_path, &bytes).await
+        test_full_get(client, parquet_file_path, &bytes).await
     }
 }

--- a/src/daft-io/src/huggingface.rs
+++ b/src/daft-io/src/huggingface.rs
@@ -717,7 +717,7 @@ mod tests {
         let checksum = format!("{:x}", md5::compute(all_bytes));
         assert_eq!(checksum, expected_md5);
 
-        test_full_get(client, &test_file_path, &bytes).await
+        test_full_get(client, test_file_path, &bytes).await
     }
 
     #[test]

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -652,12 +652,13 @@ mod resolve_alias_tests {
     use super::*;
 
     fn config_with_aliases(aliases: &[(&str, &str)]) -> IOConfig {
-        let mut config = IOConfig::default();
-        config.protocol_aliases = aliases
-            .iter()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect::<BTreeMap<_, _>>();
-        config
+        IOConfig {
+            protocol_aliases: aliases
+                .iter()
+                .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+                .collect::<BTreeMap<_, _>>(),
+            ..Default::default()
+        }
     }
 
     #[test]

--- a/src/daft-io/src/mock.rs
+++ b/src/daft-io/src/mock.rs
@@ -63,15 +63,12 @@ mod tests {
             let path_owned = path.to_string();
 
             stream! {
-                let mut sent_chunks = 0usize;
-                for chunk_data in data.chunks(chunk) {
-                    if let Some(fail) = fail_idx {
-                        if sent_chunks == fail {
+                for (sent_chunks, chunk_data) in data.chunks(chunk).enumerate() {
+                    if let Some(fail) = fail_idx
+                        && sent_chunks == fail {
                             yield Err(Error::UnableToReadBytes { path: path_owned.clone(), source: std::io::Error::new(std::io::ErrorKind::Interrupted, "mock fail") });
                             break;
                         }
-                    }
-                    sent_chunks += 1;
                     yield Ok(Bytes::copy_from_slice(chunk_data));
                 }
             }.boxed()
@@ -197,7 +194,7 @@ mod tests {
                 Some(GetRange::Offset(chunk_size * fail_at_chunk * 2 + init_off)),
                 Some(GetRange::Offset(chunk_size * fail_at_chunk * 3 + init_off)),
             ]
-        )
+        );
     }
 
     #[tokio::test]
@@ -230,7 +227,7 @@ mod tests {
                 Some(GetRange::Suffix(n - chunk_size * fail_at_chunk)),
                 Some(GetRange::Suffix(n - chunk_size * fail_at_chunk * 2)),
             ]
-        )
+        );
     }
 
     #[tokio::test]

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -1820,7 +1820,7 @@ mod tests {
         let checksum = format!("{:x}", md5::compute(all_bytes));
         assert_eq!(checksum, parquet_expected_md5);
 
-        test_full_get(client, &parquet_file_path, &bytes).await
+        test_full_get(client, parquet_file_path, &bytes).await
     }
 
     #[tokio::test]

--- a/src/daft-io/src/tos.rs
+++ b/src/daft-io/src/tos.rs
@@ -1152,6 +1152,7 @@ mod tests {
             let client = self.client.clone();
             let uris = self.uris.clone();
             // Try the best effort to clean up the object after the test.
+            #[allow(clippy::let_underscore_future)]
             let _ = Handle::current().spawn(async move {
                 for uri in uris {
                     let _ = client.delete(&uri, None).await;
@@ -1174,22 +1175,27 @@ mod tests {
         let access_key = env::var("TOS_ACCESS_KEY").ok();
         let secret_key = env::var("TOS_SECRET_KEY").ok();
 
-        if bucket.is_none() || access_key.is_none() || secret_key.is_none() {
-            None
-        } else {
+        if let Some(bucket) = bucket
+            && access_key.is_some()
+            && secret_key.is_some()
+        {
             Some((
                 TosConfig {
-                    region: Some(env::var("TOS_REGION").unwrap_or("cn-beijing".to_string())),
+                    region: Some(
+                        env::var("TOS_REGION").unwrap_or_else(|_| "cn-beijing".to_string()),
+                    ),
                     endpoint: Some(
                         env::var("TOS_ENDPOINT")
-                            .unwrap_or("https://tos-cn-beijing.volces.com".to_string()),
+                            .unwrap_or_else(|_| "https://tos-cn-beijing.volces.com".to_string()),
                     ),
                     access_key,
-                    secret_key: secret_key.map(|s| ObfuscatedString::from(s)),
+                    secret_key: secret_key.map(ObfuscatedString::from),
                     ..Default::default()
                 },
-                bucket.unwrap(),
+                bucket,
             ))
+        } else {
+            None
         }
     }
 
@@ -1257,7 +1263,7 @@ mod tests {
         let res = test_full_get(guard.client.clone(), &uri, &data).await;
 
         guard.cleanup().await;
-        res.unwrap()
+        res.unwrap();
     }
 
     #[tokio::test]
@@ -1371,7 +1377,7 @@ mod tests {
                 .contains("Your proposed upload is smaller than the minimum allowed size")
         );
 
-        guard.cleanup().await
+        guard.cleanup().await;
     }
 
     fn generate_test_object_prefix() -> String {
@@ -1389,7 +1395,7 @@ mod tests {
     }
 
     async fn build_client_guard(cfg: &TosConfig, uris: Vec<&str>) -> ClientGuard {
-        let client = TosSource::get_client(&cfg).await.unwrap();
-        ClientGuard::new(client, uris.iter().map(|s| s.to_string()).collect())
+        let client = TosSource::get_client(cfg).await.unwrap();
+        ClientGuard::new(client, uris.iter().map(|s| (*s).to_string()).collect())
     }
 }

--- a/src/daft-io/src/utils.rs
+++ b/src/daft-io/src/utils.rs
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn test_group_no_overlapping_glob_paths() {
-        let mut groups = group_glob_paths(&vec![
+        let mut groups = group_glob_paths(&[
             "tos://ai/data/a.csv".to_string(),
             "s3://ai/data/a.csv".to_string(),
             "tos://ai/data/[x,y,z].csv".to_string(),
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_group_all_overlapping_glob_paths() {
-        let mut groups = group_glob_paths(&vec![
+        let mut groups = group_glob_paths(&[
             "/data/**/*".to_string(),
             "/data/[x,y,z].csv".to_string(),
             "/data/test?/*.parquet".to_string(),

--- a/src/daft-local-execution/src/dynamic_batching/static_strategy.rs
+++ b/src/daft-local-execution/src/dynamic_batching/static_strategy.rs
@@ -64,14 +64,14 @@ mod tests {
     fn test_static_calculate_requirements_ignores_reports() {
         let req = MorselSizeRequirement::Flexible(2, NonZeroUsize::new(64).unwrap());
         let strategy = StaticBatchingStrategy::new(req);
-        let mut state = strategy.make_state();
+        strategy.make_state();
 
         // Empty batch report
-        let result = strategy.calculate_new_requirements(&mut state);
+        let result = strategy.calculate_new_requirements(&mut ());
         assert_eq!(result, req);
 
         // Non-empty batch report (would need actual BatchReport data structure)
-        let result2 = strategy.calculate_new_requirements(&mut state);
+        let result2 = strategy.calculate_new_requirements(&mut ());
         assert_eq!(result2, req);
     }
 
@@ -79,12 +79,12 @@ mod tests {
     fn test_static_consistency_across_calls() {
         let req = MorselSizeRequirement::Flexible(1, NonZeroUsize::new(256).unwrap());
         let strategy = StaticBatchingStrategy::new(req);
-        let mut state = strategy.make_state();
+        strategy.make_state();
 
         // Multiple calls should return same result
-        let result1 = strategy.calculate_new_requirements(&mut state);
-        let result2 = strategy.calculate_new_requirements(&mut state);
-        let result3 = strategy.calculate_new_requirements(&mut state);
+        let result1 = strategy.calculate_new_requirements(&mut ());
+        let result2 = strategy.calculate_new_requirements(&mut ());
+        let result3 = strategy.calculate_new_requirements(&mut ());
 
         assert_eq!(result1, req);
         assert_eq!(result2, req);

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -382,22 +382,22 @@ mod tests {
 
     #[async_trait]
     impl Subscriber for MockSubscriber {
-        fn on_query_start(&self, _: QueryID, __: Arc<QueryMetadata>) -> DaftResult<()> {
+        fn on_query_start(&self, _: QueryID, _: Arc<QueryMetadata>) -> DaftResult<()> {
             Ok(())
         }
-        fn on_query_end(&self, _: QueryID, __: QueryResult) -> DaftResult<()> {
+        fn on_query_end(&self, _: QueryID, _: QueryResult) -> DaftResult<()> {
             Ok(())
         }
-        fn on_result_out(&self, _: QueryID, __: MicroPartitionRef) -> DaftResult<()> {
+        fn on_result_out(&self, _: QueryID, _: MicroPartitionRef) -> DaftResult<()> {
             Ok(())
         }
         fn on_optimization_start(&self, _: QueryID) -> DaftResult<()> {
             Ok(())
         }
-        fn on_optimization_end(&self, _: QueryID, __: QueryPlan) -> DaftResult<()> {
+        fn on_optimization_end(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
             Ok(())
         }
-        fn on_exec_start(&self, _: QueryID, __: QueryPlan) -> DaftResult<()> {
+        fn on_exec_start(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
             Ok(())
         }
 
@@ -407,7 +407,7 @@ mod tests {
         async fn on_exec_operator_start(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
             Ok(())
         }
-        async fn on_exec_operator_end(&self, _: QueryID, __: NodeID) -> DaftResult<()> {
+        async fn on_exec_operator_end(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
             Ok(())
         }
 
@@ -529,22 +529,22 @@ mod tests {
 
         #[async_trait]
         impl Subscriber for FailingSubscriber {
-            fn on_query_start(&self, _: QueryID, __: Arc<QueryMetadata>) -> DaftResult<()> {
+            fn on_query_start(&self, _: QueryID, _: Arc<QueryMetadata>) -> DaftResult<()> {
                 Ok(())
             }
-            fn on_query_end(&self, _: QueryID, __: QueryResult) -> DaftResult<()> {
+            fn on_query_end(&self, _: QueryID, _: QueryResult) -> DaftResult<()> {
                 Ok(())
             }
-            fn on_result_out(&self, _: QueryID, __: MicroPartitionRef) -> DaftResult<()> {
+            fn on_result_out(&self, _: QueryID, _: MicroPartitionRef) -> DaftResult<()> {
                 Ok(())
             }
             fn on_optimization_start(&self, _: QueryID) -> DaftResult<()> {
                 Ok(())
             }
-            fn on_optimization_end(&self, _: QueryID, __: QueryPlan) -> DaftResult<()> {
+            fn on_optimization_end(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
                 Ok(())
             }
-            fn on_exec_start(&self, _: QueryID, __: QueryPlan) -> DaftResult<()> {
+            fn on_exec_start(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
                 Ok(())
             }
 
@@ -554,14 +554,14 @@ mod tests {
             async fn on_exec_operator_start(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
                 Ok(())
             }
-            async fn on_exec_operator_end(&self, _: QueryID, __: NodeID) -> DaftResult<()> {
+            async fn on_exec_operator_end(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
                 Ok(())
             }
 
             async fn on_exec_emit_stats(
                 &self,
                 _: QueryID,
-                __: std::sync::Arc<Vec<(NodeID, Stats)>>,
+                _: std::sync::Arc<Vec<(NodeID, Stats)>>,
             ) -> DaftResult<()> {
                 Err(common_error::DaftError::InternalError(
                     "Test error".to_string(),

--- a/src/daft-logical-plan/src/display/json.rs
+++ b/src/daft-logical-plan/src/display/json.rs
@@ -378,7 +378,7 @@ mod tests {
             }
          "#;
 
-        let expected: serde_json::Value = serde_json::from_str(&expected).unwrap();
+        let expected: serde_json::Value = serde_json::from_str(expected).unwrap();
         let actual: serde_json::Value = serde_json::from_str(&output).unwrap();
 
         assert_eq!(actual, expected);

--- a/src/daft-logical-plan/src/ops/project.rs
+++ b/src/daft-logical-plan/src/ops/project.rs
@@ -681,7 +681,7 @@ mod tests {
     /// ->
     /// 1. aaaa+aaaa as x
     /// 2. aa+aa as aaaa
-    /// 3: a+a as aa
+    /// 3. a+a as aa
     #[test]
     fn test_nested_subexpression() -> DaftResult<()> {
         let source = dummy_scan_node(dummy_scan_operator(vec![

--- a/src/daft-logical-plan/src/optimization/optimizer.rs
+++ b/src/daft-logical-plan/src/optimization/optimizer.rs
@@ -716,7 +716,7 @@ mod tests {
         let inputs = vec![resolved_col("a").into()];
         let actor_pool_expr = Arc::new(Expr::Function {
             func: FunctionExpr::Python(LegacyPythonUDF::new_testing_udf()),
-            inputs: inputs.clone(),
+            inputs,
         })
         .alias("a");
 
@@ -734,9 +734,9 @@ mod tests {
         .limit(limit, false)?
         .build();
         let expected = LogicalPlan::UDFProject(UDFProject::try_new(
-            expected.clone(),
+            expected,
             // Internally, splitting an actor pool project always re-aliases the column to its original name.
-            actor_pool_expr.clone(),
+            actor_pool_expr,
             vec![],
         )?)
         .arced();
@@ -784,7 +784,7 @@ mod tests {
         let plan = dummy_scan_node(scan_op.clone())
             .select(vec![
                 resolved_col("a"),
-                actor_pool_expr.clone().alias("renamed_col"),
+                actor_pool_expr.alias("renamed_col"),
             ])?
             .filter(resolved_col("a").lt(lit(2)))?
             .build();
@@ -796,9 +796,9 @@ mod tests {
         )
         .build();
         let expected = LogicalPlan::UDFProject(UDFProject::try_new(
-            expected.clone(),
+            expected,
             // Internally, splitting an actor pool project always re-aliases the column to its original name.
-            actor_pool_expr.clone(),
+            actor_pool_expr,
             vec![resolved_col("a")],
         )?)
         .arced();

--- a/src/daft-logical-plan/src/optimization/rules/drop_repartition.rs
+++ b/src/daft-logical-plan/src/optimization/rules/drop_repartition.rs
@@ -113,7 +113,7 @@ mod tests {
             Field::new("b", DataType::Utf8),
         ]);
         let plan = dummy_scan_node(scan_op.clone())
-            .hash_repartition(Some(num_partitions1), partition_by.clone())?
+            .hash_repartition(Some(num_partitions1), partition_by)?
             .into_partitions(num_partitions2)?
             .build();
         let expected = dummy_scan_node(scan_op)

--- a/src/daft-logical-plan/src/optimization/rules/eliminate_cross_join.rs
+++ b/src/daft-logical-plan/src/optimization/rules/eliminate_cross_join.rs
@@ -495,7 +495,7 @@ mod tests {
             expected, actual,
             "\n\nexpected:\n\n{expected:#?}\nactual:\n\n{actual:#?}\n\n"
         );
-        assert_eq!(starting_schema, actual.schema())
+        assert_eq!(starting_schema, actual.schema());
     }
 
     #[rstest]
@@ -671,8 +671,8 @@ mod tests {
             )?
             .build();
 
-        let plan = LogicalPlanBuilder::from(plan1.clone())
-            .cross_join(plan2.clone(), JoinOptions::default().prefix("t3."))?
+        let plan = LogicalPlanBuilder::from(plan1)
+            .cross_join(plan2, JoinOptions::default().prefix("t3."))?
             .filter(
                 unresolved_col("t3.a")
                     .eq(unresolved_col("a"))

--- a/src/daft-logical-plan/src/optimization/rules/extract_window_function.rs
+++ b/src/daft-logical-plan/src/optimization/rules/extract_window_function.rs
@@ -235,13 +235,15 @@ mod tests {
             Field::new("value", DataType::Int64),
         ]);
 
-        let input_plan = dummy_scan_node(scan_op.clone());
+        let input_plan = dummy_scan_node(scan_op);
 
         let category_col = resolved_col("category");
         let value_col = resolved_col("value");
 
-        let mut window_spec = WindowSpec::default();
-        window_spec.partition_by = vec![category_col.clone()];
+        let window_spec = WindowSpec {
+            partition_by: vec![category_col.clone()],
+            ..Default::default()
+        };
         let window_spec = Arc::new(window_spec);
 
         let min_expr: WindowExpr = value_col.clone().min().try_into().unwrap();
@@ -249,16 +251,16 @@ mod tests {
         let window_func =
             Arc::new(Expr::Over(min_expr.clone(), window_spec.clone())).alias("min_value");
 
-        let projection = vec![category_col.clone(), value_col.clone(), window_func.clone()];
+        let projection = vec![category_col.clone(), value_col.clone(), window_func];
 
-        let plan = input_plan.clone().select(projection)?.build();
+        let plan = input_plan.select(projection)?.build();
 
         let window_expr = Arc::new(Expr::Over(min_expr.clone(), window_spec.clone()));
         let auto_generated_name = window_expr.semantic_id(&input_plan.schema()).id.to_string();
 
         let window_op = Window::try_new(
-            input_plan.clone().build(),
-            vec![min_expr.clone()],
+            input_plan.build(),
+            vec![min_expr],
             vec![auto_generated_name.clone()],
             window_spec,
         )?;
@@ -286,14 +288,16 @@ mod tests {
             Field::new("value", DataType::Int64),
         ]);
 
-        let input_plan = dummy_scan_node(scan_op.clone());
+        let input_plan = dummy_scan_node(scan_op);
 
         let category_col = resolved_col("category");
         let group_col = resolved_col("group");
         let value_col = resolved_col("value");
 
-        let mut window_spec = WindowSpec::default();
-        window_spec.partition_by = vec![category_col.clone(), group_col.clone()];
+        let window_spec = WindowSpec {
+            partition_by: vec![category_col.clone(), group_col.clone()],
+            ..Default::default()
+        };
         let window_spec = Arc::new(window_spec);
 
         let sum_expr: WindowExpr = value_col.clone().sum().try_into().unwrap();
@@ -305,17 +309,17 @@ mod tests {
             category_col.clone(),
             group_col.clone(),
             value_col.clone(),
-            window_func.clone(),
+            window_func,
         ];
 
-        let plan = input_plan.clone().select(projection)?.build();
+        let plan = input_plan.select(projection)?.build();
 
         let window_expr = Arc::new(Expr::Over(sum_expr.clone(), window_spec.clone()));
         let auto_generated_name = window_expr.semantic_id(&input_plan.schema()).id.to_string();
 
         let window_op = Window::try_new(
-            input_plan.clone().build(),
-            vec![sum_expr.clone()],
+            input_plan.build(),
+            vec![sum_expr],
             vec![auto_generated_name.clone()],
             window_spec,
         )?;
@@ -344,18 +348,22 @@ mod tests {
             Field::new("value", DataType::Int64),
         ]);
 
-        let input_plan = dummy_scan_node(scan_op.clone());
+        let input_plan = dummy_scan_node(scan_op);
 
         let category_col = resolved_col("category");
         let group_col = resolved_col("group");
         let value_col = resolved_col("value");
 
-        let mut window_spec1 = WindowSpec::default();
-        window_spec1.partition_by = vec![category_col.clone()];
+        let window_spec1 = WindowSpec {
+            partition_by: vec![category_col.clone()],
+            ..Default::default()
+        };
         let window_spec1 = Arc::new(window_spec1);
 
-        let mut window_spec2 = WindowSpec::default();
-        window_spec2.partition_by = vec![group_col.clone()];
+        let window_spec2 = WindowSpec {
+            partition_by: vec![group_col.clone()],
+            ..Default::default()
+        };
         let window_spec2 = Arc::new(window_spec2);
 
         let min_expr: WindowExpr = value_col.clone().min().try_into().unwrap();
@@ -370,11 +378,11 @@ mod tests {
             category_col.clone(),
             group_col.clone(),
             value_col.clone(),
-            window_func1.clone(),
-            window_func2.clone(),
+            window_func1,
+            window_func2,
         ];
 
-        let plan = input_plan.clone().select(projection)?.build();
+        let plan = input_plan.select(projection)?.build();
 
         let window_expr1 = Arc::new(Expr::Over(min_expr.clone(), window_spec1.clone()));
         let window_expr2 = Arc::new(Expr::Over(sum_expr.clone(), window_spec2.clone()));
@@ -389,8 +397,8 @@ mod tests {
             .to_string();
 
         let window_op1 = Window::try_new(
-            input_plan.clone().build(),
-            vec![min_expr.clone()],
+            input_plan.build(),
+            vec![min_expr],
             vec![auto_generated_name1.clone()],
             window_spec1,
         )?;
@@ -399,7 +407,7 @@ mod tests {
 
         let window_op2 = Window::try_new(
             intermediate_plan,
-            vec![sum_expr.clone()],
+            vec![sum_expr],
             vec![auto_generated_name2.clone()],
             window_spec2,
         )?;
@@ -430,18 +438,22 @@ mod tests {
             Field::new("value", DataType::Int64),
         ]);
 
-        let input_plan = dummy_scan_node(scan_op.clone());
+        let input_plan = dummy_scan_node(scan_op);
 
         let category_col = resolved_col("category");
         let group_col = resolved_col("group");
         let value_col = resolved_col("value");
 
-        let mut multi_partition_spec = WindowSpec::default();
-        multi_partition_spec.partition_by = vec![category_col.clone(), group_col.clone()];
+        let multi_partition_spec = WindowSpec {
+            partition_by: vec![category_col.clone(), group_col.clone()],
+            ..Default::default()
+        };
         let multi_partition_spec = Arc::new(multi_partition_spec);
 
-        let mut single_partition_spec = WindowSpec::default();
-        single_partition_spec.partition_by = vec![category_col.clone()];
+        let single_partition_spec = WindowSpec {
+            partition_by: vec![category_col.clone()],
+            ..Default::default()
+        };
         let single_partition_spec = Arc::new(single_partition_spec);
 
         let sum_expr: WindowExpr = value_col.clone().sum().try_into().unwrap();
@@ -463,13 +475,13 @@ mod tests {
             category_col.clone(),
             group_col.clone(),
             value_col.clone(),
-            window_func1.clone(),
-            window_func2.clone(),
-            window_func3.clone(),
-            window_func4.clone(),
+            window_func1,
+            window_func2,
+            window_func3,
+            window_func4,
         ];
 
-        let plan = input_plan.clone().select(projection)?.build();
+        let plan = input_plan.select(projection)?.build();
 
         let window_expr1 = Arc::new(Expr::Over(sum_expr.clone(), multi_partition_spec.clone()));
         let window_expr2 = Arc::new(Expr::Over(avg_expr.clone(), multi_partition_spec.clone()));
@@ -494,8 +506,8 @@ mod tests {
             .to_string();
 
         let multi_window_op = Window::try_new(
-            input_plan.clone().build(),
-            vec![sum_expr.clone(), avg_expr.clone()],
+            input_plan.build(),
+            vec![sum_expr, avg_expr],
             vec![auto_generated_name1.clone(), auto_generated_name2.clone()],
             multi_partition_spec,
         )?;
@@ -504,7 +516,7 @@ mod tests {
 
         let single_window_op = Window::try_new(
             intermediate_plan,
-            vec![min_expr.clone(), max_expr.clone()],
+            vec![min_expr, max_expr],
             vec![auto_generated_name3.clone(), auto_generated_name4.clone()],
             single_partition_spec,
         )?;
@@ -537,22 +549,28 @@ mod tests {
             Field::new("value", DataType::Int64),
         ]);
 
-        let input_plan = dummy_scan_node(scan_op.clone());
+        let input_plan = dummy_scan_node(scan_op);
 
         let letter_col = resolved_col("letter");
         let num_col = resolved_col("num");
         let value_col = resolved_col("value");
 
-        let mut letter_window_spec = WindowSpec::default();
-        letter_window_spec.partition_by = vec![letter_col.clone()];
+        let letter_window_spec = WindowSpec {
+            partition_by: vec![letter_col.clone()],
+            ..Default::default()
+        };
         let letter_window_spec = Arc::new(letter_window_spec);
 
-        let mut num_window_spec = WindowSpec::default();
-        num_window_spec.partition_by = vec![num_col.clone()];
+        let num_window_spec = WindowSpec {
+            partition_by: vec![num_col.clone()],
+            ..Default::default()
+        };
         let num_window_spec = Arc::new(num_window_spec);
 
-        let mut combined_window_spec = WindowSpec::default();
-        combined_window_spec.partition_by = vec![letter_col.clone(), num_col.clone()];
+        let combined_window_spec = WindowSpec {
+            partition_by: vec![letter_col.clone(), num_col.clone()],
+            ..Default::default()
+        };
         let combined_window_spec = Arc::new(combined_window_spec);
 
         let letter_sum_expr: WindowExpr = value_col.clone().sum().try_into().unwrap();
@@ -578,12 +596,12 @@ mod tests {
             letter_col.clone(),
             num_col.clone(),
             value_col.clone(),
-            letter_sum.clone(),
-            num_sum.clone(),
-            combined_sum.clone(),
+            letter_sum,
+            num_sum,
+            combined_sum,
         ];
 
-        let plan = input_plan.clone().select(projection)?.build();
+        let plan = input_plan.select(projection)?.build();
 
         let window_expr1 = Arc::new(Expr::Over(
             letter_sum_expr.clone(),
@@ -609,7 +627,7 @@ mod tests {
             .to_string();
 
         let letter_window_op = Window::try_new(
-            input_plan.clone().build(),
+            input_plan.build(),
             vec![letter_sum_expr],
             vec![letter_sum_id.clone()],
             letter_window_spec,
@@ -659,13 +677,15 @@ mod tests {
             Field::new("value", DataType::Int64),
         ]);
 
-        let input_plan = dummy_scan_node(scan_op.clone());
+        let input_plan = dummy_scan_node(scan_op);
 
         let category_col = resolved_col("category");
         let value_col = resolved_col("value");
 
-        let mut window_spec = WindowSpec::default();
-        window_spec.partition_by = vec![category_col.clone()];
+        let window_spec = WindowSpec {
+            partition_by: vec![category_col.clone()],
+            ..Default::default()
+        };
         let window_spec = Arc::new(window_spec);
 
         let min_expr: WindowExpr = value_col.clone().min().try_into().unwrap();
@@ -678,18 +698,18 @@ mod tests {
         let projection = vec![
             category_col.clone(),
             value_col.clone(),
-            window_func1.clone(),
-            window_func2.clone(),
+            window_func1,
+            window_func2,
         ];
 
-        let plan = input_plan.clone().select(projection)?.build();
+        let plan = input_plan.select(projection)?.build();
 
         let window_expr = Arc::new(Expr::Over(min_expr.clone(), window_spec.clone()));
         let auto_generated_name = window_expr.semantic_id(&input_plan.schema()).id.to_string();
 
         let window_op = Window::try_new(
-            input_plan.clone().build(),
-            vec![min_expr.clone()],
+            input_plan.build(),
+            vec![min_expr],
             vec![auto_generated_name.clone()],
             window_spec,
         )?;

--- a/src/daft-logical-plan/src/optimization/rules/filter_null_join_key.rs
+++ b/src/daft-logical-plan/src/optimization/rules/filter_null_join_key.rs
@@ -223,7 +223,6 @@ mod tests {
 
         let expected = left_scan
             .filter(unresolved_col("a").is_null().not())?
-            .clone()
             .join(
                 right_scan.filter(unresolved_col("c").is_null().not())?,
                 unresolved_col("a").eq(unresolved_col("c")).into(),
@@ -273,7 +272,6 @@ mod tests {
             .and(unresolved_col("f").is_null().not());
 
         let expected = left_scan
-            .clone()
             .join(
                 right_scan.filter(expected_predicate)?,
                 (unresolved_col("a").eq(unresolved_col("d")))

--- a/src/daft-logical-plan/src/optimization/rules/lift_project_from_agg.rs
+++ b/src/daft-logical-plan/src/optimization/rules/lift_project_from_agg.rs
@@ -248,7 +248,7 @@ mod tests {
             Field::new("b", DataType::Int64),
         ]);
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(
                 vec![
                     unresolved_col("a").sum(),
@@ -277,7 +277,7 @@ mod tests {
             Field::new("b", DataType::Int64),
         ]);
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(
                 vec![
                     unresolved_col("a").sum(),

--- a/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_aggregation.rs
@@ -200,7 +200,7 @@ mod tests {
             true,
         );
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(vec![unresolved_col("a").count(CountMode::Valid)], vec![])?
             .build();
 
@@ -220,7 +220,7 @@ mod tests {
             true,
         );
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(vec![unresolved_col("a").count(CountMode::Null)], vec![])?
             .build();
 
@@ -240,7 +240,7 @@ mod tests {
             true,
         );
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(
                 vec![unresolved_col("a").count(CountMode::Null)],
                 vec![unresolved_col("b")],
@@ -263,7 +263,7 @@ mod tests {
             true,
         );
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .filter(resolved_col("a").lt(lit(2)))?
             .aggregate(vec![unresolved_col("*").count(CountMode::Null)], vec![])?
             .build();
@@ -284,7 +284,7 @@ mod tests {
             true,
         );
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .select(vec![resolved_col("a")])?
             .aggregate(vec![unresolved_col("a").count(CountMode::Null)], vec![])?
             .build();
@@ -333,7 +333,7 @@ mod tests {
 
         let unpushable_filter = resolved_col("a").is_in(vec![lit(2)]);
         let plan = dummy_scan_node_with_pushdowns(
-            scan_op.clone(),
+            scan_op,
             Pushdowns::default().with_filters(Some(unpushable_filter)),
         )
         .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
@@ -351,7 +351,7 @@ mod tests {
         let scan_op =
             dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::UInt64)], true);
         let plan = dummy_scan_node_with_pushdowns(
-            scan_op.clone(),
+            scan_op,
             Pushdowns::default().with_filters(Some(resolved_col("a").lt(lit(10)))),
         )
         .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
@@ -380,7 +380,7 @@ mod tests {
             ],
             true,
         );
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(
                 vec![unresolved_col("a").count(CountMode::All)],
                 vec![unresolved_col("b")],
@@ -396,7 +396,7 @@ mod tests {
     fn agg_multiple_aggs_should_not_pushdown() -> DaftResult<()> {
         let scan_op =
             dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::Int64)], true);
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(
                 vec![
                     unresolved_col("a").count(CountMode::All),
@@ -414,7 +414,7 @@ mod tests {
     fn agg_sum_only_should_not_pushdown() -> DaftResult<()> {
         let scan_op =
             dummy_scan_operator_for_aggregation(vec![Field::new("a", DataType::Int64)], true);
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(vec![unresolved_col("a").sum()], vec![])?
             .build();
         let expected = plan.clone();
@@ -428,7 +428,7 @@ mod tests {
             vec![Field::new("a", DataType::Int64)],
             false, // does not support count pushdown
         );
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
             .build();
         let expected = plan.clone();

--- a/src/daft-logical-plan/src/optimization/rules/push_down_anti_semi_join.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_anti_semi_join.rs
@@ -476,7 +476,7 @@ mod tests {
                     .alias("x_plus_y"),
             ])?
             .join(
-                right_scan_node.clone(),
+                right_scan_node,
                 Some(unresolved_col("x_plus_y").eq(unresolved_col("a"))),
                 vec![],
                 join_type,
@@ -529,7 +529,7 @@ mod tests {
 
         let expected = left_scan_node
             .join(
-                filtering_scan_node.clone(),
+                filtering_scan_node,
                 Some(unresolved_col("y").eq(unresolved_col("a"))),
                 vec![],
                 join_type,
@@ -537,7 +537,7 @@ mod tests {
                 Default::default(),
             )?
             .join(
-                right_scan_node.clone(),
+                right_scan_node,
                 None,
                 vec!["x".to_string()],
                 JoinType::Inner,
@@ -590,7 +590,7 @@ mod tests {
             .join(
                 right_scan_node
                     .join(
-                        filtering_scan_node.clone(),
+                        filtering_scan_node,
                         Some(unresolved_col("z").eq(unresolved_col("a"))),
                         vec![],
                         join_type,
@@ -629,7 +629,7 @@ mod tests {
 
         let plan = left_scan_node
             .join(
-                right_scan_node.clone(),
+                right_scan_node,
                 None,
                 vec!["x".to_string()],
                 JoinType::Inner,
@@ -637,7 +637,7 @@ mod tests {
                 Default::default(),
             )?
             .join(
-                filtering_scan_node.clone(),
+                filtering_scan_node,
                 Some(unresolved_col("x").eq(unresolved_col("a"))),
                 vec![],
                 join_type,
@@ -682,7 +682,7 @@ mod tests {
 
         let expected = left_scan_node
             .join(
-                right_scan_node.clone(),
+                right_scan_node,
                 Some(unresolved_col("x").eq(unresolved_col("a"))),
                 vec![],
                 join_type,

--- a/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_filter.rs
@@ -652,8 +652,7 @@ mod tests {
     }
 
     /// Tests that Filter commutes with Projection if projection expression involves deterministic compute.
-    // REASON - No expression attribute indicating whether deterministic && (pure || idempotent).
-    #[ignore]
+    #[ignore = "No expression attribute indicating whether deterministic && (pure || idempotent)."]
     #[rstest]
     fn filter_commutes_with_projection_deterministic_compute(
         #[values(false, true)] push_into_scan: bool,
@@ -837,7 +836,7 @@ mod tests {
             left_scan_op.clone(),
             Pushdowns::default().with_limit(if push_into_left_scan { None } else { Some(1) }),
         );
-        let right_scan_plan = dummy_scan_node(right_scan_op.clone());
+        let right_scan_plan = dummy_scan_node(right_scan_op);
         let join_on = if null_equals_null {
             unresolved_col("b").eq_null_safe(unresolved_col("right.b"))
         } else {
@@ -858,7 +857,7 @@ mod tests {
             .build();
         let expected_left_filter_scan = if push_into_left_scan {
             dummy_scan_node_with_pushdowns(
-                left_scan_op.clone(),
+                left_scan_op,
                 Pushdowns::default().with_filters(Some(pred)),
             )
         } else {
@@ -893,7 +892,7 @@ mod tests {
             Field::new("right.b", DataType::Utf8),
             Field::new("c", DataType::Float64),
         ]);
-        let left_scan_plan = dummy_scan_node(left_scan_op.clone());
+        let left_scan_plan = dummy_scan_node(left_scan_op);
         let right_scan_plan = dummy_scan_node_with_pushdowns(
             right_scan_op.clone(),
             Pushdowns::default().with_limit(if push_into_right_scan { None } else { Some(1) }),
@@ -917,7 +916,7 @@ mod tests {
             .build();
         let expected_right_filter_scan = if push_into_right_scan {
             dummy_scan_node_with_pushdowns(
-                right_scan_op.clone(),
+                right_scan_op,
                 Pushdowns::default().with_filters(Some(pred)),
             )
         } else {
@@ -983,7 +982,7 @@ mod tests {
             .build();
         let expected_left_filter_scan = if push_into_left_scan {
             dummy_scan_node_with_pushdowns(
-                left_scan_op.clone(),
+                left_scan_op,
                 Pushdowns::default().with_filters(Some(pred.clone())),
             )
         } else {
@@ -1025,8 +1024,8 @@ mod tests {
             Field::new("right.b", DataType::Utf8),
             Field::new("c", DataType::Float64),
         ]);
-        let left_scan_plan = dummy_scan_node(left_scan_op.clone());
-        let right_scan_plan = dummy_scan_node(right_scan_op.clone());
+        let left_scan_plan = dummy_scan_node(left_scan_op);
+        let right_scan_plan = dummy_scan_node(right_scan_op);
         let join_on = if null_equals_null {
             unresolved_col("b").eq_null_safe(unresolved_col("right.b"))
         } else {
@@ -1064,8 +1063,8 @@ mod tests {
             Field::new("right.b", DataType::Utf8),
             Field::new("c", DataType::Float64),
         ]);
-        let left_scan_plan = dummy_scan_node(left_scan_op.clone());
-        let right_scan_plan = dummy_scan_node(right_scan_op.clone());
+        let left_scan_plan = dummy_scan_node(left_scan_op);
+        let right_scan_plan = dummy_scan_node(right_scan_op);
         let join_on = if null_equals_null {
             unresolved_col("b").eq_null_safe(unresolved_col("right.b"))
         } else {
@@ -1209,7 +1208,7 @@ mod tests {
             Field::new("foo", DataType::Int64),
         ]);
         let left_scan_plan = dummy_scan_node(left_scan_op.clone());
-        let right_scan_plan = dummy_scan_node(right_scan_op.clone());
+        let right_scan_plan = dummy_scan_node(right_scan_op);
 
         // Filter on foo (which exists in both input schemas)
         let pred = resolved_col("foo").eq(lit(0));

--- a/src/daft-logical-plan/src/optimization/rules/push_down_join_predicate.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_join_predicate.rs
@@ -164,7 +164,6 @@ mod tests {
         let right_scan_node = dummy_scan_node(dummy_scan_operator(vec![b_field.clone()]));
 
         let plan = left_scan_node
-            .clone()
             .join(
                 right_scan_node.clone(),
                 Some(left_col(a_field).and(right_col(b_field))),

--- a/src/daft-logical-plan/src/optimization/rules/push_down_projection.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_projection.rs
@@ -908,7 +908,7 @@ mod tests {
             Field::new("a", DataType::Int64),
             Field::new("b", DataType::Int64),
         ]);
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .add_monotonically_increasing_id(Some("id"), None)?
             .select(vec![unresolved_col("id")])?
             .build();
@@ -930,7 +930,7 @@ mod tests {
 
         let plan = LogicalPlan::Unpivot(
             Unpivot::try_new(
-                scan_node.clone(),
+                scan_node,
                 vec![resolved_col("year")],
                 vec![resolved_col("Jan"), resolved_col("Feb")],
                 "month".to_string(),
@@ -944,7 +944,7 @@ mod tests {
         )
         .into();
         let expected_scan = dummy_scan_node_with_pushdowns(
-            scan_op.clone(),
+            scan_op,
             Pushdowns {
                 limit: None,
                 partition_filters: None,

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/brute_force_join_order.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/brute_force_join_order.rs
@@ -229,7 +229,7 @@ mod tests {
         let mut adj_list = JoinAdjList::empty();
         // Immediately create plan ids so that they match the ids in the test cases.
         for plan in &plans {
-            adj_list.get_or_create_plan_id(&plan);
+            adj_list.get_or_create_plan_id(plan);
         }
         for edge in edges {
             adj_list.add_bidirectional_edge_with_total_domain(

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/join_graph.rs
@@ -68,11 +68,10 @@ impl JoinOrderTree {
     // Check if the join structure is the same, regardless of cardinality or join conditions.
     pub(super) fn order_eq(this: &Self, other: &Self) -> bool {
         match (this, other) {
-            (JoinOrderTree::Relation(id1, _), JoinOrderTree::Relation(id2, _)) => id1 == id2,
-            (
-                JoinOrderTree::Join(left1, right1, _, _),
-                JoinOrderTree::Join(left2, right2, _, _),
-            ) => Self::order_eq(left1, left2) && Self::order_eq(right1, right2),
+            (Self::Relation(id1, _), Self::Relation(id2, _)) => id1 == id2,
+            (Self::Join(left1, right1, _, _), Self::Join(left2, right2, _, _)) => {
+                Self::order_eq(left1, left2) && Self::order_eq(right1, right2)
+            }
             _ => false,
         }
     }
@@ -80,8 +79,8 @@ impl JoinOrderTree {
     #[cfg(test)]
     pub(super) fn num_join_conditions(this: &Self) -> usize {
         match this {
-            JoinOrderTree::Relation(_, _) => 0,
-            JoinOrderTree::Join(left, right, conditions, _) => {
+            Self::Relation(_, _) => 0,
+            Self::Join(left, right, conditions, _) => {
                 Self::num_join_conditions(left)
                     + Self::num_join_conditions(right)
                     + conditions.len()
@@ -1092,7 +1091,7 @@ mod tests {
         let cfg = Arc::new(DaftExecutionConfig::default());
         let stats_enricher = EnrichWithStats::new(Some(cfg.clone()));
         let original_plan = stats_enricher.try_optimize(original_plan).data().unwrap();
-        let join_graph = JoinGraphBuilder::from_logical_plan(original_plan.clone(), cfg).build();
+        let join_graph = JoinGraphBuilder::from_logical_plan(original_plan, cfg).build();
         assert!(join_graph.fully_connected());
         // There should be edges between:
         // - a <-> b
@@ -1159,8 +1158,7 @@ mod tests {
         let cfg = Arc::new(DaftExecutionConfig::default());
         let stats_enricher = EnrichWithStats::new(Some(cfg.clone()));
         let original_plan = stats_enricher.try_optimize(original_plan).data().unwrap();
-        let join_graph =
-            JoinGraphBuilder::from_logical_plan(original_plan.clone(), cfg.clone()).build();
+        let join_graph = JoinGraphBuilder::from_logical_plan(original_plan, cfg).build();
         assert!(join_graph.fully_connected());
         // There should be edges between:
         // - a <-> b
@@ -1228,8 +1226,7 @@ mod tests {
         let cfg = Arc::new(DaftExecutionConfig::default());
         let stats_enricher = EnrichWithStats::new(Some(cfg.clone()));
         let original_plan = stats_enricher.try_optimize(original_plan).data().unwrap();
-        let join_graph =
-            JoinGraphBuilder::from_logical_plan(original_plan.clone(), cfg.clone()).build();
+        let join_graph = JoinGraphBuilder::from_logical_plan(original_plan, cfg).build();
         assert!(join_graph.fully_connected());
         // There should be edges between:
         // - a_beta <-> b
@@ -1269,10 +1266,7 @@ mod tests {
             dummy_scan_operator(vec![Field::new("c_prime", DataType::Int64)]),
             Pushdowns::default(),
         )
-        .select(vec![
-            unresolved_col("c_prime").alias("c"),
-            double_proj.clone(),
-        ])
+        .select(vec![unresolved_col("c_prime").alias("c"), double_proj])
         .unwrap();
         let scan_d = dummy_scan_node_with_pushdowns(
             dummy_scan_operator(vec![Field::new("d", DataType::Int64)]),
@@ -1296,8 +1290,7 @@ mod tests {
         let cfg = Arc::new(DaftExecutionConfig::default());
         let stats_enricher = EnrichWithStats::new(Some(cfg.clone()));
         let original_plan = stats_enricher.try_optimize(original_plan).data().unwrap();
-        let join_graph =
-            JoinGraphBuilder::from_logical_plan(original_plan.clone(), cfg.clone()).build();
+        let join_graph = JoinGraphBuilder::from_logical_plan(original_plan, cfg).build();
         assert!(join_graph.fully_connected());
         // There should be edges between:
         // - a <-> b
@@ -1356,14 +1349,11 @@ mod tests {
             dummy_scan_operator(vec![Field::new("c_prime", DataType::Int64)]),
             Pushdowns::default(),
         )
-        .filter(filter_c_prime.clone())
+        .filter(filter_c_prime)
         .unwrap()
-        .select(vec![
-            unresolved_col("c_prime").alias("c"),
-            double_proj.clone(),
-        ])
+        .select(vec![unresolved_col("c_prime").alias("c"), double_proj])
         .unwrap()
-        .filter(filter_c.clone())
+        .filter(filter_c)
         .unwrap();
         let scan_d = dummy_scan_node_with_pushdowns(
             dummy_scan_operator(vec![Field::new("d", DataType::Int64)]),
@@ -1378,7 +1368,7 @@ mod tests {
         let join_plan_r = scan_c
             .inner_join(scan_d, unresolved_col("c").eq(unresolved_col("d")))
             .unwrap()
-            .select(vec![unresolved_col("d"), quad_proj.clone()])
+            .select(vec![unresolved_col("d"), quad_proj])
             .unwrap();
         let join_plan = join_plan_l
             .inner_join(join_plan_r, unresolved_col("a").eq(unresolved_col("d")))
@@ -1392,7 +1382,7 @@ mod tests {
         let cfg = Arc::new(DaftExecutionConfig::default());
         let stats_enricher = EnrichWithStats::new(Some(cfg.clone()));
         let original_plan = stats_enricher.try_optimize(original_plan).data().unwrap();
-        let join_graph = JoinGraphBuilder::from_logical_plan(original_plan.clone(), cfg).build();
+        let join_graph = JoinGraphBuilder::from_logical_plan(original_plan, cfg).build();
         assert!(join_graph.fully_connected());
         // There should be edges between:
         // - a <-> b
@@ -1438,7 +1428,7 @@ mod tests {
             dummy_scan_operator(vec![Field::new("a_prime", DataType::Int64)]),
             Pushdowns::default(),
         )
-        .select(vec![a_proj.clone()])
+        .select(vec![a_proj])
         .unwrap()
         .aggregate(
             vec![Arc::new(Expr::Agg(AggExpr::Count(
@@ -1480,7 +1470,7 @@ mod tests {
         let cfg = Arc::new(DaftExecutionConfig::default());
         let stats_enricher = EnrichWithStats::new(Some(cfg.clone()));
         let original_plan = stats_enricher.try_optimize(original_plan).data().unwrap();
-        let join_graph = JoinGraphBuilder::from_logical_plan(original_plan.clone(), cfg).build();
+        let join_graph = JoinGraphBuilder::from_logical_plan(original_plan, cfg).build();
         assert!(join_graph.fully_connected());
         // There should be edges between:
         // - a <-> b

--- a/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
+++ b/src/daft-logical-plan/src/optimization/rules/reorder_joins/naive_left_deep_join_order.rs
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_order_basic_join_graph() {
-        let nodes = vec!["a", "b", "c", "d"];
+        let nodes = ["a", "b", "c", "d"];
         let edges = vec![
             (0, 2), // node_a <-> node_c
             (1, 2), // node_b <-> node_c
@@ -116,7 +116,7 @@ mod tests {
 
     impl UnionFind {
         pub fn create(num_nodes: usize) -> Self {
-            UnionFind {
+            Self {
                 parent: (0..num_nodes).collect(),
                 size: vec![1; num_nodes],
             }

--- a/src/daft-logical-plan/src/optimization/rules/rewrite_count_distinct.rs
+++ b/src/daft-logical-plan/src/optimization/rules/rewrite_count_distinct.rs
@@ -130,7 +130,7 @@ mod tests {
             Field::new("b", DataType::Int64),
         ]);
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(
                 vec![
                     unresolved_col("a").sum(),
@@ -156,7 +156,7 @@ mod tests {
             Field::new("b", DataType::Int64),
         ]);
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(
                 vec![
                     unresolved_col("a").count_distinct(),
@@ -178,7 +178,7 @@ mod tests {
             Field::new("b", DataType::Int64),
         ]);
 
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .aggregate(
                 vec![unresolved_col("a").count_distinct()],
                 vec![unresolved_col("b")],

--- a/src/daft-logical-plan/src/optimization/rules/rewrite_offset.rs
+++ b/src/daft-logical-plan/src/optimization/rules/rewrite_offset.rs
@@ -128,10 +128,7 @@ mod tests {
             Field::new("a", DataType::Int64),
             Field::new("b", DataType::Utf8),
         ]);
-        let plan = dummy_scan_node(scan_op.clone())
-            .offset(7)?
-            .offset(11)?
-            .build();
+        let plan = dummy_scan_node(scan_op).offset(7)?.offset(11)?.build();
         assert_optimized_plan_err(
             plan,
             DaftError::InternalError(
@@ -148,7 +145,7 @@ mod tests {
             Field::new("a", DataType::Int64),
             Field::new("b", DataType::Utf8),
         ]);
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .offset(offset)?
             .limit(limit, false)?
             .build();
@@ -243,7 +240,7 @@ mod tests {
             Field::new("a", DataType::Int64),
             Field::new("b", DataType::Utf8),
         ]);
-        let plan = dummy_scan_node(scan_op.clone()).offset(offset)?.build();
+        let plan = dummy_scan_node(scan_op).offset(offset)?.build();
         assert_optimized_plan_err(
             plan,
             DaftError::not_implemented("Offset without limit is unsupported now!"),

--- a/src/daft-logical-plan/src/optimization/rules/simplify_null_filtered_join.rs
+++ b/src/daft-logical-plan/src/optimization/rules/simplify_null_filtered_join.rs
@@ -166,7 +166,7 @@ mod tests {
                 None,
                 Default::default(),
             )?
-            .filter(filter_predicate.clone())?
+            .filter(filter_predicate)?
             .build();
 
         assert_optimized_plan_eq(plan, expected)?;

--- a/src/daft-logical-plan/src/optimization/rules/split_udfs.rs
+++ b/src/daft-logical-plan/src/optimization/rules/split_udfs.rs
@@ -1162,7 +1162,7 @@ Project: col(a), col(c)
             Field::new("b", DataType::Boolean),
             Field::new("c", DataType::Int64),
         ]);
-        let scan_node = dummy_scan_node(scan_op.clone());
+        let scan_node = dummy_scan_node(scan_op);
         let mock_udf = create_actor_pool_udf(vec![resolved_col("c")]);
 
         // Select the `udf_results` column, so the UDFProject should apply column pruning to the other columns
@@ -1206,13 +1206,13 @@ Project: col(a), col(c)
             Field::new("b", DataType::Boolean),
             Field::new("c", DataType::Int64),
         ]);
-        let scan_node = dummy_scan_node(scan_op.clone()).build();
+        let scan_node = dummy_scan_node(scan_op).build();
         let mock_udf = create_actor_pool_udf(vec![resolved_col("a")]);
 
         // Select the `udf_results` column, so the UDFProject should apply column pruning to the other columns
         let plan = LogicalPlan::UDFProject(UDFProject::try_new(
             scan_node,
-            mock_udf.clone().alias("udf_results_0"),
+            mock_udf.alias("udf_results_0"),
             vec![resolved_col("a"), resolved_col("b")],
         )?)
         .arced();
@@ -1266,7 +1266,7 @@ Project: col(a), col(c)
             Field::new("c", DataType::Int64),
         ]);
         let mock_udf = create_actor_pool_udf(vec![resolved_col("c")]);
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .with_columns(vec![mock_udf.alias("udf_results")])?
             // Select only col("a"), so the udf is redundant and should be removed
             .select(vec![resolved_col("a")])?
@@ -1295,7 +1295,7 @@ Project: col(a), col(c)
             Field::new("b", DataType::Int64),
             Field::new("c", DataType::Int64),
         ]);
-        let plan = dummy_scan_node(scan_op.clone())
+        let plan = dummy_scan_node(scan_op)
             .with_columns(vec![mock_udf.alias("udf_results")])?
             .select(vec![
                 resolved_col("a"),
@@ -1327,7 +1327,7 @@ Project: col(a), col(c)
     #[test]
     fn test_split_udf_in_filter_top() -> DaftResult<()> {
         let scan_op = dummy_scan_operator(vec![Field::new("a", DataType::Int64)]);
-        let scan_node = dummy_scan_node(scan_op.clone());
+        let scan_node = dummy_scan_node(scan_op);
         let udf = create_filter_udf(vec![resolved_col("a")]);
         let plan = scan_node.filter(udf)?.build();
 
@@ -1360,7 +1360,7 @@ Project: col(a), col(c)
     #[test]
     fn test_split_udf_in_filter_middle() -> DaftResult<()> {
         let scan_op = dummy_scan_operator(vec![Field::new("a", DataType::Int64)]);
-        let scan_node = dummy_scan_node(scan_op.clone());
+        let scan_node = dummy_scan_node(scan_op);
         let condition = create_actor_pool_udf(vec![resolved_col("a")]).not_eq(lit("hello"));
         let plan = scan_node.filter(condition)?.build();
 

--- a/src/daft-logical-plan/src/optimization/test/mod.rs
+++ b/src/daft-logical-plan/src/optimization/test/mod.rs
@@ -75,8 +75,5 @@ pub fn optimize_with_rules(
     let config = OptimizerConfig::default();
     let optimizer = Optimizer::with_rule_batches(rule_batches, config);
 
-    match optimizer.optimize(plan, |_, _, _, _, _| {}) {
-        Ok(data) => Ok(data),
-        Err(e) => Err(e),
-    }
+    optimizer.optimize(plan, |_, _, _, _, _| {})
 }

--- a/src/daft-parquet/src/arrowrs_reader.rs
+++ b/src/daft-parquet/src/arrowrs_reader.rs
@@ -1350,7 +1350,7 @@ mod tests {
         let mut writer = ArrowWriter::try_new(&mut buf, schema.clone(), None).unwrap();
 
         let batch = arrow::array::RecordBatch::try_new(
-            schema.clone(),
+            schema,
             vec![
                 Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5])),
                 Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50])),
@@ -1673,7 +1673,7 @@ mod tests {
         .unwrap();
 
         // The MVP parquet file should have some rows and columns.
-        assert!(result.len() > 0, "MVP parquet should have rows");
+        assert!(!result.is_empty(), "MVP parquet should have rows");
         assert!(result.num_columns() > 0, "MVP parquet should have columns");
     }
 
@@ -1690,7 +1690,7 @@ mod tests {
         let vals: Vec<i32> = (0..n).collect();
         let labels: Vec<String> = (0..n).map(|i| format!("row_{i}")).collect();
         let batch = arrow::array::RecordBatch::try_new(
-            schema.clone(),
+            schema,
             vec![
                 Arc::new(Int32Array::from(vals)),
                 Arc::new(arrow::array::StringArray::from(labels)),

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -991,7 +991,7 @@ mod tests {
         match schema.fields().deref() {
             [field] => assert_eq!(field.data_type(), &DataType::LargeBinary),
             _ => panic!("There should only be one field in the schema"),
-        };
+        }
     }
 
     /// Regression test: streaming with a limit equal to the batch size should

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -1722,7 +1722,7 @@ mod test {
         let e2 = resolved_col("a")
             .add(resolved_col("b"))
             .cast(&DataType::Int64);
-        let result = table.eval_expression(&&BoundExpr::try_new(e2, &table.schema)?)?;
+        let result = table.eval_expression(&BoundExpr::try_new(e2, &table.schema)?)?;
         assert_eq!(*result.data_type(), DataType::Int64);
         assert_eq!(result.len(), 3);
 

--- a/src/daft-scan/src/hive.rs
+++ b/src/daft-scan/src/hive.rs
@@ -148,7 +148,7 @@ mod tests {
         let partitions = parse_hive_partitioning(uri).unwrap();
 
         assert_eq!(partitions.get("year"), Some(&"2024".to_string()));
-        assert_eq!(partitions.get("region"), Some(&"".to_string()));
+        assert_eq!(partitions.get("region"), Some(&String::new()));
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod tests {
         let partitions = parse_hive_partitioning(uri).unwrap();
 
         assert_eq!(partitions.len(), 2);
-        assert_eq!(partitions.get("empty_key"), Some(&"".to_string()));
-        assert_eq!(partitions.get("another"), Some(&"".to_string()));
+        assert_eq!(partitions.get("empty_key"), Some(&String::new()));
+        assert_eq!(partitions.get("another"), Some(&String::new()));
     }
 }

--- a/src/daft-scan/src/scan_task_iters/split_jsonl/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/split_jsonl/mod.rs
@@ -224,7 +224,9 @@ fn ends_with_ignore_ascii_case(value: &str, suffix: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use std::{
-        env, fs,
+        env,
+        fmt::Write as _,
+        fs,
         sync::Arc,
         time::{SystemTime, UNIX_EPOCH},
     };
@@ -269,15 +271,22 @@ mod tests {
         // Construct a JSONL payload with an extremely long first line and irregular line lengths
         let mut payload = String::new();
         // Extremely long first line (> 1MB window would expand; here we only simulate the logic and avoid actual IO)
-        payload.push_str(&format!("{{\"id\":0,\"val\":\"{}\"}}\n", "x".repeat(1024)));
+        writeln!(
+            &mut payload,
+            "{{\"id\":0,\"val\":\"{}\"}}",
+            "x".repeat(1024)
+        )
+        .unwrap();
         // Several irregular line lengths
         for i in 1..50 {
             let len = (i * 13) % 257; // irregular length
-            payload.push_str(&format!(
-                "{{\"id\":{},\"val\":\"{}\"}}\n",
+            writeln!(
+                &mut payload,
+                "{{\"id\":{},\"val\":\"{}\"}}",
                 i,
                 "y".repeat(len)
-            ));
+            )
+            .unwrap();
         }
 
         // Write to a temporary file to obtain size_bytes
@@ -293,10 +302,12 @@ mod tests {
 
         // Build a ScanTask and run split_by_jsonl_ranges
         let st = make_scan_task(&uri, size_bytes);
-        let mut cfg = common_daft_config::DaftExecutionConfig::default();
-        // Lower thresholds to force splitting
-        cfg.scan_tasks_max_size_bytes = 4 * 1024; // 4KB
-        cfg.scan_tasks_min_size_bytes = 0;
+        let cfg = common_daft_config::DaftExecutionConfig {
+            // Lower thresholds to force splitting
+            scan_tasks_max_size_bytes: 4 * 1024,
+            scan_tasks_min_size_bytes: 0,
+            ..Default::default()
+        };
         let iter = split_by_jsonl_ranges(Box::new(std::iter::once(Ok(Arc::new(st).into()))), &cfg);
         let tasks = iter.collect::<Vec<_>>();
 
@@ -490,7 +501,7 @@ mod tests {
     fn test_local_path_from_uri_with_query() {
         let result = local_path_from_uri("file:///tmp/file?foo=bar").unwrap();
         // Should strip query params
-        assert!(!result.to_string_lossy().contains("?"));
+        assert!(!result.to_string_lossy().contains('?'));
     }
 
     #[test]

--- a/src/daft-shuffles/src/shuffle_cache.rs
+++ b/src/daft-shuffles/src/shuffle_cache.rs
@@ -485,7 +485,7 @@ mod tests {
             shuffle_cache
                 .file_paths_per_partition
                 .iter()
-                .all(|paths| paths.len() == 0),
+                .all(|paths| paths.is_empty()),
             "All partitions should have no file paths: {:?}",
             shuffle_cache.file_paths_per_partition
         );

--- a/src/daft-sql/src/lib.rs
+++ b/src/daft-sql/src/lib.rs
@@ -376,7 +376,7 @@ mod tests {
             .alias("tbl2")
             .join(
                 LogicalPlanBuilder::from(tbl_3).alias("tbl3"),
-                (tbl2_id.eq(tbl3_id)).and(tbl2_val.gt(lit(0 as i64))).into(),
+                (tbl2_id.eq(tbl3_id)).and(tbl2_val.gt(lit(0_i64))).into(),
                 vec![],
                 JoinType::Inner,
                 None,

--- a/src/daft-text/src/read.rs
+++ b/src/daft-text/src/read.rs
@@ -269,9 +269,7 @@ mod tests {
                 None,
             )
             .await
-            .expect(&format!(
-                "read_into_whole_text_stream should succeed for {name}"
-            ));
+            .unwrap_or_else(|_| panic!("read_into_whole_text_stream should succeed for {name}"));
 
             let results: Vec<_> = stream.collect::<Vec<_>>().await;
 
@@ -286,7 +284,7 @@ mod tests {
 
                 let actual_content = results[0]
                     .as_ref()
-                    .expect(&format!("[{name}] stream yielded error"))
+                    .unwrap_or_else(|_| panic!("[{name}] stream yielded error"))
                     .clone();
                 assert_eq!(
                     actual_content, expected_content,
@@ -329,9 +327,7 @@ mod tests {
                 None,
             )
             .await
-            .expect(&format!(
-                "read_into_line_chunk_stream should succeed for {name}"
-            ));
+            .unwrap_or_else(|_| panic!("read_into_line_chunk_stream should succeed for {name}"));
 
             let chunks: Vec<_> = stream.collect::<Vec<_>>().await;
 
@@ -340,7 +336,7 @@ mod tests {
                 .flat_map(|chunk_res| {
                     chunk_res
                         .as_ref()
-                        .expect(&format!("[{name}] stream yielded error"))
+                        .unwrap_or_else(|_| panic!("[{name}] stream yielded error"))
                         .clone()
                 })
                 .collect();

--- a/src/daft-warc/src/lib.rs
+++ b/src/daft-warc/src/lib.rs
@@ -661,7 +661,7 @@ mod tests {
         let warc_gz_file = format!("{}/test/example.warc.gz", env!("CARGO_MANIFEST_DIR"),);
 
         let convert_options = WarcConvertOptions {
-            schema: schema.clone(),
+            schema,
             predicate: None,
             include_columns: None,
             limit: None,


### PR DESCRIPTION
## Changes Made

I believe the `cargo check` pre-commit commands are useless in local development. They should run with `cargo clippy` anyways (since check just ensures that the crate compiles without errors and maybe warnings). 

Plus, because we do it 2 times with different flags, it causes a lot of recompilation which just makes it slow. So i disabled them for `git commit`s. They are still enabled when you do `make precommit` and in CI to be safe.