### PR TITLE
feat(subscriber): add Event enum and on_event dispatch for subscriber

### DIFF
--- a/daft/subscribers/abc.py
+++ b/daft/subscribers/abc.py
@@ -6,7 +6,7 @@ from functools import singledispatchmethod
 from typing import TYPE_CHECKING, Any
 
 from daft.daft import StatType
-from daft.subscribers.events import OperatorFinished, OperatorStarted, Stats
+from daft.subscribers.events import Event, OperatorFinished, OperatorStarted, Stats
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -22,7 +22,7 @@ class Subscriber(ABC):
     """
 
     @singledispatchmethod
-    def on_event(self, event: object) -> None:
+    def on_event(self, event: Event) -> None:
         """Unified dispatch for execution events."""
         warnings.warn(f"Unhandled event type: {type(event).__name__}", stacklevel=2)
 

--- a/daft/subscribers/abc.py
+++ b/daft/subscribers/abc.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+import warnings
+from abc import ABC
+from functools import singledispatchmethod
 from typing import TYPE_CHECKING, Any
 
 from daft.daft import StatType
+from daft.subscribers.events import OperatorFinished, OperatorStarted, Stats
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -12,15 +15,16 @@ if TYPE_CHECKING:
 
 
 class Subscriber(ABC):
-    """A framework for subscribing to Daft's query lifecycle.
+    """Experimental subscriber API for Daft's query lifecycle.
 
-    The engine triggers the subscriber methods as callbacks at the following points:
-    - Query from start to end
-    - Optimization from start to end
-    - Execution from start to end
-    - The execution of an operator from start to end
-    - During execution, emitting current stats of all running operators at regular intervals
+    This API is under active development and may change in minor releases.
+    Backward compatibility is not yet guaranteed.
     """
+
+    @singledispatchmethod
+    def on_event(self, event: object) -> None:
+        """Unified dispatch for execution events."""
+        warnings.warn(f"Unhandled event type: {type(event).__name__}", stacklevel=2)
 
     def close(self) -> None:
         """Called when the subscriber is detached or the process is shutting down.
@@ -29,61 +33,67 @@ class Subscriber(ABC):
         """
         pass
 
-    @abstractmethod
+    @on_event.register
+    def _(self, event: OperatorStarted) -> None:
+        self.on_operator_start(event)
+
+    @on_event.register
+    def _(self, event: OperatorFinished) -> None:
+        self.on_operator_end(event)
+
+    @on_event.register
+    def _(self, event: Stats) -> None:
+        self.on_stats(event)
+
+    def on_operator_start(self, event: OperatorStarted) -> None:
+        """Called when an operator has started executing."""
+        pass
+
+    def on_operator_end(self, event: OperatorFinished) -> None:
+        """Called when an operator has completed."""
+        pass
+
+    def on_stats(self, event: Stats) -> None:
+        """Called when emitting stats for all running operators in a query."""
+        pass
+
     def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
         """Called when starting the run for a new query."""
         pass
 
-    @abstractmethod
     def on_query_end(self, query_id: str, result: PyQueryResult) -> None:
         """Called when a query has completed."""
         pass
 
-    @abstractmethod
     def on_result_out(self, query_id: str, result: PyMicroPartition) -> None:
         """Called when a result is emitted for a query."""
         pass
 
-    @abstractmethod
     def on_optimization_start(self, query_id: str) -> None:
         """Called when starting to plan / optimize a query."""
         pass
 
-    @abstractmethod
     def on_optimization_end(self, query_id: str, optimized_plan: str) -> None:
         """Called when planning for a query has completed."""
         pass
 
-    @abstractmethod
     def on_exec_start(self, query_id: str, physical_plan: str) -> None:
         """Called when starting to execute a query. Receives the physical plan as JSON string."""
         pass
 
-    def on_operator_start(self, query_id: str, node_id: int) -> None:
-        """Called when an operator has started executing."""
-        pass
-
-    def on_operator_end(self, query_id: str, node_id: int) -> None:
-        """Called when an operator has completed."""
-        pass
-
-    def on_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
-        """Called when emitting stats for all running operators in a query."""
-        pass
-
     def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
         """Deprecated: use on_operator_start instead."""
-        self.on_operator_start(query_id, node_id)
+        self.on_operator_start(OperatorStarted(query_id=query_id, node_id=node_id, name=""))
 
     def on_exec_emit_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
         """Deprecated: use on_stats instead."""
-        self.on_stats(query_id, stats)
+        normalized_stats = {node_id: dict(node_stats.items()) for node_id, node_stats in stats.items()}
+        self.on_stats(Stats(query_id=query_id, stats=normalized_stats))
 
     def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
         """Deprecated: use on_operator_end instead."""
-        self.on_operator_end(query_id, node_id)
+        self.on_operator_end(OperatorFinished(query_id=query_id, node_id=node_id, name=""))
 
