### PR TITLE
feat(observability): track per-operator retained bytes in sinks

### DIFF
--- a/src/common/metrics/src/lib.rs
+++ b/src/common/metrics/src/lib.rs
@@ -117,6 +117,8 @@ impl IntoIterator for Stats {
 
 // Common statistic names
 pub const BYTES_READ_KEY: &str = "bytes.read";
+pub const BYTES_RETAINED_KEY: &str = "bytes.retained";
+pub const BYTES_RETAINED_PEAK_KEY: &str = "bytes.retained.peak";
 pub const BYTES_WRITTEN_KEY: &str = "bytes.written";
 pub const DURATION_KEY: &str = "duration";
 pub const ROWS_IN_KEY: &str = "rows.in";

--- a/src/common/metrics/src/meters.rs
+++ b/src/common/metrics/src/meters.rs
@@ -7,7 +7,8 @@ use atomic_float::AtomicF64;
 use opentelemetry::{InstrumentationScope, KeyValue, global};
 
 use crate::{
-    ATTR_QUERY_ID, DURATION_KEY, QueryID, ROWS_IN_KEY, ROWS_OUT_KEY, UNIT_MICROSECONDS, UNIT_ROWS,
+    ATTR_QUERY_ID, BYTES_RETAINED_KEY, DURATION_KEY, QueryID, ROWS_IN_KEY, ROWS_OUT_KEY,
+    UNIT_BYTES, UNIT_MICROSECONDS, UNIT_ROWS,
 };
 
 pub fn normalize_name(name: impl Into<Cow<'static, str>>) -> String {
@@ -203,6 +204,15 @@ impl Meter {
             ROWS_OUT_KEY,
             None,
             Some(Cow::Borrowed(UNIT_ROWS)),
+        )
+    }
+
+    pub fn bytes_retained_metric(&self) -> Gauge {
+        Gauge::new(
+            &self.otel,
+            BYTES_RETAINED_KEY,
+            None,
+            Some(Cow::Borrowed(UNIT_BYTES)),
         )
     }
 }

