### PR TITLE
perf: introduce Column type with ScalarColumn for O(1) scalar storage in RecordBatch

### DIFF
--- a/src/daft-core/src/lit/mod.rs
+++ b/src/daft-core/src/lit/mod.rs
@@ -587,6 +587,53 @@ impl Literal {
         Self::Struct(IndexMap::from_iter(iter))
     }
 
+    pub fn size_bytes(&self) -> usize {
+        match self {
+            Self::Null => 0,
+            Self::Boolean(_) => std::mem::size_of::<bool>(),
+            Self::Utf8(s) => s.len(),
+            Self::Binary(b) => b.len(),
+            Self::Int8(_) => std::mem::size_of::<i8>(),
+            Self::UInt8(_) => std::mem::size_of::<u8>(),
+            Self::Int16(_) => std::mem::size_of::<i16>(),
+            Self::UInt16(_) => std::mem::size_of::<u16>(),
+            Self::Int32(_) => std::mem::size_of::<i32>(),
+            Self::UInt32(_) => std::mem::size_of::<u32>(),
+            Self::Int64(_) => std::mem::size_of::<i64>(),
+            Self::UInt64(_) => std::mem::size_of::<u64>(),
+            Self::Timestamp(..) => std::mem::size_of::<i64>(),
+            Self::Date(_) => std::mem::size_of::<i32>(),
+            Self::Time(..) => std::mem::size_of::<i64>(),
+            Self::Duration(..) => std::mem::size_of::<i64>(),
+            Self::Interval(_) => std::mem::size_of::<IntervalValue>(),
+            Self::Float32(_) => std::mem::size_of::<f32>(),
+            Self::Float64(_) => std::mem::size_of::<f64>(),
+            Self::Decimal(..) => std::mem::size_of::<i128>(),
+            Self::List(series) => series.size_bytes(),
+            #[cfg(feature = "python")]
+            Self::Python(_) => std::mem::size_of::<PyObjectWrapper>(),
+            Self::Struct(entries) => entries.iter().map(|(k, v)| k.len() + v.size_bytes()).sum(),
+            Self::File(f) => std::mem::size_of_val(f),
+            Self::Tensor { data, shape } => {
+                data.size_bytes() + shape.len() * std::mem::size_of::<u64>()
+            }
+            Self::SparseTensor {
+                values,
+                indices,
+                shape,
+                ..
+            } => {
+                values.size_bytes()
+                    + indices.size_bytes()
+                    + shape.len() * std::mem::size_of::<u64>()
+            }
+            Self::Embedding(data) => data.size_bytes(),
+            Self::Map { keys, values } => keys.size_bytes() + values.size_bytes(),
+            Self::Image(image) => image.as_bytes().len(),
+            Self::Extension(series) => series.size_bytes(),
+        }
+    }
+
     /// Cast the literal to a data type.
     ///
     /// This method is lossy, AKA it is not guaranteed that `lit.cast(dtype).get_type() == dtype`.

