### PR TITLE
chore: deprecate all extra lance functions in favor of new daft-lance

### DIFF
--- a/daft/io/lance/_lance.py
+++ b/daft/io/lance/_lance.py
@@ -229,7 +229,7 @@ def merge_columns(
     """
     warnings.warn(
         "daft.io.lance.merge_columns is deprecated and will be removed in a future release. "
-        "Please use daft.io.lance.merge_columns_df instead.",
+        "Please use daft_lance.merge_columns from the daft-lance package instead: pip install daft-lance",
         category=DeprecationWarning,
         stacklevel=2,
     )
@@ -335,6 +335,13 @@ def merge_columns_df(
         >>> # Merge the new columns back to the table
         >>> daft.io.lance.merge_columns_df(df, "s3://my-lancedb-bucket/data/")
     """
+    warnings.warn(
+        "daft.io.lance.merge_columns_df is deprecated and will be removed in a future release. "
+        "Please use daft_lance.merge_columns_df from the daft-lance package instead: pip install daft-lance",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     io_config = context.get_context().daft_planning_config.default_io_config if io_config is None else io_config
     storage_options = storage_options or io_config_to_storage_options(io_config, uri)
 
@@ -465,6 +472,13 @@ def create_scalar_index(
         Create an index without replacing existing ones:
         >>> daft.io.lance.create_scalar_index("s3://my-bucket/dataset/", column="title", replace=False)
     """
+    warnings.warn(
+        "daft.io.lance.create_scalar_index is deprecated and will be removed in a future release. "
+        "Please use daft_lance.create_scalar_index from the daft-lance package instead: pip install daft-lance",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     try:
         import lance
         from packaging import version as packaging_version
@@ -568,6 +582,13 @@ def compact_files(
     Raises:
         RuntimeError: When compaction fails or no successful results
     """
+    warnings.warn(
+        "daft.io.lance.compact_files is deprecated and will be removed in a future release. "
+        "Please use daft_lance.compact_files from the daft-lance package instead: pip install daft-lance",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     try:
         import lance
 

--- a/daft/io/lance/rest_write.py
+++ b/daft/io/lance/rest_write.py
@@ -135,6 +135,15 @@ def create_lance_table_rest(
     Returns:
         Dictionary containing creation metadata
     """
+    import warnings
+
+    warnings.warn(
+        "daft.io.lance.create_lance_table_rest is deprecated and will be removed in a future release. "
+        "Please use daft_lance.create_lance_table_rest from the daft-lance package instead: pip install daft-lance",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     if lance_namespace is None:
         raise ImportError(
             "Unable to import the `lance_namespace` package, please ensure it is installed: `pip install lance-namespace`"
@@ -179,6 +188,15 @@ def register_lance_table_rest(
     Returns:
         Dictionary containing registration metadata
     """
+    import warnings
+
+    warnings.warn(
+        "daft.io.lance.register_lance_table_rest is deprecated and will be removed in a future release. "
+        "Please use daft_lance.register_lance_table_rest from the daft-lance package instead: pip install daft-lance",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     if lance_namespace is None:
         raise ImportError(
             "Unable to import the `lance_namespace` package, please ensure it is installed: `pip install lance-namespace`"


### PR DESCRIPTION


## Motivation

The Lance integration in Daft has grown into a substantial set of helper functions (compaction, scalar indexing, column merging, REST catalog operations) that orchestrate Lance-specific operations using Daft's distributed execution. While useful, these functions aren't part of Daft's core engine — they're Lance-specific workflows that happen to run on Daft. 

Maintaining them inside the Daft repo slows down development on both sides: Daft's core maintainers aren't Lance experts, so reviews add friction without much value, and Lance-focused contributors have to navigate Daft's release cycle for changes that don't touch the engine at all. Moving these into a standalone daft-lance package lets Lance-focused development move independently while keeping read_lance and write_lance as first-class citizens in Daft.


## Changes Made

this just adds deprecation warnings to all of these helper functions to use the new daft-lance package instead.

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
