### PR TITLE
perf(distributed): non-blocking worker startup in flotilla runner

### DIFF
--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -405,7 +405,8 @@ _pending_actors: dict[str, _PendingActor] = {}
 
 def _is_eligible_node(node: dict[str, Any]) -> bool:
     return (
-        "Resources" in node
+        node.get("Alive", True)
+        and "Resources" in node
         and "CPU" in node["Resources"]
         and "memory" in node["Resources"]
         and node["Resources"]["CPU"] > 0
@@ -433,9 +434,10 @@ atexit.register(clear_pending_ray_workers)
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker]:
     worker_startup_timeout = _get_worker_startup_timeout()
     now = time.monotonic()
+    all_nodes = ray.nodes()
 
     # Prune pending actors whose nodes no longer exist
-    current_node_ids = {node["NodeID"] for node in ray.nodes() if _is_eligible_node(node)}
+    current_node_ids = {node["NodeID"] for node in all_nodes if _is_eligible_node(node)}
     for nid in [nid for nid in _pending_actors if nid not in current_node_ids]:
         pending = _pending_actors.pop(nid)
         logger.warning("Node %s disappeared while actor was pending startup; cleaning up", nid)
@@ -443,7 +445,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
 
     # Spawn actors for new nodes (not already tracked or existing)
     skip_ids = set(existing_worker_ids) | set(_pending_actors.keys())
-    for node in ray.nodes():
+    for node in all_nodes:
         node_id = node["NodeID"]
         if node_id not in skip_ids and _is_eligible_node(node):
             actor = RaySwordfishActor.options(  # type: ignore

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import logging
 import os
 import shutil
@@ -412,6 +413,23 @@ def _is_eligible_node(node: dict[str, Any]) -> bool:
     )
 
 
+def _kill_actor(actor: ray.actor.ActorHandle) -> None:
+    try:
+        ray.kill(actor)
+    except Exception:
+        pass
+
+
+def clear_pending_ray_workers() -> None:
+    for node_id, pending in list(_pending_actors.items()):
+        logger.info("Cleaning up pending actor on node %s", node_id)
+        _pending_actors.pop(node_id, None)
+        _kill_actor(pending.actor)
+
+
+atexit.register(clear_pending_ray_workers)
+
+
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker]:
     worker_startup_timeout = _get_worker_startup_timeout()
     now = time.monotonic()
@@ -421,10 +439,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
     for nid in [nid for nid in _pending_actors if nid not in current_node_ids]:
         pending = _pending_actors.pop(nid)
         logger.warning("Node %s disappeared while actor was pending startup; cleaning up", nid)
-        try:
-            ray.kill(pending.actor)
-        except Exception:
-            pass
+        _kill_actor(pending.actor)
 
     # Spawn actors for new nodes (not already tracked or existing)
     skip_ids = set(existing_worker_ids) | set(_pending_actors.keys())
@@ -462,6 +477,7 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
     # Collect ready workers
     ready_workers: list[RaySwordfishWorker] = []
     resolved_node_ids: list[str] = []
+    failed_node_ids: list[str] = []
 
     for node_id, pending in pending_items:
         if pending.address_ref not in ready_ref_set:
@@ -481,20 +497,35 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
             )
         except (ray.exceptions.ActorDiedError, ray.exceptions.ActorUnschedulableError) as e:
             logger.warning("Pending actor on node %s died during startup: %s", node_id, e)
+            failed_node_ids.append(node_id)
+            _kill_actor(pending.actor)
         except Exception as e:
             logger.warning("Unexpected error getting address for node %s: %s", node_id, e)
+            failed_node_ids.append(node_id)
+            _kill_actor(pending.actor)
 
     for nid in resolved_node_ids:
         _pending_actors.pop(nid, None)
 
     # Expire actors that exceeded the startup timeout
+    timed_out_node_ids: list[str] = []
     for nid in [nid for nid, p in _pending_actors.items() if now - p.spawn_time > worker_startup_timeout]:
         pending = _pending_actors.pop(nid)
+        timed_out_node_ids.append(nid)
         logger.warning("Actor on node %s failed to start within %ds; killing actor", nid, worker_startup_timeout)