-    @abstractmethod
     def on_exec_end(self, query_id: str) -> None:
         """Called when a query has finished executing."""
         pass

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import atexit
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from io import TextIOWrapper
+
+    from daft.subscribers.events import OperatorFinished, OperatorStarted, Stats
+
+from daft.context import get_context
+from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState, StatType
+from daft.subscribers.abc import Subscriber
+
+_EVENT_LOG_ALIAS = "_daft_event_log"
+_DEFAULT_EVENT_LOG_DIR = Path("~/.daft/events").expanduser()
+_EVENT_LOG_ATEXIT_REGISTERED = False
+
+
+def _json_default(obj: object) -> object:
+    """JSON serializer for types not handled by the default encoder."""
+    if isinstance(obj, timedelta):
+        return round(obj.total_seconds() * 1000)
+    return str(obj)
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _mono_ms() -> float:
+    """Monotonic clock in milliseconds for duration measurement."""
+    return time.monotonic() * 1000
+
+
+class EventLogSubscriber(Subscriber):
+    """Experimental subscriber that writes query lifecycle events to a JSONL log.
+
+    Events follow the schema documented in the diagnostics plan:
+    one JSON object per line with ``event``, ``ts``, and event-specific fields.
+    """
+
+    def __init__(self, log_dir: str | Path) -> None:
+        self._log_dir = Path(log_dir).expanduser().resolve()
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._closed = False
+        self._query_files: dict[str, TextIOWrapper] = {}
+
+        # Track start times for duration computation (monotonic ms).
+        # TODO update the framework to pass this information
+        self._query_starts: dict[str, float] = {}
+        self._optimization_starts: dict[str, float] = {}
+        self._exec_starts: dict[str, float] = {}
+        self._operator_starts: dict[tuple[str, int], float] = {}
+
+    def _clear_query_state(self, query_id: str) -> None:
+        """Remove any leftover timing state for the given query."""
+        self._optimization_starts.pop(query_id, None)
+        self._exec_starts.pop(query_id, None)
+
+        stale_operator_keys = [key for key in self._operator_starts if key[0] == query_id]
+        for key in stale_operator_keys:
+            self._operator_starts.pop(key, None)
+
+    def _query_dir(self, query_id: str) -> Path:
+        return self._log_dir / query_id
+
+    def _events_path(self, query_id: str) -> Path:
+        return self._query_dir(query_id) / "events.jsonl"
+
+    def _get_query_file(self, query_id: str) -> TextIOWrapper | None:
+        if self._closed:
+            return None
+        query_file = self._query_files.get(query_id)
+        if query_file is not None:
+            return query_file
+
+        query_dir = self._query_dir(query_id)
+        query_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            query_file = open(self._events_path(query_id), "a", buffering=1)  # line-buffered
+        except OSError:
+            return None
+
+        self._query_files[query_id] = query_file
+        self._write_session_header(query_id)
+        return query_file
+
+    def _close_query_file(self, query_id: str) -> None:
+        query_file = self._query_files.pop(query_id, None)
+        if query_file is None:
+            return
+        query_file.close()
+
+    def _write_session_header(self, query_id: str) -> None:
+        from daft import __version__ as daft_version
+
+        self._write_event(
+            query_id,
+            "event_log_started",
+            {
+                "daft_version": daft_version,
+            },
+        )
+
+    def _write_event(self, query_id: str, event_name: str, payload: dict[str, Any]) -> None:
+        query_file = self._get_query_file(query_id)
+        if query_file is None:
+            return
+        record: dict[str, Any] = {"event": event_name, "ts": _iso_now(), "query_id": query_id}
+        record.update(payload)
+        try:
+            query_file.write(json.dumps(record, default=_json_default) + "\n")
+        except OSError:
+            pass  # Don't let logging failures affect query execution
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for query_file in self._query_files.values():
+            try:
+                query_file.close()
+            except OSError:
+                pass
+        self._query_files.clear()
+
+    # Query lifecycle
+
+    def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
+        self._query_starts[query_id] = _mono_ms()
+        self._write_event(query_id, "query_started", {})
+        self._write_event(query_id, "plan_unoptimized", {"plan": metadata.unoptimized_plan})
+
+    def on_query_end(self, query_id: str, result: PyQueryResult) -> None:
+        start = self._query_starts.pop(query_id, None)
+        duration_ms = round(_mono_ms() - start) if start is not None else None
+
+        payload: dict[str, Any] = {}
+        if duration_ms is not None:
+            payload["duration_ms"] = duration_ms
+
+        if result.end_state == QueryEndState.Finished:
+            payload["status"] = "ok"
+        elif result.end_state == QueryEndState.Failed:
+            payload["status"] = "failed"
+            if result.error_message:
+                payload["error_message"] = result.error_message
+        elif result.end_state == QueryEndState.Canceled:
+            payload["status"] = "canceled"
+        else:
+            payload["status"] = "dead"
+
+        self._write_event(query_id, "query_ended", payload)
+        self._clear_query_state(query_id)
+        self._close_query_file(query_id)
+
+    # Result
+
+    def on_result_out(self, query_id: str, result: PyMicroPartition) -> None:
+        self._write_event(
+            query_id,
+            "result_out",
+            {
+                "rows": len(result),
+            },
+        )
+
+    # Optimization
+
+    def on_optimization_start(self, query_id: str) -> None:
+        self._optimization_starts[query_id] = _mono_ms()
+        self._write_event(query_id, "optimization_started", {})
+
+    def on_optimization_end(self, query_id: str, optimized_plan: str) -> None:
+        start = self._optimization_starts.pop(query_id, None)
+        duration_ms = round(_mono_ms() - start) if start is not None else None
+
+        payload: dict[str, Any] = {}
+        if duration_ms is not None:
+            payload["duration_ms"] = duration_ms
+
+        self._write_event(query_id, "optimization_ended", payload)
+        self._write_event(query_id, "plan_optimized", {"plan": optimized_plan})
+
+    # Execution
+
+    def on_exec_start(self, query_id: str, physical_plan: str) -> None:
+        self._exec_starts[query_id] = _mono_ms()
+        self._write_event(query_id, "execution_started", {})
+        self._write_event(query_id, "plan_physical", {"plan": physical_plan})
+
+    def on_operator_start(self, event: OperatorStarted) -> None:
+        query_id = event.query_id
+        node_id = event.node_id
+        self._operator_starts[(query_id, node_id)] = _mono_ms()
+        self._write_event(
+            query_id,
+            "operator_started",
+            {
+                "node_id": node_id,
+                "name": event.name,
+            },
+        )
+
+    def on_stats(self, event: Stats) -> None:
+        for node_id, node_stats in event.stats.items():
+            metrics: dict[str, Any] = {}
+            for name, (_stat_type, value) in node_stats.items():
+                metrics[name] = value
+            self._write_event(
+                event.query_id,
+                "stats",
+                {
+                    "node_id": node_id,
+                    "metrics": metrics,
+                },
+            )
+
+    def on_process_stats(self, query_id: str, stats: Mapping[str, tuple[StatType, Any]]) -> None:
+        metrics: dict[str, Any] = {}
+        for name, (_stat_type, value) in stats.items():
+            metrics[name] = value
+        self._write_event(query_id, "process_stats", {"metrics": metrics})
+
+    def on_operator_end(self, event: OperatorFinished) -> None:
+        query_id = event.query_id
+        node_id = event.node_id
+        start = self._operator_starts.pop((query_id, node_id), None)
+        duration_ms = round(_mono_ms() - start) if start is not None else None
+
+        payload: dict[str, Any] = {"node_id": node_id, "name": event.name}
+        if duration_ms is not None:
+            payload["duration_ms"] = duration_ms
+
+        self._write_event(query_id, "operator_finished", payload)
+
+    def on_exec_end(self, query_id: str) -> None:
+        start = self._exec_starts.pop(query_id, None)
+        duration_ms = round(_mono_ms() - start) if start is not None else None
+
+        payload: dict[str, Any] = {}
+        if duration_ms is not None:
+            payload["duration_ms"] = duration_ms
+
+        self._write_event(query_id, "execution_ended", payload)
+
+
+_EVENT_LOG_SUBSCRIBER: EventLogSubscriber | None = None
+
+
+def enable_event_log(log_dir: str | Path | None = None) -> None:
+    """Experimental helper that attaches an event-log subscriber.
+
+    This API is currently intended for local event-log capture through
+    `enable_event_log()` / `disable_event_log()`.
+    """
+    global _EVENT_LOG_ATEXIT_REGISTERED, _EVENT_LOG_SUBSCRIBER
+    if _EVENT_LOG_SUBSCRIBER is not None:
+        disable_event_log()
+    if not _EVENT_LOG_ATEXIT_REGISTERED:
+        atexit.register(disable_event_log)
+        _EVENT_LOG_ATEXIT_REGISTERED = True
+
+    subscriber = EventLogSubscriber(log_dir or _DEFAULT_EVENT_LOG_DIR)
+    try:
+        get_context().attach_subscriber(_EVENT_LOG_ALIAS, subscriber)
+    except Exception:
+        subscriber.close()
+        raise
+    _EVENT_LOG_SUBSCRIBER = subscriber
+
+
+def disable_event_log() -> None:
+    """Detach the global EventLogSubscriber from the Daft context."""
+    global _EVENT_LOG_SUBSCRIBER
+    subscriber = _EVENT_LOG_SUBSCRIBER
+    if subscriber is None:
+        return
+    _EVENT_LOG_SUBSCRIBER = None
+    try:
+        get_context().detach_subscriber(_EVENT_LOG_ALIAS)
+    except Exception:
+        pass
+    subscriber.close()
+
+
+__all__ = ["EventLogSubscriber", "disable_event_log", "enable_event_log"]

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -1,288 +1,30 @@
 from __future__ import annotations
 
