### PR TITLE
fix: remove use_safetensors=True to allow model fallback

### DIFF
--- a/daft/ai/transformers/protocols/image_embedder.py
+++ b/daft/ai/transformers/protocols/image_embedder.py
@@ -62,7 +62,6 @@ class TransformersImageEmbedder(ImageEmbedder):
         self.model = AutoModel.from_pretrained(
             model_name_or_path,
             trust_remote_code=True,
-            use_safetensors=True,
         ).to(self.device)
         self.processor = AutoProcessor.from_pretrained(model_name_or_path, trust_remote_code=True, use_fast=True)
         self.embed_options: EmbedImageOptions = embed_options


### PR DESCRIPTION
## Changes Made

Forcing safetensors was causing unit tests to fail because these weights weren't available; removing this let's the resolution fallback to pytorch

## Related Issues

https://github.com/Eventual-Inc/Daft/actions/runs/23555955545/job/68582692936