--- a/src/common/metrics/src/snapshot.rs
+++ b/src/common/metrics/src/snapshot.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::{
-    BYTES_READ_KEY, BYTES_WRITTEN_KEY, DURATION_KEY, ROWS_IN_KEY, ROWS_OUT_KEY, ROWS_WRITTEN_KEY,
-    Stat, Stats,
+    BYTES_READ_KEY, BYTES_RETAINED_KEY, BYTES_RETAINED_PEAK_KEY, BYTES_WRITTEN_KEY, DURATION_KEY,
+    ROWS_IN_KEY, ROWS_OUT_KEY, ROWS_WRITTEN_KEY, Stat, Stats,
 };
 
 macro_rules! stats {
@@ -32,6 +32,8 @@ pub struct DefaultSnapshot {
     pub cpu_us: u64,
     pub rows_in: u64,
     pub rows_out: u64,
+    pub bytes_retained: u64,
+    pub peak_bytes_retained: u64,
 }
 
 impl StatSnapshotImpl for DefaultSnapshot {
@@ -40,19 +42,47 @@ impl StatSnapshotImpl for DefaultSnapshot {
     }
 
     fn to_stats(&self) -> Stats {
-        stats![
-            DURATION_KEY; Stat::Duration(Duration::from_micros(self.cpu_us)),
-            ROWS_IN_KEY; Stat::Count(self.rows_in),
-            ROWS_OUT_KEY; Stat::Count(self.rows_out),
-        ]
+        let mut entries = SmallVec::with_capacity(5);
+        entries.push((
+            DURATION_KEY.into(),
+            Stat::Duration(Duration::from_micros(self.cpu_us)),
+        ));
+        entries.push((ROWS_IN_KEY.into(), Stat::Count(self.rows_in)));
+        entries.push((ROWS_OUT_KEY.into(), Stat::Count(self.rows_out)));
+        if self.bytes_retained > 0 {
+            entries.push((BYTES_RETAINED_KEY.into(), Stat::Bytes(self.bytes_retained)));
+        }
+        if self.peak_bytes_retained > 0 {
+            entries.push((
+                BYTES_RETAINED_PEAK_KEY.into(),
+                Stat::Bytes(self.peak_bytes_retained),
+            ));
+        }
+        Stats(entries)
     }
 
     fn to_message(&self) -> String {
-        format!(
-            "{} rows in, {} rows out",
-            HumanCount(self.rows_in),
-            HumanCount(self.rows_out)
-        )
+        if self.bytes_retained > 0 {
+            format!(
+                "{} rows in, {} rows out, {} retained",
+                HumanCount(self.rows_in),
+                HumanCount(self.rows_out),
+                HumanBytes(self.bytes_retained)
+            )
+        } else if self.peak_bytes_retained > 0 {
+            format!(
+                "{} rows in, {} rows out, peak {} retained",
+                HumanCount(self.rows_in),
+                HumanCount(self.rows_out),
+                HumanBytes(self.peak_bytes_retained)
+            )
+        } else {
+            format!(
+                "{} rows in, {} rows out",
+                HumanCount(self.rows_in),
+                HumanCount(self.rows_out)
+            )
+        }
     }
 }
 
@@ -206,6 +236,8 @@ pub struct JoinSnapshot {
     pub build_rows_inserted: u64,
     pub probe_rows_in: u64,
     pub probe_rows_out: u64,
+    pub bytes_retained: u64,
+    pub peak_bytes_retained: u64,
 }
 
 impl StatSnapshotImpl for JoinSnapshot {
@@ -214,21 +246,47 @@ impl StatSnapshotImpl for JoinSnapshot {
     }
 
     fn to_stats(&self) -> Stats {
-        stats![
-            DURATION_KEY; Stat::Duration(Duration::from_micros(self.cpu_us)),
-            "build rows inserted"; Stat::Count(self.build_rows_inserted),
-            "probe rows in"; Stat::Count(self.probe_rows_in),
-            "probe rows out"; Stat::Count(self.probe_rows_out),
-        ]
+        let mut entries = SmallVec::with_capacity(6);
+        entries.push((
+            DURATION_KEY.into(),
+            Stat::Duration(Duration::from_micros(self.cpu_us)),
+        ));
+        entries.push((
+            "build rows inserted".into(),
+            Stat::Count(self.build_rows_inserted),
+        ));
+        entries.push(("probe rows in".into(), Stat::Count(self.probe_rows_in)));
+        entries.push(("probe rows out".into(), Stat::Count(self.probe_rows_out)));
+        if self.bytes_retained > 0 {
+            entries.push((BYTES_RETAINED_KEY.into(), Stat::Bytes(self.bytes_retained)));
+        }
+        if self.peak_bytes_retained > 0 {
+            entries.push((
+                BYTES_RETAINED_PEAK_KEY.into(),
+                Stat::Bytes(self.peak_bytes_retained),
+            ));
+        }
+        Stats(entries)
     }
 
     fn to_message(&self) -> String {
-        format!(
+        let base = format!(
             "{} build rows inserted, {} probe rows in, {} probe rows out",
             HumanCount(self.build_rows_inserted),
             HumanCount(self.probe_rows_in),
             HumanCount(self.probe_rows_out)
-        )
+        );
+        if self.bytes_retained > 0 {
+            format!("{}, {} retained", base, HumanBytes(self.bytes_retained))
+        } else if self.peak_bytes_retained > 0 {
+            format!(
+                "{}, peak {} retained",
+                base,
+                HumanBytes(self.peak_bytes_retained)
+            )
+        } else {
+            base
+        }
     }
 }
 

--- a/src/common/metrics/src/snapshot.rs
+++ b/src/common/metrics/src/snapshot.rs
@@ -61,6 +61,7 @@ impl StatSnapshotImpl for DefaultSnapshot {
         Stats(entries)
     }
 
+    // During execution: show live retained. After finalize (retained=0): show peak.
     fn to_message(&self) -> String {
         if self.bytes_retained > 0 {
             format!(
@@ -269,6 +270,7 @@ impl StatSnapshotImpl for JoinSnapshot {
         Stats(entries)
     }
 
+    // During execution: show live retained. After finalize (retained=0): show peak.
     fn to_message(&self) -> String {
         let base = format!(
             "{} build rows inserted, {} probe rows in, {} probe rows out",

--- a/src/daft-distributed/src/pipeline_node/join/broadcast_join.rs
+++ b/src/daft-distributed/src/pipeline_node/join/broadcast_join.rs
@@ -87,6 +87,8 @@ impl RuntimeStats for BroadcastJoinStats {
             build_rows_inserted: self.build_rows_inserted.load(Ordering::SeqCst),
             probe_rows_in: self.probe_rows_in.load(Ordering::SeqCst),
             probe_rows_out: self.probe_rows_out.load(Ordering::SeqCst),
+            bytes_retained: 0,
+            peak_bytes_retained: 0,
         })
     }
 }

--- a/src/daft-distributed/src/pipeline_node/join/stats.rs
+++ b/src/daft-distributed/src/pipeline_node/join/stats.rs
@@ -68,6 +68,8 @@ impl RuntimeStats for BasicJoinStats {
             build_rows_inserted: self.build_rows_inserted.load(Ordering::SeqCst),
             probe_rows_in: self.probe_rows_in.load(Ordering::SeqCst),
             probe_rows_out: self.probe_rows_out.load(Ordering::SeqCst),
+            bytes_retained: 0,
+            peak_bytes_retained: 0,
         })
     }
 }

--- a/src/daft-distributed/src/statistics/stats.rs
+++ b/src/daft-distributed/src/statistics/stats.rs
@@ -131,6 +131,8 @@ impl BaseCounters {
             cpu_us: self.duration_us.load(Ordering::Relaxed),
             rows_in: self.rows_in.load(Ordering::Relaxed),
             rows_out: self.rows_out.load(Ordering::Relaxed),
+            bytes_retained: 0,
+            peak_bytes_retained: 0,
         })
     }
 }

--- a/src/daft-local-execution/src/join/join_node.rs
+++ b/src/daft-local-execution/src/join/join_node.rs
@@ -155,6 +155,9 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
                                 node_initialized = true;
                             }
                             ctx.runtime_stats.add_build_rows_inserted(morsel.len() as u64);
+                            // Tracks raw Arrow data size. The actual hash table memory
+                            // (index structures, padding) is not captured here.
+                            ctx.runtime_stats.add_bytes_retained(morsel.size_bytes() as u64);
                             let state = ctx.build_state.take()
                                 .expect("Build state should be available for build task if ctx.build_state is some");
 
@@ -178,6 +181,7 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
             .take()
             .expect("Build state should be available for finalize build");
         let finalized = ctx.op.finalize_build(build_state)?;
+        ctx.runtime_stats.reset_bytes_retained();
         // Send finalized build state to probe side
         let _ = finalized_build_state_sender.send(finalized);
 

