### PR TITLE
fix(recordbatch): Cast should not change input argument name.

### DIFF
--- a/src/daft-recordbatch/src/lib.rs
+++ b/src/daft-recordbatch/src/lib.rs
@@ -760,7 +760,8 @@ impl RecordBatch {
                     metrics,
                 )
                 .await?
-                .cast(dtype),
+                .cast(dtype)
+                .map(|s| s.rename(expected_field.name.clone())),
             Expr::Column(Column::Bound(BoundColumn { index, .. })) => {
                 Ok(self.columns[*index].as_materialized_series().clone())
             }
@@ -1151,7 +1152,8 @@ impl RecordBatch {
             )),
             Expr::Cast(child, dtype) => self
                 .eval_expression_internal(&BoundExpr::new_unchecked(child.clone()), metrics)?
-                .cast(dtype),
+                .cast(dtype)
+                .map(|s| s.rename(expected_field.name.clone())),
             Expr::Column(Column::Bound(BoundColumn { index, .. })) => {
                 Ok(self.columns[*index].as_materialized_series().clone())
             }

--- a/tests/sql/test_sql.py
+++ b/tests/sql/test_sql.py
@@ -339,6 +339,21 @@ def test_cast_image():
     assert actual.schema()["img"].dtype == DataType.image("RGB")
 
 
+def test_cast_fixed_shape_image_preserves_column_name():
+    data = [
+        np.arange(12, dtype=np.uint8).reshape((2, 2, 3)),
+        np.arange(12, 24, dtype=np.uint8).reshape((2, 2, 3)),
+        None,
+    ]
+    s = Series.from_pylist(data, dtype=DataType.python())
+    df = daft.from_pydict({"frame": s})
+
+    actual = daft.sql("select cast(frame as image(RGB, 2, 2)) from df", **{"df": df}).collect()
+
+    assert actual.schema().column_names() == ["frame"]
+    assert actual.schema()["frame"].dtype == DataType.image("RGB", 2, 2)
+
+
 def test_count_pushdown(capsys):
     data = [
         {"id_spec": 1, "age": "2020-01-15", "tags": ["a", "b"]},


### PR DESCRIPTION
## Problem
In image-related cast paths, `cast` may produce an internal output name (`data`) instead of preserving the logical expression/column name (for example `frame`), which can trigger expression-name mismatch errors.

## Root Cause
In record batch expression evaluation, the `Expr::Cast` branch returns the raw cast result without normalizing its name back to the inferred expected field name.

## Solution
For both async and sync expression evaluators, update `Expr::Cast` to rename the cast result to `expected_field.name`.

## Tests
- `make build`
- `DAFT_RUNNER=native make test EXTRA_ARGS="-v tests/sql/test_sql.py -k 'cast_image or cast_fixed_shape_image_preserves_column_name'"`

## Impact
This keeps cast output naming stable for logical expression semantics (including fixed-shape image casts) while limiting behavior change to the cast branch only.