--- a/src/daft-csv/src/read.rs
+++ b/src/daft-csv/src/read.rs
@@ -881,7 +881,7 @@ mod tests {
             .zip(reference_series.iter())
             .enumerate()
         {
-            let out_arrow = out_col.to_arrow().unwrap();
+            let out_arrow = out_col.as_materialized_series().to_arrow().unwrap();
             let ref_arrow = ref_col.to_arrow().unwrap();
             assert_eq!(
                 out_arrow.as_ref(),

--- a/src/daft-distributed/src/pipeline_node/join/sort_merge_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/sort_merge_join.rs
@@ -249,7 +249,7 @@ impl SortMergeJoinNode {
                 .columns()
                 .iter()
                 .zip(right_boundary_names)
-                .map(|(series, name)| series.clone().rename(name))
+                .map(|(col, name)| col.as_materialized_series().rename(&name))
                 .collect::<Vec<_>>(),
         )?;
 

--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -82,7 +82,11 @@ impl PyMicroPartition {
                     .collect::<Vec<_>>();
                 Ok(series)
             }
-            Some(t) => Ok(t.columns().iter().map(|s| s.clone().into()).collect()),
+            Some(t) => Ok(t
+                .columns()
+                .iter()
+                .map(|s| s.as_materialized_series().clone().into())
+                .collect()),
         }
     }
 

--- a/src/daft-parquet/src/arrowrs_reader.rs
+++ b/src/daft-parquet/src/arrowrs_reader.rs
@@ -1710,7 +1710,7 @@ mod tests {
     fn extract_val_column(batch: &RecordBatch) -> Vec<i32> {
         let idx = batch.schema.get_index("val").unwrap();
         let series = &batch.columns()[idx];
-        let arr = series.i32().unwrap();
+        let arr = series.as_materialized_series().i32().unwrap();
         (0..arr.len()).map(|i| arr.get(i).unwrap()).collect()
     }
 

--- a/src/daft-parquet/src/read.rs
+++ b/src/daft-parquet/src/read.rs
@@ -335,7 +335,7 @@ async fn read_parquet_single_into_arrow(
     let mut all_arrays: Vec<ArrowChunk> = Vec::with_capacity(rb.schema.fields().len());
 
     for (col, daft_field) in rb.columns().iter().zip(rb.schema.fields()) {
-        let arrow_array = col.to_arrow()?;
+        let arrow_array = col.as_materialized_series().to_arrow()?;
 
         let nullable = arrow_schema
             .as_ref()

--- a/src/daft-recordbatch/src/column/mod.rs
+++ b/src/daft-recordbatch/src/column/mod.rs
@@ -299,18 +299,10 @@ impl Eq for Column {}
 
 impl Hash for Column {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            Self::Series(s) => {
-                let hashes = s.hash(None).expect("Failed to hash Series");
-                for h in &hashes {
-                    h.hash(state);
-                }
-            }
-            Self::Scalar(s) => {
-                s.name().hash(state);
-                s.scalar().hash(state);
-                s.len().hash(state);
-            }
+        let s = self.as_materialized_series();
+        let hashes = s.hash(None).expect("Failed to hash Column");
+        for h in &hashes {
+            h.hash(state);
         }
     }
 }
@@ -728,5 +720,26 @@ mod tests {
         assert!(result.is_scalar());
         assert_eq!(result.len(), 10);
         Ok(())
+    }
+
+    #[test]
+    fn column_hash_eq_contract() {
+        use std::{
+            collections::hash_map::DefaultHasher,
+            hash::{Hash as _, Hasher as _},
+        };
+
+        fn hash_column(col: &Column) -> u64 {
+            let mut hasher = DefaultHasher::new();
+            col.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let scalar = Column::new_scalar("x", DataType::Int64, Literal::Int64(42), 3);
+        let series = Column::from(make_int_series("x", vec![42, 42, 42]));
+
+        // If they're equal, their hashes must match
+        assert_eq!(scalar, series);
+        assert_eq!(hash_column(&scalar), hash_column(&series));
     }
 }

--- a/src/daft-recordbatch/src/column/mod.rs
+++ b/src/daft-recordbatch/src/column/mod.rs
@@ -165,7 +165,8 @@ impl Column {
         match self {
             Self::Series(s) => s.slice(start, end).map(Self::Series),
             Self::Scalar(s) => {
-                let new_len = s.len().min(end.saturating_sub(start));
+                let clamped_end = end.min(s.len());
+                let new_len = clamped_end.saturating_sub(start);
                 Ok(Self::Scalar(s.resize(new_len)))
             }
         }
@@ -218,14 +219,7 @@ impl Column {
             ));
         }
 
-        if let Some(ScalarColumn { .. }) = columns.first().and_then(|c| match c {
-            Self::Scalar(s) => Some(s),
-            _ => None,
-        }) {
-            let first_scalar = match columns.first().unwrap() {
-                Self::Scalar(s) => s,
-                _ => unreachable!(),
-            };
+        if let Some(Self::Scalar(first_scalar)) = columns.first() {
             if columns
                 .iter()
                 .all(|c| matches!(c, Self::Scalar(s) if s.scalar() == first_scalar.scalar()))
@@ -267,6 +261,13 @@ impl Column {
 
     /// Returns the display string for the value at `idx`.
     pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        if idx >= self.len() {
+            return Err(common_error::DaftError::ValueError(format!(
+                "index {} out of bounds for Column of length {}",
+                idx,
+                self.len()
+            )));
+        }
         match self {
             Self::Series(s) => Ok(s.str_value(idx)),
             Self::Scalar(s) => Ok(s.resize(1).as_materialized_series().str_value(0)),
@@ -608,5 +609,127 @@ mod tests {
         let col = Column::new_scalar("old", DataType::Int64, Literal::Int64(1), 5);
         let renamed = col.with_name("new");
         assert_eq!(renamed.name(), "new");
+    }
+
+    #[test]
+    fn column_slice_scalar_end_past_length() -> DaftResult<()> {
+        // len=25, slice(10, 30) should give 15 rows (rows 10..25), not 20
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 25);
+        let sliced = col.slice(10, 30)?;
+        assert!(sliced.is_scalar());
+        assert_eq!(sliced.len(), 15);
+        Ok(())
+    }
+
+    #[test]
+    fn column_slice_scalar_start_past_length() -> DaftResult<()> {
+        // len=5, slice(10, 20) should give 0 rows
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 5);
+        let sliced = col.slice(10, 20)?;
+        assert!(sliced.is_scalar());
+        assert_eq!(sliced.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn column_str_value_scalar_bounds_check() {
+        // str_value on a scalar with idx >= length should fail, not silently succeed
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(42), 5);
+        assert!(col.str_value(10).is_err());
+    }
+
+    #[test]
+    fn scalar_column_null_preserves_dtype() {
+        // A null ScalarColumn with dtype Int64 should materialize as Int64, not Null
+        let sc = ScalarColumn::new(Arc::from("x"), DataType::Int64, Literal::Null, 3);
+        let s = sc.as_materialized_series();
+        assert_eq!(s.data_type(), &DataType::Int64);
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.null_count(), 3);
+    }
+
+    #[test]
+    fn scalar_column_from_single_value_series_preserves_dtype() -> DaftResult<()> {
+        // A null Series with Int64 dtype should produce a ScalarColumn with Int64 dtype
+        let s = Int64Array::from_iter(
+            Field::new("x", DataType::Int64),
+            vec![None::<i64>].into_iter(),
+        )
+        .into_series();
+        assert_eq!(s.data_type(), &DataType::Int64);
+        let sc = ScalarColumn::from_single_value_series(&s, 10)?;
+        assert_eq!(sc.data_type(), &DataType::Int64);
+        Ok(())
+    }
+
+    #[test]
+    fn column_is_valid_scalar_no_bounds_check() {
+        // is_valid on scalar doesn't bounds-check (it's the same value everywhere),
+        // but verify it returns correct values
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 5);
+        assert!(col.is_valid(0));
+        // idx past length — for scalar this is still "valid" since the value is non-null
+        // (debatable whether this should panic, but documenting current behavior)
+        assert!(col.is_valid(100));
+    }
+
+    #[test]
+    fn column_head_past_length() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 5);
+        let headed = col.head(100)?;
+        assert!(headed.is_scalar());
+        assert_eq!(headed.len(), 5);
+        Ok(())
+    }
+
+    #[test]
+    fn column_take_null_indices() -> DaftResult<()> {
+        // take with null indices on a scalar — should still produce the right length
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(42), 100);
+        let idx = UInt64Array::from_iter(
+            Field::new("idx", DataType::UInt64),
+            vec![Some(0u64), None, Some(2)].into_iter(),
+        );
+        let taken = col.take(&idx)?;
+        assert!(taken.is_scalar());
+        assert_eq!(taken.len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn column_filter_all_false_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 3);
+        let mask = BooleanArray::from_iter(
+            "mask",
+            vec![Some(false), Some(false), Some(false)].into_iter(),
+        );
+        let filtered = col.filter(&mask)?;
+        assert!(filtered.is_scalar());
+        assert_eq!(filtered.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn column_filter_with_nulls_in_mask() -> DaftResult<()> {
+        // null in mask should be treated as false
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 4);
+        let mask = BooleanArray::from_iter(
+            "mask",
+            vec![Some(true), None, Some(true), None].into_iter(),
+        );
+        let filtered = col.filter(&mask)?;
+        assert!(filtered.is_scalar());
+        assert_eq!(filtered.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn column_concat_scalar_simplified_match() -> DaftResult<()> {
+        // Ensure concat with a single scalar works (exercises the match path)
+        let a = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 10);
+        let result = Column::concat(&[&a])?;
+        assert!(result.is_scalar());
+        assert_eq!(result.len(), 10);
+        Ok(())
     }
 }

--- a/src/daft-recordbatch/src/column/mod.rs
+++ b/src/daft-recordbatch/src/column/mod.rs
@@ -1,0 +1,612 @@
+mod scalar;
+
+use std::{
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
+
+use common_display::table_display::StrValue;
+use common_error::DaftResult;
+use daft_core::{
+    lit::Literal,
+    prelude::{DataType, Field, Series},
+};
+pub use scalar::ScalarColumn;
+
+/// A column within a [`RecordBatch`][crate::RecordBatch].
+///
+/// Can be either a fully materialized [`Series`] or a [`ScalarColumn`] that
+/// repeats a single [`Literal`] value for a given length.  Scalar columns are
+/// O(1) in memory regardless of the logical row count and are only expanded
+/// into a full array when an operation actually requires element-wise access
+/// (via [`as_materialized_series`][Column::as_materialized_series]).
+///
+/// Row-preserving operations such as [`slice`][Column::slice],
+/// [`filter`][Column::filter], and [`take`][Column::take] keep scalar columns
+/// compact — they simply adjust the logical length without allocating.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum Column {
+    Series(Series),
+    Scalar(ScalarColumn),
+}
+
+impl Column {
+    /// Returns the [`DataType`] of the column.
+    pub fn data_type(&self) -> &DataType {
+        match self {
+            Self::Series(s) => s.data_type(),
+            Self::Scalar(s) => s.data_type(),
+        }
+    }
+
+    /// Returns the name of the column.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Series(s) => s.name(),
+            Self::Scalar(s) => s.name(),
+        }
+    }
+
+    /// Returns a [`Field`] describing the column's name and type.
+    pub fn field(&self) -> Field {
+        match self {
+            Self::Series(s) => s.field().clone(),
+            Self::Scalar(s) => Field::new(s.name(), s.data_type().clone()),
+        }
+    }
+
+    /// Returns the logical number of rows in the column.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Series(s) => s.len(),
+            Self::Scalar(s) => s.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns a reference to a materialized [`Series`].
+    ///
+    /// For [`Column::Series`] this is a no-op.  For [`Column::Scalar`] the
+    /// underlying [`Series`] is lazily constructed on the first call and cached
+    /// for subsequent access via [`OnceLock`][std::sync::OnceLock].
+    pub fn as_materialized_series(&self) -> &Series {
+        match self {
+            Self::Series(s) => s,
+            Self::Scalar(s) => s.as_materialized_series(),
+        }
+    }
+
+    /// Consumes the column and returns the materialized [`Series`].
+    ///
+    /// If the scalar was already materialized the cached value is returned
+    /// without re-allocating; otherwise it is constructed on the fly.
+    pub fn take_materialized_series(self) -> Series {
+        match self {
+            Self::Series(s) => s,
+            Self::Scalar(s) => s.take_materialized_series(),
+        }
+    }
+
+    /// Renames the column in place.
+    pub fn rename(&mut self, name: &str) {
+        match self {
+            Self::Series(s) => {
+                *s = s.rename(name);
+            }
+            Self::Scalar(s) => s.rename(name),
+        }
+    }
+
+    /// Returns a new column with the given name.
+    pub fn with_name(mut self, name: &str) -> Self {
+        self.rename(name);
+        self
+    }
+
+    /// Casts the column to the given [`DataType`].
+    ///
+    /// Scalar columns are cast without materialization by casting the
+    /// underlying [`Literal`] value directly.
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Self> {
+        match self {
+            Self::Series(s) => s.cast(dtype).map(Self::Series),
+            Self::Scalar(s) => s.cast(dtype).map(Self::Scalar),
+        }
+    }
+
+    /// Returns the approximate in-memory size of the column in bytes.
+    ///
+    /// Scalar columns report only the size of the stored scalar, not the
+    /// expanded array size.
+    pub fn size_bytes(&self) -> usize {
+        match self {
+            Self::Series(s) => s.size_bytes(),
+            Self::Scalar(s) => s.size_bytes(),
+        }
+    }
+
+    /// Converts logical types to their physical representation.
+    ///
+    /// This is a no-op when the physical type already matches the logical type.
+    /// Scalar columns are cast without materialization.
+    pub fn as_physical(&self) -> DaftResult<Self> {
+        let physical_dtype = self.data_type().to_physical();
+        if &physical_dtype == self.data_type() {
+            Ok(self.clone())
+        } else {
+            self.cast(&physical_dtype)
+        }
+    }
+
+    /// Broadcasts the column to the given length.
+    ///
+    /// Scalar columns simply adjust their logical length (O(1)).  Series
+    /// columns delegate to [`Series::broadcast`].
+    pub fn broadcast(&self, length: usize) -> DaftResult<Self> {
+        match self {
+            Self::Series(s) => {
+                if s.len() == length {
+                    Ok(Self::Series(s.clone()))
+                } else {
+                    s.broadcast(length).map(Self::Series)
+                }
+            }
+            Self::Scalar(s) => Ok(Self::Scalar(s.resize(length))),
+        }
+    }
+
+    /// Returns a sub-range `[start, end)` of the column.
+    ///
+    /// Scalar columns adjust their logical length without materializing.
+    pub fn slice(&self, start: usize, end: usize) -> DaftResult<Self> {
+        match self {
+            Self::Series(s) => s.slice(start, end).map(Self::Series),
+            Self::Scalar(s) => {
+                let new_len = s.len().min(end.saturating_sub(start));
+                Ok(Self::Scalar(s.resize(new_len)))
+            }
+        }
+    }
+
+    /// Returns the first `num` rows of the column.
+    ///
+    /// Scalar columns adjust their logical length without materializing.
+    pub fn head(&self, num: usize) -> DaftResult<Self> {
+        match self {
+            Self::Series(s) => s.head(num).map(Self::Series),
+            Self::Scalar(s) => Ok(Self::Scalar(s.resize(s.len().min(num)))),
+        }
+    }
+
+    /// Filters the column by a boolean mask.
+    ///
+    /// Scalar columns count the number of `true` values in the mask and
+    /// adjust their logical length accordingly, without materializing.
+    pub fn filter(&self, mask: &daft_core::prelude::BooleanArray) -> DaftResult<Self> {
+        match self {
+            Self::Series(s) => s.filter(mask).map(Self::Series),
+            Self::Scalar(s) => {
+                let true_count = mask.into_iter().flatten().filter(|b| *b).count();
+                Ok(Self::Scalar(s.resize(true_count)))
+            }
+        }
+    }
+
+    /// Gathers rows by index.
+    ///
+    /// Scalar columns adjust their logical length to `idx.len()` without
+    /// materializing.
+    pub fn take(&self, idx: &daft_core::prelude::UInt64Array) -> DaftResult<Self> {
+        match self {
+            Self::Series(s) => s.take(idx).map(Self::Series),
+            Self::Scalar(s) => Ok(Self::Scalar(s.resize(idx.len()))),
+        }
+    }
+
+    /// Concatenates multiple columns into one.
+    ///
+    /// If every column is a scalar with the same value, the result is a single
+    /// scalar with the combined length.  Otherwise all columns are materialized
+    /// and concatenated via [`Series::concat`].
+    pub fn concat(columns: &[&Self]) -> DaftResult<Self> {
+        if columns.is_empty() {
+            return Err(common_error::DaftError::ValueError(
+                "Need at least 1 Column to concat".to_string(),
+            ));
+        }
+
+        if let Some(ScalarColumn { .. }) = columns.first().and_then(|c| match c {
+            Self::Scalar(s) => Some(s),
+            _ => None,
+        }) {
+            let first_scalar = match columns.first().unwrap() {
+                Self::Scalar(s) => s,
+                _ => unreachable!(),
+            };
+            if columns
+                .iter()
+                .all(|c| matches!(c, Self::Scalar(s) if s.scalar() == first_scalar.scalar()))
+            {
+                let total_len: usize = columns.iter().map(|c| c.len()).sum();
+                return Ok(Self::Scalar(ScalarColumn::new(
+                    Arc::from(first_scalar.name()),
+                    first_scalar.data_type().clone(),
+                    first_scalar.scalar().clone(),
+                    total_len,
+                )));
+            }
+        }
+
+        let series: Vec<&Series> = columns.iter().map(|c| c.as_materialized_series()).collect();
+        Series::concat(series.as_slice()).map(Self::Series)
+    }
+
+    /// Returns `true` if this column is a [`ScalarColumn`].
+    pub fn is_scalar(&self) -> bool {
+        matches!(self, Self::Scalar(..))
+    }
+
+    /// Creates a new scalar column from a [`Literal`] value.
+    pub fn new_scalar(name: &str, dtype: DataType, value: Literal, length: usize) -> Self {
+        Self::Scalar(ScalarColumn::new(Arc::from(name), dtype, value, length))
+    }
+
+    /// Returns `true` if the value at `idx` is non-null.
+    ///
+    /// For scalar columns, this is `true` when the underlying scalar is
+    /// non-null, regardless of `idx`.
+    pub fn is_valid(&self, idx: usize) -> bool {
+        match self {
+            Self::Series(s) => s.inner.nulls().is_none_or(|v| v.is_valid(idx)),
+            Self::Scalar(s) => !s.has_nulls(),
+        }
+    }
+
+    /// Returns the display string for the value at `idx`.
+    pub fn str_value(&self, idx: usize) -> DaftResult<String> {
+        match self {
+            Self::Series(s) => Ok(s.str_value(idx)),
+            Self::Scalar(s) => Ok(s.resize(1).as_materialized_series().str_value(0)),
+        }
+    }
+}
+
+impl From<Series> for Column {
+    fn from(s: Series) -> Self {
+        Self::Series(s)
+    }
+}
+
+impl PartialEq for Column {
+    fn eq(&self, other: &Self) -> bool {
+        if self.name() != other.name()
+            || self.data_type() != other.data_type()
+            || self.len() != other.len()
+        {
+            return false;
+        }
+        match (self, other) {
+            (Self::Scalar(a), Self::Scalar(b)) => a.scalar() == b.scalar(),
+            _ => self.as_materialized_series() == other.as_materialized_series(),
+        }
+    }
+}
+
+impl Eq for Column {}
+
+impl Hash for Column {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Series(s) => {
+                let hashes = s.hash(None).expect("Failed to hash Series");
+                for h in &hashes {
+                    h.hash(state);
+                }
+            }
+            Self::Scalar(s) => {
+                s.name().hash(state);
+                s.scalar().hash(state);
+                s.len().hash(state);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use common_error::DaftResult;
+    use daft_core::{lit::Literal, prelude::*, series::IntoSeries};
+
+    use super::{Column, ScalarColumn};
+
+    fn make_int_series(name: &str, vals: Vec<i64>) -> Series {
+        Int64Array::from_vec(name, vals).into_series()
+    }
+
+    // ---- ScalarColumn tests ----
+
+    #[test]
+    fn scalar_column_basics() {
+        let sc = ScalarColumn::new(Arc::from("x"), DataType::Int64, Literal::Int64(42), 100);
+        assert_eq!(sc.name(), "x");
+        assert_eq!(sc.data_type(), &DataType::Int64);
+        assert_eq!(sc.len(), 100);
+        assert!(!sc.is_empty());
+        assert!(!sc.has_nulls());
+        assert_eq!(sc.scalar(), &Literal::Int64(42));
+    }
+
+    #[test]
+    fn scalar_column_null() {
+        let sc = ScalarColumn::new(Arc::from("n"), DataType::Utf8, Literal::Null, 10);
+        assert!(sc.has_nulls());
+    }
+
+    #[test]
+    fn scalar_column_empty() {
+        let sc = ScalarColumn::new_empty(Arc::from("e"), DataType::Float64);
+        assert_eq!(sc.len(), 0);
+        assert!(sc.is_empty());
+        assert!(!sc.has_nulls());
+    }
+
+    #[test]
+    fn scalar_column_materialize() {
+        let sc = ScalarColumn::new(Arc::from("v"), DataType::Int64, Literal::Int64(7), 3);
+        let s = sc.as_materialized_series();
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.name(), "v");
+        assert_eq!(s.i64().unwrap().get(0).unwrap(), 7);
+        assert_eq!(s.i64().unwrap().get(2).unwrap(), 7);
+    }
+
+    #[test]
+    fn scalar_column_materialize_cached() {
+        let sc = ScalarColumn::new(Arc::from("c"), DataType::Int64, Literal::Int64(1), 5);
+        let ptr1 = sc.as_materialized_series() as *const Series;
+        let ptr2 = sc.as_materialized_series() as *const Series;
+        assert_eq!(ptr1, ptr2);
+    }
+
+    #[test]
+    fn scalar_column_resize() {
+        let sc = ScalarColumn::new(Arc::from("r"), DataType::Int64, Literal::Int64(9), 10);
+        let resized = sc.resize(3);
+        assert_eq!(resized.len(), 3);
+        assert_eq!(resized.scalar(), &Literal::Int64(9));
+    }
+
+    #[test]
+    fn scalar_column_resize_same_length() {
+        let sc = ScalarColumn::new(Arc::from("r"), DataType::Int64, Literal::Int64(9), 10);
+        let resized = sc.resize(10);
+        assert_eq!(resized.len(), 10);
+    }
+
+    #[test]
+    fn scalar_column_cast() -> DaftResult<()> {
+        let sc = ScalarColumn::new(Arc::from("c"), DataType::Int64, Literal::Int64(42), 5);
+        let casted = sc.cast(&DataType::Float64)?;
+        assert_eq!(casted.data_type(), &DataType::Float64);
+        assert_eq!(casted.len(), 5);
+        let s = casted.as_materialized_series();
+        assert_eq!(s.f64().unwrap().get(0).unwrap(), 42.0);
+        Ok(())
+    }
+
+    #[test]
+    fn scalar_column_rename() {
+        let mut sc = ScalarColumn::new(Arc::from("old"), DataType::Int64, Literal::Int64(1), 2);
+        sc.rename("new");
+        assert_eq!(sc.name(), "new");
+        assert_eq!(sc.as_materialized_series().name(), "new");
+    }
+
+    #[test]
+    fn scalar_column_from_single_value_series() -> DaftResult<()> {
+        let s = make_int_series("s", vec![99]);
+        let sc = ScalarColumn::from_single_value_series(&s, 50)?;
+        assert_eq!(sc.len(), 50);
+        assert_eq!(sc.scalar(), &Literal::Int64(99));
+        Ok(())
+    }
+
+    // ---- Column tests ----
+
+    #[test]
+    fn column_from_series() {
+        let s = make_int_series("a", vec![1, 2, 3]);
+        let col = Column::from(s);
+        assert!(!col.is_scalar());
+        assert_eq!(col.len(), 3);
+        assert_eq!(col.name(), "a");
+        assert_eq!(col.data_type(), &DataType::Int64);
+    }
+
+    #[test]
+    fn column_new_scalar() {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(42), 100);
+        assert!(col.is_scalar());
+        assert_eq!(col.len(), 100);
+        assert_eq!(col.name(), "x");
+    }
+
+    #[test]
+    fn column_scalar_materialize() {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(5), 3);
+        let s = col.as_materialized_series();
+        assert_eq!(s.len(), 3);
+        assert_eq!(s.i64().unwrap().get(1).unwrap(), 5);
+    }
+
+    #[test]
+    fn column_slice_scalar_stays_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 100);
+        let sliced = col.slice(10, 30)?;
+        assert!(sliced.is_scalar());
+        assert_eq!(sliced.len(), 20);
+        Ok(())
+    }
+
+    #[test]
+    fn column_slice_series() -> DaftResult<()> {
+        let col = Column::from(make_int_series("a", vec![10, 20, 30, 40, 50]));
+        let sliced = col.slice(1, 4)?;
+        assert!(!sliced.is_scalar());
+        assert_eq!(sliced.len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn column_filter_scalar_stays_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(7), 5);
+        let mask = BooleanArray::from_iter(
+            "mask",
+            vec![Some(true), Some(false), Some(true), Some(false), Some(true)].into_iter(),
+        );
+        let filtered = col.filter(&mask)?;
+        assert!(filtered.is_scalar());
+        assert_eq!(filtered.len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn column_take_scalar_stays_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(3), 100);
+        let idx = UInt64Array::from_vec("idx", vec![0, 5, 10]);
+        let taken = col.take(&idx)?;
+        assert!(taken.is_scalar());
+        assert_eq!(taken.len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn column_broadcast_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 1);
+        let broadcasted = col.broadcast(1000)?;
+        assert!(broadcasted.is_scalar());
+        assert_eq!(broadcasted.len(), 1000);
+        Ok(())
+    }
+
+    #[test]
+    fn column_head_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 100);
+        let headed = col.head(10)?;
+        assert!(headed.is_scalar());
+        assert_eq!(headed.len(), 10);
+        Ok(())
+    }
+
+    #[test]
+    fn column_cast_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(42), 10);
+        let casted = col.cast(&DataType::Float64)?;
+        assert!(casted.is_scalar());
+        assert_eq!(casted.data_type(), &DataType::Float64);
+        assert_eq!(casted.len(), 10);
+        Ok(())
+    }
+
+    #[test]
+    fn column_as_physical_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Date, Literal::Date(1), 5);
+        let phys = col.as_physical()?;
+        assert!(phys.is_scalar());
+        assert_eq!(phys.data_type(), &DataType::Int32);
+        assert_eq!(phys.len(), 5);
+        Ok(())
+    }
+
+    #[test]
+    fn column_concat_same_scalars() -> DaftResult<()> {
+        let a = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 10);
+        let b = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 20);
+        let c = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 30);
+        let result = Column::concat(&[&a, &b, &c])?;
+        assert!(result.is_scalar());
+        assert_eq!(result.len(), 60);
+        Ok(())
+    }
+
+    #[test]
+    fn column_concat_different_scalars_materializes() -> DaftResult<()> {
+        let a = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 2);
+        let b = Column::new_scalar("x", DataType::Int64, Literal::Int64(2), 3);
+        let result = Column::concat(&[&a, &b])?;
+        assert!(!result.is_scalar());
+        assert_eq!(result.len(), 5);
+        Ok(())
+    }
+
+    #[test]
+    fn column_concat_mixed_series_and_scalar() -> DaftResult<()> {
+        let a = Column::from(make_int_series("x", vec![1, 2]));
+        let b = Column::new_scalar("x", DataType::Int64, Literal::Int64(3), 2);
+        let result = Column::concat(&[&a, &b])?;
+        assert!(!result.is_scalar());
+        assert_eq!(result.len(), 4);
+        let s = result.as_materialized_series();
+        assert_eq!(s.i64().unwrap().get(2).unwrap(), 3);
+        assert_eq!(s.i64().unwrap().get(3).unwrap(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn column_size_bytes_scalar_is_small() {
+        let scalar = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 1_000_000);
+        let series = Column::from(make_int_series("x", vec![1; 1_000_000]));
+        assert!(scalar.size_bytes() < series.size_bytes());
+    }
+
+    #[test]
+    fn column_eq_scalar_scalar() {
+        let a = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 10);
+        let b = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 10);
+        let c = Column::new_scalar("x", DataType::Int64, Literal::Int64(2), 10);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn column_eq_different_lengths() {
+        let a = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 10);
+        let b = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 20);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn column_is_valid_scalar() {
+        let valid = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 5);
+        assert!(valid.is_valid(0));
+        assert!(valid.is_valid(4));
+
+        let null = Column::new_scalar("x", DataType::Int64, Literal::Null, 5);
+        assert!(!null.is_valid(0));
+    }
+
+    #[test]
+    fn column_is_valid_series() {
+        let s = Int64Array::from_iter(
+            Field::new("x", DataType::Int64),
+            vec![Some(1), None, Some(3)].into_iter(),
+        )
+        .into_series();
+        let col = Column::from(s);
+        assert!(col.is_valid(0));
+        assert!(!col.is_valid(1));
+        assert!(col.is_valid(2));
+    }
+
+    #[test]
+    fn column_with_name() {
+        let col = Column::new_scalar("old", DataType::Int64, Literal::Int64(1), 5);
+        let renamed = col.with_name("new");
+        assert_eq!(renamed.name(), "new");
+    }
+}