-import atexit
-import json
-import time
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-    from io import TextIOWrapper
-
-from daft.context import get_context
-from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState, StatType
-from daft.subscribers.abc import Subscriber
-
-_EVENT_LOG_ALIAS = "_daft_event_log"
-_DEFAULT_EVENT_LOG_DIR = Path("~/.daft/events").expanduser()
-_EVENT_LOG_ATEXIT_REGISTERED = False
+    from daft.daft import StatType
 
 
-def _json_default(obj: object) -> object:
-    """JSON serializer for types not handled by the default encoder."""
-    if isinstance(obj, timedelta):
-        return round(obj.total_seconds() * 1000)
-    return str(obj)
+@dataclass(frozen=True)
+class OperatorStarted:
+    query_id: str
+    node_id: int
+    name: str
 
 
-def _iso_now() -> str:
-    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+@dataclass(frozen=True)
+class OperatorFinished:
+    query_id: str
+    node_id: int
+    name: str
 
 
-def _mono_ms() -> float:
-    """Monotonic clock in milliseconds for duration measurement."""
-    return time.monotonic() * 1000
+@dataclass(frozen=True)
+class Stats:
+    query_id: str
+    stats: dict[int, dict[str, tuple[StatType, Any]]]
 
 
-class EventLogSubscriber(Subscriber):
-    """Experimental subscriber that writes query lifecycle events to a JSONL log.
-
-    Events follow the schema documented in the diagnostics plan:
-    one JSON object per line with ``event``, ``ts``, and event-specific fields.
-    """
-
-    def __init__(self, log_dir: str | Path) -> None:
-        self._log_dir = Path(log_dir).expanduser().resolve()
-        self._log_dir.mkdir(parents=True, exist_ok=True)
-        self._closed = False
-        self._query_files: dict[str, TextIOWrapper] = {}
-
-        # Track start times for duration computation (monotonic ms).
-        # TODO update the framework to pass this information
-        self._query_starts: dict[str, float] = {}
-        self._optimization_starts: dict[str, float] = {}
-        self._exec_starts: dict[str, float] = {}
-        self._operator_starts: dict[tuple[str, int], float] = {}
-
-    def _clear_query_state(self, query_id: str) -> None:
-        """Remove any leftover timing state for the given query."""
-        self._optimization_starts.pop(query_id, None)
-        self._exec_starts.pop(query_id, None)
-
-        stale_operator_keys = [key for key in self._operator_starts if key[0] == query_id]
-        for key in stale_operator_keys:
-            self._operator_starts.pop(key, None)
-
-    def _query_dir(self, query_id: str) -> Path:
-        return self._log_dir / query_id
-
-    def _events_path(self, query_id: str) -> Path:
-        return self._query_dir(query_id) / "events.jsonl"
-
-    def _get_query_file(self, query_id: str) -> TextIOWrapper | None:
-        if self._closed:
-            return None
-        query_file = self._query_files.get(query_id)
-        if query_file is not None:
-            return query_file
-
-        query_dir = self._query_dir(query_id)
-        query_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            query_file = open(self._events_path(query_id), "a", buffering=1)  # line-buffered
-        except OSError:
-            return None
-
-        self._query_files[query_id] = query_file
-        self._write_session_header(query_id)
-        return query_file
-
-    def _close_query_file(self, query_id: str) -> None:
-        query_file = self._query_files.pop(query_id, None)
-        if query_file is None:
-            return
-        query_file.close()
-
-    def _write_session_header(self, query_id: str) -> None:
-        from daft import __version__ as daft_version
-
-        self._write_event(
-            query_id,
-            "event_log_started",
-            {
-                "daft_version": daft_version,
-            },
-        )
-
-    def _write_event(self, query_id: str, event_name: str, payload: dict[str, Any]) -> None:
-        query_file = self._get_query_file(query_id)
-        if query_file is None:
-            return
-        record: dict[str, Any] = {"event": event_name, "ts": _iso_now(), "query_id": query_id}
-        record.update(payload)
-        try:
-            query_file.write(json.dumps(record, default=_json_default) + "\n")
-        except OSError:
-            pass  # Don't let logging failures affect query execution
-
-    def close(self) -> None:
-        if self._closed:
-            return
-        self._closed = True
-        for query_file in self._query_files.values():
-            try:
-                query_file.close()
-            except OSError:
-                pass
-        self._query_files.clear()
-
-    # Query lifecycle
-
-    def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
-        self._query_starts[query_id] = _mono_ms()
-        self._write_event(query_id, "query_started", {})
-        self._write_event(query_id, "plan_unoptimized", {"plan": metadata.unoptimized_plan})
-
-    def on_query_end(self, query_id: str, result: PyQueryResult) -> None:
-        start = self._query_starts.pop(query_id, None)
-        duration_ms = round(_mono_ms() - start) if start is not None else None
-
-        payload: dict[str, Any] = {}
-        if duration_ms is not None:
-            payload["duration_ms"] = duration_ms
-
-        if result.end_state == QueryEndState.Finished:
-            payload["status"] = "ok"
-        elif result.end_state == QueryEndState.Failed:
-            payload["status"] = "failed"
-            if result.error_message:
-                payload["error_message"] = result.error_message
-        elif result.end_state == QueryEndState.Canceled:
-            payload["status"] = "canceled"
-        else:
-            payload["status"] = "dead"
-
-        self._write_event(query_id, "query_ended", payload)
-        self._clear_query_state(query_id)
-        self._close_query_file(query_id)
-
-    # Result
-
-    def on_result_out(self, query_id: str, result: PyMicroPartition) -> None:
-        self._write_event(
-            query_id,
-            "result_out",
-            {
-                "rows": len(result),
-            },
-        )
-
-    # Optimization
-
-    def on_optimization_start(self, query_id: str) -> None:
-        self._optimization_starts[query_id] = _mono_ms()
-        self._write_event(query_id, "optimization_started", {})
-
-    def on_optimization_end(self, query_id: str, optimized_plan: str) -> None:
-        start = self._optimization_starts.pop(query_id, None)
-        duration_ms = round(_mono_ms() - start) if start is not None else None
-
-        payload: dict[str, Any] = {}
-        if duration_ms is not None:
-            payload["duration_ms"] = duration_ms
-
-        self._write_event(query_id, "optimization_ended", payload)
-        self._write_event(query_id, "plan_optimized", {"plan": optimized_plan})
-
-    # Execution
-
-    def on_exec_start(self, query_id: str, physical_plan: str) -> None:
-        self._exec_starts[query_id] = _mono_ms()
-        self._write_event(query_id, "execution_started", {})
-        self._write_event(query_id, "plan_physical", {"plan": physical_plan})
-
-    def on_operator_start(self, query_id: str, node_id: int) -> None:
-        self._operator_starts[(query_id, node_id)] = _mono_ms()
-        self._write_event(
-            query_id,
-            "operator_started",
-            {
-                "node_id": node_id,
-            },
-        )
-
-    def on_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
-        for node_id, node_stats in stats.items():
-            metrics: dict[str, Any] = {}
-            for name, (_stat_type, value) in node_stats.items():
-                metrics[name] = value
-            self._write_event(
-                query_id,
-                "stats",
-                {
-                    "node_id": node_id,
-                    "metrics": metrics,
-                },
-            )
-
-    def on_process_stats(self, query_id: str, stats: Mapping[str, tuple[StatType, Any]]) -> None:
-        metrics: dict[str, Any] = {}
-        for name, (_stat_type, value) in stats.items():
-            metrics[name] = value
-        self._write_event(query_id, "process_stats", {"metrics": metrics})
-
-    def on_operator_end(self, query_id: str, node_id: int) -> None:
-        start = self._operator_starts.pop((query_id, node_id), None)
-        duration_ms = round(_mono_ms() - start) if start is not None else None
-
-        payload: dict[str, Any] = {
-            "node_id": node_id,
-        }
-        if duration_ms is not None:
-            payload["duration_ms"] = duration_ms
-
-        self._write_event(query_id, "operator_ended", payload)
-
-    def on_exec_end(self, query_id: str) -> None:
-        start = self._exec_starts.pop(query_id, None)
-        duration_ms = round(_mono_ms() - start) if start is not None else None
-
-        payload: dict[str, Any] = {}
-        if duration_ms is not None:
-            payload["duration_ms"] = duration_ms
-
-        self._write_event(query_id, "execution_ended", payload)
-
-
-_EVENT_LOG_SUBSCRIBER: EventLogSubscriber | None = None
-
-
-def enable_event_log(log_dir: str | Path | None = None) -> None:
-    """Experimental helper that attaches an event-log subscriber.
-
-    This API is currently intended for local event-log capture through
-    `enable_event_log()` / `disable_event_log()`.
-    """
-    global _EVENT_LOG_ATEXIT_REGISTERED, _EVENT_LOG_SUBSCRIBER
-    if _EVENT_LOG_SUBSCRIBER is not None:
-        disable_event_log()
-    if not _EVENT_LOG_ATEXIT_REGISTERED:
-        atexit.register(disable_event_log)
-        _EVENT_LOG_ATEXIT_REGISTERED = True
-
-    subscriber = EventLogSubscriber(log_dir or _DEFAULT_EVENT_LOG_DIR)
-    try:
-        get_context().attach_subscriber(_EVENT_LOG_ALIAS, subscriber)
-    except Exception:
-        subscriber.close()
-        raise
-    _EVENT_LOG_SUBSCRIBER = subscriber
-
-
-def disable_event_log() -> None:
-    """Detach the global EventLogSubscriber from the Daft context."""
-    global _EVENT_LOG_SUBSCRIBER
-    subscriber = _EVENT_LOG_SUBSCRIBER
-    if subscriber is None:
-        return
-    _EVENT_LOG_SUBSCRIBER = None
-    try:
-        get_context().detach_subscriber(_EVENT_LOG_ALIAS)
-    except Exception:
-        pass
-    subscriber.close()
-
-
-__all__ = ["EventLogSubscriber", "disable_event_log", "enable_event_log"]
+Event = OperatorStarted | OperatorFinished | Stats

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -7,24 +8,25 @@ if TYPE_CHECKING:
     from daft.daft import StatType
 
 
