### PR TITLE
fix(io): retry transient errors on initial GET request

### DIFF
--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -381,8 +381,28 @@ impl IOClient {
             });
         }
 
-        let get_result = source
-            .get(path.as_ref(), range.clone(), io_stats.clone())
+        let path: Arc<str> = Arc::from(path.as_ref());
+        let get_result = crate::retry::ExponentialBackoff::default()
+            .retry(|| {
+                let source = source.clone();
+                let path = path.clone();
+                let range = range.clone();
+                let io_stats = io_stats.clone();
+                async move {
+                    source
+                        .get(&path, range, io_stats)
+                        .await
+                        .map_err(|e| match &e {
+                            Error::MiscTransient { .. }
+                            | Error::SocketError { .. }
+                            | Error::ConnectTimeout { .. } => {
+                                log::warn!("Transient error during GET, will retry: {}", &e);
+                                crate::retry::RetryError::Transient(e)
+                            }
+                            _ => crate::retry::RetryError::Permanent(e),
+                        })
+                }
+            })
             .await?;
         Ok(get_result.with_retry(StreamingRetryParams::new(source, input, range, io_stats)))
     }

--- a/src/daft-io/src/mock.rs
+++ b/src/daft-io/src/mock.rs
@@ -16,14 +16,25 @@ mod tests {
         object_io::{LSResult, StreamingRetryParams},
     };
 
+    /// Which error variant the mock should emit on failure.
+    #[derive(Clone)]
+    enum MockFailError {
+        UnableToReadBytes,
+        MiscTransient,
+    }
+
     /// The mocked source used for testing read operations.
     struct MockSource {
         // the object content data
         content: Arc<Vec<u8>>,
         // the object data will be chunked by this value
         chunk_size: usize,
-        // will raise UnableToReadBytes error when accumulated read chunk number of a single request reach this value
+        // will raise an error when accumulated read chunk number of a single request reaches this value
         fail_at_chunk: Option<usize>,
+        // which error to emit on stream failure
+        fail_error: MockFailError,
+        // number of get() calls that should fail before succeeding (simulates dispatch failures)
+        fail_get_remaining: Mutex<usize>,
         // the total received get requests
         requests: Arc<Mutex<Vec<Option<GetRange>>>>,
     }
@@ -34,8 +45,20 @@ mod tests {
                 content: Arc::new(data),
                 chunk_size,
                 fail_at_chunk,
+                fail_error: MockFailError::UnableToReadBytes,
+                fail_get_remaining: Mutex::new(0),
                 requests: Arc::new(Mutex::new(Vec::new())),
             }