--- a/src/daft-recordbatch/src/column/mod.rs
+++ b/src/daft-recordbatch/src/column/mod.rs
@@ -190,8 +190,16 @@ impl Column {
         match self {
             Self::Series(s) => s.filter(mask).map(Self::Series),
             Self::Scalar(s) => {
-                let true_count = mask.into_iter().flatten().filter(|b| *b).count();
-                Ok(Self::Scalar(s.resize(true_count)))
+                if mask.len() == 1 {
+                    if Some(true) == mask.get(0) {
+                        Ok(Self::Scalar(s.clone()))
+                    } else {
+                        Ok(Self::Scalar(s.resize(0)))
+                    }
+                } else {
+                    let true_count = mask.into_iter().flatten().filter(|b| *b).count();
+                    Ok(Self::Scalar(s.resize(true_count)))
+                }
             }
         }
     }
@@ -203,7 +211,13 @@ impl Column {
     pub fn take(&self, idx: &daft_core::prelude::UInt64Array) -> DaftResult<Self> {
         match self {
             Self::Series(s) => s.take(idx).map(Self::Series),
-            Self::Scalar(s) => Ok(Self::Scalar(s.resize(idx.len()))),
+            Self::Scalar(s) => {
+                if idx.null_count() > 0 && !matches!(s.scalar(), Literal::Null) {
+                    s.as_materialized_series().take(idx).map(Self::Series)
+                } else {
+                    Ok(Self::Scalar(s.resize(idx.len())))
+                }
+            }
         }
     }
 
@@ -468,16 +482,6 @@ mod tests {
     }
 
     #[test]
-    fn column_take_scalar_stays_scalar() -> DaftResult<()> {
-        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(3), 100);
-        let idx = UInt64Array::from_vec("idx", vec![0, 5, 10]);
-        let taken = col.take(&idx)?;
-        assert!(taken.is_scalar());
-        assert_eq!(taken.len(), 3);
-        Ok(())
-    }
-
-    #[test]
     fn column_broadcast_scalar() -> DaftResult<()> {
         let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 1);
         let broadcasted = col.broadcast(1000)?;
