### PR TITLE
feat(ci): the 'components' tag when creating a bug/feature should apply the correct labeles

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -35,6 +35,24 @@ body:
   validations:
     required: false
 - type: dropdown
+  id: component
+  attributes:
+    label: Component(s)
+    multiple: true
+    options:
+    - Built-in Functions
+    - UDFs (User Defined Functions)
+    - Data Sources & Sinks
+    - Native Runner (swordfish)
+    - Distributed Runner (flotilla)
+    - Cloud Storage (S3/GCS/Azure)
+    - Multimodal Operations (files/images/etc.)
+    - Memory Management/OOM's
+    - Lance Integration
+    - Other
+  validations:
+    required: true
+- type: dropdown
   id: contribute
   attributes:
     label: Would you like to implement a fix?

--- a/.github/workflows/issue-component-labeler.yml
+++ b/.github/workflows/issue-component-labeler.yml
@@ -1,0 +1,83 @@
+name: Issue Component Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  apply-component-labels:
+    if: contains(github.event.issue.body, '### Component(s)')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Apply mapped labels from Component(s)
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const issue = context.payload.issue;
+          const body = issue.body || "";
+          const sectionMatch = body.match(/### Component\(s\)\s*([\s\S]*?)(?:\n### |\n## |$)/);
+
+          if (!sectionMatch) {
+            core.info("Component(s) section not found; skipping.");
+            return;
+          }
+
+          const selectedComponents = sectionMatch[1]
+            .split("\n")
+            .map((line) => line.trim())
+            .filter((line) => line.startsWith("- "))
+            .map((line) => line.replace(/^- /, "").trim())
+            .filter(Boolean);
+
+          if (selectedComponents.length === 0) {
+            core.info("No selected components found in section; skipping.");
+            return;
+          }
+
+          const componentToLabels = {
+            "Built-in Functions": ["expression"],
+            "UDFs (User Defined Functions)": ["expression", "python"],
+            "Data Sources & Sinks": ["data-catalogs"],
+            "Native Runner (swordfish)": ["rust"],
+            "Distributed Runner (flotilla)": ["rust"],
+            "Cloud Storage (S3/GCS/Azure)": ["data-catalogs"],
+            "Multimodal Operations (files/images/etc.)": ["python"],
+            "Memory Management/OOM's": ["rust"],
+            "Lance Integration": ["rust"],
+          };
+
+          const mappedLabels = [
+            ...new Set(
+              selectedComponents.flatMap((component) => componentToLabels[component] || [])
+            ),
+          ];
+
+          if (mappedLabels.length === 0) {
+            core.info("No label mappings found for selected components; skipping.");
+            return;
+          }
+
+          const existingLabels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issue.number,
+          });
+          const existingLabelNames = new Set(existingLabels.map((label) => label.name));
+          const labelsToAdd = mappedLabels.filter((name) => !existingLabelNames.has(name));
+
+          if (labelsToAdd.length === 0) {
+            core.info("All mapped labels already present.");
+            return;
+          }
+
+          await github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issue.number,
+            labels: labelsToAdd,
+          });
+
+          core.info(`Added labels: ${labelsToAdd.join(", ")}`);


### PR DESCRIPTION
## Problem
Issue forms currently do not auto-apply component-related labels from the `Component(s)` selection, which slows triage.

## Root Cause
The repository only applies static labels in issue templates and lacks automation that parses selected components from issue body and maps them to labels.

## Solution
- Add a required `Component(s)` dropdown to `feature_request.yaml` (same options as bug report).
- Add a new workflow `.github/workflows/issue-component-labeler.yml` that:
  - parses the `### Component(s)` section,
  - maps component choices to existing repository labels,
  - adds only missing mapped labels (idempotent behavior).

## Tests
- YAML parse validation for:
  - `.github/ISSUE_TEMPLATE/feature_request.yaml`
  - `.github/ISSUE_TEMPLATE/bug_report.yml`
  - `.github/workflows/issue-component-labeler.yml`
- Workflow sanity assertions for key script markers.

## Impact
- Improves issue triage automation consistency.
- Reduces manual labeling overhead.
- No runtime behavior changes to Daft core.
