### PR TITLE
refactor(subscriber): collapse trait to single sync on_event method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,7 +2376,6 @@ dependencies = [
 name = "daft-context"
 version = "0.3.0-dev0"
 dependencies = [
- "async-trait",
  "common-daft-config",
  "common-error",
  "common-metrics",

--- a/daft/subscribers/abc.py
+++ b/daft/subscribers/abc.py
@@ -3,15 +3,26 @@ from __future__ import annotations
 import warnings
 from abc import ABC
 from functools import singledispatchmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from daft.daft import StatType
-from daft.subscribers.events import Event, OperatorFinished, OperatorStarted, Stats
+from daft.subscribers.events import (
+    Event,
+    ExecutionFinished,
+    ExecutionStarted,
+    OperatorFinished,
+    OperatorStarted,
+    OptimizationCompleted,
+    OptimizationStarted,
+    ProcessStats,
+    QueryFinished,
+    QueryStarted,
+    ResultProduced,
+    Stats,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
-    from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult
+    from daft.daft import PyQueryMetadata, PyQueryResult
 
 
 class Subscriber(ABC):
@@ -32,6 +43,38 @@ class Subscriber(ABC):
         Override to release resources (file handles, connections, etc.).
         """
         pass
+
+    @on_event.register
+    def _(self, event: QueryStarted) -> None:
+        self.on_query_started(event)
+
+    @on_event.register
+    def _(self, event: QueryFinished) -> None:
+        self.on_query_finished(event)
+
+    @on_event.register
+    def _(self, event: OptimizationStarted) -> None:
+        self.on_optimization_started(event)
+
+    @on_event.register
+    def _(self, event: OptimizationCompleted) -> None:
+        self.on_optimization_completed(event)
+
+    @on_event.register
+    def _(self, event: ExecutionStarted) -> None:
+        self.on_execution_started(event)
+
+    @on_event.register
+    def _(self, event: ExecutionFinished) -> None:
+        self.on_execution_finished(event)
+
+    @on_event.register
+    def _(self, event: ResultProduced) -> None:
+        self.on_result_produced(event)
+
+    @on_event.register
+    def _(self, event: ProcessStats) -> None:
+        self.on_process_stats(event)
 
     @on_event.register
     def _(self, event: OperatorStarted) -> None:
@@ -57,52 +100,44 @@ class Subscriber(ABC):
         """Called when emitting stats for all running operators in a query."""
         pass
 
-    def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
+    def on_query_started(self, event: QueryStarted) -> None:
         """Called when starting the run for a new query."""
         pass
 
-    def on_query_end(self, query_id: str, result: PyQueryResult) -> None:
+    def on_query_finished(self, event: QueryFinished) -> None:
         """Called when a query has completed."""
         pass
 
-    def on_result_out(self, query_id: str, result: PyMicroPartition) -> None:
-        """Called when a result is emitted for a query."""
-        pass
-
-    def on_optimization_start(self, query_id: str) -> None:
-        """Called when starting to plan / optimize a query."""
-        pass
-
-    def on_optimization_end(self, query_id: str, optimized_plan: str) -> None:
+    def on_optimization_completed(self, event: OptimizationCompleted) -> None:
         """Called when planning for a query has completed."""
         pass
 
-    def on_exec_start(self, query_id: str, physical_plan: str) -> None:
-        """Called when starting to execute a query. Receives the physical plan as JSON string."""
+    def on_optimization_started(self, event: OptimizationStarted) -> None:
+        """Called when planning for a query starts."""
         pass
 
-    def on_exec_operator_start(self, query_id: str, node_id: int) -> None:
-        """Deprecated: use on_operator_start instead."""
-        self.on_operator_start(OperatorStarted(query_id=query_id, node_id=node_id, name=""))
+    def on_execution_started(self, event: ExecutionStarted) -> None:
+        """Called when starting to execute a query."""
+        pass
 
-    def on_exec_emit_stats(self, query_id: str, stats: Mapping[int, Mapping[str, tuple[StatType, Any]]]) -> None:
-        """Deprecated: use on_stats instead."""
-        normalized_stats = {node_id: dict(node_stats.items()) for node_id, node_stats in stats.items()}
-        self.on_stats(Stats(query_id=query_id, stats=normalized_stats))
-
-    def on_exec_operator_end(self, query_id: str, node_id: int) -> None:
-        """Deprecated: use on_operator_end instead."""
-        self.on_operator_end(OperatorFinished(query_id=query_id, node_id=node_id, name=""))
-
-    def on_exec_end(self, query_id: str) -> None:
+    def on_execution_finished(self, event: ExecutionFinished) -> None:
         """Called when a query has finished executing."""
         pass
 
-    def on_process_stats(self, query_id: str, stats: Mapping[str, tuple[StatType, Any]]) -> None:
-        """Called with process-level stats (memory, CPU) on each tick.
+    def on_result_produced(self, event: ResultProduced) -> None:
+        """Called when a query emits result rows."""
+        pass
 
-        Override to capture process-level metrics. Not abstract - defaults to no-op.
-        """
+    def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
+        """Called when starting the run for a new query."""
+        self.on_query_started(QueryStarted(query_id=query_id, metadata=metadata))
+
+    def on_query_end(self, query_id: str, result: PyQueryResult) -> None:
+        """Called when a query has completed."""
+        self.on_query_finished(QueryFinished(query_id=query_id, result=result, duration_ms=None))
+
+    def on_process_stats(self, event: ProcessStats) -> None:
+        """Called with process-level stats on each tick."""
         pass
 
 

--- a/daft/subscribers/event_log.py
+++ b/daft/subscribers/event_log.py
@@ -8,13 +8,24 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
     from io import TextIOWrapper
 
-    from daft.subscribers.events import OperatorFinished, OperatorStarted, Stats
+    from daft.subscribers.events import (
+        ExecutionFinished,
+        ExecutionStarted,
+        OperatorFinished,
+        OperatorStarted,
+        OptimizationCompleted,
+        OptimizationStarted,
+        ProcessStats,
+        QueryFinished,
+        QueryStarted,
+        ResultProduced,
+        Stats,
+    )
 
 from daft.context import get_context
-from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState, StatType
+from daft.daft import QueryEndState
 from daft.subscribers.abc import Subscriber
 
 _EVENT_LOG_ALIAS = "_daft_event_log"
@@ -51,8 +62,7 @@ class EventLogSubscriber(Subscriber):
         self._closed = False
         self._query_files: dict[str, TextIOWrapper] = {}
 
-        # Track start times for duration computation (monotonic ms).
-        # TODO update the framework to pass this information
+        # Track start times locally for events that do not carry durations.
         self._query_starts: dict[str, float] = {}
         self._optimization_starts: dict[str, float] = {}
         self._exec_starts: dict[str, float] = {}
@@ -60,9 +70,9 @@ class EventLogSubscriber(Subscriber):
 
     def _clear_query_state(self, query_id: str) -> None:
         """Remove any leftover timing state for the given query."""
+        self._query_starts.pop(query_id, None)
         self._optimization_starts.pop(query_id, None)
         self._exec_starts.pop(query_id, None)
-
         stale_operator_keys = [key for key in self._operator_starts if key[0] == query_id]
         for key in stale_operator_keys:
             self._operator_starts.pop(key, None)
@@ -132,68 +142,74 @@ class EventLogSubscriber(Subscriber):
 
     # Query lifecycle
 
-    def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
-        self._query_starts[query_id] = _mono_ms()
-        self._write_event(query_id, "query_started", {})
-        self._write_event(query_id, "plan_unoptimized", {"plan": metadata.unoptimized_plan})
+    def on_query_started(self, event: QueryStarted) -> None:
+        self._query_starts[event.query_id] = _mono_ms()
+        self._write_event(event.query_id, "query_started", {})
+        self._write_event(
+            event.query_id,
+            "plan_unoptimized",
+            {"plan": event.metadata.unoptimized_plan},
+        )
 
-    def on_query_end(self, query_id: str, result: PyQueryResult) -> None:
-        start = self._query_starts.pop(query_id, None)
-        duration_ms = round(_mono_ms() - start) if start is not None else None
+    def on_query_finished(self, event: QueryFinished) -> None:
+        duration_ms = event.duration_ms
+        if duration_ms is None:
+            start = self._query_starts.pop(event.query_id, None)
+            duration_ms = _mono_ms() - start if start is not None else None
 
         payload: dict[str, Any] = {}
         if duration_ms is not None:
-            payload["duration_ms"] = duration_ms
+            payload["duration_ms"] = round(duration_ms)
 
-        if result.end_state == QueryEndState.Finished:
+        if event.result.end_state == QueryEndState.Finished:
             payload["status"] = "ok"
-        elif result.end_state == QueryEndState.Failed:
+        elif event.result.end_state == QueryEndState.Failed:
             payload["status"] = "failed"
-            if result.error_message:
-                payload["error_message"] = result.error_message
-        elif result.end_state == QueryEndState.Canceled:
+            if event.result.error_message:
+                payload["error_message"] = event.result.error_message
+        elif event.result.end_state == QueryEndState.Canceled:
             payload["status"] = "canceled"
         else:
             payload["status"] = "dead"
 
-        self._write_event(query_id, "query_ended", payload)
-        self._clear_query_state(query_id)
-        self._close_query_file(query_id)
+        self._write_event(event.query_id, "query_ended", payload)
+        self._clear_query_state(event.query_id)
+        self._close_query_file(event.query_id)
 
     # Result
 
-    def on_result_out(self, query_id: str, result: PyMicroPartition) -> None:
+    def on_result_produced(self, event: ResultProduced) -> None:
         self._write_event(
-            query_id,
+            event.query_id,
             "result_out",
             {
-                "rows": len(result),
+                "rows": event.num_rows,
             },
         )
 
     # Optimization
 
-    def on_optimization_start(self, query_id: str) -> None:
-        self._optimization_starts[query_id] = _mono_ms()
-        self._write_event(query_id, "optimization_started", {})
+    def on_optimization_started(self, event: OptimizationStarted) -> None:
+        self._optimization_starts[event.query_id] = _mono_ms()
+        self._write_event(event.query_id, "optimization_started", {})
 
-    def on_optimization_end(self, query_id: str, optimized_plan: str) -> None:
-        start = self._optimization_starts.pop(query_id, None)
+    def on_optimization_completed(self, event: OptimizationCompleted) -> None:
+        start = self._optimization_starts.pop(event.query_id, None)
         duration_ms = round(_mono_ms() - start) if start is not None else None
 
         payload: dict[str, Any] = {}
         if duration_ms is not None:
             payload["duration_ms"] = duration_ms
 
-        self._write_event(query_id, "optimization_ended", payload)
-        self._write_event(query_id, "plan_optimized", {"plan": optimized_plan})
+        self._write_event(event.query_id, "optimization_ended", payload)
+        self._write_event(event.query_id, "plan_optimized", {"plan": event.optimized_plan})
 
     # Execution
 
-    def on_exec_start(self, query_id: str, physical_plan: str) -> None:
-        self._exec_starts[query_id] = _mono_ms()
-        self._write_event(query_id, "execution_started", {})
-        self._write_event(query_id, "plan_physical", {"plan": physical_plan})
+    def on_execution_started(self, event: ExecutionStarted) -> None:
+        self._exec_starts[event.query_id] = _mono_ms()
+        self._write_event(event.query_id, "execution_started", {})
+        self._write_event(event.query_id, "plan_physical", {"plan": event.physical_plan})
 
     def on_operator_start(self, event: OperatorStarted) -> None:
         query_id = event.query_id
@@ -222,11 +238,11 @@ class EventLogSubscriber(Subscriber):
                 },
             )
 
-    def on_process_stats(self, query_id: str, stats: Mapping[str, tuple[StatType, Any]]) -> None:
+    def on_process_stats(self, event: ProcessStats) -> None:
         metrics: dict[str, Any] = {}
-        for name, (_stat_type, value) in stats.items():
+        for name, (_stat_type, value) in event.stats.items():
             metrics[name] = value
-        self._write_event(query_id, "process_stats", {"metrics": metrics})
+        self._write_event(event.query_id, "process_stats", {"metrics": metrics})
 
     def on_operator_end(self, event: OperatorFinished) -> None:
         query_id = event.query_id
@@ -240,15 +256,17 @@ class EventLogSubscriber(Subscriber):
 
         self._write_event(query_id, "operator_finished", payload)
 
-    def on_exec_end(self, query_id: str) -> None:
-        start = self._exec_starts.pop(query_id, None)
-        duration_ms = round(_mono_ms() - start) if start is not None else None
+    def on_execution_finished(self, event: ExecutionFinished) -> None:
+        duration_ms = event.duration_ms
+        if duration_ms is None:
+            start = self._exec_starts.pop(event.query_id, None)
+            duration_ms = _mono_ms() - start if start is not None else None
 
         payload: dict[str, Any] = {}
         if duration_ms is not None:
-            payload["duration_ms"] = duration_ms
+            payload["duration_ms"] = round(duration_ms)
 
-        self._write_event(query_id, "execution_ended", payload)
+        self._write_event(event.query_id, "execution_ended", payload)
 
 
 _EVENT_LOG_SUBSCRIBER: EventLogSubscriber | None = None

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, StatType
+    from daft.daft import PyQueryMetadata, PyQueryResult, StatType
 
 
 class Event(ABC):
@@ -78,4 +78,3 @@ class ProcessStats(Event):
 class ResultProduced(Event):
     query_id: str
     num_rows: int
-    data: PyMicroPartition | None = None

--- a/daft/subscribers/events.py
+++ b/daft/subscribers/events.py
@@ -5,11 +5,47 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from daft.daft import StatType
+    from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, StatType
 
 
 class Event(ABC):
     """Base class for subscriber execution events."""
+
+
+@dataclass(frozen=True)
+class QueryStarted(Event):
+    query_id: str
+    metadata: PyQueryMetadata
+
+
+@dataclass(frozen=True)
+class QueryFinished(Event):
+    query_id: str
+    result: PyQueryResult
+    duration_ms: float | None
+
+
+@dataclass(frozen=True)
+class OptimizationStarted(Event):
+    query_id: str
+
+
+@dataclass(frozen=True)
+class OptimizationCompleted(Event):
+    query_id: str
+    optimized_plan: str
+
+
+@dataclass(frozen=True)
+class ExecutionStarted(Event):
+    query_id: str
+    physical_plan: str
+
+
+@dataclass(frozen=True)
+class ExecutionFinished(Event):
+    query_id: str
+    duration_ms: float | None
 
 
 @dataclass(frozen=True)
@@ -30,3 +66,16 @@ class OperatorFinished(Event):
 class Stats(Event):
     query_id: str
     stats: dict[int, dict[str, tuple[StatType, Any]]]
+
+
+@dataclass(frozen=True)
+class ProcessStats(Event):
+    query_id: str
+    stats: dict[str, tuple[StatType, Any]]
+
+
+@dataclass(frozen=True)
+class ResultProduced(Event):
+    query_id: str
+    num_rows: int
+    data: PyMicroPartition | None = None

--- a/src/daft-context/Cargo.toml
+++ b/src/daft-context/Cargo.toml
@@ -1,5 +1,4 @@
 [dependencies]
-async-trait = {workspace = true}
 common-runtime = {path = "../common/runtime", default-features = false}
 common-daft-config = {path = "../common/daft-config", default-features = false}
 common-error = {path = "../common/error", default-features = false}

--- a/src/daft-context/src/lib.rs
+++ b/src/daft-context/src/lib.rs
@@ -11,10 +11,19 @@ use std::{
 use common_daft_config::{DaftExecutionConfig, DaftPlanningConfig, IOConfig};
 use common_error::{DaftError, DaftResult};
 use common_metrics::{QueryID, QueryPlan};
-use daft_micropartition::MicroPartitionRef;
+use daft_micropartition::{MicroPartitionRef, partitioning::Partition};
 #[cfg(feature = "python")]
 use pyo3::prelude::*;
 pub use subscribers::{Event, QueryMetadata, QueryResult, Subscriber};
+
+use crate::subscribers::{
+    event_header,
+    events::{
+        ExecEndEvent, ExecStartEvent, OperatorEndEvent, OperatorMeta, OperatorStartEvent,
+        OptimizationCompleteEvent, OptimizationStartEvent, QueryEndEvent, QueryStartEvent,
+        ResultOutEvent, StatsEvent,
+    },
+};
 
 #[derive(Default)]
 #[cfg_attr(debug_assertions, derive(Debug))]
@@ -131,22 +140,22 @@ impl DaftContext {
         query_id: QueryID,
         metadata: Arc<QueryMetadata>,
     ) -> DaftResult<()> {
-        self.with_state(|state| {
-            for subscriber in state.subscribers.values() {
-                subscriber.on_query_start(query_id.clone(), metadata.clone())?;
-            }
-            Ok::<(), DaftError>(())
-        })
+        let event = Event::QueryStart(Arc::new(QueryStartEvent {
+            header: event_header(query_id),
+            metadata,
+        }));
+        self.dispatch_event(event, "notify query start")
     }
 
     pub fn notify_query_end(&self, query_id: QueryID, result: QueryResult) {
-        self.with_state(move |state| {
-            for subscriber in state.subscribers.values() {
-                if let Err(e) = subscriber.on_query_end(query_id.clone(), result.clone()) {
-                    log::error!("Failed to notify subscriber on query end: {}", e);
-                }
-            }
-        });
+        let event = Event::QueryEnd(Arc::new(QueryEndEvent {
+            header: event_header(query_id),
+            result,
+            duration_ms: None,
+        }));
+        if let Err(e) = self.dispatch_event(event, "notify query end") {
+            log::error!("Failed to dispatch query end event: {}", e);
+        }
     }
 
     pub fn notify_result_out(
@@ -154,21 +163,20 @@ impl DaftContext {
         query_id: QueryID,
         result: MicroPartitionRef,
     ) -> DaftResult<()> {
-        self.with_state(|state| {
-            for subscriber in state.subscribers.values() {
-                subscriber.on_result_out(query_id.clone(), result.clone())?;
-            }
-            Ok::<(), DaftError>(())
-        })
+        let event = Event::ResultOut(Arc::new(ResultOutEvent {
+            header: event_header(query_id),
+            num_rows: (result.num_rows() as u64),
+            data: Some(result),
+        }));
+        self.dispatch_event(event, "notify result out")
     }
 
     pub fn notify_optimization_start(&self, query_id: QueryID) -> DaftResult<()> {
-        self.with_state(|state| {
-            for subscriber in state.subscribers.values() {
-                subscriber.on_optimization_start(query_id.clone())?;
-            }
-            Ok::<(), DaftError>(())
-        })
+        // TODO track this for a complete event and remove the start event
+        let event = Event::OptimizationStart(Arc::new(OptimizationStartEvent {
+            header: event_header(query_id),
+        }));
+        self.dispatch_event(event, "notify optimization start")
     }
 
     pub fn notify_optimization_end(
@@ -176,83 +184,44 @@ impl DaftContext {
         query_id: QueryID,
         optimized_plan: QueryPlan,
     ) -> DaftResult<()> {
-        self.with_state(|state| {
-            for subscriber in state.subscribers.values() {
-                subscriber.on_optimization_end(query_id.clone(), optimized_plan.clone())?;
-            }
-            Ok::<(), DaftError>(())
-        })
+        let event = Event::OptimizationComplete(Arc::new(OptimizationCompleteEvent {
+            header: event_header(query_id),
+            optimized_plan,
+        }));
+        self.dispatch_event(event, "notify optimization complete")
     }
 
     pub fn notify_exec_start(&self, query_id: QueryID, physical_plan: String) -> DaftResult<()> {
-        self.with_state(|state| {
-            for subscriber in state.subscribers.values() {
-                subscriber.on_exec_start(query_id.clone(), physical_plan.clone().into())?;
-            }
-            Ok::<(), DaftError>(())
-        })
+        // TODO get operator info
+        let event = Event::ExecStart(Arc::new(ExecStartEvent {
+            header: event_header(query_id),
+            physical_plan: physical_plan.into(),
+        }));
+        self.dispatch_event(event, "notify exec start")
     }
 
     pub fn notify_exec_end(&self, query_id: QueryID) -> DaftResult<()> {
-        let subscribers = self.with_state(|state| {
-            state
-                .subscribers
-                .values()
-                .cloned()
-                .collect::<Vec<Arc<dyn Subscriber>>>()
-        });
-        let rt = common_runtime::get_io_runtime(false);
-        for subscriber in subscribers {
-            let query_id = query_id.clone();
-            let _ = rt.block_within_async_context(async move {
-                if let Err(e) = subscriber.on_exec_end(query_id).await {
-                    log::error!("Failed to notify exec end: {}", e);
-                }
-            });
-        }
-        Ok(())
+        let event = Event::ExecEnd(Arc::new(ExecEndEvent {
+            header: event_header(query_id),
+            duration_ms: None,
+        }));
+        self.dispatch_event(event, "notify exec end")
     }
 
     pub fn notify_exec_operator_start(&self, query_id: QueryID, node_id: usize) -> DaftResult<()> {
-        let subscribers = self.with_state(|state| {
-            state
-                .subscribers
-                .values()
-                .cloned()
-                .collect::<Vec<Arc<dyn Subscriber>>>()
-        });
-        let rt = common_runtime::get_io_runtime(false);
-        let handle = rt.runtime.handle().clone();
-        for subscriber in subscribers {
-            let query_id = query_id.clone();
-            handle.spawn(async move {
-                if let Err(e) = subscriber.on_exec_operator_start(query_id, node_id).await {
-                    log::error!("Failed to notify exec operator start: {}", e);
-                }
-            });
-        }
-        Ok(())
+        let event = Event::OperatorStart(Arc::new(OperatorStartEvent {
+            header: event_header(query_id),
+            operator: Arc::new(OperatorMeta::from_id(node_id)),
+        }));
+        self.dispatch_event(event, "notify exec operator start")
     }
 
     pub fn notify_exec_operator_end(&self, query_id: QueryID, node_id: usize) -> DaftResult<()> {
-        let subscribers = self.with_state(|state| {
-            state
-                .subscribers
-                .values()
-                .cloned()
-                .collect::<Vec<Arc<dyn Subscriber>>>()
-        });
-        let rt = common_runtime::get_io_runtime(false);
-        let handle = rt.runtime.handle().clone();
-        for subscriber in subscribers {
-            let query_id = query_id.clone();
-            handle.spawn(async move {
-                if let Err(e) = subscriber.on_exec_operator_end(query_id, node_id).await {
-                    log::error!("Failed to notify exec operator end: {}", e);
-                }
-            });
-        }
-        Ok(())
+        let event = Event::OperatorEnd(Arc::new(OperatorEndEvent {
+            header: event_header(query_id),
+            operator: Arc::new(OperatorMeta::from_id(node_id)),
+        }));
+        self.dispatch_event(event, "notify exec operator end")
     }
 
     pub fn notify_exec_emit_stats(
@@ -260,29 +229,14 @@ impl DaftContext {
         query_id: QueryID,
         stats: Vec<(usize, common_metrics::Stats)>,
     ) -> DaftResult<()> {
-        let subscribers = self.with_state(|state| {
-            state
-                .subscribers
-                .values()
-                .cloned()
-                .collect::<Vec<Arc<dyn Subscriber>>>()
-        });
-        let rt = common_runtime::get_io_runtime(false);
-        let handle = rt.runtime.handle().clone();
-        let stats = Arc::new(stats);
-        for subscriber in subscribers {
-            let stats = stats.clone();
-            let query_id = query_id.clone();
-            handle.spawn(async move {
-                if let Err(e) = subscriber.on_exec_emit_stats(query_id, stats).await {
-                    log::error!("Failed to notify exec emit stats: {}", e);
-                }
-            });
-        }
-        Ok(())
+        let event = Event::Stats(Arc::new(StatsEvent {
+            header: event_header(query_id),
+            stats: Arc::new(stats),
+        }));
+        self.dispatch_event(event, "notify exec emit stats")
     }
 
-    pub fn notify_event(&self, event: Event) -> DaftResult<()> {
+    fn dispatch_event(&self, event: Event, err_context: &'static str) -> DaftResult<()> {
         let subscribers = self.with_state(|state| {
             state
                 .subscribers
@@ -290,15 +244,10 @@ impl DaftContext {
                 .cloned()
                 .collect::<Vec<Arc<dyn Subscriber>>>()
         });
-        let rt = common_runtime::get_io_runtime(false);
-        let handle = rt.runtime.handle().clone();
         for subscriber in subscribers {
-            let evt = event.clone();
-            handle.spawn(async move {
-                if let Err(e) = subscriber.on_event(evt).await {
-                    log::error!("Failed to notify_event: {}", e);
-                }
-            });
+            if let Err(e) = subscriber.on_event(event.clone()) {
+                log::error!("Failed to {}: {}", err_context, e);
+            }
         }
         Ok(())
     }

--- a/src/daft-context/src/lib.rs
+++ b/src/daft-context/src/lib.rs
@@ -140,20 +140,20 @@ impl DaftContext {
         query_id: QueryID,
         metadata: Arc<QueryMetadata>,
     ) -> DaftResult<()> {
-        let event = Event::QueryStart(Arc::new(QueryStartEvent {
+        let event = Event::QueryStart(QueryStartEvent {
             header: event_header(query_id),
             metadata,
-        }));
-        self.dispatch_event(event, "notify query start")
+        });
+        self.dispatch_event(&event, "notify query start")
     }
 
     pub fn notify_query_end(&self, query_id: QueryID, result: QueryResult) {
-        let event = Event::QueryEnd(Arc::new(QueryEndEvent {
+        let event = Event::QueryEnd(QueryEndEvent {
             header: event_header(query_id),
             result,
             duration_ms: None,
-        }));
-        if let Err(e) = self.dispatch_event(event, "notify query end") {
+        });
+        if let Err(e) = self.dispatch_event(&event, "notify query end") {
             log::error!("Failed to dispatch query end event: {}", e);
         }
     }
@@ -163,19 +163,19 @@ impl DaftContext {
         query_id: QueryID,
         result: MicroPartitionRef,
     ) -> DaftResult<()> {
-        let event = Event::ResultOut(Arc::new(ResultOutEvent {
+        let event = Event::ResultOut(ResultOutEvent {
             header: event_header(query_id),
             num_rows: (result.num_rows() as u64),
             data: Some(result),
-        }));
-        self.dispatch_event(event, "notify result out")
+        });
+        self.dispatch_event(&event, "notify result out")
     }
 
     pub fn notify_optimization_start(&self, query_id: QueryID) -> DaftResult<()> {
-        let event = Event::OptimizationStart(Arc::new(OptimizationStartEvent {
+        let event = Event::OptimizationStart(OptimizationStartEvent {
             header: event_header(query_id),
-        }));
-        self.dispatch_event(event, "notify optimization start")
+        });
+        self.dispatch_event(&event, "notify optimization start")
     }
 
     pub fn notify_optimization_end(
@@ -183,43 +183,43 @@ impl DaftContext {
         query_id: QueryID,
         optimized_plan: QueryPlan,
     ) -> DaftResult<()> {
-        let event = Event::OptimizationComplete(Arc::new(OptimizationCompleteEvent {
+        let event = Event::OptimizationComplete(OptimizationCompleteEvent {
             header: event_header(query_id),
             optimized_plan,
-        }));
-        self.dispatch_event(event, "notify optimization complete")
+        });
+        self.dispatch_event(&event, "notify optimization complete")
     }
 
     pub fn notify_exec_start(&self, query_id: QueryID, physical_plan: String) -> DaftResult<()> {
-        let event = Event::ExecStart(Arc::new(ExecStartEvent {
+        let event = Event::ExecStart(ExecStartEvent {
             header: event_header(query_id),
             physical_plan: physical_plan.into(),
-        }));
-        self.dispatch_event(event, "notify exec start")
+        });
+        self.dispatch_event(&event, "notify exec start")
     }
 
     pub fn notify_exec_end(&self, query_id: QueryID) -> DaftResult<()> {
-        let event = Event::ExecEnd(Arc::new(ExecEndEvent {
+        let event = Event::ExecEnd(ExecEndEvent {
             header: event_header(query_id),
             duration_ms: None,
-        }));
-        self.dispatch_event(event, "notify exec end")
+        });
+        self.dispatch_event(&event, "notify exec end")
     }
 
     pub fn notify_exec_operator_start(&self, query_id: QueryID, node_id: usize) -> DaftResult<()> {
-        let event = Event::OperatorStart(Arc::new(OperatorStartEvent {
+        let event = Event::OperatorStart(OperatorStartEvent {
             header: event_header(query_id),
             operator: Arc::new(OperatorMeta::from_id(node_id)),
-        }));
-        self.dispatch_event(event, "notify exec operator start")
+        });
+        self.dispatch_event(&event, "notify exec operator start")
     }
 
     pub fn notify_exec_operator_end(&self, query_id: QueryID, node_id: usize) -> DaftResult<()> {
-        let event = Event::OperatorEnd(Arc::new(OperatorEndEvent {
+        let event = Event::OperatorEnd(OperatorEndEvent {
             header: event_header(query_id),
             operator: Arc::new(OperatorMeta::from_id(node_id)),
-        }));
-        self.dispatch_event(event, "notify exec operator end")
+        });
+        self.dispatch_event(&event, "notify exec operator end")
     }
 
     pub fn notify_exec_emit_stats(
@@ -227,14 +227,14 @@ impl DaftContext {
         query_id: QueryID,
         stats: Vec<(usize, common_metrics::Stats)>,
     ) -> DaftResult<()> {
-        let event = Event::Stats(Arc::new(StatsEvent {
+        let event = Event::Stats(StatsEvent {
             header: event_header(query_id),
             stats: Arc::new(stats),
-        }));
-        self.dispatch_event(event, "notify exec emit stats")
+        });
+        self.dispatch_event(&event, "notify exec emit stats")
     }
 
-    fn dispatch_event(&self, event: Event, err_context: &'static str) -> DaftResult<()> {
+    fn dispatch_event(&self, event: &Event, err_context: &'static str) -> DaftResult<()> {
         let subscribers = self.with_state(|state| {
             state
                 .subscribers

--- a/src/daft-context/src/lib.rs
+++ b/src/daft-context/src/lib.rs
@@ -172,7 +172,6 @@ impl DaftContext {
     }
 
     pub fn notify_optimization_start(&self, query_id: QueryID) -> DaftResult<()> {
-        // TODO track this for a complete event and remove the start event
         let event = Event::OptimizationStart(Arc::new(OptimizationStartEvent {
             header: event_header(query_id),
         }));
@@ -192,7 +191,6 @@ impl DaftContext {
     }
 
     pub fn notify_exec_start(&self, query_id: QueryID, physical_plan: String) -> DaftResult<()> {
-        // TODO get operator info
         let event = Event::ExecStart(Arc::new(ExecStartEvent {
             header: event_header(query_id),
             physical_plan: physical_plan.into(),

--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -375,7 +375,7 @@ impl DashboardSubscriber {
         self.on_exec_end_with_id(query_id, "unknown")
     }
 
-    fn on_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
+    fn on_operator_start(&self, event: &OperatorStartEvent) -> DaftResult<()> {
         if self.is_worker() {
             return Ok(());
         }
@@ -390,7 +390,7 @@ impl DashboardSubscriber {
         Ok(())
     }
 
-    fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
+    fn on_stats(&self, event: &StatsEvent) -> DaftResult<()> {
         if self.is_worker() {
             return Ok(());
         }
@@ -426,7 +426,7 @@ impl DashboardSubscriber {
         Ok(())
     }
 
-    fn on_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
+    fn on_operator_end(&self, event: &OperatorEndEvent) -> DaftResult<()> {
         if self.is_worker() {
             return Ok(());
         }
@@ -473,31 +473,31 @@ impl Subscriber for DashboardSubscriber {
     fn on_event(&self, event: Event) -> DaftResult<()> {
         match event {
             Event::QueryStart(e) => {
-                self.on_query_start(e.header.query_id.clone(), e.metadata.clone())?;
+                self.on_query_start(e.header.query_id, e.metadata)?;
             }
             Event::QueryEnd(e) => {
-                self.on_query_end(e.header.query_id.clone(), e.result.clone())?;
+                self.on_query_end(e.header.query_id, e.result)?;
             }
             Event::OptimizationStart(e) => {
-                self.on_optimization_start(e.header.query_id.clone())?;
+                self.on_optimization_start(e.header.query_id)?;
             }
             Event::OptimizationComplete(e) => {
-                self.on_optimization_end(e.header.query_id.clone(), e.optimized_plan.clone())?;
+                self.on_optimization_end(e.header.query_id, e.optimized_plan)?;
             }
             Event::ExecStart(e) => {
-                self.on_exec_start(e.header.query_id.clone(), e.physical_plan.clone())?;
+                self.on_exec_start(e.header.query_id, e.physical_plan)?;
             }
             Event::ExecEnd(e) => {
-                self.on_exec_end(e.header.query_id.clone())?;
+                self.on_exec_end(e.header.query_id)?;
             }
             Event::OperatorStart(e) => {
-                self.on_operator_start(e)?;
+                self.on_operator_start(&e)?;
             }
             Event::OperatorEnd(e) => {
-                self.on_operator_end(e)?;
+                self.on_operator_end(&e)?;
             }
             Event::Stats(e) => {
-                self.on_stats(e)?;
+                self.on_stats(&e)?;
             }
             Event::ProcessStats(_e) => {}
             Event::ResultOut(e) => {

--- a/src/daft-context/src/subscribers/dashboard.rs
+++ b/src/daft-context/src/subscribers/dashboard.rs
@@ -6,9 +6,8 @@ use std::{
     time::SystemTime,
 };
 
-use async_trait::async_trait;
 use common_error::{DaftError, DaftResult};
-use common_metrics::{NodeID, QueryID, QueryPlan, Stats};
+use common_metrics::{QueryID, QueryPlan};
 use common_runtime::{RuntimeRef, get_io_runtime};
 use daft_micropartition::{MicroPartition, MicroPartitionRef};
 use dashmap::DashMap;
@@ -214,37 +213,8 @@ impl DashboardSubscriber {
             }
         }
     }
-}
 
-impl Drop for DashboardSubscriber {
-    fn drop(&mut self) {
-        // Close channel so worker drains buffered events and exits.
-        let _ = self.dashboard_tx.take();
-
-        // Wait up to timeout for clean drain; then force abort.
-        if let Some(mut worker) = self.dashboard_worker.take() {
-            let shutdown = self.runtime.block_within_async_context(async move {
-                if tokio::time::timeout(
-                    std::time::Duration::from_millis(DASHBOARD_SHUTDOWN_TIMEOUT_MS),
-                    &mut worker,
-                )
-                .await
-                .is_err()
-                {
-                    log::warn!("Dashboard worker did not drain in time, aborting");
-                    worker.abort();
-                }
-            });
-
-            if let Err(e) = shutdown {
-                log::warn!("Dashboard worker shutdown encountered an error: {e}");
-            }
-        }
-    }
-}
-
-#[async_trait]
-impl Subscriber for DashboardSubscriber {
+    // event handlers
     fn on_query_start(&self, query_id: QueryID, metadata: Arc<QueryMetadata>) -> DaftResult<()> {
         if self.is_worker() {
             return Ok(());
@@ -384,78 +354,7 @@ impl Subscriber for DashboardSubscriber {
         self.on_exec_start_with_id(query_id.clone(), &query_id, physical_plan)
     }
 
-    async fn on_exec_operator_start(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()> {
-        if self.is_worker() {
-            return Ok(());
-        }
-
-        self.enqueue_no_body(
-            format!("engine/query/{}/exec/{}/start", query_id, node_id),
-            "exec_operator_start",
-        );
-        Ok(())
-    }
-
-    async fn on_exec_emit_stats_with_id(
-        &self,
-        query_id: QueryID,
-        execution_id: &str,
-        stats: Arc<Vec<(NodeID, Stats)>>,
-    ) -> DaftResult<()> {
-        self.enqueue_json(
-            format!("engine/query/{}/exec/emit_stats", query_id),
-            "exec_emit_stats",
-            &daft_dashboard::engine::ExecEmitStatsArgsSend {
-                source_id: execution_id.to_string(),
-                stats: stats
-                    .iter()
-                    .map(|(node_id, snapshot)| {
-                        (
-                            *node_id,
-                            snapshot
-                                .0
-                                .iter()
-                                .map(|(name, stat)| (name.to_string(), stat.clone()))
-                                .collect(),
-                        )
-                    })
-                    .collect(),
-            },
-        );
-        Ok(())
-    }
-
-    async fn on_exec_emit_stats(
-        &self,
-        query_id: QueryID,
-        stats: Arc<Vec<(NodeID, Stats)>>,
-    ) -> DaftResult<()> {
-        if self.is_worker() {
-            return Ok(());
-        }
-
-        let source_id = self
-            .execution_ids
-            .get(&query_id)
-            .map(|id| id.clone())
-            .unwrap_or_else(|| "unknown".to_string());
-        self.on_exec_emit_stats_with_id(query_id, &source_id, stats)
-            .await
-    }
-
-    async fn on_exec_operator_end(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()> {
-        if self.is_worker() {
-            return Ok(());
-        }
-
-        self.enqueue_no_body(
-            format!("engine/query/{}/exec/{}/end", query_id, node_id),
-            "exec_operator_end",
-        );
-        Ok(())
-    }
-
-    async fn on_exec_end_with_id(&self, query_id: QueryID, _execution_id: &str) -> DaftResult<()> {
+    fn on_exec_end_with_id(&self, query_id: QueryID, _execution_id: &str) -> DaftResult<()> {
         if self.is_worker() {
             return Ok(());
         }
@@ -472,11 +371,11 @@ impl Subscriber for DashboardSubscriber {
         Ok(())
     }
 
-    async fn on_exec_end(&self, query_id: QueryID) -> DaftResult<()> {
-        self.on_exec_end_with_id(query_id, "unknown").await
+    fn on_exec_end(&self, query_id: QueryID) -> DaftResult<()> {
+        self.on_exec_end_with_id(query_id, "unknown")
     }
 
-    async fn on_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
+    fn on_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
         if self.is_worker() {
             return Ok(());
         }
@@ -491,7 +390,7 @@ impl Subscriber for DashboardSubscriber {
         Ok(())
     }
 
-    async fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
+    fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
         if self.is_worker() {
             return Ok(());
         }
@@ -527,7 +426,7 @@ impl Subscriber for DashboardSubscriber {
         Ok(())
     }
 
-    async fn on_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
+    fn on_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
         if self.is_worker() {
             return Ok(());
         }
@@ -541,12 +440,71 @@ impl Subscriber for DashboardSubscriber {
         );
         Ok(())
     }
+}
 
-    async fn on_event(&self, event: Event) -> DaftResult<()> {
+impl Drop for DashboardSubscriber {
+    fn drop(&mut self) {
+        // Close channel so worker drains buffered events and exits.
+        let _ = self.dashboard_tx.take();
+
+        // Wait up to timeout for clean drain; then force abort.
+        if let Some(mut worker) = self.dashboard_worker.take() {
+            let shutdown = self.runtime.block_within_async_context(async move {
+                if tokio::time::timeout(
+                    std::time::Duration::from_millis(DASHBOARD_SHUTDOWN_TIMEOUT_MS),
+                    &mut worker,
+                )
+                .await
+                .is_err()
+                {
+                    log::warn!("Dashboard worker did not drain in time, aborting");
+                    worker.abort();
+                }
+            });
+
+            if let Err(e) = shutdown {
+                log::warn!("Dashboard worker shutdown encountered an error: {e}");
+            }
+        }
+    }
+}
+
+impl Subscriber for DashboardSubscriber {
+    fn on_event(&self, event: Event) -> DaftResult<()> {
         match event {
-            Event::Stats(e) => self.on_stats(e).await?,
-            Event::OperatorStart(e) => self.on_operator_start(e).await?,
-            Event::OperatorEnd(e) => self.on_operator_end(e).await?,
+            Event::QueryStart(e) => {
+                self.on_query_start(e.header.query_id.clone(), e.metadata.clone())?;
+            }
+            Event::QueryEnd(e) => {
+                self.on_query_end(e.header.query_id.clone(), e.result.clone())?;
+            }
+            Event::OptimizationStart(e) => {
+                self.on_optimization_start(e.header.query_id.clone())?;
+            }
+            Event::OptimizationComplete(e) => {
+                self.on_optimization_end(e.header.query_id.clone(), e.optimized_plan.clone())?;
+            }
+            Event::ExecStart(e) => {
+                self.on_exec_start(e.header.query_id.clone(), e.physical_plan.clone())?;
+            }
+            Event::ExecEnd(e) => {
+                self.on_exec_end(e.header.query_id.clone())?;
+            }
+            Event::OperatorStart(e) => {
+                self.on_operator_start(e)?;
+            }
+            Event::OperatorEnd(e) => {
+                self.on_operator_end(e)?;
+            }
+            Event::Stats(e) => {
+                self.on_stats(e)?;
+            }
+            Event::ProcessStats(_e) => {}
+            Event::ResultOut(e) => {
+                if let Some(result) = &e.data {
+                    self.on_result_out(e.header.query_id.clone(), result.clone())?;
+                }
+            }
         }
         Ok(())
     }

--- a/src/daft-context/src/subscribers/debug.rs
+++ b/src/daft-context/src/subscribers/debug.rs
@@ -184,17 +184,17 @@ impl DebugSubscriber {
 impl Subscriber for DebugSubscriber {
     fn on_event(&self, event: Event) -> DaftResult<()> {
         match event {
-            Event::QueryStart(e) => self.handle_query_start(e.as_ref())?,
-            Event::QueryEnd(e) => self.handle_query_end(e.as_ref())?,
-            Event::OptimizationStart(e) => self.handle_optimization_start(e.as_ref())?,
-            Event::OptimizationComplete(e) => self.handle_optimization_complete(e.as_ref())?,
-            Event::ExecStart(e) => self.handle_exec_start(e.as_ref())?,
-            Event::ExecEnd(e) => self.handle_exec_end(e.as_ref())?,
-            Event::OperatorStart(e) => self.handle_operator_start(e.as_ref())?,
-            Event::OperatorEnd(e) => self.handle_operator_end(e.as_ref())?,
-            Event::Stats(e) => self.handle_stats(e.as_ref())?,
-            Event::ProcessStats(e) => self.handle_process_stats(e.as_ref())?,
-            Event::ResultOut(e) => self.handle_result_out(e.as_ref())?,
+            Event::QueryStart(e) => self.handle_query_start(&e)?,
+            Event::QueryEnd(e) => self.handle_query_end(&e)?,
+            Event::OptimizationStart(e) => self.handle_optimization_start(&e)?,
+            Event::OptimizationComplete(e) => self.handle_optimization_complete(&e)?,
+            Event::ExecStart(e) => self.handle_exec_start(&e)?,
+            Event::ExecEnd(e) => self.handle_exec_end(&e)?,
+            Event::OperatorStart(e) => self.handle_operator_start(&e)?,
+            Event::OperatorEnd(e) => self.handle_operator_end(&e)?,
+            Event::Stats(e) => self.handle_stats(&e)?,
+            Event::ProcessStats(e) => self.handle_process_stats(&e)?,
+            Event::ResultOut(e) => self.handle_result_out(&e)?,
         }
         Ok(())
     }

--- a/src/daft-context/src/subscribers/debug.rs
+++ b/src/daft-context/src/subscribers/debug.rs
@@ -1,14 +1,14 @@
-use std::sync::Arc;
-
-use async_trait::async_trait;
 use common_error::DaftResult;
-use common_metrics::{NodeID, QueryID, QueryPlan, Stat, Stats};
-use daft_micropartition::MicroPartitionRef;
+use common_metrics::{QueryID, Stat};
 use dashmap::DashMap;
 
 use crate::subscribers::{
-    Event, QueryMetadata, QueryResult, Subscriber,
-    events::{OperatorEndEvent, OperatorStartEvent, StatsEvent},
+    Event, Subscriber,
+    events::{
+        ExecEndEvent, ExecStartEvent, OperatorEndEvent, OperatorStartEvent,
+        OptimizationCompleteEvent, OptimizationStartEvent, ProcessStatsEvent, QueryEndEvent,
+        QueryStartEvent, ResultOutEvent, StatsEvent,
+    },
 };
 
 #[derive(Debug)]
@@ -22,100 +22,79 @@ impl DebugSubscriber {
             rows_out: DashMap::new(),
         }
     }
-}
 
-#[async_trait]
-impl Subscriber for DebugSubscriber {
-    fn on_query_start(&self, query_id: QueryID, metadata: Arc<QueryMetadata>) -> DaftResult<()> {
+    fn handle_query_start(&self, event: &QueryStartEvent) -> DaftResult<()> {
         eprintln!(
-            "Started query `{}` with unoptimized plan:\n{}",
-            query_id,
-            metadata.unoptimized_plan.as_ref()
+            "query_start query_id={} runner={} unoptimized_plan=\n{}",
+            event.header.query_id,
+            event.metadata.runner,
+            event.metadata.unoptimized_plan.as_ref()
         );
-        self.rows_out.insert(query_id, 0);
+        self.rows_out.insert(event.header.query_id.clone(), 0);
         Ok(())
     }
 
-    #[allow(unused_variables)]
-    fn on_query_end(&self, query_id: QueryID, end_result: QueryResult) -> DaftResult<()> {
-        eprintln!(
-            "Ended query `{}` with result of {} rows",
-            query_id,
-            self.rows_out
-                .get(&query_id)
-                .expect("Query not found")
-                .value()
-        );
-        Ok(())
-    }
-
-    fn on_result_out(&self, query_id: QueryID, result: MicroPartitionRef) -> DaftResult<()> {
-        *self
+    fn handle_query_end(&self, event: &QueryEndEvent) -> DaftResult<()> {
+        let rows_out = self
             .rows_out
-            .get_mut(&query_id)
-            .expect("Query not found")
-            .value_mut() += result.len();
+            .get(&event.header.query_id)
+            .map(|rows| *rows.value())
+            .unwrap_or(0);
+
+        match event.duration_ms {
+            Some(duration_ms) => eprintln!(
+                "query_end query_id={} end_state={:?} rows_out={} duration_ms={duration_ms}",
+                event.header.query_id, event.result.end_state, rows_out,
+            ),
+            None => eprintln!(
+                "query_end query_id={} end_state={:?} rows_out={}",
+                event.header.query_id, event.result.end_state, rows_out,
+            ),
+        }
+
+        if let Some(error_message) = event.result.error_message.as_deref() {
+            eprintln!(
+                "query_end_error query_id={} error=\"{}\"",
+                event.header.query_id, error_message
+            );
+        }
+
         Ok(())
     }
 
-    fn on_optimization_start(&self, query_id: QueryID) -> DaftResult<()> {
-        eprintln!("Started planning query `{}`", query_id);
+    fn handle_optimization_start(&self, event: &OptimizationStartEvent) -> DaftResult<()> {
+        eprintln!("optimization_start query_id={}\n", event.header.query_id);
         Ok(())
     }
 
-    fn on_optimization_end(&self, query_id: QueryID, optimized_plan: QueryPlan) -> DaftResult<()> {
+    fn handle_optimization_complete(&self, event: &OptimizationCompleteEvent) -> DaftResult<()> {
         eprintln!(
-            "Finished planning query `{}` with optimized plan:\n{}",
-            query_id, optimized_plan
+            "optimization_complete query_id={} optimized_plan=\n{}",
+            event.header.query_id, event.optimized_plan
         );
         Ok(())
     }
 
-    fn on_exec_start(&self, query_id: QueryID, physical_plan: QueryPlan) -> DaftResult<()> {
+    fn handle_exec_start(&self, event: &ExecStartEvent) -> DaftResult<()> {
         eprintln!(
-            "Started executing query `{}` with physical plan:\n{}",
-            query_id, physical_plan
+            "exec_start query_id={} physical_plan=\n{}",
+            event.header.query_id, event.physical_plan
         );
         Ok(())
     }
 
-    async fn on_exec_operator_start(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()> {
-        eprintln!(
-            "Started executing operator `{}` in query `{}`",
-            node_id, query_id
-        );
-        Ok(())
-    }
-
-    async fn on_exec_emit_stats(
-        &self,
-        query_id: QueryID,
-        stats: std::sync::Arc<Vec<(NodeID, Stats)>>,
-    ) -> DaftResult<()> {
-        eprintln!("Emitting execution stats for query `{}`", query_id);
-        for (node_id, node_stats) in stats.iter() {
-            eprintln!("  Node `{}`", node_id);
-            for (name, stat) in node_stats.iter() {
-                eprintln!("  - {} = {}", name, stat);
-            }
+    fn handle_exec_end(&self, event: &ExecEndEvent) -> DaftResult<()> {
+        match event.duration_ms {
+            Some(duration_ms) => eprintln!(
+                "exec_end query_id={} duration_ms={duration_ms}",
+                event.header.query_id
+            ),
+            None => eprintln!("exec_end query_id={}", event.header.query_id),
         }
         Ok(())
     }
 
-    async fn on_exec_operator_end(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()> {
-        eprintln!(
-            "Finished executing operator `{}` in query `{}`",
-            node_id, query_id
-        );
-        Ok(())
-    }
-
-    async fn on_exec_end(&self, query_id: QueryID) -> DaftResult<()> {
-        eprintln!("Finished executing query `{}`", query_id);
-        Ok(())
-    }
-
-    async fn on_operator_start(&self, event: Arc<OperatorStartEvent>) -> DaftResult<()> {
+    fn handle_operator_start(&self, event: &OperatorStartEvent) -> DaftResult<()> {
         if event.operator.origin_node_id == event.operator.node_id {
             eprintln!(
                 "operator_start query_id={} node_id={} name=\"{}\" type={:?} category={:?}",
@@ -139,7 +118,7 @@ impl Subscriber for DebugSubscriber {
         Ok(())
     }
 
-    async fn on_operator_end(&self, event: Arc<OperatorEndEvent>) -> DaftResult<()> {
+    fn handle_operator_end(&self, event: &OperatorEndEvent) -> DaftResult<()> {
         if event.operator.origin_node_id == event.operator.node_id {
             eprintln!(
                 "operator_end query_id={} node_id={} name=\"{}\"",
@@ -157,7 +136,7 @@ impl Subscriber for DebugSubscriber {
         Ok(())
     }
 
-    async fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
+    fn handle_stats(&self, event: &StatsEvent) -> DaftResult<()> {
         for (node_id, stats) in event.stats.iter() {
             let rendered = stats
                 .0
@@ -174,11 +153,48 @@ impl Subscriber for DebugSubscriber {
         Ok(())
     }
 
-    async fn on_event(&self, event: Event) -> DaftResult<()> {
+    fn handle_process_stats(&self, event: &ProcessStatsEvent) -> DaftResult<()> {
+        let rendered = event
+            .stats
+            .0
+            .iter()
+            .map(|(key, stat)| format!("{key}={}", render_stat(stat)))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        eprintln!(
+            "process_stats query_id={} {}",
+            event.header.query_id, rendered,
+        );
+        Ok(())
+    }
+
+    fn handle_result_out(&self, event: &ResultOutEvent) -> DaftResult<()> {
+        if let Some(mut rows_out) = self.rows_out.get_mut(&event.header.query_id) {
+            *rows_out.value_mut() += event.num_rows as usize;
+        }
+        eprintln!(
+            "result_out query_id={} num_rows={}",
+            event.header.query_id, event.num_rows
+        );
+        Ok(())
+    }
+}
+
+impl Subscriber for DebugSubscriber {
+    fn on_event(&self, event: Event) -> DaftResult<()> {
         match event {
-            Event::Stats(e) => self.on_stats(e).await?,
-            Event::OperatorStart(e) => self.on_operator_start(e).await?,
-            Event::OperatorEnd(e) => self.on_operator_end(e).await?,
+            Event::QueryStart(e) => self.handle_query_start(e.as_ref())?,
+            Event::QueryEnd(e) => self.handle_query_end(e.as_ref())?,
+            Event::OptimizationStart(e) => self.handle_optimization_start(e.as_ref())?,
+            Event::OptimizationComplete(e) => self.handle_optimization_complete(e.as_ref())?,
+            Event::ExecStart(e) => self.handle_exec_start(e.as_ref())?,
+            Event::ExecEnd(e) => self.handle_exec_end(e.as_ref())?,
+            Event::OperatorStart(e) => self.handle_operator_start(e.as_ref())?,
+            Event::OperatorEnd(e) => self.handle_operator_end(e.as_ref())?,
+            Event::Stats(e) => self.handle_stats(e.as_ref())?,
+            Event::ProcessStats(e) => self.handle_process_stats(e.as_ref())?,
+            Event::ResultOut(e) => self.handle_result_out(e.as_ref())?,
         }
         Ok(())
     }

--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -1,15 +1,26 @@
 use std::{collections::HashMap, sync::Arc};
 
 use common_metrics::{
-    NodeID, QueryID, Stats,
+    NodeID, QueryID, QueryPlan, Stats,
     ops::{NodeCategory, NodeInfo, NodeType},
 };
+use daft_micropartition::MicroPartitionRef;
+
+use super::{QueryMetadata, QueryResult};
 
 #[derive(Debug, Clone)]
 pub enum Event {
+    QueryStart(Arc<QueryStartEvent>),
+    QueryEnd(Arc<QueryEndEvent>),
+    OptimizationStart(Arc<OptimizationStartEvent>),
+    OptimizationComplete(Arc<OptimizationCompleteEvent>),
+    ExecStart(Arc<ExecStartEvent>),
+    ExecEnd(Arc<ExecEndEvent>),
     OperatorStart(Arc<OperatorStartEvent>),
     OperatorEnd(Arc<OperatorEndEvent>),
     Stats(Arc<StatsEvent>),
+    ProcessStats(Arc<ProcessStatsEvent>),
+    ResultOut(Arc<ResultOutEvent>),
 }
 
 #[derive(Debug, Clone)]
@@ -27,6 +38,22 @@ pub struct OperatorMeta {
     pub origin_node_id: NodeID,
     pub node_phase: Option<String>,
     pub context: HashMap<String, String>,
+}
+
+impl OperatorMeta {
+    // Placeholder until we can get more data from distributed
+    // on_operator_start and on_operator_end calls
+    pub fn from_id(node_id: NodeID) -> Self {
+        Self {
+            node_id,
+            name: Arc::from("unknown"),
+            node_type: NodeType::default(),
+            node_category: NodeCategory::default(),
+            origin_node_id: node_id,
+            node_phase: None,
+            context: HashMap::new(),
+        }
+    }
 }
 
 impl From<&NodeInfo> for OperatorMeta {
@@ -59,4 +86,54 @@ pub struct OperatorEndEvent {
 pub struct StatsEvent {
     pub header: EventHeader,
     pub stats: Arc<Vec<(NodeID, Stats)>>,
+}
+
+#[derive(Debug)]
+pub struct ProcessStatsEvent {
+    pub header: EventHeader,
+    pub stats: Stats,
+}
+
+#[derive(Debug)]
+pub struct QueryStartEvent {
+    pub header: EventHeader,
+    pub metadata: Arc<QueryMetadata>,
+}
+
+#[derive(Debug)]
+pub struct QueryEndEvent {
+    pub header: EventHeader,
+    pub result: QueryResult,
+    pub duration_ms: Option<f64>,
+}
+
+#[derive(Debug)]
+pub struct OptimizationStartEvent {
+    pub header: EventHeader,
+}
+
+#[derive(Debug)]
+pub struct OptimizationCompleteEvent {
+    pub header: EventHeader,
+    pub optimized_plan: QueryPlan,
+}
+
+#[derive(Debug)]
+pub struct ExecStartEvent {
+    pub header: EventHeader,
+    pub physical_plan: QueryPlan,
+}
+
+#[derive(Debug)]
+pub struct ExecEndEvent {
+    pub header: EventHeader,
+    pub duration_ms: Option<f64>,
+}
+
+#[derive(Debug)]
+pub struct ResultOutEvent {
+    pub header: EventHeader,
+    pub num_rows: u64,
+    // needed by the dashboard subscriber
+    pub data: Option<MicroPartitionRef>,
 }

--- a/src/daft-context/src/subscribers/events.rs
+++ b/src/daft-context/src/subscribers/events.rs
@@ -10,17 +10,17 @@ use super::{QueryMetadata, QueryResult};
 
 #[derive(Debug, Clone)]
 pub enum Event {
-    QueryStart(Arc<QueryStartEvent>),
-    QueryEnd(Arc<QueryEndEvent>),
-    OptimizationStart(Arc<OptimizationStartEvent>),
-    OptimizationComplete(Arc<OptimizationCompleteEvent>),
-    ExecStart(Arc<ExecStartEvent>),
-    ExecEnd(Arc<ExecEndEvent>),
-    OperatorStart(Arc<OperatorStartEvent>),
-    OperatorEnd(Arc<OperatorEndEvent>),
-    Stats(Arc<StatsEvent>),
-    ProcessStats(Arc<ProcessStatsEvent>),
-    ResultOut(Arc<ResultOutEvent>),
+    QueryStart(QueryStartEvent),
+    QueryEnd(QueryEndEvent),
+    OptimizationStart(OptimizationStartEvent),
+    OptimizationComplete(OptimizationCompleteEvent),
+    ExecStart(ExecStartEvent),
+    ExecEnd(ExecEndEvent),
+    OperatorStart(OperatorStartEvent),
+    OperatorEnd(OperatorEndEvent),
+    Stats(StatsEvent),
+    ProcessStats(ProcessStatsEvent),
+    ResultOut(ResultOutEvent),
 }
 
 #[derive(Debug, Clone)]
@@ -70,67 +70,67 @@ impl From<&NodeInfo> for OperatorMeta {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OperatorStartEvent {
     pub header: EventHeader,
     pub operator: Arc<OperatorMeta>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OperatorEndEvent {
     pub header: EventHeader,
     pub operator: Arc<OperatorMeta>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StatsEvent {
     pub header: EventHeader,
     pub stats: Arc<Vec<(NodeID, Stats)>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProcessStatsEvent {
     pub header: EventHeader,
     pub stats: Stats,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct QueryStartEvent {
     pub header: EventHeader,
     pub metadata: Arc<QueryMetadata>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct QueryEndEvent {
     pub header: EventHeader,
     pub result: QueryResult,
     pub duration_ms: Option<f64>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OptimizationStartEvent {
     pub header: EventHeader,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OptimizationCompleteEvent {
     pub header: EventHeader,
     pub optimized_plan: QueryPlan,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExecStartEvent {
     pub header: EventHeader,
     pub physical_plan: QueryPlan,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExecEndEvent {
     pub header: EventHeader,
     pub duration_ms: Option<f64>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ResultOutEvent {
     pub header: EventHeader,
     pub num_rows: u64,

--- a/src/daft-context/src/subscribers/mod.rs
+++ b/src/daft-context/src/subscribers/mod.rs
@@ -4,16 +4,20 @@ pub mod events;
 #[cfg(feature = "python")]
 pub mod python;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
-use async_trait::async_trait;
 use common_error::{DaftError, DaftResult};
-use common_metrics::{NodeID, QueryEndState, QueryID, QueryPlan, Stats};
+use common_metrics::{QueryEndState, QueryID, QueryPlan};
 use daft_core::prelude::SchemaRef;
-use daft_micropartition::MicroPartitionRef;
 pub use events::Event;
-use events::{OperatorEndEvent, OperatorStartEvent, StatsEvent};
 
+use crate::subscribers::events::EventHeader;
+
+#[derive(Debug)]
 pub struct QueryMetadata {
     pub output_schema: SchemaRef,
     pub unoptimized_plan: QueryPlan,
@@ -28,71 +32,22 @@ pub struct QueryResult {
     pub error_message: Option<String>,
 }
 
-#[async_trait]
+pub fn now_epoch_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock is before UNIX_EPOCH")
+        .as_secs_f64()
+}
+
+pub fn event_header(query_id: QueryID) -> EventHeader {
+    EventHeader {
+        query_id,
+        timestamp_epoch_secs: now_epoch_secs(),
+    }
+}
+
 pub trait Subscriber: Send + Sync + std::fmt::Debug + 'static {
-    fn on_query_start(&self, query_id: QueryID, metadata: Arc<QueryMetadata>) -> DaftResult<()>;
-    fn on_query_end(&self, query_id: QueryID, result: QueryResult) -> DaftResult<()>;
-    fn on_result_out(&self, query_id: QueryID, result: MicroPartitionRef) -> DaftResult<()>;
-    fn on_optimization_start(&self, query_id: QueryID) -> DaftResult<()>;
-    fn on_optimization_end(&self, query_id: QueryID, optimized_plan: QueryPlan) -> DaftResult<()>;
-    fn on_exec_start(&self, query_id: QueryID, physical_plan: QueryPlan) -> DaftResult<()>;
-    fn on_exec_start_with_id(
-        &self,
-        query_id: QueryID,
-        _execution_id: &str,
-        physical_plan: QueryPlan,
-    ) -> DaftResult<()> {
-        self.on_exec_start(query_id, physical_plan)
-    }
-    /// Deprecated: use on_operator_start instead
-    async fn on_exec_operator_start(&self, _query_id: QueryID, _node_id: NodeID) -> DaftResult<()> {
-        Ok(())
-    }
-    /// Deprecated: use on_stats instead
-    async fn on_exec_emit_stats(
-        &self,
-        _query_id: QueryID,
-        _stats: Arc<Vec<(NodeID, Stats)>>,
-    ) -> DaftResult<()> {
-        Ok(())
-    }
-    async fn on_exec_emit_stats_with_id(
-        &self,
-        query_id: QueryID,
-        _execution_id: &str,
-        stats: Arc<Vec<(NodeID, Stats)>>,
-    ) -> DaftResult<()> {
-        self.on_exec_emit_stats(query_id, stats).await
-    }
-    /// Deprecated: use on_operator_end instead
-    async fn on_exec_operator_end(&self, _query_id: QueryID, _node_id: NodeID) -> DaftResult<()> {
-        Ok(())
-    }
-    async fn on_exec_end(&self, query_id: QueryID) -> DaftResult<()>;
-    /// Called with process-level stats (memory, CPU) on each tick.
-    /// Default no-op; only subscribers interested in process stats need to override.
-    async fn on_process_stats(&self, _query_id: QueryID, _stats: Stats) -> DaftResult<()> {
-        Ok(())
-    }
-    async fn on_exec_end_with_id(&self, query_id: QueryID, _execution_id: &str) -> DaftResult<()> {
-        self.on_exec_end(query_id).await
-    }
-
-    async fn on_operator_start(&self, _event: Arc<OperatorStartEvent>) -> DaftResult<()> {
-        Ok(())
-    }
-
-    async fn on_operator_end(&self, _event: Arc<OperatorEndEvent>) -> DaftResult<()> {
-        Ok(())
-    }
-
-    async fn on_stats(&self, _event: Arc<StatsEvent>) -> DaftResult<()> {
-        Ok(())
-    }
-
-    async fn on_event(&self, _event: Event) -> DaftResult<()> {
-        Ok(())
-    }
+    fn on_event(&self, _event: Event) -> DaftResult<()>;
 }
 
 pub fn default_subscribers() -> HashMap<String, Arc<dyn Subscriber>> {

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use common_error::DaftResult;
 use common_metrics::{NodeID, Stats};
-use daft_micropartition::python::PyMicroPartition;
 use pyo3::{
     Bound, IntoPyObject, Py, PyAny, PyResult, Python, intern,
     types::{PyAnyMethods, PyModule},
@@ -155,15 +154,8 @@ fn build_process_stats(py: Python<'_>, event: Arc<ProcessStatsEvent>) -> PyResul
 }
 
 fn build_result_produced(py: Python<'_>, event: Arc<ResultOutEvent>) -> PyResult<Py<PyAny>> {
-    let data = event
-        .data
-        .clone()
-        .map(PyMicroPartition::from)
-        .map(|partition| partition.into_pyobject(py).map(|obj| obj.into_any()))
-        .transpose()?;
-
     event_class(py, "ResultProduced")?
-        .call1((event.header.query_id.to_string(), event.num_rows, data))
+        .call1((event.header.query_id.to_string(), event.num_rows))
         .map(Into::into)
 }
 

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashMap, sync::Arc};
 
-use async_trait::async_trait;
 use common_error::DaftResult;
-use common_metrics::{QueryID, QueryPlan, Stats};
-use daft_micropartition::{MicroPartitionRef, python::PyMicroPartition};
+use common_metrics::{NodeID, Stats};
+use daft_micropartition::python::PyMicroPartition;
 use pyo3::{
     Bound, IntoPyObject, Py, PyAny, PyResult, Python, intern,
     types::{PyAnyMethods, PyModule},
@@ -12,8 +11,12 @@ use pyo3::{
 use crate::{
     python::{PyQueryMetadata, PyQueryResult},
     subscribers::{
-        Event, NodeID, QueryMetadata, QueryResult, Subscriber,
-        events::{OperatorEndEvent, OperatorStartEvent, StatsEvent},
+        Event, Subscriber,
+        events::{
+            ExecEndEvent, ExecStartEvent, OperatorEndEvent, OperatorStartEvent,
+            OptimizationCompleteEvent, OptimizationStartEvent, ProcessStatsEvent, QueryEndEvent,
+            QueryStartEvent, ResultOutEvent, StatsEvent,
+        },
     },
 };
 
@@ -21,153 +24,8 @@ use crate::{
 #[derive(Debug)]
 pub struct PySubscriberWrapper(pub(crate) Py<PyAny>);
 
-#[async_trait]
 impl Subscriber for PySubscriberWrapper {
-    fn on_query_start(&self, query_id: QueryID, metadata: Arc<QueryMetadata>) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_query_start"),
-                (query_id.to_string(), PyQueryMetadata::from(metadata)),
-            )?;
-            Ok(())
-        })
-    }
-
-    #[allow(unused_variables)]
-    fn on_query_end(&self, query_id: QueryID, end_result: QueryResult) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_query_end"),
-                (query_id.to_string(), PyQueryResult::from(end_result)),
-            )?;
-            Ok(())
-        })
-    }
-
-    fn on_result_out(&self, query_id: QueryID, result: MicroPartitionRef) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_result_out"),
-                (query_id.to_string(), PyMicroPartition::from(result)),
-            )?;
-            Ok(())
-        })
-    }
-
-    fn on_optimization_start(&self, query_id: QueryID) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_optimization_start"),
-                (query_id.to_string(),),
-            )?;
-            Ok(())
-        })
-    }
-
-    fn on_optimization_end(&self, query_id: QueryID, optimized_plan: QueryPlan) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_optimization_end"),
-                (query_id.to_string(), optimized_plan.to_string()),
-            )?;
-            Ok(())
-        })
-    }
-
-    fn on_exec_start(&self, query_id: QueryID, physical_plan: QueryPlan) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_exec_start"),
-                (query_id.to_string(), physical_plan.to_string()),
-            )?;
-            Ok(())
-        })
-    }
-
-    async fn on_exec_operator_start(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_exec_operator_start"),
-                (query_id.to_string(), node_id),
-            )?;
-            Ok(())
-        })
-    }
-
-    async fn on_exec_emit_stats(
-        &self,
-        query_id: QueryID,
-        stats: Arc<Vec<(NodeID, Stats)>>,
-    ) -> DaftResult<()> {
-        Python::attach(|py| {
-            let stats_map = stats
-                .iter()
-                .map(|(node_id, stats)| {
-                    let stat_map = stats
-                        .iter()
-                        .map(|(name, stat)| {
-                            (name.to_string(), stat.clone().into_py_contents(py).unwrap())
-                        })
-                        .collect::<HashMap<_, _>>();
-
-                    (*node_id, stat_map)
-                })
-                .collect::<HashMap<_, _>>();
-            let py_stats = stats_map.into_pyobject(py)?;
-
-            self.0.call_method1(
-                py,
-                intern!(py, "on_exec_emit_stats"),
-                (query_id.to_string(), py_stats),
-            )?;
-            Ok(())
-        })
-    }
-
-    async fn on_exec_operator_end(&self, query_id: QueryID, node_id: NodeID) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0.call_method1(
-                py,
-                intern!(py, "on_exec_operator_end"),
-                (query_id.to_string(), node_id),
-            )?;
-            Ok(())
-        })
-    }
-
-    async fn on_exec_end(&self, query_id: QueryID) -> DaftResult<()> {
-        Python::attach(|py| {
-            self.0
-                .call_method1(py, intern!(py, "on_exec_end"), (query_id.to_string(),))?;
-            Ok(())
-        })
-    }
-
-    async fn on_process_stats(&self, query_id: QueryID, stats: Stats) -> DaftResult<()> {
-        Python::attach(|py| {
-            let stat_map = stats
-                .iter()
-                .map(|(name, stat)| (name.to_string(), stat.clone().into_py_contents(py).unwrap()))
-                .collect::<HashMap<_, _>>();
-            let py_stats = stat_map.into_pyobject(py)?;
-
-            self.0.call_method1(
-                py,
-                intern!(py, "on_process_stats"),
-                (query_id.to_string(), py_stats),
-            )?;
-            Ok(())
-        })
-    }
-
-    async fn on_event(&self, event: Event) -> DaftResult<()> {
+    fn on_event(&self, event: Event) -> DaftResult<()> {
         Python::attach(|py| {
             let py_event = build_py_event(py, event)?;
             self.0
@@ -207,6 +65,61 @@ fn build_operator_finished(py: Python<'_>, event: Arc<OperatorEndEvent>) -> PyRe
         .map(Into::into)
 }
 
+fn build_query_started(py: Python<'_>, event: Arc<QueryStartEvent>) -> PyResult<Py<PyAny>> {
+    event_class(py, "QueryStarted")?
+        .call1((
+            event.header.query_id.to_string(),
+            PyQueryMetadata::from(event.metadata.clone()),
+        ))
+        .map(Into::into)
+}
+
+fn build_query_finished(py: Python<'_>, event: Arc<QueryEndEvent>) -> PyResult<Py<PyAny>> {
+    event_class(py, "QueryFinished")?
+        .call1((
+            event.header.query_id.to_string(),
+            PyQueryResult::from(Arc::new(event.result.clone())),
+            event.duration_ms,
+        ))
+        .map(Into::into)
+}
+
+fn build_optimization_completed(
+    py: Python<'_>,
+    event: Arc<OptimizationCompleteEvent>,
+) -> PyResult<Py<PyAny>> {
+    event_class(py, "OptimizationCompleted")?
+        .call1((
+            event.header.query_id.to_string(),
+            event.optimized_plan.to_string(),
+        ))
+        .map(Into::into)
+}
+
+fn build_optimization_started(
+    py: Python<'_>,
+    event: Arc<OptimizationStartEvent>,
+) -> PyResult<Py<PyAny>> {
+    event_class(py, "OptimizationStarted")?
+        .call1((event.header.query_id.to_string(),))
+        .map(Into::into)
+}
+
+fn build_execution_started(py: Python<'_>, event: Arc<ExecStartEvent>) -> PyResult<Py<PyAny>> {
+    event_class(py, "ExecutionStarted")?
+        .call1((
+            event.header.query_id.to_string(),
+            event.physical_plan.to_string(),
+        ))
+        .map(Into::into)
+}
+
+fn build_execution_finished(py: Python<'_>, event: Arc<ExecEndEvent>) -> PyResult<Py<PyAny>> {
+    event_class(py, "ExecutionFinished")?
+        .call1((event.header.query_id.to_string(), event.duration_ms))
+        .map(Into::into)
+}
+
 fn build_py_stats<'py>(py: Python<'py>, stats: &[(NodeID, Stats)]) -> PyResult<Bound<'py, PyAny>> {
     let stats_map = stats
         .iter()
@@ -229,10 +142,43 @@ fn build_stats(py: Python<'_>, event: Arc<StatsEvent>) -> PyResult<Py<PyAny>> {
         .map(Into::into)
 }
 
+fn build_process_stats(py: Python<'_>, event: Arc<ProcessStatsEvent>) -> PyResult<Py<PyAny>> {
+    let py_stats = event
+        .stats
+        .iter()
+        .map(|(name, stat)| Ok((name.to_string(), stat.clone().into_py_contents(py)?)))
+        .collect::<PyResult<HashMap<_, _>>>()?;
+
+    event_class(py, "ProcessStats")?
+        .call1((event.header.query_id.to_string(), py_stats))
+        .map(Into::into)
+}
+
+fn build_result_produced(py: Python<'_>, event: Arc<ResultOutEvent>) -> PyResult<Py<PyAny>> {
+    let data = event
+        .data
+        .clone()
+        .map(PyMicroPartition::from)
+        .map(|partition| partition.into_pyobject(py).map(|obj| obj.into_any()))
+        .transpose()?;
+
+    event_class(py, "ResultProduced")?
+        .call1((event.header.query_id.to_string(), event.num_rows, data))
+        .map(Into::into)
+}
+
 fn build_py_event(py: Python<'_>, event: Event) -> PyResult<Py<PyAny>> {
     match event {
+        Event::QueryStart(event) => build_query_started(py, event),
+        Event::QueryEnd(event) => build_query_finished(py, event),
+        Event::OptimizationStart(event) => build_optimization_started(py, event),
+        Event::OptimizationComplete(event) => build_optimization_completed(py, event),
+        Event::ExecStart(event) => build_execution_started(py, event),
+        Event::ExecEnd(event) => build_execution_finished(py, event),
         Event::OperatorStart(event) => build_operator_started(py, event),
         Event::OperatorEnd(event) => build_operator_finished(py, event),
         Event::Stats(event) => build_stats(py, event),
+        Event::ProcessStats(event) => build_process_stats(py, event),
+        Event::ResultOut(event) => build_result_produced(py, event),
     }
 }

--- a/src/daft-context/src/subscribers/python.rs
+++ b/src/daft-context/src/subscribers/python.rs
@@ -44,7 +44,7 @@ fn event_class<'py>(py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> 
     events_module(py)?.getattr(name)
 }
 
-fn build_operator_started(py: Python<'_>, event: Arc<OperatorStartEvent>) -> PyResult<Py<PyAny>> {
+fn build_operator_started(py: Python<'_>, event: &OperatorStartEvent) -> PyResult<Py<PyAny>> {
     event_class(py, "OperatorStarted")?
         .call1((
             event.header.query_id.to_string(),
@@ -54,7 +54,7 @@ fn build_operator_started(py: Python<'_>, event: Arc<OperatorStartEvent>) -> PyR
         .map(Into::into)
 }
 
-fn build_operator_finished(py: Python<'_>, event: Arc<OperatorEndEvent>) -> PyResult<Py<PyAny>> {
+fn build_operator_finished(py: Python<'_>, event: &OperatorEndEvent) -> PyResult<Py<PyAny>> {
     event_class(py, "OperatorFinished")?
         .call1((
             event.header.query_id.to_string(),
@@ -64,7 +64,7 @@ fn build_operator_finished(py: Python<'_>, event: Arc<OperatorEndEvent>) -> PyRe
         .map(Into::into)
 }
 
-fn build_query_started(py: Python<'_>, event: Arc<QueryStartEvent>) -> PyResult<Py<PyAny>> {
+fn build_query_started(py: Python<'_>, event: &QueryStartEvent) -> PyResult<Py<PyAny>> {
     event_class(py, "QueryStarted")?
         .call1((
             event.header.query_id.to_string(),
@@ -73,7 +73,7 @@ fn build_query_started(py: Python<'_>, event: Arc<QueryStartEvent>) -> PyResult<
         .map(Into::into)
 }
 
-fn build_query_finished(py: Python<'_>, event: Arc<QueryEndEvent>) -> PyResult<Py<PyAny>> {
+fn build_query_finished(py: Python<'_>, event: &QueryEndEvent) -> PyResult<Py<PyAny>> {
     event_class(py, "QueryFinished")?
         .call1((
             event.header.query_id.to_string(),
@@ -85,7 +85,7 @@ fn build_query_finished(py: Python<'_>, event: Arc<QueryEndEvent>) -> PyResult<P
 
 fn build_optimization_completed(
     py: Python<'_>,
-    event: Arc<OptimizationCompleteEvent>,
+    event: &OptimizationCompleteEvent,
 ) -> PyResult<Py<PyAny>> {
     event_class(py, "OptimizationCompleted")?
         .call1((
@@ -97,14 +97,14 @@ fn build_optimization_completed(
 
 fn build_optimization_started(
     py: Python<'_>,
-    event: Arc<OptimizationStartEvent>,
+    event: &OptimizationStartEvent,
 ) -> PyResult<Py<PyAny>> {
     event_class(py, "OptimizationStarted")?
         .call1((event.header.query_id.to_string(),))
         .map(Into::into)
 }
 
-fn build_execution_started(py: Python<'_>, event: Arc<ExecStartEvent>) -> PyResult<Py<PyAny>> {
+fn build_execution_started(py: Python<'_>, event: &ExecStartEvent) -> PyResult<Py<PyAny>> {
     event_class(py, "ExecutionStarted")?
         .call1((
             event.header.query_id.to_string(),
@@ -113,7 +113,7 @@ fn build_execution_started(py: Python<'_>, event: Arc<ExecStartEvent>) -> PyResu
         .map(Into::into)
 }
 
-fn build_execution_finished(py: Python<'_>, event: Arc<ExecEndEvent>) -> PyResult<Py<PyAny>> {
+fn build_execution_finished(py: Python<'_>, event: &ExecEndEvent) -> PyResult<Py<PyAny>> {
     event_class(py, "ExecutionFinished")?
         .call1((event.header.query_id.to_string(), event.duration_ms))
         .map(Into::into)
@@ -134,14 +134,14 @@ fn build_py_stats<'py>(py: Python<'py>, stats: &[(NodeID, Stats)]) -> PyResult<B
     stats_map.into_pyobject(py).map(|obj| obj.into_any())
 }
 
-fn build_stats(py: Python<'_>, event: Arc<StatsEvent>) -> PyResult<Py<PyAny>> {
+fn build_stats(py: Python<'_>, event: &StatsEvent) -> PyResult<Py<PyAny>> {
     let py_stats = build_py_stats(py, event.stats.as_ref())?;
     event_class(py, "Stats")?
         .call1((event.header.query_id.to_string(), py_stats))
         .map(Into::into)
 }
 
-fn build_process_stats(py: Python<'_>, event: Arc<ProcessStatsEvent>) -> PyResult<Py<PyAny>> {
+fn build_process_stats(py: Python<'_>, event: &ProcessStatsEvent) -> PyResult<Py<PyAny>> {
     let py_stats = event
         .stats
         .iter()
@@ -153,7 +153,7 @@ fn build_process_stats(py: Python<'_>, event: Arc<ProcessStatsEvent>) -> PyResul
         .map(Into::into)
 }
 
-fn build_result_produced(py: Python<'_>, event: Arc<ResultOutEvent>) -> PyResult<Py<PyAny>> {
+fn build_result_produced(py: Python<'_>, event: &ResultOutEvent) -> PyResult<Py<PyAny>> {
     event_class(py, "ResultProduced")?
         .call1((event.header.query_id.to_string(), event.num_rows))
         .map(Into::into)
@@ -161,16 +161,16 @@ fn build_result_produced(py: Python<'_>, event: Arc<ResultOutEvent>) -> PyResult
 
 fn build_py_event(py: Python<'_>, event: Event) -> PyResult<Py<PyAny>> {
     match event {
-        Event::QueryStart(event) => build_query_started(py, event),
-        Event::QueryEnd(event) => build_query_finished(py, event),
-        Event::OptimizationStart(event) => build_optimization_started(py, event),
-        Event::OptimizationComplete(event) => build_optimization_completed(py, event),
-        Event::ExecStart(event) => build_execution_started(py, event),
-        Event::ExecEnd(event) => build_execution_finished(py, event),
-        Event::OperatorStart(event) => build_operator_started(py, event),
-        Event::OperatorEnd(event) => build_operator_finished(py, event),
-        Event::Stats(event) => build_stats(py, event),
-        Event::ProcessStats(event) => build_process_stats(py, event),
-        Event::ResultOut(event) => build_result_produced(py, event),
+        Event::QueryStart(event) => build_query_started(py, &event),
+        Event::QueryEnd(event) => build_query_finished(py, &event),
+        Event::OptimizationStart(event) => build_optimization_started(py, &event),
+        Event::OptimizationComplete(event) => build_optimization_completed(py, &event),
+        Event::ExecStart(event) => build_execution_started(py, &event),
+        Event::ExecEnd(event) => build_execution_finished(py, &event),
+        Event::OperatorStart(event) => build_operator_started(py, &event),
+        Event::OperatorEnd(event) => build_operator_finished(py, &event),
+        Event::Stats(event) => build_stats(py, &event),
+        Event::ProcessStats(event) => build_process_stats(py, &event),
+        Event::ResultOut(event) => build_result_produced(py, &event),
     }
 }

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -5,7 +5,7 @@ mod values;
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
 
 use common_error::DaftResult;
@@ -15,13 +15,16 @@ use common_metrics::{
 use common_runtime::RuntimeTask;
 use daft_context::{
     Subscriber,
-    subscribers::events::{
-        Event, EventHeader, OperatorEndEvent, OperatorMeta, OperatorStartEvent, StatsEvent,
+    subscribers::{
+        event_header,
+        events::{
+            Event, ExecEndEvent, ExecStartEvent, OperatorEndEvent, OperatorMeta,
+            OperatorStartEvent, ProcessStatsEvent, StatsEvent,
+        },
     },
 };
 use daft_dsl::common_treenode::{TreeNode, TreeNodeRecursion};
 use daft_local_plan::{ExecutionStats, InputId};
-use futures::future;
 use progress_bar::{ProgressBar, make_progress_bar_manager};
 use tokio::{
     runtime::Handle,
@@ -38,13 +41,6 @@ pub enum StatsManagerMessage {
     NodeEvent(usize, bool),
     RegisterRuntimeStats(NodeID, InputId, Arc<dyn RuntimeStats>),
     TakeInputSnapshot(InputId, oneshot::Sender<ExecutionStats>),
-}
-
-fn now_epoch_secs() -> f64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system clock is before UNIX_EPOCH")
-        .as_secs_f64()
 }
 
 fn should_enable_process_monitor() -> bool {
@@ -170,7 +166,7 @@ impl std::fmt::Debug for RuntimeStatsManager {
 }
 
 impl RuntimeStatsManager {
-    async fn flush_and_finalize_node(
+    fn flush_and_finalize_node(
         query_id: &QueryID,
         node_id: NodeID,
         input_stats: &HashMap<(NodeID, InputId), Arc<dyn RuntimeStats>>,
@@ -194,53 +190,22 @@ impl RuntimeStatsManager {
 
         if let Some(snapshot) = snapshot {
             let stats_event = Event::Stats(Arc::new(StatsEvent {
-                header: EventHeader {
-                    query_id: query_id.clone(),
-                    timestamp_epoch_secs: now_epoch_secs(),
-                },
+                header: event_header(query_id.clone()),
                 stats: Arc::new(vec![(node_id, snapshot.to_stats())]),
             }));
+            dispatch_event(subscribers, &stats_event, "flush node final stats");
 
             let end_event = Event::OperatorEnd(Arc::new(OperatorEndEvent {
-                header: EventHeader {
-                    query_id: query_id.clone(),
-                    timestamp_epoch_secs: now_epoch_secs(),
-                },
+                header: event_header(query_id.clone()),
                 operator: operator_meta.clone(),
             }));
-            for res in future::join_all(subscribers.iter().map(|subscriber| {
-                let stats_event = stats_event.clone();
-                let end_event = end_event.clone();
-                async move {
-                    subscriber.on_event(stats_event).await?;
-                    subscriber.on_event(end_event).await
-                }
-            }))
-            .await
-            {
-                if let Err(e) = res {
-                    log::error!("Failed to {}: {}", err_context, e);
-                }
-            }
+            dispatch_event(subscribers, &end_event, "flush node operator end");
         } else {
             let end_event = Event::OperatorEnd(Arc::new(OperatorEndEvent {
-                header: EventHeader {
-                    query_id: query_id.clone(),
-                    timestamp_epoch_secs: now_epoch_secs(),
-                },
+                header: event_header(query_id.clone()),
                 operator: operator_meta.clone(),
             }));
-            for res in future::join_all(
-                subscribers
-                    .iter()
-                    .map(|subscriber| subscriber.on_event(end_event.clone())),
-            )
-            .await
-            {
-                if let Err(e) = res {
-                    log::error!("Failed to {}: {}", err_context, e);
-                }
-            }
+            dispatch_event(subscribers, &end_event, "flush node operator end");
         }
     }
 
@@ -269,9 +234,12 @@ impl RuntimeStatsManager {
         let serialized_plan: Arc<str> = serde_json::to_string(&query_plan)
             .expect("Failed to serialize physical plan")
             .into();
-        for subscriber in &subscribers {
-            subscriber.on_exec_start(query_id.clone(), serialized_plan.clone())?;
-        }
+
+        let exec_start_event = Event::ExecStart(Arc::new(ExecStartEvent {
+            header: event_header(query_id.clone()),
+            physical_plan: serialized_plan,
+        }));
+        dispatch_event(&subscribers, &exec_start_event, "notify execution start");
 
         let progress_bar = match progress_bar_mode(is_flotilla_worker) {
             ProgressBarMode::Disabled => None,
@@ -348,31 +316,20 @@ impl RuntimeStatsManager {
                                     };
 
                                     let event = Event::OperatorStart(Arc::new(OperatorStartEvent {
-                                        header: EventHeader {
-                                            query_id: query_id.clone(),
-                                            timestamp_epoch_secs: now_epoch_secs(),
-                                        },
+                                        header: event_header(query_id.clone()),
                                         operator: operator_meta.clone(),
                                     }));
-
-                                    for res in future::join_all(subscribers.iter().map(|subscriber| {
-                                        subscriber.on_event(event.clone())
-                                    })).await {
-                                        if let Err(e) = res {
-                                            log::error!("Failed to initialize node: {}", e);
-                                        }
-                                    }
+                                    dispatch_event(&subscribers, &event, "notify operator start");
                                 } else if !is_initialize && active_nodes.remove(&node_id) {
                                     Self::flush_and_finalize_node(
                                         &query_id,
                                         node_id,
                                         &input_stats,
                                         progress_bar.as_deref(),
-                                        &subscribers,
-                                        "finalize node",
-                                        &operators,
-                                    )
-                                    .await;
+                                    &subscribers,
+                                    "finalize node",
+                                    &operators,
+                                    );
                                 }
                             }
                             StatsManagerMessage::RegisterRuntimeStats(node_id, input_id, stats) => {
@@ -404,8 +361,7 @@ impl RuntimeStatsManager {
                                 &subscribers,
                                 "finalize node during shutdown",
                                 &operators,
-                            )
-                            .await;
+                            );
                         }
                         break;
                     }
@@ -413,13 +369,12 @@ impl RuntimeStatsManager {
                     _ = interval.tick() => {
                         if let Some(ps) = &mut process_stats {
                             let ps_stats = ps.sample();
-                            for res in future::join_all(subscribers.iter().map(|subscriber| {
-                                subscriber.on_process_stats(query_id.clone(), ps_stats.clone())
-                            })).await {
-                                if let Err(e) = res {
-                                    log::error!("Failed to emit process stats: {}", e);
-                                }
-                            }
+                            let event = Event::ProcessStats(Arc::new(
+                                ProcessStatsEvent {
+                                    header: event_header(query_id.clone()),
+                                    stats: ps_stats,
+                                }));
+                            dispatch_event(&subscribers, &event, "notify process stats");
                         }
 
                         if active_nodes.is_empty() {
@@ -437,20 +392,11 @@ impl RuntimeStatsManager {
 
                         if !snapshot_container.is_empty() {
                             let snapshot_container = Arc::new(std::mem::take(&mut snapshot_container));
-                            let event = Arc::new(StatsEvent {
-                                header: EventHeader {
-                                    query_id: query_id.clone(),
-                                    timestamp_epoch_secs: now_epoch_secs(),
-                                },
+                            let event = Event::Stats(Arc::new(StatsEvent {
+                                header: event_header(query_id.clone()),
                                 stats: snapshot_container.clone(),
-                            });
-                            for res in future::join_all(subscribers.iter().map(|subscriber| {
-                                subscriber.on_stats(event.clone())
-                            })).await {
-                                if let Err(e) = res {
-                                    log::error!("Failed to handle event: {}", e);
-                                }
-                            }
+                            }));
+                            dispatch_event(&subscribers, &event, "notify runtime stats");
                         }
                     }
                 }
@@ -492,11 +438,11 @@ impl RuntimeStatsManager {
                 .lock()
                 .expect("finished_snapshots lock poisoned") = Some(finished);
 
-            for subscriber in subscribers {
-                if let Err(e) = subscriber.on_exec_end(query_id.clone()).await {
-                    log::error!("Failed to flush subscriber: {}", e);
-                }
-            }
+            let exec_end_event = Event::ExecEnd(Arc::new(ExecEndEvent {
+                header: event_header(query_id.clone()),
+                duration_ms: None,
+            }));
+            dispatch_event(&subscribers, &exec_end_event, "notify execution end");
         };
 
         let task_handle = RuntimeTask::new(handle, event_loop);
@@ -521,6 +467,14 @@ impl RuntimeStatsManager {
         self.stats_manager_task
             .await
             .expect("The stats_manager_task panicked");
+    }
+}
+
+fn dispatch_event(subscribers: &[Arc<dyn Subscriber>], event: &Event, err_context: &'static str) {
+    for subscriber in subscribers {
+        if let Err(e) = subscriber.on_event(event.clone()) {
+            log::error!("Failed to {}: {}", err_context, e);
+        }
     }
 }
 
@@ -549,13 +503,11 @@ mod tests {
         sync::{Arc, Mutex, atomic::AtomicU64},
     };
 
-    use async_trait::async_trait;
     use common_error::DaftResult;
     use common_metrics::{
-        DURATION_KEY, Meter, QueryPlan, ROWS_IN_KEY, ROWS_OUT_KEY, Stat, StatSnapshot, Stats,
+        DURATION_KEY, Meter, ROWS_IN_KEY, ROWS_OUT_KEY, Stat, StatSnapshot, Stats,
     };
-    use daft_context::{QueryMetadata, QueryResult, Subscriber};
-    use daft_micropartition::MicroPartitionRef;
+    use daft_context::Subscriber;
     use tokio::time::{Duration, sleep};
 
     use super::*;
@@ -624,48 +576,8 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl Subscriber for MockSubscriber {
-        fn on_query_start(&self, _: QueryID, _: Arc<QueryMetadata>) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_query_end(&self, _: QueryID, _: QueryResult) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_result_out(&self, _: QueryID, _: MicroPartitionRef) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_optimization_start(&self, _: QueryID) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_optimization_end(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_exec_start(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
-            Ok(())
-        }
-
-        async fn on_exec_end(&self, _: QueryID) -> DaftResult<()> {
-            Ok(())
-        }
-        async fn on_operator_start(&self, _: Arc<OperatorStartEvent>) -> DaftResult<()> {
-            Ok(())
-        }
-        async fn on_operator_end(&self, _: Arc<OperatorEndEvent>) -> DaftResult<()> {
-            Ok(())
-        }
-
-        async fn on_stats(&self, event: Arc<StatsEvent>) -> DaftResult<()> {
-            self.state
-                .total_calls
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            for (_, snapshot) in event.stats.iter() {
-                *self.state.event.lock().unwrap() = Some(snapshot.clone());
-            }
-            Ok(())
-        }
-
-        async fn on_event(&self, event: Event) -> DaftResult<()> {
+        fn on_event(&self, event: Event) -> DaftResult<()> {
             if let Event::Stats(e) = event {
                 self.state
                     .total_calls
@@ -775,44 +687,8 @@ mod tests {
         #[derive(Debug)]
         struct FailingSubscriber;
 
-        #[async_trait]
         impl Subscriber for FailingSubscriber {
-            fn on_query_start(&self, _: QueryID, _: Arc<QueryMetadata>) -> DaftResult<()> {
-                Ok(())
-            }
-            fn on_query_end(&self, _: QueryID, _: QueryResult) -> DaftResult<()> {
-                Ok(())
-            }
-            fn on_result_out(&self, _: QueryID, _: MicroPartitionRef) -> DaftResult<()> {
-                Ok(())
-            }
-            fn on_optimization_start(&self, _: QueryID) -> DaftResult<()> {
-                Ok(())
-            }
-            fn on_optimization_end(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
-                Ok(())
-            }
-            fn on_exec_start(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
-                Ok(())
-            }
-
-            async fn on_exec_end(&self, _: QueryID) -> DaftResult<()> {
-                Ok(())
-            }
-            async fn on_operator_start(&self, _: Arc<OperatorStartEvent>) -> DaftResult<()> {
-                Ok(())
-            }
-            async fn on_operator_end(&self, _: Arc<OperatorEndEvent>) -> DaftResult<()> {
-                Ok(())
-            }
-
-            async fn on_stats(&self, _: Arc<StatsEvent>) -> DaftResult<()> {
-                Err(common_error::DaftError::InternalError(
-                    "Test error".to_string(),
-                ))
-            }
-
-            async fn on_event(&self, event: Event) -> DaftResult<()> {
+            fn on_event(&self, event: Event) -> DaftResult<()> {
                 if let Event::Stats(_) = event {
                     return Err(common_error::DaftError::InternalError(
                         "Test error".to_string(),
@@ -979,42 +855,16 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl Subscriber for ProcessStatsMockSubscriber {
-        fn on_query_start(&self, _: QueryID, _: Arc<QueryMetadata>) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_query_end(&self, _: QueryID, _: QueryResult) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_result_out(&self, _: QueryID, _: MicroPartitionRef) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_optimization_start(&self, _: QueryID) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_optimization_end(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
-            Ok(())
-        }
-        fn on_exec_start(&self, _: QueryID, _: QueryPlan) -> DaftResult<()> {
-            Ok(())
-        }
-        async fn on_exec_end(&self, _: QueryID) -> DaftResult<()> {
-            Ok(())
-        }
-        async fn on_operator_start(&self, _: Arc<OperatorStartEvent>) -> DaftResult<()> {
-            Ok(())
-        }
-        async fn on_operator_end(&self, _: Arc<OperatorEndEvent>) -> DaftResult<()> {
-            Ok(())
-        }
-        async fn on_stats(&self, _: Arc<StatsEvent>) -> DaftResult<()> {
-            Ok(())
-        }
-        async fn on_process_stats(&self, _: QueryID, _: Stats) -> DaftResult<()> {
-            self.process_stats_calls
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            Ok(())
+        fn on_event(&self, event: Event) -> DaftResult<()> {
+            match event {
+                Event::ProcessStats(_) => {
+                    self.process_stats_calls
+                        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(())
+                }
+                _ => Ok(()),
+            }
         }
     }
 

--- a/src/daft-local-execution/src/runtime_stats/mod.rs
+++ b/src/daft-local-execution/src/runtime_stats/mod.rs
@@ -189,22 +189,22 @@ impl RuntimeStatsManager {
         };
 
         if let Some(snapshot) = snapshot {
-            let stats_event = Event::Stats(Arc::new(StatsEvent {
+            let stats_event = Event::Stats(StatsEvent {
                 header: event_header(query_id.clone()),
                 stats: Arc::new(vec![(node_id, snapshot.to_stats())]),
-            }));
+            });
             dispatch_event(subscribers, &stats_event, "flush node final stats");
 
-            let end_event = Event::OperatorEnd(Arc::new(OperatorEndEvent {
+            let end_event = Event::OperatorEnd(OperatorEndEvent {
                 header: event_header(query_id.clone()),
                 operator: operator_meta.clone(),
-            }));
+            });
             dispatch_event(subscribers, &end_event, "flush node operator end");
         } else {
-            let end_event = Event::OperatorEnd(Arc::new(OperatorEndEvent {
+            let end_event = Event::OperatorEnd(OperatorEndEvent {
                 header: event_header(query_id.clone()),
                 operator: operator_meta.clone(),
-            }));
+            });
             dispatch_event(subscribers, &end_event, "flush node operator end");
         }
     }
@@ -235,10 +235,10 @@ impl RuntimeStatsManager {
             .expect("Failed to serialize physical plan")
             .into();
 
-        let exec_start_event = Event::ExecStart(Arc::new(ExecStartEvent {
+        let exec_start_event = Event::ExecStart(ExecStartEvent {
             header: event_header(query_id.clone()),
             physical_plan: serialized_plan,
-        }));
+        });
         dispatch_event(&subscribers, &exec_start_event, "notify execution start");
 
         let progress_bar = match progress_bar_mode(is_flotilla_worker) {
@@ -315,10 +315,10 @@ impl RuntimeStatsManager {
                                         continue;
                                     };
 
-                                    let event = Event::OperatorStart(Arc::new(OperatorStartEvent {
+                                    let event = Event::OperatorStart(OperatorStartEvent {
                                         header: event_header(query_id.clone()),
                                         operator: operator_meta.clone(),
-                                    }));
+                                    });
                                     dispatch_event(&subscribers, &event, "notify operator start");
                                 } else if !is_initialize && active_nodes.remove(&node_id) {
                                     Self::flush_and_finalize_node(
@@ -369,11 +369,10 @@ impl RuntimeStatsManager {
                     _ = interval.tick() => {
                         if let Some(ps) = &mut process_stats {
                             let ps_stats = ps.sample();
-                            let event = Event::ProcessStats(Arc::new(
-                                ProcessStatsEvent {
-                                    header: event_header(query_id.clone()),
-                                    stats: ps_stats,
-                                }));
+                            let event = Event::ProcessStats(ProcessStatsEvent {
+                                header: event_header(query_id.clone()),
+                                stats: ps_stats,
+                            });
                             dispatch_event(&subscribers, &event, "notify process stats");
                         }
 
@@ -392,10 +391,10 @@ impl RuntimeStatsManager {
 
                         if !snapshot_container.is_empty() {
                             let snapshot_container = Arc::new(std::mem::take(&mut snapshot_container));
-                            let event = Event::Stats(Arc::new(StatsEvent {
+                            let event = Event::Stats(StatsEvent {
                                 header: event_header(query_id.clone()),
                                 stats: snapshot_container.clone(),
-                            }));
+                            });
                             dispatch_event(&subscribers, &event, "notify runtime stats");
                         }
                     }
@@ -438,10 +437,10 @@ impl RuntimeStatsManager {
                 .lock()
                 .expect("finished_snapshots lock poisoned") = Some(finished);
 
-            let exec_end_event = Event::ExecEnd(Arc::new(ExecEndEvent {
+            let exec_end_event = Event::ExecEnd(ExecEndEvent {
                 header: event_header(query_id.clone()),
                 duration_ms: None,
-            }));
+            });
             dispatch_event(&subscribers, &exec_end_event, "notify execution end");
         };
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -123,6 +123,7 @@ def test_on_query_end_clears_stale_timing_state_for_failed_query(tmp_path):
         metadata = _make_query_metadata()
 
         subscriber.on_query_start(query_id, metadata)
+        subscriber.on_event(OptimizationStarted(query_id=query_id))
         subscriber.on_event(OptimizationCompleted(query_id=query_id, optimized_plan='{"nodes":{}}'))
         subscriber.on_event(ExecutionStarted(query_id=query_id, physical_plan='{"nodes":{}}'))
         subscriber.on_event(OperatorStarted(query_id=query_id, node_id=1, name="op1"))
@@ -137,6 +138,7 @@ def test_on_query_end_clears_stale_timing_state_for_failed_query(tmp_path):
         )
 
         assert query_id not in subscriber._query_starts
+        assert query_id not in subscriber._optimization_starts
         assert query_id not in subscriber._exec_starts
         assert all(qid != query_id for qid, _ in subscriber._operator_starts)
     finally:
@@ -152,11 +154,13 @@ def test_on_query_end_only_clears_ended_query_state(tmp_path):
         metadata = _make_query_metadata()
 
         subscriber.on_query_start(ended_query_id, metadata)
+        subscriber.on_event(OptimizationStarted(query_id=ended_query_id))
         subscriber.on_event(OptimizationCompleted(query_id=ended_query_id, optimized_plan='{"nodes":{}}'))
         subscriber.on_event(ExecutionStarted(query_id=ended_query_id, physical_plan='{"nodes":{}}'))
         subscriber.on_event(OperatorStarted(query_id=ended_query_id, node_id=1, name="op1"))
 
         subscriber.on_query_start(live_query_id, metadata)
+        subscriber.on_event(OptimizationStarted(query_id=live_query_id))
         subscriber.on_event(OptimizationCompleted(query_id=live_query_id, optimized_plan='{"nodes":{}}'))
         subscriber.on_event(ExecutionStarted(query_id=live_query_id, physical_plan='{"nodes":{}}'))
         subscriber.on_event(OperatorStarted(query_id=live_query_id, node_id=9, name="op9"))
@@ -170,10 +174,12 @@ def test_on_query_end_only_clears_ended_query_state(tmp_path):
         )
 
         assert ended_query_id not in subscriber._query_starts
+        assert ended_query_id not in subscriber._optimization_starts
         assert ended_query_id not in subscriber._exec_starts
         assert all(qid != ended_query_id for qid, _ in subscriber._operator_starts)
 
         assert live_query_id in subscriber._query_starts
+        assert live_query_id not in subscriber._optimization_starts  # consumed by OptimizationCompleted
         assert live_query_id in subscriber._exec_starts
         assert (live_query_id, 9) in subscriber._operator_starts
     finally:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -10,6 +10,14 @@ from daft.context import get_context
 from daft.daft import PyQueryMetadata, PyQueryResult, QueryEndState
 from daft.subscribers import event_log as subscriber_event_log
 from daft.subscribers.event_log import _EVENT_LOG_ALIAS, EventLogSubscriber, disable_event_log, enable_event_log
+from daft.subscribers.events import (
+    ExecutionFinished,
+    ExecutionStarted,
+    OperatorStarted,
+    OptimizationCompleted,
+    OptimizationStarted,
+    QueryFinished,
+)
 from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
@@ -55,7 +63,13 @@ def test_event_log_subscriber_writes_query_lifecycle_events(tmp_path):
         metadata = _make_query_metadata()
 
         subscriber.on_query_start(query_id, metadata)
-        subscriber.on_query_end(query_id, PyQueryResult(QueryEndState.Finished, "Query finished"))
+        subscriber.on_event(
+            QueryFinished(
+                query_id=query_id,
+                result=PyQueryResult(QueryEndState.Finished, "Query finished"),
+                duration_ms=None,
+            )
+        )
     finally:
         subscriber.close()
 
@@ -69,6 +83,38 @@ def test_event_log_subscriber_writes_query_lifecycle_events(tmp_path):
     assert query_ended["duration_ms"] >= 0
 
 
+def test_event_log_subscriber_computes_execution_duration_locally(tmp_path):
+    subscriber = EventLogSubscriber(tmp_path)
+
+    try:
+        query_id = "q_exec"
+        subscriber.on_event(ExecutionStarted(query_id=query_id, physical_plan='{"nodes":{}}'))
+        subscriber.on_event(ExecutionFinished(query_id=query_id, duration_ms=None))
+    finally:
+        subscriber.close()
+
+    events = _load_events(tmp_path / query_id / "events.jsonl")
+    execution_ended = events[-1]
+    assert execution_ended["event"] == "execution_ended"
+    assert execution_ended["duration_ms"] >= 0
+
+
+def test_event_log_subscriber_preserves_optimization_lifecycle_schema(tmp_path):
+    subscriber = EventLogSubscriber(tmp_path)
+
+    try:
+        query_id = "q_opt"
+        subscriber.on_event(OptimizationStarted(query_id=query_id))
+        subscriber.on_event(OptimizationCompleted(query_id=query_id, optimized_plan='{"nodes":{}}'))
+    finally:
+        subscriber.close()
+
+    events = _load_events(tmp_path / query_id / "events.jsonl")
+    event_names = [event["event"] for event in events]
+    assert event_names == ["event_log_started", "optimization_started", "optimization_ended", "plan_optimized"]
+    assert events[2]["duration_ms"] >= 0
+
+
 def test_on_query_end_clears_stale_timing_state_for_failed_query(tmp_path):
     subscriber = EventLogSubscriber(tmp_path)
 
@@ -77,15 +123,20 @@ def test_on_query_end_clears_stale_timing_state_for_failed_query(tmp_path):
         metadata = _make_query_metadata()
 
         subscriber.on_query_start(query_id, metadata)
-        subscriber.on_optimization_start(query_id)
-        subscriber.on_exec_start(query_id, '{"nodes":{}}')
-        subscriber.on_exec_operator_start(query_id, 1)
-        subscriber.on_exec_operator_start(query_id, 2)
+        subscriber.on_event(OptimizationCompleted(query_id=query_id, optimized_plan='{"nodes":{}}'))
+        subscriber.on_event(ExecutionStarted(query_id=query_id, physical_plan='{"nodes":{}}'))
+        subscriber.on_event(OperatorStarted(query_id=query_id, node_id=1, name="op1"))
+        subscriber.on_event(OperatorStarted(query_id=query_id, node_id=2, name="op2"))
 
-        subscriber.on_query_end(query_id, PyQueryResult(QueryEndState.Failed, "boom"))
+        subscriber.on_event(
+            QueryFinished(
+                query_id=query_id,
+                result=PyQueryResult(QueryEndState.Failed, "boom"),
+                duration_ms=None,
+            )
+        )
 
         assert query_id not in subscriber._query_starts
-        assert query_id not in subscriber._optimization_starts
         assert query_id not in subscriber._exec_starts
         assert all(qid != query_id for qid, _ in subscriber._operator_starts)
     finally:
@@ -101,24 +152,28 @@ def test_on_query_end_only_clears_ended_query_state(tmp_path):
         metadata = _make_query_metadata()
 
         subscriber.on_query_start(ended_query_id, metadata)
-        subscriber.on_optimization_start(ended_query_id)
-        subscriber.on_exec_start(ended_query_id, '{"nodes":{}}')
-        subscriber.on_exec_operator_start(ended_query_id, 1)
+        subscriber.on_event(OptimizationCompleted(query_id=ended_query_id, optimized_plan='{"nodes":{}}'))
+        subscriber.on_event(ExecutionStarted(query_id=ended_query_id, physical_plan='{"nodes":{}}'))
+        subscriber.on_event(OperatorStarted(query_id=ended_query_id, node_id=1, name="op1"))
 
         subscriber.on_query_start(live_query_id, metadata)
-        subscriber.on_optimization_start(live_query_id)
-        subscriber.on_exec_start(live_query_id, '{"nodes":{}}')
-        subscriber.on_exec_operator_start(live_query_id, 9)
+        subscriber.on_event(OptimizationCompleted(query_id=live_query_id, optimized_plan='{"nodes":{}}'))
+        subscriber.on_event(ExecutionStarted(query_id=live_query_id, physical_plan='{"nodes":{}}'))
+        subscriber.on_event(OperatorStarted(query_id=live_query_id, node_id=9, name="op9"))
 
-        subscriber.on_query_end(ended_query_id, PyQueryResult(QueryEndState.Canceled, "canceled"))
+        subscriber.on_event(
+            QueryFinished(
+                query_id=ended_query_id,
+                result=PyQueryResult(QueryEndState.Canceled, "canceled"),
+                duration_ms=None,
+            )
+        )
 
         assert ended_query_id not in subscriber._query_starts
-        assert ended_query_id not in subscriber._optimization_starts
         assert ended_query_id not in subscriber._exec_starts
         assert all(qid != ended_query_id for qid, _ in subscriber._operator_starts)
 
         assert live_query_id in subscriber._query_starts
-        assert live_query_id in subscriber._optimization_starts
         assert live_query_id in subscriber._exec_starts
         assert (live_query_id, 9) in subscriber._operator_starts
     finally:

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -9,10 +9,20 @@ from typing import Any
 import pytest
 
 import daft
-from daft.daft import PyMicroPartition, PyQueryMetadata, PyQueryResult, QueryEndState
-from daft.recordbatch import MicroPartition
+from daft.daft import PyQueryMetadata, QueryEndState
 from daft.subscribers import Subscriber
-from daft.subscribers.events import Event, OperatorFinished, OperatorStarted, Stats
+from daft.subscribers.events import (
+    Event,
+    ExecutionFinished,
+    ExecutionStarted,
+    OperatorFinished,
+    OperatorStarted,
+    OptimizationCompleted,
+    QueryFinished,
+    QueryStarted,
+    ResultProduced,
+    Stats,
+)
 from tests.conftest import get_tests_daft_runner_name
 
 pytestmark = pytest.mark.skipif(
@@ -25,7 +35,6 @@ class MockSubscriber(Subscriber):
     query_optimized_plan: dict[str, str]
     query_physical_plan: dict[str, str]
     query_node_stats: defaultdict[str, defaultdict[int, dict[str, Any]]]
-    query_results: defaultdict[str, list[PyMicroPartition]]
     end_states: dict[str, QueryEndState]
     end_messages: dict[str, str]
     query_ids: list[str]
@@ -35,30 +44,26 @@ class MockSubscriber(Subscriber):
         self.query_optimized_plan = {}
         self.query_physical_plan = {}
         self.query_node_stats = defaultdict(lambda: defaultdict(dict))
-        self.query_results = defaultdict(list)
         self.end_states = {}
         self.end_messages = {}
         self.query_ids = []
 
-    def on_query_start(self, query_id: str, metadata: PyQueryMetadata) -> None:
-        self.query_ids.append(query_id)
-        self.query_metadata[query_id] = metadata
+    def on_query_started(self, event: QueryStarted) -> None:
+        self.query_ids.append(event.query_id)
+        self.query_metadata[event.query_id] = event.metadata
 
-    def on_query_end(self, query_id: str, result: PyQueryResult) -> None:
-        self.end_states[query_id] = result.end_state
-        self.end_messages[query_id] = result.error_message
+    def on_query_finished(self, event: QueryFinished) -> None:
+        self.end_states[event.query_id] = event.result.end_state
+        self.end_messages[event.query_id] = event.result.error_message
 
-    def on_result_out(self, query_id: str, result: PyMicroPartition) -> None:
-        self.query_results[query_id].append(result)
-
-    def on_optimization_start(self, query_id: str) -> None:
+    def on_result_produced(self, event: ResultProduced) -> None:
         pass
 
-    def on_optimization_end(self, query_id: str, optimized_plan: str) -> None:
-        self.query_optimized_plan[query_id] = optimized_plan
+    def on_optimization_completed(self, event: OptimizationCompleted) -> None:
+        self.query_optimized_plan[event.query_id] = event.optimized_plan
 
-    def on_exec_start(self, query_id: str, physical_plan: str) -> None:
-        self.query_physical_plan[query_id] = physical_plan
+    def on_execution_started(self, event: ExecutionStarted) -> None:
+        self.query_physical_plan[event.query_id] = event.physical_plan
 
     def on_operator_start(self, event: OperatorStarted) -> None:
         pass
@@ -71,7 +76,7 @@ class MockSubscriber(Subscriber):
     def on_operator_end(self, event: OperatorFinished) -> None:
         pass
 
-    def on_exec_end(self, query_id: str) -> None:
+    def on_execution_finished(self, event: ExecutionFinished) -> None:
         pass
 
 
@@ -193,10 +198,6 @@ def test_subscriber_template():
     assert subscriber.query_metadata[query_id].output_schema == output_schema._schema
     # Optimized plan should be different from unoptimized plan
     assert subscriber.query_optimized_plan[query_id] != unoptimized_plan_json
-
-    # Test output
-    mps = [MicroPartition._from_pymicropartition(mp) for mp in subscriber.query_results[query_id]]
-    assert daft.DataFrame._from_micropartitions(*mps).to_pydict() == df.to_pydict()
 
     # Test stats
     for _, stats in subscriber.query_node_stats[query_id].items():

--- a/tests/test_subscribers.py
+++ b/tests/test_subscribers.py
@@ -46,6 +46,7 @@ class MockSubscriber(Subscriber):
         self.query_node_stats = defaultdict(lambda: defaultdict(dict))
         self.end_states = {}
         self.end_messages = {}
+        self.query_result_rows: defaultdict[str, int] = defaultdict(int)
         self.query_ids = []
 
     def on_query_started(self, event: QueryStarted) -> None:
@@ -57,7 +58,7 @@ class MockSubscriber(Subscriber):
         self.end_messages[event.query_id] = event.result.error_message
 
     def on_result_produced(self, event: ResultProduced) -> None:
-        pass
+        self.query_result_rows[event.query_id] += event.num_rows
 
     def on_optimization_completed(self, event: OptimizationCompleted) -> None:
         self.query_optimized_plan[event.query_id] = event.optimized_plan
@@ -198,6 +199,9 @@ def test_subscriber_template():
     assert subscriber.query_metadata[query_id].output_schema == output_schema._schema
     # Optimized plan should be different from unoptimized plan
     assert subscriber.query_optimized_plan[query_id] != unoptimized_plan_json
+
+    # Verify ResultProduced events delivered the expected row count
+    assert subscriber.query_result_rows[query_id] == 3
 
     # Test stats
     for _, stats in subscriber.query_node_stats[query_id].items():


### PR DESCRIPTION
## Changes Made

Replace ~15 mixed sync/async methods on the Subscriber trait with a single sync `fn on_event(&self, event: Event) -> DaftResult<()>`. This eliminates async_trait, future::join_all, block_within_async_context, and handle.spawn patterns from subscriber dispatch. Subscribers that need async should handle it internally see dashboard.rs implementation.

Also adds missing event types (OptimizationStart, ProcessStats, QueryStart, QueryEnd, ExecStart, ExecEnd, ResultOut) to the Rust Event enum, and corresponding Python event dataclasses.