@@ -674,16 +678,74 @@ mod tests {
     }
 
     #[test]
-    fn column_take_null_indices() -> DaftResult<()> {
-        // take with null indices on a scalar — should still produce the right length
+    fn column_take_null_indices_materializes() -> DaftResult<()> {
         let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(42), 100);
         let idx = UInt64Array::from_iter(
             Field::new("idx", DataType::UInt64),
             vec![Some(0u64), None, Some(2)].into_iter(),
         );
         let taken = col.take(&idx)?;
+        // null indices produce null values, so must materialize
+        assert!(!taken.is_scalar());
+        assert_eq!(taken.len(), 3);
+        let s = taken.as_materialized_series();
+        assert_eq!(s.i64().unwrap().get(0).unwrap(), 42);
+        assert!(s.i64().unwrap().get(1).is_none());
+        assert_eq!(s.i64().unwrap().get(2).unwrap(), 42);
+        Ok(())
+    }
+
+    #[test]
+    fn column_take_null_indices_null_scalar_stays_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Null, 100);
+        let idx = UInt64Array::from_iter(
+            Field::new("idx", DataType::UInt64),
+            vec![Some(0u64), None, Some(2)].into_iter(),
+        );
+        let taken = col.take(&idx)?;
+        // null scalar + null indices = still all nulls, stays scalar
         assert!(taken.is_scalar());
         assert_eq!(taken.len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn column_take_no_null_indices_stays_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(42), 100);
+        let idx = UInt64Array::from_vec("idx", vec![0, 5, 10]);
+        let taken = col.take(&idx)?;
+        assert!(taken.is_scalar());
+        assert_eq!(taken.len(), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn column_filter_broadcast_true_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 50);
+        let mask = BooleanArray::from_iter("mask", vec![Some(true)].into_iter());
+        let filtered = col.filter(&mask)?;
+        assert!(filtered.is_scalar());
+        assert_eq!(filtered.len(), 50);
+        Ok(())
+    }
+
+    #[test]
+    fn column_filter_broadcast_false_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 50);
+        let mask = BooleanArray::from_iter("mask", vec![Some(false)].into_iter());
+        let filtered = col.filter(&mask)?;
+        assert!(filtered.is_scalar());
+        assert_eq!(filtered.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn column_filter_broadcast_null_scalar() -> DaftResult<()> {
+        let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 50);
+        let mask = BooleanArray::from_iter("mask", vec![None::<bool>].into_iter());
+        let filtered = col.filter(&mask)?;
+        assert!(filtered.is_scalar());
+        assert_eq!(filtered.len(), 0);
         Ok(())
     }
 

--- a/src/daft-recordbatch/src/column/mod.rs
+++ b/src/daft-recordbatch/src/column/mod.rs
@@ -219,19 +219,18 @@ impl Column {
             ));
         }
 
