### PR TITLE
fix(io): support writing to local fs via GravitinoGvfs local issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3360,6 +3360,7 @@ dependencies = [
  "parquet",
  "pyo3",
  "tokio",
+ "url",
  "urlencoding",
  "uuid",
 ]

--- a/src/daft-io/src/gravitino.rs
+++ b/src/daft-io/src/gravitino.rs
@@ -143,10 +143,29 @@ impl GravitinoSource {
         Ok(client)
     }
 
+    pub async fn resolve_url_and_config(&self, path: &str) -> super::Result<(String, IOConfig)> {
+        let (client, source_path) = self.fileset_path_to_client_and_url(path).await?;
+
+        let config: &IOConfig = &client.io_client.config;
+
+        Ok((source_path, config.clone()))
+    }
+
     async fn fileset_path_to_source_and_url(
         &self,
         path: &str,
     ) -> super::Result<(Arc<dyn ObjectSource>, String)> {
+        let (client, source_path) = self.fileset_path_to_client_and_url(path).await?;
+
+        let source = client.io_client.get_source(&source_path).await?;
+
+        Ok((source, source_path))
+    }
+
+    async fn fileset_path_to_client_and_url(
+        &self,
+        path: &str,
+    ) -> super::Result<(Arc<ClientAndLocation>, String)> {
         let url = url::Url::parse(path).context(InvalidUrlSnafu { path })?;
 
         // Check that the scheme is gvfs and host is fileset
@@ -183,9 +202,7 @@ impl GravitinoSource {
             format!("{}/{}", client.storage_location, fileset_path)
         };
 
-        let source = client.io_client.get_source(&source_path).await?;
-
-        Ok((source, source_path))
+        Ok((client, source_path))
     }
 }
 

--- a/src/daft-io/src/lib.rs
+++ b/src/daft-io/src/lib.rs
@@ -3,7 +3,7 @@ mod azure_blob;
 mod counting_reader;
 mod google_cloud;
 #[cfg(feature = "python")]
-mod gravitino;
+pub mod gravitino;
 mod http;
 mod huggingface;
 mod local;
@@ -27,7 +27,7 @@ use common_file_formats::FileFormat;
 pub use counting_reader::CountingReader;
 use google_cloud::GCSSource;
 #[cfg(feature = "python")]
-use gravitino::GravitinoSource;
+pub use gravitino::GravitinoSource;
 use huggingface::HFSource;
 use opendal_source::OpenDALSource;
 use tos::TosSource;

--- a/src/daft-writers/Cargo.toml
+++ b/src/daft-writers/Cargo.toml
@@ -22,6 +22,7 @@ parking_lot = {workspace = true}
 parquet = {workspace = true}
 pyo3 = {workspace = true, optional = true}
 tokio = {workspace = true}
+url = {workspace = true}
 urlencoding = "2.1.3"
 uuid = {workspace = true, features = ["v4"]}
 

