### PR TITLE
ci: disable HF xet storage backend in unit tests

### DIFF
--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -15,6 +15,7 @@ env:
   DAFT_ANALYTICS_ENABLED: "0"
   RUST_BACKTRACE: 1
   DAFT_PROGRESS_BAR: 0
+  HF_HUB_DISABLE_XET: "1"
 
 # Cancel in-progress CI runs for outdated PR pushes to save resources.
 # For pull requests, use the PR number to group runs.
@@ -218,7 +219,6 @@ jobs:
         CONDA_EXE: ${{ env.CONDA_HOME }}/bin/conda
 
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        HF_HUB_DISABLE_XET: "1"
 
     - name: Build library and Test with pytest (no coverage)
       if: matrix.coverage == false
@@ -234,7 +234,6 @@ jobs:
         CONDA_EXE: ${{ env.CONDA_HOME }}/bin/conda
 
         DAFT_RUNNER: ${{ matrix.daft-runner }}
-        HF_HUB_DISABLE_XET: "1"
 
     - name: Upload coverage report
       if: matrix.coverage != false

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -218,6 +218,7 @@ jobs:
         CONDA_EXE: ${{ env.CONDA_HOME }}/bin/conda
 
         DAFT_RUNNER: ${{ matrix.daft-runner }}
+        HF_HUB_DISABLE_XET: "1"
 
     - name: Build library and Test with pytest (no coverage)
       if: matrix.coverage == false
@@ -233,6 +234,7 @@ jobs:
         CONDA_EXE: ${{ env.CONDA_HOME }}/bin/conda
 
         DAFT_RUNNER: ${{ matrix.daft-runner }}
+        HF_HUB_DISABLE_XET: "1"
 
     - name: Upload coverage report
       if: matrix.coverage != false


### PR DESCRIPTION
The hf-xet package causes model download failures on macOS CI runners due to socket buffer exhaustion (ENOBUFS) and token refresh errors when downloading from HuggingFace's xet storage backend.

## Changes Made

Disable xet for now, seems like it's quite error prone

- [xet-core #483](https://github.com/huggingface/xet-core/issues/483) — "Still can't download models" — users confirmed uninstalling hf-xet resolved download
  failures
- [xet-core #373](https://github.com/huggingface/xet-core/issues/373) — "Can't download models" — connection resets and timeouts at 60-80% download
- [xet-core #409](https://github.com/huggingface/xet-core/issues/409) — Downloads stalling at 99%
- [huggingface_hub #3266](https://github.com/huggingface/huggingface_hub/issues/3266) — HF_HUB_DISABLE_XET not actually disabling xet in v0.34.1
  [huggingface_hub #3155](https://github.com/huggingface/huggingface_hub/issues/3155) — DNS resolution failures specific to the xet backend

## Related Issues

More of this: https://github.com/Eventual-Inc/Daft/actions/runs/23563614707/job/68609546169