-        if let Some(Self::Scalar(first_scalar)) = columns.first() {
-            if columns
+        if let Some(Self::Scalar(first_scalar)) = columns.first()
+            && columns
                 .iter()
                 .all(|c| matches!(c, Self::Scalar(s) if s.scalar() == first_scalar.scalar()))
-            {
-                let total_len: usize = columns.iter().map(|c| c.len()).sum();
-                return Ok(Self::Scalar(ScalarColumn::new(
-                    Arc::from(first_scalar.name()),
-                    first_scalar.data_type().clone(),
-                    first_scalar.scalar().clone(),
-                    total_len,
-                )));
-            }
+        {
+            let total_len: usize = columns.iter().map(|c| c.len()).sum();
+            return Ok(Self::Scalar(ScalarColumn::new(
+                Arc::from(first_scalar.name()),
+                first_scalar.data_type().clone(),
+                first_scalar.scalar().clone(),
+                total_len,
+            )));
         }
 
         let series: Vec<&Series> = columns.iter().map(|c| c.as_materialized_series()).collect();
@@ -713,10 +712,8 @@ mod tests {
     fn column_filter_with_nulls_in_mask() -> DaftResult<()> {
         // null in mask should be treated as false
         let col = Column::new_scalar("x", DataType::Int64, Literal::Int64(1), 4);
-        let mask = BooleanArray::from_iter(
-            "mask",
-            vec![Some(true), None, Some(true), None].into_iter(),
-        );
+        let mask =
+            BooleanArray::from_iter("mask", vec![Some(true), None, Some(true), None].into_iter());
         let filtered = col.filter(&mask)?;
         assert!(filtered.is_scalar());
         assert_eq!(filtered.len(), 2);

--- a/src/daft-recordbatch/src/column/scalar.rs
+++ b/src/daft-recordbatch/src/column/scalar.rs
@@ -68,6 +68,9 @@ impl ScalarColumn {
     fn _to_series(name: &str, scalar: &Literal, dtype: &DataType, length: usize) -> Series {
         if length == 0 {
             Series::empty(name, dtype)
+        } else if matches!(scalar, Literal::Null) {
+            use daft_core::array::ops::full::FullNull;
+            Series::full_null(name, dtype, length)
         } else {
             let s: Series = scalar.clone().into();
             s.rename(name).broadcast(length).expect("broadcast scalar")
@@ -151,7 +154,7 @@ impl ScalarColumn {
         let lit = Literal::try_from_single_value_series(series)?;
         Ok(Self::new(
             Arc::from(series.name()),
-            lit.get_type(),
+            series.data_type().clone(),
             lit,
             length,
         ))

--- a/src/daft-recordbatch/src/column/scalar.rs
+++ b/src/daft-recordbatch/src/column/scalar.rs
@@ -1,0 +1,159 @@
+use std::sync::{Arc, OnceLock};
+
+use common_error::DaftResult;
+use daft_core::{
+    lit::Literal,
+    prelude::{DataType, Series},
+};
+
+/// A column that stores a single [`Literal`] value repeated for a given length.
+///
+/// This is O(1) in memory regardless of the logical row count.  The full
+/// [`Series`] is only constructed when [`as_materialized_series`][Self::as_materialized_series]
+/// is called, and the result is cached in a [`OnceLock`] for subsequent access.
+///
+/// Operations like [`resize`][Self::resize] and [`cast`][Self::cast] produce
+/// new `ScalarColumn`s without ever touching the materialized cache.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ScalarColumn {
+    name: Arc<str>,
+    scalar: Literal,
+    dtype: DataType,
+    length: usize,
+    #[serde(skip)]
+    materialized: OnceLock<Series>,
+}
+
+impl ScalarColumn {
+    /// Creates a new scalar column.
+    pub fn new(name: Arc<str>, dtype: DataType, scalar: Literal, length: usize) -> Self {
+        Self {
+            name,
+            scalar,
+            dtype,
+            length,
+            materialized: OnceLock::new(),
+        }
+    }
+
+    /// Creates an empty scalar column (length 0) with a null value.
+    pub fn new_empty(name: Arc<str>, dtype: DataType) -> Self {
+        Self::new(name, dtype, Literal::Null, 0)
+    }
+
+    /// Returns the column name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the data type.
+    pub fn data_type(&self) -> &DataType {
+        &self.dtype
+    }
+
+    /// Returns a reference to the underlying scalar value.
+    pub fn scalar(&self) -> &Literal {
+        &self.scalar
+    }
+
+    /// Returns the logical number of rows.
+    pub fn len(&self) -> usize {
+        self.length
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
+    fn _to_series(name: &str, scalar: &Literal, dtype: &DataType, length: usize) -> Series {
+        if length == 0 {
+            Series::empty(name, dtype)
+        } else {
+            let s: Series = scalar.clone().into();
+            s.rename(name).broadcast(length).expect("broadcast scalar")
+        }
+    }
+
+    /// Constructs a new [`Series`] from the scalar value.
+    ///
+    /// This always allocates; prefer [`as_materialized_series`][Self::as_materialized_series]
+    /// to reuse a cached result.
+    pub fn to_series(&self) -> Series {
+        Self::_to_series(&self.name, &self.scalar, &self.dtype, self.length)
+    }
+
+    /// Returns a reference to a materialized [`Series`], constructing and
+    /// caching it on the first call.
+    pub fn as_materialized_series(&self) -> &Series {
+        self.materialized.get_or_init(|| self.to_series())
+    }
+
+    /// Consumes the scalar column and returns the materialized [`Series`].
+    ///
+    /// If the series was already cached it is returned without re-allocating.
+    pub fn take_materialized_series(self) -> Series {
+        self.materialized
+            .into_inner()
+            .unwrap_or_else(|| Self::_to_series(&self.name, &self.scalar, &self.dtype, self.length))
+    }
+
+    /// Returns a new scalar column with the given length.
+    ///
+    /// Returns `self` unchanged if the length already matches.
+    /// The materialized cache is not carried over.
+    pub fn resize(&self, length: usize) -> Self {
+        if self.length == length {
+            return self.clone();
+        }
+        Self::new(
+            self.name.clone(),
+            self.dtype.clone(),
+            self.scalar.clone(),
+            length,
+        )
+    }
+
+    /// Renames the column in place, updating the cached series if present.
+    pub fn rename(&mut self, name: &str) {
+        if let Some(series) = self.materialized.get_mut() {
+            *series = series.rename(name);
+        }
+        self.name = Arc::from(name);
+    }
+
+    /// Returns `true` if the scalar is null and the length is non-zero.
+    pub fn has_nulls(&self) -> bool {
+        self.length != 0 && matches!(self.scalar, Literal::Null)
+    }
+
+    /// Returns the approximate in-memory size in bytes (scalar storage only,
+    /// not the expanded array).
+    pub fn size_bytes(&self) -> usize {
+        self.name.len()
+            + std::mem::size_of::<DataType>()
+            + self.scalar.size_bytes()
+            + std::mem::size_of::<usize>()
+    }
+
+    /// Casts the scalar to the given data type without materialization.
+    pub fn cast(&self, dtype: &DataType) -> DaftResult<Self> {
+        let casted = self.scalar.clone().cast(dtype)?;
+        Ok(Self::new(
+            self.name.clone(),
+            dtype.clone(),
+            casted,
+            self.length,
+        ))
+    }
+
+    /// Creates a `ScalarColumn` from a length-1 [`Series`] expanded to `length` rows.
+    pub fn from_single_value_series(series: &Series, length: usize) -> DaftResult<Self> {
+        let lit = Literal::try_from_single_value_series(series)?;
+        Ok(Self::new(
+            Arc::from(series.name()),
+            lit.get_type(),
+            lit,
+            length,
+        ))
+    }
+}

--- a/src/daft-recordbatch/src/column/scalar.rs
+++ b/src/daft-recordbatch/src/column/scalar.rs
@@ -69,7 +69,6 @@ impl ScalarColumn {
         if length == 0 {
             Series::empty(name, dtype)
         } else if matches!(scalar, Literal::Null) {
-            use daft_core::array::ops::full::FullNull;
             Series::full_null(name, dtype, length)
         } else {
             let s: Series = scalar.clone().into();

--- a/src/daft-recordbatch/src/growable/mod.rs
+++ b/src/daft-recordbatch/src/growable/mod.rs
@@ -39,7 +39,7 @@ impl<'a> GrowableRecordBatch<'a> {
                 )));
             }
             for (col, v) in tab.columns.iter().zip(series_list.iter_mut()) {
-                v.push(col);
+                v.push(col.as_materialized_series());
             }
         }
         let growables = series_list

--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -36,6 +36,7 @@ use daft_functions_list::SeriesListExtension;
 use file_info::FileInfos;
 use futures::{StreamExt, TryStreamExt, future::try_join_all};
 use num_traits::ToPrimitive;
+pub mod column;
 #[cfg(feature = "python")]
 pub mod ffi;
 mod file_info;
@@ -66,7 +67,7 @@ macro_rules! value_err {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct RecordBatch {
     pub schema: SchemaRef,
-    columns: Arc<Vec<Series>>,
+    columns: Arc<Vec<column::Column>>,
     num_rows: usize,
 }
 
@@ -74,8 +75,7 @@ impl Hash for RecordBatch {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.schema.hash(state);
         for col in &*self.columns {
-            let hashes = col.hash(None).expect("Failed to hash column");
-            hashes.into_iter().for_each(|h| h.hash(state));
+            col.hash(state);
         }
         self.num_rows.hash(state);
     }
@@ -148,7 +148,9 @@ impl RecordBatch {
     }
 
     pub fn get_inner_arrow_arrays(&self) -> impl Iterator<Item = ArrayRef> + '_ {
-        self.columns.iter().map(|s| s.to_arrow().unwrap())
+        self.columns
+            .iter()
+            .map(|c| c.as_materialized_series().to_arrow().unwrap())
     }
 
     /// Create a new [`RecordBatch`] and validate against `num_rows`
@@ -196,6 +198,18 @@ impl RecordBatch {
     ) -> Self {
         Self {
             schema: schema.into(),
+            columns: Arc::new(columns.into_iter().map(column::Column::from).collect()),
+            num_rows,
+        }
+    }
+
+    pub fn new_unchecked_with_columns<S: Into<SchemaRef>>(
+        schema: S,
+        columns: Vec<column::Column>,
+        num_rows: usize,
+    ) -> Self {
+        Self {
+            schema: schema.into(),
             columns: Arc::new(columns),
             num_rows,
         }
@@ -218,8 +232,7 @@ impl RecordBatch {
     /// # Arguments
     ///
     /// * `columns` - Columns to create a table from as [`Series`] objects
-    pub fn from_nonempty_columns(columns: impl Into<Arc<Vec<Series>>>) -> DaftResult<Self> {
-        let columns = columns.into();
+    pub fn from_nonempty_columns(columns: Vec<Series>) -> DaftResult<Self> {
         assert!(
             !columns.is_empty(),
             "Cannot call RecordBatch::new() with empty columns. This indicates an internal error, please file an issue."
@@ -245,11 +258,7 @@ impl RecordBatch {
             }
         }
 
-        Ok(Self {
-            schema,
-            columns,
-            num_rows,
-        })
+        Ok(Self::new_unchecked(schema, columns, num_rows))
     }
 
     pub fn from_arrow<S: Into<SchemaRef>>(schema: S, arrays: Vec<ArrayRef>) -> DaftResult<Self> {
@@ -288,13 +297,20 @@ impl RecordBatch {
 
         Ok(Self {
             schema,
-            columns: Arc::new(columns),
+            columns: Arc::new(columns.into_iter().map(column::Column::from).collect()),
             num_rows,
         })
     }
 
     pub fn num_columns(&self) -> usize {
         self.columns.len()
+    }
+
+    pub fn as_materialized_series(&self) -> Vec<&Series> {
+        self.columns
+            .iter()
+            .map(|c| c.as_materialized_series())
+            .collect()
     }
 
     pub fn len(&self) -> usize {
@@ -310,10 +326,14 @@ impl RecordBatch {
     }
 
     pub fn slice(&self, start: usize, end: usize) -> DaftResult<Self> {
-        let new_series: DaftResult<Vec<_>> =
-            self.columns.iter().map(|s| s.slice(start, end)).collect();
+        let new_columns: DaftResult<Vec<_>> =
+            self.columns.iter().map(|c| c.slice(start, end)).collect();
         let new_num_rows = self.len().min(end - start);
-        Self::new_with_size(self.schema.clone(), new_series?, new_num_rows)
+        Ok(Self::new_unchecked_with_columns(
+            self.schema.clone(),
+            new_columns?,
+            new_num_rows,
+        ))
     }
 
     pub fn head(&self, num: usize) -> DaftResult<Self> {
@@ -412,7 +432,11 @@ impl RecordBatch {
         let end = start + self.len() as u64;
         let ids = (start..end).step_by(1).collect::<Vec<_>>();
         let id_series = UInt64Array::from_vec(column_name, ids).into_series();
-        Self::from_nonempty_columns([&[id_series], &self.columns[..]].concat())
+        let mut all_series = vec![id_series];
+        for c in self.columns.iter() {
+            all_series.push(c.as_materialized_series().clone());
+        }
+        Self::from_nonempty_columns(all_series)
     }
 
     pub fn quantiles(&self, num: usize) -> DaftResult<Self> {
@@ -468,10 +492,10 @@ impl RecordBatch {
 
     pub fn mask_filter(&self, mask: &Series) -> DaftResult<Self> {
         let mask = mask.bool()?;
-        let new_series = self
+        let new_columns = self
             .columns
             .iter()
-            .map(|s| s.filter(mask))
+            .map(|c| c.filter(mask))
             .collect::<DaftResult<Vec<_>>>()?;
 
         // The number of rows post-filter should be the number of 'true' values in the mask
@@ -489,16 +513,24 @@ impl RecordBatch {
             mask.len() - num_filtered
         };
 
-        Self::new_with_size(self.schema.clone(), new_series, num_rows)
+        Ok(Self::new_unchecked_with_columns(
+            self.schema.clone(),
+            new_columns,
+            num_rows,
+        ))
     }
 
     pub fn take(&self, idx: &UInt64Array) -> DaftResult<Self> {
-        let new_series = self
+        let new_columns = self
             .columns
             .iter()
-            .map(|s| s.take(idx))
+            .map(|c| c.take(idx))
             .collect::<DaftResult<Vec<_>>>()?;
-        Self::new_with_size(self.schema.clone(), new_series, idx.len())
+        Ok(Self::new_unchecked_with_columns(
+            self.schema.clone(),
+            new_columns,
+            idx.len(),
+        ))
     }
 
     pub fn concat_or_empty<T: AsRef<Self>>(
@@ -532,18 +564,19 @@ impl RecordBatch {
             }
         }
         let num_columns = first_table.num_columns();
-        let mut new_series = Vec::with_capacity(num_columns);
+        let total_rows: usize = tables.iter().map(|t| t.as_ref().len()).sum();
+        let mut new_columns = Vec::with_capacity(num_columns);
         for i in 0..num_columns {
-            let series_to_cat: Vec<&Series> =
-                tables.iter().map(|s| s.as_ref().get_column(i)).collect();
-            new_series.push(Series::concat(series_to_cat.as_slice())?);
+            let cols: Vec<&column::Column> =
+                tables.iter().map(|t| &t.as_ref().columns[i]).collect();
+            new_columns.push(column::Column::concat(cols.as_slice())?);
         }
 
-        Self::new_with_size(
+        Ok(Self::new_unchecked_with_columns(
             first_table.schema.clone(),
-            new_series,
-            tables.iter().map(|t| t.as_ref().len()).sum(),
-        )
+            new_columns,
+            total_rows,
+        ))
     }
 
     pub fn union(&self, other: &Self) -> DaftResult<Self> {
@@ -553,31 +586,34 @@ impl RecordBatch {
                 self.num_rows, other.num_rows
             )));
         }
-        let unioned = self
+        let unioned: Vec<column::Column> = self
             .columns
             .iter()
             .chain(other.columns.iter())
             .cloned()
-            .collect::<Vec<_>>();
-        Self::from_nonempty_columns(unioned)
+            .collect();
+        let schema = Schema::new(unioned.iter().map(|c| c.field()));
+        Ok(Self::new_unchecked_with_columns(
+            schema,
+            unioned,
+            self.num_rows,
+        ))
     }
 
     pub fn get_column(&self, idx: usize) -> &Series {
-        &self.columns[idx]
+        self.columns[idx].as_materialized_series()
     }
 
     pub fn get_columns(&self, indices: &[usize]) -> Self {
-        let new_columns = indices
-            .iter()
-            .map(|i| self.columns[*i].clone())
-            .collect::<Vec<_>>();
+        let new_columns: Vec<column::Column> =
+            indices.iter().map(|i| self.columns[*i].clone()).collect();
 
         let new_schema = Schema::new(indices.iter().map(|i| self.schema[*i].clone()));
 
-        Self::new_unchecked(new_schema, new_columns, self.num_rows)
+        Self::new_unchecked_with_columns(new_schema, new_columns, self.num_rows)
     }
 
-    pub fn columns(&self) -> &[Series] {
+    pub fn columns(&self) -> &[column::Column] {
         &self.columns
     }
 
@@ -591,9 +627,13 @@ impl RecordBatch {
         }
 
         let mut new_columns = self.columns.as_ref().clone();
-        new_columns.push(series);
+        new_columns.push(column::Column::from(series));
 
-        Ok(Self::new_unchecked(new_schema, new_columns, self.num_rows))
+        Ok(Self::new_unchecked_with_columns(
+            new_schema,
+            new_columns,
+            self.num_rows,
+        ))
     }
 
     /// Evaluates an expression and broadcasts the result to match `self.len()` if needed.
@@ -722,7 +762,7 @@ impl RecordBatch {
                 .await?
                 .cast(dtype),
             Expr::Column(Column::Bound(BoundColumn { index, .. })) => {
-                Ok(self.columns[*index].clone())
+                Ok(self.columns[*index].as_materialized_series().clone())
             }
             Expr::Not(child) => !(self
                 .eval_expression_async_with_metrics(
@@ -1053,7 +1093,7 @@ impl RecordBatch {
                 .eval_expression_internal(&BoundExpr::new_unchecked(child.clone()), metrics)?
                 .cast(dtype),
             Expr::Column(Column::Bound(BoundColumn { index, .. })) => {
-                Ok(self.columns[*index].clone())
+                Ok(self.columns[*index].as_materialized_series().clone())
             }
             Expr::Not(child) => !(self.eval_expression_internal(
                 &BoundExpr::new_unchecked(child.clone()),
@@ -1413,13 +1453,17 @@ impl RecordBatch {
     }
 
     pub fn as_physical(&self) -> DaftResult<Self> {
-        let new_series: Vec<Series> = self
+        let new_columns: Vec<column::Column> = self
             .columns
             .iter()
-            .map(|s| s.as_physical())
+            .map(|c| c.as_physical())
             .collect::<DaftResult<Vec<_>>>()?;
-        let new_schema = Schema::new(new_series.iter().map(|s| s.field().clone()));
-        Self::new_with_size(new_schema, new_series, self.len())
+        let new_schema = Schema::new(new_columns.iter().map(|c| c.field()));
+        Ok(Self::new_unchecked_with_columns(
+            new_schema,
+            new_columns,
+            self.len(),
+        ))
     }
 
     #[deprecated(note = "name-referenced columns")]
@@ -1516,7 +1560,7 @@ impl RecordBatch {
                     "<td data-row=\"{}\" data-col=\"{}\"><div style=\"{}\">",
                     i, col_idx, body_style
                 ));
-                res.push_str(&html_value(col, i, true));
+                res.push_str(&html_value(col.as_materialized_series(), i, true));
                 res.push_str("</div></td>");
             }
 
@@ -1534,7 +1578,7 @@ impl RecordBatch {
         let str_values = self
             .columns
             .iter()
-            .map(|s| s as &dyn StrValue)
+            .map(|c| c.as_materialized_series() as &dyn StrValue)
             .collect::<Vec<_>>();
 
         make_comfy_table(
@@ -1591,7 +1635,7 @@ impl TryFrom<RecordBatch> for arrow_array::RecordBatch {
         let columns = record_batch
             .columns
             .iter()
-            .map(|s| s.to_arrow())
+            .map(|c| c.as_materialized_series().to_arrow())
             .collect::<DaftResult<Vec<_>>>()?;
 
         Self::try_new(schema, columns).map_err(DaftError::ArrowRsError)

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -75,7 +75,12 @@ impl RecordBatch {
             .collect::<DaftResult<Vec<_>>>()?;
 
         // Combine the groupkey columns and the aggregation result columns.
-        Self::from_nonempty_columns([&groupkeys_table.columns[..], &grouped_cols].concat())
+        let groupkeys_series: Vec<Series> = groupkeys_table
+            .columns
+            .iter()
+            .map(|c| c.as_materialized_series().clone())
+            .collect();
+        Self::from_nonempty_columns([groupkeys_series.as_slice(), &grouped_cols].concat())
     }
 
     #[cfg(feature = "python")]
@@ -156,10 +161,12 @@ impl RecordBatch {
                                 let broadcasted_groupkeys = groupkeys_table
                                     .columns
                                     .iter()
-                                    .map(|c| c.broadcast(evaluated_grouped_col.len()))
+                                    .map(|c| {
+                                        c.broadcast(evaluated_grouped_col.len())
+                                            .map(|c| c.take_materialized_series())
+                                    })
                                     .collect::<DaftResult<Vec<_>>>()?;
 
-                                // Combine the broadcasted group keys into a Table
                                 Self::from_nonempty_columns(broadcasted_groupkeys)?
                             };
 
@@ -245,10 +252,12 @@ impl RecordBatch {
                                 let broadcasted_groupkeys = groupkeys_table
                                     .columns
                                     .iter()
-                                    .map(|c| c.broadcast(evaluated_grouped_col.len()))
+                                    .map(|c| {
+                                        c.broadcast(evaluated_grouped_col.len())
+                                            .map(|c| c.take_materialized_series())
+                                    })
                                     .collect::<DaftResult<Vec<_>>>()?;
 
-                                // Combine the broadcasted group keys into a Table
                                 Self::from_nonempty_columns(broadcasted_groupkeys)?
                             };
 
@@ -269,7 +278,12 @@ impl RecordBatch {
 
         // Broadcast either the keys or the grouped_cols, depending on which is unit-length
         let final_len = grouped_col.len();
-        let final_columns = [&groupkeys_table.columns[..], &[grouped_col]].concat();
+        let groupkeys_series: Vec<Series> = groupkeys_table
+            .columns
+            .iter()
+            .map(|c| c.as_materialized_series().clone())
+            .collect();
+        let final_columns = [groupkeys_series.as_slice(), &[grouped_col]].concat();
         let final_schema = Schema::new(final_columns.iter().map(|s| s.field().clone()));
         Self::new_with_broadcast(final_schema, final_columns, final_len)
     }

--- a/src/daft-recordbatch/src/ops/explode.rs
+++ b/src/daft-recordbatch/src/ops/explode.rs
@@ -133,7 +133,10 @@ impl RecordBatch {
         let capacity_expected = exploded_columns.first().unwrap().len();
         let take_idx = lengths_to_indices(&first_len, capacity_expected, ignore_empty_and_null)?;
 
-        let mut new_series = Arc::unwrap_or_clone(self.columns.clone());
+        let mut new_series: Vec<Series> = Arc::unwrap_or_clone(self.columns.clone())
+            .into_iter()
+            .map(|c| c.take_materialized_series())
+            .collect();
 
         for i in 0..self.num_columns() {
             let name = new_series.get(i).unwrap().name();

--- a/src/daft-recordbatch/src/ops/groups.rs
+++ b/src/daft-recordbatch/src/ops/groups.rs
@@ -25,7 +25,12 @@ impl RecordBatch {
         // )
 
         if self.num_columns() == 1 {
-            return self.columns.first().unwrap().make_groups();
+            return self
+                .columns
+                .first()
+                .unwrap()
+                .as_materialized_series()
+                .make_groups();
         }
 
         let probe_table = self.to_probe_hash_table()?;
@@ -54,21 +59,21 @@ impl RecordBatch {
         // )
 
         // Begin by doing the argsort.
+        let cols: Vec<Series> = self.as_materialized_series().into_iter().cloned().collect();
         let argsort_array = Series::argsort_multikey(
-            self.columns.as_slice(),
-            &vec![false; self.columns.len()],
-            &vec![false; self.columns.len()],
+            cols.as_slice(),
+            &vec![false; cols.len()],
+            &vec![false; cols.len()],
         )?;
 
-        // The result indices.
         let mut key_indices: Vec<u64> = vec![];
         let mut values_indices: Vec<UInt64Array> = vec![];
 
         let comparator = build_multi_array_is_equal(
-            self.columns.as_slice(),
-            self.columns.as_slice(),
-            vec![true; self.columns.len()].as_slice(),
-            vec![true; self.columns.len()].as_slice(),
+            cols.as_slice(),
+            cols.as_slice(),
+            vec![true; cols.len()].as_slice(),
+            vec![true; cols.len()].as_slice(),
         )?;
 
         // To group the argsort values together, we will traverse the table in argsort order,
@@ -124,7 +129,12 @@ impl IntoUniqueIdxs for RecordBatch {
         // returns: [2, 0, 4]  <-- indices of A, B, and C
 
         if self.num_columns() == 1 {
-            return self.columns.first().unwrap().make_unique_idxs();
+            return self
+                .columns
+                .first()
+                .unwrap()
+                .as_materialized_series()
+                .make_unique_idxs();
         }
 
         let idx_table = self.to_idx_hash_table()?;

--- a/src/daft-recordbatch/src/ops/hash.rs
+++ b/src/daft-recordbatch/src/ops/hash.rs
@@ -2,6 +2,7 @@ use common_error::{DaftError, DaftResult};
 use daft_core::{
     array::ops::arrow::comparison::build_multi_array_is_equal,
     datatypes::UInt64Array,
+    series::Series,
     utils::identity_hash_set::{IdentityBuildHasher, IndexHash},
 };
 use hashbrown::{HashMap, hash_map::RawEntryMut};
@@ -15,8 +16,9 @@ impl RecordBatch {
                 "Attempting to Hash Table with no columns".to_string(),
             ));
         }
-        let mut hash_so_far = self.columns.first().unwrap().hash(None)?;
-        for c in self.columns.iter().skip(1) {
+        let cols = self.as_materialized_series();
+        let mut hash_so_far = cols.first().unwrap().hash(None)?;
+        for c in cols.iter().skip(1) {
             hash_so_far = c.hash(Some(&hash_so_far))?;
         }
         Ok(hash_so_far)
@@ -28,11 +30,12 @@ impl RecordBatch {
         let hashes = self.hash_rows()?;
 
         const DEFAULT_SIZE: usize = 20;
+        let cols: Vec<Series> = self.as_materialized_series().into_iter().cloned().collect();
         let comparator = build_multi_array_is_equal(
-            self.columns.as_slice(),
-            self.columns.as_slice(),
-            vec![true; self.columns.len()].as_slice(),
-            vec![true; self.columns.len()].as_slice(),
+            cols.as_slice(),
+            cols.as_slice(),
+            vec![true; cols.len()].as_slice(),
+            vec![true; cols.len()].as_slice(),
         )?;
 
         let mut probe_table =
@@ -71,11 +74,12 @@ impl RecordBatch {
         let hashes = self.hash_rows()?;
 
         const DEFAULT_SIZE: usize = 20;
+        let cols: Vec<Series> = self.as_materialized_series().into_iter().cloned().collect();
         let comparator = build_multi_array_is_equal(
-            self.columns.as_slice(),
-            self.columns.as_slice(),
-            vec![true; self.columns.len()].as_slice(),
-            vec![true; self.columns.len()].as_slice(),
+            cols.as_slice(),
+            cols.as_slice(),
+            vec![true; cols.len()].as_slice(),
+            vec![true; cols.len()].as_slice(),
         )?;
 
         let mut idx_hash_table =
@@ -114,11 +118,12 @@ impl RecordBatch {
         let hashes = self.hash_rows()?;
 
         const DEFAULT_SIZE: usize = 20;
+        let cols: Vec<Series> = self.as_materialized_series().into_iter().cloned().collect();
         let comparator = build_multi_array_is_equal(
-            self.columns.as_slice(),
-            self.columns.as_slice(),
-            vec![true; self.columns.len()].as_slice(),
-            vec![true; self.columns.len()].as_slice(),
+            cols.as_slice(),
+            cols.as_slice(),
+            vec![true; cols.len()].as_slice(),
+            vec![true; cols.len()].as_slice(),
         )?;
 
         let mut probe_table =

--- a/src/daft-recordbatch/src/ops/joins/hash_join.rs
+++ b/src/daft-recordbatch/src/ops/joins/hash_join.rs
@@ -50,11 +50,21 @@ pub(super) fn hash_inner_join(
 
         let r_hashes = rkeys.hash_rows()?;
         use daft_core::array::ops::arrow::comparison::build_multi_array_is_equal;
+        let lcols: Vec<Series> = lkeys
+            .as_materialized_series()
+            .into_iter()
+            .cloned()
+            .collect();
+        let rcols: Vec<Series> = rkeys
+            .as_materialized_series()
+            .into_iter()
+            .cloned()
+            .collect();
         let is_equal = build_multi_array_is_equal(
-            lkeys.columns.as_slice(),
-            rkeys.columns.as_slice(),
+            lcols.as_slice(),
+            rcols.as_slice(),
             null_equals_nulls,
-            vec![false; lkeys.columns.len()].as_slice(),
+            vec![false; lcols.len()].as_slice(),
         )?;
 
         let mut left_idx = vec![];
@@ -86,11 +96,14 @@ pub(super) fn hash_inner_join(
 
     let common_cols: Vec<_> = get_common_join_cols(&left.schema, &right.schema).collect();
 
-    let mut join_series = Arc::unwrap_or_clone(
+    let mut join_series: Vec<Series> = Arc::unwrap_or_clone(
         get_columns_by_name(left, &common_cols)?
             .take(&lidx)?
             .columns,
-    );
+    )
+    .into_iter()
+    .map(|c| c.take_materialized_series())
+    .collect();
 
     drop(lkeys);
     drop(rkeys);
@@ -137,11 +150,21 @@ pub(super) fn hash_left_right_join(
 
         let r_hashes = rkeys.hash_rows()?;
 
+        let lcols: Vec<Series> = lkeys
+            .as_materialized_series()
+            .into_iter()
+            .cloned()
+            .collect();
+        let rcols: Vec<Series> = rkeys
+            .as_materialized_series()
+            .into_iter()
+            .cloned()
+            .collect();
         let is_equal = build_multi_array_is_equal(
-            lkeys.columns.as_slice(),
-            rkeys.columns.as_slice(),
+            lcols.as_slice(),
+            rcols.as_slice(),
             null_equals_nulls,
-            vec![false; lkeys.columns.len()].as_slice(),
+            vec![false; lcols.len()].as_slice(),
         )?;
 
         // we will have at least as many rows in the join table as the right table
@@ -192,11 +215,14 @@ pub(super) fn hash_left_right_join(
         (right, &ridx)
     };
 
-    let mut join_series = Arc::unwrap_or_clone(
+    let mut join_series: Vec<Series> = Arc::unwrap_or_clone(
         get_columns_by_name(common_cols_tbl, &common_cols)?
             .take(common_cols_idx)?
             .columns,
-    );
+    )
+    .into_iter()
+    .map(|c| c.take_materialized_series())
+    .collect();
 
     drop(lkeys);
     drop(rkeys);
@@ -234,11 +260,21 @@ pub(super) fn hash_semi_anti_join(
 
         let l_hashes = lkeys.hash_rows()?;
 
+        let lcols: Vec<Series> = lkeys
+            .as_materialized_series()
+            .into_iter()
+            .cloned()
+            .collect();
+        let rcols: Vec<Series> = rkeys
+            .as_materialized_series()
+            .into_iter()
+            .cloned()
+            .collect();
         let is_equal = build_multi_array_is_equal(
-            lkeys.columns.as_slice(),
-            rkeys.columns.as_slice(),
+            lcols.as_slice(),
+            rcols.as_slice(),
             null_equals_nulls,
-            vec![false; lkeys.columns.len()].as_slice(),
+            vec![false; lcols.len()].as_slice(),
         )?;
         let rows = rkeys.len();
 
@@ -307,11 +343,21 @@ pub(super) fn hash_outer_join(
 
         let r_hashes = rkeys.hash_rows()?;
 
+        let lcols: Vec<Series> = lkeys
+            .as_materialized_series()
+            .into_iter()
+            .cloned()
+            .collect();
+        let rcols: Vec<Series> = rkeys
+            .as_materialized_series()
+            .into_iter()
+            .cloned()
+            .collect();
         let is_equal = build_multi_array_is_equal(
-            lkeys.columns.as_slice(),
-            rkeys.columns.as_slice(),
+            lcols.as_slice(),
+            rcols.as_slice(),
             null_equals_nulls,
-            vec![false; lkeys.columns.len()].as_slice(),
+            vec![false; lcols.len()].as_slice(),
         )?;
 
         // we will have at least as many rows in the join table as the max of the left and right tables

--- a/src/daft-recordbatch/src/ops/joins/merge_join.rs
+++ b/src/daft-recordbatch/src/ops/joins/merge_join.rs
@@ -84,8 +84,8 @@ pub fn merge_inner_join(
     let mut cmp_list = Vec::with_capacity(left.num_columns());
     for (left_series, right_series) in left.columns.iter().zip(right.columns.iter()) {
         cmp_list.push(build_partial_compare_with_nulls(
-            left_series.to_arrow()?.as_ref(),
-            right_series.to_arrow()?.as_ref(),
+            left_series.as_materialized_series().to_arrow()?.as_ref(),
+            right_series.as_materialized_series().to_arrow()?.as_ref(),
             false,
         )?);
     }

--- a/src/daft-recordbatch/src/ops/joins/mod.rs
+++ b/src/daft-recordbatch/src/ops/joins/mod.rs
@@ -25,8 +25,8 @@ fn match_types_for_tables(
     for (ls, rs) in left.columns.iter().zip(right.columns.iter()) {
         let st = try_get_supertype(ls.data_type(), rs.data_type());
         if let Ok(st) = st {
-            lseries.push(ls.cast(&st)?);
-            rseries.push(rs.cast(&st)?);
+            lseries.push(ls.cast(&st)?.take_materialized_series());
+            rseries.push(rs.cast(&st)?.take_materialized_series());
         } else {
             return Err(DaftError::SchemaMismatch(format!(
                 "Can not perform join between due to mismatch of types of left: {} vs right: {}",
@@ -227,10 +227,16 @@ impl RecordBatch {
         let num_rows = self.len() * right.len();
 
         let join_schema = self.schema.union(&right.schema)?;
-        let mut join_columns = Arc::unwrap_or_clone(left_table.columns);
-        let mut right_columns = Arc::unwrap_or_clone(right_table.columns);
+        let mut join_columns: Vec<Series> = Arc::unwrap_or_clone(left_table.columns)
+            .into_iter()
+            .map(|c| c.take_materialized_series())
+            .collect();
+        let right_columns: Vec<Series> = Arc::unwrap_or_clone(right_table.columns)
+            .into_iter()
+            .map(|c| c.take_materialized_series())
+            .collect();
 
-        join_columns.append(&mut right_columns);
+        join_columns.extend(right_columns);
 
         Self::new_with_size(join_schema, join_columns, num_rows)
     }

--- a/src/daft-recordbatch/src/ops/pivot.rs
+++ b/src/daft-recordbatch/src/ops/pivot.rs
@@ -123,6 +123,11 @@ impl RecordBatch {
             groupby_table.take(&indices_as_arr)?
         };
 
-        Self::from_nonempty_columns([&group_keys_table.columns[..], &pivoted_cols[..]].concat())
+        let group_keys_series: Vec<Series> = group_keys_table
+            .columns
+            .iter()
+            .map(|c| c.as_materialized_series().clone())
+            .collect();
+        Self::from_nonempty_columns([group_keys_series.as_slice(), &pivoted_cols[..]].concat())
     }
 }

--- a/src/daft-recordbatch/src/ops/search_sorted.rs
+++ b/src/daft-recordbatch/src/ops/search_sorted.rs
@@ -30,9 +30,9 @@ impl RecordBatch {
                 .get_column(0)
                 .search_sorted(keys.get_column(0), *descending.first().unwrap());
         }
-        unsafe {
-            multicol_search_sorted(self.columns.as_slice(), keys.columns.as_slice(), descending)
-        }
+        let self_cols: Vec<Series> = self.as_materialized_series().into_iter().cloned().collect();
+        let keys_cols: Vec<Series> = keys.as_materialized_series().into_iter().cloned().collect();
+        unsafe { multicol_search_sorted(self_cols.as_slice(), keys_cols.as_slice(), descending) }
     }
 }
 

--- a/src/daft-recordbatch/src/ops/sort.rs
+++ b/src/daft-recordbatch/src/ops/sort.rs
@@ -34,7 +34,12 @@ impl RecordBatch {
                 .get_column(0)
                 .argsort(*descending.first().unwrap(), *nulls_first.first().unwrap())
         } else {
-            Series::argsort_multikey(sort_values.columns.as_slice(), descending, nulls_first)
+            let cols: Vec<Series> = sort_values
+                .as_materialized_series()
+                .into_iter()
+                .cloned()
+                .collect();
+            Series::argsort_multikey(cols.as_slice(), descending, nulls_first)
         }
     }
 

--- a/src/daft-recordbatch/src/ops/unpivot.rs
+++ b/src/daft-recordbatch/src/ops/unpivot.rs
@@ -33,7 +33,10 @@ impl RecordBatch {
                 .collect::<Vec<_>>(),
         );
 
-        let ids_series = ids_table.take(&ids_idx)?.columns;
+        let ids_series: Vec<Series> = Arc::unwrap_or_clone(ids_table.take(&ids_idx)?.columns)
+            .into_iter()
+            .map(|c| c.take_materialized_series())
+            .collect();
         let ids_schema = ids_table.schema;
 
         let variable_column = values_table
@@ -44,7 +47,11 @@ impl RecordBatch {
         let variable_series =
             Utf8Array::from_slice(variable_name, variable_column.as_ref()).into_series();
 
-        let values_cols: Vec<&Series> = values_table.columns.iter().collect();
+        let values_cols: Vec<&Series> = values_table
+            .columns
+            .iter()
+            .map(|c| c.as_materialized_series())
+            .collect();
         let values_casted = cast_series_to_supertype(&values_cols)?;
 
         let value_series =
@@ -55,11 +62,7 @@ impl RecordBatch {
             value_series.field().clone(),
         ]));
 
-        let unpivot_series = [
-            Arc::unwrap_or_clone(ids_series),
-            vec![variable_series, value_series],
-        ]
-        .concat();
+        let unpivot_series = [ids_series, vec![variable_series, value_series]].concat();
 
         Self::new_with_size(unpivot_schema, unpivot_series, unpivoted_len)
     }

--- a/src/daft-recordbatch/src/ops/window.rs
+++ b/src/daft-recordbatch/src/ops/window.rs
@@ -654,12 +654,17 @@ impl RecordBatch {
         let order_by_table = self.eval_expression_list(order_by)?;
 
         // Create a comparator for checking equality between rows
+        let order_by_cols: Vec<Series> = order_by_table
+            .as_materialized_series()
+            .into_iter()
+            .cloned()
+            .collect();
         let comparator: Box<dyn Fn(usize, usize) -> bool + Send + Sync> =
             build_multi_array_is_equal(
-                order_by_table.columns.as_slice(),
-                order_by_table.columns.as_slice(),
-                &vec![true; order_by_table.columns.len()],
-                &vec![true; order_by_table.columns.len()],
+                order_by_cols.as_slice(),
+                order_by_cols.as_slice(),
+                &vec![true; order_by_cols.len()],
+                &vec![true; order_by_cols.len()],
             )?;
 
         // Use iterator to generate rank numbers

--- a/src/daft-recordbatch/src/ops/window_states/mean.rs
+++ b/src/daft-recordbatch/src/ops/window_states/mean.rs
@@ -86,6 +86,7 @@ pub fn create_for_type(
     let [source] = sources.columns() else {
         unreachable!("sum should only have one input")
     };
+    let source = source.as_materialized_series();
 
     let target_type = try_mean_aggregation_supertype(source.data_type())?;
     match target_type {

--- a/src/daft-recordbatch/src/ops/window_states/mod.rs
+++ b/src/daft-recordbatch/src/ops/window_states/mod.rs
@@ -41,7 +41,7 @@ pub fn create_window_agg_state(
             };
 
             Ok(Some(Box::new(CountWindowState::new(
-                source,
+                source.as_materialized_series(),
                 total_length,
                 *mode,
             ))))
@@ -55,7 +55,7 @@ pub fn create_window_agg_state(
             };
 
             Ok(Some(Box::new(CountDistinctWindowState::new(
-                source,
+                source.as_materialized_series(),
                 total_length,
             ))))
         }

--- a/src/daft-recordbatch/src/ops/window_states/sum.rs
+++ b/src/daft-recordbatch/src/ops/window_states/sum.rs
@@ -135,6 +135,7 @@ pub fn create_for_type(
     let [source] = sources.columns() else {
         unreachable!("sum should only have one input")
     };
+    let source = source.as_materialized_series();
 
     match source.data_type() {
         DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => {

--- a/src/daft-recordbatch/src/preview.rs
+++ b/src/daft-recordbatch/src/preview.rs
@@ -222,7 +222,7 @@ impl Preview {
                 .enumerate()
                 .map(|(idx, series)| {
                     // Unfortunately actually plumbing the formatting would make this too much work right now.
-                    let mut text = series.str_value(o);
+                    let mut text = series.as_materialized_series().str_value(o);
                     let mut alignment = CellAlignment::Left;
 
                     // Use column overrides if any, falling back to the global settings.

--- a/src/daft-recordbatch/src/probeable/probe_set.rs
+++ b/src/daft-recordbatch/src/probeable/probe_set.rs
@@ -70,7 +70,7 @@ impl ProbeSet {
         let input_arrays = input
             .columns
             .iter()
-            .map(|s| s.as_physical()?.to_arrow())
+            .map(|s| s.as_physical()?.as_materialized_series().to_arrow())
             .collect::<DaftResult<Vec<_>>>()?;
 
         let comparators: Vec<_> = self
@@ -120,7 +120,7 @@ impl ProbeSet {
         let current_arrays = table
             .columns
             .iter()
-            .map(|s| s.as_physical()?.to_arrow())
+            .map(|s| s.as_physical()?.as_materialized_series().to_arrow())
             .collect::<DaftResult<Vec<_>>>()?;
 
         let mut comparators: Vec<Box<dyn Fn(usize, usize) -> bool + Send + Sync>> = self

--- a/src/daft-recordbatch/src/probeable/probe_table.rs
+++ b/src/daft-recordbatch/src/probeable/probe_table.rs
@@ -71,7 +71,7 @@ impl ProbeTable {
         let input_arrays = input
             .columns
             .iter()
-            .map(|s| s.as_physical()?.to_arrow())
+            .map(|s| s.as_physical()?.as_materialized_series().to_arrow())
             .collect::<DaftResult<Vec<_>>>()?;
 
         // Pre-create comparators for each stored table vs input.
@@ -126,7 +126,7 @@ impl ProbeTable {
         let current_arrays = table
             .columns
             .iter()
-            .map(|s| s.as_physical()?.to_arrow())
+            .map(|s| s.as_physical()?.as_materialized_series().to_arrow())
             .collect::<DaftResult<Vec<_>>>()?;
 
         // Pre-create comparators: current table vs each existing table + self.

--- a/src/daft-recordbatch/src/python.rs
+++ b/src/daft-recordbatch/src/python.rs
@@ -432,8 +432,7 @@ impl PyRecordBatch {
         self.record_batch
             .columns()
             .iter()
-            .cloned()
-            .map(Into::into)
+            .map(|c| c.as_materialized_series().clone().into())
             .collect()
     }
 

--- a/src/daft-stats/src/partition_spec.rs
+++ b/src/daft-stats/src/partition_spec.rs
@@ -33,7 +33,7 @@ impl PartitionSpec {
                 (
                     column.name(),
                     Arc::new(Expr::Literal(
-                        Literal::try_from_single_value_series(column)
+                        Literal::try_from_single_value_series(column.as_materialized_series())
                             .expect("column should have one row"),
                     )),
                 )
@@ -87,8 +87,7 @@ impl Hash for PartitionSpec {
         self.keys.schema.hash(state);
 
         for column in self.keys.columns() {
-            let column_hashes = column.hash(None).expect("Failed to hash column");
-            column_hashes.into_iter().for_each(|h| h.hash(state));
+            column.hash(state);
         }
     }
 }

--- a/src/daft-stats/src/table_stats.rs
+++ b/src/daft-stats/src/table_stats.rs
@@ -45,8 +45,8 @@ impl TableStatistics {
             .iter()
             .map(|col| {
                 Ok(ColumnRangeStatistics::new(
-                    Some(col.slice(0, 1)?),
-                    Some(col.slice(1, 2)?),
+                    Some(col.slice(0, 1)?.take_materialized_series()),
+                    Some(col.slice(1, 2)?.take_materialized_series()),
                 )?)
             })
             .collect::<DaftResult<_>>()?;
@@ -62,7 +62,7 @@ impl TableStatistics {
         let columns = table
             .columns()
             .iter()
-            .map(ColumnRangeStatistics::from_series)
+            .map(|col| ColumnRangeStatistics::from_series(col.as_materialized_series()))
             .collect();
         Self {
             columns,

--- a/src/daft-writers/src/utils.rs
+++ b/src/daft-writers/src/utils.rs
@@ -72,8 +72,8 @@ fn record_batch_to_partition_path(
         .iter()
         .map(|col| {
             let key = urlencoding::encode(col.name());
-            if col.inner.nulls().is_none_or(|v| v.is_valid(0)) {
-                let value = col.inner.str_value(0)?;
+            if col.is_valid(0) {
+                let value = col.str_value(0)?;
                 Ok(format!("{}={}", key, urlencoding::encode(&value)))
             } else {
                 Ok(format!("{}={}", key, default_partition))


### PR DESCRIPTION
## Changes Made

Introduces a `Column` enum in `daft-recordbatch` that allows RecordBatch to store scalar (constant) columns without physically broadcasting them to full-length arrays.

### Problem

When Daft evaluates expressions with literals (e.g., `col("x") + lit(42)`), the literal gets broadcast to a full-length array — a scalar value like `42` across 1M rows allocates a 1M-element `Int64Array`. This is wasteful both in memory and over the wire.

### Solution

A new `Column` type wraps either a materialized `Series` or a `ScalarColumn` that stores a single `Literal` value + logical length:

```rust
pub enum Column {
    Series(Series),
    Scalar(ScalarColumn),
}
```

`ScalarColumn` uses `OnceLock<Series>` for lazy materialization — the full array is only constructed when an operation actually requires element-wise access via `as_materialized_series()`, and the result is cached.

### What stays compact (no materialization)

Row-preserving operations on scalar columns adjust the logical length in O(1):
- `slice`, `head`, `filter`, `take`, `broadcast`
- `cast`, `as_physical` (operate on the scalar value directly)
- `concat` (if all values match, stays scalar)
- `size_bytes`, `Hash`, `PartialEq` (scalar-aware)

### What materializes (unchanged behavior)

Most `ops/` code (joins, groupby, hash, sort, etc.) materializes via `as_materialized_series()` before operating. This PR lays the groundwork — behavior is identical to before, just with the `Column` abstraction in place.

### Public API

- `get_column(idx) -> &Series` — **unchanged**. Returns a `&Series` via lazy materialization. Zero blast radius for external callers.
- `columns() -> &[Column]` — return type changed from `&[Series]`. Callers that need `&Series` add `.as_materialized_series()`.

### Follow-ups

- **Reduce materialization points**: audit `as_materialized_series()` calls and operate on scalars directly where possible
- **Expression eval**: have `Expr::Literal` produce `Column::Scalar` instead of a length-1 Series
- **REE wire format**: encode scalar columns as `RunEndEncoded` Arrow arrays for compact IPC/shuffle serialization