### PR TITLE
docs: document get_or_infer_runner_type and get_or_create_runner

### DIFF
--- a/daft/runners/__init__.py
+++ b/daft/runners/__init__.py
@@ -42,7 +42,8 @@ def get_or_infer_runner_type() -> str:
     2. Try to determine whether it's currently running on a ray cluster. If so, consider it to be a ray type;
     3. Try to determine based on `DAFT_RUNNER` env variable.
 
-    :return: runner type string ("native" or "ray")
+    Returns:
+        str: The runner type ("native" or "ray").
     """
     return _get_or_infer_runner_type()
 

--- a/daft/runners/__init__.py
+++ b/daft/runners/__init__.py
@@ -18,6 +18,19 @@ def _get_runner() -> Runner[PartitionT] | None:
 
 
 def get_or_create_runner() -> Runner[PartitionT]:
+    """Get or create the current runner instance.
+
+    If a runner has already been set, returns it. Otherwise, creates a new
+    runner using the default configuration (native) and locks it in.
+
+    Returns:
+        Runner[PartitionT]: The current runner instance.
+
+    Note:
+        After calling this function, the runner cannot be changed for the
+        lifetime of the process. Use ``get_or_infer_runner_type`` to check the
+        runner type without this side effect.
+    """
     return _get_or_create_runner()
 
 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -14,6 +14,18 @@ Control the execution backend that Daft will run on by calling these functions o
     options:
         heading_level: 3
 
+## Checking the Runner
+
+Check the execution backend that Daft is currently using.
+
+::: daft.get_or_infer_runner_type
+    options:
+        heading_level: 3
+
+::: daft.get_or_create_runner
+    options:
+        heading_level: 3
+
 ## Setting Configurations
 
 Configure Daft in various ways during execution.

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -14,15 +14,15 @@ Control the execution backend that Daft will run on by calling these functions o
     options:
         heading_level: 3
 
+::: daft.get_or_create_runner
+    options:
+        heading_level: 3
+
 ## Checking the Runner
 
 Check the execution backend that Daft is currently using.
 
 ::: daft.get_or_infer_runner_type
-    options:
-        heading_level: 3
-
-::: daft.get_or_create_runner
     options:
         heading_level: 3
 


### PR DESCRIPTION
## Changes Made

`get_or_infer_runner_type` and `get_or_create_runner` are both exported in `daft.__all__` but were not included in the API docs. This PR:

1. Adds both functions to the Configuration docs page (`docs/api/config.md`) under a new "Checking the Runner" section, placed between "Setting the Runner" and "Setting Configurations".
2. Adds a docstring to `get_or_create_runner` in `daft/runners/__init__.py`, which previously had none. The docstring explains the locking side effect (once called, the runner cannot be changed for the lifetime of the process).