### PR TITLE
refactor: consolidate BatchManager as single buffer abstraction

### DIFF
--- a/src/daft-local-execution/src/batch_manager.rs
+++ b/src/daft-local-execution/src/batch_manager.rs
@@ -1,0 +1,466 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use common_error::DaftResult;
+use daft_micropartition::MicroPartition;
+use parking_lot::Mutex;
+
+use crate::{
+    buffer::RowBasedBuffer,
+    dynamic_batching::{BatchingState, BatchingStrategy},
+    pipeline::{InputId, MorselSizeRequirement},
+    runtime_stats::RuntimeStats,
+};
+
+struct InputBuffer {
+    buffer: RowBasedBuffer,
+    active_workers: usize,
+    pending_flush: bool,
+}
+
+/// Manages per-input buffering and batch extraction for pipeline operators.
+///
+/// `BatchManager` is the single abstraction for getting data in and out of an operator's
+/// input buffers. It owns per-input `RowBasedBuffer`s, tracks worker and flush lifecycle,
+/// and delegates batch extraction to a pluggable `BatchingStrategy`.
+///
+/// # Usage
+/// ```rust,ignore
+/// let mut manager = BatchManager::new(strategy);
+///
+/// // Data in
+/// manager.push(input_id, partition);
+///
+/// // Data out (strategy-controlled, flush-aware)
+/// while let Some(batch) = manager.next_batch(input_id)? {
+///     manager.increment_workers(input_id);
+///     // spawn worker with batch...
+/// }
+///
+/// // Worker completes
+/// manager.record_completion(stats, batch_size, duration);
+/// manager.decrement_workers(input_id);
+/// ```
+pub struct BatchManager<S: BatchingStrategy> {
+    state: Arc<Mutex<S::State>>,
+    pub(crate) strategy: S,
+    inputs: HashMap<InputId, InputBuffer>,
+    current_requirements: MorselSizeRequirement,
+}
+
+impl<S> BatchManager<S>
+where
+    S: BatchingStrategy + 'static,
+    S::State: 'static,
+{
+    /// Creates a new `BatchManager` with the given batching strategy.
+    /// Initializes strategy state and sets initial batch size requirements.
+    pub fn new(strategy: S) -> Self {
+        let state = strategy.make_state();
+        let current_requirements = strategy.initial_requirements();
+        let state = Arc::new(Mutex::new(state));
+
+        Self {
+            state,
+            strategy,
+            inputs: HashMap::new(),
+            current_requirements,
+        }
+    }
+
+    /// Computes current batch size requirements from the strategy.
+    /// Used by streaming sink which manages its own buffers separately.
+    /// TODO: Migrate streaming sink to use the consolidated API (push/next_batch/record_completion)
+    /// so this can be removed.
+    pub fn calculate_batch_size(&self) -> MorselSizeRequirement {
+        let mut state = self.state.lock();
+        self.strategy.calculate_new_requirements(&mut state)
+    }
+
+    /// Records execution metrics without recalculating requirements.
+    /// Used by streaming sink which manages its own buffers separately.
+    /// TODO: Migrate streaming sink to use the consolidated API (push/next_batch/record_completion)
+    /// so this can be removed.
+    pub fn record_execution_stats(
+        &self,
+        stats: &dyn RuntimeStats,
+        batch_size: usize,
+        duration: Duration,
+    ) {
+        let mut state = self.state.lock();
+        state.record_execution_stat(stats, batch_size, duration);
+    }
+
+    /// Buffers an incoming partition for the given input. Creates the input's
+    /// buffer on first push, sized according to the current batch requirements.
+    pub fn push(&mut self, input_id: InputId, partition: MicroPartition) {
+        let input = self.inputs.entry(input_id).or_insert_with(|| {
+            let (lower, upper) = self.current_requirements.values();
+            InputBuffer {
+                buffer: RowBasedBuffer::new(lower, upper),
+                active_workers: 0,
+                pending_flush: false,
+            }
+        });
+        input.buffer.push(partition);
+    }
+
+    /// Extracts the next batch for the given input by delegating to the
+    /// batching strategy. Returns `None` when the buffer doesn't have enough
+    /// data to form a batch. During flush, drains any remaining buffered data
+    /// regardless of batch size requirements.
+    pub fn next_batch(&mut self, input_id: InputId) -> DaftResult<Option<MicroPartition>> {
+        let input = self
+            .inputs
+            .get_mut(&input_id)
+            .expect("Input should be present");
+        input.buffer.update_bounds(self.current_requirements);
+        let mut state = self.state.lock();
+        let batch = self.strategy.next_batch(&mut state, &mut input.buffer)?;
+        drop(state);
+        match batch {
+            Some(b) => Ok(Some(b)),
+            None if input.pending_flush => input.buffer.pop_all(),
+            None => Ok(None),
+        }
+    }
+
+    /// Marks that a worker task has been spawned for this input.
+    /// Must be paired with a later `decrement_workers` call when the worker completes.
+    /// The in-flight count prevents premature flush propagation.
+    pub fn increment_workers(&mut self, input_id: InputId) {
+        self.inputs
+            .get_mut(&input_id)
+            .expect("Input should be present")
+            .active_workers += 1;
+    }
+
+    /// Marks that a worker task for this input has completed.
+    pub fn decrement_workers(&mut self, input_id: InputId) {
+        self.inputs
+            .get_mut(&input_id)
+            .expect("Input should be present")
+            .active_workers -= 1;
+    }
+
+    /// Records execution metrics from a completed worker and recalculates
+    /// batch size requirements. The updated requirements are applied lazily
+    /// on the next `next_batch` call.
+    pub fn record_completion(
+        &mut self,
+        stats: &dyn RuntimeStats,
+        batch_size: usize,
+        duration: Duration,
+    ) {
+        let mut state = self.state.lock();
+        state.record_execution_stat(stats, batch_size, duration);
+        self.current_requirements = self.strategy.calculate_new_requirements(&mut state);
+    }
+
+    /// Signals that the given input has finished sending data. `next_batch`
+    /// will drain remaining buffered data, and `can_flush` will return true
+    /// once the buffer is empty and all workers have completed.
+    pub fn set_pending_flush(&mut self, input_id: InputId) {
+        if let Some(input) = self.inputs.get_mut(&input_id) {
+            input.pending_flush = true;
+        }
+    }
+
+    /// Returns true when the input is ready to propagate a flush downstream:
+    /// flush has been requested, all workers have completed, and the buffer is empty.
+    pub fn can_flush(&self, input_id: InputId) -> bool {
+        self.inputs.get(&input_id).is_some_and(|input| {
+            input.pending_flush && input.active_workers == 0 && input.buffer.is_empty()
+        })
+    }
+
+    /// Removes all state for the given input. Called after flush has been propagated.
+    pub fn remove_input(&mut self, input_id: InputId) {
+        self.inputs.remove(&input_id);
+    }
+
+    /// Returns true if the given input has been seen (via `push`).
+    pub fn has_input(&self, input_id: InputId) -> bool {
+        self.inputs.contains_key(&input_id)
+    }
+
+    /// Returns an iterator over all active input IDs.
+    pub fn input_ids(&self) -> impl Iterator<Item = InputId> + '_ {
+        self.inputs.keys().copied()
+    }
+
+    /// Signals flush for all active inputs. Used when the input channel closes.
+    pub fn set_all_pending_flush(&mut self) {
+        for input in self.inputs.values_mut() {
+            input.pending_flush = true;
+        }
+    }
+
+    #[cfg(test)]
+    pub fn initial_requirements(&self) -> MorselSizeRequirement {
+        self.strategy.initial_requirements()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        num::NonZeroUsize,
+        sync::atomic::{AtomicUsize, Ordering},
+        time::Duration,
+    };
+
+    use common_metrics::{Meter, ops::NodeInfo};
+
+    use super::*;
+    use crate::{dynamic_batching::StaticBatchingStrategy, runtime_stats::RuntimeStats};
+
+    pub(crate) struct MockRuntimeStats;
+    impl RuntimeStats for MockRuntimeStats {
+        fn new(_meter: &Meter, _node_info: &NodeInfo) -> Self {
+            Self {}
+        }
+
+        fn build_snapshot(
+            &self,
+            _ordering: std::sync::atomic::Ordering,
+        ) -> common_metrics::StatSnapshot {
+            unimplemented!()
+        }
+
+        fn add_rows_in(&self, _rows: u64) {
+            unimplemented!()
+        }
+
+        fn add_rows_out(&self, _rows: u64) {
+            unimplemented!()
+        }
+
+        fn add_duration_us(&self, _cpu_us: u64) {
+            unimplemented!()
+        }
+    }
+
+    struct MockBatchingState {
+        measurement_count: usize,
+    }
+
+    impl BatchingState for MockBatchingState {
+        fn record_execution_stat(
+            &mut self,
+            _stats: &dyn RuntimeStats,
+            _batch_size: usize,
+            _duration: Duration,
+        ) {
+            self.measurement_count += 1;
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct MockBatchingStrategy {
+        call_counter: Arc<AtomicUsize>,
+        initial_req: MorselSizeRequirement,
+    }
+
+    impl MockBatchingStrategy {
+        fn new(initial_req: MorselSizeRequirement) -> Self {
+            Self {
+                call_counter: Arc::new(AtomicUsize::new(0)),
+                initial_req,
+            }
+        }
+
+        fn call_count(&self) -> usize {
+            self.call_counter.load(Ordering::SeqCst)
+        }
+    }
+
+    impl BatchingStrategy for MockBatchingStrategy {
+        type State = MockBatchingState;
+
+        fn make_state(&self) -> Self::State {
+            MockBatchingState {
+                measurement_count: 0,
+            }
+        }
+
+        fn initial_requirements(&self) -> MorselSizeRequirement {
+            self.initial_req
+        }
+
+        fn calculate_new_requirements(&self, state: &mut Self::State) -> MorselSizeRequirement {
+            self.call_counter.fetch_add(1, Ordering::SeqCst);
+
+            match state.measurement_count {
+                0 => self.initial_req,
+                1 => MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap()),
+                2..=5 => MorselSizeRequirement::Flexible(5, NonZeroUsize::new(20).unwrap()),
+                _ => MorselSizeRequirement::Flexible(10, NonZeroUsize::new(50).unwrap()),
+            }
+        }
+    }
+
+    #[test]
+    fn test_batch_manager_creation() {
+        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
+            1,
+            NonZeroUsize::new(32).unwrap(),
+        ));
+        let manager = BatchManager::new(strategy.clone());
+
+        assert_eq!(
+            manager.initial_requirements(),
+            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(32).unwrap())
+        );
+        assert_eq!(strategy.call_count(), 0);
+    }
+
+    #[test]
+    fn test_batch_manager_calculate_no_measurements() {
+        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
+            2,
+            NonZeroUsize::new(64).unwrap(),
+        ));
+        let manager = BatchManager::new(strategy.clone());
+
+        let req = manager.calculate_batch_size();
+        assert_eq!(
+            req,
+            MorselSizeRequirement::Flexible(2, NonZeroUsize::new(64).unwrap())
+        );
+        assert_eq!(strategy.call_count(), 1);
+    }
+
+    #[test]
+    fn test_batch_manager_record_and_calculate() {
+        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
+            1,
+            NonZeroUsize::new(16).unwrap(),
+        ));
+        let manager = BatchManager::new(strategy.clone());
+
+        manager.record_execution_stats(
+            Arc::new(MockRuntimeStats).as_ref(),
+            32,
+            Duration::from_millis(100),
+        );
+
+        let req = manager.calculate_batch_size();
+        assert_eq!(
+            req,
+            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap())
+        );
+        assert_eq!(strategy.call_count(), 1);
+    }
+
+    #[test]
+    fn test_batch_manager_multiple_measurements() {
+        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
+            1,
+            NonZeroUsize::new(8).unwrap(),
+        ));
+        let manager = BatchManager::new(strategy.clone());
+
+        manager.record_execution_stats(
+            Arc::new(MockRuntimeStats).as_ref(),
+            10,
+            Duration::from_millis(50),
+        );
+        manager.record_execution_stats(
+            Arc::new(MockRuntimeStats).as_ref(),
+            20,
+            Duration::from_millis(75),
+        );
+
+        let req = manager.calculate_batch_size();
+        assert_eq!(
+            req,
+            MorselSizeRequirement::Flexible(5, NonZeroUsize::new(20).unwrap())
+        );
+        assert_eq!(strategy.call_count(), 1);
+    }
+
+    #[test]
+    fn test_batch_manager_multiple_calculations() {
+        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
+            1,
+            NonZeroUsize::new(4).unwrap(),
+        ));
+        let manager = BatchManager::new(strategy.clone());
+
+        manager.record_execution_stats(
+            Arc::new(MockRuntimeStats).as_ref(),
+            5,
+            Duration::from_millis(25),
+        );
+
+        let req1 = manager.calculate_batch_size();
+        assert_eq!(
+            req1,
+            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap())
+        );
+        assert_eq!(strategy.call_count(), 1);
+
+        let req2 = manager.calculate_batch_size();
+        assert_eq!(
+            req2,
+            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap())
+        );
+        assert_eq!(strategy.call_count(), 2);
+    }
+
+    #[test]
+    fn test_batch_manager_accumulates_measurements() {
+        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
+            2,
+            NonZeroUsize::new(8).unwrap(),
+        ));
+        let manager = BatchManager::new(strategy.clone());
+
+        manager.record_execution_stats(
+            Arc::new(MockRuntimeStats).as_ref(),
+            10,
+            Duration::from_millis(30),
+        );
+        let req1 = manager.calculate_batch_size();
+        assert_eq!(
+            req1,
+            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap())
+        );
+
+        manager.record_execution_stats(
+            Arc::new(MockRuntimeStats).as_ref(),
+            15,
+            Duration::from_millis(40),
+        );
+        manager.record_execution_stats(
+            Arc::new(MockRuntimeStats).as_ref(),
+            20,
+            Duration::from_millis(60),
+        );
+        let req2 = manager.calculate_batch_size();
+        assert_eq!(
+            req2,
+            MorselSizeRequirement::Flexible(5, NonZeroUsize::new(20).unwrap())
+        );
+
+        assert_eq!(strategy.call_count(), 2);
+    }
+
+    #[test]
+    fn test_batch_manager_with_static_strategy() {
+        let static_req = MorselSizeRequirement::Flexible(16, NonZeroUsize::new(128).unwrap());
+        let strategy = StaticBatchingStrategy::new(static_req);
+        let manager = BatchManager::new(strategy);
+
+        assert_eq!(manager.initial_requirements(), static_req);
+
+        manager.record_execution_stats(
+            Arc::new(MockRuntimeStats).as_ref(),
+            64,
+            Duration::from_millis(200),
+        );
+
+        let req = manager.calculate_batch_size();
+        assert_eq!(req, static_req);
+    }
+}

