### PR TITLE
fix(dashboard): use smart per-node stats aggregation for distributed execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,7 +2541,6 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "smallvec",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/src/daft-distributed/Cargo.toml
+++ b/src/daft-distributed/Cargo.toml
@@ -14,7 +14,6 @@ daft-context = {path = "../daft-context", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-functions = {path = "../daft-functions", default-features = false}
 daft-io = {path = "../daft-io", default-features = false}
-smallvec = "1.11"
 daft-local-plan = {path = "../daft-local-plan", default-features = false}
 daft-logical-plan = {path = "../daft-logical-plan", default-features = false}
 daft-scan = {path = "../daft-scan", default-features = false}

--- a/src/daft-distributed/src/python/dashboard.rs
+++ b/src/daft-distributed/src/python/dashboard.rs
@@ -48,30 +48,17 @@ impl StatisticsSubscriber for DashboardStatisticsSubscriber {
         }
 
         // Track started operators
-        match event {
-            TaskEvent::Submitted {
-                context: task_ctx, ..
-            } => {
-                let mut started = self.started_operators.lock().unwrap();
-                for node_id in &task_ctx.node_ids {
-                    let node_id = *node_id as usize;
-                    if !started.contains(&node_id) {
-                        started.insert(node_id);
-                    }
+        if let TaskEvent::Submitted {
+            context: task_ctx, ..
+        } = event
+        {
+            let mut started = self.started_operators.lock().unwrap();
+            for node_id in &task_ctx.node_ids {
+                let node_id = *node_id as usize;
+                if !started.contains(&node_id) {
+                    started.insert(node_id);
                 }
             }
-            TaskEvent::Completed {
-                context: task_ctx, ..
-            } => {
-                let mut started = self.started_operators.lock().unwrap();
-                for node_id in &task_ctx.node_ids {
-                    let node_id = *node_id as usize;
-                    if !started.contains(&node_id) {
-                        started.insert(node_id);
-                    }
-                }
-            }
-            _ => {}
         }
 
         // Initialize dashboard subscriber if needed

--- a/src/daft-distributed/src/python/dashboard.rs
+++ b/src/daft-distributed/src/python/dashboard.rs
@@ -4,16 +4,17 @@ use std::{
 };
 
 use common_error::DaftResult;
-use common_metrics::{
-    DURATION_KEY, QueryID, ROWS_IN_KEY, ROWS_OUT_KEY, Stat, Stats, snapshot::StatSnapshotImpl,
-};
+use common_metrics::{QueryID, snapshot::StatSnapshotImpl};
 use daft_context::get_context;
 
-use crate::statistics::{StatisticsSubscriber, TaskEvent};
+use crate::{
+    pipeline_node::NodeID,
+    statistics::{StatisticsSubscriber, TaskEvent, stats::RuntimeNodeManager},
+};
 
 pub struct DashboardStatisticsSubscriber {
     query_id: QueryID,
-    operator_stats: Mutex<HashMap<usize, HashMap<Arc<str>, Stat>>>,
+    runtime_node_managers: Option<Arc<HashMap<NodeID, RuntimeNodeManager>>>,
     started_operators: Mutex<HashSet<usize>>,
     initialized_subscriber: Mutex<bool>,
 }
@@ -22,7 +23,7 @@ impl DashboardStatisticsSubscriber {
     pub fn new(query_id: QueryID) -> Self {
         Self {
             query_id,
-            operator_stats: Mutex::new(HashMap::new()),
+            runtime_node_managers: None,
             started_operators: Mutex::new(HashSet::new()),
             initialized_subscriber: Mutex::new(false),
         }
@@ -30,6 +31,10 @@ impl DashboardStatisticsSubscriber {
 }
 
 impl StatisticsSubscriber for DashboardStatisticsSubscriber {
+    fn set_runtime_node_managers(&mut self, managers: Arc<HashMap<NodeID, RuntimeNodeManager>>) {
+        self.runtime_node_managers = Some(managers);
+    }
+
     fn handle_event(&mut self, event: &TaskEvent) -> DaftResult<()> {
         // Skip all dashboard functionality when RAY_DISABLE_DASHBOARD=1
         if std::env::var("RAY_DISABLE_DASHBOARD").as_deref() == Ok("1") {
@@ -42,7 +47,7 @@ impl StatisticsSubscriber for DashboardStatisticsSubscriber {
             return Ok(());
         }
 
-        // Accumulate statistics first
+        // Track started operators
         match event {
             TaskEvent::Submitted {
                 context: task_ctx, ..
@@ -55,46 +60,18 @@ impl StatisticsSubscriber for DashboardStatisticsSubscriber {
                     }
                 }
             }
-            TaskEvent::Completed { stats, .. } => {
-                let mut accumulated = self.operator_stats.lock().unwrap();
+            TaskEvent::Completed {
+                context: task_ctx, ..
+            } => {
                 let mut started = self.started_operators.lock().unwrap();
-
-                for (node_info, task_stats) in &stats.nodes {
-                    let node_id = node_info.id;
+                for node_id in &task_ctx.node_ids {
+                    let node_id = *node_id as usize;
                     if !started.contains(&node_id) {
                         started.insert(node_id);
                     }
-
-                    let entry = accumulated.entry(node_id).or_default();
-                    let task_stats = task_stats.to_stats();
-                    for (key, stat) in &task_stats.0 {
-                        let mapped_key = match key.as_ref() {
-                            "rows_in" => ROWS_IN_KEY,
-                            "rows_out" => ROWS_OUT_KEY,
-                            "duration_us" => DURATION_KEY,
-                            _ => key.as_ref(),
-                        };
-                        let arc_key: Arc<str> = Arc::from(mapped_key);
-                        match entry.entry(arc_key) {
-                            std::collections::hash_map::Entry::Occupied(mut e) => {
-                                let current_stat = e.get_mut();
-                                match (current_stat, stat) {
-                                    (Stat::Count(c1), Stat::Count(c2)) => *c1 += *c2,
-                                    (Stat::Bytes(b1), Stat::Bytes(b2)) => *b1 += *b2,
-                                    (Stat::Duration(d1), Stat::Duration(d2)) => *d1 += *d2,
-                                    _ => {}
-                                }
-                            }
-                            std::collections::hash_map::Entry::Vacant(e) => {
-                                e.insert(stat.clone());
-                            }
-                        }
-                    }
                 }
             }
-            _ => {
-                // Only process submitted and completed events for now
-            }
+            _ => {}
         }
 
         // Initialize dashboard subscriber if needed
@@ -136,7 +113,6 @@ impl StatisticsSubscriber for DashboardStatisticsSubscriber {
                 };
 
                 for node_id in node_ids_to_notify {
-                    // Handle notifications non-blockingly
                     if let Err(e) =
                         context.notify_exec_operator_start(self.query_id.clone(), node_id)
                     {
@@ -145,33 +121,26 @@ impl StatisticsSubscriber for DashboardStatisticsSubscriber {
                 }
             }
             TaskEvent::Completed { .. } => {
-                // Send accumulated statistics to dashboard
-                let all_stats = {
-                    let accumulated = self.operator_stats.lock().unwrap();
-                    accumulated
-                        .iter()
-                        .map(|(node_id, stats)| {
-                            let snapshot = Stats(
-                                stats
-                                    .iter()
-                                    .map(|(k, v)| (k.clone(), v.clone()))
-                                    .collect::<smallvec::SmallVec<[(Arc<str>, Stat); 3]>>(),
-                            );
-                            (*node_id, snapshot)
+                // Read smart-aggregated stats from RuntimeNodeManagers
+                // (already updated by StatisticsManager before this subscriber runs)
+                if let Some(managers) = &self.runtime_node_managers {
+                    let all_stats = managers
+                        .values()
+                        .map(|mgr| {
+                            let (info, snapshot) = mgr.export_snapshot();
+                            (info.node_origin_id, snapshot.to_stats())
                         })
-                        .collect::<Vec<(usize, Stats)>>()
-                };
+                        .collect::<Vec<_>>();
 
-                // Send the stats notification
-                if !all_stats.is_empty()
-                    && let Err(e) = context.notify_exec_emit_stats(self.query_id.clone(), all_stats)
-                {
-                    tracing::error!("Failed to notify exec emit stats: {}", e);
+                    if !all_stats.is_empty()
+                        && let Err(e) =
+                            context.notify_exec_emit_stats(self.query_id.clone(), all_stats)
+                    {
+                        tracing::error!("Failed to notify exec emit stats: {}", e);
+                    }
                 }
             }
-            _ => {
-                // For now, we only emit notifications for submitted and completed events
-            }
+            _ => {}
         }
         Ok(())
     }

--- a/src/daft-distributed/src/python/dashboard.rs
+++ b/src/daft-distributed/src/python/dashboard.rs
@@ -107,21 +107,29 @@ impl StatisticsSubscriber for DashboardStatisticsSubscriber {
                     }
                 }
             }
-            TaskEvent::Completed { .. } => {
+            TaskEvent::Completed {
+                context: task_ctx,
+                stats: _,
+            } => {
                 // Read smart-aggregated stats from RuntimeNodeManagers
                 // (already updated by StatisticsManager before this subscriber runs)
                 if let Some(managers) = &self.runtime_node_managers {
-                    let all_stats = managers
+                    // managers give us stats for all operators, but just notify for the
+                    // ones that did something according to this TaskCompleted event
+                    let relevant_stats = managers
                         .values()
                         .map(|mgr| {
                             let (info, snapshot) = mgr.export_snapshot();
                             (info.node_origin_id, snapshot.to_stats())
                         })
+                        .filter(|(node_origin_id, _)| {
+                            task_ctx.node_ids.contains(&(*node_origin_id as u32))
+                        })
                         .collect::<Vec<_>>();
 
-                    if !all_stats.is_empty()
+                    if !relevant_stats.is_empty()
                         && let Err(e) =
-                            context.notify_exec_emit_stats(self.query_id.clone(), all_stats)
+                            context.notify_exec_emit_stats(self.query_id.clone(), relevant_stats)
                     {
                         tracing::error!("Failed to notify exec emit stats: {}", e);
                     }

--- a/src/daft-distributed/src/python/dashboard.rs
+++ b/src/daft-distributed/src/python/dashboard.rs
@@ -47,20 +47,6 @@ impl StatisticsSubscriber for DashboardStatisticsSubscriber {
             return Ok(());
         }
 
-        // Track started operators
-        if let TaskEvent::Submitted {
-            context: task_ctx, ..
-        } = event
-        {
-            let mut started = self.started_operators.lock().unwrap();
-            for node_id in &task_ctx.node_ids {
-                let node_id = *node_id as usize;
-                if !started.contains(&node_id) {
-                    started.insert(node_id);
-                }
-            }
-        }
-
         // Initialize dashboard subscriber if needed
         let context = get_context();
         let should_initialize = {
@@ -88,20 +74,15 @@ impl StatisticsSubscriber for DashboardStatisticsSubscriber {
             TaskEvent::Submitted {
                 context: task_ctx, ..
             } => {
-                // Notify about newly started operators
-                let node_ids_to_notify = {
-                    let started = self.started_operators.lock().unwrap();
-                    task_ctx
-                        .node_ids
-                        .iter()
-                        .map(|id| *id as usize)
-                        .filter(|id| started.contains(id))
-                        .collect::<Vec<_>>()
-                };
+                // Notify about newly started operators, avoiding duplicate notifications
+                let mut started = self.started_operators.lock().unwrap();
 
-                for node_id in node_ids_to_notify {
-                    if let Err(e) =
-                        context.notify_exec_operator_start(self.query_id.clone(), node_id)
+                for node_id in &task_ctx.node_ids {
+                    let node_id = *node_id as usize;
+                    if started.insert(node_id)
+                        // if insert returned false, short-circuit will skip notify
+                        && let Err(e) =
+                            context.notify_exec_operator_start(self.query_id.clone(), node_id)
                     {
                         tracing::error!("Failed to notify exec operator start: {}", e);
                     }

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -87,20 +87,21 @@ impl From<(TaskContext, &DaftResult<TaskStatus>)> for TaskEvent {
 
 pub trait StatisticsSubscriber: Send + Sync + 'static {
     fn handle_event(&mut self, event: &TaskEvent) -> DaftResult<()>;
+    fn set_runtime_node_managers(&mut self, _managers: Arc<HashMap<NodeID, RuntimeNodeManager>>) {}
 }
 
 pub type StatisticsManagerRef = Arc<StatisticsManager>;
 
 #[derive(Default)]
 pub struct StatisticsManager {
-    runtime_node_managers: HashMap<NodeID, RuntimeNodeManager>,
+    runtime_node_managers: Arc<HashMap<NodeID, RuntimeNodeManager>>,
     subscribers: Mutex<Vec<Box<dyn StatisticsSubscriber>>>,
 }
 
 impl StatisticsManager {
     pub fn from_pipeline_node(
         pipeline_node: &DistributedPipelineNode,
-        subscribers: Vec<Box<dyn StatisticsSubscriber>>,
+        mut subscribers: Vec<Box<dyn StatisticsSubscriber>>,
         meter: &Meter,
     ) -> DaftResult<StatisticsManagerRef> {
         let mut runtime_node_managers = HashMap::new();
@@ -120,6 +121,12 @@ impl StatisticsManager {
             );
             Ok(TreeNodeRecursion::Continue)
         })?;
+
+        let runtime_node_managers = Arc::new(runtime_node_managers);
+
+        for subscriber in &mut subscribers {
+            subscriber.set_runtime_node_managers(runtime_node_managers.clone());
+        }
 
         Ok(Arc::new(Self {
             runtime_node_managers,

--- a/src/daft-distributed/src/statistics/mod.rs
+++ b/src/daft-distributed/src/statistics/mod.rs
@@ -87,6 +87,10 @@ impl From<(TaskContext, &DaftResult<TaskStatus>)> for TaskEvent {
 
 pub trait StatisticsSubscriber: Send + Sync + 'static {
     fn handle_event(&mut self, event: &TaskEvent) -> DaftResult<()>;
+
+    /// Called once during [`StatisticsManager`] construction, before any events
+    /// are dispatched. Provides shared access to the runtime node managers for
+    /// subscribers that need aggregated stats.
     fn set_runtime_node_managers(&mut self, _managers: Arc<HashMap<NodeID, RuntimeNodeManager>>) {}
 }
 


### PR DESCRIPTION
## Summary
- `DashboardStatisticsSubscriber` did blind summation of raw task stats, producing wrong numbers for multi-phase nodes (e.g., Sort showed `in: 10, out: 20`)
- Shares `RuntimeNodeManager`s (via `Arc`) with subscribers so the dashboard reads the same smart per-node-type aggregated stats as the OTel path
- Adds `set_runtime_node_managers` to `StatisticsSubscriber` trait with a default no-op impl

Note a separate PR #6575 actually adds multi-phase stats for Sort.

## Test plan
- [x] Run distributed query with Limit and verify dashboard stats match Swordfish query
- [x] Verify stats for single-phase operators (e.g., Filter, Project) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)