### PR TITLE
ci(test): reduce Ray resource requests in skip_existing tests

### DIFF
--- a/tests/dataframe/test_skip_existing.py
+++ b/tests/dataframe/test_skip_existing.py
@@ -44,8 +44,8 @@ def helper_write_dataframe(
             existing_path=root_dir,
             key_column=skip_existing_config["key_column"],
             file_format=fmt,
-            num_workers=4 if num_workers is None else num_workers,
-            cpus_per_worker=1.0 if cpus_per_worker is None else cpus_per_worker,
+            num_workers=2 if num_workers is None else num_workers,
+            cpus_per_worker=0.5 if cpus_per_worker is None else cpus_per_worker,
         )
     if fmt == FileFormat.Csv:
         return df.write_csv(str(root_dir), write_mode=write_mode)


### PR DESCRIPTION
The skip_existing tests added in #5931 request a Ray placement group with `num_workers=4, cpus_per_worker=1.0` (4 CPUs total). macOS CI runners don't have enough CPUs to satisfy this, so `ray.get(pg.ready(), timeout=50)` times out -- failing every CI run on main since #5931 merged.

Lower the test helper defaults to `num_workers=2, cpus_per_worker=0.5`. These tests verify logical correctness of the skip_existing filter, not Ray resource scheduling.