--- a/src/daft-local-execution/src/batch_manager.rs
+++ b/src/daft-local-execution/src/batch_manager.rs
@@ -13,14 +13,13 @@ use crate::{
 
 struct InputBuffer {
     buffer: RowBasedBuffer,
-    active_workers: usize,
     pending_flush: bool,
 }
 
 /// Manages per-input buffering and batch extraction for pipeline operators.
 ///
 /// `BatchManager` is the single abstraction for getting data in and out of an operator's
-/// input buffers. It owns per-input `RowBasedBuffer`s, tracks worker and flush lifecycle,
+/// input buffers. It owns per-input `RowBasedBuffer`s, manages flush lifecycle,
 /// and delegates batch extraction to a pluggable `BatchingStrategy`.
 ///
 /// # Usage
@@ -32,15 +31,16 @@ struct InputBuffer {
 ///
 /// // Data out (strategy-controlled, flush-aware)
 /// while let Some(batch) = manager.next_batch(input_id)? {
-///     manager.increment_workers(input_id);
 ///     // spawn worker with batch...
 /// }
 ///
 /// // Worker completes
 /// manager.record_completion(stats, batch_size, duration);
-/// manager.decrement_workers(input_id);
 /// ```
 pub struct BatchManager<S: BatchingStrategy> {
+    // TODO: Remove Arc<Mutex<>> once streaming sink is migrated to the consolidated API.
+    // Only needed because the legacy &self methods (calculate_batch_size/record_execution_stats)
+    // require interior mutability. The consolidated &mut self methods don't need it.
     state: Arc<Mutex<S::State>>,
     pub(crate) strategy: S,
     inputs: HashMap<InputId, InputBuffer>,
@@ -97,7 +97,6 @@ where
             let (lower, upper) = self.current_requirements.values();
             InputBuffer {
                 buffer: RowBasedBuffer::new(lower, upper),
-                active_workers: 0,
                 pending_flush: false,
             }
         });
@@ -114,32 +113,16 @@ where
             .get_mut(&input_id)
             .expect("Input should be present");
         input.buffer.update_bounds(self.current_requirements);
-        let mut state = self.state.lock();
-        let batch = self.strategy.next_batch(&mut state, &mut input.buffer)?;
-        drop(state);
+
+        let batch = {
+            let mut state = self.state.lock();
+            self.strategy.next_batch(&mut state, &mut input.buffer)?
+        };
         match batch {
             Some(b) => Ok(Some(b)),
             None if input.pending_flush => input.buffer.pop_all(),
             None => Ok(None),
         }
-    }
-
-    /// Marks that a worker task has been spawned for this input.
-    /// Must be paired with a later `decrement_workers` call when the worker completes.
-    /// The in-flight count prevents premature flush propagation.
-    pub fn increment_workers(&mut self, input_id: InputId) {
-        self.inputs
-            .get_mut(&input_id)
-            .expect("Input should be present")
-            .active_workers += 1;
-    }
-
-    /// Marks that a worker task for this input has completed.
-    pub fn decrement_workers(&mut self, input_id: InputId) {
-        self.inputs
-            .get_mut(&input_id)
-            .expect("Input should be present")
-            .active_workers -= 1;
     }
 
     /// Records execution metrics from a completed worker and recalculates