-        try:
-            ray.kill(pending.actor)
-        except Exception:
-            pass
+        _kill_actor(pending.actor)
+
+    if (
+        not existing_worker_ids
+        and not ready_workers
+        and not _pending_actors
+        and (failed_node_ids or timed_out_node_ids)
+    ):
+        failed_nodes = ", ".join(sorted({*failed_node_ids, *timed_out_node_ids}))
+        raise RuntimeError(
+            f"Failed to start any Ray workers within {worker_startup_timeout} seconds; "
+            f"startup failed or timed out on nodes: {failed_nodes}"
+        )
 
     return ready_workers
 
@@ -647,6 +678,9 @@ class FlotillaRunner:
                 else None
             ),
         ).remote(dashboard_url=dashboard_url)
+
+    def __del__(self) -> None:
+        clear_pending_ray_workers()
 
     def stream_plan(
         self,

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -523,8 +523,9 @@ def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker
     ):
         failed_nodes = ", ".join(sorted({*failed_node_ids, *timed_out_node_ids}))
         raise RuntimeError(
-            f"Failed to start any Ray workers within {worker_startup_timeout} seconds; "
-            f"startup failed or timed out on nodes: {failed_nodes}"
+            "Failed to start any Ray workers: "
+            f"startup failed or timed out within {worker_startup_timeout} seconds "
+            f"on nodes: {failed_nodes}"
         )
 
     return ready_workers
@@ -678,9 +679,6 @@ class FlotillaRunner:
                 else None
             ),
         ).remote(dashboard_url=dashboard_url)
