### PR TITLE
fix: using func name as result filed name in sql

### DIFF
--- a/src/daft-sql/src/modules/python.rs
+++ b/src/daft-sql/src/modules/python.rs
@@ -93,7 +93,11 @@ impl SQLFunction for WrappedUDFClass {
             });
             let e = e?;
 
-            Ok(e.expr)
+            // Alias the result expression with the UDF function name so that
+            // `SELECT *, my_func(x) FROM t` produces columns ["x", "my_func"]
+            // instead of two columns both named "x".
+            let func_name: String = self.name().map_err(DaftError::from)?;
+            Ok(e.expr.alias(func_name))
         }
 
         #[cfg(not(feature = "python"))]

--- a/tests/udf/test_udf_column_naming.py
+++ b/tests/udf/test_udf_column_naming.py
@@ -1,0 +1,67 @@
+"""Tests for UDF result column naming behavior.
+
+After the fix, UDF result columns should be named after the UDF function name,
+not the first input argument's column name. This prevents column name conflicts
+when using `select *, udf(col)` patterns.
+"""
+
+from __future__ import annotations
+
+import daft
+from daft import DataType
+
+
+def test_udf_result_column_uses_func_name():
+    @daft.func(return_dtype=DataType.string())
+    def my_func(col: int) -> str:
+        return f"my: {col}"
+
+    df = daft.from_pydict({"x": [1, 2, 3]})
+    daft.attach_function(my_func, "my_func")
+    bindings = {"test": df}
+    df = daft.sql("select *, my_func(x) from test", **bindings)
+    result = df.collect()
+    result_dict = result.to_pydict()
+
+    assert "x" in result_dict, f"Expected column 'x', got columns: {list(result_dict.keys())}"
+    assert "my_func" in result_dict, f"Expected column 'my_func', got columns: {list(result_dict.keys())}"
+    assert result_dict["x"] == [1, 2, 3]
+    assert result_dict["my_func"] == ["my: 1", "my: 2", "my: 3"]
+
+
+def test_udf_no_column_name_conflict_with_star():
+    """Select *, udf(col) should not produce duplicate column names."""
+
+    @daft.udf(return_dtype=DataType.int64())
+    def double_value(a):
+        return [x * 2 for x in a.to_pylist()]
+
+    df = daft.from_pydict({"a": [1, 2, 3], "b": [4, 5, 6]})
+    bindings = {"test": df}
+    df = daft.sql("select *, double_value(a) from test", **bindings)
+    # result = df.with_column("double_value", double_value(col("a")))
+    print(df.collect())
+
+    result_dict = df.to_pydict()
+    assert "a" in result_dict
+    assert "b" in result_dict
+    assert "double_value" in result_dict
+    assert result_dict["a"] == [1, 2, 3]
+    assert result_dict["b"] == [4, 5, 6]
+    assert result_dict["double_value"] == [2, 4, 6]
+
+
+def test_sql_udf_explicit_alias_overrides_function_name():
+    """SQL AS alias should take precedence over the auto-generated function name alias."""
+
+    @daft.func(return_dtype=DataType.int64())
+    def add_ten(val: int) -> int:
+        return val + 10
+
+    df = daft.from_pydict({"x": [1, 2, 3]})
+    daft.attach_function(add_ten, "add_ten")
+    result = daft.sql("select add_ten(x) as plus_ten from test", test=df).collect()
+    result_dict = result.to_pydict()
+
+    assert "plus_ten" in result_dict, f"Expected column 'plus_ten', got columns: {list(result_dict.keys())}"
+    assert result_dict["plus_ten"] == [11, 12, 13]


### PR DESCRIPTION
## Changes Made

When I run the SQL query select *, my_func(x) from test, I get two columns named x, and both of them contain the result calculated by my_func. Here is the test case and result:
```
def test_udf():
    @daft.func(return_dtype=DataType.string())
    def my_func(col: int) -> str:
        return f"my: {col}"

    df = daft.from_pydict({"x": [1, 2, 3]})
    daft.attach_function(my_func, "my_func")
    bindings = {"test": df}
    result = daft.sql(f"select *, my_func(x) from test", **bindings).collect()
    print(result)
```
| x | x |
| --- | --- |
| String | String |
| my: 1 | my: 1 |
| my: 2 | my: 2 |
| my: 3 | my: 3 |

I think it would be more appropriate to use the function name as the result column name, and it shouldn’t affect the original column.

## Related Issues

None