--- a/src/daft-local-execution/src/join/stats.rs
+++ b/src/daft-local-execution/src/join/stats.rs
@@ -1,24 +1,19 @@
-use std::{
-    borrow::Cow,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::{borrow::Cow, sync::atomic::Ordering};
 
 use common_metrics::{
-    Counter, Gauge, JOIN_BUILD_ROWS_INSERTED_KEY, JOIN_PROBE_ROWS_IN_KEY, JOIN_PROBE_ROWS_OUT_KEY,
-    Meter, StatSnapshot, UNIT_ROWS, ops::NodeInfo, snapshot::JoinSnapshot,
+    Counter, JOIN_BUILD_ROWS_INSERTED_KEY, JOIN_PROBE_ROWS_IN_KEY, JOIN_PROBE_ROWS_OUT_KEY, Meter,
+    StatSnapshot, UNIT_ROWS, ops::NodeInfo, snapshot::JoinSnapshot,
 };
 use opentelemetry::KeyValue;
 
-use crate::runtime_stats::RuntimeStats;
+use crate::runtime_stats::{BytesRetainedTracker, RuntimeStats};
 
 pub(crate) struct JoinStats {
     duration_us: Counter,
     build_rows_inserted: Counter,
     probe_rows_in: Counter,
     probe_rows_out: Counter,
-    bytes_retained: AtomicU64,
-    peak_bytes_retained: AtomicU64,
-    bytes_retained_gauge: Gauge,
+    retained: BytesRetainedTracker,
     node_kv: Vec<KeyValue>,
 }
 
@@ -56,9 +51,7 @@ impl RuntimeStats for JoinStats {
                 None,
                 Some(Cow::Borrowed(UNIT_ROWS)),
             ),
-            bytes_retained: AtomicU64::new(0),
-            peak_bytes_retained: AtomicU64::new(0),
-            bytes_retained_gauge: meter.bytes_retained_metric(),
+            retained: BytesRetainedTracker::new(meter),
             node_kv,
         }
     }
@@ -69,8 +62,8 @@ impl RuntimeStats for JoinStats {
             build_rows_inserted: self.build_rows_inserted.load(ordering),
             probe_rows_in: self.probe_rows_in.load(ordering),
             probe_rows_out: self.probe_rows_out.load(ordering),
-            bytes_retained: self.bytes_retained.load(ordering),
-            peak_bytes_retained: self.peak_bytes_retained.load(ordering),
+            bytes_retained: self.retained.load_current(ordering),
+            peak_bytes_retained: self.retained.load_peak(ordering),
         })
     }
 
@@ -90,26 +83,10 @@ impl RuntimeStats for JoinStats {
     }
 
     fn add_bytes_retained(&self, bytes: u64) {
-        let new_val = self.bytes_retained.fetch_add(bytes, Ordering::Relaxed) + bytes;
-        self.peak_bytes_retained
-            .fetch_max(new_val, Ordering::Relaxed);
-        self.bytes_retained_gauge
-            .update(new_val as f64, self.node_kv.as_slice());
-    }
-
-    fn sub_bytes_retained(&self, bytes: u64) {
-        let new_val = self.bytes_retained.fetch_sub(bytes, Ordering::Relaxed) - bytes;
-        self.bytes_retained_gauge
-            .update(new_val as f64, self.node_kv.as_slice());
+        self.retained.add(bytes, self.node_kv.as_slice());
     }
 
     fn reset_bytes_retained(&self) {
-        self.bytes_retained.store(0, Ordering::Relaxed);
-        self.bytes_retained_gauge
-            .update(0.0, self.node_kv.as_slice());
-    }
-
-    fn get_bytes_retained(&self) -> u64 {
-        self.bytes_retained.load(Ordering::Relaxed)
+        self.retained.reset(self.node_kv.as_slice());
     }
 }

--- a/src/daft-local-execution/src/join/stats.rs
+++ b/src/daft-local-execution/src/join/stats.rs
@@ -1,8 +1,11 @@
-use std::{borrow::Cow, sync::atomic::Ordering};
+use std::{
+    borrow::Cow,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use common_metrics::{
-    Counter, JOIN_BUILD_ROWS_INSERTED_KEY, JOIN_PROBE_ROWS_IN_KEY, JOIN_PROBE_ROWS_OUT_KEY, Meter,
-    StatSnapshot, UNIT_ROWS, ops::NodeInfo, snapshot::JoinSnapshot,
+    Counter, Gauge, JOIN_BUILD_ROWS_INSERTED_KEY, JOIN_PROBE_ROWS_IN_KEY, JOIN_PROBE_ROWS_OUT_KEY,
+    Meter, StatSnapshot, UNIT_ROWS, ops::NodeInfo, snapshot::JoinSnapshot,
 };
 use opentelemetry::KeyValue;
 
@@ -13,6 +16,9 @@ pub(crate) struct JoinStats {
     build_rows_inserted: Counter,
     probe_rows_in: Counter,
     probe_rows_out: Counter,
+    bytes_retained: AtomicU64,
+    peak_bytes_retained: AtomicU64,
+    bytes_retained_gauge: Gauge,
     node_kv: Vec<KeyValue>,
 }
 
@@ -50,6 +56,9 @@ impl RuntimeStats for JoinStats {
                 None,
                 Some(Cow::Borrowed(UNIT_ROWS)),
             ),
+            bytes_retained: AtomicU64::new(0),
+            peak_bytes_retained: AtomicU64::new(0),
+            bytes_retained_gauge: meter.bytes_retained_metric(),
             node_kv,
         }
     }
@@ -60,6 +69,8 @@ impl RuntimeStats for JoinStats {
             build_rows_inserted: self.build_rows_inserted.load(ordering),
             probe_rows_in: self.probe_rows_in.load(ordering),
             probe_rows_out: self.probe_rows_out.load(ordering),
+            bytes_retained: self.bytes_retained.load(ordering),
+            peak_bytes_retained: self.peak_bytes_retained.load(ordering),
         })
     }
 