-
-    def __del__(self) -> None:
-        clear_pending_ray_workers()
 
     def stream_plan(
         self,

--- a/daft/runners/flotilla.py
+++ b/daft/runners/flotilla.py
@@ -4,9 +4,10 @@ import asyncio
 import logging
 import os
 import shutil
+import time
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias
 
 from daft.context import get_context
 from daft.daft import (
@@ -388,53 +389,114 @@ def _get_worker_startup_timeout() -> int:
     return get_context().daft_execution_config.worker_startup_timeout
 
 
+@dataclass
+class _PendingActor:
+    """Tracks a spawned actor that hasn't yet reported its address."""
+
+    node: dict[str, Any]
+    actor: ray.actor.ActorHandle
+    address_ref: ray.ObjectRef
+    spawn_time: float
+
+
+_pending_actors: dict[str, _PendingActor] = {}
+
+
+def _is_eligible_node(node: dict[str, Any]) -> bool:
+    return (
+        "Resources" in node
+        and "CPU" in node["Resources"]
+        and "memory" in node["Resources"]
+        and node["Resources"]["CPU"] > 0
+        and node["Resources"]["memory"] > 0
+    )
+
+
 def start_ray_workers(existing_worker_ids: list[str]) -> list[RaySwordfishWorker]:
-    actors = []
+    worker_startup_timeout = _get_worker_startup_timeout()
+    now = time.monotonic()
+
+    # Prune pending actors whose nodes no longer exist
+    current_node_ids = {node["NodeID"] for node in ray.nodes() if _is_eligible_node(node)}
+    for nid in [nid for nid in _pending_actors if nid not in current_node_ids]:
+        pending = _pending_actors.pop(nid)
+        logger.warning("Node %s disappeared while actor was pending startup; cleaning up", nid)
+        try:
+            ray.kill(pending.actor)
+        except Exception:
+            pass
+
+    # Spawn actors for new nodes (not already tracked or existing)
+    skip_ids = set(existing_worker_ids) | set(_pending_actors.keys())
     for node in ray.nodes():
-        if (
-            "Resources" in node
-            and "CPU" in node["Resources"]
-            and "memory" in node["Resources"]
-            and node["Resources"]["CPU"] > 0
-            and node["Resources"]["memory"] > 0
-            and node["NodeID"] not in existing_worker_ids
-        ):
+        node_id = node["NodeID"]
+        if node_id not in skip_ids and _is_eligible_node(node):
             actor = RaySwordfishActor.options(  # type: ignore
                 scheduling_strategy=ray.util.scheduling_strategies.NodeAffinitySchedulingStrategy(
-                    node_id=node["NodeID"],
+                    node_id=node_id,
                     soft=False,
                 ),
             ).remote(
                 num_cpus=int(node["Resources"]["CPU"]),
                 num_gpus=int(node["Resources"].get("GPU", 0)),
             )
-            actors.append((node, actor))
-
-    # Batch all IP address retrievals into a single ray.get call
-    actor_startup_timeout = _get_worker_startup_timeout()
-    try:
-        ip_addresses = ray.get(
-            [actor.get_address.remote() for _, actor in actors],
-            timeout=actor_startup_timeout,
-        )
-    except ray.exceptions.GetTimeoutError:
-        raise RuntimeError(f"Failed to get IP addresses for actors within {actor_startup_timeout} seconds")
-
-    handles = []
-    for (node, actor), ip_address in zip(actors, ip_addresses):
-        actor_handle = RaySwordfishActorHandle(actor)
-        handles.append(
-            RaySwordfishWorker(
-                node["NodeID"],
-                actor_handle,
-                int(node["Resources"]["CPU"]),
-                int(node["Resources"].get("GPU", 0)),
-                int(node["Resources"]["memory"]),
-                ip_address,
+            _pending_actors[node_id] = _PendingActor(
+                node=node,
+                actor=actor,
+                address_ref=actor.get_address.remote(),
+                spawn_time=now,
             )
-        )
 
-    return handles
+    if not _pending_actors:
+        return []
+
+    # Non-blocking check for ready actors
+    pending_items = list(_pending_actors.items())
+    ready_refs, _ = ray.wait(
+        [p.address_ref for _, p in pending_items],
+        num_returns=len(pending_items),
+        timeout=0,
+    )
+    ready_ref_set = set(ready_refs)
+
+    # Collect ready workers
+    ready_workers: list[RaySwordfishWorker] = []
+    resolved_node_ids: list[str] = []
+
+    for node_id, pending in pending_items:
+        if pending.address_ref not in ready_ref_set:
+            continue
+        resolved_node_ids.append(node_id)
+        try:
+            ip_address = ray.get(pending.address_ref)
+            ready_workers.append(
+                RaySwordfishWorker(
+                    node_id,
+                    RaySwordfishActorHandle(pending.actor),
+                    int(pending.node["Resources"]["CPU"]),
+                    int(pending.node["Resources"].get("GPU", 0)),
+                    int(pending.node["Resources"]["memory"]),
+                    ip_address,
+                )
+            )
+        except (ray.exceptions.ActorDiedError, ray.exceptions.ActorUnschedulableError) as e:
+            logger.warning("Pending actor on node %s died during startup: %s", node_id, e)
+        except Exception as e:
+            logger.warning("Unexpected error getting address for node %s: %s", node_id, e)
+
+    for nid in resolved_node_ids:
+        _pending_actors.pop(nid, None)
+
+    # Expire actors that exceeded the startup timeout
+    for nid in [nid for nid, p in _pending_actors.items() if now - p.spawn_time > worker_startup_timeout]:
+        pending = _pending_actors.pop(nid)
+        logger.warning("Actor on node %s failed to start within %ds; killing actor", nid, worker_startup_timeout)
+        try:
+            ray.kill(pending.actor)
+        except Exception:
+            pass
+
+    return ready_workers
 
 
 def try_autoscale(bundles: list[dict[str, int]]) -> None:

--- a/tests/ray/test_flotilla_runner_naming.py
+++ b/tests/ray/test_flotilla_runner_naming.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import time
 
+import pytest
+import ray
+
 import daft.runners.flotilla as flotilla
 from daft.context import execution_config_ctx
 
@@ -269,10 +272,3 @@ def test_start_ray_workers_skips_already_pending_nodes(monkeypatch):
     flotilla.start_ray_workers(existing_worker_ids=[])
     assert len(flotilla._pending_actors) == 1
     assert flotilla._pending_actors[NODE_ID] is first_pending
-
-
-try:
-    import pytest
-    import ray
-except ImportError:
-    pass

--- a/tests/ray/test_flotilla_runner_naming.py
+++ b/tests/ray/test_flotilla_runner_naming.py
@@ -1,7 +1,63 @@
 from __future__ import annotations
 
+import time
+
 import daft.runners.flotilla as flotilla
 from daft.context import execution_config_ctx
+
+NODE_ID = "1" * 56
+FAKE_ADDRESS = "grpc://10.0.0.1:9999"
+
+
+def _fake_node(node_id: str = NODE_ID) -> dict:
+    return {"NodeID": node_id, "Resources": {"CPU": 4, "memory": 1024, "GPU": 1}}
+
+
+class _RemoteMethod:
+    def __init__(self, result: str) -> None:
+        self._result = result
+
+    def remote(self) -> str:
+        return self._result
+
+
+class _FakeActor:
+    def __init__(self, address: str = FAKE_ADDRESS) -> None:
+        self.get_address = _RemoteMethod(address)
+
+
+class _FakeActorOptions:
+    def remote(self, *, num_cpus: int, num_gpus: int) -> _FakeActor:
+        return _FakeActor()
+
+
+class _FakeRaySwordfishActor:
+    @staticmethod
+    def options(**kwargs) -> _FakeActorOptions:
+        return _FakeActorOptions()
+
+
+def _patch_flotilla(monkeypatch, nodes=None):
+    """Set up common monkeypatches for start_ray_workers tests."""
+    if nodes is None:
+        nodes = [_fake_node()]
+
+    monkeypatch.setattr(flotilla, "_pending_actors", {})
+    monkeypatch.setattr(flotilla.ray, "nodes", lambda: nodes)
+    monkeypatch.setattr(flotilla, "RaySwordfishActor", _FakeRaySwordfishActor)
+    monkeypatch.setattr(flotilla, "RaySwordfishActorHandle", lambda actor: ("handle", actor))
+    monkeypatch.setattr(
+        flotilla,
+        "RaySwordfishWorker",
+        lambda *args: {
+            "node_id": args[0],
+            "actor_handle": args[1],
+            "num_cpus": args[2],
+            "num_gpus": args[3],
+            "memory": args[4],
+            "ip_address": args[5],
+        },
+    )
 
 
 def test_flotilla_runner_actor_name_is_namespaced(monkeypatch):
@@ -30,66 +86,140 @@ def test_flotilla_runner_actor_name_is_namespaced(monkeypatch):
     assert flotilla.get_flotilla_runner_actor_name() == name
 
 
-def test_start_ray_workers_uses_configured_worker_startup_timeout(monkeypatch):
-    captured: dict[str, object] = {}
-    node_id = "1" * 56
+def test_start_ray_workers_returns_ready_immediately(monkeypatch):
+    """When actors are ready immediately, they are returned on the first call."""
+    _patch_flotilla(monkeypatch)
 
-    class _RemoteMethod:
-        def __init__(self, result: str) -> None:
-            self._result = result
+    # ray.wait returns all refs as ready
+    monkeypatch.setattr(flotilla.ray, "wait", lambda refs, num_returns, timeout: (refs, []))
+    monkeypatch.setattr(flotilla.ray, "get", lambda ref: FAKE_ADDRESS)
 
-        def remote(self) -> str:
-            return self._result
+    workers = flotilla.start_ray_workers(existing_worker_ids=[])
 
-    class _FakeActor:
-        def __init__(self, address: str) -> None:
-            self.get_address = _RemoteMethod(address)
-
-    class _FakeActorOptions:
-        def remote(self, *, num_cpus: int, num_gpus: int) -> _FakeActor:
-            captured["remote_args"] = {"num_cpus": num_cpus, "num_gpus": num_gpus}
-            return _FakeActor("grpc://10.0.0.1:9999")
-
-    class _FakeRaySwordfishActor:
-        @staticmethod
-        def options(**kwargs) -> _FakeActorOptions:
-            captured["options_kwargs"] = kwargs
-            return _FakeActorOptions()
-
-    def _fake_ray_get(address_refs: list[str], *, timeout: int) -> list[str]:
-        captured["address_refs"] = address_refs
-        captured["timeout"] = timeout
-        return ["grpc://10.0.0.1:9999"]
-
-    monkeypatch.setattr(
-        flotilla.ray,
-        "nodes",
-        lambda: [{"NodeID": node_id, "Resources": {"CPU": 4, "memory": 1024, "GPU": 1}}],
-    )
-    monkeypatch.setattr(flotilla.ray, "get", _fake_ray_get)
-    monkeypatch.setattr(flotilla, "RaySwordfishActor", _FakeRaySwordfishActor)
-    monkeypatch.setattr(flotilla, "RaySwordfishActorHandle", lambda actor: ("handle", actor))
-    monkeypatch.setattr(
-        flotilla,
-        "RaySwordfishWorker",
-        lambda *args: {
-            "node_id": args[0],
-            "actor_handle": args[1],
-            "num_cpus": args[2],
-            "num_gpus": args[3],
-            "memory": args[4],
-            "ip_address": args[5],
-        },
-    )
-
-    with execution_config_ctx(worker_startup_timeout=321):
-        workers = flotilla.start_ray_workers(existing_worker_ids=[])
-
-    assert captured["timeout"] == 321
-    assert captured["address_refs"] == ["grpc://10.0.0.1:9999"]
     assert len(workers) == 1
-    assert workers[0]["node_id"] == node_id
+    assert workers[0]["node_id"] == NODE_ID
     assert workers[0]["num_cpus"] == 4
     assert workers[0]["num_gpus"] == 1
     assert workers[0]["memory"] == 1024
-    assert workers[0]["ip_address"] == "grpc://10.0.0.1:9999"
+    assert workers[0]["ip_address"] == FAKE_ADDRESS
+    assert len(flotilla._pending_actors) == 0
+
+
+def test_start_ray_workers_pending_resolved_on_subsequent_call(monkeypatch):
+    """Actors not ready on the first call are returned when ready on a subsequent call."""
+    _patch_flotilla(monkeypatch)
+
+    # First call: ray.wait returns nothing ready
+    monkeypatch.setattr(flotilla.ray, "wait", lambda refs, num_returns, timeout: ([], refs))
+    monkeypatch.setattr(flotilla.ray, "get", lambda ref: FAKE_ADDRESS)
+
+    workers = flotilla.start_ray_workers(existing_worker_ids=[])
+    assert len(workers) == 0
+    assert len(flotilla._pending_actors) == 1
+
+    # Second call: ray.wait returns all ready
+    monkeypatch.setattr(flotilla.ray, "wait", lambda refs, num_returns, timeout: (refs, []))
+
+    workers = flotilla.start_ray_workers(existing_worker_ids=[])
+    assert len(workers) == 1
+    assert workers[0]["node_id"] == NODE_ID
+    assert len(flotilla._pending_actors) == 0
+
+
+def test_start_ray_workers_expires_timed_out_actors(monkeypatch):
+    """Pending actors that exceed the startup timeout are killed and removed."""
+    _patch_flotilla(monkeypatch)
+
+    killed_actors: list[object] = []
+    monkeypatch.setattr(flotilla.ray, "kill", lambda actor: killed_actors.append(actor))
+    # ray.wait returns nothing ready
+    monkeypatch.setattr(flotilla.ray, "wait", lambda refs, num_returns, timeout: ([], refs))
+
+    # Seed a pending actor that was spawned long ago
+    fake_actor = _FakeActor()
+    flotilla._pending_actors[NODE_ID] = flotilla._PendingActor(
+        node=_fake_node(),
+        actor=fake_actor,
+        address_ref=fake_actor.get_address.remote(),
+        spawn_time=time.monotonic() - 9999,
+    )
+
+    with execution_config_ctx(worker_startup_timeout=60):
+        workers = flotilla.start_ray_workers(existing_worker_ids=[])
+
+    assert len(workers) == 0
+    assert len(flotilla._pending_actors) == 0
+    assert fake_actor in killed_actors
+
+
+def test_start_ray_workers_handles_dead_actor(monkeypatch):
+    """If a ready actor's get_address raises ActorDiedError, it is removed from pending."""
+    _patch_flotilla(monkeypatch)
+
+    # ray.wait returns all refs as ready
+    monkeypatch.setattr(flotilla.ray, "wait", lambda refs, num_returns, timeout: (refs, []))
+
+    def _raise_actor_died(ref):
+        raise ray.exceptions.ActorDiedError()
+
+    monkeypatch.setattr(flotilla.ray, "get", _raise_actor_died)
+
+    workers = flotilla.start_ray_workers(existing_worker_ids=[])
+
+    assert len(workers) == 0
+    assert len(flotilla._pending_actors) == 0
+
+
+def test_start_ray_workers_prunes_disappeared_nodes(monkeypatch):
+    """Pending actors for nodes that disappear from ray.nodes() are cleaned up."""
+    _patch_flotilla(monkeypatch, nodes=[_fake_node()])
+
+    killed_actors: list[object] = []
+    monkeypatch.setattr(flotilla.ray, "kill", lambda actor: killed_actors.append(actor))
+
+    # Seed a pending actor for a node that will disappear
+    disappeared_node_id = "2" * 56
+    fake_actor = _FakeActor()
+    flotilla._pending_actors[disappeared_node_id] = flotilla._PendingActor(
+        node=_fake_node(disappeared_node_id),
+        actor=fake_actor,
+        address_ref=fake_actor.get_address.remote(),
+        spawn_time=time.monotonic(),
+    )
+
+    # ray.wait returns all as ready (for the new node spawned this call)
+    monkeypatch.setattr(flotilla.ray, "wait", lambda refs, num_returns, timeout: (refs, []))
+    monkeypatch.setattr(flotilla.ray, "get", lambda ref: FAKE_ADDRESS)
+
+    workers = flotilla.start_ray_workers(existing_worker_ids=[])
+
+    # Disappeared node's actor should be killed
+    assert fake_actor in killed_actors
+    assert disappeared_node_id not in flotilla._pending_actors
+    # The real node should produce a worker
+    assert len(workers) == 1
+    assert workers[0]["node_id"] == NODE_ID
+
+
+def test_start_ray_workers_skips_already_pending_nodes(monkeypatch):
+    """Nodes with actors already pending should not spawn duplicate actors."""
+    _patch_flotilla(monkeypatch)
+
+    # ray.wait returns nothing ready
+    monkeypatch.setattr(flotilla.ray, "wait", lambda refs, num_returns, timeout: ([], refs))
+
+    # First call spawns an actor
+    flotilla.start_ray_workers(existing_worker_ids=[])
+    assert len(flotilla._pending_actors) == 1
+    first_pending = flotilla._pending_actors[NODE_ID]
+
+    # Second call should not replace the pending actor
+    flotilla.start_ray_workers(existing_worker_ids=[])
+    assert len(flotilla._pending_actors) == 1
+    assert flotilla._pending_actors[NODE_ID] is first_pending
+
+
+try:
+    import ray
+except ImportError:
+    pass

--- a/tests/ray/test_flotilla_runner_naming.py
+++ b/tests/ray/test_flotilla_runner_naming.py
@@ -12,8 +12,8 @@ NODE_ID = "1" * 56
 FAKE_ADDRESS = "grpc://10.0.0.1:9999"
 
 
-def _fake_node(node_id: str = NODE_ID) -> dict:
-    return {"NodeID": node_id, "Resources": {"CPU": 4, "memory": 1024, "GPU": 1}}
+def _fake_node(node_id: str = NODE_ID, *, alive: bool = True) -> dict:
+    return {"NodeID": node_id, "Alive": alive, "Resources": {"CPU": 4, "memory": 1024, "GPU": 1}}
 
 
 class _RemoteMethod:
@@ -105,6 +105,15 @@ def test_start_ray_workers_returns_ready_immediately(monkeypatch):
     assert workers[0]["num_gpus"] == 1
     assert workers[0]["memory"] == 1024
     assert workers[0]["ip_address"] == FAKE_ADDRESS
+    assert len(flotilla._pending_actors) == 0
+
+
+def test_start_ray_workers_skips_dead_nodes(monkeypatch):
+    _patch_flotilla(monkeypatch, nodes=[_fake_node(alive=False)])
+
+    workers = flotilla.start_ray_workers(existing_worker_ids=[])
+
+    assert workers == []
     assert len(flotilla._pending_actors) == 0
 
 

--- a/tests/ray/test_flotilla_runner_naming.py
+++ b/tests/ray/test_flotilla_runner_naming.py
@@ -126,8 +126,8 @@ def test_start_ray_workers_pending_resolved_on_subsequent_call(monkeypatch):
     assert len(flotilla._pending_actors) == 0
 
 
-def test_start_ray_workers_expires_timed_out_actors(monkeypatch):
-    """Pending actors that exceed the startup timeout are killed and removed."""
+def test_start_ray_workers_raises_after_timeout_if_no_workers_exist(monkeypatch):
+    """Timed out startup should still fail fast if no workers ever become usable."""
     _patch_flotilla(monkeypatch)
 
     killed_actors: list[object] = []
@@ -145,15 +145,39 @@ def test_start_ray_workers_expires_timed_out_actors(monkeypatch):
     )
 
     with execution_config_ctx(worker_startup_timeout=60):
-        workers = flotilla.start_ray_workers(existing_worker_ids=[])
+        with pytest.raises(RuntimeError, match="Failed to start any Ray workers within 60 seconds"):
+            flotilla.start_ray_workers(existing_worker_ids=[])
 
-    assert len(workers) == 0
     assert len(flotilla._pending_actors) == 0
     assert fake_actor in killed_actors
 
 
-def test_start_ray_workers_handles_dead_actor(monkeypatch):
-    """If a ready actor's get_address raises ActorDiedError, it is removed from pending."""
+def test_start_ray_workers_tolerates_timeout_if_worker_already_exists(monkeypatch):
+    """A slow new node should not fail the query once a usable worker already exists."""
+    _patch_flotilla(monkeypatch)
+
+    killed_actors: list[object] = []
+    monkeypatch.setattr(flotilla.ray, "kill", lambda actor: killed_actors.append(actor))
+    monkeypatch.setattr(flotilla.ray, "wait", lambda refs, num_returns, timeout: ([], refs))
+
+    fake_actor = _FakeActor()
+    flotilla._pending_actors[NODE_ID] = flotilla._PendingActor(
+        node=_fake_node(),
+        actor=fake_actor,
+        address_ref=fake_actor.get_address.remote(),
+        spawn_time=time.monotonic() - 9999,
+    )
+
+    with execution_config_ctx(worker_startup_timeout=60):
+        workers = flotilla.start_ray_workers(existing_worker_ids=["existing-worker"])
+
+    assert workers == []
+    assert len(flotilla._pending_actors) == 0
+    assert fake_actor in killed_actors
+
+
+def test_start_ray_workers_raises_if_all_candidates_die_before_startup(monkeypatch):
+    """Dead startup actors should fail fast if no usable workers remain."""
     _patch_flotilla(monkeypatch)
 
     # ray.wait returns all refs as ready
@@ -164,10 +188,38 @@ def test_start_ray_workers_handles_dead_actor(monkeypatch):
 
     monkeypatch.setattr(flotilla.ray, "get", _raise_actor_died)
 
-    workers = flotilla.start_ray_workers(existing_worker_ids=[])
+    with pytest.raises(RuntimeError, match="Failed to start any Ray workers within 120 seconds"):
+        flotilla.start_ray_workers(existing_worker_ids=[])
 
-    assert len(workers) == 0
     assert len(flotilla._pending_actors) == 0
+
+
+def test_clear_pending_ray_workers_kills_all_pending_actors(monkeypatch):
+    _patch_flotilla(monkeypatch)
+
+    killed_actors: list[object] = []
+    monkeypatch.setattr(flotilla.ray, "kill", lambda actor: killed_actors.append(actor))
+
+    actor1 = _FakeActor()
+    actor2 = _FakeActor()
+    flotilla._pending_actors[NODE_ID] = flotilla._PendingActor(
+        node=_fake_node(),
+        actor=actor1,
+        address_ref=actor1.get_address.remote(),
+        spawn_time=time.monotonic(),
+    )
+    other_node_id = "2" * 56
+    flotilla._pending_actors[other_node_id] = flotilla._PendingActor(
+        node=_fake_node(other_node_id),
+        actor=actor2,
+        address_ref=actor2.get_address.remote(),
+        spawn_time=time.monotonic(),
+    )
+
+    flotilla.clear_pending_ray_workers()
+
+    assert len(flotilla._pending_actors) == 0
+    assert killed_actors == [actor1, actor2]
 
 
 def test_start_ray_workers_prunes_disappeared_nodes(monkeypatch):
@@ -220,6 +272,7 @@ def test_start_ray_workers_skips_already_pending_nodes(monkeypatch):
 
 
 try:
+    import pytest
     import ray
 except ImportError:
     pass

--- a/tests/ray/test_flotilla_runner_naming.py
+++ b/tests/ray/test_flotilla_runner_naming.py
@@ -148,7 +148,10 @@ def test_start_ray_workers_raises_after_timeout_if_no_workers_exist(monkeypatch)
     )
 
     with execution_config_ctx(worker_startup_timeout=60):
-        with pytest.raises(RuntimeError, match="Failed to start any Ray workers within 60 seconds"):
+        with pytest.raises(
+            RuntimeError,
+            match="Failed to start any Ray workers: startup failed or timed out within 60 seconds",
+        ):
             flotilla.start_ray_workers(existing_worker_ids=[])
 
     assert len(flotilla._pending_actors) == 0
@@ -191,10 +194,58 @@ def test_start_ray_workers_raises_if_all_candidates_die_before_startup(monkeypat
 
     monkeypatch.setattr(flotilla.ray, "get", _raise_actor_died)
 
-    with pytest.raises(RuntimeError, match="Failed to start any Ray workers within 120 seconds"):
+    with pytest.raises(
+        RuntimeError,
+        match="Failed to start any Ray workers: startup failed or timed out within 120 seconds",
+    ):
         flotilla.start_ray_workers(existing_worker_ids=[])
 
     assert len(flotilla._pending_actors) == 0
+
+
+def test_start_ray_workers_returns_ready_subset_when_another_node_fails(monkeypatch):
+    """A failed node should not prevent startup if at least one worker becomes ready."""
+    ready_node_id = NODE_ID
+    failed_node_id = "2" * 56
+    _patch_flotilla(monkeypatch, nodes=[_fake_node(ready_node_id), _fake_node(failed_node_id)])
+
+    killed_actors: list[object] = []
+    monkeypatch.setattr(flotilla.ray, "kill", lambda actor: killed_actors.append(actor))
+
+    ready_actor = _FakeActor()
+    failed_actor = _FakeActor()
+    ready_ref = "ready-ref"
+    failed_ref = "failed-ref"
+    flotilla._pending_actors[ready_node_id] = flotilla._PendingActor(
+        node=_fake_node(ready_node_id),
+        actor=ready_actor,
+        address_ref=ready_ref,
+        spawn_time=time.monotonic(),
+    )
+    flotilla._pending_actors[failed_node_id] = flotilla._PendingActor(
+        node=_fake_node(failed_node_id),
+        actor=failed_actor,
+        address_ref=failed_ref,
+        spawn_time=time.monotonic(),
+    )
+
+    monkeypatch.setattr(flotilla.ray, "wait", lambda refs, num_returns, timeout: (refs, []))
+
+    def _get_result(ref):
+        if ref == ready_ref:
+            return FAKE_ADDRESS
+        raise ray.exceptions.ActorDiedError()
+
+    monkeypatch.setattr(flotilla.ray, "get", _get_result)
+
+    workers = flotilla.start_ray_workers(existing_worker_ids=[])
+
+    assert len(workers) == 1
+    assert workers[0]["node_id"] == ready_node_id
+    assert workers[0]["ip_address"] == FAKE_ADDRESS
+    assert len(flotilla._pending_actors) == 0
+    assert failed_actor in killed_actors
+    assert ready_actor not in killed_actors
 
 
 def test_clear_pending_ray_workers_kills_all_pending_actors(monkeypatch):


### PR DESCRIPTION
`start_ray_workers()` previously called `ray.get()` with the full startup timeout (default 120s), blocking the scheduler's `RayWorkerManagerState` mutex for the entire duration. While waiting for slow actors to report their gRPC addresses, the scheduler couldn't submit tasks, collect worker snapshots, or request autoscaling.

The root cause: the Rust scheduler loop calls `worker_snapshots()`, which locks the mutex, calls `refresh_workers()`, which calls into Python's `start_ray_workers()` - and that `ray.get()` holds the GIL and the mutex until every actor responds or the timeout expires.

To fix this, `start_ray_workers()` now uses `ray.wait(timeout=0)` instead of `ray.get(timeout=N)`. Actors whose `get_address.remote()` result is already ready are returned immediately. The rest are tracked as pending state and polled again on the next refresh cycle (every 5s). Actors that die during startup, disappear with their node, or exceed `worker_startup_timeout` are killed and cleaned up.

However, we still want a bounded failure mode when startup never succeeds. If there are no existing usable workers, no new worker becomes ready, and all pending startup candidates have failed or timed out, `start_ray_workers()` now raises instead of letting the scheduler tick forever with zero workers. If at least one worker is already usable, we tolerate slow or failed new nodes and keep going.

As a follow-up hardening pass, pending startup now only considers live nodes by checking the node `Alive` flag, so we do not enqueue actors against recently-dead nodes that still linger in `ray.nodes()`. The refresh path also captures a single `ray.nodes()` snapshot per cycle and reuses it for both pruning and spawning, which removes the stale-snapshot window between those two steps.

The net effect is that worker discovery is now incremental and non-blocking for healthy startup, while still failing fast when the cluster never produces any usable worker at all.

Closes #6589