### PR TITLE
feat: Simplify opendal_backends config by removing redundant scheme and nesting

### DIFF
--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -1014,7 +1014,7 @@ class IOConfig:
     tos: TosConfig
     gravitino: GravitinoConfig
     cos: CosConfig
-    opendal_backends: dict[str, dict[str, str]]
+    opendal_backends: dict[str, str]
     protocol_aliases: dict[str, str]
 
     def __init__(
@@ -1029,7 +1029,7 @@ class IOConfig:
         tos: TosConfig | None = None,
         gravitino: GravitinoConfig | None = None,
         cos: CosConfig | None = None,
-        opendal_backends: dict[str, dict[str, str]] | None = None,
+        opendal_backends: dict[str, str] | None = None,
         protocol_aliases: dict[str, str] | None = None,
     ): ...
     def replace(
@@ -1044,7 +1044,7 @@ class IOConfig:
         tos: TosConfig | None = None,
         gravitino: GravitinoConfig | None = None,
         cos: CosConfig | None = None,
-        opendal_backends: dict[str, dict[str, str]] | None = None,
+        opendal_backends: dict[str, str] | None = None,
         protocol_aliases: dict[str, str] | None = None,
     ) -> IOConfig:
         """Replaces values if provided, returning a new IOConfig."""

--- a/src/common/io-config/src/config.rs
+++ b/src/common/io-config/src/config.rs
@@ -23,8 +23,8 @@ pub struct IOConfig {
     pub tos: TosConfig,
     pub cos: CosConfig,
     /// Additional backends configured via OpenDAL.
-    /// Keys are scheme names (e.g. "oss", "cos"), values are key-value config maps.
-    pub opendal_backends: BTreeMap<String, BTreeMap<String, String>>,
+    /// Key-value configurations for specific OpenDAL backends (e.g., oss, cos).
+    pub opendal_backends: BTreeMap<String, String>,
     /// Protocol aliases: maps custom scheme names to existing scheme names.
     /// For example, {"my-s3": "s3"} rewrites "my-s3://bucket/path" to "s3://bucket/path".
     pub protocol_aliases: BTreeMap<String, String>,

--- a/src/common/io-config/src/python.rs
+++ b/src/common/io-config/src/python.rs
@@ -241,7 +241,7 @@ impl IOConfig {
         tos: Option<TosConfig>,
         gravitino: Option<GravitinoConfig>,
         cos: Option<CosConfig>,
-        opendal_backends: Option<HashMap<String, HashMap<String, String>>>,
+        opendal_backends: Option<HashMap<String, String>>,
         protocol_aliases: Option<HashMap<String, String>>,
     ) -> PyResult<Self> {
         let cfg = config::IOConfig {
@@ -255,11 +255,7 @@ impl IOConfig {
             tos: tos.unwrap_or_default().config,
             gravitino: gravitino.unwrap_or_default().config,
             cos: cos.unwrap_or_default().config,
-            opendal_backends: opendal_backends
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(k, v)| (k, v.into_iter().collect()))
-                .collect(),
+            opendal_backends: opendal_backends.unwrap_or_default().into_iter().collect(),
             protocol_aliases: protocol_aliases
                 .unwrap_or_default()
                 .into_iter()
@@ -299,7 +295,7 @@ impl IOConfig {
         tos: Option<TosConfig>,
         gravitino: Option<GravitinoConfig>,
         cos: Option<CosConfig>,
-        opendal_backends: Option<HashMap<String, HashMap<String, String>>>,
+        opendal_backends: Option<HashMap<String, String>>,
         protocol_aliases: Option<HashMap<String, String>>,
     ) -> PyResult<Self> {
         let cfg = config::IOConfig {
@@ -332,11 +328,7 @@ impl IOConfig {
                 .map(|cos| cos.config)
                 .unwrap_or_else(|| self.config.cos.clone()),
             opendal_backends: opendal_backends
-                .map(|b| {
-                    b.into_iter()
-                        .map(|(k, v)| (k, v.into_iter().collect()))
-                        .collect()
-                })
+                .map(|b| b.into_iter().collect())
                 .unwrap_or_else(|| self.config.opendal_backends.clone()),
             protocol_aliases: protocol_aliases
                 .map(|a| {
@@ -417,17 +409,12 @@ impl IOConfig {
 
     /// Additional backends configured via OpenDAL
     #[getter]
-    pub fn opendal_backends(&self) -> PyResult<HashMap<String, HashMap<String, String>>> {
+    pub fn opendal_backends(&self) -> PyResult<HashMap<String, String>> {
         Ok(self
             .config
             .opendal_backends
             .iter()
-            .map(|(k, v)| {
-                (
-                    k.clone(),
-                    v.iter().map(|(k2, v2)| (k2.clone(), v2.clone())).collect(),
-                )
-            })
+            .map(|(k, v)| (k.clone(), v.clone()))
             .collect())
     }
 

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -302,7 +302,6 @@ impl IOClient {
                 }
             }
             SourceType::OpenDAL { scheme } => {
-                let empty_config = std::collections::BTreeMap::new();
                 let backend_config = if scheme == "cos" {
                     // Extract bucket from the URL for COS config
                     let parsed_url =
@@ -311,18 +310,10 @@ impl IOClient {
                     let cos_config = self.config.cos.to_opendal_config(bucket);
                     // Merge user-provided opendal_backends on top (if any)
                     let mut merged = cos_config;
-                    if let Some(extra) = self.config.opendal_backends.get(scheme) {
-                        for (k, v) in extra {
-                            merged.insert(k.clone(), v.clone());
-                        }
-                    }
+                    merged.extend(self.config.opendal_backends.clone());
                     merged
                 } else {
-                    self.config
-                        .opendal_backends
-                        .get(scheme)
-                        .unwrap_or(&empty_config)
-                        .clone()
+                    self.config.opendal_backends.clone()
                 };
                 OpenDALSource::get_client(scheme, &backend_config).await? as Arc<dyn ObjectSource>
             }

--- a/tests/io/test_opendal.py
+++ b/tests/io/test_opendal.py
@@ -34,13 +34,7 @@ def csv_data(tmp_path):
 
 def _fs_io_config(root_dir: Path) -> IOConfig:
     """Create an IOConfig using OpenDAL's 'fs' (filesystem) backend."""
-    return IOConfig(
-        opendal_backends={
-            "fs": {
-                "root": str(root_dir),
-            }
-        }
-    )
+    return IOConfig(opendal_backends={"root": str(root_dir)})
 
 
 def test_opendal_fs_read_parquet(parquet_data):
@@ -82,10 +76,7 @@ def test_opendal_ioconfig_roundtrip():
     import pickle
 
     config = IOConfig(
-        opendal_backends={
-            "oss": {"bucket": "my-bucket", "access_key_id": "test"},
-            "cos": {"bucket": "other-bucket"},
-        }
+        opendal_backends={"bucket": "my-bucket", "access_key_id": "test"},
     )
 
     restored = pickle.loads(pickle.dumps(config))
@@ -95,11 +86,11 @@ def test_opendal_ioconfig_roundtrip():
 
 def test_opendal_ioconfig_replace():
     """Test that IOConfig.replace works with opendal_backends."""
-    config = IOConfig(opendal_backends={"oss": {"bucket": "original"}})
-    replaced = config.replace(opendal_backends={"cos": {"bucket": "new"}})
+    config = IOConfig(opendal_backends={"bucket": "original"})
+    replaced = config.replace(opendal_backends={"bucket": "new"})
 
-    assert replaced.opendal_backends == {"cos": {"bucket": "new"}}
-    assert config.opendal_backends == {"oss": {"bucket": "original"}}
+    assert replaced.opendal_backends == {"bucket": "new"}
+    assert config.opendal_backends == {"bucket": "original"}
 
 
 def test_opendal_fs_write_parquet(tmp_path):

--- a/tests/io/test_protocol_aliases.py
+++ b/tests/io/test_protocol_aliases.py
@@ -85,7 +85,7 @@ def parquet_data(tmp_path):
 def _alias_fs_io_config(root_dir: Path) -> IOConfig:
     """Create IOConfig that aliases 'myfs' -> 'fs' with OpenDAL fs backend."""
     return IOConfig(
-        opendal_backends={"fs": {"root": str(root_dir)}},
+        opendal_backends={"root": str(root_dir)},
         protocol_aliases={"myfs": "fs"},
     )
 


### PR DESCRIPTION
## Changes Made
This PR modifies the parameter type of opendal_backends: dict[str, dict[str, str]] to dict[str, str] in order to eliminate redundant scheme definitions and unnecessary JSON nesting .
<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
"Closes #6447 "