### PR TITLE
feat(subscribers): add typed event for operator and stats callbacks

### DIFF
--- a/daft/subscribers/abc.py
+++ b/daft/subscribers/abc.py
@@ -59,20 +59,29 @@ class Subscriber(ABC):
         """Called when starting to execute a query. Receives the physical plan as JSON string."""
         pass
 
-    @abstractmethod
-    def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
+    def on_operator_start(self, query_id: str, node_id: int) -> None:
         """Called when an operator has started executing."""
         pass
 
-    @abstractmethod
-    def on_exec_emit_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
+    def on_operator_end(self, query_id: str, node_id: int) -> None:
+        """Called when an operator has completed."""
+        pass
+
+    def on_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
         """Called when emitting stats for all running operators in a query."""
         pass
 
-    @abstractmethod
+    def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
+        """Deprecated: use on_operator_start instead."""
+        self.on_operator_start(query_id, node_id)
+
+    def on_exec_emit_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
+        """Deprecated: use on_stats instead."""
+        self.on_stats(query_id, stats)
+
     def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
-        """Called when an operator has completed."""
-        pass
+        """Deprecated: use on_operator_end instead."""
+        self.on_operator_end(query_id, node_id)
 
     @abstractmethod
     def on_exec_end(self, query_id: str) -> None:

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -193,7 +193,7 @@ class EventLogSubscriber(Subscriber):
         self._write_event(query_id, "execution_started", {})
         self._write_event(query_id, "plan_physical", {"plan": physical_plan})
 
-    def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
+    def on_operator_start(self, query_id: str, node_id: int) -> None:
         self._operator_starts[(query_id, node_id)] = _mono_ms()
         self._write_event(
             query_id,
@@ -203,7 +203,7 @@ class EventLogSubscriber(Subscriber):
             },
         )
 
-    def on_exec_emit_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
+    def on_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
         for node_id, node_stats in stats.items():
             metrics: dict[str, Any] = {}
             for name, (_stat_type, value) in node_stats.items():
@@ -223,7 +223,7 @@ class EventLogSubscriber(Subscriber):
             metrics[name] = value
         self._write_event(query_id, "process_stats", {"metrics": metrics})
 
-    def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
+    def on_operator_end(self, query_id: str, node_id: int) -> None:
         start = self._operator_starts.pop((query_id, node_id), None)
         duration_ms = round(_mono_ms() - start) if start is not None else None
 

--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -16,7 +16,10 @@ use reqwest::{Client, RequestBuilder};
 use tokio::{sync::mpsc, task::JoinHandle};
 use uuid::Uuid;
 
-use crate::subscribers::{QueryMetadata, QueryResult, Subscriber};
+use crate::subscribers::{
+    QueryMetadata, QueryResult, Subscriber,
+    events::{OperatorEndEvent, OperatorStartEvent, StatsEvent},
+};
 
 const TOTAL_ROWS: usize = 10;
 const DASHBOARD_EVENT_LIMIT: usize = 512;
@@ -447,5 +450,66 @@ impl Subscriber for DashboardSubscriber {
 
     async fn on_exec_end(&self, query_id: QueryID) -> DaftResult<()> {
         self.on_exec_end_with_id(query_id, "unknown").await
+    }
+
+    async fn on_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
+        self.enqueue_no_body(
+            format!(
+                "engine/query/{}/exec/{}/start",
+                event.header.query_id, event.operator.node_id
+            ),
+            "exec_operator_start",
+        );
+        Ok(())
+    }
+
+    async fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
+        if std::env::var("DAFT_FLOTILLA_WORKER").is_ok() {
+            return Ok(());
+        }
+
+        let query_id = event.header.query_id.clone();
+        let source_id = if let Some(worker_id) = &self.worker_id {
+            worker_id.clone()
+        } else {
+            self.execution_ids
+                .get(&query_id)
+                .map(|id| id.clone())
+                .unwrap_or_else(|| "unknown".to_string())
+        };
+
+        self.enqueue_json(
+            format!("engine/query/{}/exec/emit_stats", query_id),
+            "exec_emit_stats",
+            &daft_dashboard::engine::ExecEmitStatsArgsSend {
+                source_id,
+                stats: event
+                    .stats
+                    .iter()
+                    .map(|(node_id, snapshot)| {
+                        (
+                            *node_id,
+                            snapshot
+                                .0
+                                .iter()
+                                .map(|(name, stat)| (name.to_string(), stat.clone()))
+                                .collect(),
+                        )
+                    })
+                    .collect(),
+            },
+        );
+        Ok(())
+    }
+
+    async fn on_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
+        self.enqueue_no_body(
+            format!(
+                "engine/query/{}/exec/{}/end",
+                event.header.query_id, event.operator.node_id
+            ),
+            "exec_operator_end",
+        );
+        Ok(())
     }
 }

