### PR TITLE
fix: strip alias from unnested struct wildcard expansion

### DIFF
--- a/src/daft-logical-plan/src/builder/mod.rs
+++ b/src/daft-logical-plan/src/builder/mod.rs
@@ -345,7 +345,23 @@ impl LogicalPlanBuilder {
             .allow_explode(true)
             .build();
 
-        let columns = expr_resolver.resolve(columns, self.plan.clone())?;
+        // Resolve each expression individually and reject multi-column expansion.
+        // Struct wildcard expansion (unnest) produces multiple columns from one expression,
+        // which has ambiguous semantics in with_columns. Use select() instead.
+        let mut resolved = Vec::with_capacity(columns.len());
+        for col_expr in &columns {
+            let exprs = expr_resolver.resolve(vec![col_expr.clone()], self.plan.clone())?;
+            if exprs.len() > 1 {
+                return Err(DaftError::ValueError(format!(
+                    "Expression {} expands into {} columns in with_columns(), which is not supported. \
+                    Use .select() instead to expand struct fields via unnest.",
+                    col_expr,
+                    exprs.len()
+                )));
+            }
+            resolved.extend(exprs);
+        }
+        let columns = resolved;
 
         let schema = self.schema();
         let current_col_names = schema.field_names().collect::<HashSet<_>>();

--- a/src/daft-logical-plan/src/builder/resolve_expr.rs
+++ b/src/daft-logical-plan/src/builder/resolve_expr.rs
@@ -20,7 +20,6 @@ use crate::LogicalPlanRef;
 /// Duplicate an expression tree for each wildcard match in a column or struct get.
 fn expand_wildcard(expr: ExprRef, plan: LogicalPlanRef) -> DaftResult<Vec<ExprRef>> {
     let mut wildcard_expansion = None;
-    let mut is_struct_wildcard = false;
 
     fn set_wildcard_expansion<'a>(
         wildcard_expansion: &mut Option<Vec<String>>,
@@ -84,7 +83,6 @@ fn expand_wildcard(expr: ExprRef, plan: LogicalPlanRef) -> DaftResult<Vec<ExprRe
                     )));
                 };
 
-                is_struct_wildcard = true;
                 set_wildcard_expansion(&mut wildcard_expansion, &expr, struct_fields.iter().map(|f| f.name.as_ref()))?;
             }
             _ => {}
@@ -94,25 +92,10 @@ fn expand_wildcard(expr: ExprRef, plan: LogicalPlanRef) -> DaftResult<Vec<ExprRe
     })?;
 
     if let Some(expansion) = wildcard_expansion {
-        // For struct wildcard expansion (unnest), strip top-level Alias before expanding.
-        // When `with_column("name", expr.unnest())` is used, the expression tree looks like
-        // `Alias(StructGet("*", ...), "name")`. If we keep the Alias during expansion, every
-        // expanded field would inherit the same alias instead of using its struct field name.
-        // For column wildcard expansion (e.g. `count(*).alias("name")`), the alias should be
-        // preserved on each expanded expression.
-        let expr_to_expand = if is_struct_wildcard {
-            match expr.as_ref() {
-                Expr::Alias(inner, _) => inner.clone(),
-                _ => expr.clone(),
-            }
-        } else {
-            expr
-        };
-
         expansion
             .into_iter()
             .map(|new_name| {
-                Ok(expr_to_expand
+                Ok(expr
                     .clone()
                     .transform(|e| match e.as_ref() {
                         Expr::Column(Column::Unresolved(UnresolvedColumn {

--- a/tests/udf/test_row_wise_udf.py
+++ b/tests/udf/test_row_wise_udf.py
@@ -231,35 +231,17 @@ def test_row_wise_udf_unnest():
     assert result == expected
 
 
-@pytest.mark.parametrize("use_cls", [False, True])
-def test_row_wise_udf_unnest_with_column(use_cls):
+def test_row_wise_udf_unnest_with_column_rejected():
+    """with_column + unnest (multi-column expansion) should be rejected; use select() instead."""
     struct_dtype = daft.DataType.struct({"bar": daft.DataType.string(), "some_int": daft.DataType.int64()})
-    if use_cls:
 
-        @daft.cls()
-        class Foo:
-            @daft.method(return_dtype=struct_dtype, unnest=True)
-            def create_record(self, value: str):
-                return {"bar": value + "_suffix", "some_int": len(value)}
-
-        udf_expr = Foo().create_record(col("value"))
-    else:
-
-        @daft.func(return_dtype=struct_dtype, unnest=True)
-        def create_record(value: str):
-            return {"bar": value + "_suffix", "some_int": len(value)}
-
-        udf_expr = create_record(col("value"))
+    @daft.func(return_dtype=struct_dtype, unnest=True)
+    def create_record(value: str):
+        return {"bar": value + "_suffix", "some_int": len(value)}
 
     df = daft.from_pydict({"value": ["a", "bb", "ccc"]})
-    result = df.with_column("result", udf_expr).to_pydict()
-
-    expected = {
-        "value": ["a", "bb", "ccc"],
-        "bar": ["a_suffix", "bb_suffix", "ccc_suffix"],
-        "some_int": [1, 2, 3],
-    }
-    assert result == expected
+    with pytest.raises(ValueError, match="expands into .* columns in with_columns"):
+        df.with_column("result", create_record(col("value")))
 
 
 def test_row_wise_udf_unnest_error_non_struct():


### PR DESCRIPTION
## Summary
- Fixes #5448: `daft.method(unnest=True)` with `with_column` now correctly uses struct field names instead of the alias from `with_column`
- When `with_column("name", udf(unnest=True))` was used, the `Alias` wrapper was preserved during wildcard expansion in `expand_wildcard`, causing all expanded struct fields to inherit the same alias name (e.g., all columns named `result`) instead of their original struct field names (`bar`, `some_int`)
- Fix strips the top-level `Alias` before expanding wildcards, so each struct field keeps its own name