### PR TITLE
feat: add daft-checkpoint crate with CheckpointStore trait and in-mem…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,27 +84,12 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -117,15 +102,6 @@ name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
 
 [[package]]
 name = "anstyle-parse"
@@ -182,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
 ]
@@ -274,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "58.0.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
 dependencies = [
  "bytes",
  "half",
@@ -347,12 +323,12 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "58.0.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
 dependencies = [
- "arrow-buffer 58.0.0",
- "arrow-schema 58.0.0",
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
  "half",
  "num-integer",
  "num-traits",
@@ -462,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "58.0.0"
+version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -1669,7 +1645,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -1695,9 +1671,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -2279,6 +2255,7 @@ dependencies = [
  "daft-ai",
  "daft-algebra",
  "daft-catalog",
+ "daft-checkpoint",
  "daft-cli",
  "daft-compression",
  "daft-context",
@@ -2363,6 +2340,20 @@ dependencies = [
  "regex",
  "snafu",
  "sqlparser",
+]
+
+[[package]]
+name = "daft-checkpoint"
+version = "0.3.0-dev0"
+dependencies = [
+ "async-trait",
+ "common-error",
+ "daft-checkpoint",
+ "daft-core",
+ "futures",
+ "snafu",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2598,10 +2589,10 @@ version = "0.1.1"
 dependencies = [
  "arrow-data 56.2.0",
  "arrow-data 57.3.0",
- "arrow-data 58.0.0",
+ "arrow-data 58.1.0",
  "arrow-schema 56.2.0",
  "arrow-schema 57.3.0",
- "arrow-schema 58.0.0",
+ "arrow-schema 58.1.0",
  "daft-ext-macros",
 ]
 
@@ -3406,9 +3397,9 @@ checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
 name = "deflate64"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "der"
@@ -3625,20 +3616,20 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "log",
@@ -4859,14 +4850,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4877,9 +4869,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
 dependencies = [
  "memchr",
  "serde",
@@ -4917,9 +4909,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jaq-core"
@@ -5332,9 +5324,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5431,9 +5423,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -5651,9 +5643,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.0",
  "opentelemetry",
@@ -6102,9 +6094,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
@@ -6886,7 +6878,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -6934,9 +6926,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7585,12 +7577,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7897,18 +7889,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -7918,9 +7910,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
@@ -8202,9 +8194,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -8322,9 +8314,9 @@ dependencies = [
 
 [[package]]
 name = "ve-tos-rust-sdk"
-version = "2.9.13"
+version = "2.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52877565812eaae85c9e35dd12662c1431ba046f80785e1ffb1d94a66160edc1"
+checksum = "73ee39d12c41c80db8e9e7f28a70610b56549675c1860eee0450bbd0cf3e21ff"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -8721,6 +8713,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8980,9 +8983,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -9143,18 +9146,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.42"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9269,9 +9272,9 @@ checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ common-version = {path = "src/common/version", default-features = false}
 daft-ai = {path = "src/daft-ai", default-features = false}
 daft-algebra = {path = "src/daft-algebra", default-features = false}
 daft-catalog = {path = "src/daft-catalog", default-features = false}
+daft-checkpoint = {path = "src/daft-checkpoint", default-features = false}
 daft-cli = {path = "src/daft-cli", default-features = false}
 daft-compression = {path = "src/daft-compression", default-features = false}
 daft-context = {path = "src/daft-context", default-features = false}
@@ -184,6 +185,7 @@ members = [
   "src/daft-ai",
   "src/daft-algebra",
   "src/daft-catalog",
+  "src/daft-checkpoint",
   "src/daft-context",
   "src/daft-core",
   "src/daft-csv",

--- a/src/daft-checkpoint/Cargo.toml
+++ b/src/daft-checkpoint/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "daft-checkpoint"
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+async-trait = {workspace = true}
+common-error = {path = "../common/error", default-features = false}
+daft-core = {path = "../daft-core", default-features = false}
+futures = {workspace = true}
+snafu = {workspace = true}
+uuid = {workspace = true}
+
+[features]
+test-utils = []
+
+[dev-dependencies]
+daft-checkpoint = {path = ".", features = ["test-utils"]}
+daft-core = {path = "../daft-core", default-features = false}
+futures = {workspace = true}
+tokio = {workspace = true, features = ["rt", "macros"]}
+
+[lints]
+workspace = true

--- a/src/daft-checkpoint/src/error.rs
+++ b/src/daft-checkpoint/src/error.rs
@@ -1,0 +1,38 @@
+use common_error::DaftError;
+use snafu::Snafu;
+
+use crate::CheckpointId;
+
+/// Checkpoint Result
+pub type CheckpointResult<T, E = CheckpointError> = std::result::Result<T, E>;
+
+/// Checkpoint Error
+#[derive(Debug, Snafu)]
+pub enum CheckpointError {
+    #[snafu(display("Checkpoint {id} not found"))]
+    CheckpointNotFound { id: CheckpointId },
+
+    #[snafu(display("Checkpoint {id} is already sealed"))]
+    AlreadySealed { id: CheckpointId },
+
+    #[snafu(display("Checkpoint {id} is not yet checkpointed"))]
+    NotCheckpointed { id: CheckpointId },
+
+    #[snafu(display("{message}"))]
+    Internal { message: String },
+
+    #[snafu(display("{error}"))]
+    DaftError { error: DaftError },
+}
+
+impl From<CheckpointError> for DaftError {
+    fn from(err: CheckpointError) -> Self {
+        Self::External(err.into())
+    }
+}
+
+impl From<DaftError> for CheckpointError {
+    fn from(error: DaftError) -> Self {
+        Self::DaftError { error }
+    }
+}

--- a/src/daft-checkpoint/src/impls/memory.rs
+++ b/src/daft-checkpoint/src/impls/memory.rs
@@ -1,0 +1,247 @@
+use std::{
+    collections::HashMap,
+    sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
+    time::SystemTime,
+};
+
+use async_trait::async_trait;
+use daft_core::series::Series;
+use futures::stream::{self, BoxStream};
+
+use crate::{
+    Checkpoint, CheckpointId, CheckpointStatus, CheckpointStore, FileMetadata,
+    error::{CheckpointError, CheckpointResult},
+};
+
+/// Internal state for a single checkpoint entry.
+#[derive(Debug)]
+struct CheckpointEntry {
+    status: CheckpointStatus,
+    keys: Vec<Series>,
+    files: Vec<FileMetadata>,
+    created_at: SystemTime,
+    sealed_at: Option<SystemTime>,
+    committed_at: Option<SystemTime>,
+}
+
+impl CheckpointEntry {
+    fn new() -> Self {
+        Self {
+            status: CheckpointStatus::Staged,
+            keys: Vec::new(),
+            files: Vec::new(),
+            created_at: SystemTime::now(),
+            sealed_at: None,
+            committed_at: None,
+        }
+    }
+}
+
+/// In-memory implementation of [`CheckpointStore`].
+///
+/// Backed by a `HashMap` protected by a `RwLock`. Suitable for testing.
+/// Not durable across process restarts.
+#[derive(Debug)]
+pub struct InMemoryCheckpointStore {
+    // Note: std::sync::RwLock is used intentionally. The lock is never held
+    // across .await points. This is a test-only impl — tokio::sync::RwLock
+    // is unnecessary overhead here.
+    entries: RwLock<HashMap<CheckpointId, CheckpointEntry>>,
+}
+
+impl InMemoryCheckpointStore {
+    /// Create a new empty in-memory checkpoint store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn read_entries(
+        &self,
+    ) -> CheckpointResult<RwLockReadGuard<'_, HashMap<CheckpointId, CheckpointEntry>>> {
+        self.entries.read().map_err(|e| CheckpointError::Internal {
+            message: format!("lock poisoned: {e}"),
+        })
+    }
+
+    fn write_entries(
+        &self,
+    ) -> CheckpointResult<RwLockWriteGuard<'_, HashMap<CheckpointId, CheckpointEntry>>> {
+        self.entries.write().map_err(|e| CheckpointError::Internal {
+            message: format!("lock poisoned: {e}"),
+        })
+    }
+
+    fn collect_visible_keys(entries: &HashMap<CheckpointId, CheckpointEntry>) -> Vec<Series> {
+        entries
+            .values()
+            .filter(|e| {
+                matches!(
+                    e.status,
+                    CheckpointStatus::Checkpointed | CheckpointStatus::Committed
+                )
+            })
+            .flat_map(|e| e.keys.clone())
+            .collect()
+    }
+
+    fn collect_uncommitted_files(
+        entries: &HashMap<CheckpointId, CheckpointEntry>,
+    ) -> Vec<FileMetadata> {
+        entries
+            .values()
+            .filter(|e| e.status == CheckpointStatus::Checkpointed)
+            .flat_map(|e| e.files.clone())
+            .collect()
+    }
+
+    fn collect_all_checkpoints(
+        entries: &HashMap<CheckpointId, CheckpointEntry>,
+    ) -> Vec<Checkpoint> {
+        entries
+            .iter()
+            .map(|(&id, e)| {
+                Checkpoint::new(id, e.status, e.created_at, e.sealed_at, e.committed_at)
+            })
+            .collect()
+    }
+}
+
+impl Default for InMemoryCheckpointStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl CheckpointStore for InMemoryCheckpointStore {
+    async fn stage_keys(&self, id: CheckpointId, keys: Series) -> CheckpointResult<()> {
+        let mut entries = self.write_entries()?;
+
+        let entry = entries.entry(id).or_insert_with(CheckpointEntry::new);
+
+        if entry.status != CheckpointStatus::Staged {
+            return Err(CheckpointError::AlreadySealed { id });
+        }
+
+        entry.keys.push(keys);
+        Ok(())
+    }
+
+    async fn stage_files(
+        &self,
+        id: CheckpointId,
+        files: Vec<FileMetadata>,
+    ) -> CheckpointResult<()> {
+        let mut entries = self.write_entries()?;
+
+        let entry = entries.entry(id).or_insert_with(CheckpointEntry::new);
+
+        if entry.status != CheckpointStatus::Staged {
+            return Err(CheckpointError::AlreadySealed { id });
+        }
+
+        entry.files.extend(files);
+        Ok(())
+    }
+
+    async fn checkpoint(&self, id: CheckpointId) -> CheckpointResult<()> {
+        let mut entries = self.write_entries()?;
+
+        let entry = entries
+            .get_mut(&id)
+            .ok_or(CheckpointError::CheckpointNotFound { id })?;
+
+        // Idempotent: no-op if already checkpointed or committed.
+        if entry.status != CheckpointStatus::Staged {
+            return Ok(());
+        }
+
+        entry.status = CheckpointStatus::Checkpointed;
+        entry.sealed_at = Some(SystemTime::now());
+        Ok(())
+    }
+
+    async fn get_checkpointed_keys(
+        &self,
+    ) -> CheckpointResult<BoxStream<'_, CheckpointResult<Series>>> {
+        let entries = self.read_entries()?;
+
+        // Collect into a Vec to drop the read guard before returning the stream.
+        // Both checkpointed and committed keys are visible — committed keys are
+        // still needed for the checkpoint filter on re-run.
+        let key_chunks = Self::collect_visible_keys(&entries);
+        drop(entries);
+
+        Ok(Box::pin(stream::iter(key_chunks.into_iter().map(Ok))))
+    }
+
+    async fn get_checkpointed_files(
+        &self,
+    ) -> CheckpointResult<BoxStream<'_, CheckpointResult<FileMetadata>>> {
+        let entries = self.read_entries()?;
+
+        // Collect into a Vec to drop the read guard before returning the stream.
+        // Only checkpointed (not committed) files are returned — committed files
+        // have already been written to the catalog.
+        let files = Self::collect_uncommitted_files(&entries);
+        drop(entries);
+
+        Ok(Box::pin(stream::iter(files.into_iter().map(Ok))))
+    }
+
+    async fn get_checkpoint(&self, id: CheckpointId) -> CheckpointResult<Checkpoint> {
+        let entries = self.read_entries()?;
+
+        let entry = entries
+            .get(&id)
+            .ok_or(CheckpointError::CheckpointNotFound { id })?;
+
+        Ok(Checkpoint::new(
+            id,
+            entry.status,
+            entry.created_at,
+            entry.sealed_at,
+            entry.committed_at,
+        ))
+    }
+
+    async fn list_checkpoints(
+        &self,
+    ) -> CheckpointResult<BoxStream<'_, CheckpointResult<Checkpoint>>> {
+        let entries = self.read_entries()?;
+
+        let checkpoints = Self::collect_all_checkpoints(&entries);
+        drop(entries);
+
+        Ok(Box::pin(stream::iter(checkpoints.into_iter().map(Ok))))
+    }
+
+    async fn mark_committed(&self, ids: &[CheckpointId]) -> CheckpointResult<()> {
+        let mut entries = self.write_entries()?;
+
+        for &id in ids {
+            let entry = entries
+                .get_mut(&id)
+                .ok_or(CheckpointError::CheckpointNotFound { id })?;
+
+            match entry.status {
+                // Already committed — idempotent no-op.
+                CheckpointStatus::Committed => {}
+                // Checkpointed → Committed.
+                CheckpointStatus::Checkpointed => {
+                    entry.status = CheckpointStatus::Committed;
+                    entry.committed_at = Some(SystemTime::now());
+                }
+                // Staged entries haven't been sealed yet.
+                CheckpointStatus::Staged => {
+                    return Err(CheckpointError::NotCheckpointed { id });
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/daft-checkpoint/src/impls/mod.rs
+++ b/src/daft-checkpoint/src/impls/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(any(test, feature = "test-utils"))]
+mod memory;
+
+#[cfg(any(test, feature = "test-utils"))]
+pub use memory::InMemoryCheckpointStore;

--- a/src/daft-checkpoint/src/lib.rs
+++ b/src/daft-checkpoint/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod error;
+pub mod impls;
+mod store;
+mod types;
+
+pub use error::*;
+pub use store::*;
+pub use types::*;

--- a/src/daft-checkpoint/src/store.rs
+++ b/src/daft-checkpoint/src/store.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use daft_core::series::Series;
+use futures::stream::BoxStream;
+
+use crate::{Checkpoint, CheckpointId, FileMetadata, error::CheckpointResult};
+
+/// Reference-counted checkpoint store.
+pub type CheckpointStoreRef = Arc<dyn CheckpointStore>;
+
+/// Tracks processed source rows and their produced files.
+///
+/// Enables skipping already-processed rows on re-run (progress tracking) and
+/// knowing which files to commit after a crash (recovery).
+///
+/// File tracking is essential for 2PC sinks (Iceberg, Delta) where the
+/// checkpoint store drives the catalog commit. For non-2PC sinks (e.g.,
+/// Parquet written directly to object storage), file tracking may be unused.
+///
+/// # Lifecycle
+///
+/// Each checkpoint progresses through three states:
+///
+/// `staged → checkpointed → committed`
+///
+/// - **Staged:** Keys and files written but not yet visible to readers.
+/// - **Checkpointed:** Sealed — keys and files are coupled and visible.
+/// - **Committed:** Catalog commit succeeded — files no longer returned by
+///   [`get_checkpointed_files`], but keys remain visible for skip-on-rerun.
+///
+/// 1. [`stage_keys`] and [`stage_files`] accumulate data under a
+///    [`CheckpointId`]. Staged data is invisible to readers.
+/// 2. [`checkpoint`] seals the checkpoint — its keys and files become visible
+///    to readers as an atomic unit.
+/// 3. [`mark_committed`] records that the checkpoint's files have been durably
+///    committed to an external catalog.
+///
+/// # Consistency
+///
+/// Checkpoint data is append-only and immutable once sealed. Readers of
+/// [`get_checkpointed_keys`] and [`get_checkpointed_files`] see a
+/// monotonically growing set — new checkpoints may appear between calls,
+/// but existing data never changes or disappears. No isolation between
+/// reads is required.
+///
+/// [`get_checkpointed_keys`]: CheckpointStore::get_checkpointed_keys
+/// [`get_checkpointed_files`]: CheckpointStore::get_checkpointed_files
+/// [`stage_keys`]: CheckpointStore::stage_keys
+/// [`stage_files`]: CheckpointStore::stage_files
+/// [`checkpoint`]: CheckpointStore::checkpoint
+/// [`mark_committed`]: CheckpointStore::mark_committed
+#[async_trait]
+pub trait CheckpointStore: Send + Sync {
+    /// Stage source keys into a checkpoint as a columnar [`Series`]. May be
+    /// called multiple times for the same [`CheckpointId`]. Staged keys are
+    /// not visible to readers until [`checkpoint`](Self::checkpoint) is called.
+    ///
+    /// Implicitly creates a `Staged` checkpoint entry on first call for a
+    /// new ID. Subsequent calls for the same ID append to the existing entry.
+    ///
+    /// The Series can be any Arrow-compatible type (Utf8, Int64, Struct for
+    /// composite keys, etc.). Callers must stage consistent Series types
+    /// (same schema) across calls for the same checkpoint.
+    ///
+    /// Returns [`AlreadySealed`] if the checkpoint has already been sealed.
+    ///
+    /// **Not idempotent** — uses append semantics. Duplicate keys are not
+    /// deduplicated because keys arrive incrementally in batches; dedup would
+    /// add cost for no benefit at this layer.
+    ///
+    /// [`AlreadySealed`]: crate::error::CheckpointError::AlreadySealed
+    async fn stage_keys(&self, id: CheckpointId, keys: Series) -> CheckpointResult<()>;
+
+    /// Stage output file metadata into a checkpoint. May be called multiple
+    /// times for the same [`CheckpointId`]. Staged files are not visible to
+    /// readers until [`checkpoint`](Self::checkpoint) is called.
+    ///
+    /// Implicitly creates a `Staged` checkpoint entry on first call for a
+    /// new ID, same as [`stage_keys`](Self::stage_keys).
+    ///
+    /// Returns [`AlreadySealed`] if the checkpoint has already been sealed.
+    ///
+    /// **Not idempotent** — uses append semantics, same as [`stage_keys`](Self::stage_keys).
+    ///
+    /// [`AlreadySealed`]: crate::error::CheckpointError::AlreadySealed
+    async fn stage_files(&self, id: CheckpointId, files: Vec<FileMetadata>)
+    -> CheckpointResult<()>;
+
+    /// Checkpoint (seal) a staged entry — couples the staged keys and files, making them
+    /// visible to readers. No further staging is allowed after this call.
+    ///
+    /// Returns [`CheckpointNotFound`] if the ID was never staged.
+    ///
+    /// **Idempotent** — no-op if the checkpoint has already been sealed.
+    /// This supports retry after message loss (e.g., worker sends checkpoint,
+    /// acknowledgement is lost, worker retries).
+    ///
+    /// [`CheckpointNotFound`]: crate::error::CheckpointError::CheckpointNotFound
+    async fn checkpoint(&self, id: CheckpointId) -> CheckpointResult<()>;
+
+    /// Stream all checkpointed source keys (both checkpointed and committed)
+    /// as columnar [`Series`] chunks. Useful for building a filter to skip
+    /// already-processed inputs on re-run.
+    async fn get_checkpointed_keys(
+        &self,
+    ) -> CheckpointResult<BoxStream<'_, CheckpointResult<Series>>>;
+
+    /// Stream checkpointed (but not yet committed) file metadata. These are
+    /// files that have been written but not yet durably committed to a catalog.
+    /// Useful for driving the catalog commit — consumers read these to know
+    /// which files to commit to Iceberg, Delta, or other 2PC sinks.
+    async fn get_checkpointed_files(
+        &self,
+    ) -> CheckpointResult<BoxStream<'_, CheckpointResult<FileMetadata>>>;
+
+    /// Get metadata for a single checkpoint by ID.
+    async fn get_checkpoint(&self, id: CheckpointId) -> CheckpointResult<Checkpoint>;
+
+    /// Stream metadata for all checkpoints in the store.
+    async fn list_checkpoints(
+        &self,
+    ) -> CheckpointResult<BoxStream<'_, CheckpointResult<Checkpoint>>>;
+
+    /// Mark checkpoints as committed. Committed checkpoints' keys remain
+    /// visible via [`get_checkpointed_keys`](Self::get_checkpointed_keys)
+    /// (to skip on re-run), but their files no longer appear in
+    /// [`get_checkpointed_files`](Self::get_checkpointed_files).
+    ///
+    /// **Idempotent** for already-committed checkpoints (no-op). Errors if a
+    /// checkpoint is still in `Staged` state (not yet sealed). This supports
+    /// crash recovery: if the caller crashes after committing some IDs but
+    /// before finishing, a retry succeeds without error.
+    ///
+    /// Partial application is possible on error — IDs processed before the
+    /// failing one are committed. Since the method is idempotent, retrying
+    /// the full batch after failure is safe.
+    async fn mark_committed(&self, ids: &[CheckpointId]) -> CheckpointResult<()>;
+}

--- a/src/daft-checkpoint/src/types.rs
+++ b/src/daft-checkpoint/src/types.rs
@@ -1,0 +1,116 @@
+use std::{fmt, time::SystemTime};
+
+use uuid::Uuid;
+
+/// Unique identifier for a checkpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CheckpointId(Uuid);
+
+impl CheckpointId {
+    /// Generate a new random checkpoint ID.
+    #[must_use]
+    pub fn generate() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Create a checkpoint ID from an existing UUID.
+    #[must_use]
+    pub fn from_uuid(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+
+    /// Get the inner UUID.
+    #[must_use]
+    pub fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl fmt::Display for CheckpointId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "checkpoint-{}", self.0)
+    }
+}
+
+/// Lifecycle state of a checkpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CheckpointStatus {
+    /// Keys and files are being accumulated. Not visible to readers.
+    Staged,
+    /// Sealed — keys and files are coupled and visible to readers.
+    Checkpointed,
+    /// Catalog commit succeeded. Files no longer returned by
+    /// `get_checkpointed_files`, but keys remain visible.
+    Committed,
+}
+
+impl fmt::Display for CheckpointStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Staged => write!(f, "staged"),
+            Self::Checkpointed => write!(f, "checkpointed"),
+            Self::Committed => write!(f, "committed"),
+        }
+    }
+}
+
+/// Metadata for a checkpoint (without keys/files payload).
+#[non_exhaustive]
+#[derive(Debug, Clone)]
+pub struct Checkpoint {
+    pub id: CheckpointId,
+    pub status: CheckpointStatus,
+    /// When the checkpoint entry was first created (first `stage_keys`/`stage_files` call).
+    pub created_at: SystemTime,
+    /// When the checkpoint was sealed via `checkpoint()`.
+    pub sealed_at: Option<SystemTime>,
+    /// When the checkpoint was marked committed via `mark_committed()`.
+    pub committed_at: Option<SystemTime>,
+}
+
+impl Checkpoint {
+    /// Create a new `Checkpoint` instance.
+    #[must_use]
+    pub fn new(
+        id: CheckpointId,
+        status: CheckpointStatus,
+        created_at: SystemTime,
+        sealed_at: Option<SystemTime>,
+        committed_at: Option<SystemTime>,
+    ) -> Self {
+        Self {
+            id,
+            status,
+            created_at,
+            sealed_at,
+            committed_at,
+        }
+    }
+}
+
+/// Tag indicating the format of the opaque file metadata blob.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FileFormat {
+    Iceberg,
+    Parquet,
+}
+
+/// Opaque file metadata produced by a sink writer.
+///
+/// The data is serialized by the format-specific writer and deserialized
+/// by the format-specific committer. The checkpoint store treats it as
+/// an opaque blob.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileMetadata {
+    pub format: FileFormat,
+    pub data: Vec<u8>,
+}
+
+impl FileMetadata {
+    #[must_use]
+    pub fn new(format: FileFormat, data: Vec<u8>) -> Self {
+        Self { format, data }
+    }
+}

