### PR TITLE
fix: correct grid card indentation on modalities overview page

### DIFF
--- a/docs/modalities/overview.md
+++ b/docs/modalities/overview.md
@@ -8,35 +8,35 @@ Artificial Intelligence now natively understands text, images, audio, video, and
 
 - 🔠 [**Text**](text.md)
 
-  Normalize, chunk, dedupe, prompt, and embed text data.
+    Normalize, chunk, dedupe, prompt, and embed text data.
 
 - 🌄 [**Images**](images.md)
 
-  Work with visual data and image processing.
+    Work with visual data and image processing.
 
 - 🔉 [**Audio**](audio.md)
 
-  Read, extract metadata, resample audio files.
+    Read, extract metadata, resample audio files.
 
 - 🎥 [**Video**](videos.md)
 
-  Working with video files and metadata.
+    Working with video files and metadata.
 
 - 📄 [**Documents**](documents.md)
 
-  Extract text and image data from PDF documents.
+    Extract text and image data from PDF documents.
 
 - {} [**JSON and Nested Data**](json.md)
 
-  Parse, query, and manipulate semi-structured and hierarchical data.
+    Parse, query, and manipulate semi-structured and hierarchical data.
 
 - ⊹ [**Embeddings**](embeddings.md)
 
-  Generate vector representations for RAG and AI search.
+    Generate vector representations for RAG and AI search.
 
 - 📁 [**Generic Files and URLs**](files.md)
 
-  Take advantage of Daft's built-in URL functions and `daft.File` types
+    Take advantage of Daft's built-in URL functions and `daft.File` types
 
 </div>
 


### PR DESCRIPTION
## Summary
- Fix broken grid card layout on the [Modalities Overview](https://docs.daft.ai/en/stable/modalities/overview/) page where description text rendered outside the card squares
- Change description indentation from 2 spaces to 4 spaces in `docs/modalities/overview.md` to match MkDocs Material grid card requirements (consistent with `docs/api/index.md`)

Closes #6529

## Test plan
- [x] Verify the modalities overview page renders card descriptions inside the card boxes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)