### PR TITLE
docs: add UDF patterns tutorial notebook and example page

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -81,6 +81,7 @@
     * [Generate Images from Text with Stable Diffusion](examples/image-generation.md)
     * [Querying Image Data](examples/querying-images.md)
     * [MNIST Digit Classification](examples/mnist.md)
+    * [UDF Patterns](examples/udf-patterns.md)
     * [Window Functions](examples/window-functions.md)
     * [Working with Common Crawl Data](examples/common-crawl-daft-tutorial.md)
 * Python API

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -30,6 +30,10 @@
 
     Open Source image generation model on your own GPUs using Daft UDFs.
 
+- [Daft's Four UDF Pattern Tutorial](udf-patterns.md)
+
+    One notebook, four UDF patterns, one dataset. Row-wise, generator, async, and stateful -- learn when to use each.
+
 - [Window Functions: The Great Chocolate Race](window-functions.md)
 
     Explore how window functions can reduce complex joins and groupby's to just a few simple operations.

--- a/docs/examples/udf-patterns.md
+++ b/docs/examples/udf-patterns.md
@@ -1,0 +1,383 @@
+# Daft's Four UDF Pattern Tutorial
+
+[Run this tutorial on Google Colab](https://colab.research.google.com/github/Eventual-Inc/Daft/blob/main/tutorials/udf_patterns/udf_patterns.ipynb)
+
+One notebook, four patterns, a single cohesive dataset. Each section starts with a problem, shows the pattern that solves it, runs the code, and tells you when to reach for that pattern again.
+
+| I need to... | Pattern | Decorator |
+|---|---|---|
+| Transform each row with custom logic | Row-wise | `@daft.func` |
+| Produce multiple rows from one input | Generator | `@daft.func` + `Iterator[T]` |
+| Call external services concurrently | Async | `@daft.func` + `async def` |
+| Reuse expensive resources across rows | Stateful | `@daft.cls` + `__init__` |
+
+## Setup
+
+All you need is `daft`. Install it if you haven't already.
+
+```bash
+pip install daft aiohttp
+```
+
+```python
+import daft
+```
+
+## Our Dataset
+
+We'll work with a small dataset of support tickets throughout the notebook. Each pattern solves a different problem on this same data.
+
+```python
+tickets = daft.from_pydict({
+    "ticket_id": [1, 2, 3, 4, 5],
+    "customer_email": [
+        "Alice+work@Gmail.COM",
+        "  bob@example.org  ",
+        "CAROL+spam@Yahoo.com",
+        "dave.jones@Company.IO",
+        "EVE+newsletter@Outlook.COM",
+    ],
+    "subject": [
+        "Can't log in after password reset",
+        "Billing charged twice this month",
+        "Feature request: dark mode and custom themes for the dashboard",
+        "App crashes on startup every time I open the settings page since the last update",
+        "How do I export my data to CSV or JSON format for external analysis tools",
+    ],
+    "body": [
+        "I reset my password yesterday but the new password doesn't work. I've tried clearing cookies and using incognito mode. Still locked out. This is blocking my work.",
+        "I was charged $49.99 twice on March 1st. Transaction IDs: TXN-001 and TXN-002. Please refund the duplicate charge. I've attached my bank statement as proof.",
+        "Would love to see dark mode added to the dashboard. Also, custom color themes would be great for accessibility. Several team members have mentioned this. It would really help with long coding sessions late at night.",
+        "Since updating to v2.3.1, the app crashes immediately when I navigate to Settings > Account > Preferences. I'm on macOS 14.2, Chrome 120. Console shows a null reference error in the preferences module. Happens every single time.",
+        "I need to export my usage data for the last 6 months. The dashboard only shows charts but I need the raw numbers in CSV or JSON. Is there an API endpoint for this? Our analytics team needs this data for a quarterly review next week.",
+    ],
+    "webhook_url": [
+        "https://httpbin.org/status/200",
+        "https://httpbin.org/status/200",
+        "https://httpbin.org/status/404",
+        "https://httpbin.org/status/200",
+        "https://httpbin.org/status/500",
+    ],
+})
+
+tickets.show()
+```
+
+---
+
+## Pattern 1: Row-wise -- clean every row with zero setup
+
+**Problem**: You need custom logic on every row -- normalize an email, parse a field, validate an input -- and the built-in expressions don't cover it.
+
+**Pattern**: `@daft.func` with type hints. One row in, one row out. Write regular Python. Daft handles the rest.
+
+```python
+@daft.func
+def normalize_email(raw: str) -> str:
+    """Strip whitespace, lowercase, remove plus-aliases."""
+    local, domain = raw.strip().lower().split("@")
+    local = local.split("+")[0]  # remove +alias
+    return f"{local}@{domain}"
+
+
+cleaned = tickets.select(
+    tickets["ticket_id"],
+    tickets["customer_email"],
+    normalize_email(tickets["customer_email"]).alias("clean_email"),
+)
+cleaned.show()
+```
+
+That's it. No `return_dtype`, no schema declarations, no special imports. Daft infers the return type from your type hint.
+
+Let's do another one -- categorize tickets by keyword matching:
+
+```python
+@daft.func
+def categorize_ticket(subject: str) -> str:
+    """Assign a category based on keywords in the subject line."""
+    subject_lower = subject.lower()
+    if any(kw in subject_lower for kw in ["crash", "error", "bug", "broken"]):
+        return "bug"
+    elif any(kw in subject_lower for kw in ["feature", "request", "add", "would like"]):
+        return "feature_request"
+    elif any(kw in subject_lower for kw in ["billing", "charge", "payment", "refund"]):
+        return "billing"
+    elif any(kw in subject_lower for kw in ["login", "password", "log in", "locked"]):
+        return "auth"
+    else:
+        return "general"
+
+
+categorized = tickets.select(
+    tickets["ticket_id"],
+    tickets["subject"],
+    categorize_ticket(tickets["subject"]).alias("category"),
+)
+categorized.show()
+```
+
+**When to use it**: Your function takes a single row and returns a single value. The logic is pure Python -- no external services, no model weights, no variable-length output. This is the pattern for data cleaning, validation, and field-level transformations.
+
+---
+
+## Pattern 2: Generator -- one input becomes many rows
+
+**Problem**: Each input row needs to produce a *variable number* of output rows. Splitting a document into chunks, tokenizing text into sentences, expanding nested records. You don't know ahead of time how many outputs each input will produce.
+
+**Pattern**: `@daft.func` returning `Iterator[T]`. Yield as many rows as the data demands.
+
+```python
+from typing import Iterator
+
+
+@daft.func
+def split_into_sentences(text: str) -> Iterator[str]:
+    """Split text into sentences. Each sentence becomes its own row."""
+    import re
+    sentences = re.split(r'(?<=[.!?])\s+', text.strip())
+    for sentence in sentences:
+        if sentence:
+            yield sentence
+
+
+sentences = tickets.select(
+    tickets["ticket_id"],
+    split_into_sentences(tickets["body"]).alias("sentence"),
+)
+sentences.show()
+```
+
+Notice that `ticket_id` is automatically broadcast to match the number of sentences each ticket body produces. No `explode()` needed.
+
+Here's a more practical example -- chunking text for a RAG pipeline:
+
+```python
+@daft.func
+def chunk_text(text: str, max_words: int = 20) -> Iterator[str]:
+    """Split text into word-count-limited chunks for embedding."""
+    words = text.split()
+    for i in range(0, len(words), max_words):
+        chunk = " ".join(words[i:i + max_words])
+        yield chunk
+
+
+chunks = tickets.select(
+    tickets["ticket_id"],
+    chunk_text(tickets["body"]).alias("chunk"),
+)
+chunks.show()
+```
+
+**When to use it**: One-to-many transformations. Document chunking for RAG pipelines, audio segmentation, tokenization, expanding nested structures -- anywhere `yield` is the natural way to express "this input produces N outputs." No intermediate lists, no `explode()`, no memory spike from materializing everything at once.
+
+---
+
+## Pattern 3: Async -- hit APIs without waiting in line
+
+**Problem**: Your function calls an external service -- a webhook, a geocoder, a model endpoint. Sequential execution means each row waits for the previous one to finish. At 10,000 rows, that's hours of idle waiting.
+
+**Pattern**: `async def` with `@daft.func`. Daft overlaps the I/O automatically.
+
+```python
+@daft.func
+async def ping_webhook(url: str) -> int:
+    """Hit a webhook URL and return the HTTP status code."""
+    import aiohttp
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url) as resp:
+            return resp.status
+
+
+webhook_results = tickets.select(
+    tickets["ticket_id"],
+    tickets["webhook_url"],
+    ping_webhook(tickets["webhook_url"]).alias("status_code"),
+)
+webhook_results.show()
+```
+
+You write `async def` and `await` exactly as you would outside Daft. The concurrency is automatic -- no thread pools, no executor boilerplate.
+
+Here's another example -- looking up ticket categories from an external API:
+
+```python
+@daft.func
+async def lookup_response_time_sla(category: str) -> str:
+    """Simulate an async SLA lookup based on ticket category.
+
+    In production, this would hit an internal API or database.
+    Here we simulate the async I/O with a local mapping.
+    """
+    import asyncio
+    # Simulate network latency
+    await asyncio.sleep(0.1)
+    sla_map = {
+        "bug": "4 hours",
+        "billing": "2 hours",
+        "auth": "1 hour",
+        "feature_request": "5 business days",
+        "general": "24 hours",
+    }
+    return sla_map.get(category, "24 hours")
+
+
+# First categorize, then look up SLAs
+with_sla = tickets.select(
+    tickets["ticket_id"],
+    tickets["subject"],
+    categorize_ticket(tickets["subject"]).alias("category"),
+).select(
+    daft.col("ticket_id"),
+    daft.col("subject"),
+    daft.col("category"),
+    lookup_response_time_sla(daft.col("category")).alias("sla"),
+)
+with_sla.show()
+```
+
+**When to use it**: Any I/O-bound workload -- API calls, database lookups, webhook triggers, model endpoints behind a REST API. Write standard `async`/`await` Python. Daft handles the concurrency.
+
+---
+
+## Pattern 4: Stateful -- load a resource once, use it on every row
+
+**Problem**: Loading an expensive resource for every row (or every batch) is killing your pipeline. A 2 GB model, a database connection pool, an API client with auth -- you need to initialize once and reuse across rows.
+
+**Pattern**: `@daft.cls` with `__init__` for setup and `__call__` for processing. The resource loads once per worker and stays in memory for every row that worker handles.
+
+No other distributed data framework has this.
+
+```python
+@daft.cls
+class KeywordExtractor:
+    """Extract keywords from text using a pre-loaded keyword set.
+
+    In production, __init__ would load a model, open a DB connection,
+    or authenticate with an API. The key: it runs once per worker.
+    """
+    def __init__(self):
+        # This runs ONCE per worker -- not once per row.
+        # Imagine loading a spaCy model or a TF-IDF vectorizer here.
+        self.keywords = {
+            "urgent": ["crash", "locked", "blocking", "immediately", "every time", "broken"],
+            "billing": ["charged", "refund", "payment", "transaction", "invoice"],
+            "feature": ["would love", "would be great", "add", "request", "suggestion"],
+            "data": ["export", "csv", "json", "api", "raw", "download"],
+        }
+        print("KeywordExtractor initialized (runs once per worker)")
+
+    def __call__(self, text: str) -> str:
+        """This runs on every row, reusing the keyword set from __init__."""
+        text_lower = text.lower()
+        matched = []
+        for category, terms in self.keywords.items():
+            if any(term in text_lower for term in terms):
+                matched.append(category)
+        return ", ".join(matched) if matched else "none"
+
+
+extractor = KeywordExtractor()
+
+extracted = tickets.select(
+    tickets["ticket_id"],
+    tickets["subject"],
+    extractor(tickets["body"]).alias("matched_categories"),
+)
+extracted.show()
+```
+
+Notice the print statement -- `"KeywordExtractor initialized"` appears once, not five times. That's the point. `__init__` runs once per worker. `__call__` runs on every row.
+
+In production, this pattern is how you'd load a sentiment model, an embedding model, or any resource that's expensive to initialize:
+
+```python
+# Production example -- what this pattern looks like with a real model.
+# (Not runnable without transformers installed -- shown for illustration.)
+#
+# @daft.cls(gpus=1)
+# class SentimentClassifier:
+#     def __init__(self):
+#         from transformers import pipeline
+#         self.pipe = pipeline(
+#             "sentiment-analysis",
+#             model="distilbert-base-uncased-finetuned-sst-2-english",
+#             device="cuda",
+#         )
+#         # Model loaded once. 2GB stays in GPU memory.
+#
+#     def __call__(self, text: str) -> str:
+#         return self.pipe(text)[0]["label"]
+#
+# classifier = SentimentClassifier()
+# df.select(classifier(df["text"]).alias("sentiment"))
+```
+
+**When to use it**: Any workload with expensive initialization -- model loading, database connection pools, API clients with authentication. `__init__` runs once per worker; `__call__` runs on every row. Add `gpus=1` for GPU allocation, `max_concurrency` to cap parallel instances, `use_process=True` to escape the GIL.
+
+---
+
+## Bonus: Batch processing with `@daft.func.batch`
+
+When you need to operate on entire columns at once (NumPy vectorization, pandas operations, bulk API calls), use the batch variant.
+
+```python
+@daft.func.batch(return_dtype=daft.DataType.int64())
+def word_count_batch(texts: daft.Series) -> list:
+    """Count words in each text -- operating on the entire batch at once."""
+    return [len(text.split()) for text in texts.to_pylist()]
+
+
+word_counts = tickets.select(
+    tickets["ticket_id"],
+    tickets["subject"],
+    word_count_batch(tickets["body"]).alias("body_word_count"),
+)
+word_counts.show()
+```
+
+Batch UDFs receive `daft.Series` objects instead of individual values. Use them when your operation benefits from vectorization (NumPy, pandas) or when an external library expects arrays.
+
+---
+
+## Putting It All Together
+
+Let's build a mini pipeline that chains multiple UDF patterns on our ticket data:
+
+```python
+# Pipeline: normalize emails, categorize, extract keywords, count words
+
+pipeline_result = tickets.select(
+    tickets["ticket_id"],
+    normalize_email(tickets["customer_email"]).alias("email"),
+    tickets["subject"],
+    categorize_ticket(tickets["subject"]).alias("category"),
+    extractor(tickets["body"]).alias("keywords"),
+    word_count_batch(tickets["body"]).alias("body_words"),
+)
+
+pipeline_result.show()
+```
+
+Row-wise, stateful, and batch UDFs -- all composing in a single `.select()`. This same code runs locally on your laptop or distributed across a Ray cluster. Set `daft.set_runner_ray("ray://cluster:10001")` and nothing else changes.
+
+---
+
+## Pick Your Pattern
+
+| I need to... | Pattern | Decorator | Example in this notebook |
+|---|---|---|---|
+| Transform each row with custom logic | Row-wise | `@daft.func` | `normalize_email`, `categorize_ticket` |
+| Produce multiple rows from one input | Generator | `@daft.func` + `Iterator[T]` | `split_into_sentences`, `chunk_text` |
+| Call external services concurrently | Async | `@daft.func` + `async def` | `ping_webhook`, `lookup_response_time_sla` |
+| Reuse expensive resources across rows | Stateful | `@daft.cls` + `__init__` | `KeywordExtractor` |
+| Vectorized batch operations | Batch | `@daft.func.batch` | `word_count_batch` |
+
+Your Python. Daft's scale.
+
+---
+
+**Resources:**
+- [`@daft.func` docs](https://docs.daft.ai/en/stable/custom-code/func/)
+- [`@daft.cls` docs](https://docs.daft.ai/en/stable/custom-code/cls/)
+- [Migration guide](https://docs.daft.ai/en/stable/custom-code/migration/) (if you're on the legacy `@daft.udf` API)

--- a/tutorials/udf_patterns/udf_patterns.ipynb
+++ b/tutorials/udf_patterns/udf_patterns.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Daft's Four UDF Pattern Tutorial\n",
     "\n",
-    "You've read about row-wise UDFs, generators, async, and stateful classes. You bookmarked the docs. But you haven't actually *run* any of it \u2014 because jumping between four separate posts, copying code, and figuring out which pattern fits which problem is a whole afternoon you don't have.\n",
+    "You've read about row-wise UDFs, generators, async, and stateful classes. You bookmarked the docs. But you haven't actually *run* any of it — because jumping between four separate posts, copying code, and figuring out which pattern fits which problem is a whole afternoon you don't have.\n",
     "\n",
     "This notebook eliminates the friction. One file, four patterns, a single cohesive dataset, copy-paste-and-run. Each section starts with a problem, shows the pattern that solves it, runs the code, and tells you when to reach for that pattern again.\n",
     "\n",
@@ -56,37 +56,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tickets = daft.from_pydict({\n",
-    "    \"ticket_id\": [1, 2, 3, 4, 5],\n",
-    "    \"customer_email\": [\n",
-    "        \"Alice+work@Gmail.COM\",\n",
-    "        \"  bob@example.org  \",\n",
-    "        \"CAROL+spam@Yahoo.com\",\n",
-    "        \"dave.jones@Company.IO\",\n",
-    "        \"EVE+newsletter@Outlook.COM\",\n",
-    "    ],\n",
-    "    \"subject\": [\n",
-    "        \"Can't log in after password reset\",\n",
-    "        \"Billing charged twice this month\",\n",
-    "        \"Feature request: dark mode and custom themes for the dashboard\",\n",
-    "        \"App crashes on startup every time I open the settings page since the last update\",\n",
-    "        \"How do I export my data to CSV or JSON format for external analysis tools\",\n",
-    "    ],\n",
-    "    \"body\": [\n",
-    "        \"I reset my password yesterday but the new password doesn't work. I've tried clearing cookies and using incognito mode. Still locked out. This is blocking my work.\",\n",
-    "        \"I was charged $49.99 twice on March 1st. Transaction IDs: TXN-001 and TXN-002. Please refund the duplicate charge. I've attached my bank statement as proof.\",\n",
-    "        \"Would love to see dark mode added to the dashboard. Also, custom color themes would be great for accessibility. Several team members have mentioned this. It would really help with long coding sessions late at night.\",\n",
-    "        \"Since updating to v2.3.1, the app crashes immediately when I navigate to Settings > Account > Preferences. I'm on macOS 14.2, Chrome 120. Console shows a null reference error in the preferences module. Happens every single time.\",\n",
-    "        \"I need to export my usage data for the last 6 months. The dashboard only shows charts but I need the raw numbers in CSV or JSON. Is there an API endpoint for this? Our analytics team needs this data for a quarterly review next week.\",\n",
-    "    ],\n",
-    "    \"webhook_url\": [\n",
-    "        \"https://httpbin.org/status/200\",\n",
-    "        \"https://httpbin.org/status/200\",\n",
-    "        \"https://httpbin.org/status/404\",\n",
-    "        \"https://httpbin.org/status/200\",\n",
-    "        \"https://httpbin.org/status/500\",\n",
-    "    ],\n",
-    "})\n",
+    "tickets = daft.from_pydict(\n",
+    "    {\n",
+    "        \"ticket_id\": [1, 2, 3, 4, 5],\n",
+    "        \"customer_email\": [\n",
+    "            \"Alice+work@Gmail.COM\",\n",
+    "            \"  bob@example.org  \",\n",
+    "            \"CAROL+spam@Yahoo.com\",\n",
+    "            \"dave.jones@Company.IO\",\n",
+    "            \"EVE+newsletter@Outlook.COM\",\n",
+    "        ],\n",
+    "        \"subject\": [\n",
+    "            \"Can't log in after password reset\",\n",
+    "            \"Billing charged twice this month\",\n",
+    "            \"Feature request: dark mode and custom themes for the dashboard\",\n",
+    "            \"App crashes on startup every time I open the settings page since the last update\",\n",
+    "            \"How do I export my data to CSV or JSON format for external analysis tools\",\n",
+    "        ],\n",
+    "        \"body\": [\n",
+    "            \"I reset my password yesterday but the new password doesn't work. I've tried clearing cookies and using incognito mode. Still locked out. This is blocking my work.\",\n",
+    "            \"I was charged $49.99 twice on March 1st. Transaction IDs: TXN-001 and TXN-002. Please refund the duplicate charge. I've attached my bank statement as proof.\",\n",
+    "            \"Would love to see dark mode added to the dashboard. Also, custom color themes would be great for accessibility. Several team members have mentioned this. It would really help with long coding sessions late at night.\",\n",
+    "            \"Since updating to v2.3.1, the app crashes immediately when I navigate to Settings > Account > Preferences. I'm on macOS 14.2, Chrome 120. Console shows a null reference error in the preferences module. Happens every single time.\",\n",
+    "            \"I need to export my usage data for the last 6 months. The dashboard only shows charts but I need the raw numbers in CSV or JSON. Is there an API endpoint for this? Our analytics team needs this data for a quarterly review next week.\",\n",
+    "        ],\n",
+    "        \"webhook_url\": [\n",
+    "            \"https://httpbin.org/status/200\",\n",
+    "            \"https://httpbin.org/status/200\",\n",
+    "            \"https://httpbin.org/status/404\",\n",
+    "            \"https://httpbin.org/status/200\",\n",
+    "            \"https://httpbin.org/status/500\",\n",
+    "        ],\n",
+    "    }\n",
+    ")\n",
     "\n",
     "tickets.show()"
    ]
@@ -97,9 +99,9 @@
    "source": [
     "---\n",
     "\n",
-    "## Pattern 1: Row-wise \u2014 clean every row with zero setup\n",
+    "## Pattern 1: Row-wise — clean every row with zero setup\n",
     "\n",
-    "**Problem**: You need custom logic on every row \u2014 normalize an email, parse a field, validate an input \u2014 and the built-in expressions don't cover it.\n",
+    "**Problem**: You need custom logic on every row — normalize an email, parse a field, validate an input — and the built-in expressions don't cover it.\n",
     "\n",
     "**Pattern**: `@daft.func` with type hints. One row in, one row out. Write regular Python. Daft handles the rest.\n",
     "\n",
@@ -134,7 +136,7 @@
    "source": [
     "That's it. No `return_dtype`, no schema declarations, no special imports. Daft infers the return type from your type hint.\n",
     "\n",
-    "Let's do another one \u2014 categorize tickets by keyword matching:"
+    "Let's do another one — categorize tickets by keyword matching:"
    ]
   },
   {
@@ -171,11 +173,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**When to use it**: Your function takes a single row and returns a single value. The logic is pure Python \u2014 no external services, no model weights, no variable-length output. This is the pattern for data cleaning, validation, and field-level transformations.\n",
+    "**When to use it**: Your function takes a single row and returns a single value. The logic is pure Python — no external services, no model weights, no variable-length output. This is the pattern for data cleaning, validation, and field-level transformations.\n",
     "\n",
     "---\n",
     "\n",
-    "## Pattern 2: Generator \u2014 one input becomes many rows\n",
+    "## Pattern 2: Generator — one input becomes many rows\n",
     "\n",
     "**Problem**: Each input row needs to produce a *variable number* of output rows. Splitting a document into chunks, tokenizing text into sentences, expanding nested records. You don't know ahead of time how many outputs each input will produce.\n",
     "\n",
@@ -188,14 +190,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from typing import Iterator\n",
+    "from collections.abc import Iterator\n",
     "\n",
     "\n",
     "@daft.func\n",
     "def split_into_sentences(text: str) -> Iterator[str]:\n",
     "    \"\"\"Split text into sentences. Each sentence becomes its own row.\"\"\"\n",
     "    import re\n",
-    "    sentences = re.split(r'(?<=[.!?])\\s+', text.strip())\n",
+    "\n",
+    "    sentences = re.split(r\"(?<=[.!?])\\s+\", text.strip())\n",
     "    for sentence in sentences:\n",
     "        if sentence:\n",
     "            yield sentence\n",
@@ -214,7 +217,7 @@
    "source": [
     "Notice that `ticket_id` is automatically broadcast to match the number of sentences each ticket body produces. No `explode()` needed.\n",
     "\n",
-    "Here's a more practical example \u2014 chunking text for a RAG pipeline:"
+    "Here's a more practical example — chunking text for a RAG pipeline:"
    ]
   },
   {
@@ -228,7 +231,7 @@
     "    \"\"\"Split text into word-count-limited chunks for embedding.\"\"\"\n",
     "    words = text.split()\n",
     "    for i in range(0, len(words), max_words):\n",
-    "        chunk = \" \".join(words[i:i + max_words])\n",
+    "        chunk = \" \".join(words[i : i + max_words])\n",
     "        yield chunk\n",
     "\n",
     "\n",
@@ -243,13 +246,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**When to use it**: One-to-many transformations. Document chunking for RAG pipelines, audio segmentation, tokenization, expanding nested structures \u2014 anywhere `yield` is the natural way to express \"this input produces N outputs.\" No intermediate lists, no `explode()`, no memory spike from materializing everything at once.\n",
+    "**When to use it**: One-to-many transformations. Document chunking for RAG pipelines, audio segmentation, tokenization, expanding nested structures — anywhere `yield` is the natural way to express \"this input produces N outputs.\" No intermediate lists, no `explode()`, no memory spike from materializing everything at once.\n",
     "\n",
     "---\n",
     "\n",
-    "## Pattern 3: Async \u2014 hit APIs without waiting in line\n",
+    "## Pattern 3: Async — hit APIs without waiting in line\n",
     "\n",
-    "**Problem**: Your function calls an external service \u2014 a webhook, a geocoder, a model endpoint. Sequential execution means each row waits for the previous one to finish. At 10,000 rows, that's hours of idle waiting.\n",
+    "**Problem**: Your function calls an external service — a webhook, a geocoder, a model endpoint. Sequential execution means each row waits for the previous one to finish. At 10,000 rows, that's hours of idle waiting.\n",
     "\n",
     "**Pattern**: `async def` with `@daft.func`. Daft overlaps the I/O automatically."
    ]
@@ -264,6 +267,7 @@
     "async def ping_webhook(url: str) -> int:\n",
     "    \"\"\"Hit a webhook URL and return the HTTP status code.\"\"\"\n",
     "    import aiohttp\n",
+    "\n",
     "    async with aiohttp.ClientSession() as session:\n",
     "        async with session.get(url) as resp:\n",
     "            return resp.status\n",
@@ -281,9 +285,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You write `async def` and `await` exactly as you would outside Daft. The concurrency is automatic \u2014 no thread pools, no executor boilerplate.\n",
+    "You write `async def` and `await` exactly as you would outside Daft. The concurrency is automatic — no thread pools, no executor boilerplate.\n",
     "\n",
-    "Here's another example \u2014 looking up ticket categories from an external API:"
+    "Here's another example — looking up ticket categories from an external API:"
    ]
   },
   {
@@ -295,11 +299,12 @@
     "@daft.func\n",
     "async def lookup_response_time_sla(category: str) -> str:\n",
     "    \"\"\"Simulate an async SLA lookup based on ticket category.\n",
-    "    \n",
+    "\n",
     "    In production, this would hit an internal API or database.\n",
     "    Here we simulate the async I/O with a local mapping.\n",
     "    \"\"\"\n",
     "    import asyncio\n",
+    "\n",
     "    # Simulate network latency\n",
     "    await asyncio.sleep(0.1)\n",
     "    sla_map = {\n",
@@ -330,13 +335,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**When to use it**: Any I/O-bound workload \u2014 API calls, database lookups, webhook triggers, model endpoints behind a REST API. Write standard `async`/`await` Python. Daft handles the concurrency.\n",
+    "**When to use it**: Any I/O-bound workload — API calls, database lookups, webhook triggers, model endpoints behind a REST API. Write standard `async`/`await` Python. Daft handles the concurrency.\n",
     "\n",
     "---\n",
     "\n",
-    "## Pattern 4: Stateful \u2014 load a resource once, use it on every row\n",
+    "## Pattern 4: Stateful — load a resource once, use it on every row\n",
     "\n",
-    "**Problem**: Loading an expensive resource for every row (or every batch) is killing your pipeline. A 2 GB model, a database connection pool, an API client with auth \u2014 you need to initialize once and reuse across rows.\n",
+    "**Problem**: Loading an expensive resource for every row (or every batch) is killing your pipeline. A 2 GB model, a database connection pool, an API client with auth — you need to initialize once and reuse across rows.\n",
     "\n",
     "**Pattern**: `@daft.cls` with `__init__` for setup and `__call__` for processing. The resource loads once per worker and stays in memory for every row that worker handles.\n",
     "\n",
@@ -352,12 +357,13 @@
     "@daft.cls\n",
     "class KeywordExtractor:\n",
     "    \"\"\"Extract keywords from text using a pre-loaded keyword set.\n",
-    "    \n",
+    "\n",
     "    In production, __init__ would load a model, open a DB connection,\n",
     "    or authenticate with an API. The key: it runs once per worker.\n",
     "    \"\"\"\n",
+    "\n",
     "    def __init__(self):\n",
-    "        # This runs ONCE per worker \u2014 not once per row.\n",
+    "        # This runs ONCE per worker — not once per row.\n",
     "        # Imagine loading a spaCy model or a TF-IDF vectorizer here.\n",
     "        self.keywords = {\n",
     "            \"urgent\": [\"crash\", \"locked\", \"blocking\", \"immediately\", \"every time\", \"broken\"],\n",
@@ -391,7 +397,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice the print statement \u2014 `\"KeywordExtractor initialized\"` appears once, not five times. That's the point. `__init__` runs once per worker. `__call__` runs on every row.\n",
+    "Notice the print statement — `\"KeywordExtractor initialized\"` appears once, not five times. That's the point. `__init__` runs once per worker. `__call__` runs on every row.\n",
     "\n",
     "In production, this pattern is how you'd load a sentiment model, an embedding model, or any resource that's expensive to initialize:"
    ]
@@ -402,8 +408,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Production example \u2014 what this pattern looks like with a real model.\n",
-    "# (Not runnable without transformers installed \u2014 shown for illustration.)\n",
+    "# Production example — what this pattern looks like with a real model.\n",
+    "# (Not runnable without transformers installed — shown for illustration.)\n",
     "#\n",
     "# @daft.cls(gpus=1)\n",
     "# class SentimentClassifier:\n",
@@ -427,7 +433,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**When to use it**: Any workload with expensive initialization \u2014 model loading, database connection pools, API clients with authentication. `__init__` runs once per worker; `__call__` runs on every row. Add `gpus=1` for GPU allocation, `max_concurrency` to cap parallel instances, `use_process=True` to escape the GIL.\n",
+    "**When to use it**: Any workload with expensive initialization — model loading, database connection pools, API clients with authentication. `__init__` runs once per worker; `__call__` runs on every row. Add `gpus=1` for GPU allocation, `max_concurrency` to cap parallel instances, `use_process=True` to escape the GIL.\n",
     "\n",
     "---\n",
     "\n",
@@ -444,7 +450,7 @@
    "source": [
     "@daft.func.batch(return_dtype=daft.DataType.int64())\n",
     "def word_count_batch(texts: daft.Series) -> list:\n",
-    "    \"\"\"Count words in each text \u2014 operating on the entire batch at once.\"\"\"\n",
+    "    \"\"\"Count words in each text — operating on the entire batch at once.\"\"\"\n",
     "    return [len(text.split()) for text in texts.to_pylist()]\n",
     "\n",
     "\n",
@@ -493,7 +499,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Row-wise, stateful, and batch UDFs \u2014 all composing in a single `.select()`. This same code runs locally on your laptop or distributed across a Ray cluster. Set `daft.set_runner_ray(\"ray://cluster:10001\")` and nothing else changes.\n",
+    "Row-wise, stateful, and batch UDFs — all composing in a single `.select()`. This same code runs locally on your laptop or distributed across a Ray cluster. Set `daft.set_runner_ray(\"ray://cluster:10001\")` and nothing else changes.\n",
     "\n",
     "---\n",
     "\n",
@@ -520,13 +526,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/tutorials/udf_patterns/udf_patterns.ipynb
+++ b/tutorials/udf_patterns/udf_patterns.ipynb
@@ -1,0 +1,534 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Daft's Four UDF Pattern Tutorial\n",
+    "\n",
+    "You've read about row-wise UDFs, generators, async, and stateful classes. You bookmarked the docs. But you haven't actually *run* any of it \u2014 because jumping between four separate posts, copying code, and figuring out which pattern fits which problem is a whole afternoon you don't have.\n",
+    "\n",
+    "This notebook eliminates the friction. One file, four patterns, a single cohesive dataset, copy-paste-and-run. Each section starts with a problem, shows the pattern that solves it, runs the code, and tells you when to reach for that pattern again.\n",
+    "\n",
+    "**Fifteen minutes from open to \"I get it.\"**\n",
+    "\n",
+    "| I need to... | Pattern | Decorator |\n",
+    "|---|---|---|\n",
+    "| Transform each row with custom logic | Row-wise | `@daft.func` |\n",
+    "| Produce multiple rows from one input | Generator | `@daft.func` + `Iterator[T]` |\n",
+    "| Call external services concurrently | Async | `@daft.func` + `async def` |\n",
+    "| Reuse expensive resources across rows | Stateful | `@daft.cls` + `__init__` |\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "All you need is `daft`. Install it if you haven't already."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pip install daft aiohttp\n",
+    "import daft"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Our Dataset\n",
+    "\n",
+    "We'll work with a small dataset of support tickets throughout the notebook. Each pattern solves a different problem on this same data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tickets = daft.from_pydict({\n",
+    "    \"ticket_id\": [1, 2, 3, 4, 5],\n",
+    "    \"customer_email\": [\n",
+    "        \"Alice+work@Gmail.COM\",\n",
+    "        \"  bob@example.org  \",\n",
+    "        \"CAROL+spam@Yahoo.com\",\n",
+    "        \"dave.jones@Company.IO\",\n",
+    "        \"EVE+newsletter@Outlook.COM\",\n",
+    "    ],\n",
+    "    \"subject\": [\n",
+    "        \"Can't log in after password reset\",\n",
+    "        \"Billing charged twice this month\",\n",
+    "        \"Feature request: dark mode and custom themes for the dashboard\",\n",
+    "        \"App crashes on startup every time I open the settings page since the last update\",\n",
+    "        \"How do I export my data to CSV or JSON format for external analysis tools\",\n",
+    "    ],\n",
+    "    \"body\": [\n",
+    "        \"I reset my password yesterday but the new password doesn't work. I've tried clearing cookies and using incognito mode. Still locked out. This is blocking my work.\",\n",
+    "        \"I was charged $49.99 twice on March 1st. Transaction IDs: TXN-001 and TXN-002. Please refund the duplicate charge. I've attached my bank statement as proof.\",\n",
+    "        \"Would love to see dark mode added to the dashboard. Also, custom color themes would be great for accessibility. Several team members have mentioned this. It would really help with long coding sessions late at night.\",\n",
+    "        \"Since updating to v2.3.1, the app crashes immediately when I navigate to Settings > Account > Preferences. I'm on macOS 14.2, Chrome 120. Console shows a null reference error in the preferences module. Happens every single time.\",\n",
+    "        \"I need to export my usage data for the last 6 months. The dashboard only shows charts but I need the raw numbers in CSV or JSON. Is there an API endpoint for this? Our analytics team needs this data for a quarterly review next week.\",\n",
+    "    ],\n",
+    "    \"webhook_url\": [\n",
+    "        \"https://httpbin.org/status/200\",\n",
+    "        \"https://httpbin.org/status/200\",\n",
+    "        \"https://httpbin.org/status/404\",\n",
+    "        \"https://httpbin.org/status/200\",\n",
+    "        \"https://httpbin.org/status/500\",\n",
+    "    ],\n",
+    "})\n",
+    "\n",
+    "tickets.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Pattern 1: Row-wise \u2014 clean every row with zero setup\n",
+    "\n",
+    "**Problem**: You need custom logic on every row \u2014 normalize an email, parse a field, validate an input \u2014 and the built-in expressions don't cover it.\n",
+    "\n",
+    "**Pattern**: `@daft.func` with type hints. One row in, one row out. Write regular Python. Daft handles the rest.\n",
+    "\n",
+    "This is the workhorse pattern for data cleaning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@daft.func\n",
+    "def normalize_email(raw: str) -> str:\n",
+    "    \"\"\"Strip whitespace, lowercase, remove plus-aliases.\"\"\"\n",
+    "    local, domain = raw.strip().lower().split(\"@\")\n",
+    "    local = local.split(\"+\")[0]  # remove +alias\n",
+    "    return f\"{local}@{domain}\"\n",
+    "\n",
+    "\n",
+    "cleaned = tickets.select(\n",
+    "    tickets[\"ticket_id\"],\n",
+    "    tickets[\"customer_email\"],\n",
+    "    normalize_email(tickets[\"customer_email\"]).alias(\"clean_email\"),\n",
+    ")\n",
+    "cleaned.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That's it. No `return_dtype`, no schema declarations, no special imports. Daft infers the return type from your type hint.\n",
+    "\n",
+    "Let's do another one \u2014 categorize tickets by keyword matching:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@daft.func\n",
+    "def categorize_ticket(subject: str) -> str:\n",
+    "    \"\"\"Assign a category based on keywords in the subject line.\"\"\"\n",
+    "    subject_lower = subject.lower()\n",
+    "    if any(kw in subject_lower for kw in [\"crash\", \"error\", \"bug\", \"broken\"]):\n",
+    "        return \"bug\"\n",
+    "    elif any(kw in subject_lower for kw in [\"feature\", \"request\", \"add\", \"would like\"]):\n",
+    "        return \"feature_request\"\n",
+    "    elif any(kw in subject_lower for kw in [\"billing\", \"charge\", \"payment\", \"refund\"]):\n",
+    "        return \"billing\"\n",
+    "    elif any(kw in subject_lower for kw in [\"login\", \"password\", \"log in\", \"locked\"]):\n",
+    "        return \"auth\"\n",
+    "    else:\n",
+    "        return \"general\"\n",
+    "\n",
+    "\n",
+    "categorized = tickets.select(\n",
+    "    tickets[\"ticket_id\"],\n",
+    "    tickets[\"subject\"],\n",
+    "    categorize_ticket(tickets[\"subject\"]).alias(\"category\"),\n",
+    ")\n",
+    "categorized.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**When to use it**: Your function takes a single row and returns a single value. The logic is pure Python \u2014 no external services, no model weights, no variable-length output. This is the pattern for data cleaning, validation, and field-level transformations.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Pattern 2: Generator \u2014 one input becomes many rows\n",
+    "\n",
+    "**Problem**: Each input row needs to produce a *variable number* of output rows. Splitting a document into chunks, tokenizing text into sentences, expanding nested records. You don't know ahead of time how many outputs each input will produce.\n",
+    "\n",
+    "**Pattern**: `@daft.func` returning `Iterator[T]`. Yield as many rows as the data demands."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Iterator\n",
+    "\n",
+    "\n",
+    "@daft.func\n",
+    "def split_into_sentences(text: str) -> Iterator[str]:\n",
+    "    \"\"\"Split text into sentences. Each sentence becomes its own row.\"\"\"\n",
+    "    import re\n",
+    "    sentences = re.split(r'(?<=[.!?])\\s+', text.strip())\n",
+    "    for sentence in sentences:\n",
+    "        if sentence:\n",
+    "            yield sentence\n",
+    "\n",
+    "\n",
+    "sentences = tickets.select(\n",
+    "    tickets[\"ticket_id\"],\n",
+    "    split_into_sentences(tickets[\"body\"]).alias(\"sentence\"),\n",
+    ")\n",
+    "sentences.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that `ticket_id` is automatically broadcast to match the number of sentences each ticket body produces. No `explode()` needed.\n",
+    "\n",
+    "Here's a more practical example \u2014 chunking text for a RAG pipeline:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@daft.func\n",
+    "def chunk_text(text: str, max_words: int = 20) -> Iterator[str]:\n",
+    "    \"\"\"Split text into word-count-limited chunks for embedding.\"\"\"\n",
+    "    words = text.split()\n",
+    "    for i in range(0, len(words), max_words):\n",
+    "        chunk = \" \".join(words[i:i + max_words])\n",
+    "        yield chunk\n",
+    "\n",
+    "\n",
+    "chunks = tickets.select(\n",
+    "    tickets[\"ticket_id\"],\n",
+    "    chunk_text(tickets[\"body\"]).alias(\"chunk\"),\n",
+    ")\n",
+    "chunks.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**When to use it**: One-to-many transformations. Document chunking for RAG pipelines, audio segmentation, tokenization, expanding nested structures \u2014 anywhere `yield` is the natural way to express \"this input produces N outputs.\" No intermediate lists, no `explode()`, no memory spike from materializing everything at once.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Pattern 3: Async \u2014 hit APIs without waiting in line\n",
+    "\n",
+    "**Problem**: Your function calls an external service \u2014 a webhook, a geocoder, a model endpoint. Sequential execution means each row waits for the previous one to finish. At 10,000 rows, that's hours of idle waiting.\n",
+    "\n",
+    "**Pattern**: `async def` with `@daft.func`. Daft overlaps the I/O automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@daft.func\n",
+    "async def ping_webhook(url: str) -> int:\n",
+    "    \"\"\"Hit a webhook URL and return the HTTP status code.\"\"\"\n",
+    "    import aiohttp\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        async with session.get(url) as resp:\n",
+    "            return resp.status\n",
+    "\n",
+    "\n",
+    "webhook_results = tickets.select(\n",
+    "    tickets[\"ticket_id\"],\n",
+    "    tickets[\"webhook_url\"],\n",
+    "    ping_webhook(tickets[\"webhook_url\"]).alias(\"status_code\"),\n",
+    ")\n",
+    "webhook_results.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You write `async def` and `await` exactly as you would outside Daft. The concurrency is automatic \u2014 no thread pools, no executor boilerplate.\n",
+    "\n",
+    "Here's another example \u2014 looking up ticket categories from an external API:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@daft.func\n",
+    "async def lookup_response_time_sla(category: str) -> str:\n",
+    "    \"\"\"Simulate an async SLA lookup based on ticket category.\n",
+    "    \n",
+    "    In production, this would hit an internal API or database.\n",
+    "    Here we simulate the async I/O with a local mapping.\n",
+    "    \"\"\"\n",
+    "    import asyncio\n",
+    "    # Simulate network latency\n",
+    "    await asyncio.sleep(0.1)\n",
+    "    sla_map = {\n",
+    "        \"bug\": \"4 hours\",\n",
+    "        \"billing\": \"2 hours\",\n",
+    "        \"auth\": \"1 hour\",\n",
+    "        \"feature_request\": \"5 business days\",\n",
+    "        \"general\": \"24 hours\",\n",
+    "    }\n",
+    "    return sla_map.get(category, \"24 hours\")\n",
+    "\n",
+    "\n",
+    "# First categorize, then look up SLAs\n",
+    "with_sla = tickets.select(\n",
+    "    tickets[\"ticket_id\"],\n",
+    "    tickets[\"subject\"],\n",
+    "    categorize_ticket(tickets[\"subject\"]).alias(\"category\"),\n",
+    ").select(\n",
+    "    daft.col(\"ticket_id\"),\n",
+    "    daft.col(\"subject\"),\n",
+    "    daft.col(\"category\"),\n",
+    "    lookup_response_time_sla(daft.col(\"category\")).alias(\"sla\"),\n",
+    ")\n",
+    "with_sla.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**When to use it**: Any I/O-bound workload \u2014 API calls, database lookups, webhook triggers, model endpoints behind a REST API. Write standard `async`/`await` Python. Daft handles the concurrency.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Pattern 4: Stateful \u2014 load a resource once, use it on every row\n",
+    "\n",
+    "**Problem**: Loading an expensive resource for every row (or every batch) is killing your pipeline. A 2 GB model, a database connection pool, an API client with auth \u2014 you need to initialize once and reuse across rows.\n",
+    "\n",
+    "**Pattern**: `@daft.cls` with `__init__` for setup and `__call__` for processing. The resource loads once per worker and stays in memory for every row that worker handles.\n",
+    "\n",
+    "No other distributed data framework has this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@daft.cls\n",
+    "class KeywordExtractor:\n",
+    "    \"\"\"Extract keywords from text using a pre-loaded keyword set.\n",
+    "    \n",
+    "    In production, __init__ would load a model, open a DB connection,\n",
+    "    or authenticate with an API. The key: it runs once per worker.\n",
+    "    \"\"\"\n",
+    "    def __init__(self):\n",
+    "        # This runs ONCE per worker \u2014 not once per row.\n",
+    "        # Imagine loading a spaCy model or a TF-IDF vectorizer here.\n",
+    "        self.keywords = {\n",
+    "            \"urgent\": [\"crash\", \"locked\", \"blocking\", \"immediately\", \"every time\", \"broken\"],\n",
+    "            \"billing\": [\"charged\", \"refund\", \"payment\", \"transaction\", \"invoice\"],\n",
+    "            \"feature\": [\"would love\", \"would be great\", \"add\", \"request\", \"suggestion\"],\n",
+    "            \"data\": [\"export\", \"csv\", \"json\", \"api\", \"raw\", \"download\"],\n",
+    "        }\n",
+    "        print(\"KeywordExtractor initialized (runs once per worker)\")\n",
+    "\n",
+    "    def __call__(self, text: str) -> str:\n",
+    "        \"\"\"This runs on every row, reusing the keyword set from __init__.\"\"\"\n",
+    "        text_lower = text.lower()\n",
+    "        matched = []\n",
+    "        for category, terms in self.keywords.items():\n",
+    "            if any(term in text_lower for term in terms):\n",
+    "                matched.append(category)\n",
+    "        return \", \".join(matched) if matched else \"none\"\n",
+    "\n",
+    "\n",
+    "extractor = KeywordExtractor()\n",
+    "\n",
+    "extracted = tickets.select(\n",
+    "    tickets[\"ticket_id\"],\n",
+    "    tickets[\"subject\"],\n",
+    "    extractor(tickets[\"body\"]).alias(\"matched_categories\"),\n",
+    ")\n",
+    "extracted.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice the print statement \u2014 `\"KeywordExtractor initialized\"` appears once, not five times. That's the point. `__init__` runs once per worker. `__call__` runs on every row.\n",
+    "\n",
+    "In production, this pattern is how you'd load a sentiment model, an embedding model, or any resource that's expensive to initialize:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Production example \u2014 what this pattern looks like with a real model.\n",
+    "# (Not runnable without transformers installed \u2014 shown for illustration.)\n",
+    "#\n",
+    "# @daft.cls(gpus=1)\n",
+    "# class SentimentClassifier:\n",
+    "#     def __init__(self):\n",
+    "#         from transformers import pipeline\n",
+    "#         self.pipe = pipeline(\n",
+    "#             \"sentiment-analysis\",\n",
+    "#             model=\"distilbert-base-uncased-finetuned-sst-2-english\",\n",
+    "#             device=\"cuda\",\n",
+    "#         )\n",
+    "#         # Model loaded once. 2GB stays in GPU memory.\n",
+    "#\n",
+    "#     def __call__(self, text: str) -> str:\n",
+    "#         return self.pipe(text)[0][\"label\"]\n",
+    "#\n",
+    "# classifier = SentimentClassifier()\n",
+    "# df.select(classifier(df[\"text\"]).alias(\"sentiment\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**When to use it**: Any workload with expensive initialization \u2014 model loading, database connection pools, API clients with authentication. `__init__` runs once per worker; `__call__` runs on every row. Add `gpus=1` for GPU allocation, `max_concurrency` to cap parallel instances, `use_process=True` to escape the GIL.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Bonus: Batch processing with `@daft.func.batch`\n",
+    "\n",
+    "When you need to operate on entire columns at once (NumPy vectorization, pandas operations, bulk API calls), use the batch variant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@daft.func.batch(return_dtype=daft.DataType.int64())\n",
+    "def word_count_batch(texts: daft.Series) -> list:\n",
+    "    \"\"\"Count words in each text \u2014 operating on the entire batch at once.\"\"\"\n",
+    "    return [len(text.split()) for text in texts.to_pylist()]\n",
+    "\n",
+    "\n",
+    "word_counts = tickets.select(\n",
+    "    tickets[\"ticket_id\"],\n",
+    "    tickets[\"subject\"],\n",
+    "    word_count_batch(tickets[\"body\"]).alias(\"body_word_count\"),\n",
+    ")\n",
+    "word_counts.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Batch UDFs receive `daft.Series` objects instead of individual values. Use them when your operation benefits from vectorization (NumPy, pandas) or when an external library expects arrays.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Putting It All Together\n",
+    "\n",
+    "Let's build a mini pipeline that chains multiple UDF patterns on our ticket data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pipeline: normalize emails, categorize, extract keywords, count words\n",
+    "\n",
+    "pipeline_result = tickets.select(\n",
+    "    tickets[\"ticket_id\"],\n",
+    "    normalize_email(tickets[\"customer_email\"]).alias(\"email\"),\n",
+    "    tickets[\"subject\"],\n",
+    "    categorize_ticket(tickets[\"subject\"]).alias(\"category\"),\n",
+    "    extractor(tickets[\"body\"]).alias(\"keywords\"),\n",
+    "    word_count_batch(tickets[\"body\"]).alias(\"body_words\"),\n",
+    ")\n",
+    "\n",
+    "pipeline_result.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Row-wise, stateful, and batch UDFs \u2014 all composing in a single `.select()`. This same code runs locally on your laptop or distributed across a Ray cluster. Set `daft.set_runner_ray(\"ray://cluster:10001\")` and nothing else changes.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Pick Your Pattern\n",
+    "\n",
+    "| I need to... | Pattern | Decorator | Example in this notebook |\n",
+    "|---|---|---|---|\n",
+    "| Transform each row with custom logic | Row-wise | `@daft.func` | `normalize_email`, `categorize_ticket` |\n",
+    "| Produce multiple rows from one input | Generator | `@daft.func` + `Iterator[T]` | `split_into_sentences`, `chunk_text` |\n",
+    "| Call external services concurrently | Async | `@daft.func` + `async def` | `ping_webhook`, `lookup_response_time_sla` |\n",
+    "| Reuse expensive resources across rows | Stateful | `@daft.cls` + `__init__` | `KeywordExtractor` |\n",
+    "| Vectorized batch operations | Batch | `@daft.func.batch` | `word_count_batch` |\n",
+    "\n",
+    "Your Python. Daft's scale.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Resources:**\n",
+    "- [`@daft.func` docs](https://docs.daft.ai/en/stable/custom-code/func/)\n",
+    "- [`@daft.cls` docs](https://docs.daft.ai/en/stable/custom-code/cls/)\n",
+    "- [Migration guide](https://docs.daft.ai/en/stable/custom-code/migration/) (if you're on the legacy `@daft.udf` API)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

- Adds `tutorials/udf_patterns/udf_patterns.ipynb` — a self-contained notebook covering all four UDF patterns (row-wise, generator, async, stateful) plus batch, using a support-ticket dataset throughout
- Adds `docs/examples/udf-patterns.md` — the rendered example page with a Google Colab link at the top
- Adds a card to `docs/examples/index.md` for the new example
- Adds a navigation entry to `docs/SUMMARY.md`

## Test plan

- [x] `make docs` — builds successfully
- [x] `make doctests` — 273 passed, 1 skipped
- [x] `make format` — passed
- [x] `make lint` — passed
- [x] `make precommit` — all hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)