+class Event(ABC):
+    """Base class for subscriber execution events."""
+
+
 @dataclass(frozen=True)
-class OperatorStarted:
+class OperatorStarted(Event):
     query_id: str
     node_id: int
     name: str
 
 
 @dataclass(frozen=True)
-class OperatorFinished:
+class OperatorFinished(Event):
     query_id: str
     node_id: int
     name: str
 
 
 @dataclass(frozen=True)
-class Stats:
+class Stats(Event):
     query_id: str
     stats: dict[int, dict[str, tuple[StatType, Any]]]
-
-
-Event = OperatorStarted | OperatorFinished | Stats

--- a/src/daft-context/src/lib.rs
+++ b/src/daft-context/src/lib.rs
@@ -14,8 +14,7 @@ use common_metrics::{QueryID, QueryPlan};
 use daft_micropartition::MicroPartitionRef;
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
-
-pub use crate::subscribers::{QueryMetadata, QueryResult, Subscriber};
+pub use subscribers::{Event, QueryMetadata, QueryResult, Subscriber};
 
 #[derive(Default)]
 #[cfg_attr(debug_assertions, derive(Debug))]
@@ -277,6 +276,27 @@ impl DaftContext {
             handle.spawn(async move {
                 if let Err(e) = subscriber.on_exec_emit_stats(query_id, stats).await {
                     log::error!("Failed to notify exec emit stats: {}", e);
+                }
+            });
+        }
+        Ok(())
+    }
+
+    pub fn notify_event(&self, event: Event) -> DaftResult<()> {
+        let subscribers = self.with_state(|state| {
+            state
+                .subscribers
+                .values()
+                .cloned()
+                .collect::<Vec<Arc<dyn Subscriber>>>()
+        });
+        let rt = common_runtime::get_io_runtime(false);
+        let handle = rt.runtime.handle().clone();
+        for subscriber in subscribers {
+            let evt = event.clone();
+            handle.spawn(async move {
+                if let Err(e) = subscriber.on_event(evt).await {
+                    log::error!("Failed to notify_event: {}", e);
                 }
             });
         }

--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -17,7 +17,7 @@ use tokio::{sync::mpsc, task::JoinHandle};
 use uuid::Uuid;
 
 use crate::subscribers::{
-    QueryMetadata, QueryResult, Subscriber,
+    Event, QueryMetadata, QueryResult, Subscriber,
     events::{OperatorEndEvent, OperatorStartEvent, StatsEvent},
 };
 
@@ -510,6 +510,15 @@ impl Subscriber for DashboardSubscriber {
             ),
             "exec_operator_end",
         );
