### PR TITLE
ci: refresh apt index before installing deps

### DIFF
--- a/.github/workflows/notebook-checker.yml
+++ b/.github/workflows/notebook-checker.yml
@@ -31,8 +31,8 @@ jobs:
         pip install -U jupyter papermill matplotlib nb-clean
     - name: Install Tesseract
       run: |
-        sudo apt install tesseract-ocr
-        sudo apt install libtesseract-dev
+        sudo apt-get update
+        sudo apt-get install -y tesseract-ocr libtesseract-dev
     - name: Clean all notebook output
       run: find . -name "*.ipynb" -print0 | xargs -0 nb-clean clean
     - name: Run notebooks in docs


### PR DESCRIPTION
## Changes Made

Notebook checker has been failing because it can't resolve `libcurl4-openssl-dev` and Claude tells me this is possible with a stale cache. This runs update to keep the index fresh, then combines the install commands with the -y flag for non-interactive use.

## Related Issues

https://github.com/Eventual-Inc/Daft/actions/runs/23561988465
