### PR TITLE
fix: respect scheme aliases in Iceberg writes

### DIFF
--- a/daft/filesystem.py
+++ b/daft/filesystem.py
@@ -110,6 +110,17 @@ def canonicalize_protocol(protocol: str) -> str:
     return _CANONICAL_PROTOCOLS.get(protocol, protocol)
 
 
+def _apply_protocol_alias(path: str, aliases: dict[str, str]) -> str:
+    """Rewrite the URI scheme of *path* if it matches an entry in *aliases*."""
+    sep = path.find("://")
+    if sep == -1:
+        return path
+    target = aliases.get(path[:sep].lower())
+    if target is None:
+        return path
+    return target + path[sep:]
+
+
 def _resolve_paths_and_filesystem(
     paths: str | pathlib.Path | list[str],
     io_config: IOConfig | None = None,
@@ -131,6 +142,15 @@ def _resolve_paths_and_filesystem(
     assert isinstance(paths, list), paths
     assert all(isinstance(p, str) for p in paths), paths
     assert len(paths) > 0, paths
+
+    # Apply protocol aliases from io_config (e.g. {"foo": "s3"}).
+    # This mirrors resolve_url_alias() in Rust so that custom URI schemes are
+    # handled by the appropriate PyArrow filesystem.  The original scheme is
+    # preserved by callers (e.g. Iceberg DataFile file_path entries).
+    if io_config is not None:
+        aliases = io_config.protocol_aliases
+        if aliases:
+            paths = [_apply_protocol_alias(p, aliases) for p in paths]
 
     # Sanitize s3a/s3n protocols, which are produced by Hadoop-based systems as a way of denoting which s3
     # filesystem client to use. However this doesn't matter for Daft, and PyArrow cannot recognize these protocols.

--- a/daft/io/writer.py
+++ b/daft/io/writer.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from daft.dependencies import pa, pacsv, pafs, pq
 from daft.filesystem import (
     _resolve_paths_and_filesystem,
-    canonicalize_protocol,
     get_protocol_from_path,
 )
 from daft.io.delta_lake.delta_lake_write import (
@@ -49,8 +48,9 @@ class FileWriterBase(ABC):
     ):
         self.resolved_path, self.fs = self.resolve_path_and_fs(root_dir, io_config=io_config)
         self.protocol = get_protocol_from_path(root_dir)
-        canonicalized_protocol = canonicalize_protocol(self.protocol)
-        is_local_fs = canonicalized_protocol == "file"
+        # Determine locality from the resolved filesystem type so that custom
+        # schemes aliased to file:// still trigger local directory creation.
+        is_local_fs = isinstance(self.fs, pafs.LocalFileSystem)
 
         self.file_name = (
             f"{uuid.uuid4()}-{file_idx}.{file_format}"

--- a/daft/recordbatch/recordbatch_io.py
+++ b/daft/recordbatch/recordbatch_io.py
@@ -19,7 +19,7 @@ from daft.daft import (
     JsonReadOptions,
     StorageConfig,
 )
-from daft.dependencies import pa, pads
+from daft.dependencies import pa, pads, pafs
 from daft.expressions import ExpressionsProjection
 from daft.filesystem import (
     _resolve_paths_and_filesystem,
@@ -370,9 +370,10 @@ def write_iceberg(
         path_str = base_path
 
     protocol = get_protocol_from_path(path_str)
-    canonicalized_protocol = canonicalize_protocol(protocol)
 
-    is_local_fs = canonicalized_protocol == "file"
+    # Determine locality from the resolved filesystem type so that custom
+    # schemes aliased to file:// still trigger local directory creation.
+    is_local_fs = isinstance(fs, pafs.LocalFileSystem)
 
     execution_config = get_context().daft_execution_config
     inflation_factor = execution_config.parquet_inflation_factor

--- a/tests/io/iceberg/test_iceberg_writes.py
+++ b/tests/io/iceberg/test_iceberg_writes.py
@@ -5,8 +5,12 @@ import decimal
 from unittest.mock import patch
 
 import pyarrow as pa
+import pyarrow.fs as pafs
 import pytest
 
+from daft.daft import ScanTask
+from daft.filesystem import _resolve_paths_and_filesystem
+from daft.io import IOConfig
 from tests.conftest import get_tests_daft_runner_name
 
 pyiceberg = pytest.importorskip("pyiceberg")
@@ -48,8 +52,6 @@ def patch_scan_task_file_path_scheme(request):
     use_mock = request.param
 
     if use_mock:
-        from daft.daft import ScanTask
-
         original_catalog_scan_task = ScanTask.catalog_scan_task
 
         def patched_catalog_scan_task(file: str, **kwargs):
@@ -66,10 +68,8 @@ def patch_scan_task_file_path_scheme(request):
 def local_catalog(tmpdir):
     catalog = SqlCatalog(
         "default",
-        **{
-            "uri": f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
-            "warehouse": f"file://{tmpdir}",
-        },
+        uri=f"sqlite:///{tmpdir}/pyiceberg_catalog.db",
+        warehouse=f"file://{tmpdir}",
     )
     catalog.create_namespace("default")
     yield catalog
@@ -205,7 +205,8 @@ def _get_snapshot_property(table, key: str) -> str | None:
     current_snapshot = table.current_snapshot()
     assert current_snapshot is not None
 
-    return current_snapshot.summary.get(key)
+    val = current_snapshot.summary.get(key)
+    return str(val) if val is not None else None
 
 
 def test_write_append_with_snapshot_properties(simple_local_table):
@@ -589,3 +590,117 @@ def test_complex_table_write_read(
     assert sum(as_dict["rows"]) == 3, as_dict["rows"]
     read_back = daft.read_iceberg(table)
     assert df.to_arrow() == read_back.to_arrow().sort_by("int")
+
+
+# ---------------------------------------------------------------------------
+# Protocol-alias tests
+#
+# These tests verify that when io_config.protocol_aliases maps a custom URI
+# scheme to a known one (e.g. "myscheme" -> "file"), Daft:
+#   1. Can write Iceberg data files through that alias.
+#   2. Records the ORIGINAL custom scheme (not the alias target) in the
+#      DataFile.file_path entries that end up in manifest avro files.
+#   3. Can read the written data back through the same alias.
+#
+# This is the fix for the "foo://" class of bugs where a downstream
+# system uses a custom S3-compatible URI scheme but manifest avro entries
+# were recording the underlying scheme (s3://) instead.
+# ---------------------------------------------------------------------------
+
+CUSTOM_SCHEME = "myscheme"
+
+
+@pytest.fixture
+def aliased_catalog(tmp_path):
+    """SqlCatalog backed by local storage with a separate directory for the aliased write root."""
+    warehouse = tmp_path / "warehouse"
+    warehouse.mkdir()
+    catalog = SqlCatalog(
+        "default",
+        uri=f"sqlite:///{tmp_path}/pyiceberg_catalog.db",
+        warehouse=f"file://{warehouse}",
+    )
+    catalog.create_namespace("default")
+    yield catalog
+    catalog.engine.dispose()
+
+
+def _make_alias_io_config() -> IOConfig:
+    """Return an IOConfig that maps CUSTOM_SCHEME -> file."""
+    return IOConfig(protocol_aliases={CUSTOM_SCHEME: "file"})
+
+
+def _table_location_with_custom_scheme(table) -> str:
+    """Return the table's real file:// location rewritten with CUSTOM_SCHEME."""
+    return str(table.location()).replace("file://", f"{CUSTOM_SCHEME}://", 1)
+
+
+@pytest.mark.parametrize(
+    "partition_spec",
+    [
+        pytest.param(UNPARTITIONED_PARTITION_SPEC, id="unpartitioned"),
+        pytest.param(
+            PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=IdentityTransform(), name="x_identity")),
+            id="identity_partitioned",
+        ),
+        pytest.param(
+            PartitionSpec(PartitionField(source_id=1, field_id=1000, transform=BucketTransform(2), name="x_bucket")),
+            id="bucket_partitioned",
+        ),
+    ],
+)
+def test_protocol_alias_scheme_preserved_in_manifest_paths(aliased_catalog, partition_spec):
+    """DataFile.file_path entries in Iceberg manifest avro files must use the original custom URI scheme.
+
+    Regression test for the bug where tables with a custom S3-compatible scheme
+    (e.g. foo://) would have manifest avro file_path entries recorded with
+    the underlying scheme (s3://) instead.
+    """
+    schema = Schema(NestedField(field_id=1, name="x", type=LongType()))
+    table = aliased_catalog.create_table("default.test", schema, partition_spec=partition_spec)
+
+    # Override write.data.path to use the custom scheme while keeping the
+    # physical location the same (the alias maps it back to file://).
+    custom_data_path = _table_location_with_custom_scheme(table) + "/data"
+    with table.transaction() as tx:
+        tx.set_properties(**{"write.data.path": custom_data_path})
+    table.refresh()
+
+    io_config = _make_alias_io_config()
+    df = daft.from_pydict({"x": [1, 2, 3, 4, 5]})
+    result = df.write_iceberg(table, io_config=io_config)
+    result_dict = result.to_pydict()
+
+    assert result_dict["operation"] == ["ADD"] * len(result_dict["operation"])
+    assert sum(result_dict["rows"]) == 5
+
+    # The written file paths (== DataFile.file_path, written into the manifest
+    # avro) must use the CUSTOM scheme, not "file".
+    for file_name in result_dict["file_name"]:
+        assert file_name.startswith(f"{CUSTOM_SCHEME}://"), (
+            f"Expected manifest entry to use '{CUSTOM_SCHEME}://' scheme but got: {file_name!r}"
+        )
+
+    # Round-trip: Daft must be able to read the data back using the same alias.
+    read_back = daft.read_iceberg(table, io_config=io_config)
+    assert df.to_arrow() == read_back.to_arrow().sort_by("x")
+
+
+def test_protocol_alias_resolves_to_local_filesystem(tmp_path):
+    """A custom scheme aliased to file:// resolves to LocalFileSystem with bare local paths."""
+    target_dir = tmp_path / "data"
+    custom_path = f"{CUSTOM_SCHEME}://{str(target_dir).lstrip('/')}"
+    io_config = _make_alias_io_config()
+
+    resolved_paths, fs = _resolve_paths_and_filesystem(custom_path, io_config=io_config)
+
+    assert isinstance(fs, pafs.LocalFileSystem), f"Expected LocalFileSystem, got {type(fs)}"
+    # The resolved path is a bare local path -- no scheme prefix.
+    assert not any(p.startswith(f"{CUSTOM_SCHEME}://") for p in resolved_paths)
+    assert not any(p.startswith("file://") for p in resolved_paths)
+
+
+def test_protocol_alias_unknown_scheme_raises_without_alias():
+    """Without a matching protocol alias, Daft raises NotImplementedError for an unknown URI scheme."""
+    with pytest.raises(NotImplementedError, match="Cannot infer PyArrow filesystem"):
+        _resolve_paths_and_filesystem("unknownscheme://bucket/path")

--- a/tests/io/iceberg/test_iceberg_writes.py
+++ b/tests/io/iceberg/test_iceberg_writes.py
@@ -611,7 +611,7 @@ CUSTOM_SCHEME = "myscheme"
 
 
 @pytest.fixture
-def aliased_catalog(tmp_path):
+def catalog(tmp_path):
     """SqlCatalog backed by local storage with a separate directory for the aliased write root."""
     warehouse = tmp_path / "warehouse"
     warehouse.mkdir()
@@ -649,7 +649,7 @@ def _table_location_with_custom_scheme(table) -> str:
         ),
     ],
 )
-def test_protocol_alias_scheme_preserved_in_manifest_paths(aliased_catalog, partition_spec):
+def test_protocol_alias_scheme_preserved_in_manifest_paths(catalog, partition_spec):
     """DataFile.file_path entries in Iceberg manifest avro files must use the original custom URI scheme.
 
     Regression test for the bug where tables with a custom S3-compatible scheme
@@ -657,7 +657,7 @@ def test_protocol_alias_scheme_preserved_in_manifest_paths(aliased_catalog, part
     the underlying scheme (s3://) instead.
     """
     schema = Schema(NestedField(field_id=1, name="x", type=LongType()))
-    table = aliased_catalog.create_table("default.test", schema, partition_spec=partition_spec)
+    table = catalog.create_table("default.test", schema, partition_spec=partition_spec)
 
     # Override write.data.path to use the custom scheme while keeping the
     # physical location the same (the alias maps it back to file://).
@@ -684,6 +684,12 @@ def test_protocol_alias_scheme_preserved_in_manifest_paths(aliased_catalog, part
     # Round-trip: Daft must be able to read the data back using the same alias.
     read_back = daft.read_iceberg(table, io_config=io_config)
     assert df.to_arrow() == read_back.to_arrow().sort_by("x")
+
+    # Verify all file_path metadata with pyiceberg
+    for file_path in table.inspect.files()["file_path"]:
+        assert file_path.as_py().startswith(f"{CUSTOM_SCHEME}://"), (
+            f"Expected manifest entry to use '{CUSTOM_SCHEME}://' scheme but got: {file_path!r}"
+        )
 
 
 def test_protocol_alias_resolves_to_local_filesystem(tmp_path):


### PR DESCRIPTION
## Changes Made

Iceberg uses a FileProvider interface to create the `data_file` full URI matching the scheme of the table location itself. However Daft doesn't have a single interface like this, so our read path was supporting custom schemes while the write path wasn't using the aliases. This meant we were writing `s3://` in the manifests instead of the custom scheme (bad).

This fixes that by applying the aliases to the paths in our python filesystem abstraction which is what our Iceberg writer uses. 

Because this is only python, you can actually monkeypatch this right now without waiting on a new daft release. https://gist.github.com/rchowell/7027d8c23b3674f4c57fe796d8ae429b

## Related Issues

If you previously tried to write an Iceberg table with a different object-store scheme, then the manifests are using s3:// rather than your object-store scheme.