+        Ok(())
+    }
+
+    async fn on_event(&self, event: Event) -> DaftResult<()> {
+        match event {
+            Event::Stats(e) => self.on_stats(e).await?,
+            Event::OperatorStart(e) => self.on_operator_start(e).await?,
+            Event::OperatorEnd(e) => self.on_operator_end(e).await?,
+        }
         Ok(())
     }
 }

--- a/src/daft-context/src/subscribers/debug.rs
+++ b/src/daft-context/src/subscribers/debug.rs
@@ -7,7 +7,7 @@ use daft_micropartition::MicroPartitionRef;
 use dashmap::DashMap;
 
 use crate::subscribers::{
-    QueryMetadata, QueryResult, Subscriber,
+    Event, QueryMetadata, QueryResult, Subscriber,
     events::{OperatorEndEvent, OperatorStartEvent, StatsEvent},
 };
 
@@ -170,6 +170,15 @@ impl Subscriber for DebugSubscriber {
                 "stats query_id={} node_id={} {}",
                 event.header.query_id, node_id, rendered,
             );
+        }
+        Ok(())
+    }
+
+    async fn on_event(&self, event: Event) -> DaftResult<()> {
+        match event {
+            Event::Stats(e) => self.on_stats(e).await?,
+            Event::OperatorStart(e) => self.on_operator_start(e).await?,
+            Event::OperatorEnd(e) => self.on_operator_end(e).await?,
         }
         Ok(())
     }

--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -6,6 +6,13 @@ use common_metrics::{
 };
 
 #[derive(Debug, Clone)]
