### PR TITLE
feat(tracing): add DAFT_TRACE console tracing with configurable format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8112,6 +8112,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8121,12 +8131,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,7 +360,7 @@ tokio-util = "0.7.17"
 tonic = "0.14.2"
 tonic-build = "0.14.2"
 tracing = {version = "0.1", features = ["log"]}
-tracing-subscriber = {version = "0.3.22", default-features = false, features = ["std", "fmt", "ansi", "env-filter"]}
+tracing-subscriber = {version = "0.3.22", default-features = false, features = ["std", "fmt", "ansi", "env-filter", "json"]}
 typetag = "0.2.21"
 url = "2.4.0"
 uuid = {version = "1.19.0", features = ["v4"]}

--- a/src/common/tracing/src/lib.rs
+++ b/src/common/tracing/src/lib.rs
@@ -16,7 +16,8 @@ use opentelemetry_sdk::{
     trace::{Sampler, SdkTracerProvider},
 };
 use tracing_subscriber::{
-    EnvFilter, Registry, filter::LevelFilter, layer::SubscriberExt, prelude::*,
+    EnvFilter, Registry, filter::LevelFilter, fmt::format::FmtSpan, layer::SubscriberExt,
+    prelude::*,
 };
 
 static GLOBAL_TRACER_PROVIDER: LazyLock<Mutex<Option<SdkTracerProvider>>> =
@@ -28,6 +29,27 @@ static GLOBAL_METER_PROVIDER: LazyLock<
 
 pub static GLOBAL_LOGGER_PROVIDER: LazyLock<Mutex<Option<SdkLoggerProvider>>> =
     LazyLock::new(|| Mutex::new(None));
