### PR TITLE
feat: optionally keep the native progress bar visible after job completion

### DIFF
--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -37,14 +37,24 @@ fn should_enable_process_monitor() -> bool {
     }
 }
 
-fn should_enable_progress_bar() -> bool {
+enum ProgressBarMode {
+    Disabled,
+    Enabled,
+    Persist,
+}
+
+fn progress_bar_mode() -> ProgressBarMode {
     if std::env::var("DAFT_FLOTILLA_WORKER").is_ok() {
-        return false;
+        return ProgressBarMode::Disabled;
     }
-    if let Ok(val) = std::env::var("DAFT_PROGRESS_BAR") {
-        matches!(val.trim().to_lowercase().as_str(), "1" | "true")
-    } else {
-        true // Return true when env var is not set
+    match std::env::var("DAFT_PROGRESS_BAR")
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("true")
+    {
+        val if val.eq_ignore_ascii_case("persist") => ProgressBarMode::Persist,
+        val if matches!(val.to_lowercase().as_str(), "1" | "true") => ProgressBarMode::Enabled,
+        _ => ProgressBarMode::Disabled,
     }
 }
 
@@ -146,10 +156,10 @@ impl RuntimeStatsManager {
             subscriber.on_exec_start(query_id.clone(), serialized_plan.clone())?;
         }
 
-        let progress_bar = if should_enable_progress_bar() {
-            Some(make_progress_bar_manager(&node_info_map))
-        } else {
-            None
+        let progress_bar = match progress_bar_mode() {
+            ProgressBarMode::Disabled => None,
+            ProgressBarMode::Enabled => Some(make_progress_bar_manager(&node_info_map, false)),
+            ProgressBarMode::Persist => Some(make_progress_bar_manager(&node_info_map, true)),
         };
 
         let throttle_interval = Duration::from_millis(200);

--- a/src/daft-local-execution/src/runtime_stats/progress_bar.rs
+++ b/src/daft-local-execution/src/runtime_stats/progress_bar.rs
@@ -88,10 +88,11 @@ struct IndicatifProgressBarManager {
     multi_progress: indicatif::MultiProgress,
     pbars: Vec<indicatif::ProgressBar>,
     total: usize,
+    persist_on_finish: bool,
 }
 
 impl IndicatifProgressBarManager {
-    fn new(node_info_map: &HashMap<NodeID, Arc<NodeInfo>>) -> Self {
+    fn new(node_info_map: &HashMap<NodeID, Arc<NodeInfo>>, persist_on_finish: bool) -> Self {
         let multi_progress = indicatif::MultiProgress::new();
 
         if cfg!(feature = "python") {
@@ -113,6 +114,7 @@ impl IndicatifProgressBarManager {
             multi_progress,
             pbars: Vec::new(),
             total,
+            persist_on_finish,
         };
 
         // Determine max name for alignment and minimizing whitespace
@@ -203,27 +205,36 @@ impl ProgressBar for IndicatifProgressBarManager {
     }
 
     fn finish(mut self: Box<Self>) -> DaftResult<()> {
-        self.pbars.clear();
-        self.multi_progress.clear()?;
+        if !self.persist_on_finish {
+            self.pbars.clear();
+            self.multi_progress.clear()?;
+        }
         Ok(())
     }
 }
 
 pub fn make_progress_bar_manager(
     node_info_map: &HashMap<NodeID, Arc<NodeInfo>>,
+    persist_on_finish: bool,
 ) -> Box<dyn ProgressBar> {
     #[cfg(feature = "python")]
     {
         if python::in_notebook() {
             Box::new(python::TqdmProgressBarManager::new(node_info_map))
         } else {
-            Box::new(IndicatifProgressBarManager::new(node_info_map))
+            Box::new(IndicatifProgressBarManager::new(
+                node_info_map,
+                persist_on_finish,
+            ))
         }
     }
 
     #[cfg(not(feature = "python"))]
     {
-        Box::new(IndicatifProgressBarManager::new(node_info_map))
+        Box::new(IndicatifProgressBarManager::new(
+            node_info_map,
+            persist_on_finish,
+        ))
     }
 }
 
@@ -347,6 +358,6 @@ mod tests {
         node_info_map.insert(0, node_info);
 
         // This panics in make_new_bar due to byte-level string slicing on multi-byte UTF-8
-        let _manager = IndicatifProgressBarManager::new(&node_info_map);
+        let _manager = IndicatifProgressBarManager::new(&node_info_map, false);
     }
 }


### PR DESCRIPTION
## Changes Made

Allow setting `DAFT_PROGRESS_BAR=persist` to keep the Indicatif progress bar visible after job completion, instead of the default behavior where it clears on finish.

Changes:
- Replaced `should_enable_progress_bar()` with a `ProgressBarMode` enum supporting `Disabled`, `Enabled`, and `Persist` modes
- Added `persist_on_finish` field to `IndicatifProgressBarManager`
- Updated `finish()` to conditionally persist or clear progress bars

Note: TQDM/notebook persist is not implemented because Jupyter notebooks retain cell output by default, making the persist option unnecessary.

Manually tested both persist and normal modes in terminal and Jupyter notebook.

## Related Issues

Continues work from #5570 by @samstokes, with reviewer feedback addressed.