### PR TITLE
feat: async data sources and tasks

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -149,7 +149,7 @@ from daft.viz import register_viz_hook
 from daft.window import Window
 from daft.file import File, VideoFile, AudioFile
 
-range = _range  # shadows builtin intentionally
+range = _range  # type: ignore[no-redef,unused-ignore]
 
 from daft import context
 from daft import io

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -128,7 +128,7 @@ from daft.udf import udf, func, cls, method, metrics
 from daft.io import (
     IOConfig,
     from_glob_path,
-    _range as range,
+    _range,
     read_csv,
     read_deltalake,
     read_hudi,
@@ -148,6 +148,8 @@ from daft.sql import sql, sql_expr
 from daft.viz import register_viz_hook
 from daft.window import Window
 from daft.file import File, VideoFile, AudioFile
+
+range = _range  # shadows builtin intentionally
 
 from daft import context
 from daft import io

--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -125,10 +125,10 @@ from daft.session import (
     write_table,
 )
 from daft.udf import udf, func, cls, method, metrics
+from daft.io._range import _range
 from daft.io import (
     IOConfig,
     from_glob_path,
-    _range,
     read_csv,
     read_deltalake,
     read_hudi,

--- a/daft/io/__shim.py
+++ b/daft/io/__shim.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import queue
 import warnings
 from typing import TYPE_CHECKING, TypeVar
 
@@ -11,6 +12,7 @@ from daft.daft import (
     PyRecordBatch,
     ScanTask,
 )
+from daft.event_loop import get_or_init_event_loop
 from daft.io.pushdowns import Pushdowns, SupportsPushdownFilters
 from daft.io.scan import ScanOperator
 from daft.io.source import _PyDataSourceTask
@@ -24,21 +26,46 @@ if TYPE_CHECKING:
 _T = TypeVar("_T")
 
 
-def _drain_async_iter(async_iter: AsyncIterator[_T]) -> Iterator[_T]:
-    """Synchronously drain an async iterator using a fresh event loop.
+class _Sentinel:
+    """Sentinel value for the queue to indicate the end of the iterator."""
 
-    Uses ``asyncio.new_event_loop()`` instead of ``asyncio.run()`` to avoid
-    nesting issues when called from within an existing event loop.
+    pass
+
+
+_SENTINEL: _Sentinel = _Sentinel()
+
+
+def _drain_async_iter(async_iter: AsyncIterator[_T]) -> Iterator[_T]:
+    """Synchronously drain an async iterator.
+
+    Uses the shared ``BackgroundEventLoop`` (a persistent daemon thread running
+    ``loop.run_forever()``) so that this works regardless of whether an event
+    loop is already running in the calling thread (e.g., pytest-asyncio,
+    Jupyter).  Items are streamed through a ``queue.Queue`` so memory is
+    bounded even for large iterators.
     """
-    loop = asyncio.new_event_loop()
-    try:
-        while True:
-            try:
-                yield loop.run_until_complete(async_iter.__anext__())
-            except StopAsyncIteration:
-                break
-    finally:
-        loop.close()
+    results: queue.Queue[_T | BaseException | _Sentinel] = queue.Queue()
+    event_loop = get_or_init_event_loop()
+
+    async def _produce() -> None:
+        try:
+            async for item in async_iter:
+                results.put(item)
+        except BaseException as ex:
+            results.put(ex)
+        finally:
+            results.put(_SENTINEL)
+
+    # Submit without blocking so the background loop produces while we consume.
+    asyncio.run_coroutine_threadsafe(_produce(), event_loop.loop)
+
+    while True:
+        item = results.get()
+        if isinstance(item, _Sentinel):
+            break
+        if isinstance(item, BaseException):
+            raise item
+        yield item
 
 
 class _DataSourceShim(ScanOperator):

--- a/daft/io/__shim.py
+++ b/daft/io/__shim.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
+import warnings
 from typing import TYPE_CHECKING, TypeVar
 
 from daft.daft import (
@@ -74,9 +76,22 @@ class _DataSourceShim(ScanOperator):
             f"Schema = {self.schema()}",
         ]
 
-    def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:
+    def _get_tasks(self, pushdowns: PyPushdowns) -> Iterator[DataSourceTask]:
+        """Resolve get_tasks, handling both sync (deprecated) and async implementations."""
         pds = Pushdowns._from_pypushdowns(pushdowns)
-        for task in _drain_async_iter(self._source.get_tasks(pds)):
+        result = self._source.get_tasks(pds)
+        if inspect.isasyncgen(result):
+            yield from _drain_async_iter(result)
+        else:
+            warnings.warn(
+                "Sync get_tasks() is deprecated — use 'async def get_tasks()'.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            yield from result  # type: ignore[misc]
+
+    def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:
+        for task in self._get_tasks(pushdowns):
             if isinstance(task, _PyDataSourceTask):
                 # Unwrap the native ScanTask from the DataSourceTask and yield it directly.
                 yield task.unwrap()

--- a/daft/io/__shim.py
+++ b/daft/io/__shim.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
-from typing import TYPE_CHECKING
+import asyncio
+from typing import TYPE_CHECKING, TypeVar
 
 from daft.daft import (
     PyPartitionField,
@@ -11,16 +11,36 @@ from daft.daft import (
 )
 from daft.io.pushdowns import Pushdowns, SupportsPushdownFilters
 from daft.io.scan import ScanOperator
+from daft.io.source import _PyDataSourceTask
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator, Iterator
 
     from daft.io.source import DataSource, DataSourceTask
     from daft.schema import Schema
 
+_T = TypeVar("_T")
+
+
+def _drain_async_iter(async_iter: AsyncIterator[_T]) -> Iterator[_T]:
+    """Synchronously drain an async iterator using a fresh event loop.
+
+    Uses ``asyncio.new_event_loop()`` instead of ``asyncio.run()`` to avoid
+    nesting issues when called from within an existing event loop.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        while True:
+            try:
+                yield loop.run_until_complete(async_iter.__anext__())
+            except StopAsyncIteration:
+                break
+    finally:
+        loop.close()
+
 
 class _DataSourceShim(ScanOperator):
-    """!! INTERNAL ONLY .. SHIM TO REUSE EXISTING BACKED WORK !!"""
+    """Wraps a Python DataSource as a legacy ScanOperator for the execution backend."""
 
     _source: DataSource
 
@@ -56,18 +76,23 @@ class _DataSourceShim(ScanOperator):
 
     def to_scan_tasks(self, pushdowns: PyPushdowns) -> Iterator[ScanTask]:
         pds = Pushdowns._from_pypushdowns(pushdowns)
-        for task in self._source.get_tasks(pds):
-            yield ScanTask.python_factory_func_scan_task(
-                module=_get_record_batches.__module__,
-                func_name=_get_record_batches.__name__,
-                func_args=(task,),
-                schema=task.schema._schema,
-                num_rows=None,
-                size_bytes=None,
-                pushdowns=pushdowns,
-                stats=None,
-                source_name=self.display_name(),
-            )
+        for task in _drain_async_iter(self._source.get_tasks(pds)):
+            if isinstance(task, _PyDataSourceTask):
+                # Unwrap the native ScanTask from the DataSourceTask and yield it directly.
+                yield task.unwrap()
+            else:
+                # This is a Python-based DataSourceTask, so we need to convert it to a ScanTask.
+                yield ScanTask.python_factory_func_scan_task(
+                    module=_get_record_batches.__module__,
+                    func_name=_get_record_batches.__name__,
+                    func_args=(task,),
+                    schema=task.schema._schema,
+                    num_rows=None,
+                    size_bytes=None,
+                    pushdowns=pushdowns,
+                    stats=None,
+                    source_name=self.display_name(),
+                )
 
     def as_pushdown_filter(self) -> SupportsPushdownFilters | None:
         return None
@@ -75,4 +100,4 @@ class _DataSourceShim(ScanOperator):
 
 def _get_record_batches(task: DataSourceTask) -> Iterator[PyRecordBatch]:
     """The task instance has been pickled then sent to this stateless method."""
-    yield from (rb._recordbatch for mp in task.get_micro_partitions() for rb in mp.get_record_batches())
+    yield from (rb._recordbatch for rb in _drain_async_iter(task.read()))

--- a/daft/io/__shim.py
+++ b/daft/io/__shim.py
@@ -82,6 +82,11 @@ class _DataSourceShim(ScanOperator):
         result = self._source.get_tasks(pds)
         if inspect.isasyncgen(result):
             yield from _drain_async_iter(result)
+        elif inspect.iscoroutine(result):
+            raise TypeError(
+                f"{type(self._source).__name__}.get_tasks() must be an async generator "
+                "(use 'async def ... yield ...' rather than returning an AsyncIterator)."
+            )
         else:
             warnings.warn(
                 "Sync get_tasks() is deprecated — use 'async def get_tasks()'.",

--- a/daft/io/_kafka.py
+++ b/daft/io/_kafka.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -10,10 +10,12 @@ from daft import DataType
 from daft.api_annotations import PublicAPI
 from daft.dependencies import confluent_kafka
 from daft.io.source import DataSource, DataSourceTask
-from daft.recordbatch import MicroPartition
+from daft.recordbatch import RecordBatch
 from daft.schema import Schema
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from daft.dataframe import DataFrame
     from daft.io.pushdowns import Pushdowns
 
@@ -308,7 +310,7 @@ class KafkaSource(DataSource):
     def schema(self) -> Schema:
         return _KAFKA_SCHEMA
 
-    def get_tasks(self, pushdowns: Pushdowns) -> Iterator[KafkaSourceTask]:
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[KafkaSourceTask]:
         timeout_s = self._timeout_ms / 1000.0
 
         cfg = _make_consumer_config(
@@ -429,7 +431,7 @@ class KafkaSourceTask(DataSourceTask):
     def schema(self) -> Schema:
         return _KAFKA_SCHEMA
 
-    def get_micro_partitions(self) -> Iterator[MicroPartition]:
+    async def read(self) -> AsyncIterator[RecordBatch]:
         timeout_s = self._timeout_ms / 1000.0
 
         cfg = _make_consumer_config(
@@ -451,7 +453,7 @@ class KafkaSourceTask(DataSourceTask):
                 return
 
             while True:
-                # Build up to `chunk_size` rows for the next MicroPartition.
+                # Build up to `chunk_size` rows for the next RecordBatch.
                 topics: list[str] = []
                 partitions: list[int] = []
                 offsets: list[int] = []
@@ -462,7 +464,7 @@ class KafkaSourceTask(DataSourceTask):
                 stop = False
 
                 # `consume(n)` may return fewer than `n` messages, so we keep consuming until we either
-                # fill a chunk (for larger MicroPartitions) or hit a stop condition.
+                # fill a chunk or hit a stop condition.
                 while len(topics) < self._chunk_size and remaining != 0:
                     fetch_n = self._chunk_size - len(topics)
                     if remaining is not None:
@@ -470,9 +472,6 @@ class KafkaSourceTask(DataSourceTask):
 
                     msgs = consumer.consume(fetch_n, timeout=timeout_s)
                     if not msgs:
-                        # Avoid spinning indefinitely when no messages are returned: flush the current chunk (if any),
-                        # otherwise terminate this KafkaSourceTask generator (no more MicroPartitions will be yielded
-                        # for this partition).
                         last_offset = offsets[-1] if offsets else None
                         if last_offset is None:
                             logger.warning(
@@ -505,7 +504,6 @@ class KafkaSourceTask(DataSourceTask):
 
                         offset = msg.offset()
                         if offset >= self._end_offset:
-                            # Stop once we hit the bounded end offset for this task.
                             stop = True
                             break
 
@@ -529,7 +527,6 @@ class KafkaSourceTask(DataSourceTask):
                                 break
 
                         if offset == self._end_offset - 1:
-                            # Early exit: this is the last offset in range, skip one more consume() round-trip.
                             stop = True
                             break
 
@@ -537,10 +534,9 @@ class KafkaSourceTask(DataSourceTask):
                         break
 
                 if not topics:
-                    # No rows accumulated for this chunk (e.g. consume() returned empty immediately), so terminate.
                     return
 
-                yield MicroPartition.from_pydict(
+                yield RecordBatch.from_pydict(
                     {
                         "topic": topics,
                         "partition": partitions,
@@ -601,7 +597,7 @@ def read_kafka(
             "daft-bounded-kafka-reader".
         partitions (Sequence[int] | None): Optional sequence of partition IDs to read from.
             If None, reads from all partitions of the specified topic(s). Defaults to None.
-        chunk_size (int): Maximum number of messages per MicroPartition. Defaults to 1024.
+        chunk_size (int): Maximum number of messages per RecordBatch. Defaults to 1024.
         kafka_client_config (Mapping[str, object] | None): Optional additional configuration
             options passed directly to the underlying Kafka consumer. These are merged with
             the default configuration. Defaults to None.
@@ -662,7 +658,7 @@ def read_kafka(
     if isinstance(bootstrap_servers, str):
         bootstrap_servers_str = bootstrap_servers
     else:
-        bootstrap_servers_str = ",".join([str(s) for s in bootstrap_servers])
+        bootstrap_servers_str = ",".join(str(s) for s in bootstrap_servers)
 
     if isinstance(topics, str):
         topics = [topics]

--- a/daft/io/_range.py
+++ b/daft/io/_range.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, overload
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
-
 
 from daft import DataType
 from daft.api_annotations import PublicAPI
 from daft.io.source import DataSource, DataSourceTask
-from daft.recordbatch import MicroPartition
+from daft.recordbatch import RecordBatch
 from daft.schema import Schema
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from daft.dataframe import DataFrame
     from daft.io.pushdowns import Pushdowns
 
@@ -133,8 +130,6 @@ def _range(start: int, end: int | None = None, step: int = 1, partitions: int = 
     if end is None:
         end = start
         start = 0
-    else:
-        start = start
     return RangeSource(start, end, step, partitions).read()
 
 
@@ -148,14 +143,6 @@ class RangeSource(DataSource):
     _schema = Schema.from_pydict({"id": DataType.int64()})
 
     def __init__(self, start: int, end: int, step: int = 1, partitions: int = 1) -> None:
-        """Create a RangeSource instance.
-
-        Args:
-            start (int): The start of the range.
-            end (int, optional): The end of the range. If not provided, the start is 0 and the end is `start`.
-            step (int, optional): The step size of the range. Defaults to 1.
-            partitions (int, optional): The number of partitions to split the range into. Defaults to 1.
-        """
         if step == 0:
             raise ValueError("daft.range() step parameter cannot be zero - use a positive or negative integer")
 
@@ -182,7 +169,7 @@ class RangeSource(DataSource):
     def schema(self) -> Schema:
         return self._schema
 
-    def get_tasks(self, pushdowns: Pushdowns) -> Iterator[RangeSourceTask]:
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[RangeSourceTask]:
         step = self._step
 
         # Calculate the total number of elements in the range using ceiling division
@@ -201,13 +188,8 @@ class RangeSource(DataSource):
             partition_elements = elements_per_partition + (1 if i < remainder else 0)
             curr_e = curr_s + (partition_elements * step)
 
-            # Ensure we don't exceed the end boundary
-            if step > 0:
-                if curr_e > self._end:
-                    curr_e = self._end
-            else:
-                if curr_e < self._end:
-                    curr_e = self._end
+            # Clamp to the end boundary
+            curr_e = min(curr_e, self._end) if step > 0 else max(curr_e, self._end)
 
             yield RangeSourceTask(curr_s, curr_e, step)
             curr_s = curr_e
@@ -223,5 +205,5 @@ class RangeSourceTask(DataSourceTask):
     def schema(self) -> Schema:
         return RangeSource._schema
 
-    def get_micro_partitions(self) -> Iterator[MicroPartition]:
-        yield MicroPartition.from_pydict({"id": list(range(self._start, self._end, self._step))})
+    async def read(self) -> AsyncIterator[RecordBatch]:
+        yield RecordBatch.from_pydict({"id": list(range(self._start, self._end, self._step))})

--- a/daft/io/_range.py
+++ b/daft/io/_range.py
@@ -4,8 +4,8 @@ import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, overload
 
-from daft import DataType
 from daft.api_annotations import PublicAPI
+from daft.datatype import DataType
 from daft.io.source import DataSource, DataSourceTask
 from daft.recordbatch import RecordBatch
 from daft.schema import Schema

--- a/daft/io/av/_read_video_frames.py
+++ b/daft/io/av/_read_video_frames.py
@@ -13,21 +13,18 @@ from daft.daft import FileInfos, ImageMode
 from daft.datatype import DataType
 from daft.filesystem import _infer_filesystem, glob_path_with_stats
 from daft.io import DataSource, DataSourceTask
-from daft.recordbatch import MicroPartition
+from daft.recordbatch import RecordBatch
 from daft.schema import Schema
 
 if TYPE_CHECKING:
-    from collections.abc import Generator, Iterator
+    from collections.abc import AsyncIterator, Generator
     from fractions import Fraction
 
     from av.video import VideoFrame
 
     from daft.daft import IOConfig
-    from daft.io.pushdowns import Pushdowns
-
-
-if TYPE_CHECKING:
     from daft.dependencies import np
+    from daft.io.pushdowns import Pushdowns
 
     _VideoFrameData: TypeAlias = np.typing.NDArray[Any]
 else:
@@ -103,7 +100,7 @@ class _VideoFramesSource(DataSource):
             for file_infos in self._list_file_infos():
                 yield from file_infos.file_paths
 
-    def get_tasks(self, pushdowns: Pushdowns) -> Iterator[DataSourceTask]:
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
         for path in self._list_file_paths():
             yield _VideoFramesSourceTask(
                 path=path,
@@ -117,7 +114,7 @@ class _VideoFramesSource(DataSource):
 
 @dataclass
 class _VideoFramesSourceTask(DataSourceTask):
-    """DataSourceTask which yields micropartitions of images from a video file."""
+    """DataSourceTask which yields record batches of images from a video file."""
 
     path: str
     image_height: int
@@ -269,7 +266,7 @@ class _VideoFramesSourceTask(DataSourceTask):
             if os.path.exists(temp_file):
                 os.remove(temp_file)
 
-    def get_micro_partitions(self) -> Iterator[MicroPartition]:
+    async def read(self) -> AsyncIterator[RecordBatch]:
         with self._open() as file:
             buffer = _VideoFramesBuffer(
                 image_height=self.image_height,
@@ -277,25 +274,21 @@ class _VideoFramesSourceTask(DataSourceTask):
             )
             for frame in self._list_frames(self.path, file):
                 buffer.append(frame)
-                # yield when full
                 if buffer.size() >= self._max_partition_size:
-                    yield buffer.to_micropartition()
+                    yield buffer.to_recordbatch()
                     buffer.clear()
-            # yield if non-empty
             if buffer and buffer.size() > 0:
-                yield buffer.to_micropartition()
+                yield buffer.to_recordbatch()
 
 
 class _VideoFramesBuffer:
-    """A micropartition buffer/builder for video frames.
+    """A record batch buffer/builder for video frames.
 
-    Note:
-        This enables decoupling the video source from a particular
-        library, making it possible for the VideoSource to leverage
-        an Iterable[_VideoFrame[T]] at some later time. How the iterator
-        is implemented e.g. open-cv vs. PyAV or other library is not
-        important, just that we have an Iterable of frames which this
-        builder and the source and stream as appropriately sized partitions.
+    This enables decoupling the video source from a particular library,
+    making it possible for the VideoSource to leverage an Iterable[_VideoFrame[T]]
+    at some later time. How the iterator is implemented (e.g. OpenCV vs PyAV)
+    is not important, just that we have an iterable of frames which this builder
+    and the source can stream as appropriately sized record batches.
     """
 
     image_height: int
@@ -352,9 +345,9 @@ class _VideoFramesBuffer:
         self._arr_data.append(frame.data)
         self._size_in_bytes += frame.data.nbytes + self._size_of_metadata
 
-    def to_micropartition(self) -> MicroPartition:
-        """Returns a MicroPartition for this builder."""
-        return MicroPartition.from_pydict(
+    def to_recordbatch(self) -> RecordBatch:
+        """Returns a RecordBatch for this builder."""
+        return RecordBatch.from_pydict(
             {
                 "path": self._arr_path,
                 "frame_index": self._arr_frame_index,

--- a/daft/io/mcap/_mcap.py
+++ b/daft/io/mcap/_mcap.py
@@ -10,11 +10,11 @@ from daft.dependencies import pafs
 from daft.filesystem import _resolve_paths_and_filesystem, get_protocol_from_path
 from daft.io.source import DataSource, DataSourceTask
 from daft.logical.schema import Schema
-from daft.recordbatch.micropartition import MicroPartition
+from daft.recordbatch import RecordBatch
 
 if TYPE_CHECKING:
     import pathlib
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator
     from types import TracebackType
 
     from daft import DataFrame
@@ -141,10 +141,10 @@ class MCAPSource(DataSource):
             normalize_storage_path(file_path, io_config) for file_path in list_files(file_path, io_config)
         ]
 
-        if self._file_paths is None or len(self._file_paths) == 0:
+        if not self._file_paths:
             raise FileNotFoundError(f"Path not found: {file_path}")
 
-        self._schema = self._infer_schema(self._file_paths[0])
+        self._schema = self._infer_schema()
         self._io_config = io_config
 
     @property
@@ -164,7 +164,7 @@ class MCAPSource(DataSource):
             f"Schema = {self._schema}",
         ]
 
-    def _infer_schema(self, sample_path: str) -> Schema:
+    def _infer_schema(self) -> Schema:
         import pyarrow as pa
 
         schema = pa.schema(
@@ -178,7 +178,7 @@ class MCAPSource(DataSource):
         )
         return Schema.from_pyarrow_schema(schema)
 
-    def get_tasks(self, pushdowns: Pushdowns | None = None) -> Iterator[MCAPSourceTask]:
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[MCAPSourceTask]:
         for file_path in self._file_paths:
             keyframes: dict[str, int] | None = None
             if self._topic_start_time_resolver is not None:
@@ -234,7 +234,11 @@ class MCAPSourceTask(DataSourceTask):
     _topics: list[str] | None = None
     _io_config: IOConfig | None = None
 
-    def execute(self) -> Iterator[MicroPartition]:
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    async def read(self) -> AsyncIterator[RecordBatch]:
         import importlib
 
         make_reader = importlib.import_module("mcap.reader").make_reader
@@ -280,42 +284,32 @@ class MCAPSourceTask(DataSourceTask):
         in_memory_file = BytesIO(file_content)
         reader = make_reader(_NonSeekableStreamWrapper(in_memory_file), decoder_factories=[])
 
-        buffer = []
-        try:
-            for _, channel, message in reader.iter_messages(
-                topics=self._topics,
-                start_time=self._start_time,
-                end_time=self._end_time,
-                log_time_order=True,
-            ):
-                buffer.append(
-                    {
-                        "topic": channel.topic,
-                        "log_time": message.log_time,
-                        "publish_time": message.publish_time,
-                        "sequence": message.sequence,
-                        "data": str(message.data),
-                    }
-                )
+        buffer: list[dict[str, object]] = []
+        for _, channel, message in reader.iter_messages(
+            topics=self._topics,
+            start_time=self._start_time,
+            end_time=self._end_time,
+            log_time_order=True,
+        ):
+            buffer.append(
+                {
+                    "topic": channel.topic,
+                    "log_time": message.log_time,
+                    "publish_time": message.publish_time,
+                    "sequence": message.sequence,
+                    "data": str(message.data),
+                }
+            )
 
-                if len(buffer) >= self._batch_size:
-                    yield self._create_micropartition(buffer)
-                    buffer.clear()
+            if len(buffer) >= self._batch_size:
+                yield self._create_recordbatch(buffer)
+                buffer.clear()
 
-            if buffer:
-                yield self._create_micropartition(buffer)
-        finally:
-            pass
+        if buffer:
+            yield self._create_recordbatch(buffer)
 
-    def _create_micropartition(self, data: list[dict[str, object]]) -> MicroPartition:
+    def _create_recordbatch(self, data: list[dict[str, object]]) -> RecordBatch:
         import pyarrow as pa
 
         arrow_batch = pa.RecordBatch.from_pylist(data, schema=self._schema.to_pyarrow_schema())
-        return MicroPartition.from_arrow_record_batches([arrow_batch], arrow_schema=self._schema.to_pyarrow_schema())
-
-    def get_micro_partitions(self) -> Iterator[MicroPartition]:
-        yield from self.execute()
-
-    @property
-    def schema(self) -> Schema:
-        return self._schema
+        return RecordBatch.from_arrow_record_batches([arrow_batch], arrow_schema=self._schema.to_pyarrow_schema())

--- a/daft/io/pushdowns.py
+++ b/daft/io/pushdowns.py
@@ -20,12 +20,14 @@ class Pushdowns:
         partition_filters (Expression | None): Optional partition filter predicate to apply to partitions or files.
         columns (list[str] | None): Optional list of column names to project.
         limit (int | None): Optional limit on the number of rows to return.
+        aggregation (Expression | None): Optional aggregation expression for count pushdown.
     """
 
     filters: Expression | None = None
     partition_filters: Expression | None = None
     columns: list[str] | None = None
     limit: int | None = None
+    aggregation: Expression | None = None
 
     @classmethod
     def _from_pypushdowns(cls, pushdowns: PyPushdowns) -> Pushdowns:
@@ -36,6 +38,18 @@ class Pushdowns:
             ),
             columns=pushdowns.columns,
             limit=pushdowns.limit,
+            aggregation=(Expression._from_pyexpr(pushdowns.aggregation) if pushdowns.aggregation else None),
+        )
+
+    def _to_pypushdowns(self) -> PyPushdowns:
+        from daft.daft import PyPushdowns
+
+        return PyPushdowns(
+            filters=self.filters._expr if self.filters is not None else None,
+            partition_filters=self.partition_filters._expr if self.partition_filters is not None else None,
+            columns=list(self.columns) if self.columns is not None else None,
+            limit=self.limit,
+            aggregation=self.aggregation._expr if self.aggregation is not None else None,
         )
 
     def filter_required_column_names(self) -> set[str]:

--- a/daft/io/source.py
+++ b/daft/io/source.py
@@ -4,12 +4,13 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator
 
+    from daft.daft import ScanTask, StorageConfig
     from daft.dataframe import DataFrame
     from daft.io.partitioning import PartitionField
     from daft.io.pushdowns import Pushdowns
-    from daft.recordbatch import MicroPartition
+    from daft.recordbatch import RecordBatch
     from daft.schema import Schema
 
 
@@ -49,13 +50,12 @@ class DataSource(ABC):
         return []
 
     @abstractmethod
-    def get_tasks(self, pushdowns: Pushdowns) -> Iterator[DataSourceTask]:
-        """Returns an iterator of tasks for this source.
-
-        Returns:
-            Iterable[DataSourceTask]: An iterable of tasks that can be processed independently.
-        """
+    async def get_tasks(self, pushdowns: Pushdowns) -> AsyncIterator[DataSourceTask]:
+        """Yields tasks as they are discovered. Called during execution, not planning."""
         ...
+        # https://mypy.readthedocs.io/en/latest/more_types.html#typing-async-generators
+        # This tricks the type checker into treating this as an async generator.
+        yield  # type: ignore[misc]
 
     def read(self) -> DataFrame:
         """Reads a DataSource as a DataFrame."""
@@ -73,6 +73,8 @@ class DataSource(ABC):
 class DataSourceTask(ABC):
     """DataSourceTask represents a partition of data that can be processed independently.
 
+    - :meth:`DataSourceTask.parquet` — read a Parquet file with the native reader
+
     Warning:
         This API is early in its development and is subject to change.
     """
@@ -80,14 +82,125 @@ class DataSourceTask(ABC):
     @property
     @abstractmethod
     def schema(self) -> Schema:
-        """Returns the schema shared by each MicroPartition."""
+        """Returns the schema of the record batches produced by this task."""
         ...
 
     @abstractmethod
-    def get_micro_partitions(self) -> Iterator[MicroPartition]:
-        """Executes this task to produce MicroPartitions.
+    async def read(self) -> AsyncIterator[RecordBatch]:
+        """Yields record batches. Called from an async execution context."""
+        ...
+        yield  # type: ignore[misc]
+
+    @staticmethod
+    def parquet(
+        path: str,
+        schema: Schema,
+        *,
+        pushdowns: Pushdowns | None = None,
+        num_rows: int | None = None,
+        size_bytes: int | None = None,
+        partition_values: RecordBatch | None = None,
+        stats: RecordBatch | None = None,
+        storage_config: StorageConfig | None = None,
+    ) -> DataSourceTask:
+        """Create a task that reads a Parquet file using the native reader.
+
+        This is the recommended way to create scan tasks for Parquet files when
+        building custom :class:`DataSource` implementations (e.g., catalog
+        connectors like Iceberg or Paimon).
+
+        Partition pruning is the :class:`DataSource`'s responsibility — decide
+        which files to yield in :meth:`~DataSource.get_tasks` rather than
+        relying on the task factory to filter them out.
+
+        Args:
+            path: Path or URI of the Parquet file (e.g., ``"s3://bucket/file.parquet"``).
+            schema: Schema to read the file with.
+            pushdowns: Query pushdowns (filters, column projection, limit). Pass
+                through the pushdowns received by :meth:`DataSource.get_tasks`.
+            num_rows: Exact row count, if known. Enables metadata-only optimizations.
+            size_bytes: On-disk file size in bytes. Used for task coalescing heuristics.
+            partition_values: Single-row RecordBatch of partition column values to inject.
+            stats: Column statistics as a RecordBatch for predicate pushdown evaluation.
+            storage_config: Optional :class:`StorageConfig` for IO credentials/settings.
+                Defaults to ``StorageConfig(multithreaded_io=True)``.
 
         Returns:
-            An iterable of MicroPartition objects containing the data for this task.
+            A DataSourceTask executed by the native Parquet reader.
+
+        Example::
+
+            class MyCatalogSource(DataSource):
+                async def get_tasks(self, pushdowns):
+                    for file in self.list_files():
+                        yield DataSourceTask.parquet(
+                            path=file.uri,
+                            schema=self.schema,
+                            pushdowns=pushdowns,
+                            num_rows=file.row_count,
+                            size_bytes=file.size_bytes,
+                        )
         """
-        ...
+        from dataclasses import replace
+
+        from daft.daft import FileFormatConfig, ParquetSourceConfig, ScanTask, StorageConfig
+
+        sc = storage_config if storage_config is not None else StorageConfig(multithreaded_io=True, io_config=None)
+
+        # Strip partition_filters before constructing the ScanTask. In the
+        # DataSource model, partition pruning is the DataSource's job (it
+        # decides which files to yield in get_tasks). We keep the execution
+        # pushdowns (filters, columns, limit) so the native reader can apply
+        # them per-file. Without partition_filters, catalog_scan_task never
+        # returns None.
+        if pushdowns is not None:
+            py_pd = replace(pushdowns, partition_filters=None)._to_pypushdowns()
+        else:
+            py_pd = None
+
+        st = ScanTask.catalog_scan_task(
+            file=path,
+            file_format=FileFormatConfig.from_parquet_config(ParquetSourceConfig()),
+            schema=schema._schema,
+            storage_config=sc,
+            num_rows=num_rows,
+            size_bytes=size_bytes,
+            iceberg_delete_files=None,
+            pushdowns=py_pd,
+            partition_values=partition_values._recordbatch if partition_values is not None else None,
+            stats=stats._recordbatch if stats is not None else None,
+        )
+        assert st is not None, "catalog_scan_task returned None unexpectedly (partition_filters were stripped)"
+        return _PyDataSourceTask(st, schema)
+
+
+class _PyDataSourceTask(DataSourceTask):
+    """Internal wrapper around a pre-built native ScanTask.
+
+    This is not exactly our traditional _Py* wrapper class because we do
+    not have the equivalent trait fully plumbed on the Rust side yet. This
+    is a way to wrap the existing native ScanTasks in a DataSourceTask interface
+    so we can use them in the DataSource model, and our shim is able to
+    unwrap them into the native ScanTasks for execution.
+    """
+
+    __slots__ = ("_task", "_schema")
+
+    def __init__(self, task: ScanTask, schema: Schema) -> None:
+        self._task = task
+        self._schema = schema
+
+    def unwrap(self) -> ScanTask:
+        """Unwraps the native ScanTask from this DataSourceTask, used by the shim."""
+        return self._task
+
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    async def read(self) -> AsyncIterator[RecordBatch]:
+        """We will actually implement this in the near future, but this path is unused for now."""
+        raise NotImplementedError(
+            "Native scan tasks are executed by the Rust engine. Subclass DataSourceTask for Python-based reading."
+        )
+        yield  # pragma: no cover

--- a/daft/io/source.py
+++ b/daft/io/source.py
@@ -77,7 +77,7 @@ class DataSource(ABC):
 class DataSourceTask(ABC):
     """DataSourceTask represents a partition of data that can be processed independently.
 
-    - :meth:`DataSourceTask.parquet` — read a Parquet file with the native reader
+    - DataSourceTask.parquet — read a Parquet file with the native reader
 
     Warning:
         This API is early in its development and is subject to change.
@@ -93,7 +93,7 @@ class DataSourceTask(ABC):
         """Yields record batches. Called from an async execution context.
 
         The default implementation delegates to the deprecated
-        :meth:`get_micro_partitions` for backwards compatibility.
+        get_micro_partitions for backwards compatibility.
         New subclasses should override this method directly.
         """
         try:
@@ -112,7 +112,7 @@ class DataSourceTask(ABC):
                 yield rb
 
     def get_micro_partitions(self) -> Iterator[MicroPartition]:
-        """Deprecated: override :meth:`read` instead."""
+        """Deprecated: override read instead."""
         raise NotImplementedError
 
     @staticmethod
@@ -130,30 +130,26 @@ class DataSourceTask(ABC):
         """Create a task that reads a Parquet file using the native reader.
 
         This is the recommended way to create scan tasks for Parquet files when
-        building custom :class:`DataSource` implementations (e.g., catalog
+        building custom DataSource implementations (e.g., catalog
         connectors like Iceberg or Paimon).
 
-        Partition pruning is the :class:`DataSource`'s responsibility — decide
-        which files to yield in :meth:`~DataSource.get_tasks` rather than
+        Partition pruning is the DataSource's responsibility — decide
+        which files to yield in get_tasks rather than
         relying on the task factory to filter them out.
 
         Args:
             path: Path or URI of the Parquet file (e.g., ``"s3://bucket/file.parquet"``).
             schema: Schema to read the file with.
             pushdowns: Query pushdowns (filters, column projection, limit). Pass
-                through the pushdowns received by :meth:`DataSource.get_tasks`.
+                through the pushdowns received by DataSource.get_tasks.
             num_rows: Exact row count, if known. Enables metadata-only optimizations.
             size_bytes: On-disk file size in bytes. Used for task coalescing heuristics.
             partition_values: Single-row RecordBatch of partition column values to inject.
             stats: Column statistics as a RecordBatch for predicate pushdown evaluation.
-            storage_config: Optional :class:`StorageConfig` for IO credentials/settings.
+            storage_config: Optional StorageConfig for IO credentials/settings.
                 Defaults to ``StorageConfig(multithreaded_io=True)``.
 
-        Returns:
-            A DataSourceTask executed by the native Parquet reader.
-
-        Example::
-
+        Example:
             class MyCatalogSource(DataSource):
                 async def get_tasks(self, pushdowns):
                     for file in self.list_files():
@@ -164,6 +160,9 @@ class DataSourceTask(ABC):
                             num_rows=file.row_count,
                             size_bytes=file.size_bytes,
                         )
+
+        Returns:
+            A DataSourceTask executed by the native Parquet reader.
         """
         sc = storage_config if storage_config is not None else StorageConfig(multithreaded_io=True, io_config=None)
 

--- a/daft/io/source.py
+++ b/daft/io/source.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
+from dataclasses import replace
 from typing import TYPE_CHECKING
+
+from daft.daft import FileFormatConfig, ParquetSourceConfig, ScanTask, StorageConfig
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
 
-    from daft.daft import ScanTask, StorageConfig
     from daft.dataframe import DataFrame
     from daft.io.partitioning import PartitionField
     from daft.io.pushdowns import Pushdowns
@@ -93,8 +96,6 @@ class DataSourceTask(ABC):
         :meth:`get_micro_partitions` for backwards compatibility.
         New subclasses should override this method directly.
         """
-        import warnings
-
         try:
             parts = self.get_micro_partitions()
         except NotImplementedError:
@@ -164,10 +165,6 @@ class DataSourceTask(ABC):
                             size_bytes=file.size_bytes,
                         )
         """
-        from dataclasses import replace
-
-        from daft.daft import FileFormatConfig, ParquetSourceConfig, ScanTask, StorageConfig
-
         sc = storage_config if storage_config is not None else StorageConfig(multithreaded_io=True, io_config=None)
 
         # Strip partition_filters before constructing the ScanTask. In the

--- a/daft/io/source.py
+++ b/daft/io/source.py
@@ -4,13 +4,14 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Iterator
 
     from daft.daft import ScanTask, StorageConfig
     from daft.dataframe import DataFrame
     from daft.io.partitioning import PartitionField
     from daft.io.pushdowns import Pushdowns
     from daft.recordbatch import RecordBatch
+    from daft.recordbatch.micropartition import MicroPartition
     from daft.schema import Schema
 
 
@@ -85,11 +86,33 @@ class DataSourceTask(ABC):
         """Returns the schema of the record batches produced by this task."""
         ...
 
-    @abstractmethod
     async def read(self) -> AsyncIterator[RecordBatch]:
-        """Yields record batches. Called from an async execution context."""
-        ...
-        yield  # type: ignore[misc]
+        """Yields record batches. Called from an async execution context.
+
+        The default implementation delegates to the deprecated
+        :meth:`get_micro_partitions` for backwards compatibility.
+        New subclasses should override this method directly.
+        """
+        import warnings
+
+        try:
+            parts = self.get_micro_partitions()
+        except NotImplementedError:
+            raise NotImplementedError(
+                f"{type(self).__name__} must implement async def read(self) -> AsyncIterator[RecordBatch]"
+            )
+        warnings.warn(
+            f"{type(self).__name__}.get_micro_partitions() is deprecated — override 'async def read()' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        for mp in parts:
+            for rb in mp.get_record_batches():
+                yield rb
+
+    def get_micro_partitions(self) -> Iterator[MicroPartition]:
+        """Deprecated: override :meth:`read` instead."""
+        raise NotImplementedError
 
     @staticmethod
     def parquet(

--- a/tests/io/test_kafka_mock.py
+++ b/tests/io/test_kafka_mock.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 import daft
+from daft.io.__shim import _drain_async_iter
 
 
 def test_read_kafka_is_exported() -> None:
@@ -249,8 +250,6 @@ def test_kafka_source_task_terminates_on_empty_consume(monkeypatch: pytest.Monke
         _limit=None,
     )
 
-    from daft.io.__shim import _drain_async_iter
-
     assert list(_drain_async_iter(task.read())) == []
     assert _Consumer.consume_calls == 1
 
@@ -319,8 +318,6 @@ def test_kafka_source_task_ignores_partition_eof(monkeypatch: pytest.MonkeyPatch
         _chunk_size=10,
         _limit=None,
     )
-
-    from daft.io.__shim import _drain_async_iter
 
     assert list(_drain_async_iter(task.read())) == []
 
@@ -392,8 +389,6 @@ def test_kafka_source_task_respects_chunk_size(monkeypatch: pytest.MonkeyPatch) 
         _limit=None,
     )
 
-    from daft.io.__shim import _drain_async_iter
-
     batches = list(_drain_async_iter(task.read()))
     assert len(batches) == 3
     assert [rows[0]["offset"] for rows in (rb.to_pylist() for rb in batches)] == [0, 1, 2]
@@ -460,8 +455,6 @@ def test_kafka_source_task_respects_limit(monkeypatch: pytest.MonkeyPatch) -> No
         _chunk_size=1024,
         _limit=3,
     )
-
-    from daft.io.__shim import _drain_async_iter
 
     batches = list(_drain_async_iter(task.read()))
     total_rows = sum(len(rb.to_pylist()) for rb in batches)

--- a/tests/io/test_kafka_mock.py
+++ b/tests/io/test_kafka_mock.py
@@ -206,10 +206,10 @@ def test_kafka_source_task_terminates_on_empty_consume(monkeypatch: pytest.Monke
 
     # Broker-free simulation:
     # We inject a minimal `confluent_kafka` module into `sys.modules` so that `_kafka.py` imports this stub
-    # at runtime inside `KafkaSourceTask.get_micro_partitions()`.
+    # at runtime inside `KafkaSourceTask.read()`.
     #
     # Behavior under test: if `consume()` returns an empty list immediately, the task should terminate
-    # without yielding any MicroPartitions and without retrying/spinning.
+    # without yielding any RecordBatches and without retrying/spinning.
     class _Consumer:
         consume_calls: int = 0
 
@@ -249,7 +249,9 @@ def test_kafka_source_task_terminates_on_empty_consume(monkeypatch: pytest.Monke
         _limit=None,
     )
 
-    assert list(task.get_micro_partitions()) == []
+    from daft.io.__shim import _drain_async_iter
+
+    assert list(_drain_async_iter(task.read())) == []
     assert _Consumer.consume_calls == 1
 
 
@@ -318,7 +320,9 @@ def test_kafka_source_task_ignores_partition_eof(monkeypatch: pytest.MonkeyPatch
         _limit=None,
     )
 
-    assert list(task.get_micro_partitions()) == []
+    from daft.io.__shim import _drain_async_iter
+
+    assert list(_drain_async_iter(task.read())) == []
 
 
 def test_kafka_source_task_respects_chunk_size(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -388,9 +392,11 @@ def test_kafka_source_task_respects_chunk_size(monkeypatch: pytest.MonkeyPatch) 
         _limit=None,
     )
 
-    micro_partitions = list(task.get_micro_partitions())
-    assert len(micro_partitions) == 3
-    assert [rows[0]["offset"] for rows in (mp.to_pylist() for mp in micro_partitions)] == [0, 1, 2]
+    from daft.io.__shim import _drain_async_iter
+
+    batches = list(_drain_async_iter(task.read()))
+    assert len(batches) == 3
+    assert [rows[0]["offset"] for rows in (rb.to_pylist() for rb in batches)] == [0, 1, 2]
 
 
 def test_kafka_source_task_respects_limit(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -455,6 +461,8 @@ def test_kafka_source_task_respects_limit(monkeypatch: pytest.MonkeyPatch) -> No
         _limit=3,
     )
 
-    micro_partitions = list(task.get_micro_partitions())
-    total_rows = sum(len(mp.to_pylist()) for mp in micro_partitions)
+    from daft.io.__shim import _drain_async_iter
+
+    batches = list(_drain_async_iter(task.read()))
+    total_rows = sum(len(rb.to_pylist()) for rb in batches)
     assert total_rows == 3

--- a/tests/io/test_native_tasks.py
+++ b/tests/io/test_native_tasks.py
@@ -1,0 +1,176 @@
+"""Tests for DataSourceTask.parquet() and _PyDataSourceTask."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import daft
+from daft import DataType
+from daft.io.source import DataSource, DataSourceTask
+from daft.recordbatch import RecordBatch
+from daft.schema import Schema
+
+
+@pytest.fixture
+def parquet_file(tmp_path: Path) -> str:
+    """Create a simple parquet file and return its path."""
+    table = pa.table({"x": [1, 2, 3, 4, 5], "y": ["a", "b", "c", "d", "e"]})
+    path = str(tmp_path / "test.parquet")
+    pq.write_table(table, path)
+    return path
+
+
+@pytest.fixture
+def partitioned_parquet_files(tmp_path: Path) -> list[tuple[str, int]]:
+    """Create two parquet files simulating partitioned data. Returns (path, partition_value) pairs."""
+    files = []
+    for part_val in [10, 20]:
+        table = pa.table({"x": list(range(part_val, part_val + 3))})
+        path = str(tmp_path / f"part={part_val}" / "data.parquet")
+        Path(path).parent.mkdir(parents=True)
+        pq.write_table(table, path)
+        files.append((path, part_val))
+    return files
+
+
+class SimpleParquetSource(DataSource):
+    """A DataSource that reads parquet files via DataSourceTask.parquet()."""
+
+    def __init__(self, paths: list[str], schema: Schema) -> None:
+        self._paths = paths
+        self._schema = schema
+
+    @property
+    def name(self) -> str:
+        return "SimpleParquetSource"
+
+    @property
+    def schema(self) -> Schema:
+        return self._schema
+
+    async def get_tasks(self, pushdowns) -> AsyncIterator[DataSourceTask]:
+        for path in self._paths:
+            yield DataSourceTask.parquet(path=path, schema=self._schema, pushdowns=pushdowns)
+
+
+def test_parquet_single_file(parquet_file: str):
+    """DataSourceTask.parquet() reads a single parquet file through the native reader."""
+    schema = Schema.from_pydict({"x": DataType.int64(), "y": DataType.string()})
+    source = SimpleParquetSource([parquet_file], schema)
+    df = source.read()
+    result = df.sort("x").to_pydict()
+    assert result == {"x": [1, 2, 3, 4, 5], "y": ["a", "b", "c", "d", "e"]}
+
+
+def test_parquet_multiple_files(tmp_path: Path):
+    """DataSourceTask.parquet() handles multiple files as separate tasks."""
+    schema = Schema.from_pydict({"x": DataType.int64()})
+    paths = []
+    for i in range(3):
+        table = pa.table({"x": [i * 10 + j for j in range(3)]})
+        path = str(tmp_path / f"file_{i}.parquet")
+        pq.write_table(table, path)
+        paths.append(path)
+
+    source = SimpleParquetSource(paths, schema)
+    df = source.read()
+    result = df.sort("x").to_pydict()
+    assert result == {"x": [0, 1, 2, 10, 11, 12, 20, 21, 22]}
+
+
+def test_parquet_with_column_projection(parquet_file: str):
+    """Column pushdowns work with DataSourceTask.parquet()."""
+    schema = Schema.from_pydict({"x": DataType.int64(), "y": DataType.string()})
+    source = SimpleParquetSource([parquet_file], schema)
+    df = source.read().select("x")
+    result = df.sort("x").to_pydict()
+    assert result == {"x": [1, 2, 3, 4, 5]}
+
+
+def test_parquet_with_filter(parquet_file: str):
+    """Filter pushdowns work with DataSourceTask.parquet()."""
+    schema = Schema.from_pydict({"x": DataType.int64(), "y": DataType.string()})
+    source = SimpleParquetSource([parquet_file], schema)
+    df = source.read().where(daft.col("x") > 3)
+    result = df.sort("x").to_pydict()
+    assert result == {"x": [4, 5], "y": ["d", "e"]}
+
+
+def test_parquet_with_limit(parquet_file: str):
+    """Limit pushdowns work with DataSourceTask.parquet()."""
+    schema = Schema.from_pydict({"x": DataType.int64(), "y": DataType.string()})
+    source = SimpleParquetSource([parquet_file], schema)
+    df = source.read().limit(2)
+    result = df.to_pydict()
+    assert len(result["x"]) == 2
+
+
+def test_parquet_with_partition_values(partitioned_parquet_files: list[tuple[str, int]]):
+    """DataSourceTask.parquet() with partition_values injects partition columns."""
+    schema = Schema.from_pydict({"x": DataType.int64(), "part": DataType.int64()})
+
+    class PartitionedParquetSource(DataSource):
+        def __init__(self, files):
+            self._files = files
+
+        @property
+        def name(self) -> str:
+            return "PartitionedParquetSource"
+
+        @property
+        def schema(self) -> Schema:
+            return schema
+
+        async def get_tasks(self, pushdowns) -> AsyncIterator[DataSourceTask]:
+            for path, part_val in self._files:
+                pv = RecordBatch.from_pydict({"part": [part_val]})
+                yield DataSourceTask.parquet(
+                    path=path,
+                    schema=schema,
+                    pushdowns=pushdowns,
+                    partition_values=pv,
+                    num_rows=3,
+                )
+
+    source = PartitionedParquetSource(partitioned_parquet_files)
+    df = source.read()
+    result = df.sort("x").to_pydict()
+    assert result == {
+        "x": [10, 11, 12, 20, 21, 22],
+        "part": [10, 10, 10, 20, 20, 20],
+    }
+
+
+def test_parquet_collect_multiple_times(parquet_file: str):
+    """DataSourceTask.parquet() sources can be collected multiple times."""
+    schema = Schema.from_pydict({"x": DataType.int64(), "y": DataType.string()})
+    source = SimpleParquetSource([parquet_file], schema)
+    df = source.read()
+    assert df.count_rows() == 5
+    assert df.count_rows() == 5
+    assert len(df.collect()) == 5
+
+
+def test_parquet_factory_returns_datasource_task():
+    """DataSourceTask.parquet() returns a DataSourceTask instance."""
+    schema = Schema.from_pydict({"x": DataType.int64()})
+    task = DataSourceTask.parquet(path="/tmp/fake.parquet", schema=schema)
+    assert isinstance(task, DataSourceTask)
+    assert task.schema == schema
+
+
+def test_parquet_factory_always_returns_task():
+    """DataSourceTask.parquet() always returns a task (partition pruning is the DataSource's job)."""
+    schema = Schema.from_pydict({"x": DataType.int64(), "part": DataType.int64()})
+    pv = RecordBatch.from_pydict({"part": [10]})
+    task = DataSourceTask.parquet(
+        path="/tmp/fake.parquet",
+        schema=schema,
+        partition_values=pv,
+    )
+    assert isinstance(task, DataSourceTask)


### PR DESCRIPTION
## Motivation

This makes the python DataSource and DataSourceTask interfaces async generators and switches to using RecordBatch. It's a step towards moving off of the legacy ScanOperator and onto the DataSource. This is backwards compatible because the shim is still able to handle the old interface methods, and we have proper warnings.

I am shipping this before the end-to-end native DataSource impl. because it unblocks the paimon PR and I wanted to get the async interfaces in ASAP.

A nice feature of this is that you can now use native scan tasks in a python DataSource which unblocks being able to migrate existing python ScanOperator implementations over to DataSource. There's a lot of cleanup still on the Rust side, but I wanted to get the public python side in order.

## Changes

- Fixed that annoying range redefinition error for good (fingers crossed)
- Updated DataSource task fetching to an async generator
- Updated DataSourceTask reading to an async record batch generator
- Add a _PyDataSourceTask which wraps the existing ScanTask which unblocks native tasks in python DataSource
- ScanOperator can smart unwrap the native tasks as before.
- ScanOperator is sync and materializes all ScanTasks for now, so that's why we have the drain loop
- We won't be materializing ScanTasks in the near future
