### PR TITLE
chore(dashboard): add ?debug query param for SSE event console logging

### DIFF
--- a/src/daft-dashboard/frontend/src/app/queries/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/queries/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import * as React from "react";
-import { useRouter } from "next/navigation";
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   flexRender,
   getCoreRowModel,
@@ -242,11 +243,13 @@ const EmptyState = () => {
 /**
  *  Main Component to display the queries in a table
  */
-export default function QueryList() {
+function QueryListInner() {
   "use no memo";
 
   const { queries, isLoading } = useQueries();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const debug = searchParams.has("debug");
 
   const table = useReactTable({
     data: queries,
@@ -266,7 +269,7 @@ export default function QueryList() {
     `px-[20px]`;
 
   const handleRowClick = (queryId: string) => {
-    router.push(`/query?id=${queryId}`);
+    router.push(`/query?id=${queryId}${debug ? "&debug" : ""}`);
   };
 
   if (isLoading) {
@@ -344,5 +347,13 @@ export default function QueryList() {
         </Table>
       </div>
     </div>
+  );
+}
+
+export default function QueryList() {
+  return (
+    <Suspense fallback={<LoadingPage />}>
+      <QueryListInner />
+    </Suspense>
   );
 }

--- a/src/daft-dashboard/frontend/src/app/query/page.tsx
+++ b/src/daft-dashboard/frontend/src/app/query/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { toHumanReadableDate, main, getEngineName } from "@/lib/utils";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import LoadingPage from "@/components/loading";
@@ -27,6 +27,7 @@ import ResultPreview from "./result-preview";
 function QueryPageInner() {
   const searchParams = useSearchParams();
   const queryId = searchParams.get("id");
+  const debug = useMemo(() => searchParams.has("debug"), [searchParams]);
   const [query, setQuery] = useState<QueryInfo | null>(null);
 
   useEffect(() => {
@@ -40,20 +41,23 @@ function QueryPageInner() {
     // These overwrite
     es.addEventListener("initial_state", event => {
       const data: QueryInfo = JSON.parse(event.data);
+      if (debug) console.log("[debug] initial_state (query)", data);
       setQuery(data);
     });
     // TODO: Consistent ordering of statistics
     es.addEventListener("query_info", event => {
       const data: QueryInfo = JSON.parse(event.data);
+      if (debug) console.log("[debug] query_info", data);
       setQuery(data);
     });
     // Merges with existing info, preserving the current status
     es.addEventListener("operator_info", event => {
+      const data: Record<number, OperatorInfo> = JSON.parse(event.data);
+      if (debug) console.log("[debug] operator_info", data);
       setQuery(prev => {
         if (!prev) return prev;
         if (!("exec_info" in prev.state)) return prev;
 
-        const data: Record<number, OperatorInfo> = JSON.parse(event.data);
         const new_exec_info = { ...prev.state.exec_info, operators: data };
         return {
           ...prev,
@@ -65,7 +69,7 @@ function QueryPageInner() {
       console.info("Closing query SSE endpoint");
       es.close();
     };
-  }, [queryId, setQuery]);
+  }, [queryId, debug, setQuery]);
 
   if (!query) {
     return <LoadingPage />;

--- a/src/daft-dashboard/frontend/src/components/server-provider.tsx
+++ b/src/daft-dashboard/frontend/src/components/server-provider.tsx
@@ -45,6 +45,11 @@ export function fetcher(
 
 // ---------------------- Server Provider ---------------------- //
 
+function isDebug(): boolean {
+  if (typeof window === "undefined") return false;
+  return new URLSearchParams(window.location.search).has("debug");
+}
+
 export function ServerProvider({ children }: { children: React.ReactNode }) {
   const { onQueryStart, onQueryEnd } = useNotifications();
   const [queries, setQueries] = useState<QuerySummaryMap | null>(null);
@@ -61,6 +66,7 @@ export function ServerProvider({ children }: { children: React.ReactNode }) {
 
     es.addEventListener("initial_state", event => {
       const allQueries: QuerySummaryMap = JSON.parse(event.data);
+      if (isDebug()) console.log("[debug] initial_state (queries)", allQueries);
       setQueries(allQueries);
     });
     es.addEventListener("status_update", event => {
@@ -102,6 +108,7 @@ export function ServerProvider({ children }: { children: React.ReactNode }) {
         }
       }
 
+      if (isDebug()) console.log("[debug] status_update", queryUpdate);
       setQueries(prev => {
         return { ...prev, [queryUpdate.id]: queryUpdate };
       });


### PR DESCRIPTION
## Summary
For visibility for developers working on the dashboard logic, adds opt-in logging of all SSE events sent from the dashboard server to the frontend.

- Adds `?debug` query parameter to the dashboard that enables `console.log` of all SSE events (`initial_state`, `query_info`, `operator_info`, `status_update`)
- Propagates debug flag from queries list page to query detail page
- Wraps `QueryListInner` in `Suspense` to support `useSearchParams`

## Test plan
- [x] Open dashboard with `?debug` and verify SSE events are logged to browser console
- [x] Open dashboard without `?debug` and verify no extra logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)