+
+#[derive(Debug, Clone, Copy)]
+enum TraceFormat {
+    Compact,
+    Pretty,
+    Json,
+}
+
+impl TraceFormat {
+    fn from_env() -> Self {
+        match std::env::var("DAFT_TRACE_FORMAT")
+            .unwrap_or_else(|_| "compact".to_string())
+            .to_lowercase()
+            .as_str()
+        {
+            "pretty" => Self::Pretty,
+            "json" => Self::Json,
+            _ => Self::Compact,
+        }
+    }
+}
 
 pub fn init_tracing() {
     let config = Config::from_env();
@@ -54,12 +76,49 @@ pub fn init_tracing() {
 
     let mut layers: Vec<Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync>> = Vec::new();
 
-    if let Ok(filter) = EnvFilter::try_from_default_env() {
-        layers.push(Box::new(
-            tracing_subscriber::fmt::layer()
-                .with_target(true)
-                .with_filter(filter),
-        ));
+    if let Ok(daft_trace) = std::env::var("DAFT_TRACE") {
+        // A bare level enables Daft-owned targets only. Users can opt into additional
+        // crates by passing an explicit EnvFilter directive, e.g.
+        // `DAFT_TRACE=daft_=info,Daft=info,hyper=debug`.
+        let filter_directive = if daft_trace.parse::<LevelFilter>().is_ok() {
+            format!("daft_={daft_trace},Daft={daft_trace}")
+        } else {
+            daft_trace.clone()
+        };
+        match EnvFilter::try_new(&filter_directive) {
+            Ok(filter) => {
+                let layer = match TraceFormat::from_env() {
+                    TraceFormat::Compact => tracing_subscriber::fmt::layer()
+                        .compact()
+                        .with_target(true)
+                        .with_writer(std::io::stderr)
+                        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                        .boxed(),
+                    TraceFormat::Pretty => tracing_subscriber::fmt::layer()
+                        .pretty()
+                        .with_target(true)
+                        .with_writer(std::io::stderr)
+                        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                        .boxed(),
+                    TraceFormat::Json => tracing_subscriber::fmt::layer()
+                        .json()
+                        .with_target(true)
+                        .with_current_span(true)
+                        .with_span_list(true)
+                        .with_writer(std::io::stderr)
+                        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+                        .boxed(),
+                };
+                layers.push(Box::new(layer.with_filter(filter)));
+            }
+            Err(err) => {
+                eprintln!(
+                    "DAFT_TRACE: invalid filter {daft_trace:?}, console tracing disabled: {err}. \
+                     Use a bare level like `info` for Daft logs only, or an explicit directive \
+                     like `daft_=info,Daft=info,hyper=debug` to include other crates."
+                );
+            }
+        }
     }
 
     if let Some(tracer_provider) = tracer_provider {

--- a/src/common/tracing/src/lib.rs
+++ b/src/common/tracing/src/lib.rs
@@ -32,6 +32,26 @@ pub static GLOBAL_LOGGER_PROVIDER: LazyLock<Mutex<Option<SdkLoggerProvider>>> =
 pub fn init_tracing() {
     let config = Config::from_env();
     let resource = Resource::builder().with_service_name("daft").build();
+    let tracer_provider = if config.enabled() {
+        let runtime = get_io_runtime(true);
+        runtime.block_on_current_thread(async {
+            let tracer_provider = config
+                .traces_endpoint()
+                .map(|endpoint| init_otlp_tracer_provider(&config, endpoint, resource.clone()));
+
+            if let Some(endpoint) = config.metrics_endpoint() {
+                init_otlp_metrics_provider(&config, endpoint, resource.clone());
+            }
+            if let Some(endpoint) = config.logs_endpoint() {
+                init_otlp_logger_provider(&config, endpoint, resource.clone());
+            }
+
+            tracer_provider
+        })
+    } else {
+        None
+    };
+
     let mut layers: Vec<Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync>> = Vec::new();
 
     if let Ok(filter) = EnvFilter::try_from_default_env() {
@@ -42,8 +62,7 @@ pub fn init_tracing() {
         ));
     }
 
-    if let Some(endpoint) = config.traces_endpoint() {
-        let tracer_provider = init_otlp_tracer_provider(&config, endpoint, resource.clone());
+    if let Some(tracer_provider) = tracer_provider {
         layers.push(Box::new(
             tracing_opentelemetry::layer()
                 .with_tracer(tracer_provider.tracer("daft-otel-tracer"))
@@ -59,20 +78,6 @@ pub fn init_tracing() {
             );
         }
     }
-
-    if !config.enabled() {
-        return;
-    }
-
-    let runtime = get_io_runtime(true);
-    runtime.block_on_current_thread(async {
-        if let Some(endpoint) = config.metrics_endpoint() {
-            init_otlp_metrics_provider(&config, endpoint, resource.clone());
-        }
-        if let Some(endpoint) = config.logs_endpoint() {
-            init_otlp_logger_provider(&config, endpoint, resource.clone());
-        }
-    });
 }
 
 pub fn flush_opentelemetry_providers() {

--- a/src/common/tracing/src/lib.rs
+++ b/src/common/tracing/src/lib.rs
@@ -15,7 +15,9 @@ use opentelemetry_sdk::{
     metrics::PeriodicReader,
     trace::{Sampler, SdkTracerProvider},
 };
-use tracing_subscriber::{layer::SubscriberExt, prelude::*};
+use tracing_subscriber::{
+    EnvFilter, Registry, filter::LevelFilter, layer::SubscriberExt, prelude::*,
+};
 
 static GLOBAL_TRACER_PROVIDER: LazyLock<Mutex<Option<SdkTracerProvider>>> =
     LazyLock::new(|| Mutex::new(None));
@@ -27,25 +29,48 @@ static GLOBAL_METER_PROVIDER: LazyLock<
 pub static GLOBAL_LOGGER_PROVIDER: LazyLock<Mutex<Option<SdkLoggerProvider>>> =
     LazyLock::new(|| Mutex::new(None));
 
-pub fn init_opentelemetry_providers() {
+pub fn init_tracing() {
     let config = Config::from_env();
+    let resource = Resource::builder().with_service_name("daft").build();
+    let mut layers: Vec<Box<dyn tracing_subscriber::Layer<Registry> + Send + Sync>> = Vec::new();
+
+    if let Ok(filter) = EnvFilter::try_from_default_env() {
+        layers.push(Box::new(
+            tracing_subscriber::fmt::layer()
+                .with_target(true)
+                .with_filter(filter),
+        ));
+    }
+
+    if let Some(endpoint) = config.traces_endpoint() {
+        let tracer_provider = init_otlp_tracer_provider(&config, endpoint, resource.clone());
+        layers.push(Box::new(
+            tracing_opentelemetry::layer()
+                .with_tracer(tracer_provider.tracer("daft-otel-tracer"))
+                .with_filter(LevelFilter::INFO),
+        ));
+    }
+
+    if !layers.is_empty() {
+        let subscriber = tracing_subscriber::registry().with(layers);
+        if let Err(err) = tracing::subscriber::set_global_default(subscriber) {
+            eprintln!(
+                "Daft could not install its tracing subscriber; OTLP trace export and Daft tracing output are disabled: {err}"
+            );
+        }
+    }
+
     if !config.enabled() {
         return;
     }
 
     let runtime = get_io_runtime(true);
     runtime.block_on_current_thread(async {
-        // Backed by inner Arc, cheap to clone
-        let resource = Resource::builder().with_service_name("daft").build();
-
         if let Some(endpoint) = config.metrics_endpoint() {
-            init_otlp_metrics_provider(&config, endpoint, resource.clone()).await;
-        }
-        if let Some(endpoint) = config.traces_endpoint() {
-            init_otlp_tracer_provider(&config, endpoint, resource.clone()).await;
+            init_otlp_metrics_provider(&config, endpoint, resource.clone());
         }
         if let Some(endpoint) = config.logs_endpoint() {
-            init_otlp_logger_provider(&config, endpoint, resource).await;
+            init_otlp_logger_provider(&config, endpoint, resource.clone());
         }
     });
 }
@@ -56,7 +81,7 @@ pub fn flush_opentelemetry_providers() {
     flush_oltp_logger_provider();
 }
 
-async fn init_otlp_logger_provider(config: &Config, otlp_endpoint: &str, resource: Resource) {
+fn init_otlp_logger_provider(config: &Config, otlp_endpoint: &str, resource: Resource) {
     let mut lg = GLOBAL_LOGGER_PROVIDER.lock().unwrap();
     assert!(lg.is_none(), "Expected logger provider to be None on init");
 
@@ -90,7 +115,7 @@ pub fn flush_oltp_logger_provider() {
     }
 }
 
-async fn init_otlp_metrics_provider(config: &Config, endpoint: &str, resource: Resource) {
+fn init_otlp_metrics_provider(config: &Config, endpoint: &str, resource: Resource) {
     let mut mg = GLOBAL_METER_PROVIDER.lock().unwrap();
     assert!(mg.is_none(), "Expected meter provider to be None on init");
 
@@ -139,10 +164,11 @@ pub fn flush_oltp_metrics_provider() {
     }
 }
 
-async fn init_otlp_tracer_provider(config: &Config, otlp_endpoint: &str, resource: Resource) {
-    let mut mg = GLOBAL_TRACER_PROVIDER.lock().unwrap();
-    assert!(mg.is_none(), "Expected tracer provider to be None on init");
-
+fn init_otlp_tracer_provider(
+    config: &Config,
+    otlp_endpoint: &str,
+    resource: Resource,
+) -> SdkTracerProvider {
     if config.otlp_protocol != Protocol::Grpc {
         log::warn!(
             "`http/json` or `http/protobuf` protocol is currently not supported for the OTEL traces exporter. gRPC will be used instead."
@@ -162,15 +188,13 @@ async fn init_otlp_tracer_provider(config: &Config, otlp_endpoint: &str, resourc
         .with_sampler(Sampler::AlwaysOn)
         .build();
 
-    let tracer = tracer_provider.tracer("daft-otel-tracer");
-    let telemetry_layer = tracing_opentelemetry::layer()
-        .with_tracer(tracer)
-        .with_filter(tracing::level_filters::LevelFilter::INFO);
+    {
+        let mut mg = GLOBAL_TRACER_PROVIDER.lock().unwrap();
+        assert!(mg.is_none(), "Expected tracer provider to be None on init");
+        *mg = Some(tracer_provider.clone());
+    }
 
-    tracing::subscriber::set_global_default(tracing_subscriber::registry().with(telemetry_layer))
-        .unwrap();
-
-    *mg = Some(tracer_provider);
+    tracer_provider
 }
 
 fn flush_oltp_tracer_provider() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod pylib {
     use std::sync::LazyLock;
 
     use common_logging::GLOBAL_LOGGER;
-    use common_tracing::init_opentelemetry_providers;
+    use common_tracing::init_tracing;
     use pyo3::prelude::*;
 
     static LOG_RESET_HANDLE: LazyLock<pyo3_log::ResetHandle> = LazyLock::new(|| {
@@ -109,7 +109,7 @@ pub mod pylib {
     #[pymodule]
     fn daft(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
         refresh_logger(py)?;
-        init_opentelemetry_providers();
+        init_tracing();
 
         common_daft_config::register_modules(m)?;
         common_system_info::register_modules(m)?;


### PR DESCRIPTION
## Changes Made
 Adds configurable console tracing output controlled by `DAFT_TRACE` and `DAFT_TRACE_FORMAT`.

This change:
  - adds support for `compact`, `pretty`, and `json` console trace formats
  - logs both `NEW` and `CLOSE` span lifecycle events
  - enables the `tracing-subscriber` `json` feature in the workspace
  - keeps bare `DAFT_TRACE` levels scoped to Daft-owned targets

Example
```
RAY_RUNNER=ray DAFT_TRACE=debug python ./operators/into_batches.py
```


```
(RemoteFlotillaRunner pid=88504) 2026-03-23T22:44:40.518749Z  INFO FlotillaScheduler: DaftFlotillaScheduler: Scheduling tasks for dispatch num_tasks=1
(RemoteFlotillaRunner pid=88504) 2026-03-23T22:44:40.518761Z DEBUG FlotillaScheduler: DaftFlotillaScheduler: scheduled_tasks=[
(RemoteFlotillaRunner pid=88504)     ScheduledTask(worker_id = c7d9dd09ab00f75e67f66bdd6c71155625b986fbc14608d7a5bfc36e, TaskContext(query_idx = 0, last_node_id = 5, task_id = 14), TaskDetails(name = InMemoryScan->CommitWrite, resource_request = (num_cpus = 1, num_gpus = 0, memory_bytes = 0)), Spread),
(RemoteFlotillaRunner pid=88504) ]
(RemoteFlotillaRunner pid=88504) 2026-03-23T22:44:40.519099Z  INFO FlotillaScheduler: DaftFlotillaScheduler: Task input stream exhausted
(RemoteFlotillaRunner pid=88504) 2026-03-23T22:44:40.519109Z  INFO FlotillaScheduler: DaftFlotillaScheduler: Received worker snapshots num_workers=1 pending_tasks=0
(RemoteFlotillaRunner pid=88504) 2026-03-23T22:44:40.519119Z DEBUG FlotillaScheduler: DaftFlotillaScheduler: worker_snapshots=[
(RemoteFlotillaRunner pid=88504)     WorkerSnapshot(worker_id = c7d9dd09ab00f75e67f66bdd6c71155625b986fbc14608d7a5bfc36e, total_num_cpus = 14, total_num_gpus = 0, active_task_details = {
(RemoteFlotillaRunner pid=88504)         TaskContext(query_idx = 0, last_node_id = 5, task_id = 14): TaskDetails(name = InMemoryScan->CommitWrite, resource_request = (num_cpus = 1, num_gpus = 0, memory_bytes = 0)),
(RemoteFlotillaRunner pid=88504)     }),
(RemoteFlotillaRunner pid=88504) ]
(RemoteFlotillaRunner pid=88504) 2026-03-23T22:44:40.532469Z  INFO FlotillaScheduler: DaftFlotillaDispatcher: Awaited completed tasks num_tasks=1
```