### PR TITLE
perf: Optimize GroupBy Map Building & List-Agg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,6 +2435,7 @@ dependencies = [
  "rstest",
  "serde",
  "sketches-ddsketch",
+ "smallvec",
  "xxhash-rust",
 ]
 
@@ -2790,6 +2791,7 @@ dependencies = [
  "common-error",
  "daft-core",
  "hashbrown 0.16.1",
+ "smallvec",
 ]
 
 [[package]]
@@ -3138,6 +3140,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,7 +2422,7 @@ dependencies = [
  "daft-sketch",
  "derive_more",
  "fastrand 2.3.0",
- "fnv",
+ "hashbrown 0.16.1",
  "html-escape",
  "hyperloglog",
  "image",
@@ -2783,6 +2783,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "daft-groupby"
+version = "0.3.0-dev0"
+dependencies = [
+ "arrow",
+ "common-error",
+ "daft-core",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "daft-hash"
 version = "0.3.0-dev0"
 dependencies = [
@@ -2920,6 +2930,7 @@ dependencies = [
  "daft-dsl",
  "daft-functions-list",
  "daft-functions-uri",
+ "daft-groupby",
  "daft-io",
  "daft-json",
  "daft-local-plan",
@@ -3116,6 +3127,7 @@ dependencies = [
  "daft-core",
  "daft-dsl",
  "daft-functions-list",
+ "daft-groupby",
  "daft-image",
  "futures",
  "hashbrown 0.16.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,7 +2422,6 @@ dependencies = [
  "daft-sketch",
  "derive_more",
  "fastrand 2.3.0",
- "hashbrown 0.16.1",
  "html-escape",
  "hyperloglog",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ members = [
   "src/daft-checkpoint",
   "src/daft-context",
   "src/daft-core",
+  "src/daft-groupby",
   "src/daft-csv",
   "src/daft-dashboard",
   "src/daft-dsl",
@@ -269,6 +270,7 @@ daft-algebra = {path = "src/daft-algebra"}
 daft-catalog = {path = "src/daft-catalog"}
 daft-context = {path = "src/daft-context"}
 daft-core = {path = "src/daft-core"}
+daft-groupby = {path = "src/daft-groupby"}
 daft-dsl = {path = "src/daft-dsl"}
 daft-ext-internal = {path = "src/daft-ext-internal"}
 daft-ext-macros = {path = "src/daft-ext-macros", version = "0.1.1"}

--- a/daft/dataframe/dataframe.py
+++ b/daft/dataframe/dataframe.py
@@ -380,7 +380,7 @@ class DataFrame:
             >>> df = daft.from_pydict({"x": [1, 2, 3], "y": ["a", "b", "c"]})
             >>> df.schema()
             ╭─────────────┬────────╮
-            │ column_name ┆ type   │
+            │ Column Name ┆ DType  │
             ╞═════════════╪════════╡
             │ x           ┆ Int64  │
             ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┤

--- a/src/common/display/src/table_display.rs
+++ b/src/common/display/src/table_display.rs
@@ -44,10 +44,10 @@ pub fn make_schema_vertical_table(
 
     maybe_apply_width(&mut table);
 
-    let mut header = vec![create_table_cell("column_name"), create_table_cell("type")];
+    let mut header = vec![create_table_cell("Column Name"), create_table_cell("DType")];
     let has_metadata = fields.iter().any(|(_, _, meta)| !meta.is_empty());
     if has_metadata {
-        header.push(create_table_cell("metadata"));
+        header.push(create_table_cell("Metadata"));
     }
     table.set_header(header);
 

--- a/src/daft-core/Cargo.toml
+++ b/src/daft-core/Cargo.toml
@@ -20,7 +20,7 @@ daft-schema = {path = "../daft-schema", default-features = false}
 daft-sketch = {path = "../daft-sketch", default-features = false}
 derive_more = {workspace = true}
 fastrand = "2.1.0"
-fnv = "1.0.7"
+hashbrown = {workspace = true}
 html-escape = {workspace = true}
 hyperloglog = {path = "../hyperloglog"}
 image = {workspace = true, features = [

--- a/src/daft-core/Cargo.toml
+++ b/src/daft-core/Cargo.toml
@@ -21,6 +21,7 @@ daft-sketch = {path = "../daft-sketch", default-features = false}
 derive_more = {workspace = true}
 fastrand = "2.1.0"
 hashbrown = {workspace = true}
+smallvec = {workspace = true}
 html-escape = {workspace = true}
 hyperloglog = {path = "../hyperloglog"}
 image = {workspace = true, features = [

--- a/src/daft-core/Cargo.toml
+++ b/src/daft-core/Cargo.toml
@@ -20,7 +20,6 @@ daft-schema = {path = "../daft-schema", default-features = false}
 daft-sketch = {path = "../daft-sketch", default-features = false}
 derive_more = {workspace = true}
 fastrand = "2.1.0"
-hashbrown = {workspace = true}
 smallvec = {workspace = true}
 html-escape = {workspace = true}
 hyperloglog = {path = "../hyperloglog"}

--- a/src/daft-core/src/array/ops/concat_agg.rs
+++ b/src/daft-core/src/array/ops/concat_agg.rs
@@ -10,7 +10,7 @@ use common_error::DaftResult;
 use super::{DaftConcatAggable, as_arrow::AsArrow};
 use crate::{
     array::{DataArray, ListArray},
-    prelude::Utf8Type,
+    prelude::{UInt64Array, Utf8Type},
     series::Series,
 };
 
@@ -70,7 +70,7 @@ impl DaftConcatAggable for ListArray {
         let all_valid = self.null_count() == 0;
 
         // Collect all child slices for each group
-        let mut all_slices: Vec<Series> = vec![];
+        let mut child_idxs: Vec<u64> = vec![];
         let mut group_lens: Vec<usize> = vec![];
         let mut group_valids: Vec<bool> = vec![];
 
@@ -83,7 +83,7 @@ impl DaftConcatAggable for ListArray {
                     let end = self.offsets()[*idx as usize + 1] as usize;
                     let len = end - start;
                     if len > 0 {
-                        all_slices.push(self.flat_child.slice(start, end)?);
+                        child_idxs.extend(start as u64..end as u64);
                     }
                     group_len += len;
                     group_valid = true;
@@ -93,10 +93,11 @@ impl DaftConcatAggable for ListArray {
             group_lens.push(if group_valid { group_len } else { 0 });
         }
 
-        let new_child = if all_slices.is_empty() {
+        let new_child = if child_idxs.is_empty() {
             self.flat_child.slice(0, 0)?
         } else {
-            Series::concat(&all_slices.iter().collect::<Vec<_>>())?
+            self.flat_child
+                .take(&UInt64Array::from_vec("", child_idxs))?
         };
 
         let new_offsets = OffsetBuffer::from_lengths(group_lens.iter().copied());

--- a/src/daft-core/src/array/ops/concat_agg.rs
+++ b/src/daft-core/src/array/ops/concat_agg.rs
@@ -168,6 +168,7 @@ mod test {
 
     use arrow::buffer::OffsetBuffer;
     use common_error::DaftResult;
+    use smallvec::smallvec;
 
     use crate::{
         array::{ListArray, ops::DaftConcatAggable},
@@ -266,8 +267,12 @@ mod test {
             ])),
         );
 
-        let concatted =
-            list_array.grouped_concat(&vec![vec![0, 1], vec![2, 3], vec![4, 5], vec![6, 7]])?;
+        let concatted = list_array.grouped_concat(&vec![
+            smallvec![0, 1],
+            smallvec![2, 3],
+            smallvec![4, 5],
+            smallvec![6, 7],
+        ])?;
 
         // Expected: [[0, 0, 0], [1, None, None], [2, None], None]
         assert_eq!(concatted.len(), 4);

--- a/src/daft-core/src/array/ops/mod.rs
+++ b/src/daft-core/src/array/ops/mod.rs
@@ -27,7 +27,6 @@ pub mod from_arrow;
 pub mod full;
 mod get;
 mod get_lit;
-pub(crate) mod groups;
 mod hash;
 mod hll_merge;
 mod hll_sketch;
@@ -68,7 +67,6 @@ mod variance;
 
 use std::hash::BuildHasher;
 
-use common_error::DaftResult;
 pub use hll_sketch::HLL_SKETCH_DTYPE;
 pub use sort::{build_multi_array_bicompare, build_multi_array_compare};
 
@@ -166,14 +164,6 @@ pub trait DaftMinHash {
 pub type VecIndices = Vec<u64>;
 pub type GroupIndices = Vec<VecIndices>;
 pub type GroupIndicesPair = (VecIndices, GroupIndices);
-
-pub trait IntoGroups {
-    fn make_groups(&self) -> DaftResult<GroupIndicesPair>;
-}
-
-pub trait IntoUniqueIdxs {
-    fn make_unique_idxs(&self) -> DaftResult<VecIndices>;
-}
 
 pub trait DaftCountAggable {
     type Output;

--- a/src/daft-core/src/array/ops/mod.rs
+++ b/src/daft-core/src/array/ops/mod.rs
@@ -161,9 +161,8 @@ pub trait DaftMinHash {
     ) -> Self::Output;
 }
 
-pub type VecIndices = Vec<u64>;
+pub type VecIndices = smallvec::SmallVec<[u64; 2]>;
 pub type GroupIndices = Vec<VecIndices>;
-pub type GroupIndicesPair = (VecIndices, GroupIndices);
 
 pub trait DaftCountAggable {
     type Output;

--- a/src/daft-core/src/series/ops/agg.rs
+++ b/src/daft-core/src/series/ops/agg.rs
@@ -489,7 +489,7 @@ impl DaftSetAggable for Series {
                 continue;
             }
 
-            let group_indices = UInt64Array::from_vec("", group.clone());
+            let group_indices = UInt64Array::from_vec("", group.to_vec());
             let group_series = series.take(&group_indices)?;
 
             let unique_indices = deduplicate_indices(&group_series)?;

--- a/src/daft-core/src/series/ops/mod.rs
+++ b/src/daft-core/src/series/ops/mod.rs
@@ -15,7 +15,6 @@ pub mod concat;
 pub mod downcast;
 pub mod filter;
 pub mod floor;
-pub mod groups;
 pub mod hash;
 pub mod if_else;
 pub mod is_in;

--- a/src/daft-groupby/Cargo.toml
+++ b/src/daft-groupby/Cargo.toml
@@ -1,0 +1,13 @@
+[dependencies]
+arrow = {workspace = true}
+common-error = {workspace = true}
+daft-core = {path = "../daft-core", default-features = false}
+hashbrown = {workspace = true}
+
+[lints]
+workspace = true
+
+[package]
+edition = {workspace = true}
+name = "daft-groupby"
+version = {workspace = true}

--- a/src/daft-groupby/Cargo.toml
+++ b/src/daft-groupby/Cargo.toml
@@ -3,6 +3,7 @@ arrow = {workspace = true}
 common-error = {workspace = true}
 daft-core = {path = "../daft-core", default-features = false}
 hashbrown = {workspace = true}
+smallvec = {workspace = true}
 
 [lints]
 workspace = true

--- a/src/daft-groupby/src/arrays.rs
+++ b/src/daft-groupby/src/arrays.rs
@@ -1,21 +1,19 @@
-use std::{
-    collections::hash_map::Entry::{Occupied, Vacant},
-    hash::{BuildHasherDefault, Hash},
-};
+use std::hash::Hash;
 
 use arrow::{array::Array, datatypes::ArrowPrimitiveType};
 use common_error::DaftResult;
-use fnv::FnvHashMap;
-
-use super::{IntoGroups, as_arrow::AsArrow};
-use crate::{
-    array::{DataArray, FixedSizeListArray, ListArray, StructArray, ops::IntoUniqueIdxs},
+use daft_core::{
+    array::{DataArray, FixedSizeListArray, ListArray, StructArray, ops::as_arrow::AsArrow},
     datatypes::{
-        BinaryArray, BooleanArray, DaftIntegerType, DaftNumericType, FixedSizeBinaryArray,
-        Float32Array, Float64Array, NullArray, NumericNative, Utf8Array,
+        BinaryArray, BooleanArray, DaftNumericType, FixedSizeBinaryArray, Float32Array,
+        Float64Array, Int8Type, Int16Type, Int32Type, Int64Type, NullArray, NumericNative,
+        UInt8Type, UInt16Type, UInt32Type, UInt64Type, Utf8Array,
     },
     prelude::Decimal128Array,
 };
+use hashbrown::{DefaultHashBuilder, HashMap, hash_map::Entry};
+
+use crate::{IntoGroups, IntoUniqueIdxs};
 
 /// Given a list of values, return a `(Vec<u64>, Vec<Vec<u64>>)`.
 /// The sub-vector in the first part of the tuple contains the indices of the unique values.
@@ -36,24 +34,24 @@ use crate::{
 ///
 /// Calling `make_groups` on the above list would return `(vec![0, 1, 3], vec![vec![0, 2, 4], vec![1], vec![3]])` since `a` appeared 3 times at indices `0`, `2`, and `4`, etc.
 #[inline(never)]
-fn make_groups<T>(iter: impl Iterator<Item = T>) -> DaftResult<super::GroupIndicesPair>
+fn make_groups<T>(iter: impl Iterator<Item = T>) -> DaftResult<crate::GroupIndicesPair>
 where
     T: Hash,
     T: Eq,
 {
-    const DEFAULT_SIZE: usize = 256;
-    let mut tbl = FnvHashMap::<T, (u64, Vec<u64>)>::with_capacity_and_hasher(
+    const DEFAULT_SIZE: usize = 1024;
+    let mut tbl = HashMap::<T, (u64, Vec<u64>)>::with_capacity_and_hasher(
         DEFAULT_SIZE,
-        BuildHasherDefault::default(),
+        DefaultHashBuilder::default(),
     );
     for (idx, val) in iter.enumerate() {
         let idx = idx as u64;
         let e = tbl.entry(val);
         match e {
-            Vacant(e) => {
+            Entry::Vacant(e) => {
                 e.insert((idx, vec![idx]));
             }
-            Occupied(mut e) => {
+            Entry::Occupied(mut e) => {
                 e.get_mut().1.push(idx);
             }
         }
@@ -86,22 +84,22 @@ where
 /// Calling `make_unique_idxs` on the above list would return `vec![0, 1, 3]`
 /// since those are the first indices where each unique value (`a`, `b`, `c`) appears.
 #[inline(never)]
-fn make_unique_idxs<T>(iter: impl Iterator<Item = T>) -> DaftResult<super::VecIndices>
+fn make_unique_idxs<T>(iter: impl Iterator<Item = T>) -> DaftResult<crate::VecIndices>
 where
     T: Hash,
     T: Eq,
 {
     const DEFAULT_SIZE: usize = 256;
     let mut tbl =
-        FnvHashMap::<T, u64>::with_capacity_and_hasher(DEFAULT_SIZE, BuildHasherDefault::default());
+        HashMap::<T, u64>::with_capacity_and_hasher(DEFAULT_SIZE, DefaultHashBuilder::default());
     for (idx, val) in iter.enumerate() {
         let idx = idx as u64;
         let e = tbl.entry(val);
         match e {
-            Vacant(e) => {
+            Entry::Vacant(e) => {
                 e.insert(idx);
             }
-            Occupied(_) => {}
+            Entry::Occupied(_) => {}
         }
     }
     let mut indices = Vec::with_capacity(tbl.len());
@@ -111,42 +109,51 @@ where
     Ok(indices)
 }
 
-// Primitive
+// Primitive integers: per-type impls avoid overlapping-blanket coherence errors with
+// `DataArray` type aliases defined in `daft-core` (e.g. `Float32Array`).
 
-impl<T> IntoGroups for DataArray<T>
-where
-    T: DaftIntegerType,
-    <T as DaftNumericType>::Native: Ord + Hash + Eq,
-    <<T as DaftNumericType>::Native as NumericNative>::ARROWTYPE:
-        ArrowPrimitiveType<Native = <T as DaftNumericType>::Native>,
-{
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
-        if self.null_count() > 0 {
-            make_groups(self.into_iter())
-        } else {
-            make_groups(self.values().iter())
+macro_rules! impl_into_groups_integer_array {
+    ($($T:ty),* $(,)?) => {
+        $(
+        impl IntoGroups for DataArray<$T>
+        where
+            <$T as DaftNumericType>::Native: Ord + Hash + Eq,
+            <<$T as DaftNumericType>::Native as NumericNative>::ARROWTYPE:
+                ArrowPrimitiveType<Native = <$T as DaftNumericType>::Native>,
+        {
+            fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
+                if self.null_count() > 0 {
+                    make_groups(self.into_iter())
+                } else {
+                    make_groups(self.values().iter())
+                }
+            }
         }
-    }
+
+        impl IntoUniqueIdxs for DataArray<$T>
+        where
+            <$T as DaftNumericType>::Native: Ord + Hash + Eq,
+            <<$T as DaftNumericType>::Native as NumericNative>::ARROWTYPE:
+                ArrowPrimitiveType<Native = <$T as DaftNumericType>::Native>,
+        {
+            fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+                if self.null_count() > 0 {
+                    make_unique_idxs(self.into_iter())
+                } else {
+                    make_unique_idxs(self.values().iter())
+                }
+            }
+        }
+        )*
+    };
 }
 
-impl<T> IntoUniqueIdxs for DataArray<T>
-where
-    T: DaftIntegerType,
-    <T as DaftNumericType>::Native: Ord + Hash + Eq,
-    <<T as DaftNumericType>::Native as NumericNative>::ARROWTYPE:
-        ArrowPrimitiveType<Native = <T as DaftNumericType>::Native>,
-{
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
-        if self.null_count() > 0 {
-            make_unique_idxs(self.into_iter())
-        } else {
-            make_unique_idxs(self.values().iter())
-        }
-    }
-}
+impl_into_groups_integer_array!(
+    Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
+);
 
 impl IntoGroups for Decimal128Array {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         if self.null_count() > 0 {
             make_groups(self.into_iter())
         } else {
@@ -156,7 +163,7 @@ impl IntoGroups for Decimal128Array {
 }
 
 impl IntoUniqueIdxs for Decimal128Array {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         if self.null_count() > 0 {
             make_unique_idxs(self.into_iter())
         } else {
@@ -169,7 +176,7 @@ impl IntoUniqueIdxs for Decimal128Array {
 // Canonicalize all NaN payloads so every NaN hashes/equates into one group.
 
 impl IntoGroups for Float32Array {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         if self.null_count() > 0 {
             make_groups(self.into_iter().map(|f| {
                 f.map(|v| {
@@ -193,7 +200,7 @@ impl IntoGroups for Float32Array {
 }
 
 impl IntoUniqueIdxs for Float32Array {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         if self.null_count() > 0 {
             make_unique_idxs(self.into_iter().map(|f| {
                 f.map(|v| {
@@ -217,7 +224,7 @@ impl IntoUniqueIdxs for Float32Array {
 }
 
 impl IntoGroups for Float64Array {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         if self.null_count() > 0 {
             make_groups(self.into_iter().map(|f| {
                 f.map(|v| {
@@ -241,7 +248,7 @@ impl IntoGroups for Float64Array {
 }
 
 impl IntoUniqueIdxs for Float64Array {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         if self.null_count() > 0 {
             make_unique_idxs(self.into_iter().map(|f| {
                 f.map(|v| {
@@ -267,7 +274,7 @@ impl IntoUniqueIdxs for Float64Array {
 // Variable-size binary/string
 
 impl IntoGroups for Utf8Array {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         if self.null_count() == 0 {
             make_groups(self.values()?)
         } else {
@@ -277,7 +284,7 @@ impl IntoGroups for Utf8Array {
 }
 
 impl IntoUniqueIdxs for Utf8Array {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         if self.null_count() == 0 {
             make_unique_idxs(self.values()?)
         } else {
@@ -287,7 +294,7 @@ impl IntoUniqueIdxs for Utf8Array {
 }
 
 impl IntoGroups for BinaryArray {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         if self.null_count() == 0 {
             make_groups(self.values()?)
         } else {
@@ -297,7 +304,7 @@ impl IntoGroups for BinaryArray {
 }
 
 impl IntoUniqueIdxs for BinaryArray {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         if self.null_count() == 0 {
             make_unique_idxs(self.values()?)
         } else {
@@ -309,7 +316,7 @@ impl IntoUniqueIdxs for BinaryArray {
 // Fixed-size binary
 
 impl IntoGroups for FixedSizeBinaryArray {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         let array = self.as_arrow()?;
 
         let width = array.value_length() as usize;
@@ -333,7 +340,7 @@ impl IntoGroups for FixedSizeBinaryArray {
 }
 
 impl IntoUniqueIdxs for FixedSizeBinaryArray {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         let array = self.as_arrow()?;
         let width = array.value_length() as usize;
 
@@ -354,7 +361,7 @@ impl IntoUniqueIdxs for FixedSizeBinaryArray {
 // Other
 
 impl IntoGroups for BooleanArray {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         if self.null_count() > 0 {
             make_groups(self.into_iter())
         } else {
@@ -364,7 +371,7 @@ impl IntoGroups for BooleanArray {
 }
 
 impl IntoUniqueIdxs for BooleanArray {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         if self.null_count() > 0 {
             make_unique_idxs(self.into_iter())
         } else {
@@ -374,7 +381,7 @@ impl IntoUniqueIdxs for BooleanArray {
 }
 
 impl IntoGroups for NullArray {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         // All rows are null, so there is at most one group (or none for empty arrays).
         let l = self.len() as u64;
         if l == 0 {
@@ -386,7 +393,7 @@ impl IntoGroups for NullArray {
 }
 
 impl IntoUniqueIdxs for NullArray {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         let l = self.len() as u64;
         if l == 0 {
             return Ok(vec![]);
@@ -396,37 +403,37 @@ impl IntoUniqueIdxs for NullArray {
 }
 
 impl IntoGroups for ListArray {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         self.hash(None)?.make_groups()
     }
 }
 
 impl IntoUniqueIdxs for ListArray {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         self.hash(None)?.make_unique_idxs()
     }
 }
 
 impl IntoGroups for FixedSizeListArray {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         self.hash(None)?.make_groups()
     }
 }
 
 impl IntoUniqueIdxs for FixedSizeListArray {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         self.hash(None)?.make_unique_idxs()
     }
 }
 
 impl IntoGroups for StructArray {
-    fn make_groups(&self) -> DaftResult<super::GroupIndicesPair> {
+    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
         self.hash(None)?.make_groups()
     }
 }
 
 impl IntoUniqueIdxs for StructArray {
-    fn make_unique_idxs(&self) -> DaftResult<super::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
         self.hash(None)?.make_unique_idxs()
     }
 }
@@ -436,11 +443,12 @@ mod tests {
     use std::collections::BTreeMap;
 
     use common_error::DaftResult;
-
-    use crate::{
-        array::ops::{IntoGroups, IntoUniqueIdxs, full::FullNull},
+    use daft_core::{
+        array::ops::full::FullNull,
         datatypes::{DataType, Field, FixedSizeBinaryArray, Float64Array, Int64Array, NullArray},
     };
+
+    use crate::{IntoGroups, IntoUniqueIdxs};
 
     fn grouped_by_sample(
         sample_indices: Vec<u64>,

--- a/src/daft-groupby/src/arrays.rs
+++ b/src/daft-groupby/src/arrays.rs
@@ -3,7 +3,10 @@ use std::hash::Hash;
 use arrow::array::Array;
 use common_error::DaftResult;
 use daft_core::{
-    array::{DataArray, FixedSizeListArray, ListArray, StructArray, ops::as_arrow::AsArrow},
+    array::{
+        DataArray, FixedSizeListArray, ListArray, StructArray,
+        ops::{VecIndices, as_arrow::AsArrow},
+    },
     datatypes::{
         BinaryArray, BooleanArray, Decimal128Type, FixedSizeBinaryArray, Float32Array,
         Float64Array, Int8Type, Int16Type, Int32Type, Int64Type, NullArray, UInt8Type, UInt16Type,
@@ -11,6 +14,7 @@ use daft_core::{
     },
 };
 use hashbrown::{DefaultHashBuilder, HashMap, hash_map::Entry};
+use smallvec::smallvec;
 
 use crate::{IntoGroups, IntoUniqueIdxs};
 
@@ -35,11 +39,10 @@ use crate::{IntoGroups, IntoUniqueIdxs};
 #[inline(never)]
 fn make_groups<T>(iter: impl Iterator<Item = T>) -> DaftResult<crate::GroupIndicesPair>
 where
-    T: Hash,
-    T: Eq,
+    T: Hash + Eq,
 {
     const DEFAULT_SIZE: usize = 1024;
-    let mut tbl = HashMap::<T, (u64, Vec<u64>)>::with_capacity_and_hasher(
+    let mut tbl = HashMap::<T, VecIndices>::with_capacity_and_hasher(
         DEFAULT_SIZE,
         DefaultHashBuilder::default(),
     );
@@ -48,18 +51,18 @@ where
         let e = tbl.entry(val);
         match e {
             Entry::Vacant(e) => {
-                e.insert((idx, vec![idx]));
+                e.insert(smallvec![idx]);
             }
             Entry::Occupied(mut e) => {
-                e.get_mut().1.push(idx);
+                e.get_mut().push(idx);
             }
         }
     }
     let mut sample_indices = Vec::with_capacity(tbl.len());
     let mut group_indices = Vec::with_capacity(tbl.len());
 
-    for (sample_index, group_index) in tbl.into_values() {
-        sample_indices.push(sample_index);
+    for group_index in tbl.into_values() {
+        sample_indices.push(unsafe { *group_index.get_unchecked(0) });
         group_indices.push(group_index);
     }
 
@@ -83,7 +86,7 @@ where
 /// Calling `make_unique_idxs` on the above list would return `vec![0, 1, 3]`
 /// since those are the first indices where each unique value (`a`, `b`, `c`) appears.
 #[inline(never)]
-fn make_unique_idxs<T>(iter: impl Iterator<Item = T>) -> DaftResult<crate::VecIndices>
+fn make_unique_idxs<T>(iter: impl Iterator<Item = T>) -> DaftResult<crate::Indices>
 where
     T: Hash,
     T: Eq,
@@ -124,7 +127,7 @@ macro_rules! impl_into_groups_primitive_array {
         }
 
         impl IntoUniqueIdxs for DataArray<$T> {
-            fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+            fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
                 if self.null_count() > 0 {
                     make_unique_idxs(self.into_iter())
                 } else {
@@ -173,7 +176,7 @@ impl IntoGroups for Float32Array {
 }
 
 impl IntoUniqueIdxs for Float32Array {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         if self.null_count() > 0 {
             make_unique_idxs(self.into_iter().map(|f| {
                 f.map(|v| {
@@ -221,7 +224,7 @@ impl IntoGroups for Float64Array {
 }
 
 impl IntoUniqueIdxs for Float64Array {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         if self.null_count() > 0 {
             make_unique_idxs(self.into_iter().map(|f| {
                 f.map(|v| {
@@ -257,7 +260,7 @@ impl IntoGroups for Utf8Array {
 }
 
 impl IntoUniqueIdxs for Utf8Array {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         if self.null_count() == 0 {
             make_unique_idxs(self.values()?)
         } else {
@@ -277,7 +280,7 @@ impl IntoGroups for BinaryArray {
 }
 
 impl IntoUniqueIdxs for BinaryArray {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         if self.null_count() == 0 {
             make_unique_idxs(self.values()?)
         } else {
@@ -313,7 +316,7 @@ impl IntoGroups for FixedSizeBinaryArray {
 }
 
 impl IntoUniqueIdxs for FixedSizeBinaryArray {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         let array = self.as_arrow()?;
         let width = array.value_length() as usize;
 
@@ -344,7 +347,7 @@ impl IntoGroups for BooleanArray {
 }
 
 impl IntoUniqueIdxs for BooleanArray {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         if self.null_count() > 0 {
             make_unique_idxs(self.into_iter())
         } else {
@@ -360,13 +363,13 @@ impl IntoGroups for NullArray {
         if l == 0 {
             return Ok((vec![], vec![]));
         }
-        let v = (0u64..l).collect::<Vec<u64>>();
+        let v = (0u64..l).collect::<VecIndices>();
         Ok((vec![0], vec![v]))
     }
 }
 
 impl IntoUniqueIdxs for NullArray {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         let l = self.len() as u64;
         if l == 0 {
             return Ok(vec![]);
@@ -382,7 +385,7 @@ impl IntoGroups for ListArray {
 }
 
 impl IntoUniqueIdxs for ListArray {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         self.hash(None)?.make_unique_idxs()
     }
 }
@@ -394,7 +397,7 @@ impl IntoGroups for FixedSizeListArray {
 }
 
 impl IntoUniqueIdxs for FixedSizeListArray {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         self.hash(None)?.make_unique_idxs()
     }
 }
@@ -406,7 +409,7 @@ impl IntoGroups for StructArray {
 }
 
 impl IntoUniqueIdxs for StructArray {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<crate::Indices> {
         self.hash(None)?.make_unique_idxs()
     }
 }
@@ -417,16 +420,17 @@ mod tests {
 
     use common_error::DaftResult;
     use daft_core::{
-        array::ops::full::FullNull,
+        array::ops::{VecIndices, full::FullNull},
         datatypes::{DataType, Field, FixedSizeBinaryArray, Float64Array, Int64Array, NullArray},
     };
+    use smallvec::smallvec;
 
     use crate::{IntoGroups, IntoUniqueIdxs};
 
     fn grouped_by_sample(
         sample_indices: Vec<u64>,
-        group_indices: Vec<Vec<u64>>,
-    ) -> BTreeMap<u64, Vec<u64>> {
+        group_indices: Vec<VecIndices>,
+    ) -> BTreeMap<u64, VecIndices> {
         sample_indices
             .into_iter()
             .zip(group_indices)
@@ -446,9 +450,9 @@ mod tests {
         assert_eq!(
             grouped,
             BTreeMap::from([
-                (0u64, vec![0u64, 2u64]),
-                (1u64, vec![1u64, 3u64]),
-                (4u64, vec![4u64]),
+                (0u64, smallvec![0u64, 2u64]),
+                (1u64, smallvec![1u64, 3u64]),
+                (4u64, smallvec![4u64]),
             ])
         );
 
@@ -469,7 +473,7 @@ mod tests {
 
         assert_eq!(
             grouped,
-            BTreeMap::from([(0u64, vec![0u64, 2u64]), (1u64, vec![1u64, 3u64])])
+            BTreeMap::from([(0u64, smallvec![0u64, 2u64]), (1u64, smallvec![1u64, 3u64])])
         );
 
         let mut unique_idxs = arr.make_unique_idxs()?;
@@ -481,7 +485,7 @@ mod tests {
     #[test]
     fn test_null_array_groups_and_unique_idxs() -> DaftResult<()> {
         let arr = NullArray::full_null("a", &DataType::Null, 4);
-        assert_eq!(arr.make_groups()?, (vec![0], vec![vec![0, 1, 2, 3]]));
+        assert_eq!(arr.make_groups()?, (vec![0], vec![smallvec![0, 1, 2, 3]]));
         assert_eq!(arr.make_unique_idxs()?, vec![0]);
 
         let empty = NullArray::full_null("a", &DataType::Null, 0);
@@ -501,7 +505,7 @@ mod tests {
         let grouped = grouped_by_sample(sample_indices, group_indices);
         assert_eq!(
             grouped,
-            BTreeMap::from([(0u64, vec![0u64, 1u64]), (2u64, vec![2u64])])
+            BTreeMap::from([(0u64, smallvec![0u64, 1u64]), (2u64, smallvec![2u64])])
         );
 
         let mut unique_idxs = array.make_unique_idxs()?;

--- a/src/daft-groupby/src/arrays.rs
+++ b/src/daft-groupby/src/arrays.rs
@@ -1,15 +1,14 @@
 use std::hash::Hash;
 
-use arrow::{array::Array, datatypes::ArrowPrimitiveType};
+use arrow::array::Array;
 use common_error::DaftResult;
 use daft_core::{
     array::{DataArray, FixedSizeListArray, ListArray, StructArray, ops::as_arrow::AsArrow},
     datatypes::{
-        BinaryArray, BooleanArray, DaftNumericType, FixedSizeBinaryArray, Float32Array,
-        Float64Array, Int8Type, Int16Type, Int32Type, Int64Type, NullArray, NumericNative,
-        UInt8Type, UInt16Type, UInt32Type, UInt64Type, Utf8Array,
+        BinaryArray, BooleanArray, Decimal128Type, FixedSizeBinaryArray, Float32Array,
+        Float64Array, Int8Type, Int16Type, Int32Type, Int64Type, NullArray, UInt8Type, UInt16Type,
+        UInt32Type, UInt64Type, Utf8Array,
     },
-    prelude::Decimal128Array,
 };
 use hashbrown::{DefaultHashBuilder, HashMap, hash_map::Entry};
 
@@ -112,15 +111,9 @@ where
 // Primitive integers: per-type impls avoid overlapping-blanket coherence errors with
 // `DataArray` type aliases defined in `daft-core` (e.g. `Float32Array`).
 
-macro_rules! impl_into_groups_integer_array {
-    ($($T:ty),* $(,)?) => {
-        $(
-        impl IntoGroups for DataArray<$T>
-        where
-            <$T as DaftNumericType>::Native: Ord + Hash + Eq,
-            <<$T as DaftNumericType>::Native as NumericNative>::ARROWTYPE:
-                ArrowPrimitiveType<Native = <$T as DaftNumericType>::Native>,
-        {
+macro_rules! impl_into_groups_primitive_array {
+    ($T:ty) => {
+        impl IntoGroups for DataArray<$T> {
             fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
                 if self.null_count() > 0 {
                     make_groups(self.into_iter())
@@ -130,12 +123,7 @@ macro_rules! impl_into_groups_integer_array {
             }
         }
 
-        impl IntoUniqueIdxs for DataArray<$T>
-        where
-            <$T as DaftNumericType>::Native: Ord + Hash + Eq,
-            <<$T as DaftNumericType>::Native as NumericNative>::ARROWTYPE:
-                ArrowPrimitiveType<Native = <$T as DaftNumericType>::Native>,
-        {
+        impl IntoUniqueIdxs for DataArray<$T> {
             fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
                 if self.null_count() > 0 {
                     make_unique_idxs(self.into_iter())
@@ -144,33 +132,18 @@ macro_rules! impl_into_groups_integer_array {
                 }
             }
         }
-        )*
     };
 }
 
-impl_into_groups_integer_array!(
-    Int8Type, Int16Type, Int32Type, Int64Type, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
-);
-
-impl IntoGroups for Decimal128Array {
-    fn make_groups(&self) -> DaftResult<crate::GroupIndicesPair> {
-        if self.null_count() > 0 {
-            make_groups(self.into_iter())
-        } else {
-            make_groups(self.values().iter())
-        }
-    }
-}
-
-impl IntoUniqueIdxs for Decimal128Array {
-    fn make_unique_idxs(&self) -> DaftResult<crate::VecIndices> {
-        if self.null_count() > 0 {
-            make_unique_idxs(self.into_iter())
-        } else {
-            make_unique_idxs(self.values().iter())
-        }
-    }
-}
+impl_into_groups_primitive_array!(Int8Type);
+impl_into_groups_primitive_array!(Int16Type);
+impl_into_groups_primitive_array!(Int32Type);
+impl_into_groups_primitive_array!(Int64Type);
+impl_into_groups_primitive_array!(UInt8Type);
+impl_into_groups_primitive_array!(UInt16Type);
+impl_into_groups_primitive_array!(UInt32Type);
+impl_into_groups_primitive_array!(UInt64Type);
+impl_into_groups_primitive_array!(Decimal128Type);
 
 // Floats (canonicalize NaN)
 // Canonicalize all NaN payloads so every NaN hashes/equates into one group.

--- a/src/daft-groupby/src/lib.rs
+++ b/src/daft-groupby/src/lib.rs
@@ -1,7 +1,10 @@
 //! Physical grouping helpers (`make_groups`, `make_unique_idxs`) for Daft arrays and series.
 
 use common_error::DaftResult;
-pub use daft_core::array::ops::{GroupIndicesPair, VecIndices};
+use daft_core::array::ops::GroupIndices;
+pub use daft_core::array::ops::VecIndices;
+
+pub type GroupIndicesPair = (VecIndices, GroupIndices);
 
 pub trait IntoGroups {
     fn make_groups(&self) -> DaftResult<GroupIndicesPair>;

--- a/src/daft-groupby/src/lib.rs
+++ b/src/daft-groupby/src/lib.rs
@@ -4,14 +4,15 @@ use common_error::DaftResult;
 use daft_core::array::ops::GroupIndices;
 pub use daft_core::array::ops::VecIndices;
 
-pub type GroupIndicesPair = (VecIndices, GroupIndices);
+pub type Indices = Vec<u64>;
+pub type GroupIndicesPair = (Indices, GroupIndices);
 
 pub trait IntoGroups {
     fn make_groups(&self) -> DaftResult<GroupIndicesPair>;
 }
 
 pub trait IntoUniqueIdxs {
-    fn make_unique_idxs(&self) -> DaftResult<VecIndices>;
+    fn make_unique_idxs(&self) -> DaftResult<Indices>;
 }
 
 mod arrays;

--- a/src/daft-groupby/src/lib.rs
+++ b/src/daft-groupby/src/lib.rs
@@ -1,0 +1,15 @@
+//! Physical grouping helpers (`make_groups`, `make_unique_idxs`) for Daft arrays and series.
+
+use common_error::DaftResult;
+pub use daft_core::array::ops::{GroupIndicesPair, VecIndices};
+
+pub trait IntoGroups {
+    fn make_groups(&self) -> DaftResult<GroupIndicesPair>;
+}
+
+pub trait IntoUniqueIdxs {
+    fn make_unique_idxs(&self) -> DaftResult<VecIndices>;
+}
+
+mod arrays;
+mod series;

--- a/src/daft-groupby/src/series.rs
+++ b/src/daft-groupby/src/series.rs
@@ -1,10 +1,11 @@
 use common_error::DaftResult;
-
-use crate::{
-    array::ops::{GroupIndicesPair, IntoGroups, IntoUniqueIdxs, VecIndices},
+use daft_core::{
+    array::ops::{GroupIndicesPair, VecIndices},
     series::Series,
     with_match_hashable_daft_types,
 };
+
+use crate::{IntoGroups, IntoUniqueIdxs};
 
 impl IntoGroups for Series {
     fn make_groups(&self) -> DaftResult<GroupIndicesPair> {

--- a/src/daft-groupby/src/series.rs
+++ b/src/daft-groupby/src/series.rs
@@ -1,11 +1,7 @@
 use common_error::DaftResult;
-use daft_core::{
-    array::ops::{GroupIndicesPair, VecIndices},
-    series::Series,
-    with_match_hashable_daft_types,
-};
+use daft_core::{series::Series, with_match_hashable_daft_types};
 
-use crate::{IntoGroups, IntoUniqueIdxs};
+use crate::{GroupIndicesPair, Indices, IntoGroups, IntoUniqueIdxs};
 
 impl IntoGroups for Series {
     fn make_groups(&self) -> DaftResult<GroupIndicesPair> {
@@ -18,7 +14,7 @@ impl IntoGroups for Series {
 }
 
 impl IntoUniqueIdxs for Series {
-    fn make_unique_idxs(&self) -> DaftResult<VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<Indices> {
         let s = self.as_physical()?;
         with_match_hashable_daft_types!(s.data_type(), |$T| {
             let array = s.downcast::<<$T as DaftDataType>::ArrayType>()?;

--- a/src/daft-local-execution/Cargo.toml
+++ b/src/daft-local-execution/Cargo.toml
@@ -16,6 +16,7 @@ common-system-info = {path = "../common/system-info", default-features = false}
 common-tracing = {path = "../common/tracing", default-features = false}
 console = {workspace = true}
 daft-core = {path = "../daft-core", default-features = false}
+daft-groupby = {path = "../daft-groupby", default-features = false}
 daft-context = {path = "../daft-context", default-features = false}
 daft-csv = {path = "../daft-csv", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}

--- a/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
@@ -173,7 +173,7 @@ impl BlockingSink for WindowPartitionAndDynamicFrameSink {
                                 .iter()
                                 .map(|indices| {
                                     let indices_arr =
-                                        UInt64Array::from_vec("indices", indices.clone());
+                                        UInt64Array::from_vec("indices", indices.to_vec());
                                     input_data.take(&indices_arr).unwrap()
                                 })
                                 .collect::<Vec<_>>();

--- a/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_dynamic_frame.rs
@@ -2,11 +2,12 @@ use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};
 use common_metrics::ops::NodeType;
-use daft_core::{array::ops::IntoGroups, datatypes::UInt64Array, prelude::*};
+use daft_core::{datatypes::UInt64Array, prelude::*};
 use daft_dsl::{
     WindowFrame,
     expr::bound_expr::{BoundAggExpr, BoundExpr},
 };
+use daft_groupby::IntoGroups;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use itertools::Itertools;

--- a/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
@@ -2,11 +2,12 @@ use std::sync::Arc;
 
 use common_error::{DaftError, DaftResult};
 use common_metrics::ops::NodeType;
-use daft_core::{array::ops::IntoGroups, datatypes::UInt64Array, prelude::*};
+use daft_core::{datatypes::UInt64Array, prelude::*};
 use daft_dsl::{
     Expr, WindowExpr,
     expr::bound_expr::{BoundExpr, BoundWindowExpr},
 };
+use daft_groupby::IntoGroups;
 use daft_micropartition::MicroPartition;
 use daft_recordbatch::RecordBatch;
 use itertools::Itertools;

--- a/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
+++ b/src/daft-local-execution/src/sinks/window_partition_and_order_by.rs
@@ -164,7 +164,7 @@ impl BlockingSink for WindowPartitionAndOrderBySink {
                                 .iter()
                                 .map(|indices| {
                                     let indices_arr =
-                                        UInt64Array::from_vec("indices", indices.clone());
+                                        UInt64Array::from_vec("indices", indices.to_vec());
                                     input_data.take(&indices_arr).unwrap()
                                 })
                                 .collect::<Vec<_>>();

--- a/src/daft-recordbatch/Cargo.toml
+++ b/src/daft-recordbatch/Cargo.toml
@@ -16,6 +16,7 @@ daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-functions-list = {path = "../daft-functions-list", default-features = false}
 daft-image = {path = "../daft-image", default-features = false}
 futures = {workspace = true}
+smallvec = {workspace = true}
 hashbrown = {workspace = true}
 html-escape = {workspace = true}
 indexmap = {workspace = true}

--- a/src/daft-recordbatch/Cargo.toml
+++ b/src/daft-recordbatch/Cargo.toml
@@ -11,6 +11,7 @@ common-py-serde = {path = "../common/py-serde", default-features = false}
 common-runtime = {path = "../common/runtime", default-features = false}
 common-metrics = {path = "../common/metrics", default-features = false}
 daft-core = {path = "../daft-core", default-features = false}
+daft-groupby = {path = "../daft-groupby", default-features = false}
 daft-dsl = {path = "../daft-dsl", default-features = false}
 daft-functions-list = {path = "../daft-functions-list", default-features = false}
 daft-image = {path = "../daft-image", default-features = false}

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -133,7 +133,7 @@ impl RecordBatch {
                             let evaluated_grouped_col = {
                                 // Convert group indices to Series
                                 let indices_as_arr =
-                                    UInt64Array::from_vec("", groupval_indices.clone());
+                                    UInt64Array::from_vec("", groupval_indices.to_vec());
 
                                 // Take each input Series by the group indices
                                 let input_groups = evaluated_inputs
@@ -220,7 +220,7 @@ impl RecordBatch {
                         .map(|(groupkey_index, groupval_indices)| {
                             // Convert group indices to Series
                             let indices_as_arr =
-                                UInt64Array::from_vec("", groupval_indices.clone());
+                                UInt64Array::from_vec("", groupval_indices.to_vec());
 
                             // Take each input Series by the group indices
                             let input_groups = evaluated_inputs

--- a/src/daft-recordbatch/src/ops/agg.rs
+++ b/src/daft-recordbatch/src/ops/agg.rs
@@ -1,8 +1,5 @@
 use common_error::{DaftError, DaftResult};
-use daft_core::{
-    array::ops::{IntoGroups, IntoUniqueIdxs},
-    prelude::*,
-};
+use daft_core::prelude::*;
 use daft_dsl::{
     AggExpr,
     expr::{
@@ -12,6 +9,7 @@ use daft_dsl::{
     operator_metrics::NoopMetricsCollector,
     python_udf::PyScalarFn,
 };
+use daft_groupby::{IntoGroups, IntoUniqueIdxs};
 
 use crate::RecordBatch;
 

--- a/src/daft-recordbatch/src/ops/groups.rs
+++ b/src/daft-recordbatch/src/ops/groups.rs
@@ -1,10 +1,10 @@
 use common_error::DaftResult;
 use daft_core::{
-    array::ops::{GroupIndicesPair, VecIndices, arrow::comparison::build_multi_array_is_equal},
+    array::ops::{VecIndices, arrow::comparison::build_multi_array_is_equal},
     datatypes::UInt64Array,
     series::Series,
 };
-use daft_groupby::{IntoGroups, IntoUniqueIdxs};
+use daft_groupby::{GroupIndicesPair, Indices, IntoGroups, IntoUniqueIdxs};
 
 use crate::RecordBatch;
 
@@ -33,7 +33,7 @@ impl RecordBatch {
 
         let probe_table = self.to_probe_hash_table()?;
         let mut key_indices: Vec<u64> = Vec::with_capacity(probe_table.len());
-        let mut values_indices: Vec<Vec<u64>> = Vec::with_capacity(probe_table.len());
+        let mut values_indices: Vec<VecIndices> = Vec::with_capacity(probe_table.len());
 
         for (idx_hash, val_idx) in probe_table {
             key_indices.push(idx_hash.idx);
@@ -120,7 +120,7 @@ impl IntoGroups for RecordBatch {
 }
 
 impl IntoUniqueIdxs for RecordBatch {
-    fn make_unique_idxs(&self) -> DaftResult<VecIndices> {
+    fn make_unique_idxs(&self) -> DaftResult<Indices> {
         // Returns the indices of the first occurrence of each unique row.
         //
         // e.g. given a table [B, B, A, B, C, C]

--- a/src/daft-recordbatch/src/ops/groups.rs
+++ b/src/daft-recordbatch/src/ops/groups.rs
@@ -1,12 +1,10 @@
 use common_error::DaftResult;
 use daft_core::{
-    array::ops::{
-        GroupIndicesPair, IntoGroups, IntoUniqueIdxs, VecIndices,
-        arrow::comparison::build_multi_array_is_equal,
-    },
+    array::ops::{GroupIndicesPair, VecIndices, arrow::comparison::build_multi_array_is_equal},
     datatypes::UInt64Array,
     series::Series,
 };
+use daft_groupby::{IntoGroups, IntoUniqueIdxs};
 
 use crate::RecordBatch;
 

--- a/src/daft-recordbatch/src/ops/hash.rs
+++ b/src/daft-recordbatch/src/ops/hash.rs
@@ -1,11 +1,12 @@
 use common_error::{DaftError, DaftResult};
 use daft_core::{
-    array::ops::arrow::comparison::build_multi_array_is_equal,
+    array::ops::{VecIndices, arrow::comparison::build_multi_array_is_equal},
     datatypes::UInt64Array,
     series::Series,
     utils::identity_hash_set::{IdentityBuildHasher, IndexHash},
 };
 use hashbrown::{HashMap, hash_map::RawEntryMut};
+use smallvec::smallvec;
 
 use crate::RecordBatch;
 
@@ -26,7 +27,7 @@ impl RecordBatch {
 
     pub fn to_probe_hash_table(
         &self,
-    ) -> DaftResult<HashMap<IndexHash, Vec<u64>, IdentityBuildHasher>> {
+    ) -> DaftResult<HashMap<IndexHash, VecIndices, IdentityBuildHasher>> {
         let hashes = self.hash_rows()?;
 
         const DEFAULT_SIZE: usize = 20;
@@ -39,7 +40,7 @@ impl RecordBatch {
         )?;
 
         let mut probe_table =
-            HashMap::<IndexHash, Vec<u64>, IdentityBuildHasher>::with_capacity_and_hasher(
+            HashMap::<IndexHash, VecIndices, IdentityBuildHasher>::with_capacity_and_hasher(
                 DEFAULT_SIZE,
                 Default::default(),
             );
@@ -59,7 +60,7 @@ impl RecordBatch {
                             idx: i as u64,
                             hash: *h,
                         },
-                        vec![i as u64],
+                        smallvec![i as u64],
                     );
                 }
                 RawEntryMut::Occupied(mut entry) => {

--- a/src/daft-recordbatch/src/ops/inline_agg.rs
+++ b/src/daft-recordbatch/src/ops/inline_agg.rs
@@ -951,7 +951,7 @@ impl RecordBatch {
         to_agg: &[BoundAggExpr],
         group_by: &[BoundExpr],
     ) -> DaftResult<Self> {
-        use daft_core::array::ops::IntoGroups;
+        use daft_groupby::IntoGroups;
         let groupby_table = self.eval_expression_list(group_by)?;
 
         let (groupkey_indices, groupvals_indices) = groupby_table.make_groups()?;

--- a/src/daft-recordbatch/src/ops/partition.rs
+++ b/src/daft-recordbatch/src/ops/partition.rs
@@ -111,7 +111,7 @@ impl RecordBatch {
         let output_tables = group_idx
             .into_iter()
             .map(|gidx| {
-                let gidx = UInt64Array::from_vec("idx", gidx);
+                let gidx = UInt64Array::from_vec("idx", gidx.into_vec());
                 self.take(&gidx)
             })
             .collect::<DaftResult<Vec<_>>>()?;

--- a/src/daft-recordbatch/src/ops/partition.rs
+++ b/src/daft-recordbatch/src/ops/partition.rs
@@ -1,8 +1,9 @@
 use std::ops::Rem;
 
 use common_error::{DaftError, DaftResult};
-use daft_core::{array::ops::IntoGroups, datatypes::UInt64Array};
+use daft_core::datatypes::UInt64Array;
 use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_groupby::IntoGroups;
 use rand::SeedableRng;
 
 use crate::RecordBatch;

--- a/src/daft-recordbatch/src/ops/pivot.rs
+++ b/src/daft-recordbatch/src/ops/pivot.rs
@@ -1,7 +1,7 @@
 use common_error::{DaftError, DaftResult};
 use daft_core::prelude::*;
 use daft_dsl::expr::bound_expr::BoundExpr;
-use daft_groupby::IntoGroups;
+use daft_groupby::{IntoGroups, VecIndices};
 
 use crate::RecordBatch;
 
@@ -33,8 +33,8 @@ fn map_name_to_pivot_key_idx<'a>(
 }
 
 fn map_pivot_key_idx_to_values_indices(
-    group_vals_indices: &[Vec<u64>],
-    pivot_vals_indices: &[Vec<u64>],
+    group_vals_indices: &[VecIndices],
+    pivot_vals_indices: &[VecIndices],
     pivot_keys_indices: &[u64],
 ) -> DaftResult<std::collections::HashMap<u64, Vec<Option<u64>>>> {
     let group_vals_indices_hashsets = group_vals_indices

--- a/src/daft-recordbatch/src/ops/pivot.rs
+++ b/src/daft-recordbatch/src/ops/pivot.rs
@@ -1,6 +1,7 @@
 use common_error::{DaftError, DaftResult};
-use daft_core::{array::ops::IntoGroups, prelude::*};
+use daft_core::prelude::*;
 use daft_dsl::expr::bound_expr::BoundExpr;
+use daft_groupby::IntoGroups;
 
 use crate::RecordBatch;
 

--- a/src/daft-recordbatch/src/ops/window.rs
+++ b/src/daft-recordbatch/src/ops/window.rs
@@ -1,13 +1,11 @@
 use arrow::{array::NullBufferBuilder, buffer::NullBuffer};
 use common_error::{DaftError, DaftResult};
-use daft_core::{
-    array::ops::{IntoGroups, arrow::comparison::build_multi_array_is_equal},
-    prelude::*,
-};
+use daft_core::{array::ops::arrow::comparison::build_multi_array_is_equal, prelude::*};
 use daft_dsl::{
     AggExpr, WindowBoundary, WindowFrame,
     expr::bound_expr::{BoundAggExpr, BoundExpr},
 };
+use daft_groupby::IntoGroups;
 
 use crate::{
     RecordBatch,

--- a/tests/dataframe/test_repr.py
+++ b/tests/dataframe/test_repr.py
@@ -369,7 +369,7 @@ def test_repr_empty_struct():
     assert ANSI_ESCAPE.sub("", df.schema()._truncated_table_string()) == expected_schema_truncated_repr
 
     expected_schema_repr = """╭──────────────────────┬──────────────────────────────────╮
-│ column_name          ┆ type                             │
+│ Column Name          ┆ DType                            │
 ╞══════════════════════╪══════════════════════════════════╡
 │ empty_structs        ┆ Struct[]                         │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤

--- a/tests/recordbatch/test_pivot.py
+++ b/tests/recordbatch/test_pivot.py
@@ -50,7 +50,7 @@ def test_pivot_multipartition(input: MicroPartition) -> None:
         "1": [3, 1],
         "2": [2, 4],
     }
-    assert daft_recordbatch.to_pydict() == expected
+    assert daft_recordbatch.sort([col("group")]).to_pydict() == expected
 
 
 def test_pivot_column_names_subset() -> None:
@@ -67,7 +67,7 @@ def test_pivot_column_names_subset() -> None:
         "group": ["A", "B"],
         "1": [1, 3],
     }
-    assert daft_recordbatch.to_pydict() == expected
+    assert daft_recordbatch.sort([col("group")]).to_pydict() == expected
 
 
 def test_pivot_column_names_superset() -> None:
@@ -86,7 +86,7 @@ def test_pivot_column_names_superset() -> None:
         "2": [2, None],
         "3": [None, None],
     }
-    assert daft_recordbatch.to_pydict() == expected
+    assert daft_recordbatch.sort([col("group")]).to_pydict() == expected
 
 
 def test_pivot_nulls_in_group() -> None:
@@ -104,7 +104,7 @@ def test_pivot_nulls_in_group() -> None:
         "1": [1, None, 2],
         "2": [None, 3, 4],
     }
-    assert daft_recordbatch.to_pydict() == expected
+    assert daft_recordbatch.sort([col("group")]).to_pydict() == expected
 
 
 def test_pivot_nulls_in_pivot() -> None:
@@ -122,4 +122,4 @@ def test_pivot_nulls_in_pivot() -> None:
         "1": [1, 3],
         "None": [2, 4],
     }
-    assert daft_recordbatch.to_pydict() == expected
+    assert daft_recordbatch.sort([col("group")]).to_pydict() == expected

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -100,7 +100,7 @@ def test_repr():
     assert (
         without_escape.replace("\r", "")
         == """╭─────────────┬─────────╮
-│ column_name ┆ type    │
+│ Column Name ┆ DType   │
 ╞═════════════╪═════════╡
 │ int         ┆ Int64   │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤


### PR DESCRIPTION
## Changes Made

For dedupe, tuning the `make_groups` operation for groupby to make it friendlier for high-cardinality situations without overly affecting low cardinalities. In particular:

* Used `HashBrown` directly instead of `FnvHashMap` because they use the faster `foldhash` (apparently Polars uses it too). Note, `foldhash` is particularly good for small fixed-sized types, while `ahash` is slightly better for short strings. But I believe `foldhash` is an improvement over `fnv` so I'm good with this for now. Will see if there are any regressions and in the future we can consider specializing per dtype
* Refactored out some of the groupby-agg code from `daft-core` into a new crate `daft-groupby` since we might expand on it a lot in the coming months and recompiling `daft-core` every time is a huge pain. From benchmarks, this doesn't seem to have an effect on perf, even without LTO
* In profiles, I was seeing a lot of overhead from JeMalloc deallocating, particularly small vectors. To address it:
	* For `list_agg`, I moved to using `.take()` on a large vec. I think we can do better but this already helped a ton
	* For `make_groups`, I moved to using `SmallVec<[u64; 2]>`, which helps about 20%
	* I think we can extend this to joins as well, as I'm seeing something similar there

Overall I see about a 4x improvement on connected components with these changes vs before (250s vs 70s).