### PR TITLE
refactor(io): merge conditional arms in opendal_backends ls operator

### DIFF
--- a/src/daft-io/src/opendal_source.rs
+++ b/src/daft-io/src/opendal_source.rs
@@ -297,20 +297,12 @@ impl ObjectSource for OpenDALSource {
             });
         }
 
-        let entries = if posix {
-            // Non-recursive listing (like ls)
-            self.operator
-                .list(&dir_path)
-                .await
-                .map_err(|e| opendal_err_to_daft_err(e, path, &self.scheme))?
-        } else {
-            // Recursive listing
-            self.operator
-                .list_with(&dir_path)
-                .recursive(true)
-                .await
-                .map_err(|e| opendal_err_to_daft_err(e, path, &self.scheme))?
-        };
+        let entries = self
+            .operator
+            .list_with(&dir_path)
+            .recursive(!posix)
+            .await
+            .map_err(|e| opendal_err_to_daft_err(e, path, &self.scheme))?;
 
         // Reconstruct the URL prefix for file paths
         let parsed = url::Url::parse(path).context(super::InvalidUrlSnafu { path })?;


### PR DESCRIPTION
## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->
Merge the conditional arms that separately called list() (for POSIX mode) and list_with(...).recursive(true) (for non-POSIX mode). This is possible because list() is internally implemented as list_with(...).recursive(false) in OpenDAL.
## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