@@ -76,5 +87,29 @@ impl RuntimeStats for JoinStats {
 
     fn add_duration_us(&self, duration_us: u64) {
         self.duration_us.add(duration_us, self.node_kv.as_slice());
+    }
+
+    fn add_bytes_retained(&self, bytes: u64) {
+        let new_val = self.bytes_retained.fetch_add(bytes, Ordering::Relaxed) + bytes;
+        self.peak_bytes_retained
+            .fetch_max(new_val, Ordering::Relaxed);
+        self.bytes_retained_gauge
+            .update(new_val as f64, self.node_kv.as_slice());
+    }
+
+    fn sub_bytes_retained(&self, bytes: u64) {
+        let new_val = self.bytes_retained.fetch_sub(bytes, Ordering::Relaxed) - bytes;
+        self.bytes_retained_gauge
+            .update(new_val as f64, self.node_kv.as_slice());
+    }
+
+    fn reset_bytes_retained(&self) {
+        self.bytes_retained.store(0, Ordering::Relaxed);
+        self.bytes_retained_gauge
+            .update(0.0, self.node_kv.as_slice());
+    }
+
+    fn get_bytes_retained(&self) -> u64 {
+        self.bytes_retained.load(Ordering::Relaxed)
     }
 }

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -26,6 +26,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     time::interval,
 };
+pub(crate) use values::BytesRetainedTracker;
 pub use values::{DefaultRuntimeStats, RuntimeStats};
 
 use crate::pipeline::PipelineNode;

--- a/src/daft-local-execution/src/runtime_stats/values.rs
+++ b/src/daft-local-execution/src/runtime_stats/values.rs
@@ -30,25 +30,56 @@ pub trait RuntimeStats: Send + Sync + std::any::Any {
 
     /// Add bytes currently retained by this operator (e.g. when a morsel is sinked).
     fn add_bytes_retained(&self, _bytes: u64) {}
-    /// Subtract bytes no longer retained by this operator (e.g. on finalize).
-    #[allow(dead_code)]
-    fn sub_bytes_retained(&self, _bytes: u64) {}
     /// Reset bytes retained to zero (e.g. when all state is consumed on finalize).
     fn reset_bytes_retained(&self) {}
-    /// Get the current bytes retained value (used by Phase 2 peak attribution).
-    #[allow(dead_code)]
-    fn get_bytes_retained(&self) -> u64 {
-        0
+}
+
+// ----------------------- Shared Bytes Retained Tracker ----------------------- //
+
+/// Tracks current and peak bytes retained by an operator, backed by atomics and an OTEL gauge.
+/// Shared between DefaultRuntimeStats and JoinStats to avoid duplicate implementations.
+pub(crate) struct BytesRetainedTracker {
+    current: AtomicU64,
+    peak: AtomicU64,
+    gauge: Gauge,
+}
+
+impl BytesRetainedTracker {
+    pub(crate) fn new(meter: &Meter) -> Self {
+        Self {
+            current: AtomicU64::new(0),
+            peak: AtomicU64::new(0),
+            gauge: meter.bytes_retained_metric(),
+        }
+    }
+
+    pub(crate) fn add(&self, bytes: u64, attrs: &[opentelemetry::KeyValue]) {
+        let new_val = self.current.fetch_add(bytes, Ordering::Relaxed) + bytes;
+        self.peak.fetch_max(new_val, Ordering::Relaxed);
+        self.gauge.update(new_val as f64, attrs);
+    }
+
+    pub(crate) fn reset(&self, attrs: &[opentelemetry::KeyValue]) {
+        self.current.store(0, Ordering::Relaxed);
+        self.gauge.update(0.0, attrs);
+    }
+
+    pub(crate) fn load_current(&self, ordering: Ordering) -> u64 {
+        self.current.load(ordering)
+    }
+
+    pub(crate) fn load_peak(&self, ordering: Ordering) -> u64 {
+        self.peak.load(ordering)
     }
 }
+
+// ----------------------- Default Runtime Stats ----------------------- //
 
 pub struct DefaultRuntimeStats {
     duration_us: Counter,
     rows_in: Counter,
     rows_out: Counter,
-    bytes_retained: AtomicU64,
-    peak_bytes_retained: AtomicU64,
-    bytes_retained_gauge: Gauge,
+    retained: BytesRetainedTracker,
     node_kv: Vec<KeyValue>,
 }
 
@@ -59,9 +90,7 @@ impl RuntimeStats for DefaultRuntimeStats {
             duration_us: meter.duration_us_metric(),
             rows_in: meter.rows_in_metric(),
             rows_out: meter.rows_out_metric(),
-            bytes_retained: AtomicU64::new(0),
-            peak_bytes_retained: AtomicU64::new(0),
-            bytes_retained_gauge: meter.bytes_retained_metric(),
+            retained: BytesRetainedTracker::new(meter),
             node_kv,
         }
     }
@@ -71,8 +100,8 @@ impl RuntimeStats for DefaultRuntimeStats {
             cpu_us: self.duration_us.load(ordering),
             rows_in: self.rows_in.load(ordering),
             rows_out: self.rows_out.load(ordering),
-            bytes_retained: self.bytes_retained.load(ordering),
-            peak_bytes_retained: self.peak_bytes_retained.load(ordering),
+            bytes_retained: self.retained.load_current(ordering),
+            peak_bytes_retained: self.retained.load_peak(ordering),
         })
     }
 
