### PR TITLE
chore(swordfish): Small swordfish cleanups

### DIFF
--- a/src/daft-local-execution/src/buffer.rs
+++ b/src/daft-local-execution/src/buffer.rs
@@ -3,6 +3,8 @@ use std::{collections::VecDeque, num::NonZeroUsize, sync::Arc};
 use common_error::DaftResult;
 use daft_micropartition::MicroPartition;
 
+use crate::pipeline::MorselSizeRequirement;
+
 #[derive(Debug, PartialEq)]
 enum BufferState {
     BelowLowerBound,
@@ -33,7 +35,8 @@ impl RowBasedBuffer {
             upper_bound,
         }
     }
-    pub fn update_bounds(&mut self, lower_bound: usize, upper_bound: NonZeroUsize) {
+    pub fn update_bounds(&mut self, morsel_size_requirement: MorselSizeRequirement) {
+        let (lower_bound, upper_bound) = morsel_size_requirement.values();
         assert!(
             lower_bound <= upper_bound.get(),
             "lower_bound ({}) must be <= upper_bound ({}) for a RowBasedBuffer",

--- a/src/daft-local-execution/src/concat.rs
+++ b/src/daft-local-execution/src/concat.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{ops::ControlFlow, sync::Arc};
 
 use capitalize::Capitalize;
 use common_display::tree::TreeDisplay;
@@ -12,7 +12,7 @@ use daft_logical_plan::stats::StatsState;
 use daft_micropartition::MicroPartition;
 
 use crate::{
-    ExecutionRuntimeContext, OperatorControlFlow,
+    ExecutionRuntimeContext,
     channel::{Receiver, Sender, create_channel},
     pipeline::{BuilderContext, MorselSizeRequirement, PipelineNode},
     runtime_stats::{DefaultRuntimeStats, RuntimeStats, RuntimeStatsManagerHandle},
@@ -62,7 +62,7 @@ impl ConcatNode {
         runtime_stats: Arc<dyn RuntimeStats>,
         stats_manager: &RuntimeStatsManagerHandle,
         node_initialized: &mut bool,
-    ) -> DaftResult<OperatorControlFlow> {
+    ) -> DaftResult<ControlFlow<()>> {
         while let Some(mp) = receiver.recv().await {
             if !*node_initialized {
                 stats_manager.activate_node(node_id);
@@ -71,11 +71,11 @@ impl ConcatNode {
             runtime_stats.add_rows_in(mp.len() as u64);
             runtime_stats.add_rows_out(mp.len() as u64);
             if sender.send(mp).await.is_err() {
-                return Ok(OperatorControlFlow::Break);
+                return Ok(ControlFlow::Break(()));
             }
         }
 
-        Ok(OperatorControlFlow::Continue)
+        Ok(ControlFlow::Continue(()))
     }
 }
 
@@ -197,7 +197,7 @@ impl PipelineNode for ConcatNode {
                     &mut node_initialized,
                 )
                 .await?;
-                if !control.should_continue() {
+                if control.is_break() {
                     stats_manager.finalize_node(node_id);
                     return Ok(());
                 }
@@ -211,7 +211,7 @@ impl PipelineNode for ConcatNode {
                     &mut node_initialized,
                 )
                 .await?;
-                if !control.should_continue() {
+                if control.is_break() {
                     stats_manager.finalize_node(node_id);
                     return Ok(());
                 }

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -254,9 +254,7 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
                     }
 
                     // After completing a task, update bounds and try to spawn more tasks
-                    let new_requirements = ctx.batch_manager.calculate_batch_size();
-                    let (lower, upper) = new_requirements.values();
-                    buffer.update_bounds(lower, upper);
+                    buffer.update_bounds(ctx.batch_manager.calculate_batch_size());
 
                     Self::spawn_ready_batches(&mut buffer, ctx)?;
                 }

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    ops::ControlFlow,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -20,8 +21,7 @@ use snafu::ResultExt;
 use tracing::info_span;
 
 use crate::{
-    ExecutionRuntimeContext, ExecutionTaskSpawner, OperatorControlFlow, OperatorOutput,
-    PipelineExecutionSnafu,
+    ExecutionRuntimeContext, ExecutionTaskSpawner, OperatorOutput, PipelineExecutionSnafu,
     buffer::RowBasedBuffer,
     channel::{Receiver, Sender, create_channel},
     dynamic_batching::{BatchManager, BatchingStrategy},
@@ -164,7 +164,7 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
     async fn handle_task_completion(
         result: ExecutionTaskResult<Op::State>,
         ctx: &mut ExecutionContext<Op>,
-    ) -> DaftResult<OperatorControlFlow> {
+    ) -> DaftResult<ControlFlow<()>> {
         match result.result {
             IntermediateOperatorResult::NeedMoreInput(Some(mp)) => {
                 // Record execution stats
@@ -177,7 +177,7 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
                 // Send output
                 ctx.runtime_stats.add_rows_out(mp.len() as u64);
                 if ctx.output_sender.send(mp).await.is_err() {
-                    return Ok(OperatorControlFlow::Break);
+                    return Ok(ControlFlow::Break(()));
                 }
 
                 // Return state to pool
@@ -198,14 +198,14 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
                 // Send output
                 ctx.runtime_stats.add_rows_out(output.len() as u64);
                 if ctx.output_sender.send(output).await.is_err() {
-                    return Ok(OperatorControlFlow::Break);
+                    return Ok(ControlFlow::Break(()));
                 }
 
                 // Spawn another execution with same input and state (don't return state)
                 Self::spawn_execution_task(ctx, input, result.state, result.state_id);
             }
         }
-        Ok(OperatorControlFlow::Continue)
+        Ok(ControlFlow::Continue(()))
     }
 
     fn spawn_ready_batches(
@@ -249,7 +249,7 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
                 // Branch 1: Join completed task (only if tasks exist)
                 Some(join_result) = ctx.task_set.join_next(), if !ctx.task_set.is_empty() => {
                     let control = Self::handle_task_completion(join_result??, ctx).await?;
-                    if !control.should_continue() {
+                    if control.is_break() {
                         return Ok(()); // Break
                     }
 
@@ -301,7 +301,7 @@ impl<Op: IntermediateOperator + 'static> IntermediateNode<Op> {
             // Wait for final task to complete
             while let Some(join_result) = ctx.task_set.join_next().await {
                 let control = Self::handle_task_completion(join_result??, ctx).await?;
-                if !control.should_continue() {
+                if control.is_break() {
                     return Ok(()); // Break
                 }
             }

--- a/src/daft-local-execution/src/join/join_node.rs
+++ b/src/daft-local-execution/src/join/join_node.rs
@@ -307,7 +307,7 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
                 // Branch 1: Join completed task (only if tasks exist)
                 Some(join_result) = ctx.task_set.join_next(), if !ctx.task_set.is_empty() => {
                     let control = Self::handle_probe_task_completion(join_result??, ctx).await?;
-                    if !control.is_continue() {
+                    if control.is_break() {
                         return Ok(ControlFlow::Break(()));
                     }
 
@@ -359,7 +359,7 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
             // Wait for final task to complete
             while let Some(join_result) = ctx.task_set.join_next().await {
                 let control = Self::handle_probe_task_completion(join_result??, ctx).await?;
-                if !control.is_continue() {
+                if control.is_break() {
                     return Ok(ControlFlow::Break(()));
                 }
             }
@@ -550,7 +550,7 @@ impl<Op: JoinOperator + 'static> PipelineNode for JoinNode<Op> {
                 );
 
                 build_result?;
-                if !probe_result?.is_continue() {
+                if probe_result?.is_break() {
                     stats_manager.finalize_node(node_id);
                     return Ok(());
                 }

--- a/src/daft-local-execution/src/join/join_node.rs
+++ b/src/daft-local-execution/src/join/join_node.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    ops::ControlFlow,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -19,7 +20,7 @@ use tokio::sync::oneshot;
 use tracing::info_span;
 
 use crate::{
-    ExecutionRuntimeContext, ExecutionTaskSpawner, OperatorControlFlow,
+    ExecutionRuntimeContext, ExecutionTaskSpawner,
     buffer::RowBasedBuffer,
     channel::{Receiver, Sender, create_channel},
     dynamic_batching::{BatchManager, StaticBatchingStrategy},
@@ -208,7 +209,7 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
     async fn handle_probe_task_completion(
         result: ProbeTaskResult<Op>,
         ctx: &mut ProbeExecutionContext<Op>,
-    ) -> DaftResult<OperatorControlFlow> {
+    ) -> DaftResult<ControlFlow<()>> {
         match result.output {
             ProbeOutput::NeedMoreInput(mp) => {
                 // Record execution stats
@@ -222,7 +223,7 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
                 if let Some(mp) = mp {
                     ctx.runtime_stats.add_probe_rows_out(mp.len() as u64);
                     if ctx.output_sender.send(mp).await.is_err() {
-                        return Ok(OperatorControlFlow::Break);
+                        return Ok(ControlFlow::Break(()));
                     }
                 }
 
@@ -240,14 +241,14 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
                 // Send output
                 ctx.runtime_stats.add_probe_rows_out(output.len() as u64);
                 if ctx.output_sender.send(output).await.is_err() {
-                    return Ok(OperatorControlFlow::Break);
+                    return Ok(ControlFlow::Break(()));
                 }
 
                 // Spawn another execution with same input and state (don't return state)
                 Self::spawn_probe_task(ctx, input, result.state, result.state_id);
             }
         }
-        Ok(OperatorControlFlow::Continue)
+        Ok(ControlFlow::Continue(()))
     }
 
     fn spawn_ready_probe_batches(
@@ -279,11 +280,11 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
         ctx: &mut ProbeExecutionContext<Op>,
         stats_manager: &RuntimeStatsManagerHandle,
         finalized_build_state_receiver: oneshot::Receiver<Op::FinalizedBuildState>,
-    ) -> DaftResult<OperatorControlFlow> {
+    ) -> DaftResult<ControlFlow<()>> {
         // Wait for finalized build state before starting
         let finalized_build_state = match finalized_build_state_receiver.await {
             Ok(build_state) => build_state,
-            Err(_) => return Ok(OperatorControlFlow::Break),
+            Err(_) => return Ok(ControlFlow::Break(())),
         };
 
         // Initialize probe states with the finalized build state
@@ -306,8 +307,8 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
                 // Branch 1: Join completed task (only if tasks exist)
                 Some(join_result) = ctx.task_set.join_next(), if !ctx.task_set.is_empty() => {
                     let control = Self::handle_probe_task_completion(join_result??, ctx).await?;
-                    if !control.should_continue() {
-                        return Ok(OperatorControlFlow::Break);
+                    if !control.is_continue() {
+                        return Ok(ControlFlow::Break(()));
                     }
 
                     // After completing a task, update bounds and try to spawn more tasks
@@ -358,15 +359,15 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
             // Wait for final task to complete
             while let Some(join_result) = ctx.task_set.join_next().await {
                 let control = Self::handle_probe_task_completion(join_result??, ctx).await?;
-                if !control.should_continue() {
-                    return Ok(OperatorControlFlow::Break);
+                if !control.is_continue() {
+                    return Ok(ControlFlow::Break(()));
                 }
             }
         }
 
         debug_assert_eq!(ctx.task_set.len(), 0, "TaskSet should be empty after loop");
 
-        Ok(OperatorControlFlow::Continue)
+        Ok(ControlFlow::Continue(()))
     }
 }
 
@@ -549,7 +550,7 @@ impl<Op: JoinOperator + 'static> PipelineNode for JoinNode<Op> {
                 );
 
                 build_result?;
-                if !probe_result?.should_continue() {
+                if !probe_result?.is_continue() {
                     stats_manager.finalize_node(node_id);
                     return Ok(());
                 }

--- a/src/daft-local-execution/src/join/join_node.rs
+++ b/src/daft-local-execution/src/join/join_node.rs
@@ -311,9 +311,7 @@ impl<Op: JoinOperator + 'static> JoinNode<Op> {
                     }
 
                     // After completing a task, update bounds and try to spawn more tasks
-                    let new_requirements = ctx.batch_manager.calculate_batch_size();
-                    let (lower, upper) = new_requirements.values();
-                    buffer.update_bounds(lower, upper);
+                    buffer.update_bounds(ctx.batch_manager.calculate_batch_size());
 
                     Self::spawn_ready_probe_batches(&mut buffer, ctx)?;
                 }

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -29,23 +29,6 @@ use runtime_stats::{RuntimeStats, RuntimeStatsManagerHandle, TimedFuture};
 use snafu::{ResultExt, Snafu, futures::TryFutureExt};
 use tracing::Instrument;
 
-/// Control flow indicator for processing loops.
-/// Used to signal whether processing should continue or break out of a loop.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum OperatorControlFlow {
-    /// Continue processing - caller should proceed with the next iteration
-    Continue,
-    /// Break processing - caller should exit the loop immediately
-    Break,
-}
-
-impl OperatorControlFlow {
-    /// Returns true if processing should continue
-    pub(crate) fn should_continue(&self) -> bool {
-        matches!(self, Self::Continue)
-    }
-}
-
 /// The `OperatorOutput` enum represents the output of an operator.
 /// It can be either `Ready` or `Pending`.
 /// If the output is `Ready`, the value is immediately available.

--- a/src/daft-local-execution/src/sinks/aggregate.rs
+++ b/src/daft-local-execution/src/sinks/aggregate.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
-use common_runtime::get_compute_pool_num_threads;
 use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::bound_expr::{BoundAggExpr, BoundExpr};
 use daft_micropartition::MicroPartition;
@@ -139,10 +138,6 @@ impl BlockingSink for AggregateSink {
                 .map(|e| e.to_string())
                 .join(", ")
         )]
-    }
-
-    fn max_concurrency(&self) -> usize {
-        get_compute_pool_num_threads()
     }
 
     fn make_state(&self) -> DaftResult<Self::State> {

--- a/src/daft-local-execution/src/sinks/dedup.rs
+++ b/src/daft-local-execution/src/sinks/dedup.rs
@@ -18,7 +18,6 @@ use std::sync::Arc;
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
-use common_runtime::get_compute_pool_num_threads;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_micropartition::MicroPartition;
 use itertools::Itertools;
@@ -182,10 +181,6 @@ impl BlockingSink for DedupSink {
             self.columns.iter().map(|e| e.to_string()).join(", ")
         ));
         display
-    }
-
-    fn max_concurrency(&self) -> usize {
-        get_compute_pool_num_threads()
     }
 
     fn make_state(&self) -> DaftResult<Self::State> {

--- a/src/daft-local-execution/src/sinks/grouped_aggregate.rs
+++ b/src/daft-local-execution/src/sinks/grouped_aggregate.rs
@@ -6,7 +6,6 @@ use std::{
 use common_daft_config::DaftExecutionConfig;
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
-use common_runtime::get_compute_pool_num_threads;
 use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::{
     bound_col,
@@ -443,10 +442,6 @@ impl BlockingSink for GroupedAggregateSink {
                 .join(", ")
         ));
         display
-    }
-
-    fn max_concurrency(&self) -> usize {
-        get_compute_pool_num_threads()
     }
 
     fn make_state(&self) -> DaftResult<Self::State> {

--- a/src/daft-local-execution/src/sinks/repartition.rs
+++ b/src/daft-local-execution/src/sinks/repartition.rs
@@ -2,7 +2,6 @@ use std::{collections::VecDeque, sync::Arc};
 
 use common_error::DaftResult;
 use common_metrics::ops::NodeType;
-use common_runtime::get_compute_pool_num_threads;
 use daft_core::prelude::SchemaRef;
 use daft_dsl::expr::bound_expr::BoundExpr;
 use daft_logical_plan::partitioning::RepartitionSpec;
@@ -176,10 +175,6 @@ impl BlockingSink for RepartitionSink {
                 ]
             }
         }
-    }
-
-    fn max_concurrency(&self) -> usize {
-        get_compute_pool_num_threads()
     }
 
     fn make_state(&self) -> DaftResult<Self::State> {

--- a/src/daft-local-execution/src/streaming_sink/base.rs
+++ b/src/daft-local-execution/src/streaming_sink/base.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    ops::ControlFlow,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -20,8 +21,7 @@ use snafu::ResultExt;
 use tracing::info_span;
 
 use crate::{
-    ExecutionRuntimeContext, ExecutionTaskSpawner, OperatorControlFlow, OperatorOutput,
-    PipelineExecutionSnafu,
+    ExecutionRuntimeContext, ExecutionTaskSpawner, OperatorOutput, PipelineExecutionSnafu,
     buffer::RowBasedBuffer,
     channel::{Receiver, Sender, create_channel},
     dynamic_batching::{BatchManager, BatchingStrategy},
@@ -209,7 +209,7 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
     async fn handle_task_completion(
         result: ExecutionTaskResult<Op::State>,
         ctx: &mut ExecutionContext<Op>,
-    ) -> DaftResult<OperatorControlFlow> {
+    ) -> DaftResult<ControlFlow<()>> {
         match result.output {
             StreamingSinkOutput::NeedMoreInput(mp) => {
                 // Record execution stats
@@ -223,7 +223,7 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
                 if let Some(mp) = mp {
                     ctx.runtime_stats.add_rows_out(mp.len() as u64);
                     if ctx.output_sender.send(mp).await.is_err() {
-                        return Ok(OperatorControlFlow::Break);
+                        return Ok(ControlFlow::Break(()));
                     }
                 }
 
@@ -242,7 +242,7 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
                 if let Some(mp) = output {
                     ctx.runtime_stats.add_rows_out(mp.len() as u64);
                     if ctx.output_sender.send(mp).await.is_err() {
-                        return Ok(OperatorControlFlow::Break);
+                        return Ok(ControlFlow::Break(()));
                     }
                 }
 
@@ -266,17 +266,17 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
                 // Return state to pool for finalization
                 ctx.state_pool.insert(result.state_id, result.state);
                 // Short-circuit: Finished means we should exit early (like a closed sender)
-                return Ok(OperatorControlFlow::Break);
+                return Ok(ControlFlow::Break(()));
             }
         }
-        Ok(OperatorControlFlow::Continue)
+        Ok(ControlFlow::Continue(()))
     }
 
     async fn process_input(
         node_id: usize,
         mut receiver: Receiver<Arc<MicroPartition>>,
         ctx: &mut ExecutionContext<Op>,
-    ) -> DaftResult<OperatorControlFlow> {
+    ) -> DaftResult<ControlFlow<()>> {
         let (lower, upper) = ctx.batch_manager.initial_requirements().values();
         let mut buffer = RowBasedBuffer::new(lower, upper);
         let mut input_closed = false;
@@ -290,8 +290,8 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
                 // Branch 1: Join completed task (only if tasks exist)
                 Some(join_result) = ctx.task_set.join_next(), if !ctx.task_set.is_empty() => {
                     let result = join_result??;
-                    if !Self::handle_task_completion(result, ctx).await?.should_continue() {
-                        return Ok(OperatorControlFlow::Break);
+                    if !Self::handle_task_completion(result, ctx).await?.is_continue() {
+                        return Ok(ControlFlow::Break(()));
                     }
 
                     // After completing a task, update bounds and try to spawn more tasks
@@ -343,16 +343,16 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
             while let Some(join_result) = ctx.task_set.join_next().await {
                 if !Self::handle_task_completion(join_result??, ctx)
                     .await?
-                    .should_continue()
+                    .is_continue()
                 {
-                    return Ok(OperatorControlFlow::Break);
+                    return Ok(ControlFlow::Break(()));
                 }
             }
         }
 
         debug_assert_eq!(ctx.task_set.len(), 0, "TaskSet should be empty after loop");
 
-        Ok(OperatorControlFlow::Continue)
+        Ok(ControlFlow::Continue(()))
     }
 }
 
@@ -494,7 +494,7 @@ impl<Op: StreamingSink + 'static> PipelineNode for StreamingSinkNode<Op> {
         };
         runtime_handle.spawn(
             async move {
-                Self::process_input(node_id, child_result_receiver, &mut ctx).await?;
+                let _ = Self::process_input(node_id, child_result_receiver, &mut ctx).await?;
 
                 let mut finished_states: Vec<_> =
                     ctx.state_pool.drain().map(|(_, state)| state).collect();

--- a/src/daft-local-execution/src/streaming_sink/base.rs
+++ b/src/daft-local-execution/src/streaming_sink/base.rs
@@ -295,9 +295,7 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
                     }
 
                     // After completing a task, update bounds and try to spawn more tasks
-                    let new_requirements = ctx.batch_manager.calculate_batch_size();
-                    let (lower, upper) = new_requirements.values();
-                    buffer.update_bounds(lower, upper);
+                    buffer.update_bounds(ctx.batch_manager.calculate_batch_size());
 
                     Self::spawn_ready_batches(&mut buffer, ctx)?;
                 }

--- a/src/daft-local-execution/src/streaming_sink/base.rs
+++ b/src/daft-local-execution/src/streaming_sink/base.rs
@@ -290,7 +290,7 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
                 // Branch 1: Join completed task (only if tasks exist)
                 Some(join_result) = ctx.task_set.join_next(), if !ctx.task_set.is_empty() => {
                     let result = join_result??;
-                    if !Self::handle_task_completion(result, ctx).await?.is_continue() {
+                    if Self::handle_task_completion(result, ctx).await?.is_break() {
                         return Ok(ControlFlow::Break(()));
                     }
 
@@ -341,9 +341,9 @@ impl<Op: StreamingSink + 'static> StreamingSinkNode<Op> {
 
             // Wait for final task to complete
             while let Some(join_result) = ctx.task_set.join_next().await {
-                if !Self::handle_task_completion(join_result??, ctx)
+                if Self::handle_task_completion(join_result??, ctx)
                     .await?
-                    .is_continue()
+                    .is_break()
                 {
                     return Ok(ControlFlow::Break(()));
                 }


### PR DESCRIPTION
## Summary
- `update_bounds` in `RowBasedBuffer` now takes `MorselSizeRequirement` directly instead of decomposed `(usize, NonZeroUsize)`
- Replace custom `OperatorControlFlow` enum with `std::ops::ControlFlow`
- Remove redundant `max_concurrency` overrides from sinks (trait default already returns `get_compute_pool_num_threads()`)

## Test plan
- [x] `cargo check` passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)