### PR TITLE
chore: exclude symlink files from end-of-file-fixer pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,11 @@ repos:
     exclude: (?x)^(tests/assets/mvp.csv|.*\.warc|tests/dataframe/test_show.py)$
   - id: end-of-file-fixer
     exclude: |
-      (?x)^(.*\.warc)$
+      (?x)^(
+          .*\.warc|
+          CLAUDE\.md|
+          docs/contributing/overview\.md
+      )$
   - id: check-yaml
     exclude: kubernetes-ops|k8s/charts/.*/templates/.*\.ya?ml$
     args:


### PR DESCRIPTION
## Changes Made

`CLAUDE.md` and `docs/contributing/overview.md` are symlinks (git object type `120000`). The `end-of-file-fixer` hook in pre-commit does not handle symlinks correctly and raises a formatting error on them.

This change excludes these two files from the `end-of-file-fixer` hook. Developers can now run `pre-commit run --all-files` without having to manually exclude these files, making the local development workflow smoother.