+pub enum Event {
+    OperatorStart(Arc<OperatorStartEvent>),
+    OperatorEnd(Arc<OperatorEndEvent>),
+    Stats(Arc<StatsEvent>),
+}
+
+#[derive(Debug, Clone)]
 pub struct EventHeader {
     pub query_id: QueryID,
     pub timestamp_epoch_secs: f64,

--- a/src/daft-context/src/subscribers/mod.rs
+++ b/src/daft-context/src/subscribers/mod.rs
@@ -11,8 +11,8 @@ use common_error::{DaftError, DaftResult};
 use common_metrics::{NodeID, QueryEndState, QueryID, QueryPlan, Stats};
 use daft_core::prelude::SchemaRef;
 use daft_micropartition::MicroPartitionRef;
-
-use crate::subscribers::events::{OperatorEndEvent, OperatorStartEvent, StatsEvent};
+pub use events::Event;
+use events::{OperatorEndEvent, OperatorStartEvent, StatsEvent};
 
 pub struct QueryMetadata {
     pub output_schema: SchemaRef,
@@ -87,6 +87,10 @@ pub trait Subscriber: Send + Sync + std::fmt::Debug + 'static {
     }
 
     async fn on_stats(&self, _event: Arc<StatsEvent>) -> DaftResult<()> {
+        Ok(())
+    }
+
+    async fn on_event(&self, _event: Event) -> DaftResult<()> {
         Ok(())
     }
 }

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use common_error::DaftResult;
 use common_metrics::{QueryID, QueryPlan, Stats};
 use daft_micropartition::{MicroPartitionRef, python::PyMicroPartition};
-use pyo3::{IntoPyObject, Py, PyAny, Python, intern};
+use pyo3::{
+    Bound, IntoPyObject, Py, PyAny, PyResult, Python, intern,
+    types::{PyAnyMethods, PyModule},
+};
 
 use crate::{
     python::{PyQueryMetadata, PyQueryResult},
@@ -17,55 +20,6 @@ use crate::{
 /// Wrapper around a Python object that implements the Subscriber trait
 #[derive(Debug)]
 pub struct PySubscriberWrapper(pub(crate) Py<PyAny>);
-
-impl PySubscriberWrapper {
-    fn py_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_operator_start"),
-                (event.header.query_id.to_string(), event.operator.node_id),
-            )?;
-            Ok(())
-        })
-    }
-
-    fn py_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_operator_end"),
-                (event.header.query_id.to_string(), event.operator.node_id),
-            )?;
-            Ok(())
-        })
-    }
-
-    fn py_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
-        Python::attach(|py| {
-            let stats_map = event
-                .stats
-                .iter()
-                .map(|(node_id, stats)| {
-                    let stat_map = stats
-                        .iter()
-                        .map(|(name, stat)| {
-                            (name.to_string(), stat.clone().into_py_contents(py).unwrap())
-                        })
-                        .collect::<HashMap<_, _>>();
-                    (*node_id, stat_map)
-                })
-                .collect::<HashMap<_, _>>();
-            let py_stats = stats_map.into_pyobject(py)?;
-            self.0.call_method1(
-                py,
-                intern!(py, "on_stats"),
-                (event.header.query_id.to_string(), py_stats),
-            )?;
-            Ok(())
-        })
-    }
-}
 
 #[async_trait]
 impl Subscriber for PySubscriberWrapper {
@@ -214,11 +168,71 @@ impl Subscriber for PySubscriberWrapper {
     }
 
     async fn on_event(&self, event: Event) -> DaftResult<()> {
-        match event {
-            Event::Stats(e) => self.py_stats(e)?,
-            Event::OperatorStart(e) => self.py_operator_start(e)?,
-            Event::OperatorEnd(e) => self.py_operator_end(e)?,
-        }
-        Ok(())
+        Python::attach(|py| {
+            let py_event = build_py_event(py, event)?;
+            self.0
+                .call_method1(py, intern!(py, "on_event"), (py_event,))?;
+            Ok(())
+        })
+    }
+}
+
+// Build Python subscriber event objects from Rust execution events.
+
+fn events_module(py: Python<'_>) -> PyResult<Bound<'_, PyModule>> {
+    py.import("daft.subscribers.events")
+}
+
+fn event_class<'py>(py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+    events_module(py)?.getattr(name)
+}
+
+fn build_operator_started(py: Python<'_>, event: Arc<OperatorStartEvent>) -> PyResult<Py<PyAny>> {
+    event_class(py, "OperatorStarted")?
+        .call1((
+            event.header.query_id.to_string(),
+            event.operator.node_id,
+            event.operator.name.as_ref(),
+        ))
+        .map(Into::into)
+}
+
+fn build_operator_finished(py: Python<'_>, event: Arc<OperatorEndEvent>) -> PyResult<Py<PyAny>> {
+    event_class(py, "OperatorFinished")?
+        .call1((
+            event.header.query_id.to_string(),
+            event.operator.node_id,
+            event.operator.name.as_ref(),
+        ))
+        .map(Into::into)
+}
+
+fn build_py_stats<'py>(py: Python<'py>, stats: &[(NodeID, Stats)]) -> PyResult<Bound<'py, PyAny>> {
+    let stats_map = stats
+        .iter()
+        .map(|(node_id, stats)| {
+            let stat_map = stats
+                .iter()
+                .map(|(name, stat)| Ok((name.to_string(), stat.clone().into_py_contents(py)?)))
+                .collect::<PyResult<HashMap<_, _>>>()?;
+            Ok((*node_id, stat_map))
+        })
+        .collect::<PyResult<HashMap<_, _>>>()?;
+
+    stats_map.into_pyobject(py).map(|obj| obj.into_any())
+}
+
+fn build_stats(py: Python<'_>, event: Arc<StatsEvent>) -> PyResult<Py<PyAny>> {
+    let py_stats = build_py_stats(py, event.stats.as_ref())?;
+    event_class(py, "Stats")?
+        .call1((event.header.query_id.to_string(), py_stats))
+        .map(Into::into)
+}
+
+fn build_py_event(py: Python<'_>, event: Event) -> PyResult<Py<PyAny>> {
+    match event {
+        Event::OperatorStart(event) => build_operator_started(py, event),
+        Event::OperatorEnd(event) => build_operator_finished(py, event),
+        Event::Stats(event) => build_stats(py, event),
     }
 }

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -9,7 +9,7 @@ use pyo3::{IntoPyObject, Py, PyAny, Python, intern};
 use crate::{
     python::{PyQueryMetadata, PyQueryResult},
     subscribers::{
-        NodeID, QueryMetadata, QueryResult, Subscriber,
+        Event, NodeID, QueryMetadata, QueryResult, Subscriber,
         events::{OperatorEndEvent, OperatorStartEvent, StatsEvent},
     },
 };
