### PR TITLE
fix: using func name as result filed name in sql

### DIFF
--- a/src/daft-sql/src/modules/python.rs
+++ b/src/daft-sql/src/modules/python.rs
@@ -1,4 +1,3 @@
-use common_error::DaftResult;
 use daft_dsl::{Expr, functions::python::WrappedUDFClass};
 #[cfg(feature = "python")]
 use {
@@ -50,7 +49,7 @@ impl SQLFunction for WrappedUDFClass {
     ) -> crate::error::SQLPlannerResult<daft_dsl::ExprRef> {
         #[cfg(feature = "python")]
         {
-            let e: DaftResult<PyExpr> = pyo3::Python::attach(|py| {
+            let (e, func_name) = pyo3::Python::attach(|py| {
                 let mut args = Vec::with_capacity(inputs.len());
                 let kwargs = PyDict::new(py);
 
@@ -89,14 +88,22 @@ impl SQLFunction for WrappedUDFClass {
                 }
                 let args = PyTuple::new(py, &args)?;
 
-                Ok(self.call(py, args, Some(&kwargs))?)
-            });
-            let e = e?;
+                // Retrieve the UDF function name while we already hold the GIL,
+                // avoiding a redundant GIL acquisition after the closure.
+                let full_name: String = self.inner.getattr(py, "name")?.extract(py)?;
+                let func_name = if full_name.contains('.') {
+                    full_name.split('.').next_back().unwrap().to_string()
+                } else {
+                    full_name
+                };
+
+                Ok::<_, PyErr>((self.call(py, args, Some(&kwargs))?, func_name))
+            })
+            .map_err(|e| common_error::DaftError::External(e.into()))?;
 
             // Alias the result expression with the UDF function name so that
             // `SELECT *, my_func(x) FROM t` produces columns ["x", "my_func"]
             // instead of two columns both named "x".
-            let func_name: String = self.name().map_err(DaftError::from)?;
             Ok(e.expr.alias(func_name))
         }
 

--- a/tests/udf/test_udf_column_naming.py
+++ b/tests/udf/test_udf_column_naming.py
@@ -64,3 +64,17 @@ def test_sql_udf_explicit_alias_overrides_function_name():
 
     assert "plus_ten" in result_dict, f"Expected column 'plus_ten', got columns: {list(result_dict.keys())}"
     assert result_dict["plus_ten"] == [11, 12, 13]
+
+
+def test_udf_result_column_uses_func_name_without_star():
+    """SELECT udf(col) FROM t should produce a column named after the UDF, not the argument."""
+
+    @daft.func(return_dtype=DataType.string())
+    def my_func(col: int) -> str:
+        return f"my: {col}"
+
+    df = daft.from_pydict({"x": [1, 2, 3]})
+    daft.attach_function(my_func, "my_func")
+    result_dict = daft.sql("select my_func(x) from test", test=df).collect().to_pydict()
+    assert list(result_dict.keys()) == ["my_func"], f"Got: {list(result_dict.keys())}"
+    assert result_dict["my_func"] == ["my: 1", "my: 2", "my: 3"]


### PR DESCRIPTION
## Changes Made

When I run the SQL query select *, my_func(x) from test, I got two columns named x, and both of them contain the result calculated by my_func. Here is the test case and result:
```
def test_udf():
    @daft.func(return_dtype=DataType.string())
    def my_func(col: int) -> str:
        return f"my: {col}"

    df = daft.from_pydict({"x": [1, 2, 3]})
    daft.attach_function(my_func, "my_func")
    bindings = {"test": df}
    result = daft.sql(f"select *, my_func(x) from test", **bindings).collect()
    print(result)
```
| x | x |
| --- | --- |
| String | String |
| my: 1 | my: 1 |
| my: 2 | my: 2 |
| my: 3 | my: 3 |

I think it would be more appropriate to use the function name as the result column name, and it shouldn’t affect the original column.

## Related Issues

None
