### PR TITLE
fix: close connections in io tests and address other warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,37 @@ minversion = "6.0"
 testpaths = [
   "tests"
 ]
+filterwarnings = [
+  # Expected warnings from repartition without columns (tests intentionally exercise this)
+  "ignore:No columns specified for repartition:UserWarning",
+  # Expected warnings from aggregation without columns (tests intentionally exercise this)
+  "ignore:No columns specified; performing aggregation:UserWarning",
+  # Expected warnings from datatype inference (tests exercise edge cases)
+  "ignore:Cannot derive inner type from:UserWarning",
+  "ignore:numpy.datetime64 may be converted:UserWarning",
+  # Deprecated APIs being tested (llm_generate, @daft.udf)
+  "ignore:This method is deprecated and will be removed in v0.8.0:DeprecationWarning",
+  "ignore:The `@daft.udf` decorator is deprecated:DeprecationWarning",
+  "ignore:daft.io.lance.merge_columns is deprecated:DeprecationWarning",
+  "ignore:FragmentHandler is deprecated:DeprecationWarning",
+  # Third-party deprecation warnings we can't fix
+  "ignore:datetime.datetime.utcnow\\(\\) is deprecated:DeprecationWarning:botocore",
+  "ignore:`use_push_based_shuffle` is deprecated:DeprecationWarning:ray",
+  "ignore:`use_polars` is deprecated:DeprecationWarning:ray",
+  "ignore:`free` is a deprecated API:DeprecationWarning:ray",
+  # Custom UDF metrics warning (expected outside UDF context)
+  "ignore:Custom UDF metrics will only be recorded:RuntimeWarning",
+  # pandas FutureWarning for assert_frame_equal with None/nan
+  "ignore:Mismatched null-like values:FutureWarning",
+  # pandas FutureWarning for incompatible dtype assignment in tests
+  "ignore:Setting an item of incompatible dtype is deprecated:FutureWarning",
+  # pandas FutureWarning for groupby.apply on grouping columns
+  "ignore:DataFrameGroupBy.apply operated on the grouping columns:FutureWarning",
+  # pandas arctanh/arccosh RuntimeWarnings (expected math edge cases)
+  "ignore:divide by zero encountered in arctanh:RuntimeWarning",
+  "ignore:invalid value encountered in arctanh:RuntimeWarning",
+  "ignore:invalid value encountered in arccosh:RuntimeWarning"
+]
 
 [tool.uv.sources.daft_dashboard]
 workspace = true

--- a/tests/catalog/test_iceberg.py
+++ b/tests/catalog/test_iceberg.py
@@ -34,7 +34,8 @@ def iceberg_catalog(tmp_path_factory):
         "default.tbl",
         pa.schema([("x", pa.bool_()), ("y", pa.int64()), ("z", pa.string())]),
     )
-    return catalog
+    yield catalog
+    catalog.engine.dispose()
 
 
 @pytest.fixture(scope="session")

--- a/tests/cookbook/test_pandas_cookbook.py
+++ b/tests/cookbook/test_pandas_cookbook.py
@@ -96,6 +96,7 @@ def test_multi_criteria_or_assignment(repartition_nparts, with_morsel_size):
     daft_df = daft_df.with_column(
         "AAA", when((col("BBB") > 25) | (col("CCC") >= 75), 0.1).otherwise(col("AAA").cast(DataType.float32()))
     )
+    pd_df["AAA"] = pd_df["AAA"].astype(float)
     pd_df.loc[(pd_df["BBB"] > 25) | (pd_df["CCC"] >= 75), "AAA"] = 0.1
     daft_pd_df = daft_df.to_pandas()
     assert_df_equals(daft_pd_df, pd_df, sort_key="BBB")

--- a/tests/dataframe/test_tensor_math.py
+++ b/tests/dataframe/test_tensor_math.py
@@ -27,7 +27,8 @@ def test_math_tensors(op, ldtype, rdtype) -> None:
     np.random.seed(1)
     x = np.random.randint(0, 10, (12, 10, 1)).astype(ldtype.to_arrow_dtype().to_pandas_dtype())
     y = np.random.randint(0, 10, (12, 10, 1)).astype(rdtype.to_arrow_dtype().to_pandas_dtype())
-    expected = op(x, y)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        expected = op(x, y)
 
     df = daft.from_pydict({"x": x, "y": y})
     df = df.with_column("x", df["x"].cast(daft.DataType.tensor(ldtype, (10, 1))))
