### PR TITLE
fix: handles schema inference errors when partition columns are NULL

### DIFF
--- a/daft/sql/sql_connection.py
+++ b/daft/sql/sql_connection.py
@@ -128,11 +128,11 @@ class SQLConnection:
                 return True
         return False
 
-    def execute_sql_query(self, sql: str) -> pa.Table:
-        if self._should_use_connectorx():
+    def execute_sql_query(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
+        if schema is None and self._should_use_connectorx():
             return self._execute_sql_query_with_connectorx(sql)
         else:
-            return self._execute_sql_query_with_sqlalchemy(sql)
+            return self._execute_sql_query_with_sqlalchemy(sql, schema=schema)
 
     def _execute_sql_query_with_connectorx(self, sql: str) -> pa.Table:
         import connectorx as cx
@@ -145,7 +145,7 @@ class SQLConnection:
         except Exception as e:
             raise RuntimeError(f"Failed to execute sql: {sql} with url: {self.conn}, error: {e}") from e
 
-    def _execute_sql_query_with_sqlalchemy(self, sql: str) -> pa.Table:
+    def _execute_sql_query_with_sqlalchemy(self, sql: str, schema: pa.Schema | None = None) -> pa.Table:
         from sqlalchemy import create_engine, text
 
         logger.info("Using sqlalchemy to execute sql: %s", sql)
@@ -160,8 +160,7 @@ class SQLConnection:
                     rows = result.fetchall()
 
             pydict = {column_name: [row[i] for row in rows] for i, column_name in enumerate(result.keys())}
-            # TODO: Use type codes from cursor description to create pyarrow schema
-            return pa.Table.from_pydict(pydict)
+            return pa.Table.from_pydict(pydict, schema=schema)
         except Exception as e:
             connection_str = self.conn if isinstance(self.conn, str) else self.conn.__name__
             raise RuntimeError(f"Failed to execute sql: {sql} from connection: {connection_str}, error: {e}") from e

--- a/daft/sql/sql_scan.py
+++ b/daft/sql/sql_scan.py
@@ -15,6 +15,7 @@ from daft.daft import (
     ScanTask,
     StorageConfig,
 )
+from daft.dependencies import pa
 from daft.expressions.expressions import lit
 from daft.io.common import _get_schema_from_dict
 from daft.io.scan import ScanOperator
@@ -92,8 +93,13 @@ class SQLScanOperator(ScanOperator):
             return self._single_scan_task(pushdowns, total_rows, total_size)
 
         partition_bounds = self._get_partition_bounds(num_scan_tasks)
-        partition_bounds_sql = [lit(bound)._to_sql() for bound in partition_bounds]
+        if partition_bounds is None:
+            warnings.warn(
+                "Unable to partition the data using the specified column. Falling back to a single scan task."
+            )
+            return self._single_scan_task(pushdowns, total_rows, total_size)
 
+        partition_bounds_sql = [lit(bound)._to_sql() for bound in partition_bounds]
         if any(bound is None for bound in partition_bounds_sql):
             warnings.warn(
                 "Unable to partition the data using the specified column. Falling back to a single scan task."
@@ -175,7 +181,7 @@ class SQLScanOperator(ScanOperator):
 
         return int(pa_table.column(0)[0].as_py())
 
-    def _get_partition_bounds(self, num_scan_tasks: int) -> list[Any]:
+    def _get_partition_bounds(self, num_scan_tasks: int) -> list[Any] | None:
         if self._partition_col is None:
             raise ValueError("Failed to get partition bounds: partition_col must be specified to partition the data.")
 
@@ -225,7 +231,11 @@ class SQLScanOperator(ScanOperator):
         min_max_sql = self.conn.construct_sql_query(
             self.sql, projection=[f"MIN({self._partition_col}) as min", f"MAX({self._partition_col}) as max"]
         )
-        pa_table = self.conn.execute_sql_query(min_max_sql)
+
+        # Execute the query with explicit schema to gracefully handle NULL values.
+        pa_type = self._schema[self._partition_col].dtype.to_arrow_dtype()
+        pa_schema = pa.schema([pa.field("min", pa_type), pa.field("max", pa_type)])
+        pa_table = self.conn.execute_sql_query(min_max_sql, schema=pa_schema)
 
         if pa_table.num_rows != 1:
             raise RuntimeError(f"Failed to get partition bounds: expected 1 row, but got {pa_table.num_rows}.")
@@ -236,6 +246,9 @@ class SQLScanOperator(ScanOperator):
         assert pydict.keys() == {"min", "max"}
         min_val = pydict["min"][0]
         max_val = pydict["max"][0]
+        if min_val is None or max_val is None:
+            return None
+
         range_size = (max_val - min_val) / num_scan_tasks
         return [min_val + range_size * i for i in range(num_scan_tasks)] + [max_val]
 

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from sqlalchemy import Column, Float, Integer, MetaData, String, Table, create_engine, insert
+
+import daft
+from daft.datatype import DataType
+
+
+@pytest.fixture()
+def sqlite_db(tmp_path):
+    db_path = tmp_path / "test.db"
+    url = f"sqlite:///{db_path}"
+    engine = create_engine(url)
+    metadata = MetaData()
+
+    table = Table(
+        "test_table",
+        metadata,
+        Column("id", Integer),
+        Column("value", Float),
+        Column("label", String(50)),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        conn.execute(
+            insert(table),
+            [{"id": i, "value": float(i), "label": f"row_{i}"} for i in range(100)],
+        )
+
+    return url
+
+
+@pytest.fixture()
+def sqlite_null_partition_db(tmp_path):
+    """Database where the partition column is entirely NULL."""
+    db_path = tmp_path / "null_test.db"
+    url = f"sqlite:///{db_path}"
+    engine = create_engine(url)
+    metadata = MetaData()
+
+    table = Table(
+        "null_table",
+        metadata,
+        Column("id", Integer),
+        Column("value", Float),
+        Column("label", String(50)),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        conn.execute(
+            insert(table),
+            [{"id": None, "value": float(i), "label": f"row_{i}"} for i in range(50)],
+        )
+
+    return url
+
+
+def test_sql_read_basic(sqlite_db):
+    df = daft.read_sql("SELECT * FROM test_table", sqlite_db)
+    result = df.sort("id").to_pydict()
+    assert result["id"] == list(range(100))
+    assert result["value"] == [float(i) for i in range(100)]
+    assert result["label"] == [f"row_{i}" for i in range(100)]
+
+
+@pytest.mark.parametrize("num_partitions", [2, 3, 4])
+def test_sql_partitioned_read(sqlite_db, num_partitions):
+    df = daft.read_sql(
+        "SELECT * FROM test_table",
+        sqlite_db,
+        partition_col="id",
+        num_partitions=num_partitions,
+    )
+    result = df.sort("id").to_pydict()
+    assert result["id"] == list(range(100))
+    assert result["value"] == [float(i) for i in range(100)]
+    assert result["label"] == [f"row_{i}" for i in range(100)]
+
+
+@pytest.mark.parametrize("num_partitions", [2, 3, 4])
+@pytest.mark.parametrize("partition_bound_strategy", ["min-max", "percentile"])
+def test_sql_partitioned_read_null_partition_col(sqlite_null_partition_db, num_partitions, partition_bound_strategy):
+    """When the partition column is entirely NULL, should fall back to a single scan task."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        df = daft.read_sql(
+            "SELECT * FROM null_table",
+            sqlite_null_partition_db,
+            partition_col="id",
+            num_partitions=num_partitions,
+            partition_bound_strategy=partition_bound_strategy,
+            schema={"id": DataType.int64(), "value": DataType.float64(), "label": DataType.string()},
+        )
+        result = df.to_pydict()
+
+    assert len(result["value"]) == 50
+    assert any("Falling back to a single scan task" in str(warning.message) for warning in w)
+
+
+def test_sql_partitioned_read_null_partition_col_min_max(sqlite_null_partition_db):
+    """Specifically test the MIN_MAX strategy with all-NULL partition column."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        df = daft.read_sql(
+            "SELECT * FROM null_table",
+            sqlite_null_partition_db,
+            partition_col="id",
+            num_partitions=4,
+            partition_bound_strategy="min-max",
+            schema={"id": DataType.int64(), "value": DataType.float64(), "label": DataType.string()},
+        )
+        result = df.to_pydict()
+
+    assert len(result["value"]) == 50
+    assert any("Falling back to a single scan task" in str(warning.message) for warning in w)

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -100,5 +100,3 @@ def test_sql_partitioned_read_null_partition_col(sqlite_null_partition_db, num_p
 
     assert len(result["value"]) == 50
     assert any("Falling back to a single scan task" in str(warning.message) for warning in w)
-
-

--- a/tests/io/test_sql.py
+++ b/tests/io/test_sql.py
@@ -102,19 +102,3 @@ def test_sql_partitioned_read_null_partition_col(sqlite_null_partition_db, num_p
     assert any("Falling back to a single scan task" in str(warning.message) for warning in w)
 
 
-def test_sql_partitioned_read_null_partition_col_min_max(sqlite_null_partition_db):
-    """Specifically test the MIN_MAX strategy with all-NULL partition column."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        df = daft.read_sql(
-            "SELECT * FROM null_table",
-            sqlite_null_partition_db,
-            partition_col="id",
-            num_partitions=4,
-            partition_bound_strategy="min-max",
-            schema={"id": DataType.int64(), "value": DataType.float64(), "label": DataType.string()},
-        )
-        result = df.to_pydict()
-
-    assert len(result["value"]) == 50
-    assert any("Falling back to a single scan task" in str(warning.message) for warning in w)


### PR DESCRIPTION
## Changes Made

The `read_sql` method fails when partition columns are all NULL because the schema cannot be inferred. This PR passes the schema explicitly to avoid relying on pyarrow type inference. Includes sqlite-backed read_sql tests for this exact scenario.

```sh
pytest ./tests/io/test_sql.py -v
```

## Related Issues

- Closes #6464
- Closes #6462 
