### PR TITLE
feat: support to_ray_dataset() from the native runner

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -4911,20 +4911,17 @@ class DataFrame:
 
         # Native runner path: convert MicroPartitions to Arrow tables locally,
         # then create a Ray Dataset from them.
-        import pyarrow as pa
         import ray.data
 
         from daft.runners.ray_runner import _micropartition_to_ray_dataset_block
 
         blocks = [_micropartition_to_ray_dataset_block(result.micropartition()) for _, result in partition_set.items()]
-        arrow_blocks = [b for b in blocks if isinstance(b, pa.Table)]
-        list_blocks = [b for b in blocks if not isinstance(b, pa.Table)]
-
-        if list_blocks:
-            # Fallback: some partitions couldn't be converted to Arrow
-            all_items = [item for block in list_blocks for item in block]
+        # All partitions share the same schema, so either all convert to Arrow or all
+        # fall back to pylist. Handle both cases.
+        if blocks and isinstance(blocks[0], list):
+            all_items = [item for block in blocks for item in block]
             return ray.data.from_items(all_items)
-        return ray.data.from_arrow(arrow_blocks)
+        return ray.data.from_arrow(blocks)
 
     @classmethod
     def _from_ray_dataset(cls, ds: "ray.data.dataset.DataSet") -> "DataFrame":

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -4893,21 +4893,38 @@ class DataFrame:
 
         Examples:
             >>> import daft
-            >>> daft.set_runner_ray()  # doctest: +SKIP
             >>> df = daft.from_pydict({"x": [1, 2, 3], "y": [4, 5, 6]})
             >>> ray_dataset = df.to_ray_dataset()  # doctest: +SKIP
 
         Note:
-            This function can only work if Daft is running using the RayRunner
+            This function requires Ray to be installed. It works with any Daft runner -
+            when using the native runner, partitions are converted to Arrow tables locally
+            and then handed to Ray.
         """
         from daft.runners.ray_runner import RayPartitionSet
 
         self.collect()
         partition_set = self._result
         assert partition_set is not None
-        if not isinstance(partition_set, RayPartitionSet):
-            raise ValueError("Cannot convert to Ray Dataset if not running on Ray backend")
-        return partition_set.to_ray_dataset()
+        if isinstance(partition_set, RayPartitionSet):
+            return partition_set.to_ray_dataset()
+
+        # Native runner path: convert MicroPartitions to Arrow tables locally,
+        # then create a Ray Dataset from them.
+        import pyarrow as pa
+        import ray.data
+
+        from daft.runners.ray_runner import _micropartition_to_ray_dataset_block
+
+        blocks = [_micropartition_to_ray_dataset_block(result.micropartition()) for _, result in partition_set.items()]
+        arrow_blocks = [b for b in blocks if isinstance(b, pa.Table)]
+        list_blocks = [b for b in blocks if not isinstance(b, pa.Table)]
+
+        if list_blocks:
+            # Fallback: some partitions couldn't be converted to Arrow
+            all_items = [item for block in list_blocks for item in block]
+            return ray.data.from_items(all_items)
+        return ray.data.from_arrow(arrow_blocks)
 
     @classmethod
     def _from_ray_dataset(cls, ds: "ray.data.dataset.DataSet") -> "DataFrame":

--- a/daft/runners/ray_runner.py
+++ b/daft/runners/ray_runner.py
@@ -144,8 +144,7 @@ def _glob_path_into_file_infos(
     return file_infos
 
 
-@ray.remote  # type: ignore[untyped-decorator]
-def _make_ray_block_from_micropartition(partition: MicroPartition) -> RayDatasetBlock | list[dict[str, Any]]:
+def _micropartition_to_ray_dataset_block(partition: MicroPartition) -> RayDatasetBlock | list[dict[str, Any]]:
     try:
         daft_schema = partition.schema()
         arrow_tbl = partition.to_arrow()
@@ -182,6 +181,11 @@ def _make_ray_block_from_micropartition(partition: MicroPartition) -> RayDataset
         return arrow_tbl
     except pa.ArrowInvalid:
         return partition.to_pylist()
+
+
+@ray.remote  # type: ignore[untyped-decorator]
+def _make_ray_block_from_micropartition(partition: MicroPartition) -> RayDatasetBlock | list[dict[str, Any]]:
+    return _micropartition_to_ray_dataset_block(partition)
 
 
 def _series_from_arrow_with_ray_data_extensions(

--- a/tests/ray/test_datasets.py
+++ b/tests/ray/test_datasets.py
@@ -36,7 +36,6 @@ def _row_to_pydict(row: ray.data.row.TableRow | dict) -> dict:
     return row.as_pydict()
 
 
-@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_all_arrow(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -60,7 +59,6 @@ def test_to_ray_dataset_all_arrow(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.skipif(
     RAY_VERSION >= (2, 5, 0), reason="Ray Datasets versions >= 2.5.0 no longer support Python objects as rows"
 )
@@ -87,7 +85,6 @@ def test_to_ray_dataset_with_py(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_with_numpy(n_partitions: int):
     df = daft.from_pydict(DATA).repartition(n_partitions)
@@ -119,7 +116,6 @@ def test_to_ray_dataset_with_numpy(n_partitions: int):
     )
 
 
-@pytest.mark.skipif(get_tests_daft_runner_name() != "ray", reason="Needs to run on Ray runner")
 @pytest.mark.skipif(RAY_VERSION < (2, 2, 0), reason="Variable-shaped tensor columns not supported in Ray < 2.1.0")
 @pytest.mark.parametrize("n_partitions", [1, 2])
 def test_to_ray_dataset_with_numpy_variable_shaped(n_partitions: int):


### PR DESCRIPTION
`DataFrame.to_ray_dataset()` previously required the Ray runner, raising a `ValueError` when called from the native runner. This forced users who run Daft compute on the native runner (for performance) but need Ray Datasets for downstream ML pipelines to do manual Arrow/pylist round-trips.

The restriction was artificial. When using the native runner, partitions can be converted to Arrow tables and passed directly to Ray via`ray.data.from_arrow()`.