@@ -158,24 +141,31 @@ where
 
     /// Signals that the given input has finished sending data. `next_batch`
     /// will drain remaining buffered data, and `can_flush` will return true
-    /// once the buffer is empty and all workers have completed.
+    /// once the buffer is empty.
     pub fn set_pending_flush(&mut self, input_id: InputId) {
         if let Some(input) = self.inputs.get_mut(&input_id) {
             input.pending_flush = true;
         }
     }
 
-    /// Returns true when the input is ready to propagate a flush downstream:
-    /// flush has been requested, all workers have completed, and the buffer is empty.
+    /// Returns true when the input's buffer is fully drained after a flush signal.
+    /// The caller must separately verify that all in-flight workers have completed
+    /// before propagating the flush downstream.
     pub fn can_flush(&self, input_id: InputId) -> bool {
-        self.inputs.get(&input_id).is_some_and(|input| {
-            input.pending_flush && input.active_workers == 0 && input.buffer.is_empty()
-        })
+        self.inputs
+            .get(&input_id)
+            .is_some_and(|input| input.pending_flush && input.buffer.is_empty())
     }
 
-    /// Removes all state for the given input. Called after flush has been propagated.
-    pub fn remove_input(&mut self, input_id: InputId) {
-        self.inputs.remove(&input_id);
+    /// Removes the input and returns any remaining buffered data.
+    /// If the input was fully drained (e.g. after `can_flush` returned true),
+    /// this returns `Ok(None)`.
+    pub fn drain(&mut self, input_id: InputId) -> DaftResult<Option<MicroPartition>> {
+        if let Some(mut input) = self.inputs.remove(&input_id) {
+            input.buffer.pop_all()
+        } else {
+            Ok(None)
+        }
     }
 
     /// Returns true if the given input has been seen (via `push`).

--- a/src/daft-local-execution/src/buffer.rs
+++ b/src/daft-local-execution/src/buffer.rs
@@ -20,6 +20,7 @@ pub struct RowBasedBuffer {
     upper_bound: NonZeroUsize,
 }
 
+#[allow(unused)]
 impl RowBasedBuffer {
     pub fn new(lower_bound: usize, upper_bound: NonZeroUsize) -> Self {
         assert!(
@@ -53,9 +54,34 @@ impl RowBasedBuffer {
         self.buffer.push_back(part);
     }
 
-    // Check if the buffer is empty
     pub fn is_empty(&self) -> bool {
         self.buffer.is_empty()
+    }
+
+    pub fn partitions(&self) -> &VecDeque<MicroPartition> {
+        &self.buffer
+    }
+
+    pub fn total_rows(&self) -> usize {
+        self.curr_len
+    }
+
+    pub fn take_rows(&mut self, n: usize) -> DaftResult<Option<MicroPartition>> {
+        if n == 0 || self.buffer.is_empty() {
+            return Ok(None);
+        }
+        let taken = std::mem::take(&mut self.buffer);
+        let concated = MicroPartition::concat(taken)?;
+        if n >= concated.len() {
+            self.curr_len = 0;
+            Ok(Some(concated))
+        } else {
+            let batch = concated.slice(0, n)?;
+            let remainder = concated.slice(n, concated.len())?;
+            self.curr_len = remainder.len();
+            self.buffer.push_back(remainder);
+            Ok(Some(batch))
+        }
     }
 
     fn buffer_state(&self) -> BufferState {
@@ -213,6 +239,63 @@ mod tests {
         buffer.push(MicroPartition::empty(None));
         assert!(buffer.pop_all()?.is_some());
         assert!(buffer.pop_all()?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_take_rows_exact() -> DaftResult<()> {
+        let mut buffer = RowBasedBuffer::new(0, NonZeroUsize::new(100).unwrap());
+        buffer.push(make_dummy_mp(10));
+        let batch = buffer.take_rows(10)?.unwrap();
+        assert_eq!(batch.len(), 10);
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.total_rows(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_take_rows_partial() -> DaftResult<()> {
+        let mut buffer = RowBasedBuffer::new(0, NonZeroUsize::new(100).unwrap());
+        buffer.push(make_dummy_mp(20));
+        let batch = buffer.take_rows(8)?.unwrap();
+        assert_eq!(batch.len(), 8);
+        assert_eq!(buffer.total_rows(), 12);
+        Ok(())
+    }
+
+    #[test]
+    fn test_take_rows_more_than_available() -> DaftResult<()> {
+        let mut buffer = RowBasedBuffer::new(0, NonZeroUsize::new(100).unwrap());
+        buffer.push(make_dummy_mp(5));
+        let batch = buffer.take_rows(50)?.unwrap();
+        assert_eq!(batch.len(), 5);
+        assert!(buffer.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn test_take_rows_empty_buffer() -> DaftResult<()> {
+        let mut buffer = RowBasedBuffer::new(0, NonZeroUsize::new(100).unwrap());
+        assert!(buffer.take_rows(10)?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_take_rows_zero() -> DaftResult<()> {
+        let mut buffer = RowBasedBuffer::new(0, NonZeroUsize::new(100).unwrap());
+        buffer.push(make_dummy_mp(10));
+        assert!(buffer.take_rows(0)?.is_none());
+        assert_eq!(buffer.total_rows(), 10);
+        Ok(())
+    }
+
+    #[test]
+    fn test_partitions_peek() -> DaftResult<()> {
+        let mut buffer = RowBasedBuffer::new(0, NonZeroUsize::new(100).unwrap());
+        buffer.push(make_dummy_mp(5));
+        buffer.push(make_dummy_mp(10));
+        assert_eq!(buffer.partitions().len(), 2);
+        assert_eq!(buffer.total_rows(), 15);
         Ok(())
     }
 }

--- a/src/daft-local-execution/src/dynamic_batching/dyn_strategy.rs
+++ b/src/daft-local-execution/src/dynamic_batching/dyn_strategy.rs
@@ -3,15 +3,23 @@ use std::{
     time::Duration,
 };
 
+use common_error::DaftResult;
+use daft_micropartition::MicroPartition;
+
 use crate::{
+    buffer::RowBasedBuffer,
     dynamic_batching::{BatchingState, BatchingStrategy},
     pipeline::MorselSizeRequirement,
     runtime_stats::RuntimeStats,
 };
+
+#[allow(clippy::type_complexity)]
+#[allow(clippy::struct_field_names)]
 pub struct DynBatchingState {
-    #[allow(clippy::type_complexity)]
     record_fn: Box<dyn FnMut(&dyn RuntimeStats, usize, Duration) + Send + Sync>,
     update_fn: Box<dyn FnMut() -> MorselSizeRequirement + Send + Sync>,
+    next_batch_fn:
+        Box<dyn FnMut(&mut RowBasedBuffer) -> DaftResult<Option<MicroPartition>> + Send + Sync>,
 }
 
 impl BatchingState for DynBatchingState {
@@ -54,11 +62,12 @@ impl DynBatchingStrategy {
             make_state_fn: Box::new(move || {
                 let state = strategy.make_state();
                 let strategy_clone = strategy.clone();
+                let strategy_for_next = strategy.clone();
 
-                // Use Arc<Mutex<>> to share state between closures
                 let shared_state = Arc::new(Mutex::new(state));
                 let state_for_record = shared_state.clone();
-                let state_for_update = shared_state;
+                let state_for_update = shared_state.clone();
+                let state_for_next = shared_state;
 
                 DynBatchingState {
                     record_fn: Box::new(move |stats, batch_size, duration| {
@@ -70,6 +79,10 @@ impl DynBatchingStrategy {
                     update_fn: Box::new(move || {
                         let mut state_guard = state_for_update.lock().unwrap();
                         strategy_clone.calculate_new_requirements(&mut *state_guard)
+                    }),
+                    next_batch_fn: Box::new(move |buffer| {
+                        let mut state_guard = state_for_next.lock().unwrap();
+                        strategy_for_next.next_batch(&mut *state_guard, buffer)
                     }),
                 }
             }),
@@ -98,6 +111,14 @@ impl BatchingStrategy for DynBatchingStrategy {
 
     fn initial_requirements(&self) -> MorselSizeRequirement {
         self.initial_req
+    }
+
+    fn next_batch(
+        &self,
+        state: &mut Self::State,
+        buffer: &mut RowBasedBuffer,
+    ) -> DaftResult<Option<MicroPartition>> {
+        (state.next_batch_fn)(buffer)
     }
 }
 #[cfg(test)]

--- a/src/daft-local-execution/src/dynamic_batching/latency_constrained_strategy.rs
+++ b/src/daft-local-execution/src/dynamic_batching/latency_constrained_strategy.rs
@@ -280,8 +280,32 @@ impl BatchingStrategy for LatencyConstrainedBatchingStrategy {
 mod tests {
     use std::{sync::Arc, time::Duration};
 
+    use common_metrics::{Meter, ops::NodeInfo};
+
     use super::*;
-    use crate::{dynamic_batching::tests::MockRuntimeStats, runtime_stats::RuntimeStats};
+    use crate::runtime_stats::RuntimeStats;
+
+    struct MockRuntimeStats;
+    impl RuntimeStats for MockRuntimeStats {
+        fn new(_meter: &Meter, _node_info: &NodeInfo) -> Self {
+            Self {}
+        }
+        fn build_snapshot(
+            &self,
+            _ordering: std::sync::atomic::Ordering,
+        ) -> common_metrics::StatSnapshot {
+            unimplemented!()
+        }
+        fn add_rows_in(&self, _rows: u64) {
+            unimplemented!()
+        }
+        fn add_rows_out(&self, _rows: u64) {
+            unimplemented!()
+        }
+        fn add_duration_us(&self, _cpu_us: u64) {
+            unimplemented!()
+        }
+    }
 
     fn create_strategy() -> LatencyConstrainedBatchingStrategy {
         LatencyConstrainedBatchingStrategy {

--- a/src/daft-local-execution/src/dynamic_batching/mod.rs
+++ b/src/daft-local-execution/src/dynamic_batching/mod.rs
@@ -1,379 +1,75 @@
 mod dyn_strategy;
 mod latency_constrained_strategy;
 mod static_strategy;
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
+use common_error::DaftResult;
+use daft_micropartition::MicroPartition;
 pub use dyn_strategy::*;
 pub use latency_constrained_strategy::*;
-use parking_lot::Mutex;
 pub use static_strategy::*;
 
-use crate::{pipeline::MorselSizeRequirement, runtime_stats::RuntimeStats};
+use crate::{buffer::RowBasedBuffer, pipeline::MorselSizeRequirement, runtime_stats::RuntimeStats};
 
-/// Trait for algorithms that dynamically adjust batch sizes based on execution performance.
-///
-/// Dynamic batching is a technique used to optimize throughput and latency by adjusting
-/// the number of items processed together in a batch based on runtime performance metrics.
-/// Different algorithms use various strategies to find the optimal batch size.
 #[cfg(not(debug_assertions))]
 pub trait BatchingStrategy: Send + Sync {
     type State: BatchingState + Send + Sync + Unpin;
     fn make_state(&self) -> Self::State;
-    /// adjust the batch size based on runtime performance metrics
     fn calculate_new_requirements(&self, state: &mut Self::State) -> MorselSizeRequirement;
-
     fn initial_requirements(&self) -> MorselSizeRequirement;
+
+    fn next_batch(
+        &self,
+        _state: &mut Self::State,
+        buffer: &mut RowBasedBuffer,
+    ) -> DaftResult<Option<MicroPartition>> {
+        buffer.next_batch_if_ready()
+    }
 }
 
+/// Pluggable strategy that controls how batches are sized and extracted.
+///
+/// `BatchManager` calls these methods to decide batch size requirements and to
+/// extract batches from per-input buffers. The default `next_batch` implementation
+/// uses row-count-based extraction via `RowBasedBuffer::next_batch_if_ready`.
+/// Data-aware strategies (e.g. explode) can override `next_batch` to inspect
+/// buffer contents and call `buffer.take_rows(n)` with a precisely computed count.
+///
+/// Bounds are applied to the buffer by `BatchManager` before `next_batch` is called,
+/// so strategies that use the default extraction don't need to manage bounds themselves.
 #[cfg(debug_assertions)]
 pub trait BatchingStrategy: Send + Sync + std::fmt::Debug {
     type State: BatchingState + Send + Sync + Unpin;
+
+    /// Creates a new instance of strategy-specific state.
     fn make_state(&self) -> Self::State;
+
+    /// Recalculates batch size requirements based on accumulated execution metrics.
+    /// Called by `BatchManager::record_completion` after each worker finishes.
     fn calculate_new_requirements(&self, state: &mut Self::State) -> MorselSizeRequirement;
+
+    /// Returns the batch size requirements to use before any execution metrics are available.
     fn initial_requirements(&self) -> MorselSizeRequirement;
+
+    /// Extracts the next batch from the buffer. The buffer's bounds have already been
+    /// updated by `BatchManager` before this is called. Override this for data-aware
+    /// strategies that need to inspect buffer contents to determine batch boundaries.
+    fn next_batch(
+        &self,
+        _state: &mut Self::State,
+        buffer: &mut RowBasedBuffer,
+    ) -> DaftResult<Option<MicroPartition>> {
+        buffer.next_batch_if_ready()
+    }
 }
 
+/// Accumulator for execution metrics that the strategy uses to adjust batch sizes.
 pub trait BatchingState {
+    /// Records metrics from a single completed batch execution.
     fn record_execution_stat(
         &mut self,
         stats: &dyn RuntimeStats,
         batch_size: usize,
         duration: Duration,
     );
-}
-
-/// Manages dynamic batch sizing by collecting execution metrics and adjusting
-/// batch requirements using pluggable batching strategies.
-///
-/// Reports are collected asynchronously in the background, and batch size
-/// calculations are performed lazily when `calculate_batch_size()` is called.
-/// This allows workers to report metrics without blocking while the dispatcher
-/// gets updated requirements on-demand.
-///
-/// # Usage
-/// ```rust,ignore
-/// let manager = BatchManager::new(strategy);
-///
-/// manager.record_execution_stats(stats, batch_size, duration);
-///
-/// let requirements = manager.calculate_batch_size();
-/// ```
-pub struct BatchManager<S: BatchingStrategy> {
-    state: Arc<Mutex<S::State>>,
-    pub(crate) strategy: S,
-}
-
-impl<S> BatchManager<S>
-where
-    S: BatchingStrategy + 'static,
-    S::State: 'static,
-{
-    pub fn new(strategy: S) -> Self {
-        let state = strategy.make_state();
-        let state = Arc::new(Mutex::new(state));
-
-        Self { state, strategy }
-    }
-    /// Processes pending execution reports and returns updated batch size requirements.
-    ///
-    /// This method triggers lazy evaluation - it processes all reports collected since
-    /// the last call and updates the internal requirements accordingly. If no new reports
-    /// are available, returns the current cached requirements.
-    pub fn calculate_batch_size(&self) -> MorselSizeRequirement {
-        let mut state = self.state.lock();
-        self.strategy.calculate_new_requirements(&mut state)
-    }
-
-    /// Records execution metrics for a processed batch.
-    ///
-    /// Sends the execution stats asynchronously to a background task for later processing.
-    /// This method is non-blocking and designed to be called frequently by workers.
-    pub fn record_execution_stats(
-        &self,
-        stats: &dyn RuntimeStats,
-        batch_size: usize,
-        duration: Duration,
-    ) {
-        let mut state = self.state.lock();
-        state.record_execution_stat(stats, batch_size, duration);
-    }
-
-    #[cfg(test)]
-    pub fn initial_requirements(&self) -> MorselSizeRequirement {
-        self.strategy.initial_requirements()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{
-        num::NonZeroUsize,
-        sync::atomic::{AtomicUsize, Ordering},
-        time::Duration,
-    };
-
-    use common_metrics::{Meter, ops::NodeInfo};
-
-    use super::*;
-    use crate::runtime_stats::RuntimeStats;
-
-    // Mock RuntimeStats for testing
-    pub(crate) struct MockRuntimeStats;
-    impl RuntimeStats for MockRuntimeStats {
-        fn new(_meter: &Meter, _node_info: &NodeInfo) -> Self {
-            Self {}
-        }
-
-        fn build_snapshot(
-            &self,
-            _ordering: std::sync::atomic::Ordering,
-        ) -> common_metrics::StatSnapshot {
-            unimplemented!()
-        }
-
-        fn add_rows_in(&self, _rows: u64) {
-            unimplemented!()
-        }
-
-        fn add_rows_out(&self, _rows: u64) {
-            unimplemented!()
-        }
-
-        fn add_duration_us(&self, _cpu_us: u64) {
-            unimplemented!()
-        }
-    }
-
-    // Mock state that tracks measurements
-    struct MockBatchingState {
-        measurement_count: usize,
-    }
-
-    impl BatchingState for MockBatchingState {
-        fn record_execution_stat(
-            &mut self,
-            _stats: &dyn RuntimeStats,
-            _batch_size: usize,
-            _duration: Duration,
-        ) {
-            self.measurement_count += 1;
-        }
-    }
-
-    // Mock strategy that tracks calls and returns different requirements
-    #[derive(Clone, Debug)]
-    struct MockBatchingStrategy {
-        call_counter: Arc<AtomicUsize>,
-        initial_req: MorselSizeRequirement,
-    }
-
-    impl MockBatchingStrategy {
-        fn new(initial_req: MorselSizeRequirement) -> Self {
-            Self {
-                call_counter: Arc::new(AtomicUsize::new(0)),
-                initial_req,
-            }
-        }
-
-        fn call_count(&self) -> usize {
-            self.call_counter.load(Ordering::SeqCst)
-        }
-    }
-
-    impl BatchingStrategy for MockBatchingStrategy {
-        type State = MockBatchingState;
-
-        fn make_state(&self) -> Self::State {
-            MockBatchingState {
-                measurement_count: 0,
-            }
-        }
-
-        fn initial_requirements(&self) -> MorselSizeRequirement {
-            self.initial_req
-        }
-
-        fn calculate_new_requirements(&self, state: &mut Self::State) -> MorselSizeRequirement {
-            self.call_counter.fetch_add(1, Ordering::SeqCst);
-
-            // Return different requirements based on number of measurements recorded
-            match state.measurement_count {
-                0 => self.initial_req,
-                1 => MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap()),
-                2..=5 => MorselSizeRequirement::Flexible(5, NonZeroUsize::new(20).unwrap()),
-                _ => MorselSizeRequirement::Flexible(10, NonZeroUsize::new(50).unwrap()),
-            }
-        }
-    }
-
-    #[test]
-    fn test_batch_manager_creation() {
-        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
-            1,
-            NonZeroUsize::new(32).unwrap(),
-        ));
-        let manager = BatchManager::new(strategy.clone());
-
-        assert_eq!(
-            manager.initial_requirements(),
-            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(32).unwrap())
-        );
-        assert_eq!(strategy.call_count(), 0); // No calculations yet
-    }
-
-    #[test]
-    fn test_batch_manager_calculate_no_measurements() {
-        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
-            2,
-            NonZeroUsize::new(64).unwrap(),
-        ));
-        let manager = BatchManager::new(strategy.clone());
-
-        let req = manager.calculate_batch_size();
-        assert_eq!(
-            req,
-            MorselSizeRequirement::Flexible(2, NonZeroUsize::new(64).unwrap())
-        ); // Should return initial
-        assert_eq!(strategy.call_count(), 1); // calculate_new_requirements is always called
-    }
-
-    #[test]
-    fn test_batch_manager_record_and_calculate() {
-        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
-            1,
-            NonZeroUsize::new(16).unwrap(),
-        ));
-        let manager = BatchManager::new(strategy.clone());
-
-        // Record some execution stats
-        manager.record_execution_stats(
-            Arc::new(MockRuntimeStats).as_ref(),
-            32,
-            Duration::from_millis(100),
-        );
-
-        let req = manager.calculate_batch_size();
-        assert_eq!(
-            req,
-            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap())
-        ); // First state transition
-        assert_eq!(strategy.call_count(), 1);
-    }
-
-    #[test]
-    fn test_batch_manager_multiple_measurements() {
-        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
-            1,
-            NonZeroUsize::new(8).unwrap(),
-        ));
-        let manager = BatchManager::new(strategy.clone());
-
-        // Record multiple stats
-        manager.record_execution_stats(
-            Arc::new(MockRuntimeStats).as_ref(),
-            10,
-            Duration::from_millis(50),
-        );
-        manager.record_execution_stats(
-            Arc::new(MockRuntimeStats).as_ref(),
-            20,
-            Duration::from_millis(75),
-        );
-
-        let req = manager.calculate_batch_size();
-        assert_eq!(
-            req,
-            MorselSizeRequirement::Flexible(5, NonZeroUsize::new(20).unwrap())
-        ); // 2 measurements processed
-        assert_eq!(strategy.call_count(), 1);
-    }
-
-    #[test]
-    fn test_batch_manager_multiple_calculations() {
-        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
-            1,
-            NonZeroUsize::new(4).unwrap(),
-        ));
-        let manager = BatchManager::new(strategy.clone());
-
-        manager.record_execution_stats(
-            Arc::new(MockRuntimeStats).as_ref(),
-            5,
-            Duration::from_millis(25),
-        );
-
-        let req1 = manager.calculate_batch_size();
-        assert_eq!(
-            req1,
-            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap())
-        );
-        assert_eq!(strategy.call_count(), 1);
-
-        // Second call should trigger calculation again
-        let req2 = manager.calculate_batch_size();
-        assert_eq!(
-            req2,
-            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap())
-        ); // Same result since no new measurements
-        assert_eq!(strategy.call_count(), 2); // Called again
-    }
-
-    #[test]
-    fn test_batch_manager_accumulates_measurements() {
-        let strategy = MockBatchingStrategy::new(MorselSizeRequirement::Flexible(
-            2,
-            NonZeroUsize::new(8).unwrap(),
-        ));
-        let manager = BatchManager::new(strategy.clone());
-
-        // First measurement
-        manager.record_execution_stats(
-            Arc::new(MockRuntimeStats).as_ref(),
-            10,
-            Duration::from_millis(30),
-        );
-        let req1 = manager.calculate_batch_size();
-        assert_eq!(
-            req1,
-            MorselSizeRequirement::Flexible(1, NonZeroUsize::new(10).unwrap())
-        );
-
-        // More measurements
-        manager.record_execution_stats(
-            Arc::new(MockRuntimeStats).as_ref(),
-            15,
-            Duration::from_millis(40),
-        );
-        manager.record_execution_stats(
-            Arc::new(MockRuntimeStats).as_ref(),
-            20,
-            Duration::from_millis(60),
-        );
-        let req2 = manager.calculate_batch_size();
-        assert_eq!(
-            req2,
-            MorselSizeRequirement::Flexible(5, NonZeroUsize::new(20).unwrap())
-        ); // 3 total measurements
-
-        assert_eq!(strategy.call_count(), 2);
-    }
-
-    #[test]
-    fn test_batch_manager_with_static_strategy() {
-        let static_req = MorselSizeRequirement::Flexible(16, NonZeroUsize::new(128).unwrap());
-        let strategy = StaticBatchingStrategy::new(static_req);
-        let manager = BatchManager::new(strategy);
-
-        assert_eq!(manager.initial_requirements(), static_req);
-
-        // Even after recording stats, static strategy should return same requirement
-        manager.record_execution_stats(
-            Arc::new(MockRuntimeStats).as_ref(),
-            64,
-            Duration::from_millis(200),
-        );
-
-        let req = manager.calculate_batch_size();
-        assert_eq!(req, static_req);
-    }
 }

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -90,6 +90,7 @@ struct ExecutionContext<Op: IntermediateOperator> {
     operator_states: Vec<Op::State>,
     output_sender: Sender<PipelineMessage>,
     batch_manager: BatchManager<Op::BatchingStrategy>,
+    active_workers: HashMap<InputId, usize>,
     per_input_stats: HashMap<InputId, Arc<Op::Stats>>,
     stats_manager: RuntimeStatsManagerHandle,
     meter: Meter,
@@ -116,7 +117,7 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
             let Some(batch) = self.batch_manager.next_batch(input_id)? else {
                 break;
             };
-            self.batch_manager.increment_workers(input_id);
+            *self.active_workers.entry(input_id).or_insert(0) += 1;
             let state = self.operator_states.pop().unwrap();
             let op = self.op.clone();
             let task_spawner = self.task_spawner.clone();
@@ -151,8 +152,10 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
     }
 
     async fn try_flush_input(&mut self, input_id: InputId) -> DaftResult<ControlFlow<(), ()>> {
-        if self.batch_manager.can_flush(input_id) {
-            self.batch_manager.remove_input(input_id);
+        let workers_idle = self.active_workers.get(&input_id).copied().unwrap_or(0) == 0;
+        if workers_idle && self.batch_manager.can_flush(input_id) {
+            _ = self.batch_manager.drain(input_id)?;
+            self.active_workers.remove(&input_id);
             self.per_input_stats.remove(&input_id);
             if self
                 .output_sender
@@ -195,7 +198,7 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
             return Ok(ControlFlow::Break(()));
         }
 
-        self.batch_manager.decrement_workers(input_id);
+        *self.active_workers.get_mut(&input_id).unwrap() -= 1;
         self.operator_states.push(state);
         self.try_dispatch()?;
         self.try_flush_input(input_id).await
@@ -422,6 +425,7 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
                     operator_states,
                     output_sender: destination_sender,
                     batch_manager,
+                    active_workers: HashMap::new(),
                     per_input_stats: HashMap::new(),
                     stats_manager: stats_manager.clone(),
                     meter,

--- a/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
+++ b/src/daft-local-execution/src/intermediate_ops/intermediate_op.rs
@@ -20,9 +20,9 @@ use tracing::info_span;
 
 use crate::{
     ExecutionRuntimeContext, ExecutionTaskSpawner, OperatorOutput, PipelineExecutionSnafu,
-    buffer::RowBasedBuffer,
+    batch_manager::BatchManager,
     channel::{Receiver, Sender, create_channel},
-    dynamic_batching::{BatchManager, BatchingStrategy},
+    dynamic_batching::BatchingStrategy,
     pipeline::{
         BuilderContext, InputId, MorselSizeRequirement, NodeName, PipelineEvent, PipelineMessage,
         PipelineNode, next_event,
@@ -83,38 +83,14 @@ struct WorkerResult<Op: IntermediateOperator> {
     elapsed: Duration,
 }
 
-struct InputState {
-    buffer: RowBasedBuffer,
-    active_workers: usize,
-    pending_flush: bool,
-}
-
-impl InputState {
-    fn can_flush(&self) -> bool {
-        self.pending_flush && self.active_workers == 0 && self.buffer.is_empty()
-    }
-
-    fn next_batch_if_ready(&mut self) -> DaftResult<Option<MicroPartition>> {
-        let batch = self.buffer.next_batch_if_ready()?;
-        if batch.is_some() {
-            Ok(batch)
-        } else if self.pending_flush {
-            self.buffer.pop_all()
-        } else {
-            Ok(None)
-        }
-    }
-}
-
 struct ExecutionContext<Op: IntermediateOperator> {
     op: Arc<Op>,
     task_spawner: ExecutionTaskSpawner,
     task_set: OrderingAwareJoinSet<DaftResult<WorkerResult<Op>>>,
     operator_states: Vec<Op::State>,
     output_sender: Sender<PipelineMessage>,
-    batch_manager: Arc<BatchManager<Op::BatchingStrategy>>,
+    batch_manager: BatchManager<Op::BatchingStrategy>,
     per_input_stats: HashMap<InputId, Arc<Op::Stats>>,
-    input_states: HashMap<InputId, InputState>,
     stats_manager: RuntimeStatsManagerHandle,
     meter: Meter,
     node_info: Arc<NodeInfo>,
@@ -137,17 +113,10 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
 
     fn dispatch_ready_batches(&mut self, input_id: InputId) -> DaftResult<()> {
         while !self.operator_states.is_empty() {
-            let batch = {
-                let input = self
-                    .input_states
-                    .get_mut(&input_id)
-                    .expect("Input should be present");
-                let Some(batch) = input.next_batch_if_ready()? else {
-                    break;
-                };
-                input.active_workers += 1;
-                batch
+            let Some(batch) = self.batch_manager.next_batch(input_id)? else {
+                break;
             };
+            self.batch_manager.increment_workers(input_id);
             let state = self.operator_states.pop().unwrap();
             let op = self.op.clone();
             let task_spawner = self.task_spawner.clone();
@@ -170,7 +139,7 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
     }
 
     fn try_dispatch(&mut self) -> DaftResult<()> {
-        let mut input_ids: Vec<InputId> = self.input_states.keys().copied().collect();
+        let mut input_ids: Vec<InputId> = self.batch_manager.input_ids().collect();
         input_ids.sort_unstable();
         for input_id in input_ids {
             if self.operator_states.is_empty() {
@@ -182,12 +151,8 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
     }
 
     async fn try_flush_input(&mut self, input_id: InputId) -> DaftResult<ControlFlow<(), ()>> {
-        let input_state = self
-            .input_states
-            .get_mut(&input_id)
-            .expect("Input should be present");
-        if input_state.can_flush() {
-            self.input_states.remove(&input_id);
+        if self.batch_manager.can_flush(input_id) {
+            self.batch_manager.remove_input(input_id);
             self.per_input_stats.remove(&input_id);
             if self
                 .output_sender
@@ -215,7 +180,7 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
         let runtime_stats = self.get_or_create_stats(input_id);
         runtime_stats.add_duration_us(elapsed.as_micros() as u64);
         self.batch_manager
-            .record_execution_stats(runtime_stats.as_ref(), result.len(), elapsed);
+            .record_completion(runtime_stats.as_ref(), result.len(), elapsed);
         runtime_stats.add_rows_out(result.len() as u64);
 
         if self
@@ -230,12 +195,7 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
             return Ok(ControlFlow::Break(()));
         }
 
-        let new_requirements = self.batch_manager.calculate_batch_size();
-        for input in self.input_states.values_mut() {
-            input.buffer.update_bounds(new_requirements);
-        }
-
-        self.input_states.get_mut(&input_id).unwrap().active_workers -= 1;
+        self.batch_manager.decrement_workers(input_id);
         self.operator_states.push(state);
         self.try_dispatch()?;
         self.try_flush_input(input_id).await
@@ -266,37 +226,26 @@ impl<Op: IntermediateOperator + 'static> ExecutionContext<Op> {
                     }
                     self.get_or_create_stats(input_id)
                         .add_rows_in(partition.len() as u64);
-                    let (lower, upper) = self.batch_manager.calculate_batch_size().values();
-                    let input = self
-                        .input_states
-                        .entry(input_id)
-                        .or_insert_with(|| InputState {
-                            buffer: RowBasedBuffer::new(lower, upper),
-                            active_workers: 0,
-                            pending_flush: false,
-                        });
-                    input.buffer.push(partition);
+                    self.batch_manager.push(input_id, partition);
                     self.try_dispatch()?;
                     ControlFlow::Continue(())
                 }
                 PipelineEvent::Flush(input_id) => {
-                    let Some(input) = self.input_states.get_mut(&input_id) else {
+                    if !self.batch_manager.has_input(input_id) {
                         let _ = self
                             .output_sender
                             .send(PipelineMessage::Flush(input_id))
                             .await;
                         return Ok(());
-                    };
-                    input.pending_flush = true;
+                    }
+                    self.batch_manager.set_pending_flush(input_id);
                     self.try_dispatch()?;
                     self.try_flush_input(input_id).await?
                 }
                 PipelineEvent::InputClosed => {
-                    for input_state in self.input_states.values_mut() {
-                        input_state.pending_flush = true;
-                    }
+                    self.batch_manager.set_all_pending_flush();
                     self.try_dispatch()?;
-                    let mut input_ids: Vec<InputId> = self.input_states.keys().copied().collect();
+                    let mut input_ids: Vec<InputId> = self.batch_manager.input_ids().collect();
                     input_ids.sort_unstable();
                     let mut cf = ControlFlow::Continue(());
                     for input_id in input_ids {
@@ -461,11 +410,10 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
                 let operator_states: Vec<Op::State> =
                     (0..op.max_concurrency()).map(|_| op.make_state()).collect();
 
-                let batch_manager = Arc::new(BatchManager::new(op.batching_strategy().context(
-                    PipelineExecutionSnafu {
+                let batch_manager =
+                    BatchManager::new(op.batching_strategy().context(PipelineExecutionSnafu {
                         node_name: op.name().to_string(),
-                    },
-                )?));
+                    })?);
 
                 let mut ctx = ExecutionContext {
                     op,
@@ -475,7 +423,6 @@ impl<Op: IntermediateOperator + 'static> PipelineNode for IntermediateNode<Op> {
                     output_sender: destination_sender,
                     batch_manager,
                     per_input_stats: HashMap::new(),
-                    input_states: HashMap::new(),
                     stats_manager: stats_manager.clone(),
                     meter,
                     node_info,

--- a/src/daft-local-execution/src/lib.rs
+++ b/src/daft-local-execution/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(associated_type_defaults)]
 
+mod batch_manager;
 mod buffer;
 mod channel;
 mod concat;

--- a/src/daft-local-execution/src/streaming_sink/base.rs
+++ b/src/daft-local-execution/src/streaming_sink/base.rs
@@ -18,9 +18,10 @@ use tracing::info_span;
 
 use crate::{
     ExecutionRuntimeContext, ExecutionTaskSpawner, OperatorOutput,
+    batch_manager::BatchManager,
     buffer::RowBasedBuffer,
     channel::{Receiver, Sender, create_channel},
-    dynamic_batching::{BatchManager, BatchingStrategy},
+    dynamic_batching::BatchingStrategy,
     pipeline::{
         BuilderContext, InputId, MorselSizeRequirement, NodeName, PipelineEvent, PipelineMessage,
         PipelineNode, next_event,


### PR DESCRIPTION
BatchManager now owns per-input buffers, worker tracking, and flush lifecycle — replacing the previous three-abstraction coordination between RowBasedBuffer, InputState, and BatchManager.

This enables future data-aware batching strategies (e.g. explode expansion-aware batching) to override `next_batch` on BatchingStrategy and directly inspect/extract from the buffer.

Key changes:
- BatchManager absorbs InputState (removed) and manages per-input RowBasedBuffer internally
- Add `next_batch` to BatchingStrategy trait with default row-count impl
- ExecutionContext dispatch loop goes through BatchManager exclusively
- Remove the broadcast loop that eagerly updated all buffer bounds
- Requirements applied lazily inside BatchManager::next_batch
- Add RowBasedBuffer::take_rows/partitions/total_rows for future data-aware strategies
- Move BatchManager to its own module (batch_manager.rs), leaving dynamic_batching/ for strategy traits and implementations

## Changes Made

<!-- Describe what changes were made and why. Include implementation details if necessary. -->

## Related Issues

<!-- Link to related GitHub issues, e.g., "Closes #123" -->
