### PR TITLE
feat: add dual-send telemetry to osstelemetry.io

### DIFF
--- a/daft/scarf_telemetry.py
+++ b/daft/scarf_telemetry.py
@@ -63,12 +63,26 @@ def _track_on_scarf(
             # Prepare the query string
             query_string = urllib.parse.urlencode(params)
 
-            # Make the GET request
+            # Make the GET request to Scarf
             url = f"https://daft.gateway.scarf.sh/{endpoint}?{query_string}"
             with urllib.request.urlopen(url) as response:
                 response_status = f"Response status: {response.status}"
         except Exception as e:
             response_status = f"Analytics error: {e}"
+
+        # Also send to osstelemetry.io for side-by-side comparison
+        try:
+            ot_params = {
+                "activity_type": endpoint,
+                "package": "daft",
+            }
+            ot_params.update(params)
+            ot_query_string = urllib.parse.urlencode(ot_params)
+            ot_url = f"https://osstelemetry.io/data?{ot_query_string}"
+            with urllib.request.urlopen(ot_url):
+                pass
+        except Exception:
+            pass
 
         result_container["response_status"] = response_status
         result_container["extra_value"] = extra_value

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-To help core developers improve Daft, we collect non-identifiable statistics on Daft usage in order to better understand how Daft is used, common bugs and performance bottlenecks. Data is collected from [Scarf](https://scarf.sh).
+To help core developers improve Daft, we collect non-identifiable statistics on Daft usage in order to better understand how Daft is used, common bugs and performance bottlenecks. Data is collected via [Scarf](https://scarf.sh) and [osstelemetry.io](https://osstelemetry.io).
 
 We take the privacy of our users extremely seriously, and telemetry in Daft is built to be:
 

--- a/tests/test_scarf_telemetry.py
+++ b/tests/test_scarf_telemetry.py
@@ -70,12 +70,19 @@ def test_scarf_telemetry_basic(
     else:
         assert result_container["extra_value"] is None
 
-    # Verify URL format and parameters
-    called_url = mock_urlopen.call_args[0][0]
-    assert called_url.startswith(f"https://daft.gateway.scarf.sh/{endpoint}?")
-    assert "version=0.0.0" in called_url
+    # Verify Scarf URL format and parameters (first call)
+    scarf_url = mock_urlopen.call_args_list[0][0][0]
+    assert scarf_url.startswith(f"https://daft.gateway.scarf.sh/{endpoint}?")
+    assert "version=0.0.0" in scarf_url
     if extra_params and "runner" in extra_params:
-        assert f"runner={extra_params['runner']}" in called_url
+        assert f"runner={extra_params['runner']}" in scarf_url
+
+    # Verify osstelemetry.io URL format and parameters (second call)
+    ot_url = mock_urlopen.call_args_list[1][0][0]
+    assert ot_url.startswith("https://osstelemetry.io/data?")
+    assert f"activity_type={endpoint}" in ot_url
+    assert "package=daft" in ot_url
+    assert "version=0.0.0" in ot_url
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Send telemetry data to osstelemetry.io alongside Scarf for side-by-side comparison during evaluation.

## Changes

- **`daft/scarf_telemetry.py`**: After the existing Scarf GET request, send the same data to `https://osstelemetry.io/data` with `activity_type` (mapped from endpoint name) and `package=daft` as additional params. The osstelemetry.io call is independent - failures are silently caught and do not affect existing Scarf telemetry.
- **`docs/telemetry.md`**: Updated to mention osstelemetry.io alongside Scarf.
- **`tests/test_scarf_telemetry.py`**: Updated `test_scarf_telemetry_basic` to verify both the Scarf URL (first call) and the osstelemetry.io URL (second call) using `call_args_list` instead of `call_args`.

## Request format

The existing Scarf request:
```
GET https://daft.gateway.scarf.sh/daft-import?version=0.3.0&platform=Darwin&python=3.11&arch=arm64
```

The new osstelemetry.io request:
```
GET https://osstelemetry.io/data?activity_type=daft-import&package=daft&version=0.3.0&platform=Darwin&python=3.11&arch=arm64
```

For runner events, both include the `runner` param (e.g. `runner=native` or `runner=ray`):
```
GET https://daft.gateway.scarf.sh/daft-runner?version=0.3.0&platform=Darwin&python=3.11&arch=arm64&runner=native
GET https://osstelemetry.io/data?activity_type=daft-runner&package=daft&version=0.3.0&platform=Darwin&python=3.11&arch=arm64&runner=native
```

## Details

- Opt-out flags (`SCARF_NO_ANALYTICS`, `DO_NOT_TRACK`, `DAFT_ANALYTICS_ENABLED`) apply to both endpoints
- Both calls run in the same daemon thread, so no additional threads are created
- Dev builds still skip all telemetry

## Testing

Tested locally by:
1. Creating a test branch with the dev-build check commented out and both URLs pointed to localhost servers (port 8001 for Scarf, port 8002 for osstelemetry)
2. Running a simple HTTP server that logs all incoming request paths and query params
3. Running `import daft` to trigger the import telemetry event

Both servers received the expected requests:

```
[SCARF] GET /daft-import
  version: 0.3.0-dev0
  platform: Darwin
  python: 3.11
  arch: arm64

[OSSTELEMETRY] GET /data
  activity_type: daft-import
  package: daft
  version: 0.3.0-dev0
  platform: Darwin
  python: 3.11
  arch: arm64
```

