### PR TITLE
fix(ci): use content-hash mtimes to prevent stale cargo cache artifacts

### DIFF
--- a/.github/actions/restore-mtime/action.yaml
+++ b/.github/actions/restore-mtime/action.yaml
@@ -1,55 +1,76 @@
-name: Restore file mtimes from git history
+name: Set file mtimes for cargo caching
 description: >
-  Restore each file's mtime to its last-commit timestamp so that cargo
-  fingerprints remain valid when the target/ directory is cached across
-  CI runs. Requires fetch-depth: 0 on the checkout step.
+  Ensure cargo correctly detects changed files when the target/ directory
+  is cached across CI runs.
+
+  Problem: actions/checkout sets all file mtimes to "now", which is newer
+  than the cached invoked.timestamp, causing cargo to rebuild everything.
+  We need unchanged files to be older than invoked.timestamp (skip) and
+  changed files to be newer (rebuild).
+
+  Approach: hash all source files and compare against saved hashes from
+  the previous cache-save build. Unchanged files get a fixed past
+  timestamp (2020-01-01). Changed files keep the checkout mtime ("now").
+  Since "now" (2026+) > any cached invoked.timestamp > 2020, cargo
+  correctly skips unchanged files and rebuilds changed ones.
+
+  Note: the previous git-commit-timestamp approach was broken because
+  commit timestamps are always in the past relative to the cached
+  invoked.timestamp, so cargo never rebuilt anything from cache.
 runs:
   using: composite
   steps:
-  - name: Restore file mtimes for cargo fingerprinting
+  - name: Set file mtimes for cargo caching
     shell: bash
     run: |
-      # actions/checkout sets all file mtimes to the checkout time, which
-      # invalidates cargo fingerprints and forces a full rebuild even when
-      # the cached target/ dir is restored.
-      #
-      # This pipeline walks the full git history to restore each file's
-      # mtime to its last-commit timestamp so cargo fingerprints match.
-      #
-      # git log outputs commits oldest-first (--reverse), each as:
-      #   <unix timestamp>       (--pretty=%ct: committer date in epoch seconds)
-      #   :<mode info> M\tfile   (--raw: one line per file touched in that commit)
-      #
-      # --no-merges: skips merge commits, whose combined diff omits cleanly
-      #   merged files — regular commits on each branch reliably list all
-      #   files they touched.
-      # --no-renames: prevents git from collapsing renames into a single
-      #   "R old\tnew" line that would break the awk tab parsing.
-      #
-      # awk processes line by line:
-      #   /^[0-9]+$/  — timestamp line: save in variable t
-      #   /^:[0-9]/   — raw diff line: extract filename (everything after
-      #                  the first tab) and map it to t in associative array c.
-      #                  Later commits overwrite earlier ones, so each file
-      #                  ends up with its most recent commit timestamp.
-      #   END         — print all "timestamp\tfilename" pairs.
-      #
-      # while loop reads each pair and touches the file with that timestamp.
-      #   IFS=$'\t'   — split on tab into ts and file
-      #   -r          — don't interpret backslashes in filenames as escapes
-      #   if [ -f ]   — skip files that no longer exist on disk (deletions)
-      #
-      # touch -d "@epoch" is GNU-specific (Linux). macOS/BSD touch doesn't
-      # support -d, so we fall back to touch -t with a formatted timestamp.
-      # Detection uses a temp file because /dev/null is root-owned and
-      # utimensat() requires ownership to change timestamps.
+      # Detect platform
       _tf=$(mktemp)
       if touch -d @0 "$_tf" 2>/dev/null; then
-        touch_epoch() { touch -d "@$1" "$2"; }
+        touch_past() { touch -d @1577836800 "$1"; }  # 2020-01-01
       else
-        touch_epoch() { touch -t "$(date -r "$1" +%Y%m%d%H%M.%S)" "$2"; }
+        touch_past() { touch -t 202001010000.00 "$1"; }
       fi
       rm -f "$_tf"