@@ -46,7 +47,8 @@ def test_math_tensors_with_literal(op, ldtype, rdtype) -> None:
     np.random.seed(1)
     x = np.random.randint(0, 10, (12, 10, 1)).astype(ldtype.to_arrow_dtype().to_pandas_dtype())
     y = np.random.randint(0, 10, (10, 1)).astype(rdtype.to_arrow_dtype().to_pandas_dtype())
-    expected = op(x, y)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        expected = op(x, y)
 
     df = daft.from_pydict({"x": x})
     df = df.with_column("x", df["x"].cast(daft.DataType.tensor(ldtype, (10, 1))))

--- a/tests/integration/iceberg/conftest.py
+++ b/tests/integration/iceberg/conftest.py
@@ -81,6 +81,8 @@ def azure_iceberg_catalog() -> Iterator[tuple[str, Catalog]]:
     daft.attach_catalog(cat, alias=catalog_name)
     yield catalog_name, cat
     daft.detach_catalog(alias=catalog_name)
+    if hasattr(cat, "engine"):
+        cat.engine.dispose()
 
 
 @tenacity.retry(

--- a/tests/io/iceberg/test_iceberg_writes.py
+++ b/tests/io/iceberg/test_iceberg_writes.py
@@ -72,7 +72,8 @@ def local_catalog(tmpdir):
         },
     )
     catalog.create_namespace("default")
-    return catalog
+    yield catalog
+    catalog.engine.dispose()
 
 
 @pytest.fixture(

--- a/tests/recordbatch/image/test_decode.py
+++ b/tests/recordbatch/image/test_decode.py
@@ -33,7 +33,7 @@ def test_decode_8bit_and_16bit_images():
 
         # Create a 16-bit grayscale image (TIFF format supports 16-bit)
         img_16bit_array = np.random.randint(0, 65536, size=(10, 10), dtype=np.uint16)
-        img_16bit = Image.fromarray(img_16bit_array, mode="I;16")
+        img_16bit = Image.fromarray(img_16bit_array)
         img_16bit_path = tmpdir_path / "image_16bit.tiff"
         img_16bit.save(img_16bit_path, format="TIFF")
 

--- a/tests/recordbatch/test_from_py.py
+++ b/tests/recordbatch/test_from_py.py
@@ -244,8 +244,7 @@ def test_from_pandas_roundtrip() -> None:
         assert field.dtype == PANDAS_INFERRED_TYPES[field.name]
     # pyarrow --> pandas will insert explicit Nones within the struct fields.
     df["struct"][1]["a"] = None
-    df["empty_struct"][0] = {}
-    df["empty_struct"][1] = {}
+    df["empty_struct"] = [{}, {}]
     df["nested_struct"][0]["c"] = {}
     df["nested_struct"][1]["c"] = {}
     pd.testing.assert_frame_equal(table.to_pandas(), df)

--- a/tests/sql/test_sess_sql.py
+++ b/tests/sql/test_sess_sql.py
@@ -29,19 +29,21 @@ def _create_catalog(name: str, tmpdir: str):
     catalog.create_table(f"ns_1.tbl_{name}_12", pa.schema([]))
     catalog.create_table(f"ns_2.tbl_{name}_21", pa.schema([]))
     catalog.create_table(f"ns_2.tbl_{name}_22", pa.schema([]))
-    return Catalog.from_iceberg(catalog)
+    return Catalog.from_iceberg(catalog), catalog
 
 
 @pytest.fixture()
 def sess(tmpdir) -> Session:
     # create some tmp catalogs
-    cat_1 = _create_catalog("cat_1", tmpdir)
-    cat_2 = _create_catalog("cat_2", tmpdir)
+    cat_1, raw_cat_1 = _create_catalog("cat_1", tmpdir)
+    cat_2, raw_cat_2 = _create_catalog("cat_2", tmpdir)
     # attach to a new session
     sess = Session()
     sess.attach_catalog(cat_1, alias="cat_1")
     sess.attach_catalog(cat_2, alias="cat_2")
-    return sess
+    yield sess
+    raw_cat_1.engine.dispose()
+    raw_cat_2.engine.dispose()
 
 
 # chore: consider reducing test verbosity


### PR DESCRIPTION
## Changes Made

* Iceberg tests weren't closing the sqlite connection which made our CI logs flooded with warnings.
* Several other io tests had the same issue.
* Also fixes some additional warnings which are making CI logs noisy.

## Related Issues

N/A