@@ -17,6 +17,55 @@ use crate::{
 /// Wrapper around a Python object that implements the Subscriber trait
 #[derive(Debug)]
 pub struct PySubscriberWrapper(pub(crate) Py<PyAny>);
+
+impl PySubscriberWrapper {
+    fn py_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
+        Python::attach(|py| {
+            self.0.call_method1(
+                py,
+                intern!(py, "on_operator_start"),
+                (event.header.query_id.to_string(), event.operator.node_id),
+            )?;
+            Ok(())
+        })
+    }
+
+    fn py_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
+        Python::attach(|py| {
+            self.0.call_method1(
+                py,
+                intern!(py, "on_operator_end"),
+                (event.header.query_id.to_string(), event.operator.node_id),
+            )?;
+            Ok(())
+        })
+    }
+
+    fn py_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
+        Python::attach(|py| {
+            let stats_map = event
+                .stats
+                .iter()
+                .map(|(node_id, stats)| {
+                    let stat_map = stats
+                        .iter()
+                        .map(|(name, stat)| {
+                            (name.to_string(), stat.clone().into_py_contents(py).unwrap())
+                        })
+                        .collect::<HashMap<_, _>>();
+                    (*node_id, stat_map)
+                })
+                .collect::<HashMap<_, _>>();
+            let py_stats = stats_map.into_pyobject(py)?;
+            self.0.call_method1(
+                py,
+                intern!(py, "on_stats"),
+                (event.header.query_id.to_string(), py_stats),
+            )?;
+            Ok(())
+        })
+    }
+}
 
 #[async_trait]
 impl Subscriber for PySubscriberWrapper {
@@ -164,50 +213,12 @@ impl Subscriber for PySubscriberWrapper {
         })
     }
 
-    async fn on_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_operator_start"),
-                (event.header.query_id.to_string(), event.operator.node_id),
-            )?;
-            Ok(())
-        })
-    }
-
-    async fn on_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_operator_end"),
-                (event.header.query_id.to_string(), event.operator.node_id),
-            )?;
-            Ok(())
-        })
-    }
-
-    async fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
-        Python::attach(|py| {
-            let stats_map = event
-                .stats
-                .iter()
-                .map(|(node_id, stats)| {
-                    let stat_map = stats
-                        .iter()
-                        .map(|(name, stat)| {
-                            (name.to_string(), stat.clone().into_py_contents(py).unwrap())
-                        })
-                        .collect::<HashMap<_, _>>();
-                    (*node_id, stat_map)
-                })
-                .collect::<HashMap<_, _>>();
-            let py_stats = stats_map.into_pyobject(py)?;
-            self.0.call_method1(
-                py,
-                intern!(py, "on_stats"),
-                (event.header.query_id.to_string(), py_stats),
-            )?;
-            Ok(())
-        })
+    async fn on_event(&self, event: Event) -> DaftResult<()> {
+        match event {
+            Event::Stats(e) => self.py_stats(e)?,
+            Event::OperatorStart(e) => self.py_operator_start(e)?,
+            Event::OperatorEnd(e) => self.py_operator_end(e)?,
+        }
+        Ok(())
     }
 }

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -16,7 +16,7 @@ use common_runtime::RuntimeTask;
 use daft_context::{
     Subscriber,
     subscribers::events::{
-        EventHeader, OperatorEndEvent, OperatorMeta, OperatorStartEvent, StatsEvent,
+        Event, EventHeader, OperatorEndEvent, OperatorMeta, OperatorStartEvent, StatsEvent,
     },
 };
 use daft_dsl::common_treenode::{TreeNode, TreeNodeRecursion};
