### PR TITLE
feat(file): add file_path() function

### DIFF
--- a/daft/expressions/expressions.py
+++ b/daft/expressions/expressions.py
@@ -2805,6 +2805,16 @@ class Expression:
 
         return image_hash(self, method=method, hash_size=hash_size, binbits=binbits)
 
+    def file_path(self) -> Expression:
+        """Gets the path (URL) of a file as a string.
+
+        Tip: See Also
+            [`daft.functions.file_path`](https://docs.daft.ai/en/stable/api/functions/file_path/)
+        """
+        from daft.functions import file_path
+
+        return file_path(self)
+
     def file_size(self) -> Expression:
         """Gets the size of a file in bytes.
 

--- a/daft/functions/__init__.py
+++ b/daft/functions/__init__.py
@@ -75,7 +75,7 @@ from .similarity import (
     jaccard_similarity,
 )
 
-from .file_ import file, file_size, video_file, audio_file, guess_mime_type
+from .file_ import file, file_path, file_size, video_file, audio_file, guess_mime_type
 
 from .image import (
     resize,
@@ -321,6 +321,7 @@ __all__ = [
     "explode",
     "expm1",
     "file",
+    "file_path",
     "file_size",
     "fill_nan",
     "fill_null",

--- a/daft/functions/file_.py
+++ b/daft/functions/file_.py
@@ -59,6 +59,18 @@ def audio_file(url: Expression, verify: bool = False, io_config: IOConfig | None
     return url._eval_expressions("audio_file", verify=verify, io_config=io_config)
 
 
+def file_path(file: Expression) -> Expression:
+    """Returns the path (URL) of the file as a string.
+
+    Args:
+        file (File Expression): expression to evaluate.
+
+    Returns:
+        Expression (String Expression): expression containing the file path
+    """
+    return file._eval_expressions("file_path")
+
+
 def file_size(file: Expression) -> Expression:
     """Returns the size of the file in bytes.
 

--- a/src/daft-file/src/functions.rs
+++ b/src/daft-file/src/functions.rs
@@ -250,6 +250,43 @@ impl ScalarUDF for AudioFile {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct FilePath;
+
+#[typetag::serde]
+impl ScalarUDF for FilePath {
+    fn name(&self) -> &'static str {
+        "file_path"
+    }
+
+    fn call(
+        &self,
+        args: FunctionArgs<Series>,
+        _ctx: &daft_dsl::functions::scalar::EvalContext,
+    ) -> DaftResult<Series> {
+        let UnaryArg { input } = args.try_into()?;
+
+        with_match_file_types!(input.data_type(), |$P| {
+            let s = input.file::<$P>()?;
+            let url_series = s.physical.get("url")?;
+            Ok(url_series.rename(s.name()))
+        })
+    }
+
+    fn get_return_field(&self, args: FunctionArgs<ExprRef>, schema: &Schema) -> DaftResult<Field> {
+        let UnaryArg { input } = args.try_into()?;
+        let input = input.to_field(schema)?;
+
+        match &input.dtype {
+            DataType::File(_) => Ok(Field::new(input.name, DataType::Utf8)),
+            _ => Err(DaftError::TypeError(format!(
+                "Expected File type for 'file_path' function, got: {}",
+                input.dtype
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Size;
 
 #[typetag::serde]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ pub mod pylib {
 
         functions_registry.add_fn(daft_functions::coalesce::Coalesce);
         functions_registry.add_fn(daft_file::File);
+        functions_registry.add_fn(daft_file::FilePath);
         functions_registry.add_fn(daft_file::Size);
         functions_registry.add_fn(daft_file::VideoFile);
         functions_registry.add_fn(daft_file::AudioFile);

--- a/tests/file/test_file_basics.py
+++ b/tests/file/test_file_basics.py
@@ -9,7 +9,7 @@ import pytest
 
 import daft
 from daft import DataType as dt
-from daft.functions import file, file_size
+from daft.functions import file, file_path, file_size
 from tests.conftest import get_tests_daft_runner_name
 
 
@@ -278,3 +278,36 @@ def test_file_name_property_various_formats(url, expected_name):
     file = daft.File(url)
     assert file.name == expected_name
     assert file.path == url
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() == "ray", reason="local only test")
+def test_file_path_function():
+    """Test file_path() extracts the URL from a File column."""
+    paths = ["s3://bucket/file1.csv", "/local/path/file2.txt", "https://example.com/file3.json"]
+    df = daft.from_pydict({"path": paths})
+    df = df.select(file(df["path"]).alias("file"))
+    df = df.with_column("extracted_path", file_path(daft.col("file")))
+    result = df.to_pydict()
+    assert result["extracted_path"] == paths
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() == "ray", reason="local only test")
+def test_file_path_enables_string_operations():
+    """Test that file_path() output can be used with string expressions like endswith."""
+    paths = ["/data/report.pdf", "/data/image.png", "/data/notes.pdf"]
+    df = daft.from_pydict({"path": paths})
+    df = df.select(file(df["path"]).alias("file"))
+    df = df.where(file_path(daft.col("file")).endswith(".pdf"))
+    result = df.to_pydict()
+    assert len(result["file"]) == 2
+
+
+@pytest.mark.skipif(get_tests_daft_runner_name() == "ray", reason="local only test")
+def test_file_path_expression_method():
+    """Test that .file_path() works as an expression method."""
+    paths = ["/data/report.pdf", "/data/image.png"]
+    df = daft.from_pydict({"path": paths})
+    df = df.select(file(df["path"]).alias("file"))
+    df = df.with_column("extracted_path", daft.col("file").file_path())
+    result = df.to_pydict()
+    assert result["extracted_path"] == paths


### PR DESCRIPTION
## Summary
- Adds `file_path()` expression function that extracts the URL path from a `File` reference as a `Utf8` string
- Enables string operations (e.g., `.endswith(".pdf")`) on file columns via `file_path(col("file")).endswith(".pdf")`

## Motivation
`daft.from_files()` returns a single `file` column of type `File`, but there was no expression-level way to get the path back as a string without a UDF. See #6617 for details.

## What Changed
- **`src/daft-file/src/functions.rs`**: New `FilePath` scalar UDF (File → Utf8)
- **`src/lib.rs`**: Registered `FilePath` in the function registry
- **`daft/functions/file_.py`** + **`daft/functions/__init__.py`**: Python `file_path()` function and export
- **`tests/file/test_file_basics.py`**: 2 new tests covering `file_path()` and string operations

## Test plan
- [x] `DAFT_RUNNER=native make test EXTRA_ARGS="-v tests/file/test_file_basics.py"` — 33/33 passed
- [ ] CI

Closes #6617

🤖 Generated with [Claude Code](https://claude.com/claude-code)