-      git log --raw --no-renames --no-merges --pretty=%ct --reverse \
-        | awk '/^[0-9]+$/{t=$0;next} /^:[0-9]/{f=substr($0,index($0,"\t")+1); c[f]=t} END{for(f in c) printf "%s\t%s\n",c[f],f}' \
-        | while IFS=$'\t' read -r ts file; do if [ -f "$file" ]; then touch_epoch "$ts" "$file"; fi; done
+
+      if command -v sha256sum >/dev/null 2>&1; then
+        hash_cmd="sha256sum"
+      else
+        hash_cmd="shasum -a 256"
+      fi
+
+      # Hash all build-relevant source files
+      current=$(mktemp)
+      find . -type f \
+        \( -name '*.rs' -o -name '*.toml' -o -name '*.lock' -o -name '*.py' -o -name '*.pyi' \) \
+        -not -path './target/*' \
+        -not -path './.git/*' \
+        -not -path './.venv/*' \
+        -not -path './node_modules/*' \
+        -not -path './.mypy_cache/*' \
+        -print0 \
+      | xargs -0 $hash_cmd | sort > "$current"
+
+      mkdir -p target
+      saved="target/.source-hashes"
+
+      if [ -f "$saved" ]; then
+        # Unchanged files: same hash+path in both builds.
+        # Set them to a fixed past time so cargo skips them.
+        # Changed files keep checkout mtime ("now") -> cargo rebuilds.
+        unchanged=$(mktemp)
+        comm -12 "$saved" "$current" | awk '{print $2}' > "$unchanged"
+
+        total=$(wc -l < "$current" | tr -d ' ')
+        unch=$(wc -l < "$unchanged" | tr -d ' ')
+        while IFS= read -r f; do
+          [ -f "$f" ] && touch_past "$f"
+        done < "$unchanged"
+        rm -f "$unchanged"
+        echo "Cache: $unch unchanged, $((total - unch)) changed files"
+      else
+        echo "No saved hashes (first build or cache miss), full rebuild"
+      fi
+
+      # Save for next cache cycle
+      cp "$current" "$saved"
+      rm -f "$current"

--- a/.github/actions/restore-mtime/action.yaml
+++ b/.github/actions/restore-mtime/action.yaml
@@ -1,22 +1,9 @@
 name: Set file mtimes for cargo caching
 description: >
-  Ensure cargo correctly detects changed files when the target/ directory
-  is cached across CI runs.
-
-  Problem: actions/checkout sets all file mtimes to "now", which is newer
-  than the cached invoked.timestamp, causing cargo to rebuild everything.
-  We need unchanged files to be older than invoked.timestamp (skip) and
-  changed files to be newer (rebuild).
-
-  Approach: hash all source files and compare against saved hashes from
-  the previous cache-save build. Unchanged files get a fixed past
-  timestamp (2020-01-01). Changed files keep the checkout mtime ("now").
-  Since "now" (2026+) > any cached invoked.timestamp > 2020, cargo
-  correctly skips unchanged files and rebuilds changed ones.
-
-  Note: the previous git-commit-timestamp approach was broken because
-  commit timestamps are always in the past relative to the cached
-  invoked.timestamp, so cargo never rebuilt anything from cache.
+  Set stable file mtimes so cargo correctly skips unchanged files and
+  rebuilds changed ones when the target/ directory is cached across CI
+  runs. Compares content hashes against the previous build to distinguish
+  the two cases.
 runs:
   using: composite
   steps:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -43,7 +43,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
@@ -53,6 +52,7 @@ jobs:
         cache-all-crates: "true"
         cache-workspace-crates: "true"
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:

--- a/.github/workflows/daft-profiling.yml
+++ b/.github/workflows/daft-profiling.yml
@@ -24,7 +24,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
@@ -34,6 +33,7 @@ jobs:
         cache-all-crates: "true"
         cache-workspace-crates: "true"
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
 
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7