--- a/src/daft-context/src/subscribers/debug.rs
+++ b/src/daft-context/src/subscribers/debug.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use common_error::DaftResult;
-use common_metrics::{NodeID, QueryID, QueryPlan, Stats};
+use common_metrics::{NodeID, QueryID, QueryPlan, Stat, Stats};
 use daft_micropartition::MicroPartitionRef;
 use dashmap::DashMap;
 
-use crate::subscribers::{QueryMetadata, QueryResult, Subscriber};
+use crate::subscribers::{
+    QueryMetadata, QueryResult, Subscriber,
+    events::{OperatorEndEvent, OperatorStartEvent, StatsEvent},
+};
 
 #[derive(Debug)]
 pub struct DebugSubscriber {
@@ -110,5 +113,74 @@ impl Subscriber for DebugSubscriber {
     async fn on_exec_end(&self, query_id: QueryID) -> DaftResult<()> {
         eprintln!("Finished executing query `{}`", query_id);
         Ok(())
+    }
+
+    async fn on_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
+        if event.operator.origin_node_id == event.operator.node_id {
+            eprintln!(
+                "operator_start query_id={} node_id={} name=\"{}\" type={:?} category={:?}",
+                event.header.query_id,
+                event.operator.node_id,
+                event.operator.name,
+                event.operator.node_type,
+                event.operator.node_category,
+            );
+        } else {
+            eprintln!(
+                "operator_start query_id={} node_id={} origin_node_id={} name=\"{}\" type={:?} category={:?}",
+                event.header.query_id,
+                event.operator.node_id,
+                event.operator.origin_node_id,
+                event.operator.name,
+                event.operator.node_type,
+                event.operator.node_category,
+            );
+        }
+        Ok(())
+    }
+
+    async fn on_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
+        if event.operator.origin_node_id == event.operator.node_id {
+            eprintln!(
+                "operator_end query_id={} node_id={} name=\"{}\"",
+                event.header.query_id, event.operator.node_id, event.operator.name,
+            );
+        } else {
+            eprintln!(
+                "operator_end query_id={} node_id={} origin_node_id={} name=\"{}\"",
+                event.header.query_id,
+                event.operator.node_id,
+                event.operator.origin_node_id,
+                event.operator.name,
+            );
+        }
+        Ok(())
+    }
+
+    async fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
+        for (node_id, stats) in event.stats.iter() {
+            let rendered = stats
+                .0
+                .iter()
+                .map(|(key, stat)| format!("{key}={}", render_stat(stat)))
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            eprintln!(
+                "stats query_id={} node_id={} {}",
+                event.header.query_id, node_id, rendered,
+            );
+        }
+        Ok(())
+    }
+}
+
+fn render_stat(stat: &Stat) -> String {
+    match stat {
+        Stat::Count(v) => v.to_string(),
+        Stat::Bytes(v) => v.to_string(),
+        Stat::Duration(v) => format!("{v:?}"),
+        Stat::Percent(v) => format!("{v}%"),
+        Stat::Float(v) => v.to_string(),
     }
 }