--- a/src/daft-writers/src/json_writer.rs
+++ b/src/daft-writers/src/json_writer.rs
@@ -114,7 +114,7 @@ pub(crate) fn create_native_json_writer(
         source if source.supports_native_writer() => {
             let ObjectPath { scheme, .. } = daft_io::utils::parse_object_url(root_dir.as_ref())?;
             let io_config = io_config.ok_or_else(|| {
-                DaftError::InternalError("IO config is required for S3 writes".to_string())
+                DaftError::InternalError("IO config is required for object writes".to_string())
             })?;
             let storage_backend = ObjectStorageBackend::new(scheme, io_config);
             Ok(Box::new(make_json_writer(

--- a/src/daft-writers/src/parquet_writer.rs
+++ b/src/daft-writers/src/parquet_writer.rs
@@ -134,7 +134,7 @@ pub(crate) fn create_native_parquet_writer(
         source if source.supports_native_writer() => {
             let ObjectPath { scheme, .. } = daft_io::utils::parse_object_url(root_dir.as_ref())?;
             let io_config = io_config.ok_or_else(|| {
-                DaftError::InternalError("IO config is required for S3 writes".to_string())
+                DaftError::InternalError("IO config is required for object writes".to_string())
             })?;
             let storage_backend = ObjectStorageBackend::new(scheme, io_config);
             Ok(Box::new(ParquetWriter::new(

--- a/src/daft-writers/src/physical.rs
+++ b/src/daft-writers/src/physical.rs
@@ -174,6 +174,9 @@ fn create_native_writer(
     io_config: Option<daft_io::IOConfig>,
     format_option: Option<FormatSinkOption>,
 ) -> DaftResult<Box<dyn AsyncFileWriter<Input = MicroPartition, Result = Option<RecordBatch>>>> {
+    let (path, io_config) = parse_url_and_config(root_dir, io_config)?;
+    let root_dir = path.as_str();
+
     match file_format {
         FileFormat::Parquet => {
             create_native_parquet_writer(root_dir, schema, file_idx, partition_values, io_config)
@@ -189,5 +192,25 @@ fn create_native_writer(
         _ => Err(DaftError::ComputeError(
             "Unsupported file format for native write".to_string(),
         )),
+    }
+}
+
+fn parse_url_and_config(
+    root_dir: &str,
+    io_config: Option<daft_io::IOConfig>,
+) -> DaftResult<(String, Option<daft_io::IOConfig>)> {
+    let (source_type, path) = daft_io::parse_url(root_dir)?;
+    match source_type {
+        #[cfg(feature = "python")]
+        daft_io::SourceType::Gravitino => {
+            let io_config = io_config.ok_or_else(|| {
+                DaftError::InternalError("IO config is required for Gravitino writes".to_string())
+            })?;
+            crate::storage_backend::GravitinoStorageBackend::parse_gravitino_url_and_config(
+                path.as_ref(),
+                io_config,
+            )
+        }
+        _ => Ok((root_dir.to_string(), io_config)),
     }
 }

--- a/src/daft-writers/src/storage_backend.rs
+++ b/src/daft-writers/src/storage_backend.rs
@@ -156,3 +156,59 @@ impl StorageBackend for ObjectStorageBackend {
         upload_task.await?
     }
 }
+
+#[cfg(feature = "python")]
+pub(crate) struct GravitinoStorageBackend;
+
+#[cfg(feature = "python")]
+impl GravitinoStorageBackend {
+    pub(crate) fn parse_gravitino_url_and_config(
+        root_dir: &str,
+        io_config: IOConfig,
+    ) -> DaftResult<(String, Option<IOConfig>)> {
+        let root_dir_owned = root_dir.to_string();
+
+        let runtime = get_io_runtime(true);
+
+        runtime.block_within_async_context(async move {
+            Self::parse_url_and_config(&root_dir_owned, io_config).await
+        })?
+    }
+
+    async fn parse_url_and_config(
+        root_dir: &str,
+        io_config: IOConfig,
+    ) -> DaftResult<(String, Option<IOConfig>)> {
+        let io_client = get_io_client(true, Arc::new(io_config))?;
+        let source = io_client.get_source(root_dir).await?;
+        let any = source.as_any_arc();
+
+        if let Ok(gravitino_source) = any.downcast::<daft_io::gravitino::GravitinoSource>() {
+            let (source_path, io_config) =
+                gravitino_source.resolve_url_and_config(root_dir).await?;
+            let (_, target_root_dir) = daft_io::parse_url(&source_path)?;
+            let target_url = url::Url::parse(target_root_dir.as_ref()).map_err(|_| {
+                DaftError::InternalError(format!(
+                    "Invalid target path: {}",
+                    target_root_dir.as_ref()
+                ))
+            })?;
+            let scheme = target_url.scheme();
+
+            if scheme == "gvfs" {
+                // Prevent circular nesting of gvfs protocol
+                Err(DaftError::InternalError(format!(
+                    "Resolved target path '{}' still uses the gvfs:// scheme, which would cause circular nesting",
+                    target_root_dir.as_ref()
+                )))
+            } else {
+                Ok((target_root_dir.to_string(), Some(io_config)))
+            }
+        } else {
+            Err(DaftError::InternalError(format!(
+                "The source {} does not support gvfs",
+                root_dir
+            )))
+        }
+    }
+}


### PR DESCRIPTION
## Changes Made

Currently, when writing data (Parquet, CSV, JSON) to a Gravitino Virtual File System (gvfs://) URI, Daft unconditionally attempts to use a multipart upload writer. This logic assumes the underlying target is an Object Store (like S3).
However, if the Gravitino FileSet is configured to point to a local file system (SourceType::File), the operation fails with:
"The source gvfs does not support multipart upload"

## Related Issues

This PR modifies the write path to resolve the actual underlying storage configuration from the Gravitino catalog before initializing the writer.
Resolve URI: When a gvfs:// URI is detected during a write operation, we now query the Gravitino client to fetch the actual physical path and storage type.

"Closes #6578" 