--- a/.github/workflows/pr-test-suite.yml
+++ b/.github/workflows/pr-test-suite.yml
@@ -124,7 +124,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
@@ -134,6 +133,7 @@ jobs:
         cache-all-crates: "true"
         cache-workspace-crates: "true"
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
     - name: Install cargo-llvm-cov
       if: matrix.coverage != false
       uses: taiki-e/install-action@cargo-llvm-cov
@@ -290,7 +290,6 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -312,6 +311,7 @@ jobs:
         cache-all-crates: "true"
         cache-workspace-crates: "true"
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
     - uses: actions/setup-node@v6
       with:
         node-version: "22"
@@ -1243,7 +1243,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
@@ -1254,6 +1253,7 @@ jobs:
         cache-workspace-crates: "true"
         cache-provider: github
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -1331,8 +1331,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
-      if: ${{ matrix.os != 'Windows' }}
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
@@ -1346,6 +1344,8 @@ jobs:
         cache-all-crates: "true"
         cache-workspace-crates: "true"
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
+      if: ${{ matrix.os != 'Windows' }}
     - name: Free Disk Space (Ubuntu)
       if: ${{ matrix.os == 'ubuntu' }}
       uses: jlumbroso/free-disk-space@main
@@ -1445,7 +1445,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
@@ -1455,6 +1454,7 @@ jobs:
         cache-all-crates: "true"
         cache-workspace-crates: "true"
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -1541,8 +1541,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
-      if: ${{ runner.os != 'Windows' }}
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
@@ -1552,6 +1550,8 @@ jobs:
         cache-all-crates: "true"
         cache-workspace-crates: "true"
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
+      if: ${{ runner.os != 'Windows' }}
 
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
@@ -1641,7 +1641,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
     - name: Setup Python and uv
       uses: astral-sh/setup-uv@v7
       with:
@@ -1661,6 +1660,7 @@ jobs:
         cache-all-crates: "true"
         cache-workspace-crates: "true"
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
 
     - uses: actions/cache@v5
       id: pre-commit-cache

--- a/.github/workflows/property-based-tests.yml
+++ b/.github/workflows/property-based-tests.yml
@@ -24,7 +24,6 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: ./.github/actions/restore-mtime
     - uses: moonrepo/setup-rust@v1
       with:
         cache: false
@@ -34,6 +33,7 @@ jobs:
         cache-all-crates: "true"
         cache-workspace-crates: "true"
         save-if: ${{ github.ref == 'refs/heads/main' }}
+    - uses: ./.github/actions/restore-mtime
 
     - name: Setup Python ${{ matrix.python-version  }} and UV
       uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
The `restore-mtime` action was causing CI builds to use stale cached cargo artifacts, leading to compilation errors like `no variant or associated item named 'RandomShuffle' found for enum 'NodeType'` on PR #6481.

Cargo checks freshness by asking "is any source file newer than my `invoked.timestamp`?" The old `restore-mtime` set source files to their git commit timestamps, which are always in the past relative to the cached `invoked.timestamp` (whose mtime is the build time that created the cache). So both unchanged AND changed files looked "older" than the cached artifacts, and cargo never triggered rebuilds - even when file content differed between the cache-save build and the current checkout.

To fix this, `restore-mtime` now uses content hashing instead of git timestamps. It hashes all source files via `sha256sum` and compares against saved hashes from the previous cache build (stored in `target/.source-hashes`, included in the `Swatinem/rust-cache` archive automatically). Unchanged files (same hash) get a fixed past timestamp (2020-01-01), guaranteed older than any `invoked.timestamp`. Changed files keep the checkout mtime ("now"), guaranteed newer. This gives cargo the correct signal for both cases.

Also purged the existing GitHub Actions Rust build caches to clear stale artifacts.