### PR TITLE
refactor(io): move common source fields to own type

### DIFF
--- a/src/daft-micropartition/src/python.rs
+++ b/src/daft-micropartition/src/python.rs
@@ -17,7 +17,7 @@ use daft_io::{IOStatsContext, python::IOConfig};
 use daft_json::{JsonConvertOptions, JsonParseOptions, JsonReadOptions};
 use daft_parquet::read::ParquetSchemaInferenceOptions;
 use daft_recordbatch::{RecordBatch, python::PyRecordBatch};
-use daft_scan::{ScanSource, ScanTaskRef, storage_config::StorageConfig};
+use daft_scan::{ScanSourceKind, ScanTaskRef, storage_config::StorageConfig};
 use daft_stats::{TableMetadata, TableStatistics};
 use pyo3::{PyTypeInfo, exceptions::PyValueError, prelude::*, types::PyBytes};
 use snafu::ResultExt;
@@ -1084,12 +1084,11 @@ pub fn read_pyfunc_into_table_iter(
 ) -> crate::Result<impl Iterator<Item = crate::Result<RecordBatch>>> {
     let table_iterators = scan_task.sources.iter().map(|source| {
         // Call Python function to create an Iterator (Grabs the GIL and then releases it)
-        match source {
-            ScanSource::PythonFactoryFunction {
+        match &source.kind {
+            ScanSourceKind::PythonFactoryFunction {
                 module,
                 func_name,
                 func_args,
-                ..
             } => {
                 Python::attach(|py| {
                     let func = py.import(module.as_str())
@@ -1101,7 +1100,7 @@ pub fn read_pyfunc_into_table_iter(
                         .map(Into::<pyo3::Py<pyo3::PyAny>>::into)
                 })
             },
-            _ => unreachable!("PythonFunction file format must be paired with PythonFactoryFunction data file sources"),
+            _ => unreachable!("PythonFunction file format must be paired with PythonFactoryFunction scan sources"),
         }
     }).collect::<crate::Result<Vec<_>>>()?;
 

--- a/src/daft-scan/src/anonymous.rs
+++ b/src/daft-scan/src/anonymous.rs
@@ -5,7 +5,7 @@ use daft_schema::schema::SchemaRef;
 
 use crate::{
     ChunkSpec, FileFormatConfig, ParquetSourceConfig, PartitionField, Pushdowns, ScanOperator,
-    ScanSource, ScanTask, ScanTaskRef, SourceConfig, storage_config::StorageConfig,
+    ScanSource, ScanSourceKind, ScanTask, ScanTaskRef, SourceConfig, storage_config::StorageConfig,
 };
 #[derive(Debug)]
 pub struct AnonymousScanOperator {
@@ -104,15 +104,17 @@ impl ScanOperator for AnonymousScanOperator {
             .map(|(f, rg)| {
                 let chunk_spec = rg.map(ChunkSpec::Parquet);
                 Arc::new(ScanTask::new(
-                    vec![ScanSource::File {
-                        path: f,
-                        chunk_spec,
+                    vec![ScanSource {
                         size_bytes: None,
-                        iceberg_delete_files: None,
                         metadata: None,
-                        partition_spec: None,
                         statistics: None,
-                        parquet_metadata: None,
+                        partition_spec: None,
+                        kind: ScanSourceKind::File {
+                            path: f,
+                            chunk_spec,
+                            iceberg_delete_files: None,
+                            parquet_metadata: None,
+                        },
                     }],
                     source_config.clone(),
                     schema.clone(),

--- a/src/daft-scan/src/glob.rs
+++ b/src/daft-scan/src/glob.rs
@@ -20,7 +20,7 @@ use snafu::Snafu;
 
 use crate::{
     ChunkSpec, CsvSourceConfig, FileFormatConfig, ParquetSourceConfig, PartitionField, Pushdowns,
-    ScanOperator, ScanSource, ScanTask, ScanTaskRef, SourceConfig,
+    ScanOperator, ScanSource, ScanSourceKind, ScanTask, ScanTaskRef, SourceConfig,
     hive::{hive_partitions_to_fields, hive_partitions_to_series, parse_hive_partitioning},
     storage_config::StorageConfig,
 };
@@ -576,7 +576,7 @@ impl ScanOperator for GlobScanOperator {
                         .flatten();
                     let chunk_spec = row_group.map(ChunkSpec::Parquet);
                     Ok(Some(ScanTask::new(
-                        vec![ScanSource::File {
+                        vec![ScanSource {
                             metadata: if let Some(first_filepath) = first_filepath
                                 && path == *first_filepath
                             {
@@ -584,13 +584,15 @@ impl ScanOperator for GlobScanOperator {
                             } else {
                                 None
                             },
-                            path,
-                            chunk_spec,
                             size_bytes,
-                            iceberg_delete_files: None,
                             partition_spec,
                             statistics: None,
-                            parquet_metadata: None,
+                            kind: ScanSourceKind::File {
+                                path,
+                                chunk_spec,
+                                iceberg_delete_files: None,
+                                parquet_metadata: None,
+                            },
                         }],
                         source_config.clone(),
                         schema.clone(),

--- a/src/daft-scan/src/lib.rs
+++ b/src/daft-scan/src/lib.rs
@@ -158,87 +158,66 @@ impl ChunkSpec {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum ScanSource {
+pub struct ScanSource {
+    pub size_bytes: Option<u64>,
+    pub metadata: Option<TableMetadata>,
+    pub statistics: Option<TableStatistics>,
+    pub partition_spec: Option<PartitionSpec>,
+    pub kind: ScanSourceKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ScanSourceKind {
     File {
         path: String,
         chunk_spec: Option<ChunkSpec>,
-        size_bytes: Option<u64>,
         iceberg_delete_files: Option<Vec<String>>,
-        metadata: Option<TableMetadata>,
-        partition_spec: Option<PartitionSpec>,
-        statistics: Option<TableStatistics>,
         parquet_metadata: Option<Arc<DaftParquetMetadata>>,
     },
     Database {
         path: String,
-        size_bytes: Option<u64>,
-        metadata: Option<TableMetadata>,
-        statistics: Option<TableStatistics>,
     },
     #[cfg(feature = "python")]
     PythonFactoryFunction {
         module: String,
         func_name: String,
         func_args: python::PythonTablesFactoryArgs,
-        size_bytes: Option<u64>,
-        metadata: Option<TableMetadata>,
-        statistics: Option<TableStatistics>,
-        partition_spec: Option<PartitionSpec>,
     },
 }
 
 impl Hash for ScanSource {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        // Hash everything except for cached parquet metadata.
-        match self {
-            Self::File {
+        self.size_bytes.hash(state);
+        self.metadata.hash(state);
+        self.statistics.hash(state);
+        self.partition_spec.hash(state);
+        // Hash the kind, skipping parquet_metadata (cached, not identity).
+        match &self.kind {
+            ScanSourceKind::File {
                 path,
                 chunk_spec,
-                size_bytes,
                 iceberg_delete_files,
-                metadata,
-                partition_spec,
-                statistics,
                 ..
             } => {
+                0u8.hash(state);
                 path.hash(state);
-                if let Some(chunk_spec) = chunk_spec {
-                    chunk_spec.hash(state);
-                }
-                size_bytes.hash(state);
+                chunk_spec.hash(state);
                 iceberg_delete_files.hash(state);
-                metadata.hash(state);
-                partition_spec.hash(state);
-                statistics.hash(state);
             }
-            Self::Database {
-                path,
-                size_bytes,
-                metadata,
-                statistics,
-            } => {
+            ScanSourceKind::Database { path } => {
+                1u8.hash(state);
                 path.hash(state);
-                size_bytes.hash(state);
-                metadata.hash(state);
-                statistics.hash(state);
             }
             #[cfg(feature = "python")]
-            Self::PythonFactoryFunction {
+            ScanSourceKind::PythonFactoryFunction {
                 module,
                 func_name,
                 func_args,
-                size_bytes,
-                metadata,
-                statistics,
-                partition_spec,
             } => {
+                2u8.hash(state);
                 module.hash(state);
                 func_name.hash(state);
                 func_args.hash(state);
-                size_bytes.hash(state);
-                metadata.hash(state);
-                statistics.hash(state);
-                partition_spec.hash(state);
             }
         }
     }
@@ -247,17 +226,17 @@ impl Hash for ScanSource {
 impl ScanSource {
     #[must_use]
     pub fn get_path(&self) -> &str {
-        match self {
-            Self::File { path, .. } | Self::Database { path, .. } => path,
+        match &self.kind {
+            ScanSourceKind::File { path, .. } | ScanSourceKind::Database { path, .. } => path,
             #[cfg(feature = "python")]
-            Self::PythonFactoryFunction { module, .. } => module,
+            ScanSourceKind::PythonFactoryFunction { module, .. } => module,
         }
     }
 
     #[must_use]
     pub fn get_parquet_metadata(&self) -> Option<&Arc<DaftParquetMetadata>> {
-        match self {
-            Self::File {
+        match &self.kind {
+            ScanSourceKind::File {
                 parquet_metadata, ..
             } => parquet_metadata.as_ref(),
             _ => None,
@@ -266,57 +245,16 @@ impl ScanSource {
 
     #[must_use]
     pub fn get_chunk_spec(&self) -> Option<&ChunkSpec> {
-        match self {
-            Self::File { chunk_spec, .. } => chunk_spec.as_ref(),
-            Self::Database { .. } => None,
-            #[cfg(feature = "python")]
-            Self::PythonFactoryFunction { .. } => None,
-        }
-    }
-
-    #[must_use]
-    pub fn get_size_bytes(&self) -> Option<u64> {
-        match self {
-            Self::File { size_bytes, .. } | Self::Database { size_bytes, .. } => *size_bytes,
-            #[cfg(feature = "python")]
-            Self::PythonFactoryFunction { size_bytes, .. } => *size_bytes,
-        }
-    }
-
-    #[must_use]
-    pub fn get_metadata(&self) -> Option<&TableMetadata> {
-        match self {
-            Self::File { metadata, .. } | Self::Database { metadata, .. } => metadata.as_ref(),
-            #[cfg(feature = "python")]
-            Self::PythonFactoryFunction { metadata, .. } => metadata.as_ref(),
-        }
-    }
-
-    #[must_use]
-    pub fn get_statistics(&self) -> Option<&TableStatistics> {
-        match self {
-            Self::File { statistics, .. } | Self::Database { statistics, .. } => {
-                statistics.as_ref()
-            }
-            #[cfg(feature = "python")]
-            Self::PythonFactoryFunction { statistics, .. } => statistics.as_ref(),
-        }
-    }
-
-    #[must_use]
-    pub fn get_partition_spec(&self) -> Option<&PartitionSpec> {
-        match self {
-            Self::File { partition_spec, .. } => partition_spec.as_ref(),
-            Self::Database { .. } => None,
-            #[cfg(feature = "python")]
-            Self::PythonFactoryFunction { partition_spec, .. } => partition_spec.as_ref(),
+        match &self.kind {
+            ScanSourceKind::File { chunk_spec, .. } => chunk_spec.as_ref(),
+            _ => None,
         }
     }
 
     #[must_use]
     pub fn get_iceberg_delete_files(&self) -> Option<&Vec<String>> {
-        match self {
-            Self::File {
+        match &self.kind {
+            ScanSourceKind::File {
                 iceberg_delete_files,
                 ..
             } => iceberg_delete_files.as_ref(),
@@ -327,16 +265,12 @@ impl ScanSource {
     #[must_use]
     pub fn multiline_display(&self) -> Vec<String> {
         let mut res = vec![];
-        match self {
-            Self::File {
+        match &self.kind {
+            ScanSourceKind::File {
                 path,
                 chunk_spec,
-                size_bytes,
                 iceberg_delete_files,
-                metadata,
-                partition_spec,
-                statistics,
-                parquet_metadata: _,
+                ..
             } => {
                 res.push(format!("Path = {path}"));
                 if let Some(chunk_spec) = chunk_spec {
@@ -345,78 +279,38 @@ impl ScanSource {
                         chunk_spec.multiline_display().join(", ")
                     ));
                 }
-                if let Some(size_bytes) = size_bytes {
-                    res.push(format!("Size bytes = {size_bytes}"));
-                }
                 if let Some(iceberg_delete_files) = iceberg_delete_files {
                     res.push(format!("Iceberg delete files = {iceberg_delete_files:?}"));
                 }
-                if let Some(metadata) = metadata {
-                    res.push(format!(
-                        "Metadata = {}",
-                        metadata.multiline_display().join(", ")
-                    ));
-                }
-                if let Some(partition_spec) = partition_spec {
-                    res.push(format!(
-                        "Partition spec = {}",
-                        partition_spec.multiline_display().join(", ")
-                    ));
-                }
-                if let Some(statistics) = statistics {
-                    res.push(format!("Statistics = {statistics}"));
-                }
             }
-            Self::Database {
-                path,
-                size_bytes,
-                metadata,
-                statistics,
-            } => {
+            ScanSourceKind::Database { path } => {
                 res.push(format!("Path = {path}"));
-                if let Some(size_bytes) = size_bytes {
-                    res.push(format!("Size bytes = {size_bytes}"));
-                }
-                if let Some(metadata) = metadata {
-                    res.push(format!(
-                        "Metadata = {}",
-                        metadata.multiline_display().join(", ")
-                    ));
-                }
-                if let Some(statistics) = statistics {
-                    res.push(format!("Statistics = {statistics}"));
-                }
             }
             #[cfg(feature = "python")]
-            Self::PythonFactoryFunction {
-                module,
-                func_name,
-                func_args: _func_args,
-                size_bytes,
-                metadata,
-                statistics,
-                partition_spec,
+            ScanSourceKind::PythonFactoryFunction {
+                module, func_name, ..
             } => {
                 res.push(format!("Function = {module}.{func_name}"));
-                if let Some(size_bytes) = size_bytes {
-                    res.push(format!("Size bytes = {size_bytes}"));
-                }
-                if let Some(metadata) = metadata {
-                    res.push(format!(
-                        "Metadata = {}",
-                        metadata.multiline_display().join(", ")
-                    ));
-                }
-                if let Some(partition_spec) = partition_spec {
-                    res.push(format!(
-                        "Partition spec = {}",
-                        partition_spec.multiline_display().join(", ")
-                    ));
-                }
-                if let Some(statistics) = statistics {
-                    res.push(format!("Statistics = {statistics}"));
-                }
             }
+        }
+        // Common fields.
+        if let Some(size_bytes) = self.size_bytes {
+            res.push(format!("Size bytes = {size_bytes}"));
+        }
+        if let Some(metadata) = &self.metadata {
+            res.push(format!(
+                "Metadata = {}",
+                metadata.multiline_display().join(", ")
+            ));
+        }
+        if let Some(partition_spec) = &self.partition_spec {
+            res.push(format!(
+                "Partition spec = {}",
+                partition_spec.multiline_display().join(", ")
+            ));
+        }
+        if let Some(statistics) = &self.statistics {
+            res.push(format!("Statistics = {statistics}"));
         }
         res
     }
@@ -426,13 +320,13 @@ impl DisplayAs for ScanSource {
     fn display_as(&self, level: common_display::DisplayLevel) -> String {
         match level {
             common_display::DisplayLevel::Compact | common_display::DisplayLevel::Default => {
-                match self {
-                    Self::File { path, .. } => {
+                match &self.kind {
+                    ScanSourceKind::File { path, .. } => {
                         format!("File {{{path}}}")
                     }
-                    Self::Database { path, .. } => format!("Database {{{path}}}"),
+                    ScanSourceKind::Database { path, .. } => format!("Database {{{path}}}"),
                     #[cfg(feature = "python")]
-                    Self::PythonFactoryFunction {
+                    ScanSourceKind::PythonFactoryFunction {
                         module, func_name, ..
                     } => {
                         format!("{module}:{func_name}")
@@ -507,16 +401,16 @@ impl ScanTask {
         debug_assert!(
             sources
                 .iter()
-                .all(|s| s.get_partition_spec() == sources.first().unwrap().get_partition_spec()),
+                .all(|s| s.partition_spec == sources.first().unwrap().partition_spec),
             "ScanTask sources must all have the same PartitionSpec at construction",
         );
         let (length, size_bytes_on_disk, statistics) = sources
             .iter()
             .map(|s| {
                 (
-                    s.get_metadata().map(|m| m.length),
-                    s.get_size_bytes(),
-                    s.get_statistics().cloned(),
+                    s.metadata.as_ref().map(|m| m.length),
+                    s.size_bytes,
+                    s.statistics.clone(),
                 )
             })
             .reduce(
@@ -696,8 +590,8 @@ impl ScanTask {
     pub fn get_file_paths(&self) -> Vec<String> {
         self.sources
             .iter()
-            .filter_map(|s| match s {
-                ScanSource::File { path, .. } => Some(path.clone()),
+            .filter_map(|s| match &s.kind {
+                ScanSourceKind::File { path, .. } => Some(path.clone()),
                 _ => None,
             })
             .collect()
@@ -791,8 +685,8 @@ impl ScanTask {
     fn is_gzipped(&self) -> bool {
         self.sources
             .first()
-            .and_then(|s| match s {
-                ScanSource::File { path, .. } => {
+            .and_then(|s| match &s.kind {
+                ScanSourceKind::File { path, .. } => {
                     let filename = std::path::Path::new(path);
                     Some(
                         filename
@@ -875,10 +769,7 @@ impl ScanTask {
 
     #[must_use]
     pub fn partition_spec(&self) -> Option<&PartitionSpec> {
-        match self.sources.first() {
-            None => None,
-            Some(source) => source.get_partition_spec(),
-        }
+        self.sources.first().and_then(|s| s.partition_spec.as_ref())
     }
 
     #[must_use]
@@ -985,21 +876,24 @@ mod test {
     use itertools::Itertools;
 
     use crate::{
-        FileFormatConfig, ParquetSourceConfig, Pushdowns, ScanOperator, ScanSource, ScanTask,
-        SourceConfig, WarcSourceConfig, glob::GlobScanOperator, storage_config::StorageConfig,
+        FileFormatConfig, ParquetSourceConfig, Pushdowns, ScanOperator, ScanSource, ScanSourceKind,
+        ScanTask, SourceConfig, WarcSourceConfig, glob::GlobScanOperator,
+        storage_config::StorageConfig,
     };
 
     fn make_scan_task(num_sources: usize) -> ScanTask {
         let sources = (0..num_sources)
-            .map(|i| ScanSource::File {
-                path: format!("test{i}"),
-                chunk_spec: None,
+            .map(|i| ScanSource {
                 size_bytes: None,
-                iceberg_delete_files: None,
                 metadata: None,
-                partition_spec: None,
                 statistics: None,
-                parquet_metadata: None,
+                partition_spec: None,
+                kind: ScanSourceKind::File {
+                    path: format!("test{i}"),
+                    chunk_spec: None,
+                    iceberg_delete_files: None,
+                    parquet_metadata: None,
+                },
             })
             .collect_vec();
 
@@ -1138,17 +1032,19 @@ mod test {
 
     #[test]
     fn test_warc_memory_estimation_with_extremely_large_row_count() {
-        let sources = vec![ScanSource::File {
-            path: "test.warc.gz".to_string(),
-            chunk_spec: None,
+        let sources = vec![ScanSource {
             size_bytes: Some(1_000_000),
-            iceberg_delete_files: None,
             metadata: Some(TableMetadata {
                 length: usize::MAX, // Extremely large row count
             }),
-            partition_spec: None,
             statistics: None,
-            parquet_metadata: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: "test.warc.gz".to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
         }];
 
         let schema = Arc::new(Schema::new(vec![
@@ -1180,15 +1076,17 @@ mod test {
 
     #[test]
     fn test_warc_memory_estimation_with_large_row_count_f64() {
-        let sources = vec![ScanSource::File {
-            path: "test.warc.gz".to_string(),
-            chunk_spec: None,
+        let sources = vec![ScanSource {
             size_bytes: Some(1_000_000_000_000), // 1TB file
-            iceberg_delete_files: None,
-            metadata: None, // No metadata, will use file size estimation
-            partition_spec: None,
+            metadata: None,                      // No metadata, will use file size estimation
             statistics: None,
-            parquet_metadata: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: "test.warc.gz".to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
         }];
 
         let schema = Arc::new(Schema::new(vec![
@@ -1221,17 +1119,19 @@ mod test {
 
     #[test]
     fn test_warc_memory_estimation_valid_edge_case() {
-        let sources = vec![ScanSource::File {
-            path: "test.warc.gz".to_string(),
-            chunk_spec: None,
+        let sources = vec![ScanSource {
             size_bytes: Some(10_000_000), // 10MB
-            iceberg_delete_files: None,
             metadata: Some(TableMetadata {
                 length: 1000, // 1000 rows
             }),
-            partition_spec: None,
             statistics: None,
-            parquet_metadata: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: "test.warc.gz".to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
         }];
 
         let schema = Arc::new(Schema::new(vec![
@@ -1262,17 +1162,19 @@ mod test {
 
     #[test]
     fn test_schema_row_size_estimation_with_extremely_large_row_count() {
-        let sources = vec![ScanSource::File {
-            path: "test.parquet".to_string(),
-            chunk_spec: None,
+        let sources = vec![ScanSource {
             size_bytes: Some(1_000_000),
-            iceberg_delete_files: None,
             metadata: Some(TableMetadata {
                 length: usize::MAX, // Extremely large row count
             }),
-            partition_spec: None,
             statistics: None,
-            parquet_metadata: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: "test.parquet".to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
         }];
 
         // Create a schema with multiple fields
@@ -1309,15 +1211,17 @@ mod test {
 
     #[test]
     fn test_schema_row_size_estimation_with_nested_schema() {
-        let sources = vec![ScanSource::File {
-            path: "test.parquet".to_string(),
-            chunk_spec: None,
+        let sources = vec![ScanSource {
             size_bytes: Some(100_000_000), // 100MB
-            iceberg_delete_files: None,
-            metadata: None, // Will use approx_num_rows
-            partition_spec: None,
+            metadata: None,                // Will use approx_num_rows
             statistics: None,
-            parquet_metadata: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: "test.parquet".to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
         }];
 
         // Create a deeply nested schema
@@ -1357,15 +1261,17 @@ mod test {
 
     #[test]
     fn test_schema_row_size_estimation_with_large_file_no_metadata() {
-        let sources = vec![ScanSource::File {
-            path: "test.parquet".to_string(),
-            chunk_spec: None,
+        let sources = vec![ScanSource {
             size_bytes: Some(u64::MAX / 100), // Very large file
-            iceberg_delete_files: None,
             metadata: None,
-            partition_spec: None,
             statistics: None,
-            parquet_metadata: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: "test.parquet".to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
         }];
 
         let schema = Arc::new(Schema::new(vec![
@@ -1401,15 +1307,17 @@ mod test {
 
     #[test]
     fn test_schema_row_size_estimation_valid_case() {
-        let sources = vec![ScanSource::File {
-            path: "test.parquet".to_string(),
-            chunk_spec: None,
+        let sources = vec![ScanSource {
             size_bytes: Some(1_000_000),
-            iceberg_delete_files: None,
             metadata: Some(TableMetadata { length: 10_000 }),
-            partition_spec: None,
             statistics: None,
-            parquet_metadata: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: "test.parquet".to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
         }];
 
         let schema = Arc::new(Schema::new(vec![
@@ -1445,15 +1353,17 @@ mod test {
 
     #[test]
     fn test_overflow_protection_with_infinity() {
-        let sources = vec![ScanSource::File {
-            path: "test.parquet".to_string(),
-            chunk_spec: None,
+        let sources = vec![ScanSource {
             size_bytes: Some(u64::MAX), // Maximum possible file size
-            iceberg_delete_files: None,
             metadata: None,
-            partition_spec: None,
             statistics: None,
-            parquet_metadata: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: "test.parquet".to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
         }];
 
         let schema = Arc::new(Schema::new(vec![Field::new("col1", DataType::Int64)]));

--- a/src/daft-scan/src/python.rs
+++ b/src/daft-scan/src/python.rs
@@ -183,7 +183,8 @@ pub mod pylib {
     use super::{PyFileFormatConfig, PythonTablesFactoryArgs};
     use crate::{
         DatabaseSourceConfig, FileFormatConfig, PartitionField, Pushdowns, ScanOperator,
-        ScanOperatorRef, ScanSource, ScanTask, ScanTaskRef, SourceConfig, SupportsPushdownFilters,
+        ScanOperatorRef, ScanSource, ScanSourceKind, ScanTask, ScanTaskRef, SourceConfig,
+        SupportsPushdownFilters,
         anonymous::AnonymousScanOperator,
         glob::GlobScanOperator,
         python::pylib_scan_info::{PyPartitionField, PyPushdowns},
@@ -600,15 +601,17 @@ pub mod pylib {
 
             let metadata = num_rows.map(|n| TableMetadata { length: n as usize });
 
-            let data_source = ScanSource::File {
-                path: file,
-                chunk_spec: None,
+            let data_source = ScanSource {
                 size_bytes,
-                iceberg_delete_files,
                 metadata,
-                partition_spec: Some(pspec),
                 statistics,
-                parquet_metadata: None,
+                partition_spec: Some(pspec),
+                kind: ScanSourceKind::File {
+                    path: file,
+                    chunk_spec: None,
+                    iceberg_delete_files,
+                    parquet_metadata: None,
+                },
             };
 
             let file_format_config: Arc<FileFormatConfig> = file_format.into();
@@ -648,11 +651,12 @@ pub mod pylib {
             let statistics = stats
                 .map(|s| TableStatistics::from_stats_table(&s.record_batch))
                 .transpose()?;
-            let data_source = ScanSource::Database {
-                path: url,
+            let data_source = ScanSource {
                 size_bytes,
                 metadata: num_rows.map(|n| TableMetadata { length: n as usize }),
                 statistics,
+                partition_spec: None,
+                kind: ScanSourceKind::Database { path: url },
             };
 
             let scan_task = ScanTask::new(
@@ -693,18 +697,20 @@ pub mod pylib {
             let statistics = stats
                 .map(|s| TableStatistics::from_stats_table(&s.record_batch))
                 .transpose()?;
-            let data_source = ScanSource::PythonFactoryFunction {
-                module: module.clone(),
-                func_name: func_name.clone(),
-                func_args: PythonTablesFactoryArgs::new(
-                    func_args.into_iter().map(Arc::new).collect(),
-                ),
+            let data_source = ScanSource {
                 size_bytes,
                 metadata: num_rows.map(|num_rows| TableMetadata {
                     length: num_rows as usize,
                 }),
                 statistics,
                 partition_spec: None,
+                kind: ScanSourceKind::PythonFactoryFunction {
+                    module: module.clone(),
+                    func_name: func_name.clone(),
+                    func_args: PythonTablesFactoryArgs::new(
+                        func_args.into_iter().map(Arc::new).collect(),
+                    ),
+                },
             };
 
             let source_config = Arc::new(SourceConfig::PythonFunction {
@@ -781,11 +787,8 @@ pub mod pylib {
                 None,
             ),
         )?;
-        let data_source = ScanSource::File {
-            path: uri.to_string(),
-            chunk_spec: None,
+        let data_source = ScanSource {
             size_bytes: Some(file_size),
-            iceberg_delete_files: None,
             metadata: if has_metadata.unwrap_or(false) {
                 Some(TableMetadata {
                     length: metadata.num_rows(),
@@ -793,9 +796,14 @@ pub mod pylib {
             } else {
                 None
             },
-            partition_spec: None,
             statistics: None,
-            parquet_metadata: None,
+            partition_spec: None,
+            kind: ScanSourceKind::File {
+                path: uri.to_string(),
+                chunk_spec: None,
+                iceberg_delete_files: None,
+                parquet_metadata: None,
+            },
         };
         let st = ScanTask::new(
             vec![data_source],

--- a/src/daft-scan/src/scan_task_iters/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/mod.rs
@@ -9,8 +9,8 @@ use daft_parquet::{RowGroupList, read::read_parquet_metadata};
 use indexmap::IndexMap;
 
 use crate::{
-    ChunkSpec, FileFormatConfig, ParquetSourceConfig, Pushdowns, ScanSource, ScanTask, ScanTaskRef,
-    SourceConfig,
+    ChunkSpec, FileFormatConfig, ParquetSourceConfig, Pushdowns, ScanSourceKind, ScanTask,
+    ScanTaskRef, SourceConfig,
 };
 
 type BoxScanTaskIter<'a> = Box<dyn Iterator<Item = DaftResult<ScanTaskRef>> + 'a>;
@@ -224,10 +224,10 @@ fn split_by_row_groups(
                     ) = (
                         t.source_config.as_ref(),
                         &t.sources[..],
-                        t.sources.first().map(ScanSource::get_chunk_spec),
+                        t.sources.first().map(|s| s.get_chunk_spec()),
                         t.pushdowns.limit,
                     ) && source
-                        .get_size_bytes()
+                        .size_bytes
                         .is_none_or(|s| s > max_size_bytes as u64)
                       && source
                         .get_iceberg_delete_files()
@@ -266,28 +266,23 @@ fn split_by_row_groups(
                             if curr_size_bytes >= min_size_bytes || Some(i) == last_original_index {
                                 let mut new_source = source.clone();
 
-                                if let ScanSource::File {
+                                if let ScanSourceKind::File {
                                     chunk_spec,
-                                    size_bytes,
                                     parquet_metadata,
                                     ..
-                                } = &mut new_source
+                                } = &mut new_source.kind
                                 {
                                     // only keep relevant row groups in the metadata
                                     let new_metadata = file_metadata.clone_with_row_groups(curr_num_rows, curr_row_groups);
                                     *parquet_metadata = Some(Arc::new(new_metadata));
 
                                     *chunk_spec = Some(ChunkSpec::Parquet(curr_row_group_indices));
-                                    *size_bytes = Some(curr_size_bytes as u64);
+                                    new_source.size_bytes = Some(curr_size_bytes as u64);
                                 } else {
-                                    unreachable!("Parquet file format should only be used with ScanSource::File");
+                                    unreachable!("Parquet file format should only be used with ScanSourceKind::File");
                                 }
 
-                                if let ScanSource::File {
-                                    metadata: Some(metadata),
-                                    ..
-                                } = &mut new_source
-                                {
+                                if let Some(metadata) = &mut new_source.metadata {
                                     metadata.length = curr_num_rows;
                                 }
 

--- a/src/daft-scan/src/scan_task_iters/split_jsonl/mod.rs
+++ b/src/daft-scan/src/scan_task_iters/split_jsonl/mod.rs
@@ -8,8 +8,8 @@ use url::Url;
 use urlencoding::decode;
 
 use crate::{
-    ChunkSpec, FileFormatConfig, JsonSourceConfig, ScanSource, ScanTask, ScanTaskRef, SourceConfig,
-    StorageConfig,
+    ChunkSpec, FileFormatConfig, JsonSourceConfig, ScanSourceKind, ScanTask, ScanTaskRef,
+    SourceConfig, StorageConfig,
 };
 
 type BoxScanTaskIter<'a> = Box<dyn Iterator<Item = DaftResult<ScanTaskRef>> + 'a>;
@@ -32,7 +32,7 @@ pub fn split_by_jsonl_ranges<'a>(
                 ) = (
                     t.source_config.as_ref(),
                     &t.sources[..],
-                    t.sources.first().map(ScanSource::get_chunk_spec),
+                    t.sources.first().map(|s| s.get_chunk_spec()),
                 ) {
                     let path = source.get_path();
                     if !supports_split(path) {
@@ -41,7 +41,7 @@ pub fn split_by_jsonl_ranges<'a>(
 
                     // Determine file size; prefer cached size, else fetch.
                     let size_bytes =
-                        resolve_source_size(path, source.get_size_bytes(), &t.storage_config)?;
+                        resolve_source_size(path, source.size_bytes, &t.storage_config)?;
 
                     if size_bytes <= cfg.scan_tasks_max_size_bytes {
                         return Ok(Box::new(std::iter::once(Ok(t))));
@@ -109,7 +109,7 @@ pub fn split_by_jsonl_ranges<'a>(
                         let end = w[1];
                         assert!(end > start, "Invalid chunk range: start={start}, end={end}");
                         let mut new_source = source.clone();
-                        if let ScanSource::File { chunk_spec, .. } = &mut new_source {
+                        if let ScanSourceKind::File { chunk_spec, .. } = &mut new_source.kind {
                             *chunk_spec = Some(ChunkSpec::Bytes { start, end });
                         }
                         let new_task = ScanTask::new(
@@ -232,19 +232,21 @@ mod tests {
     };
 
     use super::*;
-    use crate::{JsonSourceConfig, ScanTask, StorageConfig};
+    use crate::{JsonSourceConfig, ScanSource, ScanTask, StorageConfig};
 
     fn make_scan_task(path: &str, size_bytes: u64) -> ScanTask {
         ScanTask::new(
-            vec![ScanSource::File {
-                path: path.to_string(),
-                chunk_spec: None,
+            vec![ScanSource {
                 size_bytes: Some(size_bytes),
-                iceberg_delete_files: None,
                 metadata: None,
-                partition_spec: None,
                 statistics: None,
-                parquet_metadata: None,
+                partition_spec: None,
+                kind: ScanSourceKind::File {
+                    path: path.to_string(),
+                    chunk_spec: None,
+                    iceberg_delete_files: None,
+                    parquet_metadata: None,
+                },
             }],
             Arc::new(SourceConfig::File(FileFormatConfig::Json(
                 JsonSourceConfig::default(),
@@ -320,10 +322,10 @@ mod tests {
         for t in tasks {
             let t = t.unwrap();
             let src = &t.sources[0];
-            if let crate::ScanSource::File {
+            if let crate::ScanSourceKind::File {
                 chunk_spec: Some(crate::ChunkSpec::Bytes { start, end }),
                 ..
-            } = src
+            } = &src.kind
             {
                 assert!(
                     end > start,

--- a/src/daft-scan/src/test_utils.rs
+++ b/src/daft-scan/src/test_utils.rs
@@ -6,8 +6,8 @@ use daft_schema::schema::SchemaRef;
 use daft_stats::TableMetadata;
 
 use crate::{
-    FileFormatConfig, PartitionField, Pushdowns, ScanOperator, ScanSource, ScanTask, ScanTaskRef,
-    SourceConfig, SupportsPushdownFilters, storage_config::StorageConfig,
+    FileFormatConfig, PartitionField, Pushdowns, ScanOperator, ScanSource, ScanSourceKind,
+    ScanTask, ScanTaskRef, SourceConfig, SupportsPushdownFilters, storage_config::StorageConfig,
 };
 
 #[derive(Debug)]
@@ -68,15 +68,17 @@ impl ScanOperator for DummyScanOperator {
             .map(|i| {
                 let metadata = self.num_rows_per_task.map(|n| TableMetadata { length: n });
                 Arc::new(ScanTask::new(
-                    vec![ScanSource::File {
-                        path: format!("dummy_file_{}.txt", i),
-                        chunk_spec: None,
+                    vec![ScanSource {
                         size_bytes: None,
-                        iceberg_delete_files: None,
                         metadata,
-                        partition_spec: None,
                         statistics: None,
-                        parquet_metadata: None,
+                        partition_spec: None,
+                        kind: ScanSourceKind::File {
+                            path: format!("dummy_file_{}.txt", i),
+                            chunk_spec: None,
+                            iceberg_delete_files: None,
+                            parquet_metadata: None,
+                        },
                     }],
                     Arc::new(SourceConfig::File(FileFormatConfig::Parquet(
                         Default::default(),


### PR DESCRIPTION
## Changes Made

This splits the common and variant-specific fields from the old ScanSource (prev. DataSource enum) into a ScanSource and ScanSourceKind. This is a step towards making a unified DataSource rust trait rather than using the enums for dispatch which are somewhat the root of our struggles with abstractions here. It's as if we were trying to do OO with the enum and using switches on methods for dispatch, hence why we have methods like getting Iceberg deletes on the 'generic' enum. 

## Related Issues

- Closes #6398 