+        }
+
+        fn with_fail_error(mut self, err: MockFailError) -> Self {
+            self.fail_error = err;
+            self
+        }
+
+        fn with_fail_get(self, count: usize) -> Self {
+            *self.fail_get_remaining.lock().unwrap() = count;
+            self
         }
 
         fn slice_for_range(&self, range: Option<GetRange>) -> std::ops::Range<usize> {
@@ -60,13 +83,24 @@ mod tests {
             let data = self.content[slice].to_vec();
             let chunk = self.chunk_size;
             let fail_idx = self.fail_at_chunk;
+            let fail_error = self.fail_error.clone();
             let path_owned = path.to_string();
 
             stream! {
                 for (sent_chunks, chunk_data) in data.chunks(chunk).enumerate() {
                     if let Some(fail) = fail_idx
                         && sent_chunks == fail {
-                            yield Err(Error::UnableToReadBytes { path: path_owned.clone(), source: std::io::Error::new(std::io::ErrorKind::Interrupted, "mock fail") });
+                            let err = match fail_error {
+                                MockFailError::UnableToReadBytes => Error::UnableToReadBytes {
+                                    path: path_owned.clone(),
+                                    source: std::io::Error::new(std::io::ErrorKind::Interrupted, "mock fail"),
+                                },
+                                MockFailError::MiscTransient => Error::MiscTransient {
+                                    path: path_owned.clone(),
+                                    source: Box::new(std::io::Error::other("mock transient")),
+                                },
+                            };
+                            yield Err(err);
                             break;
                         }
                     yield Ok(Bytes::copy_from_slice(chunk_data));
@@ -87,6 +121,16 @@ mod tests {
             range: Option<GetRange>,
             _io_stats: Option<IOStatsRef>,
         ) -> Result<GetResult> {
+            {
+                let mut remaining = self.fail_get_remaining.lock().unwrap();
+                if *remaining > 0 {
+                    *remaining -= 1;
+                    return Err(Error::MiscTransient {
+                        path: uri.to_string(),
+                        source: Box::new(std::io::Error::other("mock dispatch failure")),
+                    });
+                }
+            }
             self.requests.lock().unwrap().push(range.clone());
             let s = self.read_data(range, uri);
             Ok(GetResult::Stream(s, Some(self.content.len()), None, None))
@@ -282,5 +326,74 @@ mod tests {
                 Some(GetRange::Offset(0)),
             ]
         );
+    }
+
+    /// Verify that MiscTransient errors during streaming trigger retry (same as SocketError/UnableToReadBytes).
+    #[tokio::test]
+    async fn test_misc_transient_triggers_streaming_retry() {
+        let data: Vec<u8> = (0..16_000u32).flat_map(|v| v.to_le_bytes()).collect();
+        let data_len = data.len();
+        let chunk_size = 4096;
+        let fail_at_chunk = 5;
+        let src = Arc::new(
+            MockSource::new(data.clone(), chunk_size, Some(fail_at_chunk))
+                .with_fail_error(MockFailError::MiscTransient),
+        );
+        let range = Some(GetRange::Bounded(0..data_len));
+        let initial = src.get("mock://path", range.clone(), None).await.unwrap();
+        let wrapped = initial.with_retry(StreamingRetryParams::new(
+            src.clone(),
+            "mock://path".to_string(),
+            range.clone(),
+            None,
+        ));
+        let out = wrapped.bytes().await.unwrap();
+        assert_eq!(out.len(), data.len());
+        assert_eq!(&out[..], &data[..]);
+        // Should have retried: initial request + retries on MiscTransient
+        let requests = src.requests.lock().unwrap().clone();
+        assert!(
+            requests.len() > 1,
+            "expected retry on MiscTransient, got {} requests",
+            requests.len()
+        );
+    }
+
+    /// Verify that transient get() failures are retried by ExponentialBackoff.
+    #[tokio::test]
+    async fn test_transient_get_failure_retried() {
+        use crate::retry::{ExponentialBackoff, RetryError};
+
+        let data: Vec<u8> = (0..4_000u32).flat_map(|v| v.to_le_bytes()).collect();
+        let src: Arc<dyn ObjectSource> = Arc::new(
+            MockSource::new(data.clone(), 4096, None).with_fail_get(2), // fail first 2 get() calls
+        );
+
+        let get_result = ExponentialBackoff {
+            max_tries: 4,
+            jitter_ms: 1,
+            max_backoff_ms: 10,
+            max_waittime_ms: None,
+        }
+        .retry(|| {
+            let source = src.clone();
+            async move {
+                source
+                    .get("mock://path", None, None)
+                    .await
+                    .map_err(|e| match &e {
+                        Error::MiscTransient { .. }
+                        | Error::SocketError { .. }
+                        | Error::ConnectTimeout { .. } => RetryError::Transient(e),
+                        _ => RetryError::Permanent(e),
+                    })
+            }
+        })
+        .await
+        .expect("should succeed after retries");
+
+        let out = get_result.bytes().await.unwrap();
+        assert_eq!(out.len(), data.len());
+        assert_eq!(&out[..], &data[..]);
     }
 }

--- a/src/daft-io/src/object_io.rs
+++ b/src/daft-io/src/object_io.rs
@@ -94,7 +94,8 @@ impl GetResult {
                         Err(
                             super::Error::SocketError { .. }
                             | super::Error::UnableToReadBytes { .. }
-                            | super::Error::UnableToOpenFile { .. },
+                            | super::Error::UnableToOpenFile { .. }
+                            | super::Error::MiscTransient { .. },
                         ) if let Some(rp) = &retry_params => {
                             let jitter =
                                 rand::rng().random_range(0..((1 << (attempt - 1)) * JITTER_MS));
@@ -193,7 +194,8 @@ impl ResumableByteStream {
                         match e {
                             super::Error::SocketError { .. }
                             | super::Error::UnableToReadBytes { .. }
-                            | super::Error::UnableToOpenFile { .. } => {
+                            | super::Error::UnableToOpenFile { .. }
+                            | super::Error::MiscTransient { .. } => {
                                 self.attempt += 1;
                                 if self.attempt > MAX_NUM_TRIES {
                                     yield Err(e);

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -245,6 +245,8 @@ impl From<Error> for super::Error {
             err: E,
         ) -> super::Error {
             match err.code() {
+                // None: S3 returned a service error with no Code element -- observed on AWS
+                // for connection resets / malformed error bodies, which are always transient.
                 Some("InternalError") | None => super::Error::MiscTransient {
                     path,
                     source: err.into(),

--- a/src/daft-io/src/s3_like.rs
+++ b/src/daft-io/src/s3_like.rs
@@ -245,7 +245,7 @@ impl From<Error> for super::Error {
             err: E,
         ) -> super::Error {
             match err.code() {
-                Some("InternalError") => super::Error::MiscTransient {
+                Some("InternalError") | None => super::Error::MiscTransient {
                     path,
                     source: err.into(),
                 },


### PR DESCRIPTION
`MiscTransient` errors from the HTTP client (e.g. hyper `IncompleteMessage` during S3 dispatch) were not retried at either the request or streaming level. When `source.get()` failed in `single_url_get`, the error propagated immediately with no retry. The streaming retry logic in `GetResult::bytes()` and `ResumableByteStream` also excluded `MiscTransient` from the set of retryable errors. This has been the case since `MiscTransient` was added as an error variant -- it was never included in any retry path.

Under load, S3 occasionally drops connections mid-dispatch or returns malformed error responses. The AWS SDK classifies these as `TransientError` internally, but once its own retries are exhausted the error surfaces as `MiscTransientError` in Daft with no further retry attempt. Nothing catches `DaftTransientError` at the runner, scheduler, or Python layer -- the IO layer is the only place retry happens today.

The existing streaming retry (`GetResult::with_retry()` / `ResumableByteStream`) only covers failures that occur *during* byte consumption, after `source.get()` has already succeeded and returned a stream. If the initial `get()` call itself fails (e.g. dispatch failure before any stream exists), there is no `GetResult` to wrap and the error propagates immediately.

## Changes

- Wrap the initial `source.get()` call in `single_url_get` with `ExponentialBackoff::retry()` (4 attempts, exponential backoff with jitter) for `MiscTransient`, `SocketError`, and `ConnectTimeout` errors. This is complementary to the existing streaming retry -- one covers initial request failures, the other covers mid-transfer failures.
- Add `MiscTransient` to both streaming retry match arms in `GetResult::bytes()` and `ResumableByteStream`
- In `classify_unhandled_error`, treat S3 service errors with no error code (`code: None`) as `MiscTransient` rather than `Unhandled` -- an empty error response from S3 is almost certainly transient

## Validation

Tested with a pipeline that bulk-downloads ~50k S3 images and runs MobileNet inference via Ray on a c6a.4xlarge:

| | Result | Batches completed | S3 transient errors |
|---|---|---|---|
| **Before** (daft 0.7.6) | Crashed with \`MiscTransientError\` | 956 / 48.9k (~62 min) | 1 (fatal) |
| **After** (this PR) | Running past 90 min | 1240+ / 49.2k | 113 (all retried) |

As a note, there is a separate related issue where transient IO errors during arrow-rs parquet decoding get wrapped as `DaftError::External` (via `parquet_err()` in `arrowrs_reader.rs`), losing their transient classification. The parquet2 path handled this correctly after PR #3012 by routing `arrow2::Error::Io` to `DaftError::ByteStreamError`. That is not addressed here.