@@ -174,27 +174,27 @@ impl RuntimeStatsManager {
         };
 
         if let Some(snapshot) = snapshot {
-            let stats_event = Arc::new(StatsEvent {
+            let stats_event = Event::Stats(Arc::new(StatsEvent {
                 header: EventHeader {
                     query_id: query_id.clone(),
                     timestamp_epoch_secs: now_epoch_secs(),
                 },
                 stats: Arc::new(vec![(node_id, snapshot.to_stats())]),
-            });
+            }));
 
-            let end_event = Arc::new(OperatorEndEvent {
+            let end_event = Event::OperatorEnd(Arc::new(OperatorEndEvent {
                 header: EventHeader {
                     query_id: query_id.clone(),
                     timestamp_epoch_secs: now_epoch_secs(),
                 },
                 operator: operator_meta.clone(),
-            });
+            }));
             for res in future::join_all(subscribers.iter().map(|subscriber| {
                 let stats_event = stats_event.clone();
                 let end_event = end_event.clone();
                 async move {
-                    subscriber.on_stats(stats_event).await?;
-                    subscriber.on_operator_end(end_event).await
+                    subscriber.on_event(stats_event).await?;
+                    subscriber.on_event(end_event).await
                 }
             }))
             .await
@@ -204,17 +204,17 @@ impl RuntimeStatsManager {
                 }
             }
         } else {
-            let end_event = Arc::new(OperatorEndEvent {
+            let end_event = Event::OperatorEnd(Arc::new(OperatorEndEvent {
                 header: EventHeader {
                     query_id: query_id.clone(),
                     timestamp_epoch_secs: now_epoch_secs(),
                 },
                 operator: operator_meta.clone(),
-            });
+            }));
             for res in future::join_all(
                 subscribers
                     .iter()
-                    .map(|subscriber| subscriber.on_operator_end(end_event.clone())),
+                    .map(|subscriber| subscriber.on_event(end_event.clone())),
             )
             .await
             {
@@ -322,16 +322,16 @@ impl RuntimeStatsManager {
                                         continue;
                                     };
 
-                                    let event = Arc::new(OperatorStartEvent {
+                                    let event = Event::OperatorStart(Arc::new(OperatorStartEvent {
                                         header: EventHeader {
                                             query_id: query_id.clone(),
                                             timestamp_epoch_secs: now_epoch_secs(),
                                         },
                                         operator: operator_meta.clone(),
-                                    });
+                                    }));
 
                                     for res in future::join_all(subscribers.iter().map(|subscriber| {
-                                        subscriber.on_operator_start(event.clone())
+                                        subscriber.on_event(event.clone())
                                     })).await {
                                         if let Err(e) = res {
                                             log::error!("Failed to initialize node: {}", e);
@@ -606,6 +606,18 @@ mod tests {
             }
             Ok(())
         }
+
+        async fn on_event(&self, event: Event) -> DaftResult<()> {
+            if let Event::Stats(e) = event {
+                self.state
+                    .total_calls
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                for (_, snapshot) in e.stats.iter() {
+                    *self.state.event.lock().unwrap() = Some(snapshot.clone());
+                }
+            }
+            Ok(())
+        }
     }
 
     #[tokio::test(start_paused = true)]
@@ -740,6 +752,15 @@ mod tests {
                 Err(common_error::DaftError::InternalError(
                     "Test error".to_string(),
                 ))
+            }
+
+            async fn on_event(&self, event: Event) -> DaftResult<()> {
+                if let Event::Stats(_) = event {
+                    return Err(common_error::DaftError::InternalError(
+                        "Test error".to_string(),
+                    ));
+                }
+                Ok(())
             }
         }
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -8,8 +8,8 @@ import pytest
 import daft
 from daft.context import get_context
 from daft.daft import PyQueryMetadata, PyQueryResult, QueryEndState
-from daft.subscribers import events as subscriber_events
-from daft.subscribers.events import _EVENT_LOG_ALIAS, EventLogSubscriber, disable_event_log, enable_event_log
+from daft.subscribers import event_log as subscriber_event_log
+from daft.subscribers.event_log import _EVENT_LOG_ALIAS, EventLogSubscriber, disable_event_log, enable_event_log
 from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
@@ -127,7 +127,7 @@ def test_on_query_end_only_clears_ended_query_state(tmp_path):
 
 def test_enable_event_log_attach_and_disable_close(tmp_path):
     enable_event_log(tmp_path)
-    subscriber = subscriber_events._EVENT_LOG_SUBSCRIBER
+    subscriber = subscriber_event_log._EVENT_LOG_SUBSCRIBER
 
     assert subscriber is not None
 
@@ -136,7 +136,7 @@ def test_enable_event_log_attach_and_disable_close(tmp_path):
 
     disable_event_log()
 
-    assert subscriber_events._EVENT_LOG_SUBSCRIBER is None
+    assert subscriber_event_log._EVENT_LOG_SUBSCRIBER is None
     assert subscriber._closed is True
 
     event_logs = list(tmp_path.rglob("events.jsonl"))

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -12,7 +12,7 @@ import daft
 from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState
 from daft.recordbatch import MicroPartition
 from daft.subscribers import Subscriber
-from daft.subscribers.events import OperatorFinished, OperatorStarted, Stats
+from daft.subscribers.events import Event, OperatorFinished, OperatorStarted, Stats
 from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
@@ -211,6 +211,12 @@ def test_subscriber_template():
     df.collect()
     # Should only have the previous query
     assert len(subscriber.query_metadata) == 1
+
+
+def test_execution_events_inherit_from_event_base():
+    assert isinstance(OperatorStarted(query_id="q", node_id=1, name="scan"), Event)
+    assert isinstance(Stats(query_id="q", stats={}), Event)
+    assert isinstance(OperatorFinished(query_id="q", node_id=1, name="scan"), Event)
 
 
 def test_csv_scan_reports_bytes_read(tmp_path):

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -4,7 +4,6 @@ import signal
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Mapping
 from typing import Any
 
 import pytest
@@ -12,7 +11,8 @@ import pytest
 import daft
 from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState
 from daft.recordbatch import MicroPartition
-from daft.subscribers import StatType, Subscriber
+from daft.subscribers import Subscriber
+from daft.subscribers.events import OperatorFinished, OperatorStarted, Stats
 from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
@@ -60,25 +60,16 @@ class MockSubscriber(Subscriber):
     def on_exec_start(self, query_id: str, physical_plan: str) -> None:
         self.query_physical_plan[query_id] = physical_plan
 
-    def on_operator_start(self, query_id: str, node_id: int) -> None:
+    def on_operator_start(self, event: OperatorStarted) -> None:
         pass
 
-    def on_stats(self, query_id: str, all_stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
-        for node_id, stats in all_stats.items():
+    def on_stats(self, event: Stats) -> None:
+        for node_id, stats in event.stats.items():
             for stat_name, (_, stat_value) in stats.items():
-                self.query_node_stats[query_id][node_id][stat_name] = stat_value
+                self.query_node_stats[event.query_id][node_id][stat_name] = stat_value
 
-    def on_operator_end(self, query_id: str, node_id: int) -> None:
+    def on_operator_end(self, event: OperatorFinished) -> None:
         pass
-
-    def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
-        self.on_operator_start(query_id, node_id)
-
-    def on_exec_emit_stats(self, query_id: str, all_stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
-        self.on_stats(query_id, all_stats)
-
-    def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
-        self.on_operator_end(query_id, node_id)
 
     def on_exec_end(self, query_id: str) -> None:
         pass


### PR DESCRIPTION
## Changes Made

Introduces Event transport enum with OperatorStart/OperatorEnd/Stats variants and a single on_event async method on the Subscriber trait. Ports RuntimeStatsManager to emit all events through on_event, replacing direct per-method calls. Updates dashboard, debug, and python subscribers to implement on_event.
