### PR TITLE
fix(series): unable to cast directly from string to fixed_size_binary

### DIFF
--- a/src/daft-core/src/array/ops/cast.rs
+++ b/src/daft-core/src/array/ops/cast.rs
@@ -111,6 +111,10 @@ where
                     let utf8_series = self.cast(&DataType::Utf8)?;
                     return utf8_series.cast(dtype);
                 }
+                if matches!(src, DataType::Utf8) && matches!(dtype, DataType::FixedSizeBinary(_)) {
+                    let binary_series = self.cast(&DataType::Binary)?;
+                    return binary_series.cast(dtype);
+                }
 
                 // Binary -> FixedSizeBinary: validate all non-null values match the target width
                 if let DataType::FixedSizeBinary(target_size) = dtype

--- a/tests/series/test_cast.py
+++ b/tests/series/test_cast.py
@@ -281,6 +281,23 @@ def test_cast_fixed_size_binary_to_binary():
     assert casted.to_pylist() == [b"abc", b"def", None, b"bcd", None]
 
 
+def test_cast_utf8_to_fixed_size_binary():
+    data = ["a", "b", None, "c"]
+
+    input = Series.from_pylist(data)
+    casted = input.cast(DataType.fixed_size_binary(1))
+    assert casted.datatype() == DataType.fixed_size_binary(1)
+    assert casted.to_pylist() == [b"a", b"b", None, b"c"]
+
+
+def test_cast_utf8_to_fixed_size_binary_fails_with_variable_length():
+    data = ["a", "bc", None]
+
+    input = Series.from_pylist(data)
+    with pytest.raises(DaftCoreException):
+        input.cast(DataType.fixed_size_binary(1))
+
+
 ### Python ###
 
 


### PR DESCRIPTION
## Problem
Direct casting from `Utf8` to `FixedSizeBinary(n)` fails, even though a two-step cast (`Utf8 -> Binary -> FixedSizeBinary(n)`) works.

## Root Cause
There was no explicit cast bridge for `Utf8 -> FixedSizeBinary`, so the implementation fell through to an Arrow cast path that does not support this conversion.

## Solution
Add a narrow Rust cast fast-path that routes `Utf8 -> FixedSizeBinary(n)` through `Binary`, then reuses the existing `Binary -> FixedSizeBinary` length validation.

## Tests
- `DAFT_RUNNER=native make test EXTRA_ARGS='-v tests/series/test_cast.py::test_cast_utf8_to_fixed_size_binary tests/series/test_cast.py::test_cast_utf8_to_fixed_size_binary_fails_with_variable_length tests/series/test_cast.py::test_cast_binary_to_fixed_size_binary tests/series/test_cast.py::test_cast_binary_to_fixed_size_binary_fails_with_variable_length'`

## Impact
- Fixes Issue #3749.
- Enables expected direct cast behavior without API or architecture changes.
- Preserves error behavior for variable-length values.