### PR TITLE
feat(distributed): make flotilla worker actor startup timeout configurable

### DIFF
--- a/daft/context.py
+++ b/daft/context.py
@@ -186,6 +186,7 @@ def set_execution_config(
     native_parquet_writer: bool | None = None,
     min_cpu_per_task: float | None = None,
     actor_udf_ready_timeout: int | None = None,
+    ray_worker_actor_startup_timeout: int | None = None,
     maintain_order: bool | None = None,
     enable_dynamic_batching: bool | None = None,
     dynamic_batching_strategy: str | None = None,
@@ -234,6 +235,7 @@ def set_execution_config(
         native_parquet_writer: Whether to use the native parquet writer vs the pyarrow parquet writer. Defaults to `True`.
         min_cpu_per_task: Minimum CPU per task in the Ray runner. Defaults to 0.5.
         actor_udf_ready_timeout: Timeout for UDF actors to be ready. Defaults to 120 seconds.
+        ray_worker_actor_startup_timeout: Timeout for flotilla worker actors to report their addresses. Defaults to 120 seconds.
         maintain_order: Whether to maintain order during execution. Defaults to True. Some blocking sink operators (e.g. write_parquet) won't respect this flag and will always keep maintain_order as false, and propagate to child operators. It's useful to set this to False for running df.collect() when no ordering is required.
         enable_dynamic_batching: Whether to enable dynamic batching. Defaults to False.
         dynamic_batching_strategy: The strategy to use for dynamic batching. Defaults to 'auto'.
@@ -275,6 +277,7 @@ def set_execution_config(
             native_parquet_writer=native_parquet_writer,
             min_cpu_per_task=min_cpu_per_task,
             actor_udf_ready_timeout=actor_udf_ready_timeout,
+            ray_worker_actor_startup_timeout=ray_worker_actor_startup_timeout,
             maintain_order=maintain_order,
             enable_dynamic_batching=enable_dynamic_batching,
             dynamic_batching_strategy=dynamic_batching_strategy,

--- a/daft/context.py
+++ b/daft/context.py
@@ -186,7 +186,7 @@ def set_execution_config(
     native_parquet_writer: bool | None = None,
     min_cpu_per_task: float | None = None,
     actor_udf_ready_timeout: int | None = None,
-    ray_worker_actor_startup_timeout: int | None = None,
+    worker_startup_timeout: int | None = None,
     maintain_order: bool | None = None,
     enable_dynamic_batching: bool | None = None,
     dynamic_batching_strategy: str | None = None,
@@ -235,7 +235,7 @@ def set_execution_config(
         native_parquet_writer: Whether to use the native parquet writer vs the pyarrow parquet writer. Defaults to `True`.
         min_cpu_per_task: Minimum CPU per task in the Ray runner. Defaults to 0.5.
         actor_udf_ready_timeout: Timeout for UDF actors to be ready. Defaults to 120 seconds.
-        ray_worker_actor_startup_timeout: Timeout for flotilla worker actors to report their addresses. Defaults to 120 seconds.
+        worker_startup_timeout: Timeout for worker actors to report their addresses during startup. Defaults to 120 seconds.
         maintain_order: Whether to maintain order during execution. Defaults to True. Some blocking sink operators (e.g. write_parquet) won't respect this flag and will always keep maintain_order as false, and propagate to child operators. It's useful to set this to False for running df.collect() when no ordering is required.
         enable_dynamic_batching: Whether to enable dynamic batching. Defaults to False.
         dynamic_batching_strategy: The strategy to use for dynamic batching. Defaults to 'auto'.
@@ -277,7 +277,7 @@ def set_execution_config(
             native_parquet_writer=native_parquet_writer,
             min_cpu_per_task=min_cpu_per_task,
             actor_udf_ready_timeout=actor_udf_ready_timeout,
-            ray_worker_actor_startup_timeout=ray_worker_actor_startup_timeout,
+            worker_startup_timeout=worker_startup_timeout,
             maintain_order=maintain_order,
             enable_dynamic_batching=enable_dynamic_batching,
             dynamic_batching_strategy=dynamic_batching_strategy,

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2334,7 +2334,7 @@ class PyDaftExecutionConfig:
         native_parquet_writer: bool | None = None,
         min_cpu_per_task: float | None = None,
         actor_udf_ready_timeout: int | None = None,
-        ray_worker_actor_startup_timeout: int | None = None,
+        worker_startup_timeout: int | None = None,
         maintain_order: bool | None = None,
         enable_dynamic_batching: bool | None = None,
         dynamic_batching_strategy: str | None = None,
@@ -2396,7 +2396,7 @@ class PyDaftExecutionConfig:
     @property
     def actor_udf_ready_timeout(self) -> int: ...
     @property
-    def ray_worker_actor_startup_timeout(self) -> int: ...
+    def worker_startup_timeout(self) -> int: ...
     @property
     def scantask_max_parallel(self) -> int: ...
     @property

--- a/daft/daft/__init__.pyi
+++ b/daft/daft/__init__.pyi
@@ -2334,6 +2334,7 @@ class PyDaftExecutionConfig:
         native_parquet_writer: bool | None = None,
         min_cpu_per_task: float | None = None,
         actor_udf_ready_timeout: int | None = None,
+        ray_worker_actor_startup_timeout: int | None = None,
         maintain_order: bool | None = None,
         enable_dynamic_batching: bool | None = None,
         dynamic_batching_strategy: str | None = None,
@@ -2394,6 +2395,8 @@ class PyDaftExecutionConfig:
     def min_cpu_per_task(self) -> float: ...
     @property
     def actor_udf_ready_timeout(self) -> int: ...
+    @property
+    def ray_worker_actor_startup_timeout(self) -> int: ...
     @property
     def scantask_max_parallel(self) -> int: ...
     @property

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -384,8 +384,8 @@ class RaySwordfishActorHandle:
         ray.kill(self.actor_handle)
 
 
-def _get_ray_worker_actor_startup_timeout() -> int:
-    return get_context().daft_execution_config.ray_worker_actor_startup_timeout
+def _get_worker_startup_timeout() -> int:
+    return get_context().daft_execution_config.worker_startup_timeout
 
 
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker]:
@@ -411,7 +411,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
             actors.append((node, actor))
 
     # Batch all IP address retrievals into a single ray.get call
-    actor_startup_timeout = _get_ray_worker_actor_startup_timeout()
+    actor_startup_timeout = _get_worker_startup_timeout()
     try:
         ip_addresses = ray.get(
             [actor.get_address.remote() for _, actor in actors],

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -383,8 +383,10 @@ class RaySwordfishActorHandle:
         ray.kill(self.actor_handle)
 
 
-# TODO: Consider making configurable depending on real-world behavior
-ACTOR_STARTUP_TIMEOUT = 120
+def _get_ray_worker_actor_startup_timeout() -> int:
+    from daft.context import get_context
+
+    return get_context().daft_execution_config.ray_worker_actor_startup_timeout
 
 
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker]:
@@ -410,10 +412,14 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
             actors.append((node, actor))
 
     # Batch all IP address retrievals into a single ray.get call
+    actor_startup_timeout = _get_ray_worker_actor_startup_timeout()
     try:
-        ip_addresses = ray.get([actor.get_address.remote() for _, actor in actors], timeout=ACTOR_STARTUP_TIMEOUT)
+        ip_addresses = ray.get(
+            [actor.get_address.remote() for _, actor in actors],
+            timeout=actor_startup_timeout,
+        )
     except ray.exceptions.GetTimeoutError:
-        raise RuntimeError(f"Failed to get IP addresses for actors within {ACTOR_STARTUP_TIMEOUT} seconds")
+        raise RuntimeError(f"Failed to get IP addresses for actors within {actor_startup_timeout} seconds")
 
     handles = []
     for (node, actor), ip_address in zip(actors, ip_addresses):

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -8,6 +8,7 @@ import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple, TypeAlias
 
+from daft.context import get_context
 from daft.daft import (
     DistributedPhysicalPlan,
     DistributedPhysicalPlanRunner,
@@ -384,8 +385,6 @@ class RaySwordfishActorHandle:
 
 
 def _get_ray_worker_actor_startup_timeout() -> int:
-    from daft.context import get_context
-
     return get_context().daft_execution_config.ray_worker_actor_startup_timeout
 
 

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -136,7 +136,7 @@ pub struct DaftExecutionConfig {
     pub native_parquet_writer: bool,
     pub min_cpu_per_task: f64,
     pub actor_udf_ready_timeout: usize,
-    pub ray_worker_actor_startup_timeout: usize,
+    pub worker_startup_timeout: usize,
     pub maintain_order: bool,
     pub enable_dynamic_batching: bool,
     pub dynamic_batching_strategy: String,
@@ -183,7 +183,7 @@ impl Default for DaftExecutionConfig {
             native_parquet_writer: true,
             min_cpu_per_task: 0.5,
             actor_udf_ready_timeout: 120,
-            ray_worker_actor_startup_timeout: 120,
+            worker_startup_timeout: 120,
             maintain_order: true,
             enable_dynamic_batching: false,
             dynamic_batching_strategy: "auto".to_string(),
@@ -199,8 +199,7 @@ impl DaftExecutionConfig {
     const ENV_DAFT_NATIVE_PARQUET_WRITER: &'static str = "DAFT_NATIVE_PARQUET_WRITER";
     const ENV_DAFT_MIN_CPU_PER_TASK: &'static str = "DAFT_MIN_CPU_PER_TASK";
     const ENV_DAFT_ACTOR_UDF_READY_TIMEOUT: &'static str = "DAFT_ACTOR_UDF_READY_TIMEOUT";
-    const ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT: &'static str =
-        "DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT";
+    const ENV_DAFT_WORKER_STARTUP_TIMEOUT: &'static str = "DAFT_WORKER_STARTUP_TIMEOUT";
     const ENV_PARQUET_INFLATION_FACTOR: &'static str = "DAFT_PARQUET_INFLATION_FACTOR";
     const ENV_CSV_INFLATION_FACTOR: &'static str = "DAFT_CSV_INFLATION_FACTOR";
     const ENV_JSON_INFLATION_FACTOR: &'static str = "DAFT_JSON_INFLATION_FACTOR";
@@ -243,10 +242,10 @@ impl DaftExecutionConfig {
         }
 
         if let Some(val) = parse_number_from_env(
-            Self::ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT,
-            cfg.ray_worker_actor_startup_timeout,
+            Self::ENV_DAFT_WORKER_STARTUP_TIMEOUT,
+            cfg.worker_startup_timeout,
         ) {
-            cfg.ray_worker_actor_startup_timeout = val;
+            cfg.worker_startup_timeout = val;
         }
 
         if let Some(val) = parse_bool_from_env(Self::ENV_DAFT_MAINTAIN_ORDER) {
@@ -495,33 +494,28 @@ mod tests {
             }
         }
 
-        // ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT
+        // ENV_DAFT_WORKER_STARTUP_TIMEOUT
         {
             let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.ray_worker_actor_startup_timeout, 120);
+            assert_eq!(cfg.worker_startup_timeout, 120);
 
             unsafe {
-                std::env::set_var(
-                    DaftExecutionConfig::ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT,
-                    "300",
-                );
+                std::env::set_var(DaftExecutionConfig::ENV_DAFT_WORKER_STARTUP_TIMEOUT, "300");
             }
             let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.ray_worker_actor_startup_timeout, 300);
+            assert_eq!(cfg.worker_startup_timeout, 300);
 
             unsafe {
                 std::env::set_var(
-                    DaftExecutionConfig::ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT,
+                    DaftExecutionConfig::ENV_DAFT_WORKER_STARTUP_TIMEOUT,
                     "invalid",
                 );
             }
             let cfg = DaftExecutionConfig::from_env();
-            assert_eq!(cfg.ray_worker_actor_startup_timeout, 120);
+            assert_eq!(cfg.worker_startup_timeout, 120);
 
             unsafe {
-                std::env::remove_var(
-                    DaftExecutionConfig::ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT,
-                );
+                std::env::remove_var(DaftExecutionConfig::ENV_DAFT_WORKER_STARTUP_TIMEOUT);
             }
         }
 

--- a/src/common/daft-config/src/lib.rs
+++ b/src/common/daft-config/src/lib.rs
@@ -136,6 +136,7 @@ pub struct DaftExecutionConfig {
     pub native_parquet_writer: bool,
     pub min_cpu_per_task: f64,
     pub actor_udf_ready_timeout: usize,
+    pub ray_worker_actor_startup_timeout: usize,
     pub maintain_order: bool,
     pub enable_dynamic_batching: bool,
     pub dynamic_batching_strategy: String,
@@ -182,6 +183,7 @@ impl Default for DaftExecutionConfig {
             native_parquet_writer: true,
             min_cpu_per_task: 0.5,
             actor_udf_ready_timeout: 120,
+            ray_worker_actor_startup_timeout: 120,
             maintain_order: true,
             enable_dynamic_batching: false,
             dynamic_batching_strategy: "auto".to_string(),
@@ -197,6 +199,8 @@ impl DaftExecutionConfig {
     const ENV_DAFT_NATIVE_PARQUET_WRITER: &'static str = "DAFT_NATIVE_PARQUET_WRITER";
     const ENV_DAFT_MIN_CPU_PER_TASK: &'static str = "DAFT_MIN_CPU_PER_TASK";
     const ENV_DAFT_ACTOR_UDF_READY_TIMEOUT: &'static str = "DAFT_ACTOR_UDF_READY_TIMEOUT";
+    const ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT: &'static str =
+        "DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT";
     const ENV_PARQUET_INFLATION_FACTOR: &'static str = "DAFT_PARQUET_INFLATION_FACTOR";
     const ENV_CSV_INFLATION_FACTOR: &'static str = "DAFT_CSV_INFLATION_FACTOR";
     const ENV_JSON_INFLATION_FACTOR: &'static str = "DAFT_JSON_INFLATION_FACTOR";
@@ -236,6 +240,13 @@ impl DaftExecutionConfig {
             cfg.actor_udf_ready_timeout,
         ) {
             cfg.actor_udf_ready_timeout = val;
+        }
+
+        if let Some(val) = parse_number_from_env(
+            Self::ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT,
+            cfg.ray_worker_actor_startup_timeout,
+        ) {
+            cfg.ray_worker_actor_startup_timeout = val;
         }
 
         if let Some(val) = parse_bool_from_env(Self::ENV_DAFT_MAINTAIN_ORDER) {
@@ -481,6 +492,36 @@ mod tests {
 
             unsafe {
                 std::env::remove_var(DaftExecutionConfig::ENV_DAFT_ACTOR_UDF_READY_TIMEOUT);
+            }
+        }
+
+        // ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT
+        {
+            let cfg = DaftExecutionConfig::from_env();
+            assert_eq!(cfg.ray_worker_actor_startup_timeout, 120);
+
+            unsafe {
+                std::env::set_var(
+                    DaftExecutionConfig::ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT,
+                    "300",
+                );
+            }
+            let cfg = DaftExecutionConfig::from_env();
+            assert_eq!(cfg.ray_worker_actor_startup_timeout, 300);
+
+            unsafe {
+                std::env::set_var(
+                    DaftExecutionConfig::ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT,
+                    "invalid",
+                );
+            }
+            let cfg = DaftExecutionConfig::from_env();
+            assert_eq!(cfg.ray_worker_actor_startup_timeout, 120);
+
+            unsafe {
+                std::env::remove_var(
+                    DaftExecutionConfig::ENV_DAFT_RAY_WORKER_ACTOR_STARTUP_TIMEOUT,
+                );
             }
         }
 

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -118,6 +118,7 @@ impl PyDaftExecutionConfig {
         native_parquet_writer=None,
         min_cpu_per_task=None,
         actor_udf_ready_timeout=None,
+        ray_worker_actor_startup_timeout=None,
         maintain_order=None,
         enable_dynamic_batching=None,
         dynamic_batching_strategy=None,
@@ -155,6 +156,7 @@ impl PyDaftExecutionConfig {
         native_parquet_writer: Option<bool>,
         min_cpu_per_task: Option<f64>,
         actor_udf_ready_timeout: Option<usize>,
+        ray_worker_actor_startup_timeout: Option<usize>,
         maintain_order: Option<bool>,
         enable_dynamic_batching: Option<bool>,
         dynamic_batching_strategy: Option<&str>,
@@ -272,6 +274,10 @@ impl PyDaftExecutionConfig {
 
         if let Some(actor_udf_ready_timeout) = actor_udf_ready_timeout {
             config.actor_udf_ready_timeout = actor_udf_ready_timeout;
+        }
+
+        if let Some(ray_worker_actor_startup_timeout) = ray_worker_actor_startup_timeout {
+            config.ray_worker_actor_startup_timeout = ray_worker_actor_startup_timeout;
         }
 
         if let Some(maintain_order) = maintain_order {
@@ -444,6 +450,11 @@ impl PyDaftExecutionConfig {
     #[getter]
     fn actor_udf_ready_timeout(&self) -> PyResult<usize> {
         Ok(self.config.actor_udf_ready_timeout)
+    }
+
+    #[getter]
+    fn ray_worker_actor_startup_timeout(&self) -> PyResult<usize> {
+        Ok(self.config.ray_worker_actor_startup_timeout)
     }
 
     #[getter]

--- a/src/common/daft-config/src/python.rs
+++ b/src/common/daft-config/src/python.rs
@@ -118,7 +118,7 @@ impl PyDaftExecutionConfig {
         native_parquet_writer=None,
         min_cpu_per_task=None,
         actor_udf_ready_timeout=None,
-        ray_worker_actor_startup_timeout=None,
+        worker_startup_timeout=None,
         maintain_order=None,
         enable_dynamic_batching=None,
         dynamic_batching_strategy=None,
@@ -156,7 +156,7 @@ impl PyDaftExecutionConfig {
         native_parquet_writer: Option<bool>,
         min_cpu_per_task: Option<f64>,
         actor_udf_ready_timeout: Option<usize>,
-        ray_worker_actor_startup_timeout: Option<usize>,
+        worker_startup_timeout: Option<usize>,
         maintain_order: Option<bool>,
         enable_dynamic_batching: Option<bool>,
         dynamic_batching_strategy: Option<&str>,
@@ -276,8 +276,8 @@ impl PyDaftExecutionConfig {
             config.actor_udf_ready_timeout = actor_udf_ready_timeout;
         }
 
-        if let Some(ray_worker_actor_startup_timeout) = ray_worker_actor_startup_timeout {
-            config.ray_worker_actor_startup_timeout = ray_worker_actor_startup_timeout;
+        if let Some(worker_startup_timeout) = worker_startup_timeout {
+            config.worker_startup_timeout = worker_startup_timeout;
         }
 
         if let Some(maintain_order) = maintain_order {
@@ -453,8 +453,8 @@ impl PyDaftExecutionConfig {
     }
 
     #[getter]
-    fn ray_worker_actor_startup_timeout(&self) -> PyResult<usize> {
-        Ok(self.config.ray_worker_actor_startup_timeout)
+    fn worker_startup_timeout(&self) -> PyResult<usize> {
+        Ok(self.config.worker_startup_timeout)
     }
 
     #[getter]

--- a/tests/ray/test_flotilla_runner_naming.py
+++ b/tests/ray/test_flotilla_runner_naming.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import daft.runners.flotilla as flotilla
+from daft.context import execution_config_ctx
 
 
 def test_flotilla_runner_actor_name_is_namespaced(monkeypatch):
@@ -27,3 +28,68 @@ def test_flotilla_runner_actor_name_is_namespaced(monkeypatch):
     assert name != flotilla.FLOTILLA_RUNNER_NAME
     assert name.endswith("test-job-id")
     assert flotilla.get_flotilla_runner_actor_name() == name
+
+
+def test_start_ray_workers_uses_configured_actor_startup_timeout(monkeypatch):
+    captured: dict[str, object] = {}
+    node_id = "1" * 56
+
+    class _RemoteMethod:
+        def __init__(self, result: str) -> None:
+            self._result = result
+
+        def remote(self) -> str:
+            return self._result
+
+    class _FakeActor:
+        def __init__(self, address: str) -> None:
+            self.get_address = _RemoteMethod(address)
+
+    class _FakeActorOptions:
+        def remote(self, *, num_cpus: int, num_gpus: int) -> _FakeActor:
+            captured["remote_args"] = {"num_cpus": num_cpus, "num_gpus": num_gpus}
+            return _FakeActor("grpc://10.0.0.1:9999")
+
+    class _FakeRaySwordfishActor:
+        @staticmethod
+        def options(**kwargs) -> _FakeActorOptions:
+            captured["options_kwargs"] = kwargs
+            return _FakeActorOptions()
+
+    def _fake_ray_get(address_refs: list[str], *, timeout: int) -> list[str]:
+        captured["address_refs"] = address_refs
+        captured["timeout"] = timeout
+        return ["grpc://10.0.0.1:9999"]
+
+    monkeypatch.setattr(
+        flotilla.ray,
+        "nodes",
+        lambda: [{"NodeID": node_id, "Resources": {"CPU": 4, "memory": 1024, "GPU": 1}}],
+    )
+    monkeypatch.setattr(flotilla.ray, "get", _fake_ray_get)
+    monkeypatch.setattr(flotilla, "RaySwordfishActor", _FakeRaySwordfishActor)
+    monkeypatch.setattr(flotilla, "RaySwordfishActorHandle", lambda actor: ("handle", actor))
+    monkeypatch.setattr(
+        flotilla,
+        "RaySwordfishWorker",
+        lambda *args: {
+            "node_id": args[0],
+            "actor_handle": args[1],
+            "num_cpus": args[2],
+            "num_gpus": args[3],
+            "memory": args[4],
+            "ip_address": args[5],
+        },
+    )
+
+    with execution_config_ctx(ray_worker_actor_startup_timeout=321):
+        workers = flotilla.start_ray_workers(existing_worker_ids=[])
+
+    assert captured["timeout"] == 321
+    assert captured["address_refs"] == ["grpc://10.0.0.1:9999"]
+    assert len(workers) == 1
+    assert workers[0]["node_id"] == node_id
+    assert workers[0]["num_cpus"] == 4
+    assert workers[0]["num_gpus"] == 1
+    assert workers[0]["memory"] == 1024
+    assert workers[0]["ip_address"] == "grpc://10.0.0.1:9999"

--- a/tests/ray/test_flotilla_runner_naming.py
+++ b/tests/ray/test_flotilla_runner_naming.py
@@ -30,7 +30,7 @@ def test_flotilla_runner_actor_name_is_namespaced(monkeypatch):
     assert flotilla.get_flotilla_runner_actor_name() == name
 
 
-def test_start_ray_workers_uses_configured_actor_startup_timeout(monkeypatch):
+def test_start_ray_workers_uses_configured_worker_startup_timeout(monkeypatch):
     captured: dict[str, object] = {}
     node_id = "1" * 56
 
@@ -82,7 +82,7 @@ def test_start_ray_workers_uses_configured_actor_startup_timeout(monkeypatch):
         },
     )
 
-    with execution_config_ctx(ray_worker_actor_startup_timeout=321):
+    with execution_config_ctx(worker_startup_timeout=321):
         workers = flotilla.start_ray_workers(existing_worker_ids=[])
 
     assert captured["timeout"] == 321

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -333,3 +333,12 @@ def test_set_scantask_max_parallelism_greater_than_partition_num():
         df = daft.range(start=0, end=1024, partitions=10)
         df.explain(show_all=True, file=str_io)
         assert "Num Parallel Scan Tasks = 17" in str_io.getvalue().strip()
+
+
+def test_set_ray_worker_actor_startup_timeout():
+    original_timeout = daft.context.get_context().daft_execution_config.ray_worker_actor_startup_timeout
+
+    with daft.execution_config_ctx(ray_worker_actor_startup_timeout=321):
+        assert daft.context.get_context().daft_execution_config.ray_worker_actor_startup_timeout == 321
+
+    assert daft.context.get_context().daft_execution_config.ray_worker_actor_startup_timeout == original_timeout

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -335,10 +335,10 @@ def test_set_scantask_max_parallelism_greater_than_partition_num():
         assert "Num Parallel Scan Tasks = 17" in str_io.getvalue().strip()
 
 
-def test_set_ray_worker_actor_startup_timeout():
-    original_timeout = daft.context.get_context().daft_execution_config.ray_worker_actor_startup_timeout
+def test_set_worker_startup_timeout():
+    original_timeout = daft.context.get_context().daft_execution_config.worker_startup_timeout
 
-    with daft.execution_config_ctx(ray_worker_actor_startup_timeout=321):
-        assert daft.context.get_context().daft_execution_config.ray_worker_actor_startup_timeout == 321
+    with daft.execution_config_ctx(worker_startup_timeout=321):
+        assert daft.context.get_context().daft_execution_config.worker_startup_timeout == 321
 
-    assert daft.context.get_context().daft_execution_config.ray_worker_actor_startup_timeout == original_timeout
+    assert daft.context.get_context().daft_execution_config.worker_startup_timeout == original_timeout


### PR DESCRIPTION
The flotilla runner hardcoded a 120-second timeout (`ACTOR_STARTUP_TIMEOUT`) for worker actors to report their gRPC addresses during `start_ray_workers`. In clusters with slow node provisioning or heavy resource contention, this could cause spurious failures with no way to tune the timeout short of patching the source.

This replaces the hardcoded constant with a configurable `worker_startup_timeout` parameter. It can be set via `daft.set_execution_config(worker_startup_timeout=300)` or the `DAFT_WORKER_STARTUP_TIMEOUT` environment variable (Python API takes precedence over env var). The default remains 120 seconds.

Addresses part 1 of #6589