### PR TITLE
perf: Optimize list_* aggregation functions

### DIFF
--- a/src/daft-core/src/array/ops/compare_agg.rs
+++ b/src/daft-core/src/array/ops/compare_agg.rs
@@ -287,9 +287,11 @@ impl DaftCompareAggable for DataArray<FixedSizeBinaryType> {
     }
 }
 
-fn grouped_cmp_bool(
+/// Helper for getting the min/max of a boolean array grouped by a group indices.
+/// When `FIND_VAL` is true (aka max), we are trying to find a true value per group.
+/// When `FIND_VAL` is false (aka min), we are trying to find a false value per group.
+fn grouped_cmp_bool<const FIND_VAL: bool>(
     data_array: &BooleanArray,
-    val_to_find: bool,
     groups: &GroupIndices,
 ) -> DaftResult<BooleanArray> {
     if data_array.null_count() > 0 {
@@ -301,7 +303,7 @@ fn grouped_cmp_bool(
                     (None, None) => None,
                     (None, Some(r)) => Some(r),
                     (Some(l), None) => Some(l),
-                    (Some(l), Some(r)) => Some((l | r) ^ val_to_find),
+                    (Some(l), Some(r)) => Some(if FIND_VAL { l | r } else { l & r }),
                 });
             reduced_val.unwrap_or_default()
         });
@@ -313,9 +315,9 @@ fn grouped_cmp_bool(
                 let reduced_val = g
                     .iter()
                     .map(|i| data_array.get(*i as usize).unwrap())
-                    .find(|v| *v == val_to_find);
+                    .find(|v| *v == FIND_VAL);
                 match reduced_val {
-                    None => !val_to_find,
+                    None => !FIND_VAL,
                     Some(v) => v,
                 }
             }),
@@ -339,11 +341,11 @@ impl DaftCompareAggable for DataArray<BooleanType> {
     }
 
     fn grouped_min(&self, groups: &GroupIndices) -> Self::Output {
-        grouped_cmp_bool(self, false, groups)
+        grouped_cmp_bool::<false>(self, groups)
     }
 
     fn grouped_max(&self, groups: &GroupIndices) -> Self::Output {
-        grouped_cmp_bool(self, true, groups)
+        grouped_cmp_bool::<true>(self, groups)
     }
 }
 

--- a/src/daft-functions-list/src/kernels.rs
+++ b/src/daft-functions-list/src/kernels.rs
@@ -1063,11 +1063,11 @@ fn scatter_grouped_aggs(
     })
 }
 
