### PR TITLE
refactor: Use DAFT_REF_NAME and DAFT_SHA env vars for benchmark run metadata

### DIFF
--- a/benchmarking/utils.py
+++ b/benchmarking/utils.py
@@ -43,8 +43,8 @@ def get_run_metadata():
     return {
         "started at": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f"),
         "daft version": daft.__version__,
-        "github ref": os.getenv("GITHUB_REF_NAME"),
-        "github sha": os.getenv("GITHUB_SHA"),
+        "github ref": os.getenv("DAFT_REF_NAME", os.getenv("GITHUB_REF_NAME")),
+        "github sha": os.getenv("DAFT_SHA", os.getenv("GITHUB_SHA")),
     }
 
 


### PR DESCRIPTION
## Summary
- Benchmark scripts are now invoked from the `daft-benchmarking` repo, so `GITHUB_REF_NAME`/`GITHUB_SHA` no longer point to the Daft commit being benchmarked.
- Prefer `DAFT_REF_NAME` and `DAFT_SHA` env vars (set by `daft-benchmarking`'s setup script), falling back to `GITHUB_REF_NAME`/`GITHUB_SHA` for backwards compatibility.

## Test plan
- [x] Verify env var fallback logic in `get_run_metadata()`