--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -1,0 +1,55 @@
+use std::{collections::HashMap, sync::Arc};
+
+use common_metrics::{
+    NodeID, QueryID, Stats,
+    ops::{NodeCategory, NodeInfo, NodeType},
+};
+
+#[derive(Debug, Clone)]
+pub struct EventHeader {
+    pub query_id: QueryID,
+    pub timestamp_epoch_secs: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct OperatorMeta {
+    pub node_id: NodeID,
+    pub name: Arc<str>,
+    pub node_type: NodeType,
+    pub node_category: NodeCategory,
+    pub origin_node_id: NodeID,
+    pub node_phase: Option<String>,
+    pub context: HashMap<String, String>,
+}
+
+impl From<&NodeInfo> for OperatorMeta {
+    fn from(info: &NodeInfo) -> Self {
+        Self {
+            node_id: info.id,
+            name: info.name.clone(),
+            node_type: info.node_type.clone(),
+            node_category: info.node_category.clone(),
+            origin_node_id: info.node_origin_id,
+            node_phase: info.node_phase.clone(),
+            context: info.context.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct OperatorStartEvent {
+    pub header: EventHeader,
+    pub operator: Arc<OperatorMeta>,
+}
+
+#[derive(Debug)]
+pub struct OperatorEndEvent {
+    pub header: EventHeader,
+    pub operator: Arc<OperatorMeta>,
+}
+
+#[derive(Debug)]
+pub struct StatsEvent {
+    pub header: EventHeader,
+    pub stats: Arc<Vec<(NodeID, Stats)>>,
+}

--- a/src/daft-context/src/subscribers/mod.rs
+++ b/src/daft-context/src/subscribers/mod.rs
@@ -1,5 +1,6 @@
 pub mod dashboard;
 mod debug;
+pub mod events;
 #[cfg(feature = "python")]
 pub mod python;
 
@@ -10,6 +11,8 @@ use common_error::{DaftError, DaftResult};
 use common_metrics::{NodeID, QueryEndState, QueryID, QueryPlan, Stats};
 use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartitionRef;
+
+use crate::subscribers::events::{OperatorEndEvent, OperatorStartEvent, StatsEvent};
 
 pub struct QueryMetadata {
     pub output_schema: SchemaRef,
@@ -41,12 +44,18 @@ pub trait Subscriber: Send + Sync + std::fmt::Debug + 'static {
     ) -> DaftResult<()> {
         self.on_exec_start(query_id, physical_plan)
     }
-    async fn on_exec_operator_start(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()>;
+    /// Deprecated: use on_operator_start instead
+    async fn on_exec_operator_start(&self, _query_id: QueryID, _node_id: NodeID) -> DaftResult<()> {
+        Ok(())
+    }
+    /// Deprecated: use on_stats instead
     async fn on_exec_emit_stats(
         &self,
-        query_id: QueryID,
-        stats: Arc<Vec<(NodeID, Stats)>>,
-    ) -> DaftResult<()>;
+        _query_id: QueryID,
+        _stats: Arc<Vec<(NodeID, Stats)>>,
+    ) -> DaftResult<()> {
+        Ok(())
+    }
     async fn on_exec_emit_stats_with_id(
         &self,
         query_id: QueryID,
@@ -55,7 +64,10 @@ pub trait Subscriber: Send + Sync + std::fmt::Debug + 'static {
     ) -> DaftResult<()> {
         self.on_exec_emit_stats(query_id, stats).await
     }
-    async fn on_exec_operator_end(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()>;
+    /// Deprecated: use on_operator_end instead
+    async fn on_exec_operator_end(&self, _query_id: QueryID, _node_id: NodeID) -> DaftResult<()> {
+        Ok(())
+    }
     async fn on_exec_end(&self, query_id: QueryID) -> DaftResult<()>;
     /// Called with process-level stats (memory, CPU) on each tick.
     /// Default no-op; only subscribers interested in process stats need to override.
@@ -64,6 +76,18 @@ pub trait Subscriber: Send + Sync + std::fmt::Debug + 'static {
     }
     async fn on_exec_end_with_id(&self, query_id: QueryID, _execution_id: &str) -> DaftResult<()> {
         self.on_exec_end(query_id).await
+    }
+
+    async fn on_operator_start(&self, _event: Arc<OperatorStartEvent>) -> DaftResult<()> {
+        Ok(())
+    }
+
+    async fn on_operator_end(&self, _event: Arc<OperatorEndEvent>) -> DaftResult<()> {
+        Ok(())
+    }
+
+    async fn on_stats(&self, _event: Arc<StatsEvent>) -> DaftResult<()> {
+        Ok(())
     }
 }
 

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -8,7 +8,10 @@ use pyo3::{IntoPyObject, Py, PyAny, Python, intern};
 
 use crate::{
     python::{PyQueryMetadata, PyQueryResult},
-    subscribers::{NodeID, QueryMetadata, QueryResult, Subscriber},
+    subscribers::{
+        NodeID, QueryMetadata, QueryResult, Subscriber,
+        events::{OperatorEndEvent, OperatorStartEvent, StatsEvent},
+    },
 };
 
 /// Wrapper around a Python object that implements the Subscriber trait
@@ -156,6 +159,53 @@ impl Subscriber for PySubscriberWrapper {
                 py,
                 intern!(py, "on_process_stats"),
                 (query_id.to_string(), py_stats),
+            )?;
+            Ok(())
+        })
+    }
+
+    async fn on_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
+        Python::attach(|py| {
+            self.0.call_method1(
+                py,
+                intern!(py, "on_operator_start"),
+                (event.header.query_id.to_string(), event.operator.node_id),
+            )?;
+            Ok(())
+        })
+    }
+
+    async fn on_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
+        Python::attach(|py| {
+            self.0.call_method1(
+                py,
+                intern!(py, "on_operator_end"),
+                (event.header.query_id.to_string(), event.operator.node_id),
+            )?;
+            Ok(())
+        })
+    }
+
+    async fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
+        Python::attach(|py| {
+            let stats_map = event
+                .stats
+                .iter()
+                .map(|(node_id, stats)| {
+                    let stat_map = stats
+                        .iter()
+                        .map(|(name, stat)| {
+                            (name.to_string(), stat.clone().into_py_contents(py).unwrap())
+                        })
+                        .collect::<HashMap<_, _>>();
+                    (*node_id, stat_map)
+                })
+                .collect::<HashMap<_, _>>();
+            let py_stats = stats_map.into_pyobject(py)?;
+            self.0.call_method1(
+                py,
+                intern!(py, "on_stats"),
+                (event.header.query_id.to_string(), py_stats),
             )?;
             Ok(())
         })

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -240,7 +240,7 @@ impl RuntimeStatsManager {
                             }
 
                             let Some(operator_meta) = operators.get(&node_id) else {
-                                log::warn!("Unknown node_id {node_id} in operators during activate, skipping subscriber notification");
+                                log::warn!("Unknown node_id {node_id} in operators during on_start, skipping subscriber notification");
                                 continue;
                             };
 

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -5,13 +5,18 @@ mod values;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use common_error::DaftResult;
 use common_metrics::{NodeID, QueryEndState, QueryID, ops::NodeInfo, snapshot::StatSnapshotImpl};
 use common_runtime::RuntimeTask;