-fn agg_list<T>(arr: &ListArray, op: T, target_dtype: &DataType) -> DaftResult<Series>
+fn agg_list_helper<T>(arr: &ListArray, op: T, target_dtype: &DataType) -> DaftResult<Series>
 where
     T: Fn(&Series, &GroupIndices) -> DaftResult<Series>,
 {
-    let mut groups = GroupIndices::new();
+    let mut groups = GroupIndices::with_capacity(arr.len());
     let mut scatter_indices = Vec::with_capacity(arr.len());
 
     for i in 0..arr.len() {
@@ -1093,11 +1093,7 @@ where
 
 /// Helper to construct group indices for fixed size list arrays.
 /// Used for list_sum, list_mean, list_min, list_max.
-fn agg_fixed_size_list<T>(
-    arr: &FixedSizeListArray,
-    op: T,
-    target_dtype: &DataType,
-) -> DaftResult<Series>
+fn agg_fsl_helper<T>(arr: &FixedSizeListArray, op: T, target_dtype: &DataType) -> DaftResult<Series>
 where
     T: Fn(&Series, &GroupIndices) -> DaftResult<Series>,
 {
@@ -1129,8 +1125,8 @@ where
     scatter_grouped_aggs(arr.name(), target_dtype, scatter_indices, grouped_aggs)
 }
 
-impl_aggs_list_array!(ListArray, agg_list);
-impl_aggs_list_array!(FixedSizeListArray, agg_fixed_size_list);
+impl_aggs_list_array!(ListArray, agg_list_helper);
+impl_aggs_list_array!(FixedSizeListArray, agg_fsl_helper);
 
 #[cfg(test)]
 mod tests {

--- a/src/daft-functions-list/src/kernels.rs
+++ b/src/daft-functions-list/src/kernels.rs
@@ -1020,35 +1020,27 @@ macro_rules! impl_aggs_list_array {
     ($la:ident, $agg_helper:ident) => {
         impl ListArrayAggExtension for $la {
             fn sum(&self) -> DaftResult<Series> {
-                $agg_helper(
-                    self,
-                    |child, groups| child.sum(Some(groups)),
-                    try_sum_supertype,
-                )
+                let target_dtype = try_sum_supertype(self.child_data_type())?;
+                $agg_helper(self, |child, groups| child.sum(Some(groups)), &target_dtype)
             }
 
             fn mean(&self) -> DaftResult<Series> {
+                let target_dtype = try_mean_aggregation_supertype(self.child_data_type())?;
                 $agg_helper(
                     self,
                     |child, groups| child.mean(Some(groups)),
-                    try_mean_aggregation_supertype,
+                    &target_dtype,
                 )
             }
 
             fn min(&self) -> DaftResult<Series> {
-                $agg_helper(
-                    self,
-                    |child, groups| child.min(Some(groups)),
-                    |dtype| Ok(dtype.clone()),
-                )
+                let target_dtype = self.child_data_type();
+                $agg_helper(self, |child, groups| child.min(Some(groups)), &target_dtype)
             }
 
             fn max(&self) -> DaftResult<Series> {
-                $agg_helper(
-                    self,
-                    |child, groups| child.max(Some(groups)),
-                    |dtype| Ok(dtype.clone()),
-                )
+                let target_dtype = self.child_data_type();
+                $agg_helper(self, |child, groups| child.max(Some(groups)), &target_dtype)
             }
         }
     };
@@ -1065,18 +1057,16 @@ fn scatter_grouped_aggs(
         scatter_indices.into_iter(),
     );
 
-    match grouped_aggs {
-        Some(series) => series.take(&idx).map(|s| s.rename(name)),
-        None => Ok(Series::full_null(name, target_dtype, idx.len())),
-    }
+    Ok(match grouped_aggs {
+        Some(series) => series.take(&idx)?.rename(name),
+        None => Series::full_null(name, target_dtype, idx.len()),
+    })
 }
 
-fn min_max_helper<T, F>(arr: &ListArray, op: T, target_type_getter: F) -> DaftResult<Series>
+fn agg_list<T>(arr: &ListArray, op: T, target_dtype: &DataType) -> DaftResult<Series>
 where
     T: Fn(&Series, &GroupIndices) -> DaftResult<Series>,
-    F: Fn(&DataType) -> DaftResult<DataType>,
 {
-    let target_dtype = target_type_getter(arr.child_data_type())?;
     let mut groups = GroupIndices::new();
     let mut scatter_indices = Vec::with_capacity(arr.len());
 
@@ -1098,22 +1088,22 @@ where
         Some(op(&arr.flat_child, &groups)?)
     };
 
-    scatter_grouped_aggs(arr.name(), &target_dtype, scatter_indices, grouped_aggs)
+    scatter_grouped_aggs(arr.name(), target_dtype, scatter_indices, grouped_aggs)
 }
 
-fn min_max_helper_fixed_size<T, F>(
+/// Helper to construct group indices for fixed size list arrays.
+/// Used for list_sum, list_mean, list_min, list_max.
+fn agg_fixed_size_list<T>(
     arr: &FixedSizeListArray,
     op: T,
-    target_type_getter: F,
+    target_dtype: &DataType,
 ) -> DaftResult<Series>
 where
     T: Fn(&Series, &GroupIndices) -> DaftResult<Series>,
-    F: Fn(&DataType) -> DaftResult<DataType>,
 {
-    let target_dtype = target_type_getter(arr.child_data_type())?;
     let fixed_size = arr.fixed_element_len();
     if fixed_size == 0 {
-        return Ok(Series::full_null(arr.name(), &target_dtype, arr.len()));
+        return Ok(Series::full_null(arr.name(), target_dtype, arr.len()));
     }
 
     let mut groups = GroupIndices::with_capacity(arr.len());
@@ -1136,11 +1126,11 @@ where
         Some(op(&arr.flat_child, &groups)?)
     };
 
-    scatter_grouped_aggs(arr.name(), &target_dtype, scatter_indices, grouped_aggs)
+    scatter_grouped_aggs(arr.name(), target_dtype, scatter_indices, grouped_aggs)
 }
 
-impl_aggs_list_array!(ListArray, min_max_helper);
-impl_aggs_list_array!(FixedSizeListArray, min_max_helper_fixed_size);
+impl_aggs_list_array!(ListArray, agg_list);
+impl_aggs_list_array!(FixedSizeListArray, agg_fixed_size_list);
 
 #[cfg(test)]
 mod tests {

--- a/src/daft-functions-list/src/kernels.rs
+++ b/src/daft-functions-list/src/kernels.rs
@@ -9,6 +9,7 @@ use daft_core::{
     array::{
         FixedSizeListArray, ListArray, StructArray,
         growable::{Growable, make_growable},
+        ops::GroupIndices,
     },
     datatypes::{try_mean_aggregation_supertype, try_sum_supertype},
     prelude::{
@@ -1019,49 +1020,127 @@ macro_rules! impl_aggs_list_array {
     ($la:ident, $agg_helper:ident) => {
         impl ListArrayAggExtension for $la {
             fn sum(&self) -> DaftResult<Series> {
-                $agg_helper(self, |s| s.sum(None), try_sum_supertype)
+                $agg_helper(
+                    self,
+                    |child, groups| child.sum(Some(groups)),
+                    try_sum_supertype,
+                )
             }
 
             fn mean(&self) -> DaftResult<Series> {
-                $agg_helper(self, |s| s.mean(None), try_mean_aggregation_supertype)
+                $agg_helper(
+                    self,
+                    |child, groups| child.mean(Some(groups)),
+                    try_mean_aggregation_supertype,
+                )
             }
 
             fn min(&self) -> DaftResult<Series> {
-                $agg_helper(self, |s| s.min(None), |dtype| Ok(dtype.clone()))
+                $agg_helper(
+                    self,
+                    |child, groups| child.min(Some(groups)),
+                    |dtype| Ok(dtype.clone()),
+                )
             }
 
             fn max(&self) -> DaftResult<Series> {
-                $agg_helper(self, |s| s.max(None), |dtype| Ok(dtype.clone()))
-            }
-        }
-
-        fn $agg_helper<T, F>(arr: &$la, op: T, target_type_getter: F) -> DaftResult<Series>
-        where
-            T: Fn(&Series) -> DaftResult<Series>,
-            F: Fn(&DataType) -> DaftResult<DataType>,
-        {
-            // TODO(Kevin): Currently this requires full materialization of one Series for every list. We could avoid this by implementing either sorted aggregation or an array builder
-
-            // Assumes `op`` returns a null Series given an empty Series
-            let aggs = arr
-                .into_iter()
-                .map(|s| s.unwrap_or(Series::empty("", arr.child_data_type())))
-                .map(|s| op(&s))
-                .collect::<DaftResult<Vec<_>>>()?;
-
-            let agg_refs: Vec<_> = aggs.iter().collect();
-
-            if agg_refs.is_empty() {
-                let target_type = target_type_getter(arr.child_data_type())?;
-                Ok(Series::empty(arr.name(), &target_type))
-            } else {
-                Series::concat(agg_refs.as_slice()).map(|s| s.rename(arr.name()))
+                $agg_helper(
+                    self,
+                    |child, groups| child.max(Some(groups)),
+                    |dtype| Ok(dtype.clone()),
+                )
             }
         }
     };
 }
-impl_aggs_list_array!(ListArray, list_agg_helper);
-impl_aggs_list_array!(FixedSizeListArray, fsl_agg_helper);
+
+fn scatter_grouped_aggs(
+    name: &str,
+    target_dtype: &DataType,
+    scatter_indices: Vec<Option<u64>>,
+    grouped_aggs: Option<Series>,
+) -> DaftResult<Series> {
+    let idx = UInt64Array::from_iter(
+        Field::new("", DataType::UInt64),
+        scatter_indices.into_iter(),
+    );
+
+    match grouped_aggs {
+        Some(series) => series.take(&idx).map(|s| s.rename(name)),
+        None => Ok(Series::full_null(name, target_dtype, idx.len())),
+    }
+}
+
+fn min_max_helper<T, F>(arr: &ListArray, op: T, target_type_getter: F) -> DaftResult<Series>
+where
+    T: Fn(&Series, &GroupIndices) -> DaftResult<Series>,
+    F: Fn(&DataType) -> DaftResult<DataType>,
+{
+    let target_dtype = target_type_getter(arr.child_data_type())?;
+    let mut groups = GroupIndices::new();
+    let mut scatter_indices = Vec::with_capacity(arr.len());
+
+    for i in 0..arr.len() {
+        let start = arr.offsets()[i] as u64;
+        let end = arr.offsets()[i + 1] as u64;
+
+        if arr.is_valid(i) && start < end {
+            scatter_indices.push(Some(groups.len() as u64));
+            groups.push((start..end).collect());
+        } else {
+            scatter_indices.push(None);
+        }
+    }
+
+    let grouped_aggs = if groups.is_empty() {
+        None
+    } else {
+        Some(op(&arr.flat_child, &groups)?)
+    };
+
+    scatter_grouped_aggs(arr.name(), &target_dtype, scatter_indices, grouped_aggs)
+}
+
+fn min_max_helper_fixed_size<T, F>(
+    arr: &FixedSizeListArray,
+    op: T,
+    target_type_getter: F,
+) -> DaftResult<Series>
+where
+    T: Fn(&Series, &GroupIndices) -> DaftResult<Series>,
+    F: Fn(&DataType) -> DaftResult<DataType>,
+{
+    let target_dtype = target_type_getter(arr.child_data_type())?;
+    let fixed_size = arr.fixed_element_len();
+    if fixed_size == 0 {
+        return Ok(Series::full_null(arr.name(), &target_dtype, arr.len()));
+    }
+
+    let mut groups = GroupIndices::with_capacity(arr.len());
+    let mut scatter_indices = Vec::with_capacity(arr.len());
+
+    for i in 0..arr.len() {
+        if arr.is_valid(i) {
+            scatter_indices.push(Some(groups.len() as u64));
+            let start = (i * fixed_size) as u64;
+            let end = start + fixed_size as u64;
+            groups.push((start..end).collect());
+        } else {
+            scatter_indices.push(None);
+        }
+    }
+
+    let grouped_aggs = if groups.is_empty() {
+        None
+    } else {
+        Some(op(&arr.flat_child, &groups)?)
+    };
+
+    scatter_grouped_aggs(arr.name(), &target_dtype, scatter_indices, grouped_aggs)
+}
+
+impl_aggs_list_array!(ListArray, min_max_helper);
+impl_aggs_list_array!(FixedSizeListArray, min_max_helper_fixed_size);
 
 #[cfg(test)]
 mod tests {
@@ -1544,11 +1623,29 @@ mod tests {
     }
 
     #[test]
+    fn test_list_min_empty_and_null() {
+        let arr = make_list_i64("a", vec![Some(vec![]), None, Some(vec![3, 1, 2])]);
+        let result = arr.min().unwrap();
+        assert_eq!(result.i64().unwrap().get(0), None);
+        assert_eq!(result.i64().unwrap().get(1), None);
+        assert_eq!(result.i64().unwrap().get(2), Some(1));
+    }
+
+    #[test]
     fn test_list_max() {
         let arr = make_list_i64("a", vec![Some(vec![3, 1, 2]), Some(vec![6, 4, 5])]);
         let result = arr.max().unwrap();
         assert_eq!(result.i64().unwrap().get(0), Some(3));
         assert_eq!(result.i64().unwrap().get(1), Some(6));
+    }
+
+    #[test]
+    fn test_list_max_empty_and_null() {
+        let arr = make_list_i64("a", vec![Some(vec![]), None, Some(vec![3, 1, 2])]);
+        let result = arr.max().unwrap();
+        assert_eq!(result.i64().unwrap().get(0), None);
+        assert_eq!(result.i64().unwrap().get(1), None);
+        assert_eq!(result.i64().unwrap().get(2), Some(3));
     }
 
     // ── fsl aggregation ─────────────────────────────────────────────────


### PR DESCRIPTION
## Changes Made

Optimize `list_*` operations (list_min, list_max, etc) by replacing the existing Series -> concat algorithm with an aggregator based approach.

Note, I'm not particularly happy with this approach, cause it still seems like a bunch of overhead to create a bunch of mini vectors, but its a pretty small diff and provably works.

Tested on a `m8g.2xlarge` using the connected components for dedupe script (https://github.com/Eventual-Inc/dedupe/blob/main/cc.py). 
- Original: 62.80s
- PR: 20.82s