### PR TITLE
perf: Rewrite `decode(..., "utf-8")` as a cast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,7 +2997,6 @@ dependencies = [
  "daft-core",
  "daft-dsl",
  "daft-functions",
- "daft-functions-binary",
  "daft-functions-list",
  "daft-functions-uri",
  "daft-functions-utf8",

--- a/daft/functions/binary.py
+++ b/daft/functions/binary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from daft import DataType
 from daft.expressions import Expression
 
 if TYPE_CHECKING:
@@ -12,6 +13,9 @@ if TYPE_CHECKING:
 
 def encode(expr: Expression, charset: ENCODING_CHARSET) -> Expression:
     """Encode binary or string values using the specified character set.
+
+    If an invalid encoding is encountered, an error will be raised.
+    To handle invalid encodings, use `try_encode` instead.
 
     Args:
         expr (Binary or String Expression): The expression to encode.
@@ -30,6 +34,12 @@ def encode(expr: Expression, charset: ENCODING_CHARSET) -> Expression:
 
 def decode(bytes: Expression, charset: ENCODING_CHARSET) -> Expression:
     """Decodes binary values using the specified character set.
+
+    Note that if the charset is "utf-8" or "utf8", then this is equivalent
+    to cast(bytes, daft.DataType.string())
+
+    If an invalid encoding is encountered, an error will be raised.
+    To handle invalid encodings, use `try_decode` instead.
 
     Args:
         bytes (Binary Expression): The expression to decode.
@@ -53,6 +63,9 @@ def decode(bytes: Expression, charset: ENCODING_CHARSET) -> Expression:
         <BLANKLINE>
         (Showing first 1 of 1 rows)
     """
+    if charset in ("utf-8", "utf8"):
+        return bytes.cast(DataType.string())
+
     return Expression._call_builtin_scalar_fn("decode", bytes, codec=charset)
 
 
@@ -71,6 +84,8 @@ def try_decode(bytes: Expression, charset: ENCODING_CHARSET) -> Expression:
     Tip: See Also
         [`daft.functions.decode`](https://docs.daft.ai/en/stable/api/functions/decode/)
     """
+    # TODO: Replace with a try_cast to string if the charset is "utf-8" or "utf8"
+    # We currently don't have a try_cast
     return Expression._call_builtin_scalar_fn("try_decode", bytes, codec=charset)
 
 

--- a/daft/functions/binary.py
+++ b/daft/functions/binary.py
@@ -63,7 +63,7 @@ def decode(bytes: Expression, charset: ENCODING_CHARSET) -> Expression:
         <BLANKLINE>
         (Showing first 1 of 1 rows)
     """
-    if charset in ("utf-8", "utf8"):
+    if charset.lower() in ("utf-8", "utf8"):
         return bytes.cast(DataType.string())
 
     return Expression._call_builtin_scalar_fn("decode", bytes, codec=charset)

--- a/src/daft-functions-binary/src/decode.rs
+++ b/src/daft-functions-binary/src/decode.rs
@@ -40,10 +40,7 @@ impl ScalarUDF for BinaryDecode {
         let Args { input, codec } = inputs.try_into()?;
         let input = input.to_field(schema)?;
 
-        if codec == Codec::Utf8 {
-            // special-case for decode('utf-8')
-            return Ok(Field::new(input.name, DataType::Utf8));
-        }
+        ensure!(codec != Codec::Utf8, TypeError: "codec must not be utf-8. should have been converted to cast(input, string)");
         ensure!(
             matches!(input.dtype, DataType::Binary | DataType::FixedSizeBinary(_)),
             TypeError: "Expected argument to be a Binary or FixedSizeBinary, but received {}",
@@ -59,10 +56,6 @@ impl ScalarUDF for BinaryDecode {
         _ctx: &daft_dsl::functions::scalar::EvalContext,
     ) -> DaftResult<Series> {
         let Args { input, codec } = inputs.try_into()?;
-        if codec == Codec::Utf8 {
-            // special-case for decode('utf-8')
-            return input.cast(&DataType::Utf8);
-        }
 
         match input.data_type() {
             DataType::Binary => {

--- a/src/daft-logical-plan/Cargo.toml
+++ b/src/daft-logical-plan/Cargo.toml
@@ -31,7 +31,6 @@ uuid.workspace = true
 
 [dev-dependencies]
 daft-dsl = {path = "../daft-dsl", features = ["test-utils"]}
-daft-functions-binary = {path = "../daft-functions-binary", default-features = false}
 daft-functions-utf8 = {path = "../daft-functions-utf8", default-features = false}
 indoc = "2"
 pretty_assertions = {workspace = true}

--- a/src/daft-logical-plan/src/optimization/rules/granular_projections.rs
+++ b/src/daft-logical-plan/src/optimization/rules/granular_projections.rs
@@ -218,8 +218,7 @@ mod tests {
     use std::any::TypeId;
 
     use daft_core::prelude::Operator;
-    use daft_dsl::{Column, ExprRef, ResolvedColumn, lit};
-    use daft_functions_binary::{BinaryDecode, Codec};
+    use daft_dsl::{Column, ResolvedColumn};
     use daft_functions_uri::download::UrlDownload;
     use daft_functions_utf8::{Capitalize, capitalize, lower};
     use daft_scan::Pushdowns;
@@ -281,12 +280,9 @@ mod tests {
             Pushdowns::default(),
         )
         .select(vec![
-            ExprRef::from(BuiltinScalarFn::new(
-                BinaryDecode,
-                vec![
-                    BuiltinScalarFn::new_async(UrlDownload, vec![resolved_col("url")]).into(),
-                    lit(Codec::Utf8),
-                ],
+            Arc::new(Expr::Cast(
+                BuiltinScalarFn::new_async(UrlDownload, vec![resolved_col("url")]).into(),
+                DataType::Utf8,
             ))
             .alias("url_data"),
             lower(Expr::Column(Column::Resolved(ResolvedColumn::Basic("name".into()))).arced())
@@ -322,10 +318,7 @@ mod tests {
         let Expr::Alias(func, ..) = top_project.projection[0].as_ref() else {
             panic!("Expected alias");
         };
-        assert!(matches!(
-            func.as_ref(),
-            Expr::ScalarFn(ScalarFn::Builtin(BuiltinScalarFn { func, .. })) if func.type_id() == TypeId::of::<BinaryDecode>()
-        ));
+        assert!(matches!(func.as_ref(), Expr::Cast(_, DataType::Utf8)));
 
         // Check that the top level project has a single child, which is a project
         assert!(matches!(


### PR DESCRIPTION
## Changes Made

We have LogicalPlan optimizations for simplifying casting expressions. For example, if we cast a string -> string, we eliminate the cast operation. We don't with decode because the behavior is encoded within the expression definition.

Note, we could special-case decode in the optimizer, but I think its cleaner to do it in Python because parsing is kind of ugly. Lmk if you disagree though. I think its fair to say that converting decodes to cast may be confusing in explain plans.

Also, I think this will help ClickBench a bunch, since this was blocking filter pushdowns
