### PR TITLE
fix: skip schema pruning on Source node when can_absorb_select is false

### DIFF
--- a/src/daft-logical-plan/src/optimization/optimizer.rs
+++ b/src/daft-logical-plan/src/optimization/optimizer.rs
@@ -397,7 +397,7 @@ mod tests {
     use common_treenode::{Transformed, TreeNode};
     use daft_core::prelude::*;
     use daft_dsl::{
-        Expr,
+        AggExpr, Expr,
         functions::{FunctionExpr, python::LegacyPythonUDF},
         lit, resolved_col, unresolved_col,
     };
@@ -405,10 +405,9 @@ mod tests {
 
     use super::{Optimizer, OptimizerBuilder, OptimizerConfig, RuleBatch, RuleExecutionStrategy};
     use crate::{
-        LogicalPlan, LogicalPlanBuilder,
-        ops::{Filter, Project, Source, UDFProject},
+        LogicalPlan,
+        ops::{Filter, Project, UDFProject},
         optimization::rules::{EnrichWithStats, MaterializeScans, OptimizerRule},
-        source_info::SourceInfo,
         test::{
             dummy_scan_node, dummy_scan_node_with_pushdowns, dummy_scan_operator,
             dummy_scan_operator_for_aggregation,
@@ -849,25 +848,17 @@ mod tests {
             .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
             .build();
 
-        let source = dummy_scan_node(scan_op).build();
-        let source = match source.as_ref() {
-            LogicalPlan::Source(source) => source,
-            _ => panic!("Expected Source plan"),
-        };
-        let source_info = match source.source_info.as_ref() {
-            SourceInfo::Physical(external_info) => {
-                Arc::new(SourceInfo::Physical(external_info.with_pushdowns(
-                    Pushdowns::default().with_columns(Some(Arc::new(vec!["a".to_string()]))),
-                )))
-            }
-            _ => panic!("Expected physical source"),
-        };
-        let expected_source: Arc<LogicalPlan> =
-            LogicalPlan::Source(Source::new(source.output_schema.clone(), source_info)).into();
-        let expected = LogicalPlanBuilder::from(expected_source)
-            .select(vec![resolved_col("a")])?
-            .aggregate(vec![unresolved_col("a").count(CountMode::All)], vec![])?
-            .build();
+        let expected = dummy_scan_node_with_pushdowns(
+            scan_op,
+            Pushdowns::default()
+                .with_aggregation(Some(Arc::new(Expr::Agg(AggExpr::Count(
+                    resolved_col("a"),
+                    CountMode::All,
+                )))))
+                .with_columns(Some(Arc::new(vec!["a".to_string()]))),
+        )
+        .aggregate(vec![unresolved_col("a").sum()], vec![])?
+        .build();
 
         let scan_materializer_and_stats_enricher = get_scan_materializer_and_stats_enricher();
         let expected = scan_materializer_and_stats_enricher

--- a/src/daft-logical-plan/src/optimization/rules/push_down_projection.rs
+++ b/src/daft-logical-plan/src/optimization/rules/push_down_projection.rs
@@ -143,10 +143,11 @@ impl PushDownProjection {
                 let required_columns = plan.required_columns().single();
                 match source.source_info.as_ref() {
                     SourceInfo::Physical(external_info) => {
-                        if matches!(external_info.scan_state, ScanState::Tasks(_)) {
-                            return Ok(Transformed::no(plan));
-                        }
                         if required_columns.len() < upstream_schema.names().len() {
+                            // Don't modify materialized scans — their tasks are already built.
+                            if matches!(external_info.scan_state, ScanState::Tasks(_)) {
+                                return Ok(Transformed::no(plan));
+                            }
                             let pruned_upstream_schema = upstream_schema
                                 .into_iter()
                                 .filter(|field| required_columns.contains(&*field.name))

--- a/src/daft-logical-plan/src/optimization/rules/split_udfs.rs
+++ b/src/daft-logical-plan/src/optimization/rules/split_udfs.rs
@@ -1189,12 +1189,11 @@ Project: col(a), col(c)
         Passthrough Columns = None
         Properties = { concurrency = 8, async = false, scalar = false }
         Resource request = { num_cpus = 8, num_gpus = 1 }
-          Project: col(c)
-            DummyScanOperator
-            File schema = a#Int64, b#Boolean, c#Int64
-            Partitioning keys = []
-            Projection pushdown = [c]
-            Output schema = a#Int64, b#Boolean, c#Int64
+          DummyScanOperator
+          File schema = a#Int64, b#Boolean, c#Int64
+          Partitioning keys = []
+          Projection pushdown = [c]
+          Output schema = c#Int64
         "},
         )?;
         Ok(())
@@ -1251,12 +1250,11 @@ Project: col(a), col(c)
           Passthrough Columns = col(a)
           Properties = { concurrency = 8, async = false, scalar = false }
           Resource request = { num_cpus = 8, num_gpus = 1 }
-            Project: col(a)
-              DummyScanOperator
-              File schema = a#Int64, b#Boolean, c#Int64
-              Partitioning keys = []
-              Projection pushdown = [a]
-              Output schema = a#Int64, b#Boolean, c#Int64
+            DummyScanOperator
+            File schema = a#Int64, b#Boolean, c#Int64
+            Partitioning keys = []
+            Projection pushdown = [a]
+            Output schema = a#Int64
         "},
         )?;
         Ok(())
@@ -1281,12 +1279,11 @@ Project: col(a), col(c)
         assert_optimized_plan_eq_with_projection_pushdown(
             plan,
             indoc! {"
-            Project: col(a)
-              DummyScanOperator
-              File schema = a#Int64, b#Boolean, c#Int64
-              Partitioning keys = []
-              Projection pushdown = [a]
-              Output schema = a#Int64, b#Boolean, c#Int64
+            DummyScanOperator
+            File schema = a#Int64, b#Boolean, c#Int64
+            Partitioning keys = []
+            Projection pushdown = [a]
+            Output schema = a#Int64
         "},
         )?;
         Ok(())


### PR DESCRIPTION
## Summary

- Skips projection pushdown into materialized scans (`ScanState::Tasks`)
- Adds regression tests for custom `DataSource` joins that previously panicked
- Fixes `DataSource.get_tasks` test to use async API

Fixes #6500

## Problem

Two issues with projection pushdown on Source nodes:

1. **Materialized scans**: When `ScanState::Tasks` is already materialized, pushing projections down would incorrectly modify already-built scan tasks.

2. **Custom DataSource joins**: When a custom `DataSource` applies `pushdowns.columns` and the query involves **join + select/agg**, the pushed-down column set could previously be incomplete. This was fixed upstream in the column requirement computation, and the regression tests now verify it stays correct.

## Fix

In `push_down_projection.rs`:

1. **Guard against materialized scans** — early return `Transformed::no` when `ScanState::Tasks(_)` to avoid modifying already-built scan tasks
2. **Keep standard schema pruning** — always prune Source schema + set column pushdowns + retry optimization (matching main behavior), which correctly computes required columns including join keys

## Tests

- Added `tests/io/test_datasource_join.py` with three regression tests:
  - `test_join_select_does_not_panic` — join + select
  - `test_join_groupby_agg_does_not_panic` — join + groupby/agg
  - `test_multi_join_agg_does_not_panic` — three-way join + aggregation
- Added `test_projection_does_not_pushdown_into_materialized_scan` Rust unit test