--- a/src/daft-checkpoint/tests/in_memory_store.rs
+++ b/src/daft-checkpoint/tests/in_memory_store.rs
@@ -1,0 +1,398 @@
+use std::sync::Arc;
+
+use daft_checkpoint::{
+    CheckpointError, CheckpointId, CheckpointStatus, CheckpointStore, CheckpointStoreRef,
+    FileFormat, FileMetadata, impls::InMemoryCheckpointStore,
+};
+use daft_core::{
+    datatypes::Utf8Array,
+    series::{IntoSeries, Series},
+};
+use futures::TryStreamExt;
+
+fn make_store() -> InMemoryCheckpointStore {
+    InMemoryCheckpointStore::new()
+}
+
+fn keys(values: &[&str]) -> Series {
+    Utf8Array::from_slice("key", values).into_series()
+}
+
+fn file(data: &[u8]) -> FileMetadata {
+    FileMetadata::new(FileFormat::Iceberg, data.to_vec())
+}
+
+async fn collect_key_strings(store: &InMemoryCheckpointStore) -> Vec<String> {
+    let chunks: Vec<Series> = store
+        .get_checkpointed_keys()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    let mut result = Vec::new();
+    for chunk in &chunks {
+        let utf8 = chunk.utf8().expect("expected utf8 series");
+        for i in 0..utf8.len() {
+            if let Some(val) = utf8.get(i) {
+                result.push(val.to_string());
+            }
+        }
+    }
+    result.sort();
+    result
+}
+
+async fn collect_files(store: &InMemoryCheckpointStore) -> Vec<FileMetadata> {
+    let mut files: Vec<_> = store
+        .get_checkpointed_files()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    files.sort_by(|a, b| a.data.cmp(&b.data));
+    files
+}
+
+// ------------------------------------------------------------------
+// 1. Happy path lifecycle
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_lifecycle() {
+    let store = make_store();
+    let id = CheckpointId::generate();
+
+    // Empty store listing
+    let checkpoints: Vec<_> = store
+        .list_checkpoints()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    assert!(checkpoints.is_empty());
+
+    store.stage_keys(id, keys(&["a", "b"])).await.unwrap();
+    store
+        .stage_files(id, vec![file(b"file1"), file(b"file2")])
+        .await
+        .unwrap();
+
+    // Staged data is invisible
+    assert_eq!(collect_key_strings(&store).await, Vec::<String>::new());
+    assert_eq!(collect_files(&store).await, Vec::<FileMetadata>::new());
+
+    // Seal makes data visible
+    store.checkpoint(id).await.unwrap();
+    assert_eq!(collect_key_strings(&store).await, vec!["a", "b"]);
+    assert_eq!(
+        collect_files(&store).await,
+        vec![file(b"file1"), file(b"file2")]
+    );
+
+    // Commit hides files but keeps keys
+    store.mark_committed(&[id]).await.unwrap();
+    assert_eq!(collect_key_strings(&store).await, vec!["a", "b"]);
+    assert_eq!(collect_files(&store).await, Vec::<FileMetadata>::new());
+}
+
+// ------------------------------------------------------------------
+// 2. Multiple checkpoints with incremental staging and partial commit
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_multiple_checkpoints_and_partial_commit() {
+    let store = make_store();
+    let id1 = CheckpointId::generate();
+    let id2 = CheckpointId::generate();
+
+    // Checkpoint 1: single stage call
+    store.stage_keys(id1, keys(&["a"])).await.unwrap();
+    store.stage_files(id1, vec![file(b"f1")]).await.unwrap();
+    store.checkpoint(id1).await.unwrap();
+
+    // Checkpoint 2: incremental staging (multiple calls)
+    store.stage_keys(id2, keys(&["b"])).await.unwrap();
+    store.stage_keys(id2, keys(&["c", "d"])).await.unwrap();
+    store.stage_files(id2, vec![file(b"f2")]).await.unwrap();
+    store.stage_files(id2, vec![file(b"f3")]).await.unwrap();
+    store.checkpoint(id2).await.unwrap();
+
+    assert_eq!(collect_key_strings(&store).await, vec!["a", "b", "c", "d"]);
+    assert_eq!(
+        collect_files(&store).await,
+        vec![file(b"f1"), file(b"f2"), file(b"f3")]
+    );
+
+    // Commit only checkpoint 1
+    store.mark_committed(&[id1]).await.unwrap();
+
+    // All keys still visible, only checkpoint 2's files remain
+    assert_eq!(collect_key_strings(&store).await, vec!["a", "b", "c", "d"]);
+    assert_eq!(collect_files(&store).await, vec![file(b"f2"), file(b"f3")]);
+}
+
+// ------------------------------------------------------------------
+// 3. Idempotency: seal() and mark_committed() are no-ops on repeat
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_idempotency() {
+    let store = make_store();
+    let id = CheckpointId::generate();
+
+    store.stage_keys(id, keys(&["a"])).await.unwrap();
+    store.stage_files(id, vec![file(b"f1")]).await.unwrap();
+
+    // Double seal
+    store.checkpoint(id).await.unwrap();
+    store.checkpoint(id).await.unwrap();
+    assert_eq!(collect_key_strings(&store).await, vec!["a"]);
+    assert_eq!(collect_files(&store).await, vec![file(b"f1")]);
+
+    // Double mark_committed
+    store.mark_committed(&[id]).await.unwrap();
+    store.mark_committed(&[id]).await.unwrap();
+    assert_eq!(collect_key_strings(&store).await, vec!["a"]);
+    assert_eq!(collect_files(&store).await, Vec::<FileMetadata>::new());
+
+    // seal() on committed is also a no-op
+    store.checkpoint(id).await.unwrap();
+}
+
+// ------------------------------------------------------------------
+// 4. Error paths
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_error_paths() {
+    let store = make_store();
+
+    // Seal unknown ID
+    let err = store
+        .checkpoint(CheckpointId::generate())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CheckpointError::CheckpointNotFound { .. }));
+
+    // mark_committed unknown ID
+    let err = store
+        .mark_committed(&[CheckpointId::generate()])
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CheckpointError::CheckpointNotFound { .. }));
+
+    // Stage after seal
+    let id = CheckpointId::generate();
+    store.stage_keys(id, keys(&["a"])).await.unwrap();
+    store.checkpoint(id).await.unwrap();
+
+    let err = store.stage_keys(id, keys(&["b"])).await.unwrap_err();
+    assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
+
+    let err = store.stage_files(id, vec![file(b"f")]).await.unwrap_err();
+    assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
+
+    // Stage after commit (also AlreadySealed)
+    store.mark_committed(&[id]).await.unwrap();
+    let err = store.stage_keys(id, keys(&["c"])).await.unwrap_err();
+    assert!(matches!(err, CheckpointError::AlreadySealed { .. }));
+
+    // mark_committed on staged (not sealed)
+    let id2 = CheckpointId::generate();
+    store.stage_keys(id2, keys(&["x"])).await.unwrap();
+    let err = store.mark_committed(&[id2]).await.unwrap_err();
+    assert!(matches!(err, CheckpointError::NotCheckpointed { .. }));
+}
+
+// ------------------------------------------------------------------
+// 5. Orphaned staged entries are invisible
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_orphaned_staged_entries() {
+    let store = make_store();
+
+    // Orphan: staged but never sealed (simulates crash)
+    let orphan_id = CheckpointId::generate();
+    store
+        .stage_keys(orphan_id, keys(&["orphan"]))
+        .await
+        .unwrap();
+    store
+        .stage_files(orphan_id, vec![file(b"orphan_file")])
+        .await
+        .unwrap();
+
+    // Good: completed successfully
+    let good_id = CheckpointId::generate();
+    store.stage_keys(good_id, keys(&["good"])).await.unwrap();
+    store
+        .stage_files(good_id, vec![file(b"good_file")])
+        .await
+        .unwrap();
+    store.checkpoint(good_id).await.unwrap();
+
+    assert_eq!(collect_key_strings(&store).await, vec!["good"]);
+    assert_eq!(collect_files(&store).await, vec![file(b"good_file")]);
+}
+
+// ------------------------------------------------------------------
+// 6. Keys only (no files) — valid for non-2PC sinks
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_checkpoint_keys_only() {
+    let store = make_store();
+    let id = CheckpointId::generate();
+
+    store.stage_keys(id, keys(&["a"])).await.unwrap();
+    store.checkpoint(id).await.unwrap();
+
+    assert_eq!(collect_key_strings(&store).await, vec!["a"]);
+    assert_eq!(collect_files(&store).await, Vec::<FileMetadata>::new());
+}
+
+// ------------------------------------------------------------------
+// 7. CRUD: get_checkpoint, list_checkpoints
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_crud() {
+    let store = make_store();
+    let id1 = CheckpointId::generate();
+    let id2 = CheckpointId::generate();
+
+    // get_checkpoint not found
+    let err = store
+        .get_checkpoint(CheckpointId::generate())
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CheckpointError::CheckpointNotFound { .. }));
+
+    // Stage → Sealed → Committed lifecycle via get_checkpoint
+    store.stage_keys(id1, keys(&["a"])).await.unwrap();
+    let ckpt = store.get_checkpoint(id1).await.unwrap();
+    assert_eq!(ckpt.status, CheckpointStatus::Staged);
+    assert!(ckpt.sealed_at.is_none());
+    assert!(ckpt.committed_at.is_none());
+
+    store.checkpoint(id1).await.unwrap();
+    let ckpt = store.get_checkpoint(id1).await.unwrap();
+    assert_eq!(ckpt.status, CheckpointStatus::Checkpointed);
+    assert!(ckpt.sealed_at.is_some());
+    assert!(ckpt.committed_at.is_none());
+
+    store.mark_committed(&[id1]).await.unwrap();
+    let ckpt = store.get_checkpoint(id1).await.unwrap();
+    assert_eq!(ckpt.status, CheckpointStatus::Committed);
+    assert!(ckpt.sealed_at.is_some());
+    assert!(ckpt.committed_at.is_some());
+    assert!(ckpt.sealed_at.unwrap() >= ckpt.created_at);
+    assert!(ckpt.committed_at.unwrap() >= ckpt.sealed_at.unwrap());
+
+    // list_checkpoints with mixed states
+    store.stage_keys(id2, keys(&["b"])).await.unwrap();
+
+    let checkpoints: Vec<_> = store
+        .list_checkpoints()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    assert_eq!(checkpoints.len(), 2);
+
+    let statuses: std::collections::HashSet<_> = checkpoints.iter().map(|c| c.status).collect();
+    assert!(statuses.contains(&CheckpointStatus::Committed));
+    assert!(statuses.contains(&CheckpointStatus::Staged));
+}
+
+// ------------------------------------------------------------------
+// 8. Empty inputs and edge cases
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_empty_inputs() {
+    let store = make_store();
+    let id = CheckpointId::generate();
+
+    // Empty stage calls
+    store.stage_keys(id, keys(&[])).await.unwrap();
+    store.stage_files(id, vec![]).await.unwrap();
+    store.checkpoint(id).await.unwrap();
+
+    assert_eq!(collect_key_strings(&store).await, Vec::<String>::new());
+    assert_eq!(collect_files(&store).await, Vec::<FileMetadata>::new());
+
+    // Empty mark_committed
+    store.mark_committed(&[]).await.unwrap();
+}
+
+// ------------------------------------------------------------------
+// 9. Retry after partial failure
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_retry_after_partial_failure() {
+    let store = make_store();
+    let good_id = CheckpointId::generate();
+    let staged_id = CheckpointId::generate();
+
+    // good_id: fully sealed
+    store.stage_keys(good_id, keys(&["a"])).await.unwrap();
+    store.checkpoint(good_id).await.unwrap();
+
+    // staged_id: only staged (not sealed)
+    store.stage_keys(staged_id, keys(&["b"])).await.unwrap();
+
+    // First attempt: partial failure — good_id commits, staged_id errors
+    let err = store
+        .mark_committed(&[good_id, staged_id])
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CheckpointError::NotCheckpointed { .. }));
+
+    // good_id was committed before the error
+    assert_eq!(
+        store.get_checkpoint(good_id).await.unwrap().status,
+        CheckpointStatus::Committed
+    );
+
+    // Retry the full batch — good_id is idempotent no-op, staged_id still fails
+    let err = store
+        .mark_committed(&[good_id, staged_id])
+        .await
+        .unwrap_err();
+    assert!(matches!(err, CheckpointError::NotCheckpointed { .. }));
+
+    // good_id still committed (idempotent)
+    assert_eq!(
+        store.get_checkpoint(good_id).await.unwrap().status,
+        CheckpointStatus::Committed
+    );
+}
+
+// ------------------------------------------------------------------
+// 10. Object safety: CheckpointStore works as trait object
+// ------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_object_safety() {
+    let store: CheckpointStoreRef = Arc::new(InMemoryCheckpointStore::new());
+    let id = CheckpointId::generate();
+
+    store.stage_keys(id, keys(&["a"])).await.unwrap();
+    store.checkpoint(id).await.unwrap();
+
+    let chunks: Vec<Series> = store
+        .get_checkpointed_keys()
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    assert_eq!(chunks.iter().map(|s| s.len()).sum::<usize>(), 1);
+}


### PR DESCRIPTION
Introduces a source-oriented checkpoint store for tracking which input rows have been processed and what output files were produced. This enables skipping already-processed rows on re-run (progress tracking) and knowing which files to commit after a crash (recovery for 2PC sinks like Iceberg).

Core abstractions:
- CheckpointStore async trait with stage/checkpoint/commit lifecycle
- CheckpointId (UUID), Checkpoint (metadata with timestamps), FileMetadata (opaque blob)
- Lifecycle: staged (invisible) → checkpointed (visible) → committed
- checkpoint() and mark_committed() are idempotent for crash recovery

In-memory implementation gated behind `test-utils` feature flag. 10 tests covering lifecycle, idempotency, error paths, orphan behavior, edge cases, and trait object safety.
