### PR TITLE
fix(dataframe): preserve explain() plan for all write sinks

### DIFF
--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -208,6 +208,7 @@ class DataFrame:
         self._preview = Preview(partition=None, total_rows=None)
         self._metadata: ExecutionMetadata | None = None
         self._num_preview_rows = get_context().daft_execution_config.num_preview_rows
+        self._source_builder: LogicalPlanBuilder | None = None
 
     @property
     def _builder(self) -> LogicalPlanBuilder:
@@ -364,7 +365,9 @@ class DataFrame:
             from daft.dataframe.display import MermaidFormatter
             from daft.utils import in_notebook
 
-            instance = MermaidFormatter(self.__builder, show_all, simple, is_cached)
+            instance = MermaidFormatter(
+                self._source_builder or self.__builder, show_all, simple, is_cached or self._source_builder is not None
+            )
             if file is not None:
                 # if we are printing to a file, we print the markdown representation of the plan
                 text = instance._repr_markdown_()
@@ -384,7 +387,12 @@ class DataFrame:
 
             print_to_file("However here is the logical plan used to produce this result:\n", file=file)
 
-        builder = self.__builder
+        if self._source_builder is not None:
+            builder = self._source_builder
+            if self._result_cache is None:
+                print_to_file("However here is the logical plan used to produce this result:\n", file=file)
+        else:
+            builder = self.__builder
         print_to_file("== Unoptimized Logical Plan ==\n")
         print_to_file(builder.pretty_print(simple, format=format))
         if show_all:
@@ -1544,10 +1552,9 @@ class DataFrame:
 
         from daft import from_pydict
 
-        # NOTE: We are losing the history of the plan here.
-        # This is due to the fact that the logical plan of the write_iceberg returns datafiles but we want to return the above data
         df = from_pydict(with_operations)
         df._metadata = write_df._metadata
+        df._source_builder = write_df._get_current_builder()
         return df
 
     def _write_iceberg_with_checkpoint(
@@ -2066,6 +2073,7 @@ class DataFrame:
             }
         )
         with_operations._metadata = write_df._metadata
+        with_operations._source_builder = write_df._get_current_builder()
         return with_operations
 
     def _write_deltalake_with_checkpoint(
@@ -2279,11 +2287,9 @@ class DataFrame:
             raise ValueError(
                 f"Schema mismatch between the data sink's schema and the result's schema:\nSink schema:\n{sink.schema()}\nResult schema:\n{micropartition.schema()}"
             )
-        # TODO(desmond): Connect the old and new logical plan builders so that a .explain() shows the
-        # plan from the source all the way to the sink to the sink's results. In theory we can do this
-        # for all other sinks too.
         df = DataFrame._from_micropartitions(micropartition)
         df._metadata = write_df._metadata
+        df._source_builder = write_df._get_current_builder()
         return df
 
     @DataframePublicAPI
@@ -2473,7 +2479,7 @@ class DataFrame:
         from daft.dependencies import pa as _pa
         from daft.recordbatch import MicroPartition
 
-        return DataFrame._from_micropartitions(
+        result_df = DataFrame._from_micropartitions(
             MicroPartition.from_pydict(
                 {
                     "num_fragments": _pa.array([stats["num_fragments"]], type=_pa.int64()),
@@ -2483,6 +2489,9 @@ class DataFrame:
                 }
             )
         )
+        # No Sink node in the plan (merge bypasses Daft's planner), but show the source plan
+        result_df._source_builder = self._get_current_builder()
+        return result_df
 
     @DataframePublicAPI
     def write_turbopuffer(

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -1649,6 +1649,7 @@ class DataFrame:
                 )
             result = from_pydict(with_operations)
             result._metadata = write_df._metadata
+            result._source_builder = write_df._get_current_builder()
             return result
 
         # ── 1. Check-first: did a previous attempt already land?
@@ -2205,6 +2206,7 @@ class DataFrame:
                 }
             )
             result._metadata = write_df._metadata
+            result._source_builder = write_df._get_current_builder()
             return result
 
         # Defensive retry — parity with iceberg's max_retries = 2. We narrow

--- a/tests/dataframe/test_explain.py
+++ b/tests/dataframe/test_explain.py
@@ -165,6 +165,31 @@ def test_explain_after_write_preserves_upstream_plan(tmp_path, write_fn, kwargs)
     assert "Filter:" in explain_text
 
 
+def test_explain_after_write_sink_preserves_upstream_plan():
+    from collections.abc import Iterator
+
+    from daft.io.sink import DataSink, WriteResult
+    from daft.recordbatch import MicroPartition
+    from daft.schema import Schema
+
+    class NoopSink(DataSink[None]):
+        def schema(self) -> Schema:
+            return Schema.from_pyarrow_schema(pa.schema({"rows_written": pa.int64()}))
+
+        def write(self, micropartitions: Iterator[MicroPartition]) -> Iterator[WriteResult[None]]:
+            for mp in micropartitions:
+                yield WriteResult(result=None, bytes_written=0, rows_written=len(mp))
+
+        def finalize(self, write_results: list[WriteResult[None]]) -> MicroPartition:
+            total = sum(r.rows_written for r in write_results)
+            return MicroPartition.from_pydict({"rows_written": pa.array([total], type=pa.int64())})
+
+    write_df = daft.from_pydict({"a": [1, 2, 3]}).filter(col("a") > 1).write_sink(NoopSink())
+    explain_text = explain_to_text(write_df)
+    assert "However here is the logical plan used to produce this result" in explain_text
+    assert "Filter:" in explain_text
+
+
 def test_explain_with_hash_join(small_df, large_df):
     runner_type = get_or_infer_runner_type()
     if runner_type == "native":


### PR DESCRIPTION
PR #6564 fixed `explain()` for `write_parquet`/`write_csv`/`write_json` by using `_get_current_builder()` to preserve the original logical plan after execution. However, all other write sinks still collapsed the plan to an in-memory source.

The root cause: methods like `write_iceberg`, `write_deltalake`, and `write_sink` construct a new DataFrame via `from_pydict()` or `_from_micropartitions()` with a different schema than the write plan output (e.g. Iceberg returns `{operation, rows, file_size, file_name}` while the logical plan outputs `{data_file}`). The `_get_current_builder()` swap doesn't work here because of the schema mismatch.

To fix this, we add a `_source_builder` field to `DataFrame` that stores the original write plan builder. When set, `explain()` displays the full source-to-sink plan instead of the in-memory scan. This field is set in:

- `write_iceberg` and `write_deltalake` (post-commit summary DataFrames)
- `write_sink` and all its delegates (`write_sql`, `write_paimon`, `write_turbopuffer`, `write_clickhouse`, `write_huggingface`, `write_bigtable`)
- `write_lance` merge and REST paths (which bypass Daft's planner, so we show the source plan without a Sink node)

The field does not propagate through downstream operations (e.g. `result.select(...)` creates a fresh DataFrame), which is the correct behavior since the source plan is only meaningful on the direct write result.

Closes #3827