-use daft_context::Subscriber;
+use daft_context::{
+    Subscriber,
+    subscribers::events::{
+        EventHeader, OperatorEndEvent, OperatorMeta, OperatorStartEvent, StatsEvent,
+    },
+};
 use daft_dsl::common_treenode::{TreeNode, TreeNodeRecursion};
 use daft_local_plan::ExecutionStats;
 use futures::future;
@@ -24,6 +29,13 @@ use tokio::{
 pub use values::{DefaultRuntimeStats, RuntimeStats};
 
 use crate::pipeline::PipelineNode;
+
+fn now_epoch_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before UNIX_EPOCH")
+        .as_secs_f64()
+}
 
 fn should_enable_process_monitor() -> bool {
     if let Ok(val) = std::env::var("DAFT_PROCESS_MONITOR_ENABLED") {
@@ -91,6 +103,7 @@ impl RuntimeStatsManager {
         progress_bar: Option<&dyn ProgressBar>,
         subscribers: &[Arc<dyn Subscriber>],
         err_context: &'static str,
+        operators: &HashMap<NodeID, Arc<OperatorMeta>>,
     ) {
         let runtime_stats = &node_map[&node_id].1;
         let snapshot = runtime_stats.flush();
@@ -99,14 +112,28 @@ impl RuntimeStatsManager {
             progress_bar.finalize_node(node_id, &snapshot);
         }
 
-        let event = Arc::new(vec![(node_id, snapshot.to_stats())]);
-        for res in future::join_all(subscribers.iter().map(|subscriber| async {
-            subscriber
-                .on_exec_emit_stats(query_id.clone(), event.clone())
-                .await?;
-            subscriber
-                .on_exec_operator_end(query_id.clone(), node_id)
-                .await
+        let stats_event = Arc::new(StatsEvent {
+            header: EventHeader {
+                query_id: query_id.clone(),
+                timestamp_epoch_secs: now_epoch_secs(),
+            },
+            stats: Arc::new(vec![(node_id, snapshot.to_stats())]),
+        });
+
+        let end_event = Arc::new(OperatorEndEvent {
+            header: EventHeader {
+                query_id: query_id.clone(),
+                timestamp_epoch_secs: now_epoch_secs(),
+            },
+            operator: operators[&node_id].clone(),
+        });
+        for res in future::join_all(subscribers.iter().map(|subscriber| {
+            let stats_event = stats_event.clone();
+            let end_event = end_event.clone();
+            async move {
+                subscriber.on_stats(stats_event).await?;
+                subscriber.on_operator_end(end_event).await
+            }
         }))
         .await
         {
@@ -126,11 +153,16 @@ impl RuntimeStatsManager {
         // Construct mapping between node id and their node info and runtime stats
         let mut node_map = HashMap::new();
         let mut node_info_map = HashMap::new();
+        let mut operator_meta_map: HashMap<NodeID, Arc<OperatorMeta>> = HashMap::new();
         let _ = pipeline.apply(|node| {
             let node_info = node.node_info();
             let runtime_stats = node.runtime_stats();
             node_info_map.insert(node_info.id, node_info.clone());
-            node_map.insert(node_info.id, (node_info, runtime_stats));
+            node_map.insert(node_info.id, (node_info.clone(), runtime_stats));
+            operator_meta_map.insert(
+                node_info.id,
+                Arc::new(OperatorMeta::from(node_info.as_ref())),
+            );
             Ok(TreeNodeRecursion::Continue)
         });
 
@@ -159,6 +191,7 @@ impl RuntimeStatsManager {
             node_map,
             throttle_interval,
             enable_process_monitor,
+            operator_meta_map,
         ))
     }
 
@@ -173,6 +206,7 @@ impl RuntimeStatsManager {
         node_map: HashMap<NodeID, (Arc<NodeInfo>, Arc<dyn RuntimeStats>)>,
         throttle_interval: Duration,
         enable_process_monitor: bool,
+        operators: HashMap<NodeID, Arc<OperatorMeta>>,
     ) -> Self {
         let (node_tx, mut node_rx) = mpsc::unbounded_channel::<(usize, bool)>();
         let node_tx = Arc::new(node_tx);
@@ -200,7 +234,17 @@ impl RuntimeStatsManager {
                                 progress_bar.initialize_node(node_id);
                             }
 
-                            for res in future::join_all(subscribers.iter().map(|subscriber| subscriber.on_exec_operator_start(query_id.clone(), node_id))).await {
+                            let event = Arc::new(OperatorStartEvent {
+                                header: EventHeader {
+                                    query_id: query_id.clone(),
+                                    timestamp_epoch_secs: now_epoch_secs(),
+                                },
+                                operator: operators[&node_id].clone(),
+                            });
+
+                            for res in future::join_all(subscribers.iter().map(|subscriber| {
+                                subscriber.on_operator_start(event.clone())
+                            })).await {
                                 if let Err(e) = res {
                                     log::error!("Failed to initialize node: {}", e);
                                 }
@@ -213,6 +257,7 @@ impl RuntimeStatsManager {
                                 progress_bar.as_deref(),
                                 &subscribers,
                                 "finalize node",
+                                &operators,
                             )
                             .await;
                         }
@@ -229,6 +274,7 @@ impl RuntimeStatsManager {
                                 progress_bar.as_deref(),
                                 &subscribers,
                                 "finalize node during shutdown",
+                                &operators,
                             )
                             .await;
                         }
@@ -261,8 +307,15 @@ impl RuntimeStatsManager {
                         }
 
                         let snapshot_container = Arc::new(std::mem::take(&mut snapshot_container));
+                        let event = Arc::new(StatsEvent {
+                            header: EventHeader {
+                                query_id: query_id.clone(),
+                                timestamp_epoch_secs: now_epoch_secs(),
+                            },
+                            stats: snapshot_container.clone(),
+                        });
                         for res in future::join_all(subscribers.iter().map(|subscriber| {
-                            subscriber.on_exec_emit_stats(query_id.clone(), snapshot_container.clone())
+                            subscriber.on_stats(event.clone())
                         })).await {
                             if let Err(e) = res {
                                 log::error!("Failed to handle event: {}", e);
@@ -318,19 +371,41 @@ impl RuntimeStatsManager {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex, atomic::AtomicU64};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex, atomic::AtomicU64},
+    };
 
     use async_trait::async_trait;
     use common_error::DaftResult;
     use common_metrics::{
-        DURATION_KEY, Meter, NodeID, QueryPlan, ROWS_IN_KEY, ROWS_OUT_KEY, Stat, StatSnapshot,
-        Stats,
+        DURATION_KEY, Meter, QueryPlan, ROWS_IN_KEY, ROWS_OUT_KEY, Stat, StatSnapshot, Stats,
     };
     use daft_context::{QueryMetadata, QueryResult, Subscriber};
     use daft_micropartition::MicroPartitionRef;
     use tokio::time::{Duration, sleep};
 
     use super::*;
+
+    fn make_stats_manager(
+        subscribers: Vec<Arc<dyn Subscriber>>,
+        node_stat: Arc<dyn RuntimeStats>,
+        throttle_interval: Duration,
+        query_id: &str,
+        enable_process_monitor: bool,
+    ) -> RuntimeStatsManager {
+        RuntimeStatsManager::new_impl(
+            &tokio::runtime::Handle::current(),
+            query_id.into(),
+            serde_json::Value::Null,
+            subscribers,
+            None,
+            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat))]),
+            throttle_interval,
+            enable_process_monitor,
+            HashMap::from([(0, Arc::new(OperatorMeta::from(&NodeInfo::default())))]),
+        )
+    }
 
     #[derive(Debug)]
     struct MockState {
@@ -395,22 +470,18 @@ mod tests {
         async fn on_exec_end(&self, _: QueryID) -> DaftResult<()> {
             Ok(())
         }
-        async fn on_exec_operator_start(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
+        async fn on_operator_start(&self, _: Arc<OperatorStartEvent>) -> DaftResult<()> {
             Ok(())
         }
-        async fn on_exec_operator_end(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
+        async fn on_operator_end(&self, _: Arc<OperatorEndEvent>) -> DaftResult<()> {
             Ok(())
         }
 
-        async fn on_exec_emit_stats(
-            &self,
-            _query_id: QueryID,
-            stats: std::sync::Arc<Vec<(NodeID, Stats)>>,
-        ) -> DaftResult<()> {
+        async fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
             self.state
                 .total_calls
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            for (_, snapshot) in stats.iter() {
+            for (_, snapshot) in event.stats.iter() {
                 *self.state.event.lock().unwrap() = Some(snapshot.clone());
             }
             Ok(())
@@ -427,14 +498,11 @@ mod tests {
             &node_info_from_id(0),
         )) as Arc<dyn RuntimeStats>;
         let throttle_interval = Duration::from_millis(50);
-        let stats_manager = RuntimeStatsManager::new_impl(
-            &tokio::runtime::Handle::current(),
-            "test_query_id".into(),
-            serde_json::Value::Null,
+        let stats_manager = make_stats_manager(
             vec![mock_subscriber],
-            None,
-            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
+            node_stat.clone(),
             throttle_interval,
+            "test_ps_disabled",
             false,
         );
         let handle = stats_manager.handle();
@@ -493,14 +561,11 @@ mod tests {
             &node_info_from_id(0),
         )) as Arc<dyn RuntimeStats>;
         let throttle_interval = Duration::from_millis(50);
-        let stats_manager = RuntimeStatsManager::new_impl(
-            &tokio::runtime::Handle::current(),
-            "test_query_id".into(),
-            serde_json::Value::Null,
+        let stats_manager = make_stats_manager(
             vec![subscriber1, subscriber2],
-            None,
-            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
+            node_stat.clone(),
             throttle_interval,
+            "test_query_id",
             false,
         );
         let handle = stats_manager.handle();
@@ -544,18 +609,14 @@ mod tests {
             async fn on_exec_end(&self, _: QueryID) -> DaftResult<()> {
                 Ok(())
             }
-            async fn on_exec_operator_start(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
+            async fn on_operator_start(&self, _: Arc<OperatorStartEvent>) -> DaftResult<()> {
                 Ok(())
             }
-            async fn on_exec_operator_end(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
+            async fn on_operator_end(&self, _: Arc<OperatorEndEvent>) -> DaftResult<()> {
                 Ok(())
             }
 
-            async fn on_exec_emit_stats(
-                &self,
-                _: QueryID,
-                _: std::sync::Arc<Vec<(NodeID, Stats)>>,
-            ) -> DaftResult<()> {
+            async fn on_stats(&self, _: Arc<StatsEvent>) -> DaftResult<()> {
                 Err(common_error::DaftError::InternalError(
                     "Test error".to_string(),
                 ))
@@ -571,14 +632,11 @@ mod tests {
             &node_info_from_id(0),
         )) as Arc<dyn RuntimeStats>;
         let throttle_interval = Duration::from_millis(50);
-        let stats_manager = RuntimeStatsManager::new_impl(
-            &tokio::runtime::Handle::current(),
-            "test_query_id".into(),
-            serde_json::Value::Null,
+        let stats_manager = make_stats_manager(
             vec![failing_subscriber, mock_subscriber],
-            None,
-            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
+            node_stat.clone(),
             throttle_interval,
+            "test_query_id",
             false,
         );
         let handle = stats_manager.handle();
@@ -632,14 +690,11 @@ mod tests {
             &node_info_from_id(0),
         )) as Arc<dyn RuntimeStats>;
         let throttle_interval = Duration::from_millis(50);
-        let stats_manager = RuntimeStatsManager::new_impl(
-            &tokio::runtime::Handle::current(),
-            "test_query_id".into(),
-            serde_json::Value::Null,
+        let stats_manager = make_stats_manager(
             vec![mock_subscriber],
-            None,
-            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
+            node_stat.clone(),
             throttle_interval,
+            "test_ps_disabled",
             false,
         );
         let handle = stats_manager.handle();
@@ -670,14 +725,11 @@ mod tests {
             &Meter::test_scope("test_stats"),
             &node_info_from_id(0),
         )) as Arc<dyn RuntimeStats>;
-        let stats_manager = RuntimeStatsManager::new_impl(
-            &tokio::runtime::Handle::current(),
-            "test_query_id".into(),
-            serde_json::Value::Null,
+        let stats_manager = make_stats_manager(
             vec![mock_subscriber],
-            None,
-            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat.clone()))]),
+            node_stat.clone(),
             throttle_interval,
+            "test_ps_disabled",
             false,
         );
         let handle = stats_manager.handle();
@@ -751,17 +803,13 @@ mod tests {
         async fn on_exec_end(&self, _: QueryID) -> DaftResult<()> {
             Ok(())
         }
-        async fn on_exec_operator_start(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
+        async fn on_operator_start(&self, _: Arc<OperatorStartEvent>) -> DaftResult<()> {
             Ok(())
         }
-        async fn on_exec_operator_end(&self, _: QueryID, _: NodeID) -> DaftResult<()> {
+        async fn on_operator_end(&self, _: Arc<OperatorEndEvent>) -> DaftResult<()> {
             Ok(())
         }
-        async fn on_exec_emit_stats(
-            &self,
-            _: QueryID,
-            _: Arc<Vec<(NodeID, Stats)>>,
-        ) -> DaftResult<()> {
+        async fn on_stats(&self, _: Arc<StatsEvent>) -> DaftResult<()> {
             Ok(())
         }
         async fn on_process_stats(&self, _: QueryID, _: Stats) -> DaftResult<()> {
@@ -780,15 +828,12 @@ mod tests {
             &node_info_from_id(0),
         )) as Arc<dyn RuntimeStats>;
 
-        let stats_manager = RuntimeStatsManager::new_impl(
-            &tokio::runtime::Handle::current(),
-            "test_ps_enabled".into(),
-            serde_json::Value::Null,
+        let stats_manager = make_stats_manager(
             vec![subscriber.clone()],
-            None,
-            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat))]),
+            node_stat.clone(),
             throttle_interval,
-            true, // enable process monitor
+            "test_ps_enabled",
+            true,
         );
 
         // Let a few ticks fire
@@ -812,17 +857,13 @@ mod tests {
             &node_info_from_id(0),
         )) as Arc<dyn RuntimeStats>;
 
-        let stats_manager = RuntimeStatsManager::new_impl(
-            &tokio::runtime::Handle::current(),
-            "test_ps_disabled".into(),
-            serde_json::Value::Null,
+        let stats_manager = make_stats_manager(
             vec![subscriber.clone()],
-            None,
-            HashMap::from([(0, (Arc::new(NodeInfo::default()), node_stat))]),
+            node_stat.clone(),
             throttle_interval,
-            false, // disable process monitor
+            "test_ps_disabled",
+            false,
         );
-
         // Let a few ticks fire
         sleep(Duration::from_millis(150)).await;
 

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -112,6 +112,11 @@ impl RuntimeStatsManager {
             progress_bar.finalize_node(node_id, &snapshot);
         }
 
+        let Some(operator_meta) = operators.get(&node_id) else {
+            log::warn!("Unknown node_id {node_id} in operators during {err_context}, skipping");
+            return;
+        };
+
         let stats_event = Arc::new(StatsEvent {
             header: EventHeader {
                 query_id: query_id.clone(),
@@ -125,7 +130,7 @@ impl RuntimeStatsManager {
                 query_id: query_id.clone(),
                 timestamp_epoch_secs: now_epoch_secs(),
             },
-            operator: operators[&node_id].clone(),
+            operator: operator_meta.clone(),
         });
         for res in future::join_all(subscribers.iter().map(|subscriber| {
             let stats_event = stats_event.clone();
@@ -234,12 +239,17 @@ impl RuntimeStatsManager {
                                 progress_bar.initialize_node(node_id);
                             }
 
+                            let Some(operator_meta) = operators.get(&node_id) else {
+                                log::warn!("Unknown node_id {node_id} in operators during activate, skipping subscriber notification");
+                                continue;
+                            };
+
                             let event = Arc::new(OperatorStartEvent {
                                 header: EventHeader {
                                     query_id: query_id.clone(),
                                     timestamp_epoch_secs: now_epoch_secs(),
                                 },
-                                operator: operators[&node_id].clone(),
+                                operator: operator_meta.clone(),
                             });
 
                             for res in future::join_all(subscribers.iter().map(|subscriber| {

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -60,16 +60,25 @@ class MockSubscriber(Subscriber):
     def on_exec_start(self, query_id: str, physical_plan: str) -> None:
         self.query_physical_plan[query_id] = physical_plan
 
-    def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
+    def on_operator_start(self, query_id: str, node_id: int) -> None:
         pass
 
-    def on_exec_emit_stats(self, query_id: str, all_stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
+    def on_stats(self, query_id: str, all_stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
         for node_id, stats in all_stats.items():
             for stat_name, (_, stat_value) in stats.items():
                 self.query_node_stats[query_id][node_id][stat_name] = stat_value
 
-    def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
+    def on_operator_end(self, query_id: str, node_id: int) -> None:
         pass
+
+    def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
+        self.on_operator_start(query_id, node_id)
+
+    def on_exec_emit_stats(self, query_id: str, all_stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
+        self.on_stats(query_id, all_stats)
+
+    def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
+        self.on_operator_end(query_id, node_id)
 
     def on_exec_end(self, query_id: str) -> None:
         pass


### PR DESCRIPTION
## Changes Made

Introduce OperatorStartEvent, OperatorEndEvent, and StatsEvent with EventHeader and OperatorMeta, replacing positional parameters in the three operator/stats subscriber callbacks. RuntimeStatsManager now constructs typed events and calls the new on_operator_start, on_operator_end, and on_stats methods. Old methods are kept with default no-op implementations for distributed path backward compatibility.

There will be follow up to convert the distributed code to use the events and to update the python subscriber to take events instead of positional args. Overtime the subscriber framework will be converted to use event types so additional information can be added without changing the api.


Example of output from debug subscriber.
```
Started query `daring-ocean-914054` with unoptimized plan:
{"children":[{"batch_size":10000,"children":[{"children":[{"children":[{"children":[],"type":"Source"}],"projection":["col(VendorID)","col(total_amount)","col(tpep_pickup_datetime)"],"type":"Project"}],"limit":100000,"type":"Limit"}],"type":"IntoBatches"}],"type":"Sink"}
Started planning query `daring-ocean-914054`
Finished planning query `daring-ocean-914054` with optimized plan:
{"children":[{"batch_size":10000,"children":[{"children":[{"children":[{"children":[],"type":"Source"}],"limit":100000,"type":"Limit"}],"projection":["col(VendorID)","col(total_amount)","col(tpep_pickup_datetime)"],"type":"Project"}],"type":"IntoBatches"}],"type":"Sink"}
Started executing query `daring-ocean-914054` with physical plan:
{"approx_stats":{"approx_stats":{"acc_selectivity":1.0,"num_rows":0,"size_bytes":0}},"category":"BlockingSink","children":[{"approx_stats":{"approx_stats":{"acc_selectivity":1.0,"num_rows":0,"size_bytes":0}},"category":"BlockingSink","children":[{"approx_stats":{"approx_stats":{"acc_selectivity":1.0,"num_rows":100000,"size_bytes":2400000}},"category":"Intermediate","children":[{"approx_stats":{"approx_stats":{"acc_selectivity":1.0,"num_rows":100000,"size_bytes":2400000}},"category":"Intermediate","children":[{"approx_stats":{"approx_stats":{"acc_selectivity":1.0,"num_rows":100000,"size_bytes":2400000}},"category":"StreamingSink","children":[{"approx_stats":{"approx_stats":{"acc_selectivity":1.0,"num_rows":100000,"size_bytes":2400000}},"category":"Source","id":0,"name":"Read Parquet","type":"ScanTask"}],"id":1,"name":"Limit 100000","type":"Limit"}],"id":2,"name":"Rename & Reorder","type":"Project"}],"id":3,"name":"Into Batches of 10000","type":"IntoBatches"}],"id":4,"name":"CSV Write","type":"Write"}],"id":5,"name":"Commit Write","type":"CommitWrite"}
operator_start query_id=daring-ocean-914054 node_id=0 name="Read Parquet" type=ScanTask category=Source
stats query_id=daring-ocean-914054 node_id=0 duration=0ns rows.out=0 bytes.read=0
stats query_id=daring-ocean-914054 node_id=0 duration=0ns rows.out=0 bytes.read=0
stats query_id=daring-ocean-914054 node_id=0 duration=0ns rows.out=0 bytes.read=65536
operator_start query_id=daring-ocean-914054 node_id=1 name="Limit 100000" type=Limit category=StreamingSink
operator_start query_id=daring-ocean-914054 node_id=2 name="Rename & Reorder" type=Project category=Intermediate
operator_start query_id=daring-ocean-914054 node_id=3 name="Into Batches of 10000" type=IntoBatches category=Intermediate
operator_start query_id=daring-ocean-914054 node_id=4 name="CSV Write" type=Write category=BlockingSink
stats query_id=daring-ocean-914054 node_id=0 duration=0ns rows.out=88091 bytes.read=2164041
stats query_id=daring-ocean-914054 node_id=2 duration=3.765ms rows.in=88091 rows.out=88091
stats query_id=daring-ocean-914054 node_id=3 duration=72µs rows.in=78091 rows.out=70000
stats query_id=daring-ocean-914054 node_id=1 duration=0ns rows.in=88091 rows.out=88091
stats query_id=daring-ocean-914054 node_id=4 duration=113.125ms rows.in=50000 rows.written=40000 bytes.written=960000
stats query_id=daring-ocean-914054 node_id=1 duration=0ns rows.in=100000 rows.out=100000
operator_end query_id=daring-ocean-914054 node_id=1 name="Limit 100000"
stats query_id=daring-ocean-914054 node_id=0 duration=0ns rows.out=100000 bytes.read=2164041
operator_end query_id=daring-ocean-914054 node_id=0 name="Read Parquet"
stats query_id=daring-ocean-914054 node_id=2 duration=3.806ms rows.in=100000 rows.out=100000
operator_end query_id=daring-ocean-914054 node_id=2 name="Rename & Reorder"
stats query_id=daring-ocean-914054 node_id=3 duration=90µs rows.in=100000 rows.out=100000
operator_end query_id=daring-ocean-914054 node_id=3 name="Into Batches of 10000"
stats query_id=daring-ocean-914054 node_id=4 duration=244.632ms rows.in=100000 rows.written=100000 bytes.written=2400000
operator_end query_id=daring-ocean-914054 node_id=4 name="CSV Write"
operator_start query_id=daring-ocean-914054 node_id=5 name="Commit Write" type=CommitWrite category=BlockingSink
stats query_id=daring-ocean-914054 node_id=5 duration=29.221ms rows.in=1 rows.out=1
operator_end query_id=daring-ocean-914054 node_id=5 name="Commit Write"
Finished executing query `daring-ocean-914054`
```


