### PR TITLE
feat: DataFrame.from_files

### DIFF
--- a/daft/__init__.py
+++ b/daft/__init__.py
@@ -128,6 +128,7 @@ from daft.udf import udf, func, cls, method, metrics
 from daft.io._range import _range
 from daft.io import (
     IOConfig,
+    from_files,
     from_glob_path,
     read_csv,
     read_deltalake,
@@ -219,6 +220,7 @@ __all__ = [
     "execution_config_ctx",
     "from_arrow",
     "from_dask_dataframe",
+    "from_files",
     "from_glob_path",
     "from_pandas",
     "from_pydict",

--- a/daft/io/__init__.py
+++ b/daft/io/__init__.py
@@ -29,6 +29,7 @@ from daft.io._warc import read_warc
 from daft.io.huggingface import read_huggingface
 from daft.io.mcap._mcap import read_mcap
 from daft.io._range import _range
+from daft.io._files import from_files
 from daft.io.file_path import from_glob_path
 from daft.io.sink import DataSink
 from daft.io.source import DataSource, DataSourceTask
@@ -63,6 +64,7 @@ __all__ = [
     "TosConfig",
     "UnityConfig",
     "_range",
+    "from_files",
     "from_glob_path",
     "read_csv",
     "read_deltalake",

--- a/daft/io/_files.py
+++ b/daft/io/_files.py
@@ -20,7 +20,7 @@ def from_files(path: str | list[str], io_config: IOConfig | None = None) -> Data
     3. ``[...]`` matches any single character in the brackets
     4. ``**`` recursively matches any number of layers of directories
 
-    The returned DataFrame will have a single ``"file"`` column of type :meth:`~daft.DataType.file`.
+    The returned DataFrame will have a single ``"file"`` column of type `daft.DataType.file`.
     Files are not downloaded eagerly; the ``File`` type is a lazy reference that can be read on demand.
 
     Args:
@@ -28,7 +28,7 @@ def from_files(path: str | list[str], io_config: IOConfig | None = None) -> Data
         io_config (IOConfig): Configuration to use when running IO with remote services.
 
     Returns:
-        DataFrame: DataFrame with a single ``"file"`` column containing :class:`~daft.File` references.
+        DataFrame: DataFrame with a single ``"file"`` column containing `daft.File` references.
 
     Note:
         If no files match the glob pattern(s), an empty DataFrame is returned instead of raising an error.

--- a/daft/io/_files.py
+++ b/daft/io/_files.py
@@ -11,7 +11,7 @@ from daft.logical.builder import LogicalPlanBuilder
 
 @PublicAPI
 def from_files(path: str | list[str], io_config: IOConfig | None = None) -> DataFrame:
-    """Creates a DataFrame of :class:`~daft.File` references from a glob path.
+    """Creates a DataFrame of `daft.File` references from a glob path.
 
     This method supports wildcards:
 

--- a/daft/io/_files.py
+++ b/daft/io/_files.py
@@ -1,0 +1,69 @@
+# ruff: noqa: I002
+# isort: dont-add-import: from __future__ import annotations
+
+from daft.api_annotations import PublicAPI
+from daft.context import get_context
+from daft.daft import IOConfig
+from daft.dataframe import DataFrame
+from daft.functions.file_ import file as new_file
+from daft.logical.builder import LogicalPlanBuilder
+
+
+@PublicAPI
+def from_files(path: str | list[str], io_config: IOConfig | None = None) -> DataFrame:
+    """Creates a DataFrame of :class:`~daft.File` references from a glob path.
+
+    This method supports wildcards:
+
+    1. ``*`` matches any number of any characters including none
+    2. ``?`` matches any single character
+    3. ``[...]`` matches any single character in the brackets
+    4. ``**`` recursively matches any number of layers of directories
+
+    The returned DataFrame will have a single ``"file"`` column of type :meth:`~daft.DataType.file`.
+    Files are not downloaded eagerly; the ``File`` type is a lazy reference that can be read on demand.
+
+    Args:
+        path (str | list[str]): Path to files on disk (allows wildcards). Supports remote URLs such as ``s3://``, ``gs://``, or ``az://``.
+        io_config (IOConfig): Configuration to use when running IO with remote services.
+
+    Returns:
+        DataFrame: DataFrame with a single ``"file"`` column containing :class:`~daft.File` references.
+
+    Note:
+        If no files match the glob pattern(s), an empty DataFrame is returned instead of raising an error.
+
+    Examples:
+        Read all JPEG files under a directory:
+
+        >>> import daft
+        >>> df = daft.from_files("/path/to/files/*.jpeg")  # doctest: +SKIP
+
+        Read recursively:
+
+        >>> df = daft.from_files("/path/to/files/**/*.jpeg")  # doctest: +SKIP
+
+        Read from S3:
+
+        >>> df = daft.from_files("s3://my-bucket/images/*.png")  # doctest: +SKIP
+
+        Read from multiple glob patterns:
+
+        >>> df = daft.from_files(["/path/to/files/*.jpeg", "/path/to/others/*.jpeg"])  # doctest: +SKIP
+    """
+    if isinstance(path, str):
+        path = [path]
+
+    if len(path) == 0:
+        raise ValueError("Must specify at least one glob path")
+
+    context = get_context()
+    io_config = context.daft_planning_config.default_io_config if io_config is None else io_config
+
+    builder = LogicalPlanBuilder.from_glob_scan(
+        glob_paths=path,
+        io_config=io_config,
+    )
+    df = DataFrame(builder)
+
+    return df.select(new_file(df["path"], io_config=io_config).alias("file"))

--- a/daft/io/_files.py
+++ b/daft/io/_files.py
@@ -2,11 +2,11 @@
 # isort: dont-add-import: from __future__ import annotations
 
 from daft.api_annotations import PublicAPI
-from daft.context import get_context
 from daft.daft import IOConfig
 from daft.dataframe import DataFrame
+from daft.expressions import col
 from daft.functions.file_ import file as new_file
-from daft.logical.builder import LogicalPlanBuilder
+from daft.io.file_path import from_glob_path
 
 
 @PublicAPI
@@ -25,7 +25,7 @@ def from_files(path: str | list[str], io_config: IOConfig | None = None) -> Data
 
     Args:
         path (str | list[str]): Path to files on disk (allows wildcards). Supports remote URLs such as ``s3://``, ``gs://``, or ``az://``.
-        io_config (IOConfig): Configuration to use when running IO with remote services.
+        io_config (IOConfig | None): Configuration to use when running IO with remote services.
 
     Returns:
         DataFrame: DataFrame with a single ``"file"`` column containing `daft.File` references.
@@ -51,19 +51,4 @@ def from_files(path: str | list[str], io_config: IOConfig | None = None) -> Data
 
         >>> df = daft.from_files(["/path/to/files/*.jpeg", "/path/to/others/*.jpeg"])  # doctest: +SKIP
     """
-    if isinstance(path, str):
-        path = [path]
-
-    if len(path) == 0:
-        raise ValueError("Must specify at least one glob path")
-
-    context = get_context()
-    io_config = context.daft_planning_config.default_io_config if io_config is None else io_config
-
-    builder = LogicalPlanBuilder.from_glob_scan(
-        glob_paths=path,
-        io_config=io_config,
-    )
-    df = DataFrame(builder)
-
-    return df.select(new_file(df["path"], io_config=io_config).alias("file"))
+    return from_glob_path(path, io_config=io_config).select(new_file(col("path"), io_config=io_config).alias("file"))


### PR DESCRIPTION
## Changes Made

Adds a `DataFrame.from_files` backed by our existing `from_glob_paths` and File type constructor. This addresses the long-term ask of reading arbitrary files which is normally done with from_glob_paths + url_download, but we can leverage our new File type for* late materialization.

## Related Issues

Closes #6505 