@@ -89,26 +118,10 @@ impl RuntimeStats for DefaultRuntimeStats {
     }
 
     fn add_bytes_retained(&self, bytes: u64) {
-        let new_val = self.bytes_retained.fetch_add(bytes, Ordering::Relaxed) + bytes;
-        self.peak_bytes_retained
-            .fetch_max(new_val, Ordering::Relaxed);
-        self.bytes_retained_gauge
-            .update(new_val as f64, self.node_kv.as_slice());
-    }
-
-    fn sub_bytes_retained(&self, bytes: u64) {
-        let new_val = self.bytes_retained.fetch_sub(bytes, Ordering::Relaxed) - bytes;
-        self.bytes_retained_gauge
-            .update(new_val as f64, self.node_kv.as_slice());
+        self.retained.add(bytes, self.node_kv.as_slice());
     }
 
     fn reset_bytes_retained(&self) {
-        self.bytes_retained.store(0, Ordering::Relaxed);
-        self.bytes_retained_gauge
-            .update(0.0, self.node_kv.as_slice());
-    }
-
-    fn get_bytes_retained(&self) -> u64 {
-        self.bytes_retained.load(Ordering::Relaxed)
+        self.retained.reset(self.node_kv.as_slice());
     }
 }

--- a/src/daft-local-execution/src/runtime_stats/values.rs
+++ b/src/daft-local-execution/src/runtime_stats/values.rs
@@ -1,6 +1,8 @@
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use common_metrics::{Counter, Meter, StatSnapshot, ops::NodeInfo, snapshot::DefaultSnapshot};
+use common_metrics::{
+    Counter, Gauge, Meter, StatSnapshot, ops::NodeInfo, snapshot::DefaultSnapshot,
+};
 use opentelemetry::KeyValue;
 
 // ----------------------- General Traits for Runtime Stat Collection ----------------------- //
@@ -25,12 +27,28 @@ pub trait RuntimeStats: Send + Sync + std::any::Any {
     fn add_rows_in(&self, rows: u64);
     fn add_rows_out(&self, rows: u64);
     fn add_duration_us(&self, duration_us: u64);
+
+    /// Add bytes currently retained by this operator (e.g. when a morsel is sinked).
+    fn add_bytes_retained(&self, _bytes: u64) {}
+    /// Subtract bytes no longer retained by this operator (e.g. on finalize).
+    #[allow(dead_code)]
+    fn sub_bytes_retained(&self, _bytes: u64) {}
+    /// Reset bytes retained to zero (e.g. when all state is consumed on finalize).
+    fn reset_bytes_retained(&self) {}
+    /// Get the current bytes retained value (used by Phase 2 peak attribution).
+    #[allow(dead_code)]
+    fn get_bytes_retained(&self) -> u64 {
+        0
+    }
 }
 
 pub struct DefaultRuntimeStats {
     duration_us: Counter,
     rows_in: Counter,
     rows_out: Counter,
+    bytes_retained: AtomicU64,
+    peak_bytes_retained: AtomicU64,
+    bytes_retained_gauge: Gauge,
     node_kv: Vec<KeyValue>,
 }
 
@@ -41,6 +59,9 @@ impl RuntimeStats for DefaultRuntimeStats {
             duration_us: meter.duration_us_metric(),
             rows_in: meter.rows_in_metric(),
             rows_out: meter.rows_out_metric(),
+            bytes_retained: AtomicU64::new(0),
+            peak_bytes_retained: AtomicU64::new(0),
+            bytes_retained_gauge: meter.bytes_retained_metric(),
             node_kv,
         }
     }
@@ -50,6 +71,8 @@ impl RuntimeStats for DefaultRuntimeStats {
             cpu_us: self.duration_us.load(ordering),
             rows_in: self.rows_in.load(ordering),
             rows_out: self.rows_out.load(ordering),
+            bytes_retained: self.bytes_retained.load(ordering),
+            peak_bytes_retained: self.peak_bytes_retained.load(ordering),
         })
     }
 
@@ -63,5 +86,29 @@ impl RuntimeStats for DefaultRuntimeStats {
 
     fn add_duration_us(&self, duration_us: u64) {
         self.duration_us.add(duration_us, self.node_kv.as_slice());
+    }
+
+    fn add_bytes_retained(&self, bytes: u64) {
+        let new_val = self.bytes_retained.fetch_add(bytes, Ordering::Relaxed) + bytes;
+        self.peak_bytes_retained
+            .fetch_max(new_val, Ordering::Relaxed);
+        self.bytes_retained_gauge
+            .update(new_val as f64, self.node_kv.as_slice());
+    }
+
+    fn sub_bytes_retained(&self, bytes: u64) {
+        let new_val = self.bytes_retained.fetch_sub(bytes, Ordering::Relaxed) - bytes;
+        self.bytes_retained_gauge
+            .update(new_val as f64, self.node_kv.as_slice());
+    }
+
+    fn reset_bytes_retained(&self) {
+        self.bytes_retained.store(0, Ordering::Relaxed);
+        self.bytes_retained_gauge
+            .update(0.0, self.node_kv.as_slice());
+    }
+
+    fn get_bytes_retained(&self) -> u64 {
+        self.bytes_retained.load(Ordering::Relaxed)
     }
 }

--- a/src/daft-local-execution/src/sinks/aggregate.rs
+++ b/src/daft-local-execution/src/sinks/aggregate.rs
@@ -11,7 +11,7 @@ use tracing::{Span, instrument};
 use super::blocking_sink::{
     BlockingSink, BlockingSinkFinalizeOutput, BlockingSinkFinalizeResult, BlockingSinkSinkResult,
 };
-use crate::{ExecutionTaskSpawner, pipeline::NodeName};
+use crate::{ExecutionTaskSpawner, pipeline::NodeName, runtime_stats::RuntimeStats};
 
 pub(crate) enum AggregateState {
     Accumulating(Vec<MicroPartition>),
@@ -83,7 +83,7 @@ impl BlockingSink for AggregateSink {
         &self,
         input: MicroPartition,
         mut state: Self::State,
-        _runtime_stats: Arc<Self::Stats>,
+        runtime_stats: Arc<Self::Stats>,
         spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkSinkResult<Self> {
         let params = self.agg_sink_params.clone();
@@ -91,6 +91,7 @@ impl BlockingSink for AggregateSink {
             .spawn(
                 async move {
                     let agged = input.agg(&params.sink_agg_exprs, &[])?;
+                    runtime_stats.add_bytes_retained(agged.size_bytes() as u64);
                     state.push(agged);
                     Ok(state)
                 },

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -175,6 +175,7 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
                                 node_initialized = true;
                             }
                             ctx.runtime_stats.add_rows_in(morsel.len() as u64);
+                            ctx.runtime_stats.add_bytes_retained(morsel.size_bytes() as u64);
                             let state_id = *ctx
                                 .state_pool
                                 .keys()
@@ -344,6 +345,9 @@ impl<Op: BlockingSink + 'static> PipelineNode for BlockingSinkNode<Op> {
                 // Collect finished states
                 let mut finished_states: Vec<_> =
                     ctx.state_pool.drain().map(|(_, state)| state).collect();
+
+                // Reset retained bytes: all accumulated data is consumed during finalize
+                ctx.runtime_stats.reset_bytes_retained();
 
                 // Finalize
                 loop {

--- a/src/daft-local-execution/src/sinks/blocking_sink.rs
+++ b/src/daft-local-execution/src/sinks/blocking_sink.rs
@@ -175,7 +175,6 @@ impl<Op: BlockingSink + 'static> BlockingSinkNode<Op> {
                                 node_initialized = true;
                             }
                             ctx.runtime_stats.add_rows_in(morsel.len() as u64);
-                            ctx.runtime_stats.add_bytes_retained(morsel.size_bytes() as u64);
                             let state_id = *ctx
                                 .state_pool
                                 .keys()

--- a/src/daft-local-execution/src/sinks/into_partitions.rs
+++ b/src/daft-local-execution/src/sinks/into_partitions.rs
@@ -9,7 +9,7 @@ use tracing::{Span, instrument};
 use super::blocking_sink::{
     BlockingSink, BlockingSinkFinalizeOutput, BlockingSinkFinalizeResult, BlockingSinkSinkResult,
 };
-use crate::{ExecutionTaskSpawner, pipeline::NodeName};
+use crate::{ExecutionTaskSpawner, pipeline::NodeName, runtime_stats::RuntimeStats};
 
 pub(crate) enum IntoPartitionsState {
     Building(Vec<MicroPartition>),
@@ -58,9 +58,10 @@ impl BlockingSink for IntoPartitionsSink {
         &self,
         input: MicroPartition,
         mut state: Self::State,
-        _runtime_stats: Arc<Self::Stats>,
+        runtime_stats: Arc<Self::Stats>,
         _spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkSinkResult<Self> {
+        runtime_stats.add_bytes_retained(input.size_bytes() as u64);
         state.push(input);
         Ok(state).into()
     }

--- a/src/daft-local-execution/src/sinks/pivot.rs
+++ b/src/daft-local-execution/src/sinks/pivot.rs
@@ -10,7 +10,7 @@ use tracing::{Span, instrument};
 use super::blocking_sink::{
     BlockingSink, BlockingSinkFinalizeOutput, BlockingSinkFinalizeResult, BlockingSinkSinkResult,
 };
-use crate::{ExecutionTaskSpawner, pipeline::NodeName};
+use crate::{ExecutionTaskSpawner, pipeline::NodeName, runtime_stats::RuntimeStats};
 
 pub(crate) enum PivotState {
     Accumulating(Vec<MicroPartition>),
@@ -80,9 +80,10 @@ impl BlockingSink for PivotSink {
         &self,
         input: MicroPartition,
         mut state: Self::State,
-        _runtime_stats: Arc<Self::Stats>,
+        runtime_stats: Arc<Self::Stats>,
         _spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkSinkResult<Self> {
+        runtime_stats.add_bytes_retained(input.size_bytes() as u64);
         state.push(input);
         Ok(state).into()
     }

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -12,7 +12,7 @@ use tracing::{Span, instrument};
 use super::blocking_sink::{
     BlockingSink, BlockingSinkFinalizeOutput, BlockingSinkFinalizeResult, BlockingSinkSinkResult,
 };
-use crate::{ExecutionTaskSpawner, pipeline::NodeName};
+use crate::{ExecutionTaskSpawner, pipeline::NodeName, runtime_stats::RuntimeStats};
 
 pub(crate) struct RepartitionState {
     states: VecDeque<Vec<MicroPartition>>,
@@ -58,7 +58,7 @@ impl BlockingSink for RepartitionSink {
         &self,
         input: MicroPartition,
         mut state: Self::State,
-        _runtime_stats: Arc<Self::Stats>,
+        runtime_stats: Arc<Self::Stats>,
         spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkSinkResult<Self> {
         let repartition_spec = self.repartition_spec.clone();
@@ -67,6 +67,8 @@ impl BlockingSink for RepartitionSink {
         spawner
             .spawn(
                 async move {
+                    // Repartition preserves total data size, so input size is accurate
+                    runtime_stats.add_bytes_retained(input.size_bytes() as u64);
                     let partitioned = match repartition_spec {
                         RepartitionSpec::Hash(config) => {
                             let bound_exprs = config

--- a/src/daft-local-execution/src/sinks/sort.rs
+++ b/src/daft-local-execution/src/sinks/sort.rs
@@ -10,7 +10,7 @@ use tracing::{Span, instrument};
 use super::blocking_sink::{
     BlockingSink, BlockingSinkFinalizeOutput, BlockingSinkFinalizeResult, BlockingSinkSinkResult,
 };
-use crate::{ExecutionTaskSpawner, pipeline::NodeName};
+use crate::{ExecutionTaskSpawner, pipeline::NodeName, runtime_stats::RuntimeStats};
 
 pub(crate) enum SortState {
     Building(Vec<MicroPartition>),
@@ -66,9 +66,10 @@ impl BlockingSink for SortSink {
         &self,
         input: MicroPartition,
         mut state: Self::State,
-        _runtime_stats: Arc<Self::Stats>,
+        runtime_stats: Arc<Self::Stats>,
         _spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkSinkResult<Self> {
+        runtime_stats.add_bytes_retained(input.size_bytes() as u64);
         state.push(input);
         Ok(state).into()
     }

--- a/src/daft-local-execution/src/sinks/top_n.rs
+++ b/src/daft-local-execution/src/sinks/top_n.rs
@@ -10,7 +10,7 @@ use tracing::{Span, instrument};
 use super::blocking_sink::{
     BlockingSink, BlockingSinkFinalizeOutput, BlockingSinkFinalizeResult, BlockingSinkSinkResult,
 };
-use crate::{ExecutionTaskSpawner, pipeline::NodeName};
+use crate::{ExecutionTaskSpawner, pipeline::NodeName, runtime_stats::RuntimeStats};
 
 /// Parameters for the TopN that both the state and sinker need
 struct TopNParams {
@@ -86,7 +86,7 @@ impl BlockingSink for TopNSink {
         &self,
         input: MicroPartition,
         mut state: Self::State,
-        _runtime_stats: Arc<Self::Stats>,
+        runtime_stats: Arc<Self::Stats>,
         spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkSinkResult<Self> {
         let params = self.params.clone();
@@ -105,6 +105,7 @@ impl BlockingSink for TopNSink {
                     )?;
 
                     // Append to the collection of existing top N values
+                    runtime_stats.add_bytes_retained(top_input_rows.size_bytes() as u64);
                     state.append(top_input_rows);
                     Ok(state)
                 },

--- a/src/daft-local-execution/src/sinks/window_order_by_only.rs
+++ b/src/daft-local-execution/src/sinks/window_order_by_only.rs
@@ -14,7 +14,7 @@ use tracing::{Span, instrument};
 use super::blocking_sink::{
     BlockingSink, BlockingSinkFinalizeOutput, BlockingSinkFinalizeResult, BlockingSinkSinkResult,
 };
-use crate::{ExecutionTaskSpawner, pipeline::NodeName};
+use crate::{ExecutionTaskSpawner, pipeline::NodeName, runtime_stats::RuntimeStats};
 
 struct WindowOrderByOnlyParams {
     window_exprs: Vec<BoundWindowExpr>,
@@ -75,13 +75,14 @@ impl BlockingSink for WindowOrderByOnlySink {
         &self,
         input: MicroPartition,
         mut state: Self::State,
-        _runtime_stats: Arc<Self::Stats>,
+        runtime_stats: Arc<Self::Stats>,
         spawner: &ExecutionTaskSpawner,
     ) -> BlockingSinkSinkResult<Self> {
         let sink_name = self.name().to_string();
         spawner
             .spawn(
                 async move {
+                    runtime_stats.add_bytes_retained(input.size_bytes() as u64);
                     state.push(input, &sink_name)?;
                     Ok(state)
                 },

--- a/src/daft-local-execution/src/streaming_sink/base.rs
+++ b/src/daft-local-execution/src/streaming_sink/base.rs
@@ -310,7 +310,6 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
                                 node_initialized = true;
                             }
                             ctx.runtime_stats.add_rows_in(morsel.len() as u64);
-                            ctx.runtime_stats.add_bytes_retained(morsel.size_bytes() as u64);
                             buffer.push(morsel);
                             Self::spawn_ready_batches(&mut buffer, ctx)?;
                         }
@@ -498,9 +497,6 @@ impl<Op: StreamingSink + 'static> PipelineNode for StreamingSinkNode<Op> {
 
                 let mut finished_states: Vec<_> =
                     ctx.state_pool.drain().map(|(_, state)| state).collect();
-
-                // Reset retained bytes: all accumulated data is consumed during finalize
-                ctx.runtime_stats.reset_bytes_retained();
 
                 loop {
                     let now = Instant::now();

--- a/src/daft-local-execution/src/streaming_sink/base.rs
+++ b/src/daft-local-execution/src/streaming_sink/base.rs
@@ -310,6 +310,7 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
                                 node_initialized = true;
                             }
                             ctx.runtime_stats.add_rows_in(morsel.len() as u64);
+                            ctx.runtime_stats.add_bytes_retained(morsel.size_bytes() as u64);
                             buffer.push(morsel);
                             Self::spawn_ready_batches(&mut buffer, ctx)?;
                         }
@@ -497,6 +498,10 @@ impl<Op: StreamingSink + 'static> PipelineNode for StreamingSinkNode<Op> {
 
                 let mut finished_states: Vec<_> =
                     ctx.state_pool.drain().map(|(_, state)| state).collect();
+
+                // Reset retained bytes: all accumulated data is consumed during finalize
+                ctx.runtime_stats.reset_bytes_retained();
+
                 loop {
                     let now = Instant::now();
                     let finalized_result = ctx


### PR DESCRIPTION
Accumulating operators (blocking sinks, streaming sinks, join nodes) now report how much arrow data they're currently holding via a `bytes_retained` gauge and a `peak_bytes_retained` high-water mark.

Each operator reports its own retained bytes at the point where data is actually stored, rather than tracking input size generically. This avoids overstating memory for operators that transform during accumulation (e.g. Aggregate reduces a 10 MB morsel to a few KB of partial aggregates before storing).

- Verbatim accumulators (Sort, Pivot, IntoPartitions, Repartition, WindowOrderByOnly): track `input.size_bytes()` since stored data equals input
- Transform-then-accumulate (Aggregate, TopN): track the post-transform output size

During execution, the progress bar shows live retained bytes. After finalize, the verbose plan display shows peak retained bytes. The gauge resets to zero on finalize.

## Followups

This PR skips more "complex" state operators (GroupedAggregate, Dedup, window partitioned sinks) which will be tracked as a followup.

## Examples

Consider this demo script:

```
import daft


def make_large_df(n=2_000_000):
    """Create a DataFrame with ~400 MB of payload."""
    return daft.from_pydict({
        "key": list(range(n)),
        "group": [i % 1000 for i in range(n)],
        "value": list(range(n)),
        "payload": [b"x" * 200] * n,
    })


def demo_sort():
    """Sort: verbatim accumulate. Peak retained should be close to total input size."""
    print("=" * 60)
    print("SORT — verbatim accumulate, peak ~ total input")
    print("=" * 60)
    df = make_large_df()
    df.sort("key", desc=True).collect()
    print()


def demo_aggregate():
    """Global aggregate: transform-then-accumulate. Peak retained should be tiny
    because each morsel reduces to a single partial aggregate row."""
    print("=" * 60)
    print("AGGREGATE — transform during accumulate, peak ~ tiny")
    print("=" * 60)
    df = make_large_df()
    df.agg(daft.col("value").sum(), daft.col("group").count()).collect()
    print()


def demo_top_n():
    """TopN: transform-then-accumulate. Peak retained bounded by limit * morsel count,
    much less than total input."""
    print("=" * 60)
    print("TOP N (100) — transform during accumulate, peak ~ 100 rows")
    print("=" * 60)
    df = make_large_df()
    df.sort("value", desc=True).limit(100).collect()
    print()


def demo_hash_join():
    """Hash join: build side accumulates verbatim. Peak retained should be close
    to the build side (right table) size."""
    print("=" * 60)
    print("HASH JOIN — build side accumulates, peak ~ right table size")
    print("=" * 60)
    left = daft.from_pydict({
        "key": list(range(500_000)),
        "left_val": [f"left_{i}" for i in range(500_000)],
    })
    right = make_large_df()
    left.join(right, on="key").collect()
    print()


def demo_into_partitions():
    """IntoPartitions: verbatim accumulate. Peak retained ~ total input."""
    print("=" * 60)
    print("INTO PARTITIONS — verbatim accumulate, peak ~ total input")
    print("=" * 60)
    df = make_large_df()
    df.into_partitions(4).collect()
    print()


if __name__ == "__main__":
    demo_sort()
    demo_aggregate()
    demo_top_n()
    demo_hash_join()
    demo_into_partitions()
```

Running this produces the following output:
```
============================================================
SORT — verbatim accumulate, peak ~ total input
============================================================
🗡️ 🐟[1/2] ✓✓In Memory Scan | [00:00:00] 2,000,000 rows out, 442.50 MiB read
🗡️ 🐟[2/2] ✓           Sort | [00:00:00] 2,000,000 rows in, 2,000,000 rows out, peak 442.50 MiB retained
============================================================
AGGREGATE — transform during accumulate, peak ~ tiny
============================================================
🗡️ 🐟[1/3] ✓   In Memory Scan | [00:00:00] 2,000,000 rows out, 442.50 MiB read
🗡️ 🐟[2/3] ✓ Rename & Reorder | [00:00:00] 2,000,000 rows in, 2,000,000 rows out
🗡️ 🐟[3/3] ✓        Aggregate | [00:00:00] 2,000,000 rows in, 1 rows out, peak 256 B retained
============================================================
TOP N (100) — transform during accumulate, peak ~ 100 rows
============================================================
🗡️ 🐟[1/2] ✓ In Memory Scan | [00:00:00] 2,000,000 rows out, 442.50 MiB read
🗡️ 🐟[2/2] ✓       TopN 100 | [00:00:00] 2,000,000 rows in, 100 rows out, peak 22.66 KiB retained
============================================================
HASH JOIN — build side accumulates, peak ~ right table size
============================================================
🗡️ 🐟[1/5] ✓    In Memory Scan | [00:00:00] 500,000 rows out, 12.77 MiB read
🗡️ 🐟[2/5] ✓            Filter | [00:00:00] 500,000 rows in, 500,000 rows out, 100.00% kept
🗡️ 🐟[3/5] ✓    In Memory Scan | [00:00:00] 2,000,000 rows out, 442.50 MiB read
🗡️ 🐟[4/5] ✓            Filter | [00:00:00] 2,000,000 rows in, 2,000,000 rows out, 100.00% kept
🗡️ 🐟[5/5] ✓ Hash Join (Inner) | [00:00:00] 500,000 build rows inserted, 2,000,000 probe rows in, 500,000 probe rows out, peak 28.19 MiB retained
============================================================
INTO PARTITIONS — verbatim accumulate, peak ~ total input
============================================================
/Users/desmond/Daft-4/daft/dataframe/dataframe.py:3082: UserWarning: DataFrame.into_partitions not supported on the NativeRunner. This will be a no-op. Please use the RayRunner via `daft.set_runner_ray()` instead if you need to repartition.
  warnings.warn(
IntoPartitions not supported on the NativeRunner. This will be a no-op. Please use the Ray Runner instead if you need to repartition
🗡️ 🐟[1/1] ✓ In Memory Scan | [00:00:00] 2,000,000 rows